### PR TITLE
remove condition to deploy alerts automatically when build is against…

### DIFF
--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -42,7 +42,7 @@ Pipeline.build
           , target = Size.Medium
           , depends_on = [ { name = "TestnetAlerts", key = "lint-testnet-alerts" } ]
           , docker = None Docker.Type
-          , `if` = Some "build.branch == 'compatible' || build.env('DEPLOY_ALERTS') == 'true'"
+          , `if` = Some "build.env('DEPLOY_ALERTS') == 'true'"
         }
     ]
   }


### PR DESCRIPTION
Remove condition from TestnetAlerts job so there won't be automatic testnet alerts deployment on nightly