### PR TITLE
Do not print accounts from runtime config

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -756,12 +756,17 @@ let setup_daemon logger =
             | Ok (precomputed_values, _) ->
                 precomputed_values
             | Error err ->
+                let json_config, accounts_omitted =
+                  Runtime_config.to_yojson_without_accounts config
+                in
+                let f i = List.cons ("accounts_omitted", `Int i) in
                 [%log fatal]
                   "Failed initializing with configuration $config: $error"
                   ~metadata:
-                    [ ("config", Runtime_config.to_yojson config)
-                    ; ("error", Error_json.error_to_yojson err)
-                    ] ;
+                    (Option.value_map ~f ~default:Fn.id accounts_omitted
+                       [ ("config", json_config)
+                       ; ("error", Error_json.error_to_yojson err)
+                       ] ) ;
                 Error.raise err
           in
           let rev_daemon_configs =

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -826,24 +826,25 @@ let load_config_file filename =
       | Error err ->
           Or_error.error_string err )
 
-let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
-    ~proof_level (config : Runtime_config.t) =
+let print_config ~logger config =
   let ledger_name_json =
-    match
-      let open Option.Let_syntax in
-      let%bind ledger = config.ledger in
-      ledger.name
-    with
-    | Some name ->
-        `String name
-    | None ->
-        `Null
+    Option.value ~default:`Null
+    @@ let%bind.Option ledger = config.Runtime_config.ledger in
+       let%map.Option name = ledger.name in
+       `String name
   in
+  let json_config, accounts_omitted =
+    Runtime_config.to_yojson_without_accounts config
+  in
+  let f i = List.cons ("accounts_omitted", `Int i) in
   [%log info] "Initializing with runtime configuration. Ledger name: $name"
     ~metadata:
-      [ ("name", ledger_name_json)
-      ; ("config", Runtime_config.to_yojson config)
-      ] ;
+      (Option.value_map ~f ~default:Fn.id accounts_omitted
+         [ ("name", ledger_name_json); ("config", json_config) ] )
+
+let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
+    ~proof_level (config : Runtime_config.t) =
+  print_config ~logger config ;
   let open Deferred.Or_error.Let_syntax in
   let genesis_constants = Genesis_constants.compiled in
   let proof_level =

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1006,6 +1006,19 @@ let of_json_layout { Json_layout.daemon; genesis; proof; ledger; epoch_data } =
 
 let to_yojson x = Json_layout.to_yojson (to_json_layout x)
 
+let to_yojson_without_accounts x =
+  let layout = to_json_layout x in
+  let num_accounts =
+    let%bind.Option ledger = layout.ledger in
+    let%map.Option accounts = ledger.accounts in
+    List.length accounts
+  in
+  let layout =
+    let f ledger = { ledger with Json_layout.Ledger.accounts = None } in
+    { layout with ledger = Option.map ~f layout.ledger }
+  in
+  (Json_layout.to_yojson layout, num_accounts)
+
 let of_yojson json = Result.bind ~f:of_json_layout (Json_layout.of_yojson json)
 
 let default =


### PR DESCRIPTION
Problem: when running Mina node against large ledgers defined in runtime config (say of 100k accounts), nodes struggle to start because of an extra-large logging that prints the entire ledger as part of a runtime config (an async job + RAM usage spike are guaranteed).

Explain your changes:
* When printing runtime config, omit accounts section and print `accounts_omitted` metadata item

Example output (for a ledger with 200 accounts):
```json
{
  "timestamp": "2023-09-10 16:16:41.325213Z",
  "level": "Info",
  "source": {
    "module": "Genesis_ledger_helper",
    "location": "..."
  },
  "message": "Initializing with runtime configuration. Ledger name: $name",
  "metadata": {
    "accounts_omitted": 200,
    "config": {
      "genesis": {
        "k": 12,
        "slots_per_epoch": 288,
        "genesis_state_timestamp": "2023-09-10T15:48:00+00:00"
      },
      "proof": {
        "block_window_duration_ms": 90000
      },
      "ledger": {
        "name": "testnet"
      }
    },
    "name": "testnet"
  }
}
```

Explain how you tested your changes:
* Tested by loading config from a local tool

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None