### PR TITLE
Bounded_types which know not to be too large

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -49,4 +49,4 @@ echo "--- Upload debs to amazon s3 repo"
 make publish_debs
 
 echo "--- Git diff after build is complete:"
-git diff --exit-code
+git diff --exit-code -- .

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -26,4 +26,4 @@ pr_branch=origin/${BUILDKITE_BRANCH}
 release_branch=${REMOTE}/$1
 
 echo "--- Run Python version linter with branches: ${pr_branch} ${base_branch} ${release_branch}"
-./scripts/version-linter.py ${pr_branch} ${base_branch} ${release_branch}
+./scripts/version-linter.py ${pr_branch} ${base_branch} ${release_branch} && mina internal audit-type-shapes

--- a/dockerfiles/Dockerfile-mina-test-executive
+++ b/dockerfiles/Dockerfile-mina-test-executive
@@ -80,7 +80,7 @@ ARG UID=0
 WORKDIR /root
 USER 0
 
-RUN git clone $MINA_REPO --branch $MINA_BRANCH --depth 1 \
+RUN git clone $MINA_REPO --branch $MINA_BRANCH --depth 1 mina \
   && cd ./mina
 
 WORKDIR /root/mina

--- a/scripts/require-ppxs.py
+++ b/scripts/require-ppxs.py
@@ -21,6 +21,7 @@ def dune_paths_ok(dune):
                  or path_prefix4 == ['lib', 'crypto', 'proof-systems']
                  or path_prefix3 == ['lib', 'snarky']
                  or path_prefix3 == ['lib', 'ppx_version']
+                 or path_prefix3 == ['lib', 'bounded_types']
                  or path_prefix3 == ['app', 'reformat']
                  or path_prefix3 == ['lib', 'ppx_mina']))
 

--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -4,7 +4,7 @@
  (public_name archive)
  (modules archive)
  (modes native)
- (libraries archive_cli async async_unix core_kernel base mina_version)
+ (libraries archive_cli async async_unix core_kernel base mina_version bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))
 
@@ -14,7 +14,7 @@
  (public_name archive-testnet)
  (modules archive_testnet_signatures)
  (modes native)
- (libraries archive_cli mina_signature_kind.testnet async async_unix core_kernel base mina_version)
+ (libraries archive_cli mina_signature_kind.testnet async async_unix core_kernel base mina_version bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))
 
@@ -24,6 +24,6 @@
  (public_name archive-mainnet)
  (modules archive_mainnet_signatures)
  (modes native)
- (libraries archive_cli mina_signature_kind.mainnet async async_unix core_kernel base mina_version)
+ (libraries archive_cli mina_signature_kind.mainnet async async_unix core_kernel base mina_version bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -22,6 +22,7 @@
    ppx_inline_test.config
    uri
    ;;local libraries
+   bounded_types
    mina_wire_types
    kimchi_backend
    child_processes

--- a/src/app/archive/lib/extensional.ml
+++ b/src/app/archive/lib/extensional.ml
@@ -24,7 +24,7 @@ module User_command = struct
       *)
       type t =
         { sequence_no : int
-        ; command_type : string
+        ; command_type : Bounded_types.String.Stable.V1.t
         ; fee_payer : Public_key.Compressed.Stable.V1.t
         ; source : Public_key.Compressed.Stable.V1.t
         ; receiver : Public_key.Compressed.Stable.V1.t
@@ -37,7 +37,7 @@ module User_command = struct
         ; hash : Transaction_hash.Stable.V1.t
               [@to_yojson Transaction_hash.to_yojson]
               [@of_yojson Transaction_hash.of_yojson]
-        ; status : string
+        ; status : Bounded_types.String.Stable.V1.t
         ; failure_reason : Transaction_status.Failure.Stable.V2.t option
         }
       [@@deriving yojson, equal]
@@ -57,13 +57,13 @@ module Internal_command = struct
       type t =
         { sequence_no : int
         ; secondary_sequence_no : int
-        ; command_type : string
+        ; command_type : Bounded_types.String.Stable.V1.t
         ; receiver : Public_key.Compressed.Stable.V1.t
         ; fee : Currency.Fee.Stable.V1.t
         ; hash : Transaction_hash.Stable.V1.t
               [@to_yojson Transaction_hash.to_yojson]
               [@of_yojson Transaction_hash.of_yojson]
-        ; status : string
+        ; status : Bounded_types.String.Stable.V1.t
         ; failure_reason : Transaction_status.Failure.Stable.V2.t option
         }
       [@@deriving yojson, equal]
@@ -86,7 +86,7 @@ module Zkapp_command = struct
         ; hash : Transaction_hash.Stable.V1.t
               [@to_yojson Transaction_hash.to_yojson]
               [@of_yojson Transaction_hash.of_yojson]
-        ; status : string
+        ; status : Bounded_types.String.Stable.V1.t
         ; failure_reasons :
             Transaction_status.Failure.Collection.Display.Stable.V1.t option
         }

--- a/src/app/archive_blocks/dune
+++ b/src/app/archive_blocks/dune
@@ -21,6 +21,7 @@
    ;; local libraries
    logger
    mina_block
+   bounded_types
    genesis_constants
    archive_lib
  )

--- a/src/app/batch_txn_tool/dune
+++ b/src/app/batch_txn_tool/dune
@@ -25,7 +25,7 @@
    mina_wire_types
    integration_test_lib
    logger
-
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../../graphql_schema.json)

--- a/src/app/benchmarks/dune
+++ b/src/app/benchmarks/dune
@@ -3,7 +3,7 @@
 (executable
  (name benchmarks)
  (public_name main)
- (libraries core_bench.inline_benchmarks vrf_lib_tests mina_base core_kernel core base)
+ (libraries core_bench.inline_benchmarks vrf_lib_tests mina_base core_kernel core base bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version))
  (link_flags -linkall)

--- a/src/app/berkeley_migration/dune
+++ b/src/app/berkeley_migration/dune
@@ -20,6 +20,7 @@
    async.async_command
    integers
    ;; local libraries
+   bounded_types
    logger
    archive_lib
    block_time

--- a/src/app/best_tip_merger/dune
+++ b/src/app/best_tip_merger/dune
@@ -37,6 +37,7 @@
    snark_params
    pickles
    kimchi_backend.pasta
+   bounded_types
     )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1547,6 +1547,100 @@ let dump_type_shapes =
              Core_kernel.printf "%s, %s, %s, %s\n" path digest shape_summary
                ty_decl ) ) )
 
+let primitive_ok = function
+  | "array" | "bytes" | "string" | "bigstring" ->
+      false
+  | "int" | "int32" | "int64" | "nativeint" | "char" | "bool" | "float" ->
+      true
+  | "unit" | "option" | "list" ->
+      true
+  | "kimchi_backend_bigint_32_V1" ->
+      true
+  | "Bounded_types.String.t"
+  | "Bounded_types.String.Tagged.t"
+  | "Bounded_types.Array.t" ->
+      true
+  | "8fabab0a-4992-11e6-8cca-9ba2c4686d9e" ->
+      true (* hashtbl *)
+  | "ac8a9ff4-4994-11e6-9a1b-9fb4e933bd9d" ->
+      true (* Make_iterable_binable *)
+  | s ->
+      failwithf "unknown primitive %s" s ()
+
+let audit_type_shapes : Command.t =
+  let rec shape_ok (shape : Sexp.t) : bool =
+    match shape with
+    | List [ Atom "Exp"; exp ] ->
+        exp_ok exp
+    | List [] ->
+        true
+    | _ ->
+        failwithf "bad shape: %s" (Sexp.to_string shape) ()
+  and exp_ok (exp : Sexp.t) : bool =
+    match exp with
+    | List [ Atom "Base"; Atom tyname; List exps ] ->
+        primitive_ok tyname && List.for_all exps ~f:shape_ok
+    | List [ Atom "Record"; List fields ] ->
+        List.for_all fields ~f:(fun field ->
+            match field with
+            | List [ Atom _; sh ] ->
+                shape_ok sh
+            | _ ->
+                failwithf "unhandled rec field: %s" (Sexp.to_string_hum field)
+                  () )
+    | List [ Atom "Tuple"; List exps ] ->
+        List.for_all exps ~f:shape_ok
+    | List [ Atom "Variant"; List ctors ] ->
+        List.for_all ctors ~f:(fun ctor ->
+            match ctor with
+            | List [ Atom _ctr; List exps ] ->
+                List.for_all exps ~f:shape_ok
+            | _ ->
+                failwithf "unhandled variant: %s" (Sexp.to_string_hum ctor) () )
+    | List [ Atom "Poly_variant"; List [ List [ Atom "sorted"; List ctors ] ] ]
+      ->
+        List.for_all ctors ~f:(fun ctor ->
+            match ctor with
+            | List [ Atom _ctr ] ->
+                true
+            | List [ Atom _ctr; List fields ] ->
+                List.for_all fields ~f:shape_ok
+            | _ ->
+                failwithf "unhandled poly variant: %s" (Sexp.to_string_hum ctor)
+                  () )
+    | List [ Atom "Application"; sh; List args ] ->
+        shape_ok sh && List.for_all args ~f:shape_ok
+    | List [ Atom "Rec_app"; Atom _; List args ] ->
+        List.for_all args ~f:shape_ok
+    | List [ Atom "Var"; Atom _ ] ->
+        true
+    | List (Atom ctr :: _) ->
+        failwithf "unhandled ctor (%s) in exp_ok: %s" ctr
+          (Sexp.to_string_hum exp) ()
+    | List [] | List _ | Atom _ ->
+        failwithf "bad format: %s" (Sexp.to_string_hum exp) ()
+  in
+  let handle_shape (path : string) (shape : Bin_prot.Shape.t) (ty_decl : string)
+      (good : int ref) (bad : int ref) =
+    let open Bin_prot.Shape in
+    let path, file = String.lsplit2_exn ~on:':' path in
+    let canonical = eval shape in
+    let shape_sexp = Canonical.to_string_hum canonical |> Sexp.of_string in
+    if not @@ shape_ok shape_sexp then (
+      incr bad ;
+      Core.eprintf "%s has a bad shape in %s (%s):\n%s\n" path file ty_decl
+        (Canonical.to_string_hum canonical) )
+    else incr good
+  in
+  Command.basic ~summary:"Audit shapes of versioned types"
+    (Command.Param.return (fun () ->
+         let bad, good = (ref 0, ref 0) in
+         Ppx_version_runtime.Shapes.iteri
+           ~f:(fun ~key:path ~data:(shape, ty_decl) ->
+             handle_shape path shape ty_decl good bad ) ;
+         Core.printf "good shapes:\n\t%d\nbad shapes:\n\t%d\n%!" !good !bad ;
+         if !bad > 0 then Core.exit 1 ) )
+
 [%%if force_updates]
 
 let rec ensure_testnet_id_still_good logger =
@@ -1817,6 +1911,7 @@ let internal_commands logger =
           Deferred.return ()) )
   ; ("dump-type-shapes", dump_type_shapes)
   ; ("replay-blocks", replay_blocks logger)
+  ; ("audit-type-shapes", audit_type_shapes)
   ]
 
 let mina_commands logger =

--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -36,6 +36,7 @@
    graphql-async
    mirage-crypto-ec
    ;;local libraries
+   bounded_types
    snark_profiler_lib
    archive_lib
    mina_wire_types

--- a/src/app/delegation_compliance/dune
+++ b/src/app/delegation_compliance/dune
@@ -37,6 +37,7 @@
    currency
    coda_genesis_ledger
    mina_base.import
+   bounded_types
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/display_public_key/dune
+++ b/src/app/display_public_key/dune
@@ -14,6 +14,7 @@
    core
    base.caml
    ;; local libraries
+   bounded_types
    cli_lib
    signature_lib
    secrets

--- a/src/app/dump_blocks/dune
+++ b/src/app/dump_blocks/dune
@@ -8,6 +8,7 @@
    transition_frontier_base transition_frontier_full_frontier
    logger precomputed_values block_time mina_base
    transition_frontier mina_state mina_block mina_wire_types
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_let ppx_custom_printf))

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -20,6 +20,7 @@
    ;; local libraries
    consensus_vrf
    mina_wire_types
+   bounded_types
    mina_base
    mina_base.import
    kimchi_backend.pasta

--- a/src/app/generate_keypair/dune
+++ b/src/app/generate_keypair/dune
@@ -3,7 +3,7 @@
  (name generate_keypair)
  (public_name generate_keypair)
  (modes native)
- (libraries cli_lib async core_kernel mina_version async_unix)
+ (libraries cli_lib async core_kernel mina_version async_unix bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_let ppx_sexp_conv ppx_optcomp))
  (flags -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/app/genesis_ledger_from_tsv/dune
+++ b/src/app/genesis_ledger_from_tsv/dune
@@ -2,7 +2,7 @@
  (package genesis_ledger_from_tsv)
  (name genesis_ledger_from_tsv)
  (public_name genesis_ledger_from_tsv)
- (libraries async.async_command async_kernel async core_kernel core logger consensus currency genesis_constants mina_numbers runtime_config signature_lib base base.caml stdio)
+ (libraries async.async_command async_kernel async core_kernel core logger consensus currency genesis_constants mina_numbers runtime_config signature_lib base base.caml stdio bounded_types)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_mina ppx_sexp_conv ppx_let ppx_hash ppx_compare )))

--- a/src/app/graphql_schema_dump/dune
+++ b/src/app/graphql_schema_dump/dune
@@ -1,5 +1,5 @@
 (executable
  (name graphql_schema_dump)
- (libraries graphql_parser mina_graphql async async_unix graphql-async yojson)
+ (libraries graphql_parser mina_graphql async async_unix graphql-async yojson bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))

--- a/src/app/heap_usage/dune
+++ b/src/app/heap_usage/dune
@@ -23,6 +23,7 @@
    mina_base.import
    mina_numbers
    currency
+   bounded_types
    data_hash_lib
    signature_lib
    merkle_ledger

--- a/src/app/logproc/dune
+++ b/src/app/logproc/dune
@@ -14,6 +14,7 @@
    ;;local libraries
    logger
    logproc_lib
+   bounded_types
    bash_colors
    interpolator_lib
  )

--- a/src/app/migrate-balances-table/dune
+++ b/src/app/migrate-balances-table/dune
@@ -17,6 +17,7 @@
    async.async_command
    ;; local libraries
    logger
+   bounded_types
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/missing_blocks_auditor/dune
+++ b/src/app/missing_blocks_auditor/dune
@@ -17,6 +17,7 @@
    async.async_command
    ;; local libraries
    logger
+   bounded_types
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/patch_archive_test/dune
+++ b/src/app/patch_archive_test/dune
@@ -21,6 +21,7 @@
    stdio
    base.caml
    result
+   bounded_types
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -40,6 +40,7 @@
    mina_state
    mina_ledger
    mina_base
+   bounded_types
    mina_base.import
    mina_transaction
    mina_transaction_logic

--- a/src/app/runtime_genesis_ledger/dune
+++ b/src/app/runtime_genesis_ledger/dune
@@ -17,6 +17,7 @@
    mina_runtime_config
    mina_ledger
    genesis_ledger_helper
+   bounded_types
    logger
    cache_dir
    precomputed_values

--- a/src/app/snark_work_debugger/dune
+++ b/src/app/snark_work_debugger/dune
@@ -16,6 +16,7 @@
    ;; local libraries
    mina_base
    snark_worker
+   bounded_types
    snark_work_lib
    transaction_witness
    transaction_snark

--- a/src/app/swap_bad_balances/dune
+++ b/src/app/swap_bad_balances/dune
@@ -19,6 +19,7 @@
    async.async_command
    ;; local libraries
    currency
+   bounded_types
    mina_stdlib
    logger
  )

--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -60,6 +60,7 @@
    zkapps_examples
    cache_dir
    snarky.backendless
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_mina ppx_jane ppx_deriving_yojson ppx_mina ppx_version)))

--- a/src/app/validate_keypair/dune
+++ b/src/app/validate_keypair/dune
@@ -10,6 +10,7 @@
    async_unix
    ;; local libraries
    mina_version
+   bounded_types
    cli_lib
  )
  (instrumentation (backend bisect_ppx))

--- a/src/app/zkapp_limits/dune
+++ b/src/app/zkapp_limits/dune
@@ -10,6 +10,7 @@
    ;; local libraries
    mina_base
    genesis_constants
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_mina ppx_custom_printf ppx_let ppx_hash ppx_compare ppx_sexp_conv)))

--- a/src/app/zkapp_test_transaction/dune
+++ b/src/app/zkapp_test_transaction/dune
@@ -16,6 +16,7 @@
    mina_graphql
    mina_numbers
    currency
+   bounded_types
    cli_lib
    mina_base
    signature_lib

--- a/src/app/zkapp_test_transaction/lib/dune
+++ b/src/app/zkapp_test_transaction/lib/dune
@@ -20,6 +20,7 @@
    pickles
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
+   bounded_types
    random_oracle
    mina_runtime_config
    transaction_witness

--- a/src/app/zkapps_examples/dune
+++ b/src/app/zkapps_examples/dune
@@ -25,6 +25,7 @@
    random_oracle_input
    snarky.backendless
    snark_params
+   bounded_types
    sgn
    signature_lib
    tuple_lib

--- a/src/app/zkapps_examples/test/empty_update/dune
+++ b/src/app/zkapps_examples/test/empty_update/dune
@@ -41,6 +41,7 @@
    with_hash
    zkapps_empty_update
    zkapps_examples
+   bounded_types
    )
   (preprocess
     (pps ppx_snarky ppx_version ppx_jane))

--- a/src/app/zkapps_examples/test/tokens/dune
+++ b/src/app/zkapps_examples/test/tokens/dune
@@ -41,6 +41,7 @@
    with_hash
    zkapps_tokens
    zkapps_examples
+   bounded_types
    )
   (inline_tests (flags -verbose -show-counts))
   (preprocess

--- a/src/dune-project
+++ b/src/dune-project
@@ -16,6 +16,7 @@
 (package (name block_storage))
 (package (name block_time))
 (package (name bootstrap_controller))
+(package (name bounded_types))
 (package (name bowe_gabizon_hash))
 (package (name cache_dir))
 (package (name cached))

--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -81,7 +81,7 @@ module Make () = struct
         [%%define_locally T1.(to_string, of_string)]
       end
 
-      include Binable.Of_stringable_without_uuid (Arg)
+      include Bounded_types.String.Of_stringable (Arg)
     end
   end]
 

--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -15,4 +15,5 @@
    base.caml
    ppx_inline_test.config
    ;; local libraries
+   bounded_types
    ppx_version.runtime))

--- a/src/lib/bootstrap_controller/dune
+++ b/src/lib/bootstrap_controller/dune
@@ -20,6 +20,7 @@
    transition_frontier_base
    mina_metrics
    error_json
+   bounded_types
    with_hash
    mina_state
    inline_test_quiet_logs

--- a/src/lib/bounded_types/bounded_types.ml
+++ b/src/lib/bounded_types/bounded_types.ml
@@ -1,0 +1,164 @@
+open Core_kernel
+open Core_kernel.Hash.Builtin
+
+module N16 = struct
+  let max_array_len = 16
+end
+
+module N4000 = struct
+  let max_array_len = 4000
+end
+
+module ArrayN (N : sig
+  val max_array_len : int
+end) =
+struct
+  module Stable = struct
+    module V1 = struct
+      type 'a t = 'a array [@@deriving sexp, yojson, bin_io]
+
+      let __versioned__ = ()
+
+      let hash_fold_t = hash_fold_array_frozen
+
+      [%%define_locally Core_kernel.Array.(compare, equal)]
+
+      let to_latest s = s
+
+      let bin_shape_t bin_shape_elt =
+        Bin_prot.Shape.basetype
+          (Bin_prot.Shape.Uuid.of_string "Bounded_types.Array.t")
+          [ bin_shape_elt ]
+
+      let bin_write_t bin_write_el buf ~pos a =
+        if Array.length a > N.max_array_len then
+          failwithf "Exceeded array maximum size (max %d < got %d)"
+            N.max_array_len (Array.length a) () ;
+        bin_write_array bin_write_el buf ~pos a
+
+      let bin_read_t bin_read_el buf ~pos_ref =
+        let pos = !pos_ref in
+        let len = (Bin_prot.Read.bin_read_nat0 buf ~pos_ref :> int) in
+        if len > N.max_array_len then
+          Bin_prot.Common.raise_read_error
+            Bin_prot.Common.ReadError.Array_too_long !pos_ref
+        else (
+          pos_ref := pos ;
+          bin_read_array bin_read_el buf ~pos_ref )
+    end
+  end
+
+  type 'a t = 'a Stable.V1.t
+
+  [%%define_locally
+  Stable.V1.
+    (compare, equal, hash_fold_t, sexp_of_t, t_of_sexp, to_yojson, of_yojson)]
+end
+
+module String = struct
+  let max_string_len = 100_000_000
+
+  module Stable = struct
+    module V1 = struct
+      type t = string [@@deriving sexp, yojson, bin_io]
+
+      let __versioned__ = ()
+
+      let to_latest s = s
+
+      [%%define_locally Core_kernel.String.(compare, equal)]
+
+      let hash = hash_string
+
+      let hash_fold_t = hash_fold_string
+
+      let bin_shape_t =
+        Bin_prot.Shape.basetype
+          (Bin_prot.Shape.Uuid.of_string "Bounded_types.String.t")
+          []
+
+      let bin_write_t buf ~pos s =
+        if String.length s > max_string_len then
+          failwith "Exceeded string maximum size" ;
+        bin_write_string buf ~pos s
+
+      let bin_read_t buf ~pos_ref =
+        let pos = !pos_ref in
+        let len = (Bin_prot.Read.bin_read_nat0 buf ~pos_ref :> int) in
+        if len > max_string_len then
+          Bin_prot.Common.raise_read_error
+            Bin_prot.Common.ReadError.Array_too_long !pos_ref
+        else (
+          pos_ref := pos ;
+          bin_read_string buf ~pos_ref )
+    end
+  end
+
+  type t = Stable.V1.t
+
+  [%%define_locally
+  Stable.V1.
+    ( compare
+    , equal
+    , hash
+    , hash_fold_t
+    , sexp_of_t
+    , t_of_sexp
+    , to_yojson
+    , of_yojson )]
+
+  module Tagged = struct
+    module Stable = struct
+      module V1 = struct
+        include Stable.V1
+
+        (* because this is replacing a primitive,
+           there is no actual version tag handling
+           needed (and in fact, that will make a
+           test in transaction fail *)
+        module With_all_version_tags = Stable.V1
+      end
+    end
+  end
+
+  module Of_stringable (M : Stringable.S) =
+  Bin_prot.Utils.Make_binable_without_uuid (struct
+    module Binable = Stable.V1
+
+    type t = M.t
+
+    let to_binable = M.to_string
+
+    (* Wrap exception for improved diagnostics. *)
+    exception Of_binable of string * exn [@@deriving sexp]
+
+    let of_binable s = try M.of_string s with x -> raise (Of_binable (s, x))
+  end)
+end
+
+module Wrapped_error = struct
+  module Stable = struct
+    module V1 = struct
+      type t = Core_kernel.Error.Stable.V2.t [@@deriving sexp]
+
+      let __versioned__ = ()
+
+      let to_latest = Core_kernel.Fn.id
+
+      include String.Of_stringable (struct
+        type nonrec t = t
+
+        let to_string (s : t) =
+          Core_kernel.Error.sexp_of_t s |> Core_kernel.Sexp.to_string_mach
+
+        let of_string s =
+          Core_kernel.Error.t_of_sexp (Core_kernel.Sexp.of_string s)
+      end)
+    end
+  end
+
+  type t = Stable.V1.t
+end
+
+module ArrayN16 = ArrayN (N16)
+module ArrayN4000 = ArrayN (N4000)

--- a/src/lib/bounded_types/dune
+++ b/src/lib/bounded_types/dune
@@ -1,0 +1,9 @@
+(library
+ (name bounded_types)
+ (public_name bounded_types)
+ (instrumentation (backend bisect_ppx))
+ (libraries ppx_version.runtime stdlib base.caml core_kernel bin_prot bin_prot.shape ppx_inline_test.config sexplib0)
+ (inline_tests)
+ (preprocess (pps ppx_jane ppx_mina ppx_deriving_yojson ppx_inline_test))
+ (library_flags -linkall)
+ (synopsis "Put bounds on bin_prot deserializing"))

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -28,6 +28,7 @@
    ;; local libraries
    mina_wire_types
    mina_base.util
+   bounded_types
    unsigned_extended
    kimchi_backend.pasta
    kimchi_backend.pasta.basic

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -165,7 +165,8 @@ module Output = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving sexp, equal, compare, hash, yojson]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, equal, compare, hash, yojson]
 
         let to_yojson t =
           `String (Base64.encode_exn ~alphabet:Base64.uri_safe_alphabet t)

--- a/src/lib/consensus/vrf/dune
+++ b/src/lib/consensus/vrf/dune
@@ -20,6 +20,7 @@
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    genesis_constants
+   bounded_types
    crypto_params
    random_oracle
    blake2

--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -42,7 +42,8 @@
   promise
   logger
   internal_tracing.context_logger
-  ppx_version.runtime))
+  ppx_version.runtime
+  bounded_types))
 
 (rule
  (targets version.ml)

--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -118,7 +118,8 @@ module Challenge_polynomial = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('g, 'fq) t = { challenges : 'fq array; commitment : 'g }
+      type ('g, 'fq) t =
+        { challenges : 'fq Bounded_types.ArrayN16.Stable.V1.t; commitment : 'g }
       [@@deriving version, bin_io, sexp, compare, yojson]
 
       let to_latest = Fn.id
@@ -161,7 +162,7 @@ module Make (Inputs : Inputs_intf) = struct
         type t =
           ( G.Affine.Stable.V1.t
           , Fq.Stable.V1.t
-          , Fq.Stable.V1.t array )
+          , Fq.Stable.V1.t Bounded_types.ArrayN16.Stable.V1.t )
           Pickles_types.Plonk_types.Proof.Stable.V2.t
         [@@deriving compare, sexp, yojson, hash, equal]
 
@@ -172,7 +173,7 @@ module Make (Inputs : Inputs_intf) = struct
           -> openings:
                ( G.Affine.t
                , Fq.t
-               , Fq.t array )
+               , Fq.t Bounded_types.ArrayN16.Stable.V1.t )
                Pickles_types.Plonk_types.Openings.Stable.V2.t
           -> 'a
 

--- a/src/lib/crypto/kimchi_backend/common/scale_round.ml
+++ b/src/lib/crypto/kimchi_backend/common/scale_round.ml
@@ -1,19 +1,14 @@
 open Core_kernel
 
-[%%versioned
-module Stable = struct
-  module V2 = struct
-    type 'a t =
-      { accs : ('a * 'a) array
-      ; bits : 'a array
-      ; ss : 'a array
-      ; base : 'a * 'a
-      ; n_prev : 'a
-      ; n_next : 'a
-      }
-    [@@deriving sexp, fields, hlist]
-  end
-end]
+type 'a t =
+  { accs : ('a * 'a) array
+  ; bits : 'a array
+  ; ss : 'a array
+  ; base : 'a * 'a
+  ; n_prev : 'a
+  ; n_next : 'a
+  }
+[@@deriving sexp, fields, hlist]
 
 let map { accs; bits; ss; base; n_prev; n_next } ~f =
   { accs = Array.map accs ~f:(fun (x, y) -> (f x, f y))

--- a/src/lib/crypto/kimchi_backend/pasta/basic/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/basic/dune
@@ -21,6 +21,7 @@
   promise
   kimchi_bindings
   kimchi_types
+  bounded_types
   pasta_bindings
   snarkette
   ppx_version.runtime))

--- a/src/lib/crypto/kimchi_backend/pasta/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/dune
@@ -21,6 +21,7 @@
   promise
   kimchi_bindings
   kimchi_pasta_basic
+  bounded_types
   kimchi_pasta_constraint_system
   kimchi_types
   pasta_bindings

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -96,6 +96,7 @@
  (modules kimchi_types)
  (instrumentation
   (backend bisect_ppx))
+ (libraries bounded_types)
  (inline_tests (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test)))
@@ -104,7 +105,7 @@
  (public_name pasta_bindings)
  (name pasta_bindings)
  (modules pasta_bindings)
- (libraries kimchi_types pasta_bindings.backend)
+ (libraries kimchi_types pasta_bindings.backend bounded_types)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests (flags -verbose -show-counts))
@@ -115,7 +116,7 @@
  (public_name kimchi_bindings)
  (name kimchi_bindings)
  (modules kimchi_bindings)
- (libraries pasta_bindings kimchi_types)
+ (libraries pasta_bindings kimchi_types bounded_types)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests (flags -verbose -show-counts))
@@ -128,6 +129,7 @@
  (modules pasta_bindings_backend)
  (foreign_archives wires_15_stubs)
  (c_library_flags :standard "-lpthread")
+ (libraries bounded_types)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests (flags -verbose -show-counts))

--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -20,6 +20,7 @@
    ;; local libraries
    network_peer
    genesis_constants
+   bounded_types
    currency
    mina_net2
    transition_frontier

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -7,7 +7,8 @@ module Git_sha = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = string [@@deriving sexp, to_yojson, equal]
+      type t = Bounded_types.String.Stable.V1.t
+      [@@deriving sexp, to_yojson, equal]
 
       let to_latest = Fn.id
     end

--- a/src/lib/downloader/dune
+++ b/src/lib/downloader/dune
@@ -17,6 +17,7 @@
    trust_system
    logger
    o1trace
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/fake_network/dune
+++ b/src/lib/fake_network/dune
@@ -19,6 +19,7 @@
    genesis_constants
    signature_lib
    verifier
+   bounded_types
    precomputed_values
    block_time
    trust_system

--- a/src/lib/genesis_ledger/dune
+++ b/src/lib/genesis_ledger/dune
@@ -14,7 +14,8 @@
    genesis_constants
    data_hash_lib
    mina_ledger
-   mina_base.import)
+   mina_base.import
+   bounded_types)
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp ppx_let)))

--- a/src/lib/genesis_ledger_helper/dune
+++ b/src/lib/genesis_ledger_helper/dune
@@ -17,6 +17,7 @@
    ;; local libraries
    mina_ledger
    with_hash
+   bounded_types
    blockchain_snark
    error_json
    mina_state

--- a/src/lib/genesis_ledger_helper/lib/dune
+++ b/src/lib/genesis_ledger_helper/lib/dune
@@ -17,6 +17,7 @@
    pickles
    pickles_types
    unsigned_extended
+   bounded_types
    key_cache.native
    mina_base
    mina_runtime_config

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -40,6 +40,7 @@
    error_json
    block_time
    genesis_constants
+   bounded_types
 )
  (preprocess
   (pps ppx_mina ppx_version ppx_inline_test ppx_compare ppx_deriving.make ppx_deriving_yojson ppx_optcomp

--- a/src/lib/graphql_basic_scalars/dune
+++ b/src/lib/graphql_basic_scalars/dune
@@ -18,6 +18,8 @@
    ppx_inline_test.config
    ;; local libraries
    graphql_wrapper
+   base_quickcheck
+   quickcheck_lib
    unix
  )
  (instrumentation (backend bisect_ppx))

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -41,6 +41,7 @@
    mina_runtime_config
    mina_base
    mina_lib
+   bounded_types
    genesis_constants
    transition_router
    signature_lib

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -17,6 +17,7 @@
    ppx_inline_test.config
    async_unix
    ;; local libraries
+   bounded_types
    mina_wire_types
    genesis_constants
    mina_base.import

--- a/src/lib/logger/fake/dune
+++ b/src/lib/logger/fake/dune
@@ -13,6 +13,7 @@
    interpolator_lib
    mina_compile_config
    ppx_version.runtime
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess

--- a/src/lib/logger/fake/logger.ml
+++ b/src/lib/logger/fake/logger.ml
@@ -131,7 +131,11 @@ end
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = { null : bool; metadata : Metadata.Stable.V1.t; id : string }
+    type t =
+      { null : bool
+      ; metadata : Metadata.Stable.V1.t
+      ; id : Bounded_types.String.Stable.V1.t
+      }
 
     let to_latest = Fn.id
   end

--- a/src/lib/logger/native/dune
+++ b/src/lib/logger/native/dune
@@ -17,6 +17,7 @@
    interpolator_lib
    mina_compile_config
    ppx_version.runtime
+   bounded_types
  )
  (preprocess
   (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))

--- a/src/lib/logger/native/logger.ml
+++ b/src/lib/logger/native/logger.ml
@@ -85,7 +85,7 @@ module Metadata = struct
 
       include
         Binable.Of_binable_without_uuid
-          (Core_kernel.String.Stable.V1)
+          (Bounded_types.String.Stable.V1)
           (struct
             type nonrec t = t
 
@@ -314,7 +314,11 @@ end
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = { null : bool; metadata : Metadata.Stable.V1.t; id : string }
+    type t =
+      { null : bool
+      ; metadata : Metadata.Stable.V1.t
+      ; id : Bounded_types.String.Stable.V1.t
+      }
 
     let to_latest = Fn.id
   end

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -15,6 +15,7 @@
   ;; local libraries
   direction
   ppx_version.runtime
+  bounded_types
   test_util)
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_hash ppx_compare ppx_deriving_yojson

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -45,7 +45,7 @@ module Binable_arg = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = int * string
+      type t = int * Bounded_types.String.Stable.V1.t
 
       let to_latest = Fn.id
     end

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -29,6 +29,7 @@
    mina_stdlib
    visualization
    ppx_version.runtime
+   bounded_types
  )
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_compare ppx_deriving.show ppx_deriving_yojson))

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -3,7 +3,7 @@ open Unsigned
 
 (* add functions to library module Bigstring so we can derive hash for the type t below *)
 module Bigstring = struct
-  [%%versioned
+  [%%versioned_binable
   module Stable = struct
     module V1 = struct
       type t = Core_kernel.Bigstring.Stable.V1.t [@@deriving sexp, compare]
@@ -16,6 +16,14 @@ module Bigstring = struct
 
       let hash_fold_t hash_state t =
         String.hash_fold_t hash_state (Bigstring.to_string t)
+
+      include Bounded_types.String.Of_stringable (struct
+        type nonrec t = t
+
+        let of_string s = Core_kernel.Bigstring.of_string s
+
+        let to_string s = Core_kernel.Bigstring.to_string s
+      end)
     end
   end]
 

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -19,6 +19,7 @@
    async
    core_kernel
    ;; local libraries
+   bounded_types
    merkle_ledger
    merkle_mask
    mina_base

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -90,7 +90,8 @@ module Token_symbol = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = string [@@deriving sexp, equal, compare, hash, yojson]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, equal, compare, hash, yojson]
 
         let to_latest = Fn.id
 
@@ -115,9 +116,9 @@ module Token_symbol = struct
 
       include
         Binable.Of_binable_without_uuid
-          (Core_kernel.String.Stable.V1)
+          (Bounded_types.String.Stable.V1)
           (struct
-            type t = string
+            type t = Bounded_types.String.Stable.V1.t
 
             let to_binable = Fn.id
 

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -696,7 +696,7 @@ module Update = struct
         ; verification_key :
             Verification_key_wire.Stable.V1.t Set_or_keep.Stable.V1.t
         ; permissions : Permissions.Stable.V2.t Set_or_keep.Stable.V1.t
-        ; zkapp_uri : string Set_or_keep.Stable.V1.t
+        ; zkapp_uri : Bounded_types.String.Stable.V1.t Set_or_keep.Stable.V1.t
         ; token_symbol :
             Account.Token_symbol.Stable.V1.t Set_or_keep.Stable.V1.t
         ; timing : Timing_info.Stable.V1.t Set_or_keep.Stable.V1.t
@@ -1113,7 +1113,10 @@ module Body = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = Pickles.Backend.Tick.Field.Stable.V1.t array list
+        type t =
+          Pickles.Backend.Tick.Field.Stable.V1.t
+          Bounded_types.ArrayN16.Stable.V1.t
+          list
         [@@deriving sexp, equal, hash, compare, yojson]
 
         let to_latest = Fn.id

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -38,6 +38,7 @@
    sparse_ledger_lib
    snark_params
    signature_lib
+   bounded_types
    rosetta_coding
    random_oracle
    hash_prefix_states

--- a/src/lib/mina_base/signed_command_memo.ml
+++ b/src/lib/mina_base/signed_command_memo.ml
@@ -18,7 +18,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
     module V1 = struct
       [@@@with_all_version_tags]
 
-      type t = string [@@deriving sexp, equal, compare, hash]
+      type t = Bounded_types.String.Tagged.Stable.V1.t
+      [@@deriving sexp, equal, compare, hash]
 
       let to_latest = Fn.id
 

--- a/src/lib/mina_base/sok_message.ml
+++ b/src/lib/mina_base/sok_message.ml
@@ -29,13 +29,14 @@ module Make_str (A : Wire_types.Concrete) = struct
     [%%versioned_binable
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving sexp, hash, compare, equal, yojson]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, hash, compare, equal, yojson]
 
         let to_latest = Fn.id
 
         include
           Binable.Of_binable_without_uuid
-            (Core_kernel.String.Stable.V1)
+            (Bounded_types.String.Stable.V1)
             (struct
               type nonrec t = t
 

--- a/src/lib/mina_base/staged_ledger_hash.ml
+++ b/src/lib/mina_base/staged_ledger_hash.ml
@@ -24,7 +24,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving sexp, equal, compare, hash]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, equal, compare, hash]
 
         let to_latest = Fn.id
 
@@ -107,7 +108,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving sexp, equal, compare, hash]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, equal, compare, hash]
 
         let to_latest = Fn.id
 

--- a/src/lib/mina_base/test/dune
+++ b/src/lib/mina_base/test/dune
@@ -21,6 +21,7 @@
   kimchi_backend.pasta
   kimchi_backend.pasta.basic
   mina_base
+  bounded_types
   mina_numbers
   mina_wire_types
   pickles

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -145,7 +145,8 @@ module Zkapp_uri = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = string [@@deriving sexp, equal, compare, hash, yojson]
+        type t = Bounded_types.String.Stable.V1.t
+        [@@deriving sexp, equal, compare, hash, yojson]
 
         let to_latest = Fn.id
 
@@ -170,9 +171,9 @@ module Zkapp_uri = struct
 
       include
         Binable.Of_binable_without_uuid
-          (Core_kernel.String.Stable.V1)
+          (Bounded_types.String.Stable.V1)
           (struct
-            type t = string
+            type t = Bounded_types.String.Stable.V1.t
 
             let to_binable = Fn.id
 

--- a/src/lib/mina_commands/dune
+++ b/src/lib/mina_commands/dune
@@ -15,6 +15,7 @@
    mina_base.import
    kimchi_backend
    mina_metrics
+   bounded_types
    transition_frontier
    sync_status
    pipe_lib

--- a/src/lib/mina_generators/dune
+++ b/src/lib/mina_generators/dune
@@ -18,6 +18,7 @@
    ppx_inline_test.config
    ppx_deriving_yojson.runtime
    ;; local libraries
+   bounded_types
    genesis_constants
    sgn
    pickles_types

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -24,6 +24,7 @@
    splittable_random
    stdio
    ;; local libraries
+   bounded_types
    mina_generators
    mina_wire_types
    network_pool

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -20,6 +20,7 @@
    core_kernel.uuid
    ppx_inline_test.config
    ;; local libraries
+   bounded_types
    mina_wire_types
    sgn
    syncable_ledger

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -21,6 +21,7 @@
    result
    bin_prot.shape
    ;; local libraries
+   bounded_types
    transition_chain_prover
    best_tip_prover
    proof_carrying_data

--- a/src/lib/mina_lib/tests/dune
+++ b/src/lib/mina_lib/tests/dune
@@ -53,6 +53,7 @@
    sync_handler
    with_hash
    inline_test_quiet_logs
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/mina_net2/dune
+++ b/src/lib/mina_net2/dune
@@ -36,6 +36,7 @@
    staged_ledger_diff
    ppx_version.runtime
    consensus
+   bounded_types
  )
  (inline_tests (flags -verbose -show-counts))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/mina_net2/keypair.ml
+++ b/src/lib/mina_net2/keypair.ml
@@ -5,7 +5,11 @@ open Network_peer
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = { secret : string; public : string; peer_id : Peer.Id.Stable.V1.t }
+    type t =
+      { secret : Bounded_types.String.Stable.V1.t
+      ; public : Bounded_types.String.Stable.V1.t
+      ; peer_id : Peer.Id.Stable.V1.t
+      }
 
     let to_latest = Fn.id
   end

--- a/src/lib/mina_net2/tests/dune
+++ b/src/lib/mina_net2/tests/dune
@@ -19,6 +19,7 @@
    child_processes
    network_peer
    file_system
+   bounded_types
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version))

--- a/src/lib/mina_networking/dune
+++ b/src/lib/mina_networking/dune
@@ -48,6 +48,7 @@
    transition_handler
    o1trace
    ppx_version.runtime
+   bounded_types
  )
  (inline_tests (flags -verbose -show-counts))
  (preprocess

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -201,7 +201,11 @@ module Rpcs = struct
       module T = struct
         type query = Ledger_hash.t * Sync_ledger.Query.t
 
-        type response = Sync_ledger.Answer.t Core.Or_error.t
+        type response =
+          (( Sync_ledger.Answer.t
+           , Bounded_types.Wrapped_error.Stable.V1.t )
+           Result.t
+          [@version_asserted] )
       end
 
       module Caller = T
@@ -229,12 +233,16 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+    module V3 = struct
       module T = struct
         type query = Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t
         [@@deriving sexp]
 
-        type response = Sync_ledger.Answer.Stable.V2.t Core.Or_error.Stable.V1.t
+        type response =
+          (( Sync_ledger.Answer.Stable.V2.t
+           , Bounded_types.Wrapped_error.Stable.V1.t )
+           Result.t
+          [@version_asserted] )
         [@@deriving sexp]
 
         let query_of_caller_model = Fn.id
@@ -672,15 +680,7 @@ module Rpcs = struct
       module Stable = struct
         module V2 = struct
           type t =
-            { node_ip_addr : Core.Unix.Inet_addr.Stable.V1.t
-                  [@to_yojson
-                    fun ip_addr -> `String (Unix.Inet_addr.to_string ip_addr)]
-                  [@of_yojson
-                    function
-                    | `String s ->
-                        Ok (Unix.Inet_addr.of_string s)
-                    | _ ->
-                        Error "expected string"]
+            { node_ip_addr : Network_peer.Peer.Inet_addr.Stable.V1.t
             ; node_peer_id : Network_peer.Peer.Id.Stable.V1.t
                   [@to_yojson fun peer_id -> `String peer_id]
                   [@of_yojson
@@ -695,8 +695,8 @@ module Rpcs = struct
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
             ; k_block_hashes_and_timestamps :
-                (State_hash.Stable.V1.t * string) list
-            ; git_commit : string
+                (State_hash.Stable.V1.t * Bounded_types.String.Stable.V1.t) list
+            ; git_commit : Bounded_types.String.Stable.V1.t
             ; uptime_minutes : int
             ; block_height_opt : int option [@default None]
             }
@@ -707,15 +707,7 @@ module Rpcs = struct
 
         module V1 = struct
           type t =
-            { node_ip_addr : Core.Unix.Inet_addr.Stable.V1.t
-                  [@to_yojson
-                    fun ip_addr -> `String (Unix.Inet_addr.to_string ip_addr)]
-                  [@of_yojson
-                    function
-                    | `String s ->
-                        Ok (Unix.Inet_addr.of_string s)
-                    | _ ->
-                        Error "expected string"]
+            { node_ip_addr : Network_peer.Peer.Inet_addr.Stable.V1.t
             ; node_peer_id : Network_peer.Peer.Id.Stable.V1.t
                   [@to_yojson fun peer_id -> `String peer_id]
                   [@of_yojson
@@ -730,8 +722,8 @@ module Rpcs = struct
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
             ; k_block_hashes_and_timestamps :
-                (State_hash.Stable.V1.t * string) list
-            ; git_commit : string
+                (State_hash.Stable.V1.t * Bounded_types.String.Stable.V1.t) list
+            ; git_commit : Bounded_types.String.Stable.V1.t
             ; uptime_minutes : int
             }
           [@@deriving to_yojson, of_yojson]
@@ -760,7 +752,8 @@ module Rpcs = struct
       module T = struct
         type query = unit [@@deriving sexp, to_yojson]
 
-        type response = Node_status.t Or_error.t
+        type response =
+          (Node_status.t, Bounded_types.Wrapped_error.Stable.V1.t) result
       end
 
       module Caller = T
@@ -798,7 +791,11 @@ module Rpcs = struct
       module T = struct
         type query = unit [@@deriving sexp]
 
-        type response = Node_status.Stable.V2.t Core_kernel.Or_error.Stable.V1.t
+        type response =
+          (( Node_status.Stable.V2.t
+           , Bounded_types.Wrapped_error.Stable.V1.t )
+           Result.t
+          [@version_asserted] )
 
         let query_of_caller_model = Fn.id
 
@@ -825,7 +822,11 @@ module Rpcs = struct
       module T = struct
         type query = unit [@@deriving sexp]
 
-        type response = Node_status.Stable.V1.t Core_kernel.Or_error.Stable.V1.t
+        type response =
+          (( Node_status.Stable.V1.t
+           , Bounded_types.Wrapped_error.Stable.V1.t )
+           Core_kernel.Result.t
+          [@version_asserted] )
 
         let query_of_caller_model = Fn.id
 

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -85,7 +85,7 @@ module Rpcs : sig
       module Stable : sig
         module V2 : sig
           type t =
-            { node_ip_addr : Core.Unix.Inet_addr.Stable.V1.t
+            { node_ip_addr : Network_peer.Peer.Inet_addr.Stable.V1.t
             ; node_peer_id : Peer.Id.Stable.V1.t
             ; sync_status : Sync_status.Stable.V1.t
             ; peers : Network_peer.Peer.Stable.V1.t list

--- a/src/lib/mina_wire_types/test/dune
+++ b/src/lib/mina_wire_types/test/dune
@@ -37,6 +37,7 @@
     pasta_bindings
     blake2
     staged_ledger_diff
+    bounded_types
     )
   (preprocess (pps ppx_version))
   (instrumentation (backend bisect_ppx))

--- a/src/lib/network_peer/dune
+++ b/src/lib/network_peer/dune
@@ -16,6 +16,7 @@
    async_kernel
    mina_metrics
    ppx_version.runtime
+   bounded_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_compare ppx_mina ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -20,6 +20,7 @@
    ppx_inline_test.config
    integers
    ;; local libraries
+   bounded_types
    mina_compile_config
    mina_generators
    sgn

--- a/src/lib/network_pool/test/dune
+++ b/src/lib/network_pool/test/dune
@@ -18,6 +18,7 @@
   currency
   data_hash_lib
   genesis_constants
+  bounded_types
   genesis_ledger
   logger
   mina_base

--- a/src/lib/node_addrs_and_ports/dune
+++ b/src/lib/node_addrs_and_ports/dune
@@ -13,6 +13,7 @@
    ;; local libraries
    network_peer
    ppx_version.runtime
+   bounded_types
  )
  (inline_tests (flags -verbose -show-counts))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
+++ b/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
@@ -18,8 +18,8 @@ module Display = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { external_ip : string
-        ; bind_ip : string
+        { external_ip : Bounded_types.String.Stable.V1.t
+        ; bind_ip : Bounded_types.String.Stable.V1.t
         ; peer : Peer.Display.Stable.V1.t option
         ; libp2p_port : int
         ; client_port : int

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -69,4 +69,5 @@
    internal_tracing.context_logger
    ppx_version.runtime
    error_json
+   bounded_types
 ))

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -68,7 +68,7 @@ module Base = struct
               Types.Wrap.Statement.Minimal.Stable.V1.t
           ; prev_evals :
               ( Tick.Field.Stable.V1.t
-              , Tick.Field.Stable.V1.t array )
+              , Tick.Field.Stable.V1.t Bounded_types.ArrayN16.Stable.V1.t )
               Plonk_types.All_evals.Stable.V1.t
           ; proof : Wrap_wire_proof.Stable.V1.t
           }

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -35,4 +35,5 @@
   snarky.backendless
   tuple_lib
   ppx_version.runtime
+  bounded_types
   ))

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -1139,7 +1139,7 @@ module Openings = struct
     module Stable = struct
       module V1 = struct
         type ('g, 'fq) t =
-          { lr : ('g * 'g) array
+          { lr : ('g * 'g) Bounded_types.ArrayN16.Stable.V1.t
           ; z_1 : 'fq
           ; z_2 : 'fq
           ; delta : 'g
@@ -1175,7 +1175,10 @@ module Poly_comm = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type 'g_opt t = { unshifted : 'g_opt array; shifted : 'g_opt }
+        type 'g_opt t =
+          { unshifted : 'g_opt Bounded_types.ArrayN16.Stable.V1.t
+          ; shifted : 'g_opt
+          }
         [@@deriving sexp, compare, yojson, hlist, hash, equal]
       end
     end]
@@ -1206,7 +1209,8 @@ module Poly_comm = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type 'g t = 'g array [@@deriving sexp, compare, yojson, hash, equal]
+        type 'g t = 'g Bounded_types.ArrayN16.Stable.V1.t
+        [@@deriving sexp, compare, yojson, hash, equal]
       end
     end]
   end
@@ -1224,7 +1228,11 @@ module Messages = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type 'g t = { sorted : 'g array; aggreg : 'g; runtime : 'g option }
+        type 'g t =
+          { sorted : 'g Bounded_types.ArrayN16.Stable.V1.t
+          ; aggreg : 'g
+          ; runtime : 'g option
+          }
         [@@deriving fields, sexp, compare, yojson, hash, equal, hlist]
       end
     end]
@@ -1327,7 +1335,8 @@ module Shifts = struct
   [%%versioned
   module Stable = struct
     module V2 = struct
-      type 'field t = 'field array [@@deriving sexp, compare, yojson, equal]
+      type 'field t = 'field Bounded_types.ArrayN16.Stable.V1.t
+      [@@deriving sexp, compare, yojson, equal]
     end
   end]
 end

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -109,11 +109,12 @@ end
 
 module Poly_comm : sig
   module Without_degree_bound : sig
-    type 'a t = 'a array
+    type 'a t = 'a Bounded_types.ArrayN16.Stable.V1.t
   end
 
   module With_degree_bound : sig
-    type 'a t = { unshifted : 'a array; shifted : 'a }
+    type 'a t =
+      { unshifted : 'a Bounded_types.ArrayN16.Stable.V1.t; shifted : 'a }
   end
 end
 

--- a/src/lib/ppx_version/lint_primitive_uses.ml
+++ b/src/lib/ppx_version/lint_primitive_uses.ml
@@ -1,0 +1,182 @@
+open! Core_kernel
+open Ppxlib
+
+let error which loc =
+  Location.raise_errorf ~loc
+    "Type declarations with deriving bin_io or versioning should not use the \
+     '%s' type. Use 'Bounded_types.%s.Stable.V1.t' instead."
+    which (String.capitalize which)
+
+let has_deriving_extension_with_attrs (attrs : attributes) =
+  List.exists attrs ~f:(fun attr ->
+      match attr with
+      | { attr_name = { txt = "deriving"; _ }; attr_payload = PStr str; _ } ->
+          List.exists str ~f:(fun item ->
+              match item.pstr_desc with
+              | Pstr_eval ({ pexp_desc; _ }, _) ->
+                  let rec find_in_expr = function
+                    | Pexp_ident { txt = Lident "bin_io" | Lident "version"; _ }
+                      ->
+                        true
+                    | Pexp_tuple exps ->
+                        List.exists exps ~f:(fun exp ->
+                            find_in_expr exp.pexp_desc )
+                    | _ ->
+                        false
+                  in
+                  find_in_expr pexp_desc
+              | _ ->
+                  false )
+      | _ ->
+          false )
+
+let check_type_definition module_binding =
+  match module_binding with
+  | { pmb_expr = { pmod_desc = Pmod_structure structure; _ }; _ } ->
+      List.iter structure ~f:(fun item ->
+          match item with
+          | [%stri
+              type t =
+                [%t?
+                  { ptyp_desc =
+                      Ptyp_constr
+                        ({ txt = Longident.Lident ("array" as nm); _ }, _)
+                  ; _
+                  }]]
+          | [%stri
+              type t =
+                [%t?
+                  { ptyp_desc =
+                      Ptyp_constr
+                        ({ txt = Longident.Lident ("bigstring" as nm); _ }, _)
+                  ; _
+                  }]]
+          | [%stri
+              type t =
+                [%t?
+                  { ptyp_desc =
+                      Ptyp_constr
+                        ({ txt = Longident.Lident ("bytes" as nm); _ }, _)
+                  ; _
+                  }]]
+          | [%stri
+              type t =
+                [%t?
+                  { ptyp_desc =
+                      Ptyp_constr
+                        ({ txt = Longident.Lident ("string" as nm); _ }, _)
+                  ; _
+                  }]] ->
+              (* Raise an error when type 't' uses an unsafe type above. *)
+              error nm item.pstr_loc
+          | _ ->
+              () )
+  | _ ->
+      ()
+
+let find_array_in_type_declaration decl =
+  let rec check_array_type { ptyp_desc; _ } =
+    match ptyp_desc with
+    | Ptyp_constr ({ txt = Lident ("string" as nm); loc }, _)
+    | Ptyp_constr ({ txt = Lident ("bytes" as nm); loc }, _)
+    | Ptyp_constr ({ txt = Lident ("bigstring" as nm); loc }, _)
+    | Ptyp_constr ({ txt = Lident ("array" as nm); loc }, _) ->
+        error nm loc
+    | Ptyp_constr (_, core_types) | Ptyp_tuple core_types ->
+        List.iter core_types ~f:check_array_type
+    | Ptyp_variant (rows, _, _) ->
+        List.iter rows ~f:(fun { prf_desc; _ } ->
+            match prf_desc with
+            | Rtag (_, _, typs) ->
+                List.iter typs ~f:check_array_type
+            | Rinherit typ ->
+                check_array_type typ )
+    | Ptyp_any
+    | Ptyp_var _
+    | Ptyp_arrow (_, _, _)
+    | Ptyp_object (_, _)
+    | Ptyp_class (_, _)
+    | Ptyp_alias (_, _)
+    | Ptyp_poly (_, _)
+    | Ptyp_package _
+    | Ptyp_extension _ ->
+        ()
+  in
+  match decl.ptype_kind with
+  | Ptype_abstract | Ptype_open ->
+      ()
+  | Ptype_variant decls ->
+      List.iter decls ~f:(fun decl ->
+          match decl.pcd_args with
+          | Pcstr_tuple types ->
+              List.iter types ~f:(fun typ -> check_array_type typ)
+          | Pcstr_record labels ->
+              List.iter labels ~f:(fun label ->
+                  check_array_type label.pld_type ) )
+  | Ptype_record labels ->
+      List.iter labels ~f:(fun label -> check_array_type label.pld_type)
+
+let versionedArrayTypeCheckerInsideVxModule =
+  object
+    inherit Ast_traverse.iter as super
+
+    method! type_declaration decl =
+      if String.equal decl.ptype_name.txt "t" then
+        find_array_in_type_declaration decl ;
+      super#type_declaration decl
+  end
+
+let versionedArrayTypeChecker =
+  object
+    inherit [Driver.Lint_error.t list] Ast_traverse.fold as super
+
+    method! type_declaration decl acc =
+      if has_deriving_extension_with_attrs decl.ptype_attributes then
+        find_array_in_type_declaration decl ;
+      super#type_declaration decl acc
+
+    (* Override the module declaration handling *)
+    method! extension extension acc =
+      ( match extension with
+      | { txt = "versioned"; _ }, PStr [ { pstr_desc; _ } ] -> (
+          match pstr_desc with
+          | Pstr_module
+              { pmb_name = { txt = Some "Stable"; _ }
+              ; pmb_expr = { pmod_desc = Pmod_structure l; _ }
+              ; _
+              } ->
+              List.iter l ~f:(fun { pstr_desc; _ } ->
+                  match pstr_desc with
+                  | Pstr_module
+                      { pmb_expr = { pmod_desc = Pmod_structure structure; _ }
+                      ; _
+                      } ->
+                      List.iter structure ~f:(fun { pstr_desc; _ } ->
+                          match pstr_desc with
+                          | Pstr_type (_, type_declarations) ->
+                              List.iter type_declarations ~f:(fun decl ->
+                                  if String.equal decl.ptype_name.txt "t" then
+                                    find_array_in_type_declaration decl )
+                          | Pstr_module
+                              { pmb_name = { txt = Some "T"; _ }
+                              ; pmb_expr =
+                                  { pmod_desc = Pmod_structure structure; _ }
+                              ; _
+                              } ->
+                              versionedArrayTypeCheckerInsideVxModule#structure
+                                structure
+                          | _ ->
+                              () )
+                  | _ ->
+                      () )
+          | _ ->
+              () )
+      | _ ->
+          () ) ;
+      super#extension extension acc
+  end
+
+let () =
+  Driver.register_transformation
+    ~lint_impl:(fun st -> versionedArrayTypeChecker#structure st [])
+    "enforce_bounded_array"

--- a/src/lib/ppx_version/lint_version_syntax.ml
+++ b/src/lib/ppx_version/lint_version_syntax.ml
@@ -136,6 +136,13 @@ let is_jane_street_prefix prefix =
   | _ ->
       false
 
+let is_bounded_type prefix =
+  match Longident.flatten_exn prefix with
+  | "Bounded_types" :: _ ->
+      true
+  | _ ->
+      false
+
 (* N.B.: most versioned modules are within "Stable" modules, but that's not true
    for modules in RPC type definitions, so we can't rely on that name
 *)
@@ -162,6 +169,7 @@ let is_versioned_module_lident = function
   | Ldot (prefix, vn)
     when is_version_module vn
          && (not @@ is_jane_street_prefix prefix)
+         && (not @@ is_bounded_type prefix)
          && is_stable_prefix prefix ->
       true
   | _ ->

--- a/src/lib/runtime_config/dune
+++ b/src/lib/runtime_config/dune
@@ -35,6 +35,7 @@
    with_hash
    signature_lib
    staged_ledger
+   bounded_types
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_custom_printf ppx_sexp_conv ppx_let ppx_deriving_yojson

--- a/src/lib/secrets/dune
+++ b/src/lib/secrets/dune
@@ -35,6 +35,7 @@
    snarky.backendless
    error_json
    mina_base.import
+   bounded_types
  )
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.make))

--- a/src/lib/snark_profiler_lib/dune
+++ b/src/lib/snark_profiler_lib/dune
@@ -16,6 +16,7 @@
    base.caml
    base.base_internalhash_types
    ;;local libraries
+   bounded_types
    mina_wire_types
    child_processes
    snark_worker

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -22,6 +22,7 @@
    async_unix
    bin_prot.shape
    ;; local libraries
+   bounded_types
    one_or_two
    mina_metrics
    logger

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -146,7 +146,9 @@ module type S0 = sig
     module Failed_to_generate_snark :
       Rpc_master
         with type Master.T.query =
-          Error.t * Work.Spec.t * Signature_lib.Public_key.Compressed.t
+          Bounded_types.Wrapped_error.t
+          * Work.Spec.t
+          * Signature_lib.Public_key.Compressed.t
          and type Master.T.response = unit
   end
 

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -87,7 +87,7 @@ module Worker = struct
       module V2 = struct
         module T = struct
           type query =
-            Core_kernel.Error.Stable.V2.t
+            Bounded_types.Wrapped_error.Stable.V1.t
             * ( Transaction_witness.Stable.V2.t
               , Inputs.Ledger_proof.Stable.V2.t )
               Snark_work_lib.Work.Single.Spec.Stable.V2.t

--- a/src/lib/sparse_ledger_lib/dune
+++ b/src/lib/sparse_ledger_lib/dune
@@ -15,6 +15,7 @@
    ppx_version.runtime
    ;; mina
    mina_stdlib
+   bounded_types
  )
  (preprocess
   (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -344,7 +344,8 @@ let%test_module "sparse-ledger-test" =
 
     module Account = struct
       module T = struct
-        type t = { name : string; favorite_number : int }
+        type t =
+          { name : Bounded_types.String.Stable.V1.t; favorite_number : int }
         [@@deriving bin_io, equal, sexp, yojson]
       end
 

--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -21,6 +21,7 @@
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    random_oracle_input
+   bounded_types
    mina_base.import
    mina_ledger
    quickcheck_lib

--- a/src/lib/syncable_ledger/dune
+++ b/src/lib/syncable_ledger/dune
@@ -61,6 +61,7 @@
    data_hash_lib
    mina_base.import
    signature_lib
+   bounded_types
    )
  (preprocess
   (pps ppx_version ppx_jane ppx_compare ppx_deriving_yojson))

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -47,7 +47,8 @@
    snark_params
    unsigned_extended
    ppx_version.runtime
-   with_hash)
+   with_hash
+   bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1392,7 +1392,7 @@ module Make (L : Ledger_intf.S) :
     end
 
     module Zkapp_uri = struct
-      type t = string
+      type t = Bounded_types.String.t
 
       let if_ = value_if
     end

--- a/src/lib/transaction_logic/test/dune
+++ b/src/lib/transaction_logic/test/dune
@@ -19,6 +19,7 @@
    kimchi_backend_common
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
+   bounded_types
    mina_base
    mina_base_import
    mina_base_test_helpers

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -19,6 +19,7 @@
    async_unix
    splittable_random
    ;; local libraries
+   bounded_types
    mina_wire_types
    mina_base.import
    mina_transaction

--- a/src/lib/transaction_snark/test/access_permission/dune
+++ b/src/lib/transaction_snark/test/access_permission/dune
@@ -41,6 +41,7 @@
    with_hash
    zkapps_empty_update
    zkapps_examples
+   bounded_types
    )
   (library_flags -linkall)
   (inline_tests (flags -verbose -show-counts))

--- a/src/lib/transaction_snark/test/account_timing/dune
+++ b/src/lib/transaction_snark/test/account_timing/dune
@@ -22,6 +22,7 @@
    snark_params
    data_hash_lib
    genesis_proof
+   bounded_types
    mina_ledger
    mina_base
    mina_transaction

--- a/src/lib/transaction_snark/test/account_update_network_id/dune
+++ b/src/lib/transaction_snark/test/account_update_network_id/dune
@@ -35,6 +35,7 @@
    test_util
    mina_transaction_logic
    mina_transaction
+   bounded_types
    )
   (library_flags -linkall)
   (inline_tests)

--- a/src/lib/transaction_snark/test/dune
+++ b/src/lib/transaction_snark/test/dune
@@ -14,6 +14,7 @@
    yojson
    integers
    ;; local libraries
+   bounded_types
    logger
    random_oracle_input
    pickles.backend

--- a/src/lib/transaction_snark/test/multisig_account/dune
+++ b/src/lib/transaction_snark/test/multisig_account/dune
@@ -41,6 +41,7 @@
    random_oracle_input
    with_hash
    data_hash_lib
+   bounded_types
    )
   (library_flags -linkall)
   (inline_tests (flags -verbose -show-counts))

--- a/src/lib/transaction_snark/test/token_symbol/dune
+++ b/src/lib/transaction_snark/test/token_symbol/dune
@@ -20,6 +20,7 @@
    mina_base
    mina_transaction_logic
    currency
+   bounded_types
    mina_state
    signature_lib
    genesis_constants

--- a/src/lib/transaction_snark/test/transaction_union/dune
+++ b/src/lib/transaction_snark/test/transaction_union/dune
@@ -12,6 +12,7 @@
    yojson
    ;; local libraries
    mina_base.import
+   bounded_types
    pickles
    pickles.backend
    kimchi_backend.pasta

--- a/src/lib/transaction_snark/test/zkapp_fuzzy/dune
+++ b/src/lib/transaction_snark/test/zkapp_fuzzy/dune
@@ -40,6 +40,7 @@
    random_oracle
    sexplib0
    zkapp_command_builder
+   bounded_types
    )
   (link_flags (-linkall))
   (preprocess

--- a/src/lib/transaction_snark/test/zkapp_uri/dune
+++ b/src/lib/transaction_snark/test/zkapp_uri/dune
@@ -15,6 +15,7 @@
    mina_base.import
    pickles
    transaction_snark
+   bounded_types
    snark_params
    mina_ledger
    mina_base

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4138,8 +4138,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; zkapp_account_keypairs : Signature_lib.Keypair.t list
         ; memo : Signed_command_memo.t
         ; new_zkapp_account : bool
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         ; preconditions : Account_update.Preconditions.t option
         ; authorization_kind : Account_update.Authorization_kind.t
@@ -4620,8 +4620,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; zkapp_account_keypair : Signature_lib.Keypair.t
         ; memo : Signed_command_memo.t
         ; update : Account_update.Update.t
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         }
 
@@ -4752,8 +4752,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; snapp_update : Account_update.Update.t
               (* Authorization for the update being performed *)
         ; current_auth : Permissions.Auth_required.t
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         ; preconditions : Account_update.Preconditions.t option
         }
@@ -4905,8 +4905,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; new_zkapp_account : bool
         ; snapp_update : Account_update.Update.t
               (* Authorization for the update being performed *)
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         ; preconditions : Account_update.Preconditions.t option
         }

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -295,8 +295,8 @@ module type Full = sig
         ; zkapp_account_keypair : Signature_lib.Keypair.t
         ; memo : Signed_command_memo.t
         ; update : Account_update.Update.t
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         }
     end
@@ -332,8 +332,8 @@ module type Full = sig
         ; snapp_update : Account_update.Update.t
               (* Authorization for the update being performed *)
         ; current_auth : Permissions.Auth_required.t
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         ; preconditions : Account_update.Preconditions.t option
         }
@@ -406,8 +406,8 @@ module type Full = sig
         ; new_zkapp_account : bool
         ; snapp_update : Account_update.Update.t
               (* Authorization for the update being performed *)
-        ; actions : Tick.Field.t array list
-        ; events : Tick.Field.t array list
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
         ; call_data : Tick.Field.t
         ; preconditions : Account_update.Preconditions.t option
         }

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -36,7 +36,7 @@ module Schema = struct
         [@@@no_toplevel_latest_type]
 
         module V1 = struct
-          type t = string * State_hash.Stable.V1.t
+          type t = Bounded_types.String.Stable.V1.t * State_hash.Stable.V1.t
 
           let to_latest = Fn.id
         end

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -15,6 +15,7 @@
    extlib
    async_unix
    ;;local libraries
+   bounded_types
    o1trace
    mina_metrics
    trust_system

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -16,6 +16,7 @@
    best_tip_prover
    transition_handler
    o1trace
+   bounded_types
    truth
    mina_net2
    consensus

--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -25,6 +25,7 @@
    run_in_thread
    test_util
    ppx_version.runtime
+   bounded_types
  )
  (inline_tests (flags -verbose -show-counts))
  (preprocess

--- a/src/libp2p_ipc/dune
+++ b/src/libp2p_ipc/dune
@@ -24,6 +24,7 @@
    pipe_lib
    network_peer
    o1trace
+   bounded_types
  )
  (preprocess (pps ppx_version ppx_jane))
  (instrumentation (backend bisect_ppx)))


### PR DESCRIPTION
these types are more precise than the builtins, and let us evolve the protocol-derived sizes independently of each other. finally, throw a more accurate exception in the bin_prot codepaths for the RPC stack.

Merge for develop: https://github.com/MinaProtocol/mina/pull/14969