### PR TITLE
Don't normalize signed zero currency values

### DIFF
--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -474,10 +474,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
       type magnitude = Unsigned.t [@@deriving sexp, compare]
 
-      let create ~magnitude ~sgn =
-        { magnitude
-        ; sgn = (if Unsigned.(equal magnitude zero) then Sgn.Pos else sgn)
-        }
+      let create ~magnitude ~sgn = { magnitude; sgn }
 
       let sgn { sgn; _ } = sgn
 


### PR DESCRIPTION
The `create` function for signed currency values was normalizing the sign to `Pos` if the magnitude was zero. But it was possible to create a zero value with a `Neg` sign from JSON, so the normalization did not preclude the existence of zero values with `Neg` sign.

On ITN, a zkApp had a zero balance change with a `Neg` sign. That was correctly stored in the archive db as `-0`. But `Currency.Amount.Signed.create` was called by the replayer when loading from the archive db, resulting in a zkApp that differed from the original, and so the replayer failed on that zkApp.

That change was hard to track down: the different sign caused the stack hashes in the zkApp to differ, and so the transaction commitment changed, and the receipt chain hash in the replayer differed from that in the archive db.

The `equal` and `is_zero` functions already disregard the sign if the magnitude is zero, so this change should not be harmful.