### PR TITLE
Convert `CriticallyLowMinWindowDensity` to a warning (until berkeley)

### DIFF
--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -531,7 +531,7 @@ groups:
     for: ${alert_evaluation_duration}
     labels:
       testnet: "{{ $labels.testnet }}"
-      severity: critical
+      severity: warning
     annotations:
       summary: "{{ $labels.testnet }} min density is critically low"
       description: "Critically low min density of {{ $value }} on network {{ $labels.testnet }}."


### PR DESCRIPTION
This PR builds on #15281, demoting the `CriticallyLowMinWindowDensity` alert to a warning. This alert has been firing for some time, but we can't act to fix it until after berkeley. Accordingly, we have no need to use it as an alert until berkeley is released.