### PR TITLE
Make pre-hard-fork configs compatible with berkeley

### DIFF
--- a/src/lib/mina_base/token_id.ml
+++ b/src/lib/mina_base/token_id.ml
@@ -18,7 +18,8 @@ module Stable = struct
     type t = Legacy_token.Stable.V1.t
     [@@deriving sexp, equal, compare, hash, yojson]
 
-    let to_latest _ = failwith "Not implemented"
+    let to_latest token_id =
+      Legacy_token.to_field token_id |> Account_id.Digest.of_field
   end
 end]
 
@@ -35,6 +36,11 @@ Account_id.Digest.
   , of_string
   , comparator
   , ( <> ) )]
+
+let of_string s =
+  try Account_id.Digest.of_string s
+  with Base58_check.Invalid_base58_check_length _ ->
+    Legacy_token.of_string s |> Stable.V1.to_latest
 
 include Account_id.Digest.Binables
 

--- a/src/lib/mina_numbers/global_slot_since_genesis.ml
+++ b/src/lib/mina_numbers/global_slot_since_genesis.ml
@@ -25,9 +25,17 @@ module Make_str (_ : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Wire_types.global_slot = Since_genesis of T.Stable.V1.t
-        [@@unboxed] [@@deriving hash, sexp, compare, equal, yojson]
+        [@@unboxed] [@@deriving hash, sexp, compare, equal]
 
         let to_latest = Fn.id
+
+        let to_yojson (Since_genesis u32) = `String (T.to_string u32)
+
+        let of_yojson = function
+          | `String i ->
+              Ok (Since_genesis (T.of_string i))
+          | _ ->
+              Error "Global_slot.of_yojson: Expected `String"
       end
     end]
 
@@ -36,6 +44,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let to_uint32 (Since_genesis u32) : uint32 = u32
 
     let of_uint32 u32 : t = Since_genesis u32
+
+    let to_yojson = Stable.Latest.to_yojson
+
+    let of_yojson = Stable.Latest.of_yojson
   end
 
   include M

--- a/src/lib/mina_numbers/global_slot_span.ml
+++ b/src/lib/mina_numbers/global_slot_span.ml
@@ -20,9 +20,17 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Stable = struct
     module V1 = struct
       type t = Wire_types.global_slot_span = Global_slot_span of T.Stable.V1.t
-      [@@unboxed] [@@deriving hash, sexp, compare, equal, yojson]
+      [@@unboxed] [@@deriving hash, sexp, compare, equal]
 
       let to_latest = Fn.id
+
+      let to_yojson (Global_slot_span t) = `String (T.to_string t)
+
+      let of_yojson = function
+        | `String s ->
+            Ok (Global_slot_span (T.of_string s))
+        | _ ->
+            Error "Global_slot_span.of_yojson: expected string"
     end
   end]
 
@@ -39,6 +47,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
       Snark_params.Tick.Typ.transport T.Checked.typ ~there:to_uint32
         ~back:of_uint32
   end
+
+  let to_yojson = Stable.Latest.to_yojson
+
+  let of_yojson = Stable.Latest.of_yojson
 
   let to_string t = Unsigned.UInt32.to_string @@ to_uint32 t
 


### PR DESCRIPTION
Explain your changes:
* Simplify JSON encoding of `Global_slot_span` and `Global_slot_since_genesis` by removing the tag automatically added by `deriving_yojson` preprocessor. They are unnecessary, because the type of the number is usually apparent from the context / schema. Furthermore, they make pre-hard-fork config files incompatible with current daemons. This compatibility is required in order to transfer the state of the pre-hard-fork ledger into the post-hard-fork genesis ledger.

* Add fallback parsing for `token_id`s in the runtime config. On `mainnet` `token_id` is simply a number, while on `berkeley` it's a base58-encoded binary identifier. For reasons explained above, we need the `berkeley` node to be able to parse pre-hard-fork config, so adding the fallback parsing to preserve that compatibility. This change can be reverted after the hard fork.

Explain how you tested your changes:
* Started a sandbox node initialised with a config file containing a ledger exported from a `mainnet` node. Demonstrated that the node is capable of producing blocks. The code used to perform the export will be submitted shortly in another PR.

[Cofig file used for testing](https://drive.google.com/file/d/1znm3kWNE_rw6HhrSShMytsPq4rd1HfrU/view?usp=sharing) (beware, it's quite large).

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
