### PR TITLE
Add optional logic for computing the joint_combiner

### DIFF
--- a/src/lib/pickles/opt_sponge.ml
+++ b/src/lib/pickles/opt_sponge.ml
@@ -21,7 +21,7 @@ type 'f sponge_state =
 type 'f t =
   { mutable state : 'f array
   ; params : 'f Sponge.Params.t
-  ; needs_final_permute_if_empty : bool
+  ; mutable needs_final_permute_if_empty : bool
   ; mutable sponge_state : 'f sponge_state
   }
 
@@ -224,6 +224,7 @@ struct
     | Absorbing { next_index; xs } ->
         consume ~needs_final_permute_if_empty:t.needs_final_permute_if_empty
           ~start_pos:next_index ~params:t.params (Array.of_list_rev xs) t.state ;
+        t.needs_final_permute_if_empty <- true ;
         t.sponge_state <- Squeezed 1 ;
         t.state.(0)
 

--- a/src/lib/pickles/opt_sponge.mli
+++ b/src/lib/pickles/opt_sponge.mli
@@ -19,6 +19,8 @@ module Make
 
   val create : ?init:Impl.Field.t array -> Impl.Field.t Sponge.Params.t -> t
 
+  val copy : t -> t
+
   val of_sponge : Impl.Field.t Sponge.t -> t
 
   val absorb :
@@ -27,4 +29,6 @@ module Make
   val squeeze : t -> Impl.Field.t
 
   val consume_all_pending : t -> unit
+
+  val recombine : original_sponge:t -> Impl.Boolean.var -> t -> unit
 end

--- a/src/lib/pickles/opt_sponge.mli
+++ b/src/lib/pickles/opt_sponge.mli
@@ -19,6 +19,10 @@ module Make
 
   val create : ?init:Impl.Field.t array -> Impl.Field.t Sponge.Params.t -> t
 
+  (** Create a new sponge with state copied from the given sponge.
+      In particular, this copies the underlying state array, so that any
+      mutations to the copy will not affect the original.
+  *)
   val copy : t -> t
 
   val of_sponge : Impl.Field.t Sponge.t -> t
@@ -28,7 +32,33 @@ module Make
 
   val squeeze : t -> Impl.Field.t
 
+  (** Updates the sponge state by forcing absorption of all 'pending' field
+      elements passed to [absorb].
+      This method runs logic equivalent to that in the [squeeze] method, but
+      without transitioning the state.
+      This method can be used with [copy] to create a fork of a sponge where
+      one of the branches calls the [absorb] method and the other does not.
+  *)
   val consume_all_pending : t -> unit
 
+  (** Recombines a forked copy of a sponge with the original.
+      When the boolean value is true, the sponge state will be preserved;
+      otherwise it will be overwritten by the state of the original sponge.
+
+      When an optional [squeeze] has ocurred, both the original and forked
+      sponges have called [consume_all_pending] before the squeeze, and must
+      subsequently absorb the same value or values, to bring their internal
+      states back into alignment. 1 value is sufficient, but it is slightly
+      more efficient to absorb 2.
+
+      This enables optional absorption for sponges. For example:
+{[
+      let original_sponge = Opt_sponge.copy sponge in
+      let squeezed = Opt_sponge.squeeze sponge in
+      Opt_sponge.absorb sponge x_opt ;
+      Opt_sponge.absorb original_sponge x_opt ;
+      Opt_sponge.recombine ~original_sponge b sponge
+]}
+  *)
   val recombine : original_sponge:t -> Impl.Boolean.var -> t -> unit
 end

--- a/src/lib/pickles/opt_sponge.mli
+++ b/src/lib/pickles/opt_sponge.mli
@@ -25,4 +25,6 @@ module Make
     t -> Impl.Field.t Snarky_backendless.Boolean.t * Impl.Field.t -> unit
 
   val squeeze : t -> Impl.Field.t
+
+  val consume_all_pending : t -> unit
 end

--- a/src/lib/pickles/opt_sponge.mli
+++ b/src/lib/pickles/opt_sponge.mli
@@ -8,7 +8,7 @@ type 'f sponge_state =
 type 'f t =
   { mutable state : 'f array
   ; params : 'f Sponge.Params.t
-  ; needs_final_permute_if_empty : bool
+  ; mutable needs_final_permute_if_empty : bool
   ; mutable sponge_state : 'f sponge_state
   }
 

--- a/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
+++ b/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
@@ -314,3 +314,10 @@ module Foreign_field_mul = Make_test (struct
 
   let feature_flags2 = feature_flags
 end)
+
+module Different_sizes_of_lookup = Make_test (struct
+  let feature_flags1 =
+    Plonk_types.Features.{ none_bool with foreign_field_mul = true }
+
+  let feature_flags2 = Plonk_types.Features.{ none_bool with xor = true }
+end)

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -930,9 +930,7 @@ struct
                     { inner =
                         Field.if_ b ~then_:joint_combiner_if_true.inner
                           ~else_:joint_combiner_if_false.inner
-                    }
-              | _ ->
-                  . )
+                    } )
         in
         let lookup_table_comm =
           match (messages.lookup, joint_combiner) with

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -200,7 +200,7 @@ struct
     let open Tuple_lib in
     let to_maybe = function
       | Plonk_types.Opt.None ->
-          (Boolean.false_, (Field.zero, Field.zero))
+          (Boolean.false_, Inner_curve.one)
       | Plonk_types.Opt.Maybe (b, x) ->
           (b, x)
       | Plonk_types.Opt.Some x ->

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -852,7 +852,6 @@ struct
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;
-        Opt.consume_all_pending sponge ;
         let joint_combiner =
           match messages.lookup with
           | None ->
@@ -860,6 +859,7 @@ struct
           | Maybe (_, _) ->
               failwith "TODO"
           | Some l -> (
+              Opt.consume_all_pending sponge ;
               let absorb_sorted_1 sponge =
                 let (first :: _) = l.sorted in
                 let z = Array.map first ~f:(fun z -> (Boolean.true_, z)) in

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -198,61 +198,99 @@ struct
       -> (Inner_curve.t, (Inner_curve.t, Boolean.var) Plonk_types.Opt.t) index'
       =
     let open Tuple_lib in
-    let to_maybe = function
-      | Plonk_types.Opt.None ->
-          (Boolean.false_, Inner_curve.one)
-      | Plonk_types.Opt.Maybe (b, x) ->
-          (b, x)
-      | Plonk_types.Opt.Some x ->
-          (Boolean.true_, x)
-    in
-    let map ~f_bool ~f =
-      Plonk_verification_key_evals.Step.map ~f ~f_opt:(function
-        | Plonk_types.Opt.None ->
-            Plonk_types.Opt.None
-        | Plonk_types.Opt.Maybe (b, x) ->
-            Plonk_types.Opt.Maybe (f_bool b, f x)
-        | Plonk_types.Opt.Some x ->
-            Plonk_types.Opt.Some (f x) )
-    in
-    let map2 ~f_bool ~f =
-      Plonk_verification_key_evals.Step.map2 ~f ~f_opt:(fun x y ->
-          match (x, y) with
-          | Plonk_types.Opt.None, Plonk_types.Opt.None ->
-              Plonk_types.Opt.None
-          | Plonk_types.Opt.Some x, Plonk_types.Opt.Some y ->
-              Plonk_types.Opt.Some (f x y)
-          | ( (Plonk_types.Opt.Some _ | Maybe _ | None)
-            , (Plonk_types.Opt.Some _ | Maybe _ | None) ) ->
-              let b1, x1 = to_maybe x in
-              let b2, x2 = to_maybe y in
-              let b = f_bool b1 b2 in
-              Plonk_types.Opt.Maybe (b, f x1 x2) )
-    in
     fun bs keys ->
       let open Field in
       Vector.map2
         (bs :> (Boolean.var, n) Vector.t)
         keys
         ~f:(fun b key ->
-          map
-            (Plonk_verification_key_evals.Step.map ~f:Fn.id
-               ~f_opt:(fun x ->
-                 let b, x = to_maybe x in
-                 Plonk_types.Opt.Maybe (b, x) )
-               key )
+          Plonk_verification_key_evals.Step.map key
             ~f:(fun g -> Double.map g ~f:(( * ) (b :> t)))
-            ~f_bool:(fun b_inner -> Boolean.(b &&& b_inner)) )
+            ~f_opt:(function
+              (* Here, we split the 3 variants into 3 separate accumulators. This
+                 allows us to only compute the 'maybe' flag when we need to, and
+                 allows us to fall back to the basically-free `None` when a
+                 feature is entirely unused, or to the less expensive `Some` if
+                 it is used for every circuit.
+                 In particular, it is important that we generate exactly `None`
+                 when none of the optional gates are used, otherwise we will
+                 change the serialization of the protocol circuits.
+              *)
+              | Plonk_types.Opt.None ->
+                  ([], [], [ b ])
+              | Plonk_types.Opt.Maybe (b_x, x) ->
+                  ([], [ (b, b_x, x) ], [])
+              | Plonk_types.Opt.Some x ->
+                  ([ (b, x) ], [], []) ) )
       |> Vector.reduce_exn
            ~f:
-             (map2 ~f:(Double.map2 ~f:( + ))
-                ~f_bool:(fun (b1 : Boolean.var) (b2 : Boolean.var) ->
-                  Boolean.Unsafe.of_cvar
-                    Field.(add (b1 :> Field.t) (b2 :> Field.t)) ) )
-      |> map
-           ~f:(fun g -> Double.map ~f:(Util.seal (module Impl)) g)
-           ~f_bool:(fun (b : Boolean.var) ->
-             Boolean.Unsafe.of_cvar (Util.seal (module Impl) (b :> t)) )
+             (Plonk_verification_key_evals.Step.map2 ~f:(Double.map2 ~f:( + ))
+                ~f_opt:(fun (yes_1, maybe_1, no_1) (yes_2, maybe_2, no_2) ->
+                  (yes_1 @ yes_2, maybe_1 @ maybe_2, no_1 @ no_2) ) )
+      |> Plonk_verification_key_evals.Step.map ~f:Fn.id ~f_opt:(function
+           | [], [], _nones ->
+               (* We only have `None`s, so we can emit exactly `None` without
+                  further computation.
+               *)
+               Plonk_types.Opt.None
+           | somes, [], [] ->
+               (* Special case: we don't need to compute the 'maybe' bool
+                  because we know statically that all entries are `Some`.
+               *)
+               let sum =
+                 somes
+                 |> List.map ~f:(fun ((b : Boolean.var), g) ->
+                        Double.map g ~f:(( * ) (b :> t)) )
+                 |> List.reduce_exn ~f:(Double.map2 ~f:( + ))
+               in
+               Plonk_types.Opt.Some sum
+           | somes, maybes, nones ->
+               let is_none =
+                 List.reduce nones
+                   ~f:(fun (b1 : Boolean.var) (b2 : Boolean.var) ->
+                     Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t)) )
+               in
+               let none_sum =
+                 Option.map is_none ~f:(fun (b : Boolean.var) ->
+                     Double.map Inner_curve.one ~f:(( * ) (b :> t)) )
+               in
+               let some_is_yes, some_sum =
+                 somes
+                 |> List.map ~f:(fun ((b : Boolean.var), g) ->
+                        (b, Double.map g ~f:(( * ) (b :> t))) )
+                 |> List.reduce
+                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
+                         ->
+                        ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
+                        , Double.map2 ~f:( + ) g1 g2 ) )
+                 |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
+               in
+               let maybe_is_yes, maybe_sum =
+                 maybes
+                 |> List.map
+                      ~f:(fun ((b : Boolean.var), (b_g : Boolean.var), g) ->
+                        ( Boolean.Unsafe.of_cvar Field.(mul (b :> t) (b_g :> t))
+                        , Double.map g ~f:(( * ) (b :> t)) ) )
+                 |> List.reduce
+                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
+                         ->
+                        ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
+                        , Double.map2 ~f:( + ) g1 g2 ) )
+                 |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
+               in
+               let is_yes =
+                 [| some_is_yes; maybe_is_yes |]
+                 |> Array.filter_map ~f:Fn.id
+                 |> Array.reduce_exn
+                      ~f:(fun (b1 : Boolean.var) (b2 : Boolean.var) ->
+                        Boolean.Unsafe.of_cvar ((b1 :> t) + (b2 :> t)) )
+               in
+               let sum =
+                 [| none_sum; maybe_sum; some_sum |]
+                 |> Array.filter_map ~f:Fn.id
+                 |> Array.reduce_exn ~f:(Double.map2 ~f:( + ))
+               in
+               Plonk_types.Opt.Maybe (is_yes, sum) )
 
   (* TODO: Unify with the code in step_verifier *)
   let lagrange (type n)

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -852,6 +852,7 @@ struct
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;
+        Opt.consume_all_pending sponge ;
         let joint_combiner =
           match messages.lookup with
           | None ->
@@ -859,12 +860,18 @@ struct
           | Maybe (_, _) ->
               failwith "TODO"
           | Some l -> (
-              let absorb_sorted_first_part () =
-                Vector.iter l.sorted ~f:(fun z ->
+              let absorb_sorted_1 sponge =
+                let (first :: _) = l.sorted in
+                let z = Array.map first ~f:(fun z -> (Boolean.true_, z)) in
+                absorb sponge Without_degree_bound z
+              in
+              let absorb_sorted_2_to_4 () =
+                let (_ :: rest) = l.sorted in
+                Vector.iter rest ~f:(fun z ->
                     let z = Array.map z ~f:(fun z -> (Boolean.true_, z)) in
                     absorb sponge Without_degree_bound z )
               in
-              let absorb_sorted_second_part () =
+              let absorb_sorted_5 () =
                 match l.sorted_5th_column with
                 | None ->
                     ()
@@ -880,15 +887,52 @@ struct
               with
               | _ :: Some _ :: _, _ | _, Some _ ->
                   let joint_combiner = sample_scalar () in
-                  absorb_sorted_first_part () ;
-                  absorb_sorted_second_part () ;
+                  absorb_sorted_1 sponge ;
+                  absorb_sorted_2_to_4 () ;
+                  absorb_sorted_5 () ;
                   Types.Opt.Some joint_combiner
               | _ :: None :: _, None ->
-                  absorb_sorted_first_part () ;
-                  absorb_sorted_second_part () ;
+                  absorb_sorted_1 sponge ;
+                  absorb_sorted_2_to_4 () ;
+                  absorb_sorted_5 () ;
                   Types.Opt.Some { inner = Field.zero }
+              | _ :: Maybe (b1, _) :: _, Maybe (b2, _) ->
+                  let b = Boolean.(b1 ||| b2) in
+                  let sponge2 = Opt.copy sponge in
+                  let joint_combiner_if_true =
+                    let joint_combiner = sample_scalar () in
+                    absorb_sorted_1 sponge ; joint_combiner
+                  in
+                  let joint_combiner_if_false : Scalar_challenge.t =
+                    absorb_sorted_1 sponge2 ; { inner = Field.zero }
+                  in
+                  Opt.recombine b ~original_sponge:sponge2 sponge ;
+                  absorb_sorted_2_to_4 () ;
+                  absorb_sorted_5 () ;
+                  Types.Opt.Some
+                    { inner =
+                        Field.if_ b ~then_:joint_combiner_if_true.inner
+                          ~else_:joint_combiner_if_false.inner
+                    }
+              | _ :: Maybe (b, _) :: _, _ | _, Maybe (b, _) ->
+                  let sponge2 = Opt.copy sponge in
+                  let joint_combiner_if_true =
+                    let joint_combiner = sample_scalar () in
+                    absorb_sorted_1 sponge ; joint_combiner
+                  in
+                  let joint_combiner_if_false : Scalar_challenge.t =
+                    absorb_sorted_1 sponge2 ; { inner = Field.zero }
+                  in
+                  Opt.recombine b ~original_sponge:sponge2 sponge ;
+                  absorb_sorted_2_to_4 () ;
+                  absorb_sorted_5 () ;
+                  Types.Opt.Some
+                    { inner =
+                        Field.if_ b ~then_:joint_combiner_if_true.inner
+                          ~else_:joint_combiner_if_false.inner
+                    }
               | _ ->
-                  failwith "TODO" )
+                  . )
         in
         let lookup_table_comm =
           match (messages.lookup, joint_combiner) with


### PR DESCRIPTION
This PR continues the work to enable custom gates, using the TDD style. The test added here triggers the condition where the lookup table has differing widths between the 2 different inductive rules.

In this case, we need 2 'branches' of the sponge, one where it is 'squeezed' to generate the `joint_combiner`, and the other where it is not. In order to facilitate this, the `Opt_sponge` now exposes some additional methods to allow for the forking, re-alignment, and re-combining of the sponges that execute the branches.

This PR also fixes an issue in `choose_key`, where combining a `Some` or `None` from one branch with a `Maybe` from another would not correctly set the boolean in the resulting `Maybe`. Embedded in this change is also a change to the default value for `None` commitments, from `(0, 0)` to the group generator, avoiding a division-by-zero error when computing the combined lookup table commitment.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them