### PR TITLE
[compatible] Tiny updates to nix 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1655897591,
-        "narHash": "sha256-9NuW1SpRqLLNj/vKxTY+SMYSzuZkjlYtN0Rsf10KCc4=",
+        "lastModified": 1708601497,
+        "narHash": "sha256-mDYINTjOiYLN4wT5fGlWTvHFQdWkzY46XUuZWKgmJxY=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "74ecec8eec6d5161ce99fc72378cc6e363a3faed",
+        "rev": "90d8c520a4f0b035ac51e267a8b33739c5a78b5a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     extra-trusted-public-keys = [
       "nix-cache.minaprotocol.org:fdcuDzmnM0Kbf7yU4yywBuUEJWClySc1WIF6t6Mm8h4="
       "nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c="
+      "mina-nix-cache-1:djtioLfv2oxuK2lqPUgmZbf8bY8sK/BnYZCU2iU5Q10="
     ];
   };
 


### PR DESCRIPTION
Explain your changes:
* Add another signing key for nix substituter (generated by @georgeee)
* Bump `opam-repository` (package `ocamlgraph` had broken URL in the previous version)

Explain how you tested your changes:
* Built with `#devnet` profile, observed cache is used successfully

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None