### PR TITLE
Improve clean-merge guards

### DIFF
--- a/buildkite/scripts/merges-cleanly.awk
+++ b/buildkite/scripts/merges-cleanly.awk
@@ -1,0 +1,38 @@
+BEGIN {
+    current_file = "";
+    filename_printed = 0;
+    display = 0;
+    status = 0;
+}
+
+/^  (base|our|their|result)/ {
+    if ( $4 != current_file ) {
+        current_file = $4;
+        filename_printed = 0;
+    }
+}
+
+/^[\+\-]<<</ {
+    display = 1;
+    status = 1;
+    if ( filename_printed == 0 ) {
+        print "File: " current_file;
+        filename_printed = 1;
+    }
+}
+
+/^[\+\-]>>>/ {
+    display = 0;
+    print;
+    print "";
+}
+
+/^[\+\- ]/ {
+    if ( display == 1 ) {
+        print;
+    }
+}
+
+END {
+    exit status;
+}

--- a/buildkite/scripts/merges-cleanly.sh
+++ b/buildkite/scripts/merges-cleanly.sh
@@ -8,21 +8,22 @@ echo 'Testing for conflicts between the current branch `'"${CURRENT}"'` and `'"$
 # The git merge-tree command shows the content of a 3-way merge without
 # touching the index, which we can then search for conflict markers.
 
-# Tell git where to find ssl certs
-git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt
 # Fetch a fresh copy of the repo
+git config http.sslVerify false
 git fetch origin
+git config http.sslVerify true
 # Check mergeability
-git merge-tree `git merge-base origin/$BRANCH HEAD` HEAD origin/$BRANCH | grep -A 25 "^+<<<<<<<"
+git merge-tree `git merge-base origin/$BRANCH HEAD` HEAD origin/$BRANCH \
+    | awk -f buildkite/scripts/merges-cleanly.awk
 
 RET=$?
 
 if [ $RET -eq 0 ]; then
+  echo "No conflicts found against upstream branch ${BRANCH}"
+  exit 0
+else
   # Found a conflict
   echo "[ERROR] This pull request conflicts with $BRANCH, please open a new pull request against $BRANCH at this link:"
   echo "https://github.com/MinaProtocol/mina/compare/${BRANCH}...${BUILDKITE_BRANCH}"
-  exit 1
-else
-  echo "No conflicts found against upstream branch ${BRANCH}"
-  exit 0
+  exit $RET
 fi

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -6,8 +6,8 @@
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
   minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:e4920236094ab23caad9ec9cda39babde6b777541db054e8138f71ac464f57b5",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:eea4b6cd7ce0a92649bd8d8283c97a94c0cf70ce00fd63c3d08f1bfc15d2531d",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:73562fcc35dcabd342f66f1d69ae12704e92d69edc0b37e7c88b4d11bc623f23",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:695396a777c13a7eb84e7ead702f07c78adfd64a6ca2304a1409ad2e26a38caa",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:de2ad3255acb939492fe9eb4daaac98831cabf7a4b7ef1fd1e7afceaa6b510a7",
   minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:73562fcc35dcabd342f66f1d69ae12704e92d69edc0b37e7c88b4d11bc623f23",
   minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:73562fcc35dcabd342f66f1d69ae12704e92d69edc0b37e7c88b4d11bc623f23",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -27,7 +27,7 @@ Pipeline.build
           , key = "clean-merge-compatible"
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         },
       Command.build
@@ -37,7 +37,7 @@ Pipeline.build
           , key = "clean-merge-develop"
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         },
       Command.build
@@ -47,7 +47,7 @@ Pipeline.build
           , key = "clean-merge-berkeley"
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         }
     ]

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -37,6 +37,7 @@ RUN apt-get update --yes \
     awscli \
     cmake \
     fakeroot \
+    gawk \
     gnupg2 \
     jq \
     libboost-dev \


### PR DESCRIPTION
Explain your changes:
* "Merges cleanly into X" jobs will now nicely print filenames where conflicts occur.

Explain how you tested your changes:
* Tested manually on branch [sventimir/fork_config_test](https://github.com/MinaProtocol/mina/tree/sventimir/fork_config_test), where conflicts occur at the moment.
* Run the CI.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules

