### PR TITLE
When comparing `Field.t` values, avoid the conversion to bigint

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -37,6 +37,8 @@ module type Input_intf = sig
 
   val is_square : t -> bool
 
+  val compare : t -> t -> int
+
   val equal : t -> t -> bool
 
   val print : t -> unit
@@ -194,7 +196,7 @@ module Make (F : Input_intf) :
 
       let hash = Hash.of_fold hash_fold_t
 
-      let compare t1 t2 = Bigint.compare (to_bigint t1) (to_bigint t2)
+      let compare = compare
 
       let equal = equal
 

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -11,8 +11,6 @@ module Kimchi_backend_common : sig
 
       val sexp_of_t : t -> Sexplib0.Sexp.t
 
-      val compare : t -> t -> int
-
       val bin_size_t : t Bin_prot.Size.sizer
 
       val bin_write_t : t Bin_prot.Write.writer
@@ -55,6 +53,8 @@ module Kimchi_backend_common : sig
       val square : t -> t
 
       val is_square : t -> bool
+
+      val compare : t -> t -> int
 
       val equal : t -> t -> bool
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
@@ -31,7 +31,7 @@ impl CamlFp {
     unsafe extern "C" fn ocaml_compare(x: ocaml::Raw, y: ocaml::Raw) -> i32 {
         let x = x.as_pointer::<Self>();
         let y = y.as_pointer::<Self>();
-        match x.as_ref().0.cmp(&y.as_ref().0) {
+        match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
             core::cmp::Ordering::Less => -1,
             core::cmp::Ordering::Equal => 0,
             core::cmp::Ordering::Greater => 1,
@@ -240,7 +240,7 @@ pub fn caml_pasta_fp_mut_square(mut x: ocaml::Pointer<CamlFp>) {
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fp_compare(x: ocaml::Pointer<CamlFp>, y: ocaml::Pointer<CamlFp>) -> ocaml::Int {
-    match x.as_ref().0.cmp(&y.as_ref().0) {
+    match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
         Less => -1,
         Equal => 0,
         Greater => 1,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
@@ -36,7 +36,7 @@ impl CamlFq {
     unsafe extern "C" fn ocaml_compare(x: ocaml::Raw, y: ocaml::Raw) -> i32 {
         let x = x.as_pointer::<Self>();
         let y = y.as_pointer::<Self>();
-        match x.as_ref().0.cmp(&y.as_ref().0) {
+        match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
             core::cmp::Ordering::Less => -1,
             core::cmp::Ordering::Equal => 0,
             core::cmp::Ordering::Greater => 1,
@@ -241,7 +241,7 @@ pub fn caml_pasta_fq_mut_square(mut x: ocaml::Pointer<CamlFq>) {
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fq_compare(x: ocaml::Pointer<CamlFq>, y: ocaml::Pointer<CamlFq>) -> ocaml::Int {
-    match x.as_ref().0.cmp(&y.as_ref().0) {
+    match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
         Less => -1,
         Equal => 0,
         Greater => 1,


### PR DESCRIPTION
Explain your changes:
* For `Field.compare`, perform the comparison in Rust instead of converting the values to bigints to compare them. More context [here](https://github.com/MinaProtocol/mina/pull/14595#pullrequestreview-1742896016)

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
