### PR TITLE
Ledger export upgrades – into develop

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -15250,7 +15250,25 @@
               "name": "fork_config",
               "description":
                 "The runtime configuration for a blockchain fork intended to be a continuation of the current one.",
-              "args": [],
+              "args": [
+                {
+                  "name": "height",
+                  "description":
+                    "The height of the desired block in the best chain",
+                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "defaultValue": null
+                },
+                {
+                  "name": "stateHash",
+                  "description": "The state hash of the desired block",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/src/app/ledger_export_bench/ledger_export_benchmark.ml
+++ b/src/app/ledger_export_bench/ledger_export_benchmark.ml
@@ -11,8 +11,15 @@ let load_daemon_cfg filename () =
 
 let serialize cfg () = Runtime_config.to_yojson cfg |> Yojson.Safe.to_string
 
+let map_results ~f =
+  List.fold ~init:(Ok []) ~f:(fun acc x ->
+      let open Result.Let_syntax in
+      let%bind accum = acc in
+      let%map y = f x in
+      y :: accum )
+
 let convert accounts () =
-  Runtime_config.(map_results ~f:Accounts.Single.of_account accounts)
+  map_results ~f:Runtime_config.Accounts.Single.of_account accounts
 
 let () =
   let runtime_config = Sys.getenv_exn "RUNTIME_CONFIG" in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2118,25 +2118,13 @@ module Queries = struct
       ~resolve:(fun { ctx = mina; _ } () (state_hash_base58_opt : string option)
                     (height_opt : int option) ->
         let open Result.Let_syntax in
-        let get_transition_frontier () =
-          let transition_frontier_pipe = Mina_lib.transition_frontier mina in
-          Pipe_lib.Broadcast_pipe.Reader.peek transition_frontier_pipe
-          |> Result.of_option ~error:"Could not obtain transition frontier"
-        in
         let block_from_state_hash state_hash_base58 =
           let%bind state_hash =
             State_hash.of_base58_check state_hash_base58
             |> Result.map_error ~f:Error.to_string_hum
           in
-          let%bind transition_frontier = get_transition_frontier () in
           let%map breadcrumb =
-            Transition_frontier.find transition_frontier state_hash
-            |> Result.of_option
-                 ~error:
-                   (sprintf
-                      "Block with state hash %s not found in transition \
-                       frontier"
-                      state_hash_base58 )
+            Mina_lib.best_chain_block_by_state_hash mina state_hash
           in
           block_of_breadcrumb mina breadcrumb
         in
@@ -2149,29 +2137,10 @@ module Queries = struct
             *)
             Unsigned.UInt32.of_int height
           in
-          let%bind transition_frontier = get_transition_frontier () in
-          let best_chain_breadcrumbs =
-            Transition_frontier.best_tip_path transition_frontier
+          let%map breadcrumb =
+            Mina_lib.best_chain_block_by_height mina height_uint32
           in
-          let%map desired_breadcrumb =
-            List.find best_chain_breadcrumbs ~f:(fun bc ->
-                let validated_transition =
-                  Transition_frontier.Breadcrumb.validated_transition bc
-                in
-                let block_height =
-                  Mina_block.(
-                    blockchain_length @@ With_hash.data
-                    @@ Validated.forget validated_transition)
-                in
-                Unsigned.UInt32.equal block_height height_uint32 )
-            |> Result.of_option
-                 ~error:
-                   (sprintf
-                      "Could not find block in transition frontier with height \
-                       %d"
-                      height )
-          in
-          block_of_breadcrumb mina desired_breadcrumb
+          block_of_breadcrumb mina breadcrumb
         in
         match (state_hash_base58_opt, height_opt) with
         | Some state_hash_base58, None ->
@@ -2309,85 +2278,108 @@ module Queries = struct
         "The runtime configuration for a blockchain fork intended to be a \
          continuation of the current one."
       ~typ:(non_null Types.json)
-      ~args:Arg.[]
-      ~resolve:(fun { ctx = mina; _ } () ->
-        match Mina_lib.best_tip mina with
-        | `Bootstrapping ->
-            Deferred.Result.fail "Daemon is bootstrapping"
-        | `Active best_tip ->
-            let open Deferred.Result.Let_syntax in
-            let block = Transition_frontier.Breadcrumb.(block best_tip) in
-            let blockchain_length = Mina_block.blockchain_length block in
-            let global_slot =
-              Mina_block.consensus_state block
-              |> Consensus.Data.Consensus_state.curr_global_slot
-            in
-            let staged_ledger =
-              Transition_frontier.Breadcrumb.staged_ledger best_tip
-              |> Staged_ledger.ledger
-            in
-            let protocol_state =
-              Transition_frontier.Breadcrumb.protocol_state best_tip
-            in
-            let consensus =
-              Mina_state.Protocol_state.consensus_state protocol_state
-            in
-            let staking_epoch =
-              Consensus.Proof_of_stake.Data.Consensus_state.staking_epoch_data
-                consensus
-            in
-            let next_epoch =
-              Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data
-                consensus
-            in
-            let staking_epoch_seed =
-              Mina_base.Epoch_seed.to_base58_check
-                staking_epoch.Mina_base.Epoch_data.Poly.seed
-            in
-            let next_epoch_seed =
-              Mina_base.Epoch_seed.to_base58_check
-                next_epoch.Mina_base.Epoch_data.Poly.seed
-            in
-            let runtime_config = Mina_lib.runtime_config mina in
-            let%bind staking_ledger =
-              match Mina_lib.staking_ledger mina with
-              | None ->
-                  Deferred.Result.fail "Staking ledger is not initialized."
-              | Some (Genesis_epoch_ledger l) ->
-                  return (Ledger.Any_ledger.cast (module Ledger) l)
-              | Some (Ledger_db l) ->
-                  return (Ledger.Any_ledger.cast (module Ledger.Db) l)
-            in
+      ~args:
+        Arg.
+          [ arg "stateHash" ~doc:"The state hash of the desired block"
+              ~typ:string
+          ; arg "height"
+              ~doc:"The height of the desired block in the best chain" ~typ:int
+          ]
+      ~resolve:(fun { ctx = mina; _ } () state_hash_opt block_height_opt ->
+        let open Deferred.Result.Let_syntax in
+        let%bind breadcrumb =
+          match (state_hash_opt, block_height_opt) with
+          | None, None -> (
+              match Mina_lib.best_tip mina with
+              | `Bootstrapping ->
+                  Deferred.Result.fail "Daemon is bootstrapping"
+              | `Active breadcrumb ->
+                  return breadcrumb )
+          | Some state_hash_base58, None ->
+              let open Result.Monad_infix in
+              State_hash.of_base58_check state_hash_base58
+              |> Result.map_error ~f:Error.to_string_hum
+              >>= Mina_lib.best_chain_block_by_state_hash mina
+              |> Deferred.return
+          | None, Some block_height ->
+              Mina_lib.best_chain_block_by_height mina
+                (Unsigned.UInt32.of_int block_height)
+              |> Deferred.return
+          | Some _, Some _ ->
+              Deferred.Result.fail "Cannot specify both state hash and height"
+        in
+        let block = Transition_frontier.Breadcrumb.block breadcrumb in
+        let blockchain_length = Mina_block.blockchain_length block in
+        let global_slot =
+          Mina_block.consensus_state block
+          |> Consensus.Data.Consensus_state.curr_global_slot
+        in
+        let staged_ledger =
+          Transition_frontier.Breadcrumb.staged_ledger breadcrumb
+          |> Staged_ledger.ledger
+        in
+        let protocol_state =
+          Transition_frontier.Breadcrumb.protocol_state breadcrumb
+        in
+        let consensus =
+          Mina_state.Protocol_state.consensus_state protocol_state
+        in
+        let staking_epoch =
+          Consensus.Proof_of_stake.Data.Consensus_state.staking_epoch_data
+            consensus
+        in
+        let next_epoch =
+          Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data
+            consensus
+        in
+        let staking_epoch_seed =
+          Mina_base.Epoch_seed.to_base58_check
+            staking_epoch.Mina_base.Epoch_data.Poly.seed
+        in
+        let next_epoch_seed =
+          Mina_base.Epoch_seed.to_base58_check
+            next_epoch.Mina_base.Epoch_data.Poly.seed
+        in
+        let runtime_config = Mina_lib.runtime_config mina in
+        let%bind staking_ledger =
+          match Mina_lib.staking_ledger mina with
+          | None ->
+              Deferred.Result.fail "Staking ledger is not initialized."
+          | Some (Genesis_epoch_ledger l) ->
+              return (Ledger.Any_ledger.cast (module Ledger) l)
+          | Some (Ledger_db l) ->
+              return (Ledger.Any_ledger.cast (module Ledger.Db) l)
+        in
+        assert (
+          Mina_base.Ledger_hash.equal
+            (Ledger.Any_ledger.M.merkle_root staking_ledger)
+            staking_epoch.ledger.hash ) ;
+        let%bind next_epoch_ledger =
+          match Mina_lib.next_epoch_ledger mina with
+          | None ->
+              Deferred.Result.fail "Next epoch ledger is not initialized."
+          | Some `Notfinalized ->
+              return None
+          | Some (`Finalized (Genesis_epoch_ledger l)) ->
+              return (Some (Ledger.Any_ledger.cast (module Ledger) l))
+          | Some (`Finalized (Ledger_db l)) ->
+              return (Some (Ledger.Any_ledger.cast (module Ledger.Db) l))
+        in
+        Option.iter next_epoch_ledger ~f:(fun ledger ->
             assert (
               Mina_base.Ledger_hash.equal
-                (Ledger.Any_ledger.M.merkle_root staking_ledger)
-                staking_epoch.ledger.hash ) ;
-            let%bind next_epoch_ledger =
-              match Mina_lib.next_epoch_ledger mina with
-              | None ->
-                  Deferred.Result.fail "Next epoch ledger is not initialized."
-              | Some `Notfinalized ->
-                  return None
-              | Some (`Finalized (Genesis_epoch_ledger l)) ->
-                  return (Some (Ledger.Any_ledger.cast (module Ledger) l))
-              | Some (`Finalized (Ledger_db l)) ->
-                  return (Some (Ledger.Any_ledger.cast (module Ledger.Db) l))
-            in
-            let protocol_state_hash =
-              Transition_frontier.Breadcrumb.state_hash best_tip
-            in
-            Option.iter next_epoch_ledger ~f:(fun ledger ->
-                assert (
-                  Mina_base.Ledger_hash.equal
-                    (Ledger.Any_ledger.M.merkle_root ledger)
-                    next_epoch.ledger.hash ) ) ;
-            let%map new_config =
-              Runtime_config.make_fork_config ~staged_ledger ~global_slot
-                ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
-                ~next_epoch_seed ~blockchain_length ~protocol_state_hash
-                runtime_config
-            in
-            Runtime_config.to_yojson new_config |> Yojson.Safe.to_basic )
+                (Ledger.Any_ledger.M.merkle_root ledger)
+                next_epoch.ledger.hash ) ) ;
+        let%bind new_config =
+          Runtime_config.make_fork_config ~staged_ledger ~global_slot
+            ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
+            ~next_epoch_seed ~blockchain_length ~protocol_state runtime_config
+        in
+        let%map () =
+          let open Async.Deferred.Infix in
+          Async_unix.Scheduler.yield () >>| Result.return
+        in
+        Runtime_config.to_yojson new_config |> Yojson.Safe.to_basic )
 
   let thread_graph =
     field "threadGraph"

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2271,3 +2271,35 @@ let verifier { processes = { verifier; _ }; _ } = verifier
 let vrf_evaluator { processes = { vrf_evaluator; _ }; _ } = vrf_evaluator
 
 let genesis_ledger t = Genesis_proof.genesis_ledger t.config.precomputed_values
+
+let get_transition_frontier (t : t) =
+  transition_frontier t |> Pipe_lib.Broadcast_pipe.Reader.peek
+  |> Result.of_option ~error:"Could not obtain transition frontier"
+
+let best_chain_block_by_height (t : t) height =
+  let open Result.Let_syntax in
+  let%bind transition_frontier = get_transition_frontier t in
+  Transition_frontier.best_tip_path transition_frontier
+  |> List.find ~f:(fun bc ->
+         let validated_transition =
+           Transition_frontier.Breadcrumb.validated_transition bc
+         in
+         let block_height =
+           Mina_block.(
+             blockchain_length @@ With_hash.data
+             @@ Validated.forget validated_transition)
+         in
+         Unsigned.UInt32.equal block_height height )
+  |> Result.of_option
+       ~error:
+         (sprintf "Could not find block in transition frontier with height %s"
+            (Unsigned.UInt32.to_string height) )
+
+let best_chain_block_by_state_hash (t : t) hash =
+  let open Result.Let_syntax in
+  let%bind transition_frontier = get_transition_frontier t in
+  Transition_frontier.find transition_frontier hash
+  |> Result.of_option
+       ~error:
+         (sprintf "Block with state hash %s not found in transition frontier"
+            (State_hash.to_base58_check hash) )

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -216,3 +216,9 @@ val vrf_evaluator : t -> Vrf_evaluator.t
 val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t
 
 val vrf_evaluation_state : t -> Block_producer.Vrf_evaluation_state.t
+
+val best_chain_block_by_height :
+  t -> Unsigned.UInt32.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
+
+val best_chain_block_by_state_hash :
+  t -> State_hash.t -> (Transition_frontier.Breadcrumb.t, string) Result.t

--- a/src/lib/runtime_config/dune
+++ b/src/lib/runtime_config/dune
@@ -5,6 +5,7 @@
    ;; opam libraries
    async
    async_kernel
+   async_unix
    core_kernel
    bin_prot.shape
    base.caml
@@ -14,7 +15,9 @@
    result
    sexplib0
    ;; local libraries
+   block_time
    currency
+   genesis_constants
    data_hash_lib
    kimchi_backend
    kimchi_backend.pasta
@@ -25,6 +28,7 @@
    mina_base.import
    mina_numbers
    mina_wire_types
+   mina_state
    snark_params
    unsigned_extended
    pickles

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -58,6 +58,14 @@ let of_yojson_generic ~fields of_yojson json =
   dump_on_error json @@ of_yojson
   @@ yojson_strip_fields ~keep_fields:fields json
 
+let rec deferred_list_fold ~init ~f = function
+  | [] ->
+      Async.Deferred.Result.return init
+  | h :: t ->
+      let open Async.Deferred.Result.Let_syntax in
+      let%bind init = f init h in
+      deferred_list_fold ~init ~f t
+
 module Json_layout = struct
   module Accounts = struct
     module Single = struct
@@ -1368,9 +1376,22 @@ let gen =
   }
 
 let ledger_accounts (ledger : Mina_ledger.Ledger.Any_ledger.witness) =
-  Mina_ledger.Ledger.Any_ledger.M.to_list ledger
-  |> Async.Deferred.map
-       ~f:(Mina_stdlib.Result.List.map ~f:Accounts.Single.of_account)
+  let open Async.Deferred.Result.Let_syntax in
+  let yield = Async_unix.Scheduler.yield_every ~n:100 |> Staged.unstage in
+  let%bind accounts =
+    Mina_ledger.Ledger.Any_ledger.M.to_list ledger
+    |> Async.Deferred.map ~f:Result.return
+  in
+  let%map accounts =
+    deferred_list_fold ~init:[]
+      ~f:(fun acc el ->
+        let open Async.Deferred.Infix in
+        let%bind () = yield () >>| Result.return in
+        let%map elt = Accounts.Single.of_account el |> Async.Deferred.return in
+        elt :: acc )
+      accounts
+  in
+  List.rev accounts
 
 let ledger_of_accounts accounts =
   Ledger.
@@ -1383,13 +1404,18 @@ let ledger_of_accounts accounts =
     }
 
 let make_fork_config ~staged_ledger ~global_slot ~blockchain_length
-    ~protocol_state_hash ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
+    ~protocol_state ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
     ~next_epoch_seed (runtime_config : t) =
   let open Async.Deferred.Result.Let_syntax in
   let global_slot =
     Mina_numbers.Global_slot_since_hard_fork.to_int global_slot
   in
   let blockchain_length = Unsigned.UInt32.to_int blockchain_length in
+  let yield () =
+    let open Async.Deferred.Infix in
+    Async_unix.Scheduler.yield () >>| Result.return
+  in
+  let%bind () = yield () in
   let%bind accounts =
     Mina_ledger.Ledger.Any_ledger.cast (module Mina_ledger.Ledger) staged_ledger
     |> ledger_accounts
@@ -1401,16 +1427,37 @@ let make_fork_config ~staged_ledger ~global_slot ~blockchain_length
     let%map fork = proof.fork in
     fork.previous_length + blockchain_length
   in
+  let protocol_constants = Mina_state.Protocol_state.constants protocol_state in
+  let genesis =
+    { Genesis.k =
+        Some
+          (Unsigned.UInt32.to_int
+             protocol_constants.Genesis_constants.Protocol.Poly.k )
+    ; delta = Some (Unsigned.UInt32.to_int protocol_constants.delta)
+    ; slots_per_epoch =
+        Some (Unsigned.UInt32.to_int protocol_constants.slots_per_epoch)
+    ; slots_per_sub_window =
+        Some (Unsigned.UInt32.to_int protocol_constants.slots_per_sub_window)
+    ; genesis_state_timestamp =
+        Some
+          (Block_time.to_string_exn protocol_constants.genesis_state_timestamp)
+    ; grace_period_slots =
+        Some (Unsigned.UInt32.to_int protocol_constants.grace_period_slots)
+    }
+  in
   let fork =
     Fork_config.
       { previous_state_hash =
-          Mina_base.State_hash.to_base58_check protocol_state_hash
+          Mina_base.State_hash.to_base58_check
+            protocol_state.Mina_state.Protocol_state.Poly.previous_state_hash
       ; previous_length =
           Option.value ~default:blockchain_length previous_length
       ; previous_global_slot = global_slot
       }
   in
+  let%bind () = yield () in
   let%bind staking_ledger_accounts = ledger_accounts staking_ledger in
+  let%bind () = yield () in
   let%map next_epoch_ledger_accounts =
     match next_epoch_ledger with
     | None ->
@@ -1439,7 +1486,7 @@ let make_fork_config ~staged_ledger ~global_slot ~blockchain_length
        artificially add it. In fact, it wouldn't work at all,
        because the new node would try to create this account at
        startup, even though it already exists, leading to an error.*)
-      ~epoch_data
+      ~epoch_data ~genesis
       ~ledger:
         { ledger with
           base = Accounts accounts


### PR DESCRIPTION
This PR provides more upgrades for the ledger expoort feature.

Explain your changes:
* Insert explicit yields between expensive operations to minimise the risk of node spendignto much time in GraphQL computation.
* Include the protocol state in the exported config.
* Allow users to choose any block from the transition frontier to base the export on.
* Update the relevant benchmarks.

Explain how you tested your changes:
* Performed the ledger export from mainnet.
* Ran the benchmarks:

```
┌─────────────────────────────┬──────────┬──────────┬──────────┬──────────┬────────────┐
│ Name                        │ Time/Run │  mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├─────────────────────────────┼──────────┼──────────┼──────────┼──────────┼────────────┤
│ parse_runtime_config        │    3.30s │ 614.90Mw │ 171.17Mw │ 171.17Mw │     61.27% │
│ serialize_runtime_config    │    1.69s │ 136.76Mw │ 251.67Mw │  80.26Mw │     31.34% │
│ convert_accounts_for_config │    5.39s │ 476.33Mw │  14.88Mw │  14.88Mw │    100.00% │
└─────────────────────────────┴──────────┴──────────┴──────────┴──────────┴────────────┘
```

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
