### PR TITLE
Fix issues with the Rosetta API block queries

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -79,13 +79,13 @@ final: prev: {
   # Tool for testing implementation of the rosetta api
   rosetta-cli = final.buildGoModule rec {
     pname = "rosetta-cli";
-    version = "0.10.0";
+    version = "0.10.3-pallas";
     src = final.fetchFromGitHub {
-      owner = "coinbase";
+      owner = "MinaProtocol";
       repo = "rosetta-cli";
-      rev = "085f95c85c99f607a82fb1814594d95dc9fefb55";
-      sha256 = "I3fNRiMwuk5FWiECu31Z5A23djUR0GHugy1OqNruzj8=";
+      rev = "9a8ba09359482898580bb35c3aa86896364b14ce";
+      sha256 = "sha256-3Lk5pa6fAeHGCmDjhaUjUoASxN6ozTD9e2+0wDH7hGs=";
     };
-    vendorSha256 = "sha256-ooFpB17Yu9aILx3kl2o6WVbbX110YeSdcC0RIaBUwzM=";
+    vendorSha256 = "sha256-lCBAsCNtorEu0WRZRLEMEaNyjtVIdJSAZg3icrpHIsQ=";
   };
 }

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -992,7 +992,7 @@ module Sql = struct
         tup2 Archive_lib.Processor.Zkapp_account_update_body.typ Extras.typ)
 
     let query =
-      Caqti_request.collect Caqti_type.(tup2 int string) typ
+      Caqti_request.collect Caqti_type.(tup3 int string int) typ
         {|
          SELECT zaub.account_identifier_id,
                 zaub.id,
@@ -1027,10 +1027,11 @@ module Sql = struct
            ON t.id = ai.token_id
          WHERE zc.id = ?
            AND t.value = ?
+           AND bzc.block_id = ?
     |}
 
-    let run (module Conn : Caqti_async.CONNECTION) id =
-      Conn.collect_list query (id, Mina_base.Token_id.(to_string default) )
+    let run (module Conn : Caqti_async.CONNECTION) command_id block_id =
+      Conn.collect_list query (command_id, Mina_base.Token_id.(to_string default), block_id)
     end
     
     let run (module Conn : Caqti_async.CONNECTION) input =
@@ -1190,7 +1191,7 @@ module Sql = struct
           (* TODO: check if this holds *)
           let token = Mina_base.Token_id.(to_string default) in
           let%bind raw_zkapp_account_update =
-            Zkapp_account_update.run (module Conn) cmd_id
+            Zkapp_account_update.run (module Conn) cmd_id block_id
             |> Errors.Lift.sql
                  ~context:"Finding zkapp account updates within command"
           in


### PR DESCRIPTION
There was an issue with Rosetta API when querying operations from accounts with multiple tokens where the operations would show multiplicated. This PR fixes it by constraining the queries to the default token.

Another issue was found where the API would present the same zkapp account update multiplicated when the same zkapp account updates existed in different blocks. This is fixed by constraining the zkapp account updates queries by block.

This was tested by running `rosetta-cli check:data` against ITN and verifying that the previously observed issue was fixed.

This PR also updates `rosetta-cli` in our nix flake to our fork that has the necessary signature modules.