### PR TITLE
Base58Check for receipt chain hashes in account preconditions

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -913,7 +913,7 @@ module Zkapp_account_precondition = struct
     in
     let receipt_chain_hash =
       Zkapp_basic.Or_ignore.to_option acct.receipt_chain_hash
-      |> Option.map ~f:Kimchi_backend.Pasta.Basic.Fp.to_string
+      |> Option.map ~f:Receipt.Chain_hash.to_base58_check
     in
     let proved_state = Zkapp_basic.Or_ignore.to_option acct.proved_state in
     let is_new = Zkapp_basic.Or_ignore.to_option acct.is_new in


### PR DESCRIPTION
In the archive db, receipt chain hashes in account preconditions were being written using the string representation of field elements. The replayer tries to read them as Base58Check for the `Receipt.Chain_hash.t` type (by calling `Load_data.get_account_update_body` from `zkapp_command_to_transaction`). That mismatch causes the replayer to fail.

The solution is to write the hashes as Base58Check. We already do so for receipt chain hashes in `accounts_accessed`.

Part of #14417.