### PR TITLE
Improvements for ITN orchestrator

### DIFF
--- a/src/app/itn_orchestrator/genqlient.graphql
+++ b/src/app/itn_orchestrator/genqlient.graphql
@@ -27,3 +27,7 @@ query slotsWon() {
 mutation updateGating($input: GatingUpdate!) {
     updateGating(input: $input)
 }
+
+mutation stopDaemon($delay: Int) {
+    stopDaemon(delaySeconds: $delay)
+}

--- a/src/app/itn_orchestrator/genqlient.graphql
+++ b/src/app/itn_orchestrator/genqlient.graphql
@@ -28,6 +28,6 @@ mutation updateGating($input: GatingUpdate!) {
     updateGating(input: $input)
 }
 
-mutation stopDaemon($delay: Int) {
-    stopDaemon(delaySeconds: $delay)
+mutation stopDaemon($clean: Boolean, $delay: Int) {
+    stopDaemon(cleanConfig: $clean, delaySeconds: $delay)
 }

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -102,6 +102,9 @@ type mutation {
 
   """Stop the Mina daemon"""
   stopDaemon(
+    """Whether to remove saved configuration data (default false)"""
+    cleanConfig: Boolean
+
     """Seconds to delay before stopping daemon (minimum 5)"""
     delaySeconds: Int
   ): String!

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -99,6 +99,12 @@ type mutation {
     """Greatest log ID to be deleted"""
     endLogId: Int!
   ): String!
+
+  """Stop the Mina daemon"""
+  stopDaemon(
+    """Seconds to delay before stopping daemon (minimum 5)"""
+    delaySeconds: Int
+  ): String!
 }
 
 """Network identifiers for another protocol participant"""

--- a/src/app/itn_orchestrator/src/data.go
+++ b/src/app/itn_orchestrator/src/data.go
@@ -43,13 +43,13 @@ type Config struct {
 	UptimeBucket       *storage.BucketHandle
 	Sk                 ed25519.PrivateKey
 	Log                logging.StandardLogger
-	Daemon             string
 	MinaExec           string
 	NodeData           map[NodeAddress]NodeEntry
 	SlotDurationMs     int
 	GenesisTimestamp   time.Time
 	ControlExec        string
 	StopDaemonDelaySec int
+	FundDaemonPorts    []string
 }
 
 type OutputF = func(name string, value any, multiple bool, sensitive bool)

--- a/src/app/itn_orchestrator/src/data.go
+++ b/src/app/itn_orchestrator/src/data.go
@@ -39,16 +39,17 @@ type NodeEntry struct {
 }
 
 type Config struct {
-	Ctx              context.Context
-	UptimeBucket     *storage.BucketHandle
-	Sk               ed25519.PrivateKey
-	Log              logging.StandardLogger
-	Daemon           string
-	MinaExec         string
-	NodeData         map[NodeAddress]NodeEntry
-	SlotDurationMs   int
-	GenesisTimestamp time.Time
-	ControlExec      string
+	Ctx                context.Context
+	UptimeBucket       *storage.BucketHandle
+	Sk                 ed25519.PrivateKey
+	Log                logging.StandardLogger
+	Daemon             string
+	MinaExec           string
+	NodeData           map[NodeAddress]NodeEntry
+	SlotDurationMs     int
+	GenesisTimestamp   time.Time
+	ControlExec        string
+	StopDaemonDelaySec int
 }
 
 type OutputF = func(name string, value any, multiple bool, sensitive bool)

--- a/src/app/itn_orchestrator/src/data.go
+++ b/src/app/itn_orchestrator/src/data.go
@@ -54,7 +54,17 @@ type Config struct {
 
 type OutputF = func(name string, value any, multiple bool, sensitive bool)
 
+type ActionIO struct {
+	Params json.RawMessage
+	Output OutputF
+}
+
 type Action interface {
 	Run(config Config, params json.RawMessage, output OutputF) error
 	Name() string
+}
+
+type BatchAction interface {
+	Action
+	RunMany(config Config, actionIOs []ActionIO) error
 }

--- a/src/app/itn_orchestrator/src/graphql.go
+++ b/src/app/itn_orchestrator/src/graphql.go
@@ -201,9 +201,9 @@ func UpdateGatingGql(config Config, nodeAddress NodeAddress, input GatingUpdate)
 	return nil
 }
 
-func StopDaemonGql(config Config, nodeAddress NodeAddress, delaySec int) (string, error) {
+func StopDaemonGql(config Config, nodeAddress NodeAddress, clean bool, delaySec int) (string, error) {
 	resp, err := wrapGqlRequest(config, nodeAddress, func(client graphql.Client) (any, error) {
-		return stopDaemon(config.Ctx, client, delaySec)
+		return stopDaemon(config.Ctx, client, clean, delaySec)
 	})
 	if err != nil {
 		return "", fmt.Errorf("error stoping daemon on %s (delay %d): %v", nodeAddress, delaySec, err)

--- a/src/app/itn_orchestrator/src/graphql.go
+++ b/src/app/itn_orchestrator/src/graphql.go
@@ -200,3 +200,13 @@ func UpdateGatingGql(config Config, nodeAddress NodeAddress, input GatingUpdate)
 	// TODO do something with resp.UpdateGating?
 	return nil
 }
+
+func StopDaemonGql(config Config, nodeAddress NodeAddress, delaySec int) (string, error) {
+	resp, err := wrapGqlRequest(config, nodeAddress, func(client graphql.Client) (any, error) {
+		return stopDaemon(config.Ctx, client, delaySec)
+	})
+	if err != nil {
+		return "", fmt.Errorf("error stoping daemon on %s (delay %d): %v", nodeAddress, delaySec, err)
+	}
+	return resp.(*stopDaemonResponse).StopDaemon, nil
+}

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -140,43 +140,58 @@ func main() {
 		OutputCache: outCache,
 	}
 	inDecoder := json.NewDecoder(os.Stdin)
+	outputF := func(step int) func(string, any, bool, bool) {
+		return func(name string, value_ any, multiple bool, sensitive bool) {
+			value, err := json.Marshal(value_)
+			if err != nil {
+				log.Errorf("Error marshalling value %s for step %d: %v", name, step, err)
+				os.Exit(7)
+				return
+			}
+			if _, has := outCache[""][step]; !has {
+				outCache[""][step] = map[string]lib.OutputCacheEntry{}
+			}
+			prev, has := outCache[""][step][name]
+			if has {
+				if multiple && prev.Multi {
+					outCache[""][step][name] = lib.OutputCacheEntry{Multi: true, Values: append(prev.Values, value)}
+				} else {
+					log.Errorf("Error outputing multiple values for %s on step %d", name, step)
+					os.Exit(8)
+					return
+				}
+			} else {
+				outCache[""][step][name] = lib.OutputCacheEntry{Multi: multiple, Values: []json.RawMessage{value}}
+			}
+			if !sensitive {
+				json, err := json.Marshal(lib.Output{Name: name, Multi: multiple, Value: value, Step: step})
+				if err != nil {
+					log.Errorf("Error marshalling output %s for step %d: %v", name, step, err)
+					os.Exit(8)
+					return
+				}
+				_, err = os.Stdout.Write(append(json, '\n'))
+				if err != nil {
+					log.Errorf("Error writing output %s for step %d: %v", name, step, err)
+					os.Exit(8)
+					return
+				}
+			}
+		}
+	}
 	step := 0
-	outputF := func(name string, value_ any, multiple bool, sensitive bool) {
-		value, err := json.Marshal(value_)
+	var prevAction lib.BatchAction
+	var actionAccum []lib.ActionIO
+	handlePrevAction := func() {
+		log.Infof("Performing steps %s (%d-%d)", prevAction.Name(), step-len(actionAccum), step-1)
+		err = prevAction.RunMany(config, actionAccum)
 		if err != nil {
-			log.Errorf("Error marshalling value %s for step %d: %v", name, step, err)
-			os.Exit(7)
+			log.Errorf("Error running steps %d-%d: %v", step-len(actionAccum), step-1, err)
+			os.Exit(9)
 			return
 		}
-		if _, has := outCache[""][step]; !has {
-			outCache[""][step] = map[string]lib.OutputCacheEntry{}
-		}
-		prev, has := outCache[""][step][name]
-		if has {
-			if multiple && prev.Multi {
-				outCache[""][step][name] = lib.OutputCacheEntry{Multi: true, Values: append(prev.Values, value)}
-			} else {
-				log.Errorf("Error outputing multiple values for %s on step %d", name, step)
-				os.Exit(8)
-				return
-			}
-		} else {
-			outCache[""][step][name] = lib.OutputCacheEntry{Multi: multiple, Values: []json.RawMessage{value}}
-		}
-		if !sensitive {
-			json, err := json.Marshal(lib.Output{Name: name, Multi: multiple, Value: value, Step: step})
-			if err != nil {
-				log.Errorf("Error marshalling output %s for step %d: %v", name, step, err)
-				os.Exit(8)
-				return
-			}
-			_, err = os.Stdout.Write(append(json, '\n'))
-			if err != nil {
-				log.Errorf("Error writing output %s for step %d: %v", name, step, err)
-				os.Exit(8)
-				return
-			}
-		}
+		prevAction = nil
+		actionAccum = nil
 	}
 	for {
 		var commandOrComment CommandOrComment
@@ -192,19 +207,40 @@ func main() {
 			continue
 		}
 		cmd := *commandOrComment.command
+		if prevAction != nil && prevAction.Name() != cmd.Action {
+			handlePrevAction()
+		}
 		params, err := lib.ResolveParams(rconfig, step, cmd.Params)
 		if err != nil {
 			log.Errorf("Error resolving params for step %d: %v", step, err)
 			os.Exit(6)
 			return
 		}
-		log.Infof("Performing step %s (%d)", cmd.Action, step)
-		err = actions[cmd.Action].Run(config, params, outputF)
-		if err != nil {
-			log.Errorf("Error running step %d: %v", step, err)
-			os.Exit(9)
+		action := actions[cmd.Action]
+		if action == nil {
+			log.Errorf("Unknown action name: %d", cmd.Action)
+			os.Exit(10)
 			return
 		}
+		batchAction, isBatchAction := action.(lib.BatchAction)
+		if isBatchAction {
+			prevAction = batchAction
+			actionAccum = append(actionAccum, lib.ActionIO{
+				Params: params,
+				Output: outputF(step),
+			})
+		} else {
+			log.Infof("Performing step %s (%d)", cmd.Action, step)
+			err = action.Run(config, params, outputF(step))
+			if err != nil {
+				log.Errorf("Error running step %d: %v", step, err)
+				os.Exit(9)
+				return
+			}
+		}
 		step++
+	}
+	if prevAction != nil {
+		handlePrevAction()
 	}
 }

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -40,6 +40,7 @@ func init() {
 	addAction(actions, lib.JoinAction{})
 	addAction(actions, lib.SampleAction{})
 	addAction(actions, lib.ExceptAction{})
+	addAction(actions, lib.StopDaemonAction{})
 
 }
 
@@ -128,6 +129,9 @@ func main() {
 	}
 	if config.MinaExec == "" {
 		config.MinaExec = "mina"
+	}
+	if config.StopDaemonDelaySec == 0 {
+		config.StopDaemonDelaySec = 10
 	}
 	outCache := map[string]map[int]map[string]lib.OutputCacheEntry{
 		"": {},

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -49,8 +49,8 @@ type AppConfig struct {
 	LogFile          string        `json:",omitempty"`
 	Key              itn_json_types.Ed25519Privkey
 	UptimeBucket     string
-	Daemon           string `json:",omitempty"`
-	MinaExec         string `json:",omitempty"`
+	FundDaemonPorts  []string `json:",omitempty"`
+	MinaExec         string   `json:",omitempty"`
 	SlotDurationMs   int
 	GenesisTimestamp itn_json_types.Time
 	ControlExec      string `json:",omitempty"`
@@ -120,7 +120,7 @@ func main() {
 		UptimeBucket:     client.Bucket(appConfig.UptimeBucket),
 		Sk:               ed25519.PrivateKey(appConfig.Key),
 		Log:              log,
-		Daemon:           appConfig.Daemon,
+		FundDaemonPorts:  appConfig.FundDaemonPorts,
 		MinaExec:         appConfig.MinaExec,
 		NodeData:         nodeData,
 		SlotDurationMs:   appConfig.SlotDurationMs,

--- a/src/app/itn_orchestrator/src/stop.go
+++ b/src/app/itn_orchestrator/src/stop.go
@@ -41,12 +41,13 @@ var _ Action = StopAction{}
 
 type StopDaemonParams struct {
 	Nodes []NodeAddress `json:"nodes"`
+	Clean bool          `json:"clean,omitempty"`
 }
 
 func StopDaemon(config Config, params StopDaemonParams) error {
 	errs := []error{}
 	for _, addr := range params.Nodes {
-		resp, err := StopDaemonGql(config, addr, config.StopDaemonDelaySec)
+		resp, err := StopDaemonGql(config, addr, params.Clean, config.StopDaemonDelaySec)
 		if err == nil {
 			config.Log.Infof("stopped daemon on %s: %s", addr, resp)
 		} else {

--- a/src/app/itn_orchestrator/src/stop.go
+++ b/src/app/itn_orchestrator/src/stop.go
@@ -38,3 +38,37 @@ func (StopAction) Run(config Config, rawParams json.RawMessage, output OutputF) 
 func (StopAction) Name() string { return "stop" }
 
 var _ Action = StopAction{}
+
+type StopDaemonParams struct {
+	Nodes []NodeAddress `json:"nodes"`
+}
+
+func StopDaemon(config Config, params StopDaemonParams) error {
+	errs := []error{}
+	for _, addr := range params.Nodes {
+		resp, err := StopDaemonGql(config, addr, config.StopDaemonDelaySec)
+		if err == nil {
+			config.Log.Infof("stopped daemon on %s: %s", addr, resp)
+		} else {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+type StopDaemonAction struct{}
+
+func (StopDaemonAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params StopDaemonParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return StopDaemon(config, params)
+}
+
+func (StopDaemonAction) Name() string { return "stop-daemon" }
+
+var _ Action = StopDaemonAction{}

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -70,7 +70,7 @@ func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddre
 	if err == nil {
 		config.Log.Infof("scheduled zkapp batch %d with tps %f for %s: %s", batchIx, tps, nodeAddress, handle)
 	}
-	return handle, nil
+	return handle, err
 }
 
 func zkappParams(params ZkappCommandParams, tps float64) (zkappsToDeploy int, accountQueueSize int) {


### PR DESCRIPTION
This PR delivers a number of improvements to orchestrator/generator.

Explain your changes:
* Add support for `stop-daemon` command to orchestrator and generator
* Add support for parallel execution of funding commands
   * Significantly speeds up start of an experiment (from 2 hours to ~20 minutes)
* Add support for use of multiple daemons in funding step
   * Increases reliability of funding step
* Add support for `max-cost` transactions to generator
* Fix a bug in zkapp command handling on orchestrator

Explain how you tested your changes:
* Tested by repeatedly running the tool on a cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None

* Closes #0000
