### PR TITLE
[berkeley] Speed up rosetta test in CI

### DIFF
--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -93,7 +93,7 @@ ROSETTA_CLI_CONFIG_FILES=${ROSETTA_CLI_CONFIG_FILES:="config.json mina.ros"}
 ROSETTA_CLI_MAIN_CONFIG_FILE=${ROSETTA_CLI_MAIN_CONFIG_FILE:="config.json"}
 
 # Frequency (in seconds) at which payment operations will be sent
-TRANSACTION_FREQUENCY=60
+TRANSACTION_FREQUENCY=10
 
 # Fetch zkApps
 curl -Ls https://github.com/MinaProtocol/rosetta-integration-test-zkapps/tarball/$ROSETTA_INT_TEST_ZKAPPS_VERSION | tar xz -C /tmp

--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -122,8 +122,8 @@ cat <<EOF >"$MINA_CONFIG_FILE"
   "ledger": {
     "name": "${MINA_NETWORK}",
     "accounts": [
-      { "pk": "${BLOCK_PRODUCER_PK}", "balance": "1000", "delegate": null, "sk": null },
-      { "pk": "${SNARK_PRODUCER_PK}", "balance": "2000", "delegate": "${BLOCK_PRODUCER_PK}", "sk": null }
+      { "pk": "${BLOCK_PRODUCER_PK}", "balance": "1000000", "delegate": null, "sk": null },
+      { "pk": "${SNARK_PRODUCER_PK}", "balance": "2000000", "delegate": "${BLOCK_PRODUCER_PK}", "sk": null }
     ]
   }
 }

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -3,6 +3,8 @@ open Async
 open Block
 open Rosetta_lib
 
+let () = ()
+
 (* Rosetta_models.Currency shadows our Currency so we "save" it as MinaCurrency first *)
 module MinaCurrency = Currency
 open Rosetta_models

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -3,8 +3,6 @@ open Async
 open Block
 open Rosetta_lib
 
-let () = ()
-
 (* Rosetta_models.Currency shadows our Currency so we "save" it as MinaCurrency first *)
 module MinaCurrency = Currency
 open Rosetta_models


### PR DESCRIPTION
This PR tweaks the rosetta test to run faster in CI. This is achieved by
* increasing the throughput of transactions, to better match the 20s slot time
* rebalancing the ledger to increase block outut, so that the staking nodes (the block producer and snark worker) have a majority of the stake.

These two changes save roughly 45 mins of integration test runtime.