### PR TITLE
Deploy migration apps

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -28,6 +28,8 @@ dune build "--profile=${DUNE_PROFILE}" \
   src/app/replayer/replayer.exe \
   src/app/extract_blocks/extract_blocks.exe \
   src/app/archive_blocks/archive_blocks.exe \
+  src/app/berkeley_migration/berkeley_migration.exe \
+  src/app/berkeley_account_tables/berkeley_account_tables.exe \
   src/app/batch_txn_tool/batch_txn_tool.exe \
   src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
   src/app/swap_bad_balances/swap_bad_balances.exe \

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -76,6 +76,9 @@ ls
 cp ./default/src/app/archive/archive.exe "${BUILD_DIR}/usr/local/bin/mina-archive"
 cp ./default/src/app/archive_blocks/archive_blocks.exe "${BUILD_DIR}/usr/local/bin/mina-archive-blocks"
 cp ./default/src/app/extract_blocks/extract_blocks.exe "${BUILD_DIR}/usr/local/bin/mina-extract-blocks"
+cp ./default/src/app/berkeley_migration/berkeley_migration.exe "${BUILD_DIR}/usr/local/bin/mina-berkeley-migration"
+cp ./default/src/app/berkeley_account_tables/berkeley_account_tables.exe "${BUILD_DIR}/usr/local/bin/mina-berkeley-account-tables"
+
 cp ./default/src/app/missing_blocks_auditor/missing_blocks_auditor.exe "${BUILD_DIR}/usr/local/bin/mina-missing-blocks-auditor"
 cp ./default/src/app/replayer/replayer.exe "${BUILD_DIR}/usr/local/bin/mina-replayer"
 cp ./default/src/app/swap_bad_balances/swap_bad_balances.exe "${BUILD_DIR}/usr/local/bin/mina-swap-bad-balances"


### PR DESCRIPTION
### Deploy Archive Migration tools 

Archive Migration tooling consist of two applications:

- berkeley_migration (#12906)
- berkeley_account_tables (#14339)

We need to incorporate deployment of above apps into actual process. Basically the idea is to add above apps to build step in CI and pack them together with mina archive debian package as well as docker,

Closes #14551
