### PR TITLE
fix version linter failure

### DIFF
--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -16,6 +16,7 @@ echo 'experimental-features = nix-command flakes' > "${XDG_CONFIG_HOME-${HOME}/.
 
 git config --global --add safe.directory /workdir
 
+git fetch 
 # Nix has issue when performing operations on detached head
 # On Ci machine it spit out issues like:
 # fatal: reference is not a tree: ....

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -17,7 +17,7 @@ git config --global --add safe.directory /workdir
 
 source buildkite/scripts/export-git-env-vars.sh
 
-pip3 install sexpdata
+pip3 install sexpdata==1.0.0
 
 base_branch=origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
 pr_branch=origin/${BUILDKITE_BRANCH}

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -73,8 +73,8 @@ let minimalDirtyWhen = [
   -- Snark profiler dirtyWhen
   S.exactly "buildkite/src/Jobs/Test/RunSnarkProfiler" "dhall",
   S.exactly "buildkite/scripts/run-snark-transaction-profiler" "sh",
-  S.exactly "scripts/snark_transaction_profiler" "py"
-  S.exactly "buildkite/scripts/version-linter" "sh"
+  S.exactly "scripts/snark_transaction_profiler" "py",
+  S.exactly "buildkite/scripts/version-linter" "sh",
   S.exactly "scripts/version-linter" "py"
 ]
 

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -74,6 +74,8 @@ let minimalDirtyWhen = [
   S.exactly "buildkite/src/Jobs/Test/RunSnarkProfiler" "dhall",
   S.exactly "buildkite/scripts/run-snark-transaction-profiler" "sh",
   S.exactly "scripts/snark_transaction_profiler" "py"
+  S.exactly "buildkite/scripts/version-linter" "sh"
+  S.exactly "scripts/version-linter" "py"
 ]
 
 -- The default debian version (Bullseye) is used in all downstream CI jobs

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -49,7 +49,7 @@ Pipeline.build
       let lintDirtyWhen = [
         S.strictlyStart (S.contains "src"),
         S.exactly "buildkite/src/Jobs/Test/VersionLint" "dhall",
-        S.exactly "buildkite/scripts/version_linter" "sh"
+        S.exactly "buildkite/scripts/version-linter" "sh"
       ]
 
       in


### PR DESCRIPTION
Fixes version linter script. Currently we are suffering from read version linter job as it download sexpdata 1.0.1 . It introduce issue similar to :
https://stackoverflow.com/questions/77523055/missingdynamic-license-defined-outside-of-pyproject-toml-is-ignored

Reverting sexpdata to 1.0.0 should solve our problem
