### PR TITLE
Add prepare test ledger script

### DIFF
--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -9,15 +9,15 @@ KEY_BALANCE=100000
 echo "Script assumes mainnet's start was at epoch 0 on 17th March 2021, if it's not the case, update the script please" >&2
 
 if [[ $# -eq 0 ]]; then
-  echo "No arguments specified: need block producing keys" >&2
+  echo "Usage: ./scripts/prepare-test-ledger.sh <BP key 1> <BP key 2> ... <BP key n>" >&2
   exit 1
 fi
 
 num_keys=$#
 num_keys_and_ghost=$((num_keys + NUM_GHOST_KEYS))
 
-now=`date +%s`
-mainnet_start=`date --date='2021-03-17 00:00:00' -u +%s`
+now=$(date +%s)
+mainnet_start=$(date --date='2021-03-17 00:00:00' -u +%s)
 epoch_now=$(( (now-mainnet_start)/7140/180 ))
 
 ledger_file="$epoch_now.json"
@@ -31,7 +31,7 @@ if [[ ! -f "$ledger_file" ]]; then
   wget -O $ledger_file "$ledger_url"
 fi
 
-ixs_=$(for key in $@; do
+ixs_=$(for key in "$@"; do
   <$ledger_file jq "[.[].pk] |index(\"$key\")"
 done)
 
@@ -42,7 +42,7 @@ i=0; for ix in $ixs_; do
     while $not_found; do
       found=false
       for ix_ in $ixs_; do
-        if [[ $i == $ix_ ]]; then
+        if [[ $i == "$ix_" ]]; then
           found=true
         fi
       done
@@ -52,9 +52,9 @@ i=0; for ix in $ixs_; do
         not_found=false
       fi
     done
-    ixs+=( $i )
+    ixs+=( "$i" )
   else
-    ixs+=( $ix )
+    ixs+=( "$ix" )
   fi
 done
 

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Usage: ./scripts/prepare-test-ledger.sh <BP key 1> <BP key 2> ... <BP key n>
+
+# Number of keys in ledger that won't be re-delegated
+NUM_GHOST_KEYS=${NUM_GHOST_KEYS:-0}
+KEY_BALANCE=100000
+
+echo "Script assumes mainnet's start was at epoch 0 on 17th March 2021, if it's not the case, update the script please" >&2
+
+if [[ $# -eq 0 ]]; then
+  echo "No arguments specified: need block producing keys" >&2
+  exit 1
+fi
+
+num_keys=$#
+num_keys_and_ghost=$((num_keys + NUM_GHOST_KEYS))
+
+now=`date +%s`
+mainnet_start=`date --date='2021-03-17 00:00:00' -u +%s`
+epoch_now=$(( (now-mainnet_start)/7140/180 ))
+
+ledger_file="$epoch_now.json"
+
+echo "Current epoch: $epoch_now" >&2
+
+if [[ ! -f "$ledger_file" ]]; then
+  ledgers_url="https://storage.googleapis.com/storage/v1/b/mina-staking-ledgers/o?maxResults=1&prefix=staking-$epoch_now"
+  ledger_url=$(curl "$ledgers_url" | jq -r .items[0].mediaLink)
+
+  wget -O $ledger_file "$ledger_url"
+fi
+
+ixs_=$(for key in $@; do
+  <$ledger_file jq "[.[].pk] |index(\"$key\")"
+done)
+
+ixs=()
+i=0; for ix in $ixs_; do
+  if [[ $ix == null ]]; then
+    not_found=true
+    while $not_found; do
+      found=false
+      for ix_ in $ixs_; do
+        if [[ $i == $ix_ ]]; then
+          found=true
+        fi
+      done
+      if $found; then
+        i=$((i+1))
+      else
+        not_found=false
+      fi
+    done
+    ixs+=( $i )
+  else
+    ixs+=( $ix )
+  fi
+done
+
+function join_arr(){
+  local IFS=,
+  echo "$*"
+}
+
+ixs_=$(join_arr "${ixs[@]}")
+
+num_accounts=$(<$ledger_file jq length)
+total_balance=$(<$ledger_file jq '[.[].balance | tonumber] | add | round')
+deducted_balance=$(<$ledger_file jq "[.[$ixs_].balance | tonumber] | add | ceil")
+new_total_balance=$((total_balance-deducted_balance+num_keys*KEY_BALANCE))
+
+echo "Total accounts: $num_accounts, balance: $total_balance, new balance: $new_total_balance" >&2
+
+function make_balance_expr(){
+  i=$1
+  key=$2
+  echo "$key: ((([.[range($i; $num_accounts; $num_keys_and_ghost)].balance | tonumber] | add)/$new_total_balance*10000|round/100 | tostring) + \"%\")"
+}
+
+balance_expr=$({ i=0; while [[ $i -lt $num_keys ]]; do
+  j=$((i+1))
+  make_balance_expr $i "${!j}"
+  i=$j
+done } | tr "\n" "," | head -c -1)
+
+echo "Balance map (warning: may not account well for the balance of delegate):" >&2
+jq <$ledger_file "{$balance_expr}" 1>&2
+
+function make_expr(){
+  i=$1
+  key=$2
+  echo ".[range($i; $num_accounts; $num_keys_and_ghost)].delegate = \"$key\""
+  echo ".[${ixs[$i]}].pk = \"$key\""
+  echo ".[${ixs[$i]}].balance = \"$KEY_BALANCE\""
+}
+
+expr=$({ i=0; while [[ $i -lt $num_keys ]]; do
+  j=$((i+1))
+  make_expr $i "${!j}"
+  i=$j
+done } | tr "\n" "|" | head -c -1)
+
+jq <$ledger_file "$expr"

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -35,8 +35,7 @@ keys_=""
 for key in "$@"; do
   keys_="\"$key\",$keys_"
 done
-keys_=${keys_:0:-1}
-echo $keys_
+keys_="${keys_:0:-1}"
 
 # jq filter to exclude block PKs from the ledger
 pre_filter="[.[] | select(.pk | IN($keys_) | not)]"


### PR DESCRIPTION
Adds a script that downloads staking ledger for the current epoch in mainnet and updates keys in it to delegate to a defined set of delegates.

Usage:

```
KEY_BALANCE=100 NUM_GHOST_KEYS=2 ./scripts/prepare-test-ledger.sh B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg B62qmqMrgPshhHKLJ7DqWn1KeizEgga5MuGmWb2bXajUnyivfeMW6JE B62qmVHmj3mNhouDf1hyQFCSt3ATuttrxozMunxYMLctMvnk5y7nas1 > /tmp/new_ledger.json
```

Command above generates a ledger with three keys specified as arguments being delegates, each holding balance of `100 MINA`. Parameter `NUM_GHOST_KEYS` controls how many keys are not re-delegated. With three delegate keys and `NUM_GHOST_KEYS=2`, `2/5` keys in ledger are unaltered.

Defaults:

  * `NUM_GHOST_KEYS = 0`
  * `KEY_BALANCE = 100000`

Explain how you tested your changes:

* Ran the script on a small subset of mainnet ledger, verified results

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #14854
