### PR TITLE
[o1js-main] Add missing runtime table commits in wrap verifier.

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
@@ -61,6 +61,8 @@ module Fp = struct
 
   external print : t -> unit = "caml_pasta_fp_print"
 
+  external print_rust : t -> unit = "caml_pasta_fp_print_rust"
+
   external copy : t -> t -> unit = "caml_pasta_fp_copy"
 
   external mut_add : t -> t -> unit = "caml_pasta_fp_mut_add"
@@ -127,6 +129,8 @@ module Fq = struct
   external of_string : string -> t = "caml_pasta_fq_of_string"
 
   external print : t -> unit = "caml_pasta_fq_print"
+
+  external print_rust : t -> unit = "caml_pasta_fq_print_rust"
 
   external copy : t -> t -> unit = "caml_pasta_fq_copy"
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
@@ -209,6 +209,12 @@ pub fn caml_pasta_fp_print(x: ocaml::Pointer<CamlFp>) {
 
 #[ocaml_gen::func]
 #[ocaml::func]
+pub fn caml_pasta_fp_print_rust(x: ocaml::Pointer<CamlFp>) {
+    println!("{}", x.as_ref().0);
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
 pub fn caml_pasta_fp_copy(mut x: ocaml::Pointer<CamlFp>, y: ocaml::Pointer<CamlFp>) {
     *x.as_mut() = *y.as_ref()
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
@@ -210,6 +210,12 @@ pub fn caml_pasta_fq_print(x: ocaml::Pointer<CamlFq>) {
 
 #[ocaml_gen::func]
 #[ocaml::func]
+pub fn caml_pasta_fq_print_rust(x: ocaml::Pointer<CamlFq>) {
+    println!("{}", x.as_ref().0);
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
 pub fn caml_pasta_fq_copy(mut x: ocaml::Pointer<CamlFq>, y: ocaml::Pointer<CamlFq>) {
     *x.as_mut() = *y.as_ref()
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -177,6 +177,7 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fp_to_string => "to_string");
         decl_func!(w, env, caml_pasta_fp_of_string => "of_string");
         decl_func!(w, env, caml_pasta_fp_print => "print");
+        decl_func!(w, env, caml_pasta_fp_print_rust => "print_rust");
         decl_func!(w, env, caml_pasta_fp_copy => "copy");
         decl_func!(w, env, caml_pasta_fp_mut_add => "mut_add");
         decl_func!(w, env, caml_pasta_fp_mut_sub => "mut_sub");
@@ -213,6 +214,7 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fq_to_string => "to_string");
         decl_func!(w, env, caml_pasta_fq_of_string => "of_string");
         decl_func!(w, env, caml_pasta_fq_print => "print");
+        decl_func!(w, env, caml_pasta_fq_print_rust => "print_rust");
         decl_func!(w, env, caml_pasta_fq_copy => "copy");
         decl_func!(w, env, caml_pasta_fq_mut_add => "mut_add");
         decl_func!(w, env, caml_pasta_fq_mut_sub => "mut_sub");

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -892,21 +892,29 @@ struct
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;
-        let absorb_runtime_tables () =
+        let runtime_comm =
           match messages.lookup with
           | Nothing
           | Maybe (_, { runtime = Nothing; _ })
           | Just { runtime = Nothing; _ } ->
-              ()
+              Pickles_types.Opt.Nothing
           | Maybe (b_lookup, { runtime = Maybe (b_runtime, runtime); _ }) ->
               let b = Boolean.( &&& ) b_lookup b_runtime in
-              let z = Array.map runtime ~f:(fun z -> (b, z)) in
-              absorb sponge Without_degree_bound z
+              Pickles_types.Opt.Maybe (b, runtime)
           | Maybe (b, { runtime = Just runtime; _ })
           | Just { runtime = Maybe (b, runtime); _ } ->
+              Pickles_types.Opt.Maybe (b, runtime)
+          | Just { runtime = Just runtime; _ } ->
+              Pickles_types.Opt.Just runtime
+        in
+        let absorb_runtime_tables () =
+          match runtime_comm with
+          | Nothing ->
+              ()
+          | Maybe (b, runtime) ->
               let z = Array.map runtime ~f:(fun z -> (b, z)) in
               absorb sponge Without_degree_bound z
-          | Just { runtime = Just runtime; _ } ->
+          | Just runtime ->
               let z = Array.map runtime ~f:(fun z -> (Boolean.true_, z)) in
               absorb sponge Without_degree_bound z
         in
@@ -1244,7 +1252,7 @@ struct
           let _len_4, len_4_add = Nat.N6.add Plonk_types.Lookup_sorted.n in
           let len_5, len_5_add =
             (* NB: Using explicit 11 because we can't get add on len_4 *)
-            Nat.N11.add Nat.N7.n
+            Nat.N11.add Nat.N8.n
           in
           let len_6, len_6_add = Nat.N45.add len_5 in
           let num_commitments_without_degree_bound = len_6 in
@@ -1294,6 +1302,7 @@ struct
                            [ Pickles_types.Opt.map messages.lookup ~f:(fun l ->
                                  l.aggreg )
                            ; lookup_table_comm
+                           ; runtime_comm
                            ; m.runtime_tables_selector
                            ; m.lookup_selector_xor
                            ; m.lookup_selector_lookup

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -892,6 +892,25 @@ struct
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;
+        let absorb_runtime_tables () =
+          match messages.lookup with
+          | Nothing
+          | Maybe (_, { runtime = Nothing; _ })
+          | Just { runtime = Nothing; _ } ->
+              ()
+          | Maybe (b_lookup, { runtime = Maybe (b_runtime, runtime); _ }) ->
+              let b = Boolean.( &&& ) b_lookup b_runtime in
+              let z = Array.map runtime ~f:(fun z -> (b, z)) in
+              absorb sponge Without_degree_bound z
+          | Maybe (b, { runtime = Just runtime; _ })
+          | Just { runtime = Maybe (b, runtime); _ } ->
+              let z = Array.map runtime ~f:(fun z -> (b, z)) in
+              absorb sponge Without_degree_bound z
+          | Just { runtime = Just runtime; _ } ->
+              let z = Array.map runtime ~f:(fun z -> (Boolean.true_, z)) in
+              absorb sponge Without_degree_bound z
+        in
+        absorb_runtime_tables () ;
         let joint_combiner =
           let compute_joint_combiner (l : _ Messages.Lookup.In_circuit.t) =
             let absorb_sorted_1 sponge =


### PR DESCRIPTION
Orthogonal to the issue raised by https://github.com/o1-labs/o1js/pull/1284, but there is a discrepancy between o1js-main and develop for Pickles. In particular this one.

Explain your changes:
* Add runtime table commitments to compute the joint combiner in the wrap verifier.

Explain how you tested your changes:
* `cd src/lib/pickles && dune build @runtest`

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
