### PR TITLE
Fix zero vesting period test

### DIFF
--- a/src/lib/mina_base/test/dune
+++ b/src/lib/mina_base/test/dune
@@ -17,6 +17,7 @@
   fields_derivers.zkapps
   fields_derivers.json
   fields_derivers.graphql
+  genesis_constants
   kimchi_backend.pasta
   kimchi_backend.pasta.basic
   mina_base
@@ -25,6 +26,7 @@
   pickles
   pickles.backend
   pickles_types
+  ppx_deriving_yojson.runtime
   ppx_version.runtime
   run_in_thread
   signature_lib

--- a/src/lib/mina_base/test/main.ml
+++ b/src/lib/mina_base/test/main.ml
@@ -140,9 +140,16 @@ let () =
           ] )
     ; Signature_test.
         ( "signatures"
-        , [ test_case "Signature decode after encode i identity" `Quick
+        , [ test_case "Signature decode after encode is identity" `Quick
               signature_decode_after_encode_is_identity
           ; test_case "Base58check is stable" `Quick base58Check_stable
+          ] )
+    ; Zero_vesting_period.
+        ( "zero vesting period"
+        , [ test_case "Zero vesting period is error" `Quick
+              zero_vesting_period_is_error
+          ; test_case "Nonzero vesting period is OK" `Quick
+              nonzero_vesting_period_ok
           ] )
     ; Zkapp_command_test.
         ( "zkApp commands"

--- a/src/lib/mina_base/test/zero_vesting_period.ml
+++ b/src/lib/mina_base/test/zero_vesting_period.ml
@@ -17,7 +17,7 @@ let mk_zkapp_with_vesting_period n =
   "fee_payer": {
     "body": {
       "public_key": "B62qkb7Sed1VVsogq7qXzi79JNx9MkcbRihwwuSphUtBiEFPNTQfzNR",
-      "fee": "0.01",
+      "fee": "2.0",
       "valid_until": null,
       "nonce": "0"
     },


### PR DESCRIPTION
The zero vesting period tests in `Mina_base.Test` were bit-rotted, and not being run.

Fixed:
- the JSON for the zkApp was updated with the current syntax for account preconditions
- the tests were converted from `ppx_test` inline tests to Alcotest format, added to `main.ml`

Tested by running:
```
dune exec src/lib/mina_base/test/main.exe -- test '^zero vesting period$'
```

Output:
```
...
[OK]                zero vesting period          0   Zero vesting period is error.
[OK]                zero vesting period          1   Nonzero vesting period is OK.
...
```
Also, I temporarily changed the successful branches in the test to run `assert false`, and Alcotest reported the failures.