### PR TITLE
Add tool to generate ledger accounts for testing

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2461,7 +2461,6 @@ let advanced =
     ; ("visualization", Visualization.command_group)
     ; ("verify-receipt", verify_receipt)
     ; ("generate-keypair", Cli_lib.Commands.generate_keypair)
-    ; ("generate-ledger-accounts", Cli_lib.Commands.generate_ledger_accounts)
     ; ("validate-keypair", Cli_lib.Commands.validate_keypair)
     ; ("validate-transaction", Cli_lib.Commands.validate_transaction)
     ; ("send-rosetta-transactions", send_rosetta_transactions_graphql)
@@ -2493,6 +2492,7 @@ let ledger =
     ; ("hash", hash_ledger)
     ; ("currency", currency_in_ledger)
     ; ("test-apply", test_ledger_application)
+    ; ("test-generate-accounts", Cli_lib.Commands.generate_test_ledger)
     ]
 
 let libp2p =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2461,6 +2461,7 @@ let advanced =
     ; ("visualization", Visualization.command_group)
     ; ("verify-receipt", verify_receipt)
     ; ("generate-keypair", Cli_lib.Commands.generate_keypair)
+    ; ("generate-ledger-accounts", Cli_lib.Commands.generate_ledger_accounts)
     ; ("validate-keypair", Cli_lib.Commands.validate_keypair)
     ; ("validate-transaction", Cli_lib.Commands.validate_transaction)
     ; ("send-rosetta-transactions", send_rosetta_transactions_graphql)

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -22,6 +22,51 @@ let generate_keypair =
        (Rosetta_coding.Coding.of_public_key kp.public_key) ;
      exit 0 )
 
+let balance =
+  Command.Arg_type.map Command.Param.string
+    ~f:Currency.Balance.of_mina_string_exn
+
+let generate_ledger_accounts =
+  Command.async ~summary:"Generate a ledger for testing"
+    (let open Command.Let_syntax in
+    let%map_open n =
+      Command.Param.flag "-n"
+        ~doc:(Printf.sprintf "NN number of accounts to generate")
+        (required int)
+    and min_balance =
+      flag "--min-balance" ~doc:"MINA Minimum balance of a key"
+        (optional balance)
+    and max_balance =
+      flag "--max-balance" ~doc:"MINA Maximum balance of a key"
+        (optional balance)
+    in
+    Exceptions.handle_nicely
+    @@ fun () ->
+    let min_balance = Option.value ~default:Currency.Balance.zero min_balance in
+    let max_balance =
+      Option.value ~default:(Currency.Balance.of_mina_int_exn 100) max_balance
+    in
+    let balance_seq =
+      Quickcheck.random_sequence ~seed:`Nondeterministic
+      @@ Currency.Balance.gen_incl min_balance max_balance
+    in
+    let ledger =
+      Sequence.take balance_seq n
+      |> Sequence.map ~f:(fun balance ->
+             let kp = Keypair.create () in
+             { Runtime_config.Json_layout.Accounts.Single.default with
+               pk =
+                 Public_key.compress kp.public_key
+                 |> Public_key.Compressed.to_base58_check
+             ; sk = Some (Private_key.to_base58_check kp.private_key)
+             ; balance
+             } )
+      |> Sequence.to_list
+    in
+    Yojson.Safe.pretty_print Format.std_formatter
+    @@ Runtime_config.Json_layout.Accounts.to_yojson ledger ;
+    exit 0)
+
 let validate_keypair =
   Command.async ~summary:"Validate a public, private keypair"
     (let open Command.Let_syntax in

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -26,7 +26,7 @@ let balance =
   Command.Arg_type.map Command.Param.string
     ~f:Currency.Balance.of_mina_string_exn
 
-let generate_ledger_accounts =
+let generate_test_ledger =
   Command.async ~summary:"Generate a ledger for testing"
     (let open Command.Let_syntax in
     let%map_open n =

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -44,7 +44,8 @@
   kimchi_pasta
   kimchi_pasta.basic
   ppx_version.runtime
-  gossip_net)
+  gossip_net
+  runtime_config)
  (preprocess
   (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.make))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
To test cluster on large ledgers it's useful to have a tool to randomly generate ledger accounts for testing.

Usage: `mina ledger test-generate-accounts -n 200000 > ledger.json` to generate 200'000 accounts.

Bonus: to wire the accounts generated to file `ledger.json` into a `daemon.stub.json` stub, use the following command (also sets genesis timestamp to a new value):

```bash
jq --arg timestamp $( d=$(date +%s); date -u -d @$((d - d % 180 + 180)) +%FT%H:%M:%S+00:00 ) --slurpfile accounts ledger.json '.ledger.accounts |= . + $accounts[0] | .genesis.genesis_state_timestamp |= $timestamp'  < daemon.stub.json > daemon.json
```

Unlike `scripts/prepare-test-ledger.sh`, this tool generates ledger using uniform distribution of account balances, doesn't try to follow the shape of mainnet ledger.

Explain your changes:
* Implement a new command

Explain how you tested your changes:
* Generated a ledger, ledger works well against a Mina node

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None