### PR TITLE
[easy] Update RC test to have both odd and even number of leading Generics

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
@@ -244,15 +244,15 @@ let%test_unit "range_check64 gadget" =
 
     (* Helper to test range_check64 gadget
      *   Input: value  to be range checked in [0, 2^64)
-     *          odd    whether or not to have initial odd number of generics
+     *          lead    whether or not to have one leading generic
      *)
-    let test_range_check64 ?cs ?(odd = false) base10 =
+    let test_range_check64 ?cs ?(lead = false) base10 =
       let open Runner.Impl in
       let value = Common.field_of_base10 (module Runner.Impl) base10 in
 
       let make_circuit value =
-        ( if odd then
-          (* Create half a generic to force an odd number of Generics preceding RC *)
+        ( if lead then
+          (* Create half a generic to force one Generic preceding RC *)
           let left_summand =
             exists Field.typ ~compute:(fun () -> Field.Constant.of_int 5)
           in
@@ -279,8 +279,8 @@ let%test_unit "range_check64 gadget" =
     in
 
     (* Positive tests *)
-    (* odd = true *)
-    let _cs = test_range_check64 ~odd:true "9884868923950902332" in
+    (* lead = true *)
+    let _cs = test_range_check64 ~lead:true "9884868923950902332" in
 
     let cs = test_range_check64 "0" in
     let _cs = test_range_check64 ~cs "4294967" in
@@ -306,14 +306,14 @@ let%test_unit "multi_range_check gadget" =
     in
 
     (* Helper to test multi_range_check gadget *)
-    let test_multi_range_check ?cs ?(odd = false) v0 v1 v2 =
+    let test_multi_range_check ?cs ?(lead = false) v0 v1 v2 =
       let open Runner.Impl in
       let v0 = Common.field_of_base10 (module Runner.Impl) v0 in
       let v1 = Common.field_of_base10 (module Runner.Impl) v1 in
       let v2 = Common.field_of_base10 (module Runner.Impl) v2 in
 
       let make_circuit v0 v1 v2 =
-        ( if odd then
+        ( if lead then
           let left_summand =
             exists Field.typ ~compute:(fun () -> Field.Constant.of_int 5)
           in
@@ -342,12 +342,12 @@ let%test_unit "multi_range_check gadget" =
     in
 
     (* Positive tests *)
-    (* odd = true *)
+    (* lead = true *)
     let _cs =
-      test_multi_range_check ~odd:true "309485009821345068724781055"
+      test_multi_range_check ~lead:true "309485009821345068724781055"
         "309485009821345068724781055" "309485009821345068724781055"
     in
-    (* odd = false *)
+    (* lead = false *)
     let cs =
       test_multi_range_check "0" "4294967" "309485009821345068724781055"
     in


### PR DESCRIPTION
This small PR just adds one preceding generic gate before the RC tests to force an odd number of generics before the Xor chain. This, together with the https://github.com/MinaProtocol/mina/pull/13821, will detect a wrong ordering of RC constraints if we ever refactor / rewrite the RC-related gadgets.

Closes https://github.com/MinaProtocol/mina/issues/13833