### PR TITLE
Generic formatter Keccak-ECDSA using FFMul

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml
@@ -1610,7 +1610,7 @@ let bytes_to_standard_element (type f)
    *
    *   Note: any size (up to 2^259-1) is supported using this kind of reduction
    *)
-  let one = Element.Standard.of_limbs (Field.zero, Field.zero, Field.one) in
+  let one = Element.Standard.one (module Circuit) in
   let output = mul (module Circuit) external_checks elem one fmod in
 
   (* C3: Range check z' < f *)

--- a/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml
@@ -1584,7 +1584,6 @@ let bytes_to_standard_element (type f)
     (module Circuit : Snark_intf.Run with type field = f)
     ~(endian : Keccak.endianness) (external_checks : f External_checks.t)
     (bytestring : Circuit.Field.t list) (fmod : f standard_limbs) =
-  let open Circuit in
   assert (not (List.is_empty bytestring)) ;
   (* Make the input bytestring a little endian value *)
   let bytestring =

--- a/src/lib/crypto/kimchi_backend/gadgets/test.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/test.ml
@@ -157,7 +157,7 @@ let%test_unit "custom gates integration" =
   ()
 
 let%test_unit "keccak ecdsa converter" =
-  if tests_enabled then (
+  ( if tests_enabled then
     let (* Import the gadget test runner *)
     open Kimchi_gadgets_test_runner in
     let open Foreign_field in
@@ -358,46 +358,45 @@ let%test_unit "keccak ecdsa converter" =
         ]
     in
 
-    (* NEGATIVE TESTS *)
-    (* Fails because input is larger than 2f *)
-    assert (
-      Common.is_error (fun () ->
-          test_converter
-            [ 0x01
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFF
-            ; 0xFD
-            ; 0xFF
-            ; 0xFF
-            ; 0xF8
-            ; 0x5E
-            ]
-            Keccak.Big ) ) ;
+    (* With FFMul reduction, it does not fail to convert inputs larger than 2f *)
+    let _cs =
+      test_converter
+        [ 0x01
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFF
+        ; 0xFD
+        ; 0xFF
+        ; 0xFF
+        ; 0xF8
+        ; 0x5E
+        ]
+        Keccak.Big
+    in
 
     () ) ;
   ()


### PR DESCRIPTION
Explain your changes:
* This PR updates the converter from https://github.com/MinaProtocol/mina/pull/13819 to be more generic in the type of inputs it accepts. Now, it is not tailored for 256-bit inputs and 256-bit outputs only, but arbitrary lengths.

Explain how you tested your changes:
* Now the negative test for larger inputs works, because it reduces arbitrary lengths.

* Closes https://github.com/MinaProtocol/mina/issues/13912
