### PR TITLE
Remove conflicts before merging: Imrove merges-cleanly.sh

### DIFF
--- a/buildkite/scripts/merges-cleanly.awk
+++ b/buildkite/scripts/merges-cleanly.awk
@@ -1,0 +1,38 @@
+BEGIN {
+    current_file = "";
+    filename_printed = 0;
+    display = 0;
+    status = 0;
+}
+
+/^  (base|our|their|result)/ {
+    if ( $4 != current_file ) {
+        current_file = $4;
+        filename_printed = 0;
+    }
+}
+
+/^[\+\-]<<</ {
+    display = 1;
+    status = 1;
+    if ( filename_printed == 0 ) {
+        print "File: " current_file;
+        filename_printed = 1;
+    }
+}
+
+/^[\+\-]>>>/ {
+    display = 0;
+    print;
+    print "";
+}
+
+/^[\+\- ]/ {
+    if ( display == 1 ) {
+        print;
+    }
+}
+
+END {
+    exit status;
+}

--- a/buildkite/scripts/merges-cleanly.sh
+++ b/buildkite/scripts/merges-cleanly.sh
@@ -8,21 +8,22 @@ echo 'Testing for conflicts between the current branch `'"${CURRENT}"'` and `'"$
 # The git merge-tree command shows the content of a 3-way merge without
 # touching the index, which we can then search for conflict markers.
 
-# Tell git where to find ssl certs
-git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt
 # Fetch a fresh copy of the repo
+git config http.sslVerify false
 git fetch origin
+git config http.sslVerify true
 # Check mergeability
-git merge-tree `git merge-base origin/$BRANCH HEAD` HEAD origin/$BRANCH | grep -A 25 "^+<<<<<<<"
+git merge-tree `git merge-base origin/$BRANCH HEAD` HEAD origin/$BRANCH \
+    | awk -f buildkite/scripts/merges-cleanly.awk
 
 RET=$?
 
 if [ $RET -eq 0 ]; then
+  echo "No conflicts found against upstream branch ${BRANCH}"
+  exit 0
+else
   # Found a conflict
   echo "[ERROR] This pull request conflicts with $BRANCH, please open a new pull request against $BRANCH at this link:"
   echo "https://github.com/MinaProtocol/mina/compare/${BRANCH}...${BUILDKITE_BRANCH}"
-  exit 1
-else
-  echo "No conflicts found against upstream branch ${BRANCH}"
-  exit 0
+  exit $RET
 fi

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,11 +4,12 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:563fd7adda282fb3b6765c1811a3566e0fa0560f5d1c5270003483030d82d394",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:49891eb46089f937f054afa464ce9868529981b92b30740cce32ef60957a1098",
-  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:49891eb46089f937f054afa464ce9868529981b92b30740cce32ef60957a1098",
-  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:49891eb46089f937f054afa464ce9868529981b92b30740cce32ef60957a1098",
-  delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:12ffd0a9016819c720687f440c7a46b8815f8d3ad06d306d342ee5f8dd4375f5",
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:e4920236094ab23caad9ec9cda39babde6b777541db054e8138f71ac464f57b5",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:695396a777c13a7eb84e7ead702f07c78adfd64a6ca2304a1409ad2e26a38caa",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:de2ad3255acb939492fe9eb4daaac98831cabf7a4b7ef1fd1e7afceaa6b510a7",
+  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:73562fcc35dcabd342f66f1d69ae12704e92d69edc0b37e7c88b4d11bc623f23",
+  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:73562fcc35dcabd342f66f1d69ae12704e92d69edc0b37e7c88b4d11bc623f23",
+  delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   nodeToolchain = "node:14.13.1-stretch-slim",
   ubuntu2004 = "ubuntu:20.04",

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -31,7 +31,7 @@ Pipeline.build
           , soft_fail = Some (B/SoftFail.Boolean True)
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         },
       Command.build
@@ -41,7 +41,7 @@ Pipeline.build
           , key = "clean-merge-develop"
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         },
       Command.build
@@ -51,7 +51,7 @@ Pipeline.build
           , key = "clean-merge-berkeley"
           , target = Size.Small
           , docker = Some Docker::{
-              image = (../../Constants/ContainerImages.dhall).toolchainBase
+              image = (../../Constants/ContainerImages.dhall).minaToolchain
             }
         },
       Command.build

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -24,6 +24,7 @@ RUN apt-get update --yes \
     awscli \
     cmake \
     fakeroot \
+    gawk \
     gnupg2 \
     jq \
     libboost-dev \


### PR DESCRIPTION
Merge https://github.com/MinaProtocol/mina/pull/14128 into `berkeley` so that we can merge it into `compatible` cleanly. Will probably need to update docker image hashes after this is merged, but cannot do it now, because we'll have conflicts again while merging into `compatible`.