### PR TITLE
[develop] Fix integration tests for fast seed startup

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -75,6 +75,7 @@ locals {
     logLevel             = var.log_level
     logSnarkWorkGossip   = var.log_snark_work_gossip
     logPrecomputedBlocks = var.log_precomputed_blocks
+    startFilteredLogs    = var.start_filtered_logs
     logTxnPoolGossip = var.log_txn_pool_gossip
     uploadBlocksToGCloud = var.upload_blocks_to_gcloud
     # seedPeersURL         = var.seed_peers_url

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -27,6 +27,7 @@ locals {
       // TODO: Change this to a better name
       seedPeers          = var.additional_peers
       logLevel           = var.log_level
+      startFilteredLogs    = var.start_filtered_logs
       logSnarkWorkGossip = var.log_snark_work_gossip
       logTxnPoolGossip = var.log_txn_pool_gossip
       ports = {

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -160,6 +160,11 @@ variable "log_precomputed_blocks" {
   default = false
 }
 
+variable "start_filtered_logs" {
+  type    = list(string)
+  default = []
+}
+
 variable "log_txn_pool_gossip" {
   type    = bool
   default = false

--- a/automation/terraform/modules/o1-integration/inputs.tf
+++ b/automation/terraform/modules/o1-integration/inputs.tf
@@ -93,6 +93,11 @@ variable "log_precomputed_blocks" {
   type = bool
 }
 
+variable "start_filtered_logs" {
+  type    = list(string)
+  default = []
+}
+
 variable "worker_cpu_request" {
   type    = number
   default = 0

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -39,6 +39,7 @@ module "kubernetes_testnet" {
   archive_configs = local.archive_node_configs
 
   log_precomputed_blocks = var.log_precomputed_blocks
+  start_filtered_logs = var.start_filtered_logs
   log_txn_pool_gossip = true
 
   archive_node_count   = var.archive_node_count

--- a/automation/terraform/modules/o1-testnet/inputs.tf
+++ b/automation/terraform/modules/o1-testnet/inputs.tf
@@ -275,6 +275,11 @@ variable "log_precomputed_blocks" {
   default = false
 }
 
+variable "start_filtered_logs" {
+  type    = list(string)
+  default = []
+}
+
 variable "worker_cpu_request" {
   type    = number
   default = 0

--- a/automation/terraform/modules/o1-testnet/testnet.tf
+++ b/automation/terraform/modules/o1-testnet/testnet.tf
@@ -43,6 +43,7 @@ module "kubernetes_testnet" {
   log_level              = var.log_level
   log_txn_pool_gossip    = var.log_txn_pool_gossip
   log_precomputed_blocks = var.log_precomputed_blocks
+  start_filtered_logs    = var.start_filtered_logs
 
   agent_min_fee         = var.agent_min_fee
   agent_max_fee         = var.agent_max_fee

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -203,6 +203,9 @@ spec:
           {{- if $.Values.mina.logPrecomputedBlocks }}
           "-log-precomputed-blocks", "true",
           {{- end -}}
+          {{- range $.Values.mina.startFilteredLogs }}
+          "--start-filtered-logs", {{ . | quote }},
+          {{- end -}}
           {{- if $.Values.mina.logTxnPoolGossip }}
           "-log-txn-pool-gossip", "true",
           {{- end -}}

--- a/helm/block-producer/values.yaml
+++ b/helm/block-producer/values.yaml
@@ -6,6 +6,7 @@ mina:
   logLevel: "Debug"
   logSnarkWorkGossip: false
   logPrecomputedBlocks: false
+  startFilteredLogs: []
   logTxnPoolGossip: false
   image: gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet
   useCustomEntrypoint: false

--- a/helm/plain-node/templates/plain-node.yaml
+++ b/helm/plain-node/templates/plain-node.yaml
@@ -54,6 +54,9 @@ spec:
           {{- if $.Values.mina.logPrecomputedBlocks }}
           "-log-precomputed-blocks", "true",
           {{- end -}}
+          {{- range $.Values.mina.startFilteredLogs }}
+          "--start-filtered-logs", {{ . | quote }},
+          {{- end -}}
           {{- if $.Values.mina.logTxnPoolGossip }}
           "-log-txn-pool-gossip", "true",
           {{- end -}}

--- a/helm/plain-node/values.yaml
+++ b/helm/plain-node/values.yaml
@@ -3,6 +3,7 @@ mina:
   runtimeConfig:
   generateGenesisProof: true
   logPrecomputedBlocks: true
+  startFilteredLogs: []
   logTxnPoolGossip: false
   maxConnections: 200
   image: gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -88,6 +88,9 @@ spec:
           {{- if $.Values.mina.logPrecomputedBlocks }}
           "-log-precomputed-blocks", "true",
           {{- end -}}
+          {{- range $.Values.mina.startFilteredLogs }}
+          "--start-filtered-logs", {{ . | quote }},
+          {{- end -}}
           {{- if $.Values.mina.logTxnPoolGossip }}
           "-log-txn-pool-gossip", "true",
           {{- end -}}

--- a/helm/seed-node/values.yaml
+++ b/helm/seed-node/values.yaml
@@ -3,6 +3,7 @@ mina:
   runtimeConfig:
   generateGenesisProof: true
   logPrecomputedBlocks: true
+  startFilteredLogs: []
   logTxnPoolGossip: false
   maxConnections: 200
   image: gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -410,6 +410,11 @@ let setup_daemon logger =
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
       ~doc:"true|false Include precomputed blocks in the log (default: false)"
+  and start_filtered_logs =
+    flag "--start-filtered-logs" (listed string)
+      ~doc:
+        "LOG-FILTER Include filtered logs for the given filter. May be passed \
+         multiple times"
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:
@@ -1408,9 +1413,10 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~work_reassignment_wait ~archive_process_location
                  ~log_block_creation ~precomputed_values ~start_time
                  ?precomputed_blocks_path ~log_precomputed_blocks
-                 ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
-                 ~uptime_submitter_keypair ~uptime_send_node_commit ~stop_time
-                 ~node_status_url ~graphql_control_port:itn_graphql_port () )
+                 ~start_filtered_logs ~upload_blocks_to_gcloud
+                 ~block_reward_threshold ~uptime_url ~uptime_submitter_keypair
+                 ~uptime_send_node_commit ~stop_time ~node_status_url
+                 ~graphql_control_port:itn_graphql_port () )
           in
           { mina
           ; client_trustlist

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -71,6 +71,7 @@ module Network_config = struct
           [@to_yojson fun j -> `String (Yojson.Safe.to_string j)]
     ; block_producer_configs : block_producer_config list
     ; log_precomputed_blocks : bool
+    ; start_filtered_logs : string list
     ; archive_node_count : int
     ; mina_archive_schema : string
     ; mina_archive_schema_aux_files : string list
@@ -118,6 +119,7 @@ module Network_config = struct
          ; snark_worker_fee
          ; num_archive_nodes
          ; log_precomputed_blocks (* ; num_plain_nodes *)
+         ; start_filtered_logs
          ; proof_config
          ; k
          ; delta
@@ -478,6 +480,7 @@ module Network_config = struct
         ; mina_archive_image = images.archive_node
         ; runtime_config = Runtime_config.to_yojson runtime_config
         ; block_producer_configs
+        ; start_filtered_logs
         ; log_precomputed_blocks
         ; archive_node_count = num_archive_nodes
         ; mina_archive_schema

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -68,6 +68,7 @@ type t =
   ; snark_worker_fee : string
   ; num_archive_nodes : int
   ; log_precomputed_blocks : bool
+  ; start_filtered_logs : string list
         (* ; num_plain_nodes : int  *)
         (* blockchain constants *)
   ; proof_config : Runtime_config.Proof_keys.t
@@ -105,6 +106,7 @@ let default =
   ; snark_worker_fee = "0.025"
   ; num_archive_nodes = 0
   ; log_precomputed_blocks = false (* ; num_plain_nodes = 0 *)
+  ; start_filtered_logs = []
   ; proof_config = proof_config_default
   ; k = 20
   ; slots_per_epoch = 3 * 8 * 20

--- a/src/lib/integration_test_local_engine/mina_docker.ml
+++ b/src/lib/integration_test_local_engine/mina_docker.ml
@@ -26,6 +26,7 @@ module Network_config = struct
     ; archive_node_configs : Docker_node_config.Archive_node_config.t list
     ; mina_archive_schema_aux_files : string list
     ; log_precomputed_blocks : bool
+    ; start_filtered_logs : string list
     }
   [@@deriving to_yojson]
 
@@ -56,6 +57,7 @@ module Network_config = struct
         ; snark_worker_fee
         ; num_archive_nodes
         ; log_precomputed_blocks
+        ; start_filtered_logs
         ; proof_config
         ; Test_config.k
         ; delta
@@ -525,6 +527,7 @@ module Network_config = struct
         ; mina_archive_image = images.archive_node
         ; runtime_config = Runtime_config.to_yojson runtime_config
         ; log_precomputed_blocks
+        ; start_filtered_logs
         ; block_producer_configs
         ; seed_configs
         ; mina_archive_schema_aux_files

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -52,6 +52,7 @@ type t =
   ; start_time : Time.t
   ; precomputed_blocks_path : string option
   ; log_precomputed_blocks : bool
+  ; start_filtered_logs : string list
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]


### PR DESCRIPTION
This PR adds a new CLI flag `--start-filtered-logs`, which can be passed multiple times with a filter to each argument.

This PR also includes my attempt at updating the terraform to propagate this change.

Currently, integration tests are broken against develop, because now the seed nodes start up 'too quickly' (i.e. sleeping for 60s at startup). The hope is that this PR will solve that problem without us needing to make them slow again.