### PR TITLE
Hardfork package generation: compute the global slot for the fork from the genesis timestamp

### DIFF
--- a/scripts/hardfork/create_runtime_config.sh
+++ b/scripts/hardfork/create_runtime_config.sh
@@ -4,16 +4,28 @@ set -e
 
 FORK_CONFIG_JSON=${FORK_CONFIG_JSON:=fork_config.json}
 LEDGER_HASHES_JSON=${LEDGER_HASHES_JSON:=ledger_hashes.json}
+FORKING_FROM_CONFIG_JSON=${FORKING_FROM_CONFIG_JSON:=genesis_ledgers/mainnet.json}
 
 # If not given, the genesis timestamp is set to 10 mins into the future
 GENESIS_TIMESTAMP=${GENESIS_TIMESTAMP:=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d "10 mins")}
+
+# Pull the original genesis timestamp from the pre-fork config file
+ORIGINAL_GENESIS_TIMESTAMP=$(jq '.genesis.genesis_state_timestamp' $FORKING_FROM_CONFIG_JSON | sed 's/"//g')
+
+DIFFERENCE_IN_SECONDS=$(($(date -d "$GENESIS_TIMESTAMP" "+%s") - $(date -d "$ORIGINAL_GENESIS_TIMESTAMP" "%s")))
+# TODO: Don't hard-code 180s per slot here!
+DIFFERENCE_IN_SLOTS=$(($DIFFERENCE_IN_SECONDS / 180))
 
 jq "{\
     genesis: {\
         genesis_state_timestamp: \"$GENESIS_TIMESTAMP\"\
     },\
     proof: {\
-        fork: .proof.fork\
+        fork: {\
+            previous_state_hash: .proof.fork.previous_state_hash,\
+            previous_length: .proof.fork.previous_length,\
+            previous_global_slot: $DIFFERENCE_IN_SLOTS,\
+        },\
     },\
     ledger: {\
         add_genesis_winner: false,\

--- a/scripts/hardfork/create_runtime_config.sh
+++ b/scripts/hardfork/create_runtime_config.sh
@@ -12,7 +12,7 @@ GENESIS_TIMESTAMP=${GENESIS_TIMESTAMP:=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d "10 mi
 # Pull the original genesis timestamp from the pre-fork config file
 ORIGINAL_GENESIS_TIMESTAMP=$(jq '.genesis.genesis_state_timestamp' $FORKING_FROM_CONFIG_JSON | sed 's/"//g')
 
-DIFFERENCE_IN_SECONDS=$(($(date -d "$GENESIS_TIMESTAMP" "+%s") - $(date -d "$ORIGINAL_GENESIS_TIMESTAMP" "%s")))
+DIFFERENCE_IN_SECONDS=$(($(date -d "$GENESIS_TIMESTAMP" "+%s") - $(date -d "$ORIGINAL_GENESIS_TIMESTAMP" "+%s")))
 # TODO: Don't hard-code 180s per slot here!
 DIFFERENCE_IN_SLOTS=$(($DIFFERENCE_IN_SECONDS / 180))
 

--- a/scripts/hardfork/create_runtime_config.sh
+++ b/scripts/hardfork/create_runtime_config.sh
@@ -13,8 +13,9 @@ GENESIS_TIMESTAMP=${GENESIS_TIMESTAMP:=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d "10 mi
 ORIGINAL_GENESIS_TIMESTAMP=$(jq '.genesis.genesis_state_timestamp' $FORKING_FROM_CONFIG_JSON | sed 's/"//g')
 
 DIFFERENCE_IN_SECONDS=$(($(date -d "$GENESIS_TIMESTAMP" "+%s") - $(date -d "$ORIGINAL_GENESIS_TIMESTAMP" "+%s")))
-# TODO: Don't hard-code 180s per slot here!
-DIFFERENCE_IN_SLOTS=$(($DIFFERENCE_IN_SECONDS / 180))
+# Default: mainnet currently uses 180s per slot
+SECONDS_PER_SLOT=${SECONDS_PER_SLOT:=180}
+DIFFERENCE_IN_SLOTS=$(($DIFFERENCE_IN_SECONDS / $SECONDS_PER_SLOT))
 
 jq "{\
     genesis: {\

--- a/scripts/hardfork/create_runtime_config.sh
+++ b/scripts/hardfork/create_runtime_config.sh
@@ -10,7 +10,7 @@ FORKING_FROM_CONFIG_JSON=${FORKING_FROM_CONFIG_JSON:=genesis_ledgers/mainnet.jso
 GENESIS_TIMESTAMP=${GENESIS_TIMESTAMP:=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d "10 mins")}
 
 # Pull the original genesis timestamp from the pre-fork config file
-ORIGINAL_GENESIS_TIMESTAMP=$(jq '.genesis.genesis_state_timestamp' $FORKING_FROM_CONFIG_JSON | sed 's/"//g')
+ORIGINAL_GENESIS_TIMESTAMP=$(jq -r '.genesis.genesis_state_timestamp' "$FORKING_FROM_CONFIG_JSON")
 
 DIFFERENCE_IN_SECONDS=$(($(date -d "$GENESIS_TIMESTAMP" "+%s") - $(date -d "$ORIGINAL_GENESIS_TIMESTAMP" "+%s")))
 # Default: mainnet currently uses 180s per slot


### PR DESCRIPTION
This PR updates the hardfork package generation to compute a global slot implicitly from the genesis timestamp. In particular, this ensures that we have continuity of time between the old and new networks, so that timed accounts etc. do not experience time travel and continue according to the existing schedule.

Notice that the time per slot is hard-coded in the script. We should choose a place to extract it from in future instead.

Closes #15097