### PR TITLE
ITN: rotate stake and pre-generate funding keys

### DIFF
--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -41,6 +41,7 @@ func init() {
 	addAction(actions, lib.SampleAction{})
 	addAction(actions, lib.ExceptAction{})
 	addAction(actions, lib.StopDaemonAction{})
+	addAction(actions, lib.RotateAction{})
 
 }
 

--- a/src/app/itn_orchestrator/src/keyloader.go
+++ b/src/app/itn_orchestrator/src/keyloader.go
@@ -66,6 +66,41 @@ type KeyloaderParams struct {
 	PasswordEnv string `json:"passwordEnv,omitempty"`
 }
 
+func LoadPrivateKey(fname string, password []byte) ([]byte, error) {
+	jsonFile, err := os.Open(fname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open keyfile %s: %v", fname, err)
+	}
+	defer jsonFile.Close()
+	bs, err := io.ReadAll(jsonFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read keyfile %s: %v", fname, err)
+	}
+	sk, err := DecodePrivateKey(bs, password)
+	if err != nil {
+		return nil, errors.Join(err, fmt.Errorf("failed decoding private key from file %s", fname))
+	}
+	return sk, nil
+}
+
+func DecodePrivateKey(bs []byte, password []byte) ([]byte, error) {
+	var box secretBox
+	json.Unmarshal(bs, &box)
+	if box.Box_primitive != "xsalsa20poly1305" || box.Pw_primitive != "argon2i" {
+		return nil, errors.New("unknown primitive type")
+	}
+	k := argon2.Key(password, box.Pwsalt, box.Pwdiff.Ops, box.Pwdiff.Mem/1024, 1, 32)
+	var key [32]byte
+	copy(key[:], k)
+	var nonce [24]byte
+	copy(nonce[:], box.Nonce)
+	sk, opened := secretbox.Open(nil, box.Ciphertext, &nonce, &key)
+	if !opened {
+		return nil, errors.New("failed to unseal key")
+	}
+	return sk, nil
+}
+
 func LoadPrivateKeyFiles(log logging.StandardLogger, params KeyloaderParams, output func(itn_json_types.MinaPrivateKey)) error {
 	entries, err := os.ReadDir(params.Dir)
 	if err != nil {
@@ -84,31 +119,9 @@ func LoadPrivateKeyFiles(log logging.StandardLogger, params KeyloaderParams, out
 		if strings.HasSuffix(fname, ".pub") {
 			continue
 		}
-		jsonFile, err := os.Open(params.Dir + string(os.PathSeparator) + fname)
+		sk, err := LoadPrivateKey(params.Dir+string(os.PathSeparator)+fname, password)
 		if err != nil {
-			return fmt.Errorf("failed to open keyfile %s: %v", fname, err)
-		}
-		defer jsonFile.Close()
-		bs, err := io.ReadAll(jsonFile)
-		if err != nil {
-			return fmt.Errorf("failed to read keyfile %s: %v", fname, err)
-		}
-		var box secretBox
-		json.Unmarshal(bs, &box)
-		if box.Box_primitive != "xsalsa20poly1305" || box.Pw_primitive != "argon2i" {
-			return fmt.Errorf("unknown primitive type in %s", fname)
-		}
-		k := argon2.Key(password, box.Pwsalt, box.Pwdiff.Ops, box.Pwdiff.Mem/1024, 1, 32)
-		if err != nil {
-			return fmt.Errorf("failed to parse key %s: %v", fname, err)
-		}
-		var key [32]byte
-		copy(key[:], k)
-		var nonce [24]byte
-		copy(nonce[:], box.Nonce)
-		sk, opened := secretbox.Open(nil, box.Ciphertext, &nonce, &key)
-		if !opened {
-			return fmt.Errorf("failed to unseal key %s", fname)
+			return err
 		}
 		sender := base58.CheckEncode(sk, '\x5A')
 		output(itn_json_types.MinaPrivateKey(sender))

--- a/src/app/itn_orchestrator/src/keyloader_test.go
+++ b/src/app/itn_orchestrator/src/keyloader_test.go
@@ -1,0 +1,18 @@
+package itn_orchestrator
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+)
+
+func TestDecodePrivateKey(t *testing.T) {
+	skBoxed := []byte("{\"box_primitive\":\"xsalsa20poly1305\",\"pw_primitive\":\"argon2i\",\"nonce\":\"8p9B5WcoBtfKCFhLfurLPPUT9Kih5pH141hBYdK\",\"pwsalt\":\"98Q3JzhWcpGQFkyHs6khJUyY75Tx\",\"pwdiff\":[134217728,6],\"ciphertext\":\"AVehFg79QEYuEqdb5a3CqKgRctLAfCxeiJxmiwEA5rThVEazV1w5h6QJBCcBnMbZpgE28AiJF\"}")
+	sk, err := DecodePrivateKey(skBoxed, nil)
+	if err != nil {
+		t.Fatal("failed to decode key")
+	}
+	if base58.CheckEncode(sk, '\x5A') != "EKEEpMELfQkMbJDt2fB4cFXKwSf1x4t7YD4twREy5yuJ84HBZtF9" {
+		t.Fatal("unexpected key decoded")
+	}
+}

--- a/src/app/itn_orchestrator/src/misc_test.go
+++ b/src/app/itn_orchestrator/src/misc_test.go
@@ -1,0 +1,30 @@
+package itn_orchestrator
+
+import "testing"
+
+func TestParseMina(t *testing.T) {
+	if _, err := parseMina("12.1234567890"); err == nil {
+		t.Fatal("parsing too long a number")
+	}
+	if _, err := parseMina("a"); err == nil {
+		t.Fatal("not a number")
+	}
+	if _, err := parseMina(".23"); err == nil {
+		t.Fatal("no leading zero parsed")
+	}
+	if v, err := parseMina("0.23"); err != nil || v != 23e7 {
+		t.Fatal("leading zero not parsed")
+	}
+	if v, err := parseMina("00.002300"); err != nil || v != 23e5 {
+		t.Fatal("double leading zero not parsed")
+	}
+	if v, err := parseMina("123.456789"); err != nil || v != 123456789e3 {
+		t.Fatal("double leading zero not parsed")
+	}
+	if v, err := parseMina("123.456789001"); err != nil || v != 123456789001 {
+		t.Fatal("double leading zero not parsed")
+	}
+	if v, err := parseMina("123"); err != nil || v != 123e9 {
+		t.Fatal("no dot not parsed")
+	}
+}

--- a/src/app/itn_orchestrator/src/rotate.go
+++ b/src/app/itn_orchestrator/src/rotate.go
@@ -1,0 +1,149 @@
+package itn_orchestrator
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type RotateParams struct {
+	Pubkeys []string `json:"pubkeys"`
+
+	RestServers []string `json:"servers"`
+
+	// Ratio of each private key's balance to be used in the rotation
+	Ratio float64 `json:"ratio"`
+
+	// Mapping is an array of receiver indexes:
+	//   - size of array equals `n`
+	//   - each index is from `0` to `n - 1` inclusive
+	//   - value `j` at index `i` means that in this rotation key `i` sends a payment to key `j`
+	Mapping []int `json:"mapping"`
+
+	Fee uint64 `json:"fee,omitempty"`
+
+	PasswordEnv string `json:"passwordEnv,omitempty"`
+}
+
+type RotateAction struct{}
+
+func (RotateAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params RotateParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	if len(params.RestServers) != len(params.Pubkeys) {
+		return errors.New("length of list of rest servers is not equal to number of key files")
+	}
+	if len(params.Mapping) != len(params.Pubkeys) {
+		return errors.New("length of mapping is not equal to number of key files")
+	}
+	if params.Ratio < 1e-3 {
+		return errors.New("ratio too small")
+	}
+	password := ""
+	if params.PasswordEnv != "" {
+		password, _ = os.LookupEnv(params.PasswordEnv)
+	}
+	for _, m := range params.Mapping {
+		if m < 0 || m >= len(params.Pubkeys) {
+			return errors.New("wrong index in the mapping")
+		}
+	}
+	balances := make([]uint64, len(params.Pubkeys))
+	for i, pk := range params.Pubkeys {
+		err := retryOnMultipleServers(params.RestServers, i, "rotate-get-balance", config.Log, func(restServer string) error {
+			var err error
+			balances[i], err = getBalance(config, restServer, pk)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get balance of public key %s: %s", pk, err)
+		}
+	}
+	config.Log.Infof("Retrieved balances for rotation: %v", balances)
+	fee := params.Fee
+	if fee == 0 {
+		fee = 2e9
+	}
+	for senderIx, receiverIx := range params.Mapping {
+		senderPk := params.Pubkeys[senderIx]
+		restServer := params.RestServers[senderIx]
+		err := unlockPrivkey(config, restServer, senderPk, password)
+		if err != nil {
+			config.Log.Warnf("Failed to unlock key %s on server %s", senderPk, restServer)
+			continue
+		}
+		amount := uint64(float64(balances[senderIx]-fee) * params.Ratio)
+		receiverPk := params.Pubkeys[receiverIx]
+		err = sendPayment(config, restServer, senderPk, receiverPk, amount, fee)
+		if err == nil {
+			config.Log.Infof("Rotated: %s -> %s (%d nanomina)", senderPk, receiverPk, amount)
+		} else {
+			config.Log.Warnf("Failed to rotate key %s on server %s", senderPk, restServer)
+		}
+	}
+	return nil
+}
+
+func (RotateAction) Name() string { return "rotate-balance" }
+
+func getBalance(config Config, restServer, pubkey string) (result uint64, err error) {
+	args := []string{
+		"client", "get-balance",
+		"--public-key", pubkey,
+	}
+	if restServer != "" {
+		args = append(args, "--rest-server", restServer)
+	}
+	err = execScanMina(config.Ctx, config.MinaExec, args, nil, func(scanner *bufio.Scanner) error {
+		for scanner.Scan() {
+			if scanner.Text() == "Balance:" && scanner.Scan() {
+				balanceStr := scanner.Text()
+				if !scanner.Scan() || scanner.Text() != "mina" {
+					return errors.New("unexpected currency")
+				}
+				var err error
+				result, err = parseMina(balanceStr)
+				return err
+			}
+		}
+		return errors.New("didn't get balance")
+	})
+	return
+}
+
+func formatMina(amount uint64) string {
+	s := strconv.FormatUint(amount, 10)
+	return s[:len(s)-9] + "." + s[len(s)-9:]
+}
+
+func sendPayment(config Config, restServer, senderPk, receiverPk string, amount, fee uint64) error {
+	args := []string{
+		"client", "send-payment",
+		"--sender", senderPk,
+		"--receiver", receiverPk,
+		"--amount", formatMina(amount),
+		"--fee", formatMina(fee),
+		"--memo", "rotation",
+	}
+	if restServer != "" {
+		args = append(args, "--rest-server", restServer)
+	}
+	return execMina(config.Ctx, config.MinaExec, args, nil)
+}
+
+func unlockPrivkey(config Config, restServer, pubkey, password string) error {
+	args := []string{
+		"accounts", "unlock",
+		"--public-key", pubkey,
+	}
+	if restServer != "" {
+		args = append(args, "--rest-server", restServer)
+	}
+	env := []string{"MINA_PRIVKEY_PASS=" + password}
+	return execMina(config.Ctx, config.MinaExec, args, env)
+}


### PR DESCRIPTION
Explain your changes:

* Implement stake rotations (to ensure each epoch >33% of stake changes hands)
  * Transactions are randomly generated between BP keys and are executed on each round
  * Design of stake rotations is unusual in that it requires a list of BP public keys and a list of rest servers (which have the corresponding secret keys preloaded) to be specified for experiment generation
  * Design above was chosen in order to make this change isolated to Orchestrator/Generator, without any modification of Mina Daemon code

* (NIT) Add a simple test for keyloader
* Allow funding keys to be generated from initial "seed" secret key
   * This finalizes workflow of funding, making it easy to use (because only one secret key needs to be provided to start the process) and super-efficient (by performing funding from 20 or more keys in parallel) at the same time

Explain how you tested your changes:
* Tested by running experiments with updated generator/orchestrator on the cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #13904
