### PR TITLE
[Compatible] nightly tear down fix

### DIFF
--- a/buildkite/scripts/finish-coverage-data-upload.sh
+++ b/buildkite/scripts/finish-coverage-data-upload.sh
@@ -1,0 +1,3 @@
+curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_TOKEN -d "payload[build_num]=$BUILDKITE_BUILD_NUMBER&payload[status]=done"
+
+curl --location --request POST "https://coveralls.io/rerun_build?repo_token=$COVERALLS_TOKEN&build_num=$BUILDKITE_BUILD_NUMBER"


### PR DESCRIPTION
Explain your changes:
Fixing issue with lack of script which pushed notification to coveralls that coverage gathering is finished

Explain how you tested your changes:
Have a pipeline in nightly to check if coverage is correctly pushed: 

https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/481

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
