### PR TITLE
Steven healthcheck fix - compatible

### DIFF
--- a/helm/archive-node/templates/_healthchecks.tpl
+++ b/helm/archive-node/templates/_healthchecks.tpl
@@ -28,7 +28,7 @@ readinessProbe:
     command: [
       "/bin/bash",
       "-c",
-      "source /healthcheck/utilities.sh && isArchiveSynced --db-host {{ tpl .Values.archive.postgresHost . }}"
+      "source /healthcheck/utilities.sh && isArchiveSynced --db-host {{ tpl .Values.archive.postgresHost . }} --db-port {{ tpl .Values.archive.ports.postgres . }} --db-user {{ tpl .Values.postgresql.auth.username . }} --db-password {{ tpl .Values.postgresql.auth.password . }}"
     ]
 {{- include "healthcheck.common.settings" .Values | indent 2 }}
 {{- end }}


### PR DESCRIPTION
Explain your changes:
* This PR is to repair a behavior where archive nodes are reported as offline, due to the existing healthcheck script being run with an incorrect username and password (which cannot auth to the archive database).
* Before Error: `Readiness probe failed: Archive[] is out of sync with local daemon[82] psql: error: FATAL: password authentication failed for user "postgres"`

* [Related Slack Thread ](https://o1-labs.slack.com/archives/C02BK3SK89F/p1701977003530609)

Explain how you tested your changes:
* Changes in this PR are limited to a single line which sets the valid username and password for the health check at the time of the archive deployment. This change was tested by manually applying the Archive node helm chart and verifying the values that the healthcheck configuration inherited during deployment. 
* After Fix: `Readiness probe failed: Archive[82] is out of sync with local daemon[1]`

Checklist:

- [X] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [NA] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [NA] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [NA] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [X] All tests pass (CI will check this if you didn't)
- [NA] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
