### PR TITLE
o1trace/trace-tool revival

### DIFF
--- a/buildkite/src/Jobs/Release/TraceTool.dhall
+++ b/buildkite/src/Jobs/Release/TraceTool.dhall
@@ -25,12 +25,12 @@ Pipeline.build
     steps = [
       Command.build
         Command.Config::{
-          commands = RunInToolchain.runInToolchain ([] : List Text) "cd src/app/trace-tool && PATH=/home/opam/.cargo/bin:$PATH cargo build"
+          commands = RunInToolchain.runInToolchain ([] : List Text) "cd src/app/trace-tool && PATH=/home/opam/.cargo/bin:$PATH cargo build --release"
           , label = "Build trace-tool"
           , key = "build-trace-tool"
           , target = Size.Small
           , docker = None Docker.Type
-          , artifact_paths = [ S.contains "src/app/trace-tool/target/debug/trace-tool" ]
+          , artifact_paths = [ S.contains "src/app/trace-tool/target/release/trace-tool" ]
         }
     ]
   }

--- a/buildkite/src/Jobs/Release/TraceTool.dhall
+++ b/buildkite/src/Jobs/Release/TraceTool.dhall
@@ -18,7 +18,7 @@ in
 Pipeline.build
   Pipeline.Config::{
     spec = JobSpec::{
-      dirtyWhen = [ S.contains "src/app/trace-tool", S.strictlyStart (S.contains "buildkite/src/Jobs/TraceTool") ],
+      dirtyWhen = [ S.contains "src/app/trace-tool", S.strictlyStart (S.contains "buildkite/src/Jobs/Release/TraceTool") ],
       path = "Release",
       name = "TraceTool"
     },

--- a/src/lib/o1trace/execution_timer.ml
+++ b/src/lib/o1trace/execution_timer.ml
@@ -26,4 +26,6 @@ let on_job_enter _fiber = ()
 
 let on_job_exit fiber elapsed_time = record_elapsed_time fiber elapsed_time
 
+let on_new_fiber _fiber = ()
+
 let elapsed_time_of_thread thread = !(Plugins.plugin_state (module T) thread)

--- a/src/lib/o1trace/execution_timer.ml
+++ b/src/lib/o1trace/execution_timer.ml
@@ -28,4 +28,6 @@ let on_job_exit fiber elapsed_time = record_elapsed_time fiber elapsed_time
 
 let on_new_fiber _fiber = ()
 
+let on_cycle_end () = ()
+
 let elapsed_time_of_thread thread = !(Plugins.plugin_state (module T) thread)

--- a/src/lib/o1trace/o1trace.ml
+++ b/src/lib/o1trace/o1trace.ml
@@ -109,7 +109,7 @@ let sync_thread name f =
       let ctx = with_o1trace ~name ctx in
       match
         Scheduler.Private.with_execution_context (Scheduler.Private.t ()) ctx
-          ~f:(fun () -> Result.try_with f)
+          ~f:(fun () -> Result.try_with f )
       with
       | Error exn ->
           Exn.reraise exn "exception caught by O1trace.sync_thread"
@@ -118,7 +118,11 @@ let sync_thread name f =
           on_job_exit' fiber elapsed_time ;
           result )
 
-let () = Stdlib.(Async_kernel.Tracing.fns := { on_job_enter; on_job_exit })
+let () =
+  Stdlib.(Async_kernel.Tracing.fns := { on_job_enter; on_job_exit }) ;
+  Scheduler.Expert.run_every_cycle_end (fun () ->
+      Plugins.dispatch (fun (module Plugin : Plugins.Plugin_intf) ->
+          Plugin.on_cycle_end () ) )
 
 (*
 let () =

--- a/src/lib/o1trace/o1trace.ml
+++ b/src/lib/o1trace/o1trace.ml
@@ -109,7 +109,7 @@ let sync_thread name f =
       let ctx = with_o1trace ~name ctx in
       match
         Scheduler.Private.with_execution_context (Scheduler.Private.t ()) ctx
-          ~f:(fun () -> Result.try_with f )
+          ~f:(fun () -> Result.try_with f)
       with
       | Error exn ->
           Exn.reraise exn "exception caught by O1trace.sync_thread"

--- a/src/lib/o1trace/o1trace.mli
+++ b/src/lib/o1trace/o1trace.mli
@@ -17,6 +17,8 @@ module Thread : sig
   module Fiber : sig
     type t = Thread.Fiber.t =
       { id : int; parent : t option; thread : Thread.t; key : string list }
+
+    val key : t -> string list
   end
 
   val iter_fibers : f:(Fiber.t -> unit) -> unit

--- a/src/lib/o1trace/o1trace.mli
+++ b/src/lib/o1trace/o1trace.mli
@@ -15,8 +15,11 @@ module Thread : sig
   val dump_thread_graph : unit -> bytes
 
   module Fiber : sig
-    type t = Thread.Fiber.t = { id : int; parent : t option; thread : Thread.t }
+    type t = Thread.Fiber.t =
+      { id : int; parent : t option; thread : Thread.t; key : string list }
   end
+
+  val iter_fibers : f:(Fiber.t -> unit) -> unit
 end
 
 module Plugins : module type of Plugins

--- a/src/lib/o1trace/plugins.ml
+++ b/src/lib/o1trace/plugins.ml
@@ -29,6 +29,8 @@ module type Plugin_intf = sig
   val on_job_enter : Thread.Fiber.t -> unit
 
   val on_job_exit : Thread.Fiber.t -> Time_ns.Span.t -> unit
+
+  val on_new_fiber : Thread.Fiber.t -> unit
 end
 
 module Register_plugin (Plugin_spec : Plugin_spec_intf) () :

--- a/src/lib/o1trace/plugins.ml
+++ b/src/lib/o1trace/plugins.ml
@@ -31,6 +31,8 @@ module type Plugin_intf = sig
   val on_job_exit : Thread.Fiber.t -> Time_ns.Span.t -> unit
 
   val on_new_fiber : Thread.Fiber.t -> unit
+
+  val on_cycle_end : unit -> unit
 end
 
 module Register_plugin (Plugin_spec : Plugin_spec_intf) () :

--- a/src/lib/o1trace/thread.ml
+++ b/src/lib/o1trace/thread.ml
@@ -69,7 +69,8 @@ module Fiber = struct
 
   let next_id = ref 1
 
-  type t = { id : int; parent : t option; thread : thread } [@@deriving sexp_of]
+  type t = { id : int; parent : t option; thread : thread; key : string list }
+  [@@deriving sexp_of]
 
   let ctx_id : t Type_equal.Id.t = Type_equal.Id.create ~name:"fiber" sexp_of_t
 
@@ -87,7 +88,7 @@ module Fiber = struct
         fiber
     | None ->
         let thread = register name in
-        let fiber = { id = !next_id; parent; thread } in
+        let fiber = { id = !next_id; parent; thread; key } in
         incr next_id ;
         Hashtbl.set fibers ~key ~data:fiber ;
         Option.iter parent ~f:(fun p -> Graph.add_edge graph p.thread.name name) ;
@@ -103,3 +104,5 @@ end
 let of_context ctx =
   let%map.Option fiber = Fiber.of_context ctx in
   fiber.thread
+
+let iter_fibers ~f = Hashtbl.iter Fiber.fibers ~f

--- a/src/lib/o1trace/thread.ml
+++ b/src/lib/o1trace/thread.ml
@@ -99,6 +99,8 @@ module Fiber = struct
     Execution_context.with_local ctx ctx_id (Some t)
 
   let of_context ctx = Execution_context.find_local ctx ctx_id
+
+  let key { thread = { name; _ }; parent; _ } = fiber_key name parent
 end
 
 let of_context ctx =

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -6,9 +6,9 @@ module Scheduler = Async_kernel_scheduler
 let current_wr = ref None
 
 let emit_event =
-  let buf = Bigstring.create 512 in
   fun event ->
     Option.iter !current_wr ~f:(fun wr ->
+        let buf = Bigstring.create 512 in
         try Webkit_trace_event_binary_output.emit_event ~buf wr event
         with exn ->
           Writer.writef wr "failed to write o1trace event: %s\n"

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -97,9 +97,13 @@ module T = struct
       end)
       ()
 
+  let most_recent_id = ref (-1)
+
   let on_job_enter (fiber : O1trace.Thread.Fiber.t) =
-    emit_event
-      (new_thread_event (O1trace.Thread.name fiber.thread) Thread_switch)
+    if fiber.id <> !most_recent_id then (
+      most_recent_id := fiber.id ;
+      emit_event
+        (new_thread_event (O1trace.Thread.name fiber.thread) Thread_switch) )
 
   let on_job_exit _fiber _time_elapsed = ()
 

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -113,9 +113,6 @@ let start_tracing wr =
     ()
   else (
     current_wr := Some wr ;
-    (* FIXME: these handlers cannot be removed without further
-       changes to async_kernel. Instead, we will leak a ref and
-       accumulate a bunch of NOOPs every time we call [stop_tracing] *)
     emit_event (new_event Pid_is) ;
     O1trace.Thread.iter_fibers ~f:(fun fiber ->
         emit_event

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -96,7 +96,8 @@ module T = struct
   let on_job_exit _fiber _time_elapsed = ()
 
   let on_new_fiber (fiber : O1trace.Thread.Fiber.t) =
-    emit_event (new_thread_event ~include_name:true fiber.key fiber.id New_thread)
+    emit_event
+      (new_thread_event ~include_name:true fiber.key fiber.id New_thread)
 end
 
 let cancel = ref (ref false)
@@ -110,8 +111,6 @@ let start_tracing wr =
     (* FIXME: these handlers cannot be removed without further
        changes to async_kernel. Instead, we will leak a ref and
        accumulate a bunch of NOOPs every time we call [stop_tracing] *)
-    Scheduler.Expert.run_every_cycle_end (fun () ->
-        if not !cancel then emit_event (new_event Cycle_end) ) ;
     emit_event (new_event Pid_is) ;
     O1trace.Thread.iter_fibers ~f:(fun fiber ->
         emit_event

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -5,11 +5,12 @@ module Scheduler = Async_kernel_scheduler
 
 let current_wr = ref None
 
-let emit_event' wr event =
+let emit_event' =
   let buf = Bigstring.create 512 in
-  try Webkit_trace_event_binary_output.emit_event ~buf wr event
-  with exn ->
-    Writer.writef wr "failed to write o1trace event: %s\n" (Exn.to_string exn)
+  fun wr event ->
+    try Webkit_trace_event_binary_output.emit_event ~buf wr event
+    with exn ->
+      Writer.writef wr "failed to write o1trace event: %s\n" (Exn.to_string exn)
 
 let emit_event event =
   Option.iter !current_wr ~f:(fun wr -> emit_event' wr event)


### PR DESCRIPTION
The trace-tool is still in WIP, but this at least fixes `daemon --tracing`.  The trace-tool as it exists will output one row per "fiber" in our code. We can evolve it independently.