### PR TITLE
Fix buildkite diff generation, so that dirtyWhen rules work correctly

### DIFF
--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -3,11 +3,11 @@
 TAG=$(git tag --points-at HEAD)
 
 # If this is not a PR build, or the HEAD is tagged, the entire build is dirty
-if [ -z ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} ]; then
+if [ -z "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" ]; then
   echo "This is not a PR build; considering all files dirty" >&2
   git ls-files
-elif [ -n ${TAG} ]; then
-  echo "This commit has been tagged; considering all files dirty" >&2
+elif [ -n "${TAG}" ]; then
+  echo "This commit has been tagged (${TAG}); considering all files dirty" >&2
   git ls-files
 else
   COMMIT=$(git log -1 --pretty=format:%H)

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -1,41 +1,17 @@
 #!/bin/bash
 
-# Base against origin/compatible by default, but use pull-request base otherwise
-BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-compatible}
 TAG=$(git tag --points-at HEAD)
 
-[[ -n $TAG ]] && git ls-files && exit
-
-# Finds the commit hash of HEAD of $BASE branch
-BASECOMMIT=$(git log origin/$BASE -1 --pretty=format:%H)
-# Finds the commit hash of HEAD of the current branch
-COMMIT=$(git log -1 --pretty=format:%H)
-# Use buildkite commit instead when its defined
-[[ -n "$BUILDKITE_COMMIT" ]] && COMMIT=${BUILDKITE_COMMIT}
-
-# Print it to stderr for logging/debugging
->&2 echo "Diffing current commit: ${COMMIT} against commit: ${BASECOMMIT} from branch: ${BASE} ."
-
-# Compare base to the current commit
-if [[ $BASECOMMIT != $COMMIT ]]; then
-  # Get the files that have diverged from $BASE
-  git diff $BASECOMMIT --name-only
+# If this is not a PR build, or the HEAD is tagged, the entire build is dirty
+if [ -z ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} ]; then
+  echo "This is not a PR build; considering all files dirty" >&2
+  git ls-files
+elif [ -n ${TAG} ]; then
+  echo "This commit has been tagged; considering all files dirty" >&2
+  git ls-files
 else
-  if [ -n "${BUILDKITE_INCREMENTAL+x}" ]; then
-    # TODO: remove (temporarily install network tooling)
-    apt-get install --yes curl jq
-
-    # base DIFF on last successful Buildkite `develop` RUN
-    ci_recent_pass_commit=$(
-      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer ${BUILDKITE_API_TOKEN:-$TOKEN}" \
-        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' \
-      | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
-    )
-
-    git diff "${ci_recent_pass_commit}" --name-only
-  else
-    # TODO: Dump commits as artifacts when build succeeds so we can diff against
-    # that on develop instead of always running all the tests
-    git ls-files
-  fi
+  COMMIT=$(git log -1 --pretty=format:%H)
+  BASE_COMMIT=$(git log "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
+  echo "Diffing current commit: ${COMMIT} against branch: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} (${BASE_COMMIT})" >&2 
+  git diff "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
 fi

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -96,7 +96,7 @@ in Pipeline.build Pipeline.Config::{
       target = Size.Small,
       docker = Some Docker::{
         image = (./Constants/ContainerImages.dhall).toolchainBase,
-        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_INCREMENTAL"]
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_PULL_REQUEST_BASE_BRANCH"]
       }
     }
   ]

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -96,7 +96,7 @@ in Pipeline.build Pipeline.Config::{
       target = Size.Small,
       docker = Some Docker::{
         image = (./Constants/ContainerImages.dhall).toolchainBase,
-        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_PULL_REQUEST_BASE_BRANCH"]
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_INCREMENTAL"]
       }
     }
   ]


### PR DESCRIPTION
This PR fixes the `dirtyWhen` logic, and simplifies the script.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them