### PR TITLE
Fix: run fuzzy zkapp test once

### DIFF
--- a/buildkite/scripts/fuzzy-zkapp-test.sh
+++ b/buildkite/scripts/fuzzy-zkapp-test.sh
@@ -21,8 +21,8 @@ export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
 # skip running all of the tests that have already succeeded, since dune will
 # only retry those tests that failed.
 echo "--- Run fuzzy zkapp tests"
-time dune exec "${path}" --profile="${profile}" -j16 -- --timeout "${timeout}" --individual-test-timeout "${individual_test_timeout}" --seed "${RANDOM}" || \
-(./scripts/link-coredumps.sh && \
-  echo "--- Retrying failed unit tests" && \
-  time dune exec "${path}" --profile="${profile}" -j16 -- --timeout "${timeout}" --individual-test-timeout "${individual_test_timeout}" --seed "${RANDOM}" || \
-  (./scripts/link-coredumps.sh && false))
+time dune exec "${path}" --profile="${profile}" -j16 -- --timeout "${timeout}" --individual-test-timeout "${individual_test_timeout}" --seed "${RANDOM}"
+STATUS=$?
+if [ "$STATUS" -ne 0 ]; then
+  ./scripts/link-coredumps.sh && exit "$STATUS"
+fi


### PR DESCRIPTION
We run zkapp fuzzy tests twice in nightlies within each job, but there is no reason to do this.