### PR TITLE
[o1js-main] feat: fix scripts to use different paths if mina is a submodule of o1js 

### DIFF
--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -22,7 +22,7 @@ module "o1testnet_alerts" {
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
-  berkeley_testnet       = "testnet=\"(berkeley|testworld-2-0)\""
+  berkeley_testnet       = "testnet=~\"(berkeley|testworld-2-0)\""
   synced_status_filter   = "syncStatus=\"SYNCED\""
 }
 

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -12280,6 +12280,54 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolDiffReceived",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolDiffBroadcasted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pendingSnarkWork",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolSize",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -542,7 +542,7 @@ let setup_daemon logger =
           ~transport:
             (Logger_file_system.dumb_logrotate ~directory:conf_dir
                ~log_filename:"mina-oversized-logs.log"
-               ~max_size:logrotate_max_size ~num_rotate:file_log_rotations ) ;
+               ~max_size:logrotate_max_size ~num_rotate:20 ) ;
         (* Consumer for `[%log internal]` logging used for internal tracing *)
         Itn_logger.set_message_postprocessor
           Internal_tracing.For_itn_logger.post_process_message ;

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -173,6 +173,12 @@ scalar UInt16
 
 """Keys and other information for scheduling zkapp commands"""
 input ZkappCommandsDetails {
+  """
+  Parameter of zkapp generation, each generated zkapp tx will have
+  (2*maxAccountUpdates+2) account updates (including balancing and fee payer)
+  """
+  maxAccountUpdates: Int
+
   """Generate max cost zkApp command"""
   maxCost: Boolean!
 
@@ -193,17 +199,17 @@ input ZkappCommandsDetails {
   """
   initBalance: CurrencyAmount!
 
+  """Maximum new zkapp balance"""
+  maxNewZkappBalance: CurrencyAmount!
+
+  """Minimum new zkapp balance"""
+  minNewZkappBalance: CurrencyAmount!
+
   """Maximum balance change"""
   maxBalanceChange: CurrencyAmount!
 
   """Minimum balance change"""
   minBalanceChange: CurrencyAmount!
-
-  """Minimum new zkapp balance"""
-  minNewZkappBalance: CurrencyAmount!
-
-  """Maximum new zkapp balance"""
-  maxNewZkappBalance: CurrencyAmount!
 
   """Disable the precondition in account updates"""
   noPrecondition: Boolean!

--- a/src/app/itn_orchestrator/src/generate.go
+++ b/src/app/itn_orchestrator/src/generate.go
@@ -1,0 +1,409 @@
+package itn_orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"itn_json_types"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type GenParams struct {
+	MinTps, BaseTps, StressTps, SenderRatio, ZkappRatio, NewAccountRatio float64
+	StopCleanRatio, MinStopRatio, MaxStopRatio                           float64
+	RoundDurationMin, PauseMin, Rounds, StopsPerRound, Gap               int
+	SendFromNonBpsOnly, StopOnlyBps, UseRestartScript, MaxCost           bool
+	ExperimentName, PasswordEnv, FundKeyPrefix                           string
+	Privkeys                                                             []string
+	PaymentReceiver                                                      itn_json_types.MinaPublicKey
+	PrivkeysPerFundCmd                                                   int
+	GenerateFundKeys                                                     int
+	RotationKeys, RotationServers                                        []string
+	RotationPermutation                                                  bool
+	RotationRatio                                                        float64
+	MixMaxCostTpsRatio                                                   float64
+	LargePauseEveryNRounds, LargePauseMin                                int
+	MinBalanceChange, MaxBalanceChange, DeploymentFee                    uint64
+	PaymentAmount, MinZkappFee, MaxZkappFee, FundFee                     uint64
+	MinPaymentFee, MaxPaymentFee                                         uint64
+}
+
+type GeneratedCommand struct {
+	Action  string `json:"action"`
+	Params  any    `json:"params"`
+	comment string
+}
+
+func (cmd *GeneratedCommand) Comment() string {
+	return cmd.comment
+}
+
+type GeneratedRound struct {
+	Commands           []GeneratedCommand
+	PaymentFundCommand *FundParams
+	ZkappFundCommand   *FundParams
+}
+
+func withComment(comment string, cmd GeneratedCommand) GeneratedCommand {
+	cmd.comment = comment
+	return cmd
+}
+
+func formatDur(min, sec int) string {
+	sec += min * 60
+	min = sec / 60
+	sec %= 60
+	hour := min / 60
+	min %= 60
+	day := hour / 24
+	hour %= 24
+	parts := []string{}
+	if day > 0 {
+		parts = append(parts, strconv.Itoa(day), "days")
+	}
+	if hour > 0 {
+		parts = append(parts, strconv.Itoa(hour), "hours")
+	}
+	if min > 0 {
+		parts = append(parts, strconv.Itoa(min), "mins")
+	}
+	if sec > 0 {
+		parts = append(parts, strconv.Itoa(sec), "secs")
+	}
+	if len(parts) == 0 {
+		return "immediately"
+	}
+	return strings.Join(parts, " ")
+}
+
+func rotate(p RotateParams) GeneratedCommand {
+	return GeneratedCommand{Action: RotateAction{}.Name(), Params: p}
+}
+
+func loadKeys(p KeyloaderParams) GeneratedCommand {
+	return GeneratedCommand{Action: KeyloaderAction{}.Name(), Params: p}
+}
+
+func discovery(p DiscoveryParams) GeneratedCommand {
+	return GeneratedCommand{Action: DiscoveryAction{}.Name(), Params: p}
+}
+
+type SampleRefParams struct {
+	Group  ComplexValue `json:"group"`
+	Ratios []float64    `json:"ratios"`
+}
+
+func sample(groupRef int, groupName string, ratios []float64) GeneratedCommand {
+	group := LocalComplexValue(groupRef, groupName)
+	group.OnEmpty = emptyArrayRawMessage
+	return GeneratedCommand{Action: SampleAction{}.Name(), Params: SampleRefParams{
+		Group:  group,
+		Ratios: ratios,
+	}}
+}
+
+type ZkappRefParams struct {
+	ZkappSubParams
+	FeePayers ComplexValue `json:"feePayers"`
+	Nodes     ComplexValue `json:"nodes"`
+}
+
+func zkapps(feePayersRef int, nodesRef int, nodesName string, params ZkappSubParams) GeneratedCommand {
+	cmd := GeneratedCommand{Action: ZkappCommandsAction{}.Name(), Params: ZkappRefParams{
+		ZkappSubParams: params,
+		FeePayers:      LocalComplexValue(feePayersRef, "key"),
+		Nodes:          LocalComplexValue(nodesRef, nodesName),
+	}}
+	maxCostStr := ""
+	if params.MaxCost {
+		maxCostStr = "max-cost "
+	}
+	comment := fmt.Sprintf("Scheduling %d %szkapp transactions to be sent over period of %d minutes (%.2f txs/min)",
+		int(params.Tps*float64(params.DurationMin)*60), maxCostStr, params.DurationMin, params.Tps*60,
+	)
+	return withComment(comment, cmd)
+}
+
+type PaymentRefParams struct {
+	PaymentSubParams
+	FeePayers ComplexValue `json:"feePayers"`
+	Nodes     ComplexValue `json:"nodes"`
+}
+
+func payments(feePayersRef int, nodesRef int, nodesName string, params PaymentSubParams) GeneratedCommand {
+	cmd := GeneratedCommand{Action: PaymentsAction{}.Name(), Params: PaymentRefParams{
+		PaymentSubParams: params,
+		FeePayers:        LocalComplexValue(feePayersRef, "key"),
+		Nodes:            LocalComplexValue(nodesRef, nodesName),
+	}}
+	comment := fmt.Sprintf("Scheduling %d payments to be sent over period of %d minutes (%.2f txs/min)",
+		int(params.Tps*float64(params.DurationMin)*60), params.DurationMin, params.Tps*60,
+	)
+	return withComment(comment, cmd)
+}
+
+func waitMin(min int) GeneratedCommand {
+	return GeneratedCommand{Action: WaitAction{}.Name(), Params: WaitParams{
+		Minutes: min,
+	}}
+}
+
+func GenWait(sec int) GeneratedCommand {
+	return GeneratedCommand{Action: WaitAction{}.Name(), Params: WaitParams{
+		Seconds: sec,
+	}}
+}
+
+type RestartRefParams struct {
+	Nodes ComplexValue `json:"nodes"`
+	Clean bool         `json:"clean,omitempty"`
+}
+
+/*
+ * Returns random number in normal distribution centering on 0.
+ * ~95% of numbers returned should fall between -2 and 2
+ * ie within two standard deviations
+ */
+func gaussRandom() float64 {
+	u := 2*rand.Float64() - 1
+	v := 2*rand.Float64() - 1
+	r := u*u + v*v
+	// if outside interval [0,1] start over
+	if r == 0 || r >= 1 {
+		return gaussRandom()
+	}
+
+	c := math.Sqrt(-2 * math.Log(r) / r)
+	return u * c
+}
+
+func SampleTps(baseTps, stressTps float64) float64 {
+	tpsStddev := (stressTps - baseTps) / 2
+	return tpsStddev*math.Abs(gaussRandom()) + baseTps
+}
+
+func SampleStopRatio(minRatio, maxRatio float64) float64 {
+	stddev := (maxRatio - minRatio) / 3
+	return stddev*math.Abs(gaussRandom()) + minRatio
+}
+
+func genStopDaemon(useRestartScript bool, nodesRef int, nodesName string, clean bool) GeneratedCommand {
+	var name string
+	if useRestartScript {
+		name = RestartAction{}.Name()
+	} else {
+		name = StopDaemonAction{}.Name()
+	}
+	return GeneratedCommand{Action: name, Params: RestartRefParams{
+		Nodes: LocalComplexValue(nodesRef, nodesName),
+		Clean: clean,
+	}}
+}
+
+type JoinRefParams struct {
+	Group1 ComplexValue `json:"group1"`
+	Group2 ComplexValue `json:"group2"`
+}
+
+func join(g1Ref int, g1Name string, g2Ref int, g2Name string) GeneratedCommand {
+	return GeneratedCommand{Action: JoinAction{}.Name(), Params: JoinRefParams{
+		Group1: LocalComplexValue(g1Ref, g1Name),
+		Group2: LocalComplexValue(g2Ref, g2Name),
+	}}
+}
+
+type ExceptRefParams struct {
+	Group  ComplexValue `json:"group"`
+	Except ComplexValue `json:"except"`
+}
+
+var emptyArrayRawMessage json.RawMessage
+
+func init() {
+	emptyArrayRawMessage, _ = json.Marshal([]string{})
+}
+
+func except(groupRef int, groupName string, exceptRef int, exceptName string) GeneratedCommand {
+	group := LocalComplexValue(groupRef, groupName)
+	group.OnEmpty = emptyArrayRawMessage
+	except := LocalComplexValue(exceptRef, exceptName)
+	except.OnEmpty = emptyArrayRawMessage
+	return GeneratedCommand{Action: ExceptAction{}.Name(), Params: ExceptRefParams{
+		Group:  group,
+		Except: except,
+	}}
+}
+func (p *GenParams) Generate(round int) GeneratedRound {
+	zkappsKeysDir := fmt.Sprintf("%s/%s/round-%d/zkapps", p.FundKeyPrefix, p.ExperimentName, round)
+	paymentsKeysDir := fmt.Sprintf("%s/%s/round-%d/payments", p.FundKeyPrefix, p.ExperimentName, round)
+	tps := SampleTps(p.BaseTps, p.StressTps)
+	maxCost := p.MaxCost
+	zkappRatio := p.ZkappRatio
+	if p.MixMaxCostTpsRatio > 1e-3 && (round&1) == 1 {
+		maxCost = true
+		zkappRatio = 1
+		tps *= p.MixMaxCostTpsRatio
+	}
+	experimentName := fmt.Sprintf("%s-%d", p.ExperimentName, round)
+	onlyZkapps := math.Abs(1-zkappRatio) < 1e-3
+	onlyPayments := zkappRatio < 1e-3
+	zkappTps := tps * zkappRatio
+	zkappParams := ZkappSubParams{
+		ExperimentName:   experimentName,
+		Tps:              zkappTps,
+		MinTps:           p.MinTps,
+		DurationMin:      p.RoundDurationMin,
+		Gap:              p.Gap,
+		MinBalanceChange: p.MinBalanceChange,
+		MaxBalanceChange: p.MaxBalanceChange,
+		MinFee:           p.MinZkappFee,
+		MaxFee:           p.MaxZkappFee,
+		DeploymentFee:    p.DeploymentFee,
+		MaxCost:          maxCost,
+		NewAccountRatio:  p.NewAccountRatio,
+	}
+	if maxCost {
+		// This can be set to arbitrary value as for max-cost it only
+		// matters that total zkapps deployed is above 5
+		// We need to set it this way to override setting accountQueueSize
+		// by the orchestrator
+		zkappParams.ZkappsToDeploy = 8
+		zkappParams.NewAccountRatio = 0
+	}
+	paymentParams := PaymentSubParams{
+		ExperimentName: experimentName,
+		Tps:            tps - zkappTps,
+		MinTps:         p.MinTps,
+		DurationMin:    p.RoundDurationMin,
+		MinFee:         p.MinPaymentFee,
+		MaxFee:         p.MaxPaymentFee,
+		Amount:         p.PaymentAmount,
+		Receiver:       p.PaymentReceiver,
+	}
+	cmds := []GeneratedCommand{}
+	roundStartMin := round*(p.RoundDurationMin+p.PauseMin) + round/p.LargePauseEveryNRounds*p.LargePauseMin
+	if len(p.RotationKeys) > 0 {
+		var mapping []int
+		nKeys := len(p.RotationKeys)
+		if p.RotationPermutation {
+			mapping = rand.Perm(nKeys)
+		} else {
+			mapping = make([]int, nKeys)
+			for i := range mapping {
+				mapping[i] = rand.Intn(len(p.RotationKeys))
+			}
+		}
+		cmds = append(cmds, rotate(RotateParams{
+			Pubkeys:     p.RotationKeys,
+			RestServers: p.RotationServers,
+			Mapping:     mapping,
+			Ratio:       p.RotationRatio,
+			PasswordEnv: p.PasswordEnv,
+		}))
+	}
+	cmds = append(cmds, withComment(fmt.Sprintf("Starting round %d, %s after start", round, formatDur(roundStartMin, 0)), discovery(DiscoveryParams{
+		OffsetMin:        15,
+		NoBlockProducers: p.SendFromNonBpsOnly,
+	})))
+	sendersOutName := "participant"
+	if 1-p.SenderRatio > 1e-6 {
+		sendersOutName = "group1"
+		cmds = append(cmds, sample(-1, "participant", []float64{p.SenderRatio}))
+	}
+	if onlyPayments {
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir}))
+		cmds = append(cmds, payments(-1, -2, sendersOutName, paymentParams))
+	} else if onlyZkapps {
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir}))
+		cmds = append(cmds, zkapps(-1, -2, sendersOutName, zkappParams))
+	} else {
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir}))
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir}))
+		cmds = append(cmds, zkapps(-2, -3, sendersOutName, zkappParams))
+		cmds = append(cmds, payments(-2, -4, sendersOutName, paymentParams))
+		cmds = append(cmds, join(-1, "participant", -2, "participant"))
+	}
+	sendersCmdId := len(cmds)
+	stopWaits := make([]int, p.StopsPerRound)
+	for i := 0; i < p.StopsPerRound; i++ {
+		stopWaits[i] = rand.Intn(60 * p.RoundDurationMin)
+	}
+	sort.Ints(stopWaits)
+	for i := p.StopsPerRound - 1; i > 0; i-- {
+		stopWaits[i] -= stopWaits[i-1]
+	}
+	stopRatio := SampleStopRatio(p.MinStopRatio, p.MaxStopRatio)
+	elapsed := 0
+	for _, waitSec := range stopWaits {
+		cmds = append(cmds, withComment(fmt.Sprintf("Running round %d, %s after start, waiting for %s", round, formatDur(roundStartMin, elapsed), formatDur(0, waitSec)), GenWait(waitSec)))
+		cmds = append(cmds, discovery(DiscoveryParams{
+			OffsetMin:          15,
+			OnlyBlockProducers: p.StopOnlyBps,
+		}))
+		exceptRefName := "group"
+		if onlyPayments || onlyZkapps {
+			exceptRefName = "participant"
+		}
+		cmds = append(cmds, except(-1, "participant", sendersCmdId-len(cmds)-1, exceptRefName))
+		stopCleanRatio := p.StopCleanRatio * stopRatio
+		stopNoCleanRatio := (1 - p.StopCleanRatio) * stopRatio
+		nodesOrBps := "nodes"
+		if p.StopOnlyBps {
+			nodesOrBps = "block producers"
+		}
+		if stopCleanRatio > 1e-6 && stopNoCleanRatio > 1e-6 {
+			cmds = append(cmds, sample(-1, "group", []float64{stopCleanRatio, stopNoCleanRatio}))
+			comment1 := fmt.Sprintf("Stopping %.1f%% %s with cleaning", stopCleanRatio*100, nodesOrBps)
+			cmds = append(cmds, withComment(comment1, genStopDaemon(p.UseRestartScript, -1, "group1", true)))
+			comment2 := fmt.Sprintf("Stopping %.1f%% %s without cleaning", stopNoCleanRatio*100, nodesOrBps)
+			cmds = append(cmds, withComment(comment2, genStopDaemon(p.UseRestartScript, -2, "group2", false)))
+		} else if stopCleanRatio > 1e-6 {
+			comment := fmt.Sprintf("Stopping %.1f%% %s with cleaning", stopCleanRatio*100, nodesOrBps)
+			cmds = append(cmds, sample(-1, "group", []float64{stopCleanRatio}))
+			cmds = append(cmds, withComment(comment, genStopDaemon(p.UseRestartScript, -1, "group1", true)))
+		} else if stopNoCleanRatio > 1e-6 {
+			comment := fmt.Sprintf("Stopping %.1f%% %s without cleaning", stopNoCleanRatio*100, nodesOrBps)
+			cmds = append(cmds, sample(-1, "group", []float64{stopNoCleanRatio}))
+			cmds = append(cmds, withComment(comment, genStopDaemon(p.UseRestartScript, -1, "group1", false)))
+		}
+		elapsed += waitSec
+	}
+	if round < p.Rounds-1 {
+		comment1 := fmt.Sprintf("Waiting for remainder of round %d, %s after start", round, formatDur(roundStartMin, elapsed))
+		cmds = append(cmds, withComment(comment1, GenWait(p.RoundDurationMin*60-elapsed)))
+		if p.PauseMin > 0 {
+			comment2 := fmt.Sprintf("Pause after round %d, %s after start", round, formatDur(roundStartMin+p.RoundDurationMin, 0))
+			cmds = append(cmds, withComment(comment2, waitMin(p.PauseMin)))
+		}
+		if p.LargePauseMin > 0 && (round+1)%p.LargePauseEveryNRounds == 0 {
+			comment3 := fmt.Sprintf("Large pause after round %d, %s after start", round, formatDur(roundStartMin+p.RoundDurationMin+p.PauseMin, 0))
+			cmds = append(cmds, withComment(comment3, waitMin(p.LargePauseMin)))
+		}
+	}
+	res := GeneratedRound{Commands: cmds}
+	if !onlyPayments {
+		_, _, _, initBalance := ZkappBalanceRequirements(zkappTps, zkappParams)
+		zkappKeysNum, zkappAmount := ZkappKeygenRequirements(initBalance, zkappParams)
+		res.ZkappFundCommand = &FundParams{
+			PasswordEnv: p.PasswordEnv,
+			Prefix:      zkappsKeysDir + "/key",
+			Amount:      zkappAmount,
+			Fee:         p.FundFee,
+			Num:         zkappKeysNum,
+		}
+	}
+	if !onlyZkapps {
+		paymentKeysNum, paymentAmount := PaymentKeygenRequirements(p.Gap, paymentParams)
+		res.PaymentFundCommand = &FundParams{
+			PasswordEnv: p.PasswordEnv,
+			Prefix:      paymentsKeysDir + "/key",
+			Amount:      paymentAmount,
+			Fee:         p.FundFee,
+			Num:         paymentKeysNum,
+		}
+	}
+	return res
+}

--- a/src/app/itn_orchestrator/src/generate_test.go
+++ b/src/app/itn_orchestrator/src/generate_test.go
@@ -1,0 +1,252 @@
+package itn_orchestrator
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func someParams() GenParams {
+	return GenParams{
+		MinTps:                 0.01,
+		BaseTps:                0.6,
+		StressTps:              1.4,
+		SenderRatio:            0.8,
+		ZkappRatio:             0.7,
+		NewAccountRatio:        1.5,
+		StopCleanRatio:         0.5,
+		MinStopRatio:           0.1,
+		MaxStopRatio:           0.25,
+		RoundDurationMin:       50,
+		PauseMin:               10,
+		Rounds:                 48,
+		StopsPerRound:          1,
+		Gap:                    100,
+		ExperimentName:         "test",
+		Privkeys:               []string{"key0"},
+		PaymentReceiver:        "B62qpPita1s7Dbnr7MVb3UK8fdssZixL1a4536aeMYxbTJEtRGGyS8U",
+		PrivkeysPerFundCmd:     2,
+		GenerateFundKeys:       20,
+		MixMaxCostTpsRatio:     0.7,
+		LargePauseEveryNRounds: 8,
+		LargePauseMin:          240,
+		MinBalanceChange:       1e3,
+		MaxBalanceChange:       3e3,
+		DeploymentFee:          1e9,
+		PaymentAmount:          1e5,
+		MinZkappFee:            1e9,
+		MaxZkappFee:            3e9,
+		MinPaymentFee:          1e8,
+		MaxPaymentFee:          3e8,
+		FundFee:                1e9,
+	}
+}
+
+type shuffledIxs []int
+
+func (ixs *shuffledIxs) Push(ix int) {
+	*ixs = append(*ixs, ix)
+}
+
+func (ixs *shuffledIxs) Pop() int {
+	l := len(*ixs)
+	if l == 0 {
+		panic("unexpected pop")
+	}
+	i := rand.Intn(l)
+	res := (*ixs)[i]
+	(*ixs)[i] = (*ixs)[l-1]
+	*ixs = (*ixs)[:l-1]
+	return res
+}
+
+type zkappGenState struct {
+	balances          []int64
+	availableDeployed shuffledIxs
+	availableNew      shuffledIxs
+	queue             []int
+	numNewAccounts    int
+	conf              ZkappCommandsDetails
+}
+
+func newZkappGenState(pi ZkappCommandsDetails, numFeePayers int, balances []int64) zkappGenState {
+	availableDeployed := rand.Perm(pi.NumZkappsToDeploy)
+	for i := range availableDeployed {
+		availableDeployed[i] += numFeePayers
+	}
+	return zkappGenState{
+		numNewAccounts:    pi.NumNewAccounts,
+		balances:          balances,
+		availableDeployed: availableDeployed,
+		conf:              pi,
+	}
+}
+
+func (state *zkappGenState) applyTx(numFeePayers, feePayerIx, accountUpdates, newAccounts, zkappAccounts int) {
+	state.numNewAccounts -= newAccounts
+	state.balances[feePayerIx] -= int64(state.conf.MaxFee)
+	availableDeployed := len(state.availableDeployed)
+	availableNew := len(state.availableNew)
+	tot := availableDeployed + availableNew
+	if tot <= 0 {
+		panic("not enough keys")
+	}
+	// TODO popped should be reused
+	popped := make([]int, 0, accountUpdates-newAccounts)
+	poppedCnt := make([]int, accountUpdates-newAccounts+1)
+	numNewPops := 0
+	for i := 0; i < accountUpdates-newAccounts-zkappAccounts; i++ {
+		r := rand.Intn(tot)
+		if r < len(popped) {
+			poppedCnt[r]++
+			numNewPops++
+		} else if r < availableNew {
+			popped = append(popped, state.availableNew.Pop())
+			numNewPops++
+		}
+	}
+	numDeployedToPop := accountUpdates - newAccounts - numNewPops + 1
+	newActuallyPopped := len(popped)
+	for i := 0; i < numDeployedToPop; i++ {
+		r := rand.Intn(availableDeployed) + newActuallyPopped
+		if r < len(popped) {
+			poppedCnt[r]++
+		} else {
+			popped = append(popped, state.availableDeployed.Pop())
+		}
+	}
+	balancing := popped[len(popped)-1]
+	poppedCnt[len(popped)-1]--
+	state.queue = append(state.queue, popped...)
+	for i := 0; i < newAccounts; i++ {
+		ix := len(state.balances)
+		state.balances = append(state.balances, int64(state.conf.MinNewZkappBalance)-1e9)
+		state.queue = append(state.queue, ix)
+	}
+	if len(state.queue) > state.conf.AccountQueueSize {
+		prefix := len(state.queue) - state.conf.AccountQueueSize
+		for _, ix := range state.queue[:prefix] {
+			if ix < numFeePayers+state.conf.NumZkappsToDeploy {
+				state.availableDeployed.Push(ix)
+			} else {
+				state.availableNew.Push(ix)
+			}
+		}
+		state.queue = state.queue[prefix:]
+	}
+	for i, ix := range popped {
+		state.balances[ix] -= int64(state.conf.MaxBalanceChange*2) * int64(poppedCnt[i]+1)
+	}
+	state.balances[balancing] -= int64(accountUpdates*2-newAccounts)*int64(state.conf.MaxBalanceChange) + int64(newAccounts)*int64(state.conf.MaxNewZkappBalance)
+}
+
+func testZkapp(t *testing.T, numFeePayers int, feePayerBalance int64, pi ZkappCommandsDetails) {
+	balances := make([]int64, numFeePayers+pi.NumZkappsToDeploy)
+	for i := 0; i < numFeePayers; i++ {
+		balances[i] = feePayerBalance
+	}
+	for j := 0; j < pi.NumZkappsToDeploy; j++ {
+		balances[j%numFeePayers] -= int64(pi.DeploymentFee + pi.InitBalance)
+		balances[numFeePayers+j] = int64(pi.InitBalance) - 1e9
+	}
+	numTxs := int(float64(pi.DurationMin*60) * pi.Tps)
+	if pi.MaxCost {
+		for j := pi.NumZkappsToDeploy; j < numTxs; j++ {
+			balances[j%numFeePayers] -= int64(pi.MaxFee)
+		}
+	} else {
+		state := newZkappGenState(pi, numFeePayers, balances)
+		for j := pi.NumZkappsToDeploy; j < numTxs; j++ {
+			accUpdates := rand.Intn(pi.MaxAccountUpdates) + 1
+			newAccs := 0
+			if state.numNewAccounts > 0 {
+				newAccs = rand.Intn(accUpdates + 1)
+			}
+			zkappAccs := 0
+			for k := 0; k < accUpdates-newAccs; k++ {
+				if rand.Intn(3) == 0 {
+					zkappAccs++
+				}
+			}
+			// t.Logf("%d:%d (%d new)", accUpdates*2+2, zkappAccs, newAccs)
+			state.applyTx(numFeePayers, j%numFeePayers, accUpdates, newAccs, zkappAccs)
+		}
+		balances = state.balances
+	}
+	for ix, b := range balances {
+		type_ := "new"
+		if ix < numFeePayers {
+			type_ = "fee payer"
+		} else if ix < numFeePayers+pi.NumZkappsToDeploy {
+			type_ = "zkapp"
+		}
+		if b < 0 {
+			t.Errorf("balance underflow %d for %s account", b, type_)
+		}
+	}
+	if t.Failed() {
+		t.Logf("Fee payer balance: %d", feePayerBalance)
+		t.Logf("Init zkapp balance: %d", pi.InitBalance)
+		t.Logf("New account balance: %d", pi.MaxNewZkappBalance)
+	}
+}
+
+func testPayment(t *testing.T, numFeePayers int, feePayerBalance int64, pi PaymentsDetails) {
+	balances := make([]int64, numFeePayers)
+	for i := 0; i < numFeePayers; i++ {
+		balances[i] = feePayerBalance
+	}
+	numTxs := int(float64(pi.DurationMin*60) * pi.Tps)
+	for i := 0; i < numTxs; i++ {
+		balances[i%numFeePayers] -= int64(pi.Amount + pi.MaxFee)
+	}
+	for _, b := range balances {
+		if b < 0 {
+			t.Errorf("balance underflow %d for fee payer", b)
+		}
+	}
+	if t.Failed() {
+		t.Logf("Fee payer balance: %d", feePayerBalance)
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		params := someParams()
+		for r := 0; r < params.Rounds; r++ {
+			round := params.Generate(r)
+			var zkappParams *ZkappSubParams
+			var paymentParams *PaymentSubParams
+			for _, c := range round.Commands {
+				if c.Action == (ZkappCommandsAction{}).Name() {
+					p := (c.Params.(ZkappRefParams).ZkappSubParams)
+					zkappParams = &p
+				} else if c.Action == (PaymentsAction{}).Name() {
+					p := (c.Params.(PaymentRefParams).PaymentSubParams)
+					paymentParams = &p
+				}
+			}
+			if zkappParams != nil {
+				fund := *round.ZkappFundCommand
+				participants := int(zkappParams.Tps / zkappParams.MinTps)
+				tpsPerNode := zkappParams.Tps / float64(participants)
+				pi := ZkappPaymentsInput(*zkappParams, 0, tpsPerNode)
+				numFeePayers := fund.Num / participants
+				feePayerBalance := int64(fund.Amount) / int64(fund.Num)
+				for j := 0; j < 1000; j++ {
+					testZkapp(t, numFeePayers, feePayerBalance, pi)
+				}
+			}
+			if paymentParams != nil {
+				fund := *round.PaymentFundCommand
+				participants := int(paymentParams.Tps / paymentParams.MinTps)
+				tpsPerNode := paymentParams.Tps / float64(participants)
+				numFeePayers := fund.Num / participants
+				feePayerBalance := int64(fund.Amount) / int64(fund.Num)
+				pi := paymentInput(*paymentParams, 0, tpsPerNode)
+				for j := 0; j < 1000; j++ {
+					testPayment(t, numFeePayers, feePayerBalance, pi)
+				}
+			}
+		}
+	}
+}

--- a/src/app/itn_orchestrator/src/generator/main.go
+++ b/src/app/itn_orchestrator/src/generator/main.go
@@ -4,417 +4,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"itn_json_types"
-	"math"
-	"math/rand"
 	"os"
-	"sort"
-	"strconv"
 	"strings"
 
 	lib "itn_orchestrator"
 )
 
-/*
- * Returns random number in normal distribution centering on 0.
- * ~95% of numbers returned should fall between -2 and 2
- * ie within two standard deviations
- */
-func gaussRandom() float64 {
-	u := 2*rand.Float64() - 1
-	v := 2*rand.Float64() - 1
-	r := u*u + v*v
-	// if outside interval [0,1] start over
-	if r == 0 || r >= 1 {
-		return gaussRandom()
-	}
-
-	c := math.Sqrt(-2 * math.Log(r) / r)
-	return u * c
-}
-
-func sampleTps(baseTps, stressTps float64) float64 {
-	tpsStddev := (stressTps - baseTps) / 2
-	return tpsStddev*math.Abs(gaussRandom()) + baseTps
-}
-
-func sampleStopRatio(minRatio, maxRatio float64) float64 {
-	stddev := (maxRatio - minRatio) / 3
-	return stddev*math.Abs(gaussRandom()) + minRatio
-}
-
-type Params struct {
-	MinTps, BaseTps, StressTps, SenderRatio, ZkappRatio, NewAccountRatio float64
-	StopCleanRatio, MinStopRatio, MaxStopRatio                           float64
-	RoundDurationMin, PauseMin, Rounds, StopsPerRound, Gap               int
-	SendFromNonBpsOnly, StopOnlyBps, UseRestartScript, MaxCost           bool
-	ExperimentName, PasswordEnv, FundKeyPrefix                           string
-	Privkeys                                                             []string
-	PaymentReceiver                                                      itn_json_types.MinaPublicKey
-	PrivkeysPerFundCmd                                                   int
-	GenerateFundKeys                                                     int
-	RotationKeys, RotationServers                                        []string
-	RotationPermutation                                                  bool
-	RotationRatio                                                        float64
-	MixMaxCostTpsRatio                                                   float64
-	LargePauseEveryNRounds, LargePauseMin                                int
-	MinBalanceChange, MaxBalanceChange, DeploymentFee                    uint64
-	PaymentAmount, MinFee, MaxFee, FundFee                               uint64
-}
-
-type Command struct {
-	Action  string `json:"action"`
-	Params  any    `json:"params"`
-	comment string
-}
-
-type GeneratedRound struct {
-	Commands     []Command
-	FundCommands []lib.FundParams
-}
-
-func fund(p lib.FundParams) Command {
-	return Command{Action: lib.FundAction{}.Name(), Params: p}
-}
-
-func rotate(p lib.RotateParams) Command {
-	return Command{Action: lib.RotateAction{}.Name(), Params: p}
-}
-
-func loadKeys(p lib.KeyloaderParams) Command {
-	return Command{Action: lib.KeyloaderAction{}.Name(), Params: p}
-}
-
-func discovery(p lib.DiscoveryParams) Command {
-	return Command{Action: lib.DiscoveryAction{}.Name(), Params: p}
-}
-
-type SampleRefParams struct {
-	Group  lib.ComplexValue `json:"group"`
-	Ratios []float64        `json:"ratios"`
-}
-
-func sample(groupRef int, groupName string, ratios []float64) Command {
-	group := lib.LocalComplexValue(groupRef, groupName)
-	group.OnEmpty = emptyArrayRawMessage
-	return Command{Action: lib.SampleAction{}.Name(), Params: SampleRefParams{
-		Group:  group,
-		Ratios: ratios,
-	}}
-}
-
-type ZkappRefParams struct {
-	lib.ZkappSubParams
-	FeePayers lib.ComplexValue `json:"feePayers"`
-	Nodes     lib.ComplexValue `json:"nodes"`
-}
-
-func zkapps(feePayersRef int, nodesRef int, nodesName string, params lib.ZkappSubParams) Command {
-	cmd := Command{Action: lib.ZkappCommandsAction{}.Name(), Params: ZkappRefParams{
-		ZkappSubParams: params,
-		FeePayers:      lib.LocalComplexValue(feePayersRef, "key"),
-		Nodes:          lib.LocalComplexValue(nodesRef, nodesName),
-	}}
-	maxCostStr := ""
-	if params.MaxCost {
-		maxCostStr = "max-cost "
-	}
-	comment := fmt.Sprintf("Scheduling %d %szkapp transactions to be sent over period of %d minutes (%.2f txs/min)",
-		int(params.Tps*float64(params.DurationMin)*60), maxCostStr, params.DurationMin, params.Tps*60,
-	)
-	return withComment(comment, cmd)
-}
-
-type PaymentRefParams struct {
-	lib.PaymentSubParams
-	FeePayers lib.ComplexValue `json:"feePayers"`
-	Nodes     lib.ComplexValue `json:"nodes"`
-}
-
-func payments(feePayersRef int, nodesRef int, nodesName string, params lib.PaymentSubParams) Command {
-	cmd := Command{Action: lib.PaymentsAction{}.Name(), Params: PaymentRefParams{
-		PaymentSubParams: params,
-		FeePayers:        lib.LocalComplexValue(feePayersRef, "key"),
-		Nodes:            lib.LocalComplexValue(nodesRef, nodesName),
-	}}
-	comment := fmt.Sprintf("Scheduling %d payments to be sent over period of %d minutes (%.2f txs/min)",
-		int(params.Tps*float64(params.DurationMin)*60), params.DurationMin, params.Tps*60,
-	)
-	return withComment(comment, cmd)
-}
-
-func waitMin(min int) Command {
-	return Command{Action: lib.WaitAction{}.Name(), Params: lib.WaitParams{
-		Minutes: min,
-	}}
-}
-
-func wait(sec int) Command {
-	return Command{Action: lib.WaitAction{}.Name(), Params: lib.WaitParams{
-		Seconds: sec,
-	}}
-}
-
-type RestartRefParams struct {
-	Nodes lib.ComplexValue `json:"nodes"`
-	Clean bool             `json:"clean,omitempty"`
-}
-
-func stopDaemon(useRestartScript bool, nodesRef int, nodesName string, clean bool) Command {
-	var name string
-	if useRestartScript {
-		name = lib.RestartAction{}.Name()
-	} else {
-		name = lib.StopDaemonAction{}.Name()
-	}
-	return Command{Action: name, Params: RestartRefParams{
-		Nodes: lib.LocalComplexValue(nodesRef, nodesName),
-		Clean: clean,
-	}}
-}
-
-type JoinRefParams struct {
-	Group1 lib.ComplexValue `json:"group1"`
-	Group2 lib.ComplexValue `json:"group2"`
-}
-
-func join(g1Ref int, g1Name string, g2Ref int, g2Name string) Command {
-	return Command{Action: lib.JoinAction{}.Name(), Params: JoinRefParams{
-		Group1: lib.LocalComplexValue(g1Ref, g1Name),
-		Group2: lib.LocalComplexValue(g2Ref, g2Name),
-	}}
-}
-
-type ExceptRefParams struct {
-	Group  lib.ComplexValue `json:"group"`
-	Except lib.ComplexValue `json:"except"`
-}
-
-var emptyArrayRawMessage json.RawMessage
-
-func init() {
-	emptyArrayRawMessage, _ = json.Marshal([]string{})
-}
-
-func except(groupRef int, groupName string, exceptRef int, exceptName string) Command {
-	group := lib.LocalComplexValue(groupRef, groupName)
-	group.OnEmpty = emptyArrayRawMessage
-	except := lib.LocalComplexValue(exceptRef, exceptName)
-	except.OnEmpty = emptyArrayRawMessage
-	return Command{Action: lib.ExceptAction{}.Name(), Params: ExceptRefParams{
-		Group:  group,
-		Except: except,
-	}}
-}
-
-func withComment(comment string, cmd Command) Command {
-	cmd.comment = comment
-	return cmd
-}
-
-func formatDur(min, sec int) string {
-	sec += min * 60
-	min = sec / 60
-	sec %= 60
-	hour := min / 60
-	min %= 60
-	day := hour / 24
-	hour %= 24
-	parts := []string{}
-	if day > 0 {
-		parts = append(parts, strconv.Itoa(day), "days")
-	}
-	if hour > 0 {
-		parts = append(parts, strconv.Itoa(hour), "hours")
-	}
-	if min > 0 {
-		parts = append(parts, strconv.Itoa(min), "mins")
-	}
-	if sec > 0 {
-		parts = append(parts, strconv.Itoa(sec), "secs")
-	}
-	if len(parts) == 0 {
-		return "immediately"
-	}
-	return strings.Join(parts, " ")
-}
-
-func (p *Params) Generate(round int) GeneratedRound {
-	zkappsKeysDir := fmt.Sprintf("%s/round-%d/zkapps", p.FundKeyPrefix, round)
-	paymentsKeysDir := fmt.Sprintf("%s/round-%d/payments", p.FundKeyPrefix, round)
-	tps := sampleTps(p.BaseTps, p.StressTps)
-	maxCost := p.MaxCost
-	zkappRatio := p.ZkappRatio
-	if p.MixMaxCostTpsRatio > 1e-3 && (round&1) == 1 {
-		maxCost = true
-		zkappRatio = 1
-		tps *= p.MixMaxCostTpsRatio
-	}
-	experimentName := fmt.Sprintf("%s-%d", p.ExperimentName, round)
-	onlyZkapps := math.Abs(1-zkappRatio) < 1e-3
-	onlyPayments := zkappRatio < 1e-3
-	zkappTps := tps * zkappRatio
-	zkappParams := lib.ZkappSubParams{
-		ExperimentName:   experimentName,
-		Tps:              zkappTps,
-		MinTps:           p.MinTps,
-		DurationMin:      p.RoundDurationMin,
-		Gap:              p.Gap,
-		MinBalanceChange: p.MinBalanceChange,
-		MaxBalanceChange: p.MaxBalanceChange,
-		MinFee:           p.MinFee,
-		MaxFee:           p.MaxFee,
-		DeploymentFee:    p.DeploymentFee,
-		MaxCost:          maxCost,
-		NewAccountRatio:  p.NewAccountRatio,
-	}
-	if maxCost {
-		// This can be set to arbitrary value as for max-cost it only
-		// matters that total zkapps deployed is above 5
-		// We need to set it this way to override setting accountQueueSize
-		// by the orchestrator
-		zkappParams.ZkappsToDeploy = 20
-		zkappParams.NewAccountRatio = 0
-	}
-	paymentParams := lib.PaymentSubParams{
-		ExperimentName: experimentName,
-		Tps:            tps - zkappTps,
-		MinTps:         p.MinTps,
-		DurationMin:    p.RoundDurationMin,
-		MinFee:         p.MinFee,
-		MaxFee:         p.MaxFee,
-		Amount:         p.PaymentAmount,
-		Receiver:       p.PaymentReceiver,
-	}
-	cmds := []Command{}
-	roundStartMin := round*(p.RoundDurationMin+p.PauseMin) + round/p.LargePauseEveryNRounds*p.LargePauseMin
-	if len(p.RotationKeys) > 0 {
-		var mapping []int
-		nKeys := len(p.RotationKeys)
-		if p.RotationPermutation {
-			mapping = rand.Perm(nKeys)
-		} else {
-			mapping = make([]int, nKeys)
-			for i := range mapping {
-				mapping[i] = rand.Intn(len(p.RotationKeys))
-			}
-		}
-		cmds = append(cmds, rotate(lib.RotateParams{
-			Pubkeys:     p.RotationKeys,
-			RestServers: p.RotationServers,
-			Mapping:     mapping,
-			Ratio:       p.RotationRatio,
-			PasswordEnv: p.PasswordEnv,
-		}))
-	}
-	cmds = append(cmds, withComment(fmt.Sprintf("Starting round %d, %s after start", round, formatDur(roundStartMin, 0)), discovery(lib.DiscoveryParams{
-		OffsetMin:        15,
-		NoBlockProducers: p.SendFromNonBpsOnly,
-	})))
-	sendersOutName := "participant"
-	if 1-p.SenderRatio > 1e-6 {
-		sendersOutName = "group1"
-		cmds = append(cmds, sample(-1, "participant", []float64{p.SenderRatio}))
-	}
-	if onlyPayments {
-		cmds = append(cmds, loadKeys(lib.KeyloaderParams{Dir: paymentsKeysDir}))
-		cmds = append(cmds, payments(-1, -2, sendersOutName, paymentParams))
-	} else if onlyZkapps {
-		cmds = append(cmds, loadKeys(lib.KeyloaderParams{Dir: zkappsKeysDir}))
-		cmds = append(cmds, zkapps(-1, -2, sendersOutName, zkappParams))
-	} else {
-		cmds = append(cmds, loadKeys(lib.KeyloaderParams{Dir: zkappsKeysDir}))
-		cmds = append(cmds, loadKeys(lib.KeyloaderParams{Dir: paymentsKeysDir}))
-		cmds = append(cmds, zkapps(-2, -3, sendersOutName, zkappParams))
-		cmds = append(cmds, payments(-2, -4, sendersOutName, paymentParams))
-		cmds = append(cmds, join(-1, "participant", -2, "participant"))
-	}
-	sendersCmdId := len(cmds)
-	stopWaits := make([]int, p.StopsPerRound)
-	for i := 0; i < p.StopsPerRound; i++ {
-		stopWaits[i] = rand.Intn(60 * p.RoundDurationMin)
-	}
-	sort.Ints(stopWaits)
-	for i := p.StopsPerRound - 1; i > 0; i-- {
-		stopWaits[i] -= stopWaits[i-1]
-	}
-	stopRatio := sampleStopRatio(p.MinStopRatio, p.MaxStopRatio)
-	elapsed := 0
-	for _, waitSec := range stopWaits {
-		cmds = append(cmds, withComment(fmt.Sprintf("Running round %d, %s after start, waiting for %s", round, formatDur(roundStartMin, elapsed), formatDur(0, waitSec)), wait(waitSec)))
-		cmds = append(cmds, discovery(lib.DiscoveryParams{
-			OffsetMin:          15,
-			OnlyBlockProducers: p.StopOnlyBps,
-		}))
-		exceptRefName := "group"
-		if onlyPayments || onlyZkapps {
-			exceptRefName = "participant"
-		}
-		cmds = append(cmds, except(-1, "participant", sendersCmdId-len(cmds)-1, exceptRefName))
-		stopCleanRatio := p.StopCleanRatio * stopRatio
-		stopNoCleanRatio := (1 - p.StopCleanRatio) * stopRatio
-		nodesOrBps := "nodes"
-		if p.StopOnlyBps {
-			nodesOrBps = "block producers"
-		}
-		if stopCleanRatio > 1e-6 && stopNoCleanRatio > 1e-6 {
-			cmds = append(cmds, sample(-1, "group", []float64{stopCleanRatio, stopNoCleanRatio}))
-			comment1 := fmt.Sprintf("Stopping %.1f%% %s with cleaning", stopCleanRatio*100, nodesOrBps)
-			cmds = append(cmds, withComment(comment1, stopDaemon(p.UseRestartScript, -1, "group1", true)))
-			comment2 := fmt.Sprintf("Stopping %.1f%% %s without cleaning", stopNoCleanRatio*100, nodesOrBps)
-			cmds = append(cmds, withComment(comment2, stopDaemon(p.UseRestartScript, -2, "group2", false)))
-		} else if stopCleanRatio > 1e-6 {
-			comment := fmt.Sprintf("Stopping %.1f%% %s with cleaning", stopCleanRatio*100, nodesOrBps)
-			cmds = append(cmds, sample(-1, "group", []float64{stopCleanRatio}))
-			cmds = append(cmds, withComment(comment, stopDaemon(p.UseRestartScript, -1, "group1", true)))
-		} else if stopNoCleanRatio > 1e-6 {
-			comment := fmt.Sprintf("Stopping %.1f%% %s without cleaning", stopNoCleanRatio*100, nodesOrBps)
-			cmds = append(cmds, sample(-1, "group", []float64{stopNoCleanRatio}))
-			cmds = append(cmds, withComment(comment, stopDaemon(p.UseRestartScript, -1, "group1", false)))
-		}
-		elapsed += waitSec
-	}
-	if round < p.Rounds-1 {
-		comment1 := fmt.Sprintf("Waiting for remainder of round %d, %s after start", round, formatDur(roundStartMin, elapsed))
-		cmds = append(cmds, withComment(comment1, wait(p.RoundDurationMin*60-elapsed)))
-		if p.PauseMin > 0 {
-			comment2 := fmt.Sprintf("Pause after round %d, %s after start", round, formatDur(roundStartMin+p.RoundDurationMin, 0))
-			cmds = append(cmds, withComment(comment2, waitMin(p.PauseMin)))
-		}
-		if p.LargePauseMin > 0 && (round+1)%p.LargePauseEveryNRounds == 0 {
-			comment3 := fmt.Sprintf("Large pause after round %d, %s after start", round, formatDur(roundStartMin+p.RoundDurationMin+p.PauseMin, 0))
-			cmds = append(cmds, withComment(comment3, waitMin(p.LargePauseMin)))
-		}
-	}
-	fundCmds := []lib.FundParams{}
-	if !onlyPayments {
-		_, _, _, initBalance := lib.ZkappBalanceRequirements(zkappTps, zkappParams)
-		zkappKeysNum, zkappAmount := lib.ZkappKeygenRequirements(initBalance, zkappParams)
-		fundCmds = append(fundCmds,
-			lib.FundParams{
-				PasswordEnv: p.PasswordEnv,
-				Prefix:      zkappsKeysDir + "/key",
-				Amount:      zkappAmount,
-				Fee:         p.FundFee,
-				Num:         zkappKeysNum,
-			})
-	}
-	if !onlyZkapps {
-		paymentKeysNum, paymentAmount := lib.PaymentKeygenRequirements(p.Gap, paymentParams)
-		fundCmds = append(fundCmds,
-			lib.FundParams{
-				PasswordEnv: p.PasswordEnv,
-				// Privkeys:    privkeys,
-				Prefix: paymentsKeysDir + "/key",
-				Amount: paymentAmount,
-				Fee:    p.FundFee,
-				Num:    paymentKeysNum,
-			})
-	}
-	return GeneratedRound{
-		Commands:     cmds,
-		FundCommands: fundCmds,
-	}
+func fund(p lib.FundParams) lib.GeneratedCommand {
+	return lib.GeneratedCommand{Action: lib.FundAction{}.Name(), Params: p}
 }
 
 func checkRatio(ratio float64, msg string) {
@@ -429,7 +26,7 @@ const mixMaxCostTpsRatioHelp = "when provided, specifies ratio of tps (proportio
 func main() {
 	var rotateKeys, rotateServers string
 	var mode string
-	var p Params
+	var p lib.GenParams
 	flag.Float64Var(&p.BaseTps, "base-tps", 0.3, "Base tps rate for the whole network")
 	flag.Float64Var(&p.StressTps, "stress-tps", 1, "stress tps rate for the whole network")
 	flag.Float64Var(&p.MinTps, "min-tps", 0.01, "minimal tps per node")
@@ -466,8 +63,10 @@ func main() {
 	flag.Uint64Var(&p.MinBalanceChange, "min-balance-change", 0, "Min balance change for zkapp account update")
 	flag.Uint64Var(&p.DeploymentFee, "deployment-fee", 1e9, "Zkapp deployment fee")
 	flag.Uint64Var(&p.FundFee, "fund-fee", 1e9, "Funding tx fee")
-	flag.Uint64Var(&p.MinFee, "min-fee", 1e9, "Min tx fee")
-	flag.Uint64Var(&p.MaxFee, "max-fee", 2e9, "Max tx fee")
+	flag.Uint64Var(&p.MinPaymentFee, "min-payment-fee", 1e8, "Min payment fee")
+	flag.Uint64Var(&p.MaxPaymentFee, "max-payment-fee", 2e8, "Max payment fee")
+	flag.Uint64Var(&p.MinZkappFee, "min-zkapp-fee", 1e9, "Min zkapp tx fee")
+	flag.Uint64Var(&p.MaxZkappFee, "max-zkapp-fee", 2e9, "Max zkapp tx fee")
 	flag.Uint64Var(&p.PaymentAmount, "payment-amount", 1e5, "Payment amount")
 	flag.Parse()
 	checkRatio(p.SenderRatio, "wrong sender ratio")
@@ -519,13 +118,13 @@ func main() {
 	switch mode {
 	case "stop-ratio-distribution":
 		for i := 0; i < 10000; i++ {
-			v := sampleStopRatio(p.MinStopRatio, p.MaxStopRatio)
+			v := lib.SampleStopRatio(p.MinStopRatio, p.MaxStopRatio)
 			fmt.Println(v)
 		}
 		return
 	case "tps-distribution":
 		for i := 0; i < 10000; i++ {
-			v := sampleTps(p.BaseTps, p.StressTps)
+			v := lib.SampleTps(p.BaseTps, p.StressTps)
 			fmt.Println(v)
 		}
 		return
@@ -546,25 +145,31 @@ func main() {
 	}
 	writeComment("Generated with: " + strings.Join(os.Args, " "))
 	writeComment("Funding keys for the experiment")
-	writeCommand := func(cmd Command) {
-		if cmd.comment != "" {
-			writeComment(cmd.comment)
+	writeCommand := func(cmd lib.GeneratedCommand) {
+		comment := cmd.Comment()
+		if comment != "" {
+			writeComment(comment)
 		}
 		if err := encoder.Encode(cmd); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing command: %v\n", err)
 			os.Exit(3)
 		}
 	}
-	cmds := []Command{}
+	cmds := []lib.GeneratedCommand{}
 	fundCmds := []lib.FundParams{}
 	for r := 0; r < p.Rounds; r++ {
 		round := p.Generate(r)
 		cmds = append(cmds, round.Commands...)
-		fundCmds = append(fundCmds, round.FundCommands...)
+		if round.PaymentFundCommand != nil {
+			fundCmds = append(fundCmds, *round.PaymentFundCommand)
+		}
+		if round.ZkappFundCommand != nil {
+			fundCmds = append(fundCmds, *round.ZkappFundCommand)
+		}
 	}
 	privkeys := p.Privkeys
 	if p.GenerateFundKeys > 0 {
-		fundKeysDir := fmt.Sprintf("%s/funding", p.FundKeyPrefix)
+		fundKeysDir := fmt.Sprintf("%s/funding/%s", p.FundKeyPrefix, p.ExperimentName)
 		privkeys = make([]string, p.GenerateFundKeys)
 		privkeyAmounts := make([]uint64, p.GenerateFundKeys)
 		for i := range privkeys {
@@ -594,7 +199,7 @@ func main() {
 			Fee:         p.FundFee,
 			Num:         p.GenerateFundKeys,
 		}))
-		writeCommand(wait(1))
+		writeCommand(lib.GenWait(1))
 	}
 	privkeysExt := append(privkeys, privkeys...)
 	for i, cmd := range fundCmds {

--- a/src/app/itn_orchestrator/src/payments.go
+++ b/src/app/itn_orchestrator/src/payments.go
@@ -32,15 +32,15 @@ type ScheduledPaymentsReceipt struct {
 func PaymentKeygenRequirements(gap int, params PaymentSubParams) (int, uint64) {
 	maxParticipants := int(math.Ceil(params.Tps / params.MinTps))
 	txCost := params.MaxFee + params.Amount
-	tpsGap := uint64(math.Round(params.Tps * float64(gap)))
+	tpsGap := uint64(math.Ceil(params.Tps * float64(gap)))
 	totalTxs := uint64(math.Ceil(float64(params.DurationMin) * 60 * params.Tps))
 	balance := 3 * txCost * totalTxs
 	keys := maxParticipants + int(tpsGap)*2
 	return keys, balance
 }
 
-func schedulePaymentsDo(config Config, params PaymentParams, nodeAddress NodeAddress, batchIx int, tps float64, feePayers []itn_json_types.MinaPrivateKey) (string, error) {
-	paymentInput := PaymentsDetails{
+func paymentInput(params PaymentSubParams, batchIx int, tps float64) PaymentsDetails {
+	return PaymentsDetails{
 		DurationMin: params.DurationMin,
 		Tps:         tps,
 		MemoPrefix:  fmt.Sprintf("%s-%d", params.ExperimentName, batchIx),
@@ -48,8 +48,12 @@ func schedulePaymentsDo(config Config, params PaymentParams, nodeAddress NodeAdd
 		MinFee:      params.MinFee,
 		Amount:      params.Amount,
 		Receiver:    params.Receiver,
-		Senders:     feePayers,
 	}
+}
+
+func schedulePaymentsDo(config Config, params PaymentSubParams, nodeAddress NodeAddress, batchIx int, tps float64, feePayers []itn_json_types.MinaPrivateKey) (string, error) {
+	paymentInput := paymentInput(params, batchIx, tps)
+	paymentInput.Senders = feePayers
 	handle, err := SchedulePaymentsGql(config, nodeAddress, paymentInput)
 	if err == nil {
 		config.Log.Infof("scheduled payment batch %d with tps %f for %s: %s", batchIx, tps, nodeAddress, handle)
@@ -67,7 +71,7 @@ func SchedulePayments(config Config, params PaymentParams, output func(Scheduled
 	for nodeIx, nodeAddress := range nodes {
 		feePayers := remFeePayers[:feePayersPerNode]
 		var handle string
-		handle, err = schedulePaymentsDo(config, params, nodeAddress, len(successfulNodes), tps, feePayers)
+		handle, err = schedulePaymentsDo(config, params.PaymentSubParams, nodeAddress, len(successfulNodes), tps, feePayers)
 		if err != nil {
 			config.Log.Warnf("error scheduling payments for %s: %v", nodeAddress, err)
 			n := len(nodes) - nodeIx - 1
@@ -88,7 +92,7 @@ func SchedulePayments(config Config, params PaymentParams, output func(Scheduled
 	if err != nil {
 		// last schedule payment request didn't work well
 		for _, nodeAddress := range successfulNodes {
-			handle, err2 := schedulePaymentsDo(config, params, nodeAddress, len(successfulNodes), tps, remFeePayers)
+			handle, err2 := schedulePaymentsDo(config, params.PaymentSubParams, nodeAddress, len(successfulNodes), tps, remFeePayers)
 			if err2 != nil {
 				config.Log.Warnf("error scheduling second batch of payments for %s: %v", nodeAddress, err2)
 				continue

--- a/src/lib/crypto/kimchi_backend/common/gen_version.sh
+++ b/src/lib/crypto/kimchi_backend/common/gen_version.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 if [ -z ${MARLIN_REPO_SHA+x} ]; then
-    marlin_submodule_dir=$(git submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
-    marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
+    # Check for the existence of the 'mina' submodule
+    git_root=$(git rev-parse --show-toplevel)
+    mina_submodule=$(git submodule status | grep "mina" || true)
+
+    if [[ -n "$mina_submodule" ]]; then
+        marlin_submodule_dir=$(git -C "$git_root/src/mina" submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
+        marlin_repo_sha=$(git -C "$git_root/src/mina/$marlin_submodule_dir" rev-parse --short=8 --verify HEAD)
+    else
+        marlin_submodule_dir=$(git submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
+        marlin_repo_sha=$(git -C "$marlin_submodule_dir" rev-parse --short=8 --verify HEAD)
+    fi
 else
     marlin_repo_sha=$(cut -b -8 <<< "$MARLIN_REPO_SHA")
 fi

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -191,6 +191,10 @@ module Status = struct
       ; transaction_pool_diff_broadcasted : int
       ; transactions_added_to_pool : int
       ; transaction_pool_size : int
+      ; snark_pool_diff_received : int
+      ; snark_pool_diff_broadcasted : int
+      ; pending_snark_work : int
+      ; snark_pool_size : int
       }
     [@@deriving to_yojson, bin_io_unversioned, fields]
   end
@@ -423,9 +427,19 @@ module Status = struct
         let transaction_pool_size =
           fmt_field "transaction_pool_size" string_of_int
         in
+        let snark_pool_diff_received =
+          fmt_field "snark_pool_diff_received" string_of_int
+        in
+        let snark_pool_diff_broadcasted =
+          fmt_field "snark_pool_diff_broadcasted" string_of_int
+        in
+        let pending_snark_work = fmt_field "pending_snark_work" string_of_int in
+        let snark_pool_size = fmt_field "snark_pool_size" string_of_int in
         Metrics.Fields.to_list ~block_production_delay
           ~transaction_pool_diff_received ~transaction_pool_diff_broadcasted
           ~transactions_added_to_pool ~transaction_pool_size
+          ~snark_pool_diff_received ~snark_pool_diff_broadcasted
+          ~pending_snark_work ~snark_pool_size
         |> List.concat
         |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
         |> digest_entries ~title:""

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -466,6 +466,13 @@ let get_status ~flag t =
       ; transactions_added_to_pool =
           Float.to_int
           @@ Counter.value Transaction_pool.transactions_added_to_pool
+      ; snark_pool_diff_received =
+          Float.to_int @@ Gauge.value Network.snark_pool_diff_received
+      ; snark_pool_diff_broadcasted =
+          Float.to_int @@ Gauge.value Network.snark_pool_diff_broadcasted
+      ; snark_pool_size = Float.to_int @@ Gauge.value Snark_work.snark_pool_size
+      ; pending_snark_work =
+          Float.to_int @@ Gauge.value Snark_work.pending_snark_work
       }
   in
   { Daemon_rpcs.Types.Status.num_accounts

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1665,21 +1665,23 @@ let mk_account_update ~pk ~vk : Account_update.Simple.t =
   ; authorization = Control.(dummy_of_tag Proof)
   }
 
-let mk_fee_payer ~pk ~nonce : Account_update.Fee_payer.t =
-  { body =
-      { public_key = pk
-      ; fee = Currency.Fee.of_mina_string_exn "1.0"
-      ; valid_until = None
-      ; nonce
-      }
+let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
+  { body = { public_key = pk; fee; valid_until = None; nonce }
   ; authorization = Signature.dummy
   }
 
-let gen_max_cost_zkapp_command_from
+let gen_max_cost_zkapp_command_from ?memo ?fee_range
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(account_state_tbl : (Account.t * role) Account_id.Table.t) ~vk
-    ~(genesis_constants : Genesis_constants.t) =
+    ~(genesis_constants : Genesis_constants.t) () =
   let open Quickcheck.Generator.Let_syntax in
+  let%bind memo =
+    match memo with
+    | Some memo ->
+        return @@ Signed_command_memo.create_from_string_exn memo
+    | None ->
+        Signed_command_memo.gen
+  in
   let zkapp_accounts =
     Account_id.Table.data account_state_tbl
     |> List.filter_map ~f:(fun ((a, role) : Account.t * role) ->
@@ -1702,13 +1704,12 @@ let gen_max_cost_zkapp_command_from
     |> Quickcheck.Generator.list_with_length
          genesis_constants.max_event_elements
   in
-  let%map actions =
+  let%bind actions =
     Snark_params.Tick.Field.gen
     |> Quickcheck.Generator.map ~f:(fun x -> [| x |])
     |> Quickcheck.Generator.list_with_length
          genesis_constants.max_action_elements
   in
-
   let account_updates =
     { head with body = { head.body with events; actions } } :: tail
   in
@@ -1719,16 +1720,20 @@ let gen_max_cost_zkapp_command_from
   let fee_payer_account, _ =
     Account_id.Table.find_exn account_state_tbl fee_payer_id
   in
+  let%map fee =
+    Option.value_map fee_range
+      ~default:(return @@ Currency.Fee.of_mina_string_exn "1.0")
+      ~f:Currency.Fee.(fun (lo, hi) -> gen_incl lo hi)
+  in
   let fee_payer =
-    mk_fee_payer ~pk:fee_payer_pk ~nonce:fee_payer_account.nonce
+    mk_fee_payer ~fee ~pk:fee_payer_pk ~nonce:fee_payer_account.nonce
   in
   Account_id.Table.change account_state_tbl fee_payer_id ~f:(function
     | None ->
         None
     | Some (a, role) ->
         Some ({ a with nonce = Account.Nonce.succ a.nonce }, role) ) ;
-  Zkapp_command.of_simple
-    { fee_payer; account_updates; memo = Signed_command_memo.empty }
+  Zkapp_command.of_simple { fee_payer; account_updates; memo }
 
 let%test_module _ =
   ( module struct

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -97,8 +97,11 @@ val gen_list_of_zkapp_command_from :
 
 (** Generate a zkapp command with max cost *)
 val gen_max_cost_zkapp_command_from :
-     fee_payer_keypair:Signature_lib.Keypair.t
+     ?memo:string
+  -> ?fee_range:Currency.Fee.t * Currency.Fee.t
+  -> fee_payer_keypair:Signature_lib.Keypair.t
   -> account_state_tbl:(Account.t * role) Account_id.Table.t
   -> vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
   -> genesis_constants:Genesis_constants.t
+  -> unit
   -> Zkapp_command.t Quickcheck.Generator.t

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -125,9 +125,10 @@ let rec wait_until_zkapps_deployed ?(deployed = false) ~scheduler_tbl ~mina
       "Some deployed zkApp accounts weren't found in the best tip ledger, \
        trying again" ;
     let%bind () =
+      (* Checking three times per block window to avoid unnecessary waiting after the block is created *)
       Async.after
         (Time.Span.of_ms
-           (Float.of_int constraint_constants.block_window_duration_ms) )
+           (Float.of_int constraint_constants.block_window_duration_ms /. 3.0) )
     in
     let ledger =
       Utils.get_ledger_and_breadcrumb mina
@@ -223,13 +224,19 @@ let send_zkapps ~fee_payer_array ~constraint_constants ~tm_end ~scheduler_tbl
           @@ Quickcheck.Generator.generate
                ( if zkapp_command_details.max_cost then
                  Mina_generators.Zkapp_command_generators
-                 .gen_max_cost_zkapp_command_from ~fee_payer_keypair:fee_payer
-                   ~account_state_tbl ~vk
+                 .gen_max_cost_zkapp_command_from ~memo
+                   ~fee_range:
+                     ( zkapp_command_details.min_fee
+                     , zkapp_command_details.max_fee )
+                   ~fee_payer_keypair:fee_payer ~account_state_tbl ~vk
                    ~genesis_constants:
                      (Mina_lib.config mina).precomputed_values.genesis_constants
+                   ()
                else
                  Mina_generators.Zkapp_command_generators.gen_zkapp_command_from
                    ~memo
+                   ?max_account_updates:
+                     zkapp_command_details.max_account_updates
                    ~no_account_precondition:
                      zkapp_command_details.no_precondition
                    ~fee_range:

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -299,7 +299,10 @@ module DaemonStatus = struct
              ~block_production_delay:nn_int_list
              ~transaction_pool_diff_received:nn_int
              ~transaction_pool_diff_broadcasted:nn_int
-             ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int )
+             ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int
+             ~snark_pool_diff_received:nn_int
+             ~snark_pool_diff_broadcasted:nn_int ~pending_snark_work:nn_int
+             ~snark_pool_size:nn_int )
 
   let t : (_, Daemon_rpcs.Types.Status.t option) typ =
     obj "DaemonStatus" ~fields:(fun _ ->
@@ -2941,6 +2944,7 @@ module Input = struct
         ; max_cost : bool
         ; balance_change_range :
             Mina_generators.Zkapp_command_generators.balance_change_range_t
+        ; max_account_updates : int option
         }
 
       let arg_typ : ((input, string) result option, input option) arg_typ =
@@ -2951,7 +2955,7 @@ module Input = struct
                        min_balance_change max_balance_change
                        min_new_zkapp_balance max_new_zkapp_balance init_balance
                        min_fee max_fee deployment_fee account_queue_size
-                       max_cost ->
+                       max_cost max_account_updates ->
             Result.return
               { fee_payers
               ; num_zkapps_to_deploy
@@ -2966,6 +2970,7 @@ module Input = struct
               ; deployment_fee
               ; account_queue_size
               ; max_cost
+              ; max_account_updates
               ; balance_change_range =
                   { min_balance_change
                   ; max_balance_change
@@ -2981,7 +2986,7 @@ module Input = struct
               t.balance_change_range.min_new_zkapp_balance
               t.balance_change_range.max_new_zkapp_balance t.init_balance
               t.min_fee t.max_fee t.deployment_fee t.account_queue_size
-              t.max_cost )
+              t.max_cost t.max_account_updates )
           ~fields:
             Arg.
               [ arg "feePayers"
@@ -3028,6 +3033,12 @@ module Input = struct
                   ~typ:(non_null int)
               ; arg "maxCost" ~doc:"Generate max cost zkApp command"
                   ~typ:(non_null bool)
+              ; arg "maxAccountUpdates"
+                  ~doc:
+                    "Parameter of zkapp generation, each generated zkapp tx \
+                     will have (2*maxAccountUpdates+2) account updates \
+                     (including balancing and fee payer)"
+                  ~typ:int
               ]
     end
 

--- a/src/lib/mina_ledger/sync_ledger.ml
+++ b/src/lib/mina_ledger/sync_ledger.ml
@@ -26,7 +26,7 @@ module Mask = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Any_ledger = Syncable_ledger.Make (struct
@@ -36,7 +36,7 @@ module Any_ledger = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Db = Syncable_ledger.Make (struct
@@ -46,7 +46,7 @@ module Db = Syncable_ledger.Make (struct
   module Hash = Hash
   module Root_hash = Root_hash
 
-  let account_subtree_height = 3
+  let account_subtree_height = 6
 end)
 
 module Answer = struct

--- a/src/lib/mina_version/normal/gen.sh
+++ b/src/lib/mina_version/normal/gen.sh
@@ -12,7 +12,12 @@ pushd "$root" > /dev/null
   if [[ -e .git ]] && ! git diff --quiet; then id="[DIRTY]$id"; fi
   commit_date="${MINA_COMMIT_DATE-$(git show HEAD -s --format="%cI" || echo "<unknown>")}"
 
-  pushd src/lib/crypto/proof-systems > /dev/null
+  mina_submodule=$(git submodule status | grep "mina" || true)
+  if [[ -n "$mina_submodule" ]]; then
+    pushd src/mina/src/lib/crypto/proof-systems > /dev/null
+  else
+    pushd src/lib/crypto/proof-systems > /dev/null
+  fi
     marlin_commit_id="${MARLIN_COMMIT_ID-$(git rev-parse --verify HEAD || echo "<unknown>")}"
     marlin_commit_id_short="$(printf '%s' "$marlin_commit_id" | cut -c1-8)"
     if [[ -e .git ]] && ! git diff --quiet; then marlin_commit_id="[DIRTY]$marlin_commit_id"; fi

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1047,7 +1047,7 @@ struct
           in
           Deferred.return
           @@ Result.ok_if_true
-               (not (already_mem && not is_sender_local))
+               ((not already_mem) || is_sender_local)
                ~error:Recently_seen
         in
         let%bind () =

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -152,6 +152,14 @@ let check_well_formedness ~genesis_constants (t : t) =
       Ok ()
 
 let yojson_summary_of_command =
+  let is_proof upd =
+    match Account_update.authorization upd with Proof _ -> true | _ -> false
+  in
+  let zkapp_type cmd =
+    let updates = Zkapp_command.account_updates_list cmd in
+    Printf.sprintf "zkapp:%d:%d" (List.length updates)
+      (List.count updates ~f:is_proof)
+  in
   let mk_record type_ memo signature =
     `List
       [ `String type_
@@ -161,7 +169,7 @@ let yojson_summary_of_command =
   in
   function
   | User_command.Zkapp_command cmd ->
-      mk_record "zkapp" (Zkapp_command.memo cmd)
+      mk_record (zkapp_type cmd) (Zkapp_command.memo cmd)
         ( Zkapp_command.fee_payer_account_update cmd
         |> Account_update.Fee_payer.authorization )
   | Signed_command cmd ->

--- a/src/libp2p_ipc/dune
+++ b/src/libp2p_ipc/dune
@@ -1,7 +1,7 @@
 (library
  (name libp2p_ipc)
  (public_name libp2p_ipc)
- (flags -w -53)
+ (flags -w -53-55)
  (inline_tests (flags -verbose -show-counts))
  (libraries
    ;; opam libraries


### PR DESCRIPTION
Explain your changes:
Fixes some of the scripts called by dune to use different absolute paths if we are building mina in the context of the o1js as mina being a submodule.

The issue occurs when we build o1js from the root directory with mina as a submodule. Dune will try to resolve some absolute paths from build scripts that will fail and not build o1js properly. To fix this, we conditionally check for submodule locations and change the paths if we have a mina submodule present, otherwise, we use the same build process. This lets us build mina the same way but also build o1js dependencies properly.

Explain how you tested your changes:
Built mina from the root directory to test normal building and built o1js using mina as a submodule successfully.