### PR TITLE
Revert parsetree patch

### DIFF
--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -137,8 +137,7 @@ RUN mkdir --mode=700 ~/.gnupg \
 # --- Ocaml install of a given OCAML_VERSION via opam switch
 # additionally initializes opam with sandboxing disabled, as we did not install bubblewrap above.
 RUN git clone \
-  https://github.com/emberian/opam-repository.git \
-  -b patch-2 \
+  https://github.com/ocaml/opam-repository.git \
   --depth 1 \
   /home/opam/opam-repository \
   && opam init --disable-sandboxing -k git -a ~/opam-repository --bare \


### PR DESCRIPTION
This reverts commit fe5d9eb55070f7c07a07533773366fad7c5d0b34.

That patch is no longer needed (upstream should be fine, flakiness was seemingly temporary)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None