### PR TITLE
Daemon-archive performance fix

### DIFF
--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -2,34 +2,51 @@ open Core_kernel
 open Async_kernel
 open Pipe_lib
 
-let dispatch ?(max_tries = 5) ~logger
+let dispatch ?(max_tries = 5) ~logger ~state_hash
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) diff =
+  let diff_time = Time.now () in
   let rec go tries_left errs =
     if Int.( <= ) tries_left 0 then
       let e = Error.of_list (List.rev errs) in
-      return
-        (Error
-           (Error.tag_arg e
-              (sprintf
-                 "Could not send archive diff data to archive process after %d \
-                  tries. The process may not be running, please check the \
-                  daemon-argument"
-                 max_tries )
-              ( ("host_and_port", archive_location.value)
-              , ("daemon-argument", archive_location.name) )
-              [%sexp_of: (string * Host_and_port.t) * (string * string)] ) )
+      let err =
+        Error.tag_arg e
+          (sprintf
+             "Could not send archive diff data to archive process after %d \
+              tries. The process may not be running, please check the \
+              daemon-argument"
+             max_tries )
+          ( ("host_and_port", archive_location.value)
+          , ("daemon-argument", archive_location.name) )
+          [%sexp_of: (string * Host_and_port.t) * (string * string)]
+      in
+      [%log error] "Failed to send archive data for $state_hash: $error"
+        ~metadata:
+          [ ("state_hash", Mina_base.State_hash.to_yojson state_hash)
+          ; ("error", `String (Error.to_string_hum err))
+          ]
     else
-      match%bind
-        Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
-          archive_location.value
-      with
-      | Ok () ->
-          return (Ok ())
-      | Error e ->
-          [%log error]
-            "Error sending data to the archive process $error. Retrying..."
-            ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
-          go (tries_left - 1) (e :: errs)
+      upon
+        (Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
+           archive_location.value ) (fun res ->
+          match res with
+          | Ok () ->
+              [%log debug]
+                "Dispatched archive data for $state_hash, took $time ms"
+                ~metadata:
+                  [ ("state_hash", Mina_base.State_hash.to_yojson state_hash)
+                  ; ( "time"
+                    , `Float
+                        (Time.Span.to_ms (Time.diff (Time.now ()) diff_time)) )
+                  ]
+          | Error e ->
+              [%log error]
+                "Error sending data for $state_hash to the archive process \
+                 $error. Retrying..."
+                ~metadata:
+                  [ ("state_hash", Mina_base.State_hash.to_yojson state_hash)
+                  ; ("error", `String (Error.to_string_hum e))
+                  ] ;
+              go (tries_left - 1) (e :: errs) )
   in
   go max_tries []
 
@@ -71,7 +88,7 @@ let transfer ~logger ~precomputed_values ~archive_location
       Transition_frontier.Extensions.New_breadcrumbs.view
       Broadcast_pipe.Reader.t ) =
   Broadcast_pipe.Reader.iter breadcrumb_reader ~f:(fun breadcrumbs ->
-      Deferred.List.iter breadcrumbs ~f:(fun breadcrumb ->
+      List.iter breadcrumbs ~f:(fun breadcrumb ->
           let start = Time.now () in
           let diff =
             Archive_lib.Diff.Builder.breadcrumb_added ~precomputed_values
@@ -85,30 +102,10 @@ let transfer ~logger ~precomputed_values ~archive_location
                     (Transition_frontier.Breadcrumb.state_hash breadcrumb) )
               ; ("time", `Float (Time.Span.to_ms (Time.diff diff_time start)))
               ] ;
-          match%map
-            dispatch archive_location ~logger (Transition_frontier diff)
-          with
-          | Ok () ->
-              [%log debug]
-                "Dispatched archive data for $state_hash, took $time ms"
-                ~metadata:
-                  [ ( "state_hash"
-                    , Mina_base.State_hash.to_yojson
-                        (Transition_frontier.Breadcrumb.state_hash breadcrumb)
-                    )
-                  ; ( "time"
-                    , `Float
-                        (Time.Span.to_ms (Time.diff (Time.now ()) diff_time)) )
-                  ] ;
-              ()
-          | Error e ->
-              [%log warn]
-                ~metadata:
-                  [ ("error", Error_json.error_to_yojson e)
-                  ; ( "breadcrumb"
-                    , Transition_frontier.Breadcrumb.to_yojson breadcrumb )
-                  ]
-                "Could not send breadcrumb to archive: $error" ) )
+          dispatch archive_location ~logger
+            ~state_hash:(Transition_frontier.Breadcrumb.state_hash breadcrumb)
+            (Transition_frontier diff) ) ;
+      return () )
 
 let run ~logger ~precomputed_values
     ~(frontier_broadcast_pipe :


### PR DESCRIPTION
Issue: Daemon connected to archive process is stuck in catchup during high load. It seems like either the archiving is slow or the process becomes unresponsive for a while. Regardless, I don’t think the daemon should wait for response from the archive process.

Explain your changes:
* Daemon change: Don't wait for the response from archive process when sending blocks. 
* TODO: Archive process slowness

Explain how you tested your changes:
*Tested locally. Daemon making progress when catching up during high load
* TODO: Daemons synced but archiving still very slow

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
