### PR TITLE
use consensus slot to compute the balance

### DIFF
--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -429,6 +429,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section "Check that timed2 account is partially vested"
         (let%bind best_chain =
            Integration_test_lib.Graphql_requests.must_get_best_chain ~logger
+             ~max_length:1
              (Network.Node.get_ingress_uri node_b)
          in
          let best_tip = List.hd_exn best_chain in

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -411,21 +411,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Balances.assert_equal ~expected balance )
     in
     let%bind () =
-      section "Wait 30 secs before balance check"
-      @@ let%bind global_slot_since_hard_fork =
-           Integration_test_lib.Graphql_requests
-           .must_get_global_slot_since_hard_fork ~logger
-             (Network.Node.get_ingress_uri node_b)
-         in
-         match
-           Global_slot_since_hard_fork.to_int global_slot_since_hard_fork % 5
-         with
-         | 0 ->
-             Malleable_error.lift @@ Async.after @@ Time.Span.of_int_sec 30
-         | _ ->
-             Malleable_error.return ()
-    in
-    let%bind () =
       section "Check that timed2 account is partially vested"
         (let%bind best_chain =
            Integration_test_lib.Graphql_requests.must_get_best_chain ~logger

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -427,10 +427,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "Check that timed2 account is partially vested"
-        (let%bind global_slot_since_hard_fork =
-           Integration_test_lib.Graphql_requests
-           .must_get_global_slot_since_hard_fork ~logger
+        (let%bind best_chain =
+           Integration_test_lib.Graphql_requests.must_get_best_chain ~logger
              (Network.Node.get_ingress_uri node_b)
+         in
+         let best_tip = List.hd_exn best_chain in
+         let global_slot_since_hard_fork =
+           best_tip.global_slot_since_hard_fork
          in
          let%bind balance = get_account_balances timed2 in
          Balances.log logger ~name:"timed2"

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -411,6 +411,21 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Balances.assert_equal ~expected balance )
     in
     let%bind () =
+      section "Wait 30 secs before balance check"
+      @@ let%bind global_slot_since_hard_fork =
+           Integration_test_lib.Graphql_requests
+           .must_get_global_slot_since_hard_fork ~logger
+             (Network.Node.get_ingress_uri node_b)
+         in
+         match
+           Global_slot_since_hard_fork.to_int global_slot_since_hard_fork % 5
+         with
+         | 0 ->
+             Malleable_error.lift @@ Async.after @@ Time.Span.of_int_sec 30
+         | _ ->
+             Malleable_error.return ()
+    in
+    let%bind () =
       section "Check that timed2 account is partially vested"
         (let%bind global_slot_since_hard_fork =
            Integration_test_lib.Graphql_requests


### PR DESCRIPTION
Explain your changes:
This PR fixes the flakiness of hard fork integration. The flakiness is that when getting the liquid balance, we are actually using the global slot from the consensus state: https://github.com/MinaProtocol/mina/blob/605b8c874ff5b4957e602972a4c97ed15b68c21f/src/lib/mina_graphql/types.ml#L934

My fix is also use the consensus slot instead of the most recent slot.

This fix would resolve the flakiness of the test.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
