### PR TITLE
[rampup] Store snark work in the snark pool on disk

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -72,6 +72,7 @@
    ppx_version.runtime
    internal_tracing
    itn_logger
+   proof_cache_tag.filesystem
  )
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/dune-project
+++ b/src/dune-project
@@ -156,6 +156,7 @@
 (package (name ppx_version))
 (package (name precomputed_values))
 (package (name promise))
+(package (name proof_cache_tag))
 (package (name proof_carrying_data))
 (package (name protocols))
 (package (name protocol_version))

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -34,12 +34,12 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
   module Cache_tag = struct
     type value = t [@@deriving compare, equal, sexp, yojson, hash]
 
-    type t = value
-    (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
+    type t = Transaction_snark.Cache_tag.t
+    [@@deriving compare, equal, sexp, yojson, hash]
 
-    let unwrap (x : t) : value = x
+    let unwrap (x : t) : value = Transaction_snark.Cache_tag.unwrap x
 
-    let generate (x : value) : t = x
+    let generate (x : value) : t = Transaction_snark.Cache_tag.generate x
   end
 end
 

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -30,6 +30,17 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
 
   let create ~statement ~sok_digest ~proof =
     Transaction_snark.create ~statement:{ statement with sok_digest } ~proof
+
+  module Cache_tag = struct
+    type value = t [@@deriving compare, equal, sexp, yojson, hash]
+
+    type t = value
+    (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
+
+    let unwrap (x : t) : value = x
+
+    let generate (x : value) : t = x
+  end
 end
 
 include Prod

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -42,4 +42,14 @@ module type S = sig
   val sok_digest : t -> Sok_message.Digest.t
 
   val underlying_proof : t -> Proof.t
+
+  module Cache_tag : sig
+    type value := t
+
+    type t [@@deriving compare, equal, sexp, yojson, hash]
+
+    val unwrap : t -> value
+
+    val generate : value -> t
+  end
 end

--- a/src/lib/mina_base/proof_cache_tag/dune
+++ b/src/lib/mina_base/proof_cache_tag/dune
@@ -1,0 +1,5 @@
+(library
+ (public_name proof_cache_tag)
+ (virtual_modules proof_cache_tag)
+ (default_implementation proof_cache_tag.identity)
+ (libraries mina_base))

--- a/src/lib/mina_base/proof_cache_tag/dune
+++ b/src/lib/mina_base/proof_cache_tag/dune
@@ -2,4 +2,21 @@
  (public_name proof_cache_tag)
  (virtual_modules proof_cache_tag)
  (default_implementation proof_cache_tag.identity)
- (libraries mina_base))
+ (libraries
+   ;; opam libraries
+   ppx_inline_test.config
+   base.base_internalhash_types
+   bin_prot.shape
+   sexplib0
+   core_kernel
+   base.md5
+   base.caml
+   splittable_random
+   ;; local libraries
+   mina_base
+   mina_wire_types
+   pickles)
+ (preprocess
+  (pps ppx_annot ppx_snarky ppx_here ppx_mina ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make
+       ppx_base base_quickcheck.ppx_quickcheck ppx_bench ppx_let ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
+ )))

--- a/src/lib/mina_base/proof_cache_tag/filesystem/dune
+++ b/src/lib/mina_base/proof_cache_tag/filesystem/dune
@@ -1,0 +1,26 @@
+(library
+ (public_name proof_cache_tag.filesystem)
+ (name proof_cache_tag_filesystem)
+ (implements proof_cache_tag)
+ (libraries
+   ;; opam libraries
+   ppx_inline_test.config
+   base.base_internalhash_types
+   bin_prot.shape
+   sexplib0
+   core_kernel
+   stdio
+   base.md5
+   base.caml
+   splittable_random
+   core
+   ;; local libraries
+   mina_base
+   mina_wire_types
+   pickles)
+ (preprocess
+  (pps ppx_annot ppx_snarky ppx_here ppx_mina ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make
+       ppx_base base_quickcheck.ppx_quickcheck ppx_bench ppx_let ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
+ ))
+ (instrumentation (backend bisect_ppx))
+ )

--- a/src/lib/mina_base/proof_cache_tag/filesystem/proof_cache_tag.ml
+++ b/src/lib/mina_base/proof_cache_tag/filesystem/proof_cache_tag.ml
@@ -10,9 +10,9 @@ let prefix = Filename.temp_dir "mina" "proof_cache"
 
 let path i = prefix ^ Filename.dir_sep ^ Int.to_string i
 
-type t = {idx: int} [@@deriving compare, equal, sexp, yojson, hash]
+type t = { idx : int } [@@deriving compare, equal, sexp, yojson, hash]
 
-let unwrap ({idx = x} : t) : value =
+let unwrap ({ idx = x } : t) : value =
   (* Read from the file. *)
   In_channel.with_file ~binary:true (path x) ~f:(fun chan ->
       let str = In_channel.input_all chan in
@@ -23,11 +23,10 @@ let unwrap ({idx = x} : t) : value =
 let generate (x : value) : t =
   let new_counter = !counter in
   incr counter ;
-  let res = {idx = new_counter} in
+  let res = { idx = new_counter } in
   (* When this reference is GC'd, delete the file. *)
   Gc.Expert.add_finalizer_last_exn res (fun () ->
-      Core.Unix.unlink (path new_counter)
-    ) ;
+      Core.Unix.unlink (path new_counter) ) ;
   (* Write the proof to the file. *)
   Out_channel.with_file ~binary:true (path new_counter) ~f:(fun chan ->
       Out_channel.output_string chan

--- a/src/lib/mina_base/proof_cache_tag/filesystem/proof_cache_tag.ml
+++ b/src/lib/mina_base/proof_cache_tag/filesystem/proof_cache_tag.ml
@@ -1,0 +1,37 @@
+(* Cache proofs using the filesystem, one file per proof. *)
+
+open Core
+
+type value = Pickles.Proof.Proofs_verified_2.t
+
+let counter = ref 0
+
+let prefix = Filename.temp_dir "mina" "proof_cache"
+
+let path i = prefix ^ Filename.dir_sep ^ Int.to_string i
+
+type t = {idx: int} [@@deriving compare, equal, sexp, yojson, hash]
+
+let unwrap ({idx = x} : t) : value =
+  (* Read from the file. *)
+  In_channel.with_file ~binary:true (path x) ~f:(fun chan ->
+      let str = In_channel.input_all chan in
+      Binable.of_string
+        (module Pickles.Proof.Proofs_verified_2.Stable.Latest)
+        str )
+
+let generate (x : value) : t =
+  let new_counter = !counter in
+  incr counter ;
+  let res = {idx = new_counter} in
+  (* When this reference is GC'd, delete the file. *)
+  Gc.Expert.add_finalizer_last_exn res (fun () ->
+      Core.Unix.unlink (path new_counter)
+    ) ;
+  (* Write the proof to the file. *)
+  Out_channel.with_file ~binary:true (path new_counter) ~f:(fun chan ->
+      Out_channel.output_string chan
+      @@ Binable.to_string
+           (module Pickles.Proof.Proofs_verified_2.Stable.Latest)
+           x ) ;
+  res

--- a/src/lib/mina_base/proof_cache_tag/identity/dune
+++ b/src/lib/mina_base/proof_cache_tag/identity/dune
@@ -2,4 +2,23 @@
  (public_name proof_cache_tag.identity)
  (name proof_cache_tag_identity)
  (implements proof_cache_tag)
- (libraries pickles))
+ (libraries
+   ;; opam libraries
+   ppx_inline_test.config
+   base.base_internalhash_types
+   bin_prot.shape
+   sexplib0
+   core_kernel
+   base.md5
+   base.caml
+   splittable_random
+   ;; local libraries
+   mina_base
+   mina_wire_types
+   pickles)
+ (preprocess
+  (pps ppx_annot ppx_snarky ppx_here ppx_mina ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make
+       ppx_base base_quickcheck.ppx_quickcheck ppx_bench ppx_let ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
+ ))
+ (instrumentation (backend bisect_ppx))
+ )

--- a/src/lib/mina_base/proof_cache_tag/identity/dune
+++ b/src/lib/mina_base/proof_cache_tag/identity/dune
@@ -1,0 +1,5 @@
+(library
+ (public_name proof_cache_tag.identity)
+ (name proof_cache_tag_identity)
+ (implements proof_cache_tag)
+ (libraries pickles))

--- a/src/lib/mina_base/proof_cache_tag/identity/proof_cache_tag.ml
+++ b/src/lib/mina_base/proof_cache_tag/identity/proof_cache_tag.ml
@@ -1,4 +1,7 @@
-type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t [@@deriving sexp, compare, yojson]
+open Core_kernel
+
+type t = Pickles.Proof.Proofs_verified_2.t
+[@@deriving compare, equal, sexp, yojson, hash]
 
 let unwrap = Fn.id
 

--- a/src/lib/mina_base/proof_cache_tag/identity/proof_cache_tag.ml
+++ b/src/lib/mina_base/proof_cache_tag/identity/proof_cache_tag.ml
@@ -1,0 +1,5 @@
+type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t [@@deriving sexp, compare, yojson]
+
+let unwrap = Fn.id
+
+let generate = Fn.id

--- a/src/lib/mina_base/proof_cache_tag/proof_cache_tag.mli
+++ b/src/lib/mina_base/proof_cache_tag/proof_cache_tag.mli
@@ -1,0 +1,5 @@
+type t [@@deriving compare, equal, sexp, yojson, hash]
+
+val unwrap : t -> Proof.t
+
+val generate : Proof.t -> t

--- a/src/lib/mina_base/proof_cache_tag/proof_cache_tag.mli
+++ b/src/lib/mina_base/proof_cache_tag/proof_cache_tag.mli
@@ -1,5 +1,5 @@
 type t [@@deriving compare, equal, sexp, yojson, hash]
 
-val unwrap : t -> Proof.t
+val unwrap : t -> Mina_base.Proof.t
 
-val generate : Proof.t -> t
+val generate : Mina_base.Proof.t -> t

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -47,6 +47,7 @@
    o1trace
    pickles
    pickles_base
+   proof_cache_tag
    random_oracle_input
    pickles_types
    coda_genesis_ledger

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -73,16 +73,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    module Cache_tag = struct
-      type value = t [@@deriving compare, equal, sexp, yojson, hash]
-
-      type t = value
-      (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
-
-      let unwrap (x : t) : value = x
-
-      let generate (x : value) : t = x
-    end
+    module Cache_tag = Proof_cache_tag
   end
 
   [%%versioned

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -87,6 +87,17 @@ module Make_str (A : Wire_types.Concrete) = struct
     end
   end]
 
+  module Cache_tag = struct
+    type value = t [@@deriving compare, equal, sexp, yojson, hash]
+
+    type t = value
+    (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
+
+    let unwrap (x : t) : value = x
+
+    let generate (x : value) : t = x
+  end
+
   let proof t = t.proof
 
   let statement t = { t.statement with sok_digest = () }

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -72,6 +72,17 @@ module Make_str (A : Wire_types.Concrete) = struct
         let to_latest = Fn.id
       end
     end]
+
+    module Cache_tag = struct
+      type value = t [@@deriving compare, equal, sexp, yojson, hash]
+
+      type t = value
+      (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
+
+      let unwrap (x : t) : value = x
+
+      let generate (x : value) : t = x
+    end
   end
 
   [%%versioned
@@ -90,12 +101,17 @@ module Make_str (A : Wire_types.Concrete) = struct
   module Cache_tag = struct
     type value = t [@@deriving compare, equal, sexp, yojson, hash]
 
-    type t = value
-    (* TODO: Write to disk *) [@@deriving compare, equal, sexp, yojson, hash]
+    type t =
+      { statement : Mina_state.Snarked_ledger_state.With_sok.t
+      ; proof : Proof.Cache_tag.t
+      }
+    [@@deriving compare, equal, sexp, yojson, hash]
 
-    let unwrap (x : t) : value = x
+    let unwrap ({ statement; proof } : t) : value =
+      { statement; proof = Proof.Cache_tag.unwrap proof }
 
-    let generate (x : value) : t = x
+    let generate ({ statement; proof } : value) : t =
+      { statement; proof = Proof.Cache_tag.generate proof }
   end
 
   let proof t = t.proof

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -21,6 +21,16 @@ module type Full = sig
     end
   end]
 
+  module Cache_tag : sig
+    type value := t
+
+    type t [@@deriving compare, equal, sexp, yojson, hash]
+
+    val unwrap : t -> value
+
+    val generate : value -> t
+  end
+
   val create : statement:Statement.With_sok.t -> proof:Mina_base.Proof.t -> t
 
   val proof : t -> Mina_base.Proof.t


### PR DESCRIPTION
This PR demonstrates caching the proofs for snark work in the snark pool on disk, to reduce memory pressure.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them