### PR TITLE
Add chain id to node status service

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1388,7 +1388,7 @@ let start t =
         Node_status_service.start ~logger:t.config.logger ~node_status_url
           ~network:t.components.net
           ~transition_frontier:t.components.transition_frontier
-          ~sync_status:t.sync_status
+          ~sync_status:t.sync_status ~chain_id:t.config.chain_id
           ~addrs_and_ports:t.config.gossip_net_params.addrs_and_ports
           ~start_time:t.config.start_time
           ~slot_duration:

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -61,6 +61,7 @@ type node_status_data =
   ; libp2p_cpu_usage : float
   ; commit_hash : string
   ; git_branch : string
+  ; chain_id : string
   ; peer_id : string
   ; ip_address : string
   ; timestamp : string
@@ -150,8 +151,8 @@ let reset_gauges () =
   Queue.clear Transition_frontier.validated_blocks ;
   Queue.clear Transition_frontier.rejected_blocks
 
-let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
-    ~addrs_and_ports ~start_time ~slot_duration =
+let start ~logger ~node_status_url ~transition_frontier ~sync_status ~chain_id
+    ~network ~addrs_and_ports ~start_time ~slot_duration =
   [%log info] "Starting node status service using URL $url"
     ~metadata:[ ("url", `String node_status_url) ] ;
   let five_slots = Time.Span.scale slot_duration 5. in
@@ -204,6 +205,7 @@ let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
             ; libp2p_cpu_usage
             ; commit_hash = Mina_version.commit_id
             ; git_branch = Mina_version.branch
+            ; chain_id
             ; peer_id =
                 (Node_addrs_and_ports.to_peer_exn addrs_and_ports).peer_id
             ; ip_address =


### PR DESCRIPTION
Add `chain_id` to the `node_status_data` record used by the node status service. The `chain_id` is obtained from the `Mina_lib.Config.t` instance.

Closes #13967.
