### PR TITLE
Pickles: add a test with fixed lookup tables and fixed and small table ID

### DIFF
--- a/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
+++ b/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
@@ -11,6 +11,11 @@ open Pickles.Impls.Step
     src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.exe
 *)
 
+(* Set this value for reproducibility *)
+let seed = [| Random.int 1_000_000 |]
+
+let state = Random.State.make seed
+
 let () = Pickles.Backend.Tick.Keypair.set_urs_info []
 
 let () = Pickles.Backend.Tock.Keypair.set_urs_info []
@@ -192,6 +197,48 @@ let main_foreign_field_mul () =
   add_plonk_constraint
     (Raw { kind = Zero; values = [| fresh_int 0 |]; coeffs = [||] })
 
+(* Parameters *)
+let random_table_id = Random.State.int state 1_000
+
+let size = 1 + Random.State.int state 1_000
+
+let values =
+  Array.init size ~f:(fun _ ->
+      let x = Random.State.int state 1_000_000 in
+      Field.Constant.of_int x )
+
+let idx1 = Random.State.int state size
+
+let idx2 = Random.State.int state size
+
+let idx3 = Random.State.int state size
+
+let main_fixed_lookup_tables () =
+  let table_id = random_table_id in
+  let size = size in
+  let indexes = Array.init size ~f:Field.Constant.of_int in
+  let values = values in
+  add_plonk_constraint
+    (AddFixedLookupTable
+       { id = Int32.of_int_exn table_id; data = [| indexes; values |] } ) ;
+  let idx1 = idx1 in
+  let v1 = values.(idx1) in
+  let idx2 = idx2 in
+  let v2 = values.(idx2) in
+  let idx3 = idx3 in
+  let v3 = values.(idx3) in
+  add_plonk_constraint
+    (Lookup
+       { (* table id *)
+         w0 = fresh_int table_id
+       ; (* idx1 *) w1 = fresh_int idx1
+       ; (* v1 *) w2 = exists Field.typ ~compute:(fun () -> v1)
+       ; (* idx2 *) w3 = fresh_int idx2
+       ; (* v2 *) w4 = exists Field.typ ~compute:(fun () -> v2)
+       ; (* idx3 *) w5 = fresh_int idx3
+       ; (* v3 *) w6 = exists Field.typ ~compute:(fun () -> v3)
+       } )
+
 let add_tests, get_tests =
   let tests = ref [] in
   ( (fun name testcases -> tests := (name, testcases) :: !tests)
@@ -216,7 +263,8 @@ let main_body ~(feature_flags : _ Plonk_types.Features.t) () =
   if feature_flags.range_check0 then main_range_check0 () ;
   if feature_flags.range_check1 then main_range_check1 () ;
   if feature_flags.foreign_field_add then main_foreign_field_add () ;
-  if feature_flags.foreign_field_mul then main_foreign_field_mul ()
+  if feature_flags.foreign_field_mul then main_foreign_field_mul () ;
+  if feature_flags.lookup then main_fixed_lookup_tables ()
 
 let register_test name feature_flags1 feature_flags2 =
   let _tag, _cache_handle, proof, Pickles.Provers.[ prove1; prove2 ] =
@@ -296,6 +344,8 @@ let () =
       , Plonk_types.Features.{ none_bool with foreign_field_add = true } )
     ; ( "foreign field multiplication"
       , Plonk_types.Features.{ none_bool with foreign_field_mul = true } )
+    ; ( "Fixed lookup tables"
+      , Plonk_types.Features.{ none_bool with lookup = true } )
     ]
   in
   List.iter ~f:register_feature_test configurations ;


### PR DESCRIPTION
The table ID is for RangeCheck, but the table is not used

Explain your changes:
* Adding tests in Pickles for lookup tables. It is the first PR introducing tests related to lookup tables in Pickles.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
