### PR TITLE
Unrevert 14566

### DIFF
--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -42,14 +42,11 @@ let domains (type field gates) ?feature_flags
             feature_flags
           in
           let combined_lookup_table_length =
-            let range_check_table_used = range_check0 || range_check1 || rot in
-            let range_check_table_used_again =
-              (* FIXME: This is a hack around a bug in proof-systems. *)
-              foreign_field_mul
+            let range_check_table_used =
+              range_check0 || range_check1 || foreign_field_mul || rot
             in
             let xor_table_used = xor in
             (if range_check_table_used then Int.pow 2 12 else 0)
-            + (if range_check_table_used_again then Int.pow 2 12 else 0)
             + (if xor_table_used then Int.pow 2 8 else 0)
             + ( if lookup then (
                 Kimchi_backend_common.Plonk_constraint_system


### PR DESCRIPTION
This brings back #14566 after it was reverted in #14591.

The issue I had with #14566 on my machine turned out to be caused by locally cached prover keys 😥 When forcing a recompilation, the issue is gone.

Bumps o1js to https://github.com/o1-labs/o1js/pull/1266