### PR TITLE
Optimization: Avoid duplicating proofs during txn verification

### DIFF
--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -8,6 +8,26 @@ open Blockchain_snark
 
 type invalid = Common.invalid [@@deriving bin_io_unversioned, to_yojson]
 
+module With_id_tag = struct
+  type 'a t = int * 'a [@@deriving bin_io_unversioned]
+
+  let tag_list = List.mapi ~f:(fun id command -> (id, command))
+
+  (* This function associates each tagged inputs with its corresponding result based
+     on the ID, and returns a list of tuples (input, result). *)
+  let reassociate_tagged_results tagged_inputs tagged_results =
+    let result_map = Int.Map.of_alist_exn tagged_results in
+    List.map tagged_inputs ~f:(fun (id, input) ->
+        let result =
+          match Int.Map.find result_map id with
+          | Some res ->
+              res
+          | None ->
+              failwith "Verification result missing for command"
+        in
+        (input, result) )
+end
+
 let invalid_to_error = Common.invalid_to_error
 
 type ledger_proof = Ledger_proof.Prod.t
@@ -18,7 +38,7 @@ module Worker_state = struct
       (Protocol_state.Value.t * Proof.t) list -> unit Or_error.t Deferred.t
 
     val verify_commands :
-         Mina_base.User_command.Verifiable.t With_status.t list
+         Mina_base.User_command.Verifiable.t With_status.t With_id_tag.t list
       -> [ `Valid
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
@@ -26,6 +46,7 @@ module Worker_state = struct
            * Pickles.Side_loaded.Proof.t )
            list
          | invalid ]
+         With_id_tag.t
          list
          Deferred.t
 
@@ -72,49 +93,56 @@ module Worker_state = struct
                let proof_level = proof_level
              end)
 
-             (* [verify_commands cs] verifies user commands, maintaining their input order in its output.
-                This ordering is vital as it allows the parent process to inject verified commands back
-                into the workflow without re-decoding a copy of the command in the result, thus avoiding
-                proof duplication and reducing memory overhead. *)
              let verify_commands
-                 (cs : User_command.Verifiable.t With_status.t list) :
-                 _ list Deferred.t =
-               let cs = List.map cs ~f:Common.check in
+                 (cs :
+                   User_command.Verifiable.t With_status.t With_id_tag.t list )
+                 : _ list Deferred.t =
+               let results =
+                 List.map cs ~f:(fun (id, c) -> (id, Common.check c))
+               in
                let to_verify =
-                 List.concat_map cs ~f:(function
-                   | `Valid _ ->
-                       []
-                   | `Valid_assuming (_, xs) ->
-                       xs
-                   | `Invalid_keys _
-                   | `Invalid_signature _
-                   | `Invalid_proof _
-                   | `Missing_verification_key _
-                   | `Unexpected_verification_key _
-                   | `Mismatched_authorization_kind _ ->
-                       [] )
+                 results |> List.map ~f:snd
+                 |> List.concat_map ~f:(function
+                      | `Valid _ ->
+                          []
+                      | `Valid_assuming (_, xs) ->
+                          xs
+                      | `Invalid_keys _
+                      | `Invalid_signature _
+                      | `Invalid_proof _
+                      | `Missing_verification_key _
+                      | `Unexpected_verification_key _
+                      | `Mismatched_authorization_kind _ ->
+                          [] )
                in
                let%map all_verified =
                  Pickles.Side_loaded.verify ~typ:Zkapp_statement.typ to_verify
                in
-               List.map cs ~f:(function
-                 | `Valid _ ->
-                     `Valid
-                 | `Valid_assuming (_, xs) ->
-                     if Or_error.is_ok all_verified then `Valid
-                     else `Valid_assuming xs
-                 | `Invalid_keys keys ->
-                     `Invalid_keys keys
-                 | `Invalid_signature keys ->
-                     `Invalid_signature keys
-                 | `Invalid_proof err ->
-                     `Invalid_proof err
-                 | `Missing_verification_key keys ->
-                     `Missing_verification_key keys
-                 | `Unexpected_verification_key keys ->
-                     `Unexpected_verification_key keys
-                 | `Mismatched_authorization_kind keys ->
-                     `Mismatched_authorization_kind keys )
+               List.map results ~f:(fun (id, result) ->
+                   let result =
+                     match result with
+                     | `Valid _ ->
+                         (* The command is dropped here to avoid decoding it later in the caller
+                            which would create a duplicate. Results are paired back to their inputs
+                            using the input [id]*)
+                         `Valid
+                     | `Valid_assuming (_, xs) ->
+                         if Or_error.is_ok all_verified then `Valid
+                         else `Valid_assuming xs
+                     | `Invalid_keys keys ->
+                         `Invalid_keys keys
+                     | `Invalid_signature keys ->
+                         `Invalid_signature keys
+                     | `Invalid_proof err ->
+                         `Invalid_proof err
+                     | `Missing_verification_key keys ->
+                         `Missing_verification_key keys
+                     | `Unexpected_verification_key keys ->
+                         `Unexpected_verification_key keys
+                     | `Mismatched_authorization_kind keys ->
+                         `Mismatched_authorization_kind keys
+                   in
+                   (id, result) )
 
              let verify_commands cs =
                Internal_tracing.Context_logger.with_logger (Some logger)
@@ -174,25 +202,28 @@ module Worker_state = struct
     | Check | None ->
         Deferred.return
         @@ ( module struct
-             let verify_commands cs =
-               List.map cs ~f:(fun c ->
-                   match Common.check c with
-                   | `Valid _ ->
-                       `Valid
-                   | `Valid_assuming (_, _) ->
-                       `Valid
-                   | `Invalid_keys keys ->
-                       `Invalid_keys keys
-                   | `Invalid_signature keys ->
-                       `Invalid_signature keys
-                   | `Invalid_proof err ->
-                       `Invalid_proof err
-                   | `Missing_verification_key keys ->
-                       `Missing_verification_key keys
-                   | `Unexpected_verification_key keys ->
-                       `Unexpected_verification_key keys
-                   | `Mismatched_authorization_kind keys ->
-                       `Mismatched_authorization_kind keys )
+             let verify_commands tagged_commands =
+               List.map tagged_commands ~f:(fun (id, c) ->
+                   let result =
+                     match Common.check c with
+                     | `Valid _ ->
+                         `Valid
+                     | `Valid_assuming (_, _) ->
+                         `Valid
+                     | `Invalid_keys keys ->
+                         `Invalid_keys keys
+                     | `Invalid_signature keys ->
+                         `Invalid_signature keys
+                     | `Invalid_proof err ->
+                         `Invalid_proof err
+                     | `Missing_verification_key keys ->
+                         `Missing_verification_key keys
+                     | `Unexpected_verification_key keys ->
+                         `Unexpected_verification_key keys
+                     | `Mismatched_authorization_kind keys ->
+                         `Mismatched_authorization_kind keys
+                   in
+                   (id, result) )
                |> Deferred.return
 
              let verify_blockchain_snarks _ = Deferred.return (Ok ())
@@ -235,7 +266,7 @@ module Worker = struct
           ('w, (Transaction_snark.t * Sok_message.t) list, unit Or_error.t) F.t
       ; verify_commands :
           ( 'w
-          , User_command.Verifiable.t With_status.t list
+          , User_command.Verifiable.t With_status.t With_id_tag.t list
           , [ `Valid
             | `Valid_assuming of
               ( Pickles.Side_loaded.Verification_key.t
@@ -243,6 +274,7 @@ module Worker = struct
               * Pickles.Side_loaded.Proof.t )
               list
             | invalid ]
+            With_id_tag.t
             list )
           F.t
       ; get_blockchain_verification_key :
@@ -318,6 +350,7 @@ module Worker = struct
               ( [%bin_type_class:
                   User_command.Verifiable.Stable.Latest.t
                   With_status.Stable.Latest.t
+                  With_id_tag.t
                   list]
               , [%bin_type_class:
                   [ `Valid
@@ -327,6 +360,7 @@ module Worker = struct
                     * Pickles.Side_loaded.Proof.Stable.Latest.t )
                     list
                   | invalid ]
+                  With_id_tag.t
                   list]
               , verify_commands )
         ; get_blockchain_verification_key =
@@ -661,38 +695,41 @@ let verify_transaction_snarks =
   wrap_verify_snarks_with_trace ~checkpoint_before:"Verify_transaction_snarks"
     ~checkpoint_after:"Verify_transaction_snarks_done" verify_transaction_snarks
 
-(* Reinjects the original user commands into the validation results,
-   assuming that the orders of commands and results are synchronized.
+(* Reinjects the original user commands into the validation results.
    This avoids duplicating proof data by not sending it back from the subprocess. *)
-let reinject_valid_user_commands_into_valid_results commands results =
-  List.map2_exn commands results ~f:(fun command result ->
-      match result with
-      | #invalid as invalid ->
-          invalid (* Directly return invalid results *)
-      | `Valid_assuming x ->
-          `Valid_assuming x
-      | `Valid ->
-          (* Since we have stripped the transaction from the result to save memory,
-             we reconstruct it here knowing the result is valid and the ordering is
-             maintained.
-             The use of to_valid_unsafe is justified because a [`Valid] result for this
-             command means that it has indeed been validated. *)
-          let (`If_this_is_used_it_should_have_a_comment_justifying_it
-                command_valid ) =
-            User_command.to_valid_unsafe
-              (User_command.of_verifiable (With_status.data command))
-          in
-          `Valid command_valid )
+let reinject_valid_user_command_into_valid_result (command, result) =
+  match result with
+  | #invalid as invalid ->
+      invalid
+  | `Valid_assuming x ->
+      `Valid_assuming x
+  | `Valid ->
+      (* Since we have stripped the transaction from the result, we reconstruct it here.
+         The use of [to_valid_unsafe] is justified because a [`Valid] result for this
+         command means that it has indeed been validated. *)
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it command_valid)
+          =
+        User_command.to_valid_unsafe
+          (User_command.of_verifiable (With_status.data command))
+      in
+      `Valid command_valid
+
+let finalize_verification_results tagged_commands tagged_results =
+  With_id_tag.reassociate_tagged_results tagged_commands tagged_results
+  |> List.map ~f:reinject_valid_user_command_into_valid_result
 
 let verify_commands { worker; logger } ts =
   O1trace.thread "dispatch_user_command_verification" (fun () ->
       with_retry ~logger (fun () ->
           let%bind { connection; _ } = Ivar.read !worker in
+          let tagged_commands = With_id_tag.tag_list ts in
           Worker.Connection.run connection ~f:Worker.functions.verify_commands
-            ~arg:ts
-          |> Deferred.Or_error.map ~f:(fun rs ->
-                 `Continue
-                   (reinject_valid_user_commands_into_valid_results ts rs) ) ) )
+            ~arg:tagged_commands
+          |> Deferred.Or_error.map ~f:(fun tagged_results ->
+                 let results =
+                   finalize_verification_results tagged_commands tagged_results
+                 in
+                 `Continue results ) ) )
 
 let verify_commands t ts =
   let logger = t.logger in


### PR DESCRIPTION
Explain your changes:
* When a batch of transactions are verified using the verifier helper subprocess, they are serialized and sent to the verifier subprocess. The verifier subprocess will then write the transactions as `Valid.t` back to the node, which in will decode them from a stream creating duplicates of the already existing transactions. This is an issue for zkApp transactions because those contain proofs which are quite memory-heavy.

This patch removes the duplicates from the response, and converts the `Verifiable.t` values to their `Valid.t` counterparts through the unsafe `User_command.to_valid_unsafe` function.

Explain how you tested your changes:
* Running patched nodes in a mixed-enviroment (patched and unpatched nodes) in a private cluster.

From our testing, we noted this saves quite a bit of memory (both these nodes were launched at the same time):

| Patched | Unpatched |
| ------- | --------- |
| ![Patched Image](https://github.com/MinaProtocol/mina/assets/13744/04647729-aaf9-4254-ae37-449870c01c49) | ![Unpatched Image](https://github.com/MinaProtocol/mina/assets/13744/7281999f-bdce-404a-b884-f4be5f2014c4) |

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
