### PR TITLE
Hard fork integration test

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -504,7 +504,7 @@ let setup_daemon logger =
             Daemon.daemonize ~allow_threads_to_have_been_created:true
               ~redirect_stdout:`Dev_null ?cd:working_dir
               ~redirect_stderr:`Dev_null () )
-          else ignore (Option.map working_dir ~f:Caml.Sys.chdir)
+          else Option.iter working_dir ~f:Caml.Sys.chdir
         in
         Stdout_log.setup log_json log_level ;
         (* 512MB logrotate max size = 1GB max filesystem usage *)
@@ -1011,7 +1011,7 @@ let setup_daemon logger =
                 | Sexp.List sexps ->
                     `List (List.map ~f:Error_json.sexp_record_to_yojson sexps)
                 | Sexp.Atom _ ->
-                    failwith "Expeted a sexp list" )
+                    failwith "Expected a sexp list" )
           in
           let o1trace context =
             Execution_context.find_local context O1trace.local_storage_id

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -670,7 +670,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
             let%bind max_slot =
               query_db ~f:(fun db -> Sql.Block.get_max_slot db ())
             in
-            [%log info] "Maximum global slot since genesis in blocks is %Ldd"
+            [%log info] "Maximum global slot since genesis in blocks is %Ld"
               max_slot ;
             try_slot ~logger pool max_slot
       in
@@ -918,11 +918,12 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
       let%bind max_canonical_slot =
         query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
       in
-      let%bind genesis_snarked_ledger_hash_str =
-        query_db ~f:(fun db -> Sql.Block.genesis_snarked_ledger db ())
-      in
-      let genesis_snarked_ledger_hash =
-        Frozen_ledger_hash.of_base58_check_exn genesis_snarked_ledger_hash_str
+      let%bind genesis_snarked_ledger_hash =
+        let%map hash_str =
+          query_db ~f:(fun db ->
+              Sql.Block.genesis_snarked_ledger db input.start_slot_since_genesis )
+        in
+        Frozen_ledger_hash.of_base58_check_exn hash_str
       in
       let incr_checkpoint_target () =
         Option.iter !checkpoint_target ~f:(fun target ->

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -1,0 +1,297 @@
+(* hard_fork.ml -- run nodes with fork config, epoch ledger *)
+
+open Core
+open Integration_test_lib
+open Mina_base
+
+module Make (Inputs : Intf.Test.Inputs_intf) = struct
+  open Inputs
+  open Engine
+  open Dsl
+
+  open Test_common.Make (Inputs)
+
+  type network = Network.t
+
+  type node = Network.Node.t
+
+  type dsl = Dsl.t
+
+  let fork_config : Runtime_config.Fork_config.t =
+    { previous_state_hash =
+        "3NKSiqFZQmAS12U8qeX4KNo8b4199spwNh7mrSs4Ci1Vacpfix2Q"
+    ; previous_length = 300000
+    ; previous_global_slot = 500000
+    }
+
+  let config =
+    let open Test_config in
+    let staking_accounts : Test_Account.t list =
+      [ { account_name = "node-a-key"; balance = "400000"; timing = Untimed }
+      ; { account_name = "node-b-key"; balance = "300000"; timing = Untimed }
+      ; { account_name = "snark-node-key1"; balance = "0"; timing = Untimed }
+      ; { account_name = "snark-node-key2"; balance = "0"; timing = Untimed }
+      ]
+    in
+    let staking : Test_config.Epoch_data.Data.t =
+      let epoch_seed =
+        Epoch_seed.to_base58_check Snark_params.Tick.Field.(of_int 42)
+      in
+      let epoch_ledger = staking_accounts in
+      { epoch_ledger; epoch_seed }
+    in
+    (* next accounts contains staking accounts, with balances changed, one new account *)
+    let next_accounts : Test_Account.t list =
+      [ { account_name = "node-a-key"; balance = "200000"; timing = Untimed }
+      ; { account_name = "node-b-key"; balance = "350000"; timing = Untimed }
+      ; { account_name = "snark-node-key1"; balance = "0"; timing = Untimed }
+      ; { account_name = "snark-node-key2"; balance = "0"; timing = Untimed }
+      ; { account_name = "fish1"; balance = "100"; timing = Untimed }
+      ]
+    in
+    let next : Test_config.Epoch_data.Data.t =
+      let epoch_seed =
+        Epoch_seed.to_base58_check Snark_params.Tick.Field.(of_int 1729)
+      in
+      let epoch_ledger = next_accounts in
+      { epoch_ledger; epoch_seed }
+    in
+    { default with
+      requires_graphql = true
+    ; epoch_data = Some { staking; next = Some next }
+    ; genesis_ledger =
+        (* the genesis ledger contains the staking ledger plus some other accounts *)
+        staking_accounts
+        @ [ { account_name = "fish1"; balance = "100"; timing = Untimed }
+          ; { account_name = "fish2"; balance = "100"; timing = Untimed }
+          ; { account_name = "fish3"; balance = "1000"; timing = Untimed }
+          ]
+    ; block_producers =
+        [ { node_name = "node-a"; account_name = "node-a-key" }
+        ; { node_name = "node-b"; account_name = "node-b-key" }
+        ]
+    ; snark_coordinator =
+        Some
+          { node_name = "snark-node"
+          ; account_name = "snark-node-key1"
+          ; worker_nodes = 4
+          }
+    ; snark_worker_fee = "0.0002"
+    ; num_archive_nodes = 1
+    ; proof_config =
+        { proof_config_default with
+          work_delay = Some 1
+        ; transaction_capacity =
+            Some Runtime_config.Proof_keys.Transaction_capacity.small
+        ; fork = Some fork_config
+        }
+    }
+
+  let run network t =
+    let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    let all_nodes = Network.all_nodes network in
+    let%bind () =
+      wait_for t
+        (Wait_condition.nodes_to_initialize (Core.String.Map.data all_nodes))
+    in
+    let node_a =
+      Core.String.Map.find_exn (Network.block_producers network) "node-a"
+    in
+    let node_b =
+      Core.String.Map.find_exn (Network.block_producers network) "node-b"
+    in
+    let fish1 =
+      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish1"
+    in
+    let fish2 =
+      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish2"
+    in
+    let sender = fish2.keypair in
+    let receiver = fish1.keypair in
+    [%log info] "extra genesis keypairs: %s"
+      (List.to_string [ fish1.keypair; fish2.keypair ]
+         ~f:(fun { Signature_lib.Keypair.public_key; _ } ->
+           public_key |> Signature_lib.Public_key.to_bigstring
+           |> Bigstring.to_string ) ) ;
+    let receiver_pub_key =
+      receiver.public_key |> Signature_lib.Public_key.compress
+    in
+    let sender_pub_key =
+      sender.public_key |> Signature_lib.Public_key.compress
+    in
+    let sender_account_id = Account_id.create sender_pub_key Token_id.default in
+    let%bind { nonce = sender_current_nonce; _ } =
+      Integration_test_lib.Graphql_requests.must_get_account_data ~logger
+        (Network.Node.get_ingress_uri node_b)
+        ~account_id:sender_account_id
+    in
+    let amount = Currency.Amount.of_mina_string_exn "10" in
+    let fee = Currency.Fee.of_mina_string_exn "1" in
+    let memo = "" in
+    let valid_until = Mina_numbers.Global_slot_since_genesis.max_value in
+    let payload =
+      let payment_payload =
+        { Payment_payload.Poly.receiver_pk = receiver_pub_key; amount }
+      in
+      let body = Signed_command_payload.Body.Payment payment_payload in
+      let common =
+        { Signed_command_payload.Common.Poly.fee
+        ; fee_payer_pk = sender_pub_key
+        ; nonce = sender_current_nonce
+        ; valid_until
+        ; memo = Signed_command_memo.create_from_string_exn memo
+        }
+      in
+      { Signed_command_payload.Poly.common; body }
+    in
+    let raw_signature =
+      Signed_command.sign_payload sender.private_key payload
+      |> Signature.Raw.encode
+    in
+    let%bind zkapp_command_create_accounts =
+      (* construct a Zkapp_command.t *)
+      let zkapp_keypairs =
+        List.init 3 ~f:(fun _ -> Signature_lib.Keypair.create ())
+      in
+      let constraint_constants = Network.constraint_constants network in
+      let amount = Currency.Amount.of_mina_int_exn 10 in
+      let nonce = Account.Nonce.zero in
+      let memo =
+        Signed_command_memo.create_from_string_exn "Zkapp create account"
+      in
+      let fee = Currency.Fee.of_nanomina_int_exn 20_000_000 in
+      let (zkapp_command_spec : Transaction_snark.For_tests.Deploy_snapp_spec.t)
+          =
+        { sender = (fish1.keypair, nonce)
+        ; fee
+        ; fee_payer = None
+        ; amount
+        ; zkapp_account_keypairs = zkapp_keypairs
+        ; memo
+        ; new_zkapp_account = true
+        ; snapp_update = Account_update.Update.dummy
+        ; preconditions = None
+        ; authorization_kind = Signature
+        }
+      in
+      return
+      @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants
+           zkapp_command_spec
+    in
+    let wait_for_zkapp zkapp_command =
+      let with_timeout =
+        let soft_slots = 4 in
+        let soft_timeout = Network_time_span.Slots soft_slots in
+        let hard_timeout = Network_time_span.Slots (soft_slots * 2) in
+        Wait_condition.with_timeouts ~soft_timeout ~hard_timeout
+      in
+      let%map () =
+        wait_for t @@ with_timeout
+        @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures:false
+             ~zkapp_command
+      in
+      [%log info] "ZkApp transaction included in transition frontier"
+    in
+    let%bind () =
+      section "send a single signed payment between 2 fish accounts"
+        (let%bind { hash; _ } =
+           Integration_test_lib.Graphql_requests.must_send_payment_with_raw_sig
+             (Network.Node.get_ingress_uri node_b)
+             ~logger
+             ~sender_pub_key:(Signed_command_payload.fee_payer_pk payload)
+             ~receiver_pub_key:(Signed_command_payload.receiver_pk payload)
+             ~amount ~fee
+             ~nonce:(Signed_command_payload.nonce payload)
+             ~memo ~valid_until ~raw_signature
+         in
+         wait_for t
+           (Wait_condition.signed_command_to_be_included_in_frontier
+              ~txn_hash:hash ~node_included_in:(`Node node_b) ) )
+    in
+    let%bind () =
+      section_hard "Send a zkApp transaction to create zkApp accounts"
+        (send_zkapp ~logger
+           (Network.Node.get_ingress_uri node_a)
+           zkapp_command_create_accounts )
+    in
+    let%bind () =
+      section_hard
+        "Wait for zkapp to create accounts to be included in transition \
+         frontier"
+        (wait_for_zkapp zkapp_command_create_accounts)
+    in
+    let%bind () =
+      section_hard "send out txns to fill up the snark ledger"
+        (let receiver = node_a in
+         let%bind receiver_pub_key = pub_key_of_node receiver in
+         let sender = node_b in
+         let%bind sender_pub_key = pub_key_of_node sender in
+         let%bind _ =
+           send_payments ~logger ~sender_pub_key ~receiver_pub_key
+             ~amount:Currency.Amount.one ~fee ~node:sender 10
+         in
+         wait_for t
+           (Wait_condition.ledger_proofs_emitted_since_genesis
+              ~test_config:config ~num_proofs:1 ) )
+    in
+    let%bind () =
+      section_hard "checking height, global slot since genesis in best chain"
+        (let%bind blocks =
+           Integration_test_lib.Graphql_requests.must_get_best_chain ~logger
+             (Network.Node.get_ingress_uri node_a)
+         in
+         let%bind () =
+           Malleable_error.List.iter blocks
+             ~f:(fun
+                  { height
+                  ; global_slot_since_genesis
+                  ; global_slot_since_hard_fork
+                  ; _
+                  }
+                ->
+               [%log info]
+                 "Examining block in best tip with height = %Ld, global slot \
+                  since hard fork = %d, global slot since genesis = %d"
+                 (Unsigned.UInt32.to_int64 height)
+                 (Mina_numbers.Global_slot_since_genesis.to_int
+                    global_slot_since_genesis )
+                 (Mina_numbers.Global_slot_since_hard_fork.to_int
+                    global_slot_since_hard_fork ) ;
+               let bad_height =
+                 Unsigned.UInt32.to_int height <= fork_config.previous_length
+               in
+               (* for now, we accept the "link block" with a global slot since genesis equal to the previous global slot
+                  see issue #13897
+               *)
+               let bad_slot =
+                 Mina_numbers.Global_slot_since_genesis.to_int
+                   global_slot_since_genesis
+                 < fork_config.previous_global_slot
+               in
+               if bad_height && bad_slot then
+                 Malleable_error.hard_error
+                   (Error.of_string
+                      "Block height and slot not greater than in fork config" )
+               else if bad_height then
+                 Malleable_error.hard_error
+                   (Error.of_string
+                      "Block height not greater than in fork config" )
+               else if bad_slot then
+                 Malleable_error.hard_error
+                   (Error.of_string "Block slot not greater than in fork config")
+               else return () )
+         in
+         [%log info]
+           "All blocks in best tip have a height and global slot since genesis \
+            derived from hard fork config" ;
+         return () )
+    in
+    section_hard "running replayer"
+      (let%bind logs =
+         Network.Node.run_replayer
+           ~start_slot_since_genesis:fork_config.previous_global_slot ~logger
+           (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
+       in
+       check_replayer_logs ~logger logs )
+end

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -67,6 +67,7 @@ let tests : test list =
     , (module Block_production_priority.Make : Intf.Test.Functor_intf) )
   ; ("snarkyjs", (module Snarkyjs.Make : Intf.Test.Functor_intf))
   ; ("block-reward", (module Block_reward_test.Make : Intf.Test.Functor_intf))
+  ; ("hard-fork", (module Hard_fork.Make : Intf.Test.Functor_intf))
   ]
 
 let report_test_errors ~log_error_set ~internal_error_set =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -716,10 +716,11 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     let proof = Blockchain_snark.Blockchain.proof block in
                     Interruptible.lift (Deferred.return proof)
                       (Deferred.never ())
-                | Error _ ->
+                | Error err ->
                     [%log error]
                       "Aborting block production: cannot generate a genesis \
-                       proof" ;
+                       proof"
+                      ~metadata:[ ("error", Error_json.error_to_yojson err) ] ;
                     Interruptible.lift (Deferred.never ()) (Deferred.return ())
                 )
               else

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -236,6 +236,8 @@ module type State_hooks = sig
 
   val genesis_winner : Public_key.Compressed.t * Private_key.t
 
+  val genesis_winner_account : Mina_base.Account.t
+
   module For_tests : sig
     val gen_consensus_state :
          constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -3385,6 +3385,12 @@ module Make_str (A : Wire_types.Concrete) = struct
 
       let genesis_winner = Vrf.Precomputed.genesis_winner
 
+      let genesis_winner_account =
+        Mina_base.Account.create
+          (Mina_base.Account_id.create (fst genesis_winner)
+             Mina_base.Token_id.default )
+          (Currency.Balance.of_nanomina_int_exn 1000)
+
       let check_block_data ~constants ~logger (block_data : Block_data.t)
           global_slot =
         if

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -169,11 +169,10 @@ module Constraint_constants = struct
 
       let fork =
         Some
-          { Fork_constants.previous_length =
-              Mina_numbers.Length.of_int fork_previous_length
-          ; previous_state_hash =
+          { Fork_constants.previous_state_hash =
               Data_hash_lib.State_hash.of_base58_check_exn
                 fork_previous_state_hash
+          ; previous_length = Mina_numbers.Length.of_int fork_previous_length
           ; previous_global_slot =
               Mina_numbers.Global_slot_since_genesis.of_int
                 fork_previous_global_slot

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -255,16 +255,17 @@ module Ledger = struct
             Genesis_constants.Proof_level.equal Full proof_level
       in
       if add_genesis_winner_account then
-        let pk, _ = Mina_state.Consensus_state_hooks.genesis_winner in
+        let genesis_winner_pk, _ =
+          Mina_state.Consensus_state_hooks.genesis_winner
+        in
         match accounts with
         | (_, account) :: _
-          when Public_key.Compressed.equal (Account.public_key account) pk ->
+          when Public_key.Compressed.equal
+                 (Account.public_key account)
+                 genesis_winner_pk ->
             accounts
         | _ ->
-            ( None
-            , Account.create
-                (Account_id.create pk Token_id.default)
-                (Currency.Balance.of_nanomina_int_exn 1000) )
+            (None, Mina_state.Consensus_state_hooks.genesis_winner_account)
             :: accounts
       else accounts
     in
@@ -460,7 +461,7 @@ module Epoch_data = struct
           Ledger.load ~proof_level ~genesis_dir ~logger ~constraint_constants
             ~ledger_name_prefix ledger
         in
-        let%bind staking, config' =
+        let%bind staking, staking_config =
           let%map staking_ledger, config', ledger_file =
             load_ledger config.staking.ledger
           in
@@ -472,7 +473,7 @@ module Epoch_data = struct
             }
           , { config.staking with ledger = config' } )
         in
-        let%map next, config'' =
+        let%map next, next_config =
           match config.next with
           | None ->
               [%log trace]
@@ -491,9 +492,19 @@ module Epoch_data = struct
               , Some { Runtime_config.Epoch_data.Data.ledger = config''; seed }
               )
         in
+        (* the staking ledger and the next ledger, if it exists,
+           should have the genesis winner account as the first account, under
+           the conditions where the genesis ledger has that account (proof level
+           is Full, or we've specified `add_genesis_winner = true`
+
+           because the ledger is lazy, we don't want to force it in order to
+           check that invariant
+        *)
         ( Some { Consensus.Genesis_epoch_data.staking; next }
-        , Some { Runtime_config.Epoch_data.staking = config'; next = config'' }
-        )
+        , Some
+            { Runtime_config.Epoch_data.staking = staking_config
+            ; next = next_config
+            } )
 end
 
 (* This hash encodes the data that determines a genesis proof:

--- a/src/lib/integration_test_cloud_engine/dune
+++ b/src/lib/integration_test_cloud_engine/dune
@@ -41,6 +41,7 @@
    mina_version
    timeout_lib
    mina_numbers
+   mina_state
    mina_stdlib
    mina_transaction
    file_system

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -160,7 +160,7 @@ module Node = struct
     Out_channel.with_file data_file ~f:(fun out_ch ->
         Out_channel.output_string out_ch data )
 
-  let run_replayer ~logger (t : t) =
+  let run_replayer ?(start_slot_since_genesis = 0) ~logger (t : t) =
     [%log info] "Running replayer on archived data (node: %s, container: %s)"
       (List.hd_exn t.pod_ids) mina_archive_container_id ;
     let open Malleable_error.Let_syntax in
@@ -170,8 +170,9 @@ module Node = struct
     in
     let replayer_input =
       sprintf
-        {| { "genesis_ledger": { "accounts": %s, "add_genesis_winner": true }} |}
-        accounts
+        {| { "start_slot_since_genesis": %d,
+             "genesis_ledger": { "accounts": %s, "add_genesis_winner": true }} |}
+        start_slot_since_genesis accounts
     in
     let dest = "replayer-input.json" in
     let%bind _res =

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -112,6 +112,7 @@ module Network_config = struct
       =
     let { requires_graphql
         ; genesis_ledger
+        ; epoch_data
         ; block_producers
         ; snark_coordinator
         ; snark_worker_fee
@@ -157,42 +158,32 @@ module Network_config = struct
     let keypairs =
       List.take
         (* the first keypair is the genesis winner and is assumed to be untimed. Therefore dropping it, and not assigning it to any block producer *)
-        (List.drop
-           (Array.to_list (Lazy.force Key_gen.Sample_keypairs.keypairs))
-           1 )
+        (List.tl_exn
+           (Array.to_list (Lazy.force Key_gen.Sample_keypairs.keypairs)) )
         (List.length genesis_ledger)
     in
-    let labeled_accounts :
-        ( Runtime_config.Accounts.single
-        * (Public_key.Compressed.t * Private_key.t) )
-        String.Map.t =
-      String.Map.empty
+    let runtime_timing_of_timing = function
+      | Account.Timing.Untimed ->
+          None
+      | Timed t ->
+          Some
+            { Runtime_config.Accounts.Single.Timed.initial_minimum_balance =
+                t.initial_minimum_balance
+            ; cliff_time = t.cliff_time
+            ; cliff_amount = t.cliff_amount
+            ; vesting_period = t.vesting_period
+            ; vesting_increment = t.vesting_increment
+            }
     in
-    let rec add_accounts mp zip =
-      match zip with
-      | [] ->
-          mp
-      | hd :: tl ->
-          let ( { Test_config.Test_Account.balance; account_name; timing }
-              , (pk, sk) ) =
-            hd
-          in
-          let timing =
-            match timing with
-            | Account.Timing.Untimed ->
-                None
-            | Timed t ->
-                Some
-                  { Runtime_config.Accounts.Single.Timed.initial_minimum_balance =
-                      t.initial_minimum_balance
-                  ; cliff_time = t.cliff_time
-                  ; cliff_amount = t.cliff_amount
-                  ; vesting_period = t.vesting_period
-                  ; vesting_increment = t.vesting_increment
-                  }
-          in
+    let add_accounts accounts_and_keypairs =
+      List.map accounts_and_keypairs
+        ~f:(fun
+             ( { Test_config.Test_Account.balance; account_name; timing }
+             , (pk, sk) )
+           ->
+          let timing = runtime_timing_of_timing timing in
           let default = Runtime_config.Accounts.Single.default in
-          let acct =
+          let account =
             { default with
               pk = Public_key.Compressed.to_string pk
             ; sk = Some (Private_key.to_base58_check sk)
@@ -203,17 +194,21 @@ module Network_config = struct
             ; timing
             }
           in
-          add_accounts
-            (String.Map.add_exn mp ~key:account_name ~data:(acct, (pk, sk)))
-            tl
+          (account_name, account) )
     in
-    let genesis_ledger_accounts =
-      add_accounts labeled_accounts (List.zip_exn genesis_ledger keypairs)
-    in
+    let genesis_accounts_and_keys = List.zip_exn genesis_ledger keypairs in
+    let genesis_ledger_accounts = add_accounts genesis_accounts_and_keys in
     (* DAEMON CONFIG *)
     let constraint_constants =
       Genesis_ledger_helper.make_constraint_constants
         ~default:Genesis_constants.Constraint_constants.compiled proof_config
+    in
+    let ledger_is_prefix ledger1 ledger2 =
+      List.is_prefix ledger2 ~prefix:ledger1
+        ~equal:(fun
+                 ({ account_name = name1; _ } : Test_config.Test_Account.t)
+                 ({ account_name = name2; _ } : Test_config.Test_Account.t)
+               -> String.equal name1 name2 )
     in
     let runtime_config =
       { Runtime_config.daemon =
@@ -241,9 +236,7 @@ module Network_config = struct
           Some
             { base =
                 Accounts
-                  (let tuplist = String.Map.data genesis_ledger_accounts in
-                   List.map tuplist ~f:(fun tup ->
-                       let acct, _ = tup in
+                  (List.map genesis_ledger_accounts ~f:(fun (_name, acct) ->
                        acct ) )
             ; add_genesis_winner = None
             ; num_accounts = None
@@ -251,7 +244,92 @@ module Network_config = struct
             ; hash = None
             ; name = None
             }
-      ; epoch_data = None
+      ; epoch_data =
+          (* each staking epoch ledger account must also be a genesis ledger account, though
+             the balance may be different; the converse is not necessarily true, since
+             an account may have been added after the last epoch ledger was taken
+
+             each staking epoch ledger account must also be in the next epoch ledger, if provided
+
+             if provided, each next_epoch_ledger account must be in the genesis ledger
+
+             in all ledgers, the accounts must be in the same order, so that accounts will
+             be in the same leaf order
+          *)
+          Option.map epoch_data ~f:(fun { staking = staking_ledger; next } ->
+              let genesis_winner_account : Runtime_config.Accounts.single =
+                Runtime_config.Accounts.Single.of_account
+                  Mina_state.Consensus_state_hooks.genesis_winner_account
+                |> Result.ok_or_failwith
+              in
+              let ledger_of_epoch_accounts
+                  (epoch_accounts : Test_config.Test_Account.t list) =
+                let epoch_ledger_accounts =
+                  List.map epoch_accounts
+                    ~f:(fun { account_name; balance; timing } ->
+                      let balance = Balance.of_mina_string_exn balance in
+                      let timing = runtime_timing_of_timing timing in
+                      let genesis_account =
+                        match
+                          List.Assoc.find genesis_ledger_accounts account_name
+                            ~equal:String.equal
+                        with
+                        | Some acct ->
+                            acct
+                        | None ->
+                            failwithf
+                              "Epoch ledger account %s not in genesis ledger"
+                              account_name ()
+                      in
+                      { genesis_account with balance; timing } )
+                in
+                (* because we run integration tests with Proof_level = Full, the winner account
+                   gets added to the genesis ledger
+
+                   there isn't a corresponding mechanism to add the winner account to epoch
+                   ledgers, so we add it explicitly here
+
+                   `add_genesis_winner` in the record below has no effect, it's ignored in
+                   Runtime_config.Epoch_data.to_yojson, which is used to create the config file
+                *)
+                ( { base =
+                      Accounts (genesis_winner_account :: epoch_ledger_accounts)
+                  ; add_genesis_winner = None (* no effect *)
+                  ; num_accounts = None
+                  ; balances = []
+                  ; hash = None
+                  ; name = None
+                  }
+                  : Runtime_config.Ledger.t )
+              in
+              let staking =
+                let ({ epoch_ledger; epoch_seed }
+                      : Test_config.Epoch_data.Data.t ) =
+                  staking_ledger
+                in
+                if not (ledger_is_prefix epoch_ledger genesis_ledger) then
+                  failwith "Staking epoch ledger not a prefix of genesis ledger" ;
+                let ledger = ledger_of_epoch_accounts epoch_ledger in
+                let seed = epoch_seed in
+                ({ ledger; seed } : Runtime_config.Epoch_data.Data.t)
+              in
+              let next =
+                Option.map next ~f:(fun { epoch_ledger; epoch_seed } ->
+                    if
+                      not
+                        (ledger_is_prefix staking_ledger.epoch_ledger
+                           epoch_ledger )
+                    then
+                      failwith
+                        "Staking epoch ledger not a prefix of next epoch ledger" ;
+                    if not (ledger_is_prefix epoch_ledger genesis_ledger) then
+                      failwith
+                        "Next epoch ledger not a prefix of genesis ledger" ;
+                    let ledger = ledger_of_epoch_accounts epoch_ledger in
+                    let seed = epoch_seed in
+                    ({ ledger; seed } : Runtime_config.Epoch_data.Data.t) )
+              in
+              ({ staking; next } : Runtime_config.Epoch_data.t) )
       }
     in
     let genesis_constants =
@@ -274,10 +352,14 @@ module Network_config = struct
     in
     let block_producer_configs =
       List.map block_producers ~f:(fun node ->
-          let _, key_tup =
-            match String.Map.find genesis_ledger_accounts node.account_name with
-            | Some acct ->
-                acct
+          let keypair =
+            match
+              List.find genesis_accounts_and_keys
+                ~f:(fun ({ account_name; _ }, _keypair) ->
+                  String.equal account_name node.account_name )
+            with
+            | Some (_acct, keypair) ->
+                keypair
             | None ->
                 let failstring =
                   Format.sprintf
@@ -289,7 +371,7 @@ module Network_config = struct
                 failwith failstring
           in
           block_producer_config node.node_name
-            (mk_net_keypair node.account_name key_tup) )
+            (mk_net_keypair node.account_name keypair) )
     in
     let mina_archive_schema = "create_schema.sql" in
     let long_commit_id =
@@ -308,11 +390,10 @@ module Network_config = struct
       ]
     in
     let genesis_keypairs =
-      String.Map.of_alist_exn
-        (List.map (String.Map.to_alist genesis_ledger_accounts)
-           ~f:(fun element ->
-             let kp_name, (_, (pk, sk)) = element in
-             (kp_name, mk_net_keypair kp_name (pk, sk)) ) )
+      List.fold genesis_accounts_and_keys ~init:String.Map.empty
+        ~f:(fun map ({ account_name; _ }, (pk, sk)) ->
+          let keypair = mk_net_keypair account_name (pk, sk) in
+          String.Map.add_exn map ~key:account_name ~data:keypair )
     in
     let snark_coordinator_config =
       match snark_coordinator with

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -4,10 +4,10 @@
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../graphql-ppx-config.inc ../../../graphql_schema.json)
- (preprocess (pps 
-    ppx_base ppx_fields_conv ppx_mina ppx_version ppx_let 
-    ppx_inline_test ppx_custom_printf ppx_deriving.std ppx_sexp_conv ppx_compare 
-    ppx_assert lens.ppx_deriving ppx_pipebang 
+ (preprocess (pps
+    ppx_base ppx_fields_conv ppx_mina ppx_version ppx_let
+    ppx_inline_test ppx_custom_printf ppx_deriving.std ppx_sexp_conv ppx_compare
+    ppx_assert lens.ppx_deriving ppx_pipebang
     graphql_ppx -- %{read-lines:../../graphql-ppx-config.inc}))
  (libraries
    ;; opam libraries

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -13,7 +13,13 @@ type metrics_t =
   }
 
 type best_chain_block =
-  { state_hash : string; command_transaction_count : int; creator_pk : string }
+  { state_hash : string
+  ; command_transaction_count : int
+  ; creator_pk : string
+  ; height : Mina_numbers.Length.t
+  ; global_slot_since_genesis : Mina_numbers.Global_slot_since_genesis.t
+  ; global_slot_since_hard_fork : Mina_numbers.Global_slot_since_hard_fork.t
+  }
 
 (* TODO: malleable error -> or error *)
 
@@ -54,7 +60,11 @@ module Engine = struct
       val dump_archive_data :
         logger:Logger.t -> t -> data_file:string -> unit Malleable_error.t
 
-      val run_replayer : logger:Logger.t -> t -> string Malleable_error.t
+      val run_replayer :
+           ?start_slot_since_genesis:int
+        -> logger:Logger.t
+        -> t
+        -> string Malleable_error.t
 
       val dump_mina_logs :
         logger:Logger.t -> t -> log_file:string -> unit Malleable_error.t

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -18,6 +18,15 @@ module Test_Account = struct
     }
 end
 
+module Epoch_data = struct
+  module Data = struct
+    (* the seed is a field value in Base58Check format *)
+    type t = { epoch_ledger : Test_Account.t list; epoch_seed : string }
+  end
+
+  type t = { staking : Data.t; next : Data.t option }
+end
+
 module Block_producer_node = struct
   type t = { node_name : string; account_name : string }
 end
@@ -38,6 +47,7 @@ type t =
         (* temporary flag to enable/disable graphql ingress deployments *)
         (* testnet topography *)
   ; genesis_ledger : Test_Account.t list
+  ; epoch_data : Epoch_data.t option
   ; block_producers : Block_producer_node.t list
   ; snark_coordinator : Snark_coordinator_node.t option
   ; snark_worker_fee : string
@@ -71,6 +81,7 @@ let default =
       true
       (* require_graphql maybe should just be phased out, because it always needs to be enable.  Now with the graphql polling engine, everything will definitely fail if graphql is not enabled.  But even before that, most tests relied on some sort of graphql interaction *)
   ; genesis_ledger = []
+  ; epoch_data = None
   ; block_producers = []
   ; snark_coordinator = None
   ; snark_worker_fee = "0.025"

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -526,6 +526,9 @@ module Accounts = struct
       }
     [@@deriving bin_io_unversioned, sexp]
 
+    let of_account : Mina_base.Account.t -> (t, string) Result.t =
+      Json_layout.Accounts.Single.of_account
+
     let to_json_layout : t -> Json_layout.Accounts.Single.t = Fn.id
 
     let of_json_layout : Json_layout.Accounts.Single.t -> (t, string) Result.t =

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -221,8 +221,8 @@ end = struct
           in
           failwithf
             !"Sparse_ledger.get: Bad index %i. Expected a%s, but got a%s at \
-              depth %i. Tree = %{sexp:t}"
-            idx expected_kind kind (depth - i) t ()
+              depth %i. Tree = %{sexp:t}, tree_depth = %d"
+            idx expected_kind kind (depth - i) t depth ()
     in
     go (depth - 1) tree
 


### PR DESCRIPTION
Add an integration test which uses a hard fork runtime config. The integration test framework adds the ability to specify staking and next epoch ledgers, with consistency checks against the genesis ledger. The genesis winner account is automatically added to those epoch ledgers.

The test executes a payment, a zkApp, and some additional payments to force getting a SNARKed ledger. It then checks the blocks in the best tip, to see if the height and global slot since genesis are based on the hard fork config.

The replayer is modified to look for a SNARKed ledger hash that can be from a block produced by the genesis winner, other than the genesis block. 

The goal is to run this in nightly CI, not PR CI. There was a successful run of the test here: https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/30059#018a2e06-eb9b-4286-95a1-fc4df1534894

Closes #13381.

New issue to add to nightly CI: 