### PR TITLE
Support setting zkapp limit in orchestrator

### DIFF
--- a/src/app/itn_orchestrator/genqlient.graphql
+++ b/src/app/itn_orchestrator/genqlient.graphql
@@ -31,3 +31,8 @@ mutation updateGating($input: GatingUpdate!) {
 mutation stopDaemon($clean: Boolean, $delay: Int) {
     stopDaemon(cleanConfig: $clean, delaySeconds: $delay)
 }
+
+# @genqlient(pointer: true)
+mutation setZkappSoftLimit($limit: Int) {
+    zkAppCommandLimit(limit: $limit)
+}

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -81,14 +81,17 @@ type mutation {
     """Payments details"""
     input: PaymentsDetails!
   ): String!
+  
   scheduleZkappCommands(
     """Zkapp commands details"""
     input: ZkappCommandsDetails!
   ): String!
+
   stopScheduledTransactions(
     """Transaction scheduler handle"""
     handle: String!
   ): String!
+
   updateGating(
     """Gating update"""
     input: GatingUpdate!
@@ -108,6 +111,12 @@ type mutation {
     """Seconds to delay before stopping daemon (minimum 5)"""
     delaySeconds: Int
   ): String!
+
+  """Set zkApp commands per block limit for the block producer."""
+  zkAppCommandLimit(
+    """ZkApp commands per block limit."""
+    limit: Int
+  ): Int
 }
 
 """Network identifiers for another protocol participant"""

--- a/src/app/itn_orchestrator/src/graphql.go
+++ b/src/app/itn_orchestrator/src/graphql.go
@@ -210,3 +210,13 @@ func StopDaemonGql(config Config, nodeAddress NodeAddress, clean bool, delaySec 
 	}
 	return resp.(*stopDaemonResponse).StopDaemon, nil
 }
+
+func SetZkappSoftLimitGql(config Config, nodeAddress NodeAddress, limit *int) (*int, error) {
+	resp, err := wrapGqlRequest(config, nodeAddress, func(client graphql.Client) (any, error) {
+		return setZkappSoftLimit(config.Ctx, client, limit)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setting zkapp soft limit on %s: %v", nodeAddress, err)
+	}
+	return resp.(*setZkappSoftLimitResponse).ZkAppCommandLimit, nil
+}

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -43,7 +43,7 @@ func init() {
 	addAction(actions, lib.StopDaemonAction{})
 	addAction(actions, lib.RotateAction{})
 	addAction(actions, lib.SetZkappSoftLimitAction{})
-	addAction(actions, lib.MajorityStakeCheckAction{})
+	addAction(actions, lib.SlotsCoveredCheckAction{})
 }
 
 type AppConfig struct {

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -42,7 +42,8 @@ func init() {
 	addAction(actions, lib.ExceptAction{})
 	addAction(actions, lib.StopDaemonAction{})
 	addAction(actions, lib.RotateAction{})
-
+	addAction(actions, lib.SetZkappSoftLimitAction{})
+	addAction(actions, lib.MajorityStakeCheckAction{})
 }
 
 type AppConfig struct {

--- a/src/app/itn_orchestrator/src/params.go
+++ b/src/app/itn_orchestrator/src/params.go
@@ -1,6 +1,7 @@
 package itn_orchestrator
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -113,8 +114,13 @@ func ResolveParam(config ResolutionConfig, step int, raw json.RawMessage) (json.
 	}
 }
 
+var nullJson = json.RawMessage([]byte("null"))
+
 func ResolveParams(config ResolutionConfig, step int, raw RawParams) (json.RawMessage, error) {
 	for k, v := range raw {
+		if bytes.Equal(v, nullJson) {
+			continue
+		}
 		v_, err := ResolveParam(config, step, v)
 		if err != nil {
 			return nil, err

--- a/src/app/itn_orchestrator/src/set_zkapp_soft_limit.go
+++ b/src/app/itn_orchestrator/src/set_zkapp_soft_limit.go
@@ -1,0 +1,38 @@
+package itn_orchestrator
+
+import (
+	"encoding/json"
+)
+
+type SetZkappSoftLimitParams struct {
+	Nodes []NodeAddress `json:"nodes"`
+	Limit *int          `json:"limit"`
+}
+
+func SetZkappSoftLimit(config Config, params SetZkappSoftLimitParams, output func(NodeAddress)) error {
+	for _, address := range params.Nodes {
+		_, err := SetZkappSoftLimitGql(config, address, params.Limit)
+		if err == nil {
+			output(address)
+		} else {
+			config.Log.Warnf("Failed to set soft limit to %d for %s: %s", params.Limit, address, err)
+		}
+	}
+	return nil
+}
+
+type SetZkappSoftLimitAction struct{}
+
+func (SetZkappSoftLimitAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params SetZkappSoftLimitParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return SetZkappSoftLimit(config, params, func(addr NodeAddress) {
+		output("participant", addr, true, false)
+	})
+}
+
+func (SetZkappSoftLimitAction) Name() string { return "set-zkapp-soft-limit" }
+
+var _ Action = SetZkappSoftLimitAction{}

--- a/src/app/itn_orchestrator/src/set_zkapp_soft_limit.go
+++ b/src/app/itn_orchestrator/src/set_zkapp_soft_limit.go
@@ -15,7 +15,7 @@ func SetZkappSoftLimit(config Config, params SetZkappSoftLimitParams, output fun
 		if err == nil {
 			output(address)
 		} else {
-			config.Log.Warnf("Failed to set soft limit to %d for %s: %s", params.Limit, address, err)
+			config.Log.Warnf("Failed to set soft limit for %s: %s", address, err)
 		}
 	}
 	return nil

--- a/src/app/itn_orchestrator/src/slots_won.go
+++ b/src/app/itn_orchestrator/src/slots_won.go
@@ -2,6 +2,8 @@ package itn_orchestrator
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 )
 
 type SlotsWonParams struct {
@@ -16,10 +18,11 @@ type SlotsWonOutput struct {
 func SlotsWon(config Config, params SlotsWonParams, output func(SlotsWonOutput)) error {
 	for _, address := range params.Nodes {
 		resp, slotsQueried, err := SlotsWonGql(config, address)
+		if err != nil {
+			config.Log.Warnf("failed to query slots won from %s: %s", address, err)
+			continue
+		}
 		if slotsQueried {
-			if err != nil {
-				return err
-			}
 			output(SlotsWonOutput{SlotsWon: resp, Address: address})
 		} else {
 			config.Log.Infof("not querying slots won for node %s", address)
@@ -43,3 +46,46 @@ func (SlotsWonAction) Run(config Config, rawParams json.RawMessage, output Outpu
 func (SlotsWonAction) Name() string { return "slots-won" }
 
 var _ Action = SlotsWonAction{}
+
+type MajorityStakeCheckParams struct {
+	Threshold float64          `json:"threshold"`
+	SlotsWon  []SlotsWonOutput `json:"slotsWon"`
+}
+
+func MajorityStakeCheck(config Config, params MajorityStakeCheckParams) error {
+	threshold := params.Threshold
+	allSlots := map[int]struct{}{}
+	minSlot := math.MaxInt
+	maxSlot := 0
+	for _, slotsWon := range params.SlotsWon {
+		for _, s := range slotsWon.SlotsWon {
+			allSlots[s] = struct{}{}
+			if s < minSlot {
+				minSlot = s
+			}
+			if s > maxSlot {
+				maxSlot = s
+			}
+		}
+	}
+	slotRange := maxSlot - minSlot + 1
+	proportion := float64(len(allSlots)) / float64(slotRange)
+	if proportion < threshold {
+		return fmt.Errorf("proportion %f of slots covered by queried nodes is lower than threshold %f", proportion, threshold)
+	}
+	return nil
+}
+
+type MajorityStakeCheckAction struct{}
+
+func (MajorityStakeCheckAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params MajorityStakeCheckParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return MajorityStakeCheck(config, params)
+}
+
+func (MajorityStakeCheckAction) Name() string { return "majority-stake-check" }
+
+var _ Action = MajorityStakeCheckAction{}

--- a/src/app/itn_orchestrator/src/slots_won.go
+++ b/src/app/itn_orchestrator/src/slots_won.go
@@ -47,12 +47,12 @@ func (SlotsWonAction) Name() string { return "slots-won" }
 
 var _ Action = SlotsWonAction{}
 
-type MajorityStakeCheckParams struct {
+type SlotsCoveredCheckParams struct {
 	Threshold float64          `json:"threshold"`
 	SlotsWon  []SlotsWonOutput `json:"slotsWon"`
 }
 
-func MajorityStakeCheck(config Config, params MajorityStakeCheckParams) error {
+func SlotsCoveredCheck(config Config, params SlotsCoveredCheckParams) error {
 	threshold := params.Threshold
 	allSlots := map[int]struct{}{}
 	minSlot := math.MaxInt
@@ -73,19 +73,20 @@ func MajorityStakeCheck(config Config, params MajorityStakeCheckParams) error {
 	if proportion < threshold {
 		return fmt.Errorf("proportion %f of slots covered by queried nodes is lower than threshold %f", proportion, threshold)
 	}
+	config.Log.Infof("Total %.2f%% of slots are covered", proportion*100)
 	return nil
 }
 
-type MajorityStakeCheckAction struct{}
+type SlotsCoveredCheckAction struct{}
 
-func (MajorityStakeCheckAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
-	var params MajorityStakeCheckParams
+func (SlotsCoveredCheckAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params SlotsCoveredCheckParams
 	if err := json.Unmarshal(rawParams, &params); err != nil {
 		return err
 	}
-	return MajorityStakeCheck(config, params)
+	return SlotsCoveredCheck(config, params)
 }
 
-func (MajorityStakeCheckAction) Name() string { return "majority-stake-check" }
+func (SlotsCoveredCheckAction) Name() string { return "slots-covered-check" }
 
-var _ Action = MajorityStakeCheckAction{}
+var _ Action = SlotsCoveredCheckAction{}

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1569,6 +1569,16 @@ module Mutations = struct
                  exit 0 ) ;
               return @@ Ok s )
 
+    let zkapp_cmd_limit =
+      field "zkAppCommandLimit"
+        ~args:
+          Arg.[ arg "limit" ~doc:"ZkApp commands per block limit." ~typ:int ]
+        ~typ:int
+        ~doc:"Set zkApp commands per block limit for the block producer."
+        ~resolve:(fun { ctx = _; _ } () limit ->
+          Block_producer.zkapp_cmd_limit := limit ;
+          limit )
+
     let commands =
       [ schedule_payments
       ; schedule_zkapp_commands
@@ -1576,6 +1586,7 @@ module Mutations = struct
       ; update_gating
       ; flush_internal_logs
       ; stop_daemon
+      ; zkapp_cmd_limit
       ]
   end
 end
@@ -2561,17 +2572,7 @@ module Queries = struct
           if not with_seq_no then Error "Missing sequence information"
           else Ok (Itn_logger.get_logs start_log_id) )
 
-    let zkapp_cmd_limit =
-      field "zkAppCommandLimit"
-        ~args:
-          Arg.[ arg "limit" ~doc:"ZkApp commands per block limit." ~typ:int ]
-        ~typ:int
-        ~doc:"Set zkApp commands per block limit for the block producer."
-        ~resolve:(fun { ctx = _; _ } () limit ->
-          Block_producer.zkapp_cmd_limit := limit ;
-          limit )
-
-    let commands = [ auth; slots_won; internal_logs; zkapp_cmd_limit ]
+    let commands = [ auth; slots_won; internal_logs ]
   end
 end
 


### PR DESCRIPTION
Bonus: ability to check that X% of stake were updated.

Explain your changes:

* Adds a command to Orchestrator to allow setting zkapp limit on nodes in the test environment
* Adds a command that (combined with existing `slots-won` command) allows to check that at least `X%` of stake were affected by the soft limit upgrade

Explain how you tested your changes:

* Tested on the large cluster:
   * set limit to 23 zkapp txs/min
     ```
     {"action":"discovery","params":{"offsetMin":15}}
     {"action":"set-zkapp-soft-limit","params":{"limit":23,"nodes":{"type":"output","step":-1,"name":"participant"}}}
     {"action":"slots-won","params":{"nodes":{"type":"output","step":-1,"name":"participant"}}}
     {"action":"slots-covered-check","params":{"threshold":0.6,"slotsWon":{"type":"output","step":-1,"name":"slotsWon"}}}
     ```
   * switch on the zkapp transaction sending
   * unset the limit
     ```
     {"action":"discovery","params":{"offsetMin":15}}
     {"action":"set-zkapp-soft-limit","params":{"limit":null,"nodes":{"type":"output","step":-1,"name":"participant"}}}
     {"action":"slots-won","params":{"nodes":{"type":"output","step":-1,"name":"participant"}}}
     {"action":"slots-covered-check","params":{"threshold":0.6,"slotsWon":{"type":"output","step":-1,"name":"slotsWon"}}}
     ```

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
