### PR TITLE
Update account_subtree_height to 6

### DIFF
--- a/src/lib/mina_ledger/sync_ledger.ml
+++ b/src/lib/mina_ledger/sync_ledger.ml
@@ -26,7 +26,7 @@ module Mask = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Any_ledger = Syncable_ledger.Make (struct
@@ -36,7 +36,7 @@ module Any_ledger = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Db = Syncable_ledger.Make (struct
@@ -46,7 +46,7 @@ module Db = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Answer = struct


### PR DESCRIPTION
Explain your changes:
* Update `account_subtree_height` parameter to speed up sync ledger algorithm
* Previous value of `3` was causing the algorithm to make far too many tiny RPC requests

Explain how you tested your changes:
* Tested on a small cluster: deployed with small (200 accounts) genesis ledger, grew the ledger to ~200k accounts, repeatedly deleted a pod and allowed it to bootstrap
* Tested various values for the constant (see [gist](https://gist.github.com/georgeee/9290d2ab3ff24e51c1dfa3d2b4ebc6dd)), chose the best

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #14202
