### PR TITLE
[berkeley] Track nodes going offline in integration tests, fast fail if required

### DIFF
--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -61,6 +61,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let node_c =
       Core.String.Map.find_exn (Network.block_producers network) "node-c"
     in
+
+    let online_monitor, online_monitor_subscription =
+      Wait_condition.monitor_online_nodes ~logger (event_router t)
+    in
+    (* The nodes that we synchronize to must be online. *)
+    Wait_condition.require_online online_monitor node_a ;
+    Wait_condition.require_online online_monitor node_b ;
+
     let%bind () =
       section "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 1))
@@ -112,10 +120,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_synchronize [ node_a; node_b; node_c ]) )
     in
 
-    section "network is fully connected after one node was restarted"
-      (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
-       let%bind final_connectivity_data =
-         fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
-       in
-       assert_peers_completely_connected final_connectivity_data )
+    let%bind () =
+      section "network is fully connected after one node was restarted"
+        (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
+         let%bind final_connectivity_data =
+           fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
+         in
+         assert_peers_completely_connected final_connectivity_data )
+    in
+    return (Event_router.cancel (event_router t) online_monitor_subscription ())
 end

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -70,6 +70,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       wait_for t
         (Wait_condition.nodes_to_initialize (Core.String.Map.data all_nodes))
     in
+
+    let online_monitor, online_monitor_subscription =
+      Wait_condition.monitor_online_nodes ~logger (event_router t)
+    in
+    (* The nodes that we synchronize to must be online. *)
+    Wait_condition.require_online online_monitor node_a ;
+    Wait_condition.require_online online_monitor node_b ;
+
     let%bind initial_connectivity_data =
       fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
     in
@@ -199,10 +207,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                   (Network_time_span.Literal
                      (Time.Span.of_ms (15. *. 60. *. 1000.)) ) ) )
     in
-    section "network is fully connected after one node was restarted"
-      (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
-       let%bind final_connectivity_data =
-         fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
-       in
-       assert_peers_completely_connected final_connectivity_data )
+    let%bind () =
+      section "network is fully connected after one node was restarted"
+        (let%bind () = Malleable_error.lift (after (Time.Span.of_sec 240.0)) in
+         let%bind final_connectivity_data =
+           fetch_connectivity_data ~logger (Core.String.Map.data all_nodes)
+         in
+         assert_peers_completely_connected final_connectivity_data )
+    in
+    return (Event_router.cancel (event_router t) online_monitor_subscription ())
 end

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -152,6 +152,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     Map.iter
       ~f:(Wait_condition.require_online online_monitor)
       (Network.archive_nodes network) ;
+    (* We need snark work for this test. *)
+    Core_kernel.Map.iter
+      ~f:(Wait_condition.require_online online_monitor)
+      (Network.snark_coordinators network) ;
 
     let constraint_constants = Network.constraint_constants network in
     let fish1_kp =

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -148,6 +148,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     Map.iter
       ~f:(Wait_condition.require_online online_monitor)
       (Network.archive_nodes network) ;
+    (* We need snark work for this test. *)
+    Core_kernel.Map.iter
+      ~f:(Wait_condition.require_online online_monitor)
+      (Network.snark_coordinators network) ;
 
     let keymap =
       List.fold [ fish1_kp ] ~init:Signature_lib.Public_key.Compressed.Map.empty

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -63,6 +63,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     Map.iter
       ~f:(Wait_condition.require_online online_monitor)
       (Network.archive_nodes network) ;
+    (* We need snark work for this test. *)
+    Core_kernel.Map.iter
+      ~f:(Wait_condition.require_online online_monitor)
+      (Network.snark_coordinators network) ;
 
     let constraint_constants =
       Genesis_constants.Constraint_constants.compiled

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -43,6 +43,8 @@ module Node = struct
 
   let id { pod_ids; _ } = List.hd_exn pod_ids
 
+  let app_id { app_id; _ } = app_id
+
   let network_keypair { pod_info = { network_keypair; _ }; _ } = network_keypair
 
   let base_kube_args t = [ "--cluster"; t.cluster; "--namespace"; t.namespace ]

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -43,6 +43,8 @@ module Engine = struct
 
       val id : t -> string
 
+      val app_id : t -> string
+
       val network_keypair : t -> Network_keypair.t option
 
       val start : fresh_state:bool -> t -> unit Malleable_error.t
@@ -254,6 +256,18 @@ module Dsl = struct
 
     val transition_frontier_loaded_from_persistence :
       fresh_data:bool -> sync_needed:bool -> t
+
+    type online_nodes_monitor
+
+    val require_online : online_nodes_monitor -> Engine.Network.Node.t -> unit
+
+    val not_require_online :
+      online_nodes_monitor -> Engine.Network.Node.t -> unit
+
+    val monitor_online_nodes :
+         logger:Logger.t
+      -> Event_router.t
+      -> online_nodes_monitor * unit Event_router.event_subscription
   end
 
   module type S = sig

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -379,4 +379,30 @@ struct
     ; soft_timeout = Slots soft_timeout_in_slots
     ; hard_timeout = Slots (soft_timeout_in_slots * 2)
     }
+
+  type online_nodes_monitor = { mutable required_online : String.Set.t }
+
+  let require_online t node =
+    t.required_online <-
+      Set.add t.required_online (Engine.Network.Node.app_id node)
+
+  let not_require_online t node =
+    t.required_online <-
+      Set.remove t.required_online (Engine.Network.Node.app_id node)
+
+  let monitor_online_nodes ~logger event_router =
+    let open Engine in
+    let monitor = { required_online = String.Set.empty } in
+    let node_liveness_subscription =
+      Event_router.on event_router Node_offline ~f:(fun offline_node () ->
+          let node_name = Network.Node.app_id offline_node in
+          [%log info] "Detected node offline $node"
+            ~metadata:[ ("node", `String node_name) ] ;
+          if Set.mem monitor.required_online node_name then (
+            [%log fatal] "Offline $node is required for this test"
+              ~metadata:[ ("node", `String node_name) ] ;
+            failwith "Aborted because of required offline node" ) ;
+          Async_kernel.Deferred.return `Continue )
+    in
+    (monitor, node_liveness_subscription)
 end


### PR DESCRIPTION
This PR adds a mechanism for tracking nodes that go offline during unit tests. This is https://github.com/MinaProtocol/mina/pull/13748 against berkeley.

This then modifies each test so that
* it logs any time a node goes offline
* if any nodes are 'required to be online' by the test, we halt the test immediately (by propagating an exception)

The goal of this is to get better visibility into node restarts, as well as to prevent 'zombie' tests that will fail later during their execution.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
