### PR TITLE
Let `git merge` determine whether we can merge

### DIFF
--- a/buildkite/scripts/merges-cleanly.sh
+++ b/buildkite/scripts/merges-cleanly.sh
@@ -12,8 +12,11 @@ echo 'Testing for conflicts between the current branch `'"${CURRENT}"'` and `'"$
 git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt
 # Fetch a fresh copy of the repo
 git fetch origin
-# Check mergeability
-git merge-tree `git merge-base origin/$BRANCH HEAD` HEAD origin/$BRANCH | grep -A 25 "^+<<<<<<<"
+# Check mergeability. We use flags so that
+# * `--no-commit` stops us from updating the index with a merge commit,
+# * `--no-ff` stops us from updating the index to the HEAD, if the merge is a
+#   straightforward fast-forward
+git merge --no-commit --no-ff origin/$BRANCH
 
 RET=$?
 


### PR DESCRIPTION
@nholland94 this fixes the annoying merge-check failures we discussed.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them