### PR TITLE
updated db cron container image

### DIFF
--- a/helm/archive-node/templates/db-bootstrap.yaml
+++ b/helm/archive-node/templates/db-bootstrap.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       {{- if .Values.archive.initFromDump }}
       - name: import-dump
-        image: gcr.io/o1labs-192920/postgresql-curl:latest
+        image: postgres:15-alpine
         env:
         - name: PGPASSWORD
           valueFrom:
@@ -19,6 +19,7 @@ spec:
         command: ["bash", "-c"]
         args:
         - 'sleep 30
+        && apk add curl
         && cd /tmp
         && curl https://storage.googleapis.com/mina-archive-dumps/{{ .Values.testnetName }}-archive-dump-$(date -Idate)_0000.sql.tar.gz -o {{ .Values.testnetName }}-archive-dump.tar.gz
         && tar -xvf {{ .Values.testnetName }}-archive-dump.tar.gz
@@ -37,7 +38,7 @@ spec:
         -c "ALTER DATABASE {{ .Values.postgresql.auth.database }} SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE;"'
       {{- else }}
       - name: import-schema
-        image: gcr.io/o1labs-192920/postgresql-curl:latest
+        image: postgres:15-alpine
         env:
         - name: PGPASSWORD
           valueFrom:
@@ -47,6 +48,7 @@ spec:
         command: ["bash", "-c"]
         args:
         - 'sleep 30
+        && apk add curl
         && cd /tmp
         && {{ range .Values.archive.remoteSchemaAuxFiles }} curl -O {{.}} && {{ end }}
         psql


### PR DESCRIPTION
Explain your changes:

Currently, integration tests within CI are failing when they include a replayer step, this is because the replayer logic replied on a cron job that deploys as part of the helm chart yaml.
The container that was in place was removed as part of purging intagged container images from our cloud environment.
This PR is to update the container image used within the Mina archive node helm chart.
Explain how you tested your changes:

This change has been tested using Buildkite CI, by manually running the branch within the nightly pipeline. This forces heavier integration tests which rely on the archive cron job to run.
Nightly CI Run: https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/755
PR CI Run: https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/31448

Related Slack Thread: https://o1-labs.slack.com/archives/C01SJSXSM7H/p1699383661282799?thread_ts=1699376408.396119&cid=C01SJSXSM7H

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [NA] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [NA] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [NA] Serialized types are in stable-versioned modules
- [ NA] Does this close issues? List them

