### PR TITLE
demote error to warn

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -168,9 +168,9 @@ module Ledger = struct
                   ] ;
               return None )
       | None ->
-          [%log error]
+          [%log warn]
             "Need S3 hash specified in runtime config to verify download for \
-             $ledger (root hash $root_hash), refusing unsafe download"
+             $ledger (root hash $root_hash), not attempting"
             ~metadata:
               [ ( "root_hash"
                 , `String (Option.value ~default:"not specified" config.hash) )


### PR DESCRIPTION
fixes an issue in the migration cronjob where it (very sensibly) thinks errors are important. this one isn't, it'll get logged even when an account list is provided (due to the way it falls back to the account list only after failing to download it...)