### PR TITLE
Replayer, next slot not orphaned

### DIFF
--- a/helm/cron_jobs/devnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/devnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-2627643-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-not-orphaned-slot-5827016-bullseye
             imagePullPolicy: IfNotPresent
             name: devnet-replayer-cronjob
             resources:

--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-2627643-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-not-orphaned-slot-5827016-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -113,6 +113,7 @@ module Block = struct
     Caqti_request.find_opt Caqti_type.int64 Caqti_type.int64
       {sql| SELECT global_slot_since_genesis FROM blocks
             WHERE global_slot_since_genesis >= $1
+            AND chain_status <> 'orphaned'
             ORDER BY global_slot_since_genesis ASC
             LIMIT 1
       |sql}


### PR DESCRIPTION
When replaying from a checkpoint file, the start slot may not be occupied by a slot. In that case, find the next slot occupied by the slot.

The replayer was choosing that next slot to replay from, regardless of its chain status. Make sure the status is not `orphaned`, otherwise we won't find the block in the chain chosen by the replayer.

The berkeley replayer cron job failed because it tried to replay from an orphaned slot. The fix was made for the berkeley replayer in #13715.

Update the `devnet` and `mainnet` cron jobs to use an image from this PR.