### PR TITLE
Making the Delegation Backend Unit Test soft fail

### DIFF
--- a/buildkite/src/Jobs/Test/DelegationBackendUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DelegationBackendUnitTest.dhall
@@ -12,6 +12,9 @@ let Command = ../../Command/Base.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
+let B = ../../External/Buildkite.dhall
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
 in
 
 Pipeline.build
@@ -34,6 +37,7 @@ Pipeline.build
             Cmd.runInDocker Cmd.Docker::{image = ContainerImages.delegationBackendToolchain} "cd src/app/delegation_backend && mkdir -p result && cp -R /headers result && cd src && go test"
           ],
           label = "delegation backend unit-tests",
+          soft_fail = Some (B/SoftFail.Boolean True),
           key = "delegation-backend-unit-tests",
           target = Size.Small,
           docker = None Docker.Type


### PR DESCRIPTION
Explain your changes:

Made the delegation backend unit test optional by including the soft_fail parameter to true in the step command.
Explain how you tested your changes:

Executing a CI run and confirming that even if the unit test fails it does not impact the overall job results.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
