### PR TITLE
End the suffering, turn back on `implicit_transitive_deps`

### DIFF
--- a/src/app/archive/dune-project
+++ b/src/app/archive/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name archive_lib)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/archive/lib/dune-project
+++ b/src/app/archive/lib/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name graphql_query)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/benchmarks/dune-project
+++ b/src/app/benchmarks/dune-project
@@ -1,3 +1,3 @@
 (lang dune 3.3)
 (name benchmarks)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/cli/src/dune-project
+++ b/src/app/cli/src/dune-project
@@ -1,3 +1,3 @@
 (lang dune 3.3)
 (name graphql)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/dump_blocks/dune-project
+++ b/src/app/dump_blocks/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name dump_blocks)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/logproc/dune-project
+++ b/src/app/logproc/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name logproc)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/reformat/dune-project
+++ b/src/app/reformat/dune-project
@@ -1,3 +1,3 @@
 (lang dune 3.2)
 (name reformat)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/rosetta/dune-project
+++ b/src/app/rosetta/dune-project
@@ -1,3 +1,3 @@
 (lang dune 3.3)
 (name rosetta)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/runtime_genesis_ledger/dune-project
+++ b/src/app/runtime_genesis_ledger/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name runtime_genesis_ledger)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/app/zkapp_test_transaction/dune-project
+++ b/src/app/zkapp_test_transaction/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name zkapp_test_transaction)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/dune-project
+++ b/src/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.3)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)
 
 (package (name allocation_functor))
 (package (name archive_blocks))

--- a/src/lib/transition_frontier/dune-project
+++ b/src/lib/transition_frontier/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.8)
 (name transition_frontier)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)

--- a/src/nonconsensus/dune-project
+++ b/src/nonconsensus/dune-project
@@ -1,2 +1,2 @@
 (lang dune 2.8)
-(implicit_transitive_deps false)
+(implicit_transitive_deps true)


### PR DESCRIPTION
This was a mistake, and we have now learned from it :)

**Context:**

We had hoped that this option would get dune to warn us when we were underspecifying our dependencies. In particular, since dune is able to infer the transitive dependencies, it has all the information that we need. However, in practice this is implemented in a way that's very inconvenient to use:
* dune doesn't emit any warnings;
* dune doesn't resolve upstream transitive dependencies (e.g. `core -> core_kernel -> base -> base.caml`), which makes our external dependencies unnecessarily and unhelpfully verbose;
* the OCaml compiler is the only thing 'checking' the dependencies, and missing types are treated as 'abstract'
  - this causes unpleasant and confusing error messages,
  - the OCaml compiler uses head-normalising type path expansion, so if we have `A.t = B.t = C.t = int * bool`, the error will report that `A.t` is abstract even when `B` or `C` are the missing libraries.

The correct approach is to add a mode for dune to check the (local/workspace) dependency enumeration, using its internal tracking; this is explicitly not done here.