### PR TITLE
Fix/archive db add indexes

### DIFF
--- a/src/app/archive/add_indexes.sql
+++ b/src/app/archive/add_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_zkapp_field_array_element_ids ON zkapp_field_array(element_ids);
+
+CREATE INDEX idx_zkapp_events_element_ids ON zkapp_events(element_ids);

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -33,7 +33,7 @@ CREATE TABLE zkapp_field_array
 , element_ids              int[]   NOT NULL
 );
 
-create INDEX idx_zkapp_field_array_element_ids ON zkapp_field_array(element_ids);
+CREATE INDEX idx_zkapp_field_array_element_ids ON zkapp_field_array(element_ids);
 
 /* Fixed-width arrays of algebraic fields, given as id's from
    zkapp_field
@@ -83,7 +83,7 @@ CREATE TABLE zkapp_events
 , element_ids              int[]            NOT NULL
 );
 
-create index idx_zkapp_events_element_ids ON zkapp_events(element_ids);
+CREATE INDEX idx_zkapp_events_element_ids ON zkapp_events(element_ids);
 
 
 /* field elements derived from verification keys */

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -83,6 +83,9 @@ CREATE TABLE zkapp_events
 , element_ids              int[]            NOT NULL
 );
 
+create index idx_zkapp_events_element_ids ON zkapp_events(element_ids);
+
+
 /* field elements derived from verification keys */
 CREATE TABLE zkapp_verification_key_hashes
 ( id                                    serial          PRIMARY KEY

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -85,7 +85,6 @@ CREATE TABLE zkapp_events
 
 CREATE INDEX idx_zkapp_events_element_ids ON zkapp_events(element_ids);
 
-
 /* field elements derived from verification keys */
 CREATE TABLE zkapp_verification_key_hashes
 ( id                                    serial          PRIMARY KEY

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -33,6 +33,8 @@ CREATE TABLE zkapp_field_array
 , element_ids              int[]   NOT NULL
 );
 
+create INDEX idx_zkapp_field_array_element_ids ON zkapp_field_array(element_ids);
+
 /* Fixed-width arrays of algebraic fields, given as id's from
    zkapp_field
 


### PR DESCRIPTION
Explain your changes:
This PR adds 2 indexes to archive database which helps to optimize the speed of archiving max cost zkapps.

To patch the existing database, please use `add_indexes.sql`

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
