### PR TITLE
Introduce mainnet/devnet build profiles in nix (develop)

### DIFF
--- a/nix/misc.nix
+++ b/nix/misc.nix
@@ -26,6 +26,64 @@ final: prev: {
     ];
   });
 
+  rocksdb511 = final.stdenv.mkDerivation (_:
+    let
+      buildAndInstallFlags = [
+        "USE_RTTI=1"
+        "DEBUG_LEVEL=0"
+        "DISABLE_WARNING_AS_ERROR=1"
+      ];
+    in
+    {
+      pname = "rocksdb";
+      version = "5.11.3";
+
+      src = final.fetchFromGitHub {
+        owner = "facebook";
+        repo = "rocksdb";
+        rev = "v5.11.3";
+        hash = "sha256:15x2r7aib1xinwcchl32wghs8g96k4q5xgv6z97mxgp35475x01p";
+      };
+
+      outputs = [ "out" ];
+
+      nativeBuildInputs = with final; [ which perl ];
+      buildInputs = with final; [ google-gflags ];
+
+      postPatch = ''
+        # Hack to fix typos
+        sed -i 's,#inlcude,#include,g' build_tools/build_detect_platform
+      '';
+
+      # Environment vars used for building certain configurations
+      PORTABLE = "1";
+      USE_SSE = "1";
+      CMAKE_CXX_FLAGS = "-std=gnu++11";
+      JEMALLOC_LIB = "";
+
+      # ${if enableLite then "LIBNAME" else null} = "librocksdb_lite";
+      # ${if enableLite then "CXXFLAGS" else null} = "-DROCKSDB_LITE=1";
+
+      buildFlags = buildAndInstallFlags ++ [
+        "static_lib"
+      ];
+
+      installFlags = buildAndInstallFlags ++ [
+        "INSTALL_PATH=\${out}"
+        "install-static"
+      ];
+
+      enableParallelBuilding = true;
+
+      meta = with final.lib; {
+        homepage = http://rocksdb.org;
+        description = "A library that provides an embeddable, persistent key-value store for fast storage";
+        license = licenses.bsd3;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ adev wkennington ];
+      };
+  });
+
   # Jobs/Lint/ValidationService
   # Jobs/Test/ValidationService
   validation = ((final.mix-to-nix.override {

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -234,6 +234,7 @@ let
           cp src/app/rosetta/rosetta.exe $out/bin/rosetta
           cp src/app/batch_txn_tool/batch_txn_tool.exe $batch_txn_tool/bin/batch_txn_tool
           cp src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe $genesis/bin/runtime_genesis_ledger
+          cp src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe $out/bin/runtime_genesis_ledger
           cp src/app/cli/src/mina_mainnet_signatures.exe $mainnet/bin/mina_mainnet_signatures
           cp src/app/rosetta/rosetta_mainnet_signatures.exe $mainnet/bin/rosetta_mainnet_signatures
           cp src/app/cli/src/mina_testnet_signatures.exe $testnet/bin/mina_testnet_signatures
@@ -276,20 +277,18 @@ let
 
       mainnet-pkg = self.mina-dev.overrideAttrs (s: {
         version = "mainnet";
-        configurePhase = ''
-          ${s.configurePhase}
-          export DUNE_PROFILE=mainnet
-          '';
+        DUNE_PROFILE = "mainnet";
+        # For compatibility with Docker build
+        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
       });
 
       mainnet = wrapMina self.mainnet-pkg { };
 
       devnet-pkg = self.mina-dev.overrideAttrs (s: {
         version = "devnet";
-        configurePhase = ''
-          ${s.configurePhase}
-          export DUNE_PROFILE=devnet
-          '';
+        DUNE_PROFILE = "devnet";
+        # For compatibility with Docker build
+        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
       });
 
       devnet = wrapMina self.devnet-pkg { };


### PR DESCRIPTION
Clone of #15026 against `develop`.

To build mainnet node, use `nix build mina#mainnet`

For devnet node: `nix build mina#devnet`

Explain how you tested your changes:
* Ran a node, checked that `mainnet` profile was used when compiling
* Compared output of `mina advanced constraint-system-digests` between nix version and mainnet binary built by CI

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None