### PR TITLE
Limit fuzzy job retry [develop]

### DIFF
--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -6,7 +6,6 @@ let D = S.PathPattern
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 let JobSpec = ../../Pipeline/JobSpec.dhall
-
 let Command = ../../Command/Base.dhall
 let RunInToolchain = ../../Command/RunInToolchain.dhall
 let Docker = ../../Command/Docker/Type.dhall
@@ -23,9 +22,13 @@ let buildTestCmd : Text -> Text -> Natural -> Natural -> Size -> Command.Type = 
       key = "fuzzy-zkapp-unit-test-${profile}",
       target = cmd_target,
       docker = None Docker.Type,
-      artifact_paths = [ S.contains "core_dumps/*" ]
+      artifact_paths = [ S.contains "core_dumps/*" ],
+      retries = [
+              Command.Retry::{
+                exit_status = Command.ExitStatus.Code +1,
+                limit = Some 0
+              } ]
     }
-
 in
 
 Pipeline.build

--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -23,11 +23,7 @@ let buildTestCmd : Text -> Text -> Natural -> Natural -> Size -> Command.Type = 
       target = cmd_target,
       docker = None Docker.Type,
       artifact_paths = [ S.contains "core_dumps/*" ],
-      retries = [
-              Command.Retry::{
-                exit_status = Command.ExitStatus.Code +1,
-                limit = Some 0
-              } ]
+      flake_retry_limit = Some 0
     }
 in
 


### PR DESCRIPTION
Explain your changes:
Expose parameter for setting retry limit for flaky test (exit code = +1). Then use this parameter in fuzzy zkapp tests. This will help us limit duration of nightly tests from 10h to 2h. I didn't touch other exit codes, so it should allow to retry for other reasons of build failure

Explain how you tested your changes:
run nightly job and observed failing zkapp unit tests are not rerun if tests fails

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
