### PR TITLE
Fix `to_input` for protocol constants so that all fields are included

### DIFF
--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -611,7 +611,7 @@ module Protocol_circuits = struct
     ()
 
   let blockchain () : unit =
-    let expected = "0e1896d5c5840089da3304799c01efd8" in
+    let expected = "36786c300e37c2a2f1341ad6374aa113" in
     let digest =
       Blockchain_snark.Blockchain_snark_state.constraint_system_digests
     in
@@ -627,7 +627,7 @@ module Protocol_circuits = struct
 
   let transaction () : unit =
     let expected1 = "b8879f677f622a1d86648030701f43e1" in
-    let expected2 = "c9251dbcc565e8e18d15ca96d7908925" in
+    let expected2 = "a58d09e2904bad2e3f983b3f9b0cf78f" in
     let digest =
       Transaction_snark.constraint_system_digests ~constraint_constants ()
     in

--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -643,10 +643,10 @@ module Protocol_circuits = struct
     let digest2 = Core.Md5.to_hex hash2 in
 
     let check = String.(digest1 = expected1) in
-    print_hash check expected1 digest1 ;
+    print_hash (not check) expected1 digest1 ;
     assert check ;
     let check = String.(digest2 = expected2) in
-    print_hash check expected2 digest2 ;
+    print_hash (not check) expected2 digest2 ;
     assert check ;
     ()
 

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -70,13 +70,22 @@ let t_of_value (v : value) : Genesis_constants.Protocol.t =
   ; genesis_state_timestamp = Block_time.to_int64 v.genesis_state_timestamp
   }
 
-let to_input (t : value) =
+let to_input
+    ({ k
+     ; delta
+     ; slots_per_epoch
+     ; slots_per_sub_window
+     ; grace_period_slots
+     ; genesis_state_timestamp
+     } :
+      value ) =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
-    [| T.to_input t.k
-     ; T.to_input t.delta
-     ; T.to_input t.slots_per_epoch
-     ; T.to_input t.slots_per_sub_window
-     ; Block_time.to_input t.genesis_state_timestamp
+    [| T.to_input k
+     ; T.to_input delta
+     ; T.to_input slots_per_epoch
+     ; T.to_input slots_per_sub_window
+     ; T.to_input grace_period_slots
+     ; Block_time.to_input genesis_state_timestamp
     |]
 
 [%%if defined consensus_mechanism]
@@ -95,19 +104,29 @@ let typ =
     ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
     ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
-let var_to_input (var : var) =
-  let k = T.Checked.to_input var.k
-  and delta = T.Checked.to_input var.delta
-  and slots_per_epoch = T.Checked.to_input var.slots_per_epoch
-  and slots_per_sub_window = T.Checked.to_input var.slots_per_sub_window in
+let var_to_input
+    ({ k
+     ; delta
+     ; slots_per_epoch
+     ; slots_per_sub_window
+     ; grace_period_slots
+     ; genesis_state_timestamp
+     } :
+      var ) =
+  let k = T.Checked.to_input k
+  and delta = T.Checked.to_input delta
+  and slots_per_epoch = T.Checked.to_input slots_per_epoch
+  and slots_per_sub_window = T.Checked.to_input slots_per_sub_window
+  and grace_period_slots = T.Checked.to_input grace_period_slots in
   let genesis_state_timestamp =
-    Block_time.Checked.to_input var.genesis_state_timestamp
+    Block_time.Checked.to_input genesis_state_timestamp
   in
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [| k
      ; delta
      ; slots_per_epoch
      ; slots_per_sub_window
+     ; grace_period_slots
      ; genesis_state_timestamp
     |]
 

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -52,22 +52,38 @@ end
 
 type value = Value.t
 
-let value_of_t (t : Genesis_constants.Protocol.t) : value =
-  { k = T.of_int t.k
-  ; delta = T.of_int t.delta
-  ; slots_per_epoch = T.of_int t.slots_per_epoch
-  ; slots_per_sub_window = T.of_int t.slots_per_sub_window
-  ; grace_period_slots = T.of_int t.grace_period_slots
-  ; genesis_state_timestamp = Block_time.of_int64 t.genesis_state_timestamp
+let value_of_t
+    ({ k
+     ; delta
+     ; slots_per_epoch
+     ; slots_per_sub_window
+     ; grace_period_slots
+     ; genesis_state_timestamp
+     } :
+      Genesis_constants.Protocol.t ) : value =
+  { k = T.of_int k
+  ; delta = T.of_int delta
+  ; slots_per_epoch = T.of_int slots_per_epoch
+  ; slots_per_sub_window = T.of_int slots_per_sub_window
+  ; grace_period_slots = T.of_int grace_period_slots
+  ; genesis_state_timestamp = Block_time.of_int64 genesis_state_timestamp
   }
 
-let t_of_value (v : value) : Genesis_constants.Protocol.t =
-  { k = T.to_int v.k
-  ; delta = T.to_int v.delta
-  ; slots_per_epoch = T.to_int v.slots_per_epoch
-  ; slots_per_sub_window = T.to_int v.slots_per_sub_window
-  ; grace_period_slots = T.to_int v.grace_period_slots
-  ; genesis_state_timestamp = Block_time.to_int64 v.genesis_state_timestamp
+let t_of_value
+    ({ k
+     ; delta
+     ; slots_per_epoch
+     ; slots_per_sub_window
+     ; grace_period_slots
+     ; genesis_state_timestamp
+     } :
+      value ) : Genesis_constants.Protocol.t =
+  { k = T.to_int k
+  ; delta = T.to_int delta
+  ; slots_per_epoch = T.to_int slots_per_epoch
+  ; slots_per_sub_window = T.to_int slots_per_sub_window
+  ; grace_period_slots = T.to_int grace_period_slots
+  ; genesis_state_timestamp = Block_time.to_int64 genesis_state_timestamp
   }
 
 let to_input


### PR DESCRIPTION
Fixes #15085.