### PR TITLE
Lsanabria/migration cronjobs annotations

### DIFF
--- a/helm/cron_jobs/replayer-cronjobs/templates/cronjobs.yaml
+++ b/helm/cron_jobs/replayer-cronjobs/templates/cronjobs.yaml
@@ -6,6 +6,10 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: mina-cronjob-{{ .name }}
+  annotations:
+  {{- with $.Values.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
@@ -53,6 +57,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "replayer-cronjobs.fullname" $rootContext }}-{{ .script.secretName }}
+  {{- with $.Values.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- ($rootContext.Files.Glob (printf "files/%s" .script.scriptName)).AsSecrets | nindent 2 }} 

--- a/helm/cron_jobs/replayer-cronjobs/templates/gcloud-secret.yaml
+++ b/helm/cron_jobs/replayer-cronjobs/templates/gcloud-secret.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gcloud-keyfile-cronjobs
-stringData:
+data:
   keyfile.json: |
-    {{ .Values.gcloudKeyfileRef | indent 4 }}
+    {{ .Values.gcloudKeyfileRef | toString | b64enc | indent 4 }}

--- a/helm/cron_jobs/replayer-cronjobs/values.yaml
+++ b/helm/cron_jobs/replayer-cronjobs/values.yaml
@@ -40,6 +40,8 @@ tolerations: []
 
 affinity: {}
 
+annotations: {}
+
 replayers:
 - name: mainnet-migrated
   schedule: "0 2 * * *"


### PR DESCRIPTION
This PR introduces fields used by ArgoCD as well as changes the `gcloud-keyfile` secret to admit b64 encoded strings only. This is taken care of by adding the conversion directly to the Secret.

These features allows to redeploy via ArgoCD, without the developer needing to install `helm-secrets`, `helmfile` or other plugins.

This is already deployed using ArgoCD.