### PR TITLE
Removing extra `epoch` in `lastEpochDelegators` docs

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -12534,7 +12534,7 @@
             {
               "name": "lastEpochDelegators",
               "description":
-                "The list of accounts which are delegating to you in the last epoch (note that the info is recorded in the one before last epoch epoch so it might not be up to date with the current account status)",
+                "The list of accounts which are delegating to you in the last epoch (note that the info is recorded in the one before last epoch so it might not be up to date with the current account status)",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -1416,8 +1416,8 @@ module AccountObj = struct
                ~doc:
                  "The list of accounts which are delegating to you in the last \
                   epoch (note that the info is recorded in the one before last \
-                  epoch epoch so it might not be up to date with the current \
-                  account status)"
+                  epoch so it might not be up to date with the current account \
+                  status)"
                ~args:Arg.[]
                ~resolve:(fun { ctx = mina; _ } { account; _ } ->
                  let open Option.Let_syntax in


### PR DESCRIPTION
This PR is https://github.com/MinaProtocol/mina/pull/4654, updated for the latest code.