### PR TITLE
Ledger_hash and State_hash are different

### DIFF
--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -39,7 +39,7 @@ let generate_ledger_tarball ~genesis_dir ~ledger_name_prefix ledger =
   in
   [%log info] "Generated ledger tar at %s" tar_path ;
   let hash =
-    Mina_base.State_hash.to_base58_check
+    Mina_base.Ledger_hash.to_base58_check
     @@ Mina_ledger.Ledger.merkle_root ledger
   in
   let%map s3_data_hash = Genesis_ledger_helper.sha3_hash tar_path in

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -313,7 +313,7 @@ module Ledger = struct
     Mina_ledger.Ledger.commit ledger ;
     let dirname = Option.value_exn (Mina_ledger.Ledger.get_directory ledger) in
     let root_hash =
-      State_hash.to_base58_check @@ Mina_ledger.Ledger.merkle_root ledger
+      Ledger_hash.to_base58_check @@ Mina_ledger.Ledger.merkle_root ledger
     in
     let%bind () = Unix.mkdir ~p:() genesis_dir in
     let tar_path = genesis_dir ^/ hash_filename root_hash ~ledger_name_prefix in
@@ -425,7 +425,7 @@ module Ledger = struct
             match%map
               load_from_tar ~genesis_dir ~logger ~constraint_constants
                 ~expected_merkle_root:
-                  (Option.map config.hash ~f:State_hash.of_base58_check_exn)
+                  (Option.map config.hash ~f:Ledger_hash.of_base58_check_exn)
                 ?accounts:padded_accounts_opt ~ledger_name_prefix tar_path
             with
             | Ok ledger ->
@@ -488,7 +488,7 @@ module Ledger = struct
                   { config with
                     hash =
                       Some
-                        ( State_hash.to_base58_check
+                        ( Ledger_hash.to_base58_check
                         @@ Mina_ledger.Ledger.merkle_root ledger )
                   }
                 in
@@ -531,7 +531,7 @@ module Ledger = struct
                     return (Ok (packed, config, tar_path))
                 | Error err, _ ->
                     let root_hash =
-                      State_hash.to_base58_check
+                      Ledger_hash.to_base58_check
                       @@ Mina_ledger.Ledger.merkle_root ledger
                     in
                     let tar_path =


### PR DESCRIPTION
The value in the JSON is encoded using the wrong check byte. It isn't used anywhere else though.