### PR TITLE
Field: More efficient conversion into Bignum_bigint.t

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -25,6 +25,7 @@
   base.caml
   ppx_inline_test.config
   bignum.bigint
+  zarith
   base.base_internalhash_types
   ;; local libraries
   tuple_lib

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -179,20 +179,30 @@ module Make (F : Input_intf) :
             let of_sexpable = of_bigint
           end)
 
-      let to_bignum_bigint n =
-        let rec go i two_to_the_i acc =
-          if Int.equal i size_in_bits then acc
-          else
-            let acc' =
-              if Bigint.test_bit n i then Bignum_bigint.(acc + two_to_the_i)
-              else acc
-            in
-            go (i + 1) Bignum_bigint.(two_to_the_i + two_to_the_i) acc'
-        in
-        go 0 Bignum_bigint.one Bignum_bigint.zero
+      let zero = of_int 0
 
-      let hash_fold_t s x =
-        Bignum_bigint.hash_fold_t s (to_bignum_bigint (to_bigint x))
+      let to_bignum_bigint n =
+        (* For non-zero values, conversion is done by creating the bin_prot representation
+           of the [Bignum_bigit.t] value, and then parsing it with bin_prot. *)
+        match compare n zero with
+        | 0 ->
+            Bignum_bigint.zero
+        | c ->
+            (* Tag for positive values is 1, negative is 2:
+               https://github.com/janestreet/bignum/blob/6c63419787a4e209e85befd3d823fff2790677e0/bigint/src/bigint.ml#L27-L30 *)
+            let tag_byte = if c > 0 then '\x01' else '\x02' in
+            let bytes = to_bytes n in
+            let len = Bytes.length bytes in
+            let size_byte = Char.of_int_exn len in
+            let buf = Bytes.create (2 + len) in
+            (* First byte is the tag, second the amount of bytes *)
+            Bytes.unsafe_set buf 0 tag_byte ;
+            Bytes.unsafe_set buf 1 size_byte ;
+            (* Copy the bytes representation of the value, skip the tag and size bytes *)
+            Bytes.unsafe_blit ~src:bytes ~src_pos:0 ~dst_pos:2 ~len ~dst:buf ;
+            Bin_prot.Reader.of_bytes Bignum_bigint.Stable.V1.bin_reader_t buf
+
+      let hash_fold_t s x = Bignum_bigint.hash_fold_t s (to_bignum_bigint x)
 
       let hash = Hash.of_fold hash_fold_t
 

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -37,6 +37,8 @@ module type Input_intf = sig
 
   val is_square : t -> bool
 
+  val compare : t -> t -> int
+
   val equal : t -> t -> bool
 
   val print : t -> unit
@@ -194,7 +196,7 @@ module Make (F : Input_intf) :
 
       let hash = Hash.of_fold hash_fold_t
 
-      let compare t1 t2 = Bigint.compare (to_bigint t1) (to_bigint t2)
+      let compare = compare
 
       let equal = equal
 

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -11,8 +11,6 @@ module Kimchi_backend_common : sig
 
       val sexp_of_t : t -> Sexplib0.Sexp.t
 
-      val compare : t -> t -> int
-
       val bin_size_t : t Bin_prot.Size.sizer
 
       val bin_write_t : t Bin_prot.Write.writer
@@ -55,6 +53,8 @@ module Kimchi_backend_common : sig
       val square : t -> t
 
       val is_square : t -> bool
+
+      val compare : t -> t -> int
 
       val equal : t -> t -> bool
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
@@ -31,7 +31,7 @@ impl CamlFp {
     unsafe extern "C" fn ocaml_compare(x: ocaml::Raw, y: ocaml::Raw) -> i32 {
         let x = x.as_pointer::<Self>();
         let y = y.as_pointer::<Self>();
-        match x.as_ref().0.cmp(&y.as_ref().0) {
+        match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
             core::cmp::Ordering::Less => -1,
             core::cmp::Ordering::Equal => 0,
             core::cmp::Ordering::Greater => 1,
@@ -240,7 +240,7 @@ pub fn caml_pasta_fp_mut_square(mut x: ocaml::Pointer<CamlFp>) {
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fp_compare(x: ocaml::Pointer<CamlFp>, y: ocaml::Pointer<CamlFp>) -> ocaml::Int {
-    match x.as_ref().0.cmp(&y.as_ref().0) {
+    match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
         Less => -1,
         Equal => 0,
         Greater => 1,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
@@ -36,7 +36,7 @@ impl CamlFq {
     unsafe extern "C" fn ocaml_compare(x: ocaml::Raw, y: ocaml::Raw) -> i32 {
         let x = x.as_pointer::<Self>();
         let y = y.as_pointer::<Self>();
-        match x.as_ref().0.cmp(&y.as_ref().0) {
+        match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
             core::cmp::Ordering::Less => -1,
             core::cmp::Ordering::Equal => 0,
             core::cmp::Ordering::Greater => 1,
@@ -241,7 +241,7 @@ pub fn caml_pasta_fq_mut_square(mut x: ocaml::Pointer<CamlFq>) {
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fq_compare(x: ocaml::Pointer<CamlFq>, y: ocaml::Pointer<CamlFq>) -> ocaml::Int {
-    match x.as_ref().0.cmp(&y.as_ref().0) {
+    match x.as_ref().0.into_repr().cmp(&y.as_ref().0.into_repr()) {
         Less => -1,
         Equal => 0,
         Greater => 1,


### PR DESCRIPTION
As discussed [here](https://github.com/MinaProtocol/mina/pull/14595#discussion_r1401055806), this is a more efficient conversion into `Bignum_bigint.t` values that avoids processing the input and output bit by bit.

It feels kind of dirty having to go through bin_prot for this, but `Bignum_bigint` doesn't expose any other way to interpret raw bytes to produce a bigint (which should be more efficient than the alternatives). A pro of this approach is that it didn't require any new function to be exposed (other than the `compare` added in the other field), but assumes that all implementations of `to_bytes` will produce the same output.

Explain how you tested your changes:
*

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
