### PR TITLE
Enabled logging precomputed blocks in mina local network script

### DIFF
--- a/scripts/archive/split_precomputed_log.sh
+++ b/scripts/archive/split_precomputed_log.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 precomputed-log-file [output-folder]"
+  exit 1
+fi
+
+
+
+ARCHIVE_URI=${ARCHIVE_URI:-postgres://postgres@localhost:5432/archive}
+PRECOMPUTED_LOG_FILE=$1
+
+while IFS= read -r line; do
+	LEDGER_HASH=$(echo $line | jq -r '.protocol_state.body.blockchain_state.staged_ledger_hash.non_snark.ledger_hash')
+	FILE_NAME=$(psql $ARCHIVE_URI -t -c "SELECT 'mainnet-' || height || '-' ||state_hash || '.json' FROM blocks WHERE ledger_hash = '$LEDGER_HASH'")
+	echo  $line > $FILE_NAME 
+done < $PRECOMPUTED_LOG_FILE
+
+

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# set -x
+#set -x
 
 # Exit script when commands fail
 set -e
@@ -28,6 +28,7 @@ FILE_LOG_LEVEL=${LOG_LEVEL}
 VALUE_TRANSFERS=false
 RESET=false
 UPDATE_GENESIS_TIMESTAMP=false
+LOG_PRECOMPUTED_BLOCKS=false
 
 SNARK_WORKER_FEE=0.01
 TRANSACTION_FREQUENCY=10 # in seconds
@@ -101,6 +102,8 @@ help() {
   echo "                                  |   Default: ${TRANSACTION_FREQUENCY}"
   echo "-sf |--snark-worker-fee <#>       | SNARK Worker fee"
   echo "                                  |   Default: ${SNARK_WORKER_FEE}"
+  echo "-lp |--log-precomputed-blocks     | Log precomputed blocks"
+  echo "                                  |   Default: ${LOG_PRECOMPUTED_BLOCKS}"
   echo "-r  |--reset                      | Whether to reset the Mina Local Network storage file-system (presence of argument)"
   echo "                                  |   Default: ${RESET}"
   echo "-u  |--update-genesis-timestamp   | Whether to update the Genesis Ledger timestamp (presence of argument)"
@@ -145,6 +148,8 @@ exec-daemon() {
     -log-json \
     -log-level ${LOG_LEVEL} \
     -file-log-level ${FILE_LOG_LEVEL} \
+    -precomputed-blocks-file ${FOLDER}/precomputed_blocks.log \
+    -log-precomputed-blocks ${LOG_PRECOMPUTED_BLOCKS} \
     $@
 }
 
@@ -253,6 +258,7 @@ while [[ "$#" -gt 0 ]]; do
     SNARK_WORKER_FEE="${2}"
     shift
     ;;
+  -lp | --log-precomputed-blocks) LOG_PRECOMPUTED_BLOCKS=true ;;
   -r | --reset) RESET=true ;;
   -u | --update-genesis-timestamp) UPDATE_GENESIS_TIMESTAMP=true ;;
   *)


### PR DESCRIPTION
While testing hardfork i found necessary to dump precomputed blocks during local network run. Implemented logging with some utility script to chop it into jsons which then can be put to gcloud.