### PR TITLE
[CI] soft fail for testworld 2 0 connectivity

### DIFF
--- a/buildkite/src/Jobs/Test/ConnectToTestworld-2-0.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToTestworld-2-0.dhall
@@ -24,6 +24,6 @@ in Pipeline.build Pipeline.Config::{
     name = "ConnectToTestworld-2-0"
   },
   steps = [
-    ConnectToTestnet.step dependsOn "testworld-2-0" "40s" "2m" (B/SoftFail.Boolean False)
+    ConnectToTestnet.step dependsOn "testworld-2-0" "40s" "2m" (B/SoftFail.Boolean True)
   ]
 }


### PR DESCRIPTION
Soft fail for testworld 2.0 connectivity test since berkeley is not compatible with itn right now