### PR TITLE
Replayer, check snarked ledger hash, berkeley cron job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ dhall_types: ocaml_checks
 
 replayer: ocaml_checks
 	$(info Starting Build)
-	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/replayer/replayer.exe --profile=testnet_postake_medium_curves
+	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/replayer/replayer.exe --profile=devnet
 	$(info Build complete)
 
 delegation_compliance: ocaml_checks

--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -1,0 +1,105 @@
+# kubectl apply -n berkeley -f helm/cron_jobs/berkeley-replayer-cronjob.yaml
+# the above command, with this accompanying file, needs only be run once.
+# Notes:
+# - the archive dump usually is of the form ...0000.sql.tar.gz, but not always
+#   we reverse-sort the filenames, take the most recent one
+# - ALTER USER takes a password bracketed in single-quotes or $$s
+#   too hard to make the single-quotes work inside single-quotes, so use $$
+#   the space in the password makes sure a $ isn't applied to the following string
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: berkeley-replayer-cronjob
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - 'echo "Starting replayer cron job";
+               apt update;
+               echo "Installing libjemalloc2";
+               apt-get -y install libjemalloc2;
+               echo "Installing gsutil";
+               apt-get -y install apt-transport-https ca-certificates gnupg curl;
+               echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list;
+               curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - ;
+               apt-get update && apt-get install -y google-cloud-cli ;
+               ARCHIVE_DUMP_URI=$(gsutil ls gs://mina-archive-dumps/berkeley-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
+               ARCHIVE_DUMP=$(basename $ARCHIVE_DUMP_URI);
+               ARCHIVE_SQL=$(basename $ARCHIVE_DUMP_URI .tar.gz);
+               echo "Getting archive dump" $ARCHIVE_DUMP_URI;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $ARCHIVE_DUMP_URI . ;
+               MOST_RECENT_CHECKPOINT_URI=$(gsutil ls gs://berkeley-replayer-checkpoints/berkeley-replayer-checkpoint-*.json | sort -r | head -n 1);
+               MOST_RECENT_CHECKPOINT=$(basename $MOST_RECENT_CHECKPOINT_URI);
+               echo "Getting replayer checkpoint file" $MOST_RECENT_CHECKPOINT;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $MOST_RECENT_CHECKPOINT_URI . ;
+               echo "Starting Postgresql";
+               service postgresql start;
+               echo "Importing archive dump";
+               tar -xzvf $ARCHIVE_DUMP;
+               mv $ARCHIVE_SQL ~postgres/;
+               echo "Deleting archive dump";
+               rm -f $ARCHIVE_DUMP;
+               su postgres -c "cd ~ && echo ALTER USER postgres WITH PASSWORD \\$\\$ foobar \\$\\$ | psql";
+               su postgres -c "cd ~ && echo CREATE DATABASE archive_balances_migrated | psql";
+               su postgres -c "cd ~ && psql < $ARCHIVE_SQL";
+               echo "Deleting archive SQL file";
+               su postgres -c "cd ~ && rm -f $ARCHIVE_SQL";
+               echo "Running replayer";
+               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive_balances_migrated --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
+               echo "Done running replayer";
+               rm -f $MOST_RECENT_CHECKPOINT;
+               DISK_CHECKPOINT=$(ls -t replayer-checkpoint*.json | head -n 1);
+               DATE=$(date +%F);
+               TODAY_CHECKPOINT=berkeley-replayer-checkpoint-$DATE.json;
+               mv $DISK_CHECKPOINT $TODAY_CHECKPOINT;
+               echo "Uploading checkpoint file" $TODAY_CHECKPOINT;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $TODAY_CHECKPOINT gs://berkeley-replayer-checkpoints/$TODAY_CHECKPOINT;
+               echo "Replayer errors:";
+               grep Error replayer.log;
+               HAVE_ERRORS=$?;
+               if [ $HAVE_ERRORS -eq 0 ];
+                 then REPLAYER_ERRORS=berkeley_replayer_errors_${DATE};
+                 echo "The replayer found errors, uploading log" $REPLAYER_ERRORS;
+                 mv replayer.log $REPLAYER_ERRORS;
+                 gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $REPLAYER_ERRORS gs://berkeley-replayer-checkpoints/$REPLAYER_ERRORS;
+               fi'
+            env:
+            - name: GCLOUD_KEYFILE
+              value: /gcloud/keyfile.json
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-no-final-checkpoint-5af6dba-bullseye
+            imagePullPolicy: IfNotPresent
+            name: berkeley-replayer-cronjob
+            resources:
+              limits:
+              requests:
+                memory: 32.0Gi
+                cpu: 20.0
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /gcloud/
+              name: gcloud-keyfile
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: gcloud-keyfile
+            secret:
+              defaultMode: 256
+              items:
+              - key: keyfile
+                path: keyfile.json
+              secretName: gcloud-keyfile
+  schedule: 0 2 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -77,7 +77,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup3-feature-berkeley-replayer-cronjob-snarked-ledger-check-f7dd759-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup3-feature-berkeley-replayer-cronjob-snarked-ledger-check-dab2d94-bullseye
             imagePullPolicy: IfNotPresent
             name: berkeley-replayer-cronjob
             resources:

--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -6,6 +6,8 @@
 # - ALTER USER takes a password bracketed in single-quotes or $$s
 #   too hard to make the single-quotes work inside single-quotes, so use $$
 #   the space in the password makes sure a $ isn't applied to the following string
+# - we filter out the CREATE DATABASE line from the SQL file, because psql here (v. 13)
+#   is older than the pg_dump (v. 15), which creates an unknown option "local_provider"
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -43,16 +45,18 @@ spec:
                service postgresql start;
                echo "Importing archive dump";
                tar -xzvf $ARCHIVE_DUMP;
+               cat $ARCHIVE_SQL | grep -v "CREATE DATABASE" > archive.sql;
+               mv archive.sql $ARCHIVE_SQL;
                mv $ARCHIVE_SQL ~postgres/;
                echo "Deleting archive dump";
                rm -f $ARCHIVE_DUMP;
                su postgres -c "cd ~ && echo ALTER USER postgres WITH PASSWORD \\$\\$ foobar \\$\\$ | psql";
-               su postgres -c "cd ~ && echo CREATE DATABASE archive_balances_migrated | psql";
+               su postgres -c "cd ~ && echo CREATE DATABASE archive | psql";
                su postgres -c "cd ~ && psql < $ARCHIVE_SQL";
                echo "Deleting archive SQL file";
                su postgres -c "cd ~ && rm -f $ARCHIVE_SQL";
                echo "Running replayer";
-               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive_balances_migrated --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
+               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
                echo "Done running replayer";
                rm -f $MOST_RECENT_CHECKPOINT;
                DISK_CHECKPOINT=$(ls -t replayer-checkpoint*.json | head -n 1);
@@ -73,7 +77,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-no-final-checkpoint-5af6dba-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup3-feature-berkeley-replayer-cronjob-snarked-ledger-check-f7dd759-bullseye
             imagePullPolicy: IfNotPresent
             name: berkeley-replayer-cronjob
             resources:

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -10,6 +10,8 @@
    result
    async.async_command
    async
+   base.caml
+   bin_prot.shape
    caqti-async
    core_kernel
    archive_lib
@@ -57,6 +59,7 @@
    unsigned_extended
    random_oracle
    codable
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -40,8 +40,6 @@ type output =
   }
 [@@deriving yojson]
 
-type command_type = [ `Internal_command | `User_command | `Zkapp_command ]
-
 module type Get_command_ids = sig
   val run :
        Caqti_async.connection
@@ -49,13 +47,6 @@ module type Get_command_ids = sig
     -> start_slot:int64
     -> (int list, [> Caqti_error.call_or_retrieve ]) Deferred.Result.t
 end
-
-type balance_block_data =
-  { block_id : int
-  ; block_height : int64
-  ; sequence_no : int
-  ; secondary_sequence_no : int
-  }
 
 let error_count = ref 0
 
@@ -120,39 +111,54 @@ let create_replayer_checkpoint ~ledger ~start_slot_since_genesis :
   ; genesis_ledger
   }
 
-(* map from global slots (since genesis) to state hash, ledger hash pairs *)
-let global_slot_hashes_tbl : (Int64.t, State_hash.t * Ledger_hash.t) Hashtbl.t =
+(* map from global slots (since genesis) to state hash, ledger hash, snarked ledger hash triples *)
+let global_slot_hashes_tbl :
+    (Int64.t, State_hash.t * Ledger_hash.t * Frozen_ledger_hash.t) Hashtbl.t =
   Int64.Table.create ()
 
-(* the starting slot may not have a block, so there may not be an entry in the table
-    of hashes
-   look at the predecessor slots until we find an entry
-   this search should only happen on the start slot, all other slots
-    come from commands in blocks, for which we have an entry in the table
-*)
-let get_slot_hashes ~logger slot =
-  let rec go curr_slot =
-    if Int64.is_negative curr_slot then (
-      [%log fatal]
-        "Could not find state and ledger hashes for slot %Ld, despite trying \
-         all predecessor slots"
-        slot ;
-      Core.exit 1 ) ;
-    match Hashtbl.find global_slot_hashes_tbl curr_slot with
-    | None ->
-        [%log info]
-          "State and ledger hashes not available at slot since genesis %Ld, \
-           will try predecessor slot"
-          curr_slot ;
-        go (Int64.pred curr_slot)
-    | Some hashes ->
-        hashes
-  in
-  go slot
+let get_slot_hashes slot = Hashtbl.find global_slot_hashes_tbl slot
 
-let process_block_infos_of_state_hash ~logger pool state_hash ~f =
+module First_pass_ledger_hashes = struct
+  (* ledger hashes after 1st pass, indexed by order of occurrence *)
+
+  module T = struct
+    type t = Ledger_hash.Stable.Latest.t * int
+    [@@deriving bin_io_unversioned, compare, sexp, hash]
+  end
+
+  include T
+  include Hashable.Make_binable (T)
+
+  let hash_set = Hash_set.create ()
+
+  let add =
+    let count = ref 0 in
+    fun ledger_hash ->
+      Base.Hash_set.add hash_set (ledger_hash, !count) ;
+      incr count
+
+  let find ledger_hash =
+    Base.Hash_set.find hash_set ~f:(fun (hash, _n) ->
+        Ledger_hash.equal hash ledger_hash )
+
+  (* once we find a snarked ledger hash corresponding to a ledger hash, don't need to store earlier ones *)
+  let flush_older_than ndx =
+    let elts = Base.Hash_set.to_list hash_set in
+    List.iter elts ~f:(fun ((_hash, n) as elt) ->
+        if n < ndx then Base.Hash_set.remove hash_set elt )
+
+  let get_last_snarked_hash, set_last_snarked_hash =
+    let last_snarked_hash = ref Ledger_hash.empty_hash in
+    let getter () = !last_snarked_hash in
+    let setter hash = last_snarked_hash := hash in
+    (getter, setter)
+end
+
+let process_block_infos_of_state_hash ~logger pool ~state_hash ~start_slot ~f =
   match%bind
-    Caqti_async.Pool.use (fun db -> Sql.Block_info.run db state_hash) pool
+    Caqti_async.Pool.use
+      (fun db -> Sql.Block_info.run db ~state_hash ~start_slot)
+      pool
   with
   | Ok block_infos ->
       f block_infos
@@ -380,8 +386,8 @@ let internal_cmds_to_transaction ~logger ~pool (ic : Sql.Internal_command.t)
       | ty ->
           failwithf "Unknown internal command type: %s" ty () )
 
-let user_command_to_transaction ~logger ~pool ~ledger (cmd : Sql.User_command.t)
-    : Mina_transaction.Transaction.t Deferred.t =
+let user_command_to_transaction ~logger ~pool (cmd : Sql.User_command.t) :
+    Mina_transaction.Transaction.t Deferred.t =
   [%log info]
     "Converting user command (%s) with nonce %Ld, global slot since genesis \
      %Ld, and sequence number %d to transaction"
@@ -578,7 +584,33 @@ let try_slot ~logger pool slot =
   in
   go ~slot ~tries_left:num_tries
 
-let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
+let write_replayer_checkpoint ~logger ~ledger ~last_global_slot_since_genesis
+    ~max_canonical_slot =
+  if Int64.( <= ) last_global_slot_since_genesis max_canonical_slot then (
+    (* start replaying at the slot after the one we've just finished with *)
+    let start_slot_since_genesis = Int64.succ last_global_slot_since_genesis in
+    let%map replayer_checkpoint =
+      let%map input =
+        create_replayer_checkpoint ~ledger ~start_slot_since_genesis
+      in
+      input_to_yojson input |> Yojson.Safe.pretty_to_string
+    in
+    let checkpoint_file =
+      sprintf "replayer-checkpoint-%Ld.json" start_slot_since_genesis
+    in
+    [%log info] "Writing checkpoint file"
+      ~metadata:[ ("checkpoint_file", `String checkpoint_file) ] ;
+    Out_channel.with_file checkpoint_file ~f:(fun oc ->
+        Out_channel.output_string oc replayer_checkpoint ) )
+  else (
+    [%log info] "Not writing checkpoint file at slot %Ld, because not canonical"
+      last_global_slot_since_genesis
+      ~metadata:
+        [ ("max_canonical_slot", `String (Int64.to_string max_canonical_slot)) ] ;
+    Deferred.unit )
+
+let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
+    ~checkpoint_interval () =
   let logger = Logger.create () in
   let json = Yojson.Safe.from_file input_file in
   let input =
@@ -642,35 +674,58 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
               max_slot ;
             try_slot ~logger pool max_slot
       in
-      [%log info] "Loading block information using target state hash" ;
-      let%bind block_ids =
-        process_block_infos_of_state_hash ~logger pool target_state_hash
-          ~f:(fun block_infos ->
+      [%log info]
+        "Loading block information using target state hash and start slot" ;
+      let%bind block_ids, oldest_block_id =
+        process_block_infos_of_state_hash ~logger pool
+          ~state_hash:target_state_hash
+          ~start_slot:input.start_slot_since_genesis ~f:(fun block_infos ->
+            let ({ id = oldest_block_id; _ } : Sql.Block_info.t) =
+              Option.value_exn
+                (List.min_elt block_infos ~compare:(fun bi1 bi2 ->
+                     Int64.compare bi1.global_slot_since_genesis
+                       bi2.global_slot_since_genesis ) )
+            in
             let ids = List.map block_infos ~f:(fun { id; _ } -> id) in
             (* build mapping from global slots to state and ledger hashes *)
-            List.iter block_infos
-              ~f:(fun { global_slot_since_genesis; state_hash; ledger_hash; _ }
-                 ->
-                Hashtbl.add_exn global_slot_hashes_tbl
-                  ~key:global_slot_since_genesis
-                  ~data:
-                    ( State_hash.of_base58_check_exn state_hash
-                    , Ledger_hash.of_base58_check_exn ledger_hash ) ) ;
-            return (Int.Set.of_list ids) )
+            let%bind () =
+              Deferred.List.iter block_infos
+                ~f:(fun
+                     { global_slot_since_genesis
+                     ; state_hash
+                     ; ledger_hash
+                     ; snarked_ledger_hash_id
+                     ; _
+                     }
+                   ->
+                  let%map snarked_hash =
+                    query_db ~f:(fun db ->
+                        Sql.Snarked_ledger_hashes.run db snarked_ledger_hash_id )
+                  in
+
+                  Hashtbl.add_exn global_slot_hashes_tbl
+                    ~key:global_slot_since_genesis
+                    ~data:
+                      ( State_hash.of_base58_check_exn state_hash
+                      , Ledger_hash.of_base58_check_exn ledger_hash
+                      , Frozen_ledger_hash.of_base58_check_exn snarked_hash ) )
+            in
+            return (Int.Set.of_list ids, oldest_block_id) )
       in
-      (* check that genesis block is in chain to target hash
-         assumption: genesis block occupies global slot 0
-      *)
-      if Int64.Table.mem global_slot_hashes_tbl Int64.zero then
-        [%log info]
-          "Block chain leading to target state hash includes genesis block, \
-           length = %d"
-          (Int.Set.length block_ids)
-      else (
-        [%log fatal]
-          "Block chain leading to target state hash does not include genesis \
-           block" ;
-        Core_kernel.exit 1 ) ;
+      if Int64.equal input.start_slot_since_genesis 0L then
+        (* check that genesis block is in chain to target hash                                                                                                                                                                                          assumption: genesis block occupies global slot 0
+
+           if nonzero start slot, can't assume there's a block at that slot *)
+        if Int64.Table.mem global_slot_hashes_tbl Int64.zero then
+          [%log info]
+            "Block chain leading to target state hash includes genesis block, \
+             length = %d"
+            (Int.Set.length block_ids)
+        else (
+          [%log fatal]
+            "Block chain leading to target state hash does not include genesis \
+             block" ;
+          Core_kernel.exit 1 ) ;
       (* some mutable state, less painful than passing epoch ledgers throughout *)
       let staking_epoch_ledger = ref ledger in
       let next_epoch_ledger = ref ledger in
@@ -679,7 +734,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
         let least_slot =
           Option.value_exn @@ List.min_elt slots ~compare:Int64.compare
         in
-        let state_hash, _ledger_hash =
+        let state_hash, _ledger_hash, _snarked_hash =
           Int64.Table.find_exn global_slot_hashes_tbl least_slot
         in
         let%bind { staking_epoch_data_id; next_epoch_data_id; _ } =
@@ -738,7 +793,10 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
             let open Deferred.Let_syntax in
             match%map
               Caqti_async.Pool.use
-                (fun db -> Sql.Internal_command.run db id)
+                (fun db ->
+                  Sql.Internal_command.run db
+                    ~start_slot:input.start_slot_since_genesis
+                    ~internal_cmd_id:id )
                 pool
             with
             | Ok [] ->
@@ -849,18 +907,51 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
             in
             [%compare: int64 * int] (tuple sc1) (tuple sc2) )
       in
+      let checkpoint_interval_i64 =
+        Option.map checkpoint_interval ~f:Int64.of_int
+      in
+      let checkpoint_target =
+        ref
+          (Option.map checkpoint_interval_i64 ~f:(fun interval ->
+               Int64.(input.start_slot_since_genesis + interval) ) )
+      in
+      let%bind max_canonical_slot =
+        query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
+      in
+      let%bind genesis_snarked_ledger_hash_str =
+        query_db ~f:(fun db -> Sql.Block.genesis_snarked_ledger db ())
+      in
+      let genesis_snarked_ledger_hash =
+        Frozen_ledger_hash.of_base58_check_exn genesis_snarked_ledger_hash_str
+      in
+      let incr_checkpoint_target () =
+        Option.iter !checkpoint_target ~f:(fun target ->
+            match checkpoint_interval_i64 with
+            | Some interval ->
+                let new_target = Int64.(target + interval) in
+                if Int64.( <= ) new_target max_canonical_slot then (
+                  [%log info] "Checkpoint target was %Ld, setting to %Ld" target
+                    new_target ;
+                  checkpoint_target := Some new_target )
+                else (
+                  (* set target so it can't be reached *)
+                  [%log info]
+                    "Checkpoint target was %Ld, new target would be at \
+                     noncanonical slot, set target to unreachable value"
+                    target ;
+                  checkpoint_target := Some Int64.max_value )
+            | None ->
+                failwith "Expected a checkpoint interval" )
+      in
+      let found_snarked_ledger_hash = ref false in
       (* apply commands in global slot, sequence order *)
       let rec apply_commands ~last_global_slot_since_genesis ~last_block_id
           ~(block_txns : Mina_transaction.Transaction.t list)
           (internal_cmds : Sql.Internal_command.t list)
           (user_cmds : Sql.User_command.t list)
           (zkapp_cmds : Sql.Zkapp_command.t list) =
-        let state_hash, expected_ledger_hash =
-          get_slot_hashes ~logger last_global_slot_since_genesis
-        in
-        let check_ledger_hash_at_slot () =
-          if Ledger_hash.equal (Ledger.merkle_root ledger) expected_ledger_hash
-          then
+        let check_ledger_hash_at_slot state_hash ledger_hash =
+          if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then
             [%log info]
               "Applied all commands at global slot since genesis %Ld, got \
                expected ledger hash"
@@ -878,8 +969,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                hash differs from expected ledger hash"
               ~metadata:
                 [ ("ledger_hash", json_ledger_hash_of_ledger ledger)
-                ; ( "expected_ledger_hash"
-                  , Ledger_hash.to_yojson expected_ledger_hash )
+                ; ("expected_ledger_hash", Ledger_hash.to_yojson ledger_hash)
                 ; ("state_hash", State_hash.to_yojson state_hash)
                 ; ( "global_slot_since_genesis"
                   , `String (Int64.to_string last_global_slot_since_genesis) )
@@ -887,7 +977,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
               last_global_slot_since_genesis ;
             if continue_on_error then incr error_count else Core_kernel.exit 1 )
         in
-        let check_account_accessed () =
+        let check_account_accessed state_hash =
           [%log info] "Checking accounts accessed in block just processed"
             ~metadata:
               [ ("state_hash", State_hash.to_yojson state_hash)
@@ -928,22 +1018,23 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                 if continue_on_error then incr error_count
                 else Core_kernel.exit 1 ) ) ;
           [%log info]
-            "Verifying balances and nonces for accounts accessed in block with \
-             global slot since genesis %Ld"
+            "Verifying accounts accessed in block with global slot since \
+             genesis %Ld"
             last_global_slot_since_genesis ;
           let%map accounts_accessed =
             Deferred.List.map accounts_accessed_db
               ~f:(Archive_lib.Load_data.get_account_accessed ~pool)
           in
-          List.iter accounts_accessed
-            ~f:(fun (index, { public_key; token_id; balance; nonce; _ }) ->
-              let account_id = Account_id.create public_key token_id in
+          List.iter accounts_accessed ~f:(fun (index, account) ->
+              let account_id =
+                Account_id.create account.public_key account.token_id
+              in
               let index_in_ledger =
                 Ledger.index_of_account_exn ledger account_id
               in
               if index <> index_in_ledger then (
                 [%log error]
-                  "Index in ledger does not match index in account accessed"
+                  "Account index in ledger does not match index in database"
                   ~metadata:
                     [ ("index_in_ledger", `Int index_in_ledger)
                     ; ("index_in_account_accessed", `Int index)
@@ -968,173 +1059,241 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                           "Account not in ledger, even though there's a \
                            location for it"
                   in
-                  let balance_in_ledger = account_in_ledger.balance in
-                  if not (Currency.Balance.equal balance balance_in_ledger) then (
+                  if not @@ Account.equal account account_in_ledger then
                     [%log error]
-                      "Balance in ledger does not match balance in account \
-                       accessed"
+                      "Account in ledger does not match account in database"
                       ~metadata:
                         [ ("account_id", Account_id.to_yojson account_id)
-                        ; ( "balance_in_ledger"
-                          , Currency.Balance.to_yojson balance_in_ledger )
-                        ; ( "balance_in_account_accessed"
-                          , Currency.Balance.to_yojson balance )
+                        ; ( "account_in_ledger"
+                          , Account.to_yojson account_in_ledger )
+                        ; ("account_in_database", Account.to_yojson account)
                         ] ;
-                    if continue_on_error then incr error_count
-                    else Core_kernel.exit 1 ) ;
-                  let nonce_in_ledger = account_in_ledger.nonce in
-                  if
-                    not (Mina_numbers.Account_nonce.equal nonce nonce_in_ledger)
-                  then (
-                    [%log error]
-                      "Nonce in ledger does not match nonce in account accessed"
-                      ~metadata:
-                        [ ("account_id", Account_id.to_yojson account_id)
-                        ; ( "nonce_in_ledger"
-                          , Mina_numbers.Account_nonce.to_yojson nonce_in_ledger
-                          )
-                        ; ( "nonce_in_account_accessed"
-                          , Mina_numbers.Account_nonce.to_yojson nonce )
-                        ] ;
-                    if continue_on_error then incr error_count
-                    else Core_kernel.exit 1 ) )
+                  if continue_on_error then incr error_count
+                  else Core_kernel.exit 1 )
         in
         let log_state_hash_on_next_slot curr_global_slot_since_genesis =
-          let state_hash, _ledger_hash =
-            get_slot_hashes ~logger curr_global_slot_since_genesis
-          in
-          [%log info]
-            ~metadata:
-              [ ("state_hash", `String (State_hash.to_base58_check state_hash))
-              ]
-            "Starting processing of commands in block with state_hash \
-             $state_hash at global slot since genesis %Ld"
-            curr_global_slot_since_genesis
+          match get_slot_hashes curr_global_slot_since_genesis with
+          | None ->
+              [%log fatal]
+                "Missing state hash information for current global slot" ;
+              Core.exit 1
+          | Some (state_hash, _ledger_hash, _snarked_hash) ->
+              [%log info]
+                ~metadata:
+                  [ ( "state_hash"
+                    , `String (State_hash.to_base58_check state_hash) )
+                  ]
+                "Starting processing of commands in block with state_hash \
+                 $state_hash at global slot since genesis %Ld"
+                curr_global_slot_since_genesis
         in
-        let run_transactions_on_slot_change block_txns =
-          let state_hash, _ledger_hash =
-            get_slot_hashes ~logger last_global_slot_since_genesis
-          in
-          let rec count_txns ~signed_count ~zkapp_count ~fee_transfer_count
-              ~coinbase_count = function
-            | [] ->
+        let run_transactions_on_slot_change ?(last_block = false) block_txns ()
+            =
+          match get_slot_hashes last_global_slot_since_genesis with
+          | None ->
+              if
+                Int64.equal last_global_slot_since_genesis
+                  input.start_slot_since_genesis
+              then (
                 [%log info]
-                  "Replaying transactions in block with state hash $state_hash"
+                  "No ledger hash information at start slot, not checking \
+                   against ledger, not running transactions" ;
+                Deferred.unit )
+              else (
+                [%log fatal]
+                  "Missing ledger hash information for last global slot, which \
+                   is not the start slot" ;
+                Core.exit 1 )
+          | Some (state_hash, ledger_hash, snarked_hash) ->
+              let write_checkpoint_file () =
+                let write_checkpoint () =
+                  write_replayer_checkpoint ~logger ~ledger
+                    ~last_global_slot_since_genesis ~max_canonical_slot
+                in
+                if last_block then write_checkpoint ()
+                else
+                  match !checkpoint_target with
+                  | None ->
+                      Deferred.unit
+                  | Some target ->
+                      if Int64.(last_global_slot_since_genesis >= target) then (
+                        incr_checkpoint_target () ; write_checkpoint () )
+                      else Deferred.unit
+              in
+              let rec count_txns ~signed_count ~zkapp_count ~fee_transfer_count
+                  ~coinbase_count = function
+                | [] ->
+                    [%log info]
+                      "Replaying transactions in block with state hash \
+                       $state_hash"
+                      ~metadata:
+                        [ ("state_hash", State_hash.to_yojson state_hash)
+                        ; ( "global_slot_since_genesis"
+                          , `String
+                              (Int64.to_string last_global_slot_since_genesis)
+                          )
+                        ; ("block_id", `Int last_block_id)
+                        ; ("no_signed_commands", `Int signed_count)
+                        ; ("no_zkapp_commands", `Int zkapp_count)
+                        ; ("no_fee_transfers", `Int fee_transfer_count)
+                        ; ("no_coinbases", `Int coinbase_count)
+                        ]
+                | txn :: txns -> (
+                    match txn with
+                    | Mina_transaction.Transaction.Command cmd -> (
+                        match cmd with
+                        | User_command.Signed_command _ ->
+                            count_txns ~signed_count:(signed_count + 1)
+                              ~zkapp_count ~fee_transfer_count ~coinbase_count
+                              txns
+                        | Zkapp_command _ ->
+                            count_txns ~signed_count
+                              ~zkapp_count:(zkapp_count + 1) ~fee_transfer_count
+                              ~coinbase_count txns )
+                    | Fee_transfer _ ->
+                        count_txns ~signed_count ~zkapp_count
+                          ~fee_transfer_count:(fee_transfer_count + 1)
+                          ~coinbase_count txns
+                    | Coinbase _ ->
+                        count_txns ~signed_count ~zkapp_count
+                          ~fee_transfer_count
+                          ~coinbase_count:(coinbase_count + 1) txns )
+              in
+              let run_transactions () =
+                count_txns ~signed_count:0 ~zkapp_count:0 ~fee_transfer_count:0
+                  ~coinbase_count:0 block_txns ;
+                let%bind txn_state_view =
+                  get_parent_state_view ~pool last_block_id
+                in
+                let apply_transaction_phases txns =
+                  let%bind phase_1s =
+                    Deferred.List.mapi txns ~f:(fun n txn ->
+                        match
+                          Ledger.apply_transaction_first_pass
+                            ~constraint_constants
+                            ~global_slot:
+                              (Mina_numbers.Global_slot_since_genesis.of_uint32
+                                 (Unsigned.UInt32.of_int64
+                                    last_global_slot_since_genesis ) )
+                            ~txn_state_view ledger txn
+                        with
+                        | Ok partially_applied ->
+                            (* the current ledger may become a snarked ledger *)
+                            First_pass_ledger_hashes.add
+                              (Ledger.merkle_root ledger) ;
+                            let%bind () =
+                              update_staking_epoch_data ~logger pool
+                                ~last_block_id ~ledger ~staking_epoch_ledger
+                                ~staking_seed
+                            in
+                            let%map () =
+                              update_next_epoch_data ~logger pool ~last_block_id
+                                ~ledger ~next_epoch_ledger ~next_seed
+                            in
+                            partially_applied
+                        | Error err ->
+                            [%log error]
+                              "Error during Phase 1 application of transaction \
+                               %d (0-based) in block with state hash \
+                               $state_hash"
+                              n
+                              ~metadata:
+                                [ ("state_hash", State_hash.to_yojson state_hash)
+                                ; ( "transaction"
+                                  , Mina_transaction.Transaction.to_yojson txn
+                                  )
+                                ; ("error", `String (Error.to_string_hum err))
+                                ] ;
+                            Error.raise err )
+                  in
+                  Deferred.List.iter phase_1s ~f:(fun partial ->
+                      match
+                        Ledger.apply_transaction_second_pass ledger partial
+                      with
+                      | Ok _applied ->
+                          let%bind () =
+                            update_staking_epoch_data ~logger pool
+                              ~last_block_id ~ledger ~staking_epoch_ledger
+                              ~staking_seed
+                          in
+                          update_next_epoch_data ~logger pool ~last_block_id
+                            ~ledger ~next_epoch_ledger ~next_seed
+                      | Error err ->
+                          (* must be a zkApp *)
+                          ( match partial with
+                          | Ledger.Transaction_partially_applied.Zkapp_command
+                              zk_partial ->
+                              let cmd = zk_partial.command in
+                              [%log error]
+                                "Error during Phase 2 application of \
+                                 partially-applied zkApp in block with state \
+                                 hash $state_hash"
+                                ~metadata:
+                                  [ ( "state_hash"
+                                    , State_hash.to_yojson state_hash )
+                                  ; ( "zkapp_command"
+                                    , Zkapp_command.to_yojson cmd )
+                                  ; ("error", `String (Error.to_string_hum err))
+                                  ]
+                          | _ ->
+                              failwith
+                                "Unexpected phase 2 failure of non-zkApp \
+                                 command" ) ;
+                          Error.raise err )
+                in
+                apply_transaction_phases (List.rev block_txns)
+              in
+              ( if
+                Frozen_ledger_hash.equal snarked_hash
+                  (First_pass_ledger_hashes.get_last_snarked_hash ())
+              then
+                [%log info]
+                  "Snarked ledger hash same as in the preceding block, not \
+                   checking it again"
+              else if
+              Frozen_ledger_hash.equal snarked_hash genesis_snarked_ledger_hash
+            then
+                [%log info] "Snarked ledger hash is genesis snarked ledger hash"
+              else
+                match First_pass_ledger_hashes.find snarked_hash with
+                | None ->
+                    if not !found_snarked_ledger_hash then (
+                      [%log info]
+                        "Current snarked ledger hash not among first-pass \
+                         ledger hashes, but we haven't yet found one. The \
+                         transaction that created this ledger hash might have \
+                         been in a replayer run that created a checkpoint file" ;
+                      First_pass_ledger_hashes.set_last_snarked_hash
+                        snarked_hash )
+                    else
+                      [%log error]
+                        "Current snarked ledger hash does not appear among \
+                         first-pass ledger hashes" ;
+                    if continue_on_error then incr error_count
+                    else Core_kernel.exit 1
+                | Some (_hash, n) ->
+                    [%log info]
+                      "Found snarked ledger hash among first-pass ledger hashes" ;
+                    found_snarked_ledger_hash := true ;
+                    First_pass_ledger_hashes.set_last_snarked_hash snarked_hash ;
+                    First_pass_ledger_hashes.flush_older_than n ) ;
+              if List.is_empty block_txns then (
+                [%log info]
+                  "No transactions to run for block with state hash $state_hash"
                   ~metadata:
                     [ ("state_hash", State_hash.to_yojson state_hash)
                     ; ( "global_slot_since_genesis"
                       , `String (Int64.to_string last_global_slot_since_genesis)
                       )
                     ; ("block_id", `Int last_block_id)
-                    ; ("no_signed_commands", `Int signed_count)
-                    ; ("no_zkapp_commands", `Int zkapp_count)
-                    ; ("no_fee_transfers", `Int fee_transfer_count)
-                    ; ("no_coinbases", `Int coinbase_count)
-                    ]
-            | txn :: txns -> (
-                match txn with
-                | Mina_transaction.Transaction.Command cmd -> (
-                    match cmd with
-                    | User_command.Signed_command _ ->
-                        count_txns ~signed_count:(signed_count + 1) ~zkapp_count
-                          ~fee_transfer_count ~coinbase_count txns
-                    | Zkapp_command _ ->
-                        count_txns ~signed_count ~zkapp_count:(zkapp_count + 1)
-                          ~fee_transfer_count ~coinbase_count txns )
-                | Fee_transfer _ ->
-                    count_txns ~signed_count ~zkapp_count
-                      ~fee_transfer_count:(fee_transfer_count + 1)
-                      ~coinbase_count txns
-                | Coinbase _ ->
-                    count_txns ~signed_count ~zkapp_count ~fee_transfer_count
-                      ~coinbase_count:(coinbase_count + 1) txns )
-          in
-          let run_transactions () =
-            count_txns ~signed_count:0 ~zkapp_count:0 ~fee_transfer_count:0
-              ~coinbase_count:0 block_txns ;
-            let%bind txn_state_view =
-              get_parent_state_view ~pool last_block_id
-            in
-            let apply_transaction_phases txns =
-              let%bind phase_1s =
-                Deferred.List.mapi txns ~f:(fun n txn ->
-                    match
-                      Ledger.apply_transaction_first_pass ~constraint_constants
-                        ~global_slot:
-                          (Mina_numbers.Global_slot_since_genesis.of_uint32
-                             (Unsigned.UInt32.of_int64
-                                last_global_slot_since_genesis ) )
-                        ~txn_state_view ledger txn
-                    with
-                    | Ok partially_applied ->
-                        let%bind () =
-                          update_staking_epoch_data ~logger pool ~last_block_id
-                            ~ledger ~staking_epoch_ledger ~staking_seed
-                        in
-                        let%map () =
-                          update_next_epoch_data ~logger pool ~last_block_id
-                            ~ledger ~next_epoch_ledger ~next_seed
-                        in
-                        partially_applied
-                    | Error err ->
-                        [%log error]
-                          "Error during Phase 1 application of transaction %d \
-                           (0-based) in block with state hash $state_hash"
-                          n
-                          ~metadata:
-                            [ ("state_hash", State_hash.to_yojson state_hash)
-                            ; ( "transaction"
-                              , Mina_transaction.Transaction.to_yojson txn )
-                            ; ("error", `String (Error.to_string_hum err))
-                            ] ;
-                        Error.raise err )
-              in
-              Deferred.List.iter phase_1s ~f:(fun partial ->
-                  match Ledger.apply_transaction_second_pass ledger partial with
-                  | Ok _applied ->
-                      let%bind () =
-                        update_staking_epoch_data ~logger pool ~last_block_id
-                          ~ledger ~staking_epoch_ledger ~staking_seed
-                      in
-                      update_next_epoch_data ~logger pool ~last_block_id ~ledger
-                        ~next_epoch_ledger ~next_seed
-                  | Error err ->
-                      (* must be a zkApp *)
-                      ( match partial with
-                      | Ledger.Transaction_partially_applied.Zkapp_command
-                          zk_partial ->
-                          let cmd = zk_partial.command in
-                          [%log error]
-                            "Error during Phase 2 application of \
-                             partially-applied zkApp in block with state hash \
-                             $state_hash"
-                            ~metadata:
-                              [ ("state_hash", State_hash.to_yojson state_hash)
-                              ; ("zkapp_command", Zkapp_command.to_yojson cmd)
-                              ; ("error", `String (Error.to_string_hum err))
-                              ]
-                      | _ ->
-                          failwith
-                            "Unexpected phase 2 failure of non-zkApp command" ) ;
-                      Error.raise err )
-            in
-            apply_transaction_phases (List.rev block_txns)
-          in
-          if List.is_empty block_txns then (
-            [%log info]
-              "No transactions to run for block with state hash $state_hash"
-              ~metadata:
-                [ ("state_hash", State_hash.to_yojson state_hash)
-                ; ( "global_slot_since_genesis"
-                  , `String (Int64.to_string last_global_slot_since_genesis) )
-                ; ("block_id", `Int last_block_id)
-                ] ;
-            Deferred.unit )
-          else
-            let%bind () = run_transactions () in
-            check_ledger_hash_at_slot () ;
-            let%map () = check_account_accessed () in
-            log_state_hash_on_next_slot last_global_slot_since_genesis
+                    ] ;
+                Deferred.unit )
+              else
+                let%bind () = run_transactions () in
+                check_ledger_hash_at_slot state_hash ledger_hash ;
+                let%bind () = check_account_accessed state_hash in
+                log_state_hash_on_next_slot last_global_slot_since_genesis ;
+                write_checkpoint_file ()
         in
         (* a sequence is a command type, slot, sequence number triple *)
         let get_internal_cmd_sequence (ic : Sql.Internal_command.t) =
@@ -1159,7 +1318,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
             Int64.( > ) cmd_global_slot_since_genesis
               last_global_slot_since_genesis
           then
-            let%map () = run_transactions_on_slot_change block_txns in
+            let%map () = run_transactions_on_slot_change block_txns () in
             []
           else return block_txns
         in
@@ -1167,15 +1326,10 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
         | [], [], [] ->
             (* all done *)
             let%bind _ =
-              check_for_complete_block
-                ~cmd_global_slot_since_genesis:Int64.max_value
+              run_transactions_on_slot_change ~last_block:true block_txns ()
             in
             Deferred.return
-              ( last_global_slot_since_genesis
-              , staking_epoch_ledger
-              , staking_seed
-              , next_epoch_ledger
-              , next_seed )
+              (staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed)
         | ic :: ics, [], [] ->
             (* only internal commands *)
             let%bind block_txns0 =
@@ -1199,9 +1353,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
               check_for_complete_block
                 ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
             in
-            let%bind txn =
-              user_command_to_transaction ~logger ~pool ~ledger uc
-            in
+            let%bind txn = user_command_to_transaction ~logger ~pool uc in
             apply_commands ~block_txns:(txn :: block_txns)
               ~last_global_slot_since_genesis:uc.global_slot_since_genesis
               ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
@@ -1226,9 +1378,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                   check_for_complete_block
                     ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
                 in
-                let%bind txn =
-                  user_command_to_transaction ~logger ~pool ~ledger uc
-                in
+                let%bind txn = user_command_to_transaction ~logger ~pool uc in
                 apply_commands ~block_txns:(txn :: block_txns)
                   ~last_global_slot_since_genesis:uc.global_slot_since_genesis
                   ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
@@ -1299,9 +1449,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                   check_for_complete_block
                     ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
                 in
-                let%bind txn =
-                  user_command_to_transaction ~logger ~pool ~ledger uc
-                in
+                let%bind txn = user_command_to_transaction ~logger ~pool uc in
                 apply_commands ~block_txns:(txn :: block_txns)
                   ~last_global_slot_since_genesis:uc.global_slot_since_genesis
                   ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds )
@@ -1335,9 +1483,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                   check_for_complete_block
                     ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
                 in
-                let%bind txn =
-                  user_command_to_transaction ~logger ~pool ~ledger uc
-                in
+                let%bind txn = user_command_to_transaction ~logger ~pool uc in
                 apply_commands ~block_txns:(txn :: block_txns)
                   ~last_global_slot_since_genesis:uc.global_slot_since_genesis
                   ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
@@ -1350,16 +1496,6 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                 apply_commands ~block_txns:(txn :: block_txns)
                   ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
                   ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs )
-      in
-      let%bind unparented_ids =
-        query_db ~f:(fun db -> Sql.Block.get_unparented db ())
-      in
-      let genesis_block_id =
-        match List.filter unparented_ids ~f:(Int.Set.mem block_ids) with
-        | [ id ] ->
-            id
-        | _ ->
-            failwith "Expected only the genesis block to have an unparented id"
       in
       let%bind start_slot_since_genesis =
         let%map slot_opt =
@@ -1390,36 +1526,17 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
       [%log info] "At start global slot %Ld, ledger hash"
         start_slot_since_genesis
         ~metadata:[ ("ledger_hash", json_ledger_hash_of_ledger ledger) ] ;
-      let%bind ( last_global_slot_since_genesis
-               , staking_epoch_ledger
-               , staking_seed
-               , next_epoch_ledger
-               , next_seed ) =
+      let%bind staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed
+          =
         apply_commands ~block_txns:[]
           ~last_global_slot_since_genesis:start_slot_since_genesis
-          ~last_block_id:genesis_block_id sorted_internal_cmds sorted_user_cmds
+          ~last_block_id:oldest_block_id sorted_internal_cmds sorted_user_cmds
           sorted_zkapp_cmds
       in
       match input.target_epoch_ledgers_state_hash with
       | None ->
-          (* start replaying at the slot after the one we've just finished with *)
-          let start_slot_since_genesis =
-            Int64.succ last_global_slot_since_genesis
-          in
-          let%bind replayer_checkpoint =
-            let%map input =
-              create_replayer_checkpoint ~ledger ~start_slot_since_genesis
-            in
-            input_to_yojson input |> Yojson.Safe.pretty_to_string
-          in
-          let checkpoint_file =
-            sprintf "replayer-checkpoint-%Ld.json" start_slot_since_genesis
-          in
-          [%log info] "Writing checkpoint file"
-            ~metadata:[ ("checkpoint_file", `String checkpoint_file) ] ;
-          return
-          @@ Out_channel.with_file checkpoint_file ~f:(fun oc ->
-                 Out_channel.output_string oc replayer_checkpoint )
+          [%log info] "No target epoch ledger hash supplied, not writing output" ;
+          Deferred.unit
       | Some target_epoch_ledgers_state_hash -> (
           match output_file_opt with
           | None ->
@@ -1471,5 +1588,10 @@ let () =
          and continue_on_error =
            Param.flag "--continue-on-error"
              ~doc:"Continue processing after errors" Param.no_arg
+         and checkpoint_interval =
+           Param.flag "--checkpoint-interval"
+             ~doc:"NN Write checkpoint file every NN slots"
+             Param.(optional int)
          in
-         main ~input_file ~output_file_opt ~archive_uri ~continue_on_error )))
+         main ~input_file ~output_file_opt ~archive_uri ~checkpoint_interval
+           ~continue_on_error )))

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -124,6 +124,7 @@ module Block = struct
     Caqti_request.find_opt Caqti_type.int64 Caqti_type.int64
       {sql| SELECT global_slot_since_genesis FROM blocks
             WHERE global_slot_since_genesis >= $1
+            AND chain_status <> 'orphaned'
             ORDER BY global_slot_since_genesis ASC
             LIMIT 1
       |sql}

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -82,9 +82,8 @@ let%test_unit "of_ledger_subset_exn with keys that don't exist works" =
 module T = Mina_transaction_logic.Make (L)
 
 let apply_transaction_logic f t x =
-  let open Or_error.Let_syntax in
   let t' = ref t in
-  let%map app = f t' x in
+  let%map.Or_error app = f t' x in
   (!t', app)
 
 let apply_user_command ~constraint_constants ~txn_global_slot =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -736,8 +736,7 @@ module T = struct
     let txns_from_data data =
       List.fold_right ~init:(Ok []) data
         ~f:(fun (d : Scan_state.Transaction_with_witness.t) acc ->
-          let open Or_error.Let_syntax in
-          let%map acc = acc in
+          let%map.Or_error acc = acc in
           let t =
             d.transaction_with_info |> Ledger.Transaction_applied.transaction
           in
@@ -2623,8 +2622,7 @@ let%test_module "staged ledger tests" =
               let apply_second_pass = Ledger.apply_transaction_second_pass in
               let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
                   sparse_ledger txn =
-                let open Or_error.Let_syntax in
-                let%map _ledger, partial_txn =
+                let%map.Or_error _ledger, partial_txn =
                   Mina_ledger.Sparse_ledger.apply_transaction_first_pass
                     ~constraint_constants ~global_slot ~txn_state_view
                     sparse_ledger txn


### PR DESCRIPTION
Add snarked ledger check to replayer: each snarked ledger is the ledger hash from some first-pass application of a transaction.

There's a hole, though. If replaying from a checkpoint, the transaction that created the ledger hash may have occurred before the checkpoint. We can close that hole by saving pending ledger hashes to the checkpoint file, if desired, but I'd prefer to defer that to a subsequent PR.

Add the YAML file to run a replayer cron job on berkeley.

Tested the cron job by manually running it.

Made some monad uses a little more concise, because I could.

Closes #13463.

Closes #13700.