### PR TITLE
Remove return_early_digest_exception param and related exception

### DIFF
--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -5,8 +5,6 @@ open Async_kernel
 open Pickles_types
 open Hlist
 
-exception Return_digest of Md5.t
-
 val pad_messages_for_next_wrap_proof :
      (module Pickles_types.Hlist.Maxes.S
         with type length = 'max_proofs_verified
@@ -278,7 +276,6 @@ val compile_with_wrap_main_override_promise :
   -> ?disk_keys:
        (Cache.Step.Key.Verification.t, 'branches) Vector.t
        * Cache.Wrap.Key.Verification.t
-  -> ?return_early_digest_exception:bool
   -> ?override_wrap_domain:Pickles_base.Proofs_verified.t
   -> ?override_wrap_main:
        ('max_proofs_verified, 'branches, 'prev_varss) wrap_main_generic

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -45,8 +45,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Step_verifier = Step_verifier
   module Proof_cache = Proof_cache
 
-  exception Return_digest = Compile.Return_digest
-
   type chunking_data = Verify.Instance.chunking_data =
     { num_chunks : int; domain_size : int; zk_rows : int }
 
@@ -311,14 +309,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
   let compile_with_wrap_main_override_promise =
     Compile.compile_with_wrap_main_override_promise
 
-  let compile_promise ?self ?cache ?proof_cache ?disk_keys
-      ?return_early_digest_exception ?override_wrap_domain ?num_chunks
-      ~public_input ~auxiliary_typ ~branches ~max_proofs_verified ~name
-      ~constraint_constants ~choices () =
+  let compile_promise ?self ?cache ?proof_cache ?disk_keys ?override_wrap_domain
+      ?num_chunks ~public_input ~auxiliary_typ ~branches ~max_proofs_verified
+      ~name ~constraint_constants ~choices () =
     compile_with_wrap_main_override_promise ?self ?cache ?proof_cache ?disk_keys
-      ?return_early_digest_exception ?override_wrap_domain ?num_chunks
-      ~public_input ~auxiliary_typ ~branches ~max_proofs_verified ~name
-      ~constraint_constants ~choices ()
+      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+      ~max_proofs_verified ~name ~constraint_constants ~choices ()
 
   let compile ?self ?cache ?proof_cache ?disk_keys ?override_wrap_domain
       ?num_chunks ~public_input ~auxiliary_typ ~branches ~max_proofs_verified

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -17,8 +17,6 @@ module type S = sig
   module Common = Common
   module Proof_cache = Proof_cache
 
-  exception Return_digest of Md5.t
-
   module type Statement_intf = sig
     type field
 
@@ -374,7 +372,6 @@ module type S = sig
     -> ?disk_keys:
          (Cache.Step.Key.Verification.t, 'branches) Vector.t
          * Cache.Wrap.Key.Verification.t
-    -> ?return_early_digest_exception:bool
     -> ?override_wrap_domain:Pickles_base.Proofs_verified.t
     -> ?num_chunks:int
     -> public_input:


### PR DESCRIPTION
Fix https://github.com/MinaProtocol/mina/issues/14409

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
