### PR TITLE
Nix: fix expected hashes for wasm-bindgen-cli

### DIFF
--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -141,10 +141,10 @@ in
         version = deps.wasm-bindgen.version;
         src = final.fetchCrate {
           inherit pname version;
-          sha256 = "sha256-0rK+Yx4/Jy44Fw5VwJ3tG243ZsyOIBBehYU54XP/JGk=";
+          sha256 = "sha256-0pTIzpu7dJM34CXmi83e8UV0E3N2bKJiOMw5WJQ2s/Y=";
         };
 
-        cargoSha256 = "sha256-vcpxcRlW1OKoD64owFF6mkxSqmNrvY+y3Ckn5UwEQ50=";
+        cargoSha256 = "sha256-ZwmoFKmGaf5VvTTXjLyb2714Pu536E/8UxUzxI40ID8=";
         nativeBuildInputs = [ final.pkg-config ];
 
         buildInputs = with final;
@@ -158,7 +158,7 @@ in
 
         # other tests, like --test=wasm-bindgen, require it to be ran in the
         # wasm-bindgen monorepo
-        cargoTestFlags = [ "--test=interface-types --test=reference" ];
+        cargoTestFlags = [ "--test=reference" ];
       };
     in
     rustPlatform.buildRustPackage {


### PR DESCRIPTION
Beware: this might not fix the issue anyway

