### PR TITLE
Do not log constraint failures to the console

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -648,17 +648,7 @@ module Plonk_constraint = struct
             List.reduce_exn ~f:add
               [ mul cl vl; mul cr vr; mul co vo; mul m (mul vl vr); c ]
           in
-          if not (equal zero res) then (
-            eprintf
-              !"%{sexp:t} * %{sexp:t}\n\
-                + %{sexp:t} * %{sexp:t}\n\
-                + %{sexp:t} * %{sexp:t}\n\
-                + %{sexp:t} * %{sexp:t}\n\
-                + %{sexp:t}\n\
-                = %{sexp:t}%!"
-              cl vl cr vr co vo m (mul vl vr) c res ;
-            false )
-          else true
+          equal zero res
       | _ ->
           true
   end


### PR DESCRIPTION
When checking constraints, snarky will call the `eval` function of the constraint to determine if it failed:
https://github.com/o1-labs/snarky/blob/b539752a5c075f2d822703a7d5bf00f19f805d63/src/base/checked_runner.ml#L214

If `eval` returns `false`, an error is thrown which describes the failure.

The `eval` function for `Plonk_constraint.Basic` was behaving a little unusual: Instead of just returning `false`, it also logged information about the constraint to the console.

None of the other `eval` functions do this, and it's not the right thing to do: in tests, you often _want_ to confirm that a certain constraint is failing, and don't want your console spammed by such a test. This PR fixes the behavior, which was hurting the DX of using custom generic gates in o1js.