### PR TITLE
Avoid ledger copy and mutation in `Sparse_ledger.of_ledger_subset_exn`

### DIFF
--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -215,6 +215,15 @@ let serialize ~ledger_depth path =
 
 let is_parent_of parent ~maybe_child = Bitstring.is_prefix maybe_child parent
 
+let same_height_ancestors x y =
+  let depth_x = depth x in
+  let depth_y = depth y in
+  if depth_x < depth_y then (x, slice y 0 depth_x) else (slice x 0 depth_y, y)
+
+let is_further_right ~than path =
+  let than, path = same_height_ancestors than path in
+  compare than path < 0
+
 module Range = struct
   type nonrec t = t * t
 

--- a/src/lib/merkle_address/merkle_address.mli
+++ b/src/lib/merkle_address/merkle_address.mli
@@ -74,3 +74,7 @@ val height : ledger_depth:int -> t -> int
 val to_int : t -> int
 
 val of_int_exn : ledger_depth:int -> int -> t
+
+val same_height_ancestors : t -> t -> t * t
+
+val is_further_right : than:t -> t -> bool

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -120,6 +120,8 @@ module Make_base (Inputs : Inputs_intf) :
 
     let merkle_path (T ((module Base), t)) = Base.merkle_path t
 
+    let merkle_path_batch (T ((module Base), t)) = Base.merkle_path_batch t
+
     let merkle_root (T ((module Base), t)) = Base.merkle_root t
 
     let index_of_account_exn (T ((module Base), t)) =

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -124,6 +124,8 @@ module Make_base (Inputs : Inputs_intf) :
 
     let merkle_root (T ((module Base), t)) = Base.merkle_root t
 
+    let get_hash_batch_exn (T ((module Base), t)) = Base.get_hash_batch_exn t
+
     let index_of_account_exn (T ((module Base), t)) =
       Base.index_of_account_exn t
 

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -134,6 +134,8 @@ module type S = sig
 
   val merkle_path_at_index_exn : t -> int -> Path.t
 
+  val merkle_path_batch : t -> Location.t list -> Path.t list
+
   val remove_accounts_exn : t -> account_id list -> unit
 
   (** Triggers when the ledger has been detached and should no longer be

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -136,6 +136,8 @@ module type S = sig
 
   val merkle_path_batch : t -> Location.t list -> Path.t list
 
+  val get_hash_batch_exn : t -> Location.t list -> hash list
+
   val remove_accounts_exn : t -> account_id list -> unit
 
   (** Triggers when the ledger has been detached and should no longer be

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -154,7 +154,7 @@ module Make (Inputs : Inputs_intf) :
     | None ->
         empty_hash (Location.height ~ledger_depth:mdb.depth location)
 
-  let get_hash_batch mdb locations =
+  let get_hash_batch_exn mdb locations =
     List.iter locations ~f:(fun location -> assert (Location.is_hash location)) ;
     let hashes = get_bin_batch mdb locations Hash.bin_read_t in
     List.map2_exn locations hashes ~f:(fun location hash ->
@@ -696,7 +696,7 @@ module Make (Inputs : Inputs_intf) :
     let dependency_locs, dependency_dirs =
       List.unzip (Location.merkle_path_dependencies_exn location)
     in
-    let dependency_hashes = get_hash_batch mdb dependency_locs in
+    let dependency_hashes = get_hash_batch_exn mdb dependency_locs in
     List.map2_exn dependency_dirs dependency_hashes ~f:(fun dir hash ->
         Direction.map dir ~left:(`Left hash) ~right:(`Right hash) )
 
@@ -731,7 +731,7 @@ module Make (Inputs : Inputs_intf) :
       in
       loop locations [] [] [ 0 ]
     in
-    let rev_hashes = get_hash_batch mdb rev_locations in
+    let rev_hashes = get_hash_batch_exn mdb rev_locations in
     let rec loop directions hashes lengths acc =
       match (directions, hashes, lengths, acc) with
       | [], [], [], _ (* actually [] *) :: acc_tl ->

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -700,6 +700,58 @@ module Make (Inputs : Inputs_intf) :
     List.map2_exn dependency_dirs dependency_hashes ~f:(fun dir hash ->
         Direction.map dir ~left:(`Left hash) ~right:(`Right hash) )
 
+  let merkle_path_batch mdb locations =
+    let locations =
+      List.map locations ~f:(fun location ->
+          if Location.is_account location then
+            Location.Hash (Location.to_path_exn location)
+          else (
+            assert (Location.is_hash location) ;
+            location ) )
+    in
+    let rev_locations, rev_directions, rev_lengths =
+      let rec loop locations loc_acc dir_acc length_acc =
+        match (locations, length_acc) with
+        | [], _ :: length_acc ->
+            (loc_acc, dir_acc, length_acc)
+        | k :: locations, length :: length_acc ->
+            if Location.height ~ledger_depth:mdb.depth k >= mdb.depth then
+              loop locations loc_acc dir_acc (0 :: length :: length_acc)
+            else
+              let sibling = Location.sibling k in
+              let sibling_dir =
+                Location.last_direction (Location.to_path_exn k)
+              in
+              loop
+                (Location.parent k :: locations)
+                (sibling :: loc_acc) (sibling_dir :: dir_acc)
+                ((length + 1) :: length_acc)
+        | _ ->
+            assert false
+      in
+      loop locations [] [] [ 0 ]
+    in
+    let rev_hashes = get_hash_batch mdb rev_locations in
+    let rec loop directions hashes lengths acc =
+      match (directions, hashes, lengths, acc) with
+      | [], [], [], _ (* actually [] *) :: acc_tl ->
+          acc_tl
+      | _, _, 0 :: lengths, _ ->
+          loop directions hashes lengths ([] :: acc)
+      | ( direction :: directions
+        , hash :: hashes
+        , length :: lengths
+        , acc_hd :: acc_tl ) ->
+          let dir =
+            Direction.map direction ~left:(`Left hash) ~right:(`Right hash)
+          in
+          loop directions hashes ((length - 1) :: lengths)
+            ((dir :: acc_hd) :: acc_tl)
+      | _ ->
+          failwith "Mismatched lengths"
+    in
+    loop rev_directions rev_hashes rev_lengths [ [] ]
+
   let merkle_path_at_addr_exn t addr = merkle_path t (Location.Hash addr)
 
   let merkle_path_at_index_exn t index =

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -64,6 +64,8 @@ end = struct
     in
     loop location
 
+  let merkle_path_batch t locations = List.map ~f:(merkle_path t) locations
+
   let merkle_root t = empty_hash_at_height t.depth
 
   let merkle_path_at_addr_exn t addr = merkle_path t (Location.Hash addr)

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -73,6 +73,11 @@ end = struct
   let merkle_path_at_index_exn t index =
     merkle_path_at_addr_exn t (Addr.of_int_exn ~ledger_depth:t.depth index)
 
+  let get_hash_batch_exn t locations =
+    List.map locations ~f:(fun location ->
+        empty_hash_at_height
+          (Addr.height ~ledger_depth:t.depth (Location.to_path_exn location)) )
+
   let index_of_account_exn _t =
     failwith "index_of_account_exn: null ledgers are empty"
 

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -188,17 +188,6 @@ module Make (Test : Test_intf) = struct
         (* verify all hashes to root are same in mask and parent *)
         compare_maskable_mask_hashes maskable attached_mask dummy_address )
 
-  let%test "mask delegates to parent" =
-    Test.with_instances (fun maskable mask ->
-        let attached_mask = Maskable.register_mask maskable mask in
-        (* set to parent, get from mask *)
-        Maskable.set maskable dummy_location dummy_account ;
-        let mask_result = Mask.Attached.get attached_mask dummy_location in
-        Option.is_some mask_result
-        &&
-        let mask_account = Option.value_exn mask_result in
-        Account.equal dummy_account mask_account )
-
   let%test "mask prune after parent notification" =
     Test.with_instances (fun maskable mask ->
         let attached_mask = Maskable.register_mask maskable mask in

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -23,6 +23,7 @@
    visualization
    mina_stdlib
    direction
+   empty_hashes
  )
  (preprocess
   (pps

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -141,6 +141,9 @@ module Make (Inputs : Inputs_intf) = struct
           Node (summary, List.map masks ~f:(_crawl (module Mask.Attached)))
   end
 
+  let unsafe_preload_accounts_from_parent =
+    Mask.Attached.unsafe_preload_accounts_from_parent
+
   let register_mask t mask =
     let attached_mask = Mask.set_parent mask t in
     List.iter (Uuid.Table.data registered_masks) ~f:(fun ms ->

--- a/src/lib/merkle_mask/maskable_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree_intf.ml
@@ -15,6 +15,9 @@ module type S = sig
 
   val register_mask : t -> unattached_mask -> attached_mask
 
+  val unsafe_preload_accounts_from_parent :
+    attached_mask -> account_id list -> unit
+
   (** raises an exception if mask is not registered *)
   val unregister_mask_exn :
        ?grandchildren:

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -624,6 +624,13 @@ module Make (Inputs : Inputs_intf.S) = struct
       self_find_or_batch_lookup self_find_location
         Base.location_of_account_batch
 
+    (* Adds specified accounts to the mask by laoding them from parent ledger.
+
+       Could be useful for transaction processing when to pre-populate mask with the
+       accounts used in processing a transaction (or a block) to ensure there are not loaded
+       from parent on each lookup. I.e. these accounts will be cached in mask and accessing
+       them during processing of a transaction won't use disk I/O.
+    *)
     let unsafe_preload_accounts_from_parent t account_ids =
       assert_is_attached t ;
       let locations =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -668,7 +668,6 @@ module Make (Inputs : Inputs_intf.S) = struct
           Base.location_of_account (get_parent t) account_id
 
     let location_of_account_batch t =
-      (* TODO consider handling special case of empty addresses *)
       self_find_or_batch_lookup
         (fun id -> (id, Option.map ~f:Option.some @@ self_find_location t id))
         Base.location_of_account_batch t

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -405,9 +405,9 @@ module Make (Inputs : Inputs_intf.S) = struct
     let set_merkle_path_unsafe t addr path =
       assert_is_attached t ;
       ignore
-        ( List.fold_left ~init:addr (List.rev path) ~f:(fun addr path ->
-              let addr = Location.Addr.parent_exn addr in
+        ( List.fold_left ~init:addr path ~f:(fun addr path ->
               let sibling_addr = Location.Addr.sibling addr in
+              let addr = Location.Addr.parent_exn addr in
               let hash = match path with `Left hash | `Right hash -> hash in
               self_set_hash t sibling_addr hash ;
               addr )

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -448,16 +448,31 @@ module Make (Inputs : Inputs_intf.S) = struct
       assert_is_attached t ;
       List.map locations ~f:(fun location -> get t location)
 
-    (* NB: rocksdb does not support batch reads; is this needed? *)
-    let get_hash_batch_exn t addrs =
+    let get_hash_batch_exn t locations =
       assert_is_attached t ;
-      List.map addrs ~f:(fun addr ->
-          match self_find_hash t addr with
-          | Some account ->
-              Some account
-          | None -> (
-              try Some (Base.get_inner_hash_at_addr_exn (get_parent t) addr)
-              with _ -> None ) )
+      let self_hashes_rev =
+        List.rev_map locations ~f:(fun location ->
+            (location, self_find_hash t (Location.to_path_exn location)) )
+      in
+      let parent_locations_rev =
+        List.filter_map self_hashes_rev ~f:(fun (location, hash) ->
+            match hash with None -> Some location | Some _ -> None )
+      in
+      let parent_hashes_rev =
+        if List.is_empty parent_locations_rev then []
+        else Base.get_hash_batch_exn (get_parent t) parent_locations_rev
+      in
+      let rec recombine self_hashes_rev parent_hashes_rev acc =
+        match (self_hashes_rev, parent_hashes_rev) with
+        | [], [] ->
+            acc
+        | (_location, None) :: self_hashes_rev, hash :: parent_hashes_rev
+        | (_location, Some hash) :: self_hashes_rev, parent_hashes_rev ->
+            recombine self_hashes_rev parent_hashes_rev (hash :: acc)
+        | _, [] | [], _ ->
+            assert false
+      in
+      recombine self_hashes_rev parent_hashes_rev []
 
     (* transfer state from mask to parent; flush local state *)
     let commit t =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -211,10 +211,14 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     let get_batch = self_find_or_batch_lookup self_find_account Base.get_batch
 
+    let empty_hash =
+      Empty_hashes.extensible_cache (module Hash) ~init_hash:Hash.empty_account
+
     let self_merkle_path t address =
       Option.try_with (fun () ->
           let rec self_merkle_path address =
-            if Addr.height ~ledger_depth:t.depth address >= t.depth then []
+            let height = Addr.height ~ledger_depth:t.depth address in
+            if height >= t.depth then []
             else
               let sibling = Addr.sibling address in
               let sibling_dir = Location.last_direction address in
@@ -223,7 +227,18 @@ module Make (Inputs : Inputs_intf.S) = struct
                 | Some hash ->
                     hash
                 | None ->
-                    (* Caught by [try_with] above. *) assert false
+                    let is_empty =
+                      match t.current_location with
+                      | None ->
+                          true
+                      | Some current_location ->
+                          let current_address =
+                            Location.to_path_exn current_location
+                          in
+                          Addr.is_further_right ~than:current_address sibling
+                    in
+                    if is_empty then empty_hash height
+                    else (* Caught by [try_with] above. *) assert false
               in
               let parent_address =
                 match Addr.parent address with

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -181,7 +181,16 @@ module Make (Inputs : Inputs_intf.S) = struct
       | Some account ->
           Some account
       | None ->
-          Base.get (get_parent t) location
+          let is_empty =
+            match t.current_location with
+            | None ->
+                true
+            | Some current_location ->
+                let address = Location.to_path_exn location in
+                let current_address = Location.to_path_exn current_location in
+                Addr.is_further_right ~than:current_address address
+          in
+          if is_empty then None else Base.get (get_parent t) location
 
     let self_find_or_batch_lookup self_find lookup_parent t ids =
       assert_is_attached t ;

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -217,7 +217,7 @@ module Make (Inputs : Inputs_intf.S) = struct
             if Addr.height ~ledger_depth:t.depth address >= t.depth then []
             else
               let sibling = Addr.sibling address in
-              let sibling_dir = Location.last_direction sibling in
+              let sibling_dir = Location.last_direction address in
               let hash =
                 match self_find_hash t sibling with
                 | Some hash ->

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -260,6 +260,16 @@ module Make (Inputs : Inputs_intf.S) = struct
       let parent_merkle_path = Base.merkle_path (get_parent t) location in
       fixup_merkle_path t parent_merkle_path address
 
+    let merkle_path_batch t locations =
+      assert_is_attached t ;
+      let addresses = List.map ~f:Location.to_path_exn locations in
+      let parent_merkle_paths =
+        Base.merkle_path_batch (get_parent t) locations
+      in
+      List.map2_exn
+        ~f:(fun path address -> fixup_merkle_path t path address)
+        parent_merkle_paths addresses
+
     (* given a Merkle path corresponding to a starting address, calculate
        addresses and hashes for each node affected by the starting hash; that is,
        along the path from the account address to root *)

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -76,6 +76,13 @@ module type S = sig
     (* makes new mask instance with copied tables, re-use parent *)
     val copy : t -> t
 
+    (* Adds specified accounts to the mask by laoding them from parent ledger.
+
+       Could be useful for transaction processing when to pre-populate mask with the
+       accounts used in processing a transaction (or a block) to ensure there are not loaded
+       from parent on each lookup. I.e. these accounts will be cached in mask and accessing
+       them during processing of a transaction won't use disk I/O.
+    *)
     val unsafe_preload_accounts_from_parent : t -> account_id list -> unit
 
     (** already have module For_testing from include above *)

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -73,9 +73,8 @@ module type S = sig
     (** called when parent sets an account; update local state *)
     val parent_set_notify : t -> account -> unit
 
-    val copy : t -> t
-
     (* makes new mask instance with copied tables, re-use parent *)
+    val copy : t -> t
 
     (** already have module For_testing from include above *)
     module For_testing : sig

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -76,6 +76,8 @@ module type S = sig
     (* makes new mask instance with copied tables, re-use parent *)
     val copy : t -> t
 
+    val unsafe_preload_accounts_from_parent : t -> account_id list -> unit
+
     (** already have module For_testing from include above *)
     module For_testing : sig
       val location_in_mask : t -> location -> bool

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -53,4 +53,5 @@
    unsigned_extended
    with_hash
    ppx_version.runtime
+   direction
 ))

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -271,6 +271,9 @@ module Ledger_inner = struct
 
   let register_mask t mask = Maskable.register_mask (packed t) mask
 
+  let unsafe_preload_accounts_from_parent =
+    Maskable.unsafe_preload_accounts_from_parent
+
   let unregister_mask_exn ~loc mask = Maskable.unregister_mask_exn ~loc mask
 
   let remove_and_reparent_exn t t_as_mask =

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -80,6 +80,9 @@ include
 *)
 val unregister_mask_exn : loc:string -> Mask.Attached.t -> Mask.t
 
+val unsafe_preload_accounts_from_parent :
+  Mask.Attached.t -> Account_id.t list -> unit
+
 (* The maskable ledger is t = Mask.Attached.t because register/unregister
  * work off of this type *)
 type maskable_ledger = t

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -7,15 +7,59 @@ let of_ledger_root ledger =
   of_root ~depth:(Ledger.depth ledger) (Ledger.merkle_root ledger)
 
 let of_ledger_subset_exn (oledger : Ledger.t) keys =
-  let ledger = Ledger.copy oledger in
-  let locations = Ledger.location_of_account_batch ledger keys in
-  let non_empty_locations = List.filter_map ~f:snd locations in
-  let accounts = Ledger.get_batch ledger non_empty_locations in
-  let merkle_paths = Ledger.merkle_path_batch ledger non_empty_locations in
-  let sl, _, _ =
+  let locations = Ledger.location_of_account_batch oledger keys in
+  let num_new_accounts, non_empty_locations =
+    let num_new_accounts = ref 0 in
+    let non_empty_locations =
+      List.filter_map locations ~f:(fun (_key, location) ->
+          if Option.is_none location then incr num_new_accounts ;
+          location )
+    in
+    (!num_new_accounts, non_empty_locations)
+  in
+  let accounts = Ledger.get_batch oledger non_empty_locations in
+  let merkle_paths, empty_merkle_paths =
+    let next_location_exn loc = Option.value_exn (Ledger.Location.next loc) in
+    let empty_address depth =
+      Ledger.Addr.of_directions @@ List.init depth ~f:(fun _ -> Direction.Left)
+    in
+    let merkle_path_locations =
+      (let rec add_locations remaining last_filled merkle_path_locations =
+         if remaining > 0 then
+           let new_location =
+             match last_filled with
+             | None ->
+                 Ledger.Location.Account (empty_address (Ledger.depth oledger))
+             | Some last_filled ->
+                 next_location_exn last_filled
+           in
+           add_locations (remaining - 1) (Some new_location)
+             (new_location :: merkle_path_locations)
+         else merkle_path_locations
+       in
+       add_locations )
+        num_new_accounts
+        (Ledger.last_filled oledger)
+        non_empty_locations
+    in
+    let merkle_paths = Ledger.merkle_path_batch oledger merkle_path_locations in
+    (let rec pop_empties num_empties merkle_paths locations acc =
+       if num_empties <= 0 then (merkle_paths, acc)
+       else
+         match (merkle_paths, locations) with
+         | path :: merkle_paths, location :: locations ->
+             pop_empties (num_empties - 1) merkle_paths locations
+               ((location, path) :: acc)
+         | [], _ | _, [] ->
+             assert false
+     in
+     pop_empties )
+      num_new_accounts merkle_paths merkle_path_locations []
+  in
+  let sl, _, _, _ =
     List.fold locations
-      ~init:(of_ledger_root ledger, accounts, merkle_paths)
-      ~f:(fun (sl, accounts, merkle_paths) (key, location) ->
+      ~init:(of_ledger_root oledger, accounts, merkle_paths, empty_merkle_paths)
+      ~f:(fun (sl, accounts, merkle_paths, empty_merkle_paths) (key, location) ->
         match location with
         | Some _loc -> (
             match (accounts, merkle_paths) with
@@ -23,17 +67,17 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
                 let sl =
                   add_path sl merkle_path key (Option.value_exn account)
                 in
-                (sl, rest, rest_merkle_paths)
+                (sl, rest, rest_merkle_paths, empty_merkle_paths)
             | _ ->
                 failwith "unexpected number of non empty accounts" )
         | None ->
-            let path, account = Ledger.create_empty_exn ledger key in
-            let sl = add_path sl path key account in
-            (sl, accounts, merkle_paths) )
+            let _, path = List.hd_exn empty_merkle_paths in
+            let sl = add_path sl path key Account.empty in
+            (sl, accounts, merkle_paths, List.tl_exn empty_merkle_paths) )
   in
   Debug_assert.debug_assert (fun () ->
       [%test_eq: Ledger_hash.t]
-        (Ledger.merkle_root ledger)
+        (Ledger.merkle_root oledger)
         ((merkle_root sl :> Random_oracle.Digest.t) |> Ledger_hash.of_hash) ) ;
   sl
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1019,6 +1019,14 @@ module T = struct
     let new_mask = Ledger.Mask.create ~depth:(Ledger.depth t.ledger) () in
     let new_ledger = Ledger.register_mask t.ledger new_mask in
     let transactions, works, commands_count, coinbases = pre_diff_info in
+    let accounts_accessed =
+      List.fold_left ~init:Account_id.Set.empty transactions ~f:(fun set txn ->
+          Account_id.Set.(
+            union set
+              (of_list (Transaction.accounts_referenced txn.With_status.data))) )
+      |> Set.to_list
+    in
+    Ledger.unsafe_preload_accounts_from_parent new_ledger accounts_accessed ;
     [%log internal] "Update_coinbase_stack"
       ~metadata:
         [ ("transactions", `Int (List.length transactions))


### PR DESCRIPTION
This PR builds upon #14586, removing the `Ledger.copy` and `Ledger.create_empty_exn` calls from `Sparse_ledger.of_ledger_subset_exn`. This function takes a significant amount of time in staged ledger diff application, and so this PR should further improve performance there.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them