### PR TITLE
Split unit tests into different CI jobs

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [[ $# -ne 3 ]]; then
-    echo "Usage: $0 <dune-profile> <path-to-top-level-directory> <paths-to-ignore-semicolon-delimited>"
+    echo "Usage: $0 <dune-profile> <path-to-top-level-directory> <paths-to-ignore-comma-delimited>"
     exit 1
 fi
 
@@ -15,8 +15,9 @@ ignore_paths=$3
 if [[ "${ignore_paths}" == "None" ]]; then
     ignore_paths=()
 else
-    ignore_paths=($(echo $ignore_paths | tr ";" "\n"))
+    ignore_paths=($(echo $ignore_paths | tr "," "\n"))
 fi
+echo "Ignore Paths after ${ignore_paths} and array ${ignore_paths[@]}"
 
 source ~/.profile
 
@@ -48,13 +49,13 @@ else
     grep --include=dune -ERl "${build_path}" -e "\(inline_tests|\(tests" |
     while read -r line;
     do
-        source_path=${line%"$dune_filename"}
+        source_path=${line%"$dune_filename"} #cut "dune" from the path
         execute="Y"
         for ignore_path in ${ignore_paths[@]};
         do
             if [[ "${source_path}" == "${ignore_path}"* ]]; then #ignore sub-directories too
-            execute="N"
-            break
+                execute="N"
+                break
             fi
             execute="Y"
         done
@@ -69,7 +70,7 @@ else
             time dune runtest "${source_path}" --profile="${profile}" -j16 || \
             (./scripts/link-coredumps.sh && false))
         else
-            echo "Skipping ${source_path}"
+            echo "--- Skipping ${source_path}"
         fi
     done
 fi

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -2,13 +2,19 @@
 
 set -eo pipefail
 
-if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <dune-profile> <path-to-source-tests>"
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <dune-profile> <path-to-top-level-directory> <paths-to-ignore-space-delimited>"
     exit 1
 fi
 
 profile=$1
-path=$2
+build_path=$2
+ignore_paths=$3
+
+#for some reason empty string/single space is not considered an argument when passed in dhall files
+if [[ "${ignore_paths}" == "None" ]]; then
+    ignore_paths=()
+fi
 
 source ~/.profile
 
@@ -17,17 +23,40 @@ export NO_JS_BUILD=1 # skip some JS targets which have extra implicit dependenci
 
 echo "--- Make build"
 export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
+export DUNE_PROFILE="${profile}"
 time make build
 
 echo "--- Build all targets"
-dune build "${path}" --profile="${profile}" -j16
+dune build "${build_path}" --profile="${profile}" -j16
 
-# Note: By attempting a re-run on failure here, we can avoid rebuilding and
-# skip running all of the tests that have already succeeded, since dune will
-# only retry those tests that failed.
-echo "--- Run unit tests"
-time dune runtest "${path}" --profile="${profile}" -j16 || \
-(./scripts/link-coredumps.sh && \
- echo "--- Retrying failed unit tests" && \
- time dune runtest "${path}" --profile="${profile}" -j16 || \
- (./scripts/link-coredumps.sh && false))
+dune_filename="dune"
+source_paths_to_test=()
+
+#(inline_tests) and tests stanza in dune files enable inline tests
+grep --include=dune -ERl "${build_path}" -e "\(inline_tests|\(tests" | 
+while read -r line;
+do 
+    source_path=${line%"$dune_filename"}
+    execute="Y"
+    for ignore_path in ${ignore_paths}; 
+    do
+        if [[ "${source_path}" == "${ignore_path}"* ]]; then #ignore sub-directories too
+            execute="N"
+            break
+        fi
+        execute="Y"
+    done
+    if [[ "${execute}" == "Y" ]]; then
+            # Note: By attempting a re-run on failure here, we can avoid rebuilding and
+            # skip running all of the tests that have already succeeded, since dune will
+            # only retry those tests that failed.
+            echo "--- Run unit tests in ${source_path}"
+            time dune runtest "${source_path}" --profile="${profile}" -j16 || \
+            (./scripts/link-coredumps.sh && \
+            echo "--- Retrying failed unit tests" && \
+            time dune runtest "${source_path}" --profile="${profile}" -j16 || \
+            (./scripts/link-coredumps.sh && false))
+    else
+        echo "Skipping ${source_path}"
+    fi
+done

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [[ $# -ne 3 ]]; then
-    echo "Usage: $0 <dune-profile> <path-to-top-level-directory> <paths-to-ignore-space-delimited>"
+    echo "Usage: $0 <dune-profile> <path-to-top-level-directory> <paths-to-ignore-semicolon-delimited>"
     exit 1
 fi
 
@@ -14,6 +14,8 @@ ignore_paths=$3
 #for some reason empty string/single space is not considered an argument when passed in dhall files
 if [[ "${ignore_paths}" == "None" ]]; then
     ignore_paths=()
+else
+    ignore_paths=($(echo $ignore_paths | tr ";" "\n"))
 fi
 
 source ~/.profile
@@ -38,7 +40,7 @@ while read -r line;
 do 
     source_path=${line%"$dune_filename"}
     execute="Y"
-    for ignore_path in ${ignore_paths}; 
+    for ignore_path in ${ignore_paths[@]};
     do
         if [[ "${source_path}" == "${ignore_path}"* ]]; then #ignore sub-directories too
             execute="N"

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -12,12 +12,12 @@ let RunInToolchain = ../../Command/RunInToolchain.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd : Text -> Text -> Size -> Command.Type = \(profile : Text) -> \(path : Text) -> \(cmd_target : Size) ->
+let buildTestCmd : Text -> Text -> Text -> Size -> Command.Type = \(profile : Text) -> \(path : Text) -> \(ignore_paths: Text) -> \(cmd_target : Size) ->
   let command_key = "unit-test-${profile}"
   in
   Command.build
     Command.Config::{
-      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev",
+      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} ${ignore_paths} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev",
       label = "${profile} unit-tests",
       key = command_key,
       target = cmd_target,
@@ -47,6 +47,6 @@ Pipeline.build
         name = "DaemonUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib" Size.XLarge
+      buildTestCmd "dev" "src/lib" "src/lib/transaction_snark/" Size.XLarge
     ]
   }

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -47,6 +47,6 @@ Pipeline.build
         name = "DaemonUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib" "src/lib/transaction_snark/;src/lib/staged_ledger/;src/lib/mina_lib/" Size.XLarge
+      buildTestCmd "dev" "src/lib" "src/lib/transaction_snark/,src/lib/staged_ledger/,src/lib/mina_lib/" Size.XLarge
     ]
   }

--- a/buildkite/src/Jobs/Test/MinaLibUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/MinaLibUnitTest.dhall
@@ -18,7 +18,7 @@ let buildTestCmd : Text -> Text -> Text -> Size -> Command.Type = \(profile : Te
   Command.build
     Command.Config::{
       commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} ${ignore_paths} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev",
-      label = "${profile} unit-tests",
+      label = "${profile} mina-lib unit-tests",
       key = command_key,
       target = cmd_target,
       docker = None Docker.Type,
@@ -34,7 +34,7 @@ Pipeline.build
         S.strictlyStart (S.contains "src/lib"),
         S.strictlyStart (S.contains "src/nonconsensus"),
         S.strictly (S.contains "Makefile"),
-        S.exactly "buildkite/src/Jobs/Test/DaemonUnitTest" "dhall",
+        S.exactly "buildkite/src/Jobs/Test/MinaLibUnitTest" "dhall",
         S.exactly "scripts/link-coredumps" "sh",
         S.exactly "buildkite/scripts/unit-test" "sh"
       ]
@@ -44,9 +44,9 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = unitDirtyWhen,
         path = "Test",
-        name = "DaemonUnitTest"
+        name = "MinaLibUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib" "src/lib/transaction_snark/;src/lib/staged_ledger/;src/lib/mina_lib/" Size.XLarge
+      buildTestCmd "dev" "src/lib/mina_lib/" "None" Size.XLarge
     ]
   }

--- a/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
@@ -12,11 +12,11 @@ let RunInToolchain = ../../Command/RunInToolchain.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd : Text -> Text -> Size -> Command.Type = \(profile : Text) -> \(path : Text) -> \(cmd_target : Size) ->
+let buildTestCmd : Text -> Text -> Text -> Size -> Command.Type = \(profile : Text) -> \(path : Text) -> \(ignore_paths: Text) -> \(cmd_target : Size) ->
   let key = "rosetta-unit-test-${profile}" in
   Command.build
     Command.Config::{
-      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev",
+      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} ${ignore_paths} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev",
       label = "Rosetta unit tests",
       key = key,
       target = cmd_target,
@@ -44,6 +44,6 @@ Pipeline.build
         name = "RosettaUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/app/rosetta" Size.Small
+      buildTestCmd "dev" "src/app/rosetta" "None" Size.Small
     ]
   }

--- a/buildkite/src/Jobs/Test/StagedLedgerUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/StagedLedgerUnitTest.dhall
@@ -18,7 +18,7 @@ let buildTestCmd : Text -> Text -> Text -> Size -> Command.Type = \(profile : Te
   Command.build
     Command.Config::{
       commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} ${ignore_paths} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev",
-      label = "${profile} unit-tests",
+      label = "${profile} staged-ledger unit-tests",
       key = command_key,
       target = cmd_target,
       docker = None Docker.Type,
@@ -34,7 +34,7 @@ Pipeline.build
         S.strictlyStart (S.contains "src/lib"),
         S.strictlyStart (S.contains "src/nonconsensus"),
         S.strictly (S.contains "Makefile"),
-        S.exactly "buildkite/src/Jobs/Test/DaemonUnitTest" "dhall",
+        S.exactly "buildkite/src/Jobs/Test/StagedLedgerUnitTest" "dhall",
         S.exactly "scripts/link-coredumps" "sh",
         S.exactly "buildkite/scripts/unit-test" "sh"
       ]
@@ -44,9 +44,9 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = unitDirtyWhen,
         path = "Test",
-        name = "DaemonUnitTest"
+        name = "StagedLedgerUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib" "src/lib/transaction_snark/;src/lib/staged_ledger/;src/lib/mina_lib/" Size.XLarge
+      buildTestCmd "dev" "src/lib/staged_ledger/" "None" Size.XLarge
     ]
   }

--- a/buildkite/src/Jobs/Test/ZkappExamplesUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappExamplesUnitTest.dhall
@@ -18,7 +18,7 @@ let buildTestCmd : Text -> Text -> Text -> Size -> Command.Type = \(profile : Te
   Command.build
     Command.Config::{
       commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/unit-test.sh ${profile} ${path} ${ignore_paths} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev",
-      label = "${profile} transaction snark unit-tests",
+      label = "${profile} zkApp examples unit-tests",
       key = command_key,
       target = cmd_target,
       docker = None Docker.Type,
@@ -34,7 +34,7 @@ Pipeline.build
         S.strictlyStart (S.contains "src/lib"),
         S.strictlyStart (S.contains "src/nonconsensus"),
         S.strictly (S.contains "Makefile"),
-        S.exactly "buildkite/src/Jobs/Test/TransactionSnarkUnitTest" "dhall",
+        S.exactly "buildkite/src/Jobs/Test/ZkappExamplesUnitTest" "dhall",
         S.exactly "scripts/link-coredumps" "sh",
         S.exactly "buildkite/scripts/unit-test" "sh"
       ]
@@ -44,9 +44,9 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = unitDirtyWhen,
         path = "Test",
-        name = "TransactionSnarkUnitTest"
+        name = "ZkappExamplesUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib/transaction_snark/" "src/lib/transaction_snark/test/zkapps_examples/" Size.XLarge
+      buildTestCmd "dev" "src/lib/transaction_snark/test/zkapps_examples/" "None" Size.XLarge
     ]
   }


### PR DESCRIPTION
Rationale: Daemon Unit tests take around 1hr 40mins these days and is usually the last one to complete. Any failure/flake in the test requires reruns and waiting for another 1hr 40mins. Splitting these will make overall CI faster (requires more resources for the new jobs though) and hopefully improve feedback cycle

Fix: Run the most time consuming libraries in separate CI jobs and the rest in one job
Filter all the libraries that have either `inline_tests` or `test` stanza defined.
The catch-all unit test job runs everything except the ones running in separate CI jobs. Added a new argument in `unit-test.sh` that takes paths to be ignored. 

Example: `./buildkite/scripts/unit-test.sh "integration_tests" "src/lib/" "src/lib/transaction_snark/;src/lib/staged_ledger/;src/lib/mina_lib/"` will run all the tests except the ones in `src/lib/transaction_snark`, `src/lib/staged_ledger/`, src/lib/mina_lib/, and their sub directories.

TODO: remove `inline_tests` from libraries that don't have any tests

Future work: Cache the build, they are repeated in each test

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
