### PR TITLE
Retry jobs after sigterm

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -190,6 +190,8 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                       Retry::{ exit_status = ExitStatus.Code +100, limit = Some 4 },
                       -- Git checkout error
                       Retry::{ exit_status = ExitStatus.Code +128, limit = Some 4 }
+                      -- SIGTERM
+                      Retry::{ exit_status = ExitStatus.Code +143, limit = Some 4 }
                     ] #
                     -- and the retries that are passed in (if any)
                     c.retries)

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -189,7 +189,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                       -- apt-get update race condition error
                       Retry::{ exit_status = ExitStatus.Code +100, limit = Some 4 },
                       -- Git checkout error
-                      Retry::{ exit_status = ExitStatus.Code +128, limit = Some 4 }
+                      Retry::{ exit_status = ExitStatus.Code +128, limit = Some 4 },
                       -- SIGTERM
                       Retry::{ exit_status = ExitStatus.Code +143, limit = Some 4 }
                     ] #


### PR DESCRIPTION
This PR builds upon #15113, adding a retry for `SIGTERM` (exit code 143) that we can see when buildkite kills the running command. See e.g. [this run](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/32659#018da690-e63f-4023-8f44-4b0e63be3955) (on PR #15113) for an example.