### PR TITLE
[#14206,#14205] Cosmetics for of_int, of_nat

### DIFF
--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -42,7 +42,7 @@ let actual_wrap_domain_size ~log_2_domain_size =
     | _ ->
         assert false
   in
-  Pickles_base.Proofs_verified.of_int d
+  Pickles_base.Proofs_verified.of_int_exn d
 
 let hash_messages_for_next_step_proof ~app_state
     (t : _ Types.Step.Proof_state.Messages_for_next_step_proof.t) =

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -849,7 +849,8 @@ module Side_loaded = struct
       { wrap_vk = Some (Lazy.force d.wrap_vk)
       ; wrap_index = Lazy.force d.wrap_key
       ; max_proofs_verified =
-          Pickles_base.Proofs_verified.of_nat (Nat.Add.n d.max_proofs_verified)
+          Pickles_base.Proofs_verified.of_nat_exn
+            (Nat.Add.n d.max_proofs_verified)
       ; actual_wrap_domain_size
       }
 

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -226,7 +226,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         { wrap_vk = Some (Lazy.force d.wrap_vk)
         ; wrap_index = Lazy.force d.wrap_key
         ; max_proofs_verified =
-            Pickles_base.Proofs_verified.of_nat
+            Pickles_base.Proofs_verified.of_nat_exn
               (Nat.Add.n d.max_proofs_verified)
         ; actual_wrap_domain_size
         }

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -752,7 +752,7 @@ struct
                     ~f:(fun j acc (Pow_2_roots_of_unity domain) ->
                       if Int.equal domain domain_size then j else acc )
                 in
-                Pickles_base.Proofs_verified.of_int domain_index )
+                Pickles_base.Proofs_verified.of_int_exn domain_index )
           in
           k wrap_domain_indices
       | _ -> (

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -40,7 +40,7 @@ let to_int : t -> int = function N0 -> 0 | N1 -> 1 | N2 -> 2
 
 type proofs_verified = t
 
-let of_nat (type n) (n : n Pickles_types.Nat.t) : t =
+let of_nat_exn (type n) (n : n Pickles_types.Nat.t) : t =
   let open Pickles_types.Nat in
   match n with
   | Z ->
@@ -50,9 +50,11 @@ let of_nat (type n) (n : n Pickles_types.Nat.t) : t =
   | S (S Z) ->
       N2
   | S _ ->
-      failwithf "Proofs_verified.of_nat: got %d" (to_int n) ()
+      raise
+        (Invalid_argument
+           (Printf.sprintf "Proofs_verified.of_nat: got %d" (to_int n)) )
 
-let of_int (n : int) : t =
+let of_int_exn (n : int) : t =
   match n with
   | 0 ->
       N0
@@ -61,7 +63,8 @@ let of_int (n : int) : t =
   | 2 ->
       N2
   | _ ->
-      failwithf "Proofs_verified.of_int: got %d" n ()
+      raise
+        (Invalid_argument (Printf.sprintf "Proofs_verified.of_int: got %d" n))
 
 type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
 

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -13,13 +13,13 @@ end
 type t = Stable.V1.t = N0 | N1 | N2
 [@@deriving sexp, compare, yojson, hash, equal]
 
-(** [of_nat t_n] converts the type level natural [t_n] to the data type natural.
+(** [of_nat_exn t_n] converts the type level natural [t_n] to the data type natural.
     Raise an exception if [t_n] represents a value above or equal to 3 *)
-val of_nat : 'n Pickles_types.Nat.t -> t
+val of_nat_exn : 'n Pickles_types.Nat.t -> t
 
-(** [of_int n] converts the runtime natural [n] to the data type natural. Raise
+(** [of_int_exn n] converts the runtime natural [n] to the data type natural. Raise
     an exception if the value [n] is above or equal to 3 *)
-val of_int : int -> t
+val of_int_exn : int -> t
 
 (** [to_int v] converts the value [v] to the corresponding integer, i.e [N0 ->
     0], [N1 -> 1] and [N2 -> 2] *)


### PR DESCRIPTION
Explain your changes:
* Both `of_int` and `of_nat` are now raising `Invalid_argument` instead of `failwithf`
* They are also renamed to `of_int_exn` and `of_nat_exn`

Explain how you tested your changes:
* Not tested explicitly

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #14206 #14205 
