### PR TITLE
Tweak codeowners file to require product-eng for SnarkyJS changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,7 +53,7 @@
 /src/lib/snarky_curves/ @MinaProtocol/crypto-eng-reviewers
 /src/lib/snarky_field_extensions/ @MinaProtocol/crypto-eng-reviewers
 /src/lib/snarky_group_map/ @MinaProtocol/crypto-eng-reviewers
-/src/lib/snarkyjs/ @MinaProtocol/product-eng-reviewers
+/src/lib/snarkyjs @MinaProtocol/product-eng-reviewers
 /src/lib/snarky_log/ @MinaProtocol/crypto-eng-reviewers
 /src/lib/unsigned_extended/ @MinaProtocol/crypto-eng-reviewers
 


### PR DESCRIPTION
I noticed the CODEOWNERS file doesn't behave as intended for the snarkyjs submodule. The intention is that changing the submodule requires product-eng review, but for example on this PR: https://github.com/MinaProtocol/mina/pull/13899, it seems to require protocol-eng instead.

This tiny change is an attempt to make it work.