### PR TITLE
Speed up unit tests in develop

### DIFF
--- a/src/lib/pickles/proof_cache.ml
+++ b/src/lib/pickles/proof_cache.ml
@@ -159,7 +159,7 @@ module Json = struct
     ; evals : 'poly_comm verification_evals
     ; shifts : 'fr array
     ; lookup_index : 'poly_comm lookup option
-    ; zk_rows : int
+    ; zk_rows : int [@default 3]
     }
   [@@deriving to_yojson]
 

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -113,7 +113,13 @@ let deferred_values (type n) ~(sgs : (Backend.Tick.Curve.Affine.t, n) Vector.t)
         |> to_list)
       public_input proof
   in
-  let x_hat = Option.value_exn proof.public_evals in
+  let x_hat =
+    match proof.public_evals with
+    | Some x ->
+        x
+    | None ->
+        O.([| p_eval_1 o |], [| p_eval_2 o |])
+  in
   let scalar_chal f =
     Scalar_challenge.map ~f:Challenge.Constant.of_tick_field (f o)
   in


### PR DESCRIPTION
This PR tweaks the logic in `Proof_cache` to handle ignore the new fields added for custom gates/chunking. This allows for the same unit test speed-up as we get in compatible.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them