### PR TITLE
Fix error logging in libp2p

### DIFF
--- a/src/app/libp2p_helper/src/bitswap_storage.go
+++ b/src/app/libp2p_helper/src/bitswap_storage.go
@@ -49,7 +49,7 @@ func OpenBitswapStorageLmdb(path string) (*BitswapStorageLmdb, error) {
 	}
 	statusDB, err := blockstore.OpenDB("status")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create/open lmdb status database: %w", err)
+		return nil, fmt.Errorf("failed to create/open lmdb status database: %s", err)
 	}
 	return &BitswapStorageLmdb{blockstore: blockstore, statusDB: statusDB}, nil
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
@@ -247,7 +247,7 @@ func (bs *BitswapCtx) Loop() {
 			if err == nil {
 				bs.SendResourceUpdate(ipc.ResourceUpdateType_added, root)
 			} else {
-				bitswapLogger.Errorf("Failed to announce root cid %s (%w)", codanet.BlockHashToCidSuffix(root), err)
+				bitswapLogger.Errorf("Failed to announce root cid %s (%s)", codanet.BlockHashToCidSuffix(root), err)
 			}
 		case cmd := <-bs.deleteCmds:
 			configuredCheck()
@@ -257,7 +257,7 @@ func (bs *BitswapCtx) Loop() {
 				if err == nil {
 					success = append(success, root)
 				} else {
-					bitswapLogger.Errorf("Error processing delete request for %s: %w", codanet.BlockHashToCidSuffix(root), err)
+					bitswapLogger.Errorf("Error processing delete request for %s: %s", codanet.BlockHashToCidSuffix(root), err)
 				}
 			}
 			bs.SendResourceUpdates(ipc.ResourceUpdateType_removed, success...)

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
@@ -106,7 +106,7 @@ func kickStartRootDownload(root_ BitswapBlockLink, tag BitswapDataTag, bs Bitswa
 		bitswapLogger.Errorf("Tag %d is not supported by Bitswap downloader", tag)
 	}
 	if err := bs.SetStatus(root_, codanet.Partial); err != nil {
-		bitswapLogger.Debugf("Skipping download request for %s due to status: %w", codanet.BlockHashToCidSuffix(root_), err)
+		bitswapLogger.Debugf("Skipping download request for %s due to status: %s", codanet.BlockHashToCidSuffix(root_), err)
 		status, err := bs.GetStatus(root_)
 		if err == nil && status == codanet.Full {
 			bs.SendResourceUpdate(ipc.ResourceUpdateType_added, root_)
@@ -131,7 +131,7 @@ func kickStartRootDownload(root_ BitswapBlockLink, tag BitswapDataTag, bs Bitswa
 		remainingNodeCounter: 1,
 	}
 	handleError := func(err error) {
-		bitswapLogger.Errorf("Error initializing block download: %w", err)
+		bitswapLogger.Errorf("Error initializing block download: %s", err)
 		ClearRootDownloadState(bs, root_)
 	}
 	var rootBlock []byte
@@ -319,7 +319,7 @@ func processDownloadedBlock(block blocks.Block, bs BitswapState) {
 			if err != (ipld.ErrNotFound{Cid: codanet.BlockHashToCid(link)}) {
 				// we still schedule blocks for downloading
 				// this case should rarely happen in practice
-				bitswapLogger.Warnf("Failed to retrieve block %s from storage: %w", childId, err)
+				bitswapLogger.Warnf("Failed to retrieve block %s from storage: %s", childId, err)
 			}
 			toDownload = append(toDownload, childId)
 		}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_msg.go
@@ -18,7 +18,7 @@ func fromAddResourcePush(m ipcPushMessage) (pushMessage, error) {
 func (m AddResourcePush) handle(app *app) {
 	d, err := AddResourcePushT(m).Data()
 	if err != nil {
-		app.P2p.Logger.Errorf("AddResourcePush.handle: error %w", err)
+		app.P2p.Logger.Errorf("AddResourcePush.handle: error %s", err)
 		return
 	}
 	app.bitswapCtx.addCmds <- bitswapAddCmd{
@@ -59,7 +59,7 @@ func (m DeleteResourcePush) handle(app *app) {
 		links, err = extractRootBlockList(idsM)
 	}
 	if err != nil {
-		app.P2p.Logger.Errorf("DeleteResourcePush.handle: error %w", err)
+		app.P2p.Logger.Errorf("DeleteResourcePush.handle: error %s", err)
 		return
 	}
 	app.bitswapCtx.deleteCmds <- bitswapDeleteCmd{links}
@@ -80,7 +80,7 @@ func (m DownloadResourcePush) handle(app *app) {
 		links, err = extractRootBlockList(idsM)
 	}
 	if err != nil {
-		app.P2p.Logger.Errorf("DownloadResourcePush.handle: error %w", err)
+		app.P2p.Logger.Errorf("DownloadResourcePush.handle: error %s", err)
 		return
 	}
 	app.bitswapCtx.downloadCmds <- bitswapDownloadCmd{

--- a/src/app/libp2p_helper/src/libp2p_helper/incoming_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/incoming_msg.go
@@ -69,7 +69,7 @@ func (app *app) handleIncomingMsg(msg *ipc.Libp2pHelperInterface_Message) {
 		if err == nil {
 			app.writeMsg(resp)
 		} else {
-			app.P2p.Logger.Errorf("Failed to process rpc message: %w", err)
+			app.P2p.Logger.Errorf("Failed to process rpc message: %s", err)
 		}
 	} else if msg.HasPushMessage() {
 		err := func() error {
@@ -93,7 +93,7 @@ func (app *app) handleIncomingMsg(msg *ipc.Libp2pHelperInterface_Message) {
 			return nil
 		}()
 		if err != nil {
-			app.P2p.Logger.Errorf("Failed to process push message: %w", err)
+			app.P2p.Logger.Errorf("Failed to process push message: %s", err)
 		}
 	} else {
 		app.P2p.Logger.Error("Received message of an unknown type")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -177,13 +177,13 @@ func main() {
 	for {
 		rawMsg, err := decoder.Decode()
 		if err != nil {
-			helperLog.Errorf("Error decoding raw message: %w", err)
+			helperLog.Errorf("Error decoding raw message: %s", err)
 			os.Exit(2)
 			return
 		}
 		msg, err := ipc.ReadRootLibp2pHelperInterface_Message(rawMsg)
 		if err != nil {
-			helperLog.Errorf("Error decoding capnp message: %w", err)
+			helperLog.Errorf("Error decoding capnp message: %s", err)
 			os.Exit(3)
 			return
 		}

--- a/src/app/libp2p_helper/src/libp2p_helper/peer_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/peer_msg.go
@@ -193,7 +193,7 @@ func (m HeartbeatPeerPush) handle(app *app) {
 		peerID, err = peer.Decode(id2)
 	}
 	if err != nil {
-		app.P2p.Logger.Errorf("HeartbeatPeerPush.handle: error %w", err)
+		app.P2p.Logger.Errorf("HeartbeatPeerPush.handle: error %s", err)
 		return
 	}
 	app.P2p.HeartbeatPeer(peerID)

--- a/src/app/libp2p_helper/src/libp2p_helper/pubsub_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/pubsub_msg.go
@@ -32,7 +32,7 @@ func (m ValidationPush) handle(app *app) {
 	}
 	vid, err := ValidationPushT(m).ValidationId()
 	if err != nil {
-		app.P2p.Logger.Errorf("handleValidation: error %w", err)
+		app.P2p.Logger.Errorf("handleValidation: error %s", err)
 		return
 	}
 	seqno := vid.Id()

--- a/src/lib/mina_net2/libp2p_helper.ml
+++ b/src/lib/mina_net2/libp2p_helper.ml
@@ -305,15 +305,23 @@ let do_rpc (type a b) (t : t) ((module Rpc) : (a, b) Libp2p_ipc.Rpcs.rpc)
     (not t.finished)
     && (not @@ Writer.is_closed (Child_processes.stdin t.process))
   then (
-    [%log' spam t.logger] "sending $message_type to libp2p_helper"
-      ~metadata:[ ("message_type", `String Rpc.name) ] ;
     let ivar = Ivar.create () in
     let sequence_number = Libp2p_ipc.Sequence_number.create () in
     Hashtbl.add_exn t.outstanding_requests ~key:sequence_number ~data:ivar ;
-    request |> Rpc.Request.to_rpc_request_body
-    |> Libp2p_ipc.create_rpc_request ~sequence_number
-    |> Libp2p_ipc.rpc_request_to_outgoing_message
-    |> Libp2p_ipc.write_outgoing_message (Child_processes.stdin t.process) ;
+    let outgoing_msg =
+      request |> Rpc.Request.to_rpc_request_body
+      |> Libp2p_ipc.create_rpc_request ~sequence_number
+      |> Libp2p_ipc.rpc_request_to_outgoing_message
+    in
+    let len =
+      Libp2p_ipc.write_outgoing_message
+        (Child_processes.stdin t.process)
+        outgoing_msg
+    in
+    [%log' trace t.logger]
+      "sent $message_type of $message_length to libp2p_helper"
+      ~metadata:
+        [ ("message_type", `String Rpc.name); ("message_length", `Int len) ] ;
     let%bind response = Ivar.read ivar in
     match Rpc.Response.of_rpc_response_body response with
     | Some r ->
@@ -324,16 +332,21 @@ let do_rpc (type a b) (t : t) ((module Rpc) : (a, b) Libp2p_ipc.Rpcs.rpc)
     Deferred.Or_error.errorf "helper process already exited (doing RPC %s)"
       Rpc.name
 
-let send_push ~msg t =
+let send_push ~name ~msg t =
   if
     (not t.finished)
     && (not @@ Writer.is_closed (Child_processes.stdin t.process))
   then
-    Libp2p_ipc.push_message_to_outgoing_message msg
-    |> Libp2p_ipc.write_outgoing_message (Child_processes.stdin t.process)
+    let len =
+      Libp2p_ipc.push_message_to_outgoing_message msg
+      |> Libp2p_ipc.write_outgoing_message (Child_processes.stdin t.process)
+    in
+    [%log' trace t.logger]
+      "sent push $message_type of $message_length to libp2p_helper"
+      ~metadata:[ ("message_type", `String name); ("message_length", `Int len) ]
 
 let send_validation ~validation_id ~validation_result =
-  send_push
+  send_push ~name:"Validation"
     ~msg:
       (Libp2p_ipc.create_validation_push_message ~validation_id
          ~validation_result )
@@ -342,10 +355,12 @@ let send_add_resource ~tag ~body =
   let open Staged_ledger_diff in
   let tag = Body.Tag.to_enum tag in
   let data = Body.to_binio_bigstring body |> Bigstring.to_string in
-  send_push ~msg:(Libp2p_ipc.create_add_resource_push_message ~tag ~data)
+  send_push ~name:"AddResource"
+    ~msg:(Libp2p_ipc.create_add_resource_push_message ~tag ~data)
 
 let send_heartbeat ~peer_id =
-  send_push ~msg:(Libp2p_ipc.create_heartbeat_peer_push_message ~peer_id)
+  send_push ~name:"HeartbeatPeer"
+    ~msg:(Libp2p_ipc.create_heartbeat_peer_push_message ~peer_id)
 
 let test_with_libp2p_helper ?(logger = Logger.null ())
     ?(handle_push_message = fun _ -> assert false) f =

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -340,4 +340,7 @@ let read_incoming_messages reader =
 
 let write_outgoing_message writer msg =
   msg |> Builder.Libp2pHelperInterface.Message.to_message
-  |> Capnp.Codecs.serialize_iter ~compression ~f:(Writer.write writer)
+  |> Capnp.Codecs.serialize_fold_copyless ~compression ~init:0
+       ~f:(fun total str len ->
+         Writer.write ~len writer str ;
+         total + len )

--- a/src/libp2p_ipc/libp2p_ipc.mli
+++ b/src/libp2p_ipc/libp2p_ipc.mli
@@ -105,4 +105,4 @@ val read_incoming_messages :
      string Strict_pipe.Reader.t
   -> incoming_message Or_error.t Strict_pipe.Reader.t
 
-val write_outgoing_message : Writer.t -> outgoing_message -> unit
+val write_outgoing_message : Writer.t -> outgoing_message -> int


### PR DESCRIPTION
Explain your changes:
* Replace `%w` with `%s` for errors logged in Libp2p helper (`%w` was the wrong descriptor in the first place)
* Add trace-level logging for every outgoing IPC message on Daemon

Explain how you tested your changes:
* Tested on cluster, helped in tracing an issue

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? None