### PR TITLE
[Nix] Build verifier and replayer for berkeley migration

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -285,7 +285,9 @@ let
         MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
         buildPhase = ''
           dune build --display=short \
-            src/app/berkeley_migration/berkeley_migration.exe
+            src/app/berkeley_migration/berkeley_migration.exe \
+            src/app/berkeley_migration_verifier/berkeley_migration_verifier.exe \
+            src/app/replayer/replayer.exe
         '';
 
         outputs = [ "out" ];
@@ -294,6 +296,8 @@ let
           mkdir -p $out/bin
           pushd _build/default
           cp src/app/berkeley_migration/berkeley_migration.exe $out/bin/mina-berkeley-migration
+          cp src/app/berkeley_migration_verifier/berkeley_migration_verifier.exe $out/bin/mina-berkeley-migration-verifier
+          cp src/app/replayer/replayer.exe $out/bin/mina-migration-replayer
           popd
           remove-references-to -t $(dirname $(dirname $(command -v ocaml))) $out/bin/*
         '';


### PR DESCRIPTION
Problem: mina-berkeley-migration-verifier, mina-migration-replayer are not included in the migration build offered by nix.

Solution: build the two additional apps.

Explain how you tested your changes:
* Build the tools, run `--help`


Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None