### PR TITLE
Remove some oversized logs

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -417,7 +417,7 @@ let handle_block_production_errors ~logger ~rejected_blocks_logger
       (`Prover_error
         ( err
         , ( previous_protocol_state_proof
-          , internal_transition
+          , _internal_transition
           , pending_coinbase_witness ) ) ) ->
       let msg : (_, unit, string, unit) format4 =
         "Prover failed to prove freshly generated transition: $error"
@@ -427,8 +427,9 @@ let handle_block_production_errors ~logger ~rejected_blocks_logger
         ; ("prev_state", Protocol_state.value_to_yojson previous_protocol_state)
         ; ("prev_state_proof", Proof.to_yojson previous_protocol_state_proof)
         ; ("next_state", Protocol_state.value_to_yojson protocol_state)
-        ; ( "internal_transition"
-          , Internal_transition.to_yojson internal_transition )
+          (* Commented out because for large blocks it's an oversized log *)
+          (* ; ( "internal_transition"
+             , Internal_transition.to_yojson internal_transition ) *)
         ; ( "pending_coinbase_witness"
           , Pending_coinbase_witness.to_yojson pending_coinbase_witness )
         ; time_metadata
@@ -696,8 +697,11 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
             in
             let start = Block_time.now time_controller in
             [%log info]
-              ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson crumb) ]
-              "Producing new block with parent $breadcrumb%!" ;
+              ~metadata:
+                [ ( "parent_hash"
+                  , Breadcrumb.parent_hash crumb |> State_hash.to_yojson )
+                ]
+              "Producing new block with parent $parent_hash%!" ;
             let previous_transition = Breadcrumb.block_with_hash crumb in
             let previous_protocol_state =
               Header.protocol_state

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -700,6 +700,9 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
               ~metadata:
                 [ ( "parent_hash"
                   , Breadcrumb.parent_hash crumb |> State_hash.to_yojson )
+                ; ( "protocol_state"
+                  , Breadcrumb.protocol_state crumb
+                    |> Protocol_state.value_to_yojson )
                 ]
               "Producing new block with parent $parent_hash%!" ;
             let previous_transition = Breadcrumb.block_with_hash crumb in

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -60,4 +60,5 @@
    integers
    transition_handler
    snark_worker
+   one_or_two
 ))

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -379,7 +379,8 @@ module Gossip = struct
   end
 
   module Transactions = struct
-    type r = { fee_payer_sigs : Signature.t list } [@@deriving yojson, hash]
+    type r = { fee_payer_summaries : User_command.fee_payer_summary_t list }
+    [@@deriving yojson, hash]
 
     type t = r With_direction.t [@@deriving yojson]
 
@@ -392,10 +393,10 @@ module Gossip = struct
     let parse_func message =
       match%bind parse id message with
       | Network_pool.Transaction_pool.Resource_pool.Diff.Transactions_received
-          { fee_payer_sigs; sender = _ } ->
-          Ok ({ fee_payer_sigs }, Direction.Received)
-      | Mina_networking.Gossip_transaction_pool_diff { fee_payer_sigs } ->
-          Ok ({ fee_payer_sigs }, Sent)
+          { fee_payer_summaries; sender = _ } ->
+          Ok ({ fee_payer_summaries }, Direction.Received)
+      | Mina_networking.Gossip_transaction_pool_diff { fee_payer_summaries } ->
+          Ok ({ fee_payer_summaries }, Sent)
       | _ ->
           bad_parse
 

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -247,7 +247,7 @@ module Breadcrumb_added = struct
     in
     let%map transaction_hashes =
       get_metadata message "user_commands"
-      >>= parse valid_commands_with_statuses
+      >>= parse transaction_hashes_with_statuses
     in
     { state_hash; transaction_hashes }
 

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -73,7 +73,8 @@ end
 module Breadcrumb_added : sig
   type t =
     { state_hash : State_hash.t
-    ; user_commands : User_command.Valid.t With_status.t list
+    ; transaction_hashes :
+        Mina_transaction.Transaction_hash.t With_status.t list
     }
 
   include Event_type_intf with type t := t
@@ -136,8 +137,7 @@ module Gossip : sig
   end
 
   module Transactions : sig
-    type r = { txns : Network_pool.Transaction_pool.Resource_pool.Diff.t }
-    [@@deriving hash, yojson]
+    type r = { fee_payer_sigs : Signature.t list } [@@deriving hash, yojson]
 
     type t = r With_direction.t
 

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -137,7 +137,8 @@ module Gossip : sig
   end
 
   module Transactions : sig
-    type r = { fee_payer_sigs : Signature.t list } [@@deriving hash, yojson]
+    type r = { fee_payer_summaries : User_command.fee_payer_summary_t list }
+    [@@deriving hash, yojson]
 
     type t = r With_direction.t
 

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -2,7 +2,6 @@ open Async_kernel
 open Core_kernel
 open Mina_base
 open Pipe_lib
-open Mina_transaction
 
 type metrics_t =
   { block_production_delay : int list
@@ -206,7 +205,8 @@ module Dsl = struct
       ; best_tips_by_node : State_hash.t String.Map.t
       ; blocks_produced_by_node : State_hash.t list String.Map.t
       ; blocks_seen_by_node : State_hash.Set.t String.Map.t
-      ; blocks_including_txn : State_hash.Set.t Transaction_hash.Map.t
+      ; blocks_including_txn :
+          State_hash.Set.t Mina_transaction.Transaction_hash.Map.t
       }
 
     val listen :
@@ -257,7 +257,7 @@ module Dsl = struct
     val nodes_to_synchronize : Engine.Network.Node.t list -> t
 
     val signed_command_to_be_included_in_frontier :
-         txn_hash:Transaction_hash.t
+         txn_hash:Mina_transaction.Transaction_hash.t
       -> node_included_in:[ `Any_node | `Node of Engine.Network.Node.t ]
       -> t
 

--- a/src/lib/integration_test_lib/json_parsing.ml
+++ b/src/lib/integration_test_lib/json_parsing.ml
@@ -36,7 +36,7 @@ let parser_from_of_yojson of_yojson js =
         ~metadata:[ ("module", `String modl); ("json", js) ] ;
       failwithf "Could not parse JSON using %s.of_yojson" modl ()
 
-let valid_commands_with_statuses = function
+let transaction_hashes_with_statuses = function
   | `List cmds ->
       let cmd_or_errors =
         List.map cmds
@@ -53,12 +53,12 @@ let valid_commands_with_statuses = function
                 "Failed to parse JSON for user command status" ;
               (* fail on any error *)
               failwith
-                "valid_commands_with_statuses: unable to parse JSON for user \
-                 command"
+                "transaction_hashes_with_statuses: unable to parse JSON for \
+                 user command"
           | cmds, Ok cmd ->
               cmd :: cmds )
   | _ ->
-      failwith "valid_commands_with_statuses: expected `List"
+      failwith "transaction_hashes_with_statuses: expected `List"
 
 let rec find (parser : 'a parser) (json : Yojson.Safe.t) (path : string list) :
     'a Or_error.t =

--- a/src/lib/integration_test_lib/json_parsing.ml
+++ b/src/lib/integration_test_lib/json_parsing.ml
@@ -36,15 +36,13 @@ let parser_from_of_yojson of_yojson js =
         ~metadata:[ ("module", `String modl); ("json", js) ] ;
       failwithf "Could not parse JSON using %s.of_yojson" modl ()
 
-let valid_commands_with_statuses :
-    Mina_base.User_command.Valid.t Mina_base.With_status.t list parser =
-  function
+let valid_commands_with_statuses = function
   | `List cmds ->
       let cmd_or_errors =
         List.map cmds
           ~f:
             (Mina_base.With_status.of_yojson
-               Mina_base.User_command.Valid.of_yojson )
+               Mina_transaction.Transaction_hash.of_yojson )
       in
       List.fold cmd_or_errors ~init:[] ~f:(fun accum cmd_or_err ->
           match (accum, cmd_or_err) with

--- a/src/lib/integration_test_lib/network_state.ml
+++ b/src/lib/integration_test_lib/network_state.ml
@@ -298,14 +298,11 @@ module Make
                         (Option.value block_set ~default:State_hash.Set.empty)
                         breadcrumb.state_hash )
                 in
-                let txn_hash_list =
-                  List.map breadcrumb.user_commands ~f:(fun cmd_with_status ->
-                      cmd_with_status.With_status.data
-                      |> User_command.forget_check
-                      |> Transaction_hash.hash_command )
+                let transaction_hashes =
+                  List.map breadcrumb.transaction_hashes ~f:With_status.data
                 in
                 let blocks_including_txn' =
-                  List.fold txn_hash_list ~init:state.blocks_including_txn
+                  List.fold transaction_hashes ~init:state.blocks_including_txn
                     ~f:(fun accum hash ->
                       let block_set' =
                         State_hash.Set.add

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Mina_transaction
 
 let all_equal ~equal ~compare ls =
   Option.value_map (List.hd ls) ~default:true ~f:(fun h ->
@@ -250,7 +249,7 @@ struct
     { id = Signed_command_to_be_included_in_frontier
     ; description =
         sprintf "signed command with hash %s"
-          (Transaction_hash.to_base58_check txn_hash)
+          (Mina_transaction.Transaction_hash.to_base58_check txn_hash)
     ; predicate = Network_state_predicate (check (), check)
     ; soft_timeout = Slots soft_timeout_in_slots
     ; hard_timeout = Slots (soft_timeout_in_slots * 2)
@@ -281,19 +280,17 @@ struct
     }
 
   let zkapp_to_be_included_in_frontier ~has_failures ~zkapp_command =
-    let command_matches_zkapp_command cmd =
-      let open User_command in
-      match cmd with
-      | Zkapp_command p ->
-          Zkapp_command.equal p zkapp_command
-      | Signed_command _ ->
-          false
+    let txn_hash =
+      Mina_transaction.Transaction_hash.hash_command
+        (Zkapp_command zkapp_command)
     in
     let check () _node (breadcrumb_added : Event_type.Breadcrumb_added.t) =
       let zkapp_opt =
-        List.find breadcrumb_added.user_commands ~f:(fun cmd_with_status ->
-            cmd_with_status.With_status.data |> User_command.forget_check
-            |> command_matches_zkapp_command )
+        List.find breadcrumb_added.transaction_hashes
+          ~f:
+            (Fn.compose
+               (Mina_transaction.Transaction_hash.equal txn_hash)
+               With_status.data )
       in
       [%log' info (Logger.create ())]
         "Looking for a zkApp transaction match in block with state_hash \
@@ -306,25 +303,28 @@ struct
         ~metadata:[ ("zkapp_command", Zkapp_command.to_yojson zkapp_command) ] ;
       [%log' debug (Logger.create ())]
         "wait_condition check, zkapp_to_be_included_in_frontier, user_commands \
-         from breadcrumb: $user_commands state_hash: $state_hash"
+         from breadcrumb: $tx_hashes state_hash: $state_hash"
         ~metadata:
-          [ ( "user_commands"
+          [ ( "tx_hashes"
             , `List
-                (List.map breadcrumb_added.user_commands
-                   ~f:(With_status.to_yojson User_command.Valid.to_yojson) ) )
+                (List.map breadcrumb_added.transaction_hashes
+                   ~f:
+                     (With_status.to_yojson
+                        Mina_transaction.Transaction_hash.to_yojson ) ) )
           ; ("state_hash", State_hash.to_yojson breadcrumb_added.state_hash)
           ] ;
       match zkapp_opt with
-      | Some cmd_with_status ->
+      | Some hash_with_status ->
           [%log' debug (Logger.create ())]
             "wait_condition check, zkapp_to_be_included_in_frontier, \
              cmd_with_status: $cmd_with_status "
             ~metadata:
               [ ( "cmd_with_status"
-                , (With_status.to_yojson User_command.Valid.to_yojson)
-                    cmd_with_status )
+                , (With_status.to_yojson
+                     Mina_transaction.Transaction_hash.to_yojson )
+                    hash_with_status )
               ] ;
-          let actual_status = cmd_with_status.With_status.status in
+          let actual_status = hash_with_status.With_status.status in
           let successful =
             match actual_status with
             | Transaction_status.Applied ->

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -293,11 +293,12 @@ struct
                With_status.data )
       in
       [%log' info (Logger.create ())]
-        "Looking for a zkApp transaction match with txn_hash $txn_hash in \
-         block with state_hash $state_hash"
+        "Looking for a zkApp transaction match for txn $txn with hash \
+         $txn_hash in block with state_hash $state_hash"
         ~metadata:
           [ ("state_hash", State_hash.to_yojson breadcrumb_added.state_hash)
           ; ("txn_hash", Mina_transaction.Transaction_hash.to_yojson txn_hash)
+          ; ("txn", Zkapp_command.to_yojson zkapp_command)
           ] ;
       [%log' debug (Logger.create ())]
         "wait_condition check, zkapp_to_be_included_in_frontier, \

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -293,10 +293,12 @@ struct
                With_status.data )
       in
       [%log' info (Logger.create ())]
-        "Looking for a zkApp transaction match in block with state_hash \
-         $state_hash"
+        "Looking for a zkApp transaction match with txn_hash $txn_hash in \
+         block with state_hash $state_hash"
         ~metadata:
-          [ ("state_hash", State_hash.to_yojson breadcrumb_added.state_hash) ] ;
+          [ ("state_hash", State_hash.to_yojson breadcrumb_added.state_hash)
+          ; ("txn_hash", Mina_transaction.Transaction_hash.to_yojson txn_hash)
+          ] ;
       [%log' debug (Logger.create ())]
         "wait_condition check, zkapp_to_be_included_in_frontier, \
          zkapp_command: $zkapp_command "

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -422,3 +422,10 @@ let check_well_formedness ~genesis_constants t :
         Zkapp_too_big err :: errs0
   in
   if List.is_empty errs then Ok () else Error errs
+
+let fee_payer_signature = function
+  | Zkapp_command cmd ->
+      Zkapp_command.fee_payer_account_update cmd
+      |> Account_update.Fee_payer.authorization
+  | Signed_command cmd ->
+      Signed_command.signature cmd

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -423,9 +423,29 @@ let check_well_formedness ~genesis_constants t :
   in
   if List.is_empty errs then Ok () else Error errs
 
-let fee_payer_signature = function
+type fee_payer_summary_t = Signature.t * Account.key * int
+[@@deriving yojson, hash]
+
+let fee_payer_summary : t -> fee_payer_summary_t = function
   | Zkapp_command cmd ->
-      Zkapp_command.fee_payer_account_update cmd
-      |> Account_update.Fee_payer.authorization
+      let fp = Zkapp_command.fee_payer_account_update cmd in
+      let open Account_update in
+      let body = Fee_payer.body fp in
+      ( Fee_payer.authorization fp
+      , Body.Fee_payer.public_key body
+      , Body.Fee_payer.nonce body |> Unsigned.UInt32.to_int )
   | Signed_command cmd ->
-      Signed_command.signature cmd
+      Signed_command.
+        (signature cmd, fee_payer_pk cmd, nonce cmd |> Unsigned.UInt32.to_int)
+
+let fee_payer_summary_json =
+  Fn.compose fee_payer_summary_t_to_yojson fee_payer_summary
+
+let fee_payer_summary_string =
+  let to_string (signature, pk, nonce) =
+    sprintf "%s (%s %d)"
+      (Signature.to_base58_check signature)
+      (Signature_lib.Public_key.Compressed.to_base58_check pk)
+      nonce
+  in
+  Fn.compose to_string fee_payer_summary

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -128,9 +128,11 @@ let setup_and_submit_zkapp_commands t (zkapp_commands : Zkapp_command.t list) =
   txn_count := !txn_count + num_zkapps ;
   match result with
   | Ok (`Broadcasted, commands, []) ->
-      let zkapp_jsons = List.map commands ~f:User_command.to_yojson in
+      let zkapp_jsons =
+        List.map commands ~f:User_command.fee_payer_summary_json
+      in
       [%log' info (Mina_lib.top_level_logger t)]
-        ~metadata:[ ("zkapp_commands", `List zkapp_jsons) ]
+        ~metadata:[ ("summaries", `List zkapp_jsons) ]
         "Scheduled %d zkApps" num_zkapps ;
       Ok zkapp_commands
   | Ok (decision, valid_commands, invalid_commands) ->
@@ -144,7 +146,9 @@ let setup_and_submit_zkapp_commands t (zkapp_commands : Zkapp_command.t list) =
                 | `Not_broadcasted ->
                     "not_broadcasted" ) )
           ; ( "valid_zkapp_commands"
-            , `List (List.map ~f:User_command.to_yojson valid_commands) )
+            , `List
+                (List.map ~f:User_command.fee_payer_summary_json valid_commands)
+            )
           ; ( "invalid_zkapp_commands"
             , `List
                 (List.map invalid_commands ~f:(fun (_cmd, diff_err) ->

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -271,13 +271,15 @@ let send_zkapps ~fee_payer_array ~constraint_constants ~tm_end ~scheduler_tbl
           @@ fun () ->
           match%map Zkapps.send_zkapp_command mina zkapp_command with
           | Ok _ ->
-              [%log info] "Sent out zkApp $command"
-                ~metadata:[ ("command", Zkapp_command.to_yojson zkapp_command) ]
-          | Error e ->
-              [%log info] "Failed to send out zkApp $command, see $error"
+              [%log info] "Sent out zkApp with fee payer's signature $signature"
                 ~metadata:
-                  [ ("command", Zkapp_command.to_yojson zkapp_command)
-                  ; ("error", `String e)
+                  [ ( "signature"
+                    , Zkapp_command.fee_payer_account_update zkapp_command
+                      |> Account_update.Fee_payer.authorization
+                      |> Signature.to_yojson )
                   ]
+          | Error e ->
+              [%log info] "Failed to send out zkApp command, see $error"
+                ~metadata:[ ("error", `String e) ]
         in
         repeat tm_next counter

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -271,12 +271,11 @@ let send_zkapps ~fee_payer_array ~constraint_constants ~tm_end ~scheduler_tbl
           @@ fun () ->
           match%map Zkapps.send_zkapp_command mina zkapp_command with
           | Ok _ ->
-              [%log info] "Sent out zkApp with fee payer's signature $signature"
+              [%log info] "Sent out zkApp with fee payer's summary $summary"
                 ~metadata:
-                  [ ( "signature"
-                    , Zkapp_command.fee_payer_account_update zkapp_command
-                      |> Account_update.Fee_payer.authorization
-                      |> Signature.to_yojson )
+                  [ ( "summary"
+                    , User_command.fee_payer_summary_json
+                        (Zkapp_command zkapp_command) )
                   ]
           | Error e ->
               [%log info] "Failed to send out zkApp command, see $error"

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -258,6 +258,10 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                      ~metadata:
                        [ ( "state_hash"
                          , `String (State_hash.to_base58_check hash) )
+                       ; ( "protocol_state"
+                         , Mina_block.header new_block_no_hash
+                           |> Mina_block.Header.protocol_state
+                           |> Mina_state.Protocol_state.value_to_yojson )
                        ] ) ) ;
           match
             Filtered_external_transition.validate_transactions

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -118,7 +118,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
           let new_block = Mina_block.Validated.forget new_block_validated in
           let new_block_no_hash = With_hash.data new_block in
           let hash = State_hash.With_state_hashes.state_hash new_block in
-          (let path, log = !precomputed_block_writer in
+          (let path, _ = !precomputed_block_writer in
            match Broadcast_pipe.Reader.peek transition_frontier with
            | None ->
                [%log warn]
@@ -256,16 +256,9 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                              ] ) ) ;
                    [%log info] "Saw block with state hash $state_hash"
                      ~metadata:
-                       (let state_hash_data =
-                          [ ( "state_hash"
-                            , `String (State_hash.to_base58_check hash) )
-                          ]
-                        in
-                        if is_some log then
-                          state_hash_data
-                          @ [ ("precomputed_block", Lazy.force precomputed_block)
-                            ]
-                        else state_hash_data ) ) ) ;
+                       [ ( "state_hash"
+                         , `String (State_hash.to_base58_check hash) )
+                       ] ) ) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block_no_hash

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -16,11 +16,13 @@ type Structured_log_events.t +=
   [@@deriving register_event { msg = "Broadcasting new state over gossip net" }]
 
 type Structured_log_events.t +=
-  | Gossip_transaction_pool_diff of { fee_payer_sigs : Signature.t list }
+  | Gossip_transaction_pool_diff of
+      { fee_payer_summaries : User_command.fee_payer_summary_t list }
   [@@deriving
     register_event
       { msg =
-          "Broadcasting transaction pool diff $fee_payer_sigs over gossip net"
+          "Broadcasting transaction pool diff $fee_payer_summaries over gossip \
+           net"
       }]
 
 type Structured_log_events.t +=
@@ -1479,7 +1481,8 @@ let broadcast_state t state =
 let broadcast_transaction_pool_diff ?nonce t diff =
   [%str_log' trace t.logger]
     (Gossip_transaction_pool_diff
-       { fee_payer_sigs = List.map ~f:User_command.fee_payer_signature diff } ) ;
+       { fee_payer_summaries = List.map ~f:User_command.fee_payer_summary diff }
+    ) ;
   Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_broadcasted) ;
   Gossip_net.Any.broadcast_transaction_pool_diff ?nonce t.gossip_net diff
 

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -16,11 +16,12 @@ type Structured_log_events.t +=
   [@@deriving register_event { msg = "Broadcasting new state over gossip net" }]
 
 type Structured_log_events.t +=
-  | Gossip_transaction_pool_diff of
-      { txns : Transaction_pool.Resource_pool.Diff.t }
+  | Gossip_transaction_pool_diff of { fee_payer_sigs : Signature.t list }
   [@@deriving
     register_event
-      { msg = "Broadcasting transaction pool diff over gossip net" }]
+      { msg =
+          "Broadcasting transaction pool diff $fee_payer_sigs over gossip net"
+      }]
 
 type Structured_log_events.t +=
   | Gossip_snark_pool_diff of { work : Snark_pool.Resource_pool.Diff.compact }
@@ -1468,38 +1469,26 @@ include struct
 end
 
 (* TODO: Have better pushback behavior *)
-let log_gossip logger ~log_msg msg =
-  [%str_log' trace logger]
-    ~metadata:[ ("message", Gossip_net.Message.msg_to_yojson msg) ]
-    log_msg
-
 let broadcast_state t state =
-  let msg = With_hash.data state in
-  log_gossip t.logger (Gossip_net.Message.New_state msg)
-    ~log_msg:
-      (Gossip_new_state
-         { state_hash = State_hash.With_state_hashes.state_hash state } ) ;
+  [%str_log' trace t.logger]
+    (Gossip_new_state
+       { state_hash = State_hash.With_state_hashes.state_hash state } ) ;
   Mina_metrics.(Gauge.inc_one Network.new_state_broadcasted) ;
-  Gossip_net.Any.broadcast_state t.gossip_net msg
+  Gossip_net.Any.broadcast_state t.gossip_net (With_hash.data state)
 
 let broadcast_transaction_pool_diff ?nonce t diff =
-  log_gossip t.logger
-    (Gossip_net.Message.Transaction_pool_diff
-       { message = diff; nonce = Option.value ~default:0 nonce } )
-    ~log_msg:(Gossip_transaction_pool_diff { txns = diff }) ;
+  [%str_log' trace t.logger]
+    (Gossip_transaction_pool_diff
+       { fee_payer_sigs = List.map ~f:User_command.fee_payer_signature diff } ) ;
   Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_broadcasted) ;
   Gossip_net.Any.broadcast_transaction_pool_diff ?nonce t.gossip_net diff
 
 let broadcast_snark_pool_diff ?nonce t diff =
   Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_broadcasted) ;
-  log_gossip t.logger
-    (Gossip_net.Message.Snark_pool_diff
-       { message = diff; nonce = Option.value ~default:0 nonce } )
-    ~log_msg:
-      (Gossip_snark_pool_diff
-         { work =
-             Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
-         } ) ;
+  [%str_log' trace t.logger]
+    (Gossip_snark_pool_diff
+       { work = Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
+       } ) ;
   Gossip_net.Any.broadcast_snark_pool_diff ?nonce t.gossip_net diff
 
 let find_map xs ~f =

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -9,7 +9,8 @@ exception No_initial_peers
 
 type Structured_log_events.t +=
   | Gossip_new_state of { state_hash : State_hash.t }
-  | Gossip_transaction_pool_diff of { fee_payer_sigs : Signature.t list }
+  | Gossip_transaction_pool_diff of
+      { fee_payer_summaries : User_command.fee_payer_summary_t list }
   | Gossip_snark_pool_diff of { work : Snark_pool.Resource_pool.Diff.compact }
   [@@deriving register_event]
 

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -9,8 +9,7 @@ exception No_initial_peers
 
 type Structured_log_events.t +=
   | Gossip_new_state of { state_hash : State_hash.t }
-  | Gossip_transaction_pool_diff of
-      { txns : Transaction_pool.Resource_pool.Diff.t }
+  | Gossip_transaction_pool_diff of { fee_payer_sigs : Signature.t list }
   | Gossip_snark_pool_diff of { work : Snark_pool.Resource_pool.Diff.compact }
   [@@deriving register_event]
 

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -367,7 +367,9 @@ module type Transaction_pool_diff_intf = sig
 
   type Structured_log_events.t +=
     | Transactions_received of
-        { fee_payer_sigs : Signature.t list; sender : Envelope.Sender.t }
+        { fee_payer_summaries : User_command.fee_payer_summary_t list
+        ; sender : Envelope.Sender.t
+        }
     [@@deriving register_event]
 
   include

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -311,7 +311,7 @@ module type Snark_pool_diff_intf = sig
   type verified = t [@@deriving compare, sexp]
 
   type compact =
-    { work : Transaction_snark_work.Statement.t
+    { work_ids : int One_or_two.t
     ; fee : Currency.Fee.t
     ; prover : Signature_lib.Public_key.Compressed.t
     }
@@ -366,7 +366,8 @@ module type Transaction_pool_diff_intf = sig
   end
 
   type Structured_log_events.t +=
-    | Transactions_received of { txns : t; sender : Envelope.Sender.t }
+    | Transactions_received of
+        { fee_payer_sigs : Signature.t list; sender : Envelope.Sender.t }
     [@@deriving register_event]
 
   include

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -126,8 +126,8 @@ end)
           "Refusing to rebroadcast $diff. Pool diff apply feedback: empty diff"
           ~metadata:
             [ ( "diff"
-              , Resource_pool.Diff.verified_to_yojson
-                @@ Envelope.Incoming.data diff )
+              , `String Resource_pool.Diff.(summary @@ t_of_verified diff.data)
+              )
             ] ;
         drop diff' rejected cb )
       else (

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -411,11 +411,10 @@ struct
                 :: metadata ) ;
             invalid "prover not permitted to receive fees" )
           else if not (work_is_referenced t work) then (
-            [%log' debug t.logger] "Work $stmt not referenced"
+            [%log' debug t.logger] "Work for $work_ids not referenced"
               ~metadata:
-                ( ( "stmt"
-                  , One_or_two.to_yojson Transaction_snark.Statement.to_yojson
-                      work )
+                ( ( "work_ids"
+                  , Transaction_snark_work.Statement.compact_json work )
                 :: metadata ) ;
             invalid "work not referenced" )
           else

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -41,7 +41,7 @@ module Make
   let reject_overloaded_diff _ = ()
 
   type compact =
-    { work : Work.t
+    { work_ids : int One_or_two.t
     ; fee : Currency.Fee.t
     ; prover : Signature_lib.Public_key.Compressed.t
     }
@@ -49,7 +49,11 @@ module Make
 
   let to_compact = function
     | Add_solved_work (work, { proof = _; fee = { fee; prover } }) ->
-        Some { work; fee; prover }
+        Some
+          { work_ids = Transaction_snark_work.Statement.work_ids work
+          ; fee
+          ; prover
+          }
     | Empty ->
         None
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2058,13 +2058,11 @@ module T = struct
                   | None ->
                       [%log debug]
                         ~metadata:
-                          [ ( "statement"
-                            , Transaction_snark_work.Statement.to_yojson w )
-                          ; ( "work_ids"
+                          [ ( "work_ids"
                             , Transaction_snark_work.Statement.compact_json w )
                           ]
                         !"Staged_ledger_diff creation: No snark work found for \
-                          $statement" ;
+                          $work_ids" ;
                       [%log internal] "@block_metadata"
                         ~metadata:
                           [ ("interrupt_get_completed_work_at", `Int count)

--- a/src/lib/transition_frontier/dune
+++ b/src/lib/transition_frontier/dune
@@ -51,6 +51,7 @@
    protocol_version
    mina_net2
    internal_tracing
+   mina_transaction
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_compare ppx_deriving_yojson)))

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -455,12 +455,15 @@ let add_breadcrumb_exn t breadcrumb =
     Mina_block.Validated.valid_commands
     @@ Breadcrumb.validated_transition breadcrumb
   in
+  let tx_hash_json =
+    Fn.compose
+      Mina_transaction.Transaction_hash.(Fn.compose to_yojson hash_command)
+      User_command.forget_check
+  in
   [%str_log' trace t.logger] Added_breadcrumb_user_commands
     ~metadata:
       [ ( "user_commands"
-        , `List
-            (List.map user_cmds
-               ~f:(With_status.to_yojson User_command.Valid.to_yojson) ) )
+        , `List (List.map user_cmds ~f:(With_status.to_yojson tx_hash_json)) )
       ; ("state_hash", State_hash.to_yojson (Breadcrumb.state_hash breadcrumb))
       ] ;
   let lite_diffs =

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -97,8 +97,8 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
         | Some _ ->
             ()
         | None ->
-            [%log error] "Validation timed out on $block"
-              ~metadata:[ ("block", Mina_block.to_yojson state) ] ) ;
+            [%log error] "Validation timed out on block $state_hash"
+              ~metadata:[ ("state_hash", State_hash.to_yojson state_hash) ] ) ;
       Perf_histograms.add_span ~name:"external_transition_latency"
         (Core.Time.abs_diff
            Block_time.(now time_controller |> to_time_exn)

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -82,7 +82,6 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
                 ; ("url", `String (Uri.to_string url))
                 ; ("http_code", `Int status_code)
                 ; ("http_error", `String status_string)
-                ; ("payload", json)
                 ]
           else if attempt >= max_attempts then
             let base_metadata =
@@ -90,7 +89,6 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
               ; ("url", `String (Uri.to_string url))
               ; ("http_code", `Int status_code)
               ; ("http_error", `String status_string)
-              ; ("payload", json)
               ]
             in
             let extra_metadata = metadata_of_body body in
@@ -121,7 +119,6 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
             ~metadata:
               [ ("state_hash", State_hash.to_yojson state_hash)
               ; ("url", `String (Uri.to_string url))
-              ; ("payload", json)
               ; ("error", `String (Exn.to_string exn))
               ] ;
           (* retry *)
@@ -134,10 +131,7 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
         [%log error]
           "In uptime service, POST of block with state hash $state_hash was \
            interrupted"
-          ~metadata:
-            [ ("state_hash", State_hash.to_yojson state_hash)
-            ; ("payload", json)
-            ] ;
+          ~metadata:[ ("state_hash", State_hash.to_yojson state_hash) ] ;
         (* interrupted, don't want to retry, claim success *)
         true
   in


### PR DESCRIPTION
There are many logs emitted by Mina which are unnecessarily large and in some case become oversized.

This PR aims to fix many of such logs, reducing the amount of data printed.

Explain your changes:
* Rewrite all of the logs that print directly or indirectly snark work, transaction or state transition data (as these pieces are potentially unbound in size)

Explain how you tested your changes:
* Before the change, cluster's logs were polluted by extra-large logs in `.mina-config/mina.log*` and oversized logs in `.mina-config/mina-oversized-logs.log*`
* After the change, extra large and oversized logs went away

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
