### PR TITLE
[Develop] removing if statement for running tests on develop and compatible

### DIFF
--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -90,7 +90,7 @@ in
         label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Integration,
-        depends_on = dependsOn
+        depends_on = dependsOn,
         soft_fail = Some (B/SoftFail.Boolean True)
       }
 }

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -33,8 +33,7 @@ in
             ],
         label = "Build test-executive",
         key = "build-test-executive",
-        target = Size.XLarge,
-        `if` = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
+        target = Size.XLarge
       },
 
   execute = \(testName : Text) -> \(dependsOn : List Command.TaggedKey.Type) ->
@@ -53,8 +52,7 @@ in
         label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Integration,
-        depends_on = dependsOn,
-        `if` = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
+        depends_on = dependsOn
       },
 
   buildJs = \(duneProfile : Text) -> 
@@ -72,8 +70,7 @@ in
             ],
         label = "Build JS integration tests",
         key = "build-js-tests",
-        target = Size.XLarge,
-        `if` = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
+        target = Size.XLarge
       },
 
   executeWithJs = \(testName : Text) -> \(dependsOn : List Command.TaggedKey.Type) ->
@@ -93,8 +90,7 @@ in
         label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Integration,
-        depends_on = dependsOn,
-        `if` = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'",
+        depends_on = dependsOn
         soft_fail = Some (B/SoftFail.Boolean True)
       }
 }


### PR DESCRIPTION
Explain your changes:
Remove condition in dhall files not to run test executive tests on compatible and develop branch

Explain how you tested your changes:
Unfortunately it's only possible to merge it and check if on develop tests are executed

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
