### PR TITLE
Add berkeley archive migration app to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -288,7 +288,7 @@
         # Main user-facing binaries.
         packages = rec {
           inherit (ocamlPackages)
-            mina devnet mainnet mina_tests mina-ocaml-format test_executive;
+            mina berkeley-migration devnet mainnet mina_tests mina-ocaml-format test_executive;
           inherit (pkgs)
             libp2p_helper kimchi_bindings_stubs snarky_js leaderboard
             validation trace-tool zkapp-cli;

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -277,6 +277,31 @@ let
 
       devnet = wrapMina self.devnet-pkg { };
 
+      berkeley-migration-pkg = self.mina-dev.overrideAttrs (s: {
+        pname = "mina-berkeley-migration";
+        version = "mainnet";
+        DUNE_PROFILE = "berkeley_archive_migration";
+        # For compatibility with Docker build
+        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
+        buildPhase = ''
+          dune build --display=short \
+            src/app/berkeley_migration/berkeley_migration.exe
+        '';
+
+        outputs = [ "out" ];
+
+        installPhase = ''
+          mkdir -p $out/bin
+          pushd _build/default
+          cp src/app/berkeley_migration/berkeley_migration.exe $out/bin/mina-berkeley-migration
+          popd
+          remove-references-to -t $(dirname $(dirname $(command -v ocaml))) $out/bin/*
+        '';
+        shellHook = "";
+      });
+
+      berkeley-migration = wrapMina self.berkeley-migration-pkg { };
+
       # Unit tests
       mina_tests = runMinaCheck {
         name = "tests";


### PR DESCRIPTION
_PR against develop: https://github.com/MinaProtocol/mina/pull/15340_

Problem: berkeley archive migration app is not specified in the nix build.

Solution: add berkeley archive migration app into flakes.

Note: building the archive migration app requires DUNE_PROFILE to be set to a specialized value.

Explain how you tested your changes:
* [x] Built `mina-berkeley-migration` with nix
* [ ] (TODO) Tested the whole migration flow with the app

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
