### PR TITLE
Remove the trust system DB if it is corrupted

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1091,7 +1091,7 @@ let setup_daemon logger =
           in
           let trust_dir = conf_dir ^/ "trust" in
           let%bind () = Async.Unix.mkdir ~p:() trust_dir in
-          let trust_system = Trust_system.create trust_dir in
+          let%bind trust_system = Trust_system.create trust_dir in
           trace_database_initialization "trust_system" __LOC__ trust_dir ;
           let genesis_state_hash =
             (Precomputed_values.genesis_state_hashes precomputed_values)

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -63,7 +63,9 @@ let%test_module "Epoch ledger sync tests" =
         Consensus.Constants.create ~constraint_constants
           ~protocol_constants:genesis_constants.protocol
       in
-      let trust_system = Trust_system.create (make_dirname "trust_system") in
+      let%bind trust_system =
+        Trust_system.create (make_dirname "trust_system")
+      in
       let module Context = struct
         let logger = logger
 
@@ -346,10 +348,13 @@ let%test_module "Epoch ledger sync tests" =
     let run_test ?(timeout_min = default_timeout_min) (module Context : CONTEXT)
         ~name ~staking_epoch_ledger ~next_epoch_ledger ~starting_accounts
         ~test_number =
+      let%bind fresh_trust_system =
+        Trust_system.create (make_dirname "trust_system")
+      in
       let module Context2 = struct
         include Context
 
-        let trust_system = Trust_system.create (make_dirname "trust_system")
+        let trust_system = fresh_trust_system
       end in
       let test_finished = ref false in
       let cleanup () = test_finished := true in

--- a/src/lib/trust_system/peer_trust.mli
+++ b/src/lib/trust_system/peer_trust.mli
@@ -52,7 +52,7 @@ module Make (Action : Action_intf) : sig
 
   (** Set up the trust system. Pass the directory to store the trust database
       in. *)
-  val create : string -> t
+  val create : string -> t Deferred.t
 
   (** Get a fake trust system, for tests. *)
   val null : unit -> t


### PR DESCRIPTION
This PR handles a corrupt or outdated trust system DB, by checking at startup that the values are parseable, and resetting to a new DB if not.

This is also required for starting a node running `berkeley` with a config directory from a `compatible` node.