### PR TITLE
Fix docstrings `reformat` warning

### DIFF
--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -1,5 +1,3 @@
-(* maskable_merkle_tree.ml -- Merkle tree that can have associated masks *)
-
 open Core
 
 module type Inputs_intf = sig
@@ -27,7 +25,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   let logger = Logger.create ()
 
-  (** Maps parent ledger UUIDs to child masks. *)
+  (* Maps parent ledger UUIDs to child masks. *)
   let (registered_masks : Mask.Attached.t list Uuid.Table.t) =
     Uuid.Table.create ()
 
@@ -188,7 +186,7 @@ module Make (Inputs : Inputs_intf) = struct
     in
     unregister_mask_exn_do ~trigger_signal ~loc mask
 
-  (** a set calls the Base implementation set, notifies registered mask childen *)
+  (* [set] calls the Base implementation set, notifies registered mask childen *)
   let set t location account =
     Base.set t location account ;
     let uuid = get_uuid t in

--- a/src/lib/merkle_mask/maskable_merkle_tree.mli
+++ b/src/lib/merkle_mask/maskable_merkle_tree.mli
@@ -1,3 +1,5 @@
+(** Merkle trees that can have associated masks *)
+
 module type Inputs_intf = sig
   include Inputs_intf.S
 

--- a/src/lib/merkle_mask/masking_merkle_tree.mli
+++ b/src/lib/merkle_mask/masking_merkle_tree.mli
@@ -1,3 +1,10 @@
+(** Implements a mask in front of a Merkle tree; see RFC 0004 and
+    docs/specs/merkle_tree.md *)
+
+(** Builds a Merkle tree mask.
+
+    It's a Merkle tree, with some additional operations.
+*)
 module Make (I : Inputs_intf.S) :
   Masking_merkle_tree_intf.S
     with module Location = I.Location


### PR DESCRIPTION
In reaction to the warning below , this PR removes docstring in implementation files. In addition, some are moved to the interface files, where I think they clearly belong
```
dune exec --profile=dev src/app/reformat/reformat.exe -- -path . -check
(monitor.ml.Error
 ("Process.run failed"
  ((prog ocamlformat)
   (args
    (--doc-comments=before ./src/lib/merkle_mask/masking_merkle_tree.ml))
   (exit_status (Exit_non_zero 1)) (stdout "")
   (stderr
    ("ocamlformat: ignoring \"./src/lib/merkle_mask/masking_merkle_tree.ml\" (misplaced documentation comments - warning 50)"
     "File \"./src/lib/merkle_mask/masking_merkle_tree.ml\", lines 55-73, characters 2-23:"
     "55 | ..(** Structure managing cache accumulated since the \"base\" ledger."
     "56 | "
     "57 |     Its purpose is to optimize lookups through a few consequitive masks"
     "58 |     (by using just one map lookup instead of [O(number of masks)] map lookups)."
     "59 | " ... "70 | "
     "71 |     Garbage-collection/rotation mechanism for [next] and [current] is based on idea to set"
     "72 |     [current] to [next] and [next] to [t.maps] when the mask at which accumulation of [next] started"
     "73 |     became detached. *)"
     "Warning 50 [unexpected-docstring]: ambiguous documentation comment"
     "Hint: (Warning 50) This file contains a documentation comment (** ... *) that the OCaml compiler does not know how to attach to the AST. OCamlformat does not support these cases. You can find more information at: https://github.com/ocaml-ppx/ocamlformat#overview. If you'd like to disable this check and let ocamlformat make a choice (though it might not be consistent with the ocaml compilers and odoc), you can set the --no-comment-check option."
     ""))))
```

