### PR TITLE
Support simplified data reporting in node status service

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -400,6 +400,10 @@ let setup_daemon logger =
   and node_error_url =
     flag "--node-error-url" ~aliases:[ "node-error-url" ] (optional string)
       ~doc:"URL of the node error collection service"
+  and simplified_node_stats =
+    flag "--simplified-node-stats"
+      ~aliases:[ "simplified-node-stats" ]
+      no_arg ~doc:"whether to report simplified node stats (default: false)"
   and contact_info =
     flag "--contact-info" ~aliases:[ "contact-info" ] (optional string)
       ~doc:
@@ -1300,7 +1304,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~log_block_creation ~precomputed_values ~start_time
                  ?precomputed_blocks_path ~log_precomputed_blocks
                  ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
-                 ~uptime_submitter_keypair ~stop_time ~node_status_url () )
+                 ~uptime_submitter_keypair ~stop_time ~node_status_url
+                 ~simplified_node_stats () )
           in
           { Coda_initialization.coda
           ; client_trustlist

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -403,7 +403,8 @@ let setup_daemon logger =
   and simplified_node_stats =
     flag "--simplified-node-stats"
       ~aliases:[ "simplified-node-stats" ]
-      no_arg ~doc:"whether to report simplified node stats (default: false)"
+      (optional_with_default false bool)
+      ~doc:"whether to report simplified node stats (default: false)"
   and contact_info =
     flag "--contact-info" ~aliases:[ "contact-info" ] (optional string)
       ~doc:

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -56,6 +56,7 @@ type t =
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]
+  ; simplified_node_stats : bool [@default false]
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1219,15 +1219,33 @@ let start t =
   let () =
     match t.config.node_status_url with
     | Some node_status_url ->
-        Node_status_service.start ~logger:t.config.logger ~node_status_url
-          ~network:t.components.net
-          ~transition_frontier:t.components.transition_frontier
-          ~sync_status:t.sync_status
-          ~addrs_and_ports:t.config.gossip_net_params.addrs_and_ports
-          ~start_time:t.config.start_time
-          ~slot_duration:
-            (Block_time.Span.to_time_span
-               t.config.precomputed_values.consensus_constants.slot_duration_ms )
+        if t.config.simplified_node_stats then
+          let block_producer_public_key_base58 =
+            Option.map ~f:(fun (_, pk) ->
+                Public_key.Compressed.to_base58_check pk )
+            @@ Keypair.And_compressed_pk.Set.choose
+                 t.config.block_production_keypairs
+          in
+          Node_status_service.start_simplified ~logger:t.config.logger
+            ~node_status_url ~network:t.components.net
+            ~chain_id:t.config.chain_id
+            ~addrs_and_ports:t.config.gossip_net_params.addrs_and_ports
+            ~slot_duration:
+              (Block_time.Span.to_time_span
+                 t.config.precomputed_values.consensus_constants
+                   .slot_duration_ms )
+            ~block_producer_public_key_base58
+        else
+          Node_status_service.start ~logger:t.config.logger ~node_status_url
+            ~network:t.components.net
+            ~transition_frontier:t.components.transition_frontier
+            ~sync_status:t.sync_status
+            ~addrs_and_ports:t.config.gossip_net_params.addrs_and_ports
+            ~start_time:t.config.start_time
+            ~slot_duration:
+              (Block_time.Span.to_time_span
+                 t.config.precomputed_values.consensus_constants
+                   .slot_duration_ms )
     | None ->
         ()
   in

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -74,7 +74,22 @@ type node_status_data =
   }
 [@@deriving to_yojson]
 
-let send_node_status_data ~logger ~url node_status_data =
+module Simplified = struct
+  type t =
+    { max_observed_block_height : int
+    ; commit_hash : string
+    ; git_branch : string
+    ; chain_id : string
+    ; peer_id : string
+    ; peer_count : int
+    ; timestamp : string
+    ; block_producer_public_key : string option
+    }
+  [@@deriving to_yojson]
+end
+
+let send_node_status_data (type data) ~logger ~url (node_status_data : data)
+    (node_status_data_to_yojson : data -> Yojson.Safe.t) =
   let node_status_json = node_status_data_to_yojson node_status_data in
   let json = `Assoc [ ("data", node_status_json) ] in
   let headers =
@@ -90,8 +105,10 @@ let send_node_status_data ~logger ~url node_status_data =
       let metadata =
         [ ("data", node_status_json); ("url", `String (Uri.to_string url)) ]
       in
-      if Cohttp.Code.code_of_status status = 200 then
-        [%log info] "Sent node status data to URL $url" ~metadata
+      if
+        Cohttp.Code.(
+          code_of_status status >= 200 && code_of_status status < 300)
+      then [%log info] "Sent node status data to URL $url" ~metadata
       else
         let extra_metadata =
           match body with
@@ -354,9 +371,34 @@ let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
           reset_gauges () ;
           send_node_status_data ~logger
             ~url:(Uri.of_string node_status_url)
-            node_status_data
+            node_status_data node_status_data_to_yojson
       | Error e ->
           [%log info]
             ~metadata:[ ("error", `String (Error.to_string_hum e)) ]
             "Failed to get bandwidth info from libp2p" ;
           Deferred.unit )
+
+let start_simplified ~logger ~node_status_url ~chain_id ~network
+    ~addrs_and_ports ~slot_duration ~block_producer_public_key_base58 =
+  [%log info] "Starting simplified node status service using URL $url"
+    ~metadata:[ ("url", `String node_status_url) ] ;
+  let five_slots = Time.Span.scale slot_duration 5. in
+  every ~start:(after five_slots) ~continue_on_error:true five_slots
+  @@ fun () ->
+  don't_wait_for
+  @@ let%bind peers = Mina_networking.peers network in
+     let node_status_data =
+       { Simplified.max_observed_block_height =
+           !Mina_metrics.Transition_frontier.max_blocklength_observed
+       ; commit_hash = Mina_version.commit_id
+       ; git_branch = Mina_version.branch
+       ; chain_id
+       ; peer_id = (Node_addrs_and_ports.to_peer_exn addrs_and_ports).peer_id
+       ; peer_count = List.length peers
+       ; timestamp = Rfc3339_time.get_rfc3339_time ()
+       ; block_producer_public_key = block_producer_public_key_base58
+       }
+     in
+     send_node_status_data ~logger
+       ~url:(Uri.of_string node_status_url)
+       node_status_data Simplified.to_yojson


### PR DESCRIPTION
This pull request adds support for simplified data reporting in the node status service. It includes changes to the CLI and configuration to enable the reporting of simplified node stats by providing `--simplified-node-stats`.

This was tested by running a node with `mina daemon --node-status-url https://nodestats-itn.minaprotocol.tools/submit/stats --simplified-node-stats ...` and checking if payloads are received and processed correctly by OpenSearch.

PRs for other branches:

- #15241 
- #15242