### PR TITLE
[CI] Expanded RosettaIntegrationTests dirtyWhen attribute [DEV]

### DIFF
--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -15,7 +15,7 @@ let DockerImage = ../../Command/DockerImage.dhall
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let dirtyWhen = [ 
-  S.strictlyStart (S.contains "src/app/rosetta")
+  S.strictlyStart (S.contains "src/app/rosetta"),
   S.strictlyStart (S.contains "src/lib"),
   S.strictlyStart (S.contains "src/app/archive"),
   S.strictlyStart (S.contains "src/app/cli"),

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -18,7 +18,6 @@ let dirtyWhen = [
   S.strictlyStart (S.contains "src/app/rosetta"),
   S.strictlyStart (S.contains "src/lib"),
   S.strictlyStart (S.contains "src/app/archive"),
-  S.strictlyStart (S.contains "src/app/cli"),
   S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
   S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
 ]

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -13,9 +13,14 @@ let Size = ../../Command/Size.dhall
 let Libp2p = ../../Command/Libp2pHelperBuild.dhall
 let DockerImage = ../../Command/DockerImage.dhall
 let DebianVersions = ../../Constants/DebianVersions.dhall
+
 let dirtyWhen = [ 
   S.strictlyStart (S.contains "src/app/rosetta")
-  , S.strictlyStart (S.contains "buildkite/src/Jobs/Test/RosettaIntegrationTests")
+  S.strictlyStart (S.contains "src/lib"),
+  S.strictlyStart (S.contains "src/app/archive"),
+  S.strictlyStart (S.contains "src/app/cli"),
+  S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
+  S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
 ]
 
 let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type


### PR DESCRIPTION
Explain your changes:
Expanded dirty when attribute for rosetta integration tests as per request. Now, tests are run on archive an node changes.

Explain how you tested your changes:

Run CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13656 
