### PR TITLE
berkeley ledger timestamp bump

### DIFF
--- a/genesis_ledgers/berkeley.json
+++ b/genesis_ledgers/berkeley.json
@@ -1,6 +1,6 @@
 {
   "genesis": {
-    "genesis_state_timestamp": "2023-09-05T19:01:01Z"
+    "genesis_state_timestamp": "2023-09-13T13:01:01Z"
   },
   "ledger": {
     "name": "berkeley",


### PR DESCRIPTION
This PR updates the ledger timestamp for the purpose of redeploying the Berkeley testnet. 