### PR TITLE
Fix `ForeignFieldMul` layout from RFC

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -249,28 +249,37 @@ module Plonk_constraint = struct
           ; carry : 'v
           }
       | ForeignFieldMul of
-          { (* Current row *)
-            left_input0 : 'v
+          { left_input0 : 'v
           ; left_input1 : 'v
           ; left_input2 : 'v
           ; right_input0 : 'v
           ; right_input1 : 'v
           ; right_input2 : 'v
-          ; carry1_lo : 'v
-          ; carry1_hi : 'v
-          ; carry0 : 'v
+          ; remainder01 : 'v
+          ; remainder2 : 'v
           ; quotient0 : 'v
           ; quotient1 : 'v
           ; quotient2 : 'v
-          ; quotient_bound_carry : 'v
-          ; product1_hi_1 : 'v
-          ; (* Next row *) remainder0 : 'v
-          ; remainder1 : 'v
-          ; remainder2 : 'v
-          ; quotient_bound01 : 'v
-          ; quotient_bound2 : 'v
+          ; quotient_hi_bound : 'v
           ; product1_lo : 'v
           ; product1_hi_0 : 'v
+          ; product1_hi_1 : 'v
+          ; carry0 : 'v
+          ; carry1_0 : 'v
+          ; carry1_12 : 'v
+          ; carry1_24 : 'v
+          ; carry1_36 : 'v
+          ; carry1_48 : 'v
+          ; carry1_60 : 'v
+          ; carry1_72 : 'v
+          ; carry1_84 : 'v
+          ; carry1_86 : 'v
+          ; carry1_88 : 'v
+          ; carry1_90 : 'v
+          ; (* Coefficients *) foreign_field_modulus2 : 'f
+          ; neg_foreign_field_modulus0 : 'f
+          ; neg_foreign_field_modulus1 : 'f
+          ; neg_foreign_field_modulus2 : 'f
           }
       | Rot64 of
           { (* Current row *)
@@ -498,50 +507,70 @@ module Plonk_constraint = struct
             ; carry = f carry
             }
       | ForeignFieldMul
-          { (* Current row *) left_input0
+          { left_input0
           ; left_input1
           ; left_input2
           ; right_input0
           ; right_input1
           ; right_input2
-          ; carry1_lo
-          ; carry1_hi
-          ; carry0
+          ; remainder01
+          ; remainder2
           ; quotient0
           ; quotient1
           ; quotient2
-          ; quotient_bound_carry
-          ; product1_hi_1
-          ; (* Next row *) remainder0
-          ; remainder1
-          ; remainder2
-          ; quotient_bound01
-          ; quotient_bound2
+          ; quotient_hi_bound
           ; product1_lo
           ; product1_hi_0
+          ; product1_hi_1
+          ; carry0
+          ; carry1_0
+          ; carry1_12
+          ; carry1_24
+          ; carry1_36
+          ; carry1_48
+          ; carry1_60
+          ; carry1_72
+          ; carry1_84
+          ; carry1_86
+          ; carry1_88
+          ; carry1_90
+          ; (* Coefficients *) foreign_field_modulus2
+          ; neg_foreign_field_modulus0
+          ; neg_foreign_field_modulus1
+          ; neg_foreign_field_modulus2
           } ->
           ForeignFieldMul
-            { (* Current row *) left_input0 = f left_input0
+            { left_input0 = f left_input0
             ; left_input1 = f left_input1
             ; left_input2 = f left_input2
             ; right_input0 = f right_input0
             ; right_input1 = f right_input1
             ; right_input2 = f right_input2
-            ; carry1_lo = f carry1_lo
-            ; carry1_hi = f carry1_hi
-            ; carry0 = f carry0
+            ; remainder01 = f remainder01
+            ; remainder2 = f remainder2
             ; quotient0 = f quotient0
             ; quotient1 = f quotient1
             ; quotient2 = f quotient2
-            ; quotient_bound_carry = f quotient_bound_carry
-            ; product1_hi_1 = f product1_hi_1
-            ; (* Next row *) remainder0 = f remainder0
-            ; remainder1 = f remainder1
-            ; remainder2 = f remainder2
-            ; quotient_bound01 = f quotient_bound01
-            ; quotient_bound2 = f quotient_bound2
+            ; quotient_hi_bound = f quotient_hi_bound
             ; product1_lo = f product1_lo
             ; product1_hi_0 = f product1_hi_0
+            ; product1_hi_1 = f product1_hi_1
+            ; carry0 = f carry0
+            ; carry1_0 = f carry1_0
+            ; carry1_12 = f carry1_12
+            ; carry1_24 = f carry1_24
+            ; carry1_36 = f carry1_36
+            ; carry1_48 = f carry1_48
+            ; carry1_60 = f carry1_60
+            ; carry1_72 = f carry1_72
+            ; carry1_84 = f carry1_84
+            ; carry1_86 = f carry1_86
+            ; carry1_88 = f carry1_88
+            ; carry1_90 = f carry1_90
+            ; (* Coefficients *) foreign_field_modulus2
+            ; neg_foreign_field_modulus0
+            ; neg_foreign_field_modulus1
+            ; neg_foreign_field_modulus2
             }
       | Rot64
           { (* Current row *) word
@@ -1844,7 +1873,7 @@ end = struct
            ; Some (reduce_to_v out_3)
           |]
         in
-        (* The generic gate after a Xor16 gate is a Const to check that all values are zero.
+        (* The raw gate after a Xor16 gate is a Const to check that all values are zero.
            For that, the first coefficient is 1 and the rest will be zero.
            This will be included in the gadget for a chain of Xors, not here.*)
         add_row sys curr_row Xor16 [||]
@@ -1901,86 +1930,101 @@ end = struct
         add_row sys vars ForeignFieldAdd [||]
     | Plonk_constraint.T
         (ForeignFieldMul
-          { (* Current row *) left_input0
+          { left_input0
           ; left_input1
           ; left_input2
           ; right_input0
           ; right_input1
           ; right_input2
-          ; carry1_lo
-          ; carry1_hi
-          ; carry0
+          ; remainder01
+          ; remainder2
           ; quotient0
           ; quotient1
           ; quotient2
-          ; quotient_bound_carry
-          ; product1_hi_1
-          ; (* Next row *) remainder0
-          ; remainder1
-          ; remainder2
-          ; quotient_bound01
-          ; quotient_bound2
+          ; quotient_hi_bound
           ; product1_lo
           ; product1_hi_0
+          ; product1_hi_1
+          ; carry0
+          ; carry1_0
+          ; carry1_12
+          ; carry1_24
+          ; carry1_36
+          ; carry1_48
+          ; carry1_60
+          ; carry1_72
+          ; carry1_84
+          ; carry1_86
+          ; carry1_88
+          ; carry1_90
+          ; (* Coefficients *) foreign_field_modulus2
+          ; neg_foreign_field_modulus0
+          ; neg_foreign_field_modulus1
+          ; neg_foreign_field_modulus2
           } ) ->
         (*
-        //! | Gate   | `ForeignFieldMul`            | `Zero`                    |
-        //! | ------ | ---------------------------- | ------------------------- |
-        //! | Column | `Curr`                       | `Next`                    |
-        //! | ------ | ---------------------------- | ------------------------- |
-        //! |      0 | `left_input0`         (copy) | `remainder0`       (copy) |
-        //! |      1 | `left_input1`         (copy) | `remainder1`       (copy) |
-        //! |      2 | `left_input2`         (copy) | `remainder2`       (copy) |
-        //! |      3 | `right_input0`        (copy) | `quotient_bound01` (copy) |
-        //! |      4 | `right_input1`        (copy) | `quotient_bound2`  (copy) |
-        //! |      5 | `right_input2`        (copy) | `product1_lo`      (copy) |
-        //! |      6 | `carry1_lo`           (copy) | `product1_hi_0`    (copy) |
-        //! |      7 | `carry1_hi`        (plookup) |                           |
-        //! |      8 | `carry0`                     |                           |
-        //! |      9 | `quotient0`                  |                           |
-        //! |     10 | `quotient1`                  |                           |
-        //! |     11 | `quotient2`                  |                           |
-        //! |     12 | `quotient_bound_carry`       |                           |
-        //! |     13 | `product1_hi_1`              |                           |
-        //! |     14 |                              |                           |
+          | col | `ForeignFieldMul`       | `Zero`                     |
+          | --- | ----------------------- | -------------------------- |
+          |   0 | `left_input0`    (copy) | `remainder01`       (copy) |
+          |   1 | `left_input1`    (copy) | `remainder2`        (copy) |
+          |   2 | `left_input2`    (copy) | `quotient0`         (copy) |
+          |   3 | `right_input0`   (copy) | `quotient1`         (copy) |
+          |   4 | `right_input1`   (copy) | `quotient2`         (copy) |
+          |   5 | `right_input2`   (copy) | `quotient_hi_bound` (copy) |
+          |   6 | `product1_lo`    (copy) | `product1_hi_0`     (copy) |
+          |   7 | `carry1_0`    (plookup) | `product1_hi_1`    (dummy) |
+          |   8 | `carry1_12    (plookup) | `carry1_48`      (plookup) |
+          |   9 | `carry1_24`   (plookup) | `carry1_60`      (plookup) |
+          |  10 | `carry1_36`   (plookup) | `carry1_72`      (plookup) |
+          |  11 | `carry1_84`             | `carry0`                   |
+          |  12 | `carry1_86`             |                            |
+          |  13 | `carry1_88`             |                            |
+          |  14 | `carry1_90`             |                            |
         *)
+        (* Current row *)
         let vars_curr =
-          [| (* Current row *) Some (reduce_to_v left_input0)
+          [| Some (reduce_to_v left_input0)
            ; Some (reduce_to_v left_input1)
            ; Some (reduce_to_v left_input2)
            ; Some (reduce_to_v right_input0)
            ; Some (reduce_to_v right_input1)
            ; Some (reduce_to_v right_input2)
-           ; Some (reduce_to_v carry1_lo)
-           ; Some (reduce_to_v carry1_hi)
-           ; Some (reduce_to_v carry0)
+           ; Some (reduce_to_v product1_lo)
+           ; Some (reduce_to_v carry1_0)
+           ; Some (reduce_to_v carry1_12)
+           ; Some (reduce_to_v carry1_24)
+           ; Some (reduce_to_v carry1_36)
+           ; Some (reduce_to_v carry1_84)
+           ; Some (reduce_to_v carry1_86)
+           ; Some (reduce_to_v carry1_88)
+           ; Some (reduce_to_v carry1_90)
+          |]
+        in
+        (* Next row *)
+        let vars_next =
+          [| Some (reduce_to_v remainder01)
+           ; Some (reduce_to_v remainder2)
            ; Some (reduce_to_v quotient0)
            ; Some (reduce_to_v quotient1)
            ; Some (reduce_to_v quotient2)
-           ; Some (reduce_to_v quotient_bound_carry)
-           ; Some (reduce_to_v product1_hi_1)
-           ; None
-          |]
-        in
-        let vars_next =
-          [| (* Next row *) Some (reduce_to_v remainder0)
-           ; Some (reduce_to_v remainder1)
-           ; Some (reduce_to_v remainder2)
-           ; Some (reduce_to_v quotient_bound01)
-           ; Some (reduce_to_v quotient_bound2)
-           ; Some (reduce_to_v product1_lo)
+           ; Some (reduce_to_v quotient_hi_bound)
            ; Some (reduce_to_v product1_hi_0)
-           ; None
-           ; None
-           ; None
-           ; None
-           ; None
+           ; Some (reduce_to_v product1_hi_1)
+           ; Some (reduce_to_v carry1_48)
+           ; Some (reduce_to_v carry1_60)
+           ; Some (reduce_to_v carry1_72)
+           ; Some (reduce_to_v carry0)
            ; None
            ; None
            ; None
           |]
         in
-        add_row sys vars_curr ForeignFieldMul [||] ;
+        add_row sys vars_curr ForeignFieldMul
+          [| foreign_field_modulus2
+           ; neg_foreign_field_modulus0
+           ; neg_foreign_field_modulus1
+           ; neg_foreign_field_modulus2
+          |] ;
         add_row sys vars_next Zero [||]
     | Plonk_constraint.T
         (Rot64
@@ -2015,26 +2059,26 @@ end = struct
           ; (* Coefficients *) two_to_rot
           } ) ->
         (*
-        //! | Gate   | `Rot64`             | `RangeCheck0`    |
-        //! | ------ | ------------------- | ---------------- |
-        //! | Column | `Curr`              | `Next`           |
-        //! | ------ | ------------------- | ---------------- |
-        //! |      0 | copy `word`         |`shifted`         |
-        //! |      1 | copy `rotated`      | 0                |
-        //! |      2 |      `excess`       | 0                |
-        //! |      3 |      `bound_limb0`  | `shifted_limb0`  |
-        //! |      4 |      `bound_limb1`  | `shifted_limb1`  |
-        //! |      5 |      `bound_limb2`  | `shifted_limb2`  |
-        //! |      6 |      `bound_limb3`  | `shifted_limb3`  |
-        //! |      7 |      `bound_crumb0` | `shifted_crumb0` |
-        //! |      8 |      `bound_crumb1` | `shifted_crumb1` |
-        //! |      9 |      `bound_crumb2` | `shifted_crumb2` |
-        //! |     10 |      `bound_crumb3` | `shifted_crumb3` |
-        //! |     11 |      `bound_crumb4` | `shifted_crumb4` |
-        //! |     12 |      `bound_crumb5` | `shifted_crumb5` |
-        //! |     13 |      `bound_crumb6` | `shifted_crumb6` |
-        //! |     14 |      `bound_crumb7` | `shifted_crumb7` |
-        *)
+  //! | Gate   | `Rot64`             | `RangeCheck0`    |
+  //! | ------ | ------------------- | ---------------- |
+  //! | Column | `Curr`              | `Next`           |
+  //! | ------ | ------------------- | ---------------- |
+  //! |      0 | copy `word`         |`shifted`         |
+  //! |      1 | copy `rotated`      | 0                |
+  //! |      2 |      `excess`       | 0                |
+  //! |      3 |      `bound_limb0`  | `shifted_limb0`  |
+  //! |      4 |      `bound_limb1`  | `shifted_limb1`  |
+  //! |      5 |      `bound_limb2`  | `shifted_limb2`  |
+  //! |      6 |      `bound_limb3`  | `shifted_limb3`  |
+  //! |      7 |      `bound_crumb0` | `shifted_crumb0` |
+  //! |      8 |      `bound_crumb1` | `shifted_crumb1` |
+  //! |      9 |      `bound_crumb2` | `shifted_crumb2` |
+  //! |     10 |      `bound_crumb3` | `shifted_crumb3` |
+  //! |     11 |      `bound_crumb4` | `shifted_crumb4` |
+  //! |     12 |      `bound_crumb5` | `shifted_crumb5` |
+  //! |     13 |      `bound_crumb6` | `shifted_crumb6` |
+  //! |     14 |      `bound_crumb7` | `shifted_crumb7` |
+  *)
         let vars_curr =
           [| (* Current row *) Some (reduce_to_v word)
            ; Some (reduce_to_v rotated)

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -106,7 +106,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     CamlProverProof<CamlGVesta, CamlFp>,
 ) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, GateType},
@@ -114,6 +113,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
         polynomial::COLUMNS,
         wires::Wire,
     };
+    use poly_commitment::srs::{endos, SRS};
 
     let num_gates = 1000;
     let num_tables = 5;
@@ -215,28 +215,32 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     srs: CamlFpSrs,
 ) -> (CamlPastaFpPlonkIndex, CamlProverProof<CamlGVesta, CamlFp>) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
-        polynomials::{foreign_field_add::witness::FFOps, foreign_field_mul, range_check},
+        polynomials::foreign_field_mul,
         wires::Wire,
     };
     use num_bigint::BigUint;
     use num_bigint::RandBigInt;
     use o1_utils::{foreign_field::BigUintForeignFieldHelpers, FieldHelpers};
+    use poly_commitment::srs::{endos, SRS};
     use rand::{rngs::StdRng, SeedableRng};
 
     let foreign_field_modulus = Fq::modulus_biguint();
 
     // Layout
-    //      0    ForeignFieldMul   (foreign field multiplication gadget)
-    //      1    Zero              (foreign field multiplication gadget)
-    //      4-7  multi-range-check (left multiplicand)
-    //      8-11 multi-range-check (right multiplicand)
-    //     12-15 multi-range-check (product1_lo, product1_hi_0, carry1_lo)
-    //     16-19 multi-range-check (result range check)
-    //     20-23 multi-range-check (quotient range check)
+    //      0-1  ForeignFieldMul | Zero
+    //      2-5  compact-multi-range-check (result range check)
+    //        6  "single" Generic (result bound)
+    //      7-10 multi-range-check (quotient range check)
+    //     11-14 multi-range-check (quotient_bound, product1_lo, product1_hi_0)
+    //     later limb-check result bound
+    //        15 Generic (left and right bounds)
+    //     16-19 multi-range-check (left multiplicand)
+    //     20-23 multi-range-check (right multiplicand)
+    //     24-27 multi-range-check (result bound, left bound, right bound)
+    // TODO: check when kimchi is merged to berkeley
 
     // Create foreign field multiplication gates
     let (mut next_row, mut gates) =
@@ -247,58 +251,89 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     let right_input = rng.gen_biguint_range(&BigUint::zero(), &foreign_field_modulus);
 
     // Compute multiplication witness
-    let (mut witness, external_checks) =
+    let (mut witness, mut external_checks) =
         foreign_field_mul::witness::create(&left_input, &right_input, &foreign_field_modulus);
 
-    // Bound addition for multiplication result
-    CircuitGate::extend_single_ffadd(
-        &mut gates,
-        &mut next_row,
-        FFOps::Add,
-        &foreign_field_modulus,
-    );
-    gates.connect_cell_pair((1, 0), (2, 0));
-    gates.connect_cell_pair((1, 1), (2, 1));
-    gates.connect_cell_pair((1, 2), (2, 2));
-    external_checks
-        .extend_witness_bound_addition(&mut witness, &foreign_field_modulus.to_field_limbs());
+    // Result compact-multi-range-check
+    CircuitGate::extend_compact_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((1, 0), (4, 1)); // remainder01
+    gates.connect_cell_pair((1, 1), (2, 0)); // remainder2
+    external_checks.extend_witness_compact_multi_range_checks(&mut witness);
+    // These are the coordinates (row, col) of the remainder limbs in the witness
+    // remainder0 -> (3, 0), remainder1 -> (4, 0), remainder2 -> (2,0)
 
-    // Left input multi-range-check
-    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 0), (4, 0));
-    gates.connect_cell_pair((0, 1), (5, 0));
-    gates.connect_cell_pair((0, 2), (6, 0));
-    range_check::witness::extend_multi_limbs(&mut witness, &left_input.to_field_limbs());
+    // Constant single Generic gate for result bound
+    CircuitGate::extend_high_bounds(&mut gates, &mut next_row, &foreign_field_modulus);
+    gates.connect_cell_pair((6, 0), (1, 1)); // remainder2
+    external_checks.extend_witness_high_bounds_computation(&mut witness, &foreign_field_modulus);
 
-    // Right input multi-range-check
+    // Quotient multi-range-check
     CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 3), (8, 0));
-    gates.connect_cell_pair((0, 4), (9, 0));
-    gates.connect_cell_pair((0, 5), (10, 0));
-    range_check::witness::extend_multi_limbs(&mut witness, &right_input.to_field_limbs());
+    gates.connect_cell_pair((1, 2), (7, 0)); // quotient0
+    gates.connect_cell_pair((1, 3), (8, 0)); // quotient1
+    gates.connect_cell_pair((1, 4), (9, 0)); // quotient2
+                                             // Witness updated below
 
-    // Multiplication witness value product1_lo, product1_hi_0, carry1_lo multi-range-check
+    // Multiplication witness value quotient_bound, product1_lo, product1_hi_0 multi-range-check
     CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 6), (12, 0)); // carry1_lo
-    gates.connect_cell_pair((1, 5), (13, 0)); // product1_lo
-    gates.connect_cell_pair((1, 6), (14, 0)); // product1_hi_0
+    gates.connect_cell_pair((1, 5), (11, 0)); // quotient_bound
+    gates.connect_cell_pair((0, 6), (12, 0)); // product1_lo
+    gates.connect_cell_pair((1, 6), (13, 0)); // product1_hi_0
                                               // Witness updated below
 
-    // Result/remainder bound multi-range-check
-    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((3, 0), (16, 0));
-    gates.connect_cell_pair((3, 1), (17, 0));
-    gates.connect_cell_pair((3, 2), (18, 0));
-    // Witness updated below
-
-    // Add witness for external multi-range checks (product1_lo, product1_hi_0, carry1_lo and result)
+    // Add witness for external multi-range checks:
+    // [quotient0, quotient1, quotient2]
+    // [quotient_bound, product1_lo, product1_hi_0]
     external_checks.extend_witness_multi_range_checks(&mut witness);
 
-    // Quotient bound multi-range-check
-    CircuitGate::extend_compact_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((1, 3), (22, 1));
-    gates.connect_cell_pair((1, 4), (20, 0));
-    external_checks.extend_witness_compact_multi_range_checks(&mut witness);
+    // DESIGNER CHOICE: left and right (and result bound from before)
+    let left_limbs = left_input.to_field_limbs();
+    let right_limbs = right_input.to_field_limbs();
+    // Constant Double Generic gate for result and quotient bounds
+    external_checks.add_high_bound_computation(&left_limbs[2]);
+    external_checks.add_high_bound_computation(&right_limbs[2]);
+    CircuitGate::extend_high_bounds(&mut gates, &mut next_row, &foreign_field_modulus);
+    gates.connect_cell_pair((15, 0), (0, 2)); // left2
+    gates.connect_cell_pair((15, 3), (0, 5)); // right2
+    external_checks.extend_witness_high_bounds_computation(&mut witness, &foreign_field_modulus);
+
+    // Left input multi-range-check
+    external_checks.add_multi_range_check(&left_limbs);
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((0, 0), (16, 0)); // left_input0
+    gates.connect_cell_pair((0, 1), (17, 0)); // left_input1
+    gates.connect_cell_pair((0, 2), (18, 0)); // left_input2
+                                              // Witness updated below
+
+    // Right input multi-range-check
+    external_checks.add_multi_range_check(&right_limbs);
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((0, 3), (20, 0)); // right_input0
+    gates.connect_cell_pair((0, 4), (21, 0)); // right_input1
+    gates.connect_cell_pair((0, 5), (22, 0)); // right_input2
+                                              // Witness updated below
+
+    // Add witness for external multi-range checks:
+    // left and right limbs
+    external_checks.extend_witness_multi_range_checks(&mut witness);
+
+    // [result_bound, 0, 0]
+    // Bounds for result limb range checks
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((6, 2), (24, 0)); // result_bound
+                                              // Witness updated below
+
+    // Multi-range check bounds for left and right inputs
+    let left_hi_bound =
+        foreign_field_mul::witness::compute_high_bound(&left_input, &foreign_field_modulus);
+    let right_hi_bound =
+        foreign_field_mul::witness::compute_high_bound(&right_input, &foreign_field_modulus);
+    external_checks.add_limb_check(&left_hi_bound.into());
+    external_checks.add_limb_check(&right_hi_bound.into());
+    gates.connect_cell_pair((15, 2), (25, 0)); // left_bound
+    gates.connect_cell_pair((15, 5), (26, 0)); // right_bound
+
+    external_checks.extend_witness_limb_checks(&mut witness);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -327,7 +362,10 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
         None,
     )
     .unwrap();
-    (CamlPastaFpPlonkIndex(Box::new(index)), (proof, vec![]).into())
+    (
+        CamlPastaFpPlonkIndex(Box::new(index)),
+        (proof, vec![]).into(),
+    )
 }
 
 #[ocaml_gen::func]
@@ -336,13 +374,13 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check(
     srs: CamlFpSrs,
 ) -> (CamlPastaFpPlonkIndex, CamlProverProof<CamlGVesta, CamlFp>) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem, gate::CircuitGate, polynomials::range_check, wires::Wire,
     };
     use num_bigint::BigUint;
     use num_bigint::RandBigInt;
     use o1_utils::{foreign_field::BigUintForeignFieldHelpers, BigUintFieldHelpers};
+    use poly_commitment::srs::{endos, SRS};
     use rand::{rngs::StdRng, SeedableRng};
 
     let rng = &mut StdRng::from_seed([255u8; 32]);
@@ -390,7 +428,10 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check(
         None,
     )
     .unwrap();
-    (CamlPastaFpPlonkIndex(Box::new(index)), (proof, vec![]).into())
+    (
+        CamlPastaFpPlonkIndex(Box::new(index)),
+        (proof, vec![]).into(),
+    )
 }
 
 #[ocaml_gen::func]
@@ -399,7 +440,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check0(
     srs: CamlFpSrs,
 ) -> (CamlPastaFpPlonkIndex, CamlProverProof<CamlGVesta, CamlFp>) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
@@ -407,6 +447,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check0(
         polynomials::{generic::GenericGateSpec, range_check},
         wires::Wire,
     };
+    use poly_commitment::srs::{endos, SRS};
 
     let gates = {
         // Public input row with value 0
@@ -459,7 +500,10 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check0(
         None,
     )
     .unwrap();
-    (CamlPastaFpPlonkIndex(Box::new(index)), (proof, vec![]).into())
+    (
+        CamlPastaFpPlonkIndex(Box::new(index)),
+        (proof, vec![]).into(),
+    )
 }
 
 #[ocaml_gen::func]
@@ -472,7 +516,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
     CamlProverProof<CamlGVesta, CamlFp>,
 ) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
@@ -485,6 +528,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
         wires::Wire,
     };
     use num_bigint::BigUint;
+    use poly_commitment::srs::{endos, SRS};
 
     // Includes a row to store value 1
     let num_public_inputs = 1;
@@ -599,7 +643,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
     CamlProverProof<CamlGVesta, CamlFp>,
 ) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
@@ -607,6 +650,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
         polynomials::{generic::GenericGateSpec, xor},
         wires::Wire,
     };
+    use poly_commitment::srs::{endos, SRS};
 
     let num_public_inputs = 2;
 
@@ -688,7 +732,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_rot(
     CamlProverProof<CamlGVesta, CamlFp>,
 ) {
     use ark_ff::Zero;
-    use poly_commitment::srs::{endos, SRS};
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
@@ -699,6 +742,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_rot(
         },
         wires::Wire,
     };
+    use poly_commitment::srs::{endos, SRS};
 
     // Includes the actual input of the rotation and a row with the zero value
     let num_public_inputs = 2;

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -109,7 +109,6 @@ type 'bool all_feature_flags =
   ; table_width_at_least_1 : 'bool Lazy.t
   ; table_width_at_least_2 : 'bool Lazy.t
   ; table_width_3 : 'bool Lazy.t
-  ; lookups_per_row_2 : 'bool Lazy.t
   ; lookups_per_row_3 : 'bool Lazy.t
   ; lookups_per_row_4 : 'bool Lazy.t
   ; lookup_pattern_xor : 'bool Lazy.t
@@ -142,7 +141,7 @@ let expand_feature_flags (type boolean)
   in
   (* Make sure these stay up-to-date with the layouts!! *)
   let table_width_3 =
-    (* Xor, ChaChaFinal have max_joint_size = 3 *)
+    (* Xor have max_joint_size = 3 *)
     lookup_pattern_xor
   in
   let table_width_at_least_2 =
@@ -150,7 +149,7 @@ let expand_feature_flags (type boolean)
     lazy (B.( ||| ) (Lazy.force table_width_3) lookup)
   in
   let table_width_at_least_1 =
-    (* RangeCheck, ForeignFieldMul have max_joint_size = 2 *)
+    (* RangeCheck, ForeignFieldMul have max_joint_size = 1 *)
     lazy
       (B.any
          [ Lazy.force table_width_at_least_2
@@ -159,25 +158,23 @@ let expand_feature_flags (type boolean)
          ] )
   in
   let lookups_per_row_4 =
-    (* Xor, ChaChaFinal, RangeCheckGate have max_lookups_per_row = 4 *)
+    (* Xor, RangeCheckGate, ForeignFieldMul, have max_lookups_per_row = 4 *)
     lazy
-      (B.( ||| )
-         (Lazy.force lookup_pattern_xor)
-         (Lazy.force lookup_pattern_range_check) )
+      (B.any
+         [ Lazy.force lookup_pattern_xor
+         ; Lazy.force lookup_pattern_range_check
+         ; foreign_field_mul
+         ] )
   in
   let lookups_per_row_3 =
     (* Lookup has max_lookups_per_row = 3 *)
     lazy (B.( ||| ) (Lazy.force lookups_per_row_4) lookup)
   in
-  let lookups_per_row_2 =
-    (* ForeignFieldMul has max_lookups_per_row = 2 *)
-    lazy (B.( ||| ) (Lazy.force lookups_per_row_3) foreign_field_mul)
-  in
+
   { lookup_tables
   ; table_width_at_least_1
   ; table_width_at_least_2
   ; table_width_3
-  ; lookups_per_row_2
   ; lookups_per_row_3
   ; lookups_per_row_4
   ; lookup_pattern_xor
@@ -245,10 +242,8 @@ let get_feature_flag (feature_flags : _ all_feature_flags)
       None
   | LookupsPerRow 4 ->
       Some (Lazy.force feature_flags.lookups_per_row_4)
-  | LookupsPerRow 3 ->
+  | LookupsPerRow i when i <= 3 ->
       Some (Lazy.force feature_flags.lookups_per_row_3)
-  | LookupsPerRow i when i <= 2 ->
-      Some (Lazy.force feature_flags.lookups_per_row_2)
   | LookupsPerRow _ ->
       None
   | LookupPattern Lookup ->


### PR DESCRIPTION
This PR fixes the parameters needed in the repo to be compatible with the [fixed FFMul gate](https://github.com/o1-labs/proof-systems/pull/1125) from Kimchi, before hard fork. It includes:

- Updated plonk_constraint_system with new layout and updated coefficients
- Updated lookup pattern and number of lookups per row of `ForeignFieldMul`
- Removed the `lookups_per_row_2` feature flag since now there's none. We now have 4 and 3 only.
- Updated the finalization test with the new functions
- `proof-systems` points at [64437e2](https://github.com/o1-labs/proof-systems/commit/64437e20cf24c6bead4627ac978a7b1ea8ea358c) now (`berkeley`) 

Together with https://github.com/MinaProtocol/mina/pull/13624, https://github.com/MinaProtocol/mina/pull/13625, https://github.com/MinaProtocol/mina/pull/13626, this PR replaces the old https://github.com/MinaProtocol/mina/pull/13606