### PR TITLE
Type containment

### DIFF
--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -112,6 +112,13 @@ module Versioned_v1 = struct
           include M.Stable.V1
         end)
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
         let __versioned__ = ()
 
         type 'a creator = 'a M.Stable.V1.creator
@@ -137,6 +144,13 @@ module Versioned_v1 = struct
           include M.Stable.V1
         end)
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
         let __versioned__ = ()
 
         type 'a creator = 'a M.Stable.V1.creator
@@ -161,6 +175,13 @@ module Versioned_v1 = struct
 
           include M.Stable.V1
         end)
+
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
 
         let __versioned__ = ()
 
@@ -196,6 +217,13 @@ module Versioned_v1 = struct
 
         let hash_fold_t = M.Stable.V1.hash_fold_t
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
         let __versioned__ = ()
 
         type 'a creator = 'a M.Stable.V1.creator
@@ -229,6 +257,13 @@ module Versioned_v1 = struct
           include M.Stable.V1
         end)
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
         let __versioned__ = ()
 
         type 'a creator = 'a M.Stable.V1.creator
@@ -258,6 +293,13 @@ module Versioned_v2 = struct
           include M.Stable.V2
         end)
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
         let __versioned__ = ()
 
         type 'a creator = 'a M.Stable.V2.creator
@@ -269,6 +311,13 @@ module Versioned_v2 = struct
 
           include M.Stable.V1
         end)
+
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
 
         let __versioned__ = ()
 

--- a/src/lib/block_time/intf.ml
+++ b/src/lib/block_time/intf.ml
@@ -95,14 +95,12 @@ module type S = sig
     end
 
     module Span : sig
-      type t [@@deriving sexp, compare, equal, yojson]
-
+      [%%versioned:
       module Stable : sig
         module V1 : sig
-          type nonrec t = t
-          [@@deriving bin_io, equal, sexp, compare, hash, yojson, version]
+          type t [@@deriving equal, sexp, compare, hash, yojson]
         end
-      end
+      end]
 
       val of_time_span : Time.Span.t -> t
 

--- a/src/lib/bounded_types/bounded_types.ml
+++ b/src/lib/bounded_types/bounded_types.ml
@@ -17,6 +17,13 @@ struct
     module V1 = struct
       type 'a t = 'a array [@@deriving sexp, yojson, bin_io]
 
+      let path_to_type =
+        let module_path =
+          Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+            __FUNCTION__
+        in
+        sprintf "%s:%s.%s" __FILE__ module_path "t"
+
       let __versioned__ = ()
 
       let hash_fold_t = hash_fold_array_frozen
@@ -45,6 +52,12 @@ struct
         else (
           pos_ref := pos ;
           bin_read_array bin_read_el buf ~pos_ref )
+
+      let (_ : _) =
+        Ppx_version_runtime.Contained_types.register ~path_to_type
+          ~contained_type_paths:[]
+
+      (* no shape to register, there's a type parameter *)
     end
   end
 
@@ -91,6 +104,21 @@ module String = struct
         else (
           pos_ref := pos ;
           bin_read_string buf ~pos_ref )
+
+      let path_to_type =
+        let module_path =
+          Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+            __FUNCTION__
+        in
+        sprintf "%s:%s.%s" __FILE__ module_path "t"
+
+      let (_ : _) =
+        Ppx_version_runtime.Contained_types.register ~path_to_type
+          ~contained_type_paths:[]
+
+      let (_ : _) =
+        Ppx_version_runtime.Shapes.register ~path_to_type
+          ~type_shape:bin_shape_t ~type_decl:"string"
     end
   end
 
@@ -143,6 +171,13 @@ module Wrapped_error = struct
 
       let __versioned__ = ()
 
+      let path_to_type =
+        let module_path =
+          Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+            __FUNCTION__
+        in
+        sprintf "%s:%s.%s" __FILE__ module_path "t"
+
       let to_latest = Core_kernel.Fn.id
 
       include String.Of_stringable (struct
@@ -154,6 +189,14 @@ module Wrapped_error = struct
         let of_string s =
           Core_kernel.Error.t_of_sexp (Core_kernel.Sexp.of_string s)
       end)
+
+      let (_ : _) =
+        Ppx_version_runtime.Contained_types.register ~path_to_type
+          ~contained_type_paths:[]
+
+      let (_ : _) =
+        Ppx_version_runtime.Shapes.register ~path_to_type
+          ~type_shape:bin_shape_t ~type_decl:"Core_kernel.Error.Stable.V2.t"
     end
   end
 

--- a/src/lib/crypto/kimchi_backend/common/curve.ml
+++ b/src/lib/crypto/kimchi_backend/common/curve.ml
@@ -100,6 +100,17 @@ struct
           [@@deriving equal, bin_io, sexp, compare, yojson, hash]
         end
 
+        let path_to_type =
+          let module_path =
+            Core_kernel.String.chop_suffix_if_exists ~suffix:".path_to_type"
+              __FUNCTION__
+          in
+          sprintf "%s:%s.%s" __FILE__ module_path "t"
+
+        let (_ : _) =
+          Ppx_version_runtime.Contained_types.register ~path_to_type
+            ~contained_type_paths:[]
+
         (* asserts the versioned-ness of V1
            to do this properly, we'd move the Stable module outside the functor
         *)
@@ -124,6 +135,11 @@ struct
                 if not (on_curve t) then raise (Invalid_curve_point t) ;
                 t
             end)
+
+        let (_ : _) =
+          Ppx_version_runtime.Shapes.register ~path_to_type
+            ~type_shape:bin_shape_t
+            ~type_decl:"BaseField.Stable.Latest.t * BaseField.Stable.Latest.t"
       end
 
       module Latest = V1

--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -15,13 +15,12 @@ let tuple6_to_vec (w0, w1, w2, w3, w4, w5) = Vector.[ w0; w1; w2; w3; w4; w5 ]
 let tuple6_of_vec Vector.[ w0; w1; w2; w3; w4; w5 ] = (w0, w1, w2, w3, w4, w5)
 
 module type Stable_v1 = sig
+  [%%versioned:
   module Stable : sig
     module V1 : sig
-      type t [@@deriving version, bin_io, sexp, compare, yojson, hash, equal]
+      type t [@@deriving sexp, compare, yojson, hash, equal]
     end
-
-    module Latest = V1
-  end
+  end]
 
   type t = Stable.V1.t [@@deriving sexp, compare, yojson, hash, equal]
 end
@@ -170,7 +169,7 @@ module Make (Inputs : Inputs_intf) = struct
           Pickles_types.Plonk_types.Proof.Stable.V2.t
         [@@deriving compare, sexp, yojson, hash, equal]
 
-        let id = "plong_dlog_proof_" ^ Inputs.id
+        let id = "plonk_dlog_proof_" ^ Inputs.id
 
         type 'a creator =
              messages:G.Affine.t Pickles_types.Plonk_types.Messages.Stable.V2.t

--- a/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
+++ b/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
@@ -26,6 +26,8 @@ module Stable : sig
     (* pickles required *)
     val __versioned__ : unit
 
+    val path_to_type : string
+
     (* pickles required *)
     val t_of_sexp :
       (Ppx_sexp_conv_lib.Sexp.t -> 'f) -> Ppx_sexp_conv_lib.Sexp.t -> 'f t

--- a/src/lib/merkle_address/merkle_address.mli
+++ b/src/lib/merkle_address/merkle_address.mli
@@ -6,6 +6,8 @@ module Stable : sig
   module V1 : sig
     type nonrec t = t
     [@@deriving sexp, bin_io, hash, equal, compare, to_yojson, version]
+
+    val path_to_type : string
   end
 
   module Latest : module type of V1

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -5,7 +5,7 @@ module Bigstring = struct
   [%%versioned_binable
   module Stable = struct
     module V1 = struct
-      type t = Bigstring.Stable.V1.t [@@deriving sexp, compare]
+      type t = Core_kernel.Bigstring.Stable.V1.t [@@deriving sexp, compare]
 
       let to_latest = Fn.id
 

--- a/src/lib/mina_base/coinbase_intf.ml
+++ b/src/lib/mina_base/coinbase_intf.ml
@@ -4,6 +4,7 @@ open Mina_base_import
 module type Full = sig
   module Fee_transfer = Coinbase_fee_transfer
 
+  [%%versioned:
   module Stable : sig
     module V1 : sig
       type t = private
@@ -11,19 +12,9 @@ module type Full = sig
         ; amount : Currency.Amount.Stable.V1.t
         ; fee_transfer : Fee_transfer.Stable.V1.t option
         }
-      [@@deriving sexp, bin_io, compare, equal, version, hash, yojson]
+      [@@deriving sexp, compare, equal, hash, yojson]
     end
-
-    module Latest = V1
-  end
-
-  (* bin_io intentionally omitted in deriving list *)
-  type t = Stable.Latest.t = private
-    { receiver : Public_key.Compressed.t
-    ; amount : Currency.Amount.t
-    ; fee_transfer : Fee_transfer.t option
-    }
-  [@@deriving sexp, compare, equal, hash, yojson]
+  end]
 
   include Codable.Base58_check_intf with type t := t
 

--- a/src/lib/mina_base/digest_intf.ml
+++ b/src/lib/mina_base/digest_intf.ml
@@ -27,6 +27,8 @@ module type S = sig
 
       val __versioned__ : unit
 
+      val path_to_type : string
+
       val t_of_sexp : Ppx_sexp_conv_lib.Sexp.t -> t
 
       val sexp_of_t : t -> Ppx_sexp_conv_lib.Sexp.t

--- a/src/lib/mina_base/fee_transfer_intf.ml
+++ b/src/lib/mina_base/fee_transfer_intf.ml
@@ -11,6 +11,8 @@ module type Full = sig
           ; fee_token : Token_id.Stable.V2.t
           }
         [@@deriving bin_io, sexp, compare, equal, yojson, version, hash]
+
+        val path_to_type : string
       end
 
       module Latest = V2
@@ -55,6 +57,8 @@ module type Full = sig
     module V2 : sig
       type t = private Single.Stable.V2.t One_or_two.Stable.V1.t
       [@@deriving bin_io, sexp, compare, equal, yojson, version, hash]
+
+      val path_to_type : string
     end
 
     module Latest = V2

--- a/src/lib/mina_base/pending_coinbase_intf.ml
+++ b/src/lib/mina_base/pending_coinbase_intf.ml
@@ -23,6 +23,8 @@ module type S = sig
   module Stable : sig
     module V2 : sig
       type nonrec t = t [@@deriving bin_io, sexp, to_yojson, version]
+
+      val path_to_type : string
     end
 
     module Latest = V2
@@ -33,6 +35,8 @@ module type S = sig
       module V1 : sig
         type t = Public_key.Compressed.Stable.V1.t * Amount.Stable.V1.t
         [@@deriving sexp, bin_io, to_yojson]
+
+        val path_to_type : string
       end
 
       module Latest = V1

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -137,6 +137,8 @@ module type S = sig
         [@@deriving sexp, equal, bin_io, yojson, version, compare, hash]
 
         include Gen_intf with type t := t
+
+        val path_to_type : string
       end
 
       module V2 = Latest

--- a/src/lib/mina_base/signed_command_memo_intf.ml
+++ b/src/lib/mina_base/signed_command_memo_intf.ml
@@ -15,6 +15,8 @@ module type S = sig
       type nonrec t = t
       [@@deriving bin_io, sexp, equal, compare, hash, yojson, version]
 
+      val path_to_type : string
+
       module With_all_version_tags : Bin_prot.Binable.S with type t = t
     end
 

--- a/src/lib/mina_base/sok_message_intf.ml
+++ b/src/lib/mina_base/sok_message_intf.ml
@@ -34,6 +34,8 @@ module type Full = sig
       module V1 : sig
         type nonrec t = t
         [@@deriving sexp, bin_io, hash, compare, equal, yojson, version]
+
+        val path_to_type : string
       end
 
       module Latest = V1

--- a/src/lib/mina_base/staged_ledger_hash_intf.ml
+++ b/src/lib/mina_base/staged_ledger_hash_intf.ml
@@ -27,6 +27,8 @@ module type Full = sig
     module V1 : sig
       type nonrec t = t
       [@@deriving bin_io, sexp, equal, compare, hash, yojson, version]
+
+      val path_to_type : string
     end
 
     module Latest : module type of V1

--- a/src/lib/mina_stdlib/nonempty_list.mli
+++ b/src/lib/mina_stdlib/nonempty_list.mli
@@ -1,13 +1,11 @@
 (** A non-empty list that is safe by construction. *)
 
+[%%versioned:
 module Stable : sig
   module V1 : sig
-    type 'a t
-    [@@deriving sexp, compare, equal, hash, bin_io, version, to_yojson]
+    type 'a t [@@deriving sexp, compare, equal, hash, to_yojson]
   end
-
-  module Latest = V1
-end
+end]
 
 (* no bin_io on purpose *)
 type 'a t = 'a Stable.Latest.t

--- a/src/lib/one_or_two/one_or_two.mli
+++ b/src/lib/one_or_two/one_or_two.mli
@@ -8,6 +8,8 @@ module Stable : sig
     type 'a t = 'a Intfs.t
     [@@deriving bin_io, compare, equal, hash, sexp, version, yojson]
 
+    val path_to_type : string
+
     val to_latest : ('a -> 'b) -> 'a t -> 'b t
 
     val of_latest : ('a -> ('b, 'err) Result.t) -> 'a t -> ('b t, 'err) Result.t

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -163,9 +163,10 @@ module Proofs_verified_2 : sig
     module V2 : sig
       include module type of T with module Repr := T.Repr
 
-      include Pickles_types.Sigs.VERSIONED
-
       include Pickles_types.Sigs.Binable.S with type t := t
+
+      (* %%versioned adds type path *)
+      include Pickles_types.Sigs.VERSIONED_NO_TYPE_PATH
     end
   end]
 
@@ -184,9 +185,10 @@ module Proofs_verified_max : sig
     module V2 : sig
       include module type of T with module Repr := T.Repr
 
-      include Pickles_types.Sigs.VERSIONED
-
       include Pickles_types.Sigs.Binable.S with type t := t
+
+      (* %%versioned adds type path *)
+      include Pickles_types.Sigs.VERSIONED_NO_TYPE_PATH
     end
   end]
 

--- a/src/lib/pickles_base/side_loaded_verification_key.mli
+++ b/src/lib/pickles_base/side_loaded_verification_key.mli
@@ -66,6 +66,8 @@ module Repr : sig
       include Pickles_types.Sigs.Binable.S1 with type 'a t := 'a t
 
       val __versioned__ : unit
+
+      val path_to_type : string
     end
 
     module Latest = V2
@@ -84,6 +86,8 @@ module Width : sig
       type t [@@deriving sexp, equal, compare, hash, yojson]
 
       include Pickles_types.Sigs.Binable.S with type t := t
+
+      val path_to_type : string
 
       val __versioned__ : unit
     end
@@ -112,6 +116,8 @@ module Width : sig
         [@@deriving sexp, equal, compare, hash, yojson]
 
         include Pickles_types.Sigs.Binable.S1 with type 'a t := 'a t
+
+        val path_to_type : string
 
         val __versioned__ : unit
       end

--- a/src/lib/pickles_types/sigs.mli
+++ b/src/lib/pickles_types/sigs.mli
@@ -113,10 +113,16 @@ module Comparable : sig
   end
 end
 
-module type VERSIONED = sig
+module type VERSIONED_NO_TYPE_PATH = sig
   val version : int
 
   val __versioned__ : unit
+end
+
+module type VERSIONED = sig
+  include VERSIONED_NO_TYPE_PATH
+
+  val path_to_type : string
 end
 
 module Serializable : sig

--- a/src/lib/ppx_version/runtime/contained_types.ml
+++ b/src/lib/ppx_version/runtime/contained_types.ml
@@ -1,0 +1,19 @@
+(* contained_types.ml -- registry of versioned types contained in versioned types *)
+
+open Core_kernel
+
+type path = string
+
+module Contained_type_tbl = Hashtbl.Make (Base.String)
+
+let contained_type_tbl : path list Contained_type_tbl.t =
+  Contained_type_tbl.create ()
+
+let find path_to_type = Contained_type_tbl.find contained_type_tbl path_to_type
+
+let iteri ~f = Contained_type_tbl.iteri contained_type_tbl ~f
+
+let register ~(path_to_type : string) ~(contained_type_paths : string list) =
+  Contained_type_tbl.add contained_type_tbl ~key:path_to_type
+    ~data:contained_type_paths
+  |> ignore

--- a/src/lib/ppx_version/runtime/shapes.ml
+++ b/src/lib/ppx_version/runtime/shapes.ml
@@ -14,8 +14,11 @@ let equal_shapes shape1 shape2 =
   let canonical2 = Bin_prot.Shape.eval shape2 in
   Bin_prot.Shape.Canonical.compare canonical1 canonical2 = 0
 
-let register path_to_type (shape : Bin_prot.Shape.t) (ty_decl : string) =
-  match Shape_tbl.add shape_tbl ~key:path_to_type ~data:(shape, ty_decl) with
+let register ~path_to_type ~(type_shape : Bin_prot.Shape.t) ~(type_decl : string)
+    =
+  match
+    Shape_tbl.add shape_tbl ~key:path_to_type ~data:(type_shape, type_decl)
+  with
   | `Ok ->
       ()
   | `Duplicate -> (
@@ -23,8 +26,8 @@ let register path_to_type (shape : Bin_prot.Shape.t) (ty_decl : string) =
          once will yield duplicates; OK if the shapes are the same
       *)
       match find path_to_type with
-      | Some (shape', _ty_decl) ->
-          if not (equal_shapes shape shape') then
+      | Some (type_shape', _type_decl') ->
+          if not (equal_shapes type_shape type_shape') then
             failwithf "Different type shapes at path %s" path_to_type ()
           else ()
       | None ->

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -105,21 +105,6 @@ let ocaml_builtin_types =
 
 let ocaml_builtin_type_constructors = [ "list"; "array"; "option"; "ref" ]
 
-(* true iff module_path is of form M. ... .Stable.Vn, where M is Core or Core_kernel, and n is integer *)
-let is_jane_street_stable_module module_path =
-  let hd_elt = List.hd_exn module_path in
-  List.mem jane_street_modules hd_elt ~equal:String.equal
-  &&
-  match List.rev module_path with
-  | vn :: "Stable" :: _ ->
-      Versioned_util.is_version_module vn
-  | vn :: label :: "Stable" :: "Time" :: _
-    when List.mem [ "Span"; "With_utc_sexp" ] label ~equal:String.equal ->
-      (* special cases, maybe improper module structure *)
-      is_version_module vn
-  | _ ->
-      false
-
 let trustlisted_prefix prefix ~loc =
   match prefix with
   | Lident id ->

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -73,4 +73,19 @@ let version_of_versioned_module_name name =
 let jane_street_library_modules = [ "Uuid" ]
 
 let jane_street_modules =
-  [ "Core"; "Core_kernel" ] @ jane_street_library_modules
+  [ "Base"; "Core"; "Core_kernel" ] @ jane_street_library_modules
+
+(* true iff module_path is of form M. ... .Stable.Vn, where M is Base, Core, or Core_kernel, and n is integer *)
+let is_jane_street_stable_module module_path =
+  let hd_elt = List.hd_exn module_path in
+  List.mem jane_street_modules hd_elt ~equal:String.equal
+  &&
+  match List.rev module_path with
+  | vn :: "Stable" :: _ ->
+      is_version_module vn
+  | vn :: label :: "Stable" :: "Time" :: _
+    when List.mem [ "Span"; "With_utc_sexp" ] label ~equal:String.equal ->
+      (* special cases, maybe improper module structure *)
+      is_version_module vn
+  | _ ->
+      false

--- a/src/lib/signature_lib/keypair.mli
+++ b/src/lib/signature_lib/keypair.mli
@@ -1,20 +1,15 @@
 open Core_kernel
 
+[%%versioned:
 module Stable : sig
   module V1 : sig
     type t =
       { public_key : Public_key.Stable.V1.t
       ; private_key : (Private_key.Stable.V1.t[@sexp.opaque])
       }
-    [@@deriving sexp, bin_io, version, to_yojson]
+    [@@deriving sexp, to_yojson]
   end
-
-  module Latest = V1
-end
-
-type t = Stable.Latest.t =
-  { public_key : Public_key.t; private_key : Private_key.t [@sexp.opaque] }
-[@@deriving sexp, compare, to_yojson]
+end]
 
 include Comparable.S with type t := t
 

--- a/src/lib/staged_ledger_diff/diff_intf.ml
+++ b/src/lib/staged_ledger_diff/diff_intf.ml
@@ -99,6 +99,8 @@ module type Full = sig
     module Stable : sig
       module V2 : sig
         type t [@@deriving equal, compare, sexp, bin_io, yojson, version]
+
+        val path_to_type : string
       end
     end
     with type V2.t = t
@@ -113,6 +115,8 @@ module type Full = sig
       [@@deriving equal, compare, sexp, compare, yojson, bin_io, version]
 
       val to_latest : t -> t
+
+      val path_to_type : string
     end
 
     module Latest = V2

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -71,7 +71,7 @@ module Info = struct
     ; fee : Fee.t
     ; prover : Public_key.Compressed.t
     }
-  [@@deriving to_yojson, sexp, compare]
+  [@@deriving compare, sexp, to_yojson]
 end
 
 module T = struct
@@ -85,7 +85,7 @@ module T = struct
         ; proofs : Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
         ; prover : Public_key.Compressed.Stable.V1.t
         }
-      [@@deriving equal, compare, sexp, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -96,7 +96,7 @@ module T = struct
     ; proofs : Ledger_proof.t One_or_two.t
     ; prover : Public_key.Compressed.t
     }
-  [@@deriving compare, yojson, sexp]
+  [@@deriving sexp, compare, equal, yojson]
 
   let statement t = One_or_two.map t.proofs ~f:Ledger_proof.statement
 

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -3,23 +3,21 @@ open Currency
 open Signature_lib
 
 module Statement : sig
-  type t = Transaction_snark.Statement.t One_or_two.t
-  [@@deriving compare, sexp, yojson, equal]
-
-  include Comparable.S with type t := t
-
-  include Hashable.S with type t := t
-
+  [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving bin_io, compare, sexp, version, yojson, equal]
+      type t = Transaction_snark.Statement.Stable.V2.t One_or_two.Stable.V1.t
+      [@@deriving compare, sexp, yojson, equal]
 
       include Comparable.S with type t := t
 
       include Hashable.S_binable with type t := t
     end
-  end
-  with type V2.t = t
+  end]
+
+  include Comparable.S with type t := t
+
+  include Hashable.S with type t := t
 
   val gen : t Quickcheck.Generator.t
 
@@ -29,20 +27,18 @@ module Statement : sig
 end
 
 module Info : sig
-  type t =
-    { statements : Statement.Stable.V2.t
-    ; work_ids : int One_or_two.Stable.V1.t
-    ; fee : Fee.Stable.V1.t
-    ; prover : Public_key.Compressed.Stable.V1.t
-    }
-  [@@deriving to_yojson, sexp, compare]
-
+  [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving compare, to_yojson, version, sexp, bin_io]
+      type t =
+        { statements : Statement.Stable.V2.t
+        ; work_ids : int One_or_two.Stable.V1.t
+        ; fee : Fee.Stable.V1.t
+        ; prover : Public_key.Compressed.Stable.V1.t
+        }
+      [@@deriving compare, sexp, to_yojson]
     end
-  end
-  with type V2.t = t
+  end]
 end
 
 (* TODO: The SOK message actually should bind the SNARK to
@@ -51,25 +47,23 @@ end
        H(all_statements_in_bundle || fee || public_key)
 *)
 
-type t = Mina_wire_types.Transaction_snark_work.V2.t =
-  { fee : Fee.t
-  ; proofs : Ledger_proof.t One_or_two.t
-  ; prover : Public_key.Compressed.t
-  }
-[@@deriving compare, sexp, yojson]
+[%%versioned:
+module Stable : sig
+  module V2 : sig
+    type t = Mina_wire_types.Transaction_snark_work.V2.t =
+      { fee : Fee.Stable.V1.t
+      ; proofs : Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
+      ; prover : Public_key.Compressed.Stable.V1.t
+      }
+    [@@deriving sexp, compare, equal, yojson]
+  end
+end]
 
 val fee : t -> Fee.t
 
 val info : t -> Info.t
 
 val statement : t -> Statement.t
-
-module Stable : sig
-  module V2 : sig
-    type t [@@deriving equal, sexp, compare, bin_io, yojson, version]
-  end
-end
-with type V2.t = t
 
 type unchecked = t
 


### PR DESCRIPTION
If you need to add a new version to a versioned type, you must also add a new version for all types that type is contained in, recursively up to one or more root types. It's difficult to know what all those containing types are, making the process error-prone.  This PR adds two new CLI commands to help with that process.

The first new command is `internal dump-contained-types` that prints, for each versioned type `t`, all versioned types contained within `t`:
```
$ mina internal dump-contained-types 
Type src/lib/mina_base/coinbase.ml:Mina_base__Coinbase.Make_str.Stable.V1.t contains these versioned types:
  src/lib/currency/currency.ml:Currency.Make_str.Amount.Make_str.Stable.V1.t
  src/lib/mina_base/coinbase_fee_transfer.ml:Mina_base__Coinbase_fee_transfer.Make_str.Stable.V1.t
  src/lib/non_zero_curve_point/non_zero_curve_point.ml:Non_zero_curve_point.Compressed.Stable.V1.t
...
```
Types are identified by a file and module path, the same as in `internal dump-type-shapes`. That command does not print shapes for types with parameters, because their shapes are not defined. The new command here does print those types, and the types they contain. A contained type is any versioned type that appears in a type declaration, including in type parameters or constraints.

The second new command is `internal show-containing-types`, which prints all types that contain a given versioned type:
```
$ mina internal show-containing-types --type-path src/lib/bounded_types/bounded_types.ml:Bounded_types.Wrapped_error.Stable.V1.t
Type at src/lib/bounded_types/bounded_types.ml:Bounded_types.Wrapped_error.Stable.V1.t is contained in these types:
  Type at src/lib/mina_networking/mina_networking.ml:Mina_networking.Rpcs.Answer_sync_ledger_query.V3.T.response, which is not contained in any other types
  Type at src/lib/mina_networking/mina_networking.ml:Mina_networking.Rpcs.Get_node_status.V2.T.response, which is not contained in any other types
  Type at src/lib/mina_networking/mina_networking.ml:Mina_networking.Rpcs.Get_node_status.V1.T.response, which is not contained in any other types
  Type at src/lib/snark_worker/snark_worker.ml:Snark_worker.Worker.Rpcs_versioned.Failed_to_generate_snark.V2.T.query, which is not contained in any other types
```
This result indicates that if a new version is created for `Bounded_types.Wrapped_error.t`, then, there are four versioned types that would also need to be updated.

The `%%versioned` (for structures) and `%%versioned:` (for signatures) annotations invoke the infrastructure that makes these commands work. In `ppx_version`, there's a new table that maps types to their contained types. That table is populated at load time, similarly to how type shapes are registered. 

In some places, those annotations are added in this PR where possible.

For versioned types defined without using those annotations, we define the value `path_to_type` and perform the contained type registration explicitly. The pickles code has a lot of such explicit definitions, but also in some other places where the annotations are not used.
