### PR TITLE
Port runtime_genesis_ledger from Berkeley (without SHA3 hash)

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -182,9 +182,10 @@ let
             src/app/rosetta/rosetta_testnet_signatures.exe \
             src/app/rosetta/rosetta_mainnet_signatures.exe \
             src/app/generate_keypair/generate_keypair.exe \
+            src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
             src/lib/mina_base/sample_keypairs.json \
             -j$NIX_BUILD_CORES
-          dune exec src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe -- --genesis-dir _build/coda_cache_dir
+          # dune exec src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe -- --genesis-dir _build/coda_cache_dir
           dune build @doc || true
         '';
 
@@ -193,7 +194,7 @@ let
 
         installPhase = ''
           mkdir -p $out/bin $sample/share/mina $out/share/doc $generate_keypair/bin $mainnet/bin $testnet/bin $genesis/bin $genesis/var/lib/coda $batch_txn_tool/bin
-          mv _build/coda_cache_dir/genesis* $genesis/var/lib/coda
+          # mv _build/coda_cache_dir/genesis* $genesis/var/lib/coda
           pushd _build/default
           cp src/app/cli/src/mina.exe $out/bin/mina
           cp src/app/logproc/logproc.exe $out/bin/logproc

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -192,7 +192,7 @@ for f in /tmp/coda_cache_dir/genesis*; do
 done
 
 #copy config.json
-cp '../genesis_ledgers/mainnet.json' "${BUILDDIR}/var/lib/coda/mainnet.json"
+cp ../genesis_ledgers/mainnet.json "${BUILDDIR}/var/lib/coda/mainnet.json"
 cp ../genesis_ledgers/devnet.json "${BUILDDIR}/var/lib/coda/devnet.json"
 # The default configuration:
 cp ../genesis_ledgers/mainnet.json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
@@ -270,6 +270,51 @@ ls -lh mina*.deb
 
 ##################################### END GENERATE MINA DEVNET PACKAGE #######################################
 
+##################################### GENERATE MINA CREATE LEGACY GENESIS PACKAGE #######################################
+
+echo "------------------------------------------------------------"
+echo "Building runtime genesis ledger :"
+
+rm -rf "${BUILDDIR}"
+mkdir -p "${BUILDDIR}/DEBIAN"
+cat << EOF > "${BUILDDIR}/DEBIAN/control"
+Package: mina-create-legacy-genesis
+Version: ${MINA_DEB_VERSION}
+Section: base
+Priority: optional
+Architecture: amd64
+Depends: ${SHARED_DEPS}${DAEMON_DEPS}
+Suggests: postgresql
+License: Apache-2.0
+Homepage: https://minaprotocol.com/
+Maintainer: o(1)Labs <build@o1labs.org>
+Description: Mina Client and Daemon
+ Mina Protocol Client and Daemon
+ Built from ${GITHASH} by ${BUILD_URL}
+EOF
+
+echo "------------------------------------------------------------"
+echo "Control File:"
+cat "${BUILDDIR}/DEBIAN/control"
+
+echo "------------------------------------------------------------"
+# Binaries
+mkdir -p "${BUILDDIR}/usr/local/bin"
+cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/mina-create-legacy-genesis"
+
+# echo contents of deb
+echo "------------------------------------------------------------"
+echo "Deb Contents:"
+find "${BUILDDIR}"
+
+# Build the package
+echo "------------------------------------------------------------"
+fakeroot dpkg-deb --build "${BUILDDIR}" mina-create-legacy-genesis_${MINA_DEB_VERSION}.deb
+ls -lh mina*.deb
+
+##################################### END GENERATE MINA MAINNET PACKAGE #######################################
+
+
 # TODO: Find a way to package keys properly without blocking/locking in CI
 # TODO: Keys should be their own package, which this 'non-noprovingkeys' deb depends on
 # For now, deleting keys in /tmp/ so that the complicated logic below for moving them short-circuits and both packages are built without keys
@@ -316,6 +361,6 @@ done
 #remove build dir to prevent running out of space on the host machine
 rm -rf "${BUILDDIR}"
 
-# Build mina block producer sidecar 
+# Build mina block producer sidecar
 ../automation/services/mina-bp-stats/sidecar/build.sh
 ls -lh mina*.deb

--- a/src/app/runtime_genesis_ledger/dune
+++ b/src/app/runtime_genesis_ledger/dune
@@ -7,6 +7,7 @@
    core_kernel
    async_kernel
    async
+   async_unix
    core
    result
    async.async_command
@@ -17,14 +18,9 @@
    logger
    cache_dir
    mina_base
+   precomputed_values
+   coda_genesis_ledger
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_let ppx_optcomp ppx_deriving_yojson)))
-
-(rule
- (targets genesis_filename.txt)
- (deps
-  (:< gen/gen.exe))
- (action
-  (run %{<})))
+ (preprocess (pps ppx_jane ppx_version ppx_let ppx_deriving_yojson ppx_coda)))

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -2,53 +2,163 @@ open Core
 open Async
 open Mina_base
 
-type t = Ledger.t
+module Hashes = struct
+  type t = { hash : string } [@@deriving to_yojson]
+end
 
-let main ~config_file ~genesis_dir ~proof_level () =
-  let%bind config =
-    match config_file with
-    | Some config_file -> (
-        let%map config_json =
-          Deferred.Or_error.ok_exn
-          @@ Genesis_ledger_helper.load_config_json config_file
-        in
-        match Runtime_config.of_yojson config_json with
-        | Ok config ->
-            config
-        | Error err ->
-            failwithf "Could not parse configuration: %s" err () )
-    | None ->
-        return Runtime_config.default
+module Hash_json = struct
+  type epoch_data = { staking : Hashes.t; next : Hashes.t }
+  [@@deriving to_yojson]
+
+  type t = { ledger : Hashes.t; epoch_data : epoch_data } [@@deriving to_yojson]
+end
+
+let ledger_depth =
+              Genesis_constants.Constraint_constants.compiled
+    .ledger_depth
+
+let logger = Logger.create ()
+
+let load_ledger (accounts : Runtime_config.Accounts.t) =
+  let accounts =
+    List.map accounts ~f:(fun account ->
+        (None, Runtime_config.Accounts.Single.to_account account) )
   in
-  Deferred.Or_error.ok_exn @@ Deferred.Or_error.ignore_m
-  @@ Genesis_ledger_helper.init_from_config_file ?genesis_dir
-       ~logger:(Logger.create ()) ~proof_level config
+  let packed =
+    Genesis_ledger_helper.Ledger.packed_genesis_ledger_of_accounts
+      ~depth:ledger_depth
+      (lazy accounts)
+  in
+  Lazy.force (Genesis_ledger.Packed.t packed)
+
+let generate_ledger_tarball ~genesis_dir ~ledger_name_prefix ledger =
+  let%map tar_path =
+    Deferred.Or_error.ok_exn
+    @@ Genesis_ledger_helper.Ledger.generate_tar ~genesis_dir ~logger
+         ~ledger_name_prefix ledger
+  in
+  [%log info] "Generated ledger tar at %s" tar_path ;
+  let hash =
+    Mina_base.Ledger_hash.to_base58_check
+    @@ Ledger.merkle_root ledger
+  in
+  { Hashes.hash }
+
+let generate_hash_json ~genesis_dir ledger staking_ledger next_ledger =
+  let%bind ledger_hashes =
+    generate_ledger_tarball ~ledger_name_prefix:"genesis_ledger" ~genesis_dir
+      ledger
+  in
+  let%bind staking =
+    generate_ledger_tarball ~ledger_name_prefix:"epoch_ledger" ~genesis_dir
+      staking_ledger
+  in
+  let%map next =
+    generate_ledger_tarball ~ledger_name_prefix:"epoch_ledger" ~genesis_dir
+      next_ledger
+  in
+  { Hash_json.ledger = ledger_hashes; epoch_data = { staking; next } }
+
+let is_dirty_proof = function
+  | Runtime_config.Proof_keys.
+      { level = None
+      ; sub_windows_per_window = None
+      ; ledger_depth = None
+      ; work_delay = None
+      ; block_window_duration_ms = None
+      ; transaction_capacity = None
+      ; coinbase_amount = None
+      ; supercharged_coinbase_factor = None
+      ; account_creation_fee = None
+      ; fork = _
+      } ->
+      false
+  | _ ->
+      true
+
+let extract_accounts_exn = function
+  | { Runtime_config.Ledger.base = Accounts accounts
+    ; num_accounts = None
+    ; balances = []
+    (* ; add_genesis_winner = Some false *)
+    ; _
+    } ->
+      accounts
+  | _ ->
+      failwith "Wrong ledger supplied"
+
+let load_config_exn config_file =
+  let%map config_json =
+    Deferred.Or_error.ok_exn
+    @@ Genesis_ledger_helper.load_config_json config_file
+  in
+  let config =
+    Runtime_config.of_yojson config_json
+    |> Result.map_error ~f:(fun err ->
+           Failure ("Could not parse configuration: " ^ err) )
+    |> Result.ok_exn
+  in
+  if
+    Option.(
+      is_some config.daemon || is_some config.genesis
+      || Option.value_map ~default:false ~f:is_dirty_proof config.proof)
+  then failwith "Runtime config has unexpected fields" ;
+  let ledger = Option.value_exn ~message:"No ledger provided" config.ledger in
+  let staking_ledger =
+    let%map.Option { staking; _ } = config.epoch_data in
+    staking.ledger
+  in
+  let next_ledger =
+    let%bind.Option { next; _ } = config.epoch_data in
+    let%map.Option { ledger; _ } = next in
+    ledger
+  in
+  ( extract_accounts_exn ledger
+  , Option.map ~f:extract_accounts_exn staking_ledger
+  , Option.map ~f:extract_accounts_exn next_ledger )
+
+let main ~config_file ~genesis_dir ~hash_output_file () =
+  let%bind accounts, staking_accounts_opt, next_accounts_opt =
+    load_config_exn config_file
+  in
+  let ledger = load_ledger accounts in
+  let staking_ledger =
+    Option.value_map ~default:ledger ~f:load_ledger staking_accounts_opt
+  in
+  let next_ledger =
+    Option.value_map ~default:staking_ledger ~f:load_ledger next_accounts_opt
+  in
+  let%bind hash_json =
+    generate_hash_json ~genesis_dir ledger staking_ledger next_ledger
+  in
+  Async.Writer.save hash_output_file
+    ~contents:(Yojson.Safe.to_string (Hash_json.to_yojson hash_json))
 
 let () =
   Command.run
     (Command.async
        ~summary:
          "Generate the genesis ledger and genesis proof for a given \
-          configuration file, or for the compile-time configuration if none \
-          is provided"
+          configuration file, or for the compile-time configuration if none is \
+          provided"
        Command.(
          let open Let_syntax in
          let open Command.Param in
          let%map config_file =
            flag "--config-file" ~doc:"PATH path to the JSON configuration file"
-             (optional string)
+             (required string)
          and genesis_dir =
            flag "--genesis-dir"
              ~doc:
                (sprintf
                   "Dir where the genesis ledger and genesis proof is to be \
                    saved (default: %s)"
-                  Cache_dir.autogen_path)
-             (optional string)
-         and proof_level =
-           flag "--proof-level"
-             (optional
-                (Arg_type.create Genesis_constants.Proof_level.of_string))
-             ~doc:"full|check|none"
+                  Cache_dir.autogen_path )
+             (required string)
+         and hash_output_file =
+           flag "--hash-output-file" (required string)
+             ~doc:
+               "PATH path to the file where the hashes of the ledgers are to \
+                be saved"
          in
-         main ~config_file ~genesis_dir ~proof_level))
+         main ~config_file ~genesis_dir ~hash_output_file) )


### PR DESCRIPTION
Explain your changes:
* Port changes from `berkeley` to allow for `runtime_genesis_ledger` tool to generate hashes json file with ledger hashes of config file being used as an input
* Generate a new debian package with `runtime_genesis_ledger` corresponding to mainnet's version (hence names as create "legacy" ledger)

Explain how you tested your changes:
* Part of HF unit test, tested there

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
