### PR TITLE
Set simplified node stats reporting to be default

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -403,8 +403,8 @@ let setup_daemon logger =
   and simplified_node_stats =
     flag "--simplified-node-stats"
       ~aliases:[ "simplified-node-stats" ]
-      (optional_with_default false bool)
-      ~doc:"whether to report simplified node stats (default: false)"
+      (optional_with_default true bool)
+      ~doc:"whether to report simplified node stats (default: true)"
   and contact_info =
     flag "--contact-info" ~aliases:[ "contact-info" ] (optional string)
       ~doc:


### PR DESCRIPTION
This PR attends a late request for #15231 that was left out: setting `--simplified-node-stats` to default to true.