### PR TITLE
Remove dependency from mina_numbers from compile config

### DIFF
--- a/src/lib/mina_compile_config/dune
+++ b/src/lib/mina_compile_config/dune
@@ -1,7 +1,7 @@
 (library
  (name mina_compile_config)
  (public_name mina_compile_config)
- (libraries currency mina_numbers)
+ (libraries currency)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_base ppx_optcomp)))

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -51,24 +51,24 @@ let rpc_heartbeat_send_every_sec = 10.0 (*same as the default*)
 
 [%%ifndef slot_tx_end]
 
-let slot_tx_end : Mina_numbers.Global_slot.t option = None
+let slot_tx_end : int option = None
 
 [%%else]
 
 [%%inject "slot_tx_end", slot_tx_end]
 
-let slot_tx_end = Some (Mina_numbers.Global_slot.of_int slot_tx_end)
+let slot_tx_end = Some slot_tx_end
 
 [%%endif]
 
 [%%ifndef slot_chain_end]
 
-let slot_chain_end : Mina_numbers.Global_slot.t option = None
+let slot_chain_end : int option = None
 
 [%%else]
 
 [%%inject "slot_chain_end", slot_chain_end]
 
-let slot_chain_end = Some (Mina_numbers.Global_slot.of_int slot_chain_end)
+let slot_chain_end = Some slot_chain_end
 
 [%%endif]

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1383,10 +1383,9 @@ let make_fork_config ~staged_ledger ~global_slot ~blockchain_length
 
 let slot_tx_end_or_default, slot_chain_end_or_default =
   let f compile get_runtime t =
-    Option.value_map t.daemon ~default:compile ~f:(fun daemon ->
-        Option.merge compile ~f:(fun _c r -> r)
-        @@ Option.map ~f:Mina_numbers.Global_slot.of_int
-        @@ get_runtime daemon )
+    Option.map ~f:Mina_numbers.Global_slot.of_int
+    @@ Option.value_map t.daemon ~default:compile ~f:(fun daemon ->
+           Option.merge compile ~f:(fun _c r -> r) @@ get_runtime daemon )
   in
   ( f Mina_compile_config.slot_tx_end (fun d -> d.slot_tx_end)
   , f Mina_compile_config.slot_chain_end (fun d -> d.slot_chain_end) )


### PR DESCRIPTION
#14516 introduced a dependency on `mina_numbers` for `mina_compile_config`. This broke the build of `src/nonconsensus` (see https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/1273#018d686f-508b-4630-b49e-3dddd6ee9e7d).
This PR removes that dependency by making the parameters `int` and delegation to `runtime_config` the conversion to `Global_slot.t`, as it happens already in other branches.