### PR TITLE
add a dummy protocol version when didn't find txn version

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -684,24 +684,35 @@ module Zkapp_permissions = struct
 
   let table_name = "zkapp_permissions"
 
-  let add_if_doesn't_exist (module Conn : CONNECTION) (perms : Permissions.t) =
+  let add_if_doesn't_exist (module Conn : CONNECTION) (perms : Permissions.t)
+      ~logger =
     let txn_version =
       Mina_numbers.Txn_version.to_int @@ snd perms.set_verification_key
     in
     let%bind versions =
       Protocol_versions.find_txn_version (module Conn) ~transaction:txn_version
     in
-    ( match versions with
-    | Ok [] ->
-        failwith
-          (sprintf "No transaction version exists for the permission, %s"
-             (Permissions.to_yojson perms |> Yojson.Safe.to_string) )
-    | Ok _ ->
-        ()
-    | Error e ->
-        failwith
-          (sprintf "fail to query protocol_versions table, see %s"
-             (Caqti_error.show e) ) ) ;
+    let%bind () =
+      match versions with
+      | Ok [] ->
+          [%log error]
+            ~metadata:[ ("perms", Permissions.to_yojson perms) ]
+            "No transaction version exists for the permission, adding a dummy \
+             version" ;
+          let%map _id =
+            Protocol_versions.add_if_doesn't_exist
+              (module Conn)
+              ~transaction:txn_version ~network:Int.max_value
+              ~patch:Int.max_value
+          in
+          ()
+      | Ok _ ->
+          return ()
+      | Error e ->
+          failwith
+            (sprintf "fail to query protocol_versions table, see %s"
+               (Caqti_error.show e) )
+    in
     let value =
       { edit_state = perms.edit_state
       ; send = perms.send
@@ -835,7 +846,7 @@ module Zkapp_updates = struct
   let table_name = "zkapp_updates"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
-      (update : Account_update.Update.t) =
+      (update : Account_update.Update.t) ~logger =
     let open Deferred.Result.Let_syntax in
     let%bind app_state_id =
       Vector.map ~f:Zkapp_basic.Set_or_keep.to_option update.app_state
@@ -853,7 +864,7 @@ module Zkapp_updates = struct
     in
     let%bind permissions_id =
       Mina_caqti.add_if_zkapp_set
-        (Zkapp_permissions.add_if_doesn't_exist (module Conn))
+        (Zkapp_permissions.add_if_doesn't_exist (module Conn) ~logger)
         update.permissions
     in
     let%bind timing_id =
@@ -1652,7 +1663,7 @@ module Zkapp_account_update_body = struct
 
   let table_name = "zkapp_account_update_body"
 
-  let add_if_doesn't_exist (module Conn : CONNECTION)
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~logger
       (body : Account_update.Body.Simple.t) =
     let open Deferred.Result.Let_syntax in
     let account_identifier = Account_id.create body.public_key body.token_id in
@@ -1661,7 +1672,8 @@ module Zkapp_account_update_body = struct
     in
     let%bind update_id =
       Metrics.time ~label:"zkapp_updates.add"
-      @@ fun () -> Zkapp_updates.add_if_doesn't_exist (module Conn) body.update
+      @@ fun () ->
+      Zkapp_updates.add_if_doesn't_exist (module Conn) body.update ~logger
     in
     let increment_nonce = body.increment_nonce in
     let%bind events_id =
@@ -1768,7 +1780,7 @@ module Zkapp_account_update = struct
 
   let table_name = "zkapp_account_update"
 
-  let add_if_doesn't_exist (module Conn : CONNECTION)
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~logger
       (account_update : Account_update.Simple.t) =
     let open Deferred.Result.Let_syntax in
     let%bind body_id =
@@ -1776,7 +1788,7 @@ module Zkapp_account_update = struct
       @@ fun () ->
       Zkapp_account_update_body.add_if_doesn't_exist
         (module Conn)
-        account_update.body
+        ~logger account_update.body
     in
     let value = { body_id } in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
@@ -2077,7 +2089,8 @@ module User_command = struct
         @@ Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names )
         id
 
-    let add_if_doesn't_exist (module Conn : CONNECTION) (ps : Zkapp_command.t) =
+    let add_if_doesn't_exist ~logger (module Conn : CONNECTION)
+        (ps : Zkapp_command.t) =
       let open Deferred.Result.Let_syntax in
       let zkapp_command = Zkapp_command.to_simple ps in
       let%bind zkapp_fee_payer_body_id =
@@ -2091,7 +2104,7 @@ module User_command = struct
         Metrics.time ~label:"Zkapp_account_update.add"
         @@ fun () ->
         Mina_caqti.deferred_result_list_map zkapp_command.account_updates
-          ~f:(Zkapp_account_update.add_if_doesn't_exist (module Conn))
+          ~f:(Zkapp_account_update.add_if_doesn't_exist (module Conn) ~logger)
         >>| Array.of_list
       in
       let memo = ps.memo |> Signed_command_memo.to_base58_check in
@@ -2114,13 +2127,14 @@ module User_command = struct
     | Zkapp_command _ ->
         `Zkapp_command
 
-  let add_if_doesn't_exist conn (t : User_command.t) ~v1_transaction_hash =
+  let add_if_doesn't_exist conn (t : User_command.t) ~logger
+      ~v1_transaction_hash =
     match t with
     | Signed_command sc ->
         Signed_command.add_if_doesn't_exist conn ~via:(via t)
           ~v1_transaction_hash sc
     | Zkapp_command ps ->
-        Zkapp_command.add_if_doesn't_exist conn ps
+        Zkapp_command.add_if_doesn't_exist conn ps ~logger
 
   let find conn ~(transaction_hash : Transaction_hash.t) ~v1_transaction_hash =
     let open Deferred.Result.Let_syntax in
@@ -2717,7 +2731,7 @@ module Accounts_accessed = struct
             comma_cols table_name ) )
       (block_id, account_identifier_id)
 
-  let add_if_doesn't_exist (module Conn : CONNECTION) block_id
+  let add_if_doesn't_exist ~logger (module Conn : CONNECTION) block_id
       (ledger_index, (account : Account.t)) =
     let open Deferred.Result.Let_syntax in
     let account_id = Account_id.create account.public_key account.token_id in
@@ -2754,7 +2768,7 @@ module Accounts_accessed = struct
         let%bind permissions_id =
           Zkapp_permissions.add_if_doesn't_exist
             (module Conn)
-            account.permissions
+            ~logger account.permissions
         in
         let%bind zkapp_id =
           Mina_caqti.add_if_some
@@ -2782,11 +2796,11 @@ module Accounts_accessed = struct
           (module Conn)
           account_accessed
 
-  let add_accounts_if_don't_exist (module Conn : CONNECTION) block_id
+  let add_accounts_if_don't_exist ~logger (module Conn : CONNECTION) block_id
       (accounts : (int * Account.t) list) =
     let%map results =
       Deferred.List.map accounts ~f:(fun account ->
-          add_if_doesn't_exist (module Conn) block_id account )
+          add_if_doesn't_exist (module Conn) block_id account ~logger )
     in
     Result.all results
 
@@ -2912,7 +2926,8 @@ module Block = struct
 
   let add_parts_if_doesn't_exist (module Conn : CONNECTION)
       ~constraint_constants ~protocol_state ~staged_ledger_diff
-      ~protocol_version ~proposed_protocol_version ~hash ~v1_transaction_hash =
+      ~protocol_version ~proposed_protocol_version ~hash ~v1_transaction_hash
+      ~logger =
     let open Deferred.Result.Let_syntax in
     match%bind find_opt (module Conn) ~state_hash:hash with
     | Some block_id ->
@@ -3089,7 +3104,7 @@ module Block = struct
                 let%bind id =
                   User_command.add_if_doesn't_exist
                     (module Conn)
-                    ~v1_transaction_hash user_command.data
+                    ~logger ~v1_transaction_hash user_command.data
                 in
                 let%map () =
                   match command with
@@ -4079,7 +4094,7 @@ module Block = struct
 
     return ()
 
-  let add_from_extensional (module Conn : CONNECTION)
+  let add_from_extensional ~logger (module Conn : CONNECTION)
       ?(v1_transaction_hash = false) (block : Extensional.Block.t) =
     let open Deferred.Result.Let_syntax in
     let%bind block_id =
@@ -4260,6 +4275,7 @@ module Block = struct
             let%map cmd_id =
               User_command.Zkapp_command.add_if_doesn't_exist
                 (module Conn)
+                ~logger
                 (Zkapp_command.of_simple { fee_payer; account_updates; memo })
             in
             (zkapp_cmd, cmd_id) :: acc )
@@ -4286,7 +4302,7 @@ module Block = struct
     let%bind _block_and_account_ids =
       Accounts_accessed.add_accounts_if_don't_exist
         (module Conn)
-        block_id block.accounts_accessed
+        ~logger block_id block.accounts_accessed
     in
     (* add accounts created *)
     let%bind _block_and_pk_ids =
@@ -4640,7 +4656,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                     (fun (module Conn : CONNECTION) ->
                       Accounts_accessed.add_accounts_if_don't_exist
                         (module Conn)
-                        block_id accounts_accessed )
+                        ~logger block_id accounts_accessed )
                     pool
                 with
                 | Error err ->
@@ -4698,7 +4714,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
 let add_block_aux_precomputed ~constraint_constants ~logger ?retries ~pool
     ~delete_older_than block =
   add_block_aux ~logger ?retries ~pool ~delete_older_than
-    ~add_block:(Block.add_from_precomputed ~constraint_constants)
+    ~add_block:(Block.add_from_precomputed ~constraint_constants ~logger)
     ~hash:(fun block ->
       (block.Precomputed.protocol_state |> Protocol_state.hashes).state_hash )
     ~accounts_accessed:block.Precomputed.accounts_accessed
@@ -4708,7 +4724,7 @@ let add_block_aux_precomputed ~constraint_constants ~logger ?retries ~pool
 (* used by `archive_blocks` app *)
 let add_block_aux_extensional ~logger ?retries ~pool ~delete_older_than block =
   add_block_aux ~logger ?retries ~pool ~delete_older_than
-    ~add_block:(Block.add_from_extensional ~v1_transaction_hash:false)
+    ~add_block:(Block.add_from_extensional ~v1_transaction_hash:false ~logger)
     ~hash:(fun (block : Extensional.Block.t) -> block.state_hash)
     ~accounts_accessed:block.Extensional.Block.accounts_accessed
     ~accounts_created:block.Extensional.Block.accounts_created
@@ -4721,7 +4737,9 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than :
     | Diff.Transition_frontier
         (Breadcrumb_added
           { block; accounts_accessed; accounts_created; tokens_used; _ } ) -> (
-        let add_block = Block.add_if_doesn't_exist ~constraint_constants in
+        let add_block =
+          Block.add_if_doesn't_exist ~constraint_constants ~logger
+        in
         let hash = State_hash.With_state_hashes.state_hash in
         match%bind
           add_block_aux ~logger ~pool ~delete_older_than ~hash ~add_block
@@ -4805,7 +4823,7 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
                 let%bind.Deferred.Result genesis_block_id =
                   Block.add_if_doesn't_exist
                     (module Conn)
-                    ~constraint_constants genesis_block
+                    ~logger ~constraint_constants genesis_block
                 in
                 let%bind.Deferred.Result { ledger_hash; _ } =
                   Block.load (module Conn) ~id:genesis_block_id
@@ -4869,7 +4887,7 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
                           match%bind
                             Accounts_accessed.add_if_doesn't_exist
                               (module Conn)
-                              genesis_block_id (index, acct)
+                              ~logger genesis_block_id (index, acct)
                           with
                           | Ok _ ->
                               return ()

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -137,7 +137,7 @@ let%test_module "Archive node unit tests" =
           match%map
             let open Deferred.Result.Let_syntax in
             let%bind user_command_id =
-              Processor.User_command.add_if_doesn't_exist conn
+              Processor.User_command.add_if_doesn't_exist conn ~logger
                 ~v1_transaction_hash:false user_command
             in
             let%map result =
@@ -197,7 +197,7 @@ let%test_module "Archive node unit tests" =
               match%map
                 let open Deferred.Result.Let_syntax in
                 let%bind user_command_id =
-                  Processor.User_command.add_if_doesn't_exist conn
+                  Processor.User_command.add_if_doesn't_exist conn ~logger
                     ~v1_transaction_hash:false user_command
                 in
                 let%map result =

--- a/src/app/berkeley_migration/berkeley_migration.ml
+++ b/src/app/berkeley_migration/berkeley_migration.ml
@@ -313,7 +313,7 @@ let migrate_genesis_balances ~logger ~precomputed_values ~migrated_pool =
             query_migrated_db ~f:(fun db ->
                 match%map
                   Archive_lib.Processor.Accounts_accessed.add_if_doesn't_exist
-                    db genesis_block_id (index, acct)
+                    db genesis_block_id (index, acct) ~logger
                 with
                 | Ok _ ->
                     Ok ()

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1497,7 +1497,7 @@ let main ~input_file ~output_file_opt ~migration_mode ~archive_uri
                         let acct = Ledger.get_at_index_exn ledger index in
                         query_db ~f:(fun db ->
                             Processor.Accounts_accessed.add_if_doesn't_exist db
-                              last_block_id (index, acct) )
+                              last_block_id (index, acct) ~logger )
                         |> Deferred.ignore_m ) )
                   else (
                     check_ledger_hash_at_slot state_hash ledger_hash ;


### PR DESCRIPTION
Explain how you tested your changes:
When adding permissions, if we found a txn version is not in the database, then add a dummy protocol version with (txn_version, max_int, max_int) to the database.
This should fix the broken hard fork integration test.
And it would also allow users to start an archive node without migrated database.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
