### PR TITLE
update compiler flags to suppress warnings -53-55

### DIFF
--- a/src/libp2p_ipc/dune
+++ b/src/libp2p_ipc/dune
@@ -1,7 +1,7 @@
 (library
  (name libp2p_ipc)
  (public_name libp2p_ipc)
- (flags -w -53)
+ (flags -w -53-55)
  (inline_tests)
  (libraries
    ;; opam libraries


### PR DESCRIPTION
This change adds an ignore flag to the dune file for `src/libp2p_ipc/dune`

This is needed as per the work for https://github.com/o1-labs/o1js/issues/1096. When changing some scripts to build `mina` in the context of a submodule, Nix building breaks. This fixes the Nix build.
