### PR TITLE
Customisable kimchi single gate PolishToken bindings

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -9,7 +9,7 @@ use kimchi::{
 
 /// Converts the linearization of the kimchi circuit polynomial into a printable string.
 pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
-    custom_gate_type: bool,
+    omit_custom_gate: bool,
     uses_custom_gates: bool,
 ) -> (String, Vec<(String, String)>) {
     let features = if uses_custom_gates {
@@ -35,7 +35,8 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
         })
     };
     let evaluated_cols = linearization_columns::<F>(features.as_ref());
-    let (linearization, _powers_of_alpha) = constraints_expr::<F>(custom_gate_type, features.as_ref(), true);
+    let (linearization, _powers_of_alpha) =
+        constraints_expr::<F>(omit_custom_gate, None, features.as_ref(), true);
 
     let Linearization {
         constant_term,
@@ -56,13 +57,13 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
 }
 
 #[ocaml::func]
-pub fn fp_linearization_strings_plus(custom_gate_type: bool) -> (String, Vec<(String, String)>) {
-    linearization_strings::<mina_curves::pasta::Fp>(custom_gate_type, true)
+pub fn fp_linearization_strings_minus() -> (String, Vec<(String, String)>) {
+    linearization_strings::<mina_curves::pasta::Fp>(true, true)
 }
 
 #[ocaml::func]
-pub fn fq_linearization_strings_plus(custom_gate_type: bool) -> (String, Vec<(String, String)>) {
-    linearization_strings::<mina_curves::pasta::Fq>(custom_gate_type, false)
+pub fn fq_linearization_strings_minus() -> (String, Vec<(String, String)>) {
+    linearization_strings::<mina_curves::pasta::Fq>(true, false)
 }
 
 #[ocaml::func]

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,5 +1,5 @@
 use kimchi::circuits::{
-    expr::FeatureFlag,
+    expr::{FeatureFlag, PolishToken},
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
         runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg},
@@ -115,6 +115,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
 
     decl_type!(w, env, CamlWire => "wire");
     decl_type!(w, env, GateType => "gate_type");
+    decl_type!(w, env, PolishToken::<T1> => "polish_token");
     decl_type!(w, env, LookupPattern => "lookup_pattern");
     decl_type!(w, env, LookupPatterns => "lookup_patterns");
     decl_type!(w, env, LookupFeatures => "lookup_features");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -8,6 +8,7 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use kimchi::circuits::constraints::FeatureFlags;
+use kimchi::circuits::expr::PolishToken;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupPatterns};
 use kimchi::circuits::polynomials::permutation::Shifts;
 use kimchi::circuits::polynomials::permutation::{permutation_vanishing_polynomial, zk_w};
@@ -26,6 +27,10 @@ pub type CamlPastaFpPlonkVerifierIndex =
 
 impl From<VerifierIndex<Vesta, OpeningProof<Vesta>>> for CamlPastaFpPlonkVerifierIndex {
     fn from(vi: VerifierIndex<Vesta, OpeningProof<Vesta>>) -> Self {
+        // Convert custom gate RPN from Fp to CamlFp
+        let custom_gate_type = vi
+            .custom_gate_type
+            .map(|vs| vs.into_iter().map(PolishToken::into).collect());
         Self {
             domain: CamlPlonkDomain {
                 log_size_of_group: vi.domain.log_size_of_group as isize,
@@ -60,7 +65,7 @@ impl From<VerifierIndex<Vesta, OpeningProof<Vesta>>> for CamlPastaFpPlonkVerifie
             shifts: vi.shift.to_vec().iter().map(Into::into).collect(),
             lookup_index: vi.lookup_index.map(Into::into),
             zk_rows: vi.zk_rows as isize,
-            custom_gate_type: vi.custom_gate_type,
+            custom_gate_type: custom_gate_type,
         }
     }
 }
@@ -111,9 +116,13 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta, OpeningProof<V
             },
         };
 
+        let custom_gate_type = index
+            .custom_gate_type
+            .map(|vs| vs.into_iter().map(PolishToken::into).collect());
+
         // TODO dummy_lookup_value ?
         let (linearization, powers_of_alpha) =
-            expr_linearization(index.custom_gate_type, Some(&feature_flags), true);
+            expr_linearization(custom_gate_type.as_ref(), Some(&feature_flags), true);
 
         VerifierIndex::<Vesta, OpeningProof<Vesta>> {
             domain,
@@ -162,7 +171,7 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta, OpeningProof<V
 
             lookup_index: index.lookup_index.map(Into::into),
             linearization,
-            custom_gate_type: index.custom_gate_type,
+            custom_gate_type: custom_gate_type,
         }
     }
 }
@@ -282,7 +291,7 @@ pub fn caml_pasta_fp_plonk_verifier_index_dummy() -> CamlPastaFpPlonkVerifierInd
         shifts: (0..PERMUTS - 1).map(|_| Fp::one().into()).collect(),
         lookup_index: None,
         zk_rows: 3,
-        custom_gate_type: false,
+        custom_gate_type: None,
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
@@ -1,4 +1,5 @@
 use ark_ec::AffineCurve;
+use kimchi::circuits::expr::PolishToken;
 use kimchi::circuits::lookup::index::LookupSelectors;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupInfo};
 use kimchi::verifier_index::LookupVerifierIndex;
@@ -196,5 +197,5 @@ pub struct CamlPlonkVerifierIndex<Fr, SRS, PolyComm> {
     pub shifts: Vec<Fr>,
     pub lookup_index: Option<CamlLookupVerifierIndex<PolyComm>>,
     pub zk_rows: ocaml::Int,
-    pub custom_gate_type: bool,
+    pub custom_gate_type: Option<Vec<PolishToken<Fr>>>,
 }


### PR DESCRIPTION
Iteration 2 of customisable kimchi vertical slice.  This PR gets the OCaml side of bindings in place.  Test target is that the stubs cargo build and tests pass.