### PR TITLE
Fix Rosetta SQL queries and improve Rosetta integration test reliance

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -66,7 +66,7 @@ module Sql = struct
 
     let query_pending =
       Caqti_request.find_opt
-        Caqti_type.(tup2 string int64)
+        Caqti_type.(tup3 string int64 string)
         Caqti_type.(tup4 int64 int64 int64 int64)
         {sql|
   WITH RECURSIVE pending_chain AS (
@@ -105,9 +105,11 @@ module Sql = struct
               INNER JOIN accounts_accessed aa ON full_chain.id = aa.block_id
               INNER JOIN account_identifiers ai on ai.id = aa.account_identifier_id
               INNER JOIN public_keys pks ON ai.public_key_id = pks.id
+              INNER JOIN tokens t ON ai.token_id = t.id
 
               WHERE pks.value = $1
               AND full_chain.height <= $2
+              AND t.value = $3
 
               ORDER BY full_chain.height DESC
               LIMIT 1
@@ -115,7 +117,7 @@ module Sql = struct
 
     let query_canonical =
       Caqti_request.find_opt
-        Caqti_type.(tup2 string int64)
+        Caqti_type.(tup3 string int64 string)
         Caqti_type.(tup4 int64 int64 int64 int64)
         {sql|
                 SELECT b.height,b.global_slot_since_genesis AS block_global_slot_since_genesis,balance,nonce
@@ -124,10 +126,12 @@ module Sql = struct
                 INNER JOIN accounts_accessed ac ON ac.block_id = b.id
                 INNER JOIN account_identifiers ai on ai.id = ac.account_identifier_id
                 INNER JOIN public_keys pks ON ai.public_key_id = pks.id
+                INNER JOIN tokens t ON ai.token_id = t.id
 
                 WHERE pks.value = $1
                 AND b.height <= $2
                 AND b.chain_status = 'canonical'
+                AND t.value = $3
 
                 ORDER BY (b.height) DESC
                 LIMIT 1
@@ -137,9 +141,10 @@ module Sql = struct
         address =
       let open Deferred.Result.Let_syntax in
       let%bind has_canonical_height = Sql.Block.run_has_canonical_height (module Conn) ~height:requested_block_height in
+      let token_id = Mina_base.Token_id.(to_string default) in
       Conn.find_opt
         (if has_canonical_height then query_canonical else query_pending)
-        (address, requested_block_height)
+        (address, requested_block_height, token_id)
   end
 
   let compute_incremental_balance

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -677,7 +677,8 @@ module Sql = struct
       Caqti_request.collect Caqti_type.(tup2 int string) typ
       (sprintf
         {|
-         SELECT %s,
+         SELECT u.id,
+                %s,
                 pk_payer.value as fee_payer,
                 pk_source.value as source,
                 pk_receiver.value as receiver,
@@ -752,6 +753,7 @@ module Sql = struct
       (sprintf
         {|
          SELECT DISTINCT ON (i.hash,i.command_type,bic.sequence_no,bic.secondary_sequence_no)
+           i.id,
            %s,
            ac.creation_fee,
            pk.value as receiver,

--- a/src/app/rosetta/rosetta-cli-config/config.json
+++ b/src/app/rosetta/rosetta-cli-config/config.json
@@ -35,7 +35,7 @@
    "force_retry":                false,
    "stale_depth":                3,
    "broadcast_limit":            0,
-   "ignore_broadcast_failures":  false,
+   "ignore_broadcast_failures":  true,
    "clear_broadcasts":           false,
    "broadcast_behind_tip":       false,
    "block_broadcast_limit":      0,


### PR DESCRIPTION
A change was missing from #14529. This PR fixes it, by adding the missing ids in Rosetta SQL queries.

Another issue was found in retrieving the balance from an account with multiple tokens, when the last relevant command of the account was related to a custom token. This is fixed here by constraining the queries to retrieve the balance to the default token id.

Rosetta integration test was very flaky, requiring many retries to succeed. This is improved by ignoring broadcast errors in `rosetta-cli` configuration. These errors happen because other parallel transactions are being sent to the network and they invalidate things like the nonce used by the Rosetta Construction API.