### PR TITLE
Throw an error when a pickles rule has the wrong feature flags specified

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -1275,10 +1275,10 @@ end = struct
     let public_input_size = Set_once.get_exn sys.public_input_size [%here] in
     Gates.to_json public_input_size gates
 
-  let feature_flags (sys : t) : Kimchi_types.feature_flags =
+  let rec feature_flags (sys : t) : Kimchi_types.feature_flags =
     match (sys.gates, sys.runtime_tables_cfg) with
     | Unfinalized_rev _, _ | _, Unfinalized_runtime_tables_cfg_rev _ ->
-        failwith "feature_flags called on unfinalized constraint system"
+        finalize sys ; feature_flags sys
     | Compiled (_, gates), Compiled_runtime_tables_cfg runtime_tables ->
         Gates.feature_flags gates (not (Array.is_empty runtime_tables))
 

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -68,4 +68,6 @@ module type Full = sig
   val digest : t -> Md5.t
 
   val to_json : t -> string
+
+  val feature_flags : t -> Kimchi_types.feature_flags
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -56,6 +56,9 @@ module Protocol = struct
         external digest : int -> t -> bytes
           = "caml_pasta_fp_plonk_gate_vector_digest"
 
+        external feature_flags : t -> bool -> Kimchi_types.feature_flags
+          = "caml_pasta_fp_plonk_gate_vector_feature_flags"
+
         external to_json : int -> t -> string
           = "caml_pasta_fp_plonk_circuit_serialize"
       end
@@ -78,6 +81,9 @@ module Protocol = struct
 
         external digest : int -> t -> bytes
           = "caml_pasta_fq_plonk_gate_vector_digest"
+
+        external feature_flags : t -> bool -> Kimchi_types.feature_flags
+          = "caml_pasta_fq_plonk_gate_vector_feature_flags"
 
         external to_json : int -> t -> string
           = "caml_pasta_fq_plonk_circuit_serialize"

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -174,6 +174,16 @@ type nonrec lookup_features =
   ; uses_runtime_tables : bool
   }
 
+type nonrec feature_flags =
+  { range_check0 : bool
+  ; range_check1 : bool
+  ; foreign_field_add : bool
+  ; foreign_field_mul : bool
+  ; xor : bool
+  ; rot : bool
+  ; lookup_features : lookup_features
+  }
+
 type nonrec feature_flag =
   | RangeCheck0
   | RangeCheck1

--- a/src/lib/crypto/kimchi_bindings/stubs/src/gate_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/gate_vector.rs
@@ -1,6 +1,7 @@
 //! A GateVector: this is used to represent a list of gates.
 
 use kimchi::circuits::{
+    constraints::FeatureFlags,
     gate::{caml::CamlCircuitGate, Circuit, CircuitGate},
     wires::caml::CamlWire,
 };
@@ -101,6 +102,15 @@ pub mod fp {
         let circuit = Circuit::new(usize::try_from(public_input_size).unwrap(), &v.as_ref().0);
         serde_json::to_string(&circuit).expect("couldn't serialize constraints")
     }
+
+    #[ocaml_gen::func]
+    #[ocaml::func]
+    pub fn caml_pasta_fp_plonk_gate_vector_feature_flags(
+        v: CamlPastaFpPlonkGateVectorPtr,
+        using_runtime_table: bool,
+    ) -> FeatureFlags {
+        FeatureFlags::from_gates(v.as_ref().0.as_slice(), using_runtime_table)
+    }
 }
 
 //
@@ -193,5 +203,14 @@ pub mod fq {
     ) -> String {
         let circuit = Circuit::new(usize::try_from(public_input_size).unwrap(), &v.as_ref().0);
         serde_json::to_string(&circuit).expect("couldn't serialize constraints")
+    }
+
+    #[ocaml_gen::func]
+    #[ocaml::func]
+    pub fn caml_pasta_fq_plonk_gate_vector_feature_flags(
+        v: CamlPastaFqPlonkGateVectorPtr,
+        using_runtime_table: bool,
+    ) -> FeatureFlags {
+        FeatureFlags::from_gates(v.as_ref().0.as_slice(), using_runtime_table)
     }
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,4 +1,5 @@
 use kimchi::circuits::{
+    constraints::FeatureFlags,
     expr::FeatureFlag,
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
@@ -118,6 +119,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, LookupPattern => "lookup_pattern");
     decl_type!(w, env, LookupPatterns => "lookup_patterns");
     decl_type!(w, env, LookupFeatures => "lookup_features");
+    decl_type!(w, env, FeatureFlags => "feature_flags");
     decl_type!(w, env, FeatureFlag => "feature_flag");
     decl_type!(w, env, CamlCircuitGate<T1> => "circuit_gate");
 
@@ -332,6 +334,7 @@ fn generate_kimchi_bindings(mut w: impl std::io::Write, env: &mut Env) {
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_len => "len");
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_wrap => "wrap");
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_digest => "digest");
+                    decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_feature_flags => "feature_flags");
                     decl_func!(w, env, caml_pasta_fp_plonk_circuit_serialize => "to_json");
                 });
                 decl_module!(w, env, "Fq", {
@@ -344,6 +347,7 @@ fn generate_kimchi_bindings(mut w: impl std::io::Write, env: &mut Env) {
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_len => "len");
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_wrap => "wrap");
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_digest => "digest");
+                    decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_feature_flags => "feature_flags");
                     decl_func!(w, env, caml_pasta_fq_plonk_circuit_serialize => "to_json");
                 });
             });

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -19,51 +19,55 @@ let domains (type field gates) ?feature_flags
     (Spec.ETyp.T (return_typ, _ret_conv, ret_conv_inv)) main =
   let main x () = ret_conv_inv (main (conv x)) in
 
+  let feature_flags =
+    match feature_flags with
+    | None ->
+        Pickles_types.Plonk_types.Features.none_bool
+    | Some x ->
+        x
+  in
+
   let domains2 sys =
     let open Domain in
     (* Compute the domain required for the lookup tables *)
     let lookup_table_length_log2 =
-      match feature_flags with
-      | None ->
-          0
-      | Some feature_flags ->
-          let { Pickles_types.Plonk_types.Features.range_check0
-              ; range_check1
-              ; foreign_field_add =
-                  _
-                  (* Does not use lookup tables, therefore we do
-                     not need in the computation *)
-              ; foreign_field_mul
-              ; xor
-              ; rot
-              ; lookup
-              ; runtime_tables
-              } =
-            feature_flags
-          in
-          let combined_lookup_table_length =
-            let range_check_table_used =
-              range_check0 || range_check1 || foreign_field_mul || rot
-            in
-            let xor_table_used = xor in
-            (if range_check_table_used then Int.pow 2 12 else 0)
-            + (if xor_table_used then Int.pow 2 8 else 0)
-            + ( if lookup then (
-                Kimchi_backend_common.Plonk_constraint_system
-                .finalize_fixed_lookup_tables sys ;
-                Kimchi_backend_common.Plonk_constraint_system
-                .get_concatenated_fixed_lookup_table_size sys )
-              else 0 )
-            +
-            if runtime_tables then (
-              Kimchi_backend_common.Plonk_constraint_system
-              .finalize_runtime_lookup_tables sys ;
-              Kimchi_backend_common.Plonk_constraint_system
-              .get_concatenated_runtime_lookup_table_size sys )
-            else 0
-          in
+      let { Pickles_types.Plonk_types.Features.range_check0
+          ; range_check1
+          ; foreign_field_add =
+              _
+              (* Does not use lookup tables, therefore we do
+                 not need in the computation *)
+          ; foreign_field_mul
+          ; xor
+          ; rot
+          ; lookup
+          ; runtime_tables
+          } =
+        feature_flags
+      in
+      let combined_lookup_table_length =
+        let range_check_table_used =
+          range_check0 || range_check1 || foreign_field_mul || rot
+        in
+        let xor_table_used = xor in
+        (if range_check_table_used then Int.pow 2 12 else 0)
+        + (if xor_table_used then Int.pow 2 8 else 0)
+        + ( if lookup then (
+            Kimchi_backend_common.Plonk_constraint_system
+            .finalize_fixed_lookup_tables sys ;
+            Kimchi_backend_common.Plonk_constraint_system
+            .get_concatenated_fixed_lookup_table_size sys )
+          else 0 )
+        +
+        if runtime_tables then (
+          Kimchi_backend_common.Plonk_constraint_system
+          .finalize_runtime_lookup_tables sys ;
+          Kimchi_backend_common.Plonk_constraint_system
+          .get_concatenated_runtime_lookup_table_size sys )
+        else 0
+      in
 
-          Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
+      Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
     in
     let public_input_size =
       Set_once.get_exn
@@ -77,4 +81,5 @@ let domains (type field gates) ?feature_flags
         Pow_2_roots_of_unity Int.(max lookup_table_length_log2 (ceil_log2 rows))
     }
   in
-  domains2 (Impl.constraint_system ~input_typ:typ ~return_typ main)
+  ( domains2 (Impl.constraint_system ~input_typ:typ ~return_typ main)
+  , feature_flags )

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -7,7 +7,11 @@ let rough_domains =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { Domains.h = d }
 
-let domains (type field gates) ?feature_flags
+let domains (type field gates)
+    ?(get_feature_flags :
+       (   (field, gates) Kimchi_backend_common.Plonk_constraint_system.t
+        -> Kimchi_types.feature_flags )
+       option )
     (module Impl : Snarky_backendless.Snark_intf.Run
       with type field = field
        and type R1CS_constraint_system.t = ( field
@@ -19,12 +23,38 @@ let domains (type field gates) ?feature_flags
     (Spec.ETyp.T (return_typ, _ret_conv, ret_conv_inv)) main =
   let main x () = ret_conv_inv (main (conv x)) in
 
+  let sys = Impl.constraint_system ~input_typ:typ ~return_typ main in
+
   let feature_flags =
-    match feature_flags with
+    match get_feature_flags with
     | None ->
         Pickles_types.Plonk_types.Features.none_bool
-    | Some x ->
-        x
+    | Some get_feature_flags ->
+        let ({ range_check0
+             ; range_check1
+             ; foreign_field_add
+             ; foreign_field_mul
+             ; xor
+             ; rot
+             ; lookup_features =
+                 { patterns =
+                     { xor = _; lookup; range_check = _; foreign_field_mul = _ }
+                 ; joint_lookup_used = _
+                 ; uses_runtime_tables = runtime_tables
+                 }
+             }
+              : Kimchi_types.feature_flags ) =
+          get_feature_flags sys
+        in
+        { Pickles_types.Plonk_types.Features.range_check0
+        ; range_check1
+        ; foreign_field_add
+        ; foreign_field_mul
+        ; xor
+        ; rot
+        ; lookup
+        ; runtime_tables
+        }
   in
 
   let domains2 sys =

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -4,7 +4,9 @@
 *)
 
 val domains :
-     ?feature_flags:bool Pickles_types.Plonk_types.Features.t
+     ?get_feature_flags:
+       (   ('field, 'gates) Kimchi_backend_common.Plonk_constraint_system.t
+        -> Kimchi_types.feature_flags )
   -> (module Snarky_backendless.Snark_intf.Run
         with type field = 'field
          and type R1CS_constraint_system.t = ( 'field

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -15,6 +15,6 @@ val domains :
   -> ('a, 'b, 'field) Import.Spec.ETyp.t
   -> ('c, 'd, 'field) Import.Spec.ETyp.t
   -> ('a -> 'c)
-  -> Import.Domains.t
+  -> Import.Domains.t * bool Pickles_types.Plonk_types.Features.t
 
 val rough_domains : Import.Domains.t

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -148,7 +148,7 @@ let create
     |> unstage
   in
   Timer.clock __LOC__ ;
-  let own_domains =
+  let own_domains, actual_feature_flags =
     let main =
       step
         ~step_domains:

--- a/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
@@ -19,9 +19,6 @@ let test_fix_domains_with_runtime_table_cfgs () =
   let table_sizes = [ [ 1 ]; [ 1; 1 ]; [ 1; 10; 42; 36 ] ] in
   (* Log2 value *)
   let exp_output = [ 3; 3; 7 ] in
-  let feature_flags =
-    Pickles_types.Plonk_types.Features.{ none_bool with runtime_tables = true }
-  in
   assert (
     List.for_all2
       (fun table_sizes exp_output ->
@@ -34,10 +31,12 @@ let test_fix_domains_with_runtime_table_cfgs () =
               in
               add_constraint
                 (AddRuntimeTableCfg { id = Int32.of_int i; first_column }) )
-            table_sizes
+            table_sizes ;
+          add_constraint (Raw { kind = Lookup; values = [||]; coeffs = [||] })
         in
-        let domains =
-          Pickles__Fix_domains.domains ~feature_flags
+        let domains, _feature_flags =
+          Pickles__Fix_domains.domains
+            ~get_feature_flags:Backend.Tick.R1CS_constraint_system.feature_flags
             (module Pickles.Impls.Step)
             etyp_unit etyp_unit main
         in
@@ -50,10 +49,6 @@ let test_fix_domains_with_runtime_table_cfgs_and_fixed_lookup_tables () =
   let fixed_table_sizes = [ [ 1 ]; [ 1; 1 ]; [ 1; 10; 42; 36 ]; []; [ 1 ] ] in
   let rt_cfgs_table_sizes = [ [ 1 ]; [ 1; 1 ]; [ 1; 10; 42; 36 ]; [ 1 ]; [] ] in
   let exp_outputs = [ 3; 3; 8; 3; 3 ] in
-  let feature_flags =
-    Pickles_types.Plonk_types.Features.
-      { none_bool with lookup = true; runtime_tables = true }
-  in
   assert (
     List.for_all2
       (fun (fixed_table_sizes, rt_cfgs_table_sizes) exp_output ->
@@ -81,10 +76,12 @@ let test_fix_domains_with_runtime_table_cfgs_and_fixed_lookup_tables () =
                 (AddRuntimeTableCfg
                    { id = Int32.of_int (n_fixed_table_sizes + i); first_column }
                 ) )
-            rt_cfgs_table_sizes
+            rt_cfgs_table_sizes ;
+          add_constraint (Raw { kind = Lookup; values = [||]; coeffs = [||] })
         in
-        let domains =
-          Pickles__Fix_domains.domains ~feature_flags
+        let domains, _feature_flags =
+          Pickles__Fix_domains.domains
+            ~get_feature_flags:Backend.Tick.R1CS_constraint_system.feature_flags
             (module Pickles.Impls.Step)
             etyp_unit etyp_unit main
         in
@@ -100,10 +97,6 @@ let test_fix_domains_with_runtime_table_cfgs_and_fixed_lookup_tables_sharing_id
   let rt_cfg_sizes = [ 3; 7; 8 ] in
   (* log2 value *)
   let exp_outputs = [ 4; 4; 5 ] in
-  let feature_flags =
-    Pickles_types.Plonk_types.Features.
-      { none_bool with lookup = true; runtime_tables = true }
-  in
   assert (
     List.for_all2
       (fun (fixed_table_size, rt_cfg_table_size) exp_output ->
@@ -121,10 +114,12 @@ let test_fix_domains_with_runtime_table_cfgs_and_fixed_lookup_tables_sharing_id
             Array.init rt_cfg_table_size
               Pickles.Impls.Step.Field.Constant.of_int
           in
-          add_constraint (AddRuntimeTableCfg { id; first_column })
+          add_constraint (AddRuntimeTableCfg { id; first_column }) ;
+          add_constraint (Raw { kind = Lookup; values = [||]; coeffs = [||] })
         in
-        let domains =
-          Pickles__Fix_domains.domains ~feature_flags
+        let domains, _feature_flags =
+          Pickles__Fix_domains.domains
+            ~get_feature_flags:Backend.Tick.R1CS_constraint_system.feature_flags
             (module Pickles.Impls.Step)
             etyp_unit etyp_unit main
         in
@@ -137,9 +132,6 @@ let test_fix_domains_with_fixed_lookup_tables () =
   let table_sizes = [ [ 1 ]; [ 1; 1 ]; [ 1; 10; 42; 36 ] ] in
   (* Log2 value *)
   let exp_output = [ 3; 3; 7 ] in
-  let feature_flags =
-    Pickles_types.Plonk_types.Features.{ none_bool with lookup = true }
-  in
   assert (
     List.for_all2
       (fun table_sizes exp_output ->
@@ -156,10 +148,12 @@ let test_fix_domains_with_fixed_lookup_tables () =
               add_constraint
                 (AddFixedLookupTable
                    { id = Int32.of_int i; data = [| indexes; values |] } ) )
-            table_sizes
+            table_sizes ;
+          add_constraint (Raw { kind = Lookup; values = [||]; coeffs = [||] })
         in
-        let domains =
-          Pickles__Fix_domains.domains ~feature_flags
+        let domains, _feature_flags =
+          Pickles__Fix_domains.domains
+            ~get_feature_flags:Backend.Tick.R1CS_constraint_system.feature_flags
             (module Pickles.Impls.Step)
             etyp_unit etyp_unit main
         in

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -38,7 +38,7 @@ struct
         dummy_step_keys dummy_step_widths dummy_step_domains max_proofs_verified
     in
     Timer.clock __LOC__ ;
-    let t =
+    let t, _feature_flags =
       Fix_domains.domains
         (module Impls.Wrap)
         (Impls.Wrap.input ~feature_flags ())


### PR DESCRIPTION
This PR tweaks pickles to calculate the feature flags for each particular inductive rule, and throws an error if the inferred flags from the circuit do not match.

Ideally, we would like to infer these from the circuit, but the circuit itself depends on the feature flags (if the rule is recursive). We could fully infer these by running the circuit 3 times, but it seems best to avoid this if we can; for now, an error is already better than the previous opaque failure.

Still TODO: This doesn't have any JS bindings, so o1js will be broken until they are added.