### PR TITLE
Restart jobs on exit code 125

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -191,7 +191,9 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                       -- Git checkout error
                       Retry::{ exit_status = ExitStatus.Code +128, limit = Some 4 },
                       -- SIGTERM
-                      Retry::{ exit_status = ExitStatus.Code +143, limit = Some 4 }
+                      Retry::{ exit_status = ExitStatus.Code +143, limit = Some 4 },
+                      -- Docker error
+                      Retry::{ exit_status = ExitStatus.Code +125, limit = Some 4 }
                     ] #
                     -- and the retries that are passed in (if any)
                     c.retries)


### PR DESCRIPTION
For example: docker failed
[here](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/32674#018da711-083c-4d2c-8e0a-1db265335889).