### PR TITLE
Add genesis timestamp to genesis constants in GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6352,6 +6352,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "genesisTimestamp",
+              "description": "The genesis timestamp in ISO 8601 format",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -953,6 +953,14 @@ module Types = struct
             ~resolve:(fun { ctx = mina; _ } () ->
               (Mina_lib.config mina).precomputed_values.constraint_constants
                 .coinbase_amount )
+        ; field "genesisTimestamp" ~typ:(non_null string)
+            ~doc:"The genesis timestamp in ISO 8601 format"
+            ~args:Arg.[]
+            ~resolve:(fun { ctx = mina; _ } () ->
+              (Mina_lib.config mina).precomputed_values.genesis_constants
+                .protocol
+                .genesis_state_timestamp
+              |> Genesis_constants.genesis_timestamp_to_string )
         ] )
 
   module AccountObj = struct


### PR DESCRIPTION
Add additional field `genesisTimestamp` to `genesisConstants` GraphQL query.

Tested by running a local daemon, running GraphQL query. Saw:
```
   "genesisConstants": {
      "accountCreationFee": "1000000000",
      "coinbase": "720000000000",
      "genesisTimestamp": "2020-09-16T02:15:00.000000-08:00"
    }
```

(Note: should we still be using UTC-8 as the timezone?)

Closes #12728.