### PR TITLE
Allow berkeley_migration app migrate other networks than mainnet

### DIFF
--- a/src/app/berkeley_migration/berkeley_migration.ml
+++ b/src/app/berkeley_migration/berkeley_migration.ml
@@ -184,7 +184,7 @@ let mainnet_protocol_version =
   *)
   Protocol_version.create ~transaction:1 ~network:0 ~patch:0
 
-let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
+let mainnet_block_to_extensional ~logger ~mainnet_pool ~network
     ~(genesis_block : Mina_block.t) (block : Sql.Mainnet.Block.t) ~bucket
     ~batch_size =
   let query_mainnet_db ~f = Mina_caqti.query ~f mainnet_pool in
@@ -211,7 +211,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
           ; ("num_blocks", `Int (Int64.to_int_exn num_blocks))
           ] ;
       let%bind () =
-        Precomputed_block.fetch_batch ~prefix ~height:block.height ~num_blocks
+        Precomputed_block.fetch_batch ~network ~height:block.height ~num_blocks
           ~bucket
       in
       [%log info] "Done fetching first batch of precomputed blocks" ;
@@ -219,14 +219,14 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
       Deferred.unit )
     else if Int64.(equal (block.height % batch_size)) 0L then (
       [%log info] "Deleting all precomputed blocks" ;
-      let%bind () = Precomputed_block.delete_fetched ~prefix in
+      let%bind () = Precomputed_block.delete_fetched ~network in
       [%log info] "Fetching batch of precomputed blocks"
         ~metadata:
           [ ("height", `Int (Int64.to_int_exn block.height))
           ; ("num_blocks", `Int (Int64.to_int_exn batch_size))
           ] ;
       let%bind () =
-        Precomputed_block.fetch_batch ~prefix ~height:block.height
+        Precomputed_block.fetch_batch ~network ~height:block.height
           ~num_blocks:batch_size ~bucket
       in
       [%log info] "Done fetching batch of precomputed blocks" ;
@@ -253,7 +253,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       let%map json =
         Precomputed_block.last_vrf_output ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       in
       Consensus_vrf.Output.Truncated.of_yojson json |> Result.ok_or_failwith
   in
@@ -273,7 +273,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       let%map json =
         Precomputed_block.staking_epoch_data ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       in
       match Mina_base.Epoch_data.Value.of_yojson json with
       | Ok epoch_data ->
@@ -288,7 +288,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       let%map json =
         Precomputed_block.next_epoch_data ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       in
       match Mina_base.Epoch_data.Value.of_yojson json with
       | Ok epoch_data ->
@@ -303,7 +303,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       match%map
         Precomputed_block.min_window_density ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       with
       | `String s ->
           Mina_numbers.Length.of_string s
@@ -317,7 +317,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       match%map
         Precomputed_block.total_currency ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       with
       | `String s ->
           Currency.Amount.of_string s
@@ -331,7 +331,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
     else
       match%map
         Precomputed_block.subwindow_densities ~state_hash:block.state_hash
-          ~height:block.height ~prefix
+          ~height:block.height ~network
       with
       | `List items ->
           List.map items ~f:(function
@@ -406,7 +406,7 @@ let mainnet_block_to_extensional ~logger ~mainnet_pool ~prefix
       : Archive_lib.Extensional.Block.t )
 
 let main ~mainnet_archive_uri ~migrated_archive_uri ~runtime_config_file
-    ~end_global_slot ~mina_network_blocks_bucket ~batch_size ~prefix () =
+    ~end_global_slot ~mina_network_blocks_bucket ~batch_size ~network () =
   let logger = Logger.create () in
   let mainnet_archive_uri = Uri.of_string mainnet_archive_uri in
   let migrated_archive_uri = Uri.of_string migrated_archive_uri in
@@ -503,7 +503,7 @@ let main ~mainnet_archive_uri ~migrated_archive_uri ~runtime_config_file
               block.height block.state_hash ;
             let%bind extensional_block =
               mainnet_block_to_extensional ~logger ~mainnet_pool ~genesis_block
-                block ~bucket:mina_network_blocks_bucket ~batch_size ~prefix
+                block ~bucket:mina_network_blocks_bucket ~batch_size ~network
             in
             query_migrated_db ~f:(fun db ->
                 match%map
@@ -519,7 +519,7 @@ let main ~mainnet_archive_uri ~migrated_archive_uri ~runtime_config_file
                       block.state_hash (Caqti_error.show err) () ) )
       in
       [%log info] "Deleting all precomputed blocks" ;
-      let%bind () = Precomputed_block.delete_fetched ~prefix in
+      let%bind () = Precomputed_block.delete_fetched ~network in
       [%log info] "Done migrating mainnet blocks!" ;
       Deferred.unit
 
@@ -550,18 +550,18 @@ let () =
                "NN Last global slot since genesis to include in the migration \
                 (if omitted, only canonical blocks will be migrated)"
          and mina_network_blocks_bucket =
-           Param.flag "--mainnet-blocks-bucket"
-             ~aliases:[ "-mainnet-blocks-bucket" ]
+           Param.flag "--blocks-bucket"
+             ~aliases:[ "-blocks-bucket" ]
              Param.(required string)
              ~doc:"Bucket with precomputed mainnet blocks"
          and batch_size =
            Param.flag "--batch-size" ~aliases:[ "-batch-size" ]
              Param.(required int)
              ~doc:"Batch size used when downloading precomputed blocks"
-         and prefix =
-           Param.flag "--blocks-prefix" ~aliases:[ "-blocks-prefix" ]
+         and network =
+           Param.flag "--network" ~aliases:[ "-network" ]
              Param.(required string)
-             ~doc:"Block prefix used when downloading precomputed blocks"
+             ~doc:"Network name used when downloading precomputed blocks"
          in
          main ~mainnet_archive_uri ~migrated_archive_uri ~runtime_config_file
-           ~end_global_slot ~mina_network_blocks_bucket ~batch_size ~prefix )))
+           ~end_global_slot ~mina_network_blocks_bucket ~batch_size ~network )))

--- a/src/app/berkeley_migration/berkeley_migration.ml
+++ b/src/app/berkeley_migration/berkeley_migration.ml
@@ -550,8 +550,7 @@ let () =
                "NN Last global slot since genesis to include in the migration \
                 (if omitted, only canonical blocks will be migrated)"
          and mina_network_blocks_bucket =
-           Param.flag "--blocks-bucket"
-             ~aliases:[ "-blocks-bucket" ]
+           Param.flag "--blocks-bucket" ~aliases:[ "-blocks-bucket" ]
              Param.(required string)
              ~doc:"Bucket with precomputed mainnet blocks"
          and batch_size =

--- a/src/app/berkeley_migration/precomputed_block.ml
+++ b/src/app/berkeley_migration/precomputed_block.ml
@@ -7,13 +7,13 @@ open Async
    get what we need by traversing JSON
 *)
 
-let make_target ~prefix ~state_hash ~height =
-  sprintf "%s-%Ld-%s.json" prefix height state_hash
+let make_target ~network ~state_hash ~height =
+  sprintf "%s-%Ld-%s.json" network height state_hash
 
 (* no precomputed genesis block at height 1 *)
 let min_fetchable_height = 2L
 
-let make_batch_args ~prefix ~height ~num_blocks =
+let make_batch_args ~network ~height ~num_blocks =
   let start_height = Int64.max min_fetchable_height height in
   let actual_num_blocks =
     if Int64.( < ) height min_fetchable_height then
@@ -21,10 +21,10 @@ let make_batch_args ~prefix ~height ~num_blocks =
     else num_blocks
   in
   List.init (Int64.to_int_exn actual_num_blocks) ~f:(fun n ->
-      sprintf "%s-%Ld-*.json" prefix Int64.(start_height + Int64.of_int n) )
+      sprintf "%s-%Ld-*.json" network Int64.(start_height + Int64.of_int n) )
 
-let fetch_batch ~height ~num_blocks ~bucket ~prefix =
-  let batch_args = make_batch_args ~height ~num_blocks ~prefix in
+let fetch_batch ~height ~num_blocks ~bucket ~network =
+  let batch_args = make_batch_args ~height ~num_blocks ~network in
   let block_uris =
     List.map batch_args ~f:(fun arg -> sprintf "gs://%s/%s" bucket arg)
   in
@@ -39,13 +39,13 @@ let fetch_batch ~height ~num_blocks ~bucket ~prefix =
          %s"
         height (Error.to_string_hum err) ()
 
-let block_re ~prefix = Str.regexp (sprintf "%s-[0-9]+-.+\\.json" prefix)
+let block_re ~network = Str.regexp (sprintf "%s-[0-9]+-.+\\.json" network)
 
-let delete_fetched ~prefix : unit Deferred.t =
+let delete_fetched ~network : unit Deferred.t =
   let%bind files = Sys.readdir "." in
   let block_files =
     Array.filter files ~f:(fun file ->
-        Str.string_match (block_re ~prefix) file 0 )
+        Str.string_match (block_re ~network) file 0 )
   in
   let args = Array.to_list block_files in
   if List.length args > 0 then
@@ -57,8 +57,8 @@ let delete_fetched ~prefix : unit Deferred.t =
           (Error.to_string_hum err) ()
   else Deferred.unit
 
-let get_json_item filter ~state_hash ~height ~prefix =
-  let target = make_target ~state_hash ~height ~prefix in
+let get_json_item filter ~state_hash ~height ~network =
+  let target = make_target ~state_hash ~height ~network in
   match%map Process.run ~prog:"jq" ~args:[ filter; target ] () with
   | Ok s ->
       Yojson.Safe.from_string s

--- a/src/app/berkeley_migration/precomputed_block.ml
+++ b/src/app/berkeley_migration/precomputed_block.ml
@@ -7,13 +7,13 @@ open Async
    get what we need by traversing JSON
 *)
 
-let make_target ~state_hash ~height =
-  sprintf "mainnet-%Ld-%s.json" height state_hash
+let make_target ~prefix ~state_hash ~height =
+  sprintf "%s-%Ld-%s.json" prefix height state_hash
 
 (* no precomputed genesis block at height 1 *)
 let min_fetchable_height = 2L
 
-let make_batch_args ~height ~num_blocks =
+let make_batch_args ~prefix ~height ~num_blocks =
   let start_height = Int64.max min_fetchable_height height in
   let actual_num_blocks =
     if Int64.( < ) height min_fetchable_height then
@@ -21,10 +21,10 @@ let make_batch_args ~height ~num_blocks =
     else num_blocks
   in
   List.init (Int64.to_int_exn actual_num_blocks) ~f:(fun n ->
-      sprintf "mainnet-%Ld-*.json" Int64.(start_height + Int64.of_int n) )
+      sprintf "%s-%Ld-*.json" prefix Int64.(start_height + Int64.of_int n) )
 
-let fetch_batch ~height ~num_blocks ~bucket =
-  let batch_args = make_batch_args ~height ~num_blocks in
+let fetch_batch ~height ~num_blocks ~bucket ~prefix =
+  let batch_args = make_batch_args ~height ~num_blocks ~prefix in
   let block_uris =
     List.map batch_args ~f:(fun arg -> sprintf "gs://%s/%s" bucket arg)
   in
@@ -39,12 +39,13 @@ let fetch_batch ~height ~num_blocks ~bucket =
          %s"
         height (Error.to_string_hum err) ()
 
-let block_re = Str.regexp "mainnet-[0-9]+-.+\\.json"
+let block_re ~prefix = Str.regexp (sprintf "%s-[0-9]+-.+\\.json" prefix)
 
-let delete_fetched () : unit Deferred.t =
+let delete_fetched ~prefix : unit Deferred.t =
   let%bind files = Sys.readdir "." in
   let block_files =
-    Array.filter files ~f:(fun file -> Str.string_match block_re file 0)
+    Array.filter files ~f:(fun file ->
+        Str.string_match (block_re ~prefix) file 0 )
   in
   let args = Array.to_list block_files in
   if List.length args > 0 then
@@ -56,8 +57,8 @@ let delete_fetched () : unit Deferred.t =
           (Error.to_string_hum err) ()
   else Deferred.unit
 
-let get_json_item filter ~state_hash ~height =
-  let target = make_target ~state_hash ~height in
+let get_json_item filter ~state_hash ~height ~prefix =
+  let target = make_target ~state_hash ~height ~prefix in
   match%map Process.run ~prog:"jq" ~args:[ filter; target ] () with
   | Ok s ->
       Yojson.Safe.from_string s


### PR DESCRIPTION
Introduced `--network` parameter which control prefix used when downloading precomputed blocks. This new parameter can be used when dealling with differenet network than mainnet.