### PR TITLE
Plonk checks cleanup

### DIFF
--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -5,9 +5,6 @@ module Scalars = Scalars
 module Domain = Domain
 module Opt = Opt
 
-type 'field vanishing_polynomial_domain =
-  < vanishing_polynomial : 'field -> 'field >
-
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Plonk_types.Shifts.t

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -1,9 +1,5 @@
 open Pickles_types
 
-(* TODO: why do we use objects?*)
-type 'field vanishing_polynomial_domain =
-  < vanishing_polynomial : 'field -> 'field >
-
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Pickles_types.Plonk_types.Shifts.t


### PR DESCRIPTION
Minor change removing an unused type definition and using another one to simplify a function type.

Fix #14209 
