### PR TITLE
[Nix] revert update of the go compiler version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,9 @@ endif
 ocaml_checks: ocaml_version ocaml_word_size check_opam_switch
 
 libp2p_helper:
+ifeq (, $(MINA_LIBP2P_HELPER_PATH))
 	make -C src/app/libp2p_helper
+endif
 
 genesis_ledger: ocaml_checks
 	$(info Building runtime_genesis_ledger)

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -31,7 +31,7 @@ final: prev: {
   };
 
   # Jobs/Test/Libp2pUnitTest
-  libp2p_helper = final.buildGo119Module {
+  libp2p_helper = final.buildGo118Module {
     pname = "libp2p_helper";
     version = "0.1";
     src = ../src/app/libp2p_helper/src;

--- a/nix/libp2p_helper.json
+++ b/nix/libp2p_helper.json
@@ -1,1 +1,1 @@
-{"go.mod":"d5de7e35a76f5c9ce7d6c98f0da39c763961e77b8c94761b1e89ab4bdfdc2a97","go.sum":"586fd920114d3875ec3e1d739921d77d30ad8e2f297b67781ca41d25a81b65a9","vendorSha256":"sha256-vyKrKi5bqm8Mf2rUOojSY0IXHcuNpcVNvd1Iu1RBxDo="}
+{"go.mod":"b6ae9a87b95e27779acf57dcd77fdcf1e7a0f093f1d86d716e6334ab77bfbf9c","go.sum":"91314d339b53b15a6896cbbfd914abf28248c3e5094185ee0a0acda877007fbc","vendorSha256":"sha256-hY3Ym19Bj5qFbjXukrt/2l39yUB1/9KehM2dMoBSXVQ="}


### PR DESCRIPTION
Explain your changes:
* Because of the revert of the libp2p update, Nix configuration is broken again. This fixes the issue by reverting the Go compiler version back to 1.18

Explain how you tested your changes:
* Built Nix env.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
