### PR TITLE
comment fix, ci test fix for "connect to mainnet"

### DIFF
--- a/buildkite/scripts/connect-to-mainnet-on-compatible.sh
+++ b/buildkite/scripts/connect-to-mainnet-on-compatible.sh
@@ -37,7 +37,7 @@ mina daemon \
 & # -background
 
 
-# Attempt to connect to the GraphQL client every 10s for up to 12 minutes
+# Attempt to connect to the GraphQL client every 30s for up to 12 minutes
 num_status_retries=24
 for ((i=1;i<=$num_status_retries;i++)); do
   sleep 30s


### PR DESCRIPTION
Explain your changes:
* This pr is to repair CI test "connect to testnet" by increasing the test timeout. The original test was limited to 4 minutes, but was not consistently boot and connecting to nodes in this time. 

Explain how you tested your changes:
* This change has been tested by re-running the existing CI test which happens in the nightly pipeline. At a 5th attempt, the test completed. 
* Within the test log outputs, the initial 4 attempts shows the test was reaching it's self-imposed retry limit which is implemented using a while loop and incrementing counter.  

Checklist:

- [X] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [NA] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [NA] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [NA] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [X] All tests pass (CI will check this if you didn't)
- [NA] Serialized types are in stable-versioned modules
- [NA] Does this close issues? List them

* Closes #0000
