### PR TITLE
Make buildkite dependencies depend on success

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -51,7 +51,7 @@ let B/DependsOn =
     depends =
     \(keys : List Text) ->
         OuterUnion/Type.ListDependsOn/Type
-          (List/map Text InnerUnion/Type (\(k: Text) -> InnerUnion/Type.DependsOn/Type { allow_failure = None Bool, step = Some k }) keys)
+          (List/map Text InnerUnion/Type (\(k: Text) -> InnerUnion/Type.DependsOn/Type { allow_failure = Some False, step = Some k }) keys)
   }
 
 let B/ArtifactPaths = B.definitions/commandStep/properties/artifact_paths/Type


### PR DESCRIPTION
This PR fixes an issue where a flake / infra error may lead to a job being triggered, even though its dependencies aren't actually ready. See e.g. [this run](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/32661#018da6ac-5fc9-4cd9-adc9-e4dfa11c17fd) trigger by the completion of the failed run [here](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/32661#018da6ac-582e-40a5-837c-1d53e2ec20c2).