### PR TITLE
Fix parsing of URLs

### DIFF
--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -30,7 +30,8 @@ export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
 
 if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 
   # Abort if `BUILDKITE_REPO` doesn't have the expected format
-  echo ${BUILDKITE_REPO} | grep -P '^.*github.com[:\/](.*)\.git$' > /dev/null
+  echo ${BUILDKITE_REPO} | grep -P '^.*github.com[:\/](.*)\.git$' > /dev/null || \
+      (echo "BUILDKITE_REPO does not have the expected format" && false)
 
   # We don't want to allow some operations on fork repository which should be done on main repo only. 
   # Publish to docker hub or publish to unstable debian channel should be exclusive to main repo as it can override 

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -35,7 +35,7 @@ if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then
 
   # We don't want to use tags (as this can replace our dockers/debian packages). Instead we are using repo name
   # For example: for given repo 'https://github.com/dkijania/mina.git' we convert it to 'dkijania_mina' 
-  export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e "s/https:\/\/github.com\///g" | sed -e "s/.git//g" | sed -e "s/\//-/g")
+  export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e 's/^.*github.com[:\/]\(.*\)\.git$/\1/' -e 's/\//-/')
   export THIS_COMMIT_TAG=""
   RELEASE=unstable
 

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -29,6 +29,9 @@ export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
  
 
 if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 
+  # Abort if `BUILDKITE_REPO` doesn't have the expected format
+  echo ${BUILDKITE_REPO} | grep -P '^.*github.com[:\/](.*)\.git$' > /dev/null
+
   # We don't want to allow some operations on fork repository which should be done on main repo only. 
   # Publish to docker hub or publish to unstable debian channel should be exclusive to main repo as it can override 
   # packages from main repo (by using the same commit and the same branch from forked repository)


### PR DESCRIPTION
With this change, we now support all of the likely URLs, including
```
https://foo:bar@github.com/ORG/REPO.git
https://github.com/ORG/REPO.git
git://github.com/ORG/REPO.git
git@github.com:ORG/REPO.git
```

See [this slack thread](https://o1-labs.slack.com/archives/C02BFPS6BA4/p1704773737899079) for original issue.