### PR TITLE
Fix Nix environment by bumping libp2p versions.

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -31,7 +31,7 @@ final: prev: {
   };
 
   # Jobs/Test/Libp2pUnitTest
-  libp2p_helper = final.buildGo118Module {
+  libp2p_helper = final.buildGo119Module {
     pname = "libp2p_helper";
     version = "0.1";
     src = ../src/app/libp2p_helper/src;

--- a/nix/libp2p_helper.json
+++ b/nix/libp2p_helper.json
@@ -1,1 +1,1 @@
-{"go.mod":"b6ae9a87b95e27779acf57dcd77fdcf1e7a0f093f1d86d716e6334ab77bfbf9c","go.sum":"91314d339b53b15a6896cbbfd914abf28248c3e5094185ee0a0acda877007fbc","vendorSha256":"sha256-hY3Ym19Bj5qFbjXukrt/2l39yUB1/9KehM2dMoBSXVQ="}
+{"go.mod":"d5de7e35a76f5c9ce7d6c98f0da39c763961e77b8c94761b1e89ab4bdfdc2a97","go.sum":"586fd920114d3875ec3e1d739921d77d30ad8e2f297b67781ca41d25a81b65a9","vendorSha256":"sha256-vyKrKi5bqm8Mf2rUOojSY0IXHcuNpcVNvd1Iu1RBxDo="}


### PR DESCRIPTION
Explain your changes:
*  Bump versions so that libp2p can build within Nin env again.

Explain how you tested your changes:
* CI

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
