### PR TITLE
Bump Go version in nix build

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -31,7 +31,7 @@ final: prev: {
   };
 
   # Jobs/Test/Libp2pUnitTest
-  libp2p_helper = final.buildGo118Module {
+  libp2p_helper = final.buildGo119Module {
     pname = "libp2p_helper";
     version = "0.1";
     src = ../src/app/libp2p_helper/src;

--- a/nix/libp2p_helper.json
+++ b/nix/libp2p_helper.json
@@ -1,1 +1,1 @@
-{"go.mod":"d5de7e35a76f5c9ce7d6c98f0da39c763961e77b8c94761b1e89ab4bdfdc2a97","go.sum":"586fd920114d3875ec3e1d739921d77d30ad8e2f297b67781ca41d25a81b65a9","vendorSha256":""}
+{"go.mod":"d5de7e35a76f5c9ce7d6c98f0da39c763961e77b8c94761b1e89ab4bdfdc2a97","go.sum":"586fd920114d3875ec3e1d739921d77d30ad8e2f297b67781ca41d25a81b65a9","vendorSha256":"sha256-vyKrKi5bqm8Mf2rUOojSY0IXHcuNpcVNvd1Iu1RBxDo="}


### PR DESCRIPTION
Bump the Go version used to build libp2p in nix to 1.19 due to the changes made in #14085. The beforementioned PR also changes libp2p, and the nix package hash of it must be updated as well.