### PR TITLE
Support remote_addr without port in Orchestrator

### DIFF
--- a/src/app/itn_orchestrator/src/discovery.go
+++ b/src/app/itn_orchestrator/src/discovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -76,7 +75,8 @@ func discoverParticipantsDo(config Config, params DiscoveryParams, output func(N
 			}
 			colonIx := strings.IndexRune(meta.RemoteAddr, ':')
 			if colonIx < 0 {
-				return fmt.Errorf("wrong remote address in submission %s: %s", name, meta.RemoteAddr)
+				// No port is specified in the address, hence we just take the whole remote address field
+				colonIx = len(meta.RemoteAddr)
 			}
 			addr := NodeAddress(meta.RemoteAddr[:colonIx] + ":" + strconv.Itoa(int(meta.GraphqlControlPort)))
 			if _, has := cache[addr]; has {


### PR DESCRIPTION
Explain your changes:
* Support remote_addr without port in Orchestrator
  * This is needed after recent update of uptime backend and use of `X-Forwarded-For`
  
Explain how you tested your changes:
* Note tested yet

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? Partially addresses #14374 
