### PR TITLE
Replayer, check snarked ledger hash [berkeley]

### DIFF
--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -1,0 +1,105 @@
+# kubectl apply -n berkeley -f helm/cron_jobs/berkeley-replayer-cronjob.yaml
+# the above command, with this accompanying file, needs only be run once.
+# Notes:
+# - the archive dump usually is of the form ...0000.sql.tar.gz, but not always
+#   we reverse-sort the filenames, take the most recent one
+# - ALTER USER takes a password bracketed in single-quotes or $$s
+#   too hard to make the single-quotes work inside single-quotes, so use $$
+#   the space in the password makes sure a $ isn't applied to the following string
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: berkeley-replayer-cronjob
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - 'echo "Starting replayer cron job";
+               apt update;
+               echo "Installing libjemalloc2";
+               apt-get -y install libjemalloc2;
+               echo "Installing gsutil";
+               apt-get -y install apt-transport-https ca-certificates gnupg curl;
+               echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list;
+               curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - ;
+               apt-get update && apt-get install -y google-cloud-cli ;
+               ARCHIVE_DUMP_URI=$(gsutil ls gs://mina-archive-dumps/berkeley-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
+               ARCHIVE_DUMP=$(basename $ARCHIVE_DUMP_URI);
+               ARCHIVE_SQL=$(basename $ARCHIVE_DUMP_URI .tar.gz);
+               echo "Getting archive dump" $ARCHIVE_DUMP_URI;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $ARCHIVE_DUMP_URI . ;
+               MOST_RECENT_CHECKPOINT_URI=$(gsutil ls gs://berkeley-replayer-checkpoints/berkeley-replayer-checkpoint-*.json | sort -r | head -n 1);
+               MOST_RECENT_CHECKPOINT=$(basename $MOST_RECENT_CHECKPOINT_URI);
+               echo "Getting replayer checkpoint file" $MOST_RECENT_CHECKPOINT;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $MOST_RECENT_CHECKPOINT_URI . ;
+               echo "Starting Postgresql";
+               service postgresql start;
+               echo "Importing archive dump";
+               tar -xzvf $ARCHIVE_DUMP;
+               mv $ARCHIVE_SQL ~postgres/;
+               echo "Deleting archive dump";
+               rm -f $ARCHIVE_DUMP;
+               su postgres -c "cd ~ && echo ALTER USER postgres WITH PASSWORD \\$\\$ foobar \\$\\$ | psql";
+               su postgres -c "cd ~ && echo CREATE DATABASE archive_balances_migrated | psql";
+               su postgres -c "cd ~ && psql < $ARCHIVE_SQL";
+               echo "Deleting archive SQL file";
+               su postgres -c "cd ~ && rm -f $ARCHIVE_SQL";
+               echo "Running replayer";
+               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive_balances_migrated --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
+               echo "Done running replayer";
+               rm -f $MOST_RECENT_CHECKPOINT;
+               DISK_CHECKPOINT=$(ls -t replayer-checkpoint*.json | head -n 1);
+               DATE=$(date +%F);
+               TODAY_CHECKPOINT=berkeley-replayer-checkpoint-$DATE.json;
+               mv $DISK_CHECKPOINT $TODAY_CHECKPOINT;
+               echo "Uploading checkpoint file" $TODAY_CHECKPOINT;
+               gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $TODAY_CHECKPOINT gs://berkeley-replayer-checkpoints/$TODAY_CHECKPOINT;
+               echo "Replayer errors:";
+               grep Error replayer.log;
+               HAVE_ERRORS=$?;
+               if [ $HAVE_ERRORS -eq 0 ];
+                 then REPLAYER_ERRORS=berkeley_replayer_errors_${DATE};
+                 echo "The replayer found errors, uploading log" $REPLAYER_ERRORS;
+                 mv replayer.log $REPLAYER_ERRORS;
+                 gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $REPLAYER_ERRORS gs://berkeley-replayer-checkpoints/$REPLAYER_ERRORS;
+               fi'
+            env:
+            - name: GCLOUD_KEYFILE
+              value: /gcloud/keyfile.json
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-no-final-checkpoint-5af6dba-bullseye
+            imagePullPolicy: IfNotPresent
+            name: berkeley-replayer-cronjob
+            resources:
+              limits:
+              requests:
+                memory: 32.0Gi
+                cpu: 20.0
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /gcloud/
+              name: gcloud-keyfile
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: gcloud-keyfile
+            secret:
+              defaultMode: 256
+              items:
+              - key: keyfile
+                path: keyfile.json
+              secretName: gcloud-keyfile
+  schedule: 0 2 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -77,7 +77,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup3-feature-berkeley-replayer-cronjob-snarked-ledger-check-f7dd759-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup2-feature-replayer-check-snark-ledger-hash-berkeley-c6da972-bullseye
             imagePullPolicy: IfNotPresent
             name: berkeley-replayer-cronjob
             resources:

--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -6,6 +6,8 @@
 # - ALTER USER takes a password bracketed in single-quotes or $$s
 #   too hard to make the single-quotes work inside single-quotes, so use $$
 #   the space in the password makes sure a $ isn't applied to the following string
+# - we filter out the CREATE DATABASE line from the SQL file, because psql here (v. 13)
+#   is older than the pg_dump (v. 15), which creates an unknown option "local_provider"
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -43,16 +45,18 @@ spec:
                service postgresql start;
                echo "Importing archive dump";
                tar -xzvf $ARCHIVE_DUMP;
+               cat $ARCHIVE_SQL | grep -v "CREATE DATABASE" > archive.sql;
+               mv archive.sql $ARCHIVE_SQL;
                mv $ARCHIVE_SQL ~postgres/;
                echo "Deleting archive dump";
                rm -f $ARCHIVE_DUMP;
                su postgres -c "cd ~ && echo ALTER USER postgres WITH PASSWORD \\$\\$ foobar \\$\\$ | psql";
-               su postgres -c "cd ~ && echo CREATE DATABASE archive_balances_migrated | psql";
+               su postgres -c "cd ~ && echo CREATE DATABASE archive | psql";
                su postgres -c "cd ~ && psql < $ARCHIVE_SQL";
                echo "Deleting archive SQL file";
                su postgres -c "cd ~ && rm -f $ARCHIVE_SQL";
                echo "Running replayer";
-               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive_balances_migrated --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
+               mina-replayer --archive-uri postgres://postgres:%20foobar%20@localhost/archive --input-file $MOST_RECENT_CHECKPOINT --continue-on-error --output-file /dev/null --checkpoint-interval 50 >& replayer.log ;
                echo "Done running replayer";
                rm -f $MOST_RECENT_CHECKPOINT;
                DISK_CHECKPOINT=$(ls -t replayer-checkpoint*.json | head -n 1);
@@ -73,7 +77,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-no-final-checkpoint-5af6dba-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup3-feature-berkeley-replayer-cronjob-snarked-ledger-check-f7dd759-bullseye
             imagePullPolicy: IfNotPresent
             name: berkeley-replayer-cronjob
             resources:

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -9,6 +9,8 @@
    result
    async.async_command
    async
+   base.caml
+   bin_prot.shape
    caqti-async
    core_kernel
    archive_lib
@@ -56,6 +58,7 @@
    unsigned_extended
    random_oracle
    codable
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -111,11 +111,48 @@ let create_replayer_checkpoint ~ledger ~start_slot_since_genesis :
   ; genesis_ledger
   }
 
-(* map from global slots (since genesis) to state hash, ledger hash pairs *)
-let global_slot_hashes_tbl : (Int64.t, State_hash.t * Ledger_hash.t) Hashtbl.t =
+(* map from global slots (since genesis) to state hash, ledger hash, snarked ledger hash triples *)
+let global_slot_hashes_tbl :
+    (Int64.t, State_hash.t * Ledger_hash.t * Frozen_ledger_hash.t) Hashtbl.t =
   Int64.Table.create ()
 
 let get_slot_hashes slot = Hashtbl.find global_slot_hashes_tbl slot
+
+module First_pass_ledger_hashes = struct
+  (* ledger hashes after 1st pass, indexed by order of occurrence *)
+
+  module T = struct
+    type t = Ledger_hash.Stable.Latest.t * int
+    [@@deriving bin_io_unversioned, compare, sexp, hash]
+  end
+
+  include T
+  include Hashable.Make_binable (T)
+
+  let hash_set = Hash_set.create ()
+
+  let add =
+    let count = ref 0 in
+    fun ledger_hash ->
+      Base.Hash_set.add hash_set (ledger_hash, !count) ;
+      incr count
+
+  let find ledger_hash =
+    Base.Hash_set.find hash_set ~f:(fun (hash, _n) ->
+        Ledger_hash.equal hash ledger_hash )
+
+  (* once we find a snarked ledger hash corresponding to a ledger hash, don't need to store earlier ones *)
+  let flush_older_than ndx =
+    let elts = Base.Hash_set.to_list hash_set in
+    List.iter elts ~f:(fun ((_hash, n) as elt) ->
+        if n < ndx then Base.Hash_set.remove hash_set elt )
+
+  let get_last_snarked_hash, set_last_snarked_hash =
+    let last_snarked_hash = ref Ledger_hash.empty_hash in
+    let getter () = !last_snarked_hash in
+    let setter hash = last_snarked_hash := hash in
+    (getter, setter)
+end
 
 let process_block_infos_of_state_hash ~logger pool ~state_hash ~start_slot ~f =
   match%bind
@@ -637,22 +674,43 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
               max_slot ;
             try_slot ~logger pool max_slot
       in
-      [%log info] "Loading block information using target state hash" ;
-      let%bind block_ids =
+      [%log info]
+        "Loading block information using target state hash and start slot" ;
+      let%bind block_ids, oldest_block_id =
         process_block_infos_of_state_hash ~logger pool
           ~state_hash:target_state_hash
           ~start_slot:input.start_slot_since_genesis ~f:(fun block_infos ->
+            let ({ id = oldest_block_id; _ } : Sql.Block_info.t) =
+              Option.value_exn
+                (List.min_elt block_infos ~compare:(fun bi1 bi2 ->
+                     Int64.compare bi1.global_slot_since_genesis
+                       bi2.global_slot_since_genesis ) )
+            in
             let ids = List.map block_infos ~f:(fun { id; _ } -> id) in
             (* build mapping from global slots to state and ledger hashes *)
-            List.iter block_infos
-              ~f:(fun { global_slot_since_genesis; state_hash; ledger_hash; _ }
-                 ->
-                Hashtbl.add_exn global_slot_hashes_tbl
-                  ~key:global_slot_since_genesis
-                  ~data:
-                    ( State_hash.of_base58_check_exn state_hash
-                    , Ledger_hash.of_base58_check_exn ledger_hash ) ) ;
-            return (Int.Set.of_list ids) )
+            let%bind () =
+              Deferred.List.iter block_infos
+                ~f:(fun
+                     { global_slot_since_genesis
+                     ; state_hash
+                     ; ledger_hash
+                     ; snarked_ledger_hash_id
+                     ; _
+                     }
+                   ->
+                  let%map snarked_hash =
+                    query_db ~f:(fun db ->
+                        Sql.Snarked_ledger_hashes.run db snarked_ledger_hash_id )
+                  in
+
+                  Hashtbl.add_exn global_slot_hashes_tbl
+                    ~key:global_slot_since_genesis
+                    ~data:
+                      ( State_hash.of_base58_check_exn state_hash
+                      , Ledger_hash.of_base58_check_exn ledger_hash
+                      , Frozen_ledger_hash.of_base58_check_exn snarked_hash ) )
+            in
+            return (Int.Set.of_list ids, oldest_block_id) )
       in
       if Int64.equal input.start_slot_since_genesis 0L then
         (* check that genesis block is in chain to target hash                                                                                                                                                                                          assumption: genesis block occupies global slot 0
@@ -676,7 +734,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
         let least_slot =
           Option.value_exn @@ List.min_elt slots ~compare:Int64.compare
         in
-        let state_hash, _ledger_hash =
+        let state_hash, _ledger_hash, _snarked_hash =
           Int64.Table.find_exn global_slot_hashes_tbl least_slot
         in
         let%bind { staking_epoch_data_id; next_epoch_data_id; _ } =
@@ -860,6 +918,12 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
       let%bind max_canonical_slot =
         query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
       in
+      let%bind genesis_snarked_ledger_hash_str =
+        query_db ~f:(fun db -> Sql.Block.genesis_snarked_ledger db ())
+      in
+      let genesis_snarked_ledger_hash =
+        Frozen_ledger_hash.of_base58_check_exn genesis_snarked_ledger_hash_str
+      in
       let incr_checkpoint_target () =
         Option.iter !checkpoint_target ~f:(fun target ->
             match checkpoint_interval_i64 with
@@ -879,6 +943,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
             | None ->
                 failwith "Expected a checkpoint interval" )
       in
+      let found_snarked_ledger_hash = ref false in
       (* apply commands in global slot, sequence order *)
       let rec apply_commands ~last_global_slot_since_genesis ~last_block_id
           ~(block_txns : Mina_transaction.Transaction.t list)
@@ -1012,7 +1077,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
               [%log fatal]
                 "Missing state hash information for current global slot" ;
               Core.exit 1
-          | Some (state_hash, _ledger_hash) ->
+          | Some (state_hash, _ledger_hash, _snarked_hash) ->
               [%log info]
                 ~metadata:
                   [ ( "state_hash"
@@ -1039,7 +1104,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                   "Missing ledger hash information for last global slot, which \
                    is not the start slot" ;
                 Core.exit 1 )
-          | Some (state_hash, ledger_hash) ->
+          | Some (state_hash, ledger_hash, snarked_hash) ->
               let write_checkpoint_file () =
                 let write_checkpoint () =
                   write_replayer_checkpoint ~logger ~ledger
@@ -1113,6 +1178,9 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                             ~txn_state_view ledger txn
                         with
                         | Ok partially_applied ->
+                            (* the current ledger may become a snarked ledger *)
+                            First_pass_ledger_hashes.add
+                              (Ledger.merkle_root ledger) ;
                             let%bind () =
                               update_staking_epoch_data ~logger pool
                                 ~last_block_id ~ledger ~staking_epoch_ledger
@@ -1175,6 +1243,40 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                 in
                 apply_transaction_phases (List.rev block_txns)
               in
+              ( if
+                Frozen_ledger_hash.equal snarked_hash
+                  (First_pass_ledger_hashes.get_last_snarked_hash ())
+              then
+                [%log info]
+                  "Snarked ledger hash same as in the preceding block, not \
+                   checking it again"
+              else if
+              Frozen_ledger_hash.equal snarked_hash genesis_snarked_ledger_hash
+            then
+                [%log info] "Snarked ledger hash is genesis snarked ledger hash"
+              else
+                match First_pass_ledger_hashes.find snarked_hash with
+                | None ->
+                    if not !found_snarked_ledger_hash then (
+                      [%log info]
+                        "Current snarked ledger hash not among first-pass \
+                         ledger hashes, but we haven't yet found one. The \
+                         transaction that created this ledger hash might have \
+                         been in a replayer run that created a checkpoint file" ;
+                      First_pass_ledger_hashes.set_last_snarked_hash
+                        snarked_hash )
+                    else
+                      [%log error]
+                        "Current snarked ledger hash does not appear among \
+                         first-pass ledger hashes" ;
+                    if continue_on_error then incr error_count
+                    else Core_kernel.exit 1
+                | Some (_hash, n) ->
+                    [%log info]
+                      "Found snarked ledger hash among first-pass ledger hashes" ;
+                    found_snarked_ledger_hash := true ;
+                    First_pass_ledger_hashes.set_last_snarked_hash snarked_hash ;
+                    First_pass_ledger_hashes.flush_older_than n ) ;
               if List.is_empty block_txns then (
                 [%log info]
                   "No transactions to run for block with state hash $state_hash"
@@ -1395,16 +1497,6 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                   ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
                   ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs )
       in
-      let%bind unparented_ids =
-        query_db ~f:(fun db -> Sql.Block.get_unparented db ())
-      in
-      let genesis_block_id =
-        match List.filter unparented_ids ~f:(Int.Set.mem block_ids) with
-        | [ id ] ->
-            id
-        | _ ->
-            failwith "Expected only the genesis block to have an unparented id"
-      in
       let%bind start_slot_since_genesis =
         let%map slot_opt =
           query_db ~f:(fun db ->
@@ -1438,7 +1530,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           =
         apply_commands ~block_txns:[]
           ~last_global_slot_since_genesis:start_slot_since_genesis
-          ~last_block_id:genesis_block_id sorted_internal_cmds sorted_user_cmds
+          ~last_block_id:oldest_block_id sorted_internal_cmds sorted_user_cmds
           sorted_zkapp_cmds
       in
       match input.target_epoch_ledgers_state_hash with

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -8,12 +8,13 @@ module Block_info = struct
     ; global_slot_since_genesis : int64
     ; state_hash : string
     ; ledger_hash : string
+    ; snarked_ledger_hash_id : int
     }
   [@@deriving hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int64; string; string ]
+      Caqti_type.[ int; int64; string; string; int ]
 
   (* find all blocks, working back from block with given state hash *)
   let query =
@@ -21,17 +22,17 @@ module Block_info = struct
       Caqti_type.(tup2 string int64)
       typ
       {sql| WITH RECURSIVE chain AS (
-              SELECT id,parent_id,global_slot_since_genesis,state_hash,ledger_hash FROM blocks b                                                                                                                                                           WHERE b.state_hash = $1
+              SELECT id,parent_id,global_slot_since_genesis,state_hash,ledger_hash, snarked_ledger_hash_id FROM blocks b                                                                                                                                                           WHERE b.state_hash = $1
 
               UNION ALL
 
-              SELECT b.id,b.parent_id,b.global_slot_since_genesis,b.state_hash,b.ledger_hash FROM blocks b
+              SELECT b.id,b.parent_id,b.global_slot_since_genesis,b.state_hash,b.ledger_hash, b.snarked_ledger_hash_id FROM blocks b
 
               INNER JOIN chain
 
               ON b.id = chain.parent_id AND chain.id <> chain.parent_id                                                                                                                                                                                 )
 
-           SELECT id,global_slot_since_genesis,state_hash,ledger_hash FROM chain c                                                                                                                                                                      WHERE c.global_slot_since_genesis >= $2                                                                                                                                                                                                 |sql}
+           SELECT id,global_slot_since_genesis,state_hash,ledger_hash, snarked_ledger_hash_id FROM chain c                                                                                                                                                                      WHERE c.global_slot_since_genesis >= $2                                                                                                                                                                                                 |sql}
 
   let run (module Conn : Caqti_async.CONNECTION) ~state_hash ~start_slot =
     Conn.collect_list query (state_hash, start_slot)
@@ -160,6 +161,18 @@ module Block = struct
 
   let get_chain (module Conn : Caqti_async.CONNECTION) state_hash =
     Conn.collect_list chain_query state_hash
+
+  let genesis_snarked_ledger_query =
+    Caqti_request.find Caqti_type.unit Caqti_type.string
+      {sql| SELECT value
+          FROM blocks
+          INNER JOIN snarked_ledger_hashes
+          ON snarked_ledger_hashes.id = blocks.snarked_ledger_hash_id
+          WHERE blocks.height = 1
+    |sql}
+
+  let genesis_snarked_ledger (module Conn : Caqti_async.CONNECTION) =
+    Conn.find genesis_snarked_ledger_query
 end
 
 module User_command_ids = struct

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -82,9 +82,8 @@ let%test_unit "of_ledger_subset_exn with keys that don't exist works" =
 module T = Mina_transaction_logic.Make (L)
 
 let apply_transaction_logic f t x =
-  let open Or_error.Let_syntax in
   let t' = ref t in
-  let%map app = f t' x in
+  let%map.Or_error app = f t' x in
   (!t', app)
 
 let apply_user_command ~constraint_constants ~txn_global_slot =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -736,8 +736,7 @@ module T = struct
     let txns_from_data data =
       List.fold_right ~init:(Ok []) data
         ~f:(fun (d : Scan_state.Transaction_with_witness.t) acc ->
-          let open Or_error.Let_syntax in
-          let%map acc = acc in
+          let%map.Or_error acc = acc in
           let t =
             d.transaction_with_info |> Ledger.Transaction_applied.transaction
           in
@@ -2623,8 +2622,7 @@ let%test_module "staged ledger tests" =
               let apply_second_pass = Ledger.apply_transaction_second_pass in
               let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
                   sparse_ledger txn =
-                let open Or_error.Let_syntax in
-                let%map _ledger, partial_txn =
+                let%map.Or_error _ledger, partial_txn =
                   Mina_ledger.Sparse_ledger.apply_transaction_first_pass
                     ~constraint_constants ~global_slot ~txn_state_view
                     sparse_ledger txn


### PR DESCRIPTION
Check the SNARKed ledger hashes in the replayer for `berkeley`. That was done for `rampup` in #13715; cherry-pick the commits there, apply them to `berkeley`.

The other changes from that PR include the YAML for the replayer cron job. I will update the cron job image to use a container created from this PR.

