### PR TITLE
Alerts/berkeley syncstatus related alerts compatible

### DIFF
--- a/automation/terraform/modules/testnet-alerts/alerts.tf
+++ b/automation/terraform/modules/testnet-alerts/alerts.tf
@@ -7,6 +7,7 @@ data "template_file" "testnet_alerts" {
     rule_filter               = var.rule_filter
     alert_timeframe           = var.alert_timeframe
     alert_evaluation_duration = var.alert_duration
+    berkeley_testnet          = var.berkeley_testnet
     berkeley_rule_filter      = var.berkeley_rule_filter
   }
 }

--- a/automation/terraform/modules/testnet-alerts/alerts.tf
+++ b/automation/terraform/modules/testnet-alerts/alerts.tf
@@ -7,6 +7,7 @@ data "template_file" "testnet_alerts" {
     rule_filter               = var.rule_filter
     alert_timeframe           = var.alert_timeframe
     alert_evaluation_duration = var.alert_duration
+    berkeley_testnet          = var.berkeley_testnet
   }
 }
 

--- a/automation/terraform/modules/testnet-alerts/alerts.tf
+++ b/automation/terraform/modules/testnet-alerts/alerts.tf
@@ -7,7 +7,7 @@ data "template_file" "testnet_alerts" {
     rule_filter               = var.rule_filter
     alert_timeframe           = var.alert_timeframe
     alert_evaluation_duration = var.alert_duration
-    berkeley_testnet          = var.berkeley_testnet
+    berkeley_rule_filter      = var.berkeley_rule_filter
   }
 }
 

--- a/automation/terraform/modules/testnet-alerts/alerts.tf
+++ b/automation/terraform/modules/testnet-alerts/alerts.tf
@@ -8,7 +8,7 @@ data "template_file" "testnet_alerts" {
     alert_timeframe           = var.alert_timeframe
     alert_evaluation_duration = var.alert_duration
     berkeley_testnet          = var.berkeley_testnet
-    berkeley_rule_filter      = var.berkeley_rule_filter
+    synced_status_filter      = var.synced_status_filter
   }
 }
 

--- a/automation/terraform/modules/testnet-alerts/inputs.tf
+++ b/automation/terraform/modules/testnet-alerts/inputs.tf
@@ -22,10 +22,10 @@ variable "rule_filter" {
   description = "Filter to apply to monitoring search space for managing the scope of alert rule checks"
 }
 
-variable "berkeley_testnet" {
+variable "berkeley_rule_filter" {
   type        = string
-  description = "Filter to select only berkeley network"
-  default     = "testnet=\"berkeley\""
+  description = "Filter that only applies to berkeley network with syncStatus labels"
+  default     = "{testnet=\"berkeley\",syncStatus=\"SYNCED\"}"
 }
 
 variable "alert_timeframe" {

--- a/automation/terraform/modules/testnet-alerts/inputs.tf
+++ b/automation/terraform/modules/testnet-alerts/inputs.tf
@@ -23,9 +23,9 @@ variable "rule_filter" {
 }
 
 variable "berkeley_testnet" {
-  type         = string
-  desccription = "Filter to select only berkeley network"
-  default      = "testnet=\"berkeley\""
+  type        = string
+  description = "Filter to select only berkeley network"
+  default     = "testnet=\"berkeley\""
 }
 
 variable "alert_timeframe" {

--- a/automation/terraform/modules/testnet-alerts/inputs.tf
+++ b/automation/terraform/modules/testnet-alerts/inputs.tf
@@ -28,7 +28,7 @@ variable "berkeley_testnet" {
   default     = "testnet=\"berkeley\""
 }
 
-variable "berkeley_rule_filter" {
+variable "synced_status_filter" {
   type        = string
   description = "Filter that only applies to berkeley network with syncStatus labels"
   default     = "syncStatus=\"SYNCED\""

--- a/automation/terraform/modules/testnet-alerts/inputs.tf
+++ b/automation/terraform/modules/testnet-alerts/inputs.tf
@@ -22,6 +22,12 @@ variable "rule_filter" {
   description = "Filter to apply to monitoring search space for managing the scope of alert rule checks"
 }
 
+variable "berkeley_testnet" {
+  type         = string
+  desccription = "Filter to select only berkeley network"
+  default      = "testnet=\"berkeley\""
+}
+
 variable "alert_timeframe" {
   type        = string
   description = "Range of time to inspect for alert rule violations"

--- a/automation/terraform/modules/testnet-alerts/inputs.tf
+++ b/automation/terraform/modules/testnet-alerts/inputs.tf
@@ -22,10 +22,16 @@ variable "rule_filter" {
   description = "Filter to apply to monitoring search space for managing the scope of alert rule checks"
 }
 
+variable "berkeley_testnet" {
+  type        = string 
+  description = "Filter that selects out berkeley network"
+  default     = "testnet=\"berkeley\""
+}
+
 variable "berkeley_rule_filter" {
   type        = string
   description = "Filter that only applies to berkeley network with syncStatus labels"
-  default     = "{testnet=\"berkeley\",syncStatus=\"SYNCED\"}"
+  default     = "syncStatus=\"SYNCED\""
 }
 
 variable "alert_timeframe" {

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -330,7 +330,6 @@ groups:
       description: "{{ $value }} blocks have been produced that share no common ancestor with our transition frontier on network {{ $labels.test }} in the last hour."
       runbook: "https://www.notion.so/minaprotocol/LowDisconnectedBlocksPerHour-32bd49852fbb499090106fe63a504859"
 
-
   - alert: LowOldBlocksPerHour
     expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root ${rule_filter} [${alert_timeframe}])) > 0
     labels:
@@ -394,10 +393,30 @@ groups:
       description: "{{ $value }} Missing block(s) observed on network {{ $labels.testnet }}."
       runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
 
-- name: Berkeley syncStatus related alerts
+- name: Berkeley alerts
   rules:
+  - alert: WatchdogClusterCrashes
+    expr: max by (testnet) (max_over_time(Coda_watchdog_cluster_crashes {${berkeley_testnet}} [${alert_timeframe}])) > 0.5
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} cluster nodes have crashed"
+      description: "{{ $value }} Cluster nodes have crashed on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/WatchdogClusterCrashes-1741e31b59ef4467a3bd19158418c4d8"
+
+  - alert: MultipleNodeRestarted
+    expr: count by (testnet) (Coda_Runtime_process_uptime_ms_total {${berkeley_testnet}} < 600000) > 2
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "At least 3 nodes on {{ $labels.testnet }} restarted"
+      description: "{{ $value }} nodes on {{ $labels.testnet }} restarted"
+      runbook: "https://www.notion.so/minaprotocol/MultipleNodeRestarted-360bc1ed48a24dfca4bcbae1e29d0584"
+
   - alert: HighDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor ${berkeley_rule_filter} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -407,7 +426,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighDisconnectedBlocksPerHour-14da6dc40386439799eb2a573d077ecb"
 
   - alert: HighOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root ${berkeley_rule_filter} [${alert_timeframe}])) > 5
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -417,7 +436,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighOldBlocksPerHour-134ba51aef4d482bb065ce7a02dd8fb7"
 
   - alert: HighInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof ${berkeley_rule_filter} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -426,8 +445,79 @@ groups:
       description: "{{ $value }} blocks have been produced that contains an invalid blockchain snark proof in last hour"
       runbook: "https://www.notion.so/minaprotocol/HighInvalidProofPerHour-8ff715ccf9564b6e8a27b5a9dc65ef77"
 
+  - alert: WatchdogNoNewLogs
+    expr: max by (testnet) (Coda_watchdog_pods_with_no_new_logs) {${berkeley_testnet}} > 0
+    for: 12m
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has pods which have not logged in an hour"
+      description: "There are no new logs in the last hour for {{ $value }} pods on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/WatchdogNoNewLogs-7ffb7a74bad542c78961abddd9004489"
+
+  - alert: SeedListDown
+    expr: min by (testnet) (min_over_time(Coda_watchdog_seeds_reachable {${berkeley_testnet}} [${alert_timeframe}])) == 0
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} seed list is down (no seeds are reachable)"
+      description: "Seed list is down on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/SeedListDown-d8d4e14609884c63a7086309336f3462"
+
+  - alert: BlockStorageBucketNoNewBlocks
+    expr: min by (testnet) (min_over_time(Coda_watchdog_recent_google_bucket_blocks {${berkeley_testnet}} [${alert_timeframe}])) >= 30*60
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has no new blocks posted to the google block storage bucket recently"
+      description: "{{ $value }} new blocks posted to the google storage bucket for {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/BlockStorageBucketNoNewBlock-80ddaf0fa7944fb4a9c5a4ffb4bbd6e2"
+
+  - alert: ProverErrors
+    expr: max by (testnet) (max_over_time(Coda_watchdog_prover_errors_total {${berkeley_testnet}} [${alert_timeframe}])) > 0
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has observed a prover error"
+      description: "{{ $value }} Prover errors on network {{ $labels.testnet }}."
+
+  - alert: NodesNotSynced
+    expr: min by (testnet) (Coda_watchdog_nodes_synced {${berkeley_testnet}}) <= .5
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has <= 50% of nodes synced"
+      description: "Nodes sync rate of {{ $value }} is <= 50% on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/Nodes-not-synced-34e4d4eeaeaf47e381de660bab9ce7b7"
+
+  - alert: NodesOutOfSync
+    expr: min by (testnet) (avg_over_time(Coda_watchdog_nodes_synced_near_best_tip {${berkeley_testnet}} [${alert_timeframe}])) < .6
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has < 60% of nodes that are synced on the same best tip"
+      description: "< 60% of nodes that are synced are on the same best tip for  network {{ $labels.testnet }} with rate of {{ $value }}."
+      runbook: "https://www.notion.so/minaprotocol/Nodes-out-of-sync-0f29c739e47c42e4adabe62a2a0316bd"
+
+  - alert: O1NodesOutOfSync
+    expr: min by (testnet) (increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet}} [${alert_timeframe}])) < 1
+    for: ${alert_evaluation_duration}
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "One or more {{ $labels.testnet }} nodes are stuck at an old block height (Observed block height did not increase in the last hour)"
+      description: "{{ $value }} blocks have been validated on network {{ $labels.testnet }} in the last hour (according to some node)."
+      runbook: "https://www.notion.so/minaprotocol/Nodes-out-of-sync-0f29c739e47c42e4adabe62a2a0316bd"
+
   - alert: LowPeerCount
-    expr: min by (testnet) (Coda_Network_peers ${berkeley_rule_filter}) < 3
+    expr: min by (testnet) (Coda_Network_peers {${berkeley_testnet},${berkeley_rule_filter}} ) < 3
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -438,7 +528,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowPeerCount-3a66ae1ca6fd44b585eca37f9206d429"
 
   - alert: CriticallyLowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density ${berkeley_rule_filter}) <= 13
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${berkeley_rule_filter}} ) <= 13
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -449,7 +539,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowFillRate
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate ${berkeley_rule_filter}) < 0.75 * 0.6
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {${berkeley_testnet},${berkeley_rule_filter}} ) < 0.75 * 0.6
     for: 1h
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -460,7 +550,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowFillRate-36efb1cd9b5d461db6976bc1938fab9e"
 
   - alert: NoTransactionsInSeveralBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip ${berkeley_rule_filter}) >= 5
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${berkeley_rule_filter}} ) >= 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -470,7 +560,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/No-Transactions-In-Several-Blocks-55ca13df38dd4c3491e11d8ea8020c08"
 
   - alert: NoCoinbaseInBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase ${berkeley_rule_filter}) < 1
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {${berkeley_testnet},${berkeley_rule_filter}} ) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -481,7 +571,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoCoinbaseInBlocks-aacbc2a4f9334d0db2de20c2f77ac34f"
 
   - alert: LongFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork ${berkeley_rule_filter}) >= 16
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${berkeley_rule_filter}} ) >= 16
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -491,7 +581,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${berkeley_rule_filter}) >= 15 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -501,7 +591,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec ${berkeley_rule_filter}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work ${berkeley_rule_filter}) != 0
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},${berkeley_rule_filter}} ) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -511,7 +601,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec ${berkeley_rule_filter}) >= 2 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -520,8 +610,30 @@ groups:
       description: "No node has received transactions in their transaction pool in the last 2 slots (6 minutes) on network {{ $labels.testnet }}."
       runbook: "https://www.notion.so/minaprotocol/NoNewTransactions-27dbeafab8ea4d659ee6f748acb2fd6c"
 
+  - alert: HighUnparentedBlockCount
+    expr: max by (testnet) (Coda_Archive_unparented_blocks {${berkeley_testnet}}) > 30
+    for: ${alert_evaluation_duration}
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has a critically high unparented block count"
+      description: "{{ $value }} Unparented block count is critically high on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
+
+  - alert: HighMissingBlockCount
+    expr: max by (testnet) (Coda_Archive_missing_blocks {${berkeley_testnet}}) > 30
+    for: ${alert_evaluation_duration}
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has a critically high missing block count"
+      description: "{{ $value }} Missing block count is critically high on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
+
   - alert: FewBlocksPerHour
-    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed ${berkeley_rule_filter} [30m])) < 1
+    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet},${berkeley_rule_filter}}  [30m])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -532,7 +644,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/FewBlocksPerHour-47a6356f093242d988b0d9527ce23478"
  
   - alert: HighBlockGossipLatency
-    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time ${berkeley_rule_filter} [${alert_timeframe}])) > 200
+    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 200
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -543,7 +655,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${berkeley_rule_filter}) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -553,7 +665,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/SomewhatOldBestTip-bb1509582bdd4908bcda656eebf421b5"
 
   - alert: MediumFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork ${berkeley_rule_filter}) >= 8
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${berkeley_rule_filter}} ) >= 8
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -563,7 +675,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/MediumFork-0a530813af2e40c491cdf01b3a2b2304"
 
   - alert: NoTransactionsInAtLeastOneBlock
-    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip ${berkeley_rule_filter}) > 0
+    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${berkeley_rule_filter}} ) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -573,7 +685,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoTransactionsInAtLeastOneBlock-049250ff7ae84de990233c7b6d35f763"
 
   - alert: LowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density ${berkeley_rule_filter}) <= 35
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${berkeley_rule_filter}} ) <= 35
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -583,8 +695,18 @@ groups:
       description: "Low min density on network {{ $labels.testnet }}."
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
+  - alert: SeedListDegraded
+    expr: min by (testnet) (Coda_watchdog_seeds_reachable {${berkeley_testnet}}) <= 0.5
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "{{ $labels.testnet }} seed list is degraded (less than 50% reachable)"
+      description: "Seed list is degraded at {{ $value }} on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/SeedListDown-d8d4e14609884c63a7086309336f3462"
+
   - alert: LowDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor ${berkeley_rule_filter} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -594,7 +716,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowDisconnectedBlocksPerHour-32bd49852fbb499090106fe63a504859"
 
   - alert: LowOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root ${berkeley_rule_filter} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -604,7 +726,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowOldBlocksPerHour-1cc2e92b8ca944869d810f7afd7c2d78"
 
   - alert: LowInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof ${berkeley_rule_filter} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -614,7 +736,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowInvalidProofPerHour-b6e88b9ae84f47169e7f86017ab9e340"
 
   - alert: LowPostgresBlockHeightGrowth
-    expr: min by (testnet) (increase(Coda_Archive_max_block_height ${berkeley_rule_filter} [${alert_timeframe}])) < 1
+    expr: min by (testnet) (increase(Coda_Archive_max_block_height {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -624,3 +746,34 @@ groups:
       description: "The rate of {{ $value }} new blocks observed by archive postgres instances is low on network {{ $labels.testnet }}."
       runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
 
+  - alert: NodeRestarted
+    expr: count by (testnet) (Coda_Runtime_process_uptime_ms_total {${berkeley_testnet}} < 360000) > 0
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "At least one of the nodes on {{ $labels.testnet }} restarted"
+      description: "{{ $value }} nodes on {{ $labels.testnet }} restarted"
+      runbook: "https://www.notion.so/minaprotocol/NodeRestarted-99a1cf710ff14aa6930a9f12ad5813a5"
+
+  - alert: UnparentedBlocksObserved
+    expr: max by (testnet) (Coda_Archive_unparented_blocks {${berkeley_testnet}}) > 1
+    for: ${alert_evaluation_duration}
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "Unparented blocks observed on {{ $labels.testnet }}"
+      description: "{{ $value }} Unparented block(s) observed on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
+
+  - alert: MissingBlocksObserved
+    expr: max by (testnet) (Coda_Archive_missing_blocks {${berkeley_testnet}}) > 0
+    for: ${alert_evaluation_duration}
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "Missing blocks observed on {{ $labels.testnet }}"
+      description: "{{ $value }} Missing block(s) observed on network {{ $labels.testnet }}."
+      runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -397,7 +397,7 @@ groups:
 - name: Berkeley syncStatus related alerts
   rules:
   - alert: HighDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -407,7 +407,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighDisconnectedBlocksPerHour-14da6dc40386439799eb2a573d077ecb"
 
   - alert: HighOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 5
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -417,7 +417,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighOldBlocksPerHour-134ba51aef4d482bb065ce7a02dd8fb7"
 
   - alert: HighInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -427,7 +427,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighInvalidProofPerHour-8ff715ccf9564b6e8a27b5a9dc65ef77"
 
   - alert: LowPeerCount
-    expr: min by (testnet) (Coda_Network_peers {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 3
+    expr: min by (testnet) (Coda_Network_peers {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 3
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -438,7 +438,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowPeerCount-3a66ae1ca6fd44b585eca37f9206d429"
 
   - alert: CriticallyLowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 13
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 13
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -449,7 +449,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowFillRate
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 0.75 * 0.6
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 0.75 * 0.6
     for: 1h
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -460,7 +460,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowFillRate-36efb1cd9b5d461db6976bc1938fab9e"
 
   - alert: NoTransactionsInSeveralBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 5
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -470,7 +470,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/No-Transactions-In-Several-Blocks-55ca13df38dd4c3491e11d8ea8020c08"
 
   - alert: NoCoinbaseInBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 1
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -481,7 +481,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoCoinbaseInBlocks-aacbc2a4f9334d0db2de20c2f77ac34f"
 
   - alert: LongFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 16
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 16
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -491,7 +491,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 15 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -501,7 +501,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) != 0
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -511,7 +511,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -521,7 +521,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewTransactions-27dbeafab8ea4d659ee6f748acb2fd6c"
 
   - alert: FewBlocksPerHour
-    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [30m])) < 1
+    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [30m])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -532,7 +532,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/FewBlocksPerHour-47a6356f093242d988b0d9527ce23478"
  
   - alert: HighBlockGossipLatency
-    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 200
+    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 200
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -543,7 +543,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -553,7 +553,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/SomewhatOldBestTip-bb1509582bdd4908bcda656eebf421b5"
 
   - alert: MediumFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -563,7 +563,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/MediumFork-0a530813af2e40c491cdf01b3a2b2304"
 
   - alert: NoTransactionsInAtLeastOneBlock
-    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) > 0
+    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -573,7 +573,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoTransactionsInAtLeastOneBlock-049250ff7ae84de990233c7b6d35f763"
 
   - alert: LowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 35
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 35
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -584,7 +584,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -594,7 +594,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowDisconnectedBlocksPerHour-32bd49852fbb499090106fe63a504859"
 
   - alert: LowOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -604,7 +604,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowOldBlocksPerHour-1cc2e92b8ca944869d810f7afd7c2d78"
 
   - alert: LowInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -614,7 +614,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowInvalidProofPerHour-b6e88b9ae84f47169e7f86017ab9e340"
 
   - alert: LowPostgresBlockHeightGrowth
-    expr: min by (testnet) (increase(Coda_Archive_max_block_height {testnet="berkeley",syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) < 1
+    expr: min by (testnet) (increase(Coda_Archive_max_block_height {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -446,7 +446,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighInvalidProofPerHour-8ff715ccf9564b6e8a27b5a9dc65ef77"
 
   - alert: WatchdogNoNewLogs
-    expr: max by (testnet) (Coda_watchdog_pods_with_no_new_logs) {${berkeley_testnet}} > 0
+    expr: max by (testnet) (Coda_watchdog_pods_with_no_new_logs {${berkeley_testnet}}) > 0
     for: 12m
     labels:
       testnet: "{{ $labels.testnet }}"

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -416,7 +416,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/MultipleNodeRestarted-360bc1ed48a24dfca4bcbae1e29d0584"
 
   - alert: HighDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${synced_status_filter}}  [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -426,7 +426,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighDisconnectedBlocksPerHour-14da6dc40386439799eb2a573d077ecb"
 
   - alert: HighOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 5
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${synced_status_filter}}  [${alert_timeframe}])) > 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -436,7 +436,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighOldBlocksPerHour-134ba51aef4d482bb065ce7a02dd8fb7"
 
   - alert: HighInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet}}  [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -517,7 +517,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/Nodes-out-of-sync-0f29c739e47c42e4adabe62a2a0316bd"
 
   - alert: LowPeerCount
-    expr: min by (testnet) (Coda_Network_peers {${berkeley_testnet},${berkeley_rule_filter}} ) < 3
+    expr: min by (testnet) (Coda_Network_peers {${berkeley_testnet},${synced_status_filter}} ) < 3
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -528,7 +528,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowPeerCount-3a66ae1ca6fd44b585eca37f9206d429"
 
   - alert: CriticallyLowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${berkeley_rule_filter}} ) <= 13
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${synced_status_filter}} ) <= 35
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -539,7 +539,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowFillRate
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {${berkeley_testnet},${berkeley_rule_filter}} ) < 0.75 * 0.6
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {${berkeley_testnet},${synced_status_filter}} ) < 0.75 * 0.6
     for: 1h
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -550,7 +550,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowFillRate-36efb1cd9b5d461db6976bc1938fab9e"
 
   - alert: NoTransactionsInSeveralBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${berkeley_rule_filter}} ) >= 5
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${synced_status_filter}} ) >= 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -560,7 +560,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/No-Transactions-In-Several-Blocks-55ca13df38dd4c3491e11d8ea8020c08"
 
   - alert: NoCoinbaseInBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {${berkeley_testnet},${berkeley_rule_filter}} ) < 1
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {${berkeley_testnet},${synced_status_filter}} ) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -571,7 +571,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoCoinbaseInBlocks-aacbc2a4f9334d0db2de20c2f77ac34f"
 
   - alert: LongFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${berkeley_rule_filter}} ) >= 16
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${synced_status_filter}} ) >= 16
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -581,7 +581,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 15 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -591,7 +591,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},${berkeley_rule_filter}} ) != 0
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},${synced_status_filter}} ) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -601,7 +601,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 2 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -633,7 +633,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/Archive-Node-Metrics-9edf9c51dd344f1fbf6722082a2e2465"
 
   - alert: FewBlocksPerHour
-    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet},${berkeley_rule_filter}}  [30m])) < 1
+    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet},${synced_status_filter}}  [30m])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -644,7 +644,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/FewBlocksPerHour-47a6356f093242d988b0d9527ce23478"
  
   - alert: HighBlockGossipLatency
-    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 200
+    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {${berkeley_testnet},${synced_status_filter}}  [${alert_timeframe}])) > 200
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -655,7 +655,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${berkeley_rule_filter}} ) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -665,7 +665,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/SomewhatOldBestTip-bb1509582bdd4908bcda656eebf421b5"
 
   - alert: MediumFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${berkeley_rule_filter}} ) >= 8
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},${synced_status_filter}} ) >= 8
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -675,7 +675,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/MediumFork-0a530813af2e40c491cdf01b3a2b2304"
 
   - alert: NoTransactionsInAtLeastOneBlock
-    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${berkeley_rule_filter}} ) > 0
+    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},${synced_status_filter}} ) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -685,7 +685,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoTransactionsInAtLeastOneBlock-049250ff7ae84de990233c7b6d35f763"
 
   - alert: LowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${berkeley_rule_filter}} ) <= 35
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},${synced_status_filter}} ) <= 60
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -706,7 +706,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/SeedListDown-d8d4e14609884c63a7086309336f3462"
 
   - alert: LowDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},${synced_status_filter}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -716,7 +716,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowDisconnectedBlocksPerHour-32bd49852fbb499090106fe63a504859"
 
   - alert: LowOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},${synced_status_filter}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -726,7 +726,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowOldBlocksPerHour-1cc2e92b8ca944869d810f7afd7c2d78"
 
   - alert: LowInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet}}  [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -736,7 +736,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowInvalidProofPerHour-b6e88b9ae84f47169e7f86017ab9e340"
 
   - alert: LowPostgresBlockHeightGrowth
-    expr: min by (testnet) (increase(Coda_Archive_max_block_height {${berkeley_testnet},${berkeley_rule_filter}}  [${alert_timeframe}])) < 1
+    expr: min by (testnet) (increase(Coda_Archive_max_block_height {${berkeley_testnet}}  [${alert_timeframe}])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -397,7 +397,7 @@ groups:
 - name: Berkeley syncStatus related alerts
   rules:
   - alert: HighDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor ${berkeley_rule_filter} [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -407,7 +407,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighDisconnectedBlocksPerHour-14da6dc40386439799eb2a573d077ecb"
 
   - alert: HighOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 5
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root ${berkeley_rule_filter} [${alert_timeframe}])) > 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -417,7 +417,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighOldBlocksPerHour-134ba51aef4d482bb065ce7a02dd8fb7"
 
   - alert: HighInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 3
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof ${berkeley_rule_filter} [${alert_timeframe}])) > 3
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -427,7 +427,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighInvalidProofPerHour-8ff715ccf9564b6e8a27b5a9dc65ef77"
 
   - alert: LowPeerCount
-    expr: min by (testnet) (Coda_Network_peers {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 3
+    expr: min by (testnet) (Coda_Network_peers ${berkeley_rule_filter}) < 3
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -438,7 +438,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowPeerCount-3a66ae1ca6fd44b585eca37f9206d429"
 
   - alert: CriticallyLowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 13
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density ${berkeley_rule_filter}) <= 13
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -449,7 +449,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowFillRate
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 0.75 * 0.6
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_slot_fill_rate ${berkeley_rule_filter}) < 0.75 * 0.6
     for: 1h
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -460,7 +460,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowFillRate-36efb1cd9b5d461db6976bc1938fab9e"
 
   - alert: NoTransactionsInSeveralBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 5
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_empty_blocks_at_best_tip ${berkeley_rule_filter}) >= 5
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -470,7 +470,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/No-Transactions-In-Several-Blocks-55ca13df38dd4c3491e11d8ea8020c08"
 
   - alert: NoCoinbaseInBlocks
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) < 1
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_best_tip_coinbase ${berkeley_rule_filter}) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -481,7 +481,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoCoinbaseInBlocks-aacbc2a4f9334d0db2de20c2f77ac34f"
 
   - alert: LongFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 16
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork ${berkeley_rule_filter}) >= 16
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -491,7 +491,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 15 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${berkeley_rule_filter}) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -501,7 +501,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) != 0
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec ${berkeley_rule_filter}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work ${berkeley_rule_filter}) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -511,7 +511,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 2 * 180
+    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec ${berkeley_rule_filter}) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -521,7 +521,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewTransactions-27dbeafab8ea4d659ee6f748acb2fd6c"
 
   - alert: FewBlocksPerHour
-    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [30m])) < 1
+    expr: quantile by (testnet) (0.5, increase(Coda_Transition_frontier_max_blocklength_observed ${berkeley_rule_filter} [30m])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -532,7 +532,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/FewBlocksPerHour-47a6356f093242d988b0d9527ce23478"
  
   - alert: HighBlockGossipLatency
-    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 200
+    expr: max by (testnet) (max_over_time(Coda_Block_latency_gossip_time ${berkeley_rule_filter} [${alert_timeframe}])) > 200
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -543,7 +543,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${berkeley_rule_filter}) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -553,7 +553,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/SomewhatOldBestTip-bb1509582bdd4908bcda656eebf421b5"
 
   - alert: MediumFork
-    expr: max by (testnet) (Coda_Transition_frontier_longest_fork {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) >= 8
+    expr: max by (testnet) (Coda_Transition_frontier_longest_fork ${berkeley_rule_filter}) >= 8
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -563,7 +563,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/MediumFork-0a530813af2e40c491cdf01b3a2b2304"
 
   - alert: NoTransactionsInAtLeastOneBlock
-    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) > 0
+    expr: max by (testnet) (Coda_Transition_frontier_empty_blocks_at_best_tip ${berkeley_rule_filter}) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -573,7 +573,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoTransactionsInAtLeastOneBlock-049250ff7ae84de990233c7b6d35f763"
 
   - alert: LowMinWindowDensity
-    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"}) <= 35
+    expr: quantile by (testnet) (0.5, Coda_Transition_frontier_min_window_density ${berkeley_rule_filter}) <= 35
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
@@ -584,7 +584,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowMinWindowDensity-Runbook-7908635be4754b44a862d9bec8edc239"
 
   - alert: LowDisconnectedBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_no_common_ancestor ${berkeley_rule_filter} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -594,7 +594,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowDisconnectedBlocksPerHour-32bd49852fbb499090106fe63a504859"
 
   - alert: LowOldBlocksPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_worse_than_root ${berkeley_rule_filter} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -604,7 +604,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowOldBlocksPerHour-1cc2e92b8ca944869d810f7afd7c2d78"
 
   - alert: LowInvalidProofPerHour
-    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) > 0
+    expr: max by (testnet) (increase(Coda_Rejected_blocks_invalid_proof ${berkeley_rule_filter} [${alert_timeframe}])) > 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -614,7 +614,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LowInvalidProofPerHour-b6e88b9ae84f47169e7f86017ab9e340"
 
   - alert: LowPostgresBlockHeightGrowth
-    expr: min by (testnet) (increase(Coda_Archive_max_block_height {${berkeley_testnet},syncStatus!="INIT"|"BOOTSTRAP"|"CATCHUP"} [${alert_timeframe}])) < 1
+    expr: min by (testnet) (increase(Coda_Archive_max_block_height ${berkeley_rule_filter} [${alert_timeframe}])) < 1
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -22,7 +22,7 @@ module "o1testnet_alerts" {
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
-  berkeley_testnet       = "testnet=\"berkeley\""
+  berkeley_rule_filter   = "{testnet=\"berkeley\",syncStatus=\"SYNCED\"}"
 }
 
 output "testnet_alert_rules" {

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -23,7 +23,7 @@ module "o1testnet_alerts" {
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
   berkeley_testnet       = "testnet=\"berkeley\""
-  berkeley_rule_filter   = "syncStatus=\"SYNCED\""
+  synced_status_filter   = "syncStatus=\"SYNCED\""
 }
 
 output "testnet_alert_rules" {

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -18,7 +18,7 @@ terraform {
 module "o1testnet_alerts" {
   source = "../modules/testnet-alerts"
 
-  rule_filter            = "{testnet!~\"^(it-|ci-net|test-).+\"}" # omit testnets deployed by integration/CI tests
+  rule_filter            = "{testnet!~\"^(berkeley|it-|ci-net|test-).+\"}" # omit testnets deployed by integration/CI tests and also omit berkeley network
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -22,6 +22,7 @@ module "o1testnet_alerts" {
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
+  berkeley_testnet       = "testnet=\"berkeley\""
 }
 
 output "testnet_alert_rules" {

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -22,7 +22,8 @@ module "o1testnet_alerts" {
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
-  berkeley_rule_filter   = "{testnet=\"berkeley\",syncStatus=\"SYNCED\"}"
+  berkeley_testnet       = "testnet=\"berkeley\""
+  berkeley_rule_filter   = "syncStatus=\"SYNCED\""
 }
 
 output "testnet_alert_rules" {


### PR DESCRIPTION
Explain your changes:
Compatible version for #13701 , This PR adds berkeley specific alerts. The reason I created this PR against compatible because CI would only deploy the alerts if the building branch is compatible.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
