### PR TITLE
reverse condition in mainnet check and remove toolchain stretch docker

### DIFF
--- a/buildkite/scripts/connect-to-mainnet-on-compatible.sh
+++ b/buildkite/scripts/connect-to-mainnet-on-compatible.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 
 case "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" in
     compatible|release/*)
-      echo "Not pulling against compatible or not in release branch. Therefore, not running the connect test"
-      exit 0
       ;;
     *) 
+      echo "Not pulling against compatible or not in release branch. Therefore, not running the connect test"
+      exit 0
       ;;
 esac
 

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifact.dhall
@@ -53,6 +53,6 @@ Pipeline.build
       in
 
       DockerImage.generateStep toolchainBusterSpec
+
     ]
   }
-

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifact.dhall
@@ -52,20 +52,7 @@ Pipeline.build
 
       in
 
-      DockerImage.generateStep toolchainBusterSpec,
-
-      -- mina-toolchain Debian 9 "Stretch" Toolchain
-      let toolchainStretchSpec = DockerImage.ReleaseSpec::{
-        service="mina-toolchain",
-        deb_codename="stretch",
-        extra_args="--no-cache",
-        step_key="toolchain-stretch-docker-image"
-      }
-
-      in
-
-      DockerImage.generateStep toolchainStretchSpec
-
+      DockerImage.generateStep toolchainBusterSpec
     ]
   }
 


### PR DESCRIPTION
Another portion of fixes for compatible nightly. Reverse condition on connect to testnet, so actually connection attempt will be executed on compatible. Remove leftover docker for stretch