### PR TITLE
[berkeley] Fix nix CI test issue with directory ownership

### DIFF
--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -14,6 +14,9 @@ fi
 mkdir -p "${XDG_CONFIG_HOME-${HOME}/.config}/nix"
 echo 'experimental-features = nix-command flakes' > "${XDG_CONFIG_HOME-${HOME}/.config}/nix/nix.conf"
 
+
+chown -R "${USER}" /workdir
+
 git config --global --add safe.directory /workdir
 
 git fetch 

--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -14,7 +14,9 @@ fi
 mkdir -p "${XDG_CONFIG_HOME-${HOME}/.config}/nix"
 echo 'experimental-features = nix-command flakes' > "${XDG_CONFIG_HOME-${HOME}/.config}/nix/nix.conf"
 
-
+# There's an error in CI syncing submodules saying
+# "...' is not owned by current user"
+# run chown to the current user to fix it
 chown -R "${USER}" /workdir
 
 git config --global --add safe.directory /workdir

--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -20,7 +20,7 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = [
           S.strictlyStart (S.contains "src"),
-          S.exactly "buildkite/src/Jobs/Test/NixBuild" "dhall",
+          S.exactly "buildkite/src/Jobs/Test/NixBuildTest" "dhall",
 	        S.exactly "buildkite/scripts/test-nix" "sh",
           S.strictlyStart (S.contains "nix"),
 	        S.exactly "flake" "nix",

--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -21,9 +21,9 @@ Pipeline.build
         dirtyWhen = [
           S.strictlyStart (S.contains "src"),
           S.exactly "buildkite/src/Jobs/Test/NixBuildTest" "dhall",
-	        S.exactly "buildkite/scripts/test-nix" "sh",
+          S.exactly "buildkite/scripts/test-nix" "sh",
           S.strictlyStart (S.contains "nix"),
-	        S.exactly "flake" "nix",
+          S.exactly "flake" "nix",
           S.exactly "flake" "lock",
           S.exactly "default" "nix"
         ],

--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -20,7 +20,8 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = [
           S.strictlyStart (S.contains "src"),
-          S.exactly "buildkite/src/Jobs/Test/NixBuild" "dhall"
+          S.exactly "buildkite/src/Jobs/Test/NixBuild" "dhall",
+	  S.exactly "buildkite/scripts/test-nix" "sh"
         ],
         path = "Test",
         name = "NixBuildTest",

--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -21,7 +21,11 @@ Pipeline.build
         dirtyWhen = [
           S.strictlyStart (S.contains "src"),
           S.exactly "buildkite/src/Jobs/Test/NixBuild" "dhall",
-	  S.exactly "buildkite/scripts/test-nix" "sh"
+	        S.exactly "buildkite/scripts/test-nix" "sh",
+          S.strictlyStart (S.contains "nix"),
+	        S.exactly "flake" "nix",
+          S.exactly "flake" "lock",
+          S.exactly "default" "nix"
         ],
         path = "Test",
         name = "NixBuildTest",


### PR DESCRIPTION
There's an issue with the nix test in CI where it fails due to ownership of a directory not belonging to the current user (example [here](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/32540#018d6a24-84eb-458a-a634-006347c68a5e)). This PR fixes it by changing recursively the ownership of that directory (`/workdir`) to the current user.
This PR also makes CI run the test when the test script or any nix-related file is changed.