### PR TITLE
Cli_lib: correctly mark alert as deprecated

### DIFF
--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -104,7 +104,7 @@ let validate_transaction =
     (* TODO upgrade to yojson 2.0.0 when possible to use seq_from_channel
      * instead of the deprecated stream interface *)
     let jsons = Yojson.Safe.stream_from_channel In_channel.stdin in
-    ( match[@alert "--deprecated"]
+    ( match[@alert "-deprecated"]
         Or_error.try_with (fun () ->
             Caml.Stream.iter
               (fun transaction_json ->
@@ -139,7 +139,7 @@ let validate_transaction =
       Format.printf "Some transactions failed to verify@." ;
       exit 1 )
     else
-      let[@alert "--deprecated"] first = Caml.Stream.peek jsons in
+      let[@alert "-deprecated"] first = Caml.Stream.peek jsons in
       match first with
       | None ->
           Format.printf "Could not parse any transactions@." ;


### PR DESCRIPTION
Actually really disable the deprecation alerts, or the story of an extra hyphen.

The actual better fix would be https://github.com/MinaProtocol/mina/pull/12768 but we might want to have this one low-hanging fix-fruit in nonetheless
