### PR TITLE
Pickles: change Opt.t variant names

### DIFF
--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -257,9 +257,9 @@ let combined_evaluation (type f)
   let mul_and_add ~(acc : Field.t) ~(xi : Field.t)
       (fx : (Field.t, Boolean.var) Opt.t) : Field.t =
     match fx with
-    | None ->
+    | Nothing ->
         acc
-    | Some fx ->
+    | Just fx ->
         fx + (xi * acc)
     | Maybe (b, fx) ->
         Field.if_ b ~then_:(fx + (xi * acc)) ~else_:acc
@@ -267,9 +267,9 @@ let combined_evaluation (type f)
   with_label __LOC__ (fun () ->
       Pcs_batch.combine_split_evaluations ~mul_and_add
         ~init:(function
-          | Some x ->
+          | Just x ->
               x
-          | None ->
+          | Nothing ->
               Field.zero
           | Maybe (b, x) ->
               (b :> Field.t) * x )

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -122,11 +122,11 @@ let rec pack :
           pack ~zero ~one p spec t_constant_opt t )
   | Opt { inner; dummy1; dummy2; flag = _; bool = _ } -> (
       match t with
-      | None ->
+      | Nothing ->
           let t_constant_opt = Option.map t_constant_opt ~f:(fun _ -> dummy1) in
           Array.append [| zero |]
             (pack ~zero ~one p inner t_constant_opt dummy2)
-      | Some x ->
+      | Just x ->
           let t_constant_opt =
             Option.map ~f:(fun x -> Option.value_exn x) t_constant_opt
           in
@@ -280,10 +280,10 @@ let rec etyp :
         let (T (a, f_a, f_a')) = etyp e inner in
         let opt_map ~f1 ~f2 (x : _ Opt.t) : _ Opt.t =
           match x with
-          | None ->
-              None
-          | Some x ->
-              Some (f1 x)
+          | Nothing ->
+              Opt.nothing
+          | Just x ->
+              Opt.just (f1 x)
           | Maybe (b, x) ->
               Maybe (f2 b, f1 x)
         in

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1709,7 +1709,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                   ; alpha = plonk0.alpha
                                   ; beta = chal plonk0.beta
                                   ; gamma = chal plonk0.gamma
-                                  ; joint_combiner = Opt.None
+                                  ; joint_combiner = Opt.nothing
                                   }
                               }
                           ; sponge_digest_before_evaluations =

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -934,9 +934,9 @@ struct
             Array.iter ~f:(fun x -> Sponge.absorb sponge (`Field x))
           in
           match opt with
-          | None ->
+          | Nothing ->
               ()
-          | Some (x1, x2) ->
+          | Just (x1, x2) ->
               absorb x1 ; absorb x2
           | Maybe (b, (x1, x2)) ->
               (* Cache the sponge state before *)
@@ -1041,15 +1041,15 @@ struct
           let a =
             Evals.In_circuit.to_list e
             |> List.map ~f:(function
-                 | None ->
+                 | Nothing ->
                      [||]
-                 | Some a ->
-                     Array.map a ~f:Opt.some
+                 | Just a ->
+                     Array.map a ~f:Opt.just
                  | Maybe (b, a) ->
                      Array.map a ~f:(Opt.maybe b) )
           in
           let v =
-            List.append sg_evals ([| Some x_hat |] :: [| Some ft |] :: a)
+            List.append sg_evals ([| Opt.just x_hat |] :: [| Opt.just ft |] :: a)
           in
           Common.combined_evaluation (module Impl) ~xi v
         in
@@ -1223,7 +1223,7 @@ struct
         ~proof
         ~plonk:
           (Composition_types.Step.Proof_state.Deferred_values.Plonk.In_circuit
-           .to_wrap ~opt_none:Opt.None ~false_:Boolean.false_
+           .to_wrap ~opt_none:Opt.nothing ~false_:Boolean.false_
              unfinalized.deferred_values.plonk )
     in
     with_label __LOC__ (fun () ->

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -217,9 +217,9 @@ let wrap_main
                      (Plonk_verification_key_evals.Step.map
                         ~f:Inner_curve.constant ~f_opt:(function
                        | None ->
-                           Opt.None
+                           Opt.nothing
                        | Some x ->
-                           Opt.Some (Inner_curve.constant x) ) ) ) )
+                           Opt.just (Inner_curve.constant x) ) ) ) )
         in
         let prev_step_accs =
           with_label __LOC__ (fun () ->

--- a/src/lib/pickles_types/opt.mli
+++ b/src/lib/pickles_types/opt.mli
@@ -3,8 +3,8 @@
 (** {1 Type} *)
 
 type ('a, 'bool) t =
-  | Some of 'a
-  | None
+  | Just of 'a
+  | Nothing
   | Maybe of 'bool * 'a
       (** Representation of a value that can either be [None] or [Some]
                             depending on the actual value of its first parameter. *)
@@ -12,9 +12,9 @@ type ('a, 'bool) t =
 
 (** {1 Constructors} *)
 
-val some : 'a -> ('a, 'bool) t
+val just : 'a -> ('a, 'bool) t
 
-val none : ('a, 'bool) t
+val nothing : ('a, 'bool) t
 
 val maybe : 'bool -> 'a -> ('a, 'bool) t
 
@@ -30,12 +30,12 @@ val map : ('a, 'bool) t -> f:('a -> 'b) -> ('b, 'bool) t
   **)
 val value_exn : ('a, 'bool) t -> 'a
 
-(** [to_option_unsafe opt] is [Some v] when [opt] if [Some v] or [Maybe (_, v)],
+(** [to_option_unsafe opt] is [Some v] when [opt] if [Just v] or [Maybe (_, v)],
     [None] otherwise *)
 val to_option_unsafe : ('a, 'bool) t -> 'a option
 
-(** [to_option bool_opt] maps {!const:Some} and {!const:None} to their
-    identically named constructors in {!type:Option.t}.
+(** [to_option bool_opt] maps {!const:Just}, resp. {!const:Nothing}, to
+    {!const:Option.Some}, resp. {!const:Option.None}.
     
     The difference with {!val:to_option_unsafe} lies in the treatment of
     {!const:Maybe}, where [Maybe(false, x)] maps to {!val:Option.None} and
@@ -46,20 +46,20 @@ val to_option : ('a, bool) t -> 'a option
 (** [of_option o] is a straightforward injection of a regular {!type:Option.t}
     value [o] into type {!type:t}.
 
-    {!const:Option.Some} maps to {!const:Some} and {!const:Option.None} to
-    {!const:None}.
+    {!const:Option.Some} maps to {!const:Just} and {!const:Option.None} to
+    {!const:Nothing}.
 *)
 val of_option : 'a option -> ('a, 'bool) t
 
-(** [lift ?on_maybe ~none f] lifts the application of function [f] to a value
+(** [lift ?on_maybe ~nothing f] lifts the application of function [f] to a value
     of type !{type:('a, 'bool) t} as follows:
-    - [Some v]: apply [f] to contained value [v]
-    - [None]: return the value specified by [none]
+    - [Just v]: apply [f] to contained value [v]
+    - [Nothing]: return the value specified by [nothing]
     - [Maybe (b, v)]: defaults to the case [Some v] when [on_maybe] is
       unspecified, otherwise apply [on_maybe b v]
 *)
 val lift :
-  ?on_maybe:('a -> 'b -> 'c) -> none:'c -> ('b -> 'c) -> ('b, 'a) t -> 'c
+  ?on_maybe:('a -> 'b -> 'c) -> nothing:'c -> ('b -> 'c) -> ('b, 'a) t -> 'c
 
 module Flag : sig
   type t = Yes | No | Maybe [@@deriving sexp, compare, yojson, hash, equal]

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -747,9 +747,8 @@ module Evals = struct
         ; range_check_lookup_selector
         ; foreign_field_mul_lookup_selector
         } =
-      let some x = Opt.Some x in
       let always_present =
-        List.map ~f:some
+        List.map ~f:Opt.just
           ( [ z
             ; generic_selector
             ; poseidon_selector
@@ -834,8 +833,8 @@ module Evals = struct
         ; lookup_table
         ]
       in
-      let some x = Opt.Some x in
-      List.map ~f:some always_present
+
+      List.map ~f:Opt.just always_present
       @ optional_gates
       @ Vector.to_list lookup_sorted
       @ [ runtime_lookup_table


### PR DESCRIPTION
To avoid confusion with the pre-existiong Option.Some and Option.None variants, use Just and Nothing (borrowed from Haskell's Maybe type) instead.

Fixes #13948 