### PR TITLE
[#13901] Implement accessors via derive_ppx

### DIFF
--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -191,15 +191,7 @@ module Messages : sig
           , 'bool )
           Opt.t
       }
-
-    (** Field accessors *)
-
-    val w_comm :
-      ('g, 'bool) t -> 'g Poly_comm.Without_degree_bound.t Columns_vec.t
-
-    val z_comm : ('g, 'bool) t -> 'g Poly_comm.Without_degree_bound.t
-
-    val t_comm : ('g, 'bool) t -> 'g Poly_comm.Without_degree_bound.t
+    [@@deriving fields]
   end
 
   val typ :


### PR DESCRIPTION
Explain your changes:
* Removed accessors, instead now there's `[@@derive field]`

Explain how you tested your changes:
* CI will test

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
