### PR TITLE
Make protocol-eng the codeowners for archive node

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 
 /src/external/ @bkase @psteckler @aneesharaines @mrmr1993
 
-/src/app/archive @MinaProtocol/product-eng-reviewers
+/src/app/archive @MinaProtocol/protocol-eng-reviewers
 /src/app/cli/src/mina.ml @MinaProtocol/protocol-eng-reviewers
 /src/app/cli/src/init @MinaProtocol/protocol-eng-reviewers
 /src/app/libp2p_helper @MinaProtocol/protocol-eng-reviewers


### PR DESCRIPTION
Because the SDK team is much less involved with this code than the protocol team