### PR TITLE
[develop] Compute the size of the concatenation of all fixed and runtime lookup tables

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
+++ b/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
@@ -11,6 +11,8 @@ module Plonk_constraint_system : sig
 
   val get_public_input_size : ('a, 'b) t -> int Core_kernel.Set_once.t
 
+  val get_concatenated_fixed_lookup_table_size : ('a, 'b) t -> int
+
   val get_rows_len : ('a, 'b) t -> int
 end
 

--- a/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
+++ b/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
@@ -13,6 +13,8 @@ module Plonk_constraint_system : sig
 
   val get_concatenated_fixed_lookup_table_size : ('a, 'b) t -> int
 
+  val get_concatenated_runtime_lookup_table_size : ('a, 'b) t -> int
+
   val get_rows_len : ('a, 'b) t -> int
 end
 

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -769,6 +769,19 @@ let get_prev_challenges sys = sys.prev_challenges
 let set_prev_challenges sys challenges =
   Core_kernel.Set_once.set_exn sys.prev_challenges [%here] challenges
 
+let get_concatenated_fixed_lookup_table_size sys =
+  match sys.fixed_lookup_tables with
+  | Unfinalized_fixed_lookup_tables_rev _ ->
+      failwith
+        "Cannot get the fixed lookup tables before finalizing the constraint \
+         system"
+  | Compiled_fixed_lookup_tables flts ->
+      let get_table_size (flt : _ Kimchi_types.lookup_table) =
+        if Array.length flt.data = 0 then 0
+        else Array.length (Array.get flt.data 0)
+      in
+      Array.fold_left (fun acc flt -> acc + get_table_size flt) 0 flts
+
 (* TODO: shouldn't that Make create something bounded by a signature? As we know what a back end should be? Check where this is used *)
 
 (* TODO: glossary of terms in this file (terms, reducing, feeding) + module doc *)
@@ -807,6 +820,8 @@ module Make
   val get_rows_len : t -> int
 
   val next_row : t -> int
+
+  val get_concatenated_fixed_lookup_table_size : t -> int
 
   val add_constraint :
        ?label:string
@@ -978,6 +993,9 @@ end = struct
   let get_rows_len (sys : t) = get_rows_len sys
 
   let next_row (sys : t) = sys.next_row
+
+  let get_concatenated_fixed_lookup_table_size (sys : t) =
+    get_concatenated_fixed_lookup_table_size sys
 
   (** Adds {row; col} to the system's wiring under a specific key.
       A key is an external or internal variable.

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -782,6 +782,18 @@ let get_concatenated_fixed_lookup_table_size sys =
       in
       Array.fold_left (fun acc flt -> acc + get_table_size flt) 0 flts
 
+let get_concatenated_runtime_lookup_table_size sys =
+  match sys.runtime_tables_cfg with
+  | Unfinalized_runtime_tables_cfg_rev _ ->
+      failwith
+        "Cannot get the runtime table configurations before finalizing the \
+         constraint system"
+  | Compiled_runtime_tables_cfg rt_cfgs ->
+      Array.fold_left
+        (fun acc (rt_cfg : _ Kimchi_types.runtime_table_cfg) ->
+          acc + Array.length rt_cfg.first_column )
+        0 rt_cfgs
+
 (* TODO: shouldn't that Make create something bounded by a signature? As we know what a back end should be? Check where this is used *)
 
 (* TODO: glossary of terms in this file (terms, reducing, feeding) + module doc *)
@@ -822,6 +834,8 @@ module Make
   val next_row : t -> int
 
   val get_concatenated_fixed_lookup_table_size : t -> int
+
+  val get_concatenated_runtime_lookup_table_size : t -> int
 
   val add_constraint :
        ?label:string
@@ -996,6 +1010,9 @@ end = struct
 
   let get_concatenated_fixed_lookup_table_size (sys : t) =
     get_concatenated_fixed_lookup_table_size sys
+
+  let get_concatenated_runtime_lookup_table_size (sys : t) =
+    get_concatenated_runtime_lookup_table_size sys
 
   (** Adds {row; col} to the system's wiring under a specific key.
       A key is an external or internal variable.

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -27,11 +27,13 @@ module type With_accessors = sig
 end
 
 module type Full = sig
-  include With_accessors
-
   type fp
 
   type gates
+
+  include
+    With_accessors
+      with type t = (fp, gates) Kimchi_backend_common.Plonk_constraint_system.t
 
   val add_constraint :
        ?label:string

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -53,6 +53,9 @@ module type Full = sig
       built-in XOR and RangeCheck tables *)
   val get_concatenated_fixed_lookup_table_size : t -> int
 
+  (** Return the size of all the runtime lookup tables concatenated *)
+  val get_concatenated_runtime_lookup_table_size : t -> int
+
   val digest : t -> Md5.t
 
   val to_json : t -> string

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -49,6 +49,10 @@ module type Full = sig
        * fp Kimchi_types.lookup_table array
        * fp Kimchi_types.runtime_table_cfg array
 
+  (** Return the size of all the fixed lookup tables concatenated, without the
+      built-in XOR and RangeCheck tables *)
+  val get_concatenated_fixed_lookup_table_size : t -> int
+
   val digest : t -> Md5.t
 
   val to_json : t -> string

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -31,10 +31,7 @@ let domains (type field) ?feature_flags
               ; xor
               ; rot
               ; lookup
-              ; runtime_tables =
-                  _
-                  (* TODO: add the length of the runtime table configuration. Should
-                     look like the one for the fixed lookup tables *)
+              ; runtime_tables
               } =
             feature_flags
           in
@@ -45,13 +42,17 @@ let domains (type field) ?feature_flags
             let xor_table_used = xor in
             (if range_check_table_used then Int.pow 2 12 else 0)
             + (if xor_table_used then Int.pow 2 8 else 0)
+            + ( if lookup then
+                Impl.R1CS_constraint_system
+                .get_concatenated_fixed_lookup_table_size sys
+              else 0 )
             +
-            (* TODO: add runtime table cfg *)
-            if lookup then
+            if runtime_tables then
               Impl.R1CS_constraint_system
-              .get_concatenated_fixed_lookup_table_size sys
+              .get_concatenated_runtime_lookup_table_size sys
             else 0
           in
+
           Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
     in
     let public_input_size =

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -7,7 +7,7 @@ let rough_domains =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { Domains.h = d }
 
-let domains (type field) ?(min_log2 = 0)
+let domains (type field) ?feature_flags
     (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
     (Spec.ETyp.T (typ, conv, _conv_inv))
     (Spec.ETyp.T (return_typ, _ret_conv, ret_conv_inv)) main =
@@ -15,6 +15,45 @@ let domains (type field) ?(min_log2 = 0)
 
   let domains2 sys =
     let open Domain in
+    (* Compute the domain requires for the lookup tables *)
+    let lookup_table_length_log2 =
+      match feature_flags with
+      | None ->
+          0
+      | Some feature_flags ->
+          let { Pickles_types.Plonk_types.Features.range_check0
+              ; range_check1
+              ; foreign_field_add =
+                  _
+                  (* Does not use lookup tables, therefore we do
+                     not need in the computation *)
+              ; foreign_field_mul
+              ; xor
+              ; rot
+              ; lookup
+              ; runtime_tables =
+                  _
+                  (* TODO: add the length of the runtime table configuration. Should
+                     look like the one for the fixed lookup tables *)
+              } =
+            feature_flags
+          in
+          let combined_lookup_table_length =
+            let range_check_table_used =
+              range_check0 || range_check1 || foreign_field_mul || rot
+            in
+            let xor_table_used = xor in
+            (if range_check_table_used then Int.pow 2 12 else 0)
+            + (if xor_table_used then Int.pow 2 8 else 0)
+            +
+            (* TODO: add runtime table cfg *)
+            if lookup then
+              Impl.R1CS_constraint_system
+              .get_concatenated_fixed_lookup_table_size sys
+            else 0
+          in
+          Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
+    in
     let public_input_size =
       Set_once.get_exn
         (Impl.R1CS_constraint_system.get_public_input_size sys)
@@ -23,6 +62,8 @@ let domains (type field) ?(min_log2 = 0)
     let rows =
       zk_rows + public_input_size + Impl.R1CS_constraint_system.get_rows_len sys
     in
-    { Domains.h = Pow_2_roots_of_unity Int.(max min_log2 (ceil_log2 rows)) }
+    { Domains.h =
+        Pow_2_roots_of_unity Int.(max lookup_table_length_log2 (ceil_log2 rows))
+    }
   in
   domains2 (Impl.constraint_system ~input_typ:typ ~return_typ main)

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -1,6 +1,12 @@
 val domains :
      ?feature_flags:bool Pickles_types.Plonk_types.Features.t
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'field)
+  -> (module Snarky_backendless.Snark_intf.Run
+        with type field = 'field
+         and type R1CS_constraint_system.t = ( 'field
+                                             , 'gates )
+                                             Kimchi_backend_common
+                                             .Plonk_constraint_system
+                                             .t )
   -> ('a, 'b, 'field) Import.Spec.ETyp.t
   -> ('c, 'd, 'field) Import.Spec.ETyp.t
   -> ('a -> 'c)

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -1,9 +1,5 @@
 val domains :
-     ?min_log2:int
-       (** The minimum domain size to calculate. This can be overridden if
-           there are e.g. fixed-size lookup tables that will affect the domain
-           size of the circuit.
-        *)
+     ?feature_flags:bool Pickles_types.Plonk_types.Features.t
   -> (module Snarky_backendless.Snark_intf.Run with type field = 'field)
   -> ('a, 'b, 'field) Import.Spec.ETyp.t
   -> ('c, 'd, 'field) Import.Spec.ETyp.t

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -160,36 +160,7 @@ let create
         ~wrap_rounds:Backend.Tock.Rounds.n ~feature_flags
       (* TODO *)
     in
-    let lookup_table_length_log2 =
-      let { Plonk_types.Features.range_check0
-          ; range_check1
-          ; foreign_field_add = _
-          ; foreign_field_mul
-          ; xor
-          ; rot
-          ; lookup = _
-          ; runtime_tables = _
-          } =
-        actual_feature_flags
-      in
-      let combined_lookup_table_length =
-        let range_check_table_used =
-          range_check0 || range_check1 || foreign_field_mul || rot
-        in
-        let xor_table_used = xor in
-        (if range_check_table_used then Int.pow 2 12 else 0)
-        + (if xor_table_used then Int.pow 2 8 else 0)
-        + (* TODO: ask the Plonk_constraint_system.t for the user-provided
-             lookup tables and include their size here.
-             Fix_domains.domains below already constructs the constraint
-             system, so move this code there and use it directly.
-          *)
-        0
-      in
-      let zk_rows = 3 in
-      Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
-    in
-    Fix_domains.domains ~min_log2:lookup_table_length_log2
+    Fix_domains.domains ~feature_flags:actual_feature_flags
       (module Impls.Step)
       (T (Snarky_backendless.Typ.unit (), Fn.id, Fn.id))
       etyp main


### PR DESCRIPTION
Compute the size of the concatenated fixed and runtime lookup table.
Includes a change in snarky, see https://github.com/o1-labs/snarky/pull/831

Explain your changes:
* Fix https://github.com/MinaProtocol/mina/issues/13977

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
