### PR TITLE
[develop] Use full features everywhere in pickles

### DIFF
--- a/src/lib/pickles/common.mli
+++ b/src/lib/pickles/common.mli
@@ -160,7 +160,7 @@ val hash_messages_for_next_step_proof :
 
 val tick_public_input_of_statement :
      max_proofs_verified:'a Pickles_types.Nat.t
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
   -> ( ( ( Impls.Step.Challenge.Constant.t
          , Impls.Step.Challenge.Constant.t Composition_types.Scalar_challenge.t
          , Impls.Step.Other_field.Constant.t Pickles_types.Shifted_value.Type2.t
@@ -192,7 +192,8 @@ val tick_public_input_of_statement :
 
 val tock_public_input_of_statement :
      feature_flags:
-       Pickles_types.Plonk_types.Opt.Flag.t Pickles_types.Plonk_types.Features.t
+       Pickles_types.Plonk_types.Opt.Flag.t
+       Pickles_types.Plonk_types.Features.Full.t
   -> ( Limb_vector.Challenge.Constant.t
      , Limb_vector.Challenge.Constant.t Composition_types.Scalar_challenge.t
      , Impls.Wrap.Other_field.Constant.t Pickles_types.Shifted_value.Type1.t
@@ -222,7 +223,8 @@ val tock_public_input_of_statement :
 
 val tock_unpadded_public_input_of_statement :
      feature_flags:
-       Pickles_types.Plonk_types.Opt.Flag.t Pickles_types.Plonk_types.Features.t
+       Pickles_types.Plonk_types.Opt.Flag.t
+       Pickles_types.Plonk_types.Features.Full.t
   -> ( Limb_vector.Challenge.Constant.t
      , Limb_vector.Challenge.Constant.t Composition_types.Scalar_challenge.t
      , Impls.Wrap.Other_field.Constant.t Pickles_types.Shifted_value.Type1.t

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -418,21 +418,23 @@ struct
       let rec go :
           type a b c d.
              (a, b, c, d) H4.T(IR).t
-          -> Plonk_types.Opt.Flag.t Plonk_types.Features.t =
+          -> Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t =
        fun rules ->
         match rules with
         | [] ->
-            Plonk_types.Features.none
+            Plonk_types.Features.Full.none
         | [ r ] ->
             Plonk_types.Features.map r.feature_flags ~f:(function
               | true ->
                   Plonk_types.Opt.Flag.Yes
               | false ->
                   Plonk_types.Opt.Flag.No )
+            |> Plonk_types.Features.to_full ~or_:Plonk_types.Opt.Flag.( ||| )
         | r :: rules ->
             let feature_flags = go rules in
-            Plonk_types.Features.map2 r.feature_flags feature_flags
-              ~f:(fun enabled flag ->
+            Plonk_types.Features.Full.map2
+              (Plonk_types.Features.to_full ~or_:( || ) r.feature_flags)
+              feature_flags ~f:(fun enabled flag ->
                 match (enabled, flag) with
                 | true, Yes ->
                     Plonk_types.Opt.Flag.Yes
@@ -863,7 +865,9 @@ module Side_loaded = struct
       { max_proofs_verified
       ; public_input = typ
       ; branches = Verification_key.Max_branches.n
-      ; feature_flags
+      ; feature_flags =
+          Plonk_types.Features.to_full ~or_:Plonk_types.Opt.Flag.( ||| )
+            feature_flags
       }
 
   module Proof = struct

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -155,7 +155,7 @@ module Wrap : sig
                  , bool
                  , 'f )
                  Snarky_backendless.Typ.t
-            -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+            -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
             -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
             -> ( ( 'c
                  , 'e Scalar_challenge.t
@@ -350,7 +350,7 @@ module Wrap : sig
                  Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
                snarky_typ
           -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
-          -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+          -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
           -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
           -> ( 'g
              , 'h
@@ -602,7 +602,7 @@ module Wrap : sig
                Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
              snarky_typ
         -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
-        -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+        -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
         -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
         -> ( 'g
            , 'h

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -222,23 +222,12 @@ module Wrap = struct
     let _to_bits x = Field.unpack x ~length:Field.size_in_bits
   end
 
-  let input ~feature_flags () =
+  let input
+      ~feature_flags:
+        ({ Plonk_types.Features.Full.uses_lookups; _ } as feature_flags) () =
+    let feature_flags = Plonk_types.Features.of_full feature_flags in
     let lookup =
-      { Types.Wrap.Lookup_parameters.use =
-          (let { Plonk_types.Features.range_check0
-               ; range_check1
-               ; foreign_field_add = _ (* Doesn't use lookup *)
-               ; foreign_field_mul
-               ; xor
-               ; rot
-               ; lookup
-               ; runtime_tables = _
-               } =
-             feature_flags
-           in
-           Plonk_types.Opt.Flag.(
-             range_check0 ||| range_check1 ||| foreign_field_mul ||| xor ||| rot
-             ||| lookup) )
+      { Types.Wrap.Lookup_parameters.use = uses_lookups
       ; zero =
           { value =
               { challenge = Limb_vector.Challenge.Constant.zero

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -39,7 +39,7 @@ module Step : sig
   val input :
        proofs_verified:'a Pickles_types.Nat.t
     -> wrap_rounds:'b Pickles_types.Nat.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     -> ( ( ( ( Impl.Field.t
              , Impl.Field.t Composition_types.Scalar_challenge.t
              , Other_field.t Pickles_types.Shifted_value.Type2.t
@@ -130,7 +130,7 @@ module Wrap : sig
   end
 
   val input :
-       feature_flags:Pickles_types.Plonk_types.Features.options
+       feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     -> unit
     -> ( ( Impl.Field.t
          , Impl.Field.t Composition_types.Scalar_challenge.t

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -110,7 +110,7 @@ module Constant : sig
 end
 
 val typ :
-     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
   -> ('avar, 'aval) Impl.Typ.t
   -> 'n Pickles_types.Nat.t
   -> (('avar, 'n, _) t, ('aval, 'n) Constant.t) Impl.Typ.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -228,7 +228,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
         { max_proofs_verified
         ; public_input = typ
         ; branches = Verification_key.Max_branches.n
-        ; feature_flags
+        ; feature_flags =
+            Plonk_types.(Features.to_full ~or_:Opt.Flag.( ||| ) feature_flags)
         }
 
     module Proof = struct
@@ -1136,7 +1137,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           let full_signature =
             { Full_signature.padded; maxes = (module Maxes) }
           in
-          let feature_flags = Plonk_types.Features.none in
+          let feature_flags = Plonk_types.Features.Full.none in
           let actual_feature_flags = Plonk_types.Features.none_bool in
           let wrap_domains =
             let module M =
@@ -1425,7 +1426,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                     let module O = Tick.Oracles in
                     let public_input =
                       tick_public_input_of_statement ~max_proofs_verified
-                        ~feature_flags:Plonk_types.Features.none
+                        ~feature_flags:Plonk_types.Features.Full.none
                         prev_statement_with_hashes
                     in
                     let prev_challenges =

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -220,45 +220,7 @@ let lookup_tables_used feature_flags =
 let get_feature_flag (feature_flags : _ all_feature_flags)
     (feature : Kimchi_types.feature_flag) =
   let lazy_flag =
-    match feature with
-    | RangeCheck0 ->
-        Some feature_flags.range_check0
-    | RangeCheck1 ->
-        Some feature_flags.range_check1
-    | ForeignFieldAdd ->
-        Some feature_flags.foreign_field_add
-    | ForeignFieldMul ->
-        Some feature_flags.foreign_field_mul
-    | Xor ->
-        Some feature_flags.xor
-    | Rot ->
-        Some feature_flags.rot
-    | LookupTables ->
-        Some feature_flags.uses_lookups
-    | RuntimeLookupTables ->
-        Some feature_flags.runtime_tables
-    | TableWidth 3 ->
-        Some feature_flags.table_width_3
-    | TableWidth 2 ->
-        Some feature_flags.table_width_at_least_2
-    | TableWidth i when i <= 1 ->
-        Some feature_flags.table_width_at_least_1
-    | TableWidth _ ->
-        None
-    | LookupsPerRow 4 ->
-        Some feature_flags.lookups_per_row_4
-    | LookupsPerRow i when i <= 3 ->
-        Some feature_flags.lookups_per_row_3
-    | LookupsPerRow _ ->
-        None
-    | LookupPattern Lookup ->
-        Some feature_flags.lookup
-    | LookupPattern Xor ->
-        Some feature_flags.lookup_pattern_xor
-    | LookupPattern RangeCheck ->
-        Some feature_flags.lookup_pattern_range_check
-    | LookupPattern ForeignFieldMul ->
-        Some feature_flags.foreign_field_mul
+    Plonk_types.Features.Full.get_feature_flag feature_flags feature
   in
   Option.map ~f:Lazy.force lazy_flag
 

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -105,7 +105,7 @@ let evals_of_split_evals field ~zeta ~zetaw (es : _ Plonk_types.Evals.t) ~rounds
 open Composition_types.Wrap.Proof_state.Deferred_values.Plonk
 
 type 'bool all_feature_flags =
-  { lookup_tables : 'bool Lazy.t
+  { uses_lookups : 'bool Lazy.t
   ; table_width_at_least_1 : 'bool Lazy.t
   ; table_width_at_least_2 : 'bool Lazy.t
   ; table_width_3 : 'bool Lazy.t
@@ -167,7 +167,7 @@ let expand_feature_flags (type boolean)
     (* Lookup has max_lookups_per_row = 3 *)
     lazy (B.( ||| ) (Lazy.force lookups_per_row_4) lookup)
   in
-  { lookup_tables = lookups_per_row_3
+  { uses_lookups = lookups_per_row_3
   ; table_width_at_least_1
   ; table_width_at_least_2
   ; table_width_3
@@ -207,7 +207,7 @@ let lookup_tables_used feature_flags =
     let any = List.fold_left ~f:( ||| ) ~init:false_
   end in
   let all_feature_flags = expand_feature_flags (module Bool) feature_flags in
-  Lazy.force all_feature_flags.lookup_tables
+  Lazy.force all_feature_flags.uses_lookups
 
 let get_feature_flag (feature_flags : _ all_feature_flags)
     (feature : Kimchi_types.feature_flag) =
@@ -225,7 +225,7 @@ let get_feature_flag (feature_flags : _ all_feature_flags)
   | Rot ->
       Some feature_flags.features.rot
   | LookupTables ->
-      Some (Lazy.force feature_flags.lookup_tables)
+      Some (Lazy.force feature_flags.uses_lookups)
   | RuntimeLookupTables ->
       Some feature_flags.features.runtime_tables
   | TableWidth 3 ->

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -109,64 +109,10 @@ type 'bool all_feature_flags = 'bool Lazy.t Plonk_types.Features.Full.t
 let expand_feature_flags (type boolean)
     (module B : Bool_intf with type t = boolean)
     (features : boolean Plonk_types.Features.t) : boolean all_feature_flags =
-  let { Plonk_types.Features.range_check0
-      ; range_check1
-      ; foreign_field_add
-      ; foreign_field_mul
-      ; xor
-      ; rot
-      ; lookup
-      ; runtime_tables
-      } =
-    Plonk_types.Features.map ~f:(fun x -> lazy x) features
-  in
-  let ( ||| ) x y = lazy B.(Lazy.force x ||| Lazy.force y) in
-  let lookup_pattern_range_check =
-    (* RangeCheck, Rot gates use RangeCheck lookup pattern *)
-    range_check0 ||| range_check1 ||| rot
-  in
-  let lookup_pattern_xor =
-    (* Xor lookup pattern *)
-    xor
-  in
-  (* Make sure these stay up-to-date with the layouts!! *)
-  let table_width_3 =
-    (* Xor have max_joint_size = 3 *)
-    lookup_pattern_xor
-  in
-  let table_width_at_least_2 =
-    (* Lookup has max_joint_size = 2 *)
-    table_width_3 ||| lookup
-  in
-  let table_width_at_least_1 =
-    (* RangeCheck, ForeignFieldMul have max_joint_size = 1 *)
-    table_width_at_least_2 ||| lookup_pattern_range_check ||| foreign_field_mul
-  in
-  let lookups_per_row_4 =
-    (* Xor, RangeCheckGate, ForeignFieldMul, have max_lookups_per_row = 4 *)
-    lookup_pattern_xor ||| lookup_pattern_range_check ||| foreign_field_mul
-  in
-  let lookups_per_row_3 =
-    (* Lookup has max_lookups_per_row = 3 *)
-    lookups_per_row_4 ||| lookup
-  in
-  { uses_lookups = lookups_per_row_3
-  ; table_width_at_least_1
-  ; table_width_at_least_2
-  ; table_width_3
-  ; lookups_per_row_3
-  ; lookups_per_row_4
-  ; lookup_pattern_xor
-  ; lookup_pattern_range_check
-  ; range_check0
-  ; range_check1
-  ; foreign_field_add
-  ; foreign_field_mul
-  ; xor
-  ; rot
-  ; lookup
-  ; runtime_tables
-  }
+  features
+  |> Plonk_types.Features.map ~f:(fun x -> lazy x)
+  |> Plonk_types.Features.to_full ~or_:(fun x y ->
+         lazy B.(Lazy.force x ||| Lazy.force y) )
 
 let lookup_tables_used feature_flags =
   let module Bool = struct

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -41,7 +41,7 @@ let input_size ~of_int ~add ~mul w =
   let size a =
     let (T (Typ typ, _conv, _conv_inv)) =
       Impls.Step.input ~proofs_verified:a ~wrap_rounds:Backend.Tock.Rounds.n
-        ~feature_flags:Plonk_types.Features.none
+        ~feature_flags:Plonk_types.Features.Full.none
     in
     typ.size_in_field_elements
   in
@@ -199,7 +199,7 @@ module Stable = struct
         let log2_size = Import.Domain.log2_size d in
         let public =
           let (T (input, _conv, _conv_inv)) =
-            Impls.Wrap.input ~feature_flags:Plonk_types.Features.maybe ()
+            Impls.Wrap.input ~feature_flags:Plonk_types.Features.Full.maybe ()
           in
           let (Typ typ) = input in
           typ.size_in_field_elements
@@ -365,7 +365,7 @@ let%test_unit "input_size" =
          let (T (Typ typ, _conv, _conv_inv)) =
            Impls.Step.input ~proofs_verified:a
              ~wrap_rounds:Backend.Tock.Rounds.n
-             ~feature_flags:Plonk_types.Features.none
+             ~feature_flags:Plonk_types.Features.Full.none
          in
          typ.size_in_field_elements ) )
 

--- a/src/lib/pickles/step.mli
+++ b/src/lib/pickles/step.mli
@@ -30,7 +30,7 @@ module Make
     -> prevs_length:('prev_vars, 'prevs_length) Pickles_types.Hlist.Length.t
     -> self:('a, 'b, 'c, 'd) Tag.t
     -> step_domains:(Import.Domains.t, 'self_branches) Pickles_types.Vector.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     -> self_dlog_plonk_index:
          Backend.Tick.Inner_curve.Affine.t
          Pickles_types.Plonk_verification_key_evals.t

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -73,7 +73,7 @@ let create
     (type branches max_proofs_verified var value a_var a_value ret_var ret_value)
     ~index ~(self : (var, value, max_proofs_verified, branches) Tag.t)
     ~wrap_domains
-    ~(feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
+    ~(feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t)
     ~(actual_feature_flags : bool Plonk_types.Features.t)
     ~(max_proofs_verified : max_proofs_verified Nat.t)
     ~(proofs_verifieds : (int, branches) Vector.t) ~(branches : branches Nat.t)

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -70,7 +70,7 @@ val create :
      index:int
   -> self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
   -> wrap_domains:Import.Domains.t
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
   -> actual_feature_flags:bool Plonk_types.Features.t
   -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
   -> proofs_verifieds:(int, 'branches) Pickles_types.Vector.t

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -42,8 +42,8 @@ let verify_one ~srs
         in
         (* TODO: Refactor args into an "unfinalized proof" struct *)
         finalize_other_proof d.max_proofs_verified ~step_domains:d.step_domains
-          ~feature_flags:d.feature_flags ~sponge ~prev_challenges
-          deferred_values prev_proof_evals )
+          ~feature_flags:(Plonk_types.Features.of_full d.feature_flags)
+          ~sponge ~prev_challenges deferred_values prev_proof_evals )
   in
   let branch_data = deferred_values.branch_data in
   let sponge_after_index, hash_messages_for_next_step_proof =
@@ -82,9 +82,10 @@ let verify_one ~srs
   in
   let verified =
     with_label __LOC__ (fun () ->
-        verify ~srs ~feature_flags:d.feature_flags
+        verify ~srs
+          ~feature_flags:(Plonk_types.Features.of_full d.feature_flags)
           ~lookup_parameters:
-            { use = Plonk_checks.lookup_tables_used d.feature_flags
+            { use = d.feature_flags.uses_lookups
             ; zero =
                 { var =
                     { challenge = Field.zero
@@ -197,7 +198,7 @@ let step_main :
         type pvars pvals ns1 ns2 br.
            (pvars, pvals, ns1, ns2) H4.T(Tag).t
         -> (pvars, br) Length.t
-        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.t, br) Vector.t =
+        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t, br) Vector.t =
      fun ds ld ->
       match[@warning "-4"] (ds, ld) with
       | [], Z ->
@@ -220,7 +221,7 @@ let step_main :
         -> (pvars, br) Length.t
         -> (ns1, br) Length.t
         -> (ns2, br) Length.t
-        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.t, br) Vector.t
+        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t, br) Vector.t
         -> (pvars, pvals, ns1, ns2) H4.T(Typ_with_max_proofs_verified).t =
      fun ds ns1 ns2 ld ln1 ln2 feature_flagss ->
       match[@warning "-4"] (ds, ns1, ns2, ld, ln1, ln2, feature_flagss) with

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -18,7 +18,7 @@ module Basic = struct
     ; wrap_domains : Domains.t
     ; wrap_key : Tick.Inner_curve.Affine.t Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 end
 
@@ -38,7 +38,7 @@ module Side_loaded = struct
     type ('var, 'value, 'n1, 'n2) t =
       { max_proofs_verified : (module Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
       ; branches : 'n2 Nat.t
       }
   end
@@ -82,7 +82,7 @@ module Compiled = struct
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 
   (* This is the data associated to an inductive proof system with statement type
@@ -99,7 +99,7 @@ module Compiled = struct
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 
   type packed =
@@ -140,7 +140,7 @@ module For_step = struct
         | `Side_loaded of
           Impls.Step.field Pickles_base.Proofs_verified.One_hot.Checked.t ]
     ; step_domains : [ `Known of (Domains.t, 'branches) Vector.t | `Side_loaded ]
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 
   let of_side_loaded (type a b c d)
@@ -251,7 +251,8 @@ let public_input :
 
 let feature_flags :
     type var value.
-    (var, value, _, _) Tag.t -> Plonk_types.Opt.Flag.t Plonk_types.Features.t =
+       (var, value, _, _) Tag.t
+    -> Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t =
  fun tag ->
   match tag.kind with
   | Compiled ->

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -14,7 +14,7 @@ module Basic : sig
         Backend.Tick.Inner_curve.Affine.t
         Pickles_types.Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 end
 
@@ -35,7 +35,7 @@ module Side_loaded : sig
       { max_proofs_verified :
           (module Pickles_types.Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
       ; branches : 'n2 Pickles_types.Nat.t
       }
   end
@@ -58,7 +58,7 @@ module Compiled : sig
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
@@ -75,7 +75,7 @@ module Compiled : sig
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 end
 
@@ -96,7 +96,7 @@ module For_step : sig
     ; step_domains :
         [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     }
 
   val of_side_loaded : ('a, 'b, 'c, 'd) Side_loaded.t -> ('a, 'b, 'c, 'd) t
@@ -126,7 +126,8 @@ val max_proofs_verified :
      ('a, 'b, 'n1, 'c) Tag.t
   -> (module Pickles_types.Nat.Add.Intf with type n = 'n1)
 
-val feature_flags : _ Tag.t -> Plonk_types.Opt.Flag.t Plonk_types.Features.t
+val feature_flags :
+  _ Tag.t -> Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
 
 val add_exn :
   ('var, 'value, 'c, 'd) Tag.t -> ('var, 'value, 'c, 'd) Compiled.t -> unit

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -151,7 +151,7 @@ module Stable = struct
         let log2_size = Int.ceil_log2 d.constraints in
         let public =
           let (T (input, _conv, _conv_inv)) =
-            Impls.Wrap.input ~feature_flags:Plonk_types.Features.maybe ()
+            Impls.Wrap.input ~feature_flags:Plonk_types.Features.Full.maybe ()
           in
           let (Typ typ) = input in
           typ.size_in_field_elements

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -183,12 +183,7 @@ let verify_heterogenous (ts : Instance.t list) =
         in
         let input =
           tock_unpadded_public_input_of_statement
-            ~feature_flags:
-              Plonk_types.(
-                Features.map
-                  ~f:(fun _ -> Opt.Flag.Maybe)
-                  t.statement.proof_state.deferred_values.plonk.feature_flags)
-            prepared_statement
+            ~feature_flags:Plonk_types.Features.Full.maybe prepared_statement
         in
         let message =
           Wrap_hack.pad_accumulator

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -375,6 +375,11 @@ let%test_module "gate finalization" =
           ~step_vk:vk ~public_input ~proof ~actual_proofs_verified:Nat.N0.n
       in
 
+      let full_features =
+        Plonk_types.Features.to_full ~or_:Plonk_types.Opt.Flag.( ||| )
+          feature_flags
+      in
+
       (* Define Typ.t for Deferred_values.t -- A Type.t defines how to convert a value of some type
                                               in OCaml into a var in circuit/Snarky.
 
@@ -386,7 +391,7 @@ let%test_module "gate finalization" =
         let open Step_verifier in
         Wrap.Proof_state.Deferred_values.In_circuit.typ
           (module Impls.Step)
-          ~feature_flags ~challenge:Challenge.typ
+          ~feature_flags:full_features ~challenge:Challenge.typ
           ~scalar_challenge:Challenge.typ
           ~dummy_scalar:(Shifted_value.Type1.Shifted_value Field.Constant.zero)
           ~dummy_scalar_challenge:
@@ -414,7 +419,7 @@ let%test_module "gate finalization" =
          for use in the circuit *)
       and evals =
         constant
-          (Plonk_types.All_evals.typ (module Impls.Step) feature_flags)
+          (Plonk_types.All_evals.typ (module Impls.Step) full_features)
           { evals = { public_input = x_hat_evals; evals = proof.openings.evals }
           ; ft_eval1 = proof.openings.ft_eval1
           }

--- a/src/lib/pickles/wrap.mli
+++ b/src/lib/pickles/wrap.mli
@@ -36,7 +36,7 @@ val wrap :
   -> step_vk:Kimchi_bindings.Protocol.VerifierIndex.Fp.t
   -> actual_wrap_domains:(Core_kernel.Int.t, 'c) Pickles_types.Vector.t
   -> step_plonk_indices:'d
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
   -> actual_feature_flags:bool Plonk_types.Features.t
   -> ?tweak_statement:
        (   ( Import.Challenge.Constant.t

--- a/src/lib/pickles/wrap_domains.mli
+++ b/src/lib/pickles/wrap_domains.mli
@@ -13,7 +13,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.t
 
@@ -21,7 +21,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.Stable.V2.t
 end

--- a/src/lib/pickles/wrap_main.mli
+++ b/src/lib/pickles/wrap_main.mli
@@ -3,7 +3,7 @@ open Pickles_types
 (** [wrap_main] is the SNARK function for wrapping any proof coming from the given set of
     keys **)
 val wrap_main :
-     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.Full.t
   -> ( 'max_proofs_verified
      , 'branches
      , 'max_local_max_proofs_verifieds )

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -36,7 +36,7 @@ let typ : (Checked.t, Constant.t) Typ.t =
     ~value_to_hlist:Constant.to_hlist ~value_of_hlist:Constant.of_hlist
     [ Plonk_types.Messages.typ
         (module Impl)
-        Inner_curve.typ Plonk_types.Features.none ~bool:Boolean.typ
+        Inner_curve.typ Plonk_types.Features.Full.none ~bool:Boolean.typ
         ~dummy:Inner_curve.Params.one
         ~commitment_lengths:(Commitment_lengths.create ~of_int:(fun x -> x))
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -34,6 +34,7 @@
   base.caml
   bin_prot.shape
   ;; local libraries
+  kimchi_types
   snarky.backendless
   tuple_lib
   ppx_version.runtime

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -253,6 +253,64 @@ module Features = struct
           Some feature_flags.lookup_pattern_range_check
       | LookupPattern ForeignFieldMul ->
           Some feature_flags.foreign_field_mul
+
+    let map
+        { range_check0
+        ; range_check1
+        ; foreign_field_add
+        ; foreign_field_mul
+        ; rot
+        ; xor
+        ; lookup
+        ; runtime_tables
+        ; uses_lookups
+        ; table_width_at_least_1
+        ; table_width_at_least_2
+        ; table_width_3
+        ; lookups_per_row_3
+        ; lookups_per_row_4
+        ; lookup_pattern_xor
+        ; lookup_pattern_range_check
+        } ~f =
+      { range_check0 = f range_check0
+      ; range_check1 = f range_check1
+      ; foreign_field_add = f foreign_field_add
+      ; foreign_field_mul = f foreign_field_mul
+      ; xor = f xor
+      ; rot = f rot
+      ; lookup = f lookup
+      ; runtime_tables = f runtime_tables
+      ; uses_lookups = f uses_lookups
+      ; table_width_at_least_1 = f table_width_at_least_1
+      ; table_width_at_least_2 = f table_width_at_least_2
+      ; table_width_3 = f table_width_3
+      ; lookups_per_row_3 = f lookups_per_row_3
+      ; lookups_per_row_4 = f lookups_per_row_4
+      ; lookup_pattern_xor = f lookup_pattern_xor
+      ; lookup_pattern_range_check = f lookup_pattern_range_check
+      }
+
+    let map2 x1 x2 ~f =
+      { range_check0 = f x1.range_check0 x2.range_check0
+      ; range_check1 = f x1.range_check1 x2.range_check1
+      ; foreign_field_add = f x1.foreign_field_add x2.foreign_field_add
+      ; foreign_field_mul = f x1.foreign_field_mul x2.foreign_field_mul
+      ; xor = f x1.xor x2.xor
+      ; rot = f x1.rot x2.rot
+      ; lookup = f x1.lookup x2.lookup
+      ; runtime_tables = f x1.runtime_tables x2.runtime_tables
+      ; uses_lookups = f x1.uses_lookups x2.uses_lookups
+      ; table_width_at_least_1 =
+          f x1.table_width_at_least_1 x2.table_width_at_least_1
+      ; table_width_at_least_2 =
+          f x1.table_width_at_least_2 x2.table_width_at_least_2
+      ; table_width_3 = f x1.table_width_3 x2.table_width_3
+      ; lookups_per_row_3 = f x1.lookups_per_row_3 x2.lookups_per_row_3
+      ; lookups_per_row_4 = f x1.lookups_per_row_4 x2.lookups_per_row_4
+      ; lookup_pattern_xor = f x1.lookup_pattern_xor x2.lookup_pattern_xor
+      ; lookup_pattern_range_check =
+          f x1.lookup_pattern_range_check x2.lookup_pattern_range_check
+      }
   end
 
   [%%versioned

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -211,6 +211,48 @@ module Features = struct
       ; lookup_pattern_range_check : 'bool
       }
     [@@deriving sexp, compare, yojson, hash, equal, hlist]
+
+    let get_feature_flag (feature_flags : _ t)
+        (feature : Kimchi_types.feature_flag) =
+      match feature with
+      | RangeCheck0 ->
+          Some feature_flags.range_check0
+      | RangeCheck1 ->
+          Some feature_flags.range_check1
+      | ForeignFieldAdd ->
+          Some feature_flags.foreign_field_add
+      | ForeignFieldMul ->
+          Some feature_flags.foreign_field_mul
+      | Xor ->
+          Some feature_flags.xor
+      | Rot ->
+          Some feature_flags.rot
+      | LookupTables ->
+          Some feature_flags.uses_lookups
+      | RuntimeLookupTables ->
+          Some feature_flags.runtime_tables
+      | TableWidth 3 ->
+          Some feature_flags.table_width_3
+      | TableWidth 2 ->
+          Some feature_flags.table_width_at_least_2
+      | TableWidth i when i <= 1 ->
+          Some feature_flags.table_width_at_least_1
+      | TableWidth _ ->
+          None
+      | LookupsPerRow 4 ->
+          Some feature_flags.lookups_per_row_4
+      | LookupsPerRow i when i <= 3 ->
+          Some feature_flags.lookups_per_row_3
+      | LookupsPerRow _ ->
+          None
+      | LookupPattern Lookup ->
+          Some feature_flags.lookup
+      | LookupPattern Xor ->
+          Some feature_flags.lookup_pattern_xor
+      | LookupPattern RangeCheck ->
+          Some feature_flags.lookup_pattern_range_check
+      | LookupPattern ForeignFieldMul ->
+          Some feature_flags.foreign_field_mul
   end
 
   [%%versioned

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -191,6 +191,28 @@ module Opt = struct
 end
 
 module Features = struct
+  module Full = struct
+    type 'bool t =
+      { range_check0 : 'bool
+      ; range_check1 : 'bool
+      ; foreign_field_add : 'bool
+      ; foreign_field_mul : 'bool
+      ; xor : 'bool
+      ; rot : 'bool
+      ; lookup : 'bool
+      ; runtime_tables : 'bool
+      ; uses_lookups : 'bool
+      ; table_width_at_least_1 : 'bool
+      ; table_width_at_least_2 : 'bool
+      ; table_width_3 : 'bool
+      ; lookups_per_row_3 : 'bool
+      ; lookups_per_row_4 : 'bool
+      ; lookup_pattern_xor : 'bool
+      ; lookup_pattern_range_check : 'bool
+      }
+    [@@deriving sexp, compare, yojson, hash, equal, hlist]
+  end
+
   [%%versioned
   module Stable = struct
     module V1 = struct
@@ -207,6 +229,35 @@ module Features = struct
       [@@deriving sexp, compare, yojson, hash, equal, hlist]
     end
   end]
+
+  let of_full
+      ({ range_check0
+       ; range_check1
+       ; foreign_field_add
+       ; foreign_field_mul
+       ; xor
+       ; rot
+       ; lookup
+       ; runtime_tables
+       ; uses_lookups = _
+       ; table_width_at_least_1 = _
+       ; table_width_at_least_2 = _
+       ; table_width_3 = _
+       ; lookups_per_row_3 = _
+       ; lookups_per_row_4 = _
+       ; lookup_pattern_xor = _
+       ; lookup_pattern_range_check = _
+       } :
+        'bool Full.t ) =
+    { range_check0
+    ; range_check1
+    ; foreign_field_add
+    ; foreign_field_mul
+    ; xor
+    ; rot
+    ; lookup
+    ; runtime_tables
+    }
 
   type options = Opt.Flag.t t
 

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -301,6 +301,64 @@ module Features = struct
     ; runtime_tables
     }
 
+  let to_full ~or_:( ||| )
+      { range_check0
+      ; range_check1
+      ; foreign_field_add
+      ; foreign_field_mul
+      ; xor
+      ; rot
+      ; lookup
+      ; runtime_tables
+      } : _ Full.t =
+    let lookup_pattern_range_check =
+      (* RangeCheck, Rot gates use RangeCheck lookup pattern *)
+      range_check0 ||| range_check1 ||| rot
+    in
+    let lookup_pattern_xor =
+      (* Xor lookup pattern *)
+      xor
+    in
+    (* Make sure these stay up-to-date with the layouts!! *)
+    let table_width_3 =
+      (* Xor have max_joint_size = 3 *)
+      lookup_pattern_xor
+    in
+    let table_width_at_least_2 =
+      (* Lookup has max_joint_size = 2 *)
+      table_width_3 ||| lookup
+    in
+    let table_width_at_least_1 =
+      (* RangeCheck, ForeignFieldMul have max_joint_size = 1 *)
+      table_width_at_least_2 ||| lookup_pattern_range_check
+      ||| foreign_field_mul
+    in
+    let lookups_per_row_4 =
+      (* Xor, RangeCheckGate, ForeignFieldMul, have max_lookups_per_row = 4 *)
+      lookup_pattern_xor ||| lookup_pattern_range_check ||| foreign_field_mul
+    in
+    let lookups_per_row_3 =
+      (* Lookup has max_lookups_per_row = 3 *)
+      lookups_per_row_4 ||| lookup
+    in
+    { uses_lookups = lookups_per_row_3
+    ; table_width_at_least_1
+    ; table_width_at_least_2
+    ; table_width_3
+    ; lookups_per_row_3
+    ; lookups_per_row_4
+    ; lookup_pattern_xor
+    ; lookup_pattern_range_check
+    ; range_check0
+    ; range_check1
+    ; foreign_field_add
+    ; foreign_field_mul
+    ; xor
+    ; rot
+    ; lookup
+    ; runtime_tables
+    }
+
   type options = Opt.Flag.t t
 
   type flags = bool t

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -82,6 +82,8 @@ module Features : sig
       ; lookup_pattern_range_check : 'bool
       }
     [@@deriving sexp, compare, yojson, hash, equal, hlist]
+
+    val get_feature_flag : 'bool t -> Kimchi_types.feature_flag -> 'bool option
   end
 
   [%%versioned:

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -62,6 +62,28 @@ module Opt : sig
 end
 
 module Features : sig
+  module Full : sig
+    type 'bool t =
+      { range_check0 : 'bool
+      ; range_check1 : 'bool
+      ; foreign_field_add : 'bool
+      ; foreign_field_mul : 'bool
+      ; xor : 'bool
+      ; rot : 'bool
+      ; lookup : 'bool
+      ; runtime_tables : 'bool
+      ; uses_lookups : 'bool
+      ; table_width_at_least_1 : 'bool
+      ; table_width_at_least_2 : 'bool
+      ; table_width_3 : 'bool
+      ; lookups_per_row_3 : 'bool
+      ; lookups_per_row_4 : 'bool
+      ; lookup_pattern_xor : 'bool
+      ; lookup_pattern_range_check : 'bool
+      }
+    [@@deriving sexp, compare, yojson, hash, equal, hlist]
+  end
+
   [%%versioned:
   module Stable : sig
     module V1 : sig
@@ -78,6 +100,8 @@ module Features : sig
       [@@deriving sexp, compare, yojson, hash, equal, hlist]
     end
   end]
+
+  val of_full : 'a Full.t -> 'a t
 
   (** {2 Type aliases} *)
 

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -103,6 +103,8 @@ module Features : sig
     end
   end]
 
+  val to_full : or_:('bool -> 'bool -> 'bool) -> 'bool t -> 'bool Full.t
+
   val of_full : 'a Full.t -> 'a t
 
   (** {2 Type aliases} *)

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -84,6 +84,10 @@ module Features : sig
     [@@deriving sexp, compare, yojson, hash, equal, hlist]
 
     val get_feature_flag : 'bool t -> Kimchi_types.feature_flag -> 'bool option
+
+    val map : 'a t -> f:('a -> 'b) -> 'b t
+
+    val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
   end
 
   [%%versioned:

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -88,6 +88,12 @@ module Features : sig
     val map : 'a t -> f:('a -> 'b) -> 'b t
 
     val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+
+    val none : Opt.Flag.t t
+
+    val maybe : Opt.Flag.t t
+
+    val none_bool : bool t
   end
 
   [%%versioned:
@@ -236,7 +242,7 @@ module Messages : sig
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
     -> ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> Opt.Flag.t Features.t
+    -> Opt.Flag.t Features.Full.t
     -> dummy:'b
     -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
     -> bool:('c, bool, 'f) Snarky_backendless.Typ.t
@@ -442,7 +448,7 @@ module All_evals : sig
 
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> Opt.Flag.t Features.t
+    -> Opt.Flag.t Features.Full.t
     -> ( ( 'f Snarky_backendless.Cvar.t
          , 'f Snarky_backendless.Cvar.t array
          , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -63,7 +63,7 @@ end
 
 module Features : sig
   module Full : sig
-    type 'bool t =
+    type 'bool t = private
       { range_check0 : 'bool
       ; range_check1 : 'bool
       ; foreign_field_add : 'bool


### PR DESCRIPTION
This PR tidies up the various different implementations of 'generating derived features from true features'. This is now captured in a (private) record `Features.Full.t`, which everything can use, and which can only be constructed via 1 codepath.

This ensure that we do not have inconsistencies that will break pickles if/when features about the custom gates change, and that the circuits generated are as optimised as possible.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them