### PR TITLE
[easy] Update Xor test to have both odd and even number of preceding Generics

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -708,6 +708,16 @@ let%test_unit "bitwise xor gadget" =
       let cs, _proof_keypair, _proof =
         Runner.generate_and_verify_proof ?cs (fun () ->
             let open Runner.Impl in
+            (* Create half a generic to force a possible generic in the middle *)
+            let left_summand =
+              exists Field.typ ~compute:(fun () -> Field.Constant.of_int 15)
+            in
+            let right_summand =
+              exists Field.typ ~compute:(fun () -> Field.Constant.of_int 0)
+            in
+            Field.Assert.equal
+              (Field.( + ) left_summand right_summand)
+              left_summand ;
             (* Set up snarky variables for inputs and output *)
             let left_input =
               exists Field.typ ~compute:(fun () ->


### PR DESCRIPTION
This small PR just adds one preceding generic gate before the Xor tests to force an odd number of generics before the Xor chain. This, together with the [chaining safety check](https://github.com/MinaProtocol/mina/pull/13821), will detect a wrong ordering of Xor constraints if we ever refactor / rewrite the Xor-related gadgets.

Closes https://github.com/MinaProtocol/mina/issues/13828