### PR TITLE
Fixes to migration script

### DIFF
--- a/scripts/archive/migration/README.md
+++ b/scripts/archive/migration/README.md
@@ -118,7 +118,7 @@ migration-checkpoint-597.json - is a last checkpoint from initial run
 #### Final migration
 
 ```
-./scripts/archive/migration/berkeley_migration.sh final -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_final -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-2381.json -fc ../../umt_testing/fork-umt-02-29-2024.json -f 3NLnD1Yp4MS9LtMXikD1YyySZNVgCXA82b5eQVpmYZ5kyTo4Xsr7
+./scripts/archive/migration/berkeley_migration.sh final -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_final -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-2381.json -fc ../../umt_testing/fork-umt-02-29-2024.json
 ```
 
 where `3NLnD1Yp4MS9LtMXikD1YyySZNVgCXA82b5eQVpmYZ5kyTo4Xsr7` was extracted from fork config file:

--- a/scripts/archive/migration/README.md
+++ b/scripts/archive/migration/README.md
@@ -100,7 +100,7 @@ Since berkeley migration script supports all berkeley migration phases. We need 
 #### Initial migration
 
 ```
-./scripts/archive/migration/berkeley_migration.sh initial -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_initial -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 1000 -n o1labs-umt-pre-fork-run-1
+mina-berkeley-migration-script initial -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_initial -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 1000 -n o1labs-umt-pre-fork-run-1
 ```
 
 this command should output migration-replayer-XXX.json which should be used in next run
@@ -108,7 +108,7 @@ this command should output migration-replayer-XXX.json which should be used in n
 #### Incremental migration
 
 ```
-./scripts/archive/migration/berkeley_migration.sh incremental -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_increment -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-597.json
+mina-berkeley-migration-script incremental -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_increment -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-597.json
 ```
 
 where:
@@ -118,7 +118,7 @@ migration-checkpoint-597.json - is a last checkpoint from initial run
 #### Final migration
 
 ```
-./scripts/archive/migration/berkeley_migration.sh final -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_final -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-2381.json -fc ../../umt_testing/fork-umt-02-29-2024.json
+mina-berkeley-migration-script final -g  ../../umt_testing/o1labs-umt-pre-fork-run-1-ledger.json -s postgres://postgres:postgres@localhost:5432/umt_testing_final -t postgres://postgres:postgres@localhost:5432/migrated -b mina_network_block_data -bs 50 -n o1labs-umt-pre-fork-run-1 -r migration-checkpoint-2381.json -fc ../../umt_testing/fork-umt-02-29-2024.json
 ```
 
 where `3NLnD1Yp4MS9LtMXikD1YyySZNVgCXA82b5eQVpmYZ5kyTo4Xsr7` was extracted from fork config file:

--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -209,7 +209,7 @@ function initial(){
 function check_log_for_error() {
     local __log=$1;
 
-    grep Error "$__log";
+    grep '"level":"Error"' "$__log";
     local __have_errors=$?;
 
     if [ $__have_errors -eq 0 ]; then 

--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -542,13 +542,13 @@ function final_help(){
     printf "  %-25s %s\n" "-b | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
     printf "  %-25s %s\n" "-bs | --blocks-batch-size" "[int] number of precomputed blocks to be fetch at once from Gcloud. Bigger number like 1000 can help speed up migration process";
     printf "  %-25s %s\n" "-n | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
-    printf "  %-25s %s\n" "-fc | --fork-config" "[file] Fork-state config file is dump file in form of json containing fork block and ledger file. It should be provied by MF or O(1)Labs team after fork block is announced";
+    printf "  %-25s %s\n" "-fc | --fork-genesis-config" "[file] Genesis config file for the fork network. It should be provied by MF or O(1)Labs team after fork block is announced";
     printf "  %-25s %s\n" "-d | --delete-blocks" "delete blocks after they are processed (saves space with -sb)"
     printf "  %-25s %s\n" "-p | --prefetch-blocks" "downloads all blocks at once instead of incrementally"
     echo ""
     echo "Example:"
     echo ""
-    echo "  " $CLI_NAME final --replayer-checkpoint migration-replayer-checkpoint-1233.json --genesis-ledger "genesis_ledgers/mainnet.json" --source-db "postgres://postgres:pass@localhost:5432/archive_balances_migrated" --target-db "postgres://postgres:pass@localhost:5432/migrated" --blocks-batch-size 10 --blocks-bucket "mina_network_block_data" --network "mainnet" --fork-config fork_config.json 
+    echo "  " $CLI_NAME final --replayer-checkpoint migration-replayer-checkpoint-1233.json --genesis-ledger "genesis_ledgers/mainnet.json" --source-db "postgres://postgres:pass@localhost:5432/archive_balances_migrated" --target-db "postgres://postgres:pass@localhost:5432/migrated" --blocks-batch-size 10 --blocks-bucket "mina_network_block_data" --network "mainnet" --fork-genesis-config fork_genesis_config.json 
     echo ""
     echo "Notes:"
     echo "  1. After run migrated data will be filled with migrated blocks till last block in source db"
@@ -573,7 +573,7 @@ function final(){
     local __stream_blocks=true
     local __network='' 
     local __checkpoint_interval=1000
-    local __fork_config=''
+    local __fork_genesis_config=''
     
     while [ ${#} -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -585,8 +585,8 @@ function final(){
                 __genesis_ledger=${2:?$error_message}
                 shift 2;
             ;;
-            -fc | --fork-config )
-                __fork_config=${2:?$error_message}
+            -fc | --fork-genesis-config )
+                __fork_genesis_config=${2:?$error_message}
                 shift 2;
             ;;
             -r | --replayer-checkpoint )
@@ -656,9 +656,9 @@ function final(){
         echo "Genesis ledger not defined"
         exit 1
     fi
-    if [ -z "$__fork_config" ]; then
+    if [ -z "$__fork_genesis_config" ]; then
         echo ""
-        echo "Fork config file is not defined. Please refer to mina or o(1) Labs team announcements regarding fork block state hash"
+        echo "Fork genesis config file is not defined. Please refer to mina or o(1) Labs team announcements regarding fork block state hash"
         echo "which is required to run final migration"
         exit 1
     fi
@@ -684,7 +684,7 @@ function final(){
         "$__network" \
         "$__checkpoint_interval" \
         "$__replayer_checkpoint" \
-        "$__fork_config"
+        "$__fork_genesis_config"
 }
 
 function run_final_migration() {
@@ -698,9 +698,9 @@ function run_final_migration() {
     local __network=$8
     local __checkpoint_interval=$9
     local __replayer_checkpoint=${10}
-    local __fork_config=${11}
+    local __fork_genesis_config=${11}
     
-    local __fork_state_hash="$(jq -r .proof.fork.state_hash "$__fork_config")"
+    local __fork_state_hash="$(jq -r .proof.fork.state_hash "$__fork_genesis_config")"
     local __date=$(date '+%Y-%m-%d_%H%M')
     local __berkely_migration_log="berkeley_migration_$__date.log"
     local __replayer_log="replayer_$__date.log"
@@ -744,7 +744,7 @@ function run_final_migration() {
     mina-berkeley-migration-verifier post-fork \
         --mainnet-archive-uri "$__mainnet_archive_uri" \
         --migrated-archive-uri "$__migrated_archive_uri" \
-        --fork-config-file "$__fork_config" \
+        --fork-genesis-config "$__fork_genesis_config" \
         --migrated-replayer-output "$migrated_replayer_output"
 
 }

--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -537,7 +537,6 @@ function final_help(){
     echo ""
     printf "  %-25s %s\n" "-h | --help" "show help";
     printf "  %-25s %s\n" "-r | --replayer-checkpoint" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-f | --fork-state-hash" "[hash] fork state hash";
     printf "  %-25s %s\n" "-s | --source-db" "[connection_str] connection string to database to be migrated";
     printf "  %-25s %s\n" "-t | --target-db" "[connection_str] connection string to database which will hold migrated data";
     printf "  %-25s %s\n" "-b | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
@@ -549,7 +548,7 @@ function final_help(){
     echo ""
     echo "Example:"
     echo ""
-    echo "  " $CLI_NAME final --replayer-checkpoint migration-replayer-checkpoint-1233.json --fork-state-hash 3NLnD1Yp4MS9LtMXikD1YyySZNVgCXA82b5eQVpmYZ5kyTo4Xsr7 --genesis-ledger "genesis_ledgers/mainnet.json" --source-db "postgres://postgres:pass@localhost:5432/archive_balances_migrated" --target-db "postgres://postgres:pass@localhost:5432/migrated" --blocks-batch-size 10 --blocks-bucket "mina_network_block_data" --network "mainnet" --fork-config fork_config.json 
+    echo "  " $CLI_NAME final --replayer-checkpoint migration-replayer-checkpoint-1233.json --genesis-ledger "genesis_ledgers/mainnet.json" --source-db "postgres://postgres:pass@localhost:5432/archive_balances_migrated" --target-db "postgres://postgres:pass@localhost:5432/migrated" --blocks-batch-size 10 --blocks-bucket "mina_network_block_data" --network "mainnet" --fork-config fork_config.json 
     echo ""
     echo "Notes:"
     echo "  1. After run migrated data will be filled with migrated blocks till last block in source db"
@@ -574,7 +573,6 @@ function final(){
     local __stream_blocks=true
     local __network='' 
     local __checkpoint_interval=1000
-    local __fork_state_hash=''
     local __fork_config=''
     
     while [ ${#} -gt 0 ]; do
@@ -585,10 +583,6 @@ function final(){
             ;;
             -g | --genesis-ledger )
                 __genesis_ledger=${2:?$error_message}
-                shift 2;
-            ;;
-            -f | --fork-state-hash )
-                __fork_state_hash=${2:?$error_message}
                 shift 2;
             ;;
             -fc | --fork-config )
@@ -662,12 +656,6 @@ function final(){
         echo "Genesis ledger not defined"
         exit 1
     fi
-    if [ -z "$__fork_state_hash" ]; then
-        echo ""
-        echo "Fork state hash not defined. Please refer to mina or o(1) Labs team announcements regarding fork block state hash"
-        echo "which is required to run final migration"
-        exit 1
-    fi
     if [ -z "$__fork_config" ]; then
         echo ""
         echo "Fork config file is not defined. Please refer to mina or o(1) Labs team announcements regarding fork block state hash"
@@ -694,7 +682,6 @@ function final(){
         "$__keep_precomputed_blocks" \
         "$__stream_blocks" \
         "$__network" \
-        "$__fork_state_hash" \
         "$__checkpoint_interval" \
         "$__replayer_checkpoint" \
         "$__fork_config"
@@ -709,12 +696,11 @@ function run_final_migration() {
     local __keep_precomputed_blocks=$6
     local __stream_blocks=$7
     local __network=$8
-    local __fork_state_hash=$9
-    local __checkpoint_interval=${10}
-    local __replayer_checkpoint=${11}
-    local __fork_config=${12}
+    local __checkpoint_interval=$9
+    local __replayer_checkpoint=${10}
+    local __fork_config=${11}
     
-    
+    local __fork_state_hash="$(jq -r .proof.fork.state_hash "$__fork_config")"
     local __date=$(date '+%Y-%m-%d_%H%M')
     local __berkely_migration_log="berkeley_migration_$__date.log"
     local __replayer_log="replayer_$__date.log"

--- a/src/app/berkeley_migration_verifier/Readme.md
+++ b/src/app/berkeley_migration_verifier/Readme.md
@@ -12,7 +12,7 @@ Application for validating migrated archive schema content. Performed checks rel
 Basic usage :
 
 ```
-mina-berkeley-migration-verifier --mainnet-archive-uri postgres://postgres:postgres@localhost:5432/source_archive --migrated-archive-uri postgres://postgres:postgres@localhost:5432/archive_migrated --migrated-replayer-output  migrated_replayer.json --fork-config-file fork_config_fixed.json 
+mina-berkeley-migration-verifier --mainnet-archive-uri postgres://postgres:postgres@localhost:5432/source_archive --migrated-archive-uri postgres://postgres:postgres@localhost:5432/archive_migrated --migrated-replayer-output  migrated_replayer.json --fork-genesis-config fork_config_fixed.json 
 ```
 
 where:
@@ -20,7 +20,7 @@ where:
 - **mainnet-archive-uri** is a connection string to original schema
 - **migrated-archive-uri** is a connection string to already migrated schema
 - **migrated-replayer-output** is an output for replayer on migrated schema
-- **fork-config-file** is a state dump with forked ledger
+- **fork-genesis-config** is a genesis config for the fork network
 
 ### Dependencies
 


### PR DESCRIPTION
Explain your changes:
* Remove redundant parameter `--fork-state-hash` from `final` step
* Use `grep '"level":"Error"'` instead of `grep Error` for checking errors in logs
* Rename `--fork-config` and `--fork-config-file` parameters in migration script/verifier to `--fork-genesis-config`

Explain how you tested your changes:
* [x] Ran the final step of migration with the script

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None