### PR TITLE
Draft:  fix nix on `develop`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1670004517,
-        "narHash": "sha256-7SffiN2S9pVfOoBCcEdY/iJe28p/eiRqVLXG7/8Jb3I=",
+        "lastModified": 1710414181,
+        "narHash": "sha256-Cfiyf0o5ySmi2BHpNDvWEKM/dtExNcmIiTaBbRZImqs=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "b12b7fcd6f9ea0a8a939c05c68a95525f0d80af6",
+        "rev": "8578c83725e4ceaf04913cf04da9bb36d85ad0bc",
         "type": "github"
       },
       "original": {
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665671715,
-        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -5,7 +5,7 @@ final: prev: {
   go-capnproto2 = final.buildGo119Module rec {
     pname = "capnpc-go";
     version = "v3.0.0-alpha.5";
-    vendorSha256 = "sha256-oZ6fUUpAsBS5hvl2+eqWsE3i0lwJzXeVaH2OiqWJQyY=";
+    vendorHash = "sha256-oZ6fUUpAsBS5hvl2+eqWsE3i0lwJzXeVaH2OiqWJQyY=";
     # Don't understand the problem, but it seems to build fine without examples
     excludedPackages = [ "./example/books/ex1" "./example/books/ex2" "./example/hashes" ];
     src = final.fetchFromGitHub {
@@ -36,7 +36,7 @@ final: prev: {
     version = "0.1";
     src = ../src/app/libp2p_helper/src;
     doCheck = false; # TODO: tests hang
-    vendorSha256 = let hashes = final.lib.importJSON ./libp2p_helper.json; in
+    vendorHash = let hashes = final.lib.importJSON ./libp2p_helper.json; in
     # sanity check, to make sure the fixed output drv doesn't keep working
       # when the inputs change
       if builtins.hashFile "sha256" ../src/app/libp2p_helper/src/go.mod
@@ -86,6 +86,6 @@ final: prev: {
       rev = "9a8ba09359482898580bb35c3aa86896364b14ce";
       sha256 = "sha256-3Lk5pa6fAeHGCmDjhaUjUoASxN6ozTD9e2+0wDH7hGs=";
     };
-    vendorSha256 = "sha256-lCBAsCNtorEu0WRZRLEMEaNyjtVIdJSAZg3icrpHIsQ=";
+    vendorHash = "sha256-lCBAsCNtorEu0WRZRLEMEaNyjtVIdJSAZg3icrpHIsQ=";
   };
 }

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -128,9 +128,18 @@ let
         '';
       });
 
+      # on MacOS, ctypes-foreign-threaded.cma is not installed otherwise
+      ctypes = super.ctypes.overrideAttrs
+        (oa: {
+          buildInputs = oa.buildInputs ++ [ pkgs.libffi ];
+          buildPhase = "make";
+        });
+
       # Doesn't have an explicit dependency on ctypes
       rpc_parallel = super.rpc_parallel.overrideAttrs
-        (oa: { buildInputs = oa.buildInputs ++ [ self.ctypes ]; });
+        (oa: {
+          buildInputs = oa.buildInputs ++ [ self.ctypes ];
+        });
 
       # Add specific linker configuration for MacOS ARM architecture
       postgresql = super.postgresql.overrideAttrs (_: {

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -132,6 +132,13 @@ let
       rpc_parallel = super.rpc_parallel.overrideAttrs
         (oa: { buildInputs = oa.buildInputs ++ [ self.ctypes ]; });
 
+      # Add specific linker configuration for MacOS ARM architecture
+      postgresql = super.postgresql.overrideAttrs (_: {
+        NIX_LDFLAGS =
+          optionalString (pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64)
+            "-F ${pkgs.darwin.apple_sdk.frameworks.Kerberos}/Library/Frameworks -framework Kerberos";
+      });
+
       # Some "core" Mina executables, without the version info.
       mina-dev = pkgs.stdenv.mkDerivation ({
         pname = "mina";

--- a/nix/vend/default.nix
+++ b/nix/vend/default.nix
@@ -4,7 +4,7 @@ buildGoModule {
   pname = "vend";
   version = "unstable-2020-06-04";
 
-  patches = [./remove_tidy.patch];
+  patches = [ ./remove_tidy.patch ];
 
   # A permanent fork from master is maintained to avoid non deterministic go tidy
   src = fetchFromGitHub {
@@ -14,7 +14,7 @@ buildGoModule {
     sha256 = "112p9dz9by2h2m3jha2bv1bvzn2a86bpg1wphgmf9gksjpwy835l";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   meta = with lib; {
     homepage = "https://github.com/c00w/vend";

--- a/opam.export
+++ b/opam.export
@@ -8,7 +8,6 @@ roots: [
   "bitstring.4.1.0"
   "camlp4.4.14+1"
   "capnp.3.4.0"
-  "check_opam_switch.~dev"
   "cohttp-async.5.0.0"
   "core_extended.v0.14.0"
   "extlib.1.7.8"
@@ -73,7 +72,6 @@ installed: [
   "caqti-async.1.3.0"
   "caqti-driver-postgresql.1.5.1"
   "charInfo_width.1.1.0"
-  "check_opam_switch.~dev"
   "cmdliner.1.0.3"
   "cohttp.5.0.0"
   "cohttp-async.5.0.0"
@@ -227,6 +225,7 @@ installed: [
   "re.1.9.0"
   "re2.v0.14.0"
   "react.1.2.1"
+  "reason.3.8.2"
   "res.5.0.1"
   "result.1.5"
   "rpc_parallel.v0.14.0"
@@ -266,7 +265,6 @@ installed: [
 pinned: [
   "async_kernel.v0.14.0"
   "capnp.3.4.0"
-  "check_opam_switch.~dev"
   "graphql_ppx.1.2.2"
   "rpc_parallel.v0.14.0"
 ]
@@ -405,6 +403,7 @@ package "graphql_ppx" {
     "ocaml" {>= "4.06"}
     "ppxlib" {>= "0.21.0"}
     "result" {>= "1.5"}
+    "reason"
   ]
   build: [
     ["dune" "build" "-p" name "-j" jobs]

--- a/scripts/pin-external-packages.sh
+++ b/scripts/pin-external-packages.sh
@@ -10,3 +10,5 @@ for pkg in $PACKAGES; do
     echo "Pinning package" $pkg
     opam pin -y add src/external/$pkg
 done
+
+opam pin add -y https://github.com/tweag/check_opam_switch.git#d0aa49884e0f9fd4bbb2cd1a32b798a12


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
