### PR TITLE
Updates the example using foreign field mul

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -409,6 +409,14 @@ module Protocol = struct
              Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_rot"
 
+      external example_with_foreign_field_mul :
+           SRS.Fp.t
+        -> Index.Fp.t
+           * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
+             , Pasta_bindings.Fp.t )
+             Kimchi_types.prover_proof
+        = "caml_pasta_fp_plonk_proof_example_with_foreign_field_mul"
+
       external example_with_range_check :
            SRS.Fp.t
         -> Index.Fp.t

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -455,7 +455,7 @@ fn generate_kimchi_bindings(mut w: impl std::io::Write, env: &mut Env) {
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_ffadd => "example_with_ffadd");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_xor => "example_with_xor");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_rot => "example_with_rot");
-                //decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_foreign_field_mul => "example_with_foreign_field_mul");
+                decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_foreign_field_mul => "example_with_foreign_field_mul");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_range_check => "example_with_range_check");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_range_check0 => "example_with_range_check0");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_verify => "verify");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -273,7 +273,6 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     )
 }
 
-/*
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
@@ -283,7 +282,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, Connect},
-        polynomials::{foreign_field_add::witness::FFOps, foreign_field_mul, range_check},
+        polynomials::foreign_field_mul,
         wires::Wire,
     };
     use num_bigint::BigUint;
@@ -295,13 +294,17 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     let foreign_field_modulus = Fq::modulus_biguint();
 
     // Layout
-    //      0    ForeignFieldMul   (foreign field multiplication gadget)
-    //      1    Zero              (foreign field multiplication gadget)
-    //      4-7  multi-range-check (left multiplicand)
-    //      8-11 multi-range-check (right multiplicand)
-    //     12-15 multi-range-check (product1_lo, product1_hi_0, carry1_lo)
-    //     16-19 multi-range-check (result range check)
-    //     20-23 multi-range-check (quotient range check)
+    //      0-1  ForeignFieldMul | Zero
+    //      2-5  compact-multi-range-check (result range check)
+    //        6  "single" Generic (result bound)
+    //      7-10 multi-range-check (quotient range check)
+    //     11-14 multi-range-check (quotient_bound, product1_lo, product1_hi_0)
+    //     later limb-check result bound
+    //        15 Generic (left and right bounds)
+    //     16-19 multi-range-check (left multiplicand)
+    //     20-23 multi-range-check (right multiplicand)
+    //     24-27 multi-range-check (result bound, left bound, right bound)
+    // TODO: check when kimchi is merged to berkeley
 
     // Create foreign field multiplication gates
     let (mut next_row, mut gates) =
@@ -312,58 +315,89 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     let right_input = rng.gen_biguint_range(&BigUint::zero(), &foreign_field_modulus);
 
     // Compute multiplication witness
-    let (mut witness, external_checks) =
+    let (mut witness, mut external_checks) =
         foreign_field_mul::witness::create(&left_input, &right_input, &foreign_field_modulus);
 
-    // Bound addition for multiplication result
-    CircuitGate::extend_single_ffadd(
-        &mut gates,
-        &mut next_row,
-        FFOps::Add,
-        &foreign_field_modulus,
-    );
-    gates.connect_cell_pair((1, 0), (2, 0));
-    gates.connect_cell_pair((1, 1), (2, 1));
-    gates.connect_cell_pair((1, 2), (2, 2));
-    external_checks
-        .extend_witness_bound_addition(&mut witness, &foreign_field_modulus.to_field_limbs());
+    // Result compact-multi-range-check
+    CircuitGate::extend_compact_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((1, 0), (4, 1)); // remainder01
+    gates.connect_cell_pair((1, 1), (2, 0)); // remainder2
+    external_checks.extend_witness_compact_multi_range_checks(&mut witness);
+    // These are the coordinates (row, col) of the remainder limbs in the witness
+    // remainder0 -> (3, 0), remainder1 -> (4, 0), remainder2 -> (2,0)
 
-    // Left input multi-range-check
-    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 0), (4, 0));
-    gates.connect_cell_pair((0, 1), (5, 0));
-    gates.connect_cell_pair((0, 2), (6, 0));
-    range_check::witness::extend_multi_limbs(&mut witness, &left_input.to_field_limbs());
+    // Constant single Generic gate for result bound
+    CircuitGate::extend_high_bounds(&mut gates, &mut next_row, &foreign_field_modulus);
+    gates.connect_cell_pair((6, 0), (1, 1)); // remainder2
+    external_checks.extend_witness_high_bounds_computation(&mut witness, &foreign_field_modulus);
 
-    // Right input multi-range-check
+    // Quotient multi-range-check
     CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 3), (8, 0));
-    gates.connect_cell_pair((0, 4), (9, 0));
-    gates.connect_cell_pair((0, 5), (10, 0));
-    range_check::witness::extend_multi_limbs(&mut witness, &right_input.to_field_limbs());
+    gates.connect_cell_pair((1, 2), (7, 0)); // quotient0
+    gates.connect_cell_pair((1, 3), (8, 0)); // quotient1
+    gates.connect_cell_pair((1, 4), (9, 0)); // quotient2
+                                             // Witness updated below
 
-    // Multiplication witness value product1_lo, product1_hi_0, carry1_lo multi-range-check
+    // Multiplication witness value quotient_bound, product1_lo, product1_hi_0 multi-range-check
     CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((0, 6), (12, 0)); // carry1_lo
-    gates.connect_cell_pair((1, 5), (13, 0)); // product1_lo
-    gates.connect_cell_pair((1, 6), (14, 0)); // product1_hi_0
+    gates.connect_cell_pair((1, 5), (11, 0)); // quotient_bound
+    gates.connect_cell_pair((0, 6), (12, 0)); // product1_lo
+    gates.connect_cell_pair((1, 6), (13, 0)); // product1_hi_0
                                               // Witness updated below
 
-    // Result/remainder bound multi-range-check
-    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((3, 0), (16, 0));
-    gates.connect_cell_pair((3, 1), (17, 0));
-    gates.connect_cell_pair((3, 2), (18, 0));
-    // Witness updated below
-
-    // Add witness for external multi-range checks (product1_lo, product1_hi_0, carry1_lo and result)
+    // Add witness for external multi-range checks:
+    // [quotient0, quotient1, quotient2]
+    // [quotient_bound, product1_lo, product1_hi_0]
     external_checks.extend_witness_multi_range_checks(&mut witness);
 
-    // Quotient bound multi-range-check
-    CircuitGate::extend_compact_multi_range_check(&mut gates, &mut next_row);
-    gates.connect_cell_pair((1, 3), (22, 1));
-    gates.connect_cell_pair((1, 4), (20, 0));
-    external_checks.extend_witness_compact_multi_range_checks(&mut witness);
+    // DESIGNER CHOICE: left and right (and result bound from before)
+    let left_limbs = left_input.to_field_limbs();
+    let right_limbs = right_input.to_field_limbs();
+    // Constant Double Generic gate for result and quotient bounds
+    external_checks.add_high_bound_computation(&left_limbs[2]);
+    external_checks.add_high_bound_computation(&right_limbs[2]);
+    CircuitGate::extend_high_bounds(&mut gates, &mut next_row, &foreign_field_modulus);
+    gates.connect_cell_pair((15, 0), (0, 2)); // left2
+    gates.connect_cell_pair((15, 3), (0, 5)); // right2
+    external_checks.extend_witness_high_bounds_computation(&mut witness, &foreign_field_modulus);
+
+    // Left input multi-range-check
+    external_checks.add_multi_range_check(&left_limbs);
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((0, 0), (16, 0)); // left_input0
+    gates.connect_cell_pair((0, 1), (17, 0)); // left_input1
+    gates.connect_cell_pair((0, 2), (18, 0)); // left_input2
+                                              // Witness updated below
+
+    // Right input multi-range-check
+    external_checks.add_multi_range_check(&right_limbs);
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((0, 3), (20, 0)); // right_input0
+    gates.connect_cell_pair((0, 4), (21, 0)); // right_input1
+    gates.connect_cell_pair((0, 5), (22, 0)); // right_input2
+                                              // Witness updated below
+
+    // Add witness for external multi-range checks:
+    // left and right limbs
+    external_checks.extend_witness_multi_range_checks(&mut witness);
+
+    // [result_bound, 0, 0]
+    // Bounds for result limb range checks
+    CircuitGate::extend_multi_range_check(&mut gates, &mut next_row);
+    gates.connect_cell_pair((6, 2), (24, 0)); // result_bound
+                                              // Witness updated below
+
+    // Multi-range check bounds for left and right inputs
+    let left_hi_bound =
+        foreign_field_mul::witness::compute_high_bound(&left_input, &foreign_field_modulus);
+    let right_hi_bound =
+        foreign_field_mul::witness::compute_high_bound(&right_input, &foreign_field_modulus);
+    external_checks.add_limb_check(&left_hi_bound.into());
+    external_checks.add_limb_check(&right_hi_bound.into());
+    gates.connect_cell_pair((15, 2), (25, 0)); // left_bound
+    gates.connect_cell_pair((15, 5), (26, 0)); // right_bound
+
+    external_checks.extend_witness_limb_checks(&mut witness);
 
     // Temporary workaround for lookup-table/domain-size issue
     for _ in 0..(1 << 13) {
@@ -396,7 +430,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
         CamlPastaFpPlonkIndex(Box::new(index)),
         (proof, vec![]).into(),
     )
-}*/
+}
 
 #[ocaml_gen::func]
 #[ocaml::func]


### PR DESCRIPTION
This PR updates the example in `pasta_fp_plonk_proof.rs` that was disabled in [this PR](https://github.com/MinaProtocol/mina/pull/13630/). It uses the updated functions of proof-systems for the new FFMul layout after the [revised RFC](https://github.com/o1-labs/rfcs/blob/main/0006-ffmul-revised.md)

Merge after the base branch, so that more files are not added to the diff of that PR.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
