### PR TITLE
Ensure fork slot precedes stop slot

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4312,7 +4312,7 @@ module Queries = struct
                           |> Consensus.Data.Consensus_state
                              .global_slot_since_genesis
                         in
-                        if Mina_numbers.Global_slot.( <= ) global_slot stop_slot
+                        if Mina_numbers.Global_slot.( < ) global_slot stop_slot
                         then return breadcrumb
                         else
                           let parent_hash =


### PR DESCRIPTION
Problem: when there is a block created exactly at `stop-txn-slot`, it will be chosen as the block to donor height, slot and state hash for fork config. This is an unnecessary corner case.

Solution: make sure that fork config always refers a block happening strictly before the `stop-txn-slot`.

Explain how you tested your changes:
* TBD

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None