### PR TITLE
don't be stingy with unitDirtyWhen

### DIFF
--- a/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
@@ -22,8 +22,7 @@ Pipeline.build
     { spec =
       JobSpec::
         { dirtyWhen =
-          [ S.strictlyStart (S.contains "src/lib")
-          , S.strictly (S.contains "Makefile")
+          [ S.strictlyStart (S.contains "src")
           , S.strictlyStart (S.contains "buildkite/src/Jobs/Test/ArchiveNodeUnitTest")
           ]
         , path = "Test"

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -33,8 +33,7 @@ Pipeline.build
   Pipeline.Config::{
     spec = 
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),
-        S.strictlyStart (S.contains "src/nonconsensus"),
+        S.strictlyStart (S.contains "src"),
         S.strictly (S.contains "Makefile"),
         S.exactly "buildkite/src/Jobs/Test/DaemonUnitTest" "dhall",
         S.exactly "scripts/link-coredumps" "sh",

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -17,9 +17,7 @@ let Profiles = ../../Constants/Profiles.dhall
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let dirtyWhen = [ 
-  S.strictlyStart (S.contains "src/app/rosetta"),
-  S.strictlyStart (S.contains "src/lib"),
-  S.strictlyStart (S.contains "src/app/archive"),
+  S.strictlyStart (S.contains "src"),
   S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
   S.exactly "buildkite/scripts/rosetta-integration-tests" "sh",
   S.exactly "buildkite/scripts/rosetta-integration-tests-fast" "sh"

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
@@ -16,9 +16,7 @@ let DockerImage = ../../Command/DockerImage.dhall
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let dirtyWhen = [ 
-  S.strictlyStart (S.contains "src/app/rosetta"),
-  S.strictlyStart (S.contains "src/lib"),
-  S.strictlyStart (S.contains "src/app/archive"),
+  S.strictlyStart (S.contains "src"),
   S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall",
   S.exactly "buildkite/scripts/rosetta-integration-tests" "sh",
   S.exactly "buildkite/scripts/rosetta-integration-tests-full" "sh"

--- a/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
@@ -31,8 +31,7 @@ Pipeline.build
   Pipeline.Config::{
     spec = 
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),
-        S.strictlyStart (S.contains "src/app/rosetta"),
+        S.strictlyStart (S.contains "src"),
         S.exactly "buildkite/src/Jobs/Test/RosettaUnitTest" "dhall",
         S.exactly "buildkite/scripts/unit-test" "sh"
       ]

--- a/buildkite/src/Jobs/Test/RunSnarkProfiler.dhall
+++ b/buildkite/src/Jobs/Test/RunSnarkProfiler.dhall
@@ -45,7 +45,7 @@ Pipeline.build
   Pipeline.Config::{
     spec =
       let lintDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),
+        S.strictlyStart (S.contains "src"),
         S.exactly "buildkite/src/Jobs/Test/RunSnarkProfiler" "dhall",
         S.exactly "buildkite/scripts/run-snark-transaction-profiler" "sh",
         S.exactly "scripts/snark_transaction_profiler" "py"

--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -53,8 +53,7 @@ Pipeline.build
   Pipeline.Config::{
     spec = 
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),
-        S.strictlyStart (S.contains "src/test"),
+        S.strictlyStart (S.contains "src"),
         S.strictly (S.contains "Makefile"),
         S.exactly "buildkite/src/Jobs/Test/SingleNodeTest" "dhall",
         S.exactly "buildkite/scripts/single-node-tests" "sh"

--- a/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
@@ -31,8 +31,7 @@ Pipeline.build
   Pipeline.Config::{
     spec = 
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),
-        S.strictlyStart (S.contains "src/app/zkapp_test_transaction"),
+        S.strictlyStart (S.contains "src"),
         S.exactly "buildkite/src/Jobs/Test/ZkappTestToolUnitTest" "dhall",
         S.exactly "buildkite/scripts/unit-test" "sh"
       ]

--- a/buildkite/src/Jobs/Test/ZkappsExamplesTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappsExamplesTest.dhall
@@ -32,9 +32,8 @@ Pipeline.build
   Pipeline.Config::{
     spec =
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/app/zkapps_examples"),
-        S.strictlyStart (S.contains "src/lib"),
-        S.exactly "buildkite/src/Jobs/Test/DaemonUnitTest" "dhall",
+        S.strictlyStart (S.contains "src"),
+        S.exactly "buildkite/src/Jobs/Test/ZkappsExamplesTest" "dhall",
         S.exactly "scripts/link-coredumps" "sh",
         S.exactly "buildkite/scripts/zkapps-examples-unit-tests" "sh"
       ]


### PR DESCRIPTION
we need to run all these tests when the src/configs directory changes.
there are also inconsistencies in the dependencies, such as the archive
node unit tests not running when the archive node test code changes.

this only _increases_ the scope of some jobs, so oughta be plenty safe.