### PR TITLE
Add script to run a local network for HF testing

### DIFF
--- a/scripts/prepare-test-ledger-hf-dryrun.sh
+++ b/scripts/prepare-test-ledger-hf-dryrun.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Number of extra keys to be included into ledger
+EXTRA_KEYS=${EXTRA_KEYS:-0}
+
+# Balance of each extra key
+EXTRA_KEY_BALANCE=${EXTRA_KEY_BALANCE:-10000000}
+
+# Do not use "next" ledgers
+NO_NEXT=${NO_NEXT:-}
+
+echo "Script downloads ledgers for the three latest consequetive epochs of mainnet and converts them into ledgers suitable for HF dryrun" >&2
+echo "Script creates three files in current directory: genesis.json staking.json and next.json" >&2
+echo "Script assumes mainnet's start was at epoch 0 on 17th March 2021, if it's not the case, update the script please" >&2
+echo "Usage: $0 [-e|--extra-keys $EXTRA_KEYS] [-b|--extra-key-balance $EXTRA_KEY_BALANCE] <BP key 1> <BP key 2> ... <BP key n>" >&2
+
+MAINNET_START='2021-03-17 00:00:00'
+now=$(date +%s)
+mainnet_start=$(date --date="$MAINNET_START" -u +%s)
+
+# Last epoch of mainnet (to be used as genesis ledger)
+EPOCH=${EPOCH:-$(( (now-mainnet_start)/7140/180 ))}
+
+##########################################################
+# Parse arguments
+##########################################################
+
+KEYS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -e|--extra-keys)
+      EXTRA_KEYS="$2"; shift; shift ;;
+    -b|--extra-key-balance)
+      KEY_BALANCE="$2"; shift; shift ;;
+    --no-next)
+      NO_NEXT=1; shift ;;
+    -*|--*)
+      echo "Unknown option $1"; exit 1 ;;
+    *)
+      KEYS+=("$1") ; shift ;;
+  esac
+done
+
+num_keys=${#KEYS[@]}
+if [[ $num_keys -eq 0 ]]; then
+  echo "No keys specified" >&2
+  exit 1
+fi
+
+function update_extra_balances(){
+  jq ".[range(-1; -$((EXTRA_KEYS+1)); -1)].balance=\"$EXTRA_KEY_BALANCE\""
+}
+
+ledger_script="$SCRIPT_DIR/prepare-test-ledger.sh"
+
+if [[ "$NO_NEXT" == "" ]]; then
+  "$ledger_script" -r -p next-staking-$EPOCH "${KEYS[@]}" | update_extra_balances > genesis.json
+else
+  "$ledger_script" -r -p staking-$EPOCH "${KEYS[@]}" | update_extra_balances > genesis.json
+  EPOCH=$((EPOCH-1))
+fi
+"$ledger_script" -r -p staking-$EPOCH "${KEYS[@]}" | update_extra_balances > next.json
+"$ledger_script" -r -p staking-$((EPOCH-1)) "${KEYS[@]}" | update_extra_balances > staking.json

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -1,23 +1,53 @@
 #!/usr/bin/env bash
 
-# Usage: ./scripts/prepare-test-ledger.sh <BP key 1> <BP key 2> ... <BP key n>
-
 # Number of keys in ledger that won't be re-delegated
-NUM_GHOST_KEYS=${NUM_GHOST_KEYS:-0}
-KEY_BALANCE=100000
+KEY_BALANCE=${KEY_BALANCE:-100000}
+
+# Do not touch accounts with balance below $DELEGATEE_CUTOFF
+DELEGATEE_CUTOFF=${DELEGATEE_CUTOFF:-100000}
+
+# Use (approximate) normal distribution for keys
+# Works well for latger number of keys
+NORM=${NORM:-}
 
 echo "Script assumes mainnet's start was at epoch 0 on 17th March 2021, if it's not the case, update the script please" >&2
+echo "Usage: $0 [-n|--norm] [-c|--delegation_cutoff $DELEGATEE_CUTOFF] [-b|--key-balance $KEY_BALANCE] <BP key 1> <BP key 2> ... <BP key n>" >&2
+echo "Consider reading script's code for information on optional arguments" >&2
 
-if [[ $# -eq 0 ]]; then
-  echo "Usage: ./scripts/prepare-test-ledger.sh <BP key 1> <BP key 2> ... <BP key n>" >&2
+MAINNET_START='2021-03-17 00:00:00'
+
+##########################################################
+# Parse arguments
+##########################################################
+
+KEYS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -n|--norm)
+      NORM=1; shift ;;
+    -c|--delegation-cutoff)
+      DELEGATEE_CUTOFF="$2"; shift; shift ;;
+    -b|--key-balance)
+      KEY_BALANCE="$2"; shift; shift ;;
+    -*|--*)
+      echo "Unknown option $1"; exit 1 ;;
+    *)
+      KEYS+=("$1") ; shift ;;
+  esac
+done
+
+num_keys=${#KEYS[@]}
+if [[ $num_keys -eq 0 ]]; then
+  echo "No keys specified" >&2
   exit 1
 fi
 
-num_keys=$#
-num_keys_and_ghost=$((num_keys + NUM_GHOST_KEYS))
+##########################################################
+# Download ledger
+##########################################################
 
 now=$(date +%s)
-mainnet_start=$(date --date='2021-03-17 00:00:00' -u +%s)
+mainnet_start=$(date --date="$MAINNET_START" -u +%s)
 epoch_now=$(( (now-mainnet_start)/7140/180 ))
 
 ledger_file="$epoch_now.json"
@@ -32,55 +62,65 @@ if [[ ! -f "$ledger_file" ]]; then
 fi
 
 keys_=""
-for key in "$@"; do
+for key in "${KEYS[@]}"; do
   keys_="\"$key\",$keys_"
 done
 keys_="${keys_:0:-1}"
 
-# jq filter to exclude block PKs from the ledger
-pre_filter="[.[] | select(.pk | IN($keys_) | not)]"
+tmpfile=$(mktemp)
+
+# jq filter to exclude PKs from the ledger
+<"$epoch_now.json" jq "[.[] | select(.pk | IN($keys_) | not)]" >"$tmpfile"
+
+num_accounts=$(<"$tmpfile" jq length)
 
 ##########################################################
-# Calculate and print approximate new balances
-##########################################################
-
-num_accounts=$(<$ledger_file jq "$pre_filter | length")
-total_balance=$(<$ledger_file jq "$pre_filter | [.[].balance | tonumber] | add | round")
-new_total_balance=$((total_balance+num_keys*KEY_BALANCE))
-echo "Total accounts: $num_accounts, balance: $total_balance, new balance: $new_total_balance" >&2
-
-function make_balance_expr(){
-  i=$1
-  key=$2
-  echo "$key: (((([.[range($i; $num_accounts; $num_keys_and_ghost)].balance | tonumber] | add) + $KEY_BALANCE)/$new_total_balance*10000|round/100 | tostring) + \"%\")"
-}
-
-balance_expr=$({ i=0; while [[ $i -lt $num_keys ]]; do
-  j=$((i+1))
-  make_balance_expr $i "${!j}"
-  i=$j
-done } | tr "\n" "," | head -c -1)
-
-echo "Balance map:" >&2
-jq <$ledger_file "$pre_filter | {$balance_expr}" 1>&2
-
-##########################################################
-# Build new ledger
+# Create new ledger in a temporary file
 ##########################################################
 
 function make_expr(){
   i=$1
   key=$2
+  interval=$num_keys
+  if [[ "$NORM" != "" ]]; then
+    interval=$(( (RANDOM+RANDOM+RANDOM)*num_keys/32/1024/3+1 ))
+  fi
 
   # Substitute delegate of some ledger keys with the BP key
-  echo ".[range($i; $num_accounts; $num_keys_and_ghost)].delegate = \"$key\""
-  echo ".[$((i+num_accounts))] = {pk:\"$key\", balance:\"$KEY_BALANCE\"}"
+  echo "((.[range($i; $num_accounts; $interval)] | select ((.balance|tonumber) > $DELEGATEE_CUTOFF)).delegate |= \"$key\")"
+  echo ".[$((i+num_accounts))] = {delegate:\"$key\", pk:\"$key\", balance:\"$KEY_BALANCE\"}"
 }
 
-expr=$({ i=0; while [[ $i -lt $num_keys ]]; do
-  j=$((i+1))
-  make_expr $i "${!j}"
-  i=$j
-done } | tr "\n" "|" | head -c -1)
+expr=$(for i in "${!KEYS[@]}"; do make_expr $i "${KEYS[$i]}"; done | tr "\n" "|" | head -c -1)
+expr="$expr | [.[] | select(.delegate | IN($keys_)) |= del(.receipt_chain_hash)]"
 
-jq <$ledger_file "$pre_filter | $expr"
+tmpfile2=$(mktemp)
+<"$tmpfile" jq "$expr" >"$tmpfile2"
+mv "$tmpfile2" "$tmpfile"
+
+##########################################################
+# Calculate and print new stake distribution
+##########################################################
+
+total_balance=$(<"$tmpfile" jq "[.[].balance | tonumber] | add | round")
+echo "Total accounts: $((num_accounts+num_keys)), balance: $total_balance" >&2
+
+function make_balance_expr(){
+  label="$1"
+  keys="$2"
+  echo "$label: ((([.[] | select(.delegate | IN($keys)) | .balance | tonumber] | add))/$total_balance*10000|round/100 )"
+}
+
+balance_expr=$({
+  make_balance_expr all "$keys_"
+  for key in "${KEYS[@]}"; do
+    make_balance_expr "$key" "\"$key\""
+  done } | tr "\n" "," | head -c -1)
+
+echo "Stake distribution:" >&2
+<"$tmpfile" jq "{$balance_expr} | to_entries | sort_by(.value) | reverse | from_entries | map_values((.|tostring) + \"%\")" 1>&2
+
+# Print ledger and remove temporary file
+
+cat "$tmpfile"
+rm "$tmpfile"

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -e
+export MINA_LIBP2P_PASS=
+export MINA_PRIVKEY_PASS=
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Interval at which to send transactions
+TX_INTERVAL=${TX_INTERVAL:-30s}
+
+# Delay between now and genesis timestamp, in minutes
+DELAY_MIN=${DELAY_MIN:-20}
+
+# Allows to use berkeley ledger when equals to .berkeley
+CONF_SUFFIX=${CONF_SUFFIX:-}
+
+# Mina executable
+MINA_EXE=mina
+
+echo "Creates a quick-epoch-turnaround configuration in localnet/ and launches two Mina nodes"
+echo "Usage: $0 [-m|--mina $MINA_EXE] [-i|--tx-interval $TX_INTERVAL] [-d|--delay-min $DELAY_MIN] [-b|--berkeley]" >&2
+echo "Consider reading script's code for information on optional arguments" >&2
+
+##########################################################
+# Parse arguments
+##########################################################
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--delay-min)
+      DELAY_MIN="$2"; shift; shift ;;
+    -i|--tx-interval)
+      TX_INTERVAL="$2"; shift; shift ;;
+    -b|--berkeley)
+      CONF_SUFFIX=".berkeley"; shift ;;
+    -m|--mina)
+      MINA_EXE="$2"; shift; shift ;;
+    -*|--*)
+      echo "Unknown option $1"; exit 1 ;;
+    *)
+      KEYS+=("$1") ; shift ;;
+  esac
+done
+
+# Check mina command exists
+command -v "$MINA_EXE" >/dev/null || { echo "No 'mina' executable found"; exit 1; }
+
+##########################################################
+# Generate configuration in localnet/config
+##########################################################
+
+CONF_DIR=localnet/config
+
+mkdir -p $CONF_DIR
+chmod 0700 $CONF_DIR
+
+if [[ ! -f $CONF_DIR/bp ]]; then
+  "$MINA_EXE" advanced generate-keypair --privkey-path $CONF_DIR/bp
+fi
+
+# We handle error of libp2p key generation because `compatible`'s version
+# has a different command for libp2p key generation
+if [[ ! -f $CONF_DIR/libp2p_1 ]]; then
+  "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_1 2>/dev/null || \
+    "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_1 2>/dev/null
+fi
+if [[ ! -f $CONF_DIR/libp2p_2 ]]; then
+  "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 2>/dev/null || \
+    "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_2 2>/dev/null
+fi
+if [[ ! -f $CONF_DIR/ledger.json ]]; then
+  ( cd $CONF_DIR && "$SCRIPT_DIR/prepare-test-ledger.sh" -c 100000 -b 1000000 $(cat bp.pub) >ledger.json )
+fi
+
+jq --arg timestamp $( d=$(date +%s); date -u -d @$((d - d % 60 + DELAY_MIN*60)) +%FT%H:%M:%S+00:00 ) --slurpfile accounts $CONF_DIR/ledger.json '.ledger.accounts = $accounts[0] | .genesis.genesis_state_timestamp |= $timestamp' > $CONF_DIR/daemon.json << EOF
+{
+  "genesis": {
+    "genesis_state_timestamp": "",
+    "slots_per_epoch": 48,
+    "k": 2,
+    "transaction_capacity": { "log_2": 2 },
+    "slots_per_sub_window": 3,
+    "sub_windows_per_window": 3,
+    "grace_period_slots": 3
+  },
+  "proof": {
+    "block_window_duration_ms": 25000
+  },
+  "ledger": {
+    "name": "localnet",
+    "accounts": []
+  }
+}
+EOF
+
+# Convert ledger to berkeley format
+jq '.ledger.accounts = [.ledger.accounts[] | del(.token_permissions, .permissions.stake) | .token = "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf" | .token_symbol = "" | if .permissions.set_verification_key == "signature" then .permissions.set_verification_key = {auth:"signature", txn_version: "1"} else . end ]' <$CONF_DIR/daemon.json >$CONF_DIR/daemon.berkeley.json
+
+##############################################################
+# Launch two Mina nodes and send transactions on an interval
+#############################################################
+
+# Clean runtime directories
+rm -Rf localnet/runtime_1 localnet/runtime_2
+
+CONF_FILE="$PWD/$CONF_DIR/daemon$CONF_SUFFIX.json"
+
+"$MINA_EXE" daemon --config-file "$CONF_FILE" \
+  --peer "/ip4/127.0.0.1/tcp/10312/p2p/$(cat $CONF_DIR/libp2p_2.peerid)" \
+  --libp2p-keypair "$PWD/$CONF_DIR/libp2p_1" --seed \
+  --block-producer-key "$PWD/$CONF_DIR/bp" \
+  --config-directory "$PWD/localnet/runtime_1" --file-log-level Info --log-level Error \
+  --client-port 10301 --external-port 10302 --rest-port 10303 &
+
+bp_pid=$!
+
+echo "Block producer PID: $bp_pid"
+
+"$MINA_EXE" daemon --config-file "$CONF_FILE" \
+  --libp2p-keypair "$PWD/$CONF_DIR/libp2p_2" --seed \
+  --peer "/ip4/127.0.0.1/tcp/10302/p2p/$(cat $CONF_DIR/libp2p_1.peerid)" \
+  --run-snark-worker "$(cat $CONF_DIR/bp.pub)" --work-selection seq \
+  --config-directory "$PWD/localnet/runtime_2" --file-log-level Info --log-level Error \
+  --client-port 10311 --external-port 10312 --rest-port 10313 &
+
+sw_pid=$!
+
+echo "Snark worker PID: $sw_pid"
+
+while ! "$MINA_EXE" accounts import --privkey-path "$PWD/$CONF_DIR/bp" --rest-server 10313 2>/dev/null; do
+  sleep 1m
+done
+
+i=0
+while kill -0 $sw_pid; do
+  <"$CONF_FILE" jq -r '.ledger.accounts[].pk' | shuf | while read acc; do
+    if ! kill -0 $sw_pid; then
+      exit 0
+    fi
+    "$MINA_EXE" client send-payment --sender "$(cat $CONF_DIR/bp.pub)" --receiver "$acc" \
+      --amount 0.1 --memo "payment_$i" --rest-server 10313 \
+      && i=$((i+1)) && echo "Sent tx #$i" || echo "Failed to send tx #$i"
+    sleep "$TX_INTERVAL"
+  done
+done
+
+wait

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -97,7 +97,7 @@ if [[ "$CUSTOM_CONF" == "" ]]; then
   },
   "proof": {
     "work_delay": 1,
-    "block_window_duration_ms": 25000
+    "block_window_duration_ms": 30000
   },
   "ledger": {
     "name": "localnet",

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -122,7 +122,14 @@ if [[ "$CUSTOM_CONF" == "" ]]; then
   },
   "proof": {
     "work_delay": 1,
-    "block_window_duration_ms": 30000
+    "block_window_duration_ms": 30000,
+    "level": "full",
+    "sub_windows_per_window": 11,
+    "ledger_depth": 20,
+    "transaction_capacity": { "2_to_the": 2 },
+    "coinbase_amount": "720",
+    "supercharged_coinbase_factor": 1,
+    "account_creation_fee": "1"
   },
   "ledger": {
     "name": "localnet",

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -201,9 +201,15 @@ while ! "$MINA_EXE" accounts import --privkey-path "$PWD/$CONF_DIR/bp" --rest-se
   sleep 1m
 done
 
+# Export staged ledger
+# Will succeed after bootstrap is over
+while ! "$MINA_EXE" ledger export staged-ledger --daemon-port 10311 > localnet/exported_staged_ledger.json; do
+  sleep 1m
+done
+
 i=0
 while kill -0 $sw_pid; do
-  <"$CONF_FILE" jq -r '.ledger.accounts[].pk' | shuf | while read acc; do
+  <localnet/exported_staged_ledger.json jq -r '.[].pk' | shuf | while read acc; do
     if ! kill -0 $sw_pid; then
       exit 0
     fi

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
+
 export MINA_LIBP2P_PASS=
 export MINA_PRIVKEY_PASS=
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -27,7 +29,7 @@ SLOT_CHAIN_END=${SLOT_CHAIN_END:-}
 # Mina executable
 MINA_EXE=mina
 
-echo "Creates a quick-epoch-turnaround configuration in localnet/ and launches two Mina nodes"
+echo "Creates a quick-epoch-turnaround configuration in localnet/ and launches two Mina nodes" >&2
 echo "Usage: $0 [-m|--mina $MINA_EXE] [-i|--tx-interval $TX_INTERVAL] [-d|--delay-min $DELAY_MIN] [-b|--berkeley]" >&2
 echo "Consider reading script's code for information on optional arguments" >&2
 

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -81,16 +81,20 @@ fi
 
 libp2p_1_args=( --libp2p-keypair "$PWD/$CONF_DIR/libp2p_1" )
 libp2p_2_args=( --libp2p-keypair "$PWD/$CONF_DIR/libp2p_2" )
+
 # We handle error of libp2p key generation because `compatible`'s version
 # has a different command for libp2p key generation
-if [[ ! -f $CONF_DIR/libp2p_1 ]]; then
-  "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_1 2>/dev/null || \
-    libp2p_1_args=()
+"$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_1 2>/dev/null || \
+  libp2p_1_args[0]="--discovery-keypair"
+if [[ "${#libp2p_1_args[0]}" == "--discovery-keypair" ]]; then
+  "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_1
 fi
-if [[ ! -f $CONF_DIR/libp2p_2 ]]; then
-  "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 2>/dev/null || \
-    libp2p_2_args=()
+"$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 2>/dev/null || \
+  libp2p_2_args[0]="--discovery-keypair"
+if [[ "${#libp2p_2_args[0]}" == "--discovery-keypair" ]]; then
+  "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_2
 fi
+
 if [[ "$CUSTOM_CONF" == "" ]] && [[ ! -f $CONF_DIR/ledger.json ]]; then
   ( cd $CONF_DIR && "$SCRIPT_DIR/prepare-test-ledger.sh" -c 100000 -b 1000000 $(cat bp.pub) >ledger.json )
 fi
@@ -154,7 +158,7 @@ bp_pid=$!
 echo "Block producer PID: $bp_pid"
 
 "$MINA_EXE" daemon --config-file "$CONF_FILE" \
-  "${libp2p_2_args[@]}"  --seed \
+  "${libp2p_2_args[@]}" --seed \
   --peer "/ip4/127.0.0.1/tcp/10302/p2p/$(cat $CONF_DIR/libp2p_1.peerid)" \
   --run-snark-worker "$(cat $CONF_DIR/bp.pub)" --work-selection seq \
   --config-directory "$PWD/localnet/runtime_2" --file-log-level Info --log-level Error \

--- a/scripts/run-hf-localnet.sh
+++ b/scripts/run-hf-localnet.sh
@@ -86,12 +86,12 @@ libp2p_2_args=( --libp2p-keypair "$PWD/$CONF_DIR/libp2p_2" )
 # has a different command for libp2p key generation
 "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_1 2>/dev/null || \
   libp2p_1_args[0]="--discovery-keypair"
-if [[ "${#libp2p_1_args[0]}" == "--discovery-keypair" ]]; then
+if [[ "${libp2p_1_args[0]}" == "--discovery-keypair" ]]; then
   "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_1
 fi
 "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 2>/dev/null || \
   libp2p_2_args[0]="--discovery-keypair"
-if [[ "${#libp2p_2_args[0]}" == "--discovery-keypair" ]]; then
+if [[ "${libp2p_2_args[0]}" == "--discovery-keypair" ]]; then
   "$MINA_EXE" advanced generate-libp2p-keypair --privkey-path $CONF_DIR/libp2p_2
 fi
 


### PR DESCRIPTION
1. Update prepare-test-ledger.sh to allow generating a ledger with normal distribution, delegatee balance cutoff and a nicer CLi interface
2. Introduce a new script that generates a mainnet-like ledger with all stake delegated to a key and start a network of two nodes operating off this ledger

To learn about usage of both scripts, run them with `-h` flag.

Script `scripts/run-hf-localnet.sh` can be used without change with both `compatible` and `berkeley`. In latter case `-b` flag should be provided.

Script `scripts/run-hf-localnet.sh` generates a configuration based on mainnet ledger and launches two local nodes.
It also sends transactions on interval to simulate networking activity and ledger mutation.

Usage as simple as (launches a local node with the given mina executable, if not provided `mina` command will be used):
```
./scripts/run-hf-localnet.sh -m _build/default/src/app/cli/src/mina.exe -b
```

Explain how you tested your changes:
* Ran the script locally, observed transactions were generated (tested with mina from `compatible`, `berkeley` branches) and nodes to live for more than two epochs
* Requires #14990 for the test above to pass

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None, only a step towards #14709 