### PR TITLE
Write scan state proofs to disk

### DIFF
--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -121,6 +121,8 @@
    string_sign
    zkapp_command_builder
    internal_tracing
+   transaction_witness
+   ledger_proof
  )
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../../../config.mlh

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -433,6 +433,13 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                 ~f:Fn.const
             in
             let%map r = Mina_lib.request_work mina in
+            let r =
+              Snark_work_lib.Work.Spec.map
+                ~f:
+                  (Snark_work_lib.Work.Single.Spec.map_proof
+                     ~f:Ledger_proof.Cache_tag.unwrap )
+                r
+            in
             [%log trace]
               ~metadata:[ ("work_spec", Snark_worker.Work.Spec.to_yojson r) ]
               "responding to a Get_work request with some new work" ;

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -523,7 +523,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
             |> Lazy.force |> Mina_ledger.Ledger.merkle_root
             |> Frozen_ledger_hash.of_ledger_hash )
     | Some (proof, _) ->
-        target_hash_of_ledger_proof proof
+        target_hash_of_ledger_proof (Ledger_proof.Cache_tag.unwrap proof)
   in
   let maybe_errors =
     Option.all

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -102,6 +102,7 @@
    kimchi_backend.pasta.basic
    mina_wire_types
    internal_tracing
+   transaction_witness
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -87,7 +87,13 @@ val snark_work_fee : t -> Currency.Fee.t
 
 val set_snark_work_fee : t -> Currency.Fee.t -> unit
 
-val request_work : t -> Snark_worker.Work.Spec.t option
+val request_work :
+     t
+  -> ( Transaction_witness.t
+     , Ledger_proof.Cache_tag.t )
+     Snark_work_lib.Work.Single.Spec.t
+     Snark_work_lib.Work.Spec.t
+     option
 
 val work_selection_method : t -> (module Work_selector.Selection_method_intf)
 

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -30,6 +30,12 @@ module Single = struct
 
     let statement = function Transition (s, _) -> s | Merge (s, _, _) -> s
 
+    let map_proof ~f = function
+      | Transition (stmt, witness) ->
+          Transition (stmt, witness)
+      | Merge (stmt, p1, p2) ->
+          Merge (stmt, f p1, f p2)
+
     let gen :
            'witness Quickcheck.Generator.t
         -> 'ledger_proof Quickcheck.Generator.t
@@ -81,6 +87,9 @@ module Spec = struct
   type 'single t = 'single Stable.Latest.t =
     { instances : 'single One_or_two.t; fee : Currency.Fee.t }
   [@@deriving fields, sexp, yojson]
+
+  let map ~f { instances; fee } =
+    { instances = One_or_two.map ~f instances; fee }
 end
 
 module Result = struct

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -63,15 +63,27 @@ module type Work_S = sig
 
   type ledger_proof
 
+  type ledger_proof_cache_tag
+
   module Single : sig
     module Spec : sig
       type t = (Transaction_witness.t, ledger_proof) Work.Single.Spec.t
       [@@deriving sexp, yojson]
+
+      module Cache_tag : sig
+        type t =
+          (Transaction_witness.t, ledger_proof_cache_tag) Work.Single.Spec.t
+        [@@deriving sexp, yojson]
+      end
     end
   end
 
   module Spec : sig
     type t = Single.Spec.t Work.Spec.t [@@deriving sexp, yojson]
+
+    module Cache_tag : sig
+      type t = Single.Spec.Cache_tag.t Work.Spec.t [@@deriving sexp, yojson]
+    end
   end
 
   module Result : sig
@@ -129,7 +141,12 @@ end
 module type S0 = sig
   type ledger_proof
 
-  module Work : Work_S with type ledger_proof := ledger_proof
+  type ledger_proof_cache_tag
+
+  module Work :
+    Work_S
+      with type ledger_proof := ledger_proof
+       and type ledger_proof_cache_tag := ledger_proof_cache_tag
 
   module Rpcs : sig
     module Get_work :
@@ -151,7 +168,9 @@ module type S0 = sig
   end
 
   val command_from_rpcs :
-       (module Rpcs_versioned_S with type Work.ledger_proof = ledger_proof)
+       (module Rpcs_versioned_S
+          with type Work.ledger_proof = ledger_proof
+           and type Work.ledger_proof_cache_tag = ledger_proof_cache_tag )
     -> Command.t
 
   val arguments :
@@ -166,7 +185,9 @@ module type S = sig
   include S0
 
   module Rpcs_versioned :
-    Rpcs_versioned_S with type Work.ledger_proof = ledger_proof
+    Rpcs_versioned_S
+      with type Work.ledger_proof = ledger_proof
+       and type Work.ledger_proof_cache_tag = ledger_proof_cache_tag
 
   val command : Command.t
 end

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -17,6 +17,8 @@ module Worker = struct
     module Work = struct
       type ledger_proof = Inputs.Ledger_proof.t
 
+      type ledger_proof_cache_tag = Inputs.Ledger_proof.Cache_tag.t
+
       include Work
     end
 

--- a/src/lib/snark_worker/snark_worker.mli
+++ b/src/lib/snark_worker/snark_worker.mli
@@ -2,7 +2,10 @@ module Prod = Prod
 
 module Intf : module type of Intf
 
-include Intf.S with type ledger_proof := Ledger_proof.t
+include
+  Intf.S
+    with type ledger_proof := Ledger_proof.t
+     and type ledger_proof_cache_tag := Ledger_proof.Prod.Cache_tag.t
 
 type Structured_log_events.t +=
   | Generating_snark_work_failed of { error : Yojson.Safe.t }

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -194,7 +194,7 @@ val apply :
   -> supercharge_coinbase:bool
   -> ( [ `Hash_after_applying of Staged_ledger_hash.t ]
        * [ `Ledger_proof of
-           ( Ledger_proof.t
+           ( Ledger_proof.Cache_tag.t
            * ( Transaction.t With_status.t
              * State_hash.t
              * Mina_numbers.Global_slot_since_genesis.t )
@@ -218,7 +218,7 @@ val apply_diff_unchecked :
   -> supercharge_coinbase:bool
   -> ( [ `Hash_after_applying of Staged_ledger_hash.t ]
        * [ `Ledger_proof of
-           ( Ledger_proof.t
+           ( Ledger_proof.Cache_tag.t
            * ( Transaction.t With_status.t
              * State_hash.t
              * Mina_numbers.Global_slot_since_genesis.t )
@@ -283,7 +283,9 @@ val of_scan_state_pending_coinbases_and_snarked_ledger_unchecked :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+  -> ( Transaction_witness.t
+     , Ledger_proof.Cache_tag.t )
+     Snark_work_lib.Work.Single.Spec.t
      One_or_two.t
      list
      Or_error.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -48,7 +48,7 @@ module Make_statement_scanner (Verifier : sig
 
   val verify :
        verifier:t
-    -> Ledger_proof_with_sok_message.t list
+    -> (Ledger_proof.Cache_tag.t * Sok_message.t) list
     -> unit Or_error.t Deferred.Or_error.t
 end) : sig
   val scan_statement :
@@ -97,7 +97,7 @@ val fill_work_and_enqueue_transactions :
   -> logger:Logger.t
   -> Transaction_with_witness.t list
   -> Transaction_snark_work.t list
-  -> ( ( Ledger_proof.t
+  -> ( ( Ledger_proof.Cache_tag.t
        * ( Transaction.t With_status.t
          * State_hash.t
          * Mina_numbers.Global_slot_since_genesis.t )
@@ -109,7 +109,7 @@ val fill_work_and_enqueue_transactions :
 
 val latest_ledger_proof :
      t
-  -> ( Ledger_proof_with_sok_message.t
+  -> ( (Ledger_proof.Cache_tag.t * Sok_message.t)
      * ( Transaction.t With_status.t
        * State_hash.t
        * Mina_numbers.Global_slot_since_genesis.t )
@@ -266,7 +266,9 @@ val check_required_protocol_states :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+  -> ( Transaction_witness.t
+     , Ledger_proof.Cache_tag.t )
+     Snark_work_lib.Work.Single.Spec.t
      One_or_two.t
      list
      Or_error.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -416,9 +416,9 @@ module For_tests = struct
         |> Blockchain_state.ledger_proof_statement
       in
       let ledger_proof_statement =
-        Option.value_map ledger_proof_opt
-          ~f:(fun (proof, _) -> Ledger_proof.statement proof)
-          ~default:previous_ledger_proof_stmt
+        Option.value_map ledger_proof_opt ~default:previous_ledger_proof_stmt
+          ~f:(fun (proof, _) ->
+            Ledger_proof.statement @@ Ledger_proof.Cache_tag.unwrap proof )
       in
       let genesis_ledger_hash =
         previous_protocol_state |> Protocol_state.blockchain_state

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -324,7 +324,9 @@ let send_block_and_transaction_snark ~logger ~interruptor ~url ~snark_worker
                 match%bind
                   make_interruptible
                     (Uptime_snark_worker.perform_single snark_worker
-                       (message, single_spec) )
+                       ( message
+                       , Snark_work_lib.Work.Single.Spec.map_proof
+                           ~f:Ledger_proof.Cache_tag.unwrap single_spec ) )
                 with
                 | Error e ->
                     (* error in submitting to process *)

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -14,6 +14,10 @@ module Test_inputs = struct
 
   module Ledger_proof = struct
     type t = Fee.t [@@deriving hash, compare, sexp]
+
+    module Cache_tag = struct
+      type t = Fee.t [@@deriving hash, compare, sexp]
+    end
   end
 
   module Transaction_snark_work = struct

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -20,6 +20,10 @@ module type Inputs_intf = sig
 
   module Ledger_proof : sig
     type t
+
+    module Cache_tag : sig
+      type t
+    end
   end
 
   module Transaction_snark_work : sig
@@ -53,7 +57,7 @@ module type Inputs_intf = sig
       -> get_state:
            (Mina_base.State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
       -> ( Transaction_witness.t
-         , Ledger_proof.t )
+         , Ledger_proof.Cache_tag.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
          list
@@ -102,23 +106,21 @@ module type Lib_intf = sig
     val all_unseen_works :
          t
       -> ( Transaction_witness.t
-         , Ledger_proof.t )
+         , Ledger_proof.Cache_tag.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
          list
 
     val remove :
          t
-      -> ( Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
+      -> (Transaction_witness.t, _) Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
       -> unit
 
     val set :
          t
       -> ( Transaction_witness.t
-         , Ledger_proof.t )
+         , Ledger_proof.Cache_tag.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
       -> unit
@@ -127,10 +129,14 @@ module type Lib_intf = sig
   val get_expensive_work :
        snark_pool:Snark_pool.t
     -> fee:Fee.t
-    -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+    -> ( Transaction_witness.t
+       , Ledger_proof.Cache_tag.t )
+       Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
-    -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+    -> ( Transaction_witness.t
+       , Ledger_proof.Cache_tag.t )
+       Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
 
@@ -157,11 +163,13 @@ module type Selection_method_intf = sig
 
   type work
 
+  type _ work_poly
+
   type transition_frontier
 
   module State : State_intf with type transition_frontier := transition_frontier
 
-  val remove : State.t -> work One_or_two.t -> unit
+  val remove : State.t -> _ work_poly One_or_two.t -> unit
 
   val work :
        snark_pool:snark_pool
@@ -185,8 +193,10 @@ module type Make_selection_method_intf = functor
     with type staged_ledger := Inputs.Staged_ledger.t
      and type work :=
       ( Inputs.Transaction_witness.t
-      , Inputs.Ledger_proof.t )
+      , Inputs.Ledger_proof.Cache_tag.t )
       Snark_work_lib.Work.Single.Spec.t
+     and type 'a work_poly :=
+      (Inputs.Transaction_witness.t, 'a) Snark_work_lib.Work.Single.Spec.t
      and type snark_pool := Inputs.Snark_pool.t
      and type transition_frontier := Inputs.Transition_frontier.t
      and module State := Lib.State

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -27,7 +27,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
     type t =
       { mutable available_jobs :
-          (Inputs.Transaction_witness.t, Inputs.Ledger_proof.t) Work_spec.t
+          ( Inputs.Transaction_witness.t
+          , Inputs.Ledger_proof.Cache_tag.t )
+          Work_spec.t
           One_or_two.t
           list
       ; mutable jobs_seen : Job_status.t Seen_key.Map.t

--- a/src/lib/work_selector/work_selector.ml
+++ b/src/lib/work_selector/work_selector.ml
@@ -6,7 +6,11 @@ module type Selection_method_intf =
     with type snark_pool := Network_pool.Snark_pool.t
      and type staged_ledger := Staged_ledger.t
      and type work :=
-      (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+      ( Transaction_witness.t
+      , Ledger_proof.Cache_tag.t )
+      Snark_work_lib.Work.Single.Spec.t
+     and type 'a work_poly :=
+      (Transaction_witness.t, 'a) Snark_work_lib.Work.Single.Spec.t
      and type transition_frontier := Transition_frontier.t
      and module State := State
 

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -6,7 +6,11 @@ module type Selection_method_intf =
     with type snark_pool := Network_pool.Snark_pool.t
      and type staged_ledger := Staged_ledger.t
      and type work :=
-      (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+      ( Transaction_witness.t
+      , Ledger_proof.Cache_tag.t )
+      Snark_work_lib.Work.Single.Spec.t
+     and type 'a work_poly :=
+      (Transaction_witness.t, 'a) Snark_work_lib.Work.Single.Spec.t
      and type transition_frontier := Transition_frontier.t
      and module State := State
 


### PR DESCRIPTION
This PR uses the `Proof_cache` to write all ledger proofs in the scan state to disk. This reduces the RAM usage of the node.

This PR builds upon #14511.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them