### PR TITLE
Update berkeley replayer cron image

### DIFF
--- a/helm/cron_jobs/berkeley-replayer-cronjob.yaml
+++ b/helm/cron_jobs/berkeley-replayer-cronjob.yaml
@@ -32,12 +32,12 @@ spec:
                echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list;
                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - ;
                apt-get update && apt-get install -y google-cloud-cli ;
-               ARCHIVE_DUMP_URI=$(gsutil ls gs://mina-archive-dumps/berkeley-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
+               ARCHIVE_DUMP_URI=$(gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json ls gs://mina-archive-dumps/berkeley-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
                ARCHIVE_DUMP=$(basename $ARCHIVE_DUMP_URI);
                ARCHIVE_SQL=$(basename $ARCHIVE_DUMP_URI .tar.gz);
                echo "Getting archive dump" $ARCHIVE_DUMP_URI;
                gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $ARCHIVE_DUMP_URI . ;
-               MOST_RECENT_CHECKPOINT_URI=$(gsutil ls gs://berkeley-replayer-checkpoints/berkeley-replayer-checkpoint-*.json | sort -r | head -n 1);
+               MOST_RECENT_CHECKPOINT_URI=$(gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json ls gs://berkeley-replayer-checkpoints/berkeley-replayer-checkpoint-*.json | sort -r | head -n 1);
                MOST_RECENT_CHECKPOINT=$(basename $MOST_RECENT_CHECKPOINT_URI);
                echo "Getting replayer checkpoint file" $MOST_RECENT_CHECKPOINT;
                gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $MOST_RECENT_CHECKPOINT_URI . ;
@@ -77,7 +77,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup2-feature-replayer-check-snark-ledger-hash-berkeley-c6da972-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:2.0.0rampup4-14047c5-bullseye
             imagePullPolicy: IfNotPresent
             name: berkeley-replayer-cronjob
             resources:


### PR DESCRIPTION
Update image used for berkeley replayer cron job.

Also, add auth credential for `gsutil` in the script, which started to fail recently.

Tested by manually starting the cron job, verifying that a new checkpoint file was created.

