### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,5 @@ frontend/website/static/*.bc.js filter=lfs diff=lfs merge=lfs -text
 src/app/archive/archive_graphql_schema.json linguist-generated=true
 docs/res/block_production_fsm.dot.png filter=lfs diff=lfs merge=lfs -text
 rfcs/res/hard-fork-package-generation-buildkite-pipeline.dot.png filter=lfs diff=lfs merge=lfs -text
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
---

Explain your changes:
* [Some files](https://github.com/search?q=repo%3AMinaProtocol%2Fmina++language%3A%22Standard+ML%22&type=code) are being incorrectly recognized as SML instead of OCaml by Linguist. This change explicitly marks *.ml{i} files as always OCaml for Linguist.

Explain how you tested your changes:
* N/A

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
