### PR TITLE
Replace tables with maps in merkle masks

### DIFF
--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -97,9 +97,9 @@ let height ~ledger_depth path = ledger_depth - depth path
 
 let get = get
 
-[%%define_locally
-Stable.Latest.(t_of_sexp, sexp_of_t, to_yojson, compare, equal)]
+[%%define_locally Stable.Latest.(t_of_sexp, sexp_of_t, to_yojson)]
 
+include Comparable.Make_binable (Stable.Latest)
 include Hashable.Make_binable (Stable.Latest)
 
 let of_byte_string = bitstring_of_string
@@ -114,13 +114,13 @@ let copy (path : t) : t =
 (* returns a slice of the original path, so the returned key needs to be
        copied before mutating the path *)
 let parent (path : t) =
-  if bitstring_length path = 0 then
+  if Int.equal (bitstring_length path) 0 then
     Or_error.error_string "Address length should be nonzero"
   else Or_error.return (slice path 0 (bitstring_length path - 1))
 
 let parent_exn = Fn.compose Or_error.ok_exn parent
 
-let is_leaf ~ledger_depth path = bitstring_length path >= ledger_depth
+let is_leaf ~ledger_depth path = Int.(bitstring_length path >= ledger_depth)
 
 let child ~ledger_depth (path : t) dir : t Or_error.t =
   if is_leaf ~ledger_depth path then
@@ -137,10 +137,10 @@ let to_int (path : t) : int =
   Sequence.range 0 (depth path)
   |> Sequence.fold ~init:0 ~f:(fun acc i ->
          let index = depth path - 1 - i in
-         acc + ((if get path index <> 0 then 1 else 0) lsl i) )
+         acc + ((if Int.(get path index <> 0) then 1 else 0) lsl i) )
 
 let of_int_exn ~ledger_depth index =
-  if index >= 1 lsl ledger_depth then failwith "Index is too large"
+  if Int.(index >= 1 lsl ledger_depth) then failwith "Index is too large"
   else
     let buf = create_bitstring ledger_depth in
     ignore
@@ -160,7 +160,7 @@ let root () = create_bitstring 0
 let sibling (path : t) : t =
   let path = copy path in
   let last_bit_index = depth path - 1 in
-  let last_bit = if get path last_bit_index = 0 then 1 else 0 in
+  let last_bit = if Int.equal (get path last_bit_index) 0 then 1 else 0 in
   put path last_bit_index last_bit ;
   path
 
@@ -169,12 +169,12 @@ let next (path : t) : t Option.t =
   let path = copy path in
   let len = depth path in
   let rec find_rightmost_clear_bit i =
-    if i < 0 then None
+    if Int.(i < 0) then None
     else if is_clear path i then Some i
     else find_rightmost_clear_bit (i - 1)
   in
   let rec clear_bits i =
-    if i >= len then ()
+    if Int.(i >= len) then ()
     else (
       clear path i ;
       clear_bits (i + 1) )
@@ -189,12 +189,12 @@ let prev (path : t) : t Option.t =
   let path = copy path in
   let len = depth path in
   let rec find_rightmost_one_bit i =
-    if i < 0 then None
+    if Int.(i < 0) then None
     else if is_set path i then Some i
     else find_rightmost_one_bit (i - 1)
   in
   let rec set_bits i =
-    if i >= len then ()
+    if Int.(i >= len) then ()
     else (
       set path i ;
       set_bits (i + 1) )
@@ -208,7 +208,7 @@ let serialize ~ledger_depth path =
   let path = add_padding path in
   let path_len = depth path in
   let required_bits = 8 * byte_count_of_bits ledger_depth in
-  assert (path_len <= required_bits) ;
+  assert (Int.(path_len <= required_bits)) ;
   let required_padding = required_bits - path_len in
   Bigstring.of_string @@ string_of_bitstring
   @@ concat [ path; zeroes_bitstring required_padding ]
@@ -218,27 +218,28 @@ let is_parent_of parent ~maybe_child = Bitstring.is_prefix maybe_child parent
 let same_height_ancestors x y =
   let depth_x = depth x in
   let depth_y = depth y in
-  if depth_x < depth_y then (x, slice y 0 depth_x) else (slice x 0 depth_y, y)
+  if Int.(depth_x < depth_y) then (x, slice y 0 depth_x)
+  else (slice x 0 depth_y, y)
 
 let is_further_right ~than path =
   let than, path = same_height_ancestors than path in
-  compare than path < 0
+  Int.( < ) (compare than path) 0
 
 module Range = struct
   type nonrec t = t * t
 
   let rec fold_exl (first, last) ~init ~f =
     let comparison = compare first last in
-    if comparison > 0 then
+    if Int.(comparison > 0) then
       raise (Invalid_argument "first address needs to precede last address")
-    else if comparison = 0 then init
+    else if Int.(comparison = 0) then init
     else fold_exl (next first |> Option.value_exn, last) ~init:(f first init) ~f
 
   let fold_incl (first, last) ~init ~f =
     f last @@ fold_exl (first, last) ~init ~f
 
   let fold ?(stop = `Inclusive) (first, last) ~init ~f =
-    assert (depth first = depth last) ;
+    assert (Int.(depth first = depth last)) ;
     match stop with
     | `Inclusive ->
         fold_incl (first, last) ~init ~f
@@ -262,7 +263,7 @@ module Range = struct
         | _, `Stop ->
             None
         | current_node, `Don't_stop ->
-            if compare current_node last_node = 0 then
+            if Int.equal (compare current_node last_node) 0 then
               Some (current_node, (current_node, `Stop))
             else
               Option.map (next current_node) ~f:(fun next_node ->

--- a/src/lib/merkle_address/merkle_address.mli
+++ b/src/lib/merkle_address/merkle_address.mli
@@ -11,6 +11,8 @@ module Stable : sig
   module Latest : module type of V1
 end
 
+include Comparable.S_binable with type t := t
+
 include Hashable.S_binable with type t := t
 
 val of_byte_string : string -> t

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -752,8 +752,9 @@ module Make_maskable_and_mask_with_depth (Depth : Depth_S) = struct
       | Generic of Merkle_ledger.Location.Bigstring.t
       | Account of Location.Addr.t
       | Hash of Location.Addr.t
-    [@@deriving hash, sexp, compare]
+    [@@deriving hash, sexp]
 
+    include Comparable.Make_binable (Arg)
     include Hashable.Make_binable (Arg) [@@deriving sexp, compare, hash, yojson]
   end
 

--- a/src/lib/merkle_mask/inputs_intf.ml
+++ b/src/lib/merkle_mask/inputs_intf.ml
@@ -20,8 +20,11 @@ module type S = sig
 
   module Location : Merkle_ledger.Location_intf.S
 
-  module Location_binable :
-    Core_kernel.Hashable.S_binable with type t := Location.t
+  module Location_binable : sig
+    include Core_kernel.Hashable.S_binable with type t := Location.t
+
+    include Core_kernel.Comparable.S_binable with type t := Location.t
+  end
 
   module Base :
     Base_merkle_tree_intf.S

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -40,12 +40,12 @@ module Make (Inputs : Inputs_intf.S) = struct
 
   type t =
     { uuid : Uuid.Stable.V1.t
-    ; account_tbl : Account.t Location_binable.Table.t
-    ; token_owners : Account_id.t Token_id.Table.t
+    ; mutable accounts : Account.t Location_binable.Map.t
+    ; mutable token_owners : Account_id.t Token_id.Map.t
     ; mutable parent : Parent.t
     ; detached_parent_signal : Detached_parent_signal.t
-    ; hash_tbl : Hash.t Addr.Table.t
-    ; location_tbl : Location.t Account_id.Table.t
+    ; mutable hashes : Hash.t Addr.Map.t
+    ; mutable locations : Location.t Account_id.Map.t
     ; mutable current_location : Location.t option
     ; depth : int
     }
@@ -57,10 +57,10 @@ module Make (Inputs : Inputs_intf.S) = struct
     { uuid = Uuid_unix.create ()
     ; parent = Error __LOC__
     ; detached_parent_signal = Async.Ivar.create ()
-    ; account_tbl = Location_binable.Table.create ()
-    ; token_owners = Token_id.Table.create ()
-    ; hash_tbl = Addr.Table.create ()
-    ; location_tbl = Account_id.Table.create ()
+    ; accounts = Location_binable.Map.empty
+    ; token_owners = Token_id.Map.empty
+    ; hashes = Addr.Map.empty
+    ; locations = Account_id.Map.empty
     ; current_location = None
     ; depth
     }
@@ -133,12 +133,11 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     (* don't rely on a particular implementation *)
     let self_find_hash t address =
-      assert_is_attached t ;
-      Addr.Table.find t.hash_tbl address
+      assert_is_attached t ; Map.find t.hashes address
 
     let self_set_hash t address hash =
       assert_is_attached t ;
-      Addr.Table.set t.hash_tbl ~key:address ~data:hash
+      t.hashes <- Map.set t.hashes ~key:address ~data:hash
 
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;
@@ -148,11 +147,11 @@ module Make (Inputs : Inputs_intf.S) = struct
     (* don't rely on a particular implementation *)
     let self_find_location t account_id =
       assert_is_attached t ;
-      Account_id.Table.find t.location_tbl account_id
+      Map.find t.locations account_id
 
     let self_set_location t account_id location =
       assert_is_attached t ;
-      Account_id.Table.set t.location_tbl ~key:account_id ~data:location ;
+      t.locations <- Map.set t.locations ~key:account_id ~data:location ;
       (* if account is at a hitherto-unused location, that
          becomes the current location
       *)
@@ -166,11 +165,11 @@ module Make (Inputs : Inputs_intf.S) = struct
     (* don't rely on a particular implementation *)
     let self_find_account t location =
       assert_is_attached t ;
-      Location_binable.Table.find t.account_tbl location
+      Map.find t.accounts location
 
     let self_set_account t location account =
       assert_is_attached t ;
-      Location_binable.Table.set t.account_tbl ~key:location ~data:account ;
+      t.accounts <- Map.set t.accounts ~key:location ~data:account ;
       self_set_location t (Account.identifier account) location
 
     (* a read does a lookup in the account_tbl; if that fails, delegate to
@@ -424,14 +423,15 @@ module Make (Inputs : Inputs_intf.S) = struct
       assert_is_attached t ;
       (* remove account and key from tables *)
       let account = Option.value_exn (self_find_account t location) in
-      Location_binable.Table.remove t.account_tbl location ;
+      t.accounts <- Map.remove t.accounts location ;
       (* Update token info. *)
       let account_id = Account.identifier account in
-      Token_id.Table.remove t.token_owners
-        (Account_id.derive_token_id ~owner:account_id) ;
+      t.token_owners <-
+        Token_id.Map.remove t.token_owners
+          (Account_id.derive_token_id ~owner:account_id) ;
       (* TODO : use stack database to save unused location, which can be used
          when allocating a location *)
-      Account_id.Table.remove t.location_tbl account_id ;
+      t.locations <- Map.remove t.locations account_id ;
       (* reuse location if possible *)
       Option.iter t.current_location ~f:(fun curr_loc ->
           if Location.equal location curr_loc then
@@ -456,9 +456,10 @@ module Make (Inputs : Inputs_intf.S) = struct
       self_set_account t location account ;
       (* Update token info. *)
       let account_id = Account.identifier account in
-      Token_id.Table.set t.token_owners
-        ~key:(Account_id.derive_token_id ~owner:account_id)
-        ~data:account_id
+      t.token_owners <-
+        Map.set t.token_owners
+          ~key:(Account_id.derive_token_id ~owner:account_id)
+          ~data:account_id
 
     (* a write writes only to the mask, parent is not involved need to update
        both account and hash pieces of the mask *)
@@ -541,10 +542,10 @@ module Make (Inputs : Inputs_intf.S) = struct
     let commit t =
       assert_is_attached t ;
       let old_root_hash = merkle_root t in
-      let account_data = Location_binable.Table.to_alist t.account_tbl in
+      let account_data = Map.to_alist t.accounts in
       Base.set_batch (get_parent t) account_data ;
-      Location_binable.Table.clear t.account_tbl ;
-      Addr.Table.clear t.hash_tbl ;
+      t.accounts <- Location_binable.Map.empty ;
+      t.hashes <- Addr.Map.empty ;
       Debug_assert.debug_assert (fun () ->
           [%test_result: Hash.t]
             ~message:
@@ -562,10 +563,10 @@ module Make (Inputs : Inputs_intf.S) = struct
       { uuid = Uuid_unix.create ()
       ; parent = Ok (get_parent t)
       ; detached_parent_signal = Async.Ivar.create ()
-      ; account_tbl = Location_binable.Table.copy t.account_tbl
-      ; token_owners = Token_id.Table.copy t.token_owners
-      ; location_tbl = Account_id.Table.copy t.location_tbl
-      ; hash_tbl = Addr.Table.copy t.hash_tbl
+      ; accounts = t.accounts
+      ; token_owners = t.token_owners
+      ; locations = t.locations
+      ; hashes = t.hashes
       ; current_location = t.current_location
       ; depth = t.depth
       }
@@ -627,15 +628,15 @@ module Make (Inputs : Inputs_intf.S) = struct
       let set_location_batch ~last_location t account_to_location_list =
         t.current_location <- Some last_location ;
         Mina_stdlib.Nonempty_list.iter account_to_location_list
-          ~f:(fun (key, data) ->
-            Account_id.Table.set t.location_tbl ~key ~data )
+          ~f:(fun (key, data) -> t.locations <- Map.set t.locations ~key ~data)
 
       let set_raw_account_batch t locations_and_accounts =
         List.iter locations_and_accounts ~f:(fun (location, account) ->
             let account_id = Account.identifier account in
-            Token_id.Table.set t.token_owners
-              ~key:(Account_id.derive_token_id ~owner:account_id)
-              ~data:account_id ;
+            t.token_owners <-
+              Map.set t.token_owners
+                ~key:(Account_id.derive_token_id ~owner:account_id)
+                ~data:account_id ;
             self_set_account t location account )
     end)
 
@@ -650,7 +651,7 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     let token_owner t tid =
       assert_is_attached t ;
-      match Token_id.Table.find t.token_owners tid with
+      match Map.find t.token_owners tid with
       | Some id ->
           Some id
       | None ->
@@ -659,7 +660,7 @@ module Make (Inputs : Inputs_intf.S) = struct
     let token_owners (t : t) : Account_id.Set.t =
       assert_is_attached t ;
       let mask_owners =
-        Hashtbl.fold t.token_owners ~init:Account_id.Set.empty
+        Map.fold t.token_owners ~init:Account_id.Set.empty
           ~f:(fun ~key:_tid ~data:owner acc -> Set.add acc owner)
       in
       Set.union mask_owners (Base.token_owners (get_parent t))
@@ -667,7 +668,7 @@ module Make (Inputs : Inputs_intf.S) = struct
     let tokens t pk =
       assert_is_attached t ;
       let mask_tokens =
-        Account_id.Table.keys t.location_tbl
+        Map.keys t.locations
         |> List.filter_map ~f:(fun aid ->
                if Key.equal pk (Account_id.public_key aid) then
                  Some (Account_id.token_id aid)
@@ -798,9 +799,9 @@ module Make (Inputs : Inputs_intf.S) = struct
        as sometimes this is desired behavior *)
     let close t =
       assert_is_attached t ;
-      Location_binable.Table.clear t.account_tbl ;
-      Addr.Table.clear t.hash_tbl ;
-      Account_id.Table.clear t.location_tbl ;
+      t.accounts <- Location_binable.Map.empty ;
+      t.hashes <- Addr.Map.empty ;
+      t.locations <- Account_id.Map.empty ;
       Async.Ivar.fill_if_empty t.detached_parent_signal ()
 
     let index_of_account_exn t key =
@@ -844,9 +845,7 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     let foldi_with_ignored_accounts t ignored_accounts ~init ~f =
       assert_is_attached t ;
-      let locations_and_accounts =
-        Location_binable.Table.to_alist t.account_tbl
-      in
+      let locations_and_accounts = Map.to_alist t.accounts in
       (* parent should ignore accounts in this mask *)
       let mask_accounts =
         List.map locations_and_accounts ~f:(fun (_loc, acct) ->

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -22,6 +22,7 @@ module Ledger_inner = struct
       | Hash of Location_at_depth.Addr.t
     [@@deriving hash, sexp, compare]
 
+    include Comparable.Make_binable (Arg)
     include Hashable.Make_binable (Arg) [@@deriving sexp, compare, hash, yojson]
   end
 


### PR DESCRIPTION
This PR builds on #14594.

In this PR, the hash tables used in merkle masks are replaced with maps in order to avoid hashing data at every single mask traversal when evaluating ledger reads. This showed ~7.5x speedup in applying transactions to a chain of `k=290` masks.