### PR TITLE
ITN tooling: fix new accounts and max cost

### DIFF
--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -199,6 +199,12 @@ input ZkappCommandsDetails {
   """Minimum balance change"""
   minBalanceChange: CurrencyAmount!
 
+  """Minimum new zkapp balance"""
+  minNewZkappBalance: CurrencyAmount!
+
+  """Maximum new zkapp balance"""
+  maxNewZkappBalance: CurrencyAmount!
+
   """Disable the precondition in account updates"""
   noPrecondition: Boolean!
 

--- a/src/app/itn_orchestrator/src/generator/main.go
+++ b/src/app/itn_orchestrator/src/generator/main.go
@@ -521,18 +521,22 @@ func main() {
 	default:
 		os.Exit(1)
 	}
-	if p.PaymentReceiver == "" {
+	if p.PaymentReceiver == "" && p.ZkappRatio < 0.999 {
 		fmt.Fprintln(os.Stderr, "Payment receiver not specified")
 		os.Exit(2)
 	}
 	encoder := json.NewEncoder(os.Stdout)
-	_ = encoder.Encode("Funding keys for the experiment")
+	writeComment := func(comment string) {
+		if err := encoder.Encode(comment); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing comment: %v\n", err)
+			os.Exit(3)
+		}
+	}
+	writeComment("Generated with: " + strings.Join(os.Args, " "))
+	writeComment("Funding keys for the experiment")
 	writeCommand := func(cmd Command) {
 		if cmd.comment != "" {
-			if err := encoder.Encode(cmd.comment); err != nil {
-				fmt.Fprintf(os.Stderr, "Error writing comment: %v\n", err)
-				os.Exit(3)
-			}
+			writeComment(cmd.comment)
 		}
 		if err := encoder.Encode(cmd); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing command: %v\n", err)

--- a/src/app/itn_orchestrator/src/generator/main.go
+++ b/src/app/itn_orchestrator/src/generator/main.go
@@ -95,8 +95,10 @@ type SampleRefParams struct {
 }
 
 func sample(groupRef int, groupName string, ratios []float64) Command {
+	group := lib.LocalComplexValue(groupRef, groupName)
+	group.OnEmpty = emptyArrayRawMessage
 	return Command{Action: lib.SampleAction{}.Name(), Params: SampleRefParams{
-		Group:  lib.LocalComplexValue(groupRef, groupName),
+		Group:  group,
 		Ratios: ratios,
 	}}
 }
@@ -188,10 +190,20 @@ type ExceptRefParams struct {
 	Except lib.ComplexValue `json:"except"`
 }
 
+var emptyArrayRawMessage json.RawMessage
+
+func init() {
+	emptyArrayRawMessage, _ = json.Marshal([]string{})
+}
+
 func except(groupRef int, groupName string, exceptRef int, exceptName string) Command {
+	group := lib.LocalComplexValue(groupRef, groupName)
+	group.OnEmpty = emptyArrayRawMessage
+	except := lib.LocalComplexValue(exceptRef, exceptName)
+	except.OnEmpty = emptyArrayRawMessage
 	return Command{Action: lib.ExceptAction{}.Name(), Params: ExceptRefParams{
-		Group:  lib.LocalComplexValue(groupRef, groupName),
-		Except: lib.LocalComplexValue(exceptRef, exceptName),
+		Group:  group,
+		Except: except,
 	}}
 }
 

--- a/src/app/itn_orchestrator/src/generator/main.go
+++ b/src/app/itn_orchestrator/src/generator/main.go
@@ -252,6 +252,13 @@ func (p *Params) Generate(round int) GeneratedRound {
 		MaxCost:          maxCost,
 		NewAccounts:      newAccounts,
 	}
+	if maxCost {
+		// This can be set to arbitrary value as for max-cost it only
+		// matters that total zkapps deployed is above 5
+		// We need to set it this way to override setting accountQueueSize
+		// by the orchestrator
+		zkappParams.ZkappsToDeploy = 20
+	}
 	paymentParams := lib.PaymentSubParams{
 		ExperimentName: experimentName,
 		Tps:            tps - zkappTps,

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -122,7 +122,13 @@ func outputF(outCache outCacheT, log logging.StandardLogger, step int) func(stri
 			outCache[""][step][name] = lib.OutputCacheEntry{Multi: multiple, Values: []json.RawMessage{value}}
 		}
 		if !sensitive {
-			json, err := json.Marshal(lib.Output{Name: name, Multi: multiple, Value: value, Step: step})
+			json, err := json.Marshal(lib.Output{
+				Name:  name,
+				Multi: multiple,
+				Value: value,
+				Step:  step,
+				Time:  time.Now().UTC(),
+			})
 			if err != nil {
 				log.Errorf("Error marshalling output %s for step %d: %v", name, step, err)
 				os.Exit(8)

--- a/src/app/itn_orchestrator/src/params.go
+++ b/src/app/itn_orchestrator/src/params.go
@@ -59,10 +59,11 @@ func loadOutputFile(filename string) (map[int]map[string]OutputCacheEntry, error
 }
 
 type ComplexValue struct {
-	Type string `json:"type"`
-	File string `json:"file,omitempty"`
-	Step int    `json:"step"`
-	Name string `json:"name"`
+	Type    string          `json:"type"`
+	File    string          `json:"file,omitempty"`
+	Step    int             `json:"step"`
+	Name    string          `json:"name"`
+	OnEmpty json.RawMessage `json:"onEmpty,omitempty"`
 }
 
 func LocalComplexValue(step int, name string) ComplexValue {
@@ -96,7 +97,10 @@ func ResolveParam(config ResolutionConfig, step int, raw json.RawMessage) (json.
 	}
 	entry, has := config.OutputCache[val.File][val.Step][val.Name]
 	if !has {
-		return nil, fmt.Errorf("couldn't find output %s (step %d, file \"%s\") needed for step %d", val.Name, val.Step, val.File, step)
+		if val.OnEmpty == nil {
+			return nil, fmt.Errorf("couldn't find output %s (step %d, file \"%s\") needed for step %d", val.Name, val.Step, val.File, step)
+		}
+		return val.OnEmpty, nil
 	}
 	if entry.Multi {
 		res, err := json.Marshal(entry.Values)

--- a/src/app/itn_orchestrator/src/params.go
+++ b/src/app/itn_orchestrator/src/params.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type Output struct {
+	Time  time.Time       `json:"time,omitempty"`
 	Step  int             `json:"step"`
 	Name  string          `json:"name"`
 	Multi bool            `json:"multi,omitempty"`

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -9,21 +9,21 @@ import (
 )
 
 type ZkappSubParams struct {
-	ExperimentName    string  `json:"experimentName"`
-	Tps               float64 `json:"tps"`
-	MinTps            float64 `json:"minTps"`
-	DurationInMinutes int     `json:"durationMin"`
-	MaxFee            uint64  `json:"maxFee"`
-	MinFee            uint64  `json:"minFee"`
-	ZkappsToDeploy    int     `json:"zkapps"`
-	NewAccounts       int     `json:"newAccounts"`
-	AccountQueueSize  int     `json:"queueSize"`
-	Gap               int     `json:"gap"`
-	NoPrecondition    bool    `json:"noPrecondition"`
-	MaxCost           bool    `json:"maxCost"`
-	MinBalanceChange  uint64  `json:"minBalanceChange"`
-	MaxBalanceChange  uint64  `json:"maxBalanceChange"`
-	DeploymentFee     uint64  `json:"deploymentFee"`
+	ExperimentName   string  `json:"experimentName"`
+	Tps              float64 `json:"tps"`
+	MinTps           float64 `json:"minTps"`
+	DurationMin      int     `json:"durationMin"`
+	MaxFee           uint64  `json:"maxFee"`
+	MinFee           uint64  `json:"minFee"`
+	ZkappsToDeploy   int     `json:"zkapps"`
+	NewAccounts      int     `json:"newAccounts"`
+	AccountQueueSize int     `json:"queueSize"`
+	Gap              int     `json:"gap"`
+	NoPrecondition   bool    `json:"noPrecondition"`
+	MaxCost          bool    `json:"maxCost"`
+	MinBalanceChange uint64  `json:"minBalanceChange"`
+	MaxBalanceChange uint64  `json:"maxBalanceChange"`
+	DeploymentFee    uint64  `json:"deploymentFee"`
 }
 
 type ZkappCommandParams struct {
@@ -42,7 +42,7 @@ func ZkappKeygenRequirements(params ZkappSubParams) (int, uint64) {
 	initBalance := 1e10 * uint64(params.NewAccounts+1)
 	txCost := params.MaxBalanceChange + params.MaxFee
 	tpsGap := uint64(math.Round(params.Tps * float64(params.Gap)))
-	totalTxs := uint64(math.Ceil(float64(params.DurationInMinutes) * 60 * params.Tps))
+	totalTxs := uint64(math.Ceil(float64(params.DurationMin) * 60 * params.Tps))
 	balance := 3 * ((initBalance+params.DeploymentFee)*tpsGap*3 + txCost*totalTxs)
 	keys := maxParticipants + int(tpsGap)*2
 	return keys, balance
@@ -51,7 +51,7 @@ func ZkappKeygenRequirements(params ZkappSubParams) (int, uint64) {
 func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddress NodeAddress, batchIx int, tps float64, zkappsToDeploy, accountQueueSize int, feePayers []itn_json_types.MinaPrivateKey) (string, error) {
 	paymentInput := ZkappCommandsDetails{
 		MemoPrefix:        fmt.Sprintf("%s-%d", params.ExperimentName, batchIx),
-		DurationMin:       params.DurationInMinutes,
+		DurationMin:       params.DurationMin,
 		Tps:               tps,
 		NumZkappsToDeploy: zkappsToDeploy,
 		NumNewAccounts:    params.NewAccounts,

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -16,7 +16,7 @@ type ZkappSubParams struct {
 	MaxFee           uint64  `json:"maxFee"`
 	MinFee           uint64  `json:"minFee"`
 	ZkappsToDeploy   int     `json:"zkapps"`
-	NewAccounts      int     `json:"newAccounts"`
+	NewAccountRatio  float64 `json:"newAccountRatio"`
 	AccountQueueSize int     `json:"queueSize"`
 	Gap              int     `json:"gap"`
 	NoPrecondition   bool    `json:"noPrecondition"`
@@ -37,38 +37,59 @@ type ScheduledZkappCommandsReceipt struct {
 	Handle  string      `json:"handle"`
 }
 
-func ZkappKeygenRequirements(params ZkappSubParams) (int, uint64) {
+func ZkappBalanceRequirements(tps float64, p ZkappSubParams) (int, uint64, uint64, uint64) {
+	totalZkappsToDeploy := p.Gap * 4
+	// new accounts are set to ration multplied by (number of txs minus zkapp deploying txs)
+	newAccounts := int(tps * float64(p.DurationMin*60-totalZkappsToDeploy) * p.NewAccountRatio)
+	// not accounting for Birthday paradox, we multiply by three at a later stage for this reason
+	maxExpectedUsagesPerNewAccount := float64(p.DurationMin*60) / float64(p.Gap)
+	//We multiply by three because by matter of chance some zkapps may generate more new accounts
+	newAccountsPerZkapp := int(float64(newAccounts) / float64(totalZkappsToDeploy) * 3)
+	balanceDeductedPerUsage := p.MaxBalanceChange * 5
+	// We add 1e9 because of account creation fee
+	minNewZkappBalance := uint64(maxExpectedUsagesPerNewAccount*float64(balanceDeductedPerUsage))*3 + 1e9
+	maxNewZkappBalance := minNewZkappBalance * 3
+	// multiply by two for "error factor"
+	initBalance := maxNewZkappBalance * (uint64(newAccountsPerZkapp) + 1) * 2
+	return newAccounts, minNewZkappBalance, maxNewZkappBalance, initBalance
+}
+
+func ZkappKeygenRequirements(initZkappBalance uint64, params ZkappSubParams) (int, uint64) {
 	maxParticipants := int(math.Ceil(params.Tps / params.MinTps))
-	initBalance := 1e10 * uint64(params.NewAccounts+1)
 	txCost := params.MaxBalanceChange + params.MaxFee
 	tpsGap := uint64(math.Round(params.Tps * float64(params.Gap)))
 	totalTxs := uint64(math.Ceil(float64(params.DurationMin) * 60 * params.Tps))
-	balance := 3 * ((initBalance+params.DeploymentFee)*tpsGap*3 + txCost*totalTxs)
+	totalZkappsToDeploy := params.Gap * 4
+	balance := 3 * ((initZkappBalance+params.DeploymentFee)*uint64(totalZkappsToDeploy) + txCost*totalTxs)
 	keys := maxParticipants + int(tpsGap)*2
 	return keys, balance
 }
 
-func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddress NodeAddress, batchIx int, tps float64, zkappsToDeploy, accountQueueSize int, feePayers []itn_json_types.MinaPrivateKey) (string, error) {
+func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddress NodeAddress, batchIx int, tps float64, feePayers []itn_json_types.MinaPrivateKey) (string, error) {
+	zkappsToDeploy, accountQueueSize := zkappParams(params, tps)
+	newAccounts, minNewZkappBalance, maxNewZkappBalance, initBalance := ZkappBalanceRequirements(tps, params.ZkappSubParams)
 	paymentInput := ZkappCommandsDetails{
-		MemoPrefix:        fmt.Sprintf("%s-%d", params.ExperimentName, batchIx),
-		DurationMin:       params.DurationMin,
-		Tps:               tps,
-		NumZkappsToDeploy: zkappsToDeploy,
-		NumNewAccounts:    params.NewAccounts,
-		FeePayers:         feePayers,
-		NoPrecondition:    params.NoPrecondition,
-		MinBalanceChange:  params.MinBalanceChange,
-		MaxBalanceChange:  params.MaxBalanceChange,
-		// TODO hardcoded in generator, TODO update
-		InitBalance:      1e10 * uint64(params.NewAccounts+1),
-		MinFee:           params.MinFee,
-		MaxFee:           params.MaxFee,
-		DeploymentFee:    params.DeploymentFee,
-		AccountQueueSize: accountQueueSize,
-		MaxCost:          params.MaxCost,
+		MemoPrefix:         fmt.Sprintf("%s-%d", params.ExperimentName, batchIx),
+		DurationMin:        params.DurationMin,
+		Tps:                tps,
+		NumZkappsToDeploy:  zkappsToDeploy,
+		NumNewAccounts:     newAccounts,
+		FeePayers:          feePayers,
+		NoPrecondition:     params.NoPrecondition,
+		MinBalanceChange:   params.MinBalanceChange,
+		MaxBalanceChange:   params.MaxBalanceChange,
+		MinNewZkappBalance: minNewZkappBalance,
+		MaxNewZkappBalance: maxNewZkappBalance,
+		InitBalance:        initBalance,
+		MinFee:             params.MinFee,
+		MaxFee:             params.MaxFee,
+		DeploymentFee:      params.DeploymentFee,
+		AccountQueueSize:   accountQueueSize,
+		MaxCost:            params.MaxCost,
 	}
 	handle, err := ScheduleZkappCommands(config, nodeAddress, paymentInput)
 	if err == nil {
+		config.Log.Info(paymentInput)
 		config.Log.Infof("scheduled zkapp batch %d with tps %f for %s: %s", batchIx, tps, nodeAddress, handle)
 	}
 	return handle, err
@@ -89,7 +110,6 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 	}
 	tps, nodes := selectNodes(params.Tps, params.MinTps, params.Nodes)
 	feePayersPerNode := len(params.FeePayers) / len(nodes)
-	zkappsToDeploy, accountQueueSize := zkappParams(params, tps)
 	successfulNodes := make([]NodeAddress, 0, len(nodes))
 	remTps := params.Tps
 	remFeePayers := params.FeePayers
@@ -97,14 +117,13 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 	for nodeIx, nodeAddress := range nodes {
 		feePayers := remFeePayers[:feePayersPerNode]
 		var handle string
-		handle, err = scheduleZkappCommandsDo(config, params, nodeAddress, len(successfulNodes), tps, zkappsToDeploy, accountQueueSize, feePayers)
+		handle, err = scheduleZkappCommandsDo(config, params, nodeAddress, len(successfulNodes), tps, feePayers)
 		if err != nil {
 			config.Log.Warnf("error scheduling zkapp txs for %s: %v", nodeAddress, err)
 			n := len(nodes) - nodeIx - 1
 			if n > 0 {
 				tps = remTps / float64(n)
 				feePayersPerNode = len(remFeePayers) / n
-				zkappsToDeploy, accountQueueSize = zkappParams(params, tps)
 			}
 			continue
 		}
@@ -119,7 +138,7 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 	if err != nil {
 		// last schedule payment request didn't work well
 		for _, nodeAddress := range successfulNodes {
-			handle, err2 := scheduleZkappCommandsDo(config, params, nodeAddress, len(successfulNodes), tps, zkappsToDeploy, accountQueueSize, remFeePayers)
+			handle, err2 := scheduleZkappCommandsDo(config, params, nodeAddress, len(successfulNodes), tps, remFeePayers)
 			if err2 != nil {
 				config.Log.Warnf("error scheduling second batch of zkapp txs for %s: %v", nodeAddress, err2)
 				continue

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -59,12 +59,13 @@ func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddre
 		NoPrecondition:    params.NoPrecondition,
 		MinBalanceChange:  params.MinBalanceChange,
 		MaxBalanceChange:  params.MaxBalanceChange,
-		InitBalance:       1e10 * uint64(params.NewAccounts+1),
-		MinFee:            params.MinFee,
-		MaxFee:            params.MaxFee,
-		DeploymentFee:     params.DeploymentFee,
-		AccountQueueSize:  accountQueueSize,
-		MaxCost:           params.MaxCost,
+		// TODO hardcoded in generator, TODO update
+		InitBalance:      1e10 * uint64(params.NewAccounts+1),
+		MinFee:           params.MinFee,
+		MaxFee:           params.MaxFee,
+		DeploymentFee:    params.DeploymentFee,
+		AccountQueueSize: accountQueueSize,
+		MaxCost:          params.MaxCost,
 	}
 	handle, err := ScheduleZkappCommands(config, nodeAddress, paymentInput)
 	if err == nil {

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -89,7 +89,6 @@ func scheduleZkappCommandsDo(config Config, params ZkappCommandParams, nodeAddre
 	}
 	handle, err := ScheduleZkappCommands(config, nodeAddress, paymentInput)
 	if err == nil {
-		config.Log.Info(paymentInput)
 		config.Log.Infof("scheduled zkapp batch %d with tps %f for %s: %s", batchIx, tps, nodeAddress, handle)
 	}
 	return handle, err

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -1,6 +1,13 @@
 open Mina_base
 open Core_kernel
 
+type balance_change_range_t =
+  { min_balance_change : Currency.Amount.t
+  ; max_balance_change : Currency.Amount.t
+  ; min_new_zkapp_balance : Currency.Amount.t
+  ; max_new_zkapp_balance : Currency.Amount.t
+  }
+
 type failure =
   | Invalid_account_precondition
   | Invalid_protocol_state_precondition
@@ -51,7 +58,7 @@ val gen_zkapp_command_from :
   -> ?memo:string
   -> ?no_account_precondition:bool
   -> ?fee_range:Currency.Fee.t * Currency.Fee.t
-  -> ?balance_change_range:Currency.Amount.t * Currency.Amount.t
+  -> ?balance_change_range:balance_change_range_t
   -> ?ignore_sequence_events_precond:bool
   -> ?no_token_accounts:bool
   -> ?limited:bool

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -236,8 +236,7 @@ let send_zkapps ~fee_payer_array ~constraint_constants ~tm_end ~scheduler_tbl
                      ( zkapp_command_details.min_fee
                      , zkapp_command_details.max_fee )
                    ~balance_change_range:
-                     ( zkapp_command_details.min_balance_change
-                     , zkapp_command_details.max_balance_change )
+                     zkapp_command_details.balance_change_range
                    ~ignore_sequence_events_precond:true ~no_token_accounts:true
                    ~limited:true ~fee_payer_keypair:fee_payer ~keymap
                    ~account_state_tbl ~generate_new_accounts ~ledger ~vk

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -2925,14 +2925,14 @@ module Input = struct
         ; duration_min : int
         ; memo_prefix : string
         ; no_precondition : bool
-        ; min_balance_change : Currency.Amount.t
-        ; max_balance_change : Currency.Amount.t
         ; init_balance : Currency.Amount.t
         ; min_fee : Currency.Fee.t
         ; max_fee : Currency.Fee.t
         ; deployment_fee : Currency.Fee.t
         ; account_queue_size : int
         ; max_cost : bool
+        ; balance_change_range :
+            Mina_generators.Zkapp_command_generators.balance_change_range_t
         }
 
       let arg_typ : ((input, string) result option, input option) arg_typ =
@@ -2940,7 +2940,8 @@ module Input = struct
           ~doc:"Keys and other information for scheduling zkapp commands"
           ~coerce:(fun fee_payers num_zkapps_to_deploy num_new_accounts tps
                        duration_min memo_prefix no_precondition
-                       min_balance_change max_balance_change init_balance
+                       min_balance_change max_balance_change
+                       min_new_zkapp_balance max_new_zkapp_balance init_balance
                        min_fee max_fee deployment_fee account_queue_size
                        max_cost ->
             Result.return
@@ -2951,20 +2952,28 @@ module Input = struct
               ; duration_min
               ; memo_prefix
               ; no_precondition
-              ; min_balance_change
-              ; max_balance_change
               ; init_balance
               ; min_fee
               ; max_fee
               ; deployment_fee
               ; account_queue_size
               ; max_cost
+              ; balance_change_range =
+                  { min_balance_change
+                  ; max_balance_change
+                  ; min_new_zkapp_balance
+                  ; max_new_zkapp_balance
+                  }
               } )
           ~split:(fun f (t : input) ->
             f t.fee_payers t.num_zkapps_to_deploy t.num_new_accounts t.tps
               t.duration_min t.memo_prefix t.no_precondition
-              t.min_balance_change t.max_balance_change t.init_balance t.min_fee
-              t.max_fee t.deployment_fee t.account_queue_size t.max_cost )
+              t.balance_change_range.min_balance_change
+              t.balance_change_range.max_balance_change
+              t.balance_change_range.min_new_zkapp_balance
+              t.balance_change_range.max_new_zkapp_balance t.init_balance
+              t.min_fee t.max_fee t.deployment_fee t.account_queue_size
+              t.max_cost )
           ~fields:
             Arg.
               [ arg "feePayers"
@@ -2991,6 +3000,10 @@ module Input = struct
               ; arg "minBalanceChange" ~doc:"Minimum balance change"
                   ~typ:(non_null CurrencyAmount.arg_typ)
               ; arg "maxBalanceChange" ~doc:"Maximum balance change"
+                  ~typ:(non_null CurrencyAmount.arg_typ)
+              ; arg "minNewZkappBalance" ~doc:"Minimum new zkapp balance"
+                  ~typ:(non_null CurrencyAmount.arg_typ)
+              ; arg "maxNewZkappBalance" ~doc:"Maximum new zkapp balance"
                   ~typ:(non_null CurrencyAmount.arg_typ)
               ; arg "initBalance"
                   ~typ:(non_null CurrencyAmount.arg_typ)


### PR DESCRIPTION
Explain your changes:
* Add two new parameters to zkapp scheduler (part of ITN graphql) to control balance to be deployed onto new accounts
* Implement formulas in Generator and Orchestrator to support new account-generating experiments (and most importantly ensure tx generators' balances never fall below zero
* Override number of zkapps deployed for max-cost transaction generation
  * Max-cost tx generator doesn't need nearly as many zkapps to be deployed as the regular tx generator
* Improvements to logging in Orchestrator and generator

Explain how you tested your changes:
* Tested by launching experiments on the "small" cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #13902
