### PR TITLE
Invert order of constraints in Xor Snarky gadget

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -257,9 +257,6 @@ let bxor (type f)
     let open Circuit in
     (* If inputs are zero and length is zero, add the zero check *)
     if length = 0 then (
-      Field.Assert.equal Field.zero in1 ;
-      Field.Assert.equal Field.zero in2 ;
-      Field.Assert.equal Field.zero out ;
       with_label "xor_zero_check" (fun () ->
           assert_
             { annotation = Some __LOC__
@@ -270,7 +267,11 @@ let bxor (type f)
                      ; values = [| in1; in2; out |]
                      ; coeffs = [||]
                      } )
-            } ) )
+            } ) ;
+      Field.Assert.equal Field.zero in1 ;
+      Field.Assert.equal Field.zero in2 ;
+      Field.Assert.equal Field.zero out ;
+      () )
     else
       (* Define shorthand helper *)
       let of_bits =


### PR DESCRIPTION
This PR inverts the order of some constraints that insert generic gates, and the `Zero` row that needs to follow the chain of `Xor16` rows. Otherwise Snarky could insert generic gates in between, breaking the linkability between Xor inputs and outputs.

Related to a subsequent PR to detect these situations automatically.

* Closes https://github.com/MinaProtocol/mina/issues/13757