### PR TITLE
cache_dir loads from google storage now

### DIFF
--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -54,6 +54,9 @@ _build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --confi
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
 
+echo "--- Uploading ledger tarballs"
+gsutil -m cp -c -a public-read hardfork_ledgers/*.tar.gz gs://mina-genesis-ledgers
+
 echo "--- Build hardfork package for Debian ${MINA_DEB_CODENAME}"
 RUNTIME_CONFIG_JSON=new_config.json LEDGER_TARBALLS="$(echo hardfork_ledgers/*.tar.gz)" ./scripts/create_hardfork_deb.sh
 mkdir -p /tmp/artifacts

--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -55,7 +55,7 @@ echo "--- Create hardfork config"
 FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
 
 echo "--- Uploading ledger tarballs"
-gsutil -m cp -c -a public-read hardfork_ledgers/*.tar.gz gs://mina-genesis-ledgers
+gsutil -m cp -n -a public-read hardfork_ledgers/*.tar.gz gs://mina-genesis-ledgers
 
 echo "--- Build hardfork package for Debian ${MINA_DEB_CODENAME}"
 RUNTIME_CONFIG_JSON=new_config.json LEDGER_TARBALLS="$(echo hardfork_ledgers/*.tar.gz)" ./scripts/create_hardfork_deb.sh

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -103,6 +103,8 @@ let hardforkPipeline : DebianVersions.DebVersion -> Pipeline.Config.Type =
                   , "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL"
                   , "AWS_ACCESS_KEY_ID"
                   , "AWS_SECRET_ACCESS_KEY"
+                  , "GOOGLE_APPLICATION_CREDENTIALS"
+                  , "GCLOUD_API_KEY"
                   , "MINA_BRANCH=\$BUILDKITE_BRANCH"
                   , "MINA_COMMIT_SHA1=\$BUILDKITE_COMMIT"
                   , "MINA_DEB_CODENAME=${DebianVersions.lowerName debVersion}"

--- a/docs/uploading-genesis-proofs.md
+++ b/docs/uploading-genesis-proofs.md
@@ -47,4 +47,4 @@ Pull requests on CI will run the ['Build Mina daemon debian package' job](https:
   - `_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file PATH/TO/YOUR/config.json`
 * upload the generated ledger and proof files to S3
   - You will need the access keys for the `snark-keys` bucket, and the `aws` tool installed to use this command
-  - `aws s3 sync --exclude "*" --include "genesis_*" --acl public-read /tmp/coda_cache_dir/genesis_* s3://snark-keys.o1test.net/`
+  - `gsutil rsync -r -a public-read /tmp/coda_cache_dir/genesis_* gs://mina-genesis-ledgers/`

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -25,23 +25,23 @@ cd "${SCRIPTPATH}/../_build"
 # Set dependencies based on debian release
 SHARED_DEPS="libssl1.1, libgmp10, libgomp1, tzdata"
 
-TEST_EXECUTIVE_DEPS=", mina-logproc, python3, nodejs, yarn, google-cloud-sdk, kubectl, google-cloud-sdk-gke-gcloud-auth-plugin, terraform, helm"
+TEST_EXECUTIVE_DEPS=", mina-logproc, python3, nodejs, yarn, kubectl, google-cloud-sdk-gke-gcloud-auth-plugin, terraform, helm"
 
 case "${MINA_DEB_CODENAME}" in
   bookworm|jammy)
-    DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc, google-cloud-sdk"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc, google-cloud-sdk"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   buster)
-    DAEMON_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc"
+    DAEMON_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc, google-cloud-sdk"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)
-    DAEMON_DEPS=", libffi6, libjemalloc1, libpq-dev, libprocps6, mina-logproc"
+    DAEMON_DEPS=", libffi6, libjemalloc1, libpq-dev, libprocps6, mina-logproc, google-cloud-sdk"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc1"
     ;;
   *)

--- a/scripts/hardfork/create_runtime_config.sh
+++ b/scripts/hardfork/create_runtime_config.sh
@@ -34,18 +34,18 @@ jq "{\
     ledger: {\
         add_genesis_winner: false,\
         hash: \$hashes[0].ledger.hash,\
-        s3_data_hash: \$hashes[0].ledger.s3_data_hash\
+        tar_data_hash: \$hashes[0].ledger.tar_data_hash\
     },\
     epoch_data: {\
         staking: {\
             seed: .epoch_data.staking.seed,\
             hash: \$hashes[0].epoch_data.staking.hash,\
-            s3_data_hash: \$hashes[0].epoch_data.staking.s3_data_hash\
+            tar_data_hash: \$hashes[0].epoch_data.staking.tar_data_hash\
         },\
         next: {\
             seed: .epoch_data.next.seed,\
             hash: \$hashes[0].epoch_data.next.hash,\
-            s3_data_hash: \$hashes[0].epoch_data.next.s3_data_hash\
+            tar_data_hash: \$hashes[0].epoch_data.next.tar_data_hash\
         }\
     }\
   }" -M \

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -144,7 +144,7 @@ let create_replayer_checkpoint ~ledger ~start_slot_since_genesis :
     ; num_accounts = None
     ; balances = []
     ; hash = None
-    ; s3_data_hash = None
+    ; tar_data_hash = None
     ; name = None
     ; add_genesis_winner = Some true
     }

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -3,7 +3,7 @@ open Async
 module Ledger = Mina_ledger.Ledger
 
 module Hashes = struct
-  type t = { s3_data_hash : string; hash : string } [@@deriving to_yojson]
+  type t = { tar_data_hash : string; hash : string } [@@deriving to_yojson]
 end
 
 module Hash_json = struct
@@ -42,8 +42,8 @@ let generate_ledger_tarball ~genesis_dir ~ledger_name_prefix ledger =
     Mina_base.State_hash.to_base58_check
     @@ Mina_ledger.Ledger.merkle_root ledger
   in
-  let%map s3_data_hash = Genesis_ledger_helper.sha3_hash tar_path in
-  { Hashes.s3_data_hash; hash }
+  let%map tar_data_hash = Genesis_ledger_helper.sha3_hash tar_path in
+  { Hashes.tar_data_hash; hash }
 
 let generate_hash_json ~genesis_dir ledger staking_ledger next_ledger =
   let%bind ledger_hashes =

--- a/src/lib/cache_dir/cache_dir.mli
+++ b/src/lib/cache_dir/cache_dir.mli
@@ -1,8 +1,8 @@
 val autogen_path : string
 
-val s3_install_path : string
+val gs_install_path : string
 
-val s3_keys_bucket_prefix : string
+val gs_ledger_bucket_prefix : string
 
 val manual_install_path : string
 
@@ -14,5 +14,9 @@ val env_path : string
 
 val possible_paths : string -> string list
 
-val load_from_s3 :
-  string -> string -> logger:Logger.t -> unit Async_kernel.Deferred.Or_error.t
+val load_from_gs :
+     string
+  -> gs_bucket_prefix:string
+  -> gs_object_name:string
+  -> logger:Logger.t
+  -> unit Async_kernel.Deferred.Or_error.t

--- a/src/lib/cache_dir/fake/cache_dir.ml
+++ b/src/lib/cache_dir/fake/cache_dir.ml
@@ -3,10 +3,9 @@ open Async_kernel
 
 let autogen_path = "/tmp/coda_cache_dir"
 
-let s3_install_path = "/tmp/s3_cache_dir"
+let gs_install_path  = "/tmp/gs_cache_dir"
 
-let s3_keys_bucket_prefix =
-  "https://s3-us-west-2.amazonaws.com/snark-keys.o1test.net"
+let gs_ledger_bucket_prefix = "mina-genesis-ledgers"
 
 let manual_install_path = "/var/lib/coda"
 
@@ -20,10 +19,10 @@ let possible_paths base =
   List.map
     [ env_path
     ; brew_install_path
-    ; s3_install_path
+    ; gs_install_path
     ; autogen_path
     ; manual_install_path
     ] ~f:(fun d -> d ^ "/" ^ base)
 
-let load_from_s3 _s3_bucket_prefix _s3_install_path ~logger:_ =
-  Deferred.Or_error.fail (Error.createf "Cannot load files from S3")
+let load_from_gs ~gs_bucket_prefix:_ ~gs_object_name:_ _gs_install_path ~logger:_ =
+  Deferred.Or_error.fail (Error.createf "Cannot load files from Google Storage")

--- a/src/lib/cache_dir/native/cache_dir.ml
+++ b/src/lib/cache_dir/native/cache_dir.ml
@@ -3,10 +3,9 @@ open Async
 
 let autogen_path = Filename.temp_dir_name ^/ "coda_cache_dir"
 
-let s3_install_path = "/tmp/s3_cache_dir"
+let gs_install_path = "/tmp/s3_cache_dir"
 
-let s3_keys_bucket_prefix =
-  "https://s3-us-west-2.amazonaws.com/snark-keys.o1test.net"
+let gs_ledger_bucket_prefix = "mina-genesis-ledgers"
 
 let manual_install_path = "/var/lib/coda"
 
@@ -25,10 +24,12 @@ let cache =
   let dir d w = Key_cache.Spec.On_disk { directory = d; should_write = w } in
   [ dir manual_install_path false
   ; dir brew_install_path false
-  ; dir s3_install_path false
+  ; dir gs_install_path false
   ; dir autogen_path true
   ; Key_cache.Spec.S3
-      { bucket_prefix = s3_keys_bucket_prefix; install_path = s3_install_path }
+      { bucket_prefix = gs_ledger_bucket_prefix
+      ; install_path = gs_install_path
+      }
   ]
 
 let env_path =
@@ -42,13 +43,13 @@ let possible_paths base =
   List.map
     [ env_path
     ; brew_install_path
-    ; s3_install_path
+    ; gs_install_path
     ; autogen_path
     ; manual_install_path
     ] ~f:(fun d -> d ^/ base)
 
-let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
-  let%bind () = Unix.mkdir ~p:() (Filename.dirname s3_install_path) in
+let load_from_gs  gs_install_path ~gs_bucket_prefix ~gs_object_name ~logger =
+  let%bind () = Unix.mkdir ~p:() (Filename.dirname gs_install_path) in
   Deferred.map ~f:Result.join
   @@ Monitor.try_with ~here:[%here] (fun () ->
          let each_uri (uri_string, file_path) =
@@ -59,15 +60,8 @@ let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
                ; ("local_file_path", `String file_path)
                ] ;
            let%map _result =
-             Process.run_exn ~prog:"curl"
-               ~args:
-                 [ "--fail"
-                 ; "--silent"
-                 ; "--show-error"
-                 ; "-o"
-                 ; file_path
-                 ; uri_string
-                 ]
+             Process.run ~prog:"gsutil"
+               ~args:[ "-m"; "cp"; uri_string; gs_install_path ]
                ()
            in
            [%log trace] "Download finished"
@@ -77,5 +71,7 @@ let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
                ] ;
            Result.return ()
          in
-         each_uri (s3_bucket_prefix, s3_install_path) )
+         each_uri
+           ( sprintf "gs://%s/%s" gs_bucket_prefix gs_object_name
+           , gs_install_path ) )
   |> Deferred.Result.map_error ~f:Error.of_exn

--- a/src/lib/cache_dir/native/cache_dir.ml
+++ b/src/lib/cache_dir/native/cache_dir.ml
@@ -48,20 +48,20 @@ let possible_paths base =
     ; manual_install_path
     ] ~f:(fun d -> d ^/ base)
 
-let load_from_gs  gs_install_path ~gs_bucket_prefix ~gs_object_name ~logger =
+let load_from_gs gs_install_path ~gs_bucket_prefix ~gs_object_name ~logger =
   let%bind () = Unix.mkdir ~p:() (Filename.dirname gs_install_path) in
   Deferred.map ~f:Result.join
   @@ Monitor.try_with ~here:[%here] (fun () ->
          let each_uri (uri_string, file_path) =
            let open Deferred.Let_syntax in
-           [%log trace] "Downloading file from S3"
+           [%log trace] "Downloading file from Google Storage"
              ~metadata:
                [ ("url", `String uri_string)
                ; ("local_file_path", `String file_path)
                ] ;
            let%map _result =
              Process.run ~prog:"gsutil"
-               ~args:[ "-m"; "cp"; uri_string; gs_install_path ]
+               ~args:[ "-m"; "cp"; uri_string; file_path ]
                ()
            in
            [%log trace] "Download finished"

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -150,7 +150,7 @@ module Ledger = struct
         None )
     in
     let load_from_gs filename =
-      match config.s3_data_hash with
+      match config.tar_data_hash with
       | Some s3_hash -> (
           let local_path = Cache_dir.gs_install_path ^/ filename in
           match%bind
@@ -1014,7 +1014,7 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
            { base = Named Mina_compile_config.genesis_ledger
            ; num_accounts = None
            ; balances = []
-           ; s3_data_hash = None
+           ; tar_data_hash = None
            ; hash = None
            ; name = None
            ; add_genesis_winner = None

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -262,7 +262,7 @@ module Network_config = struct
             ; num_accounts = None
             ; balances = []
             ; hash = None
-            ; s3_data_hash = None
+            ; tar_data_hash = None
             ; name = None
             }
       ; epoch_data =
@@ -334,7 +334,7 @@ module Network_config = struct
                   ; num_accounts = None
                   ; balances = []
                   ; hash = None
-                  ; s3_data_hash = None
+                  ; tar_data_hash = None
                   ; name = None
                   }
                   : Runtime_config.Ledger.t )

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -338,7 +338,7 @@ module Json_layout = struct
       ; num_accounts : int option [@default None]
       ; balances : Balance_spec.t list [@default []]
       ; hash : string option [@default None]
-      ; s3_data_hash : string option [@default None]
+      ; tar_data_hash : string option [@default None]
       ; name : string option [@default None]
       ; add_genesis_winner : bool option [@default None]
       }
@@ -433,7 +433,7 @@ module Json_layout = struct
       type t =
         { accounts : Accounts.t option [@default None]
         ; seed : string
-        ; s3_data_hash : string option [@default None]
+        ; tar_data_hash : string option [@default None]
         ; hash : string option [@default None]
         }
       [@@deriving yojson, fields, dhall_type]
@@ -751,7 +751,7 @@ module Ledger = struct
     ; num_accounts : int option
     ; balances : (int * Currency.Balance.Stable.Latest.t) list
     ; hash : string option
-    ; s3_data_hash : string option
+    ; tar_data_hash : string option
     ; name : string option
     ; add_genesis_winner : bool option
     }
@@ -764,7 +764,7 @@ module Ledger = struct
       ; hash
       ; name
       ; add_genesis_winner
-      ; s3_data_hash
+      ; tar_data_hash
       } : Json_layout.Ledger.t =
     let balances =
       List.map balances ~f:(fun (number, balance) ->
@@ -775,7 +775,7 @@ module Ledger = struct
       ; num_accounts
       ; balances
       ; hash
-      ; s3_data_hash
+      ; tar_data_hash
       ; name
       ; add_genesis_winner
       }
@@ -793,7 +793,7 @@ module Ledger = struct
        ; num_accounts
        ; balances
        ; hash
-       ; s3_data_hash
+       ; tar_data_hash
        ; name
        ; add_genesis_winner
        } :
@@ -826,7 +826,7 @@ module Ledger = struct
     ; num_accounts
     ; balances
     ; hash
-    ; s3_data_hash
+    ; tar_data_hash
     ; name
     ; add_genesis_winner
     }
@@ -854,7 +854,7 @@ module Ledger = struct
     ; num_accounts = Some num_accounts
     ; balances
     ; hash
-    ; s3_data_hash = None
+    ; tar_data_hash = None
     ; name = Some name
     ; add_genesis_winner = Some add_genesis_winner
     }
@@ -1257,7 +1257,7 @@ module Epoch_data = struct
       { Json_layout.Epoch_data.Data.accounts = accounts staking.ledger
       ; seed = staking.seed
       ; hash = staking.ledger.hash
-      ; s3_data_hash = staking.ledger.s3_data_hash
+      ; tar_data_hash = staking.ledger.tar_data_hash
       }
     in
     let next =
@@ -1265,7 +1265,7 @@ module Epoch_data = struct
           { Json_layout.Epoch_data.Data.accounts = accounts n.ledger
           ; seed = n.seed
           ; hash = n.ledger.hash
-          ; s3_data_hash = n.ledger.s3_data_hash
+          ; tar_data_hash = n.ledger.tar_data_hash
           } )
     in
     { Json_layout.Epoch_data.staking; next }
@@ -1274,7 +1274,7 @@ module Epoch_data = struct
    fun { staking; next } ->
     let open Result.Let_syntax in
     let data (t : [ `Staking | `Next ])
-        { Json_layout.Epoch_data.Data.accounts; seed; hash; s3_data_hash } =
+        { Json_layout.Epoch_data.Data.accounts; seed; hash; tar_data_hash } =
       let%map base =
         match accounts with
         | Some accounts ->
@@ -1298,7 +1298,7 @@ module Epoch_data = struct
         ; num_accounts = None
         ; balances = []
         ; hash
-        ; s3_data_hash
+        ; tar_data_hash
         ; name = None
         ; add_genesis_winner = Some false
         }
@@ -1451,7 +1451,7 @@ let ledger_of_accounts accounts =
     ; num_accounts = Some (List.length accounts)
     ; balances = List.mapi accounts ~f:(fun i a -> (i, a.balance))
     ; hash = None
-    ; s3_data_hash = None
+    ; tar_data_hash = None
     ; name = None
     ; add_genesis_winner = Some false
     }


### PR DESCRIPTION
Hardfork packages upload their ledgers into Google Storage. If a ledger is already present with the same hash, the one in the bucket is NOT overwritten, and the job will fail, because it would invalidate tar_data_hash values. This may complicate things somewhat, we want to treat this data as content-addressed but we don't have a deterministic reproduction function...