### PR TITLE
fix flaking insufficient replace fee check in zkApps test

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -745,17 +745,19 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Network.Node.get_ingress_uri node)
            zkapp_command_update_all )
     in
+    (*Transaction pool ledger may not be updated after the most recent block which causes this transaction to fail with invalid nonce instead of insufficient replace fee (last if branch in Indexed_pool.add_from_gossip_exn)*)
+    let%bind () =
+      section_hard "Send a zkapp with an insufficient replace fee"
+        (send_invalid_zkapp ~logger
+           (Network.Node.get_ingress_uri node)
+           zkapp_command_insufficient_replace_fee "Insufficient_replace_fee"
+           ~retries:5 )
+    in
     let%bind () =
       section_hard "Send a zkapp with an invalid proof"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
            zkapp_command_invalid_proof "Verification_failed" )
-    in
-    let%bind () =
-      section_hard "Send a zkapp with an insufficient replace fee"
-        (send_invalid_zkapp ~logger
-           (Network.Node.get_ingress_uri node)
-           zkapp_command_insufficient_replace_fee "Insufficient_replace_fee" )
     in
     let%bind () =
       section_hard "Send a zkApp transaction with an invalid nonce"


### PR DESCRIPTION
`zkapp_command_insufficient_replace_fee` is a transaction trying to replace `zkapp_command_update_all` transaction with insufficient replace fee. However, at times this check fails due to invalid nonce.

Possible causes:
1. if the previous transaction got into a block and the pool is updated. https://github.com/MinaProtocol/mina/blob/d257f0ba16ccef219cb6ab5815aa7d260442c24d/src/lib/network_pool/indexed_pool.ml#L931. I did not see this in the logs. Sending the replace transaction immediately after the to-be-replaced transaction to make this unlikely (previously an invalid-proof transaction was sent before the replace transaction)

2. if the previous transaction was included in the block, the pool's ledger was updated but the transaction wasn't removed from the pool yet. https://github.com/MinaProtocol/mina/blob/d257f0ba16ccef219cb6ab5815aa7d260442c24d/src/lib/network_pool/indexed_pool.ml#L1118 This is a race condition for which

Note: Haven't seen this case https://github.com/MinaProtocol/mina/blob/d257f0ba16ccef219cb6ab5815aa7d260442c24d/src/lib/network_pool/indexed_pool.ml#L998 (with `Between` in the invalid nonce error)

Fix:  I made a change to retry the insufficient-replace-fee transaction but that doesn't seem to fix case 2

Test: Haven't seen Case (1), blocks are produced before to-be-replaced transaction is sent and after failing transaction
Case(2) seems to happening even after 5 retries
Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13854
