### PR TITLE
fix helm chart lints comp

### DIFF
--- a/frontend/leaderboard/helm/templates/leaderboard-cron-job.yaml
+++ b/frontend/leaderboard/helm/templates/leaderboard-cron-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.leaderboard.name }}


### PR DESCRIPTION
Explain your changes:
Fix for Helm chart lints observed in berkeley based PRs. It manifests with below error:

```
  | Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "leaderboard-cron" namespace: "" from "": no matches for kind "CronJob" in version "batch/v1beta1"
  | ensure CRDs are installed first

```

The hint is in some line above:

```
==> Linting ./frontend/leaderboard/helm
--
  | [WARNING] templates/leaderboard-cron-job.yaml: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

This PR updates apiVersion

Explain how you tested your changes:
run CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules

