### PR TITLE
Fixes for migration tools

### DIFF
--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -138,10 +138,11 @@ let%test_module "Archive node unit tests" =
             let open Deferred.Result.Let_syntax in
             let%bind user_command_id =
               Processor.User_command.add_if_doesn't_exist conn ~logger
-                user_command
+                ~v1_transaction_hash:false user_command
             in
             let%map result =
               Processor.User_command.find conn ~transaction_hash
+                ~v1_transaction_hash:false
               >>| function
               | Some (`Signed_command_id signed_command_id) ->
                   Some signed_command_id
@@ -191,10 +192,11 @@ let%test_module "Archive node unit tests" =
                 let open Deferred.Result.Let_syntax in
                 let%bind user_command_id =
                   Processor.User_command.add_if_doesn't_exist conn ~logger
-                    user_command
+                    ~v1_transaction_hash:false user_command
                 in
                 let%map result =
                   Processor.User_command.find conn ~transaction_hash
+                    ~v1_transaction_hash:false
                   >>| function
                   | Some (`Zkapp_command_id zkapp_command_id) ->
                       Some zkapp_command_id

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -602,8 +602,12 @@ let try_slot ~logger pool slot =
   go ~slot ~tries_left:num_tries
 
 let write_replayer_checkpoint ~logger ~ledger ~last_global_slot_since_genesis
-    ~max_canonical_slot ~checkpoint_output_folder_opt ~checkpoint_file_prefix =
-  if Int64.( <= ) last_global_slot_since_genesis max_canonical_slot then (
+    ~max_canonical_slot ~checkpoint_output_folder_opt ~checkpoint_file_prefix
+    ~migration_mode =
+  if
+    migration_mode
+    || Int64.( <= ) last_global_slot_since_genesis max_canonical_slot
+  then (
     (* start replaying at the slot after the one we've just finished with *)
     let start_slot_since_genesis = Int64.succ last_global_slot_since_genesis in
     let%map replayer_checkpoint =
@@ -1140,11 +1144,12 @@ let main ~input_file ~output_file_opt ~migration_mode ~archive_uri
                 Core.exit 1 )
           | Some (state_hash, ledger_hash, snarked_hash) ->
               let write_checkpoint_file ~checkpoint_output_folder_opt
-                  ~checkpoint_file_prefix () =
+                  ~checkpoint_file_prefix ~migration_mode () =
                 let write_checkpoint () =
                   write_replayer_checkpoint ~logger ~ledger
                     ~last_global_slot_since_genesis ~max_canonical_slot
                     ~checkpoint_output_folder_opt ~checkpoint_file_prefix
+                    ~migration_mode
                 in
                 if last_block then write_checkpoint ()
                 else
@@ -1393,7 +1398,7 @@ let main ~input_file ~output_file_opt ~migration_mode ~archive_uri
                 let%bind () = check_account_accessed state_hash in
                 log_state_hash_on_next_slot last_global_slot_since_genesis ;
                 write_checkpoint_file ~checkpoint_output_folder_opt
-                  ~checkpoint_file_prefix ()
+                  ~checkpoint_file_prefix ~migration_mode ()
         in
         (* a sequence is a command type, slot, sequence number triple *)
         let get_internal_cmd_sequence (ic : Sql.Internal_command.t) =

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -689,11 +689,8 @@ let main ~input_file ~output_file_opt ~migration_mode ~archive_uri
       in
       let%bind target_state_hash =
         match epoch_ledgers_state_hash_opt with
-        | Some epoch_ledgers_state_hash ->
-            [%log info] "Retrieving fork block state_hash" ;
-            query_db ~f:(fun db ->
-                Sql.Parent_block.get_parent_state_hash db
-                  epoch_ledgers_state_hash )
+        | Some hash ->
+            return hash
         | None ->
             [%log info]
               "Searching for block with greatest height on canonical chain" ;

--- a/src/app/replayer/test/input.json
+++ b/src/app/replayer/test/input.json
@@ -1,5 +1,5 @@
 {
-  "target_epoch_ledgers_state_hash": "3NKsyvrS5sw6LSq4BaNBnn5cXxFR4adRADyL21J1S8ZxrJPmAxcD",
+  "target_epoch_ledgers_state_hash": "3NKs8ugWuKYypPMDTPZz6PjZyFe3usVK5shzftFP4xPn9enWe1YF",
   "genesis_ledger": {
     "name": "release",
     "num_accounts": 250,


### PR DESCRIPTION
Explain your changes:
This PR contains 4 different fixes against our migration tools. Those 4 different fixes corresponding to 4 different commits.

[use v1_transaction_hash for find user_commands](https://github.com/MinaProtocol/mina/pull/15069/commits/231ac86d415dc20444cd18c81e38c20398fe0694) This commits fixes the processor so that when searching for the user command we would use `v1_state_hash`

[always create a checkpoint with migration mode](https://github.com/MinaProtocol/mina/pull/15069/commits/5e60c261de9a2ea2c2771c6d4a3761bdd5e61097) This commits makes the replayer always create a checkpoint when we are in the migration-mode

[mark all the blocks to be canonical in berkeley_migration app](https://github.com/MinaProtocol/mina/pull/15069/commits/77ebba65c91415353e35c5b35a4cfc6b2bf184a5) This commits replace the flag `end_global_slot`  in berkeley_migration tool with a new flag called `fork_state_hash`. Given the `fork_state_hash`, the berkeley_migration tool would first mark the chain to the fork block as canonical then start doing migration. This way we would avoid migrating pending blocks.

 [don't search for target](https://github.com/MinaProtocol/mina/pull/15069/commits/22113b0868a505c2cf94aeb0de488911fe66560f)
[22113b0](https://github.com/MinaProtocol/mina/pull/15069/commits/22113b0868a505c2cf94aeb0de488911fe66560f) This could be optional. The replayer has a field called `target_epoch_ledgers_state_hash` and if this field is set, then the replayer would apply all the blocks up till its parent block. I changed the behavior of this so that it would replay all the blocks including the fork block. The intention of the `replayer --migration` was to generate some epoch ledgers according to paul's original rfc. That's why it behaves like this. But for now we are just using this to do migration stuff. So I changed the behavior this a little bit.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
