### PR TITLE
add an optional submitter key to node status service

### DIFF
--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -55,6 +55,7 @@ type t =
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]
+  ; status_submitter_pubkey : Public_key.t option [@default None]
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; uptime_send_node_commit : bool [@default false]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1397,6 +1397,7 @@ let start t =
     match t.config.node_status_url with
     | Some node_status_url ->
         Node_status_service.start ~logger:t.config.logger ~node_status_url
+          ~submitter_pubkey:t.config.status_submitter_pubkey
           ~network:t.components.net
           ~transition_frontier:t.components.transition_frontier
           ~sync_status:t.sync_status ~chain_id:t.config.chain_id

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -427,7 +427,7 @@ let get_node_state t =
   in
   let uptime_of_node =
     Time.(
-      Span.to_string_hum
+      Span.to_sec
       @@ Time.diff (now ())
            (Time_ns.to_time_float_round_nearest_microsecond daemon_start_time))
   in

--- a/src/lib/node_error_service/node_error_service.ml
+++ b/src/lib/node_error_service/node_error_service.ml
@@ -14,7 +14,7 @@ type node_state =
   ; block_height_at_best_tip : int option
   ; sync_status : Sync_status.t
   ; hardware_info : string list option
-  ; uptime_of_node : string
+  ; uptime_of_node : float
   }
 
 type node_error_report =
@@ -35,7 +35,7 @@ type node_error_report =
   ; block_height_at_best_tip : int option
   ; max_observed_block_height : int
   ; max_observed_unvalidated_block_height : int
-  ; uptime_of_node : string
+  ; uptime_of_node : float
   }
 [@@deriving to_yojson]
 

--- a/src/lib/node_error_service/node_error_service.mli
+++ b/src/lib/node_error_service/node_error_service.mli
@@ -11,7 +11,7 @@ type node_state =
   ; block_height_at_best_tip : int option
   ; sync_status : Sync_status.t
   ; hardware_info : string list option
-  ; uptime_of_node : string
+  ; uptime_of_node : float
   }
 
 val set_config :

--- a/src/lib/node_status_service/dune
+++ b/src/lib/node_status_service/dune
@@ -14,6 +14,7 @@
    integers
    base.caml
    ;; local libraries
+   signature_lib
    network_peer
    mina_base
    mina_networking

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -64,6 +64,7 @@ type node_status_data =
   ; chain_id : string
   ; peer_id : string
   ; ip_address : string
+  ; submitter_pubkey : Signature_lib.Public_key.t option
   ; timestamp : string
   ; uptime_of_node : float
   ; peer_count : int
@@ -151,8 +152,9 @@ let reset_gauges () =
   Queue.clear Transition_frontier.validated_blocks ;
   Queue.clear Transition_frontier.rejected_blocks
 
-let start ~logger ~node_status_url ~transition_frontier ~sync_status ~chain_id
-    ~network ~addrs_and_ports ~start_time ~slot_duration =
+let start ~logger ~node_status_url ~submitter_pubkey ~transition_frontier
+    ~sync_status ~chain_id ~network ~addrs_and_ports ~start_time ~slot_duration
+    =
   [%log info] "Starting node status service using URL $url"
     ~metadata:[ ("url", `String node_status_url) ] ;
   let five_slots = Time.Span.scale slot_duration 5. in
@@ -211,6 +213,7 @@ let start ~logger ~node_status_url ~transition_frontier ~sync_status ~chain_id
             ; ip_address =
                 Node_addrs_and_ports.external_ip addrs_and_ports
                 |> Core.Unix.Inet_addr.to_string
+            ; submitter_pubkey
             ; timestamp = Rfc3339_time.get_rfc3339_time ()
             ; uptime_of_node =
                 Time.Span.to_sec @@ Time.diff (Time.now ()) start_time


### PR DESCRIPTION
Explain your changes:
This PR adds an optional submitter key and changed the format for uptime of node error report

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #14426  #14427
