### PR TITLE
Fix parsing of `set_verification_key` permission from mainnet

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -161,7 +161,7 @@ module Json_layout = struct
           let of_yojson = function
             | `String _ as json ->
                 let%map.Result auth = Auth_required.of_yojson json in
-                { auth; txn_version = Txn_version.current }
+                { auth; txn_version = 1 }
             | json ->
                 of_yojson json
         end

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -161,7 +161,7 @@ module Json_layout = struct
           let of_yojson = function
             | `String _ as json ->
                 let%map.Result auth = Auth_required.of_yojson json in
-                { auth; txn_version = 1 }
+                { auth; txn_version = Txn_version.of_int 1 }
             | json ->
                 of_yojson json
         end

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -157,6 +157,13 @@ module Json_layout = struct
         module Verification_key_perm = struct
           type t = { auth : Auth_required.t; txn_version : Txn_version.t }
           [@@deriving dhall_type, sexp, yojson, bin_io_unversioned]
+
+          let of_yojson = function
+            | `String _ as json ->
+                let%map.Result auth = Auth_required.of_yojson json in
+                { auth; txn_version = Txn_version.current }
+            | json ->
+                of_yojson json
         end
 
         type t =


### PR DESCRIPTION
This PR allows for the parsing of the `set_verification_key` permission format that's emitted by mainnet/`compatible` nodes. This allows us to import the accounts dumped by the `fork_config` GraphQL query.