### PR TITLE
zkapp_cmd_limit devnet/mainnet

### DIFF
--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -47,6 +47,6 @@
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
-[%%undef zkapp_cmd_limit]
+[%%define zkapp_cmd_limit 24]
 [%%undef slot_tx_end]
 [%%undef slot_chain_end]

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -47,6 +47,6 @@
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
-[%%undef zkapp_cmd_limit]
+[%%define zkapp_cmd_limit 24]
 [%%undef slot_tx_end]
 [%%undef slot_chain_end]


### PR DESCRIPTION
Sets these compile-time values correctly to 24