### PR TITLE
PoC: show progress for bootstrap ledger sync in `client status`

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -14133,6 +14133,26 @@
               "deprecationReason": null
             },
             {
+              "name": "bootstrapStatus",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "blockProductionKeys",
               "description": null,
               "args": [],

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -1,3 +1,4 @@
+open Core_kernel
 open Async_kernel
 open Pipe_lib
 open Network_peer
@@ -43,6 +44,12 @@ val run :
   -> persistent_frontier:Transition_frontier.Persistent_frontier.t
   -> initial_root_transition:Mina_block.Validated.t
   -> catchup_mode:[ `Normal | `Super ]
+  -> bootstrap_stats_fetcher:
+       (   unit
+        -> (int Int.Table.t * int Int.Table.t)
+           * (int Int.Table.t * int Int.Table.t) )
+       option
+       ref
   -> ( Transition_frontier.t
      * Mina_block.initial_valid_block Envelope.Incoming.t list )
      Deferred.t

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -200,6 +200,16 @@ module Status = struct
     [@@deriving to_yojson, bin_io_unversioned, fields]
   end
 
+  module Bootstrap_status = struct
+    type t =
+      { waiting_parents : (int * int) list
+      ; completed_parents : (int * int) list
+      ; waiting_content : (int * int) list
+      ; completed_content : (int * int) list
+      }
+    [@@deriving to_yojson, bin_io_unversioned, fields]
+  end
+
   module Make_entries (FieldT : sig
     type 'a t
 
@@ -409,6 +419,25 @@ module Status = struct
       in
       option_entry "Catchup status" ~f:render
 
+    let bootstrap_status_one xs =
+      List.map xs ~f:(fun (i, j) ->
+          (sprintf "\t ledger depth %i" i, Int.to_string j) )
+      |> digest_entries ~title:""
+
+    let bootstrap_status =
+      let render conf =
+        let fmt_field field =
+          let name = Field.name field in
+          (name, bootstrap_status_one (Field.get field conf))
+        in
+        Bootstrap_status.Fields.to_list ~waiting_parents:fmt_field
+          ~completed_parents:fmt_field ~waiting_content:fmt_field
+          ~completed_content:fmt_field
+        |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
+        |> digest_entries ~title:""
+      in
+      option_entry "Bootstrap snarked ledger status" ~f:render
+
     let metrics =
       let render conf =
         let fmt_field name op field = [ (name, op (Field.get field conf)) ] in
@@ -467,6 +496,7 @@ module Status = struct
     ; catchup_status :
         (Transition_frontier.Full_catchup_tree.Node.State.Enum.t * int) list
         option
+    ; bootstrap_status : Bootstrap_status.t option
     ; block_production_keys : string list
     ; coinbase_receiver : string option
     ; histograms : Histograms.t option
@@ -496,7 +526,8 @@ module Status = struct
       ~coinbase_receiver ~histograms ~consensus_time_best_tip
       ~global_slot_since_genesis_best_tip ~consensus_time_now
       ~consensus_mechanism ~consensus_configuration ~next_block_production
-      ~snark_work_fee ~addrs_and_ports ~catchup_status ~metrics
+      ~snark_work_fee ~addrs_and_ports ~catchup_status ~bootstrap_status
+      ~metrics
     |> List.filter_map ~f:Fn.id
 
   let to_text (t : t) =

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -452,6 +452,25 @@ let get_status ~flag t =
     | _ ->
         None
   in
+  let bootstrap_status =
+    match Mina_lib.bootstrap_stats t with
+    | None ->
+        None
+    | Some
+        ( (waiting_parents, completed_parents)
+        , (waiting_content, completed_content) ) ->
+        let dump_and_sort tbl =
+          Int.Table.to_alist tbl
+          |> List.sort ~compare:(fun (idx_a, _) (idx_b, _) -> idx_a - idx_b)
+        in
+        Some
+          { Daemon_rpcs.Types.Status.Bootstrap_status.waiting_parents =
+              dump_and_sort waiting_parents
+          ; completed_parents = dump_and_sort completed_parents
+          ; waiting_content = dump_and_sort waiting_content
+          ; completed_content = dump_and_sort completed_content
+          }
+  in
   let metrics =
     let open Mina_metrics.Block_producer in
     Mina_metrics.
@@ -478,6 +497,7 @@ let get_status ~flag t =
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; catchup_status
+  ; bootstrap_status
   ; blockchain_length
   ; highest_block_length_received =
       (*if this function is not called until after catchup max_block_height will be 1 and most_recent_valid_transition pipe might have the genesis block as the latest transition in which case return the best tip length*)

--- a/src/lib/mina_graphql/reflection.ml
+++ b/src/lib/mina_graphql/reflection.ml
@@ -66,6 +66,19 @@ module Shorthand = struct
       ~typ:(list (non_null string))
       a x
 
+  let nn_bootstrap_status a x =
+    reflect
+      (fun o ->
+        Option.map o
+          ~f:(fun (_ : Daemon_rpcs.Types.Status.Bootstrap_status.t) ->
+            [ "waiting_parents"
+            ; "completed_parents"
+            ; "waiting_content"
+            ; "completed_content"
+            ] ) )
+      ~typ:(list (non_null string))
+      a x
+
   let string a x = id ~typ:string a x
 
   module F = struct

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -310,7 +310,8 @@ module DaemonStatus = struct
         let open Reflection.Shorthand in
         List.rev
         @@ Daemon_rpcs.Types.Status.Fields.fold ~init:[] ~num_accounts:int
-             ~catchup_status:nn_catchup_status ~chain_id:nn_string
+             ~catchup_status:nn_catchup_status
+             ~bootstrap_status:nn_bootstrap_status ~chain_id:nn_string
              ~next_block_production:(id ~typ:block_producer_timing)
              ~blockchain_length:int ~uptime_secs:nn_int
              ~ledger_merkle_root:string ~state_hash:string ~commit_id:nn_string

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -352,9 +352,15 @@ module type Transition_router_intf = sig
           -> Transaction_snark_work.Checked.t option )
     -> catchup_mode:[ `Normal | `Super ]
     -> notify_online:(unit -> unit Deferred.t)
+    -> bootstrap_stats_fetcher:
+         (   unit
+          -> (int Int.Table.t * int Int.Table.t)
+             * (int Int.Table.t * int Int.Table.t) )
+         option
+         ref
     -> unit
     -> ( [ `Transition of Mina_block.Validated.t ]
-       * [ `Source of [ `Gossip | `Catchup | `Internal ] ]
+       * [> `Source of [> `Gossip | `Catchup | `Internal ] ]
        * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Strict_pipe.Reader.t
        * unit Ivar.t

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -225,3 +225,8 @@ val best_chain_block_by_height :
 
 val best_chain_block_by_state_hash :
   t -> State_hash.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
+
+val bootstrap_stats :
+     t
+  -> ((int Int.Table.t * int Int.Table.t) * (int Int.Table.t * int Int.Table.t))
+     option

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -156,6 +156,10 @@ module type S = sig
   val merkle_path_at_addr : 'a t -> addr -> merkle_path Or_error.t
 
   val get_account_at_addr : 'a t -> addr -> account Or_error.t
+
+  val waiting_parents : 'a t -> int Int.Table.t * int Int.Table.t
+
+  val waiting_content : 'a t -> int Int.Table.t * int Int.Table.t
 end
 
 (*
@@ -365,6 +369,8 @@ end = struct
     val find_exn : 'a t -> Addr.t -> 'a
 
     val remove : 'a t -> Addr.t -> unit
+
+    val added_and_removed : 'a t -> int Int.Table.t * int Int.Table.t
   end = struct
     type 'a t =
       { table : 'a Addr.Table.t
@@ -406,6 +412,8 @@ end = struct
             1
         | Some x ->
             x + 1 )
+
+    let added_and_removed { added; removed; table = _ } = (added, removed)
   end
 
   type 'a t =
@@ -427,6 +435,12 @@ end = struct
     ; mutable validity_listener :
         [ `Ok | `Target_changed of Root_hash.t option * Root_hash.t ] Ivar.t
     }
+
+  let waiting_parents { waiting_parents; _ } =
+    Waiting.added_and_removed waiting_parents
+
+  let waiting_content { waiting_content; _ } =
+    Waiting.added_and_removed waiting_content
 
   let t_of_sexp _ = failwith "t_of_sexp: not implemented"
 

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -366,19 +366,19 @@ end = struct
 
     val remove : 'a t -> Addr.t -> unit
   end = struct
-    type 'a t = 'a Addr.Table.t
+    type 'a t = { table : 'a Addr.Table.t }
 
-    let create () = Addr.Table.create ()
+    let create () = { table = Addr.Table.create () }
 
-    let clear = Addr.Table.clear
+    let clear { table } = Addr.Table.clear table
 
-    let add_exn = Addr.Table.add_exn
+    let add_exn { table } ~key ~data = Addr.Table.add_exn table ~key ~data
 
-    let find = Addr.Table.find
+    let find { table } addr = Addr.Table.find table addr
 
-    let find_exn = Addr.Table.find_exn
+    let find_exn { table } addr = Addr.Table.find_exn table addr
 
-    let remove = Addr.Table.remove
+    let remove { table } addr = Addr.Table.remove table addr
   end
 
   type 'a t =


### PR DESCRIPTION
This PR is the hackiest possible way to show bootstrapping progress, driven by my frustration with no progress bar.

Sample output of the [`compatible` port](https://github.com/MinaProtocol/mina/compare/compatible...feature/add-sync-ledger-tracking-COMPATIBLE?expand=1) syncing against mainnet:
```
Sync status:                            Bootstrap
Bootstrap snarked ledger status:
        waiting_parents:
         ledger depth 0:   0
         ledger depth 1:   0
         ledger depth 2:   0
         ledger depth 3:   0
         ledger depth 4:   0
         ledger depth 5:   0
         ledger depth 6:   0
         ledger depth 7:   0
         ledger depth 8:   0
         ledger depth 9:   0
         ledger depth 10:  0
         ledger depth 11:  0
         ledger depth 12:  0
         ledger depth 13:  0
         ledger depth 14:  0
         ledger depth 15:  468
         ledger depth 16:  664

        completed_parents:
         ledger depth 0:   1
         ledger depth 1:   1
         ledger depth 2:   1
         ledger depth 3:   2
         ledger depth 4:   4
         ledger depth 5:   7
         ledger depth 6:   13
         ledger depth 7:   26
         ledger depth 8:   52
         ledger depth 9:   104
         ledger depth 10:  208
         ledger depth 11:  415
         ledger depth 12:  830
         ledger depth 13:  1660
         ledger depth 14:  3319
         ledger depth 15:  6170
         ledger depth 16:  11676

        waiting_content:
         ledger depth 17:  276

        completed_content:
         ledger depth 17:  23075



```
This currently only tracks the ledger sync for the snarked ledger, but it's easy to extend it to the epoch ledgers. It's probably harder to do that *and* not route the data through to `client status` in a horrible way.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them