### PR TITLE
Fix nix environments for MacOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1670004517,
-        "narHash": "sha256-7SffiN2S9pVfOoBCcEdY/iJe28p/eiRqVLXG7/8Jb3I=",
+        "lastModified": 1710414181,
+        "narHash": "sha256-Cfiyf0o5ySmi2BHpNDvWEKM/dtExNcmIiTaBbRZImqs=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "b12b7fcd6f9ea0a8a939c05c68a95525f0d80af6",
+        "rev": "8578c83725e4ceaf04913cf04da9bb36d85ad0bc",
         "type": "github"
       },
       "original": {
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665671715,
-        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -81,26 +81,32 @@ let
 
       # Make a script wrapper around a binary, setting all the necessary environment variables and adding necessary tools to PATH.
       # Also passes the version information to the executable.
-      wrapMina = let
-        commit_sha1 = inputs.self.sourceInfo.rev or "<dirty>";
-        commit_date = inputs.flockenzeit.lib.RFC-5322 inputs.self.sourceInfo.lastModified or 0;
-      in package:
-      { deps ? [ pkgs.gnutar pkgs.gzip ], }:
-      pkgs.runCommand "${package.name}-release" {
-        buildInputs = [ pkgs.makeBinaryWrapper pkgs.xorg.lndir ];
-        outputs = package.outputs;
-      } (map (output: ''
-        mkdir -p ${placeholder output}
-        lndir -silent ${package.${output}} ${placeholder output}
-        for i in $(find -L "${placeholder output}/bin" -type f); do
-          wrapProgram "$i" \
-            --prefix PATH : ${makeBinPath deps} \
-            --set MINA_LIBP2P_HELPER_PATH ${pkgs.libp2p_helper}/bin/libp2p_helper \
-            --set MINA_COMMIT_SHA1 ${escapeShellArg commit_sha1} \
-            --set MINA_COMMIT_DATE ${escapeShellArg commit_date} \
-            --set MINA_BRANCH "''${MINA_BRANCH-<unknown due to nix build>}"
-        done
-      '') package.outputs);
+      wrapMina =
+        let
+          commit_sha1 = inputs.self.sourceInfo.rev or "<dirty>";
+          commit_date = inputs.flockenzeit.lib.RFC-5322 inputs.self.sourceInfo.lastModified or 0;
+        in
+        package:
+        { deps ? [ pkgs.gnutar pkgs.gzip ], }:
+        pkgs.runCommand "${package.name}-release"
+          {
+            buildInputs = [ pkgs.makeBinaryWrapper pkgs.xorg.lndir ];
+            outputs = package.outputs;
+          }
+          (map
+            (output: ''
+              mkdir -p ${placeholder output}
+              lndir -silent ${package.${output}} ${placeholder output}
+              for i in $(find -L "${placeholder output}/bin" -type f); do
+                wrapProgram "$i" \
+                  --prefix PATH : ${makeBinPath deps} \
+                  --set MINA_LIBP2P_HELPER_PATH ${pkgs.libp2p_helper}/bin/libp2p_helper \
+                  --set MINA_COMMIT_SHA1 ${escapeShellArg commit_sha1} \
+                  --set MINA_COMMIT_DATE ${escapeShellArg commit_date} \
+                  --set MINA_BRANCH "''${MINA_BRANCH-<unknown due to nix build>}"
+              done
+            '')
+            package.outputs);
 
       # Derivation which has all Mina's dependencies in it, and creates an empty output if the command succeds.
       # Useful for unit tests.
@@ -114,7 +120,8 @@ let
             outputs = [ "out" ];
             installPhase = "touch $out";
           } // extraArgs);
-    in {
+    in
+    {
       # https://github.com/Drup/ocaml-lmdb/issues/41
       lmdb = super.lmdb.overrideAttrs
         (oa: { buildInputs = oa.buildInputs ++ [ self.conf-pkg-config ]; });
@@ -128,9 +135,18 @@ let
         '';
       });
 
+      # on MacOS, ctypes-foreign-threaded.cma is not installed otherwise
+      ctypes = super.ctypes.overrideAttrs
+        (oa: {
+          buildInputs = oa.buildInputs ++ [ pkgs.libffi ];
+          buildPhase = "make";
+        });
+
       # Doesn't have an explicit dependency on ctypes
       rpc_parallel = super.rpc_parallel.overrideAttrs
-        (oa: { buildInputs = oa.buildInputs ++ [ self.ctypes ]; });
+        (oa: {
+          buildInputs = oa.buildInputs ++ [ self.ctypes ];
+        });
 
       # Some "core" Mina executables, without the version info.
       mina-dev = pkgs.stdenv.mkDerivation ({
@@ -151,7 +167,7 @@ let
 
         NIX_LDFLAGS =
           optionalString (pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64)
-          "-F${pkgs.darwin.apple_sdk.frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation";
+            "-F${pkgs.darwin.apple_sdk.frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation";
 
         buildInputs = ocaml-libs ++ external-libs;
 
@@ -307,16 +323,17 @@ let
       berkeley-migration = wrapMina self.berkeley-migration-pkg { };
 
       # Unit tests
-      mina_tests = runMinaCheck {
-        name = "tests";
-        extraArgs = {
-          MINA_LIBP2P_HELPER_PATH = "${pkgs.libp2p_helper}/bin/libp2p_helper";
-          MINA_LIBP2P_PASS = "naughty blue worm";
-          MINA_PRIVKEY_PASS = "naughty blue worm";
-          TZDIR = "${pkgs.tzdata}/share/zoneinfo";
-        };
-        extraInputs = [ pkgs.ephemeralpg ];
-      } ''
+      mina_tests = runMinaCheck
+        {
+          name = "tests";
+          extraArgs = {
+            MINA_LIBP2P_HELPER_PATH = "${pkgs.libp2p_helper}/bin/libp2p_helper";
+            MINA_LIBP2P_PASS = "naughty blue worm";
+            MINA_PRIVKEY_PASS = "naughty blue worm";
+            TZDIR = "${pkgs.tzdata}/share/zoneinfo";
+          };
+          extraInputs = [ pkgs.ephemeralpg ];
+        } ''
         dune build graphql_schema.json --display=short
         export MINA_TEST_POSTGRES="$(pg_tmp -w 1200)"
         pushd src/app/archive
@@ -348,4 +365,5 @@ let
 
       test_executive = wrapMina self.test_executive-dev { };
     };
-in scope.overrideScope' overlay
+in
+scope.overrideScope' overlay

--- a/opam.export
+++ b/opam.export
@@ -225,6 +225,7 @@ installed: [
   "re.1.9.0"
   "re2.v0.14.0"
   "react.1.2.1"
+  "reason.3.8.2"
   "res.5.0.1"
   "result.1.5"
   "rpc_parallel.v0.14.0"

--- a/opam.export
+++ b/opam.export
@@ -8,7 +8,6 @@ roots: [
   "bitstring.4.1.0"
   "camlp4.4.14+1"
   "capnp.3.4.0"
-  "check_opam_switch.~dev"
   "cohttp-async.5.0.0"
   "core_extended.v0.14.0"
   "extlib.1.7.8"
@@ -73,7 +72,6 @@ installed: [
   "caqti-async.1.3.0"
   "caqti-driver-postgresql.1.5.1"
   "charInfo_width.1.1.0"
-  "check_opam_switch.~dev"
   "cmdliner.1.0.3"
   "cohttp.5.0.0"
   "cohttp-async.5.0.0"
@@ -266,7 +264,6 @@ installed: [
 pinned: [
   "async_kernel.v0.14.0"
   "capnp.3.4.0"
-  "check_opam_switch.~dev"
   "graphql_ppx.1.2.2"
   "rpc_parallel.v0.14.0"
 ]


### PR DESCRIPTION
The following changes are required to make `nix` work for MacOS:
- update `opam-nix` to get `conf-postgresql`
- fix `opam_check_switch.~dev` in `opam.export`
- add an overlay for `ctypes` in order to actually compile `ctypes.foreign`