### PR TITLE
ITN3 VM Node 1 - Infra Configs (DO NOT MERGE)

### DIFF
--- a/automation/terraform/modules/testworld-vm-nodes/main.tf
+++ b/automation/terraform/modules/testworld-vm-nodes/main.tf
@@ -1,0 +1,114 @@
+terraform {
+  backend "gcs" {
+    bucket = "o1labs-terraform"
+    prefix = "itn3-vm-nodes"
+  }
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}
+
+#####################################
+# Google Cloud Secrets Imports
+#####################################
+
+data "google_secret_manager_secret_version" "itn_log_backend_keys" {
+  provider = google
+  secret   = var.itn_log_backend_keys
+}
+
+data "google_secret_manager_secret_version" "itn_node_vm_1_libp2p_pass" {
+  provider = google
+  secret   = var.itn_node_vm_1_libp2p_pass
+}
+
+data "google_secret_manager_secret_version" "itn_node_vm_1_privkey" {
+  provider = google
+  secret   = var.itn_node_vm_1_privkey
+}
+
+data "google_secret_manager_secret_version" "itn_node_vm_1_privkey_pass" {
+  provider = google
+  secret   = var.itn_node_vm_1_privkey_pass
+}
+
+data "google_secret_manager_secret_version" "itn_node_vm_1_pubkey" {
+  provider = google
+  secret   = var.itn_node_vm_1_pubkey
+}
+
+#####################################
+# Deploying Resources
+#####################################
+
+resource "google_compute_address" "node_1_address" {
+  name = "itn3-node-1-static-ip"
+}
+
+resource "google_compute_instance_template" "itn3_node_1" {
+  name_prefix  = "whale-template-"
+  machine_type = "n2-standard-8"
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      nat_ip = google_compute_address.node_1_address.address
+    }
+  }
+
+  disk {
+    boot         = true
+    disk_type    = "pd-standard"
+    source_image = "debian-cloud/debian-10"
+  }
+
+  metadata = {
+    startup-script = <<SCRIPT
+  ${data.template_file.mina-config-node-1.rendered}
+  ${data.template_file.startup.rendered}
+  SCRIPT
+  }
+
+  lifecycle {
+    create_before_destroy = false
+  }
+
+  labels = {
+    service = var.billing_label
+  }
+
+  tags = var.firewall_label
+}
+
+resource "google_compute_instance_group_manager" "node-1" {
+  name               = "node-1-mig"
+  base_instance_name = "itn3-node-1"
+  version {
+    instance_template = google_compute_instance_template.itn3_node_1.id
+  }
+
+  target_size = 1
+
+  named_port {
+    name = "http"
+    port = 3086
+  }
+}
+
+resource "google_compute_firewall" "allow_http_3086" {
+  name    = "allow-http-3086"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3086"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+
+  target_tags = var.firewall_label
+}

--- a/automation/terraform/modules/testworld-vm-nodes/output.tf
+++ b/automation/terraform/modules/testworld-vm-nodes/output.tf
@@ -1,0 +1,12 @@
+output "confirmation" {
+  value = "The new node VMs have been deployed sucessfully."
+}
+
+output "node_1_ip" {
+  description = "The IP address of the first node:"
+  value       = google_compute_address.node_1_address.address
+}
+
+output "ssh_instructions" {
+  value = "gcloud compute ssh VM_NAME --zone=${var.gcp_zone}"
+}

--- a/automation/terraform/modules/testworld-vm-nodes/templates/mina-config-node-1.tpl
+++ b/automation/terraform/modules/testworld-vm-nodes/templates/mina-config-node-1.tpl
@@ -1,0 +1,84 @@
+cat > /root/startup.sh <<- "SCRIPT"
+#!/bin/bash
+
+export MINA_LIBP2P_PASS=${mina_libp2p_pass}
+export MINA_PRIVKEY_PASS=${wallet_privkey_pass}
+export UPTIME_PRIVKEY_PASS=${wallet_privkey_pass}
+
+# check if mina is installed
+function mina_installed() {
+    if which mina >/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function install_mina() {
+    sudo rm /etc/apt/sources.list.d/mina*.list
+    echo "deb [trusted=yes] http://packages.o1test.net/ buster rampup" | sudo tee /etc/apt/sources.list.d/mina-rampup.list
+    sudo apt-get update
+    sudo apt-get install -y mina-berkeley=2.0.0rampup7-4a0fff9
+    sudo curl https://raw.githubusercontent.com/MinaProtocol/mina/rampup/genesis_ledgers/berkeley.json > /root/berkeley.json
+}
+
+function generate_libp2p_key() {
+    mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+    chmod -R 0700 /root/libp2p-keys/
+}
+
+function install_mina_keygen() {
+    echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
+    sudo apt-get update
+    sudo apt-get install mina-generate-keypair=1.4.0-c980ba8
+}
+
+function generate_block_producer_key() {
+    mkdir /root/wallet-keys
+    chmod 700 /root/wallet-keys
+
+    # keys are being manually assigned in this case
+    # mina-generate-keypair --privkey-path /root/wallet-keys/key
+
+    echo "\"${wallet_privkey}\"" >> /root/wallet-keys/key
+    echo ${wallet_pubkey} >> /root/wallet-keys/key.pub
+}
+
+function start_mina() {
+    mina daemon \
+    --config-file /root/berkeley.json \
+    --peer-list-url "https://storage.googleapis.com/seed-lists/testworld-2-0_seeds.txt" \
+    --libp2p-keypair "/root/libp2p-keys/key" \
+    --log-level "Debug" \
+    --log-json \
+    --itn-keys "${itn_logger_keys}" \
+    --uptime-url "https://block-producers-uptime-itn.minaprotocol.tools/v1/submit" \
+    --node-status-url "https://nodestats-itn.minaprotocol.tools/submit/stats" \
+    --node-error-url "https://nodestats-itn.minaprotocol.tools/submit/stats" \
+    --uptime-submitter-key "/root/wallet-keys/key" \
+    --internal-tracing \
+    --enable-peer-exchange true \
+    --config-directory "/root/.mina-config" \
+    --insecure-rest-server \
+    --client-port 8301 \
+    --rest-port 3085 \
+    --itn-graphql-port 3086 \
+    --external-port 10501 \
+    --metrics-port 10001 \
+    --block-producer-key "/root/wallet-keys/key" \
+    --upload-blocks-to-gcloud false \
+    --generate-genesis-proof true \
+    --itn-max-logs 10000
+}
+
+# sudo su
+if ! mina_installed; then
+    install_mina
+    generate_libp2p_key
+    install_mina_keygen
+    generate_block_producer_key
+    start_mina
+else
+    start_mina
+fi
+SCRIPT

--- a/automation/terraform/modules/testworld-vm-nodes/templates/mina-config-node-1.tpl
+++ b/automation/terraform/modules/testworld-vm-nodes/templates/mina-config-node-1.tpl
@@ -18,7 +18,7 @@ function install_mina() {
     sudo rm /etc/apt/sources.list.d/mina*.list
     echo "deb [trusted=yes] http://packages.o1test.net/ buster rampup" | sudo tee /etc/apt/sources.list.d/mina-rampup.list
     sudo apt-get update
-    sudo apt-get install -y mina-berkeley=2.0.0rampup7-4a0fff9
+    sudo apt-get install -y mina-berkeley=2.0.0rampup7-4a0fff9 tzdata
     sudo curl https://raw.githubusercontent.com/MinaProtocol/mina/rampup/genesis_ledgers/berkeley.json > /root/berkeley.json
 }
 
@@ -40,8 +40,10 @@ function generate_block_producer_key() {
     # keys are being manually assigned in this case
     # mina-generate-keypair --privkey-path /root/wallet-keys/key
 
-    echo "\"${wallet_privkey}\"" >> /root/wallet-keys/key
-    echo ${wallet_pubkey} >> /root/wallet-keys/key.pub
+    echo '${wallet_privkey}' >> /root/wallet-keys/key
+    echo '${wallet_pubkey}' >> /root/wallet-keys/key.pub
+
+    chmod 600 /root/wallet-keys/key
 }
 
 function start_mina() {

--- a/automation/terraform/modules/testworld-vm-nodes/templates/startup.tpl
+++ b/automation/terraform/modules/testworld-vm-nodes/templates/startup.tpl
@@ -1,0 +1,5 @@
+#!/bin/bash
+apt install -y tmux
+chmod 700 /root/startup.sh
+tmux new-session -d -s 0
+tmux send-keys -t 0 'bash /root/startup.sh' C-m

--- a/automation/terraform/modules/testworld-vm-nodes/vars.tf
+++ b/automation/terraform/modules/testworld-vm-nodes/vars.tf
@@ -1,0 +1,63 @@
+variable "gcp_project" {
+  default = "o1labs-192920"
+}
+
+variable "gcp_region" {
+  default = "us-east4"
+}
+
+variable "gcp_zone" {
+  default = "us-east4-b"
+}
+
+variable "billing_label" {
+  default = "itn3"
+}
+
+variable "firewall_label" {
+  default = ["itn3-node-vms"]
+}
+
+
+#####################################
+# Secret Vars
+#####################################
+
+variable "itn_log_backend_keys" {
+  default = "itn-log-backend-keys" # name of secret in Google Cloud
+}
+
+variable "itn_node_vm_1_libp2p_pass" {
+  default = "itn-node-vm-1-libp2p-pass"
+}
+
+variable "itn_node_vm_1_privkey" {
+  default = "itn-node-vm-1-privkey"
+}
+
+variable "itn_node_vm_1_privkey_pass" {
+  default = "itn-node-vm-1-privkey-pass" # name of secret in Google Cloud
+}
+
+variable "itn_node_vm_1_pubkey" {
+  default = "itn-node-vm-1-pubkey" # name of secret in Google Cloud
+}
+
+#####################################
+# Passing Secrets To Templates
+#####################################
+
+data "template_file" "mina-config-node-1" {
+  template = file("templates/mina-config-node-1.tpl")
+  vars = {
+    mina_libp2p_pass    = data.google_secret_manager_secret_version.itn_node_vm_1_libp2p_pass.secret_data
+    wallet_privkey_pass = data.google_secret_manager_secret_version.itn_node_vm_1_privkey_pass.secret_data
+    wallet_privkey      = data.google_secret_manager_secret_version.itn_node_vm_1_privkey.secret_data
+    wallet_pubkey       = data.google_secret_manager_secret_version.itn_node_vm_1_pubkey.secret_data
+    itn_logger_keys     = data.google_secret_manager_secret_version.itn_log_backend_keys.secret_data
+  }
+}
+
+data "template_file" "startup" {
+  template = file("templates/startup.tpl")
+}


### PR DESCRIPTION
# DO NOT MERGE

## Explain your changes:
* This draft PR holds terraform configurations for the deployment of a single VM-based Mina node. 
* These terraform configuration includes 3 parts: a google cloud vm, a vm host configuration script, and a firewall rule to allow access on ITN3 graphql port 3086.
* Secrets such as wallet key and logging keys have been uploaded as Google Cloud Secrets and are omitted from the code.
* These deployment configurations are being used for testing during the ITN3 phase of hardfork work, it does not use the standard kubernetes deployment flow and does not include features such as healthchecks, or visibility within the o1Labs grafana dashboard and alerting. For this reason, the code is not expected to be used outside of the ITN3 period and is requested not to merge into the main `mina` repo branches.

[Related Slack Thread](https://o1-labs.slack.com/archives/C02ASV6BZCY/p1702334919297049)

## Explain how you tested your changes:
* Code within this PR was tested by applying it Google Cloud using `terraform init` and then `terraform apply`. 
* The code successfully deployed the Mina node and was able to sync to the ITN3 (`testworld-2-0`) network.

# Using and updating this code

This code can be used by anyone with Google Cloud admin permissions, and relies on the GCloud user auth on the local machine. Applying the code is done in the standard Terraform 3-command sequence: 

* `terraform init` (to sync the current state to your local machine)
* `terraform plan` (to see a preview of what the code will do if applied again)
* `terraform apply --auto-approve` (to apply the code)

If the node has been manually modified, or for any reason needs to be redeployed, the existing deployment can be removed using the command `terraform destroy`. This will show a change preview and ask for confirmation before the relevant resources are destroyed.

## Editing the installed Mina version

If upgrading the version of Mina installed to the node is required, this can be done by changing the `deb` name that is used in the `install_mina()` within file `mina-config-node-1.tpl` file.


