### PR TITLE
Hard fork protocol version is 2.0

### DIFF
--- a/src/config/protocol_version/current.mlh
+++ b/src/config/protocol_version/current.mlh
@@ -1,4 +1,4 @@
-(* transaction >= 1, network >= 1, patch >= 0 *)
-[%%define protocol_version_transaction 3]
-[%%define protocol_version_network 1]
+(* transaction >= 1, network >= 0, patch >= 0 *)
+[%%define protocol_version_transaction 2]
+[%%define protocol_version_network 0]
 [%%define protocol_version_patch 0]

--- a/src/lib/protocol_version/protocol_version.ml
+++ b/src/lib/protocol_version/protocol_version.ml
@@ -70,7 +70,7 @@ module Make_str (A : Wire_types.Concrete) = struct
   (* when an external transition is deserialized, might contain
      negative numbers
   *)
-  let is_valid t = t.transaction >= 1 && t.network >= 1 && t.patch >= 0
+  let is_valid t = t.transaction >= 1 && t.network >= 0 && t.patch >= 0
 end
 
 include Wire_types.Make (Make_sig) (Make_str)


### PR DESCRIPTION
After getting clarification from the protocol team, set the berkeley hard fork protocol version to `transaction = 2, network = 0, patch = 0`.

Update `Protocol_version.is_valid` to accept 0 as the network version.