### PR TITLE
Fix off by one in blockchain slot

### DIFF
--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -478,8 +478,8 @@ let make_constraint_constants
                 State_hash.of_base58_check_exn previous_state_hash
             ; previous_length = Mina_numbers.Length.of_int previous_length
             ; genesis_slot =
-                Mina_numbers.Global_slot_since_genesis.of_int
-                  previous_global_slot
+                Mina_numbers.Global_slot_since_genesis.(
+                  succ @@ of_int previous_global_slot)
             } )
   }
 


### PR DESCRIPTION
This PR fixes an off-by-one error, where the global slot for the genesis block after the hard-fork has the same global slot as the final block of the network.

IMO this is the incorrect way to fix this: slot time should be tied to wall-clock time -- that is, any slots that pass between the final block of the pre-fork network and the first block in the post-fork network should just be empty -- instead of munging the concept of time when we set up the new network. This also does weird things to timed accounts. Oh well.