### PR TITLE
Fix premature stops of Orchestrator

### DIFF
--- a/src/app/itn_orchestrator/src/discovery.go
+++ b/src/app/itn_orchestrator/src/discovery.go
@@ -32,7 +32,7 @@ type DiscoveryParams struct {
 	Exactly            bool `json:"exactly,omitempty"`
 }
 
-func DiscoverParticipants(config Config, params DiscoveryParams, output func(NodeAddress)) error {
+func discoverParticipantsDo(config Config, params DiscoveryParams, output func(NodeAddress)) error {
 	before := time.Now().Add(-time.Duration(params.OffsetMin) * time.Minute)
 	query := &storage.Query{StartOffset: prefixByTime(before)}
 	log := config.Log
@@ -87,7 +87,24 @@ func DiscoverParticipants(config Config, params DiscoveryParams, output func(Nod
 	if len(cache) != params.Limit && params.Exactly {
 		return errors.New("failed to discover the exact number of nodes")
 	}
+	if len(cache) == 0 {
+		return errors.New("didn't find any participants")
+	}
 	return nil
+}
+
+func DiscoverParticipants(config Config, params DiscoveryParams, output func(NodeAddress)) (err error) {
+	for retryPause := 10; retryPause <= 40; retryPause = retryPause * 2 {
+		err = discoverParticipantsDo(config, params, output)
+		if err == nil {
+			return
+		}
+		if retryPause <= 20 {
+			config.Log.Warnf("Failed to discover participants, retrying in %d minutes: %s", retryPause, err)
+			time.Sleep(time.Duration(retryPause) * time.Minute)
+		}
+	}
+	return
 }
 
 type DiscoveryAction struct{}

--- a/src/app/itn_orchestrator/src/stop.go
+++ b/src/app/itn_orchestrator/src/stop.go
@@ -45,17 +45,13 @@ type StopDaemonParams struct {
 }
 
 func StopDaemon(config Config, params StopDaemonParams) error {
-	errs := []error{}
 	for _, addr := range params.Nodes {
 		resp, err := StopDaemonGql(config, addr, params.Clean, config.StopDaemonDelaySec)
 		if err == nil {
 			config.Log.Infof("stopped daemon on %s: %s", addr, resp)
 		} else {
-			errs = append(errs, err)
+			config.Log.Warnf("failed to stop daemon on %s: %s", addr, err)
 		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
 	}
 	return nil
 }


### PR DESCRIPTION
Problem: Orchestrator gets stopped if it can't reach a node for executing stop-daemon command or if it can't find any participants.

Solution: don't treat no-reply on stop-daemon as an error and repeat discovery in the loop to prevent stopping an experiment because of glitches.

Explain how you tested your changes:

* Orchestrator/generator were tested as part of a cluster experiment
* To be tested on cluster by repeatedly running experiments and seeing Orchestrator is not stopped prematurely (over the following weeks, condition that caused the issue #13957 was infrequent)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #13957
