### PR TITLE
[CI] Expanded RosettaIntegrationTests dirtyWhen attribute [COMP]

### DIFF
--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -15,7 +15,7 @@ let DockerImage = ../../Command/DockerImage.dhall
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let dirtyWhen = [ 
-  S.strictlyStart (S.contains "src/app/rosetta")
+  S.strictlyStart (S.contains "src/app/rosetta"),
   S.strictlyStart (S.contains "src/lib"),
   S.strictlyStart (S.contains "src/app/archive"),
   S.strictlyStart (S.contains "src/app/cli"),

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -1,0 +1,54 @@
+let Prelude = ../../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+let Size = ../../Command/Size.dhall
+let Libp2p = ../../Command/Libp2pHelperBuild.dhall
+let DockerImage = ../../Command/DockerImage.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let dirtyWhen = [ 
+  S.strictlyStart (S.contains "src/app/rosetta")
+  S.strictlyStart (S.contains "src/lib"),
+  S.strictlyStart (S.contains "src/app/archive"),
+  S.strictlyStart (S.contains "src/app/cli"),
+  S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
+  S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
+]
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
+in
+
+Pipeline.build
+  Pipeline.Config::
+    { spec =
+      JobSpec::{
+        dirtyWhen = dirtyWhen,
+        path = "Test",
+        name = "RosettaIntegrationTests"
+      }
+    , steps = [
+      Command.build
+        Command.Config::{
+          commands = [
+             Cmd.run ("export MINA_DEB_CODENAME=bullseye && source ./buildkite/scripts/export-git-env-vars.sh && echo \\\${MINA_DOCKER_TAG}") ]
+            # RunInToolchain.runInToolchain ([] : List Text) "./buildkite/scripts/build-snarkyjs-bindings.sh"
+            # [
+            Cmd.runInDocker Cmd.Docker::{image="gcr.io/o1labs-192920/mina-rosetta:\\\${MINA_DOCKER_TAG}", entrypoint=" --entrypoint buildkite/scripts/rosetta-integration-tests.sh"} "bash"
+          ],
+          label = "Rosetta integration tests Bullseye"
+          , key = "rosetta-integration-tests-bullseye"
+          , target = Size.Small
+          , depends_on = [ { name = "MinaArtifactBullseye", key = "rosetta-bullseye-docker-image" } ]
+          , soft_fail = Some (B/SoftFail.Boolean True)
+        }
+    ]
+  }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -18,7 +18,6 @@ let dirtyWhen = [
   S.strictlyStart (S.contains "src/app/rosetta"),
   S.strictlyStart (S.contains "src/lib"),
   S.strictlyStart (S.contains "src/app/archive"),
-  S.strictlyStart (S.contains "src/app/cli"),
   S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
   S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
 ]


### PR DESCRIPTION
Explain your changes:
Expanded dirty when attribute for rosetta integration tests as per request. Now, tests are run on archive an node changes.

Explain how you tested your changes:

Run CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13656 
