### PR TITLE
Add ledger proof statement to blockchain state in GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6376,68 +6376,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "sign",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "PLUS",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MINUS",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "SignedFee",
-          "description": "Signed fee",
-          "fields": [
-            {
-              "name": "sign",
-              "description": "+/-",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": { "kind": "ENUM", "name": "sign", "ofType": null }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "feeMagnitude",
-              "description": "Fee",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Amount",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "WorkDescription",
           "description":
@@ -6521,7 +6459,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SignedFee",
+                  "name": "FeeExcess",
                   "ofType": null
                 }
               },
@@ -6553,7 +6491,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SignedFee",
+                  "name": "SignedAmount",
                   "ofType": null
                 }
               },
@@ -10467,6 +10405,659 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SignedFee",
+          "description": "Signed fee",
+          "fields": [
+            {
+              "name": "sign",
+              "description": "+/-",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "ENUM", "name": "sign", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeMagnitude",
+              "description": "Fee",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Fee", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeExcess",
+          "description": "Fee excess divided into left, right components",
+          "fields": [
+            {
+              "name": "feeTokenLeft",
+              "description": "Token id for left component of fee excess",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeExcessLeft",
+              "description": "Fee for left component of fee excess",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedFee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeTokenRight",
+              "description": "Token id for right component of fee excess",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeExcessRight",
+              "description": "Fee for right component of fee excess",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedFee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "sign",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "PLUS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MINUS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SignedAmount",
+          "description": "Signed amount",
+          "fields": [
+            {
+              "name": "sign",
+              "description": "+/-",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "ENUM", "name": "sign", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountMagnitude",
+              "description": "Amount",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Amount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LocalState",
+          "description": null,
+          "fields": [
+            {
+              "name": "stackFrame",
+              "description": "Stack frame component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "callStack",
+              "description": "Call stack component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionCommitment",
+              "description":
+                "Transaction commitment component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fullTransactionCommitment",
+              "description":
+                "Full transaction commitment component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "excess",
+              "description": "Excess component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "supplyIncrease",
+              "description": "Supply increase component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ledger",
+              "description": "Ledger component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": "Success component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accountUpdateIndex",
+              "description": "Account update index component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt32",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "failureStatusTable",
+              "description": "Failure status table component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "willSucceed",
+              "description": "Will-succeed component of local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StateStack",
+          "description": null,
+          "fields": [
+            {
+              "name": "initial",
+              "description": "Initial hash",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "current",
+              "description": "Current hash",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PendingCoinbaseStack",
+          "description": null,
+          "fields": [
+            {
+              "name": "dataStack",
+              "description": "Data component of pending coinbase stack",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FieldElem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stateStack",
+              "description": "State component of pending coinbase stack",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "StateStack",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Registers",
+          "description": null,
+          "fields": [
+            {
+              "name": "firstPassLedger",
+              "description": "First pass ledger hash",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secondPassLedger",
+              "description": "Second pass ledger hash",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pendingCoinbaseStack",
+              "description": "Pending coinbase stack",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PendingCoinbaseStack",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "localState",
+              "description": "Local state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnarkedLedgerState",
+          "description": null,
+          "fields": [
+            {
+              "name": "sourceRegisters",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Registers",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetRegisters",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Registers",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "connectingLedgerLeft",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "connectingLedgerRight",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "supplyIncrease",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeExcess",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FeeExcess",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sokDigest",
+              "description": "Placeholder for SOK digest",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "PendingCoinbaseHash",
           "description":
@@ -10638,6 +11229,22 @@
                 "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available or no block found, this will return null.",
               "args": [],
               "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ledgerProofStatement",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SnarkedLedgerState",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1034,13 +1034,13 @@ let pending_snark_work =
                  (Array.map
                     ~f:(fun bundle ->
                       Array.map bundle.workBundle ~f:(fun w ->
-                          let f = w.fee_excess in
+                          let fee_excess_left = w.fee_excess.feeExcessLeft in
                           { Cli_lib.Graphql_types.Pending_snark_work.Work
                             .work_id = w.work_id
                           ; fee_excess =
                               Currency.Amount.Signed.of_fee
-                                (to_signed_fee_exn f.sign
-                                   (Currency.Amount.to_fee f.fee_magnitude) )
+                                (to_signed_fee_exn fee_excess_left.sign
+                                   fee_excess_left.feeMagnitude )
                           ; supply_increase = w.supply_increase
                           ; source_first_pass_ledger_hash =
                               w.source_first_pass_ledger_hash

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -109,8 +109,16 @@ query pendingSnarkWork {
       source_second_pass_ledger_hash: sourceSecondPassLedgerHash
       target_second_pass_ledger_hash: targetSecondPassLedgerHash
       fee_excess: feeExcess {
-        sign
-        fee_magnitude: feeMagnitude
+        feeTokenLeft
+        feeExcessLeft {
+          sign
+          feeMagnitude
+        }
+        feeTokenRight
+        feeExcessRight {
+          sign
+          feeMagnitude
+        }
       }
       supply_increase: supplyIncrease
       work_id: workId

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -259,6 +259,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
+    let init (t : t) = t.init
+
+    let curr (t : t) = t.curr
+
     type var = Stack_hash.var Poly.t
 
     let gen : t Quickcheck.Generator.t =
@@ -526,6 +530,10 @@ module Make_str (A : Wire_types.Concrete) = struct
         let to_latest = Fn.id
       end
     end]
+
+    let data (t : t) = t.data
+
+    let state (t : t) = t.state
   end
 
   module Hash_versioned = struct

--- a/src/lib/mina_base/pending_coinbase_intf.ml
+++ b/src/lib/mina_base/pending_coinbase_intf.ml
@@ -96,6 +96,28 @@ module type S = sig
     end]
   end
 
+  module Coinbase_stack : sig
+    [%%versioned:
+    module Stable : sig
+      module V1 : sig
+        type t = Field.t
+      end
+    end]
+  end
+
+  module State_stack : sig
+    [%%versioned:
+    module Stable : sig
+      module V1 : sig
+        type t
+      end
+    end]
+
+    val init : t -> Field.t
+
+    val curr : t -> Field.t
+  end
+
   module Stack_versioned : sig
     [%%versioned:
     module Stable : sig
@@ -103,6 +125,10 @@ module type S = sig
         type nonrec t [@@deriving sexp, compare, equal, yojson, hash]
       end
     end]
+
+    val data : t -> Coinbase_stack.t
+
+    val state : t -> State_stack.t
   end
 
   module Stack : sig
@@ -166,15 +192,6 @@ module type S = sig
 
       val create_with : t -> t
     end
-  end
-
-  module State_stack : sig
-    [%%versioned:
-    module Stable : sig
-      module V1 : sig
-        type t
-      end
-    end]
   end
 
   module Update : sig

--- a/src/lib/mina_base/stack_frame.ml
+++ b/src/lib/mina_base/stack_frame.ml
@@ -61,7 +61,7 @@ module Make_str (A : Wire_types.Concrete) = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
+      type t = Zkapp_basic.F.Stable.V1.t
       [@@deriving sexp, compare, equal, hash, yojson]
 
       let to_latest = Fn.id

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -21,6 +21,8 @@ let token_id = Scalars.TokenId.typ ()
 
 let json = Scalars.JSON.typ ()
 
+let field_elem = Mina_base_unix.Graphql_scalars.FieldElem.typ ()
+
 let epoch_seed = Scalars.EpochSeed.typ ()
 
 let balance = Scalars.Balance.typ ()
@@ -204,7 +206,6 @@ let block_producer_timing :
 
 let merkle_path_element :
     (_, [ `Left of Zkapp_basic.F.t | `Right of Zkapp_basic.F.t ] option) typ =
-  let field_elem = Mina_base_unix.Graphql_scalars.FieldElem.typ () in
   obj "MerklePathElement" ~fields:(fun _ ->
       [ field "left" ~typ:field_elem
           ~args:Arg.[]
@@ -509,10 +510,45 @@ let signed_fee =
   obj "SignedFee" ~doc:"Signed fee" ~fields:(fun _ ->
       [ field "sign" ~typ:(non_null sign) ~doc:"+/-"
           ~args:Arg.[]
-          ~resolve:(fun _ fee -> Currency.Amount.Signed.sgn fee)
-      ; field "feeMagnitude" ~typ:(non_null amount) ~doc:"Fee"
+          ~resolve:(fun _ fee -> Currency.Fee.Signed.sgn fee)
+      ; field "feeMagnitude" ~typ:(non_null fee) ~doc:"Fee"
           ~args:Arg.[]
-          ~resolve:(fun _ fee -> Currency.Amount.Signed.magnitude fee)
+          ~resolve:(fun _ fee -> Currency.Fee.Signed.magnitude fee)
+      ] )
+
+let signed_amount =
+  obj "SignedAmount" ~doc:"Signed amount" ~fields:(fun _ ->
+      [ field "sign" ~typ:(non_null sign) ~doc:"+/-"
+          ~args:Arg.[]
+          ~resolve:(fun _ fee -> Currency.Amount.Signed.sgn fee)
+      ; field "amountMagnitude" ~typ:(non_null amount) ~doc:"Amount"
+          ~args:Arg.[]
+          ~resolve:(fun _ amount -> Currency.Amount.Signed.magnitude amount)
+      ] )
+
+let fee_excess : (Mina_lib.t, Fee_excess.t option) typ =
+  let module M = Fee_excess.Poly in
+  obj "FeeExcess" ~doc:"Fee excess divided into left, right components"
+    ~fields:(fun _ ->
+      [ field "feeTokenLeft"
+          ~args:Arg.[]
+          ~doc:"Token id for left component of fee excess"
+          ~typ:(non_null token_id)
+          ~resolve:(fun _ ({ fee_token_l; _ } : _ M.t) -> fee_token_l)
+      ; field "feeExcessLeft"
+          ~args:Arg.[]
+          ~doc:"Fee for left component of fee excess" ~typ:(non_null signed_fee)
+          ~resolve:(fun _ ({ fee_excess_l; _ } : _ M.t) -> fee_excess_l)
+      ; field "feeTokenRight"
+          ~args:Arg.[]
+          ~doc:"Token id for right component of fee excess"
+          ~typ:(non_null token_id)
+          ~resolve:(fun _ ({ fee_token_r; _ } : _ M.t) -> fee_token_r)
+      ; field "feeExcessRight"
+          ~args:Arg.[]
+          ~doc:"Fee for right component of fee excess"
+          ~typ:(non_null signed_fee)
+          ~resolve:(fun _ ({ fee_excess_r; _ } : _ M.t) -> fee_excess_r)
       ] )
 
 let work_statement =
@@ -540,18 +576,13 @@ let work_statement =
           ~args:Arg.[]
           ~resolve:(fun _ { Transaction_snark.Statement.Poly.target; _ } ->
             target.second_pass_ledger )
-      ; field "feeExcess" ~typ:(non_null signed_fee)
+      ; field "feeExcess" ~typ:(non_null fee_excess)
           ~doc:
             "Total transaction fee that is not accounted for in the transition \
              from source ledger to target ledger"
           ~args:Arg.[]
-          ~resolve:(fun _
-                        ({ fee_excess = { fee_excess_l; _ }; _ } :
-                          Transaction_snark.Statement.t ) ->
-            (* TODO: Expose full fee excess data. *)
-            { fee_excess_l with
-              magnitude = Currency.Amount.of_fee fee_excess_l.magnitude
-            } )
+          ~resolve:(fun _ ({ fee_excess; _ } : Transaction_snark.Statement.t) ->
+            fee_excess )
       ; field "supplyIncrease" ~typ:(non_null amount)
           ~doc:"Increase in total supply"
           ~args:Arg.[]
@@ -559,7 +590,7 @@ let work_statement =
           ~resolve:(fun _
                         ({ supply_increase; _ } : Transaction_snark.Statement.t) ->
             supply_increase.magnitude )
-      ; field "supplyChange" ~typ:(non_null signed_fee)
+      ; field "supplyChange" ~typ:(non_null signed_amount)
           ~doc:"Increase/Decrease in total supply"
           ~args:Arg.[]
           ~resolve:(fun _
@@ -580,6 +611,155 @@ let pending_work =
           ~doc:"Work bundle with one or two snark work"
           ~typ:(non_null @@ list @@ non_null work_statement)
           ~resolve:(fun _ w -> One_or_two.to_list w)
+      ] )
+
+let state_stack =
+  let module M = Pending_coinbase.State_stack in
+  obj "StateStack" ~fields:(fun _ ->
+      [ field "initial"
+          ~args:Arg.[]
+          ~doc:"Initial hash" ~typ:(non_null field_elem)
+          ~resolve:(fun _ t -> M.init t)
+      ; field "current"
+          ~args:Arg.[]
+          ~doc:"Current hash" ~typ:(non_null field_elem)
+          ~resolve:(fun _ t -> M.curr t)
+      ] )
+
+let pending_coinbase_stack =
+  let module M = Pending_coinbase.Stack_versioned in
+  obj "PendingCoinbaseStack" ~fields:(fun _ ->
+      [ field "dataStack"
+          ~args:Arg.[]
+          ~doc:"Data component of pending coinbase stack"
+          ~typ:(non_null field_elem)
+          ~resolve:(fun _ t -> M.data t)
+      ; field "stateStack"
+          ~args:Arg.[]
+          ~doc:"State component of pending coinbase stack"
+          ~typ:(non_null state_stack)
+          ~resolve:(fun _ t -> M.state t)
+      ] )
+
+let local_state : (Mina_lib.t, Mina_state.Local_state.t option) typ =
+  let module M = Mina_transaction_logic.Zkapp_command_logic.Local_state in
+  obj "LocalState" ~fields:(fun _ ->
+      [ field "stackFrame"
+          ~args:Arg.[]
+          ~doc:"Stack frame component of local state" ~typ:(non_null field_elem)
+          ~resolve:(fun _ t ->
+            (M.stack_frame t : Stack_frame.Digest.t :> Zkapp_basic.F.Stable.V1.t)
+            )
+      ; field "callStack"
+          ~args:Arg.[]
+          ~doc:"Call stack component of local state" ~typ:(non_null field_elem)
+          ~resolve:(fun _ t ->
+            (M.call_stack t : Call_stack_digest.t :> Zkapp_basic.F.Stable.V1.t)
+            )
+      ; field "transactionCommitment"
+          ~args:Arg.[]
+          ~doc:"Transaction commitment component of local state"
+          ~typ:(non_null field_elem)
+          ~resolve:(fun _ t -> M.transaction_commitment t)
+      ; field "fullTransactionCommitment"
+          ~args:Arg.[]
+          ~doc:"Full transaction commitment component of local state"
+          ~typ:(non_null field_elem)
+          ~resolve:(fun _ t -> M.full_transaction_commitment t)
+      ; field "excess"
+          ~args:Arg.[]
+          ~doc:"Excess component of local state" ~typ:(non_null signed_amount)
+          ~resolve:(fun _ t -> M.excess t)
+      ; field "supplyIncrease"
+          ~args:Arg.[]
+          ~doc:"Supply increase component of local state"
+          ~typ:(non_null signed_amount)
+          ~resolve:(fun _ t -> M.supply_increase t)
+      ; field "ledger"
+          ~args:Arg.[]
+          ~doc:"Ledger component of local state" ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ t -> M.ledger t)
+      ; field "success"
+          ~args:Arg.[]
+          ~doc:"Success component of local state" ~typ:(non_null bool)
+          ~resolve:(fun _ t -> M.success t)
+      ; field "accountUpdateIndex"
+          ~args:Arg.[]
+          ~doc:"Account update index component of local state"
+          ~typ:(non_null @@ Graphql_basic_scalars.UInt32.typ ())
+          ~resolve:(fun _ t -> M.account_update_index t)
+      ; field "failureStatusTable"
+          ~args:Arg.[]
+          ~doc:"Failure status table component of local state"
+          ~typ:(non_null (list (non_null (list (non_null string)))))
+          ~resolve:(fun _ t ->
+            List.map (M.failure_status_tbl t)
+              ~f:(List.map ~f:Mina_base.Transaction_status.Failure.to_string) )
+      ; field "willSucceed"
+          ~args:Arg.[]
+          ~doc:"Will-succeed component of local state" ~typ:(non_null bool)
+          ~resolve:(fun _ t -> M.will_succeed t)
+      ] )
+
+let registers : (Mina_lib.t, Mina_state.Registers.Value.t option) typ =
+  let module M = Mina_state.Registers in
+  obj "Registers" ~fields:(fun _ ->
+      [ field "firstPassLedger"
+          ~args:Arg.[]
+          ~doc:"First pass ledger hash" ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ ({ first_pass_ledger; _ } : _ M.t) ->
+            first_pass_ledger )
+      ; field "secondPassLedger"
+          ~args:Arg.[]
+          ~doc:"Second pass ledger hash" ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ ({ second_pass_ledger; _ } : _ M.t) ->
+            second_pass_ledger )
+      ; field "pendingCoinbaseStack"
+          ~args:Arg.[]
+          ~doc:"Pending coinbase stack"
+          ~typ:(non_null pending_coinbase_stack)
+          ~resolve:(fun _ ({ pending_coinbase_stack; _ } : _ M.t) ->
+            pending_coinbase_stack )
+      ; field "localState"
+          ~args:Arg.[]
+          ~doc:"Local state" ~typ:(non_null local_state)
+          ~resolve:(fun _ ({ local_state; _ } : _ M.t) -> local_state)
+      ] )
+
+let snarked_ledger_state :
+    (Mina_lib.t, Mina_state.Snarked_ledger_state.t option) typ =
+  let module M = Mina_state.Snarked_ledger_state.Poly in
+  obj "SnarkedLedgerState" ~fields:(fun _ ->
+      [ field "sourceRegisters"
+          ~args:Arg.[]
+          ~typ:(non_null registers)
+          ~resolve:(fun _ ({ source; _ } : _ M.t) -> source)
+      ; field "targetRegisters"
+          ~args:Arg.[]
+          ~typ:(non_null registers)
+          ~resolve:(fun _ ({ target; _ } : _ M.t) -> target)
+      ; field "connectingLedgerLeft"
+          ~args:Arg.[]
+          ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ ({ connecting_ledger_left; _ } : _ M.t) ->
+            connecting_ledger_left )
+      ; field "connectingLedgerRight"
+          ~args:Arg.[]
+          ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ ({ connecting_ledger_right; _ } : _ M.t) ->
+            connecting_ledger_right )
+      ; field "supplyIncrease"
+          ~args:Arg.[]
+          ~typ:(non_null signed_amount)
+          ~resolve:(fun _ ({ supply_increase; _ } : _ M.t) -> supply_increase)
+      ; field "feeExcess"
+          ~args:Arg.[]
+          ~typ:(non_null fee_excess)
+          ~resolve:(fun _ ({ fee_excess; _ } : _ M.t) -> fee_excess)
+      ; field "sokDigest"
+          ~args:Arg.[]
+          ~doc:"Placeholder for SOK digest" ~typ:string
+          ~resolve:(fun _ ({ sok_digest = _; _ } : _ M.t) -> None)
       ] )
 
 let blockchain_state :
@@ -664,6 +844,13 @@ let blockchain_state :
                 None
             | Some b ->
                 Some (Transition_frontier.Breadcrumb.just_emitted_a_proof b) )
+      ; field "ledgerProofStatement"
+          ~typ:(non_null snarked_ledger_state)
+          ~args:Arg.[]
+          ~resolve:(fun _ t ->
+            let blockchain_state, _ = t in
+            Mina_state.Blockchain_state.ledger_proof_statement blockchain_state
+            )
       ; field "bodyReference"
           ~typ:(non_null @@ Graphql_lib.Scalars.BodyReference.typ ())
           ~doc:


### PR DESCRIPTION
V2 of `Blockchain_state.t` includes a `ledger_proof_statement` field, which was not being included in blocks returned by GraphQL. Add that field as `ledgerProofStatement` in GraphQL.

That change involved creating a `fee_excess` `typ`, so the TODO in `work_statement`, to add the full fee excess information, has been implemented.

In `Client.pending_snark_work`, only the "left" component of a fee excess was used. That behavior is preserved, but the code had to change to compensate for the changed GraphQL code.

Tested by running a local network, and querying for a block.

Closes #14155.