### PR TITLE
Merging berkeley testnet config into develop

### DIFF
--- a/automation/terraform/modules/o1-testnet/files.tf
+++ b/automation/terraform/modules/o1-testnet/files.tf
@@ -1,9 +1,11 @@
-data "local_file" "genesis_ledger" {
-  filename = "${var.artifact_path}/genesis_ledger.json"
-  depends_on = [
-    null_resource.block_producer_key_generation
-  ]
-}
+# terraform cannot handle file sizes above 4mb, as a result, using a genesis_ledger.json file is no longer supported
+
+# data "local_file" "genesis_ledger" {
+#   filename = "${var.artifact_path}/genesis_ledger.json"
+#   depends_on = [
+#     null_resource.block_producer_key_generation
+#   ]
+# }
 
 # data "local_file" "libp2p_peers" {
 #   for_each = toset(concat(local.whale_block_producer_libp2p_names, local.fish_block_producer_libp2p_names))
@@ -16,7 +18,7 @@ data "local_file" "genesis_ledger" {
 data "local_file" "libp2p_seed_peers" {
   for_each = toset(local.seed_names)
   filename = "${var.artifact_path}/keys/libp2p-keys/${each.key}.peerid"
-  depends_on = [
-    null_resource.block_producer_key_generation
-  ]
+  #   depends_on = [
+  #     null_resource.block_producer_key_generation
+  #   ]
 }

--- a/automation/terraform/modules/o1-testnet/scripts.tf
+++ b/automation/terraform/modules/o1-testnet/scripts.tf
@@ -1,9 +1,11 @@
-resource "null_resource" "block_producer_key_generation" {
-  provisioner "local-exec" {
-    working_dir = "${path.module}/../../.."
-    command     = "./scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --sc=${var.seed_count} --wu=${local.whale_count_unique} --wt=${local.whale_count_total} --fu=${local.fish_count_unique} --ft=${local.fish_count_total} --reset=false --artifact-path=${var.artifact_path}"
-  }
-}
+# dynamic key and ledger generation is not used in production testnets, only for disposable integration tests
+
+# resource "null_resource" "block_producer_key_generation" {
+#   provisioner "local-exec" {
+#     working_dir = "${path.module}/../../.."
+#     command     = "./scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --sc=${var.seed_count} --wu=${local.whale_count_unique} --wt=${local.whale_count_total} --fu=${local.fish_count_unique} --ft=${local.fish_count_total} --reset=false --artifact-path=${var.artifact_path}"
+#   }
+# }
 
 resource "null_resource" "block_producer_uploads" {
   provisioner "local-exec" {
@@ -15,7 +17,7 @@ resource "null_resource" "block_producer_uploads" {
   }
   depends_on = [
     module.kubernetes_testnet.testnet_namespace,
-    null_resource.block_producer_key_generation
+    # null_resource.block_producer_key_generation
   ]
 }
 
@@ -26,6 +28,6 @@ resource "null_resource" "seed_list" {
   }
   depends_on = [
     module.kubernetes_testnet.testnet_namespace,
-    null_resource.block_producer_key_generation
+    # null_resource.block_producer_key_generation
   ]
 }

--- a/automation/terraform/modules/o1-testnet/testnet.tf
+++ b/automation/terraform/modules/o1-testnet/testnet.tf
@@ -51,7 +51,7 @@ module "kubernetes_testnet" {
   agent_send_every_mins = var.agent_send_every_mins
 
   additional_peers = [for peer in local.static_peers : peer.full_peer]
-  runtime_config   = var.use_embedded_runtime_config ? "" : data.local_file.genesis_ledger.content
+  runtime_config   = var.use_embedded_runtime_config ? "" : ""
 
   seed_zone   = var.seed_zone
   seed_region = var.seed_region

--- a/automation/terraform/testnets/berkeley/main.tf
+++ b/automation/terraform/testnets/berkeley/main.tf
@@ -60,8 +60,8 @@ variable "plain_node_count" {
 
 locals {
   testnet_name       = "berkeley"
-  mina_image         = "minaprotocol/mina-daemon:focal-berkeley-latest" #"minaprotocol/mina-daemon:1.3.2beta2-release-2.0.0-6f9d956-focal-berkeley"
-  mina_archive_image = "minaprotocol/mina-archive:focal-latest"         #"minaprotocol/mina-archive:1.3.2beta2-release-2.0.0-6f9d956-focal"
+  mina_image         = "gcr.io/o1labs-192920/mina-daemon:2.0.0rampup1-rampup-b1facec-focal-berkeley" #"minaprotocol/mina-daemon:1.3.2beta2-release-2.0.0-6f9d956-focal-berkeley"
+  mina_archive_image = "gcr.io/o1labs-192920/mina-archive:2.0.0rampup1-rampup-b1facec-focal"         #"minaprotocol/mina-archive:1.3.2beta2-release-2.0.0-6f9d956-focal"
   seed_region        = "us-central1"
   seed_zone          = "us-central1-b"
 
@@ -76,14 +76,14 @@ locals {
 }
 
 module "berkeley" {
-  providers = { google.gke = google.google-us-east1 }
+  providers = { google.gke = google.google-us-central1 }
   source    = "../../modules/o1-testnet"
 
   artifact_path = abspath(path.module)
 
-  cluster_name   = "coda-infra-east"
-  cluster_region = "us-east1"
-  k8s_context    = "gke_o1labs-192920_us-east1_coda-infra-east"
+  cluster_name   = "coda-infra-central1"
+  cluster_region = "us-central1"
+  k8s_context    = "gke_o1labs-192920_us-central1_coda-infra-central1"
   testnet_name   = local.testnet_name
 
   mina_image                  = local.mina_image
@@ -96,7 +96,7 @@ module "berkeley" {
 
   archive_node_count            = 2
   mina_archive_schema           = "create_schema.sql"
-  mina_archive_schema_aux_files = ["https://raw.githubusercontent.com/MinaProtocol/mina/8468f29424fa5e70cfedf69ee281f4fa24037dfe/src/app/archive/create_schema.sql", "https://raw.githubusercontent.com/MinaProtocol/mina/8468f29424fa5e70cfedf69ee281f4fa24037dfe/src/app/archive/zkapp_tables.sql"]
+  mina_archive_schema_aux_files = ["https://raw.githubusercontent.com/MinaProtocol/mina/b1facecde934ce3969771c34962b878d75321ca7/src/app/archive/create_schema.sql", "https://raw.githubusercontent.com/MinaProtocol/mina/b1facecde934ce3969771c34962b878d75321ca7/src/app/archive/zkapp_tables.sql"]
 
   archive_configs = [
     {

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -69,7 +69,7 @@ locals {
 
 
 module "ci_testnet" {
-  source    = "../../modules/o1-testnet"
+  source = "../../modules/o1-testnet"
 
   artifact_path = var.ci_artifact_path
 
@@ -108,21 +108,23 @@ module "ci_testnet" {
 
   snark_coordinators = [
     {
-      snark_worker_replicas   = var.snark_worker_count
-      snark_worker_fee        = "0.025"
-      snark_worker_public_key = "B62qk4nuKn2U5kb4dnZiUwXeRNtP1LncekdAKddnd1Ze8cWZnjWpmMU"
-      snark_coordinators_host_port  = 10401
+      snark_coordinator_name       = "ci-net"
+      snark_worker_replicas        = var.snark_worker_count
+      snark_worker_fee             = "0.025"
+      snark_worker_public_key      = "B62qk4nuKn2U5kb4dnZiUwXeRNtP1LncekdAKddnd1Ze8cWZnjWpmMU"
+      snark_coordinators_host_port = 10401
+      persist_working_dir          = false
     }
   ]
 
-  whales= [
-    for i in range(var.whale_count):{
+  whales = [
+    for i in range(var.whale_count) : {
       duplicates = 1
     }
   ]
-  
-  fishes= [
-    for i in range(var.fish_count):{
+
+  fishes = [
+    for i in range(var.fish_count) : {
       duplicates = 1
     }
   ]


### PR DESCRIPTION
**Explain your changes:**

This PR applies update to terraform modules related to testnet deployments. These changes have the following effect:

* Removes support for using a `genesis_ledger.json` file from the local machine. This is due to the current ledger sizes exceeding the 4mb that can be handled by Terraform. Note that this change is only applying to production testnet deployments that use the `o1-testnet` terraform module. This change does not apply to integration tests which use a separate `o1-integration` module. Integration tests will still be able to generate an use ledgers within tests (because they are under 4mb). 
* The `main.tf` files within the `berkeley` and `ci-net` testnets have been updated. This is to make them compatible with the latest terraform module changes (a few additional var vals are required). The change also brings the `berkeley` deployment files into sync with the branch `berkeley-v2-deployment` which was being used to deploy Berkeley up until now. After this change merged into `develop` and `berkeley`, the `berkeley-v2-deployment` branch can be retired. 

Explain how you tested your changes:
* This change was tested both in CI, but also by running `terraform plan` and `terraform apply` from my local machine.
* It should be noted that the `ci-net` testnet is still not functional, in part because it mixes some file dependencies and dir references that are no longer consistent between integration tests and testnet deployment. Additional repairs will be needed for that testnet, this PR only aims to update the var refs within its `main.tf` file to prevent it falling further out of sync.

Checklist:

- [X] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [NA] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [NA] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [NA] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
