### PR TITLE
Add vesting accounts to hard fork test

### DIFF
--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -56,17 +56,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let epoch_ledger = next_accounts in
       { epoch_ledger; epoch_seed }
     in
-    let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
-        ~vesting_increment : Mina_base.Account_timing.t =
-      let open Currency in
-      Timed
-        { initial_minimum_balance = Balance.of_nanomina_int_exn min_balance
-        ; cliff_time = Mina_numbers.Global_slot_since_genesis.of_int cliff_time
-        ; cliff_amount = Amount.of_nanomina_int_exn cliff_amount
-        ; vesting_period = Mina_numbers.Global_slot_span.of_int vesting_period
-        ; vesting_increment = Amount.of_nanomina_int_exn vesting_increment
-        }
-    in
     { default with
       requires_graphql = true
     ; epoch_data = Some { staking; next = Some next }

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -21,17 +21,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   (* TODO: test account creation fee *)
   let config =
     let open Test_config in
-    let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
-        ~vesting_increment : Mina_base.Account_timing.t =
-      let open Currency in
-      Timed
-        { initial_minimum_balance = Balance.of_nanomina_int_exn min_balance
-        ; cliff_time = Mina_numbers.Global_slot_since_genesis.of_int cliff_time
-        ; cliff_amount = Amount.of_nanomina_int_exn cliff_amount
-        ; vesting_period = Mina_numbers.Global_slot_span.of_int vesting_period
-        ; vesting_increment = Amount.of_nanomina_int_exn vesting_increment
-        }
-    in
     { default with
       requires_graphql = true
     ; genesis_ledger =

--- a/src/app/test_executive/test_common.ml
+++ b/src/app/test_executive/test_common.ml
@@ -438,4 +438,15 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     else
       let error = String.concat error_logs ~sep:"\n  " in
       Malleable_error.hard_error_string ("Replayer errors:\n  " ^ error)
+
+  let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
+      ~vesting_increment : Mina_base.Account_timing.t =
+    let open Currency in
+    Timed
+      { initial_minimum_balance = Balance.of_nanomina_int_exn min_balance
+      ; cliff_time = Mina_numbers.Global_slot_since_genesis.of_int cliff_time
+      ; cliff_amount = Amount.of_nanomina_int_exn cliff_amount
+      ; vesting_period = Mina_numbers.Global_slot_span.of_int vesting_period
+      ; vesting_increment = Amount.of_nanomina_int_exn vesting_increment
+      }
 end


### PR DESCRIPTION
Add vesting accounts to hard fork integration test.

- timed1 fully vests before the hard fork
- timed2 has cliff before the hard fork
- timed3 has cliff at hard fork

Check that total, locked, liquid balances all comport with the vesting schedule.

The hard fork test is not part of PR CI, it's in the nightly CI. Here's a successful run from an earlier draft PR: https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/30221#018a6660-58c9-440c-9638-6b89876c96ce

Closes #13811.