### PR TITLE
[DO NOT MERGE] Disable zkapps_examples in unit tests

### DIFF
--- a/src/lib/transaction_snark/test/dune
+++ b/src/lib/transaction_snark/test/dune
@@ -1,3 +1,4 @@
+(dirs :standard \ zkapps_examples)
 (library
   (name transaction_snark_tests)
   (public_name transaction_snark_tests)


### PR DESCRIPTION
This PR is for testing only. This will give us a baseline to see what proportion of `dev-unit-tests` is dedicated to these particular tests.

If it is as significant as expected, these tests are a prime candidate for moving to the nightly job; they still add value, but on a protocol-sanity-checking basis, rather than a per-PR basis.