### PR TITLE
opam.export includes full metadata

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -275,7 +275,7 @@ $ opam install alcotest cmdliner=1.0.3 fmt=0.8.6
 Then, run the following command to update the `ocaml.export` file:
 
 ```console
-$ opam switch export opam.export
+$ opam switch export --full opam.export
 ```
 
 ## Steps for adding a new OCaml pinned dependency

--- a/opam.export
+++ b/opam.export
@@ -1,4 +1,39 @@
+extra-files: [
+  [
+    "md5=026b31e1df290373198373d5aaa26e42"
+    "bGliOlsKICAiTUVUQS5zZXEiIHsiTUVUQSJ9Cl0K"
+  ]
+  [
+    "md5=2fd2970c293c36222a6d299ec155823f"
+    "I2luY2x1ZGUgPGdtcC5oPgojaWZuZGVmIF9fR01QX0hfXwojZXJyb3IgIk5vIEdNUCBoZWFkZXIiCiNlbmRpZgoKdm9pZCB0ZXN0KHZvaWQpIHsKICBtcHpfdCBuOwogIG1wel9pbml0KG4pOwogIG1wel9jbGVhcihuKTsKfQo="
+  ]
+  [
+    "md5=3163a4c3f8dd084653eeb64d95311a2a"
+    "RnJvbSA3Njg4YmI0ZmVhMjQ0NjNjOTJlOWM0ODcwYWNjMDg0OTVhNGM3N2NiIE1vbiBTZXAgMTcgMDA6MDA6MDAgMjAwMQpGcm9tOiBEYXZpZCBBbGxzb3BwIDxkYXZpZC5hbGxzb3BwQG1ldGFzdGFjay5jb20+CkRhdGU6IFdlZCwgMTAgSmFuIDIwMTggMTU6MjA6NDYgKzAwMDAKU3ViamVjdDogW1BBVENIXSBQcm92aWRlIGZpbmRsaWItaW5zdGFsbCB0YXJnZXQKCkFsbG93cyBpbnN0YWxsaW5nIHRoZSBlbnRpcmUgbGlicmFyeSB1c2luZyBvY2FtbGZpbmQuCi0tLQogTWFrZWZpbGUgICAgIHwgMTAgKysrKysrKysrLQogc3JjL01FVEEgICAgIHwgMTcgLS0tLS0tLS0tLS0tLS0tLS0KIHNyYy9NRVRBLmluICB8IDE5ICsrKysrKysrKysrKysrKysrKysKIHNyYy9NYWtlZmlsZSB8IDE3ICsrKysrKysrKysrKysrKy0tCiA0IGZpbGVzIGNoYW5nZWQsIDQzIGluc2VydGlvbnMoKyksIDIwIGRlbGV0aW9ucygtKQogZGVsZXRlIG1vZGUgMTAwNjQ0IHNyYy9NRVRBCiBjcmVhdGUgbW9kZSAxMDA2NDQgc3JjL01FVEEuaW4KCmRpZmYgLS1naXQgYS9NYWtlZmlsZSBiL01ha2VmaWxlCmluZGV4IDZhNWQwOGYuLmI0MGU1ODggMTAwNjQ0Ci0tLSBhL01ha2VmaWxlCisrKyBiL01ha2VmaWxlCkBAIC0xNCw4ICsxNCwxNiBAQCBpbnN0YWxsOgogCSQoTUFLRSkgLUMgc3JjIGluc3RhbGwKIAkkKE1BS0UpIC1DIHRvcGxldmVsIGluc3RhbGwKIAorZmluZGxpYi1pbnN0YWxsOgorCSQoTUFLRSkgLUMgc3JjIGZpbmRsaWItaW5zdGFsbAorCSQoTUFLRSkgLUMgdG9wbGV2ZWwgaW5zdGFsbAorCiB1bmluc3RhbGw6CiAJJChNQUtFKSAtQyBzcmMgdW5pbnN0YWxsCiAJJChNQUtFKSAtQyB0b3BsZXZlbCB1bmluc3RhbGwKIAotLlBIT05ZOiBhbGwgdGVzdCBjbGVhbiBpbnN0YWxsIHVuaW5zdGFsbAorZmluZGxpYi11bmluc3RhbGw6CisJJChNQUtFKSAtQyBzcmMgZmluZGxpYi11bmluc3RhbGwKKwkkKE1BS0UpIC1DIHRvcGxldmVsIHVuaW5zdGFsbAorCisuUEhPTlk6IGFsbCB0ZXN0IGNsZWFuIGluc3RhbGwgdW5pbnN0YWxsIGZpbmRsaWItaW5zdGFsbCBmaW5kbGliLXVuaW5zdGFsbApkaWZmIC0tZ2l0IGEvc3JjL01FVEEgYi9zcmMvTUVUQQpkZWxldGVkIGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggNjZhYzE3MC4uMDAwMDAwMAotLS0gYS9zcmMvTUVUQQorKysgL2Rldi9udWxsCkBAIC0xLDE3ICswLDAgQEAKLSMgVGhpcyBNRVRBIGlzIHRoZSBvbmUgcHJvdmlkZWQgYnkgZmluZGxpYiB3aGVuIHRoZSAibnVtIiBsaWJyYXJ5IHdhcwotIyBwYXJ0IG9mIHRoZSBjb3JlIE9DYW1sIGRpc3RyaWJ1dGlvbi4gIEZvciBiYWNrd2FyZCBjb21wYXRpYmlsaXR5LAotIyBpdCBpbnN0YWxscyBpbnRvIE9DYW1sJ3Mgc3RhbmRhcmQgbGlicmFyeSBkaXJlY3RvcnksIG5vdCBpbiBhIHN1YmRpcmVjdG9yeQotCi1yZXF1aXJlcyA9ICJudW0uY29yZSIKLXJlcXVpcmVzKHRvcGxvb3ApID0gIm51bS5jb3JlLG51bS10b3AiCi12ZXJzaW9uID0gIjEuMCIKLWRlc2NyaXB0aW9uID0gIkFyYml0cmFyeS1wcmVjaXNpb24gcmF0aW9uYWwgYXJpdGhtZXRpYyIKLXBhY2thZ2UgImNvcmUiICgKLSAgZGlyZWN0b3J5ID0gIl4iCi0gIHZlcnNpb24gPSAiMS4wIgotICBicm93c2VfaW50ZXJmYWNlcyA9ICIiCi0gIGFyY2hpdmUoYnl0ZSkgPSAibnVtcy5jbWEiCi0gIGFyY2hpdmUobmF0aXZlKSA9ICJudW1zLmNteGEiCi0gIHBsdWdpbihieXRlKSA9ICJudW1zLmNtYSIKLSAgcGx1Z2luKG5hdGl2ZSkgPSAibnVtcy5jbXhzIgotKQpkaWZmIC0tZ2l0IGEvc3JjL01FVEEuaW4gYi9zcmMvTUVUQS5pbgpuZXcgZmlsZSBtb2RlIDEwMDY0NAppbmRleCAwMDAwMDAwLi5iNTY3OGI3Ci0tLSAvZGV2L251bGwKKysrIGIvc3JjL01FVEEuaW4KQEAgLTAsMCArMSwxOSBAQAorIyBUaGlzIE1FVEEgaXMgdGhlIG9uZSBwcm92aWRlZCBieSBmaW5kbGliIHdoZW4gdGhlICJudW0iIGxpYnJhcnkgd2FzCisjIHBhcnQgb2YgdGhlIGNvcmUgT0NhbWwgZGlzdHJpYnV0aW9uLiAgRm9yIGJhY2t3YXJkIGNvbXBhdGliaWxpdHksCisjIGl0IGlzIGluc3RhbGxlZCBpbnRvIE9DYW1sJ3Mgc3RhbmRhcmQgbGlicmFyeSBkaXJlY3RvcnkuIElmIHRoZQorIyBkaXJlY3RvcnkgbGluZSBiZWxvdyBpcyByZW1vdmVkLCB0aGVuIGl0J3MgaW5zdGFsbGVkIGluIGEKKyMgc3ViZGlyZWN0b3J5LCBhcyBub3JtYWwgZm9yIGEgZmluZGxpYiBwYWNrYWdlLgorCityZXF1aXJlcyA9ICJudW0uY29yZSIKK3JlcXVpcmVzKHRvcGxvb3ApID0gIm51bS5jb3JlLG51bS10b3AiCit2ZXJzaW9uID0gIjEuMCIKK2Rlc2NyaXB0aW9uID0gIkFyYml0cmFyeS1wcmVjaXNpb24gcmF0aW9uYWwgYXJpdGhtZXRpYyIKK3BhY2thZ2UgImNvcmUiICgKKyAgZGlyZWN0b3J5ID0gIl4iCisgIHZlcnNpb24gPSAiMS4wIgorICBicm93c2VfaW50ZXJmYWNlcyA9ICIiCisgIGFyY2hpdmUoYnl0ZSkgPSAibnVtcy5jbWEiCisgIGFyY2hpdmUobmF0aXZlKSA9ICJudW1zLmNteGEiCisgIHBsdWdpbihieXRlKSA9ICJudW1zLmNtYSIKKyAgcGx1Z2luKG5hdGl2ZSkgPSAibnVtcy5jbXhzIgorKQpkaWZmIC0tZ2l0IGEvc3JjL01ha2VmaWxlIGIvc3JjL01ha2VmaWxlCmluZGV4IDk3ZGMwNzQuLmZmMjcxZmUgMTAwNjQ0Ci0tLSBhL3NyYy9NYWtlZmlsZQorKysgYi9zcmMvTWFrZWZpbGUKQEAgLTgwLDIxICs4MCwzNCBAQCBlbmRpZgogaWZlcSAiJChOQVREWU5MSU5LKSIgInRydWUiCiBUT0lOU1RBTEwrPW51bXMuY214cwogZW5kaWYKK2lmZXEgIiQoU1VQUE9SVFNfU0hBUkVEX0xJQlJBUklFUykiICJ0cnVlIgogVE9JTlNUQUxMX1NUVUJTPWRsbG51bXMuJChTTykKK2Vsc2UKK1RPSU5TVEFMTF9TVFVCUz0KK2VuZGlmCiAKIGluc3RhbGw6CisJY3AgTUVUQS5pbiBNRVRBCiAJJChPQ0FNTEZJTkQpIGluc3RhbGwgbnVtIE1FVEEKKwlybSAtZiBNRVRBCiAJJChJTlNUQUxMX0RBVEEpICQoVE9JTlNUQUxMKSAkKFNURExJQkRJUikKIGlmZXEgIiQoU1VQUE9SVFNfU0hBUkVEX0xJQlJBUklFUykiICJ0cnVlIgogCSQoSU5TVEFMTF9ETEwpICQoVE9JTlNUQUxMX1NUVUJTKSAkKFNURExJQkRJUikvc3R1YmxpYnMKIGVuZGlmCiAKLXVuaW5zdGFsbDoKK2ZpbmRsaWItaW5zdGFsbDoKKwlncmVwIC1GdiAnXicgTUVUQS5pbiA+IE1FVEEKKwkkKE9DQU1MRklORCkgaW5zdGFsbCBudW0gTUVUQSAkKFRPSU5TVEFMTCkgJChUT0lOU1RBTExfU1RVQlMpCisJcm0gLWYgTUVUQQorCitmaW5kbGliLXVuaW5zdGFsbDoKKwkkKE9DQU1MRklORCkgcmVtb3ZlIG51bQorCit1bmluc3RhbGw6IGZpbmRsaWItdW5pbnN0YWxsCiAJY2QgJChTVERMSUJESVIpICYmIHJtIC1mICQoVE9JTlNUQUxMKQogaWZlcSAiJChTVVBQT1JUU19TSEFSRURfTElCUkFSSUVTKSIgInRydWUiCiAJY2QgJChTVERMSUJESVIpL3N0dWJsaWJzICYmIHJtIC1mICQoVE9JTlNUQUxMX1NUVUJTKSAKIGVuZGlmCi0JJChPQ0FNTEZJTkQpIHJlbW92ZSBudW0KIAogY2xlYW46CiAJcm0gLWYgKi5jbVtpb3h0YV0gKi5jbXhbYXNdICouY210aSAqLiQoTykgKi4kKEEpICouJChTTykKLS0gCjIuMTQuMQoK"
+  ]
+  [
+    "md5=3e969b841df1f51ca448e6e6295cb451"
+    "c2hhcmVfcm9vdDogWyJjb25maWcuY2FjaGUiIHsib2NhbWwvY29uZmlnLmNhY2hlIn1dCg=="
+  ]
+  [
+    "md5=8e50c5e2517d3463b3aad649748cafd7"
+    "c2hhcmU6IFsiZ2VuX29jYW1sX2NvbmZpZy5tbCJdCg=="
+  ]
+  [
+    "md5=93c92bf6da6bae09d068da42b1bbaaac"
+    "RnJvbSBkYjhkNzQ4YjJjYWQwYWRjMjY5OGU5ZmNmMjg3MjcwODNhNzExYmFlIE1vbiBTZXAgMTcgMDA6MDA6MDAgMjAwMQpGcm9tOiBEYXZpZCBBbGxzb3BwIDxkYXZpZC5hbGxzb3BwQG1ldGFzdGFjay5jb20+CkRhdGU6IFdlZCwgMjQgSmFuIDIwMTggMTY6MDE6NTYgKzAwMDAKU3ViamVjdDogW1BBVENIXSBXYXJuIGFib3V0IGluc3RhbGxhdGlvbnMgYnJva2VuIGJ5IHByZXZpb3VzIGZhdWx0eSBwYWNrYWdlCgotLS0KIE1ha2VmaWxlIHwgMzMgKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrCiAxIGZpbGUgY2hhbmdlZCwgMzMgaW5zZXJ0aW9ucygrKQoKZGlmZiAtLWdpdCBhL01ha2VmaWxlIGIvTWFrZWZpbGUKaW5kZXggYjQwZTU4OC4uZDRkY2Q3MCAxMDA2NDQKLS0tIGEvTWFrZWZpbGUKKysrIGIvTWFrZWZpbGUKQEAgLTE0LDkgKzE0LDQyIEBAIGluc3RhbGw6CiAJJChNQUtFKSAtQyBzcmMgaW5zdGFsbAogCSQoTUFLRSkgLUMgdG9wbGV2ZWwgaW5zdGFsbAogCitPQ0FNTEZJTkRfRElSOj0kKGRpciAkKHNoZWxsIGNvbW1hbmQgLXYgb2NhbWxmaW5kIDI+L2Rldi9udWxsKSkKK09DQU1MQ19ESVI6PSQoZGlyICQoc2hlbGwgY29tbWFuZCAtdiBvY2FtbGMgMj4vZGV2L251bGwpKQorTlVNX0lOU1RBTExFRDo9JChzaGVsbCBvY2FtbGZpbmQgcXVlcnkgbnVtIDI+L2Rldi9udWxsKQorCitpZmVxICgkKE5VTV9JTlNUQUxMRUQpLCkKKyMgVGhlIG51bSBmaW5kbGliIHBhY2thZ2UgaXMgbm90IGFscmVhZHkgcHJlc2VudCAtIHdvaG9vIQorT1VSX0ZBVUxUPW5vCitlbHNlCitpZmVxICgkKE9DQU1MRklORF9ESVIpLCQoT0NBTUxDX0RJUikpCisjIFRoZSBudW0gZmluZGxpYiBwYWNrYWdlIGlzIHByZXNlbnQsIGJ1dCBvY2FtbGMgYW5kIG9jYW1sZmluZCBhcmUgaW4gdGhlCisjIHNhbWUgcGxhY2UsIHdoaWNoIG1lYW5zIHRoYXQgZWl0aGVyIHdlJ3JlIGxvb2tpbmcgYXQgYSBzeXN0ZW0taW5zdGFsbGVkCisjIG9jYW1sZmluZCAod2hpY2ggaXNuJ3Qgc3VwcG9ydGVkKSwgb3IgdGhlIHVzZXIgaGFzIGRvbmUgc29tZXRoaW5nIGVsc2UKKyMgbmVmYXJpb3VzIGFuZCBkb2Vzbid0IGRlc2VydmUgb3VyIHN5bXBhdGh5IChvciwgYXQgbGVhc3QsIG91ciBwb3RlbnRpYWxseQorIyB1bmhlbHBmdWwgYWR2aWNlKQorT1VSX0ZBVUxUPW5vCitlbHNlCisjIFRoZSBudW0gZmluZGxpYiBwYWNrYWdlIHBhY2thZ2UgaXMgcHJlc2VudCwgYW5kIG9jYW1sYyBhbmQgb2NhbWxmaW5kIHJlc2lkZQorIyBpbiBkaWZmZXJlbnQgZGlyZWN0b3JpZXMsIHdoaWNoIG1lYW5zIHRoYXQgd2UncmUgYWxtb3N0IGNlcnRhaW5seSBsb29raW5nIGF0CisjIGEgc3lzdGVtIHN3aXRjaCB3aGljaCBoYXMgYmVlbiBkYW1hZ2VkIGJ5IGEgcHJldmlvdXMgbnVtIHBhY2thZ2UgaW5zdGFsbGF0aW9uCisjIG9uIGFuIE9TIHdoaWNoIGRpZG4ndCBwcm90ZWN0IHRoZSBzeXN0ZW0gbGliIGRpcmVjdG9yeS4KK09VUl9GQVVMVD1wcm9iYWJseQorZW5kaWYKK2VuZGlmCisKIGZpbmRsaWItaW5zdGFsbDoKK2lmZXEgKCQoT1VSX0ZBVUxUKSxubykKIAkkKE1BS0UpIC1DIHNyYyBmaW5kbGliLWluc3RhbGwKIAkkKE1BS0UpIC1DIHRvcGxldmVsIGluc3RhbGwKK2Vsc2UKKwlAZWNobyAiXDAzM1swOzMxbVtFUlJPUl1cMDMzW20gSXQgYXBwZWFycyB0aGF0IHRoZSBudW0gbGlicmFyeSB3YXMgcHJldmlvdXNseSBpbnN0YWxsZWQgdG8geW91ciBzeXN0ZW0iCisJQGVjaG8gIiAgICAgICAgY29tcGlsZXIncyBsaWIgZGlyZWN0b3J5LCBwcm9iYWJseSBieSBhIGZhdWx0eSBvcGFtIHBhY2thZ2UuIgorCUBlY2hvICIgICAgICAgIFlvdSB3aWxsIG5lZWQgdG8gcmVtb3ZlIGFyaXRoX2ZsYWdzLiosIGFyaXRoX3N0YXR1cy4qLCBiaWdfaW50LiosIgorCUBlY2hvICIgICAgICAgIGludF9taXNjLiosIG5hdC4qLCBudW0uKiwgcmF0aW8uKiwgbnVtcy4qLCBsaWJudW1zLiogYW5kIgorCUBlY2hvICIgICAgICAgIHN0dWJsaWJzL2RsbG51bXMuKiBmcm9tICQoc2hlbGwgb2NhbWxjIC13aGVyZSkuIgorCUBmYWxzZQorZW5kaWYKIAogdW5pbnN0YWxsOgogCSQoTUFLRSkgLUMgc3JjIHVuaW5zdGFsbAotLSAKMi4xNC4xCgo="
+  ]
+  [
+    "md5=a4b41e3236593d8271295b84b0969172"
+    "bGV0ICgpID0KICBsZXQgb2NhbWxfdmVyc2lvbiA9CiAgICBsZXQgdiA9IFN5cy5vY2FtbF92ZXJzaW9uIGluCiAgICBsZXQgbCA9IFN0cmluZy5sZW5ndGggdiBpbgogICAgbGV0IHBsdXMgPSB0cnkgU3RyaW5nLmluZGV4IHYgJysnIHdpdGggTm90X2ZvdW5kIC0+IGwgaW4KICAgICgqIEludHJvZHVjZWQgaW4gNC4xMS4wOyB1c2VkIGZyb20gNC4xMi4wICopCiAgICBsZXQgdGlsZGUgPSB0cnkgU3RyaW5nLmluZGV4IHYgJ34nIHdpdGggTm90X2ZvdW5kIC0+IGwgaW4KICAgIFN0cmluZy5zdWIgdiAwIChtaW4gKG1pbiBwbHVzIHRpbGRlKSBsKQogIGluCiAgaWYgb2NhbWxfdmVyc2lvbiA8PiBTeXMuYXJndi4oMSkgdGhlbgogICAgKFByaW50Zi5lcHJpbnRmCiAgICAgICAiT0NhbWwgdmVyc2lvbiBtaXNtYXRjaDogJSVzLCBleHBlY3RlZCAlcyIKICAgICAgIG9jYW1sX3ZlcnNpb24gU3lzLmFyZ3YuKDEpOwogICAgIGV4aXQgMSkKICBlbHNlCiAgbGV0IG9jID0gb3Blbl9vdXQgKFN5cy5hcmd2LigyKSBeICIuY29uZmlnIikgaW4KICBsZXQgZXhlID0gIi5leGUiIGluCiAgbGV0IChvY2FtbCwgc3VmZml4KSA9CiAgICBsZXQgcyA9IFN5cy5leGVjdXRhYmxlX25hbWUgaW4KICAgIGlmIEZpbGVuYW1lLmNoZWNrX3N1ZmZpeCBzIGV4ZSB0aGVuCiAgICAgIChGaWxlbmFtZS5jaG9wX3N1ZmZpeCBzIGV4ZSwgZXhlKQogICAgZWxzZQogICAgICAocywgIiIpCiAgaW4KICBsZXQgb2NhbWxjID0gb2NhbWxeImMiXnN1ZmZpeCBpbgogIGxldCBsaWJkaXIgPQogICAgaWYgU3lzLmNvbW1hbmQgKG9jYW1sY14iIC13aGVyZSA+IHdoZXJlIikgPSAwIHRoZW4KICAgICAgKCogTXVzdCBiZSBvcGVuZWQgaW4gdGV4dCBtb2RlIGZvciBXaW5kb3dzICopCiAgICAgIGxldCBpYyA9IG9wZW5faW4gIndoZXJlIiBpbgogICAgICBsZXQgciA9IGlucHV0X2xpbmUgaWMgaW4KICAgICAgY2xvc2VfaW4gaWM7IHIKICAgIGVsc2UKICAgICAgZmFpbHdpdGggIkJhZCByZXR1cm4gZnJvbSAnb2NhbWxjIC13aGVyZSciCiAgaW4KICBsZXQgc3R1YnNkaXIgPQogICAgbGV0IGljID0gb3Blbl9pbiAoRmlsZW5hbWUuY29uY2F0IGxpYmRpciAibGQuY29uZiIpIGluCiAgICBsZXQgcmVjIHIgYWNjID0gdHJ5IHIgKGlucHV0X2xpbmUgaWM6OmFjYykgd2l0aCBFbmRfb2ZfZmlsZSAtPiBhY2MgaW4KICAgIGxldCBsaW5lcyA9IExpc3QucmV2IChyIFtdKSBpbgogICAgY2xvc2VfaW4gaWM7CiAgICBTdHJpbmcuY29uY2F0ICI6IiBsaW5lcwogIGluCiAgbGV0IHAgZm10ID0gUHJpbnRmLmZwcmludGYgb2MgKGZtdCBeXiAiXG4iKSBpbgogIHAgIm9wYW0tdmVyc2lvbjogXCIyLjBcIiI7CiAgcCAidmFyaWFibGVzIHsiOwogIHAgIiAgbmF0aXZlOiAlJWIiCiAgICAoU3lzLmZpbGVfZXhpc3RzIChvY2FtbF4ib3B0Il5zdWZmaXgpKTsKICBwICIgIG5hdGl2ZS10b29sczogJSViIgogICAgKFN5cy5maWxlX2V4aXN0cyAob2NhbWxjXiIub3B0Il5zdWZmaXgpKTsKICBwICIgIG5hdGl2ZS1keW5saW5rOiAlJWIiCiAgICAoU3lzLmZpbGVfZXhpc3RzIChGaWxlbmFtZS5jb25jYXQgbGliZGlyICJkeW5saW5rLmNteGEiKSk7CiAgcCAiICBzdHVic2RpcjogJSVTIgogICAgc3R1YnNkaXI7CiAgcCAiICBwcmVpbnN0YWxsZWQ6ICV7b2NhbWwtc3lzdGVtOmluc3RhbGxlZH0lIjsKICBwICIgIGNvbXBpbGVyOiBcIiV7b2NhbWwtc3lzdGVtOmluc3RhbGxlZD9zeXN0ZW06fSUle29jYW1sLWJhc2UtY29tcGlsZXI6dmVyc2lvbn0lJXtvY2FtbC12YXJpYW50czp2ZXJzaW9ufSUle29jYW1sLW9wdGlvbi0zMmJpdDppbnN0YWxsZWQ/KzMyYml0On0lJXtvY2FtbC1vcHRpb24tYWZsOmluc3RhbGxlZD8rYWZsOn0lJXtvY2FtbC1vcHRpb24tYnl0ZWNvZGUtb25seTppbnN0YWxsZWQ/K2J5dGVjb2RlLW9ubHk6fSUle29jYW1sLW9wdGlvbi1kZWZhdWx0LXVuc2FmZS1zdHJpbmc6aW5zdGFsbGVkPytkZWZhdWx0LXVuc2FmZS1zdHJpbmc6fSUle29jYW1sLW9wdGlvbi1mcDppbnN0YWxsZWQ/K2ZwOn0lJXtvY2FtbC1vcHRpb24tZmxhbWJkYTppbnN0YWxsZWQ/K2ZsYW1iZGE6fSUle29jYW1sLW9wdGlvbi1tdXNsOmluc3RhbGxlZD8rbXVzbDp9JSV7b2NhbWwtb3B0aW9uLW5ucDppbnN0YWxsZWQ/K25ucDp9JSV7b2NhbWwtb3B0aW9uLW5vLWZsYXQtZmxvYXQtYXJyYXk6aW5zdGFsbGVkPytuby1mbGF0LWZsb2F0LWFycmF5On0lJXtvY2FtbC1vcHRpb24tc3BhY2V0aW1lOmluc3RhbGxlZD8rc3BhY2V0aW1lOn0lJXtvY2FtbC1vcHRpb24tc3RhdGljOmluc3RhbGxlZD8rc3RhdGljOn0lXCIiOwogIHAgIn0iOwogIGNsb3NlX291dCBvYwo="
+  ]
+  [
+    "md5=b33c8a1a6c7ed797816ce27df4855107"
+    "bmFtZT0ic2VxIgp2ZXJzaW9uPSJbZGlzdHJpYnV0ZWQgd2l0aCBPQ2FtbCA0LjA3IG9yIGFib3ZlXSIKZGVzY3JpcHRpb249ImR1bW15IGJhY2t3YXJkLWNvbXBhdGliaWxpdHkgcGFja2FnZSBmb3IgaXRlcmF0b3JzIgpyZXF1aXJlcz0iIgo="
+  ]
+]
 opam-version: "2.0"
+compiler: ["ocaml-base-compiler.4.14.0"]
 roots: [
   "alcotest.1.1.0"
   "angstrom.0.15.0"
@@ -108,6 +143,7 @@ installed: [
   "dune-build-info.3.1.1"
   "dune-configurator.2.8.2"
   "dune-private-libs.2.6.2"
+  "duration.0.2.1"
   "easy-format.1.3.2"
   "either.1.0.0"
   "eqaf.0.9"
@@ -150,8 +186,8 @@ installed: [
   "mew.0.1.0"
   "mew_vi.0.5.0"
   "minicli.5.0.2"
-  "mirage-crypto-ec.0.11.0"
   "mirage-crypto.0.11.0"
+  "mirage-crypto-ec.0.11.0"
   "mirage-crypto-rng.0.11.0"
   "mirage-crypto-rng-async.0.11.0"
   "mmap.1.1.0"
@@ -270,6 +306,201 @@ pinned: [
   "graphql_ppx.1.2.2"
   "rpc_parallel.v0.14.0"
 ]
+package "alcotest" {
+  opam-version: "2.0"
+  version: "1.1.0"
+  synopsis: "Alcotest is a lightweight and colourful test framework"
+  description: """\
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run."""
+  maintainer: "thomas@gazagnaire.org"
+  authors: "Thomas Gazagnaire"
+  license: "ISC"
+  homepage: "https://github.com/mirage/alcotest"
+  doc: "https://mirage.github.io/alcotest"
+  bug-reports: "https://github.com/mirage/alcotest/issues"
+  depends: [
+    "dune" {>= "2.0"}
+    "ocaml" {>= "4.03.0"}
+    "fmt" {>= "0.8.6"}
+    "astring"
+    "cmdliner" {>= "1.0.3" & < "1.1.0"}
+    "uuidm"
+    "re" {>= "1.7.2"}
+    "stdlib-shims"
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/mirage/alcotest.git"
+  url {
+    src:
+      "https://github.com/mirage/alcotest/releases/download/1.1.0/alcotest-lwt-1.1.0.tbz"
+    checksum: [
+      "sha256=212827a49abf4008581c0da53e7ec78a9d639b415380dcb1fdeeb23f3ff083e2"
+      "sha512=c47d04b3c7100af703b470b93ff9fe9fe22790415370b6d5972736f46a5c83901717d67caf0c4115d01020d3078dc7f3063838578174921cab352546dad00148"
+    ]
+  }
+}
+package "angstrom" {
+  opam-version: "2.0"
+  version: "0.15.0"
+  synopsis: "Parser combinators built for speed and memory-efficiency"
+  description: """\
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""
+  maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  authors: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  license: "BSD-3-clause"
+  homepage: "https://github.com/inhabitedtype/angstrom"
+  bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.8"}
+    "alcotest" {with-test & >= "0.8.1"}
+    "bigstringaf"
+    "result"
+    "ppx_let" {with-test & >= "0.14.0"}
+    "ocaml-syntax-shims" {build}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
+  url {
+    src: "https://github.com/inhabitedtype/angstrom/archive/0.15.0.tar.gz"
+    checksum: "md5=5104768c404ea92fd0a53a5b0f75cd50"
+  }
+}
+package "asetmap" {
+  opam-version: "2.0"
+  version: "0.8.1"
+  synopsis: "Alternative, compatible, OCaml standard library Sets and Maps"
+  description: """\
+asetmap provides slightly tweaked OCaml standard library Set and Map
+functors. asetmap tries to maximize compatibility with the standard
+library. It essentially gets rid of `Not_found` exceptions and provide
+pretty-printers for the data types.
+
+asetmap has no dependency is distributed under the ISC license."""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["org:erratique" "set" "map" "stdlib"]
+  homepage: "http://erratique.ch/software/asetmap"
+  doc: "http://erratique.ch/software/asetmap/doc"
+  bug-reports: "https://github.com/dbuenzli/asetmap/issues"
+  depends: [
+    "ocaml" {>= "4.01.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+  ]
+  build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  dev-repo: "git+http://erratique.ch/repos/asetmap.git"
+  url {
+    src: "http://erratique.ch/software/asetmap/releases/asetmap-0.8.1.tbz"
+    checksum: "md5=9e4a518bfb6350e2f296c7f3147989c7"
+  }
+}
+package "astring" {
+  opam-version: "2.0"
+  version: "0.8.5"
+  synopsis: "Alternative String module for OCaml"
+  description: """\
+Astring exposes an alternative `String` module for OCaml. This module
+tries to balance minimality and expressiveness for basic, index-free,
+string processing and provides types and functions for substrings,
+string sets and string maps.
+
+Remaining compatible with the OCaml `String` module is a non-goal. The
+`String` module exposed by Astring has exception safe functions,
+removes deprecated and rarely used functions, alters some signatures
+and names, adds a few missing functions and fully exploits OCaml's
+newfound string immutability.
+
+Astring depends only on the OCaml standard library. It is distributed
+under the ISC license."""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The astring programmers"
+  license: "ISC"
+  tags: ["string" "org:erratique"]
+  homepage: "https://erratique.ch/software/astring"
+  doc: "https://erratique.ch/software/astring/doc"
+  bug-reports: "https://github.com/dbuenzli/astring/issues"
+  depends: [
+    "ocaml" {>= "4.05.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+  ]
+  build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  dev-repo: "git+http://erratique.ch/repos/astring.git"
+  url {
+    src: "https://erratique.ch/software/astring/releases/astring-0.8.5.tbz"
+    checksum: "md5=e148907c24157d1df43bec89b58b3ec8"
+  }
+}
+package "async" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Monadic concurrency library"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/async"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async/index.html"
+  bug-reports: "https://github.com/janestreet/async/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "async_kernel" {>= "v0.14" & < "v0.15"}
+    "async_rpc_kernel" {>= "v0.14" & < "v0.15"}
+    "async_unix" {>= "v0.14" & < "v0.15"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "textutils" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/async.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/async-v0.14.0.tar.gz"
+    checksum: "md5=9f80cfb72e3defcc9fca50f67e23e93c"
+  }
+}
 package "async_kernel" {
   opam-version: "2.0"
   version: "v0.14.0"
@@ -299,6 +530,651 @@ Part of Jane Street's Core library
       "https://github.com/MinaProtocol/async_kernel/archive/bf02e69c129b6ffec97cc5b7a5d85125802968bb.tar.gz"
     checksum:
       "sha256=ae824169495106fa9099aa53c0367e58651de426f70653897b3e1168c9a7edb6"
+  }
+}
+package "async_rpc_kernel" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Platform-independent core of Async RPC library"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/async_rpc_kernel"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_rpc_kernel/index.html"
+  bug-reports: "https://github.com/janestreet/async_rpc_kernel/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "async_kernel" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "protocol_version_header" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/async_rpc_kernel.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/async_rpc_kernel-v0.14.0.tar.gz"
+    checksum: "md5=f435ab9bfb29aa43be1e0aa6b295252b"
+  }
+}
+package "async_ssl" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "An Async-pipe-based interface with OpenSSL"
+  description: """\
+This library allows you to create an SSL client and server, with
+encrypted communication between both."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/async_ssl"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+  bug-reports: "https://github.com/janestreet/async_ssl/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "async" {>= "v0.14" & < "v0.15"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "conf-libssl"
+    "ctypes" {>= "0.16.0" & < "0.18.0"}
+    "ctypes-foreign"
+    "dune" {>= "2.0.0"}
+    "dune-configurator"
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/async_ssl-v0.14.0.tar.gz"
+    checksum: "md5=3b35d352c7f7927c4f91f96ef74e0417"
+  }
+}
+package "async_unix" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Monadic concurrency library"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/async_unix"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_unix/index.html"
+  bug-reports: "https://github.com/janestreet/async_unix/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "async_kernel" {>= "v0.14" & < "v0.15"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/async_unix.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/async_unix-v0.14.0.tar.gz"
+    checksum: "md5=a67300edf50a56e5bac760333404c6e7"
+  }
+}
+package "base" {
+  opam-version: "2.0"
+  version: "v0.14.3"
+  synopsis: "Full standard library replacement for OCaml"
+  description: """\
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio"""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/base"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+  bug-reports: "https://github.com/janestreet/base/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "sexplib0" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "dune-configurator"
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/base.git"
+  url {
+    src: "https://github.com/janestreet/base/archive/v0.14.3.tar.gz"
+    checksum:
+      "sha256=e34dc0dd052a386c84f5f67e71a90720dff76e0edd01f431604404bee86ebe5a"
+  }
+}
+package "base-bigarray" {
+  opam-version: "2.0"
+  version: "base"
+  synopsis: ""
+  description: "Bigarray library distributed with the OCaml compiler"
+  maintainer: "https://github.com/ocaml/opam-repository/issues"
+}
+package "base-bytes" {
+  opam-version: "2.0"
+  version: "base"
+  synopsis: "Bytes library distributed with the OCaml compiler"
+  maintainer: " "
+  authors: " "
+  homepage: " "
+  depends: [
+    "ocaml" {>= "4.02.0"}
+    "ocamlfind" {>= "1.5.3"}
+  ]
+}
+package "base-threads" {
+  opam-version: "2.0"
+  version: "base"
+  synopsis: ""
+  description: "Threads library distributed with the OCaml compiler"
+  maintainer: "https://github.com/ocaml/opam-repository/issues"
+}
+package "base-unix" {
+  opam-version: "2.0"
+  version: "base"
+  synopsis: ""
+  description: "Unix library distributed with the OCaml compiler"
+  maintainer: "https://github.com/ocaml/opam-repository/issues"
+}
+package "base58" {
+  opam-version: "2.0"
+  version: "0.1.0"
+  synopsis: "Base58 encoding and decoding"
+  description:
+    "This library enables you to encode and decode into base58 representation using the alphabet of your choice."
+  maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+  authors: "Maxime Ransan <maxime.ransan@gmail.com>"
+  license: "MIT"
+  tags: ["base58" "encoding"]
+  homepage: "https://github.com/mransan/base58"
+  bug-reports: "https://github.com/mransan/base58/issues"
+  depends: [
+    "ocaml" {>= "4.02.1"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "num"
+  ]
+  build: [
+    [make "lib.byte"]
+    [make "lib.native"] {ocaml:native}
+  ]
+  install: [make "lib.install"]
+  remove: [make "lib.uninstall"]
+  dev-repo: "git+https://github.com/mransan/base58.git"
+  url {
+    src: "https://github.com/mransan/base58/archive/0.1.0.tar.gz"
+    checksum: "md5=e1f6fd4ad91b96b4c2bd678648a319bb"
+  }
+}
+package "base64" {
+  opam-version: "2.0"
+  version: "3.4.0"
+  synopsis: "Base64 encoding for OCaml"
+  description: """\
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648."""
+  maintainer: "mirageos-devel@lists.xenproject.org"
+  authors: [
+    "Thomas Gazagnaire"
+    "Anil Madhavapeddy"
+    "Calascibetta Romain"
+    "Peter Zotov"
+  ]
+  license: "ISC"
+  homepage: "https://github.com/mirage/ocaml-base64"
+  doc: "http://mirage.github.io/ocaml-base64/"
+  bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "base-bytes"
+    "dune-configurator"
+    "dune" {>= "2.0"}
+    "bos" {with-test}
+    "rresult" {with-test}
+    "alcotest" {with-test}
+  ]
+  build: [
+    ["dune" "subst"]
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-base64/releases/download/v3.4.0/base64-v3.4.0.tbz"
+    checksum: [
+      "sha256=1c9cf655bdd771a4d20014f7f29aadfde7e3821b01772b49f8ba4d4bda2b1634"
+      "sha512=e66a67302a9eb136044bebf66a89a1d6e38a96c70622bb6cd27916fec36dcaf4b5b7e7d00c25608f0a2363f2ca4264a5fe765fe7747590958325dbce06311db9"
+    ]
+  }
+}
+package "base_bigstring" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "String type based on [Bigarray], for use in I/O and C-bindings"
+  description:
+    "String type based on [Bigarray], for use in I/O and C-bindings."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/base_bigstring"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_bigstring/index.html"
+  bug-reports: "https://github.com/janestreet/base_bigstring/issues"
+  depends: [
+    "ocaml" {>= "4.07.0"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/base_bigstring.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/base_bigstring-v0.14.0.tar.gz"
+    checksum: "md5=b6c68507bef58c3e1b4df483ed516144"
+  }
+}
+package "base_quickcheck" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis:
+    "Randomized testing framework, designed for compatibility with Base"
+  description: """\
+Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,
+with support for built-in types as well as types provided by Base."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/base_quickcheck"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/base_quickcheck/index.html"
+  bug-reports: "https://github.com/janestreet/base_quickcheck/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "ppx_fields_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_let" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_message" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_value" {>= "v0.14" & < "v0.15"}
+    "splittable_random" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.22.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/base_quickcheck.git"
+  url {
+    src:
+      "https://github.com/janestreet/base_quickcheck/archive/v0.14.1.tar.gz"
+    checksum: "md5=d04738d4499e256b752bc40fcdb9730d"
+  }
+}
+package "bigarray-compat" {
+  opam-version: "2.0"
+  version: "1.0.0"
+  synopsis: "Compatibility library to use Stdlib.Bigarray when possible"
+  maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+  authors: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+  license: "ISC"
+  homepage: "https://github.com/mirage/bigarray-compat"
+  bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+  depends: [
+    "ocaml" {>= "4.02.3" & < "5.0"}
+    "dune" {>= "1.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+  url {
+    src: "https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz"
+    checksum: [
+      "md5=1cc7c25382a8900bada34aadfd66632e"
+      "sha512=c365fee15582aca35d7b05268cde29e54774ad7df7be56762b4aad78ca1409d4326ad3b34af0f1cc2c7b872837290a9cd9ff43b47987c03bba7bba32fe8a030f"
+    ]
+  }
+}
+package "bignum" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "Core-flavoured wrapper around zarith's arbitrary-precision rationals"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/bignum"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/bignum/index.html"
+  bug-reports: "https://github.com/janestreet/bignum/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "splittable_random" {>= "v0.14" & < "v0.15"}
+    "typerep" {>= "v0.14" & < "v0.15"}
+    "zarith_stubs_js" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "num"
+    "zarith" {>= "1.5"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/bignum.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/bignum-v0.14.0.tar.gz"
+    checksum: "md5=d97af8dc866db3eda78b1edc6c0982bf"
+  }
+}
+package "bigstringaf" {
+  opam-version: "2.0"
+  version: "0.5.0"
+  synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"
+  description: """\
+Bigstring intrinsics and fast blits based on memcpy/memmove
+
+The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+widely-known, sometimes misused, and so programs that use Bigstrings are slower
+than they have to be. And even if a library got that part right and exposed the
+intrinsics properly, the compiler doesn't have any fast blits between
+Bigstrings and other string-like types.
+
+So here they are. Go crazy."""
+  maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  authors: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/inhabitedtype/bigstringaf"
+  bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+  depends: [
+    "dune"
+    "alcotest" {with-test}
+    "base-bigarray"
+    "ocaml" {>= "4.03.0"}
+  ]
+  depopts: ["mirage-xen-posix" "ocaml-freestanding"]
+  conflicts: [
+    "mirage-xen-posix" {< "3.1.0"}
+    "ocaml-freestanding" {< "0.4.1"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+  ]
+  dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+  url {
+    src: "https://github.com/inhabitedtype/bigstringaf/archive/0.5.0.tar.gz"
+    checksum: "md5=e6b5e7eb0469ef21b27d1c66feeac356"
+  }
+}
+package "bin_prot" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "A binary protocol generator"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/bin_prot"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/index.html"
+  bug-reports: "https://github.com/janestreet/bin_prot/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_compare" {>= "v0.14" & < "v0.15"}
+    "ppx_custom_printf" {>= "v0.14" & < "v0.15"}
+    "ppx_fields_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_optcomp" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_variants_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  depopts: ["mirage-xen-ocaml"]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/bin_prot.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/bin_prot-v0.14.0.tar.gz"
+    checksum: "md5=a4fee6c7d57a05e2420a69e16c287faf"
+  }
+}
+package "biniou" {
+  opam-version: "2.0"
+  version: "1.2.1"
+  synopsis:
+    "Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve"
+  description: """\
+Biniou (pronounced "be new") is a binary data format designed for speed, safety,
+ease of use and backward compatibility as protocols evolve. Biniou is vastly
+equivalent to JSON in terms of functionality but allows implementations several
+times faster (4 times faster than yojson), with 25-35% space savings.
+
+Biniou data can be decoded into human-readable form without knowledge of type
+definitions except for field and variant names which are represented by 31-bit
+hashes. A program named bdump is provided for routine visualization of biniou
+data files.
+
+The program atdgen is used to derive OCaml-Biniou serializers and deserializers
+from type definitions.
+
+Biniou format specification: mjambon.github.io/atdgen-doc/biniou-format.txt"""
+  maintainer: "martin@mjambon.com"
+  authors: "Martin Jambon"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/mjambon/biniou"
+  doc: "https://mjambon.github.io/biniou/"
+  bug-reports: "https://github.com/mjambon/biniou/issues"
+  depends: [
+    "easy-format"
+    "dune" {>= "1.10"}
+    "ocaml" {>= "4.02.3" & < "5.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "-p" name "@doc"] {with-doc}
+  ]
+  dev-repo: "git+https://github.com/mjambon/biniou.git"
+  url {
+    src:
+      "https://github.com/mjambon/biniou/releases/download/1.2.1/biniou-1.2.1.tbz"
+    checksum: [
+      "sha256=35546c68b1929a8e6d27a3b39ecd17b38303a0d47e65eb9d1480c2061ea84335"
+      "sha512=82670cc77bf3e869ee26e5fbe5a5affa45a22bc8b6c4bd7e85473912780e0111baca59b34a2c14feae3543ce6e239d7fddaeab24b686a65bfe642cdb91d27ebf"
+    ]
+  }
+}
+package "bisect_ppx" {
+  opam-version: "2.0"
+  version: "2.8.1"
+  synopsis: "Code coverage for OCaml"
+  description: """\
+Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."""
+  maintainer: [
+    "Anton Bachin <antonbachin@yahoo.com>"
+    "Leonid Rozenberg <leonidr@gmail.com>"
+  ]
+  authors: [
+    "Xavier Clerc <bisect@x9c.fr>"
+    "Leonid Rozenberg <leonidr@gmail.com>"
+    "Anton Bachin <antonbachin@yahoo.com>"
+  ]
+  license: "MIT"
+  homepage: "https://github.com/aantron/bisect_ppx"
+  doc: "https://github.com/aantron/bisect_ppx"
+  bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+  depends: [
+    "base-unix"
+    "cmdliner" {>= "1.0.0"}
+    "dune" {>= "2.7.0"}
+    "ocaml" {>= "4.03.0"}
+    "ppxlib" {>= "0.21.0" & < "0.26.0"}
+    "ocamlformat" {with-test & = "0.16.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "-p" name "-j" jobs "@compatible"] {with-test}
+  ]
+  dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+  url {
+    src: "https://github.com/aantron/bisect_ppx/archive/2.8.1.tar.gz"
+    checksum: "md5=e8831e6e99292f221ded6fb02652e2a5"
+  }
+}
+package "bitstring" {
+  opam-version: "2.0"
+  version: "4.1.0"
+  synopsis: "Bitstrings and bitstring matching for OCaml"
+  description: """\
+The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml. 
+You can use this module to both parse and generate binary formats, files and protocols. 
+Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
+  maintainer: "Xavier R. Guérin <github@applepine.org>"
+  authors: ["Richard W.M. Jones" "Xavier R. Guérin"]
+  license: "LGPL-2.0-or-later"
+  homepage: "https://github.com/xguerin/bitstring"
+  bug-reports: "https://github.com/xguerin/bitstring/issues"
+  depends: [
+    "dune" {>= "2.5"}
+    "ocaml" {>= "4.04.1"}
+    "stdlib-shims" {>= "0.1.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/xguerin/bitstring.git"
+  url {
+    src: "https://github.com/xguerin/bitstring/archive/v4.1.0.tar.gz"
+    checksum: "md5=8ae6f04eaa29481c6830ee3be5cba755"
+  }
+}
+package "camlp4" {
+  opam-version: "2.0"
+  version: "4.14+1"
+  synopsis:
+    "Camlp4 is a system for writing extensible parsers for programming languages"
+  description: """\
+It provides a set of OCaml libraries that are used to define grammars as well
+as loadable syntax extensions of such grammars. Camlp4 stands for Caml
+Preprocessor and Pretty-Printer and one of its most important applications is
+the definition of domain-specific extensions of the syntax of OCaml.
+
+Camlp4 was part of the official OCaml distribution until its version 4.01.0.
+Since then it has been replaced by a simpler system which is easier to maintain
+and to learn: ppx rewriters and extension points."""
+  maintainer: "ygrek@autistici.org"
+  authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
+  license: "LGPL-2.1-only"
+  homepage: "https://github.com/camlp4/camlp4"
+  bug-reports: "https://github.com/camlp4/camlp4/issues"
+  depends: [
+    "ocaml" {>= "4.14" & < "4.15"}
+    "ocamlbuild" {build}
+  ]
+  build: [
+    [
+      "./configure"
+      "--bindir=%{bin}%"
+      "--libdir=%{lib}%/ocaml"
+      "--pkgdir=%{lib}%"
+      "--pinned"
+    ]
+    [make "clean"]
+    [make "all"] {ocaml:native-dynlink}
+    [make "byte"] {!ocaml:native-dynlink}
+  ]
+  install: [make "install" "install-META"]
+  dev-repo: "git+https://github.com/camlp4/camlp4.git"
+  url {
+    src: "https://github.com/camlp4/camlp4/archive/refs/tags/4.14+1.tar.gz"
+    checksum: [
+      "md5=39def6befe8f961a89250e3106199359"
+      "sha512=7838bcfc88edec73667669ea6562435b946e79f0b4a0e8117a83b403936337f08aaf8abe39d8f800483d77381ae122fc89aa68505cf60ec2f1cc835a04da93f2"
+    ]
+  }
+}
+package "camomile" {
+  opam-version: "2.0"
+  version: "1.0.2"
+  synopsis: "A Unicode library"
+  description: """\
+Camomile is a Unicode library for OCaml. Camomile provides Unicode character
+type, UTF-8, UTF-16, UTF-32 strings, conversion to/from about 200 encodings,
+collation and locale-sensitive case mappings, and more. The library is currently
+designed for Unicode Standard 3.2."""
+  maintainer: "yoriyuki.y@gmail.com"
+  authors: "Yoriyuki Yamagata"
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/yoriyuki/Camomile"
+  doc: "https://yoriyuki.github.io/Camomile/"
+  bug-reports: "https://github.com/yoriyuki/Camomile/issues"
+  depends: [
+    "dune" {>= "1.11"}
+    "ocaml" {>= "4.02.3" & < "5.0"}
+  ]
+  available: arch != "ppc64"
+  build: [
+    ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
+  url {
+    src:
+      "https://github.com/yoriyuki/Camomile/releases/download/1.0.2/camomile-1.0.2.tbz"
+    checksum: [
+      "sha256=f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632"
+      "sha512=7586422e68779476206027c6ebbe19b677fbe459153221f7c952c7fae374c5c8232249cb76fdb1f482069707aa1580be827cd39693906142988268b7f0e7f6d0"
+    ]
   }
 }
 package "capnp" {
@@ -350,6 +1226,156 @@ Cap'n Proto is a multi-language code generation framework designed for
       "sha256=03aac06742f3d4ec8a189f0db65d46393b7497e8637ece15c39ff4ec01117b8b"
   }
 }
+package "caqti" {
+  opam-version: "2.0"
+  version: "1.5.0"
+  synopsis: "Unified interface to relational database libraries"
+  description: """\
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+  maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+  authors: [
+    "Petter A. Urkedal <paurkedal@gmail.com>"
+    "Nathan Rebours <nathan@cryptosense.com>"
+  ]
+  license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/paurkedal/ocaml-caqti/"
+  doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+  bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+  depends: [
+    "cppo" {build & >= "1.1.0"}
+    "dune" {>= "1.11"}
+    "logs"
+    "ocaml" {>= "4.04.0"}
+    "ptime"
+    "uri" {>= "1.9.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+  url {
+    src:
+      "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.0/caqti-v1.5.0.tbz"
+    checksum: [
+      "sha256=9524c75c87677eb75e68fbbf421d84b7b610bf2f344bfa227e23465644e62e26"
+      "sha512=8c1f289d269d0017bf8b489e64c1153448c62f79a991349662722f4de74c0cbbd75dcdca266b7276af55200346d38dce8135da247e5fbc235a3660785a03b01f"
+    ]
+  }
+  x-commit-hash: "bccdbe39e813e76e87b910ca875392703f8e4caa"
+}
+package "caqti-async" {
+  opam-version: "2.0"
+  version: "1.3.0"
+  synopsis: "Async support for Caqti"
+  maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+  authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+  license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/paurkedal/ocaml-caqti/"
+  doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+  bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+  depends: [
+    "ocaml"
+    "async_kernel" {>= "v0.11.0"}
+    "async_unix" {>= "v0.11.0"}
+    "caqti" {>= "1.3.0" & < "1.6.0~"}
+    "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+    "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+    "core_kernel"
+    "dune" {>= "1.11"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+  url {
+    src:
+      "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.3.0/caqti-v1.3.0.tbz"
+    checksum: [
+      "sha256=a15d71b6428997703273dc6d55a99045fb62c3243c751de5ae8c3fc25421f16a"
+      "sha512=386502d9ea2f1769081b81e6888bf4c2a27248498eabc0d4eb4adfde04c74f48f2aa587c0ce3a34604c73d157ed6533052b4d0b9a0fb3f352929ef847f3aa9fa"
+    ]
+  }
+  x-commit-hash: "60bd0293d8deffe72e8f909775bfdd2ed4a8ec0d"
+}
+package "caqti-driver-postgresql" {
+  opam-version: "2.0"
+  version: "1.5.1"
+  synopsis: "PostgreSQL driver for Caqti based on C bindings"
+  maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+  authors: [
+    "Petter A. Urkedal <paurkedal@gmail.com>"
+    "James Owen <james@cryptosense.com>"
+  ]
+  license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/paurkedal/ocaml-caqti/"
+  doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+  bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+  depends: [
+    "ocaml"
+    "caqti" {>= "1.5.0" & < "1.6.0~"}
+    "dune" {>= "1.11"}
+    "postgresql" {>= "5.0.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+  url {
+    src:
+      "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.5.1/caqti-v1.5.1.tbz"
+    checksum: [
+      "sha256=4baa3d95e2e72ef6946bd1f46d6957f76e077b2b47cfb62096167389cdcc2e49"
+      "sha512=b7a6d60e98e70e3f1cf6f43ee5a4bae90c942605615c132ad1401d1efbd669cf72d5334880f64881a501128b6ca52f23b34526a7873b9c0b7cf83f53d30a5196"
+    ]
+  }
+  x-commit-hash: "06242515a50e2e413b7958ae09acf3aa1381de68"
+}
+package "charInfo_width" {
+  opam-version: "2.0"
+  version: "1.1.0"
+  synopsis: "Determine column width for a character"
+  description:
+    "This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."
+  maintainer: "zandoye@gmail.com"
+  authors: "ZAN DoYe"
+  license: "MIT"
+  homepage: "https://github.com/kandu/charinfo_width/"
+  bug-reports: "https://github.com/kandu/charinfo_width/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "result"
+    "camomile" {>= "1.0.0" & < "2.0~"}
+    "dune"
+    "ppx_expect" {with-test}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs]
+      {with-test & ocaml:version >= "4.04.0"}
+  ]
+  dev-repo: "git+https://github.com/kandu/charinfo_width.git"
+  url {
+    src: "https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+    checksum: "md5=a539436d1da4aeb93711303f107bec7e"
+  }
+}
 package "check_opam_switch" {
   opam-version: "2.0"
   version: "~dev"
@@ -386,6 +1412,1929 @@ package "check_opam_switch" {
       "sha256=24ab29ea4aff9da9d649f0b577c5d4e27ce2bef51058e139965cc9be25494a46"
   }
 }
+package "cmdliner" {
+  opam-version: "2.0"
+  version: "1.0.3"
+  synopsis: "Declarative definition of command line interfaces for OCaml"
+  description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["cli" "system" "declarative" "org:erratique"]
+  homepage: "http://erratique.ch/software/cmdliner"
+  doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+  bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+  depends: [
+    "ocaml" {>= "4.03.0" & < "5.0"}
+  ]
+  build: [make "all" "PREFIX=%{prefix}%"]
+  install: [
+    [make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+    [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+  ]
+  dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+  url {
+    src: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.3.tbz"
+    checksum: "md5=3674ad01d4445424105d33818c78fba8"
+  }
+}
+package "cohttp" {
+  opam-version: "2.0"
+  version: "5.0.0"
+  synopsis: "An OCaml library for HTTP clients and servers"
+  description: """\
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+  maintainer: "anil@recoil.org"
+  authors: [
+    "Anil Madhavapeddy"
+    "Stefano Zacchiroli"
+    "David Sheets"
+    "Thomas Gazagnaire"
+    "David Scott"
+    "Rudi Grinberg"
+    "Andy Ray"
+  ]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-cohttp"
+  doc: "https://mirage.github.io/ocaml-cohttp/"
+  bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "dune" {>= "2.0"}
+    "re" {>= "1.9.0"}
+    "uri" {>= "2.0.0"}
+    "uri-sexp"
+    "sexplib0"
+    "ppx_sexp_conv" {>= "v0.13.0"}
+    "stringext"
+    "base64" {>= "3.1.0"}
+    "fmt" {with-test}
+    "jsonm" {build}
+    "alcotest" {with-test}
+    "crowbar" {with-test & >= "0.2"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-cohttp/releases/download/v5.0.0/cohttp-5.0.0.tbz"
+    checksum: [
+      "sha256=fd6ff4b86c818355d61b3a08628596dbf517d6a7da6e8edec481bb0653ca5a05"
+      "sha512=f0bfd715806965af5488010cc9388d05406b67ece0b2cb8f7803553b17a5264d03094e59127a62d37c0d6c0e74d4717e643737c43d9bcfb10b112a73d5f49c4d"
+    ]
+  }
+  x-commit-hash: "5f9c0ae88a69e4280810fe73344367e90954dea5"
+}
+package "cohttp-async" {
+  opam-version: "2.0"
+  version: "5.0.0"
+  synopsis: "CoHTTP implementation for the Async concurrency library"
+  description: """\
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively."""
+  maintainer: "anil@recoil.org"
+  authors: [
+    "Anil Madhavapeddy"
+    "Stefano Zacchiroli"
+    "David Sheets"
+    "Thomas Gazagnaire"
+    "David Scott"
+    "Rudi Grinberg"
+    "Andy Ray"
+  ]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-cohttp"
+  doc: "https://mirage.github.io/ocaml-cohttp/"
+  bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "dune" {>= "2.0"}
+    "async_kernel" {>= "v0.14.0" & < "v0.16.0"}
+    "async_unix" {>= "v0.14.0"}
+    "async" {>= "v0.14.0"}
+    "base" {>= "v0.11.0"}
+    "core" {with-test}
+    "core_unix" {>= "v0.14.0"}
+    "cohttp" {= version}
+    "conduit-async" {>= "1.2.0"}
+    "magic-mime"
+    "mirage-crypto" {with-test}
+    "logs"
+    "fmt" {>= "0.8.2"}
+    "sexplib0"
+    "ppx_sexp_conv" {>= "v0.13.0"}
+    "ounit" {with-test}
+    "async" {with-test & < "v0.15"}
+    "uri" {>= "2.0.0"}
+    "uri-sexp"
+    "ipaddr"
+  ]
+  available: arch != "s390x"
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-cohttp/releases/download/v5.0.0/cohttp-5.0.0.tbz"
+    checksum: [
+      "sha256=fd6ff4b86c818355d61b3a08628596dbf517d6a7da6e8edec481bb0653ca5a05"
+      "sha512=f0bfd715806965af5488010cc9388d05406b67ece0b2cb8f7803553b17a5264d03094e59127a62d37c0d6c0e74d4717e643737c43d9bcfb10b112a73d5f49c4d"
+    ]
+  }
+  x-commit-hash: "5f9c0ae88a69e4280810fe73344367e90954dea5"
+}
+package "conduit" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "A network connection establishment library"
+  description: """\
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation"""
+  maintainer: "anil@recoil.org"
+  authors: [
+    "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+  ]
+  license: "ISC"
+  tags: "org:mirage"
+  homepage: "https://github.com/mirage/ocaml-conduit"
+  doc: "https://mirage.github.io/ocaml-conduit/"
+  bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "2.0"}
+    "ppx_sexp_conv" {>= "v0.13.0"}
+    "sexplib"
+    "astring"
+    "uri"
+    "logs" {>= "0.5.0"}
+    "ipaddr" {>= "4.0.0"}
+    "ipaddr-sexp"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.0/conduit-v4.0.0.tbz"
+    checksum: [
+      "sha256=74b29d72bf47adc5d5c4cae6130ad5a2a4923118b9c571331bd1cb3c56decd2a"
+      "sha512=5c60f19eb4d38ea358710bf402a535d610e68280ff4484c2dcad45c31c2dbc447aa3eadc2b7d5243bd65a97cde76b67ee1fd57bb34f8ef6a4ab10786f4bb0d5e"
+    ]
+  }
+  x-commit-hash: "e4b58b17a6cb1f8de7cce68246cc2f339e029ed3"
+}
+package "conduit-async" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "A network connection establishment library for Async"
+  maintainer: "anil@recoil.org"
+  authors: [
+    "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+  ]
+  license: "ISC"
+  tags: "org:mirage"
+  homepage: "https://github.com/mirage/ocaml-conduit"
+  bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune"
+    "core"
+    "uri" {>= "4.0.0"}
+    "ppx_here" {>= "v0.9.0"}
+    "ppx_sexp_conv" {>= "v0.13.0"}
+    "sexplib"
+    "conduit" {= version}
+    "async" {>= "v0.10.0"}
+    "ipaddr" {>= "3.0.0"}
+  ]
+  depopts: ["async_ssl"]
+  conflicts: [
+    "async_ssl" {< "v0.9.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.0/conduit-v4.0.0.tbz"
+    checksum: [
+      "sha256=74b29d72bf47adc5d5c4cae6130ad5a2a4923118b9c571331bd1cb3c56decd2a"
+      "sha512=5c60f19eb4d38ea358710bf402a535d610e68280ff4484c2dcad45c31c2dbc447aa3eadc2b7d5243bd65a97cde76b67ee1fd57bb34f8ef6a4ab10786f4bb0d5e"
+    ]
+  }
+  x-commit-hash: "e4b58b17a6cb1f8de7cce68246cc2f339e029ed3"
+}
+package "conf-g++" {
+  opam-version: "2.0"
+  version: "1.0"
+  synopsis: "Virtual package relying on the g++ compiler (for C++)"
+  description:
+    "This package can only install if the g++ compiler is installed on the system."
+  maintainer: "unixjunkie@sdf.org"
+  authors: "Francois Berenger"
+  license: "GPL-2.0-or-later"
+  homepage: "https://github.com/ocaml/opam-repository"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: ["g++" "--version"]
+  depexts: [
+    ["gcc-c++"] {os-distribution = "centos"}
+    ["gcc-c++"] {os-distribution = "fedora"}
+    ["gcc-c++"] {os-family = "suse" | os-family = "opensuse"}
+    ["g++"] {os-family = "debian"}
+    ["g++"] {os-distribution = "alpine"}
+    ["gcc"] {os-distribution = "nixos"}
+    ["gcc"] {os-distribution = "arch"}
+    ["gcc"] {os = "macos" & os-distribution = "homebrew"}
+    ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
+    ["gcc"] {os = "freebsd"}
+  ]
+}
+package "conf-gmp" {
+  opam-version: "2.0"
+  version: "2"
+  synopsis: "Virtual package relying on a GMP lib system installation"
+  description:
+    "This package can only install if the GMP lib is installed on the system."
+  maintainer: "nbraud"
+  authors: "nbraud"
+  license: "GPL-1.0-or-later"
+  homepage: "http://gmplib.org/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: [
+    ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos"}
+    [
+      "sh"
+      "-exc"
+      "cc -c $CFLAGS -I/opt/local/include -I/usr/local/include test.c"
+    ] {os = "macos"}
+  ]
+  depexts: [
+    ["libgmp-dev"] {os-family = "debian"}
+    ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+    ["gmp"] {os-distribution = "macports" & os = "macos"}
+    ["gmp" "gmp-devel"] {os-distribution = "centos"}
+    ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+    ["gmp" "gmp-devel"] {os-distribution = "ol"}
+    ["gmp"] {os = "openbsd"}
+    ["gmp"] {os = "freebsd"}
+    ["gmp-dev"] {os-distribution = "alpine"}
+    ["gmp-devel"] {os-family = "suse" | os-family = "opensuse"}
+    ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
+  ]
+  extra-files: ["test.c" "md5=2fd2970c293c36222a6d299ec155823f"]
+}
+package "conf-libffi" {
+  opam-version: "2.0"
+  version: "2.0.0"
+  synopsis: "Virtual package relying on libffi system installation"
+  description:
+    "This package can only install if libffi is installed on the system."
+  maintainer: "blue-prawn"
+  authors: "Anthony Green"
+  license: "MIT"
+  homepage: "http://sourceware.org/libffi/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  depends: [
+    "conf-pkg-config" {build}
+  ]
+  flags: conf
+  build: ["pkg-config" "libffi"]
+  depexts: [
+    ["libffi"] {os = "macos" & os-distribution = "homebrew"}
+    ["libffi"] {os = "macos" & os-distribution = "macports"}
+    ["libffi-dev"] {os-distribution = "alpine"}
+    ["libffi-dev"] {os-family = "debian"}
+    ["libffi-devel"] {os-distribution = "centos"}
+    ["libffi-devel"] {os-distribution = "fedora"}
+    ["libffi-devel"] {os-distribution = "mageia"}
+    ["libffi-devel"] {os-distribution = "ol"}
+    ["libffi-devel"] {os-family = "suse" | os-family = "opensuse"}
+    ["libffi"] {os = "freebsd"}
+    ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
+    ["libffi"] {os-distribution = "nixos"}
+  ]
+}
+package "conf-libssl" {
+  opam-version: "2.0"
+  version: "2"
+  synopsis:
+    "Virtual package relying on an OpenSSL library system installation"
+  description:
+    "This package can only install if the OpenSSL library is installed on the system."
+  maintainer: "David Sheets <sheets@alum.mit.edu>"
+  authors: "The OpenSSL Project"
+  license: "Apache-1.0"
+  homepage: "https://www.openssl.org/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  depends: [
+    "conf-pkg-config" {build}
+  ]
+  flags: conf
+  build:
+    ["pkg-config" "openssl"]
+      {os != "freebsd" & os != "openbsd" & os != "netbsd"}
+  build-env: HOMEBREW_NO_AUTO_UPDATE = "1"
+  post-messages: [
+    "Make sure libssl/openssl is installed and accessible using pkg-config."
+      {failure}
+    "Set the PKG_CONFIG_PATH environment variable if necessary." {failure}
+    "For example: export PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig"
+      {failure & os-distribution = "homebrew"}
+    "For example: export PKG_CONFIG_PATH=$HOME/.nix-profile/lib/pkgconfig"
+      {failure & os-distribution = "nixos"}
+    "For example: export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig"
+      {failure & os-distribution = "macports"}
+  ]
+  depexts: [
+    ["libssl-dev"] {os-family = "debian"}
+    ["openssl-devel"] {os-distribution = "centos"}
+    ["openssl-devel"] {os-distribution = "ol"}
+    ["openssl-devel"] {os-distribution = "fedora"}
+    ["openssl"] {os = "macos" & os-distribution = "homebrew"}
+    ["openssl"] {os = "macos" & os-distribution = "macports"}
+    ["openssl-dev"] {os-distribution = "alpine"}
+    ["openssl"] {os-distribution = "nixos"}
+    ["openssl"] {os-distribution = "arch"}
+    ["libopenssl-devel"] {os-family = "suse" | os-family = "opensuse"}
+    ["openssl"] {os = "win32" & os-distribution = "cygwinports"}
+  ]
+}
+package "conf-m4" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis: "Virtual package relying on m4"
+  description:
+    "This package can only install if the m4 binary is installed on the system."
+  maintainer: "tim@gfxmonk.net"
+  authors: "GNU Project"
+  license: "GPL-3.0-only"
+  homepage: "http://www.gnu.org/software/m4/m4.html"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: ["sh" "-exc" "echo | m4"]
+  depexts: [
+    ["m4"] {os-family = "debian"}
+    ["m4"] {os-distribution = "fedora"}
+    ["m4"] {os-distribution = "rhel"}
+    ["m4"] {os-distribution = "centos"}
+    ["m4"] {os-distribution = "alpine"}
+    ["m4"] {os-distribution = "nixos"}
+    ["m4"] {os-family = "suse" | os-family = "opensuse"}
+    ["m4"] {os-distribution = "ol"}
+    ["m4"] {os-distribution = "arch"}
+  ]
+}
+package "conf-openssl" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis:
+    "Virtual package relying on an OpenSSL library system installation (deprecated version)"
+  description: """\
+This package can only install if the OpenSSL library is installed on the system.
+This version of this metapackage is left here for compatibility purpose only."""
+  maintainer: "Kate <kit.ty.kate@disroot.org>"
+  authors: "The OpenSSL Project"
+  license: "Apache-1.0"
+  homepage: "https://www.openssl.org/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  depends: ["conf-libssl"]
+  flags: conf
+  post-messages:
+    "This package shouldn't be used. Please use conf-libssl.1 or conf-openssl.2 instead."
+}
+package "conf-perl" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis: "Virtual package relying on perl"
+  description:
+    "This package can only install if the perl program is installed on the system."
+  maintainer: "tim@gfxmonk.net"
+  authors: "Larry Wall"
+  license: "GPL-1.0-or-later"
+  homepage: "https://www.perl.org/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: ["perl" "--version"]
+  depexts: [
+    ["perl"] {os-family = "debian"}
+    ["perl"] {os-distribution = "alpine"}
+    ["perl"] {os-distribution = "nixos"}
+    ["perl"] {os-distribution = "arch"}
+    ["perl-Pod-Html"] {os-distribution = "fedora"}
+    ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
+  ]
+}
+package "conf-pkg-config" {
+  opam-version: "2.0"
+  version: "1.1"
+  synopsis: "Virtual package relying on pkg-config installation"
+  description: """\
+This package can only install if the pkg-config package is installed
+on the system."""
+  maintainer: "unixjunkie@sdf.org"
+  authors: "Francois Berenger"
+  license: "GPL-1.0-or-later"
+  homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: ["pkg-config" "--help"]
+  install:
+    ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"]
+      {os = "openbsd"}
+  remove: ["rm" "-f" "%{bin}%/pkg-config"] {os = "openbsd"}
+  post-messages:
+    "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation."
+      {os = "openbsd"}
+  depexts: [
+    ["pkg-config"] {os-family = "debian"}
+    ["pkgconf"] {os-distribution = "arch"}
+    ["pkgconfig"] {os-distribution = "fedora"}
+    ["pkgconfig"] {os-distribution = "centos"}
+    ["pkgconfig"] {os-distribution = "mageia"}
+    ["pkgconfig"] {os-distribution = "rhel"}
+    ["pkgconfig"] {os-distribution = "ol"}
+    ["pkgconf"] {os-distribution = "alpine"}
+    ["pkgconfig"] {os-distribution = "nixos"}
+    ["devel/pkgconf"] {os = "openbsd"}
+    ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+    ["pkgconf"] {os = "freebsd"}
+    ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ]
+}
+package "conf-postgresql" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis: "Virtual package relying on a PostgreSQL system installation"
+  description:
+    "This package can only install if PostgreSQL is installed on the system."
+  maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+  authors: "Markus Mottl <markus.mottl@gmail.com>"
+  license: "PD"
+  homepage: "https://www.postgresql.org"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: "pg_config"
+  post-messages:
+    "If this package failed with \"Command not found: pg_config\", you might need to call \"brew link postgresql@15\" and retry to install this package afterwards."
+      {failure & os = "macos" & os-distribution = "homebrew"}
+  depexts: [
+    ["libpq-dev"] {os-family = "debian"}
+    ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
+    ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
+    ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
+    ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
+    ["postgresql96-client"] {os-distribution = "freebsd"}
+    ["postgresql96-client"] {os-distribution = "openbsd"}
+    ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
+    ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
+    ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
+    ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
+    ["postgresql-server-devel"] {os-family = "suse" | os-family = "opensuse"}
+    ["postgresql-dev"] {os-distribution = "alpine" & os-version < "3.15"}
+    ["postgresql14-dev"] {os-distribution = "alpine" & os-version >= "3.15"}
+    ["postgresql"] {os = "win32" & os-distribution = "cygwinports"}
+    ["postgresql-libs"] {os-family = "arch"}
+    ["postgresql@15"] {os = "macos" & os-distribution = "homebrew"}
+    ["postgresql96"] {os = "macos" & os-distribution = "macports"}
+    ["postgresql"] {os-distribution = "nixos"}
+  ]
+  dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+}
+package "conf-which" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis: "Virtual package relying on which"
+  description:
+    "This package can only install if the which program is installed on the system."
+  maintainer: "unixjunkie@sdf.org"
+  authors: "Carlo Wood"
+  license: "GPL-2.0-or-later"
+  homepage: "http://www.gnu.org/software/which/"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  flags: conf
+  build: ["which" "which"]
+  depexts: [
+    ["which"] {os-distribution = "centos"}
+    ["which"] {os-distribution = "fedora"}
+    ["which"] {os-distribution = "ol"}
+    ["which"] {os-family = "suse" | os-family = "opensuse"}
+    ["debianutils"] {os-family = "debian"}
+    ["debianutils"] {os-family = "ubuntu"}
+    ["which"] {os-distribution = "nixos"}
+    ["which"] {os-family = "arch"}
+  ]
+}
+package "core" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Industrial strength alternative to OCaml's standard library"
+  description: """\
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/core"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
+  bug-reports: "https://github.com/janestreet/core/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "jst-config" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "sexplib" {>= "v0.14" & < "v0.15"}
+    "timezone" {>= "v0.14" & < "v0.15"}
+    "base-threads"
+    "dune" {>= "2.0.0"}
+    "spawn" {>= "v0.12"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  depexts: ["linux-headers"] {os-distribution = "alpine"}
+  dev-repo: "git+https://github.com/janestreet/core.git"
+  url {
+    src: "https://github.com/janestreet/core/archive/v0.14.1.tar.gz"
+    checksum: "md5=b11f58205953d84cedb0003efcdab231"
+  }
+}
+package "core_bench" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Benchmarking library"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/core_bench"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_bench/index.html"
+  bug-reports: "https://github.com/janestreet/core_bench/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "textutils" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "re" {>= "1.8.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/core_bench.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/core_bench-v0.14.0.tar.gz"
+    checksum: "md5=96c9241f978acbc3a6817b20b281996f"
+  }
+}
+package "core_extended" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "Extra components that are not as closely vetted or as stable as Core"
+  description: """\
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/core_extended"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_extended/index.html"
+  bug-reports: "https://github.com/janestreet/core_extended/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "re" {>= "1.8.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/core_extended.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/core_extended-v0.14.0.tar.gz"
+    checksum: "md5=00eb9b3ed6b0b02f74a2cf01e4d5827f"
+  }
+}
+package "core_kernel" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Industrial strength alternative to OCaml's standard library"
+  description: """\
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+Core_kernel is the system-independent part of Core."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/core_kernel"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/index.html"
+  bug-reports: "https://github.com/janestreet/core_kernel/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "base_bigstring" {>= "v0.14" & < "v0.15"}
+    "base_quickcheck" {>= "v0.14" & < "v0.15"}
+    "bin_prot" {>= "v0.14" & < "v0.15"}
+    "fieldslib" {>= "v0.14" & < "v0.15"}
+    "jane-street-headers" {>= "v0.14" & < "v0.15"}
+    "jst-config" {>= "v0.14" & < "v0.15"}
+    "ppx_assert" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "ppx_hash" {>= "v0.14" & < "v0.15"}
+    "ppx_inline_test" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_message" {>= "v0.14" & < "v0.15"}
+    "sexplib" {>= "v0.14" & < "v0.15"}
+    "splittable_random" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "time_now" {>= "v0.14" & < "v0.15"}
+    "typerep" {>= "v0.14" & < "v0.15"}
+    "variantslib" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/core_kernel.git"
+  url {
+    src: "https://github.com/janestreet/core_kernel/archive/v0.14.1.tar.gz"
+    checksum: "md5=77b25affd5155128ca757d38e496d89f"
+  }
+}
+package "core_unix" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Unix-specific portions of Core"
+  description:
+    "Unix-specific extensions to some of the modules defined in [core] and [core_kernel]."
+  maintainer: "opensource@janestreet.com"
+  authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/core_unix"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_unix/index.html"
+  bug-reports: "https://github.com/janestreet/core_unix/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  depexts: ["linux-headers"] {os-distribution = "alpine"}
+  dev-repo: "git+https://github.com/janestreet/core_unix.git"
+  url {
+    src: "https://github.com/janestreet/core_unix/archive/v0.14.0.tar.gz"
+    checksum: [
+      "md5=f9a74834f239874286d84ec99d75e5fa"
+      "sha512=d020db759cde35c0e9d9919dee2c0ea5bb5b7a5ee75515be922d816f28eb9f74dba37e6e424a636e362eab5120b2c1e672f4e5ba798f2dac7974c0e135f80faf"
+    ]
+  }
+}
+package "cppo" {
+  opam-version: "2.0"
+  version: "1.6.7"
+  synopsis: "Code preprocessor like cpp for OCaml"
+  description: """\
+Cppo is an equivalent of the C preprocessor for OCaml programs.
+It allows the definition of simple macros and file inclusion.
+
+Cppo is:
+
+* more OCaml-friendly than cpp
+* easy to learn without consulting a manual
+* reasonably fast
+* simple to install and to maintain"""
+  maintainer: "martin@mjambon.com"
+  authors: "Martin Jambon"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-community/cppo"
+  doc: "https://ocaml-community.github.io/cppo/"
+  bug-reports: "https://github.com/ocaml-community/cppo/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "1.0"}
+    "base-unix"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+  url {
+    src:
+      "https://github.com/ocaml-community/cppo/releases/download/v1.6.7/cppo-v1.6.7.tbz"
+    checksum: [
+      "sha256=db553e3e6c206df09b1858c3aef5e21e56564d593642a3c78bcedb6af36f529d"
+      "sha512=9722b50fd23aaccf86816313333a3bf8fc7c6b4ef06b153e5e1e1aaf14670cf51a4aac52fb1b4a0e5531699c4047a1eff6c24c969f7e5063e78096c2195b5819"
+    ]
+  }
+  x-commit-hash: "7d217864a5fdc4551699e248137a2f8b719d2078"
+}
+package "cppo_ocamlbuild" {
+  opam-version: "2.0"
+  version: "1.6.7"
+  synopsis: "Plugin to use cppo with ocamlbuild"
+  description: """\
+This ocamlbuild plugin lets you use cppo in ocamlbuild projects.
+
+To use it, you can call ocamlbuild with the argument `-plugin-tag
+package(cppo_ocamlbuild)` (only since ocaml 4.01 and cppo >= 0.9.4)."""
+  maintainer: "martin@mjambon.com"
+  authors: "Martin Jambon"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-community/cppo"
+  doc: "https://ocaml-community.github.io/cppo/"
+  bug-reports: "https://github.com/ocaml-community/cppo/issues"
+  depends: [
+    "ocaml"
+    "dune" {>= "1.0"}
+    "ocamlbuild"
+    "ocamlfind"
+  ]
+  conflicts: [
+    "cppo" {< "1.6.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+  url {
+    src:
+      "https://github.com/ocaml-community/cppo/releases/download/v1.6.7/cppo-v1.6.7.tbz"
+    checksum: [
+      "sha256=db553e3e6c206df09b1858c3aef5e21e56564d593642a3c78bcedb6af36f529d"
+      "sha512=9722b50fd23aaccf86816313333a3bf8fc7c6b4ef06b153e5e1e1aaf14670cf51a4aac52fb1b4a0e5531699c4047a1eff6c24c969f7e5063e78096c2195b5819"
+    ]
+  }
+  x-commit-hash: "7d217864a5fdc4551699e248137a2f8b719d2078"
+}
+package "crunch" {
+  opam-version: "2.0"
+  version: "3.0.0"
+  synopsis: "Convert a filesystem into a static OCaml module"
+  description: """\
+`ocaml-crunch` takes a directory of files and compiles them into a standalone
+OCaml module which serves the contents directly from memory.  This can be
+convenient for libraries that need a few embedded files (such as a web server)
+and do not want to deal with all the trouble of file configuration."""
+  maintainer: "MirageOS team"
+  authors: [
+    "Anil Madhavapeddy"
+    "Thomas Gazagnaire"
+    "Stefanie Schirmer"
+    "Hannes Mehnert"
+  ]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-crunch"
+  doc: "https://mirage.github.io/ocaml-crunch/"
+  bug-reports: "https://github.com/mirage/ocaml-crunch/issues"
+  depends: [
+    "ocaml" {>= "4.05.0"}
+    "cmdliner"
+    "ptime"
+    "dune" {>= "1.0"}
+    "lwt" {with-test}
+    "mirage-kv-lwt" {with-test & >= "2.0.0"}
+    "mirage-kv-mem" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-crunch.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-crunch/releases/download/v3.0.0/crunch-v3.0.0.tbz"
+    checksum: "md5=83936d6316c2f81e3c64695bfac62f77"
+  }
+}
+package "csexp" {
+  opam-version: "2.0"
+  version: "1.5.1"
+  synopsis: "Parsing and printing of S-expressions in Canonical form"
+  description: """\
+This library provides minimal support for Canonical S-expressions
+[1]. Canonical S-expressions are a binary encoding of S-expressions
+that is super simple and well suited for communication between
+programs.
+
+This library only provides a few helpers for simple applications. If
+you need more advanced support, such as parsing from more fancy input
+sources, you should consider copying the code of this library given
+how simple parsing S-expressions in canonical form is.
+
+To avoid a dependency on a particular S-expression library, the only
+module of this library is parameterised by the type of S-expressions.
+
+[1] https://en.wikipedia.org/wiki/Canonical_S-expressions"""
+  maintainer: "Jeremie Dimino <jeremie@dimino.org>"
+  authors: [
+    "Quentin Hocquet <mefyl@gruntech.org>"
+    "Jane Street Group, LLC"
+    "Jeremie Dimino <jeremie@dimino.org>"
+  ]
+  license: "MIT"
+  homepage: "https://github.com/ocaml-dune/csexp"
+  doc: "https://ocaml-dune.github.io/csexp/"
+  bug-reports: "https://github.com/ocaml-dune/csexp/issues"
+  depends: [
+    "dune" {>= "1.11"}
+    "ocaml" {>= "4.03.0"}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
+  url {
+    src:
+      "https://github.com/ocaml-dune/csexp/releases/download/1.5.1/csexp-1.5.1.tbz"
+    checksum: [
+      "sha256=d605e4065fa90a58800440ef2f33a2d931398bf2c22061a8acb7df845c0aac02"
+      "sha512=d785bbabaff9f6bf601399149ef0a42e5e99647b54e27f97ef1625907793dda22a45bf83e0e8a1eba2c63634c5484b54739ff0904ef556f5fc592efa38af7505"
+    ]
+  }
+  x-commit-hash: "7eeb86206819d2b1782d6cde1be9d6cf8b5fc851"
+}
+package "cstruct" {
+  opam-version: "2.0"
+  version: "6.0.1"
+  synopsis: "Access C-like structures directly from OCaml"
+  description: """\
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+  maintainer: "anil@recoil.org"
+  authors: [
+    "Anil Madhavapeddy"
+    "Richard Mortier"
+    "Thomas Gazagnaire"
+    "Pierre Chambart"
+    "David Kaloper"
+    "Jeremy Yallop"
+    "David Scott"
+    "Mindy Preston"
+    "Thomas Leonard"
+    "Anton Kochkov"
+    "Etienne Millon"
+  ]
+  license: "ISC"
+  tags: ["org:mirage" "org:ocamllabs"]
+  homepage: "https://github.com/mirage/ocaml-cstruct"
+  doc: "https://mirage.github.io/ocaml-cstruct/"
+  bug-reports: "https://github.com/mirage/ocaml-cstruct/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "2.0.0"}
+    "bigarray-compat"
+    "alcotest" {with-test}
+    ("crowbar" {with-test} | "ocaml" {with-test & < "4.08"})
+  ]
+  conflicts: [
+    "js_of_ocaml" {< "3.5.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.1/cstruct-v6.0.1.tbz"
+    checksum: [
+      "sha256=4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed"
+      "sha512=3eeeb6ae0fd3b625cf1d308498f0a1e6951d16566561f3362fdf74e7158d92d8f6c6d9fa968ff15f8c19a1886dce99d0ef17b44dbb37b97cc68c9b088fdc2248"
+    ]
+  }
+  x-commit-hash: "28dade8963a9edfddeb8dba782a8eae0341e80d4"
+}
+package "ctypes" {
+  opam-version: "2.0"
+  version: "0.17.1"
+  synopsis: "Combinators for binding to C libraries without writing any C"
+  description: """\
+ctypes is a library for binding to C libraries using pure OCaml. The primary
+aim is to make writing C extensions as straightforward as possible.
+
+The core of ctypes is a set of combinators for describing the structure of C
+types -- numeric types, arrays, pointers, structs, unions and functions. You
+can use these combinators to describe the types of the functions that you want
+to call, then bind directly to those functions -- all without writing or
+generating any C!
+
+To install the optional `ctypes.foreign` interface (which uses `libffi` to
+provide dynamic access to foreign libraries), you will need to also install
+the `ctypes-foreign` optional dependency:
+
+    opam install ctypes ctypes-foreign
+
+This will make the `ctypes.foreign` ocamlfind subpackage available."""
+  maintainer: "yallop@gmail.com"
+  authors: "yallop@gmail.com"
+  license: "MIT"
+  homepage: "https://github.com/yallop/ocaml-ctypes"
+  doc: "http://yallop.github.io/ocaml-ctypes"
+  bug-reports: "http://github.com/yallop/ocaml-ctypes/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "integers" {>= "0.3.0"}
+    "ocamlfind" {build}
+    "conf-pkg-config" {build}
+    "lwt" {with-test & >= "3.2.0"}
+    "ctypes-foreign" {with-test}
+    "ounit" {with-test}
+    "conf-ncurses" {with-test}
+  ]
+  depopts: ["ctypes-foreign" "mirage-xen"]
+  conflicts: [
+    "mirage-xen" {>= "6.0.0"}
+    "base-nnp"
+    "ocaml-option-nnpchecker"
+  ]
+  build: [
+    [make "XEN=%{mirage-xen:enable}%" "libffi.config"]
+      {ctypes-foreign:installed}
+    ["touch" "libffi.config"] {!ctypes-foreign:installed}
+    [make "XEN=%{mirage-xen:enable}%" "ctypes-base" "ctypes-stubs"]
+    [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"]
+      {ctypes-foreign:installed}
+    [make "test"] {with-test}
+  ]
+  install: [make "install" "XEN=%{mirage-xen:enable}%"]
+  dev-repo: "git+http://github.com/yallop/ocaml-ctypes.git"
+  url {
+    src: "https://github.com/yallop/ocaml-ctypes/archive/0.17.1.tar.gz"
+    checksum: "md5=508ea062105518c14fd516aa2ea9db5e"
+  }
+}
+package "ctypes-foreign" {
+  opam-version: "2.0"
+  version: "0.4.0"
+  synopsis: "Virtual package for enabling the ctypes.foreign subpackage"
+  description: """\
+`ctypes-foreign` is just a virtual OPAM package that determines
+whether the foreign subpackage should built as part of ctypes.
+In order to actually get the ctypes package, you should also:
+
+    opam install ctypes ctypes-foreign
+
+You can verify the existence of the ocamlfind subpackage by:
+
+    ocamlfind list | grep ctypes
+
+Which should output something like:
+
+    ctypes              (version: 0.4.1)
+    ctypes.foreign      (version: 0.4.1)
+    ctypes.foreign.base (version: 0.4.1)
+    ctypes.foreign.threaded (version: 0.4.1)
+    ctypes.foreign.unthreaded (version: 0.4.1)
+    ctypes.stubs        (version: 0.4.1)
+    ctypes.top          (version: 0.4.1)"""
+  maintainer: "yallop@gmail.com"
+  authors: "yallop@gmail.com"
+  license: "MIT"
+  homepage: "https://github.com/yallop/ocaml-ctypes"
+  bug-reports: "http://github.com/yallop/ocaml-ctypes/issues"
+  depends: [
+    "conf-libffi" {>= "2.0.0"}
+  ]
+  post-messages: "This package requires libffi on your system" {failure}
+  dev-repo: "git+http://github.com/yallop/ocaml-ctypes.git"
+}
+package "digestif" {
+  opam-version: "2.0"
+  version: "0.9.0"
+  synopsis: "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+  description: """\
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * SHA3
+ * WHIRLPOOL
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160"""
+  maintainer: [
+    "Eyyüb Sari <eyyub.sari@epitech.eu>"
+    "Romain Calascibetta <romain.calascibetta@gmail.com>"
+  ]
+  authors: [
+    "Eyyüb Sari <eyyub.sari@epitech.eu>"
+    "Romain Calascibetta <romain.calascibetta@gmail.com>"
+  ]
+  license: "MIT"
+  homepage: "https://github.com/mirage/digestif"
+  doc: "https://mirage.github.io/digestif/"
+  bug-reports: "https://github.com/mirage/digestif/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "2.6.0"}
+    "eqaf"
+    "base-bytes"
+    "bigarray-compat"
+    "stdlib-shims"
+    "fmt" {with-test}
+    "alcotest" {with-test}
+    "bos" {with-test}
+    "astring" {with-test}
+    "fpath" {with-test}
+    "rresult" {with-test}
+    "ocamlfind" {build & with-test}
+  ]
+  depopts: ["ocaml-freestanding" "mirage-xen-posix"]
+  conflicts: [
+    "mirage-xen-posix" {< "3.1.0"}
+    "ocaml-freestanding" {< "0.4.3"}
+  ]
+  available: arch != "s390x"
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["./install/install.ml"]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  install: [
+    ["dune" "install" "-p" name] {with-test}
+    ["./test/test_runes.ml"] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/digestif.git"
+  url {
+    src:
+      "https://github.com/mirage/digestif/releases/download/v0.9.0/digestif-v0.9.0.tbz"
+    checksum: [
+      "sha256=040f1558635c7fc49609406866ab1752e26ae4fcfae01f31d2dd902b5fbe696e"
+      "sha512=a3b904ed1b3e2354f5efd71ee546041d2bb31091161597acb82e4bc2d0686b34d348adba1aef5b927efa28e1764b60f65c171019dd11952c72a76c92510878ee"
+    ]
+  }
+}
+package "domain-name" {
+  opam-version: "2.0"
+  version: "0.3.0"
+  synopsis: "RFC 1035 Internet domain names"
+  description: """\
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner."""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: "Hannes Mehnert <hannes@mehnert.org>"
+  license: "ISC"
+  homepage: "https://github.com/hannesm/domain-name"
+  doc: "https://hannesm.github.io/domain-name/doc"
+  bug-reports: "https://github.com/hannesm/domain-name/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "dune"
+    "fmt"
+    "astring"
+    "alcotest" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/hannesm/domain-name.git"
+  url {
+    src:
+      "https://github.com/hannesm/domain-name/releases/download/v0.3.0/domain-name-v0.3.0.tbz"
+    checksum: [
+      "sha256=4dd9ed1bc619886d1adcaff14edfb503dedb77fc0b7a28d88d213aa1c44d6c8a"
+      "sha512=8229766b20a44622d3a94250c6909dbe64269aab6dde8dd13f6b1c027d63e119658fd35b459c6556817ab583bbfdbc5dbea97d3022f590184d70a72ecd7c0a34"
+    ]
+  }
+}
+package "dot-merlin-reader" {
+  opam-version: "2.0"
+  version: "4.2"
+  synopsis: "Reads config files for merlin"
+  description:
+    "Helper process: reads .merlin files and gives the normalized content to merlin"
+  maintainer: "defree@gmail.com"
+  authors: "The Merlin team"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/merlin"
+  bug-reports: "https://github.com/ocaml/merlin/issues"
+  depends: [
+    "ocaml" {>= "4.08" & < "5.0.0"}
+    "dune" {>= "2.9.0"}
+    "yojson" {>= "1.6.0"}
+    "ocamlfind" {>= "1.6.0"}
+    "csexp" {>= "1.5.1"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocaml/merlin.git"
+  url {
+    src:
+      "https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz"
+    checksum: [
+      "sha256=31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+      "sha512=cc2cf2c208091b3ae435a8124617e56f2002b7091532002ab49a1f817d90a5c4f9cf0bc5741dc7f2526e0352c3ca95b42c3b3a17c6cbfb80ad73d42310a25d22"
+    ]
+  }
+  x-commit-hash: "cc1582373e5baea1d236a63be39493858032a182"
+}
+package "dune" {
+  opam-version: "2.0"
+  version: "3.3.1"
+  synopsis: "Fast, portable, and opinionated build system"
+  description: """\
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free."""
+  maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+  authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/dune"
+  doc: "https://dune.readthedocs.io/"
+  bug-reports: "https://github.com/ocaml/dune/issues"
+  depends: [
+    ("ocaml" {>= "4.08"} |
+     ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+    "base-unix"
+    "base-threads"
+  ]
+  conflicts: [
+    "merlin" {< "3.4.0"}
+    "ocaml-lsp-server" {< "1.3.0"}
+    "dune-configurator" {< "2.3.0"}
+    "odoc" {< "2.0.1"}
+    "dune-release" {< "1.3.0"}
+    "js_of_ocaml-compiler" {< "3.6.0"}
+    "jbuilder" {= "transition"}
+  ]
+  build: [
+    ["ocaml" "bootstrap.ml" "-j" jobs]
+    [
+      "./dune.exe"
+      "build"
+      "dune.install"
+      "--release"
+      "--profile"
+      "dune-bootstrap"
+      "-j"
+      jobs
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml/dune.git"
+  url {
+    src:
+      "https://github.com/ocaml/dune/releases/download/3.3.1/dune-3.3.1.tbz"
+    checksum: [
+      "sha256=840c80491bfe12bab5f2b99d49e163f3e4c4d2fc4b4a3e6fb16c24dccd5502e1"
+      "sha512=b5d7639336b5df8cf37b8aac45906c6d0ff7e38b1a4a2c6ddb616ea81cdc5a8ff36cecf3d4ee4ff9282c835ed2958d4702ae1b3dd1f048c4269f5e7fedbe50d5"
+    ]
+  }
+  x-commit-hash: "b3232b22e13ff2fe4db994ba7ae3db727d1493cd"
+}
+package "dune-build-info" {
+  opam-version: "2.0"
+  version: "3.1.1"
+  synopsis: "Embed build informations inside executable"
+  description: """\
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built."""
+  maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+  authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/dune"
+  doc: "https://dune.readthedocs.io/"
+  bug-reports: "https://github.com/ocaml/dune/issues"
+  depends: [
+    "dune" {>= "3.0"}
+    "ocaml" {>= "4.08"}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["rm" "-rf" "vendor/csexp"]
+    ["rm" "-rf" "vendor/pp"]
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/ocaml/dune.git"
+  url {
+    src:
+      "https://github.com/ocaml/dune/releases/download/3.1.1/fiber-3.1.1.tbz"
+    checksum: [
+      "sha256=02484454ab1b998840c7873509ec6b2301eb92662c132ef8f5f4f569b35a6b60"
+      "sha512=c92199924af75f801d264d3b3e98497757c9932d8e03fa100fca2df16315b87d595a3e0cbbc3ce9b8d86adb2a8b6d3a7cef0f88c7654f15f6b6a4d10d523fad1"
+    ]
+  }
+  x-commit-hash: "09eac98ced1fff7dea4e5ac45b59e00c1874067e"
+}
+package "dune-configurator" {
+  opam-version: "2.0"
+  version: "2.8.2"
+  synopsis: "Helper library for gathering system configuration"
+  description: """\
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file"""
+  maintainer: "Jane Street Group, LLC"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/dune"
+  doc: "https://dune.readthedocs.io/"
+  bug-reports: "https://github.com/ocaml/dune/issues"
+  depends: [
+    "dune" {>= "2.8"}
+    "ocaml" {>= "4.03.0"}
+    "result"
+    "csexp" {>= "1.3.0"}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/ocaml/dune.git"
+  url {
+    src:
+      "https://github.com/ocaml/dune/releases/download/2.8.2/dune-2.8.2.tbz"
+    checksum: [
+      "sha256=e2c4e8230f7c96236503fd75f22bdbc263639971bf104509e446855ded35ae1e"
+      "sha512=d3cca73f5a72440273f7b4e3934dfa7e89fcb64710f3c734d2583123f5d9f3e573f0ab96a4892b2f11313038da6b4e2c614951199ffef0a3f12669d729b25376"
+    ]
+  }
+  x-commit-hash: "6c471da57bea666267a8a63034aed57962f378b0"
+}
+package "dune-private-libs" {
+  opam-version: "2.0"
+  version: "2.6.2"
+  synopsis: "Private libraries of Dune"
+  description: """\
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee."""
+  maintainer: "Jane Street Group, LLC"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/dune"
+  doc: "https://dune.readthedocs.io/"
+  bug-reports: "https://github.com/ocaml/dune/issues"
+  depends: [
+    "dune" {>= "2.5"}
+    "ocaml" {>= "4.07" & < "5.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/ocaml/dune.git"
+  url {
+    src:
+      "https://github.com/ocaml/dune/releases/download/2.6.2/dune-2.6.2.tbz"
+    checksum: [
+      "sha256=4f6ec1f3f27ac48753d03b4a172127e4a56ae724201a3a18dc827c94425788e9"
+      "sha512=d195479c99a59edb0cb7674375f45e518389b2f251b02e5f603c196b9592acbcf2a12193b3de70831a543fa477f57abb101fdd210660e25805b147c66877cafa"
+    ]
+  }
+}
+package "duration" {
+  opam-version: "2.0"
+  version: "0.2.1"
+  synopsis: "Conversions to various time units"
+  description: """\
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input."""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: "Hannes Mehnert <hannes@mehnert.org>"
+  license: "ISC"
+  homepage: "https://github.com/hannesm/duration"
+  doc: "https://hannesm.github.io/duration/doc"
+  bug-reports: "https://github.com/hannesm/duration/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "dune" {>= "1.0"}
+    "alcotest" {with-test & >= "0.8.1"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/hannesm/duration.git"
+  url {
+    src:
+      "https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz"
+    checksum: [
+      "sha256=c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b"
+      "sha512=0de9e15c7d6188872ddd9994f08616c4a1822e4ac92724efa2c312fbb2fc44cd7cbe4b36bcf66a8451d510c1fc95de481760afbcacb8f83e183262595dcf5f0c"
+    ]
+  }
+  x-commit-hash: "6abe42ebe585a96f79eb91045911b9a73c1db19e"
+}
+package "easy-format" {
+  opam-version: "2.0"
+  version: "1.3.2"
+  synopsis:
+    "High-level and functional interface to the Format module of the OCaml standard library"
+  description: """\
+This module offers a high-level and functional interface to the Format module of
+the OCaml standard library. It is a pretty-printing facility, i.e. it takes as
+input some code represented as a tree and formats this code into the most
+visually satisfying result, breaking and indenting lines of code where
+appropriate.
+
+Input data must be first modelled and converted into a tree using 3 kinds of
+nodes:
+
+* atoms
+* lists
+* labelled nodes
+
+Atoms represent any text that is guaranteed to be printed as-is. Lists can model
+any sequence of items such as arrays of data or lists of definitions that are
+labelled with something like "int main", "let x =" or "x:"."""
+  maintainer: ["martin@mjambon.com" "rudi.grinberg@gmail.com"]
+  authors: "Martin Jambon"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/mjambon/easy-format"
+  doc: "https://mjambon.github.io/easy-format/"
+  bug-reports: "https://github.com/mjambon/easy-format/issues"
+  depends: [
+    "dune" {>= "1.10"}
+    "ocaml" {>= "4.02.3" & < "5.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "-p" name "@doc"] {with-doc}
+  ]
+  dev-repo: "git+https://github.com/mjambon/easy-format.git"
+  url {
+    src:
+      "https://github.com/mjambon/easy-format/releases/download/1.3.2/easy-format-1.3.2.tbz"
+    checksum: [
+      "sha256=3440c2b882d537ae5e9011eb06abb53f5667e651ea4bb3b460ea8230fa8c1926"
+      "sha512=e39377a2ff020ceb9ac29e8515a89d9bdbc91dfcfa871c4e3baafa56753fac2896768e5d9822a050dc1e2ade43c8967afb69391a386c0a8ecd4e1f774e236135"
+    ]
+  }
+}
+package "either" {
+  opam-version: "2.0"
+  version: "1.0.0"
+  synopsis: "Compatibility Either module"
+  description: """\
+Projects that want to use the Either module defined in OCaml 4.12.0 while
+staying compatible with older versions of OCaml should use this library
+instead."""
+  maintainer: "Craig Ferguson <me@craigfe.io>"
+  authors: "Craig Ferguson <me@craigfe.io>"
+  license: "MIT"
+  homepage: "https://github.com/mirage/either"
+  doc: "https://mirage.github.io/either"
+  bug-reports: "https://github.com/mirage/either/issues"
+  depends: [
+    "dune" {>= "2.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/mirage/either.git"
+  url {
+    src:
+      "https://github.com/mirage/either/releases/download/1.0.0/either-1.0.0.tbz"
+    checksum: [
+      "sha256=bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884"
+      "sha512=147854c09f897dd028b18a9f19acea8666107aaa7b1aab3c92f568af531364f57298edcaf3897d74246d3857d52e9bfb7ad0fc39220d988d9f14694ca1d5e9ed"
+    ]
+  }
+  x-commit-hash: "a270ceac58e3e5bed6fe7e8bfb7132b14ee9c322"
+}
+package "eqaf" {
+  opam-version: "2.0"
+  version: "0.9"
+  synopsis: "Constant-time equal function on string"
+  description:
+    "This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff."
+  maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+  authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+  license: "MIT"
+  homepage: "https://github.com/mirage/eqaf"
+  doc: "https://mirage.github.io/eqaf/"
+  bug-reports: "https://github.com/mirage/eqaf/issues"
+  depends: [
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "2.0"}
+    "cstruct" {>= "1.1.0"}
+    "base64" {with-test}
+    "alcotest" {with-test}
+    "crowbar" {with-test}
+    "fmt" {with-test & >= "0.8.7"}
+    "bechamel" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose"]
+      {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/eqaf.git"
+  url {
+    src: "https://github.com/mirage/eqaf/releases/download/v0.9/eqaf-0.9.tbz"
+    checksum: [
+      "sha256=ec0e28a946ac6817f95d5854f05a9961ae3a8408bb610e79cfad01b9b255dfe0"
+      "sha512=4df7fd3ea35156953a172c1a021aab05b8b122ee8d3cfdb34f96edb1b5133d1fe2721b90cb64287841d770b16c2ffe70559c66e90f8d61a92b73857da22548c4"
+    ]
+  }
+  x-commit-hash: "e878ed56e40ca05c851a0e3297ab00ab76b10e0e"
+}
+package "extlib" {
+  opam-version: "2.0"
+  version: "1.7.8"
+  synopsis:
+    "A complete yet small extension for OCaml standard library (reduced, recommended)"
+  description: """\
+The purpose of this library is to add new functions to OCaml standard library
+modules, to modify some functions in order to get better performances or
+safety (tail-recursive) and also to provide new modules which should be useful
+for day to day programming.
+
+Current goal is to maintain compatibility, new software is encouraged to not use extlib since stdlib
+is now seeing many additions and improvements which make many parts of extlib obsolete.
+For tail-recursion safety consider using other libraries e.g. containers."""
+  maintainer: "ygrek@autistici.org"
+  authors: [
+    "Nicolas Cannasse"
+    "Brian Hurt"
+    "Yamagata Yoriyuki"
+    "Markus Mottl"
+    "Jesse Guardiani"
+    "John Skaller"
+    "Bardur Arantsson"
+    "Janne Hellsten"
+    "Richard W.M. Jones"
+    "ygrek"
+    "Gabriel Scherer"
+    "Pietro Abate"
+  ]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ygrek/ocaml-extlib"
+  doc: "https://ygrek.org/p/extlib/doc/"
+  bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
+  depends: [
+    "ocaml" {< "5.0"}
+    "ocamlfind" {build}
+    "cppo" {build}
+    "base-bytes" {build}
+  ]
+  build: [
+    [make "minimal=1" "build"]
+    [make "minimal=1" "test"] {with-test}
+    [make "minimal=1" "doc"] {with-doc}
+  ]
+  install: [make "minimal=1" "install"]
+  dev-repo: "git+https://github.com/ygrek/ocaml-extlib.git"
+  url {
+    src: "https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.8.tar.gz"
+    checksum: [
+      "md5=7e0df072af4e2daa094e5936a661cb11"
+      "sha256=935ca46843af40dc33306d9cce66163d3733312bf444e969b5a8fa3f3024f85a"
+      "sha512=664a8366fb4eed685bd8f8907dbc9a8103bbf75ebb5d7635f6db890722e673107aa052bd09c276f5ed10dc3695220234c382d90d4f8c4e6b93ff68dd22e876e4"
+    ]
+    mirrors:
+      "https://github.com/ygrek/ocaml-extlib/releases/download/1.7.8/extlib-1.7.8.tar.gz"
+  }
+}
+package "fieldslib" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/fieldslib"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/fieldslib/index.html"
+  bug-reports: "https://github.com/janestreet/fieldslib/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/fieldslib.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/fieldslib-v0.14.0.tar.gz"
+    checksum: "md5=4fbf05d88be119e883abecba8c33cb85"
+  }
+}
+package "fix" {
+  opam-version: "2.0"
+  version: "20201120"
+  synopsis: "Facilities for memoization and fixed points"
+  maintainer: "francois.pottier@inria.fr"
+  authors: "François Pottier <francois.pottier@inria.fr>"
+  homepage: "https://gitlab.inria.fr/fpottier/fix"
+  bug-reports: "francois.pottier@inria.fr"
+  depends: [
+    "ocaml" {>= "4.03" & < "5.0"}
+    "dune" {>= "1.3"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+  url {
+    src:
+      "https://gitlab.inria.fr/fpottier/fix/-/archive/20201120/archive.tar.gz"
+    checksum: [
+      "md5=7eb570b759635fe66f3556d2b1cc88e3"
+      "sha512=344dcc619f9e8b8a6c998775b6d2dab2ea5253e6a67abe4797f76dc5dd30bc776568abce1e90477422e9db447821579889737e3531c42139708f813e983ea5d4"
+    ]
+  }
+}
+package "fmt" {
+  opam-version: "2.0"
+  version: "0.8.6"
+  synopsis: "OCaml Format pretty-printer combinators"
+  description: """\
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The fmt programmers"
+  license: "ISC"
+  tags: ["string" "format" "pretty-print" "org:erratique"]
+  homepage: "https://erratique.ch/software/fmt"
+  doc: "https://erratique.ch/software/fmt"
+  bug-reports: "https://github.com/dbuenzli/fmt/issues"
+  depends: [
+    "ocaml" {>= "4.03.0" & < "5.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build & >= "0.9.0"}
+    "seq"
+    "stdlib-shims"
+  ]
+  depopts: ["base-unix" "cmdliner"]
+  conflicts: [
+    "cmdliner" {< "0.9.8"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--dev-pkg"
+    "%{pinned}%"
+    "--with-base-unix"
+    "%{base-unix:installed}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  dev-repo: "git+https://erratique.ch/repos/fmt.git"
+  url {
+    src: "https://erratique.ch/software/fmt/releases/fmt-0.8.6.tbz"
+    checksum: "md5=5407789e5f0ea42272ca19353b1abfd3"
+  }
+}
+package "fpath" {
+  opam-version: "2.0"
+  version: "0.7.3"
+  synopsis: "File system paths for OCaml"
+  description: """\
+Fpath is an OCaml module for handling file system paths with POSIX or
+Windows conventions. Fpath processes paths without accessing the file
+system and is independent from any system library.
+
+Fpath depends on [Astring][astring] and is distributed under the ISC
+license.
+
+[astring]: http://erratique.ch/software/astring"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The fpath programmers"
+  license: "ISC"
+  tags: ["file" "system" "path" "org:erratique"]
+  homepage: "https://erratique.ch/software/fpath"
+  doc: "https://erratique.ch/software/fpath/doc"
+  bug-reports: "https://github.com/dbuenzli/fpath/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build & >= "0.9.0"}
+    "astring"
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--dev-pkg=true" {dev}
+  ]
+  dev-repo: "git+https://erratique.ch/repos/fpath.git"
+  url {
+    src: "https://erratique.ch/software/fpath/releases/fpath-0.7.3.tbz"
+    checksum: "md5=0740b530e8fed5b0adc5eee8463cfc2f"
+  }
+}
+package "graphql" {
+  opam-version: "2.0"
+  version: "0.13.0"
+  synopsis: "Build GraphQL schemas and execute queries against them"
+  description: """\
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
+
+- Type-safe schema design
+- GraphQL parser in pure OCaml using Menhir
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
+- Subscriptions
+
+Supporting packages:
+
+- Use `graphql-lwt` for Lwt support.
+- Use `graphql-async` for Async support.
+- Use `graphql-cohttp` to run a GraphQL server with `cohttp`."""
+  maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  homepage: "https://github.com/andreas/ocaml-graphql-server"
+  doc: "https://andreas.github.io/ocaml-graphql-server/"
+  bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "graphql_parser" {>= "0.9.0"}
+    "yojson" {< "2.0.0"}
+    "rresult" {>= "0.3.0"}
+    "seq"
+    "alcotest" {with-test}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+  url {
+    src:
+      "https://github.com/andreas/ocaml-graphql-server/releases/download/0.13.0/graphql-0.13.0.tbz"
+    checksum: "md5=089104444ae28ebcfa85fec88628507a"
+  }
+}
+package "graphql-async" {
+  opam-version: "2.0"
+  version: "0.13.0"
+  synopsis: "Build GraphQL schemas with Async support"
+  description:
+    "`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."
+  maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  homepage: "https://github.com/andreas/ocaml-graphql-server"
+  doc: "https://andreas.github.io/ocaml-graphql-server/"
+  bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "graphql" {>= "0.13.0" & < "0.14.0"}
+    "async_kernel" {>= "v0.9.0" & < "v0.15"}
+    "alcotest" {with-test}
+    "async_unix" {with-test & >= "v0.9.0" & < "v0.15"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+  url {
+    src:
+      "https://github.com/andreas/ocaml-graphql-server/releases/download/0.13.0/graphql-0.13.0.tbz"
+    checksum: "md5=089104444ae28ebcfa85fec88628507a"
+  }
+}
+package "graphql-cohttp" {
+  opam-version: "2.0"
+  version: "0.13.0"
+  synopsis: "Run GraphQL servers with `cohttp`"
+  description:
+    "This package allows you to execute Cohttp HTTP requests against GraphQL schemas build with `graphql`. The package is agnostic to Lwt/Async."
+  maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  license: "MIT"
+  homepage: "https://github.com/andreas/ocaml-graphql-server"
+  doc: "https://andreas.github.io/ocaml-graphql-server/"
+  bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "graphql" {>= "0.13.0"}
+    "cohttp" {>= "2.0.0"}
+    "crunch"
+    "astring" {>= "0.8.3"}
+    "base64" {>= "3.0.0"}
+    "ocplib-endian" {>= "1.0"}
+    "digestif" {>= "0.7.0"}
+    "yojson" {>= "1.6.0"}
+    "alcotest" {with-test}
+    "cohttp-lwt-unix" {with-test}
+    "graphql-lwt" {with-test}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+  url {
+    src:
+      "https://github.com/andreas/ocaml-graphql-server/releases/download/0.13.0/graphql-0.13.0.tbz"
+    checksum: "md5=089104444ae28ebcfa85fec88628507a"
+  }
+}
+package "graphql-lwt" {
+  opam-version: "2.0"
+  version: "0.13.0"
+  synopsis: "Build GraphQL schemas with Lwt support"
+  description:
+    "`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions."
+  maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  homepage: "https://github.com/andreas/ocaml-graphql-server"
+  doc: "https://andreas.github.io/ocaml-graphql-server/"
+  bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.1"}
+    "graphql" {>= "0.13.0" & < "0.14.0"}
+    "alcotest" {with-test}
+    "lwt"
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+  url {
+    src:
+      "https://github.com/andreas/ocaml-graphql-server/releases/download/0.13.0/graphql-0.13.0.tbz"
+    checksum: "md5=089104444ae28ebcfa85fec88628507a"
+  }
+}
+package "graphql_parser" {
+  opam-version: "2.0"
+  version: "0.12.2"
+  synopsis: "Library for parsing GraphQL queries"
+  maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+  homepage: "https://github.com/andreas/ocaml-graphql-server"
+  doc: "https://andreas.github.io/ocaml-graphql-server/"
+  bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune" {>= "1.4"}
+    "menhir" {build & >= "20180523"}
+    "alcotest" {with-test & >= "0.8.1"}
+    "fmt" {>= "0.8.0" & < "0.8.7"}
+    "re" {>= "1.5.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+  url {
+    src:
+      "https://github.com/andreas/ocaml-graphql-server/releases/download/0.12.2/graphql-0.12.2.tbz"
+    checksum: "md5=d7c79e9527a57051b40c005c36cf236f"
+  }
+}
 package "graphql_ppx" {
   opam-version: "2.0"
   version: "1.2.2"
@@ -416,6 +3365,3964 @@ package "graphql_ppx" {
       "https://github.com/o1-labs/graphql_ppx/archive/f3ba4f7622240a2299f622b0c1d910f734579c25.tar.gz"
     checksum:
       "sha256=8aff33988218c99a95a91fb04ef703a3b8cde0676b7a90ee72478959829867d8"
+  }
+}
+package "incremental" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Library for incremental computations"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/incremental"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/incremental/index.html"
+  bug-reports: "https://github.com/janestreet/incremental/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/incremental.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/incremental-v0.14.0.tar.gz"
+    checksum: "md5=01098e7e363cb403b52fcbe625d46641"
+  }
+}
+package "integers" {
+  opam-version: "2.0"
+  version: "0.4.0"
+  synopsis: "Various signed and unsigned integer types for OCaml"
+  maintainer: "yallop@gmail.com"
+  authors: [
+    "Jeremy Yallop" "Demi Obenour" "Stephane Glondu" "Andreas Hauptmann"
+  ]
+  license: "MIT"
+  homepage: "https://github.com/yallop/ocaml-integers"
+  doc: "http://yallop.github.io/ocaml-integers/api.docdir/"
+  bug-reports: "https://github.com/yallop/ocaml-integers/issues"
+  depends: [
+    "ocaml" {>= "4.02" & < "5.0"}
+    "dune"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/yallop/ocaml-integers.git"
+  url {
+    src: "https://github.com/yallop/ocaml-integers/archive/0.4.0.tar.gz"
+    checksum: "md5=c1492352e6525048790508c57aad93c3"
+  }
+}
+package "ipaddr" {
+  opam-version: "2.0"
+  version: "5.0.1"
+  synopsis:
+    "A library for manipulation of IP (and MAC) address representations"
+  description: """\
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers"""
+  maintainer: "anil@recoil.org"
+  authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-ipaddr"
+  doc: "https://mirage.github.io/ocaml-ipaddr/"
+  bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.9.0"}
+    "macaddr" {= version}
+    "stdlib-shims"
+    "domain-name" {>= "0.3.0"}
+    "ounit" {with-test}
+    "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.1/ipaddr-v5.0.1.tbz"
+    checksum: [
+      "sha256=00f7c3c38cff938d3ace70dd32e6d3103390567c9030b406ba85840f01d76602"
+      "sha512=0c01117255692f929bb99ba0f7b973859bebb09e7d738adb72954471099a6a4d10741cd5796415fa106f04169c2b5455fa669d4a7fee400505bd3ba005b5b7fb"
+    ]
+  }
+  x-commit-hash: "dc36c61789255003bb10c95f550b64fad33f600e"
+}
+package "ipaddr-sexp" {
+  opam-version: "2.0"
+  version: "5.0.1"
+  synopsis:
+    "A library for manipulation of IP address representations usnig sexp"
+  description: "Sexp convertions for ipaddr"
+  maintainer: "anil@recoil.org"
+  authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-ipaddr"
+  doc: "https://mirage.github.io/ocaml-ipaddr/"
+  bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.9.0"}
+    "sexplib0"
+    "ipaddr" {= version}
+    "ipaddr-cstruct" {with-test & = version}
+    "ounit" {with-test}
+    "ppx_sexp_conv" {>= "v0.9.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.1/ipaddr-v5.0.1.tbz"
+    checksum: [
+      "sha256=00f7c3c38cff938d3ace70dd32e6d3103390567c9030b406ba85840f01d76602"
+      "sha512=0c01117255692f929bb99ba0f7b973859bebb09e7d738adb72954471099a6a4d10741cd5796415fa106f04169c2b5455fa669d4a7fee400505bd3ba005b5b7fb"
+    ]
+  }
+  x-commit-hash: "dc36c61789255003bb10c95f550b64fad33f600e"
+}
+package "jane-street-headers" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Jane Street C header files"
+  description:
+    "C header files shared between the various Jane Street packages"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/jane-street-headers"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/jane-street-headers/index.html"
+  bug-reports: "https://github.com/janestreet/jane-street-headers/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/jane-street-headers.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/jane-street-headers-v0.14.0.tar.gz"
+    checksum: "md5=e8d253ac44d25c8c66367153a0c77495"
+  }
+}
+package "js_of_ocaml" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "Compiler from OCaml bytecode to JavaScript"
+  description:
+    "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+  maintainer: "Ocsigen team <dev@ocsigen.org>"
+  authors: "Ocsigen team <dev@ocsigen.org>"
+  license:
+    "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+  depends: [
+    "dune" {>= "2.9"}
+    "ocaml" {>= "4.04"}
+    "js_of_ocaml-compiler" {= version}
+    "ppxlib" {>= "0.15"}
+    "uchar"
+    "num" {with-test}
+    "ppx_expect" {>= "v0.14.2" & with-test}
+    "re" {>= "1.9.0" & with-test}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files=false"
+      "@install"
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+  url {
+    src:
+      "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+    checksum: [
+      "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+      "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+    ]
+  }
+  x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+}
+package "js_of_ocaml-compiler" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "Compiler from OCaml bytecode to JavaScript"
+  description:
+    "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+  maintainer: "Ocsigen team <dev@ocsigen.org>"
+  authors: "Ocsigen team <dev@ocsigen.org>"
+  license:
+    "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+  depends: [
+    "dune" {>= "2.9"}
+    "ocaml" {>= "4.04" & < "4.15"}
+    "num" {with-test}
+    "ppx_expect" {>= "v0.14.2" & with-test}
+    "ppxlib" {>= "0.15.0"}
+    "re" {with-test}
+    "cmdliner" {>= "1.0.0"}
+    "menhir"
+    "menhirLib"
+    "menhirSdk"
+    "yojson"
+    "odoc" {with-doc}
+  ]
+  depopts: ["ocamlfind"]
+  conflicts: [
+    "ocamlfind" {< "1.5.1"}
+    "js_of_ocaml" {< "3.0"}
+    "base-domains"
+    "ocaml-option-bytecode-only"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files=false"
+      "@install"
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+  url {
+    src:
+      "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+    checksum: [
+      "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+      "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+    ]
+  }
+  x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+}
+package "js_of_ocaml-ppx" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "Compiler from OCaml bytecode to JavaScript"
+  description:
+    "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+  maintainer: "Ocsigen team <dev@ocsigen.org>"
+  authors: "Ocsigen team <dev@ocsigen.org>"
+  license:
+    "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+  depends: [
+    "dune" {>= "2.9"}
+    "ocaml" {>= "4.04"}
+    "js_of_ocaml" {= version}
+    "ppxlib" {>= "0.15.0"}
+    "num" {with-test}
+    "ppx_expect" {>= "v0.14.2" & with-test}
+    "re" {>= "1.9.0" & with-test}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files=false"
+      "@install"
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+  url {
+    src:
+      "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+    checksum: [
+      "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+      "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+    ]
+  }
+  x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+}
+package "js_of_ocaml-toplevel" {
+  opam-version: "2.0"
+  version: "4.0.0"
+  synopsis: "Compiler from OCaml bytecode to JavaScript"
+  description:
+    "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+  maintainer: "Ocsigen team <dev@ocsigen.org>"
+  authors: "Ocsigen team <dev@ocsigen.org>"
+  license:
+    "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+  bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+  depends: [
+    "dune" {>= "2.9"}
+    "ocaml" {>= "4.04"}
+    "js_of_ocaml" {= version}
+    "js_of_ocaml-compiler" {= version}
+    "js_of_ocaml-ppx" {= version}
+    "ocamlfind" {>= "1.5.1"}
+    "cohttp-lwt-unix" {with-test}
+    "graphics" {with-test}
+    "num" {with-test}
+    "ppx_expect" {>= "v0.14.2" & with-test}
+    "ppxlib" {>= "0.15" & with-test}
+    "re" {>= "1.9.0" & with-test}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files=false"
+      "@install"
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+  url {
+    src:
+      "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+    checksum: [
+      "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+      "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+    ]
+  }
+  x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+}
+package "jsonm" {
+  opam-version: "2.0"
+  version: "1.0.1"
+  synopsis: "Non-blocking streaming JSON codec for OCaml"
+  description: """\
+Jsonm is a non-blocking streaming codec to decode and encode the JSON
+data format. It can process JSON text without blocking on IO and
+without a complete in-memory representation of the data.
+
+The alternative "uncut" codec also processes whitespace and
+(non-standard) JSON with JavaScript comments.
+
+Jsonm is made of a single module and depends on [Uutf][uutf]. It is distributed
+under the ISC license.
+
+[uutf]: http://erratique.ch/software/uutf"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["json" "codec" "org:erratique"]
+  homepage: "http://erratique.ch/software/jsonm"
+  doc: "http://erratique.ch/software/jsonm/doc/Jsonm"
+  bug-reports: "https://github.com/dbuenzli/jsonm/issues"
+  depends: [
+    "ocaml" {>= "4.01.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+    "uchar"
+    "uutf" {>= "1.0.0"}
+  ]
+  build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  dev-repo: "git+http://erratique.ch/repos/jsonm.git"
+  url {
+    src: "http://erratique.ch/software/jsonm/releases/jsonm-1.0.1.tbz"
+    checksum: "md5=e2ca39eaefd55b8d155c4f1ec5885311"
+  }
+}
+package "jst-config" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Compile-time configuration for Jane Street libraries"
+  description: """\
+Defines compile-time constants used in Jane Street libraries such as Base, Core, and
+Async.
+
+This package has an unstable interface; it is intended only to share configuration between
+different packages from Jane Street. Future updates may not be backward-compatible, and we
+do not recommend using this package directly."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/jst-config"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/jst-config/index.html"
+  bug-reports: "https://github.com/janestreet/jst-config/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_assert" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "dune-configurator"
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/jst-config.git"
+  url {
+    src:
+      "https://github.com/janestreet/jst-config/archive/refs/tags/v0.14.1.tar.gz"
+    checksum: "md5=ca0d970356cc99b0a5660058a93ff589"
+  }
+}
+package "lambda-term" {
+  opam-version: "2.0"
+  version: "3.1.0"
+  synopsis: "Terminal manipulation library for OCaml"
+  description: """\
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+  maintainer: "jeremie@dimino.org"
+  authors: "Jérémie Dimino"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-community/lambda-term"
+  bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "lwt" {>= "4.2.0"}
+    "lwt_log"
+    "react"
+    "zed" {>= "3.1.0" & < "3.2.0"}
+    "camomile" {>= "1.0.1" & < "2.0.0"}
+    "lwt_react"
+    "mew_vi" {>= "0.5.0" & < "0.6.0"}
+    "dune" {>= "1.1.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-community/lambda-term.git"
+  url {
+    src:
+      "https://github.com/ocaml-community/lambda-term/archive/3.1.0.tar.gz"
+    checksum: "md5=78180c04ecfc8060b23d7d0014f24196"
+  }
+}
+package "lens" {
+  opam-version: "2.0"
+  version: "1.2.5"
+  synopsis: "Functional lenses"
+  description: """\
+Based on F# implementation in https://github.com/fsharp/fsharpx
+see https://github.com/fsharp/fsharpx/blob/master/src/FSharpx.Extras/Lens.fs for the original implementation
+see http://bugsquash.blogspot.com/2011/11/lenses-in-f.html -  Lenses in F#
+see http://stackoverflow.com/questions/8179485/updating-nested-immutable-data-structures - Stackoverflow question about Updating nested immutable data structures
+see http://stackoverflow.com/questions/5767129/lenses-fclabels-data-accessor-which-library-for-structure-access-and-mutatio - Haskell libraries for structure access and mutation
+see http://www.youtube.com/watch?v=efv0SQNde5Q - Functional lenses for Scala by Edward Kmett on YouTube
+see http://patternsinfp.wordpress.com/2011/01/31/lenses-are-the-coalgebras-for-the-costate-comonad - Lenses are the coalgebras for the costate comonad by Jeremy Gibbons"""
+  maintainer: "Paolo Donadeo <p.donadeo@gmail.com>"
+  authors: "Alessandro Strada <alessandro.strada@gmail.com>"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/pdonadeo/ocaml-lens"
+  bug-reports: "https://github.com/pdonadeo/ocaml-lens/issues"
+  depends: [
+    "ocaml" {>= "4.10"}
+    "ppx_deriving" {>= "5.1"}
+    "ppxlib" {>= "0.14.0"}
+    "dune" {>= "1.0"}
+    "ounit" {with-test}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/pdonadeo/ocaml-lens.git"
+  url {
+    src: "https://github.com/pdonadeo/ocaml-lens/archive/v1.2.5.tar.gz"
+    checksum: "md5=92e4f12cc563927b03953d293a2676be"
+  }
+}
+package "lmdb" {
+  opam-version: "2.0"
+  version: "1.0"
+  synopsis:
+    "Bindings for LMDB, a fast in-file database with ACID transactions"
+  maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+  authors: [
+    "Gabriel Radanne <drupyog@zoho.com>"
+    "Christopher Zimmermann <christopher@gmerlin.de>"
+  ]
+  license: "MIT"
+  tags: ["clib:lmdb" "database"]
+  homepage: "https://github.com/Drup/ocaml-lmdb"
+  doc: "https://drup.github.io/ocaml-lmdb/dev/lmdb/Lmdb/index.html"
+  bug-reports: "https://github.com/Drup/ocaml-lmdb/issues"
+  depends: [
+    "ocaml" {>= "4.03"}
+    "bigstringaf"
+    "dune" {>= "1.2"}
+    "dune-configurator" {build}
+    "alcotest" {with-test}
+    "benchmark" {with-test}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  depexts: [
+    ["liblmdb-dev"] {os-family = "debian"}
+    ["lmdb"] {os-family = "bsd"}
+    ["lmdb"] {os-family = "homebrew"}
+    ["lmdb"] {os-family = "macports"}
+    ["lmdb"] {os-family = "archlinux"}
+    ["lmdb"] {os-family = "gentoo"}
+    ["lmdb-dev"] {os-family = "alpine"}
+    ["lmdb-devel"] {os-family = "fedora"}
+    ["lmdb-devel"] {os-family = "suse" | os-family = "opensuse"}
+    ["liblmdb-devel"] {os-family = "mageia"}
+  ]
+  dev-repo: "git+https://github.com/Drup/ocaml-lmdb.git"
+  url {
+    src: "https://github.com/Drup/ocaml-lmdb/archive/1.0.tar.gz"
+    checksum: [
+      "md5=0f16e523fedbc513827dcc6819e4654d"
+      "sha512=9c4da6b89d6ab025a5c2d773065ac4101c1fc30b0a63ac7e909dda38906905d25568288bc5d32ae7d860b0010d0488760a94fa4553163a1d5cffedcefbc3af1d"
+    ]
+  }
+}
+package "logs" {
+  opam-version: "2.0"
+  version: "0.7.0"
+  synopsis: "Logging infrastructure for OCaml"
+  description: """\
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The logs programmers"
+  license: "ISC"
+  tags: ["log" "system" "org:erratique"]
+  homepage: "https://erratique.ch/software/logs"
+  doc: "https://erratique.ch/software/logs/doc"
+  bug-reports: "https://github.com/dbuenzli/logs/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+    "mtime" {with-test}
+  ]
+  depopts: ["js_of_ocaml" "fmt" "cmdliner" "lwt" "base-threads"]
+  conflicts: [
+    "cmdliner" {< "0.9.8"}
+    "js_of_ocaml" {< "3.3.0"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pinned"
+    "%{pinned}%"
+    "--with-js_of_ocaml"
+    "%{js_of_ocaml:installed}%"
+    "--with-fmt"
+    "%{fmt:installed}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+    "--with-lwt"
+    "%{lwt:installed}%"
+    "--with-base-threads"
+    "%{base-threads:installed}%"
+  ]
+  dev-repo: "git+https://erratique.ch/repos/logs.git"
+  url {
+    src: "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz"
+    checksum: "md5=2bf021ca13331775e33cf34ab60246f7"
+  }
+}
+package "lwt" {
+  opam-version: "2.0"
+  version: "5.4.0"
+  synopsis: "Promises and event-driven I/O"
+  description: """\
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."""
+  maintainer: [
+    "Raphaël Proust <code@bnwr.net>" "Anton Bachin <antonbachin@yahoo.com>"
+  ]
+  authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+  license: "MIT"
+  homepage: "https://github.com/ocsigen/lwt"
+  doc: "https://ocsigen.org/lwt"
+  bug-reports: "https://github.com/ocsigen/lwt/issues"
+  depends: [
+    "cppo" {build & >= "1.1.0"}
+    "dune" {>= "1.8.0"}
+    "dune-configurator"
+    "mmap" {>= "1.1.0"}
+    "ocaml" {>= "4.02.0" & < "5.0"}
+    ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+    "ocplib-endian"
+    "result"
+    "seq"
+    "ocamlfind" {dev & >= "1.7.3-1"}
+  ]
+  depopts: ["base-threads" "base-unix" "conf-libev"]
+  conflicts: [
+    "ocaml-variants" {= "4.02.1+BER"}
+  ]
+  build: [
+    [
+      "dune"
+      "exec"
+      "-p"
+      name
+      "src/unix/config/discover.exe"
+      "--"
+      "--save"
+      "--use-libev"
+      "%{conf-libev:installed}%"
+    ]
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/lwt.git"
+  url {
+    src: "https://github.com/ocsigen/lwt/archive/5.4.0.zip"
+    checksum: [
+      "md5=fc4721bdb1a01225b96e3a2debde95fa"
+      "sha512=e427f08223b77f9af696c9e6f90ff68e27e02e446910ef90d3da542e7b00bf23dd191ac77c1871288faa2289f8d28fc2f44efc3d3fe9165fe1c7a6be88ee49ff"
+    ]
+  }
+}
+package "lwt_log" {
+  opam-version: "2.0"
+  version: "1.1.1"
+  synopsis: "Lwt logging library (deprecated)"
+  maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+  authors: ["Shawn Wagner" "Jérémie Dimino"]
+  license: "LGPL-2.0-or-later"
+  homepage: "https://github.com/ocsigen/lwt_log"
+  doc:
+    "https://github.com/ocsigen/lwt_log/blob/master/src/core/lwt_log_core.mli"
+  bug-reports: "https://github.com/ocsigen/lwt_log/issues"
+  depends: [
+    "ocaml" {< "5.0"}
+    "dune" {>= "1.0"}
+    "lwt" {>= "4.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
+  url {
+    src: "https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz"
+    checksum: "md5=02e93be62288037870ae5b1ce099fe59"
+  }
+}
+package "lwt_react" {
+  opam-version: "2.0"
+  version: "1.1.2"
+  synopsis: "Helpers for using React with Lwt"
+  maintainer: [
+    "Anton Bachin <antonbachin@yahoo.com>"
+    "Mauricio Fernandez <mfp@acm.org>"
+    "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+  ]
+  authors: "Jérémie Dimino"
+  license: "MIT"
+  homepage: "https://github.com/ocsigen/lwt"
+  doc: "https://ocsigen.org/lwt/api/Lwt_react"
+  bug-reports: "https://github.com/ocsigen/lwt/issues"
+  depends: [
+    "dune"
+    "lwt" {>= "3.0.0"}
+    "ocaml"
+    "react" {>= "1.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocsigen/lwt.git"
+  url {
+    src: "https://github.com/ocsigen/lwt/archive/4.2.0.tar.gz"
+    checksum: "md5=2ce7827948adc611319f9449e4519070"
+  }
+}
+package "macaddr" {
+  opam-version: "2.0"
+  version: "5.0.1"
+  synopsis: "A library for manipulation of MAC address representations"
+  description: """\
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * oUnit-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library."""
+  maintainer: "anil@recoil.org"
+  authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+  license: "ISC"
+  tags: ["org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-ipaddr"
+  doc: "https://mirage.github.io/ocaml-ipaddr/"
+  bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.9.0"}
+    "ounit" {with-test}
+    "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  ]
+  conflicts: [
+    "ipaddr" {< "3.0.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.0.1/ipaddr-v5.0.1.tbz"
+    checksum: [
+      "sha256=00f7c3c38cff938d3ace70dd32e6d3103390567c9030b406ba85840f01d76602"
+      "sha512=0c01117255692f929bb99ba0f7b973859bebb09e7d738adb72954471099a6a4d10741cd5796415fa106f04169c2b5455fa669d4a7fee400505bd3ba005b5b7fb"
+    ]
+  }
+  x-commit-hash: "dc36c61789255003bb10c95f550b64fad33f600e"
+}
+package "magic-mime" {
+  opam-version: "2.0"
+  version: "1.1.2"
+  synopsis: "Map filenames to common MIME types"
+  description: """\
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css\""""
+  maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+  authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+  license: "ISC"
+  homepage: "https://github.com/mirage/ocaml-magic-mime"
+  doc: "https://mirage.github.io/ocaml-magic-mime/"
+  bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "dune"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.1.2/magic-mime-v1.1.2.tbz"
+    checksum: [
+      "sha256=0c590bbc747531b56d392ee8f063d879df1e2026ba2dfa2d1bc98c9a9acb04eb"
+      "sha512=8264db78adc2c75b8adabc23c26ad34eab98383bd3a8f2068f2236ff3425d653c0238fbd7361e55a3d70d843413ef8671b6e97293074b4d3a1e300628d5292ab"
+    ]
+  }
+}
+package "menhir" {
+  opam-version: "2.0"
+  version: "20210419"
+  synopsis: "An LR(1) parser generator"
+  maintainer: "francois.pottier@inria.fr"
+  authors: [
+    "François Pottier <francois.pottier@inria.fr>"
+    "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+  ]
+  license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+  homepage: "http://gitlab.inria.fr/fpottier/menhir"
+  bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "2.2.0"}
+    "menhirLib" {= version}
+    "menhirSdk" {= version}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+  url {
+    src:
+      "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210419/archive.tar.gz"
+    checksum: [
+      "md5=1af2d137eb20811c74ca516500164fd4"
+      "sha512=37a88b3ea0bde6089e5fbf0c1f10c1867c4edcd033ed3d5b75e7ed93e14ddd4f4c4db96baf638a054f65e294b83411497615c7fc14c6ff3a2a007e70f9d12c98"
+    ]
+  }
+}
+package "menhirLib" {
+  opam-version: "2.0"
+  version: "20210419"
+  synopsis: "Runtime support library for parsers generated by Menhir"
+  maintainer: "francois.pottier@inria.fr"
+  authors: [
+    "François Pottier <francois.pottier@inria.fr>"
+    "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+  ]
+  license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+  homepage: "http://gitlab.inria.fr/fpottier/menhir"
+  bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "2.0.0"}
+  ]
+  conflicts: [
+    "menhir" {!= version}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+  url {
+    src:
+      "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210419/archive.tar.gz"
+    checksum: [
+      "md5=1af2d137eb20811c74ca516500164fd4"
+      "sha512=37a88b3ea0bde6089e5fbf0c1f10c1867c4edcd033ed3d5b75e7ed93e14ddd4f4c4db96baf638a054f65e294b83411497615c7fc14c6ff3a2a007e70f9d12c98"
+    ]
+  }
+}
+package "menhirSdk" {
+  opam-version: "2.0"
+  version: "20210419"
+  synopsis: "Compile-time library for auxiliary tools related to Menhir"
+  maintainer: "francois.pottier@inria.fr"
+  authors: [
+    "François Pottier <francois.pottier@inria.fr>"
+    "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+  ]
+  license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+  homepage: "http://gitlab.inria.fr/fpottier/menhir"
+  bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "2.0.0"}
+  ]
+  conflicts: [
+    "menhir" {!= version}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+  url {
+    src:
+      "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210419/archive.tar.gz"
+    checksum: [
+      "md5=1af2d137eb20811c74ca516500164fd4"
+      "sha512=37a88b3ea0bde6089e5fbf0c1f10c1867c4edcd033ed3d5b75e7ed93e14ddd4f4c4db96baf638a054f65e294b83411497615c7fc14c6ff3a2a007e70f9d12c98"
+    ]
+  }
+}
+package "merlin" {
+  opam-version: "2.0"
+  version: "4.5-414"
+  synopsis:
+    "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+  description:
+    "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+  maintainer: "defree@gmail.com"
+  authors: "The Merlin team"
+  license: "MIT"
+  homepage: "https://github.com/ocaml/merlin"
+  bug-reports: "https://github.com/ocaml/merlin/issues"
+  depends: [
+    "ocaml" {>= "4.14" & < "4.15"}
+    "dune" {>= "2.9.0"}
+    "dot-merlin-reader" {>= "4.2"}
+    "yojson" {>= "1.6.0" & < "2.0.0"}
+    "conf-jq" {with-test}
+    "csexp" {>= "1.5.1"}
+    "menhir" {dev}
+    "menhirLib" {dev}
+    "menhirSdk" {dev}
+  ]
+  conflicts: [
+    "base-effects"
+    "biniou" {>= "1.2.2"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+  ]
+  post-messages:
+    """\
+merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute "set rtp+=" . g:opamshare . "/merlin/vim"
+
+Also run the following line in vim to index the documentation:
+  :execute "helptags " . g:opamshare . "/merlin/vim/doc"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines "opam" "var" "share")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name "emacs/site-lisp" opam-share))
+    (autoload 'merlin-mode "merlin" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup"""
+      {success & !user-setup:installed}
+  dev-repo: "git+https://github.com/ocaml/merlin.git"
+  url {
+    src:
+      "https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz"
+    checksum: [
+      "sha256=31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+      "sha512=cc2cf2c208091b3ae435a8124617e56f2002b7091532002ab49a1f817d90a5c4f9cf0bc5741dc7f2526e0352c3ca95b42c3b3a17c6cbfb80ad73d42310a25d22"
+    ]
+  }
+  x-commit-hash: "cc1582373e5baea1d236a63be39493858032a182"
+}
+package "merlin-extend" {
+  opam-version: "2.0"
+  version: "0.6.1"
+  synopsis: "A protocol to provide custom frontend to Merlin"
+  description: """\
+This protocol allows to replace the OCaml frontend of Merlin.
+It extends what used to be done with the `-pp' flag to handle a few more cases."""
+  maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+  authors: "Frederic Bour <frederic.bour@lakaban.net>"
+  license: "MIT"
+  homepage: "https://github.com/let-def/merlin-extend"
+  doc: "https://let-def.github.io/merlin-extend"
+  bug-reports: "https://github.com/let-def/merlin-extend"
+  depends: [
+    "dune" {>= "1.0"}
+    "cppo" {build & >= "1.1.0"}
+    "ocaml" {>= "4.02.3"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/let-def/merlin-extend.git"
+  url {
+    src:
+      "https://github.com/let-def/merlin-extend/releases/download/v0.6.1/merlin-extend-0.6.1.tbz"
+    checksum: [
+      "sha256=5ec84b355ddb2d129a5948b132bfacc93adcbde2158c7de695f7bfc3650bead7"
+      "sha512=631fc96aab2f35e12a078c9b4907ca7b0db9f1e3a4026040e6c23b82e0171c256a89fb5d4c887f1d156eb9e3152783cdf7a546b2496051007a1bcf5777417396"
+    ]
+  }
+  x-commit-hash: "cf2707bbe8e034c6ecf5d0fecd3fd889f6ab14bf"
+}
+package "mew" {
+  opam-version: "2.0"
+  version: "0.1.0"
+  synopsis: "Modal editing witch"
+  description:
+    "This is the core module of mew, a general modal editing engine generator."
+  maintainer: "zandoye@gmail.com"
+  authors: "ZAN DoYe"
+  license: "MIT"
+  homepage: "https://github.com/kandu/mew"
+  bug-reports: "https://github.com/kandu/mew/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "result"
+    "trie" {>= "1.0.0"}
+    "dune" {>= "1.1.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/kandu/mew.git"
+  url {
+    src: "https://github.com/kandu/mew/archive/0.1.0.tar.gz"
+    checksum: "md5=2298149d1415cd804ab4e01f01ea10a0"
+  }
+}
+package "mew_vi" {
+  opam-version: "2.0"
+  version: "0.5.0"
+  synopsis: "Modal editing witch, VI interpreter"
+  description: "A vi-like modal editing engine generator."
+  maintainer: "zandoye@gmail.com"
+  authors: "ZAN DoYe"
+  license: "MIT"
+  homepage: "https://github.com/kandu/mew_vi"
+  bug-reports: "https://github.com/kandu/mew_vi/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "mew" {>= "0.1.0" & < "0.2"}
+    "react"
+    "dune" {>= "1.1.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/kandu/mew_vi.git"
+  url {
+    src: "https://github.com/kandu/mew_vi/archive/0.5.0.tar.gz"
+    checksum: "md5=341e9a9a20383641015bf503952906bc"
+  }
+}
+package "minicli" {
+  opam-version: "2.0"
+  version: "5.0.2"
+  synopsis: "Minimalist library for command line parsing"
+  description: """\
+minicli provides the CLI module.
+It allows programmers to quickly and correctly handle options passed via
+the command line to their program. minicli is intended at
+people who develop software fast, but who don't want to break things.
+minicli can throw a variety of informative exceptions to the end user,
+when the command line interface is not being used properly.
+So that, the end user has a good chance to correct himself before calling
+the software support team.
+Another design goal of minicli is to make command-line scientific programs
+harder to use incorrectly."""
+  maintainer: "unixjunkie@sdf.org"
+  authors: "Francois Berenger"
+  homepage: "https://github.com/UnixJunkie/minicli"
+  bug-reports: "https://github.com/UnixJunkie/minicli/issues"
+  depends: [
+    "ocaml"
+    "dune" {>= "1.6"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/UnixJunkie/minicli.git"
+  url {
+    src: "https://github.com/UnixJunkie/minicli/archive/v5.0.2.tar.gz"
+    checksum: "md5=4d251eafc27d8f667f6c13f890f17546"
+  }
+}
+package "mirage-crypto" {
+  opam-version: "2.0"
+  version: "0.11.0"
+  synopsis: "Simple symmetric cryptography for the modern age"
+  description: """\
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2)."""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: [
+    "David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>"
+  ]
+  license: "ISC"
+  homepage: "https://github.com/mirage/mirage-crypto"
+  doc: "https://mirage.github.io/mirage-crypto/doc"
+  bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.7"}
+    "dune-configurator" {>= "2.0.0"}
+    "ounit2" {with-test}
+    "cstruct" {>= "6.0.0"}
+    "eqaf" {>= "0.8"}
+  ]
+  conflicts: ["ocaml-freestanding"]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+  url {
+    src:
+      "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+    checksum: [
+      "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+      "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+    ]
+  }
+  x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"
+}
+package "mirage-crypto-ec" {
+  opam-version: "2.0"
+  version: "0.11.0"
+  synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+  description: """\
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P224 (SECP224R1), P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package."""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: [
+    "Hannes Mehnert <hannes@mehnert.org>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+    "Clément Pascutto <clement@tarides.com>"
+    "Etienne Millon <me@emillon.org>"
+    "Andres Erbsen <andreser@mit.edu>"
+    "Google Inc."
+    "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+    "Massachusetts Institute of Technology"
+    "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+  ]
+  license: "MIT"
+  tags: "org:mirage"
+  homepage: "https://github.com/mirage/mirage-crypto"
+  doc: "https://mirage.github.io/mirage-crypto/doc"
+  bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+  depends: [
+    "dune" {>= "2.7"}
+    "ocaml" {>= "4.08.0"}
+    "cstruct" {>= "6.0.0"}
+    "dune-configurator"
+    "eqaf" {>= "0.7"}
+    "mirage-crypto" {= version}
+    "mirage-crypto-rng" {= version}
+    "mirage-crypto-pk" {with-test & = version}
+    "hex" {with-test}
+    "alcotest" {with-test & >= "0.8.1"}
+    "asn1-combinators" {with-test & >= "0.2.5"}
+    "ppx_deriving_yojson" {with-test}
+    "ppx_deriving" {with-test}
+    "yojson" {with-test & >= "1.6.0"}
+  ]
+  conflicts: ["ocaml-freestanding"]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+  url {
+    src:
+      "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+    checksum: [
+      "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+      "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+    ]
+  }
+  x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"
+}
+package "mirage-crypto-rng" {
+  opam-version: "2.0"
+  version: "0.11.0"
+  synopsis: "A cryptographically secure PRNG"
+  description: """\
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)"""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: [
+    "David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>"
+  ]
+  license: "ISC"
+  homepage: "https://github.com/mirage/mirage-crypto"
+  doc: "https://mirage.github.io/mirage-crypto/doc"
+  bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.7"}
+    "dune-configurator" {>= "2.0.0"}
+    "duration"
+    "cstruct" {>= "6.0.0"}
+    "logs"
+    "mirage-crypto" {= version}
+    "ounit2" {with-test}
+    "randomconv" {with-test & >= "0.1.3"}
+  ]
+  conflicts: [
+    "mirage-runtime" {< "3.8.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+  url {
+    src:
+      "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+    checksum: [
+      "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+      "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+    ]
+  }
+  x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"
+}
+package "mirage-crypto-rng-async" {
+  opam-version: "2.0"
+  version: "0.11.0"
+  synopsis: "Feed the entropy source in an Async-friendly way"
+  description: """\
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way."""
+  maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+  authors: [
+    "David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>"
+  ]
+  license: "ISC"
+  homepage: "https://github.com/mirage/mirage-crypto"
+  doc: "https://mirage.github.io/mirage-crypto/doc"
+  bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.7"}
+    "dune-configurator" {>= "2.0.0"}
+    "async" {>= "v0.14"}
+    "logs"
+    "mirage-crypto" {= version}
+    "mirage-crypto-rng" {= version}
+  ]
+  available: os != "win32"
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+  url {
+    src:
+      "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+    checksum: [
+      "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+      "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+    ]
+  }
+  x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"
+}
+package "mmap" {
+  opam-version: "2.0"
+  version: "1.1.0"
+  synopsis: "File mapping functionality"
+  description:
+    "This project provides a Mmap.map_file functions for mapping files in memory."
+  maintainer: "jeremie@dimino.org"
+  authors: ["Jérémie Dimino <jeremie@dimino.org>" "Anton Bachin"]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/mirage/mmap"
+  doc: "https://mirage.github.io/mmap/"
+  bug-reports: "https://github.com/mirage/mmap/issues"
+  depends: [
+    "ocaml"
+    "dune" {>= "1.6"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/mirage/mmap.git"
+  url {
+    src:
+      "https://github.com/mirage/mmap/releases/download/v1.1.0/mmap-v1.1.0.tbz"
+    checksum: "md5=8c5d5fbc537296dc525867535fb878ba"
+  }
+}
+package "num" {
+  opam-version: "2.0"
+  version: "1.1"
+  synopsis:
+    "The legacy Num library for arbitrary-precision integer and rational arithmetic"
+  maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+  authors: ["Valérie Ménissier-Morain" "Pierre Weis" "Xavier Leroy"]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ocaml/num/"
+  bug-reports: "https://github.com/ocaml/num/issues"
+  depends: [
+    "ocaml" {>= "4.06.0"}
+    "ocamlfind" {build & >= "1.7.3"}
+  ]
+  conflicts: ["base-num" "ocaml-option-bytecode-only"]
+  build: make
+  install: [
+    ["ocamlfind" "remove" "num"]
+    ["ocamlfind" "remove" "num-top"]
+    [
+      make
+      "install" {!ocaml:preinstalled}
+      "findlib-install" {ocaml:preinstalled}
+    ]
+  ]
+  remove: [
+    make
+    "uninstall" {!ocaml:preinstalled}
+    "findlib-uninstall" {ocaml:preinstalled}
+  ]
+  patches: ["findlib-install.patch" "installation-warning.patch"]
+  dev-repo: "git+https://github.com/ocaml/num.git"
+  extra-files: [
+    ["installation-warning.patch" "md5=93c92bf6da6bae09d068da42b1bbaaac"]
+    ["findlib-install.patch" "md5=3163a4c3f8dd084653eeb64d95311a2a"]
+  ]
+  url {
+    src: "https://github.com/ocaml/num/archive/v1.1.tar.gz"
+    checksum: "md5=710cbe18b144955687a03ebab439ff2b"
+  }
+}
+package "ocaml" {
+  opam-version: "2.0"
+  version: "4.14.0"
+  synopsis: "The OCaml compiler (virtual package)"
+  description: """\
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+  maintainer: "platform@lists.ocaml.org"
+  authors: [
+    "Xavier Leroy"
+    "Damien Doligez"
+    "Alain Frisch"
+    "Jacques Garrigue"
+    "Didier Rémy"
+    "Jérôme Vouillon"
+  ]
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  depends: [
+    "ocaml-config" {>= "2"}
+    "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |
+    "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
+    "ocaml-system" {>= "4.14.0" & < "4.14.1~"} |
+    "dkml-base-compiler" {>= "4.14.0~" & < "4.14.1~"}
+  ]
+  flags: conf
+  setenv: [
+    [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+    [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+    [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+  ]
+  build: [
+    "ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name
+  ]
+  build-env: CAML_LD_LIBRARY_PATH = ""
+}
+package "ocaml-base-compiler" {
+  opam-version: "2.0"
+  version: "4.14.0"
+  synopsis: "Official release 4.14.0"
+  maintainer: "platform@lists.ocaml.org"
+  authors: "Xavier Leroy and many contributors"
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  depends: [
+    "ocaml" {= "4.14.0" & post}
+    "base-unix" {post}
+    "base-bigarray" {post}
+    "base-threads" {post}
+    "ocaml-options-vanilla" {post}
+  ]
+  conflict-class: "ocaml-core-compiler"
+  flags: compiler
+  setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+  build: [
+    [
+      "./configure"
+      "--prefix=%{prefix}%"
+      "--docdir=%{doc}%/ocaml"
+      "-C"
+      "CC=cc" {os = "openbsd" | os = "macos"}
+      "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+    ]
+    [make "-j%{jobs}%"]
+  ]
+  install: [make "install"]
+  post-messages: [
+    """\
+A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"""
+      {failure & jobs > "1"}
+    """\
+You can try installing again including --jobs=1
+   to force a sequential build instead."""
+      {failure & jobs > "1" & opam-version >= "2.0.5"}
+  ]
+  dev-repo: "git+https://github.com/ocaml/ocaml"
+  extra-files: [
+    "ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"
+  ]
+  url {
+    src: "https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz"
+    checksum:
+      "sha256=39f44260382f28d1054c5f9d8bf4753cb7ad64027da792f7938344544da155e8"
+  }
+}
+package "ocaml-compiler-libs" {
+  opam-version: "2.0"
+  version: "v0.12.3"
+  synopsis: "OCaml compiler libraries repackaged"
+  description: """\
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ..."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+  bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+  depends: [
+    "ocaml" {>= "4.04.1"}
+    "dune" {>= "1.5.1"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+  url {
+    src:
+      "https://github.com/janestreet/ocaml-compiler-libs/releases/download/v0.12.3/ocaml-compiler-libs-v0.12.3.tbz"
+    checksum: [
+      "sha256=a8403531439c14bbda2d504ef93610fd29a8e9520fc700f21889d893a513e3c9"
+      "sha512=0bb03b38e93bab3274a8ade38d017808110bc02f2181a594d8775c68fdd465733393f0451dbbf8860e6b50b56c45671d2182637c0840d1d6574803ec18673972"
+    ]
+  }
+  x-commit-hash: "7f5d1d2931b96fb3ee6dd569a469b51f621a6dd4"
+}
+package "ocaml-config" {
+  opam-version: "2.0"
+  version: "2"
+  synopsis: "OCaml Switch Configuration"
+  description:
+    "This package is used by the OCaml package to set-up its variables."
+  maintainer: "platform@lists.ocaml.org"
+  authors: [
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "David Allsopp <david.allsopp@metastack.com>"
+  ]
+  homepage: "https://opam.ocaml.org/"
+  bug-reports: "https://github.com/ocaml/opam/issues"
+  depends: [
+    "ocaml-base-compiler" {>= "4.12.0~"} | "ocaml-variants" {>= "4.12.0~"} |
+    "ocaml-system" {>= "4.12.0~"}
+  ]
+  substs: "gen_ocaml_config.ml"
+  extra-files: [
+    ["gen_ocaml_config.ml.in" "md5=a4b41e3236593d8271295b84b0969172"]
+    ["ocaml-config.install" "md5=8e50c5e2517d3463b3aad649748cafd7"]
+  ]
+}
+package "ocaml-migrate-parsetree" {
+  opam-version: "2.0"
+  version: "2.3.0"
+  synopsis: "Convert OCaml parsetrees between different versions"
+  description: """\
+Deprecated. Please, use Ppxlib instead.
+More info on https://ocaml.org/changelog/2023-10-23-omp-deprecation
+
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version."""
+  maintainer: "frederic.bour@lakaban.net"
+  authors: [
+    "Frédéric Bour <frederic.bour@lakaban.net>"
+    "Jérémie Dimino <jeremie@dimino.org>"
+  ]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  tags: ["syntax" "org:ocamllabs"]
+  homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+  doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+  bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+  depends: [
+    "dune" {>= "2.3"}
+    "ocaml" {>= "4.02.3" & < "4.15"}
+    "cinaps" {with-test & >= "v0.13.0"}
+  ]
+  conflicts: ["base-effects"]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  run-test: ["dune" "runtest" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.3.0/ocaml-migrate-parsetree-2.3.0.tbz"
+    checksum: [
+      "sha256=108126b247f190e04c8afd3d72ced0b63ffdf73c3f801f09be5db0cd7280bf0a"
+      "sha512=cccd766d33e2c70015735e050c2b7cdacf9f046e2874b563ef64b77706f56d004aa9b9df7d5cc201e5f3ba6e3267f95f654e1e3de58891b91f9c28a61988a9ee"
+    ]
+  }
+  x-commit-hash: "7ef6ff49bfd7d6d816be61d3acea460af25d7d99"
+}
+package "ocaml-options-vanilla" {
+  opam-version: "2.0"
+  version: "1"
+  synopsis: "Ensure that OCaml is compiled with no special options enabled"
+  maintainer: "platform@lists.ocaml.org"
+  depends: [
+    "ocaml-base-compiler" {post} | "ocaml-system" {post} |
+    "ocaml-variants" {post & >= "4.12.0~"}
+  ]
+  conflicts: [
+    "ocaml-option-32bit"
+    "ocaml-option-afl"
+    "ocaml-option-bytecode-only" {arch = "arm64" | arch = "x86_64"}
+    "ocaml-option-default-unsafe-string"
+    "ocaml-option-flambda"
+    "ocaml-option-fp"
+    "ocaml-option-musl"
+    "ocaml-option-no-flat-float-array"
+    "ocaml-option-no-compression"
+    "ocaml-option-spacetime"
+    "ocaml-option-static"
+    "ocaml-option-nnp"
+    "ocaml-option-nnpchecker"
+    "ocaml-option-address-sanitizer"
+    "ocaml-option-leak-sanitizer"
+    "ocaml-option-tsan"
+  ]
+  flags: compiler
+}
+package "ocaml-syntax-shims" {
+  opam-version: "2.0"
+  version: "1.0.0"
+  synopsis: "Backport new syntax to older OCaml versions"
+  description: """\
+This packages backports new features of the language to older
+compilers, such as let+."""
+  maintainer: "jeremie@dimino.org"
+  authors: "Jérémie Dimino <jeremie@dimino.org>"
+  license: "MIT"
+  homepage: "https://github.com/ocaml-ppx/ocaml-syntax-shims"
+  doc: "https://ocaml-ppx.github.io/ocaml-syntax-shims/"
+  bug-reports: "https://github.com/ocaml-ppx/ocaml-syntax-shims/issues"
+  depends: [
+    "dune" {>= "2.0"}
+    "ocaml" {>= "4.02.3"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml-ppx/ocaml-syntax-shims.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
+    checksum: [
+      "sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+      "sha512=75c4c6b0bfa1267a8a49a82ba494d08cf0823fc8350863d6d3d4971528cb09e5a2a29e2981d04c75e76ad0f49360b05a432c9efeff9a4fbc1ec6b28960399852"
+    ]
+  }
+}
+package "ocaml-version" {
+  opam-version: "2.0"
+  version: "3.4.0"
+  synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+  description: """\
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>"""
+  maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+  authors: "Anil Madhavapeddy <anil@recoil.org>"
+  license: "ISC"
+  tags: "org:ocamllabs"
+  homepage: "https://github.com/ocurrent/ocaml-version"
+  doc: "https://ocurrent.github.io/ocaml-version/doc"
+  bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+  depends: [
+    "ocaml" {>= "4.07.0"}
+    "dune" {>= "1.0"}
+    "alcotest" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+  url {
+    src:
+      "https://github.com/ocurrent/ocaml-version/releases/download/v3.4.0/ocaml-version-v3.4.0.tbz"
+    checksum: [
+      "sha256=d8c1beb5e8d8ebb7710b5f434ce66a3ec8b752b1e4d6ba87c4fe27452bdb8a25"
+      "sha512=215e5b0c4ea5fa5461cdc0fc81fbd84a2a319a246a19504d0a0abc8c891e252a9e41644356150a1dc25d56b3f7e084db7a0b15becab4e1339992e645fc3d8ef1"
+    ]
+  }
+  x-commit-hash: "c535ad2f463664b31001888fc99495dd01632747"
+}
+package "ocamlbuild" {
+  opam-version: "2.0"
+  version: "0.14.0"
+  synopsis:
+    "OCamlbuild is a build system with builtin rules to easily build most OCaml projects."
+  maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+  authors: ["Nicolas Pouillard" "Berke Durak"]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ocaml/ocamlbuild/"
+  doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+  bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+  depends: [
+    "ocaml" {>= "4.03" & < "5.0"}
+  ]
+  conflicts: [
+    "base-ocamlbuild"
+    "ocamlfind" {< "1.6.2"}
+  ]
+  available: os != "win32"
+  build: [
+    [
+      make
+      "-f"
+      "configure.make"
+      "all"
+      "OCAMLBUILD_PREFIX=%{prefix}%"
+      "OCAMLBUILD_BINDIR=%{bin}%"
+      "OCAMLBUILD_LIBDIR=%{lib}%"
+      "OCAMLBUILD_MANDIR=%{man}%"
+      "OCAML_NATIVE=%{ocaml:native}%"
+      "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+    ]
+    [make "check-if-preinstalled" "all" "opam-install"]
+  ]
+  dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+  url {
+    src: "https://github.com/ocaml/ocamlbuild/archive/0.14.0.tar.gz"
+    checksum:
+      "sha256=87b29ce96958096c0a1a8eeafeb6268077b2d11e1bf2b3de0f5ebc9cf8d42e78"
+  }
+}
+package "ocamlfind" {
+  opam-version: "2.0"
+  version: "1.9.3"
+  synopsis: "A library manager for OCaml"
+  description: """\
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+  maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+  license: "MIT"
+  homepage: "http://projects.camlcity.org/projects/findlib.html"
+  bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+  depends: [
+    "ocaml" {>= "4.00.0" & < "5.0"}
+  ]
+  depopts: ["graphics"]
+  build: [
+    [
+      "./configure"
+      "-bindir"
+      bin
+      "-sitelib"
+      lib
+      "-mandir"
+      man
+      "-config"
+      "%{lib}%/findlib.conf"
+      "-no-custom"
+      "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+      "-no-topfind" {ocaml:preinstalled}
+    ]
+    [make "all"]
+    [make "opt"] {ocaml:native}
+  ]
+  install: [
+    [make "install"]
+    ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+  ]
+  dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+  url {
+    src: "http://download.camlcity.org/download/findlib-1.9.3.tar.gz"
+    checksum: [
+      "md5=24047dd8a0da5322253de9b7aa254e42"
+      "sha512=27cc4ce141576bf477fb9d61a82ad65f55478740eed59fb43f43edb794140829fd2ff89ad27d8a890cfc336b54c073a06de05b31100fc7c01cacbd7d88e928ea"
+    ]
+  }
+}
+package "ocamlformat" {
+  opam-version: "2.0"
+  version: "0.20.1"
+  synopsis: "Auto-formatter for OCaml code"
+  description:
+    "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+  maintainer: "OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"
+  authors: "Josh Berdine <jjb@fb.com>"
+  license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+  homepage: "https://github.com/ocaml-ppx/ocamlformat"
+  bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+  depends: [
+    "dune" {>= "2.8"}
+    "dune" {with-test & < "3.0"}
+    "ocaml" {>= "4.08" & < "4.15"}
+    "alcotest" {with-test}
+    "base" {>= "v0.12.0" & < "v0.15"}
+    "cmdliner"
+    "cmdliner" {with-test & < "1.1.0"}
+    "dune-build-info"
+    "either"
+    "fix"
+    "fpath"
+    "menhir" {>= "20201216"}
+    "menhirLib" {>= "20201216"}
+    "menhirSdk" {>= "20201216"}
+    "ocaml-version" {>= "3.3.0" & < "3.6.0"}
+    "ocp-indent"
+    "odoc-parser" {>= "1.0.0" & < "2.0.0"}
+    "re" {>= "1.7.2"}
+    "stdio" {< "v0.15"}
+    "uuseg" {>= "10.0.0"}
+    "uutf" {>= "1.0.1"}
+    "odoc" {with-doc}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-0.20.1.tbz"
+    checksum: [
+      "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
+      "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"
+    ]
+  }
+  x-commit-hash: "74668925ca977e252acb084bd139b3077cf95b58"
+}
+package "ocamlgraph" {
+  opam-version: "2.0"
+  version: "1.8.8"
+  synopsis: "A generic graph library for OCaml"
+  maintainer: "filliatr@lri.fr"
+  authors: ["Sylvain Conchon" "Jean-Christophe Filliâtre" "Julien Signoles"]
+  license: "LGPL-2.1-only"
+  tags: [
+    "graph"
+    "library"
+    "algorithms"
+    "directed graph"
+    "vertice"
+    "edge"
+    "persistent"
+    "imperative"
+  ]
+  homepage: "http://ocamlgraph.lri.fr/"
+  doc: "http://ocamlgraph.lri.fr/doc"
+  bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
+  depends: [
+    "ocaml" {< "5.0"}
+    "ocamlfind" {build}
+  ]
+  depopts: ["lablgtk" "conf-gnomecanvas"]
+  flags: light-uninstall
+  build: [
+    ["touch" "./configure"]
+    ["./configure"]
+    [make]
+  ]
+  install: [make "install-findlib"]
+  remove: ["ocamlfind" "remove" "ocamlgraph"]
+  dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+  url {
+    src: "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.8.tar.gz"
+    checksum: "md5=9d71ca69271055bd22d0dfe4e939831a"
+  }
+}
+package "ocp-browser" {
+  opam-version: "2.0"
+  version: "1.3.3"
+  synopsis:
+    "Console browser for the documentation of installed OCaml libraries"
+  description: """\
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules."""
+  maintainer: "louis.gesbert@ocamlpro.com"
+  authors: ["Louis Gesbert" "Gabriel Radanne"]
+  license: "GPL-3.0-only"
+  tags: ["org:ocamlpro" "org:typerex"]
+  homepage: "http://www.typerex.org/ocp-index.html"
+  bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+  depends: [
+    "ocaml" {>= "4.02.0"}
+    "cppo" {build & >= "1.1.0"}
+    "dune" {>= "1.0"}
+    "ocp-index" {= version}
+    "cmdliner"
+    "lambda-term" {< "3.3.0"}
+    "zed" {>= "2.0.0"}
+    "odoc" {with-test}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+  url {
+    src:
+      "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.3.tar.gz"
+    checksum: [
+      "md5=738dd32765ce0b6b6423620cc62b7db9"
+      "sha512=6360240c951ac64baf9b3736c9a37c41a5ac8c5ddf52e723019fb5ef294e786e245712fd88f408bd8f6881d8741ab152872181062acd81443eec07d1d703e85a"
+    ]
+  }
+}
+package "ocp-indent" {
+  opam-version: "2.0"
+  version: "1.7.0"
+  synopsis: "A simple tool to indent OCaml programs"
+  description: """\
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+- An indentor program, callable from the command-line or from within editors
+- Bindings for popular editors
+- A library that can be directly used by editor writers, or just for
+  fault-tolerant/approximate parsing."""
+  maintainer: "contact@ocamlpro.com"
+  authors: [
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "Thomas Gazagnaire <thomas@gazagnaire.org>"
+    "Jun Furuse"
+  ]
+  license: "LGPL-2.0-or-later"
+  tags: ["org:ocamlpro" "org:typerex"]
+  homepage: "http://www.typerex.org/ocp-indent.html"
+  bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+  depends: [
+    "ocaml"
+    "dune"
+    "cmdliner" {>= "1.0.0"}
+    "ocamlfind"
+    "base-bytes"
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  run-test: ["dune" "runtest" "-p" name]
+  post-messages:
+    """\
+This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path "%{share}%/emacs/site-lisp")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^="%{share}%/ocp-indent/vim\""""
+      {success & !user-setup:installed}
+  dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git"
+  url {
+    src: "https://github.com/OCamlPro/ocp-indent/archive/1.7.0.tar.gz"
+    checksum: [
+      "md5=3bc327e38f453f38494098725c97d2cb"
+      "sha512=5b28ae8695612c95cb0f5748de9b9f01d8ef4ad18b31340dc526ccae5fb1b6ee7e12024ff1beb817a43796183a83bca144222ca2d77d7750f2ff56108b5fa350"
+    ]
+  }
+}
+package "ocp-index" {
+  opam-version: "2.0"
+  version: "1.3.3"
+  synopsis:
+    "Lightweight completion and documentation browsing for OCaml libraries"
+  description: """\
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`."""
+  maintainer: "louis.gesbert@ocamlpro.com"
+  authors: ["Louis Gesbert" "Gabriel Radanne"]
+  license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+  tags: ["org:ocamlpro" "org:typerex"]
+  homepage: "http://www.typerex.org/ocp-index.html"
+  bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+  depends: [
+    "ocaml" {>= "4.02.0" & < "5.1"}
+    "cppo" {build & >= "1.1.0"}
+    "dune" {>= "1.0"}
+    "ocp-indent" {>= "1.4.2"}
+    "re" {>= "1.9.0"}
+    "cmdliner"
+    "odoc" {with-doc}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  post-messages:
+    """\
+This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path "%{prefix}%/share/emacs/site-lisp")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim"""
+      {success & !user-setup:installed}
+  dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+  url {
+    src:
+      "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.3.tar.gz"
+    checksum: [
+      "md5=738dd32765ce0b6b6423620cc62b7db9"
+      "sha512=6360240c951ac64baf9b3736c9a37c41a5ac8c5ddf52e723019fb5ef294e786e245712fd88f408bd8f6881d8741ab152872181062acd81443eec07d1d703e85a"
+    ]
+  }
+}
+package "ocplib-endian" {
+  opam-version: "2.0"
+  version: "1.0"
+  synopsis:
+    "Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01."
+  description: """\
+The library implements three modules:
+* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.cppo.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.cppo.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.cppo.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;"""
+  maintainer: "pierre.chambart@ocamlpro.com"
+  authors: "Pierre Chambart"
+  homepage: "https://github.com/OCamlPro/ocplib-endian"
+  bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
+  depends: [
+    "ocaml" {< "5.0"}
+    "base-bytes"
+    "ocamlfind"
+    "cppo" {>= "1.1.0"}
+    "ocamlbuild" {build}
+  ]
+  flags: light-uninstall
+  build: [
+    ["ocaml" "setup.ml" "-configure" "--disable-debug" "--prefix" prefix]
+    ["ocaml" "setup.ml" "-build"]
+  ]
+  install: ["ocaml" "setup.ml" "-install"]
+  remove: ["ocamlfind" "remove" "ocplib-endian"]
+  dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
+  url {
+    src: "https://github.com/OCamlPro/ocplib-endian/archive/1.0.tar.gz"
+    checksum: "md5=74b45ba33e189283170a748c2a3ed477"
+  }
+}
+package "octavius" {
+  opam-version: "2.0"
+  version: "1.2.2"
+  synopsis: "Ocamldoc comment syntax parser"
+  description:
+    "Octavius is a library to parse the `ocamldoc` comment syntax."
+  maintainer: "leo@lpw25.net"
+  authors: "Leo White <leo@lpw25.net>"
+  license: "ISC"
+  homepage: "https://github.com/ocaml-doc/octavius"
+  doc: "http://ocaml-doc.github.io/octavius/"
+  bug-reports: "https://github.com/ocaml-doc/octavius/issues"
+  depends: [
+    "dune" {>= "1.11"}
+    "ocaml" {>= "4.03.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml-doc/octavius.git"
+  url {
+    src: "https://github.com/ocaml-doc/octavius/archive/v1.2.2.tar.gz"
+    checksum: "md5=72f9e1d996e6c5089fc513cc9218607b"
+  }
+}
+package "odoc" {
+  opam-version: "2.0"
+  version: "2.1.0"
+  synopsis: "OCaml documentation generator"
+  description: """\
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML."""
+  maintainer: "Jon Ludlam <jon@recoil.org>"
+  authors: [
+    "Thomas Refis <trefis@janestreet.com>"
+    "David Sheets <sheets@alum.mit.edu>"
+    "Leo White <leo@lpw25.net>"
+    "Anton Bachin <antonbachin@yahoo.com>"
+    "Jon Ludlam <jon@recoil.org>"
+    "Jules Aguillon <juloo.dsi@gmail.com>"
+    "Lubega Simon <lubegasimon73@gmail.com>"
+  ]
+  license: "ISC"
+  homepage: "http://github.com/ocaml/odoc"
+  doc: "https://ocaml.github.io/odoc/"
+  bug-reports: "https://github.com/ocaml/odoc/issues"
+  depends: [
+    "odoc-parser" {>= "0.9.0" & < "2.0.0"}
+    "astring"
+    "cmdliner" {>= "1.0.0"}
+    "cppo" {build & >= "1.1.0"}
+    "dune" {>= "2.9.1"}
+    "fpath"
+    "ocaml" {>= "4.02.0" & < "5.0"}
+    "result"
+    "tyxml" {>= "4.3.0"}
+    "fmt"
+    "ocamlfind" {with-test}
+    "yojson" {with-test}
+    ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+    "conf-jq" {with-test}
+    "ppx_expect" {with-test}
+    "bos" {with-test}
+    "bisect_ppx" {dev & > "2.5.0"}
+    ("ocaml" {< "4.03.0" & dev} | "mdx" {dev})
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocaml/odoc.git"
+  url {
+    src:
+      "https://github.com/ocaml/odoc/releases/download/2.1.0/odoc-2.1.0.tbz"
+    checksum: [
+      "sha256=65a2523a50ee368164f1f24f75866a6a36cdb0d00039c3006ec824351d4e4967"
+      "sha512=cf4d7e884b94a9b9c4bcb62d4423d7289d7bbbf2642c5eacf9577b76eb835cf6ecc79d2384d36d174d2e9d8f758b5082c0c4bf8f66b5c6db4e9805dc3fc9ee1a"
+    ]
+  }
+  x-commit-hash: "d654ee2a4ff3e1465dcf92b882c26de71f7a9986"
+}
+package "odoc-parser" {
+  opam-version: "2.0"
+  version: "1.0.0"
+  synopsis: "Parser for ocaml documentation comments"
+  description: """\
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+  maintainer: "Jon Ludlam <jon@recoil.org>"
+  authors: "Anton Bachin <antonbachin@yahoo.com>"
+  license: "ISC"
+  homepage: "https://github.com/ocaml-doc/odoc-parser"
+  doc: "https://ocaml-doc.github.io/odoc-parser/"
+  bug-reports: "https://github.com/ocaml-doc/odoc-parser/issues"
+  depends: [
+    "dune" {>= "2.8"}
+    "ocaml" {>= "4.02.0" & < "5.0"}
+    "astring"
+    "result"
+    "ppx_expect" {with-test}
+    ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+  ]
+  dev-repo: "git+https://github.com/ocaml-doc/odoc-parser.git"
+  url {
+    src:
+      "https://github.com/ocaml-doc/odoc-parser/releases/download/1.0.0/odoc-parser-1.0.0.tbz"
+    checksum: [
+      "sha256=b6aa08ea71a9ebad9b2bebc4da1eda0d713cf3674e6d57d10459d934286e7aa1"
+      "sha512=b5caee3a0d288aeaa95e3f32de8e5f75f169ad2691d75f8d6c932e4fb0e6cb188813ac2d92d4076fe75b12217130e6999c46e7890cf0fa765070870f85a96d63"
+    ]
+  }
+  x-commit-hash: "b13ffc2f30ca20ca5bb733be4f630d46bd274fd6"
+}
+package "opam-core" {
+  opam-version: "2.0"
+  version: "2.1.2"
+  synopsis: "Core library for opam 2.1"
+  description:
+    "Small standard library extensions, and generic system interaction modules used by opam."
+  maintainer: "opam-devel@lists.ocaml.org"
+  authors: [
+    "Vincent Bernardoff <vb@luminar.eu.org>"
+    "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+    "Roberto Di Cosmo <roberto@dicosmo.org>"
+    "Thomas Gazagnaire <thomas@gazagnaire.org>"
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+    "Anil Madhavapeddy <anil@recoil.org>"
+    "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+    "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+    "Frederic Tuong <tuong@users.gforge.inria.fr>"
+  ]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://opam.ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "base-unix"
+    "base-bigarray"
+    "ocamlgraph"
+    "re" {>= "1.9.0"}
+    "dune" {>= "1.11.0"}
+    "cppo" {build & >= "1.1.0"}
+  ]
+  conflicts: ["extlib-compat"]
+  build: [
+    ["./configure" "--disable-checks" "--prefix" prefix]
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocaml/opam.git"
+  url {
+    src: "https://github.com/ocaml/opam/archive/2.1.2.tar.gz"
+    checksum: [
+      "md5=d50bdf14ebda2ed9627c1c8af5f5888f"
+      "sha512=bea6f75728a6ef25bcae4f8903dde7a297df7186208dccacb3f58bd6a0caec551c11b79e8544f0983feac038971dbe49481fc405a5962973a5f56ec811abe396"
+    ]
+  }
+}
+package "opam-depext" {
+  opam-version: "2.0"
+  version: "1.2.1"
+  synopsis: "Install OS distribution packages"
+  description: """\
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them."""
+  maintainer: [
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "Anil Madhavapeddy <anil@recoil.org>"
+  ]
+  authors: [
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "Anil Madhavapeddy <anil@recoil.org>"
+  ]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ocaml/opam-depext"
+  bug-reports: "https://github.com/ocaml/opam-depext/issues"
+  depends: [
+    "ocaml" {>= "4.00"}
+    "base-unix"
+    "cmdliner" {>= "0.9.8" & dev}
+    "ocamlfind" {dev}
+  ]
+  available: opam-version >= "2.0.0~beta5"
+  flags: plugin
+  build: [
+    [make] {!dev}
+    [
+      "ocamlfind"
+      "%{ocaml:native?ocamlopt:ocamlc}%"
+      "-package"
+      "unix,cmdliner"
+      "-linkpkg"
+      "-o"
+      "opam-depext"
+      "depext.ml"
+    ] {dev}
+  ]
+  post-messages:
+    "opam-depext is unnecessary when used with opam >= 2.1. Please use opam install directly instead"
+      {opam-version >= "2.1"}
+  dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+  url {
+    src:
+      "https://github.com/ocaml-opam/opam-depext/releases/download/v1.2.1/opam-depext-full-1.2.1.tbz"
+    checksum: [
+      "md5=7bda1fdbd88322e8f515919c82a37a2a"
+      "sha512=a031289ac4e2d4d28bf02b892313b2a0ee724c94f0b7a131b3d9bccc5fbaf2292834d53dd6a0b7134f43bab06ee70bd2c98562fb3a6a03f1a526981290cbf501"
+    ]
+  }
+}
+package "opam-file-format" {
+  opam-version: "2.0"
+  version: "2.1.4"
+  synopsis: "Parser and printer for the opam file syntax"
+  maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://opam.ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+  depends: [
+    ("ocaml" {< "5.0.0"} | "dune")
+    "alcotest" {with-test}
+  ]
+  conflicts: [
+    "dune" {< "1.3.0"}
+  ]
+  build: [
+    [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+      {dune:installed}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:installed}
+  ]
+  install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+  dev-repo: "git+https://github.com/ocaml/opam-file-format"
+  url {
+    src:
+      "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.4.tar.gz"
+    checksum: [
+      "md5=cd9dac41c2153d07067c5f30cdcf77db"
+      "sha512=fb5e584080d65c5b5d04c7d2ac397b69a3fd077af3f51eb22967131be22583fea507390eb0d7e6f5c92035372a9e753adbfbc8bfd056d8fd4697c6f95dd8e0ad"
+    ]
+  }
+}
+package "opam-format" {
+  opam-version: "2.0"
+  version: "2.1.2"
+  synopsis: "Format library for opam 2.1"
+  description: "Definition of opam datastructures and its file interface."
+  maintainer: "opam-devel@lists.ocaml.org"
+  authors: [
+    "Vincent Bernardoff <vb@luminar.eu.org>"
+    "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+    "Roberto Di Cosmo <roberto@dicosmo.org>"
+    "Thomas Gazagnaire <thomas@gazagnaire.org>"
+    "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+    "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+    "Anil Madhavapeddy <anil@recoil.org>"
+    "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+    "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+    "Frederic Tuong <tuong@users.gforge.inria.fr>"
+  ]
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://opam.ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "opam-core" {= version}
+    "opam-file-format" {>= "2.1.3"}
+    "re" {>= "1.9.0"}
+    "dune" {>= "1.11.0"}
+  ]
+  build: [
+    ["./configure" "--disable-checks" "--prefix" prefix]
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/ocaml/opam.git"
+  url {
+    src: "https://github.com/ocaml/opam/archive/2.1.2.tar.gz"
+    checksum: [
+      "md5=d50bdf14ebda2ed9627c1c8af5f5888f"
+      "sha512=bea6f75728a6ef25bcae4f8903dde7a297df7186208dccacb3f58bd6a0caec551c11b79e8544f0983feac038971dbe49481fc405a5962973a5f56ec811abe396"
+    ]
+  }
+}
+package "ounit2" {
+  opam-version: "2.0"
+  version: "2.2.6"
+  synopsis: "OUnit testing framework"
+  description: """\
+OUnit is a unit test framework for OCaml. It allows one to easily create
+unit-tests for OCaml code. It is loosely based on [HUnit], a unit testing
+framework for Haskell. It is similar to [JUnit], and other XUnit testing
+frameworks."""
+  maintainer: "Sylvain Le Gall <sylvaini+ocaml@le-gall.net>"
+  authors: ["Maas-Maarten Zeeman" "Sylvain Le Gall"]
+  license: "MIT"
+  homepage: "https://github.com/gildor478/ounit"
+  doc: "https://gildor478.github.io/ounit/"
+  bug-reports: "https://github.com/gildor478/ounit/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.11.0"}
+    "base-bytes"
+    "base-unix"
+    "seq"
+    "stdlib-shims"
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ]
+  dev-repo: "git+https://github.com/gildor478/ounit.git"
+  url {
+    src:
+      "https://github.com/gildor478/ounit/releases/download/v2.2.6/ounit-2.2.6.tbz"
+    checksum: [
+      "sha256=0690fb1e0e90a18eed5c3566b3cc1825d98b0e8c7d51bb6b846c95c45a615913"
+      "sha512=d7cb36a1fe245d02afab606cd1ee755a178ee4cb18fbbfec1df32baa88fa90ef6c9a50d9fd5bde46c7fd9c481f2debe4bafac75c4e3bdfbdb63fc18b0ccce3cc"
+    ]
+  }
+  x-commit-hash: "77f01c482bd618eabde7c5065beae2d68db88723"
+}
+package "parsexp" {
+  opam-version: "2.0"
+  version: "v0.14.2"
+  synopsis: "S-expression parsing library"
+  description: """\
+This library provides generic parsers for parsing S-expressions from
+strings or other medium.
+
+The library is focused on performances but still provide full generic
+parsers that can be used with strings, bigstrings, lexing buffers,
+character streams or any other sources effortlessly.
+
+It provides three different class of parsers:
+- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
+- the parsers with positions, building compact position sequences so
+  that one can recover original positions in order to report properly
+  located errors at little cost
+- the Concrete Syntax Tree parsers, produce values of type
+  [Parsexp.Cst.t] which record the concrete layout of the s-expression
+  syntax, including comments
+
+This library is portable and doesn't provide IO functions. To read
+s-expressions from files or other external sources, you should use
+parsexp_io."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/parsexp"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
+  bug-reports: "https://github.com/janestreet/parsexp/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "sexplib0" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/parsexp.git"
+  url {
+    src:
+      "https://github.com/janestreet/parsexp/archive/refs/tags/v0.14.2.tar.gz"
+    checksum:
+      "sha256=f6e17e4e08dcdce08a6372485a381dcdb3fda0f71b4506d7be982b87b5a1f230"
+  }
+}
+package "postgresql" {
+  opam-version: "2.0"
+  version: "5.0.0"
+  synopsis: "Bindings to the PostgreSQL library"
+  description:
+    "Postgresql offers library functions for accessing PostgreSQL databases."
+  maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+  authors: [
+    "Alain Frisch <alain.frisch@lexifi.com>"
+    "Markus Mottl <markus.mottl@gmail.com>"
+    "Petter Urkedal <paurkedal@gmail.com>"
+  ]
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://mmottl.github.io/postgresql-ocaml"
+  doc: "https://mmottl.github.io/postgresql-ocaml/api"
+  bug-reports: "https://github.com/mmottl/postgresql-ocaml/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "dune" {>= "1.10"}
+    "dune-configurator"
+    "conf-postgresql" {build}
+    "base-bytes"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "-p" name "@doc"] {with-doc}
+  ]
+  dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
+  url {
+    src:
+      "https://github.com/mmottl/postgresql-ocaml/releases/download/5.0.0/postgresql-5.0.0.tbz"
+    checksum: [
+      "sha256=9ccd405bf2a4811d86995102b0837f07230f30d05ed620b9d05fa66f607ef9d8"
+      "sha512=5f5780327c776d69e208efe531c0dfd2cdab900fc26f8e0db698e777b386b3cc993df3af6e1cb5805dfcd003160d7e48d5c87cc73664698e96089fe0ac24cc42"
+    ]
+  }
+}
+package "ppx_assert" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Assert-like extension nodes that raise useful errors on failure"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_assert"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_assert/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_assert/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_cold" {>= "v0.14" & < "v0.15"}
+    "ppx_compare" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_assert.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_assert-v0.14.0.tar.gz"
+    checksum: "md5=535b5f241eb7f10da8c044c26afbc186"
+  }
+}
+package "ppx_base" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Base set of ppx rewriters"
+  description: """\
+ppx_base is the set of ppx rewriters used for Base.
+
+Note that Base doesn't need ppx to build, it is only used as a
+verification tool."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_base"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_base/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_base/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "ppx_cold" {>= "v0.14" & < "v0.15"}
+    "ppx_compare" {>= "v0.14" & < "v0.15"}
+    "ppx_enumerate" {>= "v0.14" & < "v0.15"}
+    "ppx_hash" {>= "v0.14" & < "v0.15"}
+    "ppx_js_style" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_base.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_base-v0.14.0.tar.gz"
+    checksum: "md5=b29a24907e60f42e050ad90e5209bb92"
+  }
+}
+package "ppx_bench" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_bench"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "ppx_inline_test" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.14.0" & < "0.29.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+  url {
+    src: "https://github.com/janestreet/ppx_bench/archive/v0.14.1.tar.gz"
+    checksum: "md5=f2852170a6396d60d4fc1c156be1ec62"
+  }
+}
+package "ppx_bin_prot" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Generation of bin_prot readers and writers from types"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_bin_prot"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bin_prot/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "bin_prot" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_bin_prot-v0.14.0.tar.gz"
+    checksum: "md5=016e777c366b9b464f016d70ae4d7b7f"
+  }
+}
+package "ppx_bitstring" {
+  opam-version: "2.0"
+  version: "4.1.0"
+  synopsis: "Bitstrings and bitstring matching for OCaml - PPX extension"
+  description: """\
+The ocaml-bitstring project adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml. 
+You can use this module to both parse and generate binary formats, files and protocols. 
+Bitstring handling is added as primitives to the language, making it exceptionally simple to use and very powerful."""
+  maintainer: "Xavier R. Guérin <github@applepine.org>"
+  authors: ["Richard W.M. Jones" "Xavier R. Guérin"]
+  license: "LGPL-2.0-or-later"
+  homepage: "https://github.com/xguerin/bitstring"
+  bug-reports: "https://github.com/xguerin/bitstring/issues"
+  depends: [
+    "dune" {>= "2.5"}
+    "ocaml" {>= "4.04.1"}
+    "bitstring" {>= "4.0.0"}
+    "ocaml" {with-test & >= "4.08.0"}
+    "ppxlib" {>= "0.18.0"}
+    "ounit" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/xguerin/bitstring.git"
+  url {
+    src: "https://github.com/xguerin/bitstring/archive/v4.1.0.tar.gz"
+    checksum: "md5=8ae6f04eaa29481c6830ee3be5cba755"
+  }
+}
+package "ppx_cold" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "Expands [@cold] into [@inline never][@specialise never][@local never]"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_cold"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_cold/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_cold/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_cold.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_cold-v0.14.0.tar.gz"
+    checksum: "md5=6a61807cd3b105b8c885bd2076986339"
+  }
+}
+package "ppx_compare" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Generation of comparison functions from types"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_compare"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_compare/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_compare/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_compare.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_compare-v0.14.0.tar.gz"
+    checksum: "md5=9149b3a0c954fe2cef2b0705d254b9e3"
+  }
+}
+package "ppx_custom_printf" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Printf-style format-strings for user-defined string conversion"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_custom_printf"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_custom_printf/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.18.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_custom_printf/archive/v0.14.1.tar.gz"
+    checksum: "md5=18518b0464d61d165f4c73475d648ccb"
+  }
+}
+package "ppx_derivers" {
+  opam-version: "2.0"
+  version: "1.2.1"
+  synopsis: "Shared [@@deriving] plugin registry"
+  description: """\
+Ppx_derivers is a tiny package whose sole purpose is to allow
+ppx_deriving and ppx_type_conv to inter-operate gracefully when linked
+as part of the same ocaml-migrate-parsetree driver."""
+  maintainer: "jeremie@dimino.org"
+  authors: "Jérémie Dimino"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-ppx/ppx_derivers"
+  bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
+  depends: ["ocaml" "dune"]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocaml-ppx/ppx_derivers.git"
+  url {
+    src: "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz"
+    checksum: "md5=5dc2bf130c1db3c731fe0fffc5648b41"
+  }
+}
+package "ppx_deriving" {
+  opam-version: "2.0"
+  version: "5.2.1"
+  synopsis: "Type-driven code generation for OCaml"
+  description: """\
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks."""
+  maintainer: "whitequark <whitequark@whitequark.org>"
+  authors: "whitequark <whitequark@whitequark.org>"
+  license: "MIT"
+  tags: "syntax"
+  homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+  doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+  bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+  depends: [
+    "ocaml" {>= "4.05.0"}
+    "dune" {>= "1.6.3"}
+    "cppo" {build & >= "1.1.0"}
+    "ocamlfind"
+    "ppx_derivers"
+    "ppxlib" {>= "0.20.0"}
+    "result"
+    "ounit2" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs]
+      {with-test & ocaml:version < "5.0.0"}
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ]
+  dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v5.2.1/ppx_deriving-v5.2.1.tbz"
+    checksum: [
+      "sha256=e96b5fb25b7632570e4b329e22e097fcd4b8e8680d1e43ef003a8fbd742b0786"
+      "sha512=f28cd778a2d48ababa53f73131b25229a11b03685610d020b7b9228b1e25570891cd927b37475aeda49be72debaf5f2dda4c1518a0965db7a361c0ebe325a8d2"
+    ]
+  }
+  x-commit-hash: "7211546d6527bf57d3eff8174c90fc3c22250dae"
+}
+package "ppx_deriving_yojson" {
+  opam-version: "2.0"
+  version: "3.6.1"
+  synopsis: "JSON codec generator for OCaml"
+  description: """\
+ppx_deriving_yojson is a ppx_deriving plugin that provides
+a JSON codec generator."""
+  maintainer: "whitequark <whitequark@whitequark.org>"
+  authors: "whitequark <whitequark@whitequark.org>"
+  license: "MIT"
+  tags: ["syntax" "json"]
+  homepage: "https://github.com/ocaml-ppx/ppx_deriving_yojson"
+  bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_yojson/issues"
+  depends: [
+    "ocaml" {>= "4.05.0"}
+    "dune" {>= "1.0"}
+    "yojson" {>= "1.6.0"}
+    "result"
+    "ppx_deriving" {>= "5.1"}
+    "ppxlib" {>= "0.14.0" & < "0.26.0"}
+    "ounit" {with-test & >= "2.0.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.6.1/ppx_deriving_yojson-v3.6.1.tbz"
+    checksum: [
+      "sha256=712ee9207c70dd144e72cd689bee2d2beb120b804e77c74ec6f7b843a88944e6"
+      "sha512=d8c828902b8441f73e08fc03e2173ce81a09cccfe091471fbcffe098b2272739b98a05e8308016da3efeb3d4d1abd7d941bfaac42c85961ea40915ddce526577"
+    ]
+  }
+  x-commit-hash: "d0abe462de8bab52d763eeafd751e8ea1ba211ac"
+}
+package "ppx_enumerate" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Generate a list containing all values of a finite type"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_enumerate"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_enumerate/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_enumerate-v0.14.0.tar.gz"
+    checksum: "md5=188421af960759f6e45dd748f4f08e8d"
+  }
+}
+package "ppx_expect" {
+  opam-version: "2.0"
+  version: "v0.14.2"
+  synopsis: "Cram like framework for OCaml"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_expect"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_expect/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_expect/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "ppx_inline_test" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.18.0"}
+    "re" {>= "1.8.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
+  url {
+    src: "https://github.com/janestreet/ppx_expect/archive/v0.14.2.tar.gz"
+    checksum: "md5=ce1bb859cf695eb8f165fe1e03fff2c1"
+  }
+}
+package "ppx_fail" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Add location to calls to failwiths"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_fail"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fail/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_fail/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_fail.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_fail-v0.14.0.tar.gz"
+    checksum: "md5=8ac8d34542eebc2587cdb7e57a2d8350"
+  }
+}
+package "ppx_fields_conv" {
+  opam-version: "2.0"
+  version: "v0.14.2"
+  synopsis:
+    "Generation of accessor and iteration functions for ocaml records"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_fields_conv"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "fieldslib" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.18.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_fields_conv/archive/v0.14.2.tar.gz"
+    checksum: "md5=f9ff1b882775718cba29bd67839405f0"
+  }
+}
+package "ppx_fixed_literal" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Simpler notation for fixed point literals"
+  description: """\
+A ppx rewriter that rewrites fixed point literal of the 
+form 1.0v to conversion functions currently in scope."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_fixed_literal"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fixed_literal/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_fixed_literal/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_fixed_literal.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_fixed_literal-v0.14.0.tar.gz"
+    checksum: "md5=960bff66d1119cef42c16027e204554f"
+  }
+}
+package "ppx_hash" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "A ppx rewriter that generates hash functions from type expressions and definitions"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_hash"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_hash/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_hash/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_compare" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_hash.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_hash-v0.14.0.tar.gz"
+    checksum: "md5=b78aee19bb4469731f9626b04fe7f341"
+  }
+}
+package "ppx_here" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Expands [%here] into its location"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_here"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_here/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_here/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_here.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_here-v0.14.0.tar.gz"
+    checksum: "md5=bb3bbde0964a1f866de09f3df44def4d"
+  }
+}
+package "ppx_inline_test" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Syntax extension for writing in-line tests in ocaml code"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_inline_test"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "time_now" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.14.0" & < "0.29.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_inline_test/archive/v0.14.1.tar.gz"
+    checksum: "md5=132754f0757188c3b700a2c5b6a2fb3f"
+  }
+}
+package "ppx_jane" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Standard Jane Street ppx rewriters"
+  description: """\
+This package installs a ppx-jane executable, which is a ppx driver
+including all standard Jane Street ppx rewriters."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_jane"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_jane/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_jane/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base_quickcheck" {>= "v0.14" & < "v0.15"}
+    "ppx_assert" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "ppx_bench" {>= "v0.14" & < "v0.15"}
+    "ppx_bin_prot" {>= "v0.14" & < "v0.15"}
+    "ppx_custom_printf" {>= "v0.14" & < "v0.15"}
+    "ppx_expect" {>= "v0.14" & < "v0.15"}
+    "ppx_fields_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_fixed_literal"
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "ppx_inline_test" {>= "v0.14" & < "v0.15"}
+    "ppx_let" {>= "v0.14" & < "v0.15"}
+    "ppx_module_timer" {>= "v0.14" & < "v0.15"}
+    "ppx_optcomp" {>= "v0.14" & < "v0.15"}
+    "ppx_optional" {>= "v0.14" & < "v0.15"}
+    "ppx_pipebang" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_message" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_value" {>= "v0.14" & < "v0.15"}
+    "ppx_stable" {>= "v0.14" & < "v0.15"}
+    "ppx_string" {>= "v0.14" & < "v0.15"}
+    "ppx_typerep_conv" {>= "v0.14" & < "v0.15"}
+    "ppx_variants_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_jane.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_jane-v0.14.0.tar.gz"
+    checksum: "md5=ce8e39f9fe7ddcaf821e468a27766083"
+  }
+}
+package "ppx_js_style" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Code style checker for Jane Street Packages"
+  description: """\
+Part of the Jane Street's PPX rewriters collection.
+
+This packages is a no-op ppx rewriter. It is used as a 'lint' tool to
+enforce some coding conventions across all Jane Street packages."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_js_style"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_js_style/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "octavius"
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_js_style/archive/refs/tags/v0.14.1.tar.gz"
+    checksum: "md5=2d79afa4f954aeafb81b64ecfc11c3fb"
+  }
+}
+package "ppx_let" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Monadic let-bindings"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_let"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_let/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_let/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_let.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_let-v0.14.0.tar.gz"
+    checksum: "md5=faf5b4b69ef2595916f74fff251a9d2c"
+  }
+}
+package "ppx_module_timer" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Ppx rewriter that records top-level module startup times"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_module_timer"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_module_timer/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_module_timer/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "time_now" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_module_timer.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_module_timer-v0.14.0.tar.gz"
+    checksum: "md5=7ec9de2d5f07a1ceecdbefce0f0dea2c"
+  }
+}
+package "ppx_optcomp" {
+  opam-version: "2.0"
+  version: "v0.14.3"
+  synopsis: "Optional compilation for OCaml"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "opensource@janestreet.com"
+  authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_optcomp"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optcomp/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.18.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
+  url {
+    src: "https://github.com/janestreet/ppx_optcomp/archive/v0.14.3.tar.gz"
+    checksum: "md5=2d012df62dd0bc82d2ea4ab25b628992"
+  }
+}
+package "ppx_optional" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Pattern matching on flat options"
+  description: """\
+A ppx rewriter that rewrites simple match statements with an if then
+else expression."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_optional"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_optional/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_optional/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_optional.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_optional-v0.14.0.tar.gz"
+    checksum: "md5=0c85a3233f660a500f7d7481a1ab3c6c"
+  }
+}
+package "ppx_pipebang" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "A ppx rewriter that inlines reverse application operators `|>` and `|!`"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_pipebang"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_pipebang/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_pipebang-v0.14.0.tar.gz"
+    checksum: "md5=fa42f83b1851956dbae5716fab4776d3"
+  }
+}
+package "ppx_sexp_conv" {
+  opam-version: "2.0"
+  version: "v0.14.3"
+  synopsis:
+    "[@@deriving] plugin to generate S-expression conversion functions"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_sexp_conv"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "sexplib0" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.22.0" & < "0.26.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+  url {
+    src: "https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.3.tar.gz"
+    checksum: "md5=25caf01245e0113e035ccefe275f85d9"
+  }
+}
+package "ppx_sexp_message" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "A ppx rewriter for easy construction of s-expressions"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_sexp_message"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_message/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.18.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_sexp_message/archive/v0.14.1.tar.gz"
+    checksum: "md5=a6f4478ba28e7f16cd37789e64a7cb79"
+  }
+}
+package "ppx_sexp_value" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "A ppx rewriter that simplifies building s-expressions from ocaml values"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_sexp_value"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_value/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_here" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_conv" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/ppx_sexp_value-v0.14.0.tar.gz"
+    checksum: "md5=8bc8a75c992e8af371dfd71804ac2133"
+  }
+}
+package "ppx_stable" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Stable types conversions generator"
+  description: """\
+A ppx extension for easier implementation of conversion functions between almost
+identical types."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_stable"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_stable/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_stable/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.14.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_stable.git"
+  url {
+    src: "https://github.com/janestreet/ppx_stable/archive/v0.14.1.tar.gz"
+    checksum: "md5=78fd32fd0e72ebfd8e522008949066b5"
+  }
+}
+package "ppx_string" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Ppx extension for string interpolation"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_string"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_string/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_string/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "stdio" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.11.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_string.git"
+  url {
+    src: "https://github.com/janestreet/ppx_string/archive/v0.14.1.tar.gz"
+    checksum: "md5=5765a8ca47970b2290fbd7c5d589b449"
+  }
+}
+package "ppx_tools" {
+  opam-version: "2.0"
+  version: "6.5"
+  synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+  maintainer: "Kate <kit.ty.kate@disroot.org>"
+  authors: "Alain Frisch <alain.frisch@lexifi.com>"
+  license: "MIT"
+  tags: "syntax"
+  homepage: "https://github.com/ocaml-ppx/ppx_tools"
+  bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+  depends: [
+    "ocaml" {>= "4.08.0" & < "4.15.0"}
+    "dune" {>= "1.6"}
+    "cppo" {build & >= "1.1.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocaml-ppx/ppx_tools.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ppx_tools/releases/download/6.5/ppx_tools-6.5.tar.gz"
+    checksum: [
+      "md5=57439259c19b1615588c613a4e7c10e3"
+      "sha512=9f24e5feb9d32a5f038e94db33b6a8ba22ef0f83964bf657ac12fd0d39ae2580769612b1ba8988a56a146e4ae5da99e089bda24a4944b18b1df6e146bb75237b"
+    ]
+  }
+}
+package "ppx_typerep_conv" {
+  opam-version: "2.0"
+  version: "v0.14.2"
+  synopsis: "Generation of runtime types from type declarations"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_typerep_conv"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_typerep_conv/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "typerep" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.22.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_typerep_conv/archive/v0.14.2.tar.gz"
+    checksum: "md5=33ce6d705b7323772379712511daac0b"
+  }
+}
+package "ppx_variants_conv" {
+  opam-version: "2.0"
+  version: "v0.14.2"
+  synopsis:
+    "Generation of accessor and iteration functions for ocaml variant types"
+  description: "Part of the Jane Street's PPX rewriters collection."
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/ppx_variants_conv"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index.html"
+  bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "variantslib" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "ppxlib" {>= "0.23.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
+  url {
+    src:
+      "https://github.com/janestreet/ppx_variants_conv/archive/v0.14.2.tar.gz"
+    checksum: "md5=de29f93732da2fad0b221edbd763f5c1"
+  }
+}
+package "ppxlib" {
+  opam-version: "2.0"
+  version: "0.25.0"
+  synopsis: "Standard library for ppx rewriters"
+  description: """\
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code."""
+  maintainer: "opensource@janestreet.com"
+  authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+  license: "MIT"
+  homepage: "https://github.com/ocaml-ppx/ppxlib"
+  doc: "https://ocaml-ppx.github.io/ppxlib/"
+  bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+  depends: [
+    "dune" {>= "2.7"}
+    "ocaml" {>= "4.04.1" & < "4.15"}
+    "ocaml-compiler-libs" {>= "v0.11.0"}
+    "ppx_derivers" {>= "1.0"}
+    "sexplib0" {>= "v0.12"}
+    "stdlib-shims"
+    "ocamlfind" {with-test}
+    "re" {with-test & >= "1.9.0"}
+    "cinaps" {with-test & >= "v0.12.1"}
+    "sexplib0" {with-test & < "v0.15"}
+    "base" {with-test}
+    "stdio" {with-test}
+    "odoc" {with-doc}
+  ]
+  conflicts: [
+    "ocaml-migrate-parsetree" {< "2.0.0"}
+    "base-effects"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+  url {
+    src:
+      "https://github.com/ocaml-ppx/ppxlib/releases/download/0.25.0/ppxlib-0.25.0.tbz"
+    checksum: [
+      "sha256=2d2f150e7715845dc578d254f705a67600be71c986b7e67e81befda612870bd5"
+      "sha512=464220e3d8c75503824b73393df0b8ad16019acf55b8ecef89f8d464cd6d054e470ce4866b244216c5f7b85a5e8abad908aad212a78b4a132f3092fa785da0de"
+    ]
+  }
+  x-commit-hash: "2fde140076144150d01997d529d451bbcae439c4"
+}
+package "prometheus" {
+  opam-version: "2.0"
+  version: "1.1"
+  synopsis: "Client library for Prometheus monitoring"
+  description: """\
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly."""
+  maintainer: "talex5@gmail.com"
+  authors: ["Thomas Leonard" "David Scott"]
+  license: "Apache-2.0"
+  homepage: "https://github.com/mirage/prometheus"
+  doc: "https://mirage.github.io/prometheus/"
+  bug-reports: "https://github.com/mirage/prometheus/issues"
+  depends: [
+    "ocaml" {>= "4.01.0"}
+    "dune"
+    "astring"
+    "asetmap"
+    "fmt"
+    "re"
+    "lwt" {>= "2.5.0"}
+    "alcotest" {with-test}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/prometheus.git"
+  url {
+    src:
+      "https://github.com/mirage/prometheus/releases/download/v1.1/prometheus-v1.1.tbz"
+    checksum: [
+      "sha256=fbcf8bb28c02bfe4f61d2494bc2b70fdedd62f2b41fd1343e6f73d583bf599e4"
+      "sha512=9cf49689f6d33138cf41eca585e0d15bd17f670a3334b8235a52cc6c210fdc763fb967b19a91a110759a206aa9223cca1c7064e0eb2e2e6d3d13957ec7a38201"
+    ]
+  }
+  x-commit-hash: "4a85699fa5e37975484fc99bdf3ff944a315a1ed"
+}
+package "protocol_version_header" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Protocol versioning"
+  description: """\
+This library offers a lightweight way for applications protocols to
+version themselves. The more protocols that add themselves to
+[Known_protocol], the nicer error messages we will get when connecting
+to a service while using the wrong protocol."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/protocol_version_header"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/protocol_version_header/index.html"
+  bug-reports: "https://github.com/janestreet/protocol_version_header/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/protocol_version_header.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/protocol_version_header-v0.14.0.tar.gz"
+    checksum: "md5=b318922abe9d7b8c91523ff7ea767069"
+  }
+}
+package "ptime" {
+  opam-version: "2.0"
+  version: "0.8.5"
+  synopsis: "POSIX time for OCaml"
+  description: """\
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to a
+human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime depends on the `result` compatibility package. Ptime_clock
+depends on your system library. Ptime_clock's optional JavaScript
+support depends on [js_of_ocaml][jsoo]. Ptime and its libraries are
+distributed under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+[jsoo]: http://ocsigen.org/js_of_ocaml/"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The ptime programmers"
+  license: "ISC"
+  tags: ["time" "posix" "system" "org:erratique"]
+  homepage: "https://erratique.ch/software/ptime"
+  doc: "https://erratique.ch/software/ptime/doc"
+  bug-reports: "https://github.com/dbuenzli/ptime/issues"
+  depends: [
+    "ocaml" {>= "4.01.0" & < "5.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build & != "0.9.0"}
+    "topkg" {build}
+    "result"
+  ]
+  depopts: ["js_of_ocaml"]
+  conflicts: [
+    "js_of_ocaml" {< "3.3.0"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pinned"
+    "%{pinned}%"
+    "--with-js_of_ocaml"
+    "%{js_of_ocaml:installed}%"
+  ]
+  dev-repo: "git+http://erratique.ch/repos/ptime.git"
+  url {
+    src: "https://erratique.ch/software/ptime/releases/ptime-0.8.5.tbz"
+    checksum: "md5=4d48055d623ecf2db792439b3e96a520"
+  }
+}
+package "qcheck" {
+  opam-version: "2.0"
+  version: "0.20"
+  synopsis: "Compatibility package for qcheck"
+  maintainer: "simon.cruanes.2007@m4x.org"
+  authors: "the qcheck contributors"
+  license: "BSD-2-Clause"
+  tags: ["test" "property" "quickcheck"]
+  homepage: "https://github.com/c-cube/qcheck/"
+  doc: "http://c-cube.github.io/qcheck/"
+  bug-reports: "https://github.com/c-cube/qcheck/issues"
+  depends: [
+    "dune" {>= "2.2"}
+    "base-bytes"
+    "base-unix"
+    "qcheck-core" {= version}
+    "qcheck-ounit" {= version}
+    "alcotest" {with-test}
+    "odoc" {with-doc}
+    "ocaml" {>= "4.08.0"}
+  ]
+  conflicts: [
+    "ounit" {< "2.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/c-cube/qcheck.git"
+  url {
+    src: "https://github.com/c-cube/qcheck/archive/refs/tags/v0.20.tar.gz"
+    checksum: [
+      "md5=413d7ca480a6aa6fb9061159d6f07103"
+      "sha512=1fb178bee5353b870fe55e5c5379982345c2e1b7f417733be4168e8a58d448d26464d73f8a4470655ddea2701a2a44bc5b08b0de422c0f88f229d8a1ed9c3e87"
+    ]
+  }
+}
+package "qcheck-alcotest" {
+  opam-version: "2.0"
+  version: "0.20"
+  synopsis: "Alcotest backend for qcheck"
+  maintainer: "simon.cruanes.2007@m4x.org"
+  authors: "the qcheck contributors"
+  license: "BSD-2-Clause"
+  tags: ["test" "quickcheck" "qcheck" "alcotest"]
+  homepage: "https://github.com/c-cube/qcheck/"
+  doc: "http://c-cube.github.io/qcheck/"
+  bug-reports: "https://github.com/c-cube/qcheck/issues"
+  depends: [
+    "dune" {>= "2.2"}
+    "base-bytes"
+    "base-unix"
+    "qcheck-core" {= version}
+    "alcotest" {>= "0.8.1"}
+    "odoc" {with-doc}
+    "ocaml" {>= "4.08.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/c-cube/qcheck.git"
+  url {
+    src: "https://github.com/c-cube/qcheck/archive/refs/tags/v0.20.tar.gz"
+    checksum: [
+      "md5=413d7ca480a6aa6fb9061159d6f07103"
+      "sha512=1fb178bee5353b870fe55e5c5379982345c2e1b7f417733be4168e8a58d448d26464d73f8a4470655ddea2701a2a44bc5b08b0de422c0f88f229d8a1ed9c3e87"
+    ]
+  }
+}
+package "qcheck-core" {
+  opam-version: "2.0"
+  version: "0.20"
+  synopsis: "Core qcheck library"
+  maintainer: "simon.cruanes.2007@m4x.org"
+  authors: "the qcheck contributors"
+  license: "BSD-2-Clause"
+  tags: ["test" "property" "quickcheck"]
+  homepage: "https://github.com/c-cube/qcheck/"
+  doc: "http://c-cube.github.io/qcheck/"
+  bug-reports: "https://github.com/c-cube/qcheck/issues"
+  depends: [
+    "dune" {>= "2.2"}
+    "base-bytes"
+    "base-unix"
+    "alcotest" {with-test}
+    "odoc" {with-doc}
+    "ocaml" {>= "4.08.0"}
+  ]
+  conflicts: [
+    "ounit" {< "2.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/c-cube/qcheck.git"
+  url {
+    src: "https://github.com/c-cube/qcheck/archive/refs/tags/v0.20.tar.gz"
+    checksum: [
+      "md5=413d7ca480a6aa6fb9061159d6f07103"
+      "sha512=1fb178bee5353b870fe55e5c5379982345c2e1b7f417733be4168e8a58d448d26464d73f8a4470655ddea2701a2a44bc5b08b0de422c0f88f229d8a1ed9c3e87"
+    ]
+  }
+}
+package "qcheck-ounit" {
+  opam-version: "2.0"
+  version: "0.20"
+  synopsis: "OUnit backend for qcheck"
+  maintainer: "simon.cruanes.2007@m4x.org"
+  authors: "the qcheck contributors"
+  license: "BSD-2-Clause"
+  tags: ["qcheck" "quickcheck" "ounit"]
+  homepage: "https://github.com/c-cube/qcheck/"
+  doc: "http://c-cube.github.io/qcheck/"
+  bug-reports: "https://github.com/c-cube/qcheck/issues"
+  depends: [
+    "dune" {>= "2.2"}
+    "base-bytes"
+    "base-unix"
+    "qcheck-core" {= version}
+    "ounit2"
+    "odoc" {with-doc}
+    "ocaml" {>= "4.08.0"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/c-cube/qcheck.git"
+  url {
+    src: "https://github.com/c-cube/qcheck/archive/refs/tags/v0.20.tar.gz"
+    checksum: [
+      "md5=413d7ca480a6aa6fb9061159d6f07103"
+      "sha512=1fb178bee5353b870fe55e5c5379982345c2e1b7f417733be4168e8a58d448d26464d73f8a4470655ddea2701a2a44bc5b08b0de422c0f88f229d8a1ed9c3e87"
+    ]
+  }
+}
+package "re" {
+  opam-version: "2.0"
+  version: "1.9.0"
+  synopsis: "RE is a regular expression library for OCaml"
+  description: """\
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)"""
+  maintainer: "rudi.grinberg@gmail.com"
+  authors: [
+    "Jerome Vouillon"
+    "Thomas Gazagnaire"
+    "Anil Madhavapeddy"
+    "Rudi Grinberg"
+    "Gabriel Radanne"
+  ]
+  license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ocaml/ocaml-re"
+  bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+  depends: [
+    "ocaml" {>= "4.08"}
+    "dune"
+    "ounit" {with-test}
+    "seq"
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs]
+      {with-test & ocaml:version < "5.0"}
+  ]
+  dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+  url {
+    src:
+      "https://github.com/ocaml/ocaml-re/releases/download/1.9.0/re-1.9.0.tbz"
+    checksum: "md5=bddaed4f386a22cace7850c9c7dac296"
+  }
+}
+package "re2" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "OCaml bindings for RE2, Google's regular expression library"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/re2"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/re2/index.html"
+  bug-reports: "https://github.com/janestreet/re2/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "conf-g++" {build}
+    "dune" {>= "2.0.0"}
+  ]
+  available: arch != "arm32"
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/re2.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/re2-v0.14.0.tar.gz"
+    checksum: "md5=1ba423969e51a6a226d19f4cbb898719"
+  }
+}
+package "react" {
+  opam-version: "2.0"
+  version: "1.2.1"
+  synopsis: "Declarative events and signals for OCaml"
+  description: """\
+Release %%VERSION%%
+
+React is an OCaml module for functional reactive programming (FRP). It
+provides support to program with time varying values : declarative
+events and signals. React doesn't define any primitive event or
+signal, it lets the client chooses the concrete timeline.
+
+React is made of a single, independent, module and distributed under
+the ISC license."""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["reactive" "declarative" "signal" "event" "frp" "org:erratique"]
+  homepage: "http://erratique.ch/software/react"
+  doc: "http://erratique.ch/software/react/doc/React"
+  bug-reports: "https://github.com/dbuenzli/react/issues"
+  depends: [
+    "ocaml" {>= "4.01.0" & < "5.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build & >= "0.9.0"}
+  ]
+  build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%"]
+  dev-repo: "git+http://erratique.ch/repos/react.git"
+  url {
+    src: "http://erratique.ch/software/react/releases/react-1.2.1.tbz"
+    checksum: "md5=ce1454438ce4e9d2931248d3abba1fcc"
+  }
+}
+package "res" {
+  opam-version: "2.0"
+  version: "5.0.1"
+  synopsis: "RES - Library for resizable, contiguous datastructures"
+  description:
+    "RES is a library containing resizable arrays, strings, and bitvectors."
+  maintainer: "Markus Mottl <markus.mottl@gmail.com>"
+  authors: "Markus Mottl <markus.mottl@gmail.com>"
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  homepage: "https://mmottl.github.io/res"
+  doc: "https://mmottl.github.io/res/api"
+  bug-reports: "https://github.com/mmottl/res/issues"
+  depends: [
+    "ocaml" {>= "4.04"}
+    "dune" {>= "1.4.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  dev-repo: "git+https://github.com/mmottl/res.git"
+  url {
+    src:
+      "https://github.com/mmottl/res/releases/download/5.0.1/res-5.0.1.tbz"
+    checksum: "md5=386f1d006ba898c5f806db551719aec7"
+  }
+}
+package "result" {
+  opam-version: "2.0"
+  version: "1.5"
+  synopsis: "Compatibility Result module"
+  description: """\
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/janestreet/result"
+  bug-reports: "https://github.com/janestreet/result/issues"
+  depends: [
+    "ocaml"
+    "dune" {>= "1.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/result.git"
+  url {
+    src:
+      "https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz"
+    checksum: "md5=1b82dec78849680b49ae9a8a365b831b"
   }
 }
 package "rpc_parallel" {
@@ -449,5 +7356,1145 @@ Rpc_parallel offers an API to define various workers and protocols,
       "https://github.com/MinaProtocol/rpc_parallel/archive/39d6eec98705d5cc1f3ed8479ef19b1a1e0ee70e.tar.gz"
     checksum:
       "sha256=2b6c758433c5fd12b4971380147be96f0ce5d239932fc7f6df1d84f306bcbd2a"
+  }
+}
+package "rresult" {
+  opam-version: "2.0"
+  version: "0.6.0"
+  synopsis: "Result value combinators for OCaml"
+  description: """\
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+Rresult depends on the compatibility `result` package and is
+distributed under the ISC license."""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["result" "error" "declarative" "org:erratique"]
+  homepage: "http://erratique.ch/software/rresult"
+  doc: "http://erratique.ch/software/rresult"
+  bug-reports: "https://github.com/dbuenzli/rresult/issues"
+  depends: [
+    "ocaml" {>= "4.01.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+    "result"
+  ]
+  build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  dev-repo: "git+http://erratique.ch/repos/rresult.git"
+  url {
+    src: "http://erratique.ch/software/rresult/releases/rresult-0.6.0.tbz"
+    checksum: "md5=aba88cffa29081714468c2c7bcdf7fb1"
+  }
+}
+package "seq" {
+  opam-version: "2.0"
+  version: "base"
+  synopsis:
+    "Compatibility package for OCaml's standard iterator type starting from 4.07."
+  maintainer: " "
+  authors: " "
+  homepage: " "
+  bug-reports: "https://caml.inria.fr/mantis/main_page.php"
+  depends: [
+    "ocaml" {>= "4.07.0"}
+  ]
+  dev-repo: "git+https://github.com/ocaml/ocaml.git"
+  extra-files: [
+    ["seq.install" "md5=026b31e1df290373198373d5aaa26e42"]
+    ["META.seq" "md5=b33c8a1a6c7ed797816ce27df4855107"]
+  ]
+}
+package "sexp_diff_kernel" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Code for computing the diff of two sexps"
+  description: """\
+The code behind the [diff] subcommand of the Jane Street's [sexp]
+command line tool."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/sexp_diff_kernel"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexp_diff_kernel/index.html"
+  bug-reports: "https://github.com/janestreet/sexp_diff_kernel/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/sexp_diff_kernel.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexp_diff_kernel-v0.14.0.tar.gz"
+    checksum: "md5=4c87284d82317ae938af97f517074410"
+  }
+}
+package "sexplib" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Library for serializing OCaml values to and from S-expressions"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/sexplib"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
+  bug-reports: "https://github.com/janestreet/sexplib/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "parsexp" {>= "v0.14" & < "v0.15"}
+    "sexplib0" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+    "num"
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/sexplib.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib-v0.14.0.tar.gz"
+    checksum: "md5=6e230eae22face46cb8645e53e351067"
+  }
+}
+package "sexplib0" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis:
+    "Library containing the definition of S-expressions and some base converters"
+  description: """\
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/sexplib0"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+  bug-reports: "https://github.com/janestreet/sexplib0/issues"
+  depends: [
+    "ocaml" {>= "4.04.2" & < "5.0"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/sexplib0-v0.14.0.tar.gz"
+    checksum: "md5=37aff0af8f8f6f759249475684aebdc4"
+  }
+}
+package "spawn" {
+  opam-version: "2.0"
+  version: "v0.13.0"
+  synopsis: "Spawning sub-processes"
+  description: """\
+Spawn is a small library exposing only one functionality: spawning sub-process.
+
+It has three main goals:
+
+1. provide missing features of Unix.create_process such as providing a
+working directory
+
+2. provide better errors when a system call fails in the
+sub-process. For instance if a command is not found, you get a proper
+[Unix.Unix_error] exception
+
+3. improve performances by using vfork when available. It is often
+claimed that nowadays fork is as fast as vfork, however in practice
+fork takes time proportional to the process memory while vfork is
+constant time. In application using a lot of memory, vfork can be
+thousands of times faster than fork."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "Apache-2.0"
+  homepage: "https://github.com/janestreet/spawn"
+  doc: "https://janestreet.github.io/spawn/"
+  bug-reports: "https://github.com/janestreet/spawn/issues"
+  depends: [
+    "dune"
+    "ppx_expect" {with-test & < "v0.14"}
+    "ocaml" {>= "4.02.3"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml >= "4.04"}
+  ]
+  dev-repo: "git+https://github.com/janestreet/spawn.git"
+  url {
+    src:
+      "https://github.com/janestreet/spawn/releases/download/v0.13.0/spawn-v0.13.0.tbz"
+    checksum: "md5=6eaadbf8f9231415b51658da6b8b090f"
+  }
+}
+package "splittable_random" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "PRNG that can be split into independent streams"
+  description: """\
+PRNG that can be split into independent streams
+
+A splittable pseudo-random number generator (SPRNG) functions like a PRNG in that it can
+be used as a stream of random values; it can also be "split" to produce a second,
+independent stream of random values.
+
+This library implements a splittable pseudo-random number generator that sacrifices
+cryptographic-quality randomness in favor of performance."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/splittable_random"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/splittable_random/index.html"
+  bug-reports: "https://github.com/janestreet/splittable_random/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "ppx_assert" {>= "v0.14" & < "v0.15"}
+    "ppx_bench" {>= "v0.14" & < "v0.15"}
+    "ppx_inline_test" {>= "v0.14" & < "v0.15"}
+    "ppx_sexp_message" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/splittable_random.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/splittable_random-v0.14.0.tar.gz"
+    checksum: "md5=18ecdf4352883c70c48a3e02931b9521"
+  }
+}
+package "stdint" {
+  opam-version: "2.0"
+  version: "0.7.0"
+  synopsis: "Signed and unsigned integer types having specified widths"
+  description: """\
+The stdint library provides signed and unsigned integer types of various fixed
+widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical), conversion
+to and from buffers in both big endian and little endian byte order."""
+  maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  authors: [
+    "Andre Nathan <andre@digirati.com.br>"
+    "Jeff Shaw <shawjef3@msu.edu>"
+    "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+    "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+  ]
+  license: "MIT"
+  homepage: "https://github.com/andrenth/ocaml-stdint"
+  doc: "https://andrenth.github.io/ocaml-stdint/"
+  bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+  depends: [
+    "ocaml" {>= "4.03" & < "5.0"}
+    "odoc" {with-doc}
+    "dune" {>= "1.10"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+  ]
+  dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
+  url {
+    src:
+      "https://github.com/andrenth/ocaml-stdint/releases/download/0.7.0/stdint-0.7.0.tbz"
+    checksum: [
+      "sha256=4fcc66aef58e2b96e7af3bbca9d910aa239e045ba5fb2400aaef67d0041252dc"
+      "sha512=9b05b6cf691320b718dd2118b1e3f96a2997e42e6c99a34b470b060c82fc16c50d57c6ee392d1b62bdb8df73094657eea56050da3e74745a4afb0f150a60a584"
+    ]
+  }
+  x-commit-hash: "f3eb95c3807249e1fb8ca635bdaa1ef98f7249da"
+}
+package "stdio" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Standard IO library for OCaml"
+  description: """\
+Stdio implements simple input/output functionalities for OCaml.
+
+It re-exports the input/output functions of the OCaml standard
+libraries using a more consistent API."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/stdio"
+  doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
+  bug-reports: "https://github.com/janestreet/stdio/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/stdio.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/stdio-v0.14.0.tar.gz"
+    checksum: "md5=4cbdf15f0be88c3258aaeff9e04e00e9"
+  }
+}
+package "stdlib-shims" {
+  opam-version: "2.0"
+  version: "0.1.0"
+  synopsis: "Backport some of the new stdlib features to older compiler"
+  description: """\
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code."""
+  maintainer: "The stdlib-shims programmers"
+  authors: "The stdlib-shims programmers"
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  tags: ["stdlib" "compatibility" "org:ocaml"]
+  homepage: "https://github.com/ocaml/stdlib-shims"
+  doc: "https://ocaml.github.io/stdlib-shims/"
+  bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune"
+    ("dune" {>= "2.8.0"} | "ocaml" {< "4.12.0~~"})
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+  url {
+    src:
+      "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+    checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+  }
+}
+package "stringext" {
+  opam-version: "2.0"
+  version: "1.6.0"
+  synopsis: "Extra string functions for OCaml"
+  description: """\
+Extra string functions for OCaml. Mainly splitting. All functions are in the
+Stringext module."""
+  maintainer: "rudi.grinberg@gmail.com"
+  authors: "Rudi Grinberg"
+  license: "MIT"
+  homepage: "https://github.com/rgrinberg/stringext"
+  bug-reports: "https://github.com/rgrinberg/stringext/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "1.0"}
+    "ounit" {with-test}
+    "qtest" {with-test & >= "2.2"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/rgrinberg/stringext.git"
+  url {
+    src:
+      "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz"
+    checksum: [
+      "sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+      "sha512=d8ebe40f42b598a9bd99f1ef4b00ba93458385a4accd121af66a0bf3b3f8d7135f576740adf1a43081dd409977c2219fd4bdbb5b3d1308890d301d553ed49900"
+    ]
+  }
+}
+package "textutils" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Text output utilities"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/textutils"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/textutils/index.html"
+  bug-reports: "https://github.com/janestreet/textutils/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core" {>= "v0.14" & < "v0.15"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/textutils.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/textutils-v0.14.0.tar.gz"
+    checksum: "md5=32980ca8c5c6128273bb6f662efc7c60"
+  }
+}
+package "textutils_kernel" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Text output utilities"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/textutils_kernel"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/textutils_kernel/index.html"
+  bug-reports: "https://github.com/janestreet/textutils_kernel/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/textutils_kernel.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/textutils_kernel-v0.14.0.tar.gz"
+    checksum: "md5=60108803a21379909ca35d2ba96d3843"
+  }
+}
+package "time_now" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Reports the current time"
+  description: """\
+Provides a single function to report the current time in nanoseconds
+since the start of the Unix epoch."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/time_now"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/time_now/index.html"
+  bug-reports: "https://github.com/janestreet/time_now/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "jane-street-headers" {>= "v0.14" & < "v0.15"}
+    "jst-config" {>= "v0.14" & < "v0.15"}
+    "ppx_base" {>= "v0.14" & < "v0.15"}
+    "ppx_optcomp" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/time_now.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/time_now-v0.14.0.tar.gz"
+    checksum: "md5=a93116938783587f8b9f5152dd543037"
+  }
+}
+package "timezone" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Time-zone handling"
+  description: """\
+Timezone handles parsing timezone data and create [Timezone.t] that
+can later be used to manipulate time in core_kernel or core."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/timezone"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/timezone/index.html"
+  bug-reports: "https://github.com/janestreet/timezone/issues"
+  depends: [
+    "ocaml" {>= "4.08.0"}
+    "core_kernel" {>= "v0.14" & < "v0.15"}
+    "ppx_jane" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/timezone.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/timezone-v0.14.0.tar.gz"
+    checksum: "md5=41a3d1bc43d3215e44018674776b07ca"
+  }
+}
+package "topkg" {
+  opam-version: "2.0"
+  version: "1.0.3"
+  synopsis: "The transitory OCaml software packager"
+  description: """\
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["packaging" "ocamlbuild" "org:erratique"]
+  homepage: "http://erratique.ch/software/topkg"
+  doc: "http://erratique.ch/software/topkg/doc"
+  bug-reports: "https://github.com/dbuenzli/topkg/issues"
+  depends: [
+    "ocaml" {>= "4.03.0" & < "5.0"}
+    "ocamlfind" {build & >= "1.6.1"}
+    "ocamlbuild"
+  ]
+  conflicts: ["ocaml-option-bytecode-only"]
+  build: [
+    "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{pinned}%"
+  ]
+  dev-repo: "git+http://erratique.ch/repos/topkg.git"
+  url {
+    src: "http://erratique.ch/software/topkg/releases/topkg-1.0.3.tbz"
+    checksum: "md5=e285f7a296d77ee7d831ba9a6bfb396f"
+  }
+}
+package "trie" {
+  opam-version: "2.0"
+  version: "1.0.0"
+  synopsis: "Strict impure trie tree"
+  maintainer: "zandoye@gmail.com"
+  authors: "ZAN DoYe"
+  license: "MIT"
+  homepage: "https://github.com/kandu/trie/"
+  bug-reports: "https://github.com/kandu/trie/issues"
+  depends: [
+    "ocaml" {>= "4.02"}
+    "dune" {>= "1.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/kandu/trie.git"
+  url {
+    src: "https://github.com/kandu/trie/archive/1.0.0.tar.gz"
+    checksum: "md5=84519b5f8bd92490bfc68a52f706ba14"
+  }
+}
+package "typerep" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Typerep is a library for runtime types"
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/typerep"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/typerep/index.html"
+  bug-reports: "https://github.com/janestreet/typerep/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/typerep.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/typerep-v0.14.0.tar.gz"
+    checksum: "md5=a1d10bec724e500fd2f6b7798fc0409c"
+  }
+}
+package "tyxml" {
+  opam-version: "2.0"
+  version: "4.5.0"
+  synopsis: "A library for building correct HTML and SVG documents"
+  description:
+    "TyXML provides a set of convenient combinators that uses the OCaml type system to ensure the validity of the generated documents. TyXML can be used with any representation of HTML and SVG: the textual one, provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`) virtual DOM (`virtual-dom`) and reactive or replicated trees (`eliom`). You can also create your own representation and use it to instantiate a new set of combinators."
+  maintainer: "dev@ocsigen.org"
+  authors: "The ocsigen team"
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  homepage: "https://github.com/ocsigen/tyxml"
+  doc: "https://ocsigen.org/tyxml/latest/manual/intro"
+  bug-reports: "https://github.com/ocsigen/tyxml/issues"
+  depends: [
+    "dune" {>= "2.0"}
+    "ocaml" {>= "4.02"}
+    "alcotest" {with-test}
+    "re" {>= "1.5.0"}
+    "seq"
+    "uutf" {>= "1.0.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+  url {
+    src:
+      "https://github.com/ocsigen/tyxml/releases/download/4.5.0/tyxml-4.5.0.tbz"
+    checksum: [
+      "sha256=c69accef5df4dd89d38f6aa0baad01e8fda4e9e98bb7dad61bec1452c5716068"
+      "sha512=772535441b09c393d53c27152e65f404a0a541aa0cea1bda899a8d751ab64d1729237e583618c3ff33d75e3865d53503d1ea413c6bbc8c68c413347efd1709b3"
+    ]
+  }
+  x-commit-hash: "ef431a4bceaefb2d9248e79092e6c1a1a9420095"
+}
+package "uchar" {
+  opam-version: "2.0"
+  version: "0.0.2"
+  synopsis: "Compatibility library for OCaml's Uchar module"
+  description: """\
+The `uchar` package provides a compatibility library for the
+[`Uchar`][1] module introduced in OCaml 4.03.
+
+The `uchar` package is distributed under the license of the OCaml
+compiler. See [LICENSE](LICENSE) for details.
+
+[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  tags: ["text" "character" "unicode" "compatibility" "org:ocaml.org"]
+  homepage: "http://ocaml.org"
+  doc: "https://ocaml.github.io/uchar/"
+  bug-reports: "https://github.com/ocaml/uchar/issues"
+  depends: [
+    "ocaml" {>= "3.12.0"}
+    "ocamlbuild" {build}
+  ]
+  build: [
+    ["ocaml" "pkg/git.ml"]
+    [
+      "ocaml"
+      "pkg/build.ml"
+      "native=%{ocaml:native}%"
+      "native-dynlink=%{ocaml:native-dynlink}%"
+    ]
+  ]
+  dev-repo: "git+https://github.com/ocaml/uchar.git"
+  url {
+    src:
+      "https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz"
+    checksum: "md5=c9ba2c738d264c420c642f7bb1cf4a36"
+  }
+}
+package "uri" {
+  opam-version: "2.0"
+  version: "4.2.0"
+  synopsis: "An RFC3986 URI/URL parsing library"
+  description: """\
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs."""
+  maintainer: "anil@recoil.org"
+  authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+  license: "ISC"
+  tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-uri"
+  doc: "https://mirage.github.io/ocaml-uri/"
+  bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+  depends: [
+    "ocaml" {>= "4.04.0"}
+    "dune" {>= "1.2.0"}
+    "ounit" {with-test & >= "1.0.2"}
+    "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+    "stringext" {>= "1.4.0"}
+    "angstrom" {>= "0.14.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-uri/releases/download/v4.2.0/uri-v4.2.0.tbz"
+    checksum: [
+      "sha256=c5c013d940dbb6731ea2ee75c2bf991d3435149c3f3659ec2e55476f5473f16b"
+      "sha512=119e39bf53db9e94383a4e3a3df492b60b2db097266b3a8660de431ad85bc87997718305972fd2abbfb529973475ce6b210ba5e34d12e85a5dabbb0e24130aa1"
+    ]
+  }
+  x-commit-hash: "0ff3efbbc235bef5a7d67cc01bc1dadbe2e859b9"
+}
+package "uri-sexp" {
+  opam-version: "2.0"
+  version: "4.2.0"
+  synopsis: "An RFC3986 URI/URL parsing library"
+  description: "ocaml-uri with sexp support"
+  maintainer: "anil@recoil.org"
+  authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+  license: "ISC"
+  tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+  homepage: "https://github.com/mirage/ocaml-uri"
+  doc: "https://mirage.github.io/ocaml-uri/"
+  bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+  depends: [
+    "uri" {= version}
+    "dune" {>= "1.2.0"}
+    "ppx_sexp_conv" {>= "v0.13.0"}
+    "sexplib0"
+    "ounit" {with-test}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+  url {
+    src:
+      "https://github.com/mirage/ocaml-uri/releases/download/v4.2.0/uri-v4.2.0.tbz"
+    checksum: [
+      "sha256=c5c013d940dbb6731ea2ee75c2bf991d3435149c3f3659ec2e55476f5473f16b"
+      "sha512=119e39bf53db9e94383a4e3a3df492b60b2db097266b3a8660de431ad85bc87997718305972fd2abbfb529973475ce6b210ba5e34d12e85a5dabbb0e24130aa1"
+    ]
+  }
+  x-commit-hash: "0ff3efbbc235bef5a7d67cc01bc1dadbe2e859b9"
+}
+package "utop" {
+  opam-version: "2.0"
+  version: "2.9.1"
+  synopsis: "Universal toplevel for OCaml"
+  description: """\
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs."""
+  maintainer: "jeremie@dimino.org"
+  authors: "Jérémie Dimino"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-community/utop"
+  doc: "https://ocaml-community.github.io/utop/"
+  bug-reports: "https://github.com/ocaml-community/utop/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "base-unix"
+    "base-threads"
+    "ocamlfind" {>= "1.7.2"}
+    "lambda-term" {>= "3.1.0" & < "3.3.0"}
+    "lwt"
+    "lwt_react"
+    "camomile" {< "2.0.0"}
+    "react" {>= "1.0.0"}
+    "cppo" {build & >= "1.1.2"}
+    "dune" {>= "1.0"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-community/utop.git"
+  url {
+    src:
+      "https://github.com/ocaml-community/utop/releases/download/2.9.1/utop-2.9.1.tbz"
+    checksum: [
+      "md5=470dd7d91f8624be5af2868c9616eabe"
+      "sha512=002fa809d4924419f51b81df968b653a111ae5992837792fcb867adf2e44c15d40fadccc9784ef61f21ea3233f9da74016433920bf909d808752b7f825f8cdb1"
+    ]
+  }
+}
+package "uucp" {
+  opam-version: "2.0"
+  version: "13.0.0"
+  synopsis: "Unicode character properties for OCaml"
+  description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The uucp programmers"
+  license: "ISC"
+  tags: ["unicode" "text" "character" "org:erratique"]
+  homepage: "https://erratique.ch/software/uucp"
+  doc: "https://erratique.ch/software/uucp/doc/Uucp"
+  bug-reports: "https://github.com/dbuenzli/uucp/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build & >= "0.9.0"}
+    "uucd" {with-test}
+    "uunf" {with-test}
+    "uutf" {with-test}
+  ]
+  depopts: ["uunf" "uutf" "cmdliner"]
+  conflicts: [
+    "uutf" {< "1.0.1"}
+    "cmdliner" {< "1.0.0"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--dev-pkg"
+    "%{pinned}%"
+    "--with-uutf"
+    "%{uutf:installed}%"
+    "--with-uunf"
+    "%{uunf:installed}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  dev-repo: "git+https://erratique.ch/repos/uucp.git"
+  url {
+    src: "https://erratique.ch/software/uucp/releases/uucp-13.0.0.tbz"
+    checksum: "md5=07e706249ddb2d02f0fa298804d3c739"
+  }
+}
+package "uuidm" {
+  opam-version: "2.0"
+  version: "0.9.7"
+  synopsis: "Universally unique identifiers (UUIDs) for OCaml"
+  description: """\
+Uuidm is an OCaml module implementing 128 bits universally unique
+identifiers version 3, 5 (named based with MD5, SHA-1 hashing) and 4
+(random based) according to [RFC 4122][rfc4122].
+
+Uuidm has no dependency and is distributed under the ISC license.
+
+[rfc4122]: http://tools.ietf.org/html/rfc4122"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["uuid" "codec" "org:erratique"]
+  homepage: "https://erratique.ch/software/uuidm"
+  doc: "https://erratique.ch/software/uuidm/doc/Uuidm"
+  bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+  depends: [
+    "ocaml" {>= "4.03.0" & < "5.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+  ]
+  depopts: ["cmdliner"]
+  conflicts: [
+    "cmdliner" {< "0.9.8"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pinned"
+    "%{pinned}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  dev-repo: "git+https://erratique.ch/repos/uuidm.git"
+  url {
+    src: "https://erratique.ch/software/uuidm/releases/uuidm-0.9.7.tbz"
+    checksum: "md5=54658248e3981d8c05237d0a4277ccd3"
+  }
+}
+package "uuseg" {
+  opam-version: "2.0"
+  version: "13.0.0"
+  synopsis: "Unicode text segmentation for OCaml"
+  description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/"""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "The uuseg programmers"
+  license: "ISC"
+  tags: ["segmentation" "text" "unicode" "org:erratique"]
+  homepage: "https://erratique.ch/software/uuseg"
+  doc: "https://erratique.ch/software/uuseg"
+  bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+  depends: [
+    "ocaml" {>= "4.03.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+    "uucp" {>= "13.0.0" & < "14.0.0"}
+  ]
+  depopts: [
+    "uutf"
+    "cmdliner"
+    "uutf" {with-test}
+    "cmdliner" {with-test}
+  ]
+  conflicts: [
+    "uutf" {< "1.0.0"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pinned"
+    "%{pinned}%"
+    "--with-uutf"
+    "%{uutf:installed}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+  url {
+    src: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+    checksum: "md5=a07a97fff61da604614ea8da0547ef6a"
+  }
+}
+package "uutf" {
+  opam-version: "2.0"
+  version: "1.0.2"
+  synopsis: "Non-blocking streaming Unicode codec for OCaml"
+  description: """\
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values.
+
+Uutf has no dependency and is distributed under the ISC license."""
+  maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+  license: "ISC"
+  tags: ["unicode" "text" "utf-8" "utf-16" "codec" "org:erratique"]
+  homepage: "http://erratique.ch/software/uutf"
+  doc: "http://erratique.ch/software/uutf/doc/Uutf"
+  bug-reports: "https://github.com/dbuenzli/uutf/issues"
+  depends: [
+    "ocaml" {>= "4.01.0" & < "5.0"}
+    "ocamlfind" {build}
+    "ocamlbuild" {build}
+    "topkg" {build}
+    "uchar"
+  ]
+  depopts: ["cmdliner"]
+  conflicts: [
+    "cmdliner" {< "0.9.6"}
+  ]
+  build: [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pinned"
+    "%{pinned}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+  ]
+  dev-repo: "git+http://erratique.ch/repos/uutf.git"
+  url {
+    src: "http://erratique.ch/software/uutf/releases/uutf-1.0.2.tbz"
+    checksum: "md5=a7c542405a39630c689a82bd7ef2292c"
+  }
+}
+package "variantslib" {
+  opam-version: "2.0"
+  version: "v0.14.0"
+  synopsis: "Part of Jane Street's Core library"
+  description: """\
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml."""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/variantslib"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/variantslib/index.html"
+  bug-reports: "https://github.com/janestreet/variantslib/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "base" {>= "v0.14" & < "v0.15"}
+    "dune" {>= "2.0.0"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/variantslib.git"
+  url {
+    src:
+      "https://ocaml.janestreet.com/ocaml-core/v0.14/files/variantslib-v0.14.0.tar.gz"
+    checksum: "md5=c0a0481de7df3df028bdec76d9993892"
+  }
+}
+package "yojson" {
+  opam-version: "2.0"
+  version: "1.7.0"
+  synopsis:
+    "Yojson is an optimized parsing and printing library for the JSON format"
+  description: """\
+Yojson is an optimized parsing and printing library for the JSON format.
+
+It addresses a few shortcomings of json-wheel including 2x speedup,
+polymorphic variants and optional syntax for tuples and variants.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package.
+
+The program atdgen can be used to derive OCaml-JSON serializers and
+deserializers from type definitions."""
+  maintainer: "martin@mjambon.com"
+  authors: "Martin Jambon"
+  homepage: "https://github.com/ocaml-community/yojson"
+  doc: "https://ocaml-community.github.io/yojson/"
+  bug-reports: "https://github.com/ocaml-community/yojson/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune"
+    "cppo" {build}
+    "easy-format"
+    "biniou" {>= "1.2.0"}
+    "alcotest" {with-test & >= "0.8.5"}
+  ]
+  build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  run-test: ["dune" "runtest" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+  url {
+    src:
+      "https://github.com/ocaml-community/yojson/releases/download/1.7.0/yojson-1.7.0.tbz"
+    checksum: "md5=b89d39ca3f8c532abe5f547ad3b8f84d"
+  }
+}
+package "zarith" {
+  opam-version: "2.0"
+  version: "1.7"
+  synopsis:
+    "Implements arithmetic and logical operations over arbitrary-precision integers"
+  description: """\
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+  maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+  authors: ["Antoine Miné" "Xavier Leroy" "Pascal Cuoq"]
+  homepage: "https://github.com/ocaml/Zarith"
+  bug-reports: "https://github.com/ocaml/Zarith/issues"
+  depends: [
+    "ocaml"
+    "ocamlfind"
+    "conf-gmp"
+    "conf-perl" {build}
+  ]
+  flags: light-uninstall
+  build: [
+    ["./configure"] {os != "openbsd" & os != "freebsd" & os != "macos"}
+    [
+      "sh"
+      "-exc"
+      "LDFLAGS=\"$LDFLAGS -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/usr/local/include\" ./configure"
+    ] {os = "openbsd" | os = "freebsd"}
+    [
+      "sh"
+      "-exc"
+      "LDFLAGS=\"$LDFLAGS -L/opt/local/lib -L/usr/local/lib\" CFLAGS=\"$CFLAGS -I/opt/local/include -I/usr/local/include\" ./configure"
+    ] {os = "macos"}
+    [make]
+  ]
+  install: [make "install"]
+  remove: ["ocamlfind" "remove" "zarith"]
+  dev-repo: "git+https://github.com/ocaml/Zarith.git"
+  url {
+    src: "https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz"
+    checksum: "md5=80944e2755ebb848451a77dc2ad0651b"
+  }
+}
+package "zarith_stubs_js" {
+  opam-version: "2.0"
+  version: "v0.14.1"
+  synopsis: "Javascripts stubs for the Zarith library"
+  description: """\
+This library contains no ocaml code, but instead implements
+all of the Zarith C stubs in Javascript for use in Js_of_ocaml"""
+  maintainer: "Jane Street developers"
+  authors: "Jane Street Group, LLC"
+  license: "MIT"
+  homepage: "https://github.com/janestreet/zarith_stubs_js"
+  doc:
+    "https://ocaml.janestreet.com/ocaml-core/latest/doc/zarith_stubs_js/index.html"
+  bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
+  depends: [
+    "ocaml" {>= "4.04.2"}
+    "dune" {>= "2.0.0"}
+  ]
+  conflicts: [
+    "zarith" {>= "1.12"}
+  ]
+  build: ["dune" "build" "-p" name "-j" jobs]
+  dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"
+  url {
+    src:
+      "https://github.com/janestreet/zarith_stubs_js/archive/refs/tags/v0.14.1.tar.gz"
+    checksum: "md5=948430731b9e3d0890cfc930b6829c37"
+  }
+}
+package "zed" {
+  opam-version: "2.0"
+  version: "3.1.0"
+  synopsis: "Abstract engine for text edition in OCaml"
+  description: """\
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+  maintainer: "opam-devel@lists.ocaml.org"
+  authors: "Jérémie Dimino"
+  license: "BSD-3-Clause"
+  homepage: "https://github.com/ocaml-community/zed"
+  bug-reports: "https://github.com/ocaml-community/zed/issues"
+  depends: [
+    "ocaml" {>= "4.02.3"}
+    "dune" {>= "1.1.0"}
+    "base-bytes"
+    "camomile" {>= "1.0.1"}
+    "react"
+    "charInfo_width" {>= "1.1.0" & < "2.0~"}
+  ]
+  build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ]
+  dev-repo: "git+https://github.com/ocaml-community/zed.git"
+  url {
+    src: "https://github.com/ocaml-community/zed/archive/3.1.0.tar.gz"
+    checksum: "md5=51e8676ba972e5ad727633c161e404b1"
   }
 }


### PR DESCRIPTION
protects against certain supply chain attacks (opam package repository subversion). created by `opam switch export --full opam.export`