### PR TITLE
Add stopDaemon to ITN GraphQL

### DIFF
--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -22,11 +22,13 @@
    ppx_deriving_yojson.runtime
    graphql_parser
    splittable_random
+   stdio
    ;; local libraries
    mina_generators
    mina_wire_types
    network_pool
    cli_lib
+   file_system
    itn_crypto
    kimchi_backend.pasta
    kimchi_backend.pasta.basic

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -28,6 +28,7 @@
    mina_wire_types
    network_pool
    cli_lib
+   exit_handlers
    file_system
    itn_crypto
    kimchi_backend.pasta

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5220,79 +5220,80 @@ module Mutations = struct
             else
               let clean_config = Option.value ~default:false clean_config in
               let conf_dir = (Mina_lib.config mina).conf_dir in
-              let%bind () =
-                if clean_config then
-                  let epoch_ledger_json_file =
-                    conf_dir ^/ "epoch_ledger.json"
-                  in
-                  let%bind () =
-                    match%bind Sys.file_exists epoch_ledger_json_file with
-                    | `Yes -> (
-                        let json =
-                          In_channel.with_file epoch_ledger_json_file
-                            ~f:(fun ic ->
-                              In_channel.input_all ic |> Yojson.Safe.from_string )
-                        in
-                        match json with
-                        | `Assoc items ->
-                            let find_uuid name =
-                              match
-                                List.Assoc.find items name ~equal:String.equal
-                              with
-                              | Some (`String s) ->
-                                  s
-                              | _ ->
-                                  failwithf
-                                    "In epoch ledger JSON file, expected to \
-                                     find entry for %s"
-                                    name ()
-                            in
-                            let staking_uuid = find_uuid "staking" in
-                            let next_uuid = find_uuid "next" in
-                            let rm_epoch_ledger uuid =
-                              let filename =
-                                conf_dir ^/ sprintf "epoch_ledger%s" uuid
+              if clean_config then
+                Exit_handlers.register_async_shutdown_handler
+                  ~logger:(Mina_lib.config mina).logger
+                  ~description:"Remove configuration data" (fun () ->
+                    let epoch_ledger_json_file =
+                      conf_dir ^/ "epoch_ledger.json"
+                    in
+                    let%bind () =
+                      match%bind Sys.file_exists epoch_ledger_json_file with
+                      | `Yes -> (
+                          let json =
+                            In_channel.with_file epoch_ledger_json_file
+                              ~f:(fun ic ->
+                                In_channel.input_all ic
+                                |> Yojson.Safe.from_string )
+                          in
+                          match json with
+                          | `Assoc items ->
+                              let find_uuid name =
+                                match
+                                  List.Assoc.find items name ~equal:String.equal
+                                with
+                                | Some (`String s) ->
+                                    s
+                                | _ ->
+                                    failwithf
+                                      "In epoch ledger JSON file, expected to \
+                                       find entry for %s"
+                                      name ()
                               in
-                              Sys.remove filename
-                            in
-                            let%bind () = rm_epoch_ledger staking_uuid in
-                            rm_epoch_ledger next_uuid
-                        | _ ->
-                            failwith "Expected JSON record" )
-                    | `No | `Unknown ->
-                        Deferred.unit
-                  in
-                  let files_to_remove =
-                    [ "epoch_ledger.json"; "root" ^/ "root" ]
-                  in
-                  let%bind () =
-                    Deferred.List.iter files_to_remove ~f:(fun file ->
-                        let path = conf_dir ^/ file in
+                              let staking_uuid = find_uuid "staking" in
+                              let next_uuid = find_uuid "next" in
+                              let rm_epoch_ledger uuid =
+                                let filename =
+                                  conf_dir ^/ sprintf "epoch_ledger%s" uuid
+                                in
+                                Sys.remove filename
+                              in
+                              let%bind () = rm_epoch_ledger staking_uuid in
+                              rm_epoch_ledger next_uuid
+                          | _ ->
+                              failwith "Expected JSON record" )
+                      | `No | `Unknown ->
+                          Deferred.unit
+                    in
+                    let files_to_remove =
+                      [ "epoch_ledger.json"; "root" ^/ "root" ]
+                    in
+                    let%bind () =
+                      Deferred.List.iter files_to_remove ~f:(fun file ->
+                          let path = conf_dir ^/ file in
+                          match%bind Sys.file_exists path with
+                          | `Yes ->
+                              Sys.remove path
+                          | `No | `Unknown ->
+                              Deferred.unit )
+                    in
+                    let dirs_to_remove =
+                      [ "root" ^/ "snarked_ledger"; "frontier" ]
+                    in
+                    Deferred.List.iter dirs_to_remove ~f:(fun dir ->
+                        let path = conf_dir ^/ dir in
                         match%bind Sys.file_exists path with
                         | `Yes ->
-                            Sys.remove path
+                            File_system.remove_dir path
                         | `No | `Unknown ->
-                            Deferred.unit )
-                  in
-                  let dirs_to_remove =
-                    [ "root" ^/ "snarked_ledger"; "frontier" ]
-                  in
-                  Deferred.List.iter dirs_to_remove ~f:(fun dir ->
-                      let path = conf_dir ^/ dir in
-                      match%bind Sys.file_exists path with
-                      | `Yes ->
-                          File_system.remove_dir path
-                      | `No | `Unknown ->
-                          Deferred.unit )
-                else Deferred.unit
-              in
+                            Deferred.unit ) ) ;
               let s =
-                if clean_config then
-                  sprintf
-                    "Cleaned configuration directory %s, stopping daemon in %d \
-                     seconds"
-                    conf_dir delay_secs
-                else sprintf "Stopping daemon in %d seconds" delay_secs
+                let clean_str =
+                  if clean_config then
+                    sprintf ", will clean configuration directory %s" conf_dir
+                  else ""
+                in
+                sprintf "Stopping daemon in %d seconds%s" delay_secs clean_str
               in
               let delay_span = delay_secs |> Float.of_int |> Time.Span.of_sec in
               Async.Deferred.don't_wait_for

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5253,10 +5253,14 @@ module Mutations = struct
                               let staking_uuid = find_uuid "staking" in
                               let next_uuid = find_uuid "next" in
                               let rm_epoch_ledger uuid =
-                                let filename =
+                                let path =
                                   conf_dir ^/ sprintf "epoch_ledger%s" uuid
                                 in
-                                Sys.remove filename
+                                match%bind Sys.file_exists path with
+                                | `Yes ->
+                                    File_system.remove_dir path
+                                | `No | `Unknown ->
+                                    Deferred.unit
                               in
                               let%bind () = rm_epoch_ledger staking_uuid in
                               rm_epoch_ledger next_uuid

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5198,9 +5198,13 @@ module Mutations = struct
                      "Seconds to delay before stopping daemon (minimum %d)"
                      min_delay_secs )
                 ~typ:int
+            ; arg "cleanConfig"
+                ~doc:
+                  "Whether to remove saved configuration data (default false)"
+                ~typ:bool
             ]
         ~typ:(non_null string)
-        ~resolve:(fun { ctx = with_seq_no, _; _ } () delay_secs ->
+        ~resolve:(fun { ctx = with_seq_no, mina; _ } () delay_secs clean_config ->
           O1trace.thread "itn_stop_daemon"
           @@ fun () ->
           if not with_seq_no then return @@ Error "Missing sequence information"
@@ -5214,7 +5218,82 @@ module Mutations = struct
                    (sprintf "Delay of %d seconds is less than minimum %d"
                       delay_secs min_delay_secs )
             else
-              let s = sprintf "Stopping daemon in %d seconds" delay_secs in
+              let clean_config = Option.value ~default:false clean_config in
+              let conf_dir = (Mina_lib.config mina).conf_dir in
+              let%bind () =
+                if clean_config then
+                  let epoch_ledger_json_file =
+                    conf_dir ^/ "epoch_ledger.json"
+                  in
+                  let%bind () =
+                    match%bind Sys.file_exists epoch_ledger_json_file with
+                    | `Yes -> (
+                        let json =
+                          In_channel.with_file epoch_ledger_json_file
+                            ~f:(fun ic ->
+                              In_channel.input_all ic |> Yojson.Safe.from_string )
+                        in
+                        match json with
+                        | `Assoc items ->
+                            let find_uuid name =
+                              match
+                                List.Assoc.find items name ~equal:String.equal
+                              with
+                              | Some (`String s) ->
+                                  s
+                              | _ ->
+                                  failwithf
+                                    "In epoch ledger JSON file, expected to \
+                                     find entry for %s"
+                                    name ()
+                            in
+                            let staking_uuid = find_uuid "staking" in
+                            let next_uuid = find_uuid "next" in
+                            let rm_epoch_ledger uuid =
+                              let filename =
+                                conf_dir ^/ sprintf "epoch_ledger%s" uuid
+                              in
+                              Sys.remove filename
+                            in
+                            let%bind () = rm_epoch_ledger staking_uuid in
+                            rm_epoch_ledger next_uuid
+                        | _ ->
+                            failwith "Expected JSON record" )
+                    | `No | `Unknown ->
+                        Deferred.unit
+                  in
+                  let files_to_remove =
+                    [ "epoch_ledger.json"; "root" ^/ "root" ]
+                  in
+                  let%bind () =
+                    Deferred.List.iter files_to_remove ~f:(fun file ->
+                        let path = conf_dir ^/ file in
+                        match%bind Sys.file_exists path with
+                        | `Yes ->
+                            Sys.remove path
+                        | `No | `Unknown ->
+                            Deferred.unit )
+                  in
+                  let dirs_to_remove =
+                    [ "root" ^/ "snarked_ledger"; "frontier" ]
+                  in
+                  Deferred.List.iter dirs_to_remove ~f:(fun dir ->
+                      let path = conf_dir ^/ dir in
+                      match%bind Sys.file_exists path with
+                      | `Yes ->
+                          File_system.remove_dir path
+                      | `No | `Unknown ->
+                          Deferred.unit )
+                else Deferred.unit
+              in
+              let s =
+                if clean_config then
+                  sprintf
+                    "Cleaned configuration directory %s, stopping daemon in %d \
+                     seconds"
+                    conf_dir delay_secs
+                else sprintf "Stopping daemon in %d seconds" delay_secs
+              in
               let delay_span = delay_secs |> Float.of_int |> Time.Span.of_sec in
               Async.Deferred.don't_wait_for
                 (let%bind () = Async.after delay_span in


### PR DESCRIPTION
Add `stopDaemon` as an endpoint to the ITN GraphQL server.

Arguments:
- `delaySeconds` : how long to pause before stopping daemon (needed to allow response)
- `cleanConfig` : removes some data from the config dir

Tested by @georgeee (who also fixed a bug in my original code).

Closes #13758.
