### PR TITLE
Don't pre-allocate account locations in the sparse ledger

### DIFF
--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -198,9 +198,12 @@ let get_or_initialize_exn account_id t idx =
   else (`Existed, account)
 
 let has_locked_tokens_exn ~global_slot ~account_id t =
-  let idx = Option.value_exn (find_index t account_id) in
-  let _, account = get_or_initialize_exn account_id t idx in
-  Account.has_locked_tokens ~global_slot account
+  match find_index t account_id with
+  | Some idx ->
+      let _, account = get_or_initialize_exn account_id t idx in
+      Account.has_locked_tokens ~global_slot account
+  | None ->
+      false
 
 let merkle_root t = Ledger_hash.of_hash (merkle_root t :> Random_oracle.Digest.t)
 

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -25,8 +25,7 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
                 ( Ledger.get ledger loc
                 |> Option.value_exn ?here:None ?error:None ?message:None ) )
         | None ->
-            let path, acct = Ledger.create_empty_exn ledger key in
-            (key :: new_keys, add_path sl path key acct) )
+            (new_keys, sl) )
       ~init:([], of_ledger_root ledger)
   in
   Debug_assert.debug_assert (fun () ->

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -26,11 +26,14 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
         | None -> (
             match Ledger.last_filled ledger with
             | Some loc ->
+                let account =
+                  Ledger.get ledger loc
+                  |> Option.value_exn ?here:None ?error:None ?message:None
+                in
                 add_path sl
                   (Ledger.merkle_path ledger loc)
-                  key
-                  ( Ledger.get ledger loc
-                  |> Option.value_exn ?here:None ?error:None ?message:None )
+                  (Account.identifier account)
+                  account
             | None ->
                 sl ) )
       ~init:(of_ledger_root ledger)

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -225,7 +225,7 @@ end = struct
       | false, Node (_, l, r) ->
           let go_right = ith_bit idx i in
           if go_right then go (i - 1) r else go (i - 1) l
-      | _, Hash h when Hash.equal h (empty_hash i) ->
+      | _, Hash h when Hash.equal h (empty_hash (i + 1)) ->
           Lazy.force Account.empty
       | _ ->
           let expected_kind = if i < 0 then "n account" else " node" in
@@ -256,13 +256,13 @@ end = struct
             if go_right then (l, go (i - 1) r) else (go (i - 1) l, r)
           in
           Node (Hash.merge ~height:i (hash l) (hash r), l, r)
-      | false, Hash h when Hash.equal h (empty_hash i) ->
+      | false, Hash h when Hash.equal h (empty_hash (i + 1)) ->
           let inner =
-            if i > 0 then Tree.Hash (empty_hash (i - 1))
+            if i > 0 then Tree.Hash (empty_hash i)
             else Tree.Account (Lazy.force Account.empty)
           in
           go i (Node (h, inner, inner))
-      | true, Hash h when Hash.equal h (empty_hash i) ->
+      | true, Hash h when Hash.equal h (empty_hash (i + 1)) ->
           Tree.Account acct
       | _ ->
           let expected_kind = if i < 0 then "n account" else " node" in
@@ -289,9 +289,9 @@ end = struct
         match tree with
         | Tree.Account _ ->
             failwithf "Sparse_ledger.path: Bad depth at index %i." idx ()
-        | Hash h when Hash.equal h (empty_hash i) ->
+        | Hash h when Hash.equal h (empty_hash (i + 1)) ->
             let inner =
-              if i > 0 then Tree.Hash (empty_hash (i - 1))
+              if i > 0 then Tree.Hash (empty_hash i)
               else Tree.Account (Lazy.force Account.empty)
             in
             go acc i (Tree.Node (h, inner, inner))


### PR DESCRIPTION
This PR builds upon #14520, attempting to fix the potential 'gappy allocations' caused by the current protocol. In particular, a pair of transactions in a block where
* the first creates a new account, but the transaction failed
* the second creates a different new account, and the transaction succeeded.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them