### PR TITLE
Update chaining safety check for Rotation

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -310,6 +310,7 @@ module Plonk_constraint = struct
           ; bound_crumb5 : 'v
           ; bound_crumb6 : 'v
           ; bound_crumb7 : 'v
+          ; (* Next row *) shifted : 'v
           ; (* Coefficients *) two_to_rot : 'f (* Rotation scalar 2^rot *)
           }
       | Raw of
@@ -617,10 +618,11 @@ module Plonk_constraint = struct
           ; bound_crumb5
           ; bound_crumb6
           ; bound_crumb7
+          ; (* Next row *) shifted
           ; (* Coefficients *) two_to_rot
           } ->
           Rot64
-            { word = f word
+            { (* Current row *) word = f word
             ; rotated = f rotated
             ; excess = f excess
             ; bound_limb0 = f bound_limb0
@@ -635,6 +637,7 @@ module Plonk_constraint = struct
             ; bound_crumb5 = f bound_crumb5
             ; bound_crumb6 = f bound_crumb6
             ; bound_crumb7 = f bound_crumb7
+            ; (* Next row *) shifted = f shifted
             ; (* Coefficients *) two_to_rot
             }
       | Raw { kind; values; coeffs } ->
@@ -1020,11 +1023,19 @@ end = struct
             match value with
             | None ->
                 ()
-            | Some target ->
+            | Some target -> (
                 if Stdlib.(vars.(col) <> value) then
-                  failwith
-                    (sprintf "Invalid witness value in row %d column %d\n"
-                       (List.length sys.rows_rev) col ) ) ;
+                  match vars.(col) with
+                  | None ->
+                      ()
+                  | Some x ->
+                      print_endline "INSIDE PLONK_CONSRAINT_SYSTEM.ML" ;
+                      Format.printf "\n%a\n" Sexplib0.Sexp.pp (V.sexp_of_t x) ;
+                      Format.printf "\n%a\n" Sexplib0.Sexp.pp
+                        (V.sexp_of_t @@ Option.value_exn value) ;
+                      failwith
+                        (sprintf "Invalid witness value in row %d column %d\n"
+                           (List.length sys.rows_rev) col ) ) ) ;
 
         (* Add to row. *)
         sys.rows_rev <- vars :: sys.rows_rev ;
@@ -1935,8 +1946,9 @@ end = struct
            ; None
           |]
         in
-        (* The raw gate after a Xor16 gate is a Const to check that all values are zero.
-           For that, the first coefficient is 1 and the rest will be zero.
+        (* The raw gate after a Xor16 gate is a Zero to check that all values are zero.
+           For that, the first 3 witness cells are wired to a Generic gate containing
+           the Const 0, but the Zero row needs to happen right after the Xor16 row.
            This will be included in the gadget for a chain of Xors, not here.*)
         add_row sys curr_row Xor16 [||] ;
         set_next_row_witness_requirement sys next_row
@@ -2123,7 +2135,8 @@ end = struct
         add_row sys vars_next Zero [||]
     | Plonk_constraint.T
         (Rot64
-          { word
+          { (* Current row *)
+            word
           ; rotated
           ; excess
           ; bound_limb0
@@ -2138,30 +2151,32 @@ end = struct
           ; bound_crumb5
           ; bound_crumb6
           ; bound_crumb7
+          ; (* Next row *)
+            shifted
           ; (* Coefficients *) two_to_rot
           } ) ->
         (*
-        //! | Gate   | `Rot64`             | `RangeCheck0` gadgets (designer's duty)                   |
-        //! | ------ | ------------------- | --------------------------------------------------------- |
-        //! | Column | `Curr`              | `Next`           | `Next` + 1      | `Next`+ 2, if needed |
-        //! | ------ | ------------------- | ---------------- | --------------- | -------------------- |
-        //! |      0 | copy `word`         |`shifted`         |   copy `excess` |    copy      `word`  |
-        //! |      1 | copy `rotated`      | 0                |              0  |                  0   |
-        //! |      2 |      `excess`       | 0                |              0  |                  0   |
-        //! |      3 |      `bound_limb0`  | `shifted_limb0`  |  `excess_limb0` |        `word_limb0`  |
-        //! |      4 |      `bound_limb1`  | `shifted_limb1`  |  `excess_limb1` |        `word_limb1`  |
-        //! |      5 |      `bound_limb2`  | `shifted_limb2`  |  `excess_limb2` |        `word_limb2`  |
-        //! |      6 |      `bound_limb3`  | `shifted_limb3`  |  `excess_limb3` |        `word_limb3`  |
-        //! |      7 |      `bound_crumb0` | `shifted_crumb0` | `excess_crumb0` |       `word_crumb0`  |
-        //! |      8 |      `bound_crumb1` | `shifted_crumb1` | `excess_crumb1` |       `word_crumb1`  |
-        //! |      9 |      `bound_crumb2` | `shifted_crumb2` | `excess_crumb2` |       `word_crumb2`  |
-        //! |     10 |      `bound_crumb3` | `shifted_crumb3` | `excess_crumb3` |       `word_crumb3`  |
-        //! |     11 |      `bound_crumb4` | `shifted_crumb4` | `excess_crumb4` |       `word_crumb4`  |
-        //! |     12 |      `bound_crumb5` | `shifted_crumb5` | `excess_crumb5` |       `word_crumb5`  |
-        //! |     13 |      `bound_crumb6` | `shifted_crumb6` | `excess_crumb6` |       `word_crumb6`  |
-        //! |     14 |      `bound_crumb7` | `shifted_crumb7` | `excess_crumb7` |       `word_crumb7`  |
+        //! | Gate   | `Rot64`             | `RangeCheck0`    | `RangeCheck0` gadgets (designer's duty) |                   |
+        //! | ------ | ------------------- | ---------------------------------------------------------- |
+        //! | Column | `Curr`              | `Next`           | `Next` + 1      | `Next`+ 2, if needed  |
+        //! | ------ | ------------------- | ---------------- | --------------- | --------------------- |
+        //! |      0 | copy `word`         |`shifted`         |   copy `excess` |    copy      `word`   |
+        //! |      1 | copy `rotated`      | 0                |              0  |                  0    |
+        //! |      2 |      `excess`       | 0                |              0  |                  0    |
+        //! |      3 |      `bound_limb0`  | `shifted_limb0`  |  `excess_limb0` |        `word_limb0`   |
+        //! |      4 |      `bound_limb1`  | `shifted_limb1`  |  `excess_limb1` |        `word_limb1`   |
+        //! |      5 |      `bound_limb2`  | `shifted_limb2`  |  `excess_limb2` |        `word_limb2`   |
+        //! |      6 |      `bound_limb3`  | `shifted_limb3`  |  `excess_limb3` |        `word_limb3`   |
+        //! |      7 |      `bound_crumb0` | `shifted_crumb0` | `excess_crumb0` |       `word_crumb0`   |
+        //! |      8 |      `bound_crumb1` | `shifted_crumb1` | `excess_crumb1` |       `word_crumb1`   |
+        //! |      9 |      `bound_crumb2` | `shifted_crumb2` | `excess_crumb2` |       `word_crumb2`   |
+        //! |     10 |      `bound_crumb3` | `shifted_crumb3` | `excess_crumb3` |       `word_crumb3`   |
+        //! |     11 |      `bound_crumb4` | `shifted_crumb4` | `excess_crumb4` |       `word_crumb4`   |
+        //! |     12 |      `bound_crumb5` | `shifted_crumb5` | `excess_crumb5` |       `word_crumb5`   |
+        //! |     13 |      `bound_crumb6` | `shifted_crumb6` | `excess_crumb6` |       `word_crumb6`   |
+        //! |     14 |      `bound_crumb7` | `shifted_crumb7` | `excess_crumb7` |       `word_crumb7`   |
         *)
-        let vars_curr =
+        let curr_row =
           [| (* Current row *) Some (reduce_to_v word)
            ; Some (reduce_to_v rotated)
            ; Some (reduce_to_v excess)
@@ -2179,7 +2194,31 @@ end = struct
            ; Some (reduce_to_v bound_crumb7)
           |]
         in
-        add_row sys vars_curr Rot64 [| two_to_rot |]
+        (* Next row *)
+        let next_row =
+          [| Some (reduce_to_v shifted)
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+          |]
+        in
+
+        (* The gate after a Rot64 gate is always a RangeCheck0 containing the shifted value *)
+        add_row sys curr_row Rot64 [| two_to_rot |] ;
+        set_next_row_witness_requirement sys next_row
+        (* TODO: functionality to force it to be a certain type of gate OR look witness value instead of variable *)
+        (* set_next_allowed_gate sys RangeCheck0 *)
     | Plonk_constraint.T (Raw { kind; values; coeffs }) ->
         let values =
           Array.init 15 ~f:(fun i ->

--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -576,7 +576,7 @@ let bnot64_unchecked (type f)
 (**************)
 
 let%test_unit "bitwise rotation gadget" =
-  if tests_enabled then
+  if tests_enabled then (
     let (* Import the gadget test runner *)
     open Kimchi_gadgets_test_runner in
     (* Initialize the SRS cache. *)
@@ -627,8 +627,6 @@ let%test_unit "bitwise rotation gadget" =
     in
 
     let _cs = test_rot "0" 0 Left "0" in
-    ()
-(*
     let _cs = test_rot "0" 32 Right "0" in
     let _cs = test_rot "1" 1 Left "2" in
     let _cs = test_rot "1" 63 Left "9223372036854775808" in
@@ -645,8 +643,8 @@ let%test_unit "bitwise rotation gadget" =
     (* Negatve tests *)
     assert (Common.is_error (fun () -> test_rot "0" 1 Left "1")) ;
     assert (Common.is_error (fun () -> test_rot "1" 64 Left "1")) ;
-    assert (Common.is_error (fun () -> test_rot ~cs "0" 0 Left "0")) ) ;
-  ()
+    assert (Common.is_error (fun () -> test_rot ~cs "0" 0 Left "0")) ;
+    () )
 
 let%test_unit "bitwise shift gadgets" =
   if tests_enabled then (
@@ -939,4 +937,3 @@ let%test_unit "bitwise not gadget" =
             "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
             "0" 255 ) ) ) ;
   ()
-*)

--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -126,6 +126,7 @@ let rot_aux (type f)
                  ; bound_crumb5 = of_bits bound 4 6
                  ; bound_crumb6 = of_bits bound 2 4
                  ; bound_crumb7 = of_bits bound 0 2
+                 ; shifted
                  ; two_to_rot =
                      Common.bignum_bigint_to_field
                        (module Circuit)
@@ -575,7 +576,7 @@ let bnot64_unchecked (type f)
 (**************)
 
 let%test_unit "bitwise rotation gadget" =
-  if tests_enabled then (
+  if tests_enabled then
     let (* Import the gadget test runner *)
     open Kimchi_gadgets_test_runner in
     (* Initialize the SRS cache. *)
@@ -586,11 +587,23 @@ let%test_unit "bitwise rotation gadget" =
     (* Helper to test ROT gadget
      *   Input operands and expected output: word len mode rotated
      *   Returns unit if constraints are satisfied, error otherwise.
+     *   If odd is true, it inserts one initial dummy generic gate
      *)
-    let test_rot ?cs word length mode result =
+    let test_rot ?cs ?(odd = false) word length mode result =
       let cs, _proof_keypair, _proof =
         Runner.generate_and_verify_proof ?cs (fun () ->
             let open Runner.Impl in
+            ( if odd then
+              (* Create half a generic to force an odd number of Generics preceding Xor *)
+              let left_summand =
+                exists Field.typ ~compute:(fun () -> Field.Constant.of_int 15)
+              in
+              let right_summand =
+                exists Field.typ ~compute:(fun () -> Field.Constant.of_int 0)
+              in
+              Field.Assert.equal
+                (Field.( + ) left_summand right_summand)
+                left_summand ) ;
             (* Set up snarky variables for inputs and output *)
             let word =
               exists Field.typ ~compute:(fun () ->
@@ -608,7 +621,14 @@ let%test_unit "bitwise rotation gadget" =
       cs
     in
     (* Positive tests *)
+    (* odd = true *)
+    let _cs =
+      test_rot ~odd:true "6510615555426900570" 4 Left "11936128518282651045"
+    in
+
     let _cs = test_rot "0" 0 Left "0" in
+    ()
+(*
     let _cs = test_rot "0" 32 Right "0" in
     let _cs = test_rot "1" 1 Left "2" in
     let _cs = test_rot "1" 63 Left "9223372036854775808" in
@@ -919,3 +939,4 @@ let%test_unit "bitwise not gadget" =
             "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
             "0" 255 ) ) ) ;
   ()
+*)


### PR DESCRIPTION
This PR updates the chaining tool to provide support for the Rotation gadget. 

It only creates the next_row requirement with `shifted` and not all the decomposition, because otherwise there are duplicates in RangeCheck0 and then the variable equality didn't match. 

Possible future work: include a `set_next_allowed_gate sys` functionality to force the type of the following gate (in this case it should be RangeCheck0, but it is also sound if it is anything else but still containing `shifted` in the first cell. Another option would be to check the witness value instead of the variable inside `plonk_constraint_system.ml`. But for now, this includes Rotation and tests with even/odd number of initial leading generics (doing this helped catch the problem with `bits64` in https://github.com/MinaProtocol/mina/pull/13837)

Closes https://github.com/MinaProtocol/mina/issues/13832
