### PR TITLE
Fix duplicated rows in zkapp_account_precondition table

### DIFF
--- a/scripts/archive/zkapp_duplicated_precondition/add_constraint.sql
+++ b/scripts/archive/zkapp_duplicated_precondition/add_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE zkapp_account_precondition
+ADD CONSTRAINT zkapp_account_precondition_unique UNIQUE(balance_id, receipt_chain_hash, delegate_id, state_id, action_state_id, proved_state, is_new, nonce_id);

--- a/scripts/archive/zkapp_duplicated_precondition/remove_duplicated_zkapp_account_precondition_rows.sh
+++ b/scripts/archive/zkapp_duplicated_precondition/remove_duplicated_zkapp_account_precondition_rows.sh
@@ -12,7 +12,7 @@ PRECONDITION_DATA_TMP=zkapp_precondition_table.tmp
 PRECONDITION_UPDATE_SCRIPT=zkapp_precondition_script.sql
 BODY_UPDATE_SCRIPT=zkapp_update_body_script.sql
 
-echo "This script will produce two scripts which will remove duplicated zkppp account preconditions rows in archive db" "$ARCHIVE_DB"
+echo "This Shell script will produce two SQL scripts that will remove duplicated zkApp account preconditions rows in the archive DB" "$ARCHIVE_DB"
 
 rm -f $BODY_DATA_BCK
 rm -f $PRECONDITION_DATA_BCK
@@ -53,4 +53,4 @@ do
 done
 
 echo
-echo "Scripts are ready $PRECONDITION_UPDATE_SCRIPT, $BODY_UPDATE_SCRIPT !"
+echo "SQL scripts are ready: $PRECONDITION_UPDATE_SCRIPT, $BODY_UPDATE_SCRIPT !"

--- a/scripts/archive/zkapp_duplicated_precondition/remove_duplicated_zkapp_account_precondition_rows.sh
+++ b/scripts/archive/zkapp_duplicated_precondition/remove_duplicated_zkapp_account_precondition_rows.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [ $# -gt 2 ]; then
+    echo "Usage $0 archive-db"
+    exit 0
+fi
+
+ARCHIVE_DB=$1
+BODY_DATA_BCK=zkapp_update_body_data_table.bck
+PRECONDITION_DATA_BCK=zkapp_precondition_table.bck
+PRECONDITION_DATA_TMP=zkapp_precondition_table.tmp
+PRECONDITION_UPDATE_SCRIPT=zkapp_precondition_script.sql
+BODY_UPDATE_SCRIPT=zkapp_update_body_script.sql
+
+echo "This script will produce two scripts which will remove duplicated zkppp account preconditions rows in archive db" "$ARCHIVE_DB"
+
+rm -f $BODY_DATA_BCK
+rm -f $PRECONDITION_DATA_BCK
+rm -f $PRECONDITION_DATA_TMP
+rm -f $PRECONDITION_UPDATE_SCRIPT
+rm -f $BODY_UPDATE_SCRIPT
+
+ALL_TABLES="balance_id,receipt_chain_hash,delegate_id,state_id,action_state_id,proved_state, is_new, nonce_id"
+
+echo "Creating backup of zkapp_account_preconditions table " "$PRECONDITION_DATA_BCK" 
+
+echo "SELECT * FROM zkapp_account_precondition" | \
+    psql -U postgres --csv -q -t "$ARCHIVE_DB" > $PRECONDITION_DATA_BCK
+
+echo "Creating backup of zkapp_update_body table " "$BODY_DATA_BCK"
+
+echo "SELECT * FROM zkapp_account_update_body" | \
+    psql -U postgres --csv -q -t "$ARCHIVE_DB" > $BODY_DATA_BCK
+
+
+echo "Creating temporary file of zkapp_account_preconditions table " "$PRECONDITION_DATA_TMP"
+
+echo "SELECT  MIN(id) as id, $ALL_TABLES, MAX(id) as duplicated_id  \
+		FROM zkapp_account_precondition \
+		GROUP BY $ALL_TABLES \
+		HAVING COUNT(*) > 1" | \
+    psql -U postgres --csv -q -t "$ARCHIVE_DB" > $PRECONDITION_DATA_TMP
+
+echo "Creating SQL scripts for removing duplications" "$PRECONDITION_UPDATE_SCRIPT" "and updating references" "$BODY_UPDATE_SCRIPT"
+
+cat $PRECONDITION_DATA_TMP | while IFS= read -r line 
+do  
+    ID_TO_REPLACE=$(echo "$line" | awk -F , '{print $1}');
+    ID_TO_REMOVE=$(echo "$line" | awk -F , '{print $10}');
+    echo -n .
+    echo "$ID_TO_REPLACE $ID_TO_REMOVE" | awk '{print "UPDATE zkapp_account_update_body SET zkapp_account_precondition_id = " $1 " WHERE zkapp_account_precondition_id =" $2 ";"}' >> $BODY_UPDATE_SCRIPT
+    echo "$ID_TO_REMOVE" | awk '{print "DELETE FROM zkapp_account_precondition WHERE id=" $1 ";"}' >> $PRECONDITION_UPDATE_SCRIPT
+done
+
+echo
+echo "Scripts are ready $PRECONDITION_UPDATE_SCRIPT, $BODY_UPDATE_SCRIPT !"

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -162,6 +162,7 @@ CREATE TABLE zkapp_account_precondition
 , action_state_id          int                     REFERENCES zkapp_field(id)
 , proved_state             boolean
 , is_new                   boolean
+, UNIQUE(balance_id, receipt_chain_hash, delegate_id, state_id, action_state_id, proved_state, is_new, nonce_id)
 );
 
 CREATE TABLE zkapp_accounts

--- a/src/app/rosetta/download-missing-blocks.sh
+++ b/src/app/rosetta/download-missing-blocks.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-BLOCKS_BUCKET="${BLOCKS_BUCKET:=gs://mina_network_block_data}"
+BLOCKS_BUCKET="${BLOCKS_BUCKET:=https://storage.googleapis.com/mina_network_block_data}"
 
-set -ux
+set -u
 
 MINA_NETWORK=${1}
 # Postgres database connection string and related variables
@@ -25,7 +25,7 @@ function populate_db() {
 
 function download_block() {
     echo "Downloading $1 block"
-    gsutil cp "${BLOCKS_BUCKET}/${1}" .
+    curl -sO "${BLOCKS_BUCKET}/${1}"
 }
 
 HASH='map(select(.metadata.parent_hash != null and .metadata.parent_height != null)) | .[0].metadata.parent_hash'

--- a/src/app/rosetta/download-missing-blocks.sh
+++ b/src/app/rosetta/download-missing-blocks.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-BLOCKS_BUCKET="${BLOCKS_BUCKET:=https://storage.googleapis.com/mina_network_block_data}"
+BLOCKS_BUCKET="${BLOCKS_BUCKET:=gs://mina_network_block_data}"
 
-set -u
+set -ux
 
 MINA_NETWORK=${1}
 # Postgres database connection string and related variables
@@ -25,7 +25,7 @@ function populate_db() {
 
 function download_block() {
     echo "Downloading $1 block"
-    curl -sO "${BLOCKS_BUCKET}/${1}"
+    gsutil cp "${BLOCKS_BUCKET}/${1}" .
 }
 
 HASH='map(select(.metadata.parent_hash != null and .metadata.parent_height != null)) | .[0].metadata.parent_hash'


### PR DESCRIPTION
Added shell script which generated two sql scripts for patching database:

- zkapp_precondition_script.sql - Removes duplicated rows in zkapp_account_precondition
- zkapp_update_body_script.sql - Updates zkapp_account_update_body table which has foreign key to zkapp_account_precondition table

Moreover i've updated zkapp_tables.sql script and added unique constraint so that whenever we bypass Ocaml code and manipulate data directly db constraint will complain

Lastly added update script which adds constraint if we want to patch existing database.

In order to fix current schemas in ITN we need to follow below steps:

- run `zkapp_duplicated_precondition/remove_duplicated_zkapp_account_precondition_rows.sh {schema}`
- run produced scripts in correct order: zkapp_precondition_script.sql, zkapp_update_body_script.sql 
- update constraint for zkapp_account_precondition table: add_constraint.sql



Closes #14777