### PR TITLE
add o1js-main branch case in snark-transaction-profiler-script

### DIFF
--- a/buildkite/scripts/run-snark-transaction-profiler.sh
+++ b/buildkite/scripts/run-snark-transaction-profiler.sh
@@ -9,7 +9,7 @@ apt-get update
 apt-get install -y git apt-transport-https ca-certificates tzdata curl python3
 
 case "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" in
-  rampup|berkeley|release/2.0.0|develop)
+  rampup|berkeley|release/2.0.0|develop|o1js-main)
     TESTNET_NAME="berkeley"
   ;;
   *)
@@ -17,7 +17,6 @@ case "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" in
 esac
 
 git config --global --add safe.directory /workdir
-
 source buildkite/scripts/export-git-env-vars.sh
 
 echo "Installing mina daemon package: mina-${TESTNET_NAME}=${MINA_DEB_VERSION}"

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -66,7 +66,8 @@ let minimalDirtyWhen = [
   S.strictlyStart (S.contains "dockerfiles/stages"),
   S.exactly "scripts/rebuild-deb" "sh",
   S.exactly "scripts/release-docker" "sh",
-  S.exactly "buildkite/scripts/build-artifact" "sh"
+  S.exactly "buildkite/scripts/build-artifact" "sh",
+  S.exactly "buildkite/scripts/run-snark-transaction-profiler" "sh"
 ]
 
 -- The default debian version (Bullseye) is used in all downstream CI jobs


### PR DESCRIPTION
Add case for  o1js-main branch when determining which debian package use for tests