### PR TITLE
Do not build mina on single-node-tests job

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -36,7 +36,8 @@ dune build "--profile=${DUNE_PROFILE}" \
   src/app/zkapp_test_transaction/zkapp_test_transaction.exe \
   src/app/rosetta/rosetta_testnet_signatures.exe \
   src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe \
-  src/app/test_executive/test_executive.exe # 2>&1 | tee /tmp/buildocaml.log
+  src/app/test_executive/test_executive.exe  \
+  src/test/command_line_tests/command_line_tests.exe # 2>&1 | tee /tmp/buildocaml.log
 
 echo "--- Bundle all packages for Debian ${MINA_DEB_CODENAME}"
 echo " Includes mina daemon, archive-node, rosetta, generate keypair for berkeley"

--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -26,18 +26,25 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let Command = ../../Command/Base.dhall
 let RunInToolchain = ../../Command/RunInToolchain.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
+let Profiles = ../../Constants/Profiles.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd : Text -> Text -> Size -> Command.Type = \(profile : Text) -> \(path : Text) -> \(cmd_target : Size) ->
-  let key = "single-node-tests-${profile}" in
+
+let dependsOn = DebianVersions.dependsOn DebianVersions.DebVersion.Bullseye Profiles.Type.Standard
+
+
+let buildTestCmd : Size -> Command.Type = \(cmd_target : Size) ->
+  let key = "single-node-tests" in
   Command.build
     Command.Config::{
-      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/single-node-tests.sh ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev",
-      label = "${profile} single-node-tests",
+      commands = RunInToolchain.runInToolchain ["DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN"] "buildkite/scripts/single-node-tests.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}",
+      label = "single-node-tests",
       key = key,
       target = cmd_target,
-      docker = None Docker.Type
+      docker = None Docker.Type,
+      depends_on = dependsOn 
     }
 
 in
@@ -62,6 +69,6 @@ Pipeline.build
         tags = [ PipelineTag.Type.Long, PipelineTag.Type.Test ]
       },
     steps = [
-      buildTestCmd "dev" "src/test/command_line_tests/command_line_tests.exe" Size.XLarge
+      buildTestCmd Size.XLarge
     ]
   }

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -240,6 +240,20 @@ cp ./default/src/app/batch_txn_tool/batch_txn_tool.exe "${BUILDDIR}/usr/local/bi
 
 build_deb mina-batch-txn
 
+##################################### END BATCH TXN TOOL PACKAGE #######################################
+
+##################################### GENERATE TEST SUITE PACKAGE #######################################
+
+
+create_control_file mina-test-suite "${SHARED_DEPS}" 'Test suite apps for mina.'
+
+# Binaries
+cp ./default/src/test/command_line_tests/command_line_tests.exe "${BUILDDIR}/usr/local/bin/mina-command-line-tests"
+
+build_deb mina-test-suite
+
+##################################### END TEST SUITE PACKAGE #######################################
+
 ##################################### MAINNET PACKAGE #######################################
 if ${MINA_BUILD_MAINNET} # only builds on mainnet-like branches
 then

--- a/src/test/command_line_tests/config.ml
+++ b/src/test/command_line_tests/config.ml
@@ -9,16 +9,6 @@ let p2p_dir = "mina_test_libp2p_keypair"
 
 let default_root_path = "/tmp"
 
-(* executable location relative to src/default/lib/command_line_tests
-
-   dune won't allow running it via "dune exec", because it's outside its
-   workspace, so we invoke the executable directly
-
-   the mina.exe executable must have been built before running the test
-   here, else it will fail
-*)
-let default_mina_exe = "_build/default/src/app/cli/src/mina.exe"
-
 module ConfigDirs = struct
   type t =
     { root_path : string
@@ -54,7 +44,7 @@ module Config = struct
 
   let create port dirs mina_exe clean_up = { port; dirs; mina_exe; clean_up }
 
-  let default port =
+  let default port mina_path =
     let dirs = ConfigDirs.create default_root_path in
-    create port dirs default_mina_exe true
+    create port dirs mina_path true
 end

--- a/src/test/command_line_tests/dune
+++ b/src/test/command_line_tests/dune
@@ -10,6 +10,7 @@
    async_unix
    stdio
    alcotest
+   cmdliner
    ;; mina libraries
    init
  )

--- a/src/test/command_line_tests/mina_bootstrapper.ml
+++ b/src/test/command_line_tests/mina_bootstrapper.ml
@@ -12,7 +12,7 @@ module MinaBootstrapper = struct
     }
 
   let create config =
-    { config; client_delay = 40.; retry_delay = 30.; retry_attempts = 5 }
+    { config; client_delay = 40.; retry_delay = 60.; retry_attempts = 10 }
 
   let get_args t working_dir =
     [ "daemon"

--- a/src/test/command_line_tests/runner.ml
+++ b/src/test/command_line_tests/runner.ml
@@ -11,10 +11,10 @@ module TestRunner = struct
     Deferred.List.iter dirs ~f:(fun dir ->
         Deferred.ignore_m @@ Process.run_exn ~prog:"rm" ~args:[ "-rf"; dir ] () )
 
-  let run test_case =
+  let run test_case mina_exe =
     let test_failed = ref false in
     let open Deferred.Let_syntax in
-    let config = Config.default 1337 in
+    let config = Config.default 1337 mina_exe in
     let%bind () = ConfigDirs.generate_keys config.dirs in
     Monitor.protect
       ~finally:(fun () ->


### PR DESCRIPTION
Explain your changes:
Skip building mina on single node tests. Instead, use already built mina lightnet packages. Command line tests evolved from being a test with dev profile (kind of unit test but on already built mina ) to became component test for release version of mina. Execution time is similar (~14 min) but we are testing on higher level and more production alike mina.

Explain how you tested your changes:
Run CI and observe green single node tests

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
