### PR TITLE
Fix flakiness insufficient replace fee

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -765,9 +765,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Network.Node.get_ingress_uri node)
            zkapp_command_insufficient_fee "Insufficient fee" )
     in
-    let%bind () =
-      Malleable_error.lift (after (Time.Span.of_sec 120.0))
-    in
+    let%bind () = wait_for t (Wait_condition.blocks_to_be_produced 1) in
+    let%bind () = Malleable_error.lift (after (Time.Span.of_sec 30.0)) in
     (* Won't be accepted until the previous transactions are applied *)
     let%bind () =
       section_hard "Send a zkApp transaction to update all fields"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -765,6 +765,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Network.Node.get_ingress_uri node)
            zkapp_command_insufficient_fee "Insufficient fee" )
     in
+    let%bind () =
+      Malleable_error.lift (after (Time.Span.of_sec 120.0))
+    in
     (* Won't be accepted until the previous transactions are applied *)
     let%bind () =
       section_hard "Send a zkApp transaction to update all fields"


### PR DESCRIPTION
Explain your changes:
Fix flakiness of the zkapps test, the timeout is added to avoid a race condition between ledger update and transaction pool update. A more detailed analysis of this can be find in #13854

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13854
