### PR TITLE
Use first pass ledger for snarked ledger everywhere

### DIFF
--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -242,7 +242,7 @@ module type State_hooks = sig
     val gen_consensus_state :
          constraint_constants:Genesis_constants.Constraint_constants.t
       -> constants:Constants.t
-      -> gen_slot_advancement:int Quickcheck.Generator.t
+      -> slot_advancement:int
       -> (   previous_protocol_state:
                protocol_state Mina_base.State_hash.With_state_hashes.t
           -> snarked_ledger_hash:Mina_base.Frozen_ledger_hash.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -3467,7 +3467,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       module For_tests = struct
         let gen_consensus_state
             ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-            ~constants ~(gen_slot_advancement : int Quickcheck.Generator.t) :
+            ~constants ~(slot_advancement : int) :
             (   previous_protocol_state:
                   Protocol_state.Value.t
                   Mina_base.State_hash.With_state_hashes.t
@@ -3483,7 +3483,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             |> Mina_base.Frozen_ledger_hash.of_ledger_hash
           in
           let open Quickcheck.Let_syntax in
-          let%bind slot_advancement = gen_slot_advancement in
           let%map producer_vrf_result = Vrf.Output.gen in
           fun ~(previous_protocol_state :
                  Protocol_state.Value.t Mina_base.State_hash.With_state_hashes.t

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -28,6 +28,9 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
 
   let underlying_proof = Transaction_snark.proof
 
+  let snarked_ledger_hash =
+    Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash statement
+
   let create ~statement ~sok_digest ~proof =
     Transaction_snark.create ~statement:{ statement with sok_digest } ~proof
 end

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -42,4 +42,6 @@ module type S = sig
   val sok_digest : t -> Sok_message.Digest.t
 
   val underlying_proof : t -> Proof.t
+
+  val snarked_ledger_hash : t -> Frozen_ledger_hash.t
 end

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -462,10 +462,6 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
     ~get_completed_work ~precomputed_values ~verifier ~parent_staged_ledger
     ~parent_protocol_state (t, validation) =
   [%log internal] "Validate_staged_ledger_diff" ;
-  let target_hash_of_ledger_proof =
-    Fn.compose Registers.second_pass_ledger
-    @@ Fn.compose Ledger_proof.statement_target Ledger_proof.statement
-  in
   let block = With_hash.data t in
   let header = Block.header block in
   let protocol_state = Header.protocol_state header in
@@ -512,43 +508,39 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
         , `Float Core.Time.(Span.to_ms @@ diff (now ()) apply_start_time) )
       ]
     "Staged_ledger.apply takes $time_elapsed" ;
-  let target_ledger_hash =
+  let snarked_ledger_hash =
     match proof_opt with
     | None ->
-        Option.value_map
-          (Staged_ledger.current_ledger_proof transitioned_staged_ledger)
-          ~f:target_hash_of_ledger_proof
-          ~default:
-            ( Precomputed_values.genesis_ledger precomputed_values
-            |> Lazy.force |> Mina_ledger.Ledger.merkle_root
-            |> Frozen_ledger_hash.of_ledger_hash )
+        (*There was no proof emitted, snarked ledger hash shouldn't change*)
+        Protocol_state.snarked_ledger_hash parent_protocol_state
     | Some (proof, _) ->
-        target_hash_of_ledger_proof proof
+        Ledger_proof.snarked_ledger_hash proof
   in
-  let maybe_errors =
-    Option.all
-      [ Option.some_if
-          (not
-             (Staged_ledger_hash.equal staged_ledger_hash
-                (Blockchain_state.staged_ledger_hash blockchain_state) ) )
-          `Incorrect_target_staged_ledger_hash
-      ; Option.some_if
-          (not
-             (Frozen_ledger_hash.equal target_ledger_hash
-                (Blockchain_state.snarked_ledger_hash blockchain_state) ) )
-          `Incorrect_target_snarked_ledger_hash
+  let hash_errors =
+    Result.combine_errors_unit
+      [ ( if
+          Staged_ledger_hash.equal staged_ledger_hash
+            (Blockchain_state.staged_ledger_hash blockchain_state)
+        then Ok ()
+        else Error `Incorrect_target_staged_ledger_hash )
+      ; ( if
+          Frozen_ledger_hash.equal snarked_ledger_hash
+            (Blockchain_state.snarked_ledger_hash blockchain_state)
+        then Ok ()
+        else Error `Incorrect_target_snarked_ledger_hash )
       ]
   in
   Deferred.return
-    ( match maybe_errors with
-    | Some errors ->
-        Error (`Invalid_staged_ledger_diff errors)
-    | None ->
-        Ok
-          ( `Just_emitted_a_proof (Option.is_some proof_opt)
-          , `Block_with_validation
-              (t, Unsafe.set_valid_staged_ledger_diff validation)
-          , `Staged_ledger transitioned_staged_ledger ) )
+  @@
+  match hash_errors with
+  | Ok () ->
+      Ok
+        ( `Just_emitted_a_proof (Option.is_some proof_opt)
+        , `Block_with_validation
+            (t, Unsafe.set_valid_staged_ledger_diff validation)
+        , `Staged_ledger transitioned_staged_ledger )
+  | Error errors ->
+      Error (`Invalid_staged_ledger_diff errors)
 
 let validate_staged_ledger_hash
     (`Staged_ledger_already_materialized staged_ledger_hash) (t, validation) =

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -56,7 +56,7 @@ Poly.
   , of_hlist )]
 
 let snarked_ledger_hash (t : _ Poly.t) =
-  t.ledger_proof_statement.target.first_pass_ledger
+  Snarked_ledger_state.snarked_ledger_hash t.ledger_proof_statement
 
 let snarked_local_state (t : _ Poly.t) =
   t.ledger_proof_statement.target.local_state

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -254,6 +254,10 @@ module Make_str (A : Wire_types.Concrete) = struct
   let constants { Poly.Stable.Latest.body = { Body.Poly.constants; _ }; _ } =
     constants
 
+  let snarked_ledger_hash
+      { Poly.Stable.Latest.body = { Body.Poly.blockchain_state; _ }; _ } =
+    Blockchain_state.snarked_ledger_hash blockchain_state
+
   [%%ifdef consensus_mechanism]
 
   let create_var = create'

--- a/src/lib/mina_state/protocol_state_intf.ml
+++ b/src/lib/mina_state/protocol_state_intf.ml
@@ -121,6 +121,25 @@ module type Full = sig
   val genesis_state_hash :
     ?state_hash:State_hash.t option -> Value.t -> State_hash.t
 
+  val snarked_ledger_hash :
+       ( _
+       , ( _
+         , ( _
+           , 'snarked_ledger_hash
+           , _
+           , _
+           , _
+           , _
+           , _
+           , _
+           , _ )
+           Blockchain_state.Poly.t
+         , _
+         , _ )
+         Body.t )
+       Poly.t
+    -> 'snarked_ledger_hash
+
   val genesis_state_hash_checked :
     state_hash:State_hash.var -> var -> State_hash.var Checked.t
 

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -549,6 +549,8 @@ module Make_str (A : Wire_types.Concrete) = struct
       }
   end
 
+  let snarked_ledger_hash (t : _ Poly.t) = Registers.first_pass_ledger t.target
+
   let validate_ledgers_at_merge (type a error bool)
       (module L : Ledger_hash_intf
         with type t = a

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -250,6 +250,8 @@ module type Full = sig
 
   val merge : t -> t -> t Or_error.t
 
+  val snarked_ledger_hash : ('ledger_hash, _, _, _, _, _) Poly.t -> 'ledger_hash
+
   include Hashable.S_binable with type t := t
 
   include Comparable.S with type t := t


### PR DESCRIPTION
Explain your changes:
* Block validation to use first pass ledger for snarked ledger
* Lift snarked ledger hash to the protocol state/blockchain state lib and refactored the code a bit to make it clearer
* Fixed a bug in breadcrumb generation for tests

Explain how you tested your changes:
* Existing unit tests covered the changes

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
