### PR TITLE
Add specialized slot times for integration tests

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -55,6 +55,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           work_delay = Some 1
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.small
+        ; block_window_duration_ms = Some 60000
         }
     }
 

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -24,6 +24,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (let open Test_account in
         [ create ~account_name:"node-key" ~balance:"1000" () ])
     ; block_producers = [ { node_name = "node"; account_name = "node-key" } ]
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 30000 }
     }
 
   let run network t =

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -30,6 +30,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; { node_name = "node-b"; account_name = "node-b-key" }
         ; { node_name = "node-c"; account_name = "node-c-key" }
         ]
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 30000 }
     }
 
   let run network t =

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -57,7 +57,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         [ { node_name = "node-a"; account_name = "node-a-key" }
         ; { node_name = "node-b"; account_name = "node-b-key" }
         ]
-    ; proof_config = { proof_config_default with fork = Some fork_config }
+    ; proof_config =
+        { proof_config_default with
+          fork = Some fork_config
+        ; block_window_duration_ms = Some 20000
+        }
     }
 
   let run network t =

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -28,6 +28,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         [ { node_name = "node-a"; account_name = "node-a-key" }
         ; { node_name = "node-b"; account_name = "node-b-key" }
         ]
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 60000 }
     }
 
   let run network t =

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -207,6 +207,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.small
         ; fork = Some fork_config
+        ; block_window_duration_ms = Some 30000
         }
     }
 

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -32,6 +32,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; { node_name = "node-b"; account_name = "node-b-key" }
         ; { node_name = "node-c"; account_name = "node-c-key" }
         ]
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 30000 }
     }
 
   (*

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -57,6 +57,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           work_delay = Some 1
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.small
+        ; block_window_duration_ms = Some 45000
         }
     }
 

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -31,6 +31,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; { node_name = "node-b"; account_name = "node-b-key" }
         ; { node_name = "node-c"; account_name = "node-c-key" }
         ]
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 30000 }
     }
 
   let run network t =

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -59,6 +59,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           work_delay = Some 1
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.small
+        ; block_window_duration_ms = Some 45000
         }
     ; slot_tx_end = Some slot_tx_end
     ; slot_chain_end = Some slot_chain_end

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -45,6 +45,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           work_delay = Some 1
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.small
+        ; block_window_duration_ms = Some 45000
         }
     }
 

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -45,6 +45,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           work_delay = Some 1
         ; transaction_capacity =
             Some Runtime_config.Proof_keys.Transaction_capacity.medium
+        ; block_window_duration_ms = Some 45000
         }
     }
 

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -31,6 +31,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; { node_name = "node-c"; account_name = "node-c-key" }
         ]
     ; num_archive_nodes = 1
+    ; proof_config =
+        { proof_config_default with block_window_duration_ms = Some 30000 }
     }
 
   let run network t =


### PR DESCRIPTION
This PR attempts to reduce integration test runtime by reducing the slot times.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them