### PR TITLE
CI: make unit-tests job fails if dune runtest fails

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -30,4 +30,4 @@ time dune runtest "src/app/print_blockchain_snark_vk" --profile="${profile}" -j1
 export ERROR_ON_PROOF=true
 
 echo "--- Run unit tests"
-time dune runtest "${path}" --profile="${profile}" -j16 || (./scripts/link-coredumps.sh)
+time dune runtest "${path}" --profile="${profile}" -j16 || (./scripts/link-coredumps.sh && false)


### PR DESCRIPTION
Explain your changes:
* Partially reverting https://github.com/MinaProtocol/mina/commit/332b53212ae53ad066fc331a1b6b297765eea95a

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
