### PR TITLE
Skip local snark work check

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -477,6 +477,11 @@ let setup_daemon logger =
          for the associated private key that is being tracked by this daemon. \
          You cannot provide both `uptime-submitter-key` and \
          `uptime-submitter-pubkey`."
+  and verify_local_snark_works =
+    flag "--verify_local_snark_works" no_arg
+      ~doc:
+        "Verify snark works coming from workers connected to this snark \
+         coordinator"
   in
   let to_pubsub_topic_mode_option =
     let open Gossip_net.Libp2p in
@@ -1347,6 +1352,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                    }
                  ~snark_coordinator_key:run_snark_coordinator_flag
                  ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
+                 ~skip_local_snark_work_verification:
+                   (not verify_local_snark_works)
                  ~wallets_disk_location:(conf_dir ^/ "wallets")
                  ~persistent_root_location:(conf_dir ^/ "root")
                  ~persistent_frontier_location:(conf_dir ^/ "frontier")

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -35,6 +35,7 @@ type t =
         (* Option.t instead of option, so that the derived `make' requires an argument *)
   ; proposed_protocol_version_opt : Protocol_version.t Option.t
   ; snark_pool_disk_location : string
+  ; skip_local_snark_work_verification : bool
   ; wallets_disk_location : string
   ; persistent_root_location : string
   ; persistent_frontier_location : string

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1785,6 +1785,8 @@ let create ?wallets (config : Config.t) =
             Network_pool.Snark_pool.Resource_pool.make_config ~verifier
               ~trust_system:config.trust_system
               ~disk_location:config.snark_pool_disk_location
+              ~skip_local_snark_work_verification:
+                config.skip_local_snark_work_verification
           in
           let snark_pool, snark_remote_sink, snark_local_sink =
             Network_pool.Snark_pool.create ~config:snark_pool_config

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -227,6 +227,7 @@ module type Snark_resource_pool_intf = sig
        trust_system:Trust_system.t
     -> verifier:Verifier.t
     -> disk_location:string
+    -> skip_local_snark_work_verification:bool
     -> Config.t
 
   val add_snark :

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -97,6 +97,7 @@ struct
           { trust_system : (Trust_system.t[@sexp.opaque])
           ; verifier : (Verifier.t[@sexp.opaque])
           ; disk_location : string
+          ; skip_local_snark_work_verification : bool
           }
         [@@deriving sexp, make]
       end
@@ -431,7 +432,9 @@ struct
                     ~sender
                 in
                 match Signature_lib.Public_key.decompress prover with
-                | Some _ when is_local ->
+                | Some _
+                  when is_local && t.config.skip_local_snark_work_verification
+                  ->
                     Deferred.return true
                 | None ->
                     (* We may need to decompress the key when paying the fee
@@ -624,6 +627,7 @@ let%test_module "random set test" =
     let config =
       Mock_snark_pool.Resource_pool.make_config ~verifier ~trust_system
         ~disk_location:"/tmp/snark-pool"
+        ~skip_local_snark_work_verification:true
 
     let gen ?length () =
       let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -431,6 +431,8 @@ struct
                     ~sender
                 in
                 match Signature_lib.Public_key.decompress prover with
+                | Some _ when is_local ->
+                    Deferred.return true
                 | None ->
                     (* We may need to decompress the key when paying the fee
                        transfer, so check that we can do it now.

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -36,6 +36,7 @@ let%test_module "network pool test" =
     let config =
       Mock_snark_pool.Resource_pool.make_config ~verifier ~trust_system
         ~disk_location:"/tmp/snark-pool"
+        ~skip_local_snark_work_verification:true
 
     let%test_unit "Work that gets fed into apply_and_broadcast will be \
                    received in the pool's reader" =

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -21,6 +21,7 @@
    result
    async_unix
    bin_prot.shape
+   base.md5
    ;; local libraries
    one_or_two
    mina_metrics

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -3,6 +3,8 @@ open Async
 
 let command_name = "snark-worker"
 
+type constraint_system_digests_t = (string * string) list
+
 module type Inputs_intf = sig
   open Snark_work_lib
 
@@ -87,7 +89,7 @@ module type Rpcs_versioned_S = sig
 
   module Get_work : sig
     module V2 : sig
-      type query = unit [@@deriving bin_io]
+      type query = constraint_system_digests_t [@@deriving bin_io]
 
       type response =
         (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
@@ -134,7 +136,8 @@ module type S0 = sig
   module Rpcs : sig
     module Get_work :
       Rpc_master
-        with type Master.T.query = unit
+      (* Contains constraint systems digest for compatibility check *)
+        with type Master.T.query = constraint_system_digests_t
          and type Master.T.response =
           (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
 

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -22,7 +22,8 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       let name = "get_work"
 
       module T = struct
-        type query = unit
+        (* Contains constraint systems digest for compatibility check *)
+        type query = Intf.constraint_system_digests_t
 
         type response =
           ( (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -24,7 +24,8 @@ module Worker = struct
     module Get_work = struct
       module V2 = struct
         module T = struct
-          type query = unit
+          (* Contains constraint systems digest for compatibility check *)
+          type query = (string * string) list
 
           type response =
             ( ( Transaction_witness.Stable.V2.t


### PR DESCRIPTION
Explain your changes:
* Skip local snark work (unless a special flag is provided)
* Make snark worker submit its transaction constraints digest to the coordinator in `GetWork` rpc to ensure there is no incompatibility

Explain how you tested your changes:
* Tested on a snark worker in a private cluster with 20 workers connected to a single coordinator, confirmed serious performance improvement and reduction of delay in block processing

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
