### PR TITLE
Format last_vrf_output as Base64

### DIFF
--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -27,8 +27,8 @@
    child_processes
    precomputed_values
    coda_genesis_ledger
+   consensus.vrf
    mina_runtime_config
-   hex
    sgn
    mina_base.util
    kimchi_backend.pasta
@@ -72,9 +72,10 @@
    mina_version
    staged_ledger_diff
    error_json
+   ppx_deriving_yojson.runtime
    ppx_version.runtime
  )
  (inline_tests (flags -verbose -show-counts))
  (modes native)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_mina ppx_version ppx_jane ppx_custom_printf h_list.ppx)))
+ (preprocess (pps ppx_mina ppx_version ppx_jane ppx_custom_printf ppx_deriving_yojson h_list.ppx)))

--- a/src/app/archive/lib/extensional.ml
+++ b/src/app/archive/lib/extensional.ml
@@ -111,7 +111,7 @@ module Block = struct
         ; parent_hash : State_hash.Stable.V1.t
         ; creator : Public_key.Compressed.Stable.V1.t
         ; block_winner : Public_key.Compressed.Stable.V1.t
-        ; last_vrf_output : string
+        ; last_vrf_output : Consensus_vrf.Output.Truncated.Stable.V1.t
         ; snarked_ledger_hash : Frozen_ledger_hash.Stable.V1.t
         ; staking_epoch_data : Mina_base.Epoch_data.Value.Stable.V1.t
         ; next_epoch_data : Mina_base.Epoch_data.Value.Stable.V1.t

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -18,6 +18,7 @@
    uri
    async.async_command
    ;; local libraries
+   consensus_vrf
    mina_wire_types
    mina_base
    mina_base.import

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -49,8 +49,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
   let%bind creator = pk_of_id block.creator_id in
   let%bind block_winner = pk_of_id block.block_winner_id in
   let last_vrf_output =
-    (* keep hex encoding *)
-    block.last_vrf_output
+    Base64.decode_exn ~alphabet:Base64.uri_safe_alphabet block.last_vrf_output
   in
   let%bind snarked_ledger_hash_str =
     query_db ~f:(fun db ->

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1574,7 +1574,7 @@ let () =
       Command.async ~summary:"Replay transactions from Mina archive database"
         (let%map input_file =
            Param.flag "--input-file"
-             ~doc:"file File containing the genesis ledger"
+             ~doc:"file File containing the starting ledger"
              Param.(required string)
          and output_file_opt =
            Param.flag "--output-file"

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -464,16 +464,3 @@ module Parent_block = struct
       epoch_ledgers_state_hash =
     Conn.find query_parent_state_hash epoch_ledgers_state_hash
 end
-
-module Balances = struct
-  let query_insert_nonce =
-    Caqti_request.exec
-      Caqti_type.(tup2 int int64)
-      {sql| UPDATE balances
-            SET nonce = $2
-            WHERE id = $1
-      |sql}
-
-  let insert_nonce (module Conn : Caqti_async.CONNECTION) ~id ~nonce =
-    Conn.exec query_insert_nonce (id, nonce)
-end

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -165,20 +165,24 @@ module Output = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving sexp, equal, compare, hash]
+        type t = string [@@deriving sexp, equal, compare, hash, yojson]
 
         let to_yojson t =
           `String (Base64.encode_exn ~alphabet:Base64.uri_safe_alphabet t)
 
         let of_yojson = function
           | `String s ->
-              Result.map_error
-                  (Base64.decode ~alphabet:Base64.uri_safe_alphabet s)
-                  ~f:(function `Msg err ->
-                  sprintf
-                    "Error decoding vrf output in \
-                     Vrf.Output.Truncated.Stable.V1.of_yojson: %s"
-                    err )
+              (* missing type equation somewhere, add explicit type *)
+              ( match Base64.decode ~alphabet:Base64.uri_safe_alphabet s with
+                | Ok b64 ->
+                    Ppx_deriving_yojson_runtime.Result.Ok b64
+                | Error (`Msg err) ->
+                    Error
+                      (sprintf
+                         "Error decoding vrf output in \
+                          Vrf.Output.Truncated.Stable.V1.of_yojson: %s"
+                         err )
+                : (t, string) Ppx_deriving_yojson_runtime.Result.result )
           | _ ->
               Error
                 "Vrf.Output.Truncated.Stable.V1.of_yojson: Expected a string"
@@ -194,6 +198,9 @@ module Output = struct
 
       let description = "Vrf Truncated Output"
     end)
+
+    (* don't want the yojson functions from Make_base58_check *)
+    [%%define_locally Stable.Latest.(of_yojson, to_yojson)]
 
     open Tick
 

--- a/src/lib/consensus/vrf/dune
+++ b/src/lib/consensus/vrf/dune
@@ -47,6 +47,7 @@
    kimchi_bindings
    kimchi_types
    pasta_bindings
+   ppx_deriving_yojson.runtime
    ppx_version.runtime
  )
  (inline_tests (flags -verbose -show-counts))


### PR DESCRIPTION
The same change was made in the migration app in #12906, which is against `berkeley`. This is consistent with the formatting in precomputed blocks.

This PR is against `rampup`, in order to get this change for the next ITN deployment.

I will add the hex-to-Base64 change to #14419, so the migration script will take care of this column.

Also: in the replayer, fixed a comment and removed an unused module.

