### PR TITLE
Fix genesis ledger directory growing in size

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -47,6 +47,9 @@ module Tar = struct
         Ok ()
     | Error err ->
         Error (Error.tag err ~tag:"Error extracting tar file")
+
+  let filename_without_extension =
+    String.chop_suffix_if_exists ~suffix:".tar.gz"
 end
 
 let file_exists ?follow_symlinks filename =
@@ -186,7 +189,9 @@ module Ledger = struct
     [%log trace] "Loading $ledger from $path"
       ~metadata:
         [ ("ledger", `String ledger_name_prefix); ("path", `String filename) ] ;
-    let dirname = Uuid.to_string (Uuid_unix.create ()) in
+    let dirname =
+      Tar.filename_without_extension @@ Filename.basename filename
+    in
     (* Unpack the ledger in the autogen directory, since we know that we have
        write permissions there.
     *)


### PR DESCRIPTION
Genesis ledger tar was being extracted to a random sub dir inside the genesis dir, resulting in each subsequent node run with persistence producing a new dir with the contents of the tar file, making the genesis grow indefinitely in size (issue #14548).

This PR fixes this issue, by making the tar extraction into a dir with the same name as the tar file. Subsequent runs of the node will check for the presence of that dir before extracting, delete it if it exists, and extract the tar. This results in a constant size of the genesis dir, assuming the node is rerun with the same genesis ledger config.
Some small improvements to the overall tar-loading logic were also made.

This was tested by doing node runs with different genesis ledger configurations (accounts, hash, name) and checking if the genesis ledger was correctly loaded and the respective tar files and extract directories correctly created and loaded. 

Although it was previously discussed improving this process by skipping the tar extraction if the corresponding extraction dir was already present, it seems to me now that it is safer and easier to recreate the dir from the tar file than doing a sanity check on the existing dir, so that change was dropped from this PR and can be better investigated in the future if required.

Closes #14548