### PR TITLE
Add Quickcheck generators for runtime config.

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4299,7 +4299,11 @@ module Queries = struct
             `Assoc [ ("error", `String "Daemon is bootstrapping") ]
         | `Active best_tip -> (
             let block = Transition_frontier.Breadcrumb.(block best_tip) in
-            let global_slot = Mina_block.blockchain_length block in
+            let blockchain_length = Mina_block.blockchain_length block in
+            let global_slot =
+              Mina_block.consensus_state block
+              |> Consensus.Data.Consensus_state.curr_global_slot
+            in
             let ledger =
               Transition_frontier.Breadcrumb.staged_ledger best_tip
               |> Staged_ledger.ledger
@@ -4310,6 +4314,7 @@ module Queries = struct
             let runtime_config = Mina_lib.runtime_config mina in
             match
               Runtime_config.make_fork_config ~ledger ~global_slot
+                ~blockchain_length
                 ~protocol_state_hash:protocol_state.previous_state_hash
                 runtime_config
             with

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4299,18 +4299,17 @@ module Queries = struct
             `Assoc [ ("error", `String "Daemon is bootstrapping") ]
         | `Active best_tip -> (
             let block = Transition_frontier.Breadcrumb.(block best_tip) in
-            let global_slot =
-              Mina_block.blockchain_length block |> Unsigned.UInt32.to_int
-            in
-            let staged_ledger =
+            let global_slot = Mina_block.blockchain_length block in
+            let ledger =
               Transition_frontier.Breadcrumb.staged_ledger best_tip
+              |> Staged_ledger.ledger
             in
             let protocol_state =
               Transition_frontier.Breadcrumb.protocol_state best_tip
             in
             let runtime_config = Mina_lib.runtime_config mina in
             match
-              Runtime_config.make_fork_config ~staged_ledger ~global_slot
+              Runtime_config.make_fork_config ~ledger ~global_slot
                 ~protocol_state_hash:protocol_state.previous_state_hash
                 runtime_config
             with

--- a/src/lib/runtime_config/dune
+++ b/src/lib/runtime_config/dune
@@ -22,8 +22,9 @@
    pickles
    pickles.backend
    pickles_types
-   signature_lib
    with_hash
+   signature_lib
+   staged_ledger
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_custom_printf ppx_sexp_conv ppx_let ppx_deriving_yojson ppx_dhall_type ppx_version ppx_compare)))

--- a/src/lib/runtime_config/dune
+++ b/src/lib/runtime_config/dune
@@ -8,8 +8,9 @@
    base.caml
    base
    base64
-   sexplib0
+   integers
    result
+   sexplib0
    ;; local libraries
    currency
    data_hash_lib


### PR DESCRIPTION
Explain your changes:
* In order to facilitate testing the hard-fork mechanism, I added generators to generate random runtime configs.
* Fixed some problems in the hard-fork-config generation which became apparent in the process.

I'm not entirely sure that all the ranges I chose for values like genesis constants make sense, so I'd be particularly grateful for any suggestions concerning that.

Explain how you tested your changes:
* These generators will serve fir writing tests in the future.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes [#38](https://github.com/MinaFoundation/mina/issues/38) in MinaFoundation repo.
