### PR TITLE
Upgrade nodesource install to supported nodejs version

### DIFF
--- a/dockerfiles/Dockerfile-mina-test-executive
+++ b/dockerfiles/Dockerfile-mina-test-executive
@@ -60,7 +60,7 @@ RUN curl https://baltocdn.com/helm/signing.asc | sudo apt-key add - \
     && sudo apt-get install -y helm
 
 # Get yarn + nodejs
-RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash - \
+RUN curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && sudo apt-get update \

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -91,7 +91,7 @@ RUN curl https://baltocdn.com/helm/signing.asc | apt-key add - \
     && rm -rf /var/lib/apt/lists/*
 
 # --- yarn + nodejs, pinned version
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && apt update --yes \


### PR DESCRIPTION
This avoids a 60s wait when building these docker images caused by the deprecated version warning.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them