### PR TITLE
Bump per-test timeout in zkapp fuzzy tests

### DIFF
--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -46,6 +46,6 @@ Pipeline.build
         name = "FuzzyZkappTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.exe" 3600 120 Size.Small
+      buildTestCmd "dev" "src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.exe" 3600 150 Size.Small
     ]
   }


### PR DESCRIPTION
We were seeing timeouts in the nightly tests, reproducible locally. Raising the per-test timeout from 120 to 150 avoided the timeouts locally.