### PR TITLE
[compatible] Give dedicated error messages and exit codes for node offline states

### DIFF
--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -62,6 +62,8 @@ module Engine = struct
 
       val dump_precomputed_blocks :
         logger:Logger.t -> t -> unit Malleable_error.t
+
+      val get_id_nocache : t -> string Malleable_error.t
     end
 
     type t
@@ -241,6 +243,14 @@ module Dsl = struct
       test_config:Test_config.t -> num_proofs:int -> t
 
     type online_nodes_monitor
+
+    exception Required_node_is_offline of string
+
+    exception Required_node_moved_id of string * string * string
+
+    exception
+      Required_node_offline_with_query_error of
+        string * Malleable_error.Hard_fail.t
 
     val require_online : online_nodes_monitor -> Engine.Network.Node.t -> unit
 


### PR DESCRIPTION
This PR adds dedicated exit codes and error messages, depending on the status of a node when it goes offline. This builds upon https://github.com/MinaProtocol/mina/pull/13748.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them