### PR TITLE
fix select_epoch_snapshot

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -499,10 +499,16 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                     , Some ("Received valid scan state from peer", []) ))
             in
             let best_seen_block_with_hash, _ = t.best_seen_transition in
-            let consensus_state =
+            let protocol_state =
               With_hash.data best_seen_block_with_hash
               |> Mina_block.header |> Mina_block.Header.protocol_state
-              |> Protocol_state.consensus_state
+            in
+            let consensus_state =
+              protocol_state |> Protocol_state.consensus_state
+            in
+            let genesis_ledger_hash =
+              protocol_state |> Protocol_state.blockchain_state
+              |> Blockchain_state.genesis_ledger_hash
             in
             (* Synchronize consensus local state if necessary *)
             let%bind ( local_state_sync_time
@@ -512,6 +518,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                     Consensus.Hooks.required_local_state_sync
                       ~constants:precomputed_values.consensus_constants
                       ~consensus_state ~local_state:consensus_local_state
+                      ~genesis_ledger_hash
                   with
                 | None ->
                     [%log debug]

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -731,6 +731,7 @@ module type S = sig
          constants:Constants.t
       -> consensus_state:Consensus_state.Value.t
       -> local_state:Local_state.t
+      -> genesis_ledger_hash:Ledger_hash.t
       -> Data.Local_state.Snapshot.Ledger_snapshot.t
 
     val epoch_end_time :

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -696,6 +696,7 @@ module type S = sig
       -> Consensus_state.Value.t
       -> local_state:Local_state.t
       -> logger:Logger.t
+      -> genesis_ledger_hash:Ledger_hash.t
       -> Data.Epoch_data_for_vrf.t * Local_state.Snapshot.Ledger_snapshot.t
 
     val get_block_data :
@@ -745,6 +746,7 @@ module type S = sig
          constants:Constants.t
       -> consensus_state:Consensus_state.Value.t
       -> local_state:Local_state.t
+      -> genesis_ledger_hash:Ledger_hash.t
       -> local_state_sync option
 
     (**

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1074,13 +1074,19 @@ let staking_ledger t =
   let%map transition_frontier =
     Broadcast_pipe.Reader.peek t.components.transition_frontier
   in
+  let best_tip = Transition_frontier.best_tip transition_frontier in
   let consensus_state =
-    Transition_frontier.Breadcrumb.consensus_state
-      (Transition_frontier.best_tip transition_frontier)
+    Transition_frontier.Breadcrumb.consensus_state best_tip
   in
+  let genesis_ledger_hash =
+    Transition_frontier.Breadcrumb.protocol_state best_tip
+    |> Mina_state.Protocol_state.blockchain_state
+    |> Mina_state.Blockchain_state.genesis_ledger_hash
+  in
+
   let local_state = t.config.consensus_local_state in
   Consensus.Hooks.get_epoch_ledger ~constants:consensus_constants
-    ~consensus_state ~local_state
+    ~consensus_state ~local_state ~genesis_ledger_hash
 
 let next_epoch_ledger t =
   let open Option.Let_syntax in

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -421,6 +421,11 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
               "Successfully loaded frontier, but failed downloaded best tip \
                from network" ;
           let curr_best_tip = Transition_frontier.best_tip frontier in
+          let genesis_ledger_hash =
+            Transition_frontier.Breadcrumb.protocol_state curr_best_tip
+            |> Mina_state.Protocol_state.blockchain_state
+            |> Mina_state.Blockchain_state.genesis_ledger_hash
+          in
           let%map () =
             if not sync_local_state then (
               [%log info] "Not syncing local state, should only occur in tests" ;
@@ -433,7 +438,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
                   ~consensus_state:
                     (Transition_frontier.Breadcrumb.consensus_state
                        curr_best_tip )
-                  ~local_state:consensus_local_state
+                  ~local_state:consensus_local_state ~genesis_ledger_hash
               with
               | None ->
                   [%log info] "Local state already in sync" ;


### PR DESCRIPTION
Explain your changes:
This PR fixes when we select the epoch snapshot we would always special-case the 0th epoch.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
