### PR TITLE
Use staking ledger corresponding to stop-txn-slot (berkeley)

### DIFF
--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -726,6 +726,9 @@ module type S = sig
            Consensus_state.Value.t Mina_base.State_hash.With_state_hashes.t
       -> bool
 
+    val epoch_ledgers_finalized :
+      constants:Constants.t -> Consensus_state.Value.t -> bool
+
     val get_epoch_ledger :
          constants:Constants.t
       -> consensus_state:Consensus_state.Value.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2641,6 +2641,15 @@ module Make_str (A : Wire_types.Concrete) = struct
       | `Last ->
           "last"
 
+    let epoch_ledgers_finalized ~(constants : Constants.t)
+        ({ next_epoch_data = { epoch_length; _ }
+         ; curr_global_slot_since_hard_fork = slot
+         ; _
+         } :
+          Consensus_state.Value.t ) =
+      let open Length in
+      Global_slot.epoch slot = zero || epoch_length > constants.k
+
     (* Select the correct epoch snapshot to use from local state for an epoch.
      * The rule for selecting the correct epoch snapshot is predicated off of
      * whether or not the first transition in the epoch in question has been
@@ -2653,25 +2662,16 @@ module Make_str (A : Wire_types.Concrete) = struct
      * (i.e. it does not check that the epoch snapshot's ledger hash is the same
      * as the ledger hash specified by the epoch data).
      *)
-    let select_epoch_snapshot ~(constants : Constants.t)
-        ~(consensus_state : Consensus_state.Value.t) ~local_state ~epoch =
-      let open Local_state in
-      let open Epoch_data.Poly in
+    let select_epoch_snapshot ~constants ~consensus_state ~local_state ~epoch =
       (* are we in the next epoch after the consensus state? *)
       let in_next_epoch =
         Epoch.equal epoch
           (Epoch.succ (Consensus_state.curr_epoch consensus_state))
       in
-      (* has the first transition in the epoch (other than the genesis epoch) reached finalization? *)
-      let epoch_is_not_finalized =
-        let is_genesis_epoch = Length.equal epoch Length.zero in
-        let epoch_is_finalized =
-          Length.(consensus_state.next_epoch_data.epoch_length > constants.k)
-        in
-        (not epoch_is_finalized) && not is_genesis_epoch
-      in
-      if in_next_epoch || epoch_is_not_finalized then
-        (`Curr, !local_state.Data.next_epoch_snapshot)
+      if
+        in_next_epoch
+        || not (epoch_ledgers_finalized ~constants consensus_state)
+      then (`Curr, !local_state.Local_state.Data.next_epoch_snapshot)
       else (`Last, !local_state.staking_epoch_snapshot)
 
     let get_epoch_ledger ~constants ~(consensus_state : Consensus_state.Value.t)
@@ -2681,7 +2681,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~epoch:(Data.Consensus_state.curr_epoch consensus_state)
           ~local_state
       in
-      Data.Local_state.Snapshot.ledger snapshot
+      Local_state.Snapshot.ledger snapshot
 
     type required_snapshot =
       { snapshot_id : Local_state.snapshot_identifier

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2436,6 +2436,8 @@ module Queries = struct
               Mina_lib.get_snarked_ledger_full mina (Some target_state_hash)
               |> Deferred.Result.map_error ~f:Error.to_string_hum
             in
+            (* The next epoch ledger isn't finalized: we manually grab the snarked
+               ledger for the targer block instead. *)
             ( local_next_epoch_ledger
             , Ledger.Any_ledger.cast (module Ledger) ledger )
           else (
@@ -2461,8 +2463,6 @@ module Queries = struct
             (Ledger.Any_ledger.M.merkle_root staking_ledger)
             target_staking_epoch.ledger.hash ) ;
         let%bind new_config =
-          (* The next epoch ledger isn't finalized: we manually grab the snarked
-               ledger for this block instead. *)
           Runtime_config.make_fork_config ~staged_ledger:target_staged_ledger
             ~global_slot:target_slot ~state_hash:target_state_hash
             ~staking_ledger ~staking_epoch_seed:target_staking_epoch_seed

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1083,7 +1083,7 @@ let staking_ledger t =
   Consensus.Hooks.get_epoch_ledger ~constants:consensus_constants
     ~consensus_state ~local_state
 
-let next_epoch_ledger ?(unsafe_always_return_ledger_as_if_finalized = false) t =
+let next_epoch_ledger t =
   let open Option.Let_syntax in
   let%map frontier =
     Broadcast_pipe.Reader.peek t.components.transition_frontier
@@ -1101,7 +1101,6 @@ let next_epoch_ledger ?(unsafe_always_return_ledger_as_if_finalized = false) t =
   if
     Mina_numbers.Length.(
       equal root_epoch best_tip_epoch || equal best_tip_epoch zero)
-    || unsafe_always_return_ledger_as_if_finalized
   then
     (*root is in the same epoch as the best tip and so the next epoch ledger in the local state will be updated by Proof_of_stake.frontier_root_transition. Next epoch ledger in genesis epoch is the genesis ledger*)
     `Finalized

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -667,7 +667,7 @@ let get_ledger t state_hash_opt =
       Deferred.return
       @@ Or_error.error_string "state hash not found in transition frontier"
 
-let get_snarked_ledger t state_hash_opt =
+let get_snarked_ledger_full t state_hash_opt =
   let open Deferred.Or_error.Let_syntax in
   let%bind state_hash =
     Option.value_map state_hash_opt ~f:Deferred.Or_error.return
@@ -742,10 +742,8 @@ let get_snarked_ledger t state_hash_opt =
         |> Mina_state.Blockchain_state.snarked_ledger_hash
       in
       let merkle_root = Ledger.merkle_root ledger in
-      if Frozen_ledger_hash.equal snarked_ledger_hash merkle_root then (
-        let%map.Deferred res = Ledger.to_list ledger in
-        ignore @@ Ledger.unregister_mask_exn ~loc:__LOC__ ledger ;
-        Ok res )
+      if Frozen_ledger_hash.equal snarked_ledger_hash merkle_root then
+        return ledger
       else
         Deferred.Or_error.errorf
           "Expected snarked ledger hash %s but got %s for state hash %s"
@@ -755,6 +753,13 @@ let get_snarked_ledger t state_hash_opt =
   | None ->
       Deferred.Or_error.error_string
         "get_snarked_ledger: state hash not found in transition frontier"
+
+let get_snarked_ledger t state_hash_opt =
+  let open Deferred.Or_error.Let_syntax in
+  let%bind ledger = get_snarked_ledger_full t state_hash_opt in
+  let%map.Deferred res = Ledger.to_list ledger in
+  ignore @@ Ledger.unregister_mask_exn ~loc:__LOC__ ledger ;
+  Ok res
 
 let get_account t aid =
   let open Participating_state.Let_syntax in

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -198,6 +198,9 @@ val transition_frontier :
 
 val get_ledger : t -> State_hash.t option -> Account.t list Deferred.Or_error.t
 
+val get_snarked_ledger_full :
+  t -> State_hash.t option -> Ledger.t Deferred.Or_error.t
+
 val get_snarked_ledger :
   t -> State_hash.t option -> Account.t list Deferred.Or_error.t
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -58,8 +58,7 @@ val staking_ledger :
   t -> Consensus.Data.Local_state.Snapshot.Ledger_snapshot.t option
 
 val next_epoch_ledger :
-     ?unsafe_always_return_ledger_as_if_finalized:bool
-  -> t
+     t
   -> [ `Finalized of Consensus.Data.Local_state.Snapshot.Ledger_snapshot.t
      | `Notfinalized ]
      option


### PR DESCRIPTION
Problem: Mina_lib.staking_ledger internally gets staking ledger of the current best tip, whereas we need a staking ledger corresponding to the slot-stop-txn in some cases.

Port of #15213 against `berkeley`.

Solution: carefully consider different cases based on whether best tip and slot-stop-txn are in the same epoch.

Explain how you tested your changes:
* TODO: HF unit test to be executed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #15212 
