### PR TITLE
[ITN] optimize zkapp generator for large ledgers

### DIFF
--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1122,13 +1122,14 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t )
-    ?account_state_tbl ~ledger ?protocol_state_view ?vk () =
+    ?account_state_tbl ~ledger ?protocol_state_view ?vk ?available_public_keys
+    () =
   let open Quickcheck.Let_syntax in
   let fee_payer_pk =
     Signature_lib.Public_key.compress fee_payer_keypair.public_key
   in
   let fee_payer_acct_id = Account_id.create fee_payer_pk Token_id.default in
-  let ledger_accounts = Ledger.to_list_sequential ledger in
+  let ledger_accounts = lazy (Ledger.to_list_sequential ledger) in
   (* table of public keys to accounts, updated when generating each account_update
 
      a Map would be more principled, but threading that map through the code
@@ -1137,11 +1138,11 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   let account_state_tbl =
     Option.value account_state_tbl ~default:(Account_id.Table.create ())
   in
-  (* make sure all ledger keys are in the keymap *)
-  List.iter ledger_accounts ~f:(fun acct ->
-      let acct_id = Account.identifier acct in
-      (*Initialize account states*)
-      if not limited then
+  if not limited then
+    (* make sure all ledger keys are in the keymap *)
+    List.iter (Lazy.force ledger_accounts) ~f:(fun acct ->
+        let acct_id = Account.identifier acct in
+        (*Initialize account states*)
         Account_id.Table.update account_state_tbl acct_id ~f:(function
           | None ->
               if Account_id.equal acct_id fee_payer_acct_id then
@@ -1160,28 +1161,37 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   (* table of public keys not in the ledger, to be used for new zkapp_command
      we have the corresponding private keys, so we can create signatures for those new zkapp_command
   *)
-  let ledger_account_ids =
-    List.map ledger_accounts ~f:Account.identifier |> Account_id.Set.of_list
-  in
-  let ledger_account_list =
-    Account_id.Set.union_list
-      [ ledger_account_ids; Account_id.Set.of_hashtbl_keys account_state_tbl ]
-    |> Account_id.Set.to_list
-  in
-  let ledger_pk_list =
-    List.map ledger_account_list ~f:(fun account_id ->
-        Account_id.public_key account_id )
-  in
-  let ledger_pk_set =
-    Signature_lib.Public_key.Compressed.Set.of_list ledger_pk_list
-  in
   let available_public_keys =
-    let tbl = Signature_lib.Public_key.Compressed.Table.create () in
-    Signature_lib.Public_key.Compressed.Map.iter_keys keymap ~f:(fun pk ->
-        if not (Signature_lib.Public_key.Compressed.Set.mem ledger_pk_set pk)
-        then
-          Signature_lib.Public_key.Compressed.Table.add_exn tbl ~key:pk ~data:() ) ;
-    tbl
+    match available_public_keys with
+    | Some pks ->
+        pks
+    | None ->
+        let ledger_account_ids =
+          List.map (Lazy.force ledger_accounts) ~f:Account.identifier
+          |> Account_id.Set.of_list
+        in
+        let ledger_account_list =
+          Account_id.Set.union_list
+            [ ledger_account_ids
+            ; Account_id.Set.of_hashtbl_keys account_state_tbl
+            ]
+          |> Account_id.Set.to_list
+        in
+        let ledger_pk_list =
+          List.map ledger_account_list ~f:(fun account_id ->
+              Account_id.public_key account_id )
+        in
+        let ledger_pk_set =
+          Signature_lib.Public_key.Compressed.Set.of_list ledger_pk_list
+        in
+        let tbl = Signature_lib.Public_key.Compressed.Table.create () in
+        Signature_lib.Public_key.Compressed.Map.iter_keys keymap ~f:(fun pk ->
+            if
+              not (Signature_lib.Public_key.Compressed.Set.mem ledger_pk_set pk)
+            then
+              Signature_lib.Public_key.Compressed.Table.add_exn tbl ~key:pk
+                ~data:() ) ;
+        tbl
   in
   (* account ids seen, to generate receipt chain hash precondition only if
      a account_update with a given account id has not been encountered before

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -66,6 +66,7 @@ val gen_zkapp_command_from :
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
+  -> ?available_public_keys:unit Signature_lib.Public_key.Compressed.Table.t
   -> unit
   -> Zkapp_command.t Quickcheck.Generator.t
 

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -66,7 +66,7 @@ val gen_zkapp_command_from :
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
-  -> ?available_public_keys:unit Signature_lib.Public_key.Compressed.Table.t
+  -> ?available_public_keys:Signature_lib.Public_key.Compressed.Hash_set.t
   -> unit
   -> Zkapp_command.t Quickcheck.Generator.t
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4736,10 +4736,9 @@ module Mutations = struct
               ~wait_span ~stop_signal ~stop_time ~uuid keypairs )
           else return ()
         in
-        let%bind accounts = Ledger.to_list ledger in
-        [%log debug] "The accounts were not in the best tip $ledger, try again"
-          ~metadata:
-            [ ("ledger", `List (List.map accounts ~f:Account.to_yojson)) ] ;
+        [%log debug]
+          "Some deployed zkApp accounts weren't found in the best tip ledger, \
+           trying again" ;
         let%bind () =
           Async.after
             (Time.Span.of_ms

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4854,8 +4854,8 @@ module Mutations = struct
                           let unused_pks =
                             List.map unused_keypairs
                               ~f:(fun { public_key; _ } ->
-                                (Public_key.compress public_key, ()) )
-                            |> Public_key.Compressed.Table.of_alist_exn
+                                Public_key.compress public_key )
+                            |> Public_key.Compressed.Hash_set.of_list
                           in
                           let `VK vk, `Prover prover =
                             Transaction_snark.For_tests.create_trivial_snapp

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4851,6 +4851,12 @@ module Mutations = struct
                                 (Public_key.compress public_key, private_key) )
                             |> Public_key.Compressed.Map.of_alist_exn
                           in
+                          let unused_pks =
+                            List.map unused_keypairs
+                              ~f:(fun { public_key; _ } ->
+                                (Public_key.compress public_key, ()) )
+                            |> Public_key.Compressed.Table.of_alist_exn
+                          in
                           let `VK vk, `Prover prover =
                             Transaction_snark.For_tests.create_trivial_snapp
                               ~constraint_constants ()
@@ -4959,7 +4965,8 @@ module Mutations = struct
                                             ~fee_payer_keypair:fee_payer ~keymap
                                             ~account_state_tbl
                                             ~generate_new_accounts ~ledger ~vk
-                                            () )
+                                            ~available_public_keys:unused_pks ()
+                                        )
                                         ~size:1
                                         ~random:
                                           (Splittable_random.State.create


### PR DESCRIPTION
When testing zkapp generator on a cluster, it was found that the tool wasn't working as expected. First, it wasn't going beyond deploying of zkapp accounts. Later it was discovered that even if it deployed all the zkapps, generation produced long async jobs of roughly `75 s`. duration.

Explain your changes:
* Remove unnecessary log line which was causing the first issue
* Rewrite zkapp generator to make no use of ledger when being called from ITN Graphql code

Explain how you tested your changes:
* Tested on a cluster launched with 140k ledger
* Confirmed that zkapp txs are sent even after deployment of zkapps

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?

* Closes #13917