### PR TITLE
Enable Rosetta to connect to custom networks

### DIFF
--- a/src/app/rosetta/docker-start.sh
+++ b/src/app/rosetta/docker-start.sh
@@ -30,10 +30,11 @@ export MINA_LIBP2P_KEYPAIR_PATH="${MINA_LIBP2P_KEYPAIR_PATH:=$HOME/libp2p-keypai
 export MINA_LIBP2P_PASS=${MINA_LIBP2P_PASS:=''}
 export MINA_NETWORK=${MINA_NETWORK:=mainnet}
 export MINA_SUFFIX=${MINA_SUFFIX:=}
+export MINA_GENESIS_LEDGER_URL=${MINA_GENESIS_LEDGER_URL:=}
 export MINA_CONFIG_FILE=/genesis_ledgers/${MINA_NETWORK}.json
 export MINA_CONFIG_DIR="${MINA_CONFIG_DIR:=/data/.mina-config}"
 export MINA_CLIENT_TRUSTLIST=${MINA_CLIENT_TRUSTLIST:=}
-export PEER_LIST_URL=https://storage.googleapis.com/seed-lists/${MINA_NETWORK}_seeds.txt
+export PEER_LIST_URL=${PEER_LIST_URL:=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt}
 # Allows configuring the port that each service runs on.
 # To interact with rosetta, use MINA_ROSETTA_ONLINE_PORT and MINA_ROSETTA_OFFLINE_PORT
 export MINA_GRAPHQL_PORT=${MINA_GRAPHQL_PORT:=3085}
@@ -51,6 +52,14 @@ POSTGRES_DBNAME=${POSTGRES_DBNAME:=archive}
 POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:=/data/postgresql}
 PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:5432/${POSTGRES_DBNAME}
 DUMP_TIME=${DUMP_TIME:=0000}
+
+# Genesis Ledger
+if [ -n "$MINA_GENESIS_LEDGER_URL" ]; then
+    curl -o "$MINA_CONFIG_FILE" "$MINA_GENESIS_LEDGER_URL"
+    echo "Downloaded content from $MINA_GENESIS_LEDGER_URL to $MINA_CONFIG_FILE"
+else
+   echo "Variable MINA_GENESIS_LEDGER_URL is empty, will use $MINA_CONFIG_FILE as Genesis Ledger"
+fi
 
 # Postgres
 echo "========================= INITIALIZING POSTGRESQL ==========================="

--- a/src/app/rosetta/init-db.sh
+++ b/src/app/rosetta/init-db.sh
@@ -7,6 +7,7 @@ POSTGRES_DATA_DIR=$4
 POSTGRES_VERSION=$(psql -V | cut -d " " -f 3 | sed 's/.[[:digit:]]*$//g')
 PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:5432/${POSTGRES_DBNAME}
 DUMP_TIME=${5:=0000}
+MINA_ARCHIVE_DUMP_URL=${MINA_ARCHIVE_DUMP_URL:=https://storage.googleapis.com/mina-archive-dumps}
 
 pg_ctlcluster ${POSTGRES_VERSION} main start
 echo "[POPULATE] Top 10 blocks in ${POSTGRES_DATA_DIR} archiveDB:"
@@ -32,12 +33,12 @@ i=0
 while [ $i -lt $MAX_DAYS_LOOKBACK ]
 do
     DATE=$(date -d "$TODAY- $i days" +%G-%m-%d)_${DUMP_TIME}
-    STATUS_CODE=$(curl -s -o /dev/null --head -w "%{http_code}" "https://storage.googleapis.com/mina-archive-dumps/${MINA_NETWORK}-archive-dump-${DATE}.sql.tar.gz")
+    STATUS_CODE=$(curl -s -o /dev/null --head -w "%{http_code}" "${MINA_ARCHIVE_DUMP_URL}/${MINA_NETWORK}-archive-dump-${DATE}.sql.tar.gz")
     if [[ ! $STATUS_CODE =~ 2[0-9]{2} ]]; then
         i=$((i+1))
     else
         echo "Download ${MINA_NETWORK}-archive-dump-${DATE}"
-        curl "https://storage.googleapis.com/mina-archive-dumps/${MINA_NETWORK}-archive-dump-${DATE}.sql.tar.gz" -o o1labs-archive-dump.tar.gz
+        curl "${MINA_ARCHIVE_DUMP_URL}/${MINA_NETWORK}-archive-dump-${DATE}.sql.tar.gz" -o o1labs-archive-dump.tar.gz
         break;
     fi
 done


### PR DESCRIPTION
---

Explain your changes:
* This changes add te possibility to pull the SQL Dump, Genesis ledger and precomputed blocks from custom URLs
* As a consequence, it allows Rosetta to connect to custom network other that Mainnet, Berkeley or DevNet.
* There are no breaking changes

Explain how you tested your changes:
* I have built the images an managed to connect Rosetta to Testworld 2-0 minafoundation/mina-rosetta:2.0.0rampup8-56fa1db-focal

Checklist:

- [x] Dependency versions are unchanged
- [x] Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
- [x] Document test purpose, significance of failures
- [x] Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #14931
