### PR TITLE
Fixing packages versions to last supported

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -49,7 +49,7 @@ RUN apt-get update --quiet --yes \
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt-get update --quiet --yes \
-  && apt-get install --quiet --yes --no-install-recommends google-cloud-sdk kubectl google-cloud-sdk-gke-gcloud-auth-plugin \
+  && apt-get install --quiet --yes --no-install-recommends google-cloud-sdk=462.0.1-0 kubectl=1:462.0.1-0 google-cloud-sdk-gke-gcloud-auth-plugin=462.0.1-0 \
   && rm -rf /var/lib/apt/lists/*
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True

--- a/dockerfiles/Dockerfile-mina-test-executive
+++ b/dockerfiles/Dockerfile-mina-test-executive
@@ -47,7 +47,7 @@ RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt-get update --quiet --yes \
-  && apt-get install --quiet --yes --no-install-recommends google-cloud-sdk kubectl google-cloud-sdk-gke-gcloud-auth-plugin \
+  && apt-get install --quiet --yes --no-install-recommends google-cloud-sdk=462.0.1-0 kubectl=1:462.0.1-0 google-cloud-sdk-gke-gcloud-auth-plugin=462.0.1-0 \
   && rm -rf /var/lib/apt/lists/*
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -100,7 +100,7 @@ RUN wget -O- https://apt.releases.hashicorp.com/gpg | \
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && apt-get update --yes \
-    && apt-get install --yes google-cloud-sdk kubectl \
+    && apt-get install --yes google-cloud-sdk=462.0.1-0 kubectl=1:462.0.1-0  \
     && rm -rf /var/lib/apt/lists/*
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True


### PR DESCRIPTION
CI runs were failing due to a possible external issue regarding gcloud packages obtained via apt-get.
To avoid this the versions of the last working artifacts were fixed