### PR TITLE
Pickles: remove `of_int` parameters in `create`, rename to `default`

### DIFF
--- a/src/lib/pickles/commitment_lengths.ml
+++ b/src/lib/pickles/commitment_lengths.ml
@@ -1,10 +1,9 @@
 open Pickles_types
-open Plonk_types
 
-let create (type a) ~(of_int : int -> a) :
-    (a Columns_vec.t, a, a) Messages.Poly.t =
-  let one = of_int 1 in
-  { w = Vector.init Plonk_types.Columns.n ~f:(fun _ -> one)
+let default =
+  let one = 1 in
+  { Plonk_types.Messages.Poly.w =
+      Vector.init Plonk_types.Columns.n ~f:(fun _ -> one)
   ; z = one
-  ; t = of_int 7
+  ; t = 7
   }

--- a/src/lib/pickles/commitment_lengths.mli
+++ b/src/lib/pickles/commitment_lengths.mli
@@ -5,7 +5,7 @@
     understanding of the different polynomials involved in a proof.
 *)
 
-(** [create ~of_int] returns a tuple of naturals [(length_w, length_z, length_t)]
+(** [default] returns a tuple of naturals [(length_w, length_z, length_t)]
     encoding at the type level the number of polynomials we must commit to.
     - [length_w] is the number of wires. It must be in line with
       {Plonk_types.Commons}.
@@ -15,9 +15,8 @@
     Encoding the size at the type level allows to check at compile time the
     length of vectors, and avoid runtime checks.
 *)
-val create :
-     of_int:(int -> 'a)
-  -> ( 'a Pickles_types.Plonk_types.Columns_vec.t
-     , 'a
-     , 'a )
-     Pickles_types.Plonk_types.Messages.Poly.t
+val default :
+  ( int Pickles_types.Plonk_types.Columns_vec.t
+  , int
+  , int )
+  Pickles_types.Plonk_types.Messages.Poly.t

--- a/src/lib/pickles/dummy.ml
+++ b/src/lib/pickles/dummy.ml
@@ -10,7 +10,7 @@ let evals =
   lazy
     (let open Plonk_types in
     let e =
-      Evals.map (Evaluation_lengths.create ~of_int:Fn.id) ~f:(fun n ->
+      Evals.map Evaluation_lengths.default ~f:(fun n ->
           let a () = Array.create ~len:n (Ro.tock ()) in
           (a (), a ()) )
     in

--- a/src/lib/pickles/evaluation_lengths.ml
+++ b/src/lib/pickles/evaluation_lengths.ml
@@ -1,5 +1,5 @@
-let create ~of_int =
-  let one = of_int 1 in
+let default =
+  let one = 1 in
   let open Pickles_types in
   let open Plonk_types in
   Evals.

--- a/src/lib/pickles/evaluation_lengths.mli
+++ b/src/lib/pickles/evaluation_lengths.mli
@@ -17,6 +17,9 @@
  *)
 type 'a t := 'a Pickles_types.Plonk_types.Evals.t
 
-(** [create of_int] creates a value of type ['a t] with default values set to
-    [1]. *)
-val create : of_int:(int -> 'a) -> 'a t
+(** [default] is a value of type [int t].
+
+    Its field values are set to [1] when they are non-optional, contains only
+    [1]-values when they are containers (like {!type:Pickles_types.Vector.t})
+    and are set to {!Option.None} when optional. *)
+val default : int t

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -116,7 +116,7 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
   let g0 = Tock.Curve.(to_affine_exn one) in
   let g len = Array.create ~len g0 in
   let tick_arr len = Array.init len ~f:(fun _ -> tick ()) in
-  let lengths = Commitment_lengths.create ~of_int:Fn.id in
+  let lengths = Commitment_lengths.default in
   T
     { statement =
         { proof_state =

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -190,8 +190,8 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
           }
     ; prev_evals =
         (let e =
-           Plonk_types.Evals.map (Evaluation_lengths.create ~of_int:Fn.id)
-             ~f:(fun n -> (tick_arr n, tick_arr n))
+           Plonk_types.Evals.map Evaluation_lengths.default ~f:(fun n ->
+               (tick_arr n, tick_arr n) )
          in
          let ex =
            { Plonk_types.All_evals.With_public_input.public_input =

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -390,8 +390,7 @@ let wrap_main
                      (module Impl)
                      Inner_curve.typ ~bool:Boolean.typ feature_flags
                      ~dummy:Inner_curve.Params.one
-                     ~commitment_lengths:
-                       (Commitment_lengths.create ~of_int:Fn.id) )
+                     ~commitment_lengths:Commitment_lengths.default )
                   ~request:(fun () -> Req.Messages) )
           in
           let sponge = Wrap_verifier.Opt.create sponge_params in

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -38,7 +38,7 @@ let typ : (Checked.t, Constant.t) Typ.t =
         (module Impl)
         Inner_curve.typ Plonk_types.Features.Full.none ~bool:Boolean.typ
         ~dummy:Inner_curve.Params.one
-        ~commitment_lengths:(Commitment_lengths.create ~of_int:(fun x -> x))
+        ~commitment_lengths:Commitment_lengths.default
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)
         ( Typ.transport Other_field.typ
             ~there:(fun x ->


### PR DESCRIPTION
`Evaluation_lengths.create` and `Commitment_lengths.create`'s `of_int` parameters were only ever instantiated with `Fn.id`.  

This PR removes the unnecessary parameter and renames the `create` functions to a more apt `default` since they're not functions anymore.

#