### PR TITLE
Node status type flag

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -400,11 +400,12 @@ let setup_daemon logger =
   and node_error_url =
     flag "--node-error-url" ~aliases:[ "node-error-url" ] (optional string)
       ~doc:"URL of the node error collection service"
-  and simplified_node_stats =
-    flag "--simplified-node-stats"
-      ~aliases:[ "simplified-node-stats" ]
-      (optional_with_default true bool)
-      ~doc:"whether to report simplified node stats (default: true)"
+  and node_status_type =
+    flag "--node-status-type" ~aliases:[ "node-status-type" ]
+      (optional_with_default `Simple Cli_lib.Arg_type.node_status_type)
+      ~doc:
+        "full|simple|none Whether to report simple, full or no node stats \
+         (default: simple)"
   and contact_info =
     flag "--contact-info" ~aliases:[ "contact-info" ] (optional string)
       ~doc:
@@ -1306,7 +1307,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ?precomputed_blocks_path ~log_precomputed_blocks
                  ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
                  ~uptime_submitter_keypair ~stop_time ~node_status_url
-                 ~simplified_node_stats () )
+                 ~node_status_type () )
           in
           { Coda_initialization.coda
           ; client_trustlist

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -145,3 +145,14 @@ let work_selection_method_to_module :
       (module Work_selector.Selection_methods.Sequence)
   | Random ->
       (module Work_selector.Selection_methods.Random)
+
+let node_status_type : [ `Full | `Simple | `None ] Command.Arg_type.t =
+  Command.Arg_type.map Command.Param.string ~f:(function
+    | "full" ->
+        `Full
+    | "simple" ->
+        `Simple
+    | "none" ->
+        `None
+    | s ->
+        failwithf "unrecognised node stats type %s" s () )

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -56,7 +56,7 @@ type t =
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]
-  ; simplified_node_stats : bool [@default false]
+  ; node_status_type : [ `Simple | `Full | `None ] [@default `Simple]
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1248,10 +1248,8 @@ let start t =
             ~start_time:t.config.start_time
             ~slot_duration:
               (Block_time.Span.to_time_span
-                 t.config.precomputed_values.consensus_constants
-                   .slot_duration_ms )
-    | None ->
-        ()
+               t.config.precomputed_values.consensus_constants.slot_duration_ms )
+          ~block_producer_public_key_base58
   in
   Uptime_service.start ~logger:t.config.logger ~uptime_url:t.config.uptime_url
     ~snark_worker_opt:t.processes.uptime_snark_worker_opt

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -71,6 +71,7 @@ type node_status_data =
   ; pubsub_msg_received : gossip_count
   ; pubsub_msg_broadcasted : gossip_count
   ; received_blocks : block list
+  ; block_producer_public_key : string option
   }
 [@@deriving to_yojson]
 
@@ -168,7 +169,8 @@ let reset_gauges () =
   Queue.clear Transition_frontier.rejected_blocks
 
 let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
-    ~addrs_and_ports ~start_time ~slot_duration =
+    ~addrs_and_ports ~start_time ~slot_duration
+    ~block_producer_public_key_base58 =
   [%log info] "Starting node status service using URL $url"
     ~metadata:[ ("url", `String node_status_url) ] ;
   let five_slots = Time.Span.scale slot_duration 5. in
@@ -366,6 +368,7 @@ let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
                       ; is_valid = true
                       ; reason_for_rejection = None
                       } )
+            ; block_producer_public_key = block_producer_public_key_base58
             }
           in
           reset_gauges () ;


### PR DESCRIPTION
This pull request replaces the `--simplified-node-stats` flag with the optional node status type flag (`--node-status-type`). This flag allows three values: `simple` enables simple status reporting, `full` enables full status reporting, and `none` disables status reporting. The default value is `simple` and a hard coded node status URL is used. This URL can be overridden at runtime by using the `--node-status-url` flag.

It also adds the block producer public key to the full node status payload.

Tested by running the daemon with the different combinations of flags and the observed behaviour matches the expected one.