### PR TITLE
Introduce mainnet/devnet build profiles in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,7 @@
 
         packages = {
           inherit (ocamlPackages)
-            mina mina_tests mina-ocaml-format mina_client_sdk test_executive;
+            mina devnet mainnet mina_tests mina-ocaml-format mina_client_sdk test_executive;
           inherit (pkgs) libp2p_helper marlin_plonk_bindings_stubs;
         };
 

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -218,6 +218,20 @@ let
 
       mina = wrapMina self.mina-dev { };
 
+      mainnet-pkg = self.mina-dev.overrideAttrs (s: {
+        version = "mainnet";
+        DUNE_PROFILE = "mainnet";
+      });
+
+      mainnet = wrapMina self.mainnet-pkg { };
+
+      devnet-pkg = self.mina-dev.overrideAttrs (s: {
+        version = "devnet";
+        DUNE_PROFILE = "devnet";
+      });
+
+      devnet = wrapMina self.devnet-pkg { };
+
       mina_tests = runMinaCheck {
         name = "tests";
         extraArgs = {


### PR DESCRIPTION
To build mainnet node, use `nix build mina#mainnet`

For devnet node: `nix build mina#devnet`

Explain how you tested your changes:
* Ran a node, checked that `mainnet` profile was used when compiling
* Compared output of `mina advanced constraint-system-digests` between nix version and mainnet binary built by CI

Related PRs:

* https://github.com/MinaProtocol/mina/pull/15026
* https://github.com/MinaProtocol/mina/pull/15028
* https://github.com/MinaProtocol/mina/pull/15181

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None