### PR TITLE
don't store ledger hash

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -143,7 +143,7 @@ let create_replayer_checkpoint ~ledger ~start_slot_since_genesis :
     { base = Accounts accounts
     ; num_accounts = None
     ; balances = []
-    ; hash = Some (Ledger.merkle_root ledger |> Ledger_hash.to_base58_check)
+    ; hash = None
     ; s3_data_hash = None
     ; name = None
     ; add_genesis_winner = Some true


### PR DESCRIPTION
Explain your changes:
This PR remove the ledger hash in replayer checkpoint file. The reason is that when we do migration we are using a different profile (`berkeley_archive_migration`). The resulting ledger hash is not compatible with the ledger hash computed using `devnet`/`mainnet` profile.

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
