### PR TITLE
Use the pre-computed hashes from the database when preloading into a sparse ledger mask

### DIFF
--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -124,6 +124,8 @@ module Make_base (Inputs : Inputs_intf) :
 
     let merkle_root (T ((module Base), t)) = Base.merkle_root t
 
+    let get_hash_batch_exn (T ((module Base), t)) = Base.get_hash_batch_exn t
+
     let index_of_account_exn (T ((module Base), t)) =
       Base.index_of_account_exn t
 

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -136,6 +136,8 @@ module type S = sig
 
   val merkle_path_batch : t -> Location.t list -> Path.t list
 
+  val get_hash_batch_exn : t -> Location.t list -> hash list
+
   val remove_accounts_exn : t -> account_id list -> unit
 
   (** Triggers when the ledger has been detached and should no longer be

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -154,7 +154,7 @@ module Make (Inputs : Inputs_intf) :
     | None ->
         empty_hash (Location.height ~ledger_depth:mdb.depth location)
 
-  let get_hash_batch mdb locations =
+  let get_hash_batch_exn mdb locations =
     List.iter locations ~f:(fun location -> assert (Location.is_hash location)) ;
     let hashes = get_bin_batch mdb locations Hash.bin_read_t in
     List.map2_exn locations hashes ~f:(fun location hash ->
@@ -705,7 +705,7 @@ module Make (Inputs : Inputs_intf) :
       in
       loop location [] []
     in
-    let rev_hashes = get_hash_batch mdb rev_locations in
+    let rev_hashes = get_hash_batch_exn mdb rev_locations in
     let rec loop directions hashes acc =
       match (directions, hashes) with
       | [], [] ->
@@ -751,7 +751,7 @@ module Make (Inputs : Inputs_intf) :
       in
       loop locations [] [] [ 0 ]
     in
-    let rev_hashes = get_hash_batch mdb rev_locations in
+    let rev_hashes = get_hash_batch_exn mdb rev_locations in
     let rec loop directions hashes lengths acc =
       match (directions, hashes, lengths, acc) with
       | [], [], [], _ (* actually [] *) :: acc_tl ->

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -73,6 +73,11 @@ end = struct
   let merkle_path_at_index_exn t index =
     merkle_path_at_addr_exn t (Addr.of_int_exn ~ledger_depth:t.depth index)
 
+  let get_hash_batch_exn t locations =
+    List.map locations ~f:(fun location ->
+        empty_hash_at_height
+          (Addr.height ~ledger_depth:t.depth (Location.to_path_exn location)) )
+
   let index_of_account_exn _t =
     failwith "index_of_account_exn: null ledgers are empty"
 

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -435,16 +435,20 @@ module Make (Inputs : Inputs_intf.S) = struct
       List.iter addresses_and_hashes ~f:(fun (addr, hash) ->
           self_set_hash t addr hash )
 
-    (* a write writes only to the mask, parent is not involved need to update
-       both account and hash pieces of the mask *)
-    let set t location account =
+    let set_account_unsafe t location account =
       assert_is_attached t ;
       self_set_account t location account ;
       (* Update token info. *)
       let account_id = Account.identifier account in
       Token_id.Table.set t.token_owners
         ~key:(Account_id.derive_token_id ~owner:account_id)
-        ~data:account_id ;
+        ~data:account_id
+
+    (* a write writes only to the mask, parent is not involved need to update
+       both account and hash pieces of the mask *)
+    let set t location account =
+      assert_is_attached t ;
+      set_account_unsafe t location account ;
       (* Update merkle path. *)
       let account_address = Location.to_path_exn location in
       let account_hash = Hash.hash_account account in
@@ -739,28 +743,42 @@ module Make (Inputs : Inputs_intf.S) = struct
         List.filter_map locations ~f:(fun (_account_id, location) -> location)
       in
       let accounts = Base.get_batch (get_parent t) non_empty_locations in
-      let non_empty_locations =
-        match t.current_location with
-        | None ->
-            non_empty_locations
-        | Some location ->
-            location :: non_empty_locations
+      let all_hash_locations =
+        let rec generate_locations account_locations acc =
+          match account_locations with
+          | [] ->
+              acc
+          | location :: account_locations -> (
+              let address = Location.to_path_exn location in
+              match Addr.parent address with
+              | Ok parent ->
+                  let sibling = Addr.sibling address in
+                  generate_locations
+                    (Location.Hash parent :: account_locations)
+                    (Location.Hash address :: Location.Hash sibling :: acc)
+              | Error _ ->
+                  (* This is the root. It's somewhat wasteful to add it for
+                     every account, but makes this logic simpler.
+                  *)
+                  generate_locations account_locations
+                    (Location.Hash address :: acc) )
+        in
+        generate_locations non_empty_locations []
       in
-      let merkle_paths =
-        Base.merkle_path_batch (get_parent t) non_empty_locations
+      let all_hashes =
+        Base.get_hash_batch_exn (get_parent t) all_hash_locations
       in
-      (* Batch import merkle paths. *)
-      List.iter2_exn non_empty_locations merkle_paths
-        ~f:(fun location merkle_path ->
-          let addr = Location.to_path_exn location in
-          set_merkle_path_unsafe t addr merkle_path ) ;
+      (* Batch import merkle paths and self hashes. *)
+      List.iter2_exn all_hash_locations all_hashes ~f:(fun location hash ->
+          let address = Location.to_path_exn location in
+          self_set_hash t address hash ) ;
       (* Batch import accounts. *)
       List.iter accounts ~f:(fun (location, account) ->
           match account with
           | None ->
               ()
           | Some account ->
-              set t location account )
+              set_account_unsafe t location account )
 
     (* not needed for in-memory mask; in the database, it's currently a NOP *)
     let make_space_for t =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -502,16 +502,31 @@ module Make (Inputs : Inputs_intf.S) = struct
       assert_is_attached t ;
       List.map locations ~f:(fun location -> get t location)
 
-    (* NB: rocksdb does not support batch reads; is this needed? *)
-    let get_hash_batch_exn t addrs =
+    let get_hash_batch_exn t locations =
       assert_is_attached t ;
-      List.map addrs ~f:(fun addr ->
-          match self_find_hash t addr with
-          | Some account ->
-              Some account
-          | None -> (
-              try Some (Base.get_inner_hash_at_addr_exn (get_parent t) addr)
-              with _ -> None ) )
+      let self_hashes_rev =
+        List.rev_map locations ~f:(fun location ->
+            (location, self_find_hash t (Location.to_path_exn location)) )
+      in
+      let parent_locations_rev =
+        List.filter_map self_hashes_rev ~f:(fun (location, hash) ->
+            match hash with None -> Some location | Some _ -> None )
+      in
+      let parent_hashes_rev =
+        if List.is_empty parent_locations_rev then []
+        else Base.get_hash_batch_exn (get_parent t) parent_locations_rev
+      in
+      let rec recombine self_hashes_rev parent_hashes_rev acc =
+        match (self_hashes_rev, parent_hashes_rev) with
+        | [], [] ->
+            acc
+        | (_location, None) :: self_hashes_rev, hash :: parent_hashes_rev
+        | (_location, Some hash) :: self_hashes_rev, parent_hashes_rev ->
+            recombine self_hashes_rev parent_hashes_rev (hash :: acc)
+        | _, [] | [], _ ->
+            assert false
+      in
+      recombine self_hashes_rev parent_hashes_rev []
 
     (* transfer state from mask to parent; flush local state *)
     let commit t =


### PR DESCRIPTION
This PR replaces some re-hashing during mask preloading with more batch hash reads from the underlying ledger. This should help to improve the performance of staged ledger diff application. This builds upon #14585.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them