### PR TITLE
Introduce mainnet/devnet build profiles in nix (berkeley)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -287,7 +287,7 @@
         # Main user-facing binaries.
         packages = rec {
           inherit (ocamlPackages)
-            mina mina_tests mina-ocaml-format test_executive;
+            mina devnet mainnet mina_tests mina-ocaml-format test_executive;
           inherit (pkgs)
             libp2p_helper kimchi_bindings_stubs snarky_js leaderboard
             validation trace-tool zkapp-cli;

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -256,6 +256,26 @@ let
       # Same as above, but wrapped with version info.
       mina = wrapMina self.mina-dev { };
 
+      mainnet-pkg = self.mina-dev.overrideAttrs (s: {
+        version = "mainnet";
+        configurePhase = ''
+          ${s.configurePhase}
+          export DUNE_PROFILE=mainnet
+          '';
+      });
+
+      mainnet = wrapMina self.mainnet-pkg { };
+
+      devnet-pkg = self.mina-dev.overrideAttrs (s: {
+        version = "devnet";
+        configurePhase = ''
+          ${s.configurePhase}
+          export DUNE_PROFILE=devnet
+          '';
+      });
+
+      devnet = wrapMina self.devnet-pkg { };
+
       # Unit tests
       mina_tests = runMinaCheck {
         name = "tests";


### PR DESCRIPTION
Clone of #15026 against `berkeley`.

To build mainnet node, use `nix build mina#mainnet`

For devnet node: `nix build mina#devnet`

Explain how you tested your changes:
* Ran a node, checked that `mainnet` profile was used when compiling

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None