### PR TITLE
Fixing condition not to run nightly on PR

### DIFF
--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -43,7 +43,7 @@ let makeCommand : JobSpec.Type -> Cmd.Type = \(job : JobSpec.Type) ->
       fi
     ''
   }
-  in Cmd.quietly (merge pipelineHandlers pipelineType)
+  in Cmd.quietly (merge pipelineHandlers requestedPipeline)
 
 let prefixCommands = [
   Cmd.run "git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt", -- Tell git where to find certs for https connections

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -33,7 +33,7 @@ let makeCommand : JobSpec.Type -> Cmd.Type = \(job : JobSpec.Type) ->
           echo "Triggering ${job.name} for reason:"
           cat _computed_diff.txt | egrep '${dirtyWhen}'
           ${Cmd.format trigger}
-        fi 
+        fi
       fi
     '',
     Stable = ''

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -20,7 +20,7 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
   steps = [
     Command.build Command.Config::{
       commands = [
-        Cmd.run "export BUILDKITE_PIPELINE_MODE=${env:BUILDKITE_PIPELINE_MODE as Text ? "(./buildkite/src/Pipeline/Mode.dhall).PullRequest"}",
+        Cmd.run "export BUILDKITE_PIPELINE_MODE=${env:BUILDKITE_PIPELINE_MODE as Text ? "PullRequest"}",
         Cmd.run "./buildkite/scripts/generate-jobs.sh > buildkite/src/gen/Jobs.dhall",
         triggerCommand "src/Monorepo.dhall"
       ],

--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -169,7 +169,7 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
   let batch_count = ref 0 in
   let limit =
     (* call this function after a transaction happens *)
-    (* TODO, in the current state of things, this function counts to limit_level of transactions, and then slaps a pause after it.  This happens even if the transactions themselves took far longer than the pause.  It thereby makes the rate slower and more conservative than would appear.  In future, perhaps implement with some sort of Timer *)
+    (* TODO: in the current state of things, this function counts to limit_level of transactions, and then slaps a pause after it.  This happens even if the transactions themselves took far longer than the pause.  It thereby makes the rate slower and more conservative than would appear.  In future, perhaps implement with some sort of Timer *)
     if rate_limit then ( fun () ->
       incr batch_count ;
       if !batch_count >= limit_level then


### PR DESCRIPTION
Explain your changes:
Small maintenance for CI logic. Currently after #13802 pipeline on PullRequest runs also Jobs designed to run only on Nightly. This pr is fixing this problem

Explain how you tested your changes:
Run CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

