### PR TITLE
Function to preserve sign for 0

### DIFF
--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -448,7 +448,8 @@ let get_account_update_body ~pool body_id =
       | _ ->
           failwith "Ill-formatted string for balance change"
     in
-    Currency.Amount.Signed.create ~magnitude ~sgn
+    (* amount might be negative zero *)
+    Currency.Amount.Signed.create_preserve_zero_sign ~magnitude ~sgn
   in
   let%bind events = load_events pool events_id in
   let%bind actions = load_events pool actions_id in

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -479,6 +479,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; sgn = (if Unsigned.(equal magnitude zero) then Sgn.Pos else sgn)
         }
 
+      let create_preserve_zero_sign ~magnitude ~sgn = { magnitude; sgn }
+
       let sgn { sgn; _ } = sgn
 
       let magnitude { magnitude; _ } = magnitude

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -125,6 +125,9 @@ module type Signed_intf = sig
 
   val create : magnitude:magnitude -> sgn:Sgn.t -> t
 
+  (* allows creation of negative 0 *)
+  val create_preserve_zero_sign : magnitude:magnitude -> sgn:Sgn.t -> t
+
   val sgn : t -> Sgn.t
 
   val magnitude : t -> magnitude


### PR DESCRIPTION
Add `Amount.Sign.create_preserve_zero_sign`, to allow replayer to load negative zero from database.

This approach allowed replayer to succeed on ITN database.

Closes #14452.