### PR TITLE
Expose `unequal` in module `Mina_stdlib.List`

### DIFF
--- a/src/lib/mina_stdlib/list.mli
+++ b/src/lib/mina_stdlib/list.mli
@@ -7,6 +7,10 @@ module Length : sig
    *)
   val equal : 'a t
 
+  (** [unequal l len] returns [true] if [List.length l <> len], [false] otherwise.
+   *)
+  val unequal : 'a t
+
   (** [gte l len] returns [true] if [List.length l >= len], [false]
     otherwise.
    *)

--- a/src/lib/mina_stdlib/list.mli
+++ b/src/lib/mina_stdlib/list.mli
@@ -33,24 +33,24 @@ module Length : sig
 
   (** {2 Infix comparison operators} *)
 
-  (** [Compare] contains infix aliases for functions of {!module:Length} *)
+  (** [Compare] contains infix aliases for functions of {!module:Length}. *)
   module Compare : sig
-    (** [( = )] is [equal] *)
+    (** [( = )] is {!val:equal}. *)
     val ( = ) : 'a t
 
-    (** [( <> )] is [unequal] *)
+    (** [( <> )] is {!val:unequal}. *)
     val ( <> ) : 'a t
 
-    (** [( >= )] is [gte] *)
+    (** [( >= )] is {!val:gte}. *)
     val ( >= ) : 'a t
 
-    (** [l > len] is [gt] *)
+    (** [l > len] is {!val:gt}. *)
     val ( > ) : 'a t
 
-    (** [( <= )] is [lte] *)
+    (** [( <= )] is {!val:lte}. *)
     val ( <= ) : 'a t
 
-    (** [l < len] is [lt] *)
+    (** [l < len] is {!val:lt}. *)
     val ( < ) : 'a t
   end
 end


### PR DESCRIPTION
The `unequal` function was not exposed while its infix counterpart was - this was the lone example of such an instance.

This also adds links to the generated doc, using `{!val:foo}` instead of `[foo]`.