### PR TITLE
Remove support for bionic and stretch [compatible]

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBionic.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBionic.dhall
@@ -1,6 +1,0 @@
-let ArtifactPipelines = ../../Command/MinaArtifact.dhall
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-in
-
-Pipeline.build ArtifactPipelines.bionic

--- a/buildkite/src/Jobs/Release/MinaArtifactStretch.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactStretch.dhall
@@ -1,6 +1,0 @@
-let ArtifactPipelines = ../../Command/MinaArtifact.dhall
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-in
-
-Pipeline.build ArtifactPipelines.stretch

--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -1,4 +1,4 @@
-ARG image=debian:stretch-slim
+ARG image=debian:bullseye-slim
 FROM ${image}
 
 # Run with `docker build --build-arg deb_version=<version>`

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -1,4 +1,4 @@
-ARG image=debian:stretch-slim
+ARG image=debian:bullseye-slim
 FROM ${image}
 # Run with `docker build --build-arg deb_version=<version>`
 ARG deb_version

--- a/dockerfiles/Dockerfile-mina-test-executive
+++ b/dockerfiles/Dockerfile-mina-test-executive
@@ -1,4 +1,4 @@
-ARG image=debian:stretch-slim
+ARG image=debian:bullseye-slim
 FROM ${image}
 # Run with `docker build --build-arg deb_version=<version>`
 ARG deb_version


### PR DESCRIPTION
Explain your changes:
Removes support for bionic and stretch dockers alike to berkeley and develop

Explain how you tested your changes:
Running CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

