### PR TITLE
Customisable kimchi single gate PolishToken bindings

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -205,7 +205,7 @@ module Protocol = struct
         = "caml_pasta_fp_plonk_index_create_bytecode" "caml_pasta_fp_plonk_index_create"
 
       external create_plus :
-           bool
+           Pasta_bindings.Fp.t Kimchi_types.polish_token array option
         -> Gates.Vector.Fp.t
         -> int
         -> Pasta_bindings.Fp.t Kimchi_types.lookup_table array
@@ -250,7 +250,7 @@ module Protocol = struct
         = "caml_pasta_fq_plonk_index_create_bytecode" "caml_pasta_fq_plonk_index_create"
 
       external create_plus :
-           bool
+           Pasta_bindings.Fq.t Kimchi_types.polish_token array option
         -> Gates.Vector.Fq.t
         -> int
         -> Pasta_bindings.Fq.t Kimchi_types.lookup_table array

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -187,13 +187,53 @@ type nonrec feature_flag =
   | TableWidth of int
   | LookupsPerRow of int
 
+type nonrec row_offset = { zk_rows : bool; offset : int32 }
+
+type nonrec column =
+  | Witness of int
+  | Z
+  | LookupSorted of int
+  | LookupAggreg
+  | LookupTable
+  | LookupKindIndex of lookup_pattern
+  | LookupRuntimeSelector
+  | LookupRuntimeTable
+  | Index of gate_type
+  | Coefficient of int
+  | Permutation of int
+
+type nonrec curr_or_next = Curr | Next
+
+type nonrec variable = { col : column; row : curr_or_next }
+
+type nonrec mds = { row : int; col : int }
+
+type nonrec 'f polish_token =
+  | Alpha
+  | Beta
+  | Gamma
+  | JointCombiner
+  | EndoCoefficient
+  | Mds of mds
+  | Literal of 'f
+  | Cell of variable
+  | Dup
+  | Pow of int32
+  | Add
+  | Mul
+  | Sub
+  | VanishesOnZeroKnowledgeAndPreviousRows
+  | UnnormalizedLagrangeBasis of row_offset
+  | Store
+  | Load of int
+  | SkipIf of feature_flag * int
+  | SkipIfNot of feature_flag * int
+
 type nonrec 'f circuit_gate =
   { typ : gate_type
   ; wires : wire * wire * wire * wire * wire * wire * wire
   ; coeffs : 'f array
   }
-
-type nonrec curr_or_next = Curr | Next
 
 type nonrec 'f oracles =
   { o : 'f random_oracles
@@ -255,6 +295,6 @@ module VerifierIndex = struct
     ; shifts : 'fr array
     ; lookup_index : 'poly_comm Lookup.t option
     ; zk_rows : int
-    ; custom_gate_type : bool
+    ; custom_gate_type : 'fr polish_token array option
     }
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -9,7 +9,7 @@ use kimchi::{
 
 /// Converts the linearization of the kimchi circuit polynomial into a printable string.
 pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
-    custom_gate_type: bool,
+    omit_custom_gate: bool,
     uses_custom_gates: bool,
 ) -> (String, Vec<(String, String)>) {
     let features = if uses_custom_gates {
@@ -35,7 +35,8 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
         })
     };
     let evaluated_cols = linearization_columns::<F>(features.as_ref());
-    let (linearization, _powers_of_alpha) = constraints_expr::<F>(custom_gate_type, features.as_ref(), true);
+    let (linearization, _powers_of_alpha) =
+        constraints_expr::<F>(omit_custom_gate, None, features.as_ref(), true);
 
     let Linearization {
         constant_term,
@@ -56,13 +57,13 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
 }
 
 #[ocaml::func]
-pub fn fp_linearization_strings_plus(custom_gate_type: bool) -> (String, Vec<(String, String)>) {
-    linearization_strings::<mina_curves::pasta::Fp>(custom_gate_type, true)
+pub fn fp_linearization_strings_minus() -> (String, Vec<(String, String)>) {
+    linearization_strings::<mina_curves::pasta::Fp>(true, true)
 }
 
 #[ocaml::func]
-pub fn fq_linearization_strings_plus(custom_gate_type: bool) -> (String, Vec<(String, String)>) {
-    linearization_strings::<mina_curves::pasta::Fq>(custom_gate_type, false)
+pub fn fq_linearization_strings_minus() -> (String, Vec<(String, String)>) {
+    linearization_strings::<mina_curves::pasta::Fq>(true, false)
 }
 
 #[ocaml::func]

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,5 +1,5 @@
 use kimchi::circuits::{
-    expr::{FeatureFlag, PolishToken},
+    expr::{Column, FeatureFlag, Mds, PolishToken, RowOffset, Variable},
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
         runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg},
@@ -115,14 +115,17 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
 
     decl_type!(w, env, CamlWire => "wire");
     decl_type!(w, env, GateType => "gate_type");
-    decl_type!(w, env, PolishToken::<T1> => "polish_token");
     decl_type!(w, env, LookupPattern => "lookup_pattern");
     decl_type!(w, env, LookupPatterns => "lookup_patterns");
     decl_type!(w, env, LookupFeatures => "lookup_features");
     decl_type!(w, env, FeatureFlag => "feature_flag");
-    decl_type!(w, env, CamlCircuitGate<T1> => "circuit_gate");
-
+    decl_type!(w, env, RowOffset => "row_offset");
+    decl_type!(w, env, Column => "column");
     decl_type!(w, env, CurrOrNext => "curr_or_next");
+    decl_type!(w, env, Variable => "variable");
+    decl_type!(w, env, Mds => "mds");
+    decl_type!(w, env, PolishToken::<T1> => "polish_token");
+    decl_type!(w, env, CamlCircuitGate<T1> => "circuit_gate");
 
     decl_type!(w, env, CamlOracles<T1> => "oracles");
     decl_module!(w, env, "VerifierIndex", {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,5 +1,5 @@
 use kimchi::circuits::{
-    expr::FeatureFlag,
+    expr::{FeatureFlag, PolishToken},
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
         runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg},
@@ -115,6 +115,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
 
     decl_type!(w, env, CamlWire => "wire");
     decl_type!(w, env, GateType => "gate_type");
+    decl_type!(w, env, PolishToken::<T1> => "polish_token");
     decl_type!(w, env, LookupPattern => "lookup_pattern");
     decl_type!(w, env, LookupPatterns => "lookup_patterns");
     decl_type!(w, env, LookupFeatures => "lookup_features");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -8,6 +8,7 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use kimchi::circuits::constraints::FeatureFlags;
+use kimchi::circuits::expr::PolishToken;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupPatterns};
 use kimchi::circuits::polynomials::permutation::Shifts;
 use kimchi::circuits::polynomials::permutation::{permutation_vanishing_polynomial, zk_w};
@@ -26,6 +27,10 @@ pub type CamlPastaFpPlonkVerifierIndex =
 
 impl From<VerifierIndex<Vesta, OpeningProof<Vesta>>> for CamlPastaFpPlonkVerifierIndex {
     fn from(vi: VerifierIndex<Vesta, OpeningProof<Vesta>>) -> Self {
+        // Convert custom gate RPN from Fp to CamlFp
+        let custom_gate_type = vi
+            .custom_gate_type
+            .map(|vs| vs.into_iter().map(PolishToken::into).collect());
         Self {
             domain: CamlPlonkDomain {
                 log_size_of_group: vi.domain.log_size_of_group as isize,
@@ -60,7 +65,7 @@ impl From<VerifierIndex<Vesta, OpeningProof<Vesta>>> for CamlPastaFpPlonkVerifie
             shifts: vi.shift.to_vec().iter().map(Into::into).collect(),
             lookup_index: vi.lookup_index.map(Into::into),
             zk_rows: vi.zk_rows as isize,
-            custom_gate_type: vi.custom_gate_type,
+            custom_gate_type: custom_gate_type,
         }
     }
 }
@@ -111,9 +116,13 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta, OpeningProof<V
             },
         };
 
+        let custom_gate_type = index
+            .custom_gate_type
+            .map(|vs| vs.into_iter().map(PolishToken::into).collect());
+
         // TODO dummy_lookup_value ?
         let (linearization, powers_of_alpha) =
-            expr_linearization(index.custom_gate_type, Some(&feature_flags), true);
+            expr_linearization(custom_gate_type.as_ref(), Some(&feature_flags), true);
 
         VerifierIndex::<Vesta, OpeningProof<Vesta>> {
             domain,
@@ -162,7 +171,7 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta, OpeningProof<V
 
             lookup_index: index.lookup_index.map(Into::into),
             linearization,
-            custom_gate_type: index.custom_gate_type,
+            custom_gate_type: custom_gate_type,
         }
     }
 }
@@ -282,7 +291,7 @@ pub fn caml_pasta_fp_plonk_verifier_index_dummy() -> CamlPastaFpPlonkVerifierInd
         shifts: (0..PERMUTS - 1).map(|_| Fp::one().into()).collect(),
         lookup_index: None,
         zk_rows: 3,
-        custom_gate_type: false,
+        custom_gate_type: None,
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
@@ -1,4 +1,5 @@
 use ark_ec::AffineCurve;
+use kimchi::circuits::expr::PolishToken;
 use kimchi::circuits::lookup::index::LookupSelectors;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupInfo};
 use kimchi::verifier_index::LookupVerifierIndex;
@@ -196,5 +197,5 @@ pub struct CamlPlonkVerifierIndex<Fr, SRS, PolyComm> {
     pub shifts: Vec<Fr>,
     pub lookup_index: Option<CamlLookupVerifierIndex<PolyComm>>,
     pub zk_rows: ocaml::Int,
-    pub custom_gate_type: bool,
+    pub custom_gate_type: Option<Vec<PolishToken<Fr>>>,
 }


### PR DESCRIPTION
This gets the OCaml side of bindings updates in place for customisable kimchi & pickles vertical slice iteration 2.  The test target for this passing is that the stubs build.