### PR TITLE
[berkeley] feat: fix scripts to use different paths if mina is a submodule of o1js

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/gen_version.sh
+++ b/src/lib/crypto/kimchi_backend/common/gen_version.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 if [ -z ${MARLIN_REPO_SHA+x} ]; then
-    marlin_submodule_dir=$(git submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
-    marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
+    # Check for the existence of the 'mina' submodule
+    git_root=$(git rev-parse --show-toplevel)
+    mina_submodule=$(git submodule status | grep "mina" || true)
+
+    if [[ -n "$mina_submodule" ]]; then
+        marlin_submodule_dir=$(git -C "$git_root/src/mina" submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
+        marlin_repo_sha=$(git -C "$git_root/src/mina/$marlin_submodule_dir" rev-parse --short=8 --verify HEAD)
+    else
+        marlin_submodule_dir=$(git submodule status | grep proof-systems | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
+        marlin_repo_sha=$(git -C "$marlin_submodule_dir" rev-parse --short=8 --verify HEAD)
+    fi
 else
     marlin_repo_sha=$(cut -b -8 <<< "$MARLIN_REPO_SHA")
 fi

--- a/src/lib/mina_version/normal/gen.sh
+++ b/src/lib/mina_version/normal/gen.sh
@@ -12,7 +12,12 @@ pushd "$root" > /dev/null
   if [[ -e .git ]] && ! git diff --quiet; then id="[DIRTY]$id"; fi
   commit_date="${MINA_COMMIT_DATE-$(git show HEAD -s --format="%cI" || echo "<unknown>")}"
 
-  pushd src/lib/crypto/proof-systems > /dev/null
+  mina_submodule=$(git submodule status | grep "mina" || true)
+  if [[ -n "$mina_submodule" ]]; then
+    pushd src/mina/src/lib/crypto/proof-systems > /dev/null
+  else
+    pushd src/lib/crypto/proof-systems > /dev/null
+  fi
     marlin_commit_id="${MARLIN_COMMIT_ID-$(git rev-parse --verify HEAD || echo "<unknown>")}"
     marlin_commit_id_short="$(printf '%s' "$marlin_commit_id" | cut -c1-8)"
     if [[ -e .git ]] && ! git diff --quiet; then marlin_commit_id="[DIRTY]$marlin_commit_id"; fi

--- a/src/libp2p_ipc/dune
+++ b/src/libp2p_ipc/dune
@@ -1,7 +1,7 @@
 (library
  (name libp2p_ipc)
  (public_name libp2p_ipc)
- (flags -w -53)
+ (flags -w -53-55)
  (inline_tests (flags -verbose -show-counts))
  (libraries
    ;; opam libraries


### PR DESCRIPTION
Explain your changes:
Fixes some of the scripts called by dune to use different absolute paths if we are building mina in the context of the o1js as mina being a submodule.

The issue occurs when we build o1js from the root directory with mina as a submodule. Dune will try to resolve some absolute paths from build scripts that will fail and not build o1js properly. To fix this, we conditionally check for submodule locations and change the paths if we have a mina submodule present, otherwise, we use the same build process. This lets us build mina the same way but also build o1js dependencies properly.

Explain how you tested your changes:
Built mina from the root directory to test normal building and built o1js using mina as a submodule successfully.

Addresses https://github.com/o1-labs/o1js/issues/1096