### PR TITLE
Update mainnet replayer cron image

### DIFF
--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-not-orphaned-slot-5827016-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-compatible-47be9b9-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:


### PR DESCRIPTION
The image that had been used, `mina-rosetta:1.4.0beta2-alerts-readme-ea8d0f2-bullseye`, seems unavailable. That's different than the one in the `compatible` branch.

This PR updates the image. The replayer cron job ran successfully with the new image.