### PR TITLE
Add optional logic for lookups

### DIFF
--- a/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
+++ b/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
@@ -321,3 +321,9 @@ module Different_sizes_of_lookup = Make_test (struct
 
   let feature_flags2 = Plonk_types.Features.{ none_bool with xor = true }
 end)
+
+module With_and_without_lookup = Make_test (struct
+  let feature_flags1 = Plonk_types.Features.{ none_bool with xor = true }
+
+  let feature_flags2 = Plonk_types.Features.none_bool
+end)

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -853,224 +853,243 @@ struct
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;
         let joint_combiner =
+          let compute_joint_combiner (l : _ Messages.Lookup.In_circuit.t) =
+            let absorb_sorted_1 sponge =
+              let (first :: _) = l.sorted in
+              let z = Array.map first ~f:(fun z -> (Boolean.true_, z)) in
+              absorb sponge Without_degree_bound z
+            in
+            let absorb_sorted_2_to_4 () =
+              let (_ :: rest) = l.sorted in
+              Vector.iter rest ~f:(fun z ->
+                  let z = Array.map z ~f:(fun z -> (Boolean.true_, z)) in
+                  absorb sponge Without_degree_bound z )
+            in
+            let absorb_sorted_5 () =
+              match l.sorted_5th_column with
+              | None ->
+                  ()
+              | Maybe (b, z) ->
+                  let z = Array.map z ~f:(fun z -> (b, z)) in
+                  absorb sponge Without_degree_bound z
+              | Some z ->
+                  let z = Array.map z ~f:(fun z -> (Boolean.true_, z)) in
+                  absorb sponge Without_degree_bound z
+            in
+            match[@warning "-4"]
+              (m.lookup_table_comm, m.runtime_tables_selector)
+            with
+            | _ :: Some _ :: _, _ | _, Some _ ->
+                let joint_combiner = sample_scalar () in
+                absorb_sorted_1 sponge ;
+                absorb_sorted_2_to_4 () ;
+                absorb_sorted_5 () ;
+                joint_combiner
+            | _ :: None :: _, None ->
+                absorb_sorted_1 sponge ;
+                absorb_sorted_2_to_4 () ;
+                absorb_sorted_5 () ;
+                { inner = Field.zero }
+            | _ :: Maybe (b1, _) :: _, Maybe (b2, _) ->
+                let b = Boolean.(b1 ||| b2) in
+                let sponge2 = Opt.copy sponge in
+                let joint_combiner_if_true =
+                  let joint_combiner = sample_scalar () in
+                  absorb_sorted_1 sponge ; joint_combiner
+                in
+                let joint_combiner_if_false : Scalar_challenge.t =
+                  absorb_sorted_1 sponge2 ; { inner = Field.zero }
+                in
+                Opt.recombine b ~original_sponge:sponge2 sponge ;
+                absorb_sorted_2_to_4 () ;
+                absorb_sorted_5 () ;
+                { inner =
+                    Field.if_ b ~then_:joint_combiner_if_true.inner
+                      ~else_:joint_combiner_if_false.inner
+                }
+            | _ :: Maybe (b, _) :: _, _ | _, Maybe (b, _) ->
+                let sponge2 = Opt.copy sponge in
+                let joint_combiner_if_true =
+                  let joint_combiner = sample_scalar () in
+                  absorb_sorted_1 sponge ; joint_combiner
+                in
+                let joint_combiner_if_false : Scalar_challenge.t =
+                  absorb_sorted_1 sponge2 ; { inner = Field.zero }
+                in
+                Opt.recombine b ~original_sponge:sponge2 sponge ;
+                absorb_sorted_2_to_4 () ;
+                absorb_sorted_5 () ;
+                { inner =
+                    Field.if_ b ~then_:joint_combiner_if_true.inner
+                      ~else_:joint_combiner_if_false.inner
+                }
+          in
           match messages.lookup with
           | None ->
               Types.Opt.None
-          | Maybe (_, _) ->
-              failwith "TODO"
-          | Some l -> (
+          | Maybe (b, l) ->
               Opt.consume_all_pending sponge ;
-              let absorb_sorted_1 sponge =
-                let (first :: _) = l.sorted in
-                let z = Array.map first ~f:(fun z -> (Boolean.true_, z)) in
-                absorb sponge Without_degree_bound z
-              in
-              let absorb_sorted_2_to_4 () =
-                let (_ :: rest) = l.sorted in
-                Vector.iter rest ~f:(fun z ->
-                    let z = Array.map z ~f:(fun z -> (Boolean.true_, z)) in
-                    absorb sponge Without_degree_bound z )
-              in
-              let absorb_sorted_5 () =
-                match l.sorted_5th_column with
-                | None ->
-                    ()
-                | Maybe (b, z) ->
-                    let z = Array.map z ~f:(fun z -> (b, z)) in
-                    absorb sponge Without_degree_bound z
-                | Some z ->
-                    let z = Array.map z ~f:(fun z -> (Boolean.true_, z)) in
-                    absorb sponge Without_degree_bound z
-              in
-              match[@warning "-4"]
-                (m.lookup_table_comm, m.runtime_tables_selector)
-              with
-              | _ :: Some _ :: _, _ | _, Some _ ->
-                  let joint_combiner = sample_scalar () in
-                  absorb_sorted_1 sponge ;
-                  absorb_sorted_2_to_4 () ;
-                  absorb_sorted_5 () ;
-                  Types.Opt.Some joint_combiner
-              | _ :: None :: _, None ->
-                  absorb_sorted_1 sponge ;
-                  absorb_sorted_2_to_4 () ;
-                  absorb_sorted_5 () ;
-                  Types.Opt.Some { inner = Field.zero }
-              | _ :: Maybe (b1, _) :: _, Maybe (b2, _) ->
-                  let b = Boolean.(b1 ||| b2) in
-                  let sponge2 = Opt.copy sponge in
-                  let joint_combiner_if_true =
-                    let joint_combiner = sample_scalar () in
-                    absorb_sorted_1 sponge ; joint_combiner
-                  in
-                  let joint_combiner_if_false : Scalar_challenge.t =
-                    absorb_sorted_1 sponge2 ; { inner = Field.zero }
-                  in
-                  Opt.recombine b ~original_sponge:sponge2 sponge ;
-                  absorb_sorted_2_to_4 () ;
-                  absorb_sorted_5 () ;
-                  Types.Opt.Some
-                    { inner =
-                        Field.if_ b ~then_:joint_combiner_if_true.inner
-                          ~else_:joint_combiner_if_false.inner
-                    }
-              | _ :: Maybe (b, _) :: _, _ | _, Maybe (b, _) ->
-                  let sponge2 = Opt.copy sponge in
-                  let joint_combiner_if_true =
-                    let joint_combiner = sample_scalar () in
-                    absorb_sorted_1 sponge ; joint_combiner
-                  in
-                  let joint_combiner_if_false : Scalar_challenge.t =
-                    absorb_sorted_1 sponge2 ; { inner = Field.zero }
-                  in
-                  Opt.recombine b ~original_sponge:sponge2 sponge ;
-                  absorb_sorted_2_to_4 () ;
-                  absorb_sorted_5 () ;
-                  Types.Opt.Some
-                    { inner =
-                        Field.if_ b ~then_:joint_combiner_if_true.inner
-                          ~else_:joint_combiner_if_false.inner
-                    } )
+              let sponge2 = Opt.copy sponge in
+              let joint_combiner = compute_joint_combiner l in
+              Opt.consume_all_pending sponge ;
+              Opt.recombine b ~original_sponge:sponge2 sponge ;
+              (* We explicitly set this, because when we squeeze for [beta], we
+                 there will be no pending values *but* we don't want to add a
+                 dedicated permutation.
+              *)
+              sponge.needs_final_permute_if_empty <- false ;
+              Types.Opt.Maybe (b, joint_combiner)
+          | Some l ->
+              Opt.consume_all_pending sponge ;
+              Types.Opt.Some (compute_joint_combiner l)
         in
         let lookup_table_comm =
+          let compute_lookup_table_comm (l : _ Messages.Lookup.In_circuit.t)
+              joint_combiner =
+            let (first_column :: second_column :: rest) =
+              Vector.map
+                ~f:(Types.Opt.map ~f:(fun x -> [| x |]))
+                m.lookup_table_comm
+            in
+            let second_column_with_runtime =
+              match (second_column, l.runtime) with
+              | Types.Opt.None, comm | comm, Types.Opt.None ->
+                  comm
+              | ( Types.Opt.Maybe (has_second_column, second_column)
+                , Types.Opt.Maybe (has_runtime, runtime) ) ->
+                  let second_with_runtime =
+                    let sum =
+                      Array.map2_exn ~f:Inner_curve.( + ) second_column runtime
+                    in
+                    Array.map2_exn second_column sum
+                      ~f:(fun second_column sum ->
+                        Inner_curve.if_ has_runtime ~then_:sum
+                          ~else_:second_column )
+                  in
+                  let res =
+                    Array.map2_exn second_with_runtime runtime
+                      ~f:(fun second_with_runtime runtime ->
+                        Inner_curve.if_ has_second_column
+                          ~then_:second_with_runtime ~else_:runtime )
+                  in
+                  let b = Boolean.(has_second_column ||| has_runtime) in
+                  Types.Opt.Maybe (b, res)
+              | ( Types.Opt.Maybe (has_second_column, second_column)
+                , Types.Opt.Some runtime ) ->
+                  let res =
+                    let sum =
+                      Array.map2_exn ~f:Inner_curve.( + ) second_column runtime
+                    in
+                    Array.map2_exn runtime sum ~f:(fun runtime sum ->
+                        Inner_curve.if_ has_second_column ~then_:sum
+                          ~else_:runtime )
+                  in
+                  Types.Opt.Some res
+              | ( Types.Opt.Some second_column
+                , Types.Opt.Maybe (has_runtime, runtime) ) ->
+                  let res =
+                    let sum =
+                      Array.map2_exn ~f:Inner_curve.( + ) second_column runtime
+                    in
+                    Array.map2_exn second_column sum
+                      ~f:(fun second_column sum ->
+                        Inner_curve.if_ has_runtime ~then_:sum
+                          ~else_:second_column )
+                  in
+                  Types.Opt.Some res
+              | Types.Opt.Some second_column, Types.Opt.Some runtime ->
+                  Types.Opt.Some
+                    (Array.map2_exn ~f:Inner_curve.( + ) second_column runtime)
+            in
+            let rest_rev =
+              Vector.rev (first_column :: second_column_with_runtime :: rest)
+            in
+            let table_ids =
+              Types.Opt.map m.lookup_table_ids ~f:(fun x -> [| x |])
+            in
+            Vector.fold ~init:table_ids rest_rev ~f:(fun acc comm ->
+                match acc with
+                | Types.Opt.None ->
+                    comm
+                | Types.Opt.Maybe (has_acc, acc) -> (
+                    match comm with
+                    | Types.Opt.None ->
+                        Types.Opt.Maybe (has_acc, acc)
+                    | Types.Opt.Maybe (has_comm, comm) ->
+                        let scaled_acc =
+                          Array.map acc ~f:(fun acc ->
+                              Scalar_challenge.endo acc joint_combiner )
+                        in
+                        let sum =
+                          Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
+                        in
+                        let acc_with_comm =
+                          Array.map2_exn sum comm ~f:(fun sum comm ->
+                              Inner_curve.if_ has_acc ~then_:sum ~else_:comm )
+                        in
+                        let res =
+                          Array.map2_exn acc acc_with_comm
+                            ~f:(fun acc acc_with_comm ->
+                              Inner_curve.if_ has_comm ~then_:acc_with_comm
+                                ~else_:acc )
+                        in
+                        let b = Boolean.(has_acc ||| has_comm) in
+                        Types.Opt.Maybe (b, res)
+                    | Types.Opt.Some comm ->
+                        let scaled_acc =
+                          Array.map acc ~f:(fun acc ->
+                              Scalar_challenge.endo acc joint_combiner )
+                        in
+                        let sum =
+                          Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
+                        in
+                        let res =
+                          Array.map2_exn sum comm ~f:(fun sum comm ->
+                              Inner_curve.if_ has_acc ~then_:sum ~else_:comm )
+                        in
+                        Types.Opt.Some res )
+                | Types.Opt.Some acc -> (
+                    match comm with
+                    | Types.Opt.None ->
+                        Types.Opt.Some acc
+                    | Types.Opt.Maybe (has_comm, comm) ->
+                        let scaled_acc =
+                          Array.map acc ~f:(fun acc ->
+                              Scalar_challenge.endo acc joint_combiner )
+                        in
+                        let sum =
+                          Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
+                        in
+                        let res =
+                          Array.map2_exn sum acc ~f:(fun sum acc ->
+                              Inner_curve.if_ has_comm ~then_:sum ~else_:acc )
+                        in
+                        Types.Opt.Some res
+                    | Types.Opt.Some comm ->
+                        let scaled_acc =
+                          Array.map acc ~f:(fun acc ->
+                              Scalar_challenge.endo acc joint_combiner )
+                        in
+                        Types.Opt.Some
+                          (Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm)
+                    ) )
+          in
           match (messages.lookup, joint_combiner) with
           | Types.Opt.None, Types.Opt.None ->
               Types.Opt.None
           | ( Types.Opt.Maybe (b_l, l)
-            , Types.Opt.Maybe (b_joint_combiner, joint_combiner) ) ->
-              ignore ((b_l, l, b_joint_combiner, joint_combiner) : _ * _ * _ * _) ;
-              failwith "TODO"
+            , Types.Opt.Maybe (_b_joint_combiner, joint_combiner) ) -> (
+              (* NB: b_l = _b_joint_combiner by construction *)
+              match compute_lookup_table_comm l joint_combiner with
+              | Types.Opt.None ->
+                  Types.Opt.None
+              | Types.Opt.Maybe (b_lookup_table_comm, lookup_table_comm) ->
+                  Types.Opt.Maybe
+                    (Boolean.(b_l &&& b_lookup_table_comm), lookup_table_comm)
+              | Types.Opt.Some lookup_table_comm ->
+                  Types.Opt.Maybe (b_l, lookup_table_comm) )
           | Types.Opt.Some l, Types.Opt.Some joint_combiner ->
-              let (first_column :: second_column :: rest) =
-                Vector.map
-                  ~f:(Types.Opt.map ~f:(fun x -> [| x |]))
-                  m.lookup_table_comm
-              in
-              let second_column_with_runtime =
-                match (second_column, l.runtime) with
-                | Types.Opt.None, comm | comm, Types.Opt.None ->
-                    comm
-                | ( Types.Opt.Maybe (has_second_column, second_column)
-                  , Types.Opt.Maybe (has_runtime, runtime) ) ->
-                    let second_with_runtime =
-                      let sum =
-                        Array.map2_exn ~f:Inner_curve.( + ) second_column
-                          runtime
-                      in
-                      Array.map2_exn second_column sum
-                        ~f:(fun second_column sum ->
-                          Inner_curve.if_ has_runtime ~then_:sum
-                            ~else_:second_column )
-                    in
-                    let res =
-                      Array.map2_exn second_with_runtime runtime
-                        ~f:(fun second_with_runtime runtime ->
-                          Inner_curve.if_ has_second_column
-                            ~then_:second_with_runtime ~else_:runtime )
-                    in
-                    let b = Boolean.(has_second_column ||| has_runtime) in
-                    Types.Opt.Maybe (b, res)
-                | ( Types.Opt.Maybe (has_second_column, second_column)
-                  , Types.Opt.Some runtime ) ->
-                    let res =
-                      let sum =
-                        Array.map2_exn ~f:Inner_curve.( + ) second_column
-                          runtime
-                      in
-                      Array.map2_exn runtime sum ~f:(fun runtime sum ->
-                          Inner_curve.if_ has_second_column ~then_:sum
-                            ~else_:runtime )
-                    in
-                    Types.Opt.Some res
-                | ( Types.Opt.Some second_column
-                  , Types.Opt.Maybe (has_runtime, runtime) ) ->
-                    let res =
-                      let sum =
-                        Array.map2_exn ~f:Inner_curve.( + ) second_column
-                          runtime
-                      in
-                      Array.map2_exn second_column sum
-                        ~f:(fun second_column sum ->
-                          Inner_curve.if_ has_runtime ~then_:sum
-                            ~else_:second_column )
-                    in
-                    Types.Opt.Some res
-                | Types.Opt.Some second_column, Types.Opt.Some runtime ->
-                    Types.Opt.Some
-                      (Array.map2_exn ~f:Inner_curve.( + ) second_column runtime)
-              in
-              let rest_rev =
-                Vector.rev (first_column :: second_column_with_runtime :: rest)
-              in
-              let table_ids =
-                Types.Opt.map m.lookup_table_ids ~f:(fun x -> [| x |])
-              in
-              Vector.fold ~init:table_ids rest_rev ~f:(fun acc comm ->
-                  match acc with
-                  | Types.Opt.None ->
-                      comm
-                  | Types.Opt.Maybe (has_acc, acc) -> (
-                      match comm with
-                      | Types.Opt.None ->
-                          Types.Opt.Maybe (has_acc, acc)
-                      | Types.Opt.Maybe (has_comm, comm) ->
-                          let scaled_acc =
-                            Array.map acc ~f:(fun acc ->
-                                Scalar_challenge.endo acc joint_combiner )
-                          in
-                          let sum =
-                            Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
-                          in
-                          let acc_with_comm =
-                            Array.map2_exn sum comm ~f:(fun sum comm ->
-                                Inner_curve.if_ has_acc ~then_:sum ~else_:comm )
-                          in
-                          let res =
-                            Array.map2_exn acc acc_with_comm
-                              ~f:(fun acc acc_with_comm ->
-                                Inner_curve.if_ has_comm ~then_:acc_with_comm
-                                  ~else_:acc )
-                          in
-                          let b = Boolean.(has_acc ||| has_comm) in
-                          Types.Opt.Maybe (b, res)
-                      | Types.Opt.Some comm ->
-                          let scaled_acc =
-                            Array.map acc ~f:(fun acc ->
-                                Scalar_challenge.endo acc joint_combiner )
-                          in
-                          let sum =
-                            Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
-                          in
-                          let res =
-                            Array.map2_exn sum comm ~f:(fun sum comm ->
-                                Inner_curve.if_ has_acc ~then_:sum ~else_:comm )
-                          in
-                          Types.Opt.Some res )
-                  | Types.Opt.Some acc -> (
-                      match comm with
-                      | Types.Opt.None ->
-                          Types.Opt.Some acc
-                      | Types.Opt.Maybe (has_comm, comm) ->
-                          let scaled_acc =
-                            Array.map acc ~f:(fun acc ->
-                                Scalar_challenge.endo acc joint_combiner )
-                          in
-                          let sum =
-                            Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm
-                          in
-                          let res =
-                            Array.map2_exn sum acc ~f:(fun sum acc ->
-                                Inner_curve.if_ has_comm ~then_:sum ~else_:acc )
-                          in
-                          Types.Opt.Some res
-                      | Types.Opt.Some comm ->
-                          let scaled_acc =
-                            Array.map acc ~f:(fun acc ->
-                                Scalar_challenge.endo acc joint_combiner )
-                          in
-                          Types.Opt.Some
-                            (Array.map2_exn ~f:Inner_curve.( + ) scaled_acc comm)
-                      ) )
+              compute_lookup_table_comm l joint_combiner
           | ( (Types.Opt.None | Maybe _ | Some _)
             , (Types.Opt.None | Maybe _ | Some _) ) ->
               assert false

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -1517,11 +1517,11 @@ module Messages = struct
       [@@deriving hlist]
     end
 
-    let dummy ~lookups_per_row_4 ~runtime_tables z =
+    let dummy z =
       { aggreg = z
       ; sorted = Vector.init Lookup_sorted_minus_1.n ~f:(fun _ -> z)
-      ; sorted_5th_column = Option.some_if lookups_per_row_4 z
-      ; runtime = Option.some_if runtime_tables z
+      ; sorted_5th_column = None
+      ; runtime = None
       }
 
     let typ bool_typ e ~lookups_per_row_4 ~runtime_tables ~dummy =
@@ -1537,11 +1537,7 @@ module Messages = struct
     let opt_typ bool_typ ~(uses_lookup : Opt.Flag.t)
         ~(lookups_per_row_4 : Opt.Flag.t) ~(runtime_tables : Opt.Flag.t)
         ~dummy:z elt =
-      Opt.typ bool_typ uses_lookup
-        ~dummy:
-          (dummy z
-             ~lookups_per_row_4:Opt.Flag.(not (equal lookups_per_row_4 No))
-             ~runtime_tables:Opt.Flag.(not (equal runtime_tables No)) )
+      Opt.typ bool_typ uses_lookup ~dummy:(dummy z)
         (typ bool_typ ~lookups_per_row_4 ~runtime_tables ~dummy:z elt)
   end
 


### PR DESCRIPTION
This PR completes the missing logic in the pickles verifier, adding support for combinations of circuit rules where some use the lookup argument and others do not.

In addition to that new code, this includes a bugfix around the handling of `Maybe` for the dummy values in the `Lookup` structure.

This PR completes the changes required to use the optional custom gates in pickles.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them