### PR TITLE
[compatible] Update fork_config export to expose unfinalized next_epoch_ledgers

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4387,25 +4387,34 @@ module Queries = struct
             (Ledger.Any_ledger.M.merkle_root staking_ledger)
             staking_epoch.ledger.hash ) ;
         let%bind next_epoch_ledger =
-          match Mina_lib.next_epoch_ledger mina with
+          match
+            (* We always want to return the next epoch ledger here, in case we
+               need to hard-fork from a block where it is unfinalized. The
+               safety concern doesn't apply here, because we are only using
+               this to build a snapshot, and never applying it back to the
+               running network.
+            *)
+            Mina_lib.next_epoch_ledger
+              ~unsafe_always_return_ledger_as_if_finalized:true mina
+          with
           | None ->
               Deferred.Result.fail "Next epoch ledger is not initialized."
           | Some `Notfinalized ->
-              return None
+              failwith "next_epoch_ledger returned a disallowed value"
           | Some (`Finalized (Genesis_epoch_ledger l)) ->
-              return (Some (Ledger.Any_ledger.cast (module Ledger) l))
+              return (Ledger.Any_ledger.cast (module Ledger) l)
           | Some (`Finalized (Ledger_db l)) ->
-              return (Some (Ledger.Any_ledger.cast (module Ledger.Db) l))
+              return (Ledger.Any_ledger.cast (module Ledger.Db) l)
         in
-        Option.iter next_epoch_ledger ~f:(fun ledger ->
-            assert (
-              Mina_base.Ledger_hash.equal
-                (Ledger.Any_ledger.M.merkle_root ledger)
-                next_epoch.ledger.hash ) ) ;
+        assert (
+          Mina_base.Ledger_hash.equal
+            (Ledger.Any_ledger.M.merkle_root next_epoch_ledger)
+            next_epoch.ledger.hash ) ;
         let%bind new_config =
           Runtime_config.make_fork_config ~staged_ledger ~global_slot
-            ~state_hash ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
-            ~next_epoch_seed ~blockchain_length runtime_config
+            ~state_hash ~staking_ledger ~staking_epoch_seed
+            ~next_epoch_ledger:(Some next_epoch_ledger) ~next_epoch_seed
+            ~blockchain_length runtime_config
         in
         let%map () =
           let open Async.Deferred.Infix in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -923,7 +923,7 @@ let staking_ledger t =
   Consensus.Hooks.get_epoch_ledger ~constants:consensus_constants
     ~consensus_state ~local_state
 
-let next_epoch_ledger t =
+let next_epoch_ledger ?(unsafe_always_return_ledger_as_if_finalized = false) t =
   let open Option.Let_syntax in
   let%map frontier =
     Broadcast_pipe.Reader.peek t.components.transition_frontier
@@ -941,6 +941,7 @@ let next_epoch_ledger t =
   if
     Mina_numbers.Length.(
       equal root_epoch best_tip_epoch || equal best_tip_epoch zero)
+    || unsafe_always_return_ledger_as_if_finalized
   then
     (*root is in the same epoch as the best tip and so the next epoch ledger in the local state will be updated by Proof_of_stake.frontier_root_transition. Next epoch ledger in genesis epoch is the genesis ledger*)
     `Finalized

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -47,7 +47,8 @@ val staking_ledger :
   t -> Consensus.Data.Local_state.Snapshot.Ledger_snapshot.t option
 
 val next_epoch_ledger :
-     t
+     ?unsafe_always_return_ledger_as_if_finalized:bool
+  -> t
   -> [ `Finalized of Consensus.Data.Local_state.Snapshot.Ledger_snapshot.t
      | `Notfinalized ]
      option


### PR DESCRIPTION
This PR fixes https://github.com/MinaProtocol/mina/issues/15149, by adapting the Mina_lib.next_epoch_ledger to ignore the finalisation check when a flag is passed, and then passing that flag in the fork_config GraphQL endpoint.

Berkeley counterpart in https://github.com/MinaProtocol/mina/pull/15186.