### PR TITLE
Fix order of accounts in the ledger witness

### DIFF
--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -56,7 +56,11 @@ module Make_str (A : Wire_types.Concrete) = struct
       receiver t
       :: List.map ~f:Fee_transfer.receiver (Option.to_list t.fee_transfer)
     in
+    (* The order of this list will impact the order of new accounts in the ledger witness.
+       We use `List.rev` to have the same order than the tx application (in `apply_coinbase`)
+       where the "coinbase fee transfer" receiver is created before the "coinbase" receiver *)
     List.map account_ids ~f:(fun acct_id -> (acct_id, access_status))
+    |> List.rev
 
   let accounts_referenced t =
     List.map (account_access_statuses t Transaction_status.Applied)


### PR DESCRIPTION
With coinbase transaction:
When **both** the "coinbase" receiver and "coinbase fee transfer" receiver do not exist, those 2 accounts are created in a different order, in the ledger witness and the regular ledger.

- In the ledger witness, the order of new accounts depends on [this list](https://github.com/MinaProtocol/mina/blob/810871fceff743349bff601d32e18f9dd71207ca/src/lib/mina_base/coinbase.ml#L59).
Here the "coinbase" receiver is created first, then the "coinbase fee transfer" receiver.

- But in the [transaction application](https://github.com/MinaProtocol/mina/blob/810871fceff743349bff601d32e18f9dd71207ca/src/lib/transaction_logic/mina_transaction_logic.ml#L2348):
The "coinbase fee transfer" receiver is created first [here](https://github.com/MinaProtocol/mina/blob/810871fceff743349bff601d32e18f9dd71207ca/src/lib/transaction_logic/mina_transaction_logic.ml#L2386)
Then, a few lines below, the "coinbase" receiver is created [here](https://github.com/MinaProtocol/mina/blob/810871fceff743349bff601d32e18f9dd71207ca/src/lib/transaction_logic/mina_transaction_logic.ml#L2428)

This leads to a different merkle root hash, between the ledger witness, and the regular ledger.
The order needs to be the same in both cases.


#### Explain how you tested your changes:
This was found while fuzzing the staged ledger logic

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
