### PR TITLE
Faster to_bignum_bigint

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/bigint.ml
+++ b/src/lib/crypto/kimchi_backend/common/bigint.ml
@@ -13,6 +13,8 @@ module type Bindings = sig
 
   val test_bit : t -> int -> bool
 
+  val test_uint32 : t -> int -> int
+
   val print : t -> unit
 
   val to_string : t -> string

--- a/src/lib/crypto/kimchi_backend/common/bigint.mli
+++ b/src/lib/crypto/kimchi_backend/common/bigint.mli
@@ -11,6 +11,8 @@ module type Bindings = sig
 
   val test_bit : t -> int -> bool
 
+  val test_uint32 : t -> int -> int
+
   val print : t -> unit
 
   val to_string : t -> string
@@ -52,6 +54,8 @@ module type Intf = sig
   val div : t -> t -> t
 
   val test_bit : t -> int -> bool
+
+  val test_uint32 : t -> int -> int
 
   val print : t -> unit
 
@@ -111,6 +115,8 @@ module Make : functor
   val div : t -> t -> t
 
   val test_bit : t -> int -> bool
+
+  val test_uint32 : t -> int -> int
 
   val print : t -> unit
 

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -180,10 +180,10 @@ module Make (F : Input_intf) :
       let two_to_32 = Bignum_bigint.of_int64 4294967296L
 
       let to_bignum_bigint n =
-        let result = ref Bignum_bigint.zero in
-        for i = 7 downto 0 do
+        let result = ref (Bignum_bigint.of_int (Bigint.test_uint32 n 7)) in
+        for i = 6 downto 0 do
           let ni = Bignum_bigint.of_int (Bigint.test_uint32 n i) in
-          result := Bignum_bigint.(ni + (!result * two_to_32))
+          result := Bignum_bigint.(ni + (two_to_32 * !result))
         done ;
         !result
 

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -177,17 +177,15 @@ module Make (F : Input_intf) :
             let of_sexpable = of_bigint
           end)
 
+      let two_to_32 = Bignum_bigint.of_int64 4294967296L
+
       let to_bignum_bigint n =
-        let rec go i two_to_the_i acc =
-          if Int.equal i size_in_bits then acc
-          else
-            let acc' =
-              if Bigint.test_bit n i then Bignum_bigint.(acc + two_to_the_i)
-              else acc
-            in
-            go (i + 1) Bignum_bigint.(two_to_the_i + two_to_the_i) acc'
-        in
-        go 0 Bignum_bigint.one Bignum_bigint.zero
+        let result = ref Bignum_bigint.zero in
+        for i = 7 downto 0 do
+          let ni = Bignum_bigint.of_int (Bigint.test_uint32 n i) in
+          result := Bignum_bigint.(ni + (!result * two_to_32))
+        done ;
+        !result
 
       let hash_fold_t s x =
         Bignum_bigint.hash_fold_t s (to_bignum_bigint (to_bigint x))

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -177,13 +177,15 @@ module Make (F : Input_intf) :
             let of_sexpable = of_bigint
           end)
 
-      let two_to_32 = Bignum_bigint.of_int64 4294967296L
+      let size_in_uint32 = (size_in_bits + 31) / 32
 
-      let to_bignum_bigint n =
-        let result = ref (Bignum_bigint.of_int (Bigint.test_uint32 n 7)) in
-        for i = 6 downto 0 do
-          let ni = Bignum_bigint.of_int (Bigint.test_uint32 n i) in
-          result := Bignum_bigint.(ni + (two_to_32 * !result))
+      let to_bignum_bigint x =
+        let result =
+          ref (Bignum_bigint.of_int (Bigint.test_uint32 x (size_in_uint32 - 1)))
+        in
+        for i = size_in_uint32 - 2 downto 0 do
+          let xi = Bignum_bigint.of_int (Bigint.test_uint32 x i) in
+          result := Bignum_bigint.(xi + shift_left !result 32)
         done ;
         !result
 

--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
@@ -21,6 +21,8 @@ module BigInt256 = struct
 
   external test_bit : t -> int -> bool = "caml_bigint_256_test_bit"
 
+  external test_uint32 : t -> int -> int = "caml_bigint_256_test_uint32"
+
   external to_bytes : t -> bytes = "caml_bigint_256_to_bytes"
 
   external of_bytes : bytes -> t = "caml_bigint_256_of_bytes"

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/bigint_256.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/bigint_256.rs
@@ -201,6 +201,15 @@ pub fn caml_bigint_256_test_bit(
 
 #[ocaml_gen::func]
 #[ocaml::func]
+pub fn caml_bigint_256_test_uint32(
+    x: ocaml::Pointer<CamlBigInteger256>,
+    i: ocaml::Int,
+) -> Result<ocaml::Int, ocaml::Error> {
+    panic!("caml_bigint_256_test_uint32: not implemented");
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
 pub fn caml_bigint_256_to_bytes(
     x: ocaml::Pointer<CamlBigInteger256>,
 ) -> [u8; std::mem::size_of::<BigInteger256>()] {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -154,6 +154,7 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_bigint_256_print => "print");
         decl_func!(w, env, caml_bigint_256_to_string => "to_string");
         decl_func!(w, env, caml_bigint_256_test_bit => "test_bit");
+        decl_func!(w, env, caml_bigint_256_test_uint32 => "test_uint32");
         decl_func!(w, env, caml_bigint_256_to_bytes => "to_bytes");
         decl_func!(w, env, caml_bigint_256_of_bytes => "of_bytes");
         decl_func!(w, env, caml_bigint_256_deep_copy => "deep_copy");


### PR DESCRIPTION
o1js: https://github.com/o1-labs/o1js/pull/1338

This reimplements conversion of Rust field elements to Zarith bigints (`Bigint.to_bignum_bigint`). The conversion is used for the `Hashable` implementation of field elements, which previously was one of the main bottlenecks during witness generation, because `plonk_constraint_system.ml` uses a hashtable with field element keys.

The old conversion tested each individual bit of the Rust field. The new version tests 32 bits at once, and introduces a new bindings function `test_uint32` for this purpose.

Empirically, this PR makes brings the witness generation time in a JS benchmark (Keccak) down by about **60%**, from 1.7 to 0.7 seconds. The cost of `hash` calls, which used to be >50%, becomes negligible.

Note: IMO, this isn't the cleanest way to achieve the goal. It keeps the dependency on Zarith -- a separate, arbitrary-length bigint implementation, which is slow at least in the JS version -- just for support of a few methods like `Hashable.hash`. Ideally, we would implement hashing in Rust and JS and get rid of Zarith. However, that's a more impactful change and would have required more research. This here seems to be the minimal change that removes the bottleneck.

TODO: So far, only the JS backend implements `test_uint32`. Rust and Rust/wasm versions have to be added.