### PR TITLE
Use sparse ledger for staged ledger diff application

### DIFF
--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -766,17 +766,16 @@ module Make_str (A : Wire_types.Concrete) = struct
             Type_equal.t ) =
         Type_equal.T
 
-      module M = Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id) (Stack)
+      module M =
+        Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id)
+          (struct
+            include Stack
+
+            let empty = lazy empty
+          end)
 
       [%%define_locally
-      M.
-        ( of_hash
-        , get_exn
-        , path_exn
-        , set_exn
-        , find_index_exn
-        , add_path
-        , merkle_root )]
+      M.(of_hash, get_exn, path_exn, set_exn, find_index, add_path, merkle_root)]
     end
 
     module Checked = struct
@@ -1055,7 +1054,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let root_hash = hash_at_level depth in
       { Poly.tree =
-          make_tree (Merkle_tree.of_hash ~depth root_hash) Stack_id.zero
+          make_tree
+            (Merkle_tree.of_hash ~depth root_hash
+               ~current_location:(* Hack: unused*) None )
+            Stack_id.zero
       ; pos_list = []
       ; new_pos = Stack_id.zero
       }
@@ -1073,7 +1075,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       try_with (fun () -> Merkle_tree.path_exn t.tree index)
 
     let find_index (t : t) key =
-      try_with (fun () -> Merkle_tree.find_index_exn t.tree key)
+      try_with (fun () -> Option.value_exn @@ Merkle_tree.find_index t.tree key)
 
     let next_index ~depth (t : t) =
       if
@@ -1110,7 +1112,9 @@ module Make_str (A : Wire_types.Concrete) = struct
         Option.value ~default:Stack_id.zero (curr_stack_id t)
       in
       Or_error.try_with (fun () ->
-          let index = Merkle_tree.find_index_exn t.tree prev_stack_id in
+          let index =
+            Option.value_exn @@ Merkle_tree.find_index t.tree prev_stack_id
+          in
           Merkle_tree.get_exn t.tree index )
 
     let latest_stack (t : t) ~is_new_stack =
@@ -1118,7 +1122,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let key = latest_stack_id t ~is_new_stack in
       let%bind res =
         Or_error.try_with (fun () ->
-            let index = Merkle_tree.find_index_exn t.tree key in
+            let index = Option.value_exn @@ Merkle_tree.find_index t.tree key in
             Merkle_tree.get_exn t.tree index )
       in
       if is_new_stack then

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -42,9 +42,11 @@ val set_exn : t -> int -> Account.t -> t
 val path_exn :
   t -> int -> [ `Left of Ledger_hash.t | `Right of Ledger_hash.t ] list
 
-val find_index_exn : t -> Account_id.t -> int
+val allocate_index : t -> Account_id.t -> int * t
 
-val of_root : depth:int -> Ledger_hash.t -> t
+val find_index : t -> Account_id.t -> int option
+
+val of_root : depth:int -> current_location:int option -> Ledger_hash.t -> t
 
 (** Create a new 'empty' ledger.
     This ledger has an invalid root hash, and cannot be used except as a

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -53,4 +53,5 @@
    unsigned_extended
    with_hash
    ppx_version.runtime
+   sparse_ledger_lib
 ))

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -71,21 +71,21 @@ let sparse_ledger_subset_exn (oledger : t) keys =
   in
   let uses_last, ledger =
     List.fold ~init:(false, ledger) keys ~f:(fun (uses_last, ledger) key ->
-        match find_index ledger key with
+        match find_index oledger key with
         | Some index ->
-            let path = path_exn ledger index in
-            let account = get_exn ledger index in
+            let path = path_exn oledger index in
+            let account = get_exn oledger index in
             (uses_last, add_path ledger path key account)
         | None ->
-            (uses_last, ledger) )
+            (true, ledger) )
   in
   let ledger =
     if uses_last then
       match ledger.current_location with
       | Some loc ->
-          let account = Mina_base.Sparse_ledger_base.get_exn ledger loc in
+          let account = Mina_base.Sparse_ledger_base.get_exn oledger loc in
           add_path ledger
-            (Mina_base.Sparse_ledger_base.path_exn ledger loc)
+            (Mina_base.Sparse_ledger_base.path_exn oledger loc)
             (Account.identifier account)
             account
       | None ->

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -43,6 +43,14 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
         ((merkle_root sparse :> Random_oracle.Digest.t) |> Ledger_hash.of_hash) ) ;
   sparse
 
+let sparse_ledger_subset_exn (oledger : t) keys =
+  let ledger = of_root ~depth:(depth oledger) (merkle_root oledger) in
+  List.fold ~init:ledger keys ~f:(fun ledger key ->
+      let index = find_index_exn ledger key in
+      let path = path_exn ledger index in
+      let account = get_exn ledger index in
+      add_path ledger path key account )
+
 let of_ledger_index_subset_exn (ledger : Ledger.Any_ledger.witness) indexes =
   List.fold indexes
     ~init:

--- a/src/lib/sparse_ledger_lib/dune
+++ b/src/lib/sparse_ledger_lib/dune
@@ -13,6 +13,8 @@
    bin_prot.shape
    result
    ppx_version.runtime
+   ;; local libraries
+   empty_hashes
  )
  (preprocess
   (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1225,11 +1225,11 @@ module Make (L : Ledger_intf.S) :
 
       type inclusion_proof = [ `Existing of location | `New ]
 
-      let get_account p l =
+      let get_or_initialize_account p l =
         let loc, acct =
           Or_error.ok_exn (get_with_location l (Account_update.account_id p))
         in
-        (acct, loc)
+        (l, acct, loc)
 
       let set_account l (a, loc) =
         Or_error.ok_exn (set_with_location l loc a) ;


### PR DESCRIPTION
This PR modifies the staged ledger diff application to use a sparse ledger for the transaction logic. This should significantly speed up catchup, where we have to apply a large number of blocks.

This PR builds upon https://github.com/MinaProtocol/mina/pull/14528, but also includes the sparse ledger fixes from https://github.com/MinaProtocol/mina/pull/14521 and https://github.com/MinaProtocol/mina/pull/14520.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
