### PR TITLE
Kimchi_backend: fix unerasable-optional-argument warning

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -505,7 +505,7 @@ module Make (Inputs : Inputs_intf) = struct
     to_backend_with_public_evals' chal_polys (List.to_array primary_input) t
 
   (* Extract challenges and commitments from the (optional) message *)
-  let extract_challenges_and_commitments ?message =
+  let extract_challenges_and_commitments ~message =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -522,12 +522,12 @@ module Make (Inputs : Inputs_intf) = struct
     (challenges, commitments)
 
   let create ?message pk ~primary ~auxiliary =
-    let prev_chals, prev_comms = extract_challenges_and_commitments ?message in
+    let prev_chals, prev_comms = extract_challenges_and_commitments ~message in
     let res = Backend.create pk ~primary ~auxiliary ~prev_chals ~prev_comms in
     of_backend_with_public_evals res
 
   let create_async ?message pk ~primary ~auxiliary =
-    let prev_chals, prev_comms = extract_challenges_and_commitments ?message in
+    let prev_chals, prev_comms = extract_challenges_and_commitments ~message in
     let%map.Promise res =
       Backend.create_async pk ~primary ~auxiliary ~prev_chals ~prev_comms
     in


### PR DESCRIPTION
Instead of the typical change which would have added a unit () argument to the function (to make the optional argument erasable), making the function look like

```
  let extract_challenges_and_commitments ?message ()
```

, I chose to make the argument a labeled option type (which thus cannot be omitted), since it looks like the context in which this function is called never actually needs to omit this labeled parameter.

