### PR TITLE
Fix/payment tests compatible

### DIFF
--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -500,7 +500,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ~amount:Currency.Amount.one ~fee ~node:sender 12
          in
          wait_for t
-           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:3
+           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:2
               ~test_config:config ) )
     in
     let%bind () =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -485,7 +485,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "change snark work fee from 0.0002 to 0.0001"
         (Integration_test_lib.Graphql_requests.must_set_snark_work_fee ~logger
            (Network.Node.get_ingress_uri snark_coordinator)
-           ~new_snark_work_fee:1 )
+           ~new_snark_work_fee:100000 )
     in
     let%bind () =
       section_hard

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -481,11 +481,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ( snark_node_key2.keypair.public_key
              |> Signature_lib.Public_key.compress ) )
     in
+    let new_snark_work_fee = Currency.Amount.of_mina_string_exn "0.0001" in
     let%bind () =
       section_hard "change snark work fee from 0.0002 to 0.0001"
         (Integration_test_lib.Graphql_requests.must_set_snark_work_fee ~logger
            (Network.Node.get_ingress_uri snark_coordinator)
-           ~new_snark_work_fee:100000 )
+           ~new_snark_work_fee:
+             (Currency.Amount.to_nanomina_int new_snark_work_fee) )
     in
     let%bind () =
       section_hard
@@ -521,22 +523,19 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                ( snark_node_key2.keypair.public_key
                |> Signature_lib.Public_key.compress )
          in
-         let key_2_balance_expected =
-           Currency.Amount.of_formatted_string "0.0001"
-         in
          if
            Currency.Amount.( >= )
              (Currency.Balance.to_amount key_2_balance_actual)
-             key_2_balance_expected
+             new_snark_work_fee
          then (
            [%log info]
              "balance check successful.  \n\
               snark-node-key1 balance: %s.  \n\
               snark-node-key2 balance: %s.  \n\
-              snark-worker-fee: %s"
+              new-snark-worker-fee: %s"
              (Currency.Balance.to_formatted_string key_1_balance_actual)
              (Currency.Balance.to_formatted_string key_2_balance_actual)
-             (Currency.Amount.to_formatted_string key_2_balance_expected) ;
+             (Currency.Amount.to_formatted_string new_snark_work_fee) ;
 
            Malleable_error.return () )
          else
@@ -544,10 +543,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              "Error with balance of snark-node-key2.  \n\
               snark-node-key1 balance: %s.  \n\
               snark-node-key2 balance: %s.  \n\
-              snark-worker-fee: %s"
+              new-snark-worker-fee: %s"
              (Currency.Balance.to_formatted_string key_1_balance_actual)
              (Currency.Balance.to_formatted_string key_2_balance_actual)
-             (Currency.Amount.to_formatted_string key_2_balance_expected) )
+             (Currency.Amount.to_formatted_string new_snark_work_fee) )
     in
     section_hard "running replayer"
       (let%bind logs =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -481,13 +481,12 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ( snark_node_key2.keypair.public_key
              |> Signature_lib.Public_key.compress ) )
     in
-    let new_snark_work_fee = Currency.Amount.of_mina_string_exn "0.0001" in
+    let new_snark_work_fee = Currency.Amount.of_formatted_string "0.0001" in
     let%bind () =
       section_hard "change snark work fee from 0.0002 to 0.0001"
         (Integration_test_lib.Graphql_requests.must_set_snark_work_fee ~logger
            (Network.Node.get_ingress_uri snark_coordinator)
-           ~new_snark_work_fee:
-             (Currency.Amount.to_nanomina_int new_snark_work_fee) )
+           ~new_snark_work_fee:(Currency.Amount.to_int new_snark_work_fee) )
     in
     let%bind () =
       section_hard

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -536,7 +536,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               snark-worker-fee: %s"
              (Currency.Balance.to_formatted_string key_1_balance_actual)
              (Currency.Balance.to_formatted_string key_2_balance_actual)
-             config.snark_worker_fee ;
+             (Currency.Amount.to_formatted_string key_2_balance_expected) ;
 
            Malleable_error.return () )
          else
@@ -547,7 +547,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               snark-worker-fee: %s"
              (Currency.Balance.to_formatted_string key_1_balance_actual)
              (Currency.Balance.to_formatted_string key_2_balance_actual)
-             config.snark_worker_fee )
+             (Currency.Amount.to_formatted_string key_2_balance_expected) )
     in
     section_hard "running replayer"
       (let%bind logs =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -67,7 +67,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ; account_name = "snark-node-key1"
           ; worker_nodes = 4
           }
-    ; snark_worker_fee = "0.0001"
+    ; snark_worker_fee = "0.0002"
     ; num_archive_nodes = 1
     ; proof_config =
         { proof_config_default with
@@ -475,15 +475,17 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let%bind () =
       section_hard
         "change snark worker key from snark-node-key1 to snark-node-key2"
-        (let%bind () =
-           Integration_test_lib.Graphql_requests.must_set_snark_worker ~logger
-             (Network.Node.get_ingress_uri snark_coordinator)
-             ~new_snark_pub_key:
-               ( snark_node_key2.keypair.public_key
-               |> Signature_lib.Public_key.compress )
-         in
-         (* adding a wait for 3 minutes so that the new snark worker can start.  this is a temporary solution to what's essentially a race condition causing lots of flakiness/non-determinism for this test *)
-         Malleable_error.lift (Async.after (Time.Span.of_int_sec 180)) )
+        (Integration_test_lib.Graphql_requests.must_set_snark_worker ~logger
+           (Network.Node.get_ingress_uri snark_coordinator)
+           ~new_snark_pub_key:
+             ( snark_node_key2.keypair.public_key
+             |> Signature_lib.Public_key.compress ) )
+    in
+    let%bind () =
+      section_hard "change snark work fee from 0.0002 to 0.0001"
+        (Integration_test_lib.Graphql_requests.must_set_snark_work_fee ~logger
+           (Network.Node.get_ingress_uri snark_coordinator)
+           ~new_snark_work_fee:1 )
     in
     let%bind () =
       section_hard

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -522,7 +522,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                |> Signature_lib.Public_key.compress )
          in
          let key_2_balance_expected =
-           Currency.Amount.of_formatted_string config.snark_worker_fee
+           Currency.Amount.of_formatted_string "0.0001"
          in
          if
            Currency.Amount.( >= )

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -498,7 +498,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ~amount:Currency.Amount.one ~fee ~node:sender 12
          in
          wait_for t
-           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:2
+           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:3
               ~test_config:config ) )
     in
     let%bind () =

--- a/src/lib/integration_test_lib/graphql_requests.ml
+++ b/src/lib/integration_test_lib/graphql_requests.ml
@@ -105,6 +105,16 @@ module Graphql = struct
     }
   |}]
 
+  module Set_snark_work_fee =
+  [%graphql
+  {|
+    mutation ($fee: UInt64!) @encoders(module: "Encoders"){
+      setSnarkWorkFee(input: {fee: $fee}) {
+        lastFee
+      }
+    }
+  |}]
+
   module Get_account_data =
   [%graphql
   {|
@@ -594,8 +604,39 @@ let set_snark_worker ~logger node_uri ~new_snark_pub_key =
     ~metadata:[ ("lastSnarkWorker", `String last_snark_worker) ] ;
   ()
 
+let set_snark_work_fee ~logger node_uri ~new_snark_work_fee =
+  [%log info] "Changing snark work fee"
+    ~metadata:
+      [ ("new_snark_work_fee", `Int new_snark_work_fee)
+      ; ("node_uri", `String (Uri.to_string node_uri))
+      ] ;
+  let open Deferred.Or_error.Let_syntax in
+  let set_snark_work_fee_graphql () =
+    let set_snark_work_fee_obj =
+      Graphql.Set_snark_work_fee.(
+        make
+        @@ makeVariables ~fee:(Unsigned.UInt64.of_int new_snark_work_fee) ())
+    in
+    exec_graphql_request ~logger ~node_uri
+      ~query_name:"set_snark_work_fee_graphql" set_snark_work_fee_obj
+  in
+  let%map result_obj = set_snark_work_fee_graphql () in
+  let last_snark_work_fee =
+    Currency.Fee.to_string result_obj.setSnarkWorkFee.lastFee
+  in
+  [%log info] "snark work fee changed, lastSnarkWorkFee: %s" last_snark_work_fee
+    ~metadata:
+      [ ("lastSnarkWorkFee", `String last_snark_work_fee)
+      ; ("node_uri", `String (Uri.to_string node_uri))
+      ] ;
+  ()
+
 let must_set_snark_worker ~logger t ~new_snark_pub_key =
   set_snark_worker ~logger t ~new_snark_pub_key
+  |> Deferred.bind ~f:Malleable_error.or_hard_error
+
+let must_set_snark_work_fee ~logger t ~new_snark_work_fee =
+  set_snark_work_fee ~logger t ~new_snark_work_fee
   |> Deferred.bind ~f:Malleable_error.or_hard_error
 
 let get_metrics ~logger node_uri =

--- a/src/lib/integration_test_lib/graphql_requests.ml
+++ b/src/lib/integration_test_lib/graphql_requests.ml
@@ -622,7 +622,7 @@ let set_snark_work_fee ~logger node_uri ~new_snark_work_fee =
   in
   let%map result_obj = set_snark_work_fee_graphql () in
   let last_snark_work_fee =
-    Currency.Fee.to_string result_obj.setSnarkWorkFee.lastFee
+    Unsigned.UInt64.to_string result_obj.setSnarkWorkFee.lastFee
   in
   [%log info] "snark work fee changed, lastSnarkWorkFee: %s" last_snark_work_fee
     ~metadata:


### PR DESCRIPTION
Explain your changes:
This PR tries to fix the payment tests. The change is simple here: after we changed the snark worker key, we change the snark fee immediately. Since we have some delay in the scan state, once we changed the snark worker key, there're still some works that produced before we changed the key. To replace those works, we simply need to make the fee lower so that the newly produced snark work would be selected over the old ones.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
