### PR TITLE
Sparse ledger changes to support dynamic account creation

### DIFF
--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -766,7 +766,13 @@ module Make_str (A : Wire_types.Concrete) = struct
             Type_equal.t ) =
         Type_equal.T
 
-      module M = Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id) (Stack)
+      module M =
+        Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id)
+          (struct
+            include Stack
+
+            let empty = lazy empty
+          end)
 
       [%%define_locally
       M.(of_hash, get_exn, path_exn, set_exn, find_index, add_path, merkle_root)]

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -769,14 +769,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       module M = Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id) (Stack)
 
       [%%define_locally
-      M.
-        ( of_hash
-        , get_exn
-        , path_exn
-        , set_exn
-        , find_index_exn
-        , add_path
-        , merkle_root )]
+      M.(of_hash, get_exn, path_exn, set_exn, find_index, add_path, merkle_root)]
     end
 
     module Checked = struct
@@ -1076,7 +1069,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       try_with (fun () -> Merkle_tree.path_exn t.tree index)
 
     let find_index (t : t) key =
-      try_with (fun () -> Merkle_tree.find_index_exn t.tree key)
+      try_with (fun () -> Option.value_exn @@ Merkle_tree.find_index t.tree key)
 
     let next_index ~depth (t : t) =
       if
@@ -1113,7 +1106,9 @@ module Make_str (A : Wire_types.Concrete) = struct
         Option.value ~default:Stack_id.zero (curr_stack_id t)
       in
       Or_error.try_with (fun () ->
-          let index = Merkle_tree.find_index_exn t.tree prev_stack_id in
+          let index =
+            Option.value_exn @@ Merkle_tree.find_index t.tree prev_stack_id
+          in
           Merkle_tree.get_exn t.tree index )
 
     let latest_stack (t : t) ~is_new_stack =
@@ -1121,7 +1116,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let key = latest_stack_id t ~is_new_stack in
       let%bind res =
         Or_error.try_with (fun () ->
-            let index = Merkle_tree.find_index_exn t.tree key in
+            let index = Option.value_exn @@ Merkle_tree.find_index t.tree key in
             Merkle_tree.get_exn t.tree index )
       in
       if is_new_stack then

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -1055,7 +1055,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let root_hash = hash_at_level depth in
       { Poly.tree =
-          make_tree (Merkle_tree.of_hash ~depth root_hash) Stack_id.zero
+          make_tree
+            (Merkle_tree.of_hash ~depth root_hash
+               ~current_location:(* Hack: unused*) None )
+            Stack_id.zero
       ; pos_list = []
       ; new_pos = Stack_id.zero
       }

--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -152,6 +152,7 @@ M.
   , get_exn
   , path_exn
   , set_exn
+  , allocate_index
   , find_index
   , find_index_exn
   , add_path

--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -50,7 +50,8 @@ type account_state = [ `Added | `Existed ] [@@deriving equal]
     This ledger has an invalid root hash, and cannot be used except as a
     placeholder.
 *)
-let empty ~depth () = M.of_hash ~depth Outside_hash_image.t
+let empty ~depth () =
+  M.of_hash ~depth ~current_location:None Outside_hash_image.t
 
 module L = struct
   type t = M.t ref
@@ -156,8 +157,9 @@ M.
   , merkle_root
   , iteri )]
 
-let of_root ~depth (h : Ledger_hash.t) =
-  of_hash ~depth (Ledger_hash.of_digest (h :> Random_oracle.Digest.t))
+let of_root ~depth ~current_location (h : Ledger_hash.t) =
+  of_hash ~depth ~current_location
+    (Ledger_hash.of_digest (h :> Random_oracle.Digest.t))
 
 let get_or_initialize_exn account_id t idx =
   let account = get_exn t idx in

--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -152,6 +152,7 @@ M.
   , get_exn
   , path_exn
   , set_exn
+  , find_index
   , find_index_exn
   , add_path
   , merkle_root

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -46,8 +46,6 @@ val allocate_index : t -> Account_id.t -> int * t
 
 val find_index : t -> Account_id.t -> int option
 
-val find_index_exn : t -> Account_id.t -> int
-
 val of_root : depth:int -> current_location:int option -> Ledger_hash.t -> t
 
 (** Create a new 'empty' ledger.

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -42,6 +42,8 @@ val set_exn : t -> int -> Account.t -> t
 val path_exn :
   t -> int -> [ `Left of Ledger_hash.t | `Right of Ledger_hash.t ] list
 
+val find_index : t -> Account_id.t -> int option
+
 val find_index_exn : t -> Account_id.t -> int
 
 val of_root : depth:int -> current_location:int option -> Ledger_hash.t -> t

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -42,6 +42,8 @@ val set_exn : t -> int -> Account.t -> t
 val path_exn :
   t -> int -> [ `Left of Ledger_hash.t | `Right of Ledger_hash.t ] list
 
+val allocate_index : t -> Account_id.t -> int * t
+
 val find_index : t -> Account_id.t -> int option
 
 val find_index_exn : t -> Account_id.t -> int

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -44,7 +44,7 @@ val path_exn :
 
 val find_index_exn : t -> Account_id.t -> int
 
-val of_root : depth:int -> Ledger_hash.t -> t
+val of_root : depth:int -> current_location:int option -> Ledger_hash.t -> t
 
 (** Create a new 'empty' ledger.
     This ledger has an invalid root hash, and cannot be used except as a

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -4,7 +4,12 @@ include Sparse_ledger_base
 module GS = Global_state
 
 let of_ledger_root ledger =
-  of_root ~depth:(Ledger.depth ledger) (Ledger.merkle_root ledger)
+  of_root ~depth:(Ledger.depth ledger)
+    ~current_location:
+      ( Option.map ~f:(fun x ->
+            Ledger.Location.Addr.to_int @@ Ledger.Location.to_path_exn x )
+      @@ Ledger.last_filled ledger )
+    (Ledger.merkle_root ledger)
 
 let of_ledger_subset_exn (oledger : Ledger.t) keys =
   let ledger = Ledger.copy oledger in
@@ -35,6 +40,10 @@ let of_ledger_index_subset_exn (ledger : Ledger.Any_ledger.witness) indexes =
     ~init:
       (of_root
          ~depth:(Ledger.Any_ledger.M.depth ledger)
+         ~current_location:
+           ( Option.map ~f:(fun x ->
+                 Ledger.Location.Addr.to_int @@ Ledger.Location.to_path_exn x )
+           @@ Ledger.Any_ledger.M.last_filled ledger )
          (Ledger.Any_ledger.M.merkle_root ledger) )
     ~f:(fun acc i ->
       let account = Ledger.Any_ledger.M.get_at_index_exn ledger i in

--- a/src/lib/sparse_ledger_lib/dune
+++ b/src/lib/sparse_ledger_lib/dune
@@ -13,6 +13,8 @@
    bin_prot.shape
    result
    ppx_version.runtime
+   ;; local libraries
+   empty_hashes
  )
  (preprocess
   (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -71,6 +71,8 @@ module type S = sig
 
   val set_exn : t -> int -> account -> t
 
+  val find_index : t -> account_id -> int option
+
   val find_index_exn : t -> account_id -> int
 
   val add_path :
@@ -192,8 +194,11 @@ end = struct
 
   let ith_bit idx i = (idx lsr i) land 1 = 1
 
+  let find_index (t : t) aid =
+    List.Assoc.find t.indexes ~equal:Account_id.equal aid
+
   let find_index_exn (t : t) aid =
-    match List.Assoc.find t.indexes ~equal:Account_id.equal aid with
+    match find_index t aid with
     | Some x ->
         x
     | None ->

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -65,6 +65,8 @@ module type S = sig
 
   val of_hash : depth:int -> current_location:int option -> hash -> t
 
+  val allocate_index : t -> account_id -> int * t
+
   val get_exn : t -> int -> account
 
   val path_exn : t -> int -> [ `Left of hash | `Right of hash ] list
@@ -208,6 +210,16 @@ end = struct
           aid
           (List.map t.indexes ~f:fst)
           ()
+
+  let allocate_index ({ T.current_location; indexes; _ } as t) account_id =
+    let new_location =
+      match current_location with None -> 0 | Some x -> x + 1
+    in
+    ( new_location
+    , { t with
+        current_location = Some new_location
+      ; indexes = (account_id, new_location) :: indexes
+      } )
 
   let get_exn ({ T.tree; depth; _ } as t) idx =
     let rec go i tree =

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -75,8 +75,6 @@ module type S = sig
 
   val find_index : t -> account_id -> int option
 
-  val find_index_exn : t -> account_id -> int
-
   val add_path :
     t -> [ `Left of hash | `Right of hash ] list -> account_id -> account -> t
 
@@ -198,18 +196,6 @@ end = struct
 
   let find_index (t : t) aid =
     List.Assoc.find t.indexes ~equal:Account_id.equal aid
-
-  let find_index_exn (t : t) aid =
-    match find_index t aid with
-    | Some x ->
-        x
-    | None ->
-        failwithf
-          !"Sparse_ledger.find_index_exn: %{sexp:Account_id.t} not in %{sexp: \
-            Account_id.t list}"
-          aid
-          (List.map t.indexes ~f:fst)
-          ()
 
   let allocate_index ({ T.current_location; indexes; _ } as t) account_id =
     let new_location =

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1225,11 +1225,11 @@ module Make (L : Ledger_intf.S) :
 
       type inclusion_proof = [ `Existing of location | `New ]
 
-      let get_account p l =
+      let get_or_initialize_account p l =
         let loc, acct =
           Or_error.ok_exn (get_with_location l (Account_update.account_id p))
         in
-        (acct, loc)
+        (l, acct, loc)
 
       let set_account l (a, loc) =
         Or_error.ok_exn (set_with_location l loc a) ;


### PR DESCRIPTION
This PR tweaks the sparse ledger implementation to
* track the number of allocated accounts in the ledger
* support allocating additional accounts
* support reading, writing, and getting paths for locations that are 'empty' (i.e. after the last allocated account).

To achieve this, `Sparse_ledger.find_index_exn` has been replaced with a new `Sparse_ledger.find_index`, along with a limited set of other changes.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them