### PR TITLE
[berkeley] Make medium bootstrap sections hard fail

### DIFF
--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -49,8 +49,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let logger = Logger.create () in
     let all_nodes = Network.all_nodes network in
     let%bind () =
-      wait_for t
-        (Wait_condition.nodes_to_initialize (Core.String.Map.data all_nodes))
+      section_hard "Wait for nodes to initialize"
+        (wait_for t
+           (Wait_condition.nodes_to_initialize (Core.String.Map.data all_nodes)) )
     in
     let node_a =
       Core.String.Map.find_exn (Network.block_producers network) "node-a"
@@ -62,11 +63,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       Core.String.Map.find_exn (Network.block_producers network) "node-c"
     in
     let%bind () =
-      section "blocks are produced"
+      section_hard "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 1))
     in
     let%bind () =
-      section "restart node after 2k+1, ie 5, blocks"
+      section_hard "restart node after 2k+1, ie 5, blocks"
         (let%bind () = Node.stop node_c in
          [%log info] "%s stopped, will now wait for blocks to be produced"
            (Node.id node_c) ;
@@ -80,7 +81,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_synchronize [ node_a; node_b; node_c ]) )
     in
     let%bind () =
-      section "network is fully connected after one node was restarted"
+      section_hard "network is fully connected after one node was restarted"
         (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
          let%bind final_connectivity_data =
            fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
@@ -88,11 +89,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          assert_peers_completely_connected final_connectivity_data )
     in
     let%bind () =
-      section "blocks are produced"
+      section_hard "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 1))
     in
     let%bind () =
-      section "restart node with the same state after 1 block"
+      section_hard "restart node with the same state after 1 block"
         (let%bind () = Node.stop node_c in
          [%log info] "%s stopped, will now wait for blocks to be produced"
            (Node.id node_c) ;
@@ -112,7 +113,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_synchronize [ node_a; node_b; node_c ]) )
     in
 
-    section "network is fully connected after one node was restarted"
+    section_hard "network is fully connected after one node was restarted"
       (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
        let%bind final_connectivity_data =
          fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -206,7 +206,8 @@ struct
       then Predicate_passed
       else Predicate_continuation ()
     in
-    let soft_timeout_in_slots = 8 * 3 in
+    let soft_timeout_in_slots = 4 in
+    let hard_timeout_in_slots = 6 in
     let formatted_nodes =
       nodes
       |> List.map ~f:(fun node -> "\"" ^ Node.id node ^ "\"")
@@ -216,7 +217,7 @@ struct
     ; description = sprintf "%s to synchronize" formatted_nodes
     ; predicate = Network_state_predicate (check (), check)
     ; soft_timeout = Slots soft_timeout_in_slots
-    ; hard_timeout = Slots (soft_timeout_in_slots * 2)
+    ; hard_timeout = Slots hard_timeout_in_slots
     }
 
   let signed_command_to_be_included_in_frontier ~txn_hash


### PR DESCRIPTION
This PR converts the `section` calls in the medium bootstrap test to `section_hard`. This ensures that the test will end if any step fails, rather than attempting to continue in a failed state.

This should also stop the test earlier when we hit the hard timeouts, which should reduce the runtime of the test when it's failing.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them