### PR TITLE
Check if block exists on S3Save - delegation backend performance improvement.

### DIFF
--- a/src/app/delegation_backend/src/delegation_backend/submit.go
+++ b/src/app/delegation_backend/src/delegation_backend/submit.go
@@ -183,7 +183,7 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	metaBytes, err1 := req.MakeMetaToBeSaved(remoteAddr)
 	if err1 != nil {
-		h.app.Log.Errorf("Error while marshaling JSON for metaToBeSaved: %v", err)
+		h.app.Log.Errorf("Error while marshaling JSON for metaToBeSaved: %v", err1)
 		w.WriteHeader(500)
 		writeErrorResponse(h.app, &w, "Unexpected server error")
 		return


### PR DESCRIPTION
Explain your changes:

Prior the change there was a check in `S3Save` if particular item (submission or block) already exists on S3, however whether it existed or not, the item was overwritten anyway. The change only checks whether block exists, and if it does, it skips writing it to S3. I believe that the same check for the submission is not needed as it has a timestamp in the 'filename' so it will be always different.

Explain how you tested your changes:

This change seem to significantly improve response times and memory usage of the application.
Load test has been performed prior and after applying the fix. Results gathered in the report: https://github.com/MinaFoundation/mina-delegation-program-tech/wiki/Load-Test-Report-2024%E2%80%9001%E2%80%9018

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
