### PR TITLE
support ci runs on forks

### DIFF
--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 echo "Exporting Variables: "
 
+export MINA_REPO="https://github.com/MinaProtocol/mina.git"
+
 function find_most_recent_numeric_tag() {
     TAG=$(git describe --always --abbrev=0 $1 | sed 's!/!-!g; s!_!-!g')
     if [[ $TAG != [0-9]* ]]; then
@@ -13,8 +15,7 @@ function find_most_recent_numeric_tag() {
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
 export GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g' )
-# GITTAG is the closest tagged commit to this commit, while THIS_COMMIT_TAG only has a value when the current commit is tagged
-export GITTAG=$(find_most_recent_numeric_tag HEAD)
+
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 export PROJECT="mina"
 
@@ -24,8 +25,47 @@ export BUILD_URL=${BUILDKITE_BUILD_URL}
 set -u
 
 export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
-
 [[ -n "$BUILDKITE_BRANCH" ]] && export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g')
+ 
+
+if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 
+  # We don't want to allow some operations on fork repository which should be done on main repo only. 
+  # Publish to docker hub or publish to unstable debian channel should be exclusive to main repo as it can override 
+  # packages from main repo (by using the same commit and the same branch from forked repository)
+
+  # We don't want to use tags (as this can replace our dockers/debian packages). Instead we are using repo name
+  # For example: for given repo 'https://github.com/dkijania/mina.git' we convert it to 'dkijania_mina' 
+  export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e "s/https:\/\/github.com\///g" | sed -e "s/.git//g" | sed -e "s/\//-/g")
+  export THIS_COMMIT_TAG=""
+  RELEASE=unstable
+
+else
+  # GITTAG is the closest tagged commit to this commit, while THIS_COMMIT_TAG only has a value when the current commit is tagged
+  export GITTAG=$(find_most_recent_numeric_tag HEAD)
+
+  # Determine deb repo to use
+  case $GITBRANCH in
+      berkeley|rampup|compatible|master|release*) # whitelist of branches that can be tagged
+          case "${THIS_COMMIT_TAG}" in
+            *alpha*) # any tag including the string `alpha`
+              RELEASE=alpha ;;
+            *beta*) # any tag including the string `beta`
+              RELEASE=beta ;;
+            *rampup*) # any tag including the string `rampup`
+              RELEASE=rampup ;;
+            ?*) # Any other non-empty tag. ? matches a single character and * matches 0 or more characters.
+              RELEASE=stable ;;
+            "") # No tag
+              RELEASE=unstable ;;
+            *) # The above set of cases should be exhaustive, if they're not then still set RELEASE=unstable
+              RELEASE=unstable
+              echo "git tag --points-at HEAD may have failed, falling back to unstable. Value: \"$(git tag --points-at HEAD)\""
+              ;;
+          esac ;;
+      *)
+          RELEASE=unstable ;;
+  esac
+fi
 
 if [[ -n "${THIS_COMMIT_TAG}" ]]; then # If the commit is tagged
     export MINA_DEB_VERSION="${GITTAG}-${GITHASH}"
@@ -34,30 +74,6 @@ else
     export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
     export MINA_DOCKER_TAG="$(echo "${MINA_DEB_VERSION}-${MINA_DEB_CODENAME}" | sed 's!/!-!g; s!_!-!g')"
 fi
-
-
-# Determine deb repo to use
-case $GITBRANCH in
-    berkeley|rampup|compatible|master|release*) # whitelist of branches that can be tagged
-        case "${THIS_COMMIT_TAG}" in
-          *alpha*) # any tag including the string `alpha`
-            RELEASE=alpha ;;
-          *beta*) # any tag including the string `beta`
-            RELEASE=beta ;;
-          *rampup*) # any tag including the string `rampup`
-            RELEASE=rampup ;;
-          ?*) # Any other non-empty tag. ? matches a single character and * matches 0 or more characters.
-            RELEASE=stable ;;
-          "") # No tag
-            RELEASE=unstable ;;
-          *) # The above set of cases should be exhaustive, if they're not then still set RELEASE=unstable
-            RELEASE=unstable
-            echo "git tag --points-at HEAD may have failed, falling back to unstable. Value: \"$(git tag --points-at HEAD)\""
-            ;;
-        esac ;;
-    *)
-        RELEASE=unstable ;;
-esac
 
 # Determine the packages to build (mainnet y/N)
 case $GITBRANCH in

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -2,6 +2,8 @@
 
 TAG=$(git tag --points-at HEAD)
 
+source buildkite/scripts/handle-fork.sh
+
 # If this is not a PR build, or the HEAD is tagged, the entire build is dirty
 if [ -z "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" ]; then
   echo "This is not a PR build; considering all files dirty" >&2
@@ -11,7 +13,7 @@ elif [ -n "${TAG}" ]; then
   git ls-files
 else
   COMMIT=$(git log -1 --pretty=format:%H)
-  BASE_COMMIT=$(git log "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
+  BASE_COMMIT=$(git log "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
   echo "Diffing current commit: ${COMMIT} against branch: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} (${BASE_COMMIT})" >&2 
-  git diff "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
+  git diff "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
 fi

--- a/buildkite/scripts/handle-fork.sh
+++ b/buildkite/scripts/handle-fork.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export MINA_REPO="https://github.com/MinaProtocol/mina.git"
+
+if [ "${BUILDKITE_REPO}" ==  ${MINA_REPO} ]; then
+    echo "This is not a Forked repo, skipping..."
+    export REMOTE="origin"
+    export FORK=0
+else
+    git remote add mina ${MINA_REPO} || true
+    git fetch mina
+    export REMOTE="mina"
+    export FORK=1
+fi

--- a/buildkite/scripts/merges-cleanly.sh
+++ b/buildkite/scripts/merges-cleanly.sh
@@ -4,6 +4,7 @@ BRANCH=$1
 CURRENT=$(git branch --show-current)
 echo 'Testing for conflicts between the current branch `'"${CURRENT}"'` and `'"${BRANCH}"'`...'
 
+
 # Adapted from this stackoverflow answer: https://stackoverflow.com/a/10856937
 # The git merge-tree command shows the content of a 3-way merge without
 # touching the index, which we can then search for conflict markers.
@@ -11,14 +12,23 @@ echo 'Testing for conflicts between the current branch `'"${CURRENT}"'` and `'"$
 # Tell git where to find ssl certs
 git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt
 # Fetch a fresh copy of the repo
-git fetch origin
+if [ "${BUILDKITE_REPO}" == "https://github.com/MinaProtocol/mina.git" ]; then
+    REMOTE="origin"
+else
+    REMOTE="mina"
+    git remote add ${REMOTE} https://github.com/MinaProtocol/mina.git --fetch --tags
+fi
+
+git fetch ${REMOTE}
+
+
 git config --global user.email "hello@ci.com"
 git config --global user.name "It's me, CI"
 # Check mergeability. We use flags so that
 # * `--no-commit` stops us from updating the index with a merge commit,
 # * `--no-ff` stops us from updating the index to the HEAD, if the merge is a
 #   straightforward fast-forward
-git merge --no-commit --no-ff origin/$BRANCH
+git merge --no-commit --no-ff ${REMOTE}/$BRANCH
 
 RET=$?
 

--- a/buildkite/scripts/run-snark-transaction-profiler.sh
+++ b/buildkite/scripts/run-snark-transaction-profiler.sh
@@ -23,5 +23,5 @@ K=1
 MAX_NUM_UPDATES=4
 MIN_NUM_UPDATES=2   
 
-echo "--- Run Snark Transaction Profiler with parameters: --zkapps --k ${K} --max-num-updates ${MAX_NUM_UPDATES} --min-num-updates ${MIN_NUM_UPDATES}"
+echo "-- Run Snark Transaction Profiler with parameters: --zkapps --k ${K} --max-num-updates ${MAX_NUM_UPDATES} --min-num-updates ${MIN_NUM_UPDATES}"
 python3 ./scripts/snark_transaction_profiler.py ${K} ${MAX_NUM_UPDATES} ${MIN_NUM_UPDATES}

--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -euo pipefail
-
 set -eou pipefail
 set +x
 
@@ -16,7 +14,8 @@ echo 'experimental-features = nix-command flakes' > "${XDG_CONFIG_HOME-${HOME}/.
 
 git config --global --add safe.directory /workdir
 
-# Nix has issue when performing operations on detached head
+git fetch
+# Nix has issue when performing operations on detached head.
 # On Ci machine it spit out issues like:
 # fatal: reference is not a tree: ....
 # error:
@@ -24,7 +23,7 @@ git config --global --add safe.directory /workdir
 #
 #       error: program 'git' failed with exit code 128
 # That is why we checkout branch explicitly
-git checkout $1
+git checkout origin/$1
 
 ./nix/pin.sh
 

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -15,13 +15,15 @@ apt-get install -y git apt-transport-https ca-certificates tzdata curl python3 p
 
 git config --global --add safe.directory /workdir
 
+
+source buildkite/scripts/handle-fork.sh
 source buildkite/scripts/export-git-env-vars.sh
 
 pip3 install sexpdata
 
-base_branch=origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+base_branch=${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
 pr_branch=origin/${BUILDKITE_BRANCH}
-release_branch=origin/$1
+release_branch=${REMOTE}/$1
 
 echo "--- Run Python version linter with branches: ${pr_branch} ${base_branch} ${release_branch}"
 ./scripts/version-linter.py ${pr_branch} ${base_branch} ${release_branch}

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -20,6 +20,7 @@ let ReleaseSpec = {
     service: Text,
     version: Text,
     branch: Text,
+    repo: Text,
     deb_codename: Text,
     deb_release: Text,
     deb_version: Text,
@@ -34,6 +35,7 @@ let ReleaseSpec = {
     version = "\\\${MINA_DOCKER_TAG}",
     service = "\\\${MINA_SERVICE}",
     branch = "\\\${BUILDKITE_BRANCH}",
+    repo = "\\\${BUILDKITE_REPO}",
     deb_codename = "bullseye",
     deb_profile = "devnet",
     deb_release = "\\\${MINA_DEB_RELEASE}",
@@ -50,7 +52,7 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
     [
         Cmd.run (
           "export MINA_DEB_CODENAME=${spec.deb_codename} && source ./buildkite/scripts/export-git-env-vars.sh && ./scripts/release-docker.sh " ++
-              "--service ${spec.service} --version ${spec.version} --network ${spec.network} --branch ${spec.branch} --deb-codename ${spec.deb_codename} --deb-release ${spec.deb_release} --deb-version ${spec.deb_version} --deb-profile ${spec.deb_profile} --extra-args \\\"${spec.extra_args}\\\""
+              "--service ${spec.service} --version ${spec.version} --network ${spec.network} --branch ${spec.branch} --deb-codename ${spec.deb_codename} --deb-release ${spec.deb_release} --deb-version ${spec.deb_version} --deb-profile ${spec.deb_profile} --repo ${spec.repo} --extra-args \\\"${spec.extra_args}\\\""
         )
     ]
 

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -49,7 +49,7 @@ Pipeline.build
       let lintDirtyWhen = [
         S.strictlyStart (S.contains "src"),
         S.exactly "buildkite/src/Jobs/Test/VersionLint" "dhall",
-        S.exactly "buildkite/scripts/version_linter" "sh"
+        S.exactly "buildkite/scripts/version-linter" "sh"
       ]
 
       in

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -30,6 +30,7 @@ let jobs : List JobSpec.Type =
 let prefixCommands = [
   Cmd.run "git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt", -- Tell git where to find certs for https connections
   Cmd.run "git fetch origin", -- Freshen the cache
+  Cmd.run "./buildkite/scripts/handle-fork.sh",
   Cmd.run "./buildkite/scripts/generate-diff.sh > _computed_diff.txt"
 ]
 

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -21,6 +21,7 @@ function usage() {
   echo "  -v, --version             The version to be used in the docker image tag"
   echo "  -n, --network             The network configuration to use (devnet or mainnet). Default=devnet"
   echo "  -b, --branch              The branch of the mina repository to use for staged docker builds. Default=compatible"
+  echo "  -r, --repo                The currently used mina repository"
   echo "      --deb-codename        The debian codename (stretch or buster) to build the docker image from. Default=stretch"
   echo "      --deb-release         The debian package release channel to pull from (unstable,alpha,beta,stable). Default=unstable"
   echo "      --deb-version         The version string for the debian package to install"
@@ -38,6 +39,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--network) NETWORK="--build-arg network=$2"; shift;;
   -b|--branch) BRANCH="--build-arg MINA_BRANCH=$2"; shift;;
   -c|--cache-from) CACHE="--cache-from $2"; shift;;
+  -r|--repo) MINA_REPO="$2"; shift;;
   --deb-codename) DEB_CODENAME="--build-arg deb_codename=$2"; shift;;
   --deb-release) DEB_RELEASE="--build-arg deb_release=$2"; shift;;
   --deb-version) DEB_VERSION="--build-arg deb_version=$2"; shift;;
@@ -137,8 +139,8 @@ itn-orchestrator)
 esac
 
 
-REPO="--build-arg MINA_REPO=${BUILDKITE_PULL_REQUEST_REPO}"
-if [[ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]]; then
+REPO="--build-arg MINA_REPO=${MINA_REPO}"
+if [[ -z "${MINA_REPO}" ]]; then
   REPO="--build-arg MINA_REPO=https://github.com/MinaProtocol/mina"
 fi
 


### PR DESCRIPTION
Currently our CI build system is not prepared to handle change from fork repo to mina. There are various problems like:

many jobs checkout origin branches as reference to some comparison and they will checkout branch from fork repo rather than mina (for example merges cleanly)
we should not allow to publish dockers to docker hub from forked repositories
we need to tag dockers properly not to override main repo based dockers

This PR addresses above problems. It adds yet another remote (mina) which always point to mina protocol repository. If CI is run against forked repository it uses branches from mina remote for comparison instead of origin which point to forked repositories. It also changes behavior when running export env variables script. It does not allow to publish dockers and debian packages stable channels or to dockerhub.

Closes #14575