### PR TITLE
Don't check the transaction version when adding accounts

### DIFF
--- a/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
+++ b/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
@@ -979,7 +979,7 @@ index 8b90db5952..313b424f55 100644
  
    let typ =
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-@@ -682,14 +931,58 @@ module Zkapp_permissions = struct
+@@ -682,9 +931,51 @@ module Zkapp_permissions = struct
        ; auth_required_typ
        ]
  
@@ -1029,18 +1029,10 @@ index 8b90db5952..313b424f55 100644
 +
 +  let add_if_doesn't_exist (module Conn : Mina_caqti.CONNECTION)
 +      (perms : Permissions.t) =
-     let txn_version =
-       Mina_numbers.Txn_version.to_int @@ snd perms.set_verification_key
-     in
-     let%bind versions =
--      Protocol_versions.find_txn_version (module Conn) ~transaction:txn_version
-+      Protocol_versions.find_by_txn_version
-+        (module Conn)
-+        ~transaction:txn_version
-     in
-     ( match versions with
-     | Ok [] ->
-@@ -720,16 +1013,21 @@ module Zkapp_permissions = struct
+     let value =
+       { edit_state = perms.edit_state
+       ; send = perms.send
+@@ -703,16 +994,21 @@ module Zkapp_permissions = struct
        ; set_timing = perms.set_timing
        }
      in
@@ -1071,7 +1063,7 @@ index 8b90db5952..313b424f55 100644
  end
  
  module Zkapp_timing_info = struct
-@@ -748,7 +1046,7 @@ module Zkapp_timing_info = struct
+@@ -731,7 +1027,7 @@ module Zkapp_timing_info = struct
  
    let table_name = "zkapp_timing_info"
  
@@ -1080,7 +1072,7 @@ index 8b90db5952..313b424f55 100644
        (timing_info : Account_update.Update.Timing_info.t) =
      let initial_minimum_balance =
        Currency.Balance.to_string timing_info.initial_minimum_balance
-@@ -778,9 +1076,9 @@ module Zkapp_timing_info = struct
+@@ -761,9 +1057,9 @@ module Zkapp_timing_info = struct
        (module Conn)
        value
  
@@ -1092,7 +1084,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -792,16 +1090,16 @@ module Zkapp_uri = struct
+@@ -775,16 +1071,16 @@ module Zkapp_uri = struct
  
    let table_name = "zkapp_uris"
  
@@ -1112,7 +1104,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "value" ]) )
        id
  end
-@@ -834,7 +1132,7 @@ module Zkapp_updates = struct
+@@ -817,7 +1113,7 @@ module Zkapp_updates = struct
  
    let table_name = "zkapp_updates"
  
@@ -1121,7 +1113,7 @@ index 8b90db5952..313b424f55 100644
        (update : Account_update.Update.t) =
      let open Deferred.Result.Let_syntax in
      let%bind app_state_id =
-@@ -892,9 +1190,9 @@ module Zkapp_updates = struct
+@@ -875,9 +1171,9 @@ module Zkapp_updates = struct
        (module Conn)
        value
  
@@ -1133,7 +1125,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -909,7 +1207,7 @@ module Zkapp_balance_bounds = struct
+@@ -892,7 +1188,7 @@ module Zkapp_balance_bounds = struct
  
    let table_name = "zkapp_balance_bounds"
  
@@ -1142,7 +1134,7 @@ index 8b90db5952..313b424f55 100644
        (balance_bounds :
          Currency.Balance.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let balance_lower_bound = Currency.Balance.to_string balance_bounds.lower in
-@@ -920,9 +1218,9 @@ module Zkapp_balance_bounds = struct
+@@ -903,9 +1199,9 @@ module Zkapp_balance_bounds = struct
        (module Conn)
        value
  
@@ -1154,7 +1146,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -937,7 +1235,7 @@ module Zkapp_nonce_bounds = struct
+@@ -920,7 +1216,7 @@ module Zkapp_nonce_bounds = struct
  
    let table_name = "zkapp_nonce_bounds"
  
@@ -1163,7 +1155,7 @@ index 8b90db5952..313b424f55 100644
        (nonce_bounds :
          Mina_numbers.Account_nonce.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -949,9 +1247,9 @@ module Zkapp_nonce_bounds = struct
+@@ -932,9 +1228,9 @@ module Zkapp_nonce_bounds = struct
        (module Conn)
        value
  
@@ -1175,7 +1167,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -984,7 +1282,7 @@ module Zkapp_account_precondition = struct
+@@ -967,7 +1263,7 @@ module Zkapp_account_precondition = struct
  
    let table_name = "zkapp_account_precondition"
  
@@ -1184,7 +1176,7 @@ index 8b90db5952..313b424f55 100644
        (acct : Zkapp_precondition.Account.t) =
      let open Deferred.Result.Let_syntax in
      let%bind balance_id =
-@@ -1033,9 +1331,9 @@ module Zkapp_account_precondition = struct
+@@ -1016,9 +1312,9 @@ module Zkapp_account_precondition = struct
        (module Conn)
        value
  
@@ -1196,7 +1188,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1050,7 +1348,7 @@ module Zkapp_token_id_bounds = struct
+@@ -1033,7 +1329,7 @@ module Zkapp_token_id_bounds = struct
  
    let table_name = "zkapp_token_id_bounds"
  
@@ -1205,7 +1197,7 @@ index 8b90db5952..313b424f55 100644
        (token_id_bounds :
          Token_id.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let token_id_lower_bound = token_id_bounds.lower |> Token_id.to_string in
-@@ -1061,9 +1359,9 @@ module Zkapp_token_id_bounds = struct
+@@ -1044,9 +1340,9 @@ module Zkapp_token_id_bounds = struct
        (module Conn)
        value
  
@@ -1217,7 +1209,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1078,7 +1376,7 @@ module Zkapp_timestamp_bounds = struct
+@@ -1061,7 +1357,7 @@ module Zkapp_timestamp_bounds = struct
  
    let table_name = "zkapp_timestamp_bounds"
  
@@ -1226,7 +1218,7 @@ index 8b90db5952..313b424f55 100644
        (timestamp_bounds :
          Block_time.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let timestamp_lower_bound =
-@@ -1093,9 +1391,9 @@ module Zkapp_timestamp_bounds = struct
+@@ -1076,9 +1372,9 @@ module Zkapp_timestamp_bounds = struct
        (module Conn)
        value
  
@@ -1238,7 +1230,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1110,7 +1408,7 @@ module Zkapp_length_bounds = struct
+@@ -1093,7 +1389,7 @@ module Zkapp_length_bounds = struct
  
    let table_name = "zkapp_length_bounds"
  
@@ -1247,7 +1239,7 @@ index 8b90db5952..313b424f55 100644
        (length_bounds :
          Unsigned.uint32 Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let length_lower_bound = Unsigned.UInt32.to_int64 length_bounds.lower in
-@@ -1121,9 +1419,9 @@ module Zkapp_length_bounds = struct
+@@ -1104,9 +1400,9 @@ module Zkapp_length_bounds = struct
        (module Conn)
        value
  
@@ -1259,7 +1251,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1138,7 +1436,7 @@ module Zkapp_amount_bounds = struct
+@@ -1121,7 +1417,7 @@ module Zkapp_amount_bounds = struct
  
    let table_name = "zkapp_amount_bounds"
  
@@ -1268,7 +1260,7 @@ index 8b90db5952..313b424f55 100644
        (amount_bounds :
          Currency.Amount.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let amount_lower_bound = Currency.Amount.to_string amount_bounds.lower in
-@@ -1149,9 +1447,9 @@ module Zkapp_amount_bounds = struct
+@@ -1132,9 +1428,9 @@ module Zkapp_amount_bounds = struct
        (module Conn)
        value
  
@@ -1280,7 +1272,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1166,7 +1464,7 @@ module Zkapp_global_slot_bounds = struct
+@@ -1149,7 +1445,7 @@ module Zkapp_global_slot_bounds = struct
  
    let table_name = "zkapp_global_slot_bounds"
  
@@ -1289,7 +1281,7 @@ index 8b90db5952..313b424f55 100644
        (global_slot_bounds :
          Mina_numbers.Global_slot_since_genesis.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -1184,38 +1482,104 @@ module Zkapp_global_slot_bounds = struct
+@@ -1167,38 +1463,104 @@ module Zkapp_global_slot_bounds = struct
        (module Conn)
        value
  
@@ -1407,7 +1399,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1224,10 +1588,10 @@ module Timing_info = struct
+@@ -1207,10 +1569,10 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1420,7 +1412,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1236,8 +1600,9 @@ module Timing_info = struct
+@@ -1219,8 +1581,9 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1432,7 +1424,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let slot_to_int64 x =
        Mina_numbers.Global_slot_since_genesis.to_uint32 x
-@@ -1268,65 +1633,46 @@ module Timing_info = struct
+@@ -1251,65 +1614,46 @@ module Timing_info = struct
            ; vesting_increment = zero
            }
      in
@@ -1514,7 +1506,7 @@ index 8b90db5952..313b424f55 100644
             "SELECT id FROM snarked_ledger_hashes WHERE value = ?" )
          hash
      with
-@@ -1334,13 +1680,13 @@ module Snarked_ledger_hash = struct
+@@ -1317,13 +1661,13 @@ module Snarked_ledger_hash = struct
          return id
      | None ->
          Conn.find
@@ -1531,7 +1523,7 @@ index 8b90db5952..313b424f55 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  end
-@@ -1355,7 +1701,7 @@ module Zkapp_epoch_ledger = struct
+@@ -1338,7 +1682,7 @@ module Zkapp_epoch_ledger = struct
  
    let table_name = "zkapp_epoch_ledger"
  
@@ -1540,7 +1532,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_ledger : _ Epoch_ledger.Poly.t) =
      let open Deferred.Result.Let_syntax in
      let%bind hash_id =
-@@ -1374,9 +1720,9 @@ module Zkapp_epoch_ledger = struct
+@@ -1357,9 +1701,9 @@ module Zkapp_epoch_ledger = struct
        (module Conn)
        value
  
@@ -1552,7 +1544,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1398,7 +1744,7 @@ module Zkapp_epoch_data = struct
+@@ -1381,7 +1725,7 @@ module Zkapp_epoch_data = struct
  
    let table_name = "zkapp_epoch_data"
  
@@ -1561,7 +1553,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_data : Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.t) =
      let open Deferred.Result.Let_syntax in
      let%bind epoch_ledger_id =
-@@ -1434,9 +1780,9 @@ module Zkapp_epoch_data = struct
+@@ -1417,9 +1761,9 @@ module Zkapp_epoch_data = struct
        (module Conn)
        value
  
@@ -1573,7 +1565,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1460,7 +1806,7 @@ module Zkapp_network_precondition = struct
+@@ -1443,7 +1787,7 @@ module Zkapp_network_precondition = struct
  
    let table_name = "zkapp_network_precondition"
  
@@ -1582,7 +1574,7 @@ index 8b90db5952..313b424f55 100644
        (ps : Mina_base.Zkapp_precondition.Protocol_state.t) =
      let open Deferred.Result.Let_syntax in
      let%bind snarked_ledger_hash_id =
-@@ -1509,9 +1855,9 @@ module Zkapp_network_precondition = struct
+@@ -1492,9 +1836,9 @@ module Zkapp_network_precondition = struct
        (module Conn)
        value
  
@@ -1594,7 +1586,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1545,7 +1891,7 @@ module Zkapp_events = struct
+@@ -1528,7 +1872,7 @@ module Zkapp_events = struct
       7. use "M'" and the list of list of field_ids to compute the list of field_array_ids
       8. insert the list of field_arrays
    *)
@@ -1603,7 +1595,7 @@ index 8b90db5952..313b424f55 100644
        (events : Account_update.Body.Events'.t) =
      let open Deferred.Result.Let_syntax in
      let%bind field_array_id_list =
-@@ -1601,9 +1947,9 @@ module Zkapp_events = struct
+@@ -1584,9 +1928,9 @@ module Zkapp_events = struct
        (module Conn)
        field_array_id_list
  
@@ -1615,7 +1607,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]) )
        id
  end
-@@ -1652,7 +1998,7 @@ module Zkapp_account_update_body = struct
+@@ -1635,7 +1979,7 @@ module Zkapp_account_update_body = struct
  
    let table_name = "zkapp_account_update_body"
  
@@ -1624,7 +1616,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let account_identifier = Account_id.create body.public_key body.token_id in
-@@ -1753,9 +2099,9 @@ module Zkapp_account_update_body = struct
+@@ -1736,9 +2080,9 @@ module Zkapp_account_update_body = struct
        (module Conn)
        value
  
@@ -1636,7 +1628,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1768,7 +2114,7 @@ module Zkapp_account_update = struct
+@@ -1751,7 +2095,7 @@ module Zkapp_account_update = struct
  
    let table_name = "zkapp_account_update"
  
@@ -1645,7 +1637,7 @@ index 8b90db5952..313b424f55 100644
        (account_update : Account_update.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let%bind body_id =
-@@ -1784,9 +2130,9 @@ module Zkapp_account_update = struct
+@@ -1767,9 +2111,9 @@ module Zkapp_account_update = struct
        (module Conn)
        value
  
@@ -1657,7 +1649,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1806,7 +2152,7 @@ module Zkapp_fee_payer_body = struct
+@@ -1789,7 +2133,7 @@ module Zkapp_fee_payer_body = struct
  
    let table_name = "zkapp_fee_payer_body"
  
@@ -1666,7 +1658,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Fee_payer.t) =
      let open Deferred.Result.Let_syntax in
      let%bind public_key_id =
-@@ -1828,9 +2174,9 @@ module Zkapp_fee_payer_body = struct
+@@ -1811,9 +2155,9 @@ module Zkapp_fee_payer_body = struct
        (module Conn)
        value
  
@@ -1678,7 +1670,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1857,7 +2203,7 @@ module Epoch_data = struct
+@@ -1840,7 +2184,7 @@ module Epoch_data = struct
  
    let table_name = "epoch_data"
  
@@ -1687,7 +1679,7 @@ index 8b90db5952..313b424f55 100644
        (t : Mina_base.Epoch_data.Value.t) =
      let open Deferred.Result.Let_syntax in
      let Mina_base.Epoch_ledger.Poly.{ hash; total_currency } =
-@@ -1885,9 +2231,9 @@ module Epoch_data = struct
+@@ -1868,9 +2212,9 @@ module Epoch_data = struct
        ; epoch_length
        }
  
@@ -1699,7 +1691,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1925,22 +2271,22 @@ module User_command = struct
+@@ -1908,22 +2252,22 @@ module User_command = struct
  
      let table_name = "user_commands"
  
@@ -1728,7 +1720,7 @@ index 8b90db5952..313b424f55 100644
          (t : Signed_command.t) =
        let open Deferred.Result.Let_syntax in
        let%bind fee_payer_id =
-@@ -1953,8 +2299,9 @@ module User_command = struct
+@@ -1936,8 +2280,9 @@ module User_command = struct
        in
        { fee_payer_id; receiver_id }
  
@@ -1740,7 +1732,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let transaction_hash = Transaction_hash.hash_command (Signed_command t) in
        match%bind find (module Conn) ~transaction_hash ~v1_transaction_hash with
-@@ -1978,7 +2325,7 @@ module User_command = struct
+@@ -1961,7 +2306,7 @@ module User_command = struct
            in
            (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
            Conn.find
@@ -1749,7 +1741,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2005,7 +2352,7 @@ module User_command = struct
+@@ -1988,7 +2333,7 @@ module User_command = struct
                  |> txn_hash_to_base58_check ~v1_transaction_hash
              }
  
@@ -1758,7 +1750,7 @@ index 8b90db5952..313b424f55 100644
          ?(v1_transaction_hash = false) (user_cmd : Extensional.User_command.t) =
        let open Deferred.Result.Let_syntax in
        match%bind
-@@ -2025,7 +2372,7 @@ module User_command = struct
+@@ -2008,7 +2353,7 @@ module User_command = struct
              Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
            in
            Conn.find
@@ -1767,7 +1759,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2063,21 +2410,22 @@ module User_command = struct
+@@ -2046,21 +2391,22 @@ module User_command = struct
  
      let table_name = "zkapp_commands"
  
@@ -1795,7 +1787,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let zkapp_command = Zkapp_command.to_simple ps in
        let%bind zkapp_fee_payer_body_id =
-@@ -2146,11 +2494,12 @@ module Internal_command = struct
+@@ -2129,11 +2475,12 @@ module Internal_command = struct
  
    let table_name = "internal_commands"
  
@@ -1812,7 +1804,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.int
           (Mina_caqti.select_cols ~select:"id" ~table_name
              ~tannot:(function
-@@ -2159,13 +2508,13 @@ module Internal_command = struct
+@@ -2142,13 +2489,13 @@ module Internal_command = struct
        ( txn_hash_to_base58_check ~v1_transaction_hash transaction_hash
        , command_type )
  
@@ -1829,7 +1821,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false)
        (internal_cmd : Extensional.Internal_command.t) =
      let open Deferred.Result.Let_syntax in
-@@ -2182,7 +2531,7 @@ module Internal_command = struct
+@@ -2165,7 +2512,7 @@ module Internal_command = struct
            Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
          in
          Conn.find
@@ -1838,7 +1830,7 @@ index 8b90db5952..313b424f55 100644
               (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                  ~tannot:(function
                    | "command_type" -> Some "internal_command_type" | _ -> None
-@@ -2227,10 +2576,10 @@ module Fee_transfer = struct
+@@ -2210,10 +2557,10 @@ module Fee_transfer = struct
        in
        Ok { kind; receiver_id; fee; hash }
      in
@@ -1851,7 +1843,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Fee_transfer.Single.t)
        (kind : [ `Normal | `Via_coinbase ]) =
      let open Deferred.Result.Let_syntax in
-@@ -2249,7 +2598,7 @@ module Fee_transfer = struct
+@@ -2232,7 +2579,7 @@ module Fee_transfer = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1860,7 +1852,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2277,10 +2626,10 @@ module Coinbase = struct
+@@ -2260,10 +2607,10 @@ module Coinbase = struct
      let decode (_, receiver_id, amount, hash) =
        Ok { receiver_id; amount; hash }
      in
@@ -1873,7 +1865,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Coinbase.t) =
      let open Deferred.Result.Let_syntax in
      let transaction_hash = Transaction_hash.hash_coinbase t in
-@@ -2298,7 +2647,7 @@ module Coinbase = struct
+@@ -2281,7 +2628,7 @@ module Coinbase = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1882,7 +1874,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2330,14 +2679,14 @@ module Block_and_internal_command = struct
+@@ -2313,14 +2660,14 @@ module Block_and_internal_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; int; string; option string ]
  
@@ -1900,7 +1892,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_internal_commands
                   (block_id,
                   internal_command_id,
-@@ -2355,11 +2704,11 @@ module Block_and_internal_command = struct
+@@ -2338,11 +2685,11 @@ module Block_and_internal_command = struct
        ; failure_reason
        }
  
@@ -1915,7 +1907,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.string
           {sql| SELECT 'exists' FROM blocks_internal_commands
                 WHERE block_id = $1
-@@ -2369,7 +2718,7 @@ module Block_and_internal_command = struct
+@@ -2352,7 +2699,7 @@ module Block_and_internal_command = struct
           |sql} )
        (block_id, internal_command_id, sequence_no, secondary_sequence_no)
  
@@ -1924,7 +1916,7 @@ index 8b90db5952..313b424f55 100644
        ~internal_command_id ~sequence_no ~secondary_sequence_no ~status
        ~failure_reason =
      let open Deferred.Result.Let_syntax in
-@@ -2386,12 +2735,12 @@ module Block_and_internal_command = struct
+@@ -2369,12 +2716,12 @@ module Block_and_internal_command = struct
            ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
            ~status ~failure_reason
  
@@ -1940,7 +1932,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_internal_commands
-@@ -2420,13 +2769,13 @@ module Block_and_signed_command = struct
+@@ -2403,13 +2750,13 @@ module Block_and_signed_command = struct
  
    let table_name = "blocks_user_commands"
  
@@ -1957,7 +1949,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_user_commands
                   (block_id,
                   user_command_id,
-@@ -2437,8 +2786,8 @@ module Block_and_signed_command = struct
+@@ -2420,8 +2767,8 @@ module Block_and_signed_command = struct
           |sql} )
        { block_id; user_command_id; sequence_no; status; failure_reason }
  
@@ -1968,7 +1960,7 @@ index 8b90db5952..313b424f55 100644
      let status_str, failure_reason =
        match status with
        | Applied ->
-@@ -2451,13 +2800,13 @@ module Block_and_signed_command = struct
+@@ -2434,13 +2781,13 @@ module Block_and_signed_command = struct
        (module Conn)
        ~block_id ~user_command_id ~sequence_no ~status:status_str ~failure_reason
  
@@ -1986,7 +1978,7 @@ index 8b90db5952..313b424f55 100644
             Caqti_type.string
             {sql| SELECT 'exists' FROM blocks_user_commands
                   WHERE block_id = $1
-@@ -2473,11 +2822,12 @@ module Block_and_signed_command = struct
+@@ -2456,11 +2803,12 @@ module Block_and_signed_command = struct
            (module Conn)
            ~block_id ~user_command_id ~sequence_no ~status ~failure_reason
  
@@ -2002,7 +1994,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_user_commands
-@@ -2498,7 +2848,8 @@ module Zkapp_account_update_failures = struct
+@@ -2481,7 +2829,8 @@ module Zkapp_account_update_failures = struct
  
    let table_name = "zkapp_account_update_failures"
  
@@ -2012,7 +2004,7 @@ index 8b90db5952..313b424f55 100644
      let failures =
        List.map failures ~f:Transaction_status.Failure.to_string |> Array.of_list
      in
-@@ -2509,9 +2860,9 @@ module Zkapp_account_update_failures = struct
+@@ -2492,9 +2841,9 @@ module Zkapp_account_update_failures = struct
        (module Conn)
        { index; failures }
  
@@ -2024,7 +2016,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name
              ~cols:[ "index"; "failures" ] ) )
        id
-@@ -2533,7 +2884,7 @@ module Block_and_zkapp_command = struct
+@@ -2516,7 +2865,7 @@ module Block_and_zkapp_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; string; option Mina_caqti.array_int_typ ]
  
@@ -2033,7 +2025,7 @@ index 8b90db5952..313b424f55 100644
        ~zkapp_command_id ~sequence_no ~status
        ~(failure_reasons : Transaction_status.Failure.Collection.Display.t option)
        =
-@@ -2554,8 +2905,7 @@ module Block_and_zkapp_command = struct
+@@ -2537,8 +2886,7 @@ module Block_and_zkapp_command = struct
      in
      Mina_caqti.select_insert_into_cols
        ~select:
@@ -2043,7 +2035,7 @@ index 8b90db5952..313b424f55 100644
        ~table_name
        ~cols:
          ( [ "block_id"
-@@ -2575,21 +2925,22 @@ module Block_and_zkapp_command = struct
+@@ -2558,21 +2906,22 @@ module Block_and_zkapp_command = struct
        (module Conn)
        { block_id; zkapp_command_id; sequence_no; status; failure_reasons_ids }
  
@@ -2071,7 +2063,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2613,7 +2964,7 @@ module Zkapp_account = struct
+@@ -2596,7 +2945,7 @@ module Zkapp_account = struct
  
    let table_name = "zkapp_accounts"
  
@@ -2080,7 +2072,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let ({ app_state
           ; verification_key
-@@ -2659,9 +3010,9 @@ module Zkapp_account = struct
+@@ -2642,9 +2991,9 @@ module Zkapp_account = struct
        ; zkapp_uri_id
        }
  
@@ -2092,7 +2084,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -2702,11 +3053,31 @@ module Accounts_accessed = struct
+@@ -2685,11 +3034,31 @@ module Accounts_accessed = struct
  
    let table_name = "accounts_accessed"
  
@@ -2127,7 +2119,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s
-@@ -2717,72 +3088,71 @@ module Accounts_accessed = struct
+@@ -2700,72 +3069,71 @@ module Accounts_accessed = struct
              comma_cols table_name ) )
        (block_id, account_identifier_id)
  
@@ -2257,7 +2249,7 @@ index 8b90db5952..313b424f55 100644
        (accounts : (int * Account.t) list) =
      let%map results =
        Deferred.List.map accounts ~f:(fun account ->
-@@ -2790,10 +3160,10 @@ module Accounts_accessed = struct
+@@ -2773,10 +3141,10 @@ module Accounts_accessed = struct
      in
      Result.all results
  
@@ -2270,7 +2262,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~select:comma_cols ~table_name
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2810,30 +3180,30 @@ module Accounts_created = struct
+@@ -2793,30 +3161,30 @@ module Accounts_created = struct
  
    let table_name = "accounts_created"
  
@@ -2308,7 +2300,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT block_id, account_identifier_id, creation_fee
                 FROM accounts_created
                 WHERE block_id = ?
-@@ -2899,18 +3269,19 @@ module Block = struct
+@@ -2882,18 +3250,19 @@ module Block = struct
           "SELECT id FROM blocks WHERE state_hash = ?" )
        (State_hash.to_base58_check state_hash)
  
@@ -2334,7 +2326,7 @@ index 8b90db5952..313b424f55 100644
        ~constraint_constants ~protocol_state ~staged_ledger_diff
        ~protocol_version ~proposed_protocol_version ~hash ~v1_transaction_hash =
      let open Deferred.Result.Let_syntax in
-@@ -3011,7 +3382,7 @@ module Block = struct
+@@ -2994,7 +3363,7 @@ module Block = struct
          let blockchain_state = Protocol_state.blockchain_state protocol_state in
          let%bind block_id =
            Conn.find
@@ -2343,7 +2335,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "chain_status" ->
-@@ -3331,7 +3702,7 @@ module Block = struct
+@@ -3314,7 +3683,7 @@ module Block = struct
  
    (* NB: this batching logic an lead to partial writes; it is acceptable to be used with the
       migration tool, but not acceptable to be used with the archive node in its current form *)
@@ -2352,7 +2344,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (blocks : Extensional.Block.t list) =
      let open Deferred.Result.Let_syntax in
      (* zkapps are currently unsupported in the batch implementation of this function *)
-@@ -3393,9 +3764,7 @@ module Block = struct
+@@ -3376,9 +3745,7 @@ module Block = struct
      in
  
      (* we don't need to specify all types here, just the ones that sql may infer incorrectly *)
@@ -2363,7 +2355,7 @@ index 8b90db5952..313b424f55 100644
        | Bool ->
            Some "BOOL"
        | Int ->
-@@ -3408,39 +3777,36 @@ module Block = struct
+@@ -3391,39 +3758,36 @@ module Block = struct
            Some "BIGINT"
        | Float ->
            Some "FLOAT"
@@ -2422,7 +2414,7 @@ index 8b90db5952..313b424f55 100644
        match typ with
        | Bool ->
            Bool.to_string value
-@@ -3468,45 +3834,30 @@ module Block = struct
+@@ -3451,45 +3815,30 @@ module Block = struct
            (* we are ignoring the enum annotation in this context because it's not always valid to apply *)
            (* NOTE: we assume enum values do not contain special characters (eg "'") *)
            "'" ^ value ^ "'"
@@ -2490,7 +2482,7 @@ index 8b90db5952..313b424f55 100644
      in
      let render_row (type a) (typ : a Caqti_type.t) (value : a) : string =
        "(" ^ String.concat ~sep:"," (render_type typ value) ^ ")"
-@@ -3557,8 +3908,8 @@ module Block = struct
+@@ -3540,8 +3889,8 @@ module Block = struct
          in
          let%map entries =
            Conn.collect_list
@@ -2501,7 +2493,7 @@ index 8b90db5952..313b424f55 100644
                 query )
              ()
          in
-@@ -3576,7 +3927,7 @@ module Block = struct
+@@ -3559,7 +3908,7 @@ module Block = struct
            String.concat ~sep:"," @@ List.map ~f:(render_row typ) values
          in
          Conn.collect_list
@@ -2510,7 +2502,7 @@ index 8b90db5952..313b424f55 100644
               (sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table
                  fields_sql values_sql ) )
            () )
-@@ -3928,7 +4279,7 @@ module Block = struct
+@@ -3911,7 +4260,7 @@ module Block = struct
        let ids_sql = String.concat ~sep:"," ids in
        let parent_ids_sql = String.concat ~sep:"," parent_ids in
        Conn.exec
@@ -2519,7 +2511,7 @@ index 8b90db5952..313b424f55 100644
             (sprintf
                "UPDATE %s AS b SET parent_id = data.parent_id FROM (SELECT \
                 unnest(array[%s]) as id, unnest(array[%s]) as parent_id) AS \
-@@ -4079,7 +4430,7 @@ module Block = struct
+@@ -4062,7 +4411,7 @@ module Block = struct
  
      return ()
  
@@ -2528,7 +2520,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (block : Extensional.Block.t) =
      let open Deferred.Result.Let_syntax in
      let%bind block_id =
-@@ -4138,7 +4489,7 @@ module Block = struct
+@@ -4121,7 +4470,7 @@ module Block = struct
                  Some id )
            in
            Conn.find
@@ -2537,7 +2529,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "sub_window_densities" ->
-@@ -4296,18 +4647,19 @@ module Block = struct
+@@ -4279,18 +4628,19 @@ module Block = struct
      in
      return block_id
  
@@ -2561,7 +2553,7 @@ index 8b90db5952..313b424f55 100644
      (* derive query from type `t` *)
      let concat = String.concat ~sep:"," in
      let columns_with_id = concat ("id" :: Fields.names) in
-@@ -4316,8 +4668,8 @@ module Block = struct
+@@ -4299,8 +4649,8 @@ module Block = struct
      in
      let columns = concat Fields.names in
      Conn.collect_list
@@ -2572,7 +2564,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| WITH RECURSIVE chain AS (
-@@ -4341,39 +4693,42 @@ module Block = struct
+@@ -4324,39 +4674,42 @@ module Block = struct
              columns_with_id b_columns_with_id columns ) )
        (end_block_id, start_block_id)
  
@@ -2629,7 +2621,7 @@ index 8b90db5952..313b424f55 100644
           {sql| UPDATE blocks SET chain_status='orphaned'
                 WHERE height = $2
                 AND state_hash <> $1
-@@ -4381,7 +4736,7 @@ module Block = struct
+@@ -4364,7 +4717,7 @@ module Block = struct
        (state_hash, height)
  
    (* update chain_status for blocks now known to be canonical or orphaned *)
@@ -2638,7 +2630,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      match%bind get_highest_canonical_block_opt (module Conn) () with
      | None ->
-@@ -4453,7 +4808,7 @@ module Block = struct
+@@ -4436,7 +4789,7 @@ module Block = struct
            Deferred.Result.return ()
  
    let delete_if_older_than ?height ?num_blocks ?timestamp
@@ -2647,7 +2639,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let%bind height =
        match (height, num_blocks) with
-@@ -4462,7 +4817,7 @@ module Block = struct
+@@ -4445,7 +4798,7 @@ module Block = struct
        | None, Some num_blocks -> (
            match%map
              Conn.find_opt
@@ -2656,7 +2648,7 @@ index 8b90db5952..313b424f55 100644
                   "SELECT MAX(height) FROM blocks" )
                ()
            with
-@@ -4478,8 +4833,8 @@ module Block = struct
+@@ -4461,8 +4814,8 @@ module Block = struct
        let%bind () =
          (* Delete user commands from old blocks. *)
          Conn.exec
@@ -2667,7 +2659,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM user_commands\n\
                WHERE id IN\n\
                (SELECT user_command_id FROM blocks_user_commands\n\
-@@ -4490,8 +4845,8 @@ module Block = struct
+@@ -4473,8 +4826,8 @@ module Block = struct
        let%bind () =
          (* Delete old blocks. *)
          Conn.exec
@@ -2678,7 +2670,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
                ?" )
            (height, timestamp)
-@@ -4499,7 +4854,7 @@ module Block = struct
+@@ -4482,7 +4835,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned internal commands. *)
          Conn.exec
@@ -2687,7 +2679,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM internal_commands\n\
                WHERE id NOT IN\n\
                (SELECT internal_commands.id FROM internal_commands\n\
-@@ -4510,7 +4865,7 @@ module Block = struct
+@@ -4493,7 +4846,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned snarked ledger hashes. *)
          Conn.exec
@@ -2696,7 +2688,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM snarked_ledger_hashes\n\
                WHERE id NOT IN\n\
                (SELECT snarked_ledger_hash_id FROM blocks)" )
-@@ -4519,7 +4874,7 @@ module Block = struct
+@@ -4502,7 +4855,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned public keys. *)
          Conn.exec
@@ -2705,7 +2697,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM public_keys\n\
                WHERE id NOT IN (SELECT fee_payer_id FROM user_commands)\n\
                AND id NOT IN (SELECT source_id FROM user_commands)\n\
-@@ -4569,8 +4924,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4552,8 +4905,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              ()
          | Some acct_id ->
              Token_owners.add_if_doesn't_exist token_id acct_id ) ;
@@ -2716,7 +2708,7 @@ index 8b90db5952..313b424f55 100644
          let%bind res =
            let open Deferred.Result.Let_syntax in
            let%bind () = Conn.start () in
-@@ -4581,7 +4936,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4564,7 +4917,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              O1trace.thread "archive_processor.add_block"
              @@ fun () ->
              Metrics.time ~label:"add_block"
@@ -2725,7 +2717,7 @@ index 8b90db5952..313b424f55 100644
            in
            (* if an existing block has a parent hash that's for the block just added,
               set its parent id
-@@ -4636,8 +4991,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4619,8 +4972,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                      ] ;
                  let%bind.Deferred.Result () = Conn.start () in
                  match%bind
@@ -2736,7 +2728,7 @@ index 8b90db5952..313b424f55 100644
                        Accounts_accessed.add_accounts_if_don't_exist
                          (module Conn)
                          block_id accounts_accessed )
-@@ -4662,8 +5017,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4645,8 +4998,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                            , `Int (List.length accounts_accessed) )
                          ] ;
                      match%bind
@@ -2747,7 +2739,7 @@ index 8b90db5952..313b424f55 100644
                            Accounts_created.add_accounts_created_if_don't_exist
                              (module Conn)
                              block_id accounts_created )
-@@ -4800,8 +5155,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
+@@ -4783,8 +5136,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
              With_hash.{ data = block; hash = the_hash }
            in
            let add_accounts () =
@@ -2758,7 +2750,7 @@ index 8b90db5952..313b424f55 100644
                  let%bind.Deferred.Result genesis_block_id =
                    Block.add_if_doesn't_exist
                      (module Conn)
-@@ -4944,7 +5299,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
+@@ -4927,7 +5280,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
            Strict_pipe.Writer.write extensional_block_writer extensional_block )
      ]
    in

--- a/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
+++ b/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
@@ -803,7 +803,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -586,13 +750,37 @@ module Protocol_versions = struct
+@@ -586,32 +750,59 @@ module Protocol_versions = struct
  
    let table_name = "protocol_versions"
  
@@ -844,10 +844,43 @@ index 8b90db5952..313b424f55 100644
 +        in
 +        Hashtbl.add_exn t_to_id ~key:t ~data:new_id ;
 +        new_id
- end
  
- module Zkapp_permissions = struct
-@@ -625,23 +813,81 @@ module Zkapp_permissions = struct
+-  let find (module Conn : CONNECTION) ~transaction ~network ~patch =
++  let find (module Conn : Mina_caqti.CONNECTION) ~transaction ~network ~patch =
+     Conn.find
+-      (Caqti_request.find
+-         Caqti_type.(tup3 int int int)
++      (find_req
++         Caqti_type.(t3 int int int)
+          Caqti_type.int
+          (Mina_caqti.select_cols ~select:"id" ~table_name ~cols:Fields.names ()) )
+       (transaction, network, patch)
+ 
+-  let find_txn_version (module Conn : CONNECTION) ~transaction =
+-    Conn.collect_list
+-      (Caqti_request.collect Caqti_type.int Caqti_type.int
+-         {sql| SELECT id FROM protocol_versions WHERE transaction = ?
+-        |sql} )
+-      transaction
++  let find_by_txn_version (module Conn : Mina_caqti.CONNECTION) ~transaction =
++    let%map t_to_id = load_copy (module Conn) in
++    let matching_ids =
++      Hashtbl.fold ~init:[]
++        ~f:(fun ~key ~data acc ->
++          if Int.(key.transaction = transaction) then data :: acc else acc )
++        t_to_id
++    in
++    Ok matching_ids
+ 
+-  let load (module Conn : CONNECTION) id =
++  let load (module Conn : Mina_caqti.CONNECTION) id =
+     Conn.find
+-      (Caqti_request.find Caqti_type.int typ
++      (find_req Caqti_type.int typ
+          (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
+       id
+ end
+@@ -646,23 +837,81 @@ module Zkapp_permissions = struct
      in
      Caqti_type.enum ~encode ~decode "zkapp_auth_required_type"
  
@@ -946,7 +979,7 @@ index 8b90db5952..313b424f55 100644
  
    let typ =
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-@@ -661,9 +907,51 @@ module Zkapp_permissions = struct
+@@ -682,14 +931,58 @@ module Zkapp_permissions = struct
        ; auth_required_typ
        ]
  
@@ -996,10 +1029,18 @@ index 8b90db5952..313b424f55 100644
 +
 +  let add_if_doesn't_exist (module Conn : Mina_caqti.CONNECTION)
 +      (perms : Permissions.t) =
-     let value =
-       { edit_state = perms.edit_state
-       ; send = perms.send
-@@ -682,16 +970,21 @@ module Zkapp_permissions = struct
+     let txn_version =
+       Mina_numbers.Txn_version.to_int @@ snd perms.set_verification_key
+     in
+     let%bind versions =
+-      Protocol_versions.find_txn_version (module Conn) ~transaction:txn_version
++      Protocol_versions.find_by_txn_version
++        (module Conn)
++        ~transaction:txn_version
+     in
+     ( match versions with
+     | Ok [] ->
+@@ -720,16 +1013,21 @@ module Zkapp_permissions = struct
        ; set_timing = perms.set_timing
        }
      in
@@ -1030,7 +1071,7 @@ index 8b90db5952..313b424f55 100644
  end
  
  module Zkapp_timing_info = struct
-@@ -710,7 +1003,7 @@ module Zkapp_timing_info = struct
+@@ -748,7 +1046,7 @@ module Zkapp_timing_info = struct
  
    let table_name = "zkapp_timing_info"
  
@@ -1039,7 +1080,7 @@ index 8b90db5952..313b424f55 100644
        (timing_info : Account_update.Update.Timing_info.t) =
      let initial_minimum_balance =
        Currency.Balance.to_string timing_info.initial_minimum_balance
-@@ -740,9 +1033,9 @@ module Zkapp_timing_info = struct
+@@ -778,9 +1076,9 @@ module Zkapp_timing_info = struct
        (module Conn)
        value
  
@@ -1051,7 +1092,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -754,16 +1047,16 @@ module Zkapp_uri = struct
+@@ -792,16 +1090,16 @@ module Zkapp_uri = struct
  
    let table_name = "zkapp_uris"
  
@@ -1071,7 +1112,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "value" ]) )
        id
  end
-@@ -796,7 +1089,7 @@ module Zkapp_updates = struct
+@@ -834,7 +1132,7 @@ module Zkapp_updates = struct
  
    let table_name = "zkapp_updates"
  
@@ -1080,7 +1121,7 @@ index 8b90db5952..313b424f55 100644
        (update : Account_update.Update.t) =
      let open Deferred.Result.Let_syntax in
      let%bind app_state_id =
-@@ -854,9 +1147,9 @@ module Zkapp_updates = struct
+@@ -892,9 +1190,9 @@ module Zkapp_updates = struct
        (module Conn)
        value
  
@@ -1092,7 +1133,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -871,7 +1164,7 @@ module Zkapp_balance_bounds = struct
+@@ -909,7 +1207,7 @@ module Zkapp_balance_bounds = struct
  
    let table_name = "zkapp_balance_bounds"
  
@@ -1101,7 +1142,7 @@ index 8b90db5952..313b424f55 100644
        (balance_bounds :
          Currency.Balance.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let balance_lower_bound = Currency.Balance.to_string balance_bounds.lower in
-@@ -882,9 +1175,9 @@ module Zkapp_balance_bounds = struct
+@@ -920,9 +1218,9 @@ module Zkapp_balance_bounds = struct
        (module Conn)
        value
  
@@ -1113,7 +1154,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -899,7 +1192,7 @@ module Zkapp_nonce_bounds = struct
+@@ -937,7 +1235,7 @@ module Zkapp_nonce_bounds = struct
  
    let table_name = "zkapp_nonce_bounds"
  
@@ -1122,7 +1163,7 @@ index 8b90db5952..313b424f55 100644
        (nonce_bounds :
          Mina_numbers.Account_nonce.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -911,9 +1204,9 @@ module Zkapp_nonce_bounds = struct
+@@ -949,9 +1247,9 @@ module Zkapp_nonce_bounds = struct
        (module Conn)
        value
  
@@ -1134,7 +1175,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -946,7 +1239,7 @@ module Zkapp_account_precondition = struct
+@@ -984,7 +1282,7 @@ module Zkapp_account_precondition = struct
  
    let table_name = "zkapp_account_precondition"
  
@@ -1143,7 +1184,7 @@ index 8b90db5952..313b424f55 100644
        (acct : Zkapp_precondition.Account.t) =
      let open Deferred.Result.Let_syntax in
      let%bind balance_id =
-@@ -995,9 +1288,9 @@ module Zkapp_account_precondition = struct
+@@ -1033,9 +1331,9 @@ module Zkapp_account_precondition = struct
        (module Conn)
        value
  
@@ -1155,7 +1196,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1012,7 +1305,7 @@ module Zkapp_token_id_bounds = struct
+@@ -1050,7 +1348,7 @@ module Zkapp_token_id_bounds = struct
  
    let table_name = "zkapp_token_id_bounds"
  
@@ -1164,7 +1205,7 @@ index 8b90db5952..313b424f55 100644
        (token_id_bounds :
          Token_id.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let token_id_lower_bound = token_id_bounds.lower |> Token_id.to_string in
-@@ -1023,9 +1316,9 @@ module Zkapp_token_id_bounds = struct
+@@ -1061,9 +1359,9 @@ module Zkapp_token_id_bounds = struct
        (module Conn)
        value
  
@@ -1176,7 +1217,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1040,7 +1333,7 @@ module Zkapp_timestamp_bounds = struct
+@@ -1078,7 +1376,7 @@ module Zkapp_timestamp_bounds = struct
  
    let table_name = "zkapp_timestamp_bounds"
  
@@ -1185,7 +1226,7 @@ index 8b90db5952..313b424f55 100644
        (timestamp_bounds :
          Block_time.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let timestamp_lower_bound =
-@@ -1055,9 +1348,9 @@ module Zkapp_timestamp_bounds = struct
+@@ -1093,9 +1391,9 @@ module Zkapp_timestamp_bounds = struct
        (module Conn)
        value
  
@@ -1197,7 +1238,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1072,7 +1365,7 @@ module Zkapp_length_bounds = struct
+@@ -1110,7 +1408,7 @@ module Zkapp_length_bounds = struct
  
    let table_name = "zkapp_length_bounds"
  
@@ -1206,7 +1247,7 @@ index 8b90db5952..313b424f55 100644
        (length_bounds :
          Unsigned.uint32 Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let length_lower_bound = Unsigned.UInt32.to_int64 length_bounds.lower in
-@@ -1083,9 +1376,9 @@ module Zkapp_length_bounds = struct
+@@ -1121,9 +1419,9 @@ module Zkapp_length_bounds = struct
        (module Conn)
        value
  
@@ -1218,7 +1259,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1100,7 +1393,7 @@ module Zkapp_amount_bounds = struct
+@@ -1138,7 +1436,7 @@ module Zkapp_amount_bounds = struct
  
    let table_name = "zkapp_amount_bounds"
  
@@ -1227,7 +1268,7 @@ index 8b90db5952..313b424f55 100644
        (amount_bounds :
          Currency.Amount.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let amount_lower_bound = Currency.Amount.to_string amount_bounds.lower in
-@@ -1111,9 +1404,9 @@ module Zkapp_amount_bounds = struct
+@@ -1149,9 +1447,9 @@ module Zkapp_amount_bounds = struct
        (module Conn)
        value
  
@@ -1239,7 +1280,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1128,7 +1421,7 @@ module Zkapp_global_slot_bounds = struct
+@@ -1166,7 +1464,7 @@ module Zkapp_global_slot_bounds = struct
  
    let table_name = "zkapp_global_slot_bounds"
  
@@ -1248,7 +1289,7 @@ index 8b90db5952..313b424f55 100644
        (global_slot_bounds :
          Mina_numbers.Global_slot_since_genesis.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -1146,38 +1439,104 @@ module Zkapp_global_slot_bounds = struct
+@@ -1184,38 +1482,104 @@ module Zkapp_global_slot_bounds = struct
        (module Conn)
        value
  
@@ -1366,7 +1407,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1186,10 +1545,10 @@ module Timing_info = struct
+@@ -1224,10 +1588,10 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1379,7 +1420,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1198,8 +1557,9 @@ module Timing_info = struct
+@@ -1236,8 +1600,9 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1391,7 +1432,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let slot_to_int64 x =
        Mina_numbers.Global_slot_since_genesis.to_uint32 x
-@@ -1230,65 +1590,46 @@ module Timing_info = struct
+@@ -1268,65 +1633,46 @@ module Timing_info = struct
            ; vesting_increment = zero
            }
      in
@@ -1473,7 +1514,7 @@ index 8b90db5952..313b424f55 100644
             "SELECT id FROM snarked_ledger_hashes WHERE value = ?" )
          hash
      with
-@@ -1296,13 +1637,13 @@ module Snarked_ledger_hash = struct
+@@ -1334,13 +1680,13 @@ module Snarked_ledger_hash = struct
          return id
      | None ->
          Conn.find
@@ -1490,7 +1531,7 @@ index 8b90db5952..313b424f55 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  end
-@@ -1317,7 +1658,7 @@ module Zkapp_epoch_ledger = struct
+@@ -1355,7 +1701,7 @@ module Zkapp_epoch_ledger = struct
  
    let table_name = "zkapp_epoch_ledger"
  
@@ -1499,7 +1540,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_ledger : _ Epoch_ledger.Poly.t) =
      let open Deferred.Result.Let_syntax in
      let%bind hash_id =
-@@ -1336,9 +1677,9 @@ module Zkapp_epoch_ledger = struct
+@@ -1374,9 +1720,9 @@ module Zkapp_epoch_ledger = struct
        (module Conn)
        value
  
@@ -1511,7 +1552,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1360,7 +1701,7 @@ module Zkapp_epoch_data = struct
+@@ -1398,7 +1744,7 @@ module Zkapp_epoch_data = struct
  
    let table_name = "zkapp_epoch_data"
  
@@ -1520,7 +1561,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_data : Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.t) =
      let open Deferred.Result.Let_syntax in
      let%bind epoch_ledger_id =
-@@ -1396,9 +1737,9 @@ module Zkapp_epoch_data = struct
+@@ -1434,9 +1780,9 @@ module Zkapp_epoch_data = struct
        (module Conn)
        value
  
@@ -1532,7 +1573,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1422,7 +1763,7 @@ module Zkapp_network_precondition = struct
+@@ -1460,7 +1806,7 @@ module Zkapp_network_precondition = struct
  
    let table_name = "zkapp_network_precondition"
  
@@ -1541,7 +1582,7 @@ index 8b90db5952..313b424f55 100644
        (ps : Mina_base.Zkapp_precondition.Protocol_state.t) =
      let open Deferred.Result.Let_syntax in
      let%bind snarked_ledger_hash_id =
-@@ -1471,9 +1812,9 @@ module Zkapp_network_precondition = struct
+@@ -1509,9 +1855,9 @@ module Zkapp_network_precondition = struct
        (module Conn)
        value
  
@@ -1553,7 +1594,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1507,7 +1848,7 @@ module Zkapp_events = struct
+@@ -1545,7 +1891,7 @@ module Zkapp_events = struct
       7. use "M'" and the list of list of field_ids to compute the list of field_array_ids
       8. insert the list of field_arrays
    *)
@@ -1562,7 +1603,7 @@ index 8b90db5952..313b424f55 100644
        (events : Account_update.Body.Events'.t) =
      let open Deferred.Result.Let_syntax in
      let%bind field_array_id_list =
-@@ -1563,9 +1904,9 @@ module Zkapp_events = struct
+@@ -1601,9 +1947,9 @@ module Zkapp_events = struct
        (module Conn)
        field_array_id_list
  
@@ -1574,7 +1615,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]) )
        id
  end
-@@ -1614,7 +1955,7 @@ module Zkapp_account_update_body = struct
+@@ -1652,7 +1998,7 @@ module Zkapp_account_update_body = struct
  
    let table_name = "zkapp_account_update_body"
  
@@ -1583,7 +1624,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let account_identifier = Account_id.create body.public_key body.token_id in
-@@ -1715,9 +2056,9 @@ module Zkapp_account_update_body = struct
+@@ -1753,9 +2099,9 @@ module Zkapp_account_update_body = struct
        (module Conn)
        value
  
@@ -1595,7 +1636,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1730,7 +2071,7 @@ module Zkapp_account_update = struct
+@@ -1768,7 +2114,7 @@ module Zkapp_account_update = struct
  
    let table_name = "zkapp_account_update"
  
@@ -1604,7 +1645,7 @@ index 8b90db5952..313b424f55 100644
        (account_update : Account_update.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let%bind body_id =
-@@ -1746,9 +2087,9 @@ module Zkapp_account_update = struct
+@@ -1784,9 +2130,9 @@ module Zkapp_account_update = struct
        (module Conn)
        value
  
@@ -1616,7 +1657,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1768,7 +2109,7 @@ module Zkapp_fee_payer_body = struct
+@@ -1806,7 +2152,7 @@ module Zkapp_fee_payer_body = struct
  
    let table_name = "zkapp_fee_payer_body"
  
@@ -1625,7 +1666,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Fee_payer.t) =
      let open Deferred.Result.Let_syntax in
      let%bind public_key_id =
-@@ -1790,9 +2131,9 @@ module Zkapp_fee_payer_body = struct
+@@ -1828,9 +2174,9 @@ module Zkapp_fee_payer_body = struct
        (module Conn)
        value
  
@@ -1637,7 +1678,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1819,7 +2160,7 @@ module Epoch_data = struct
+@@ -1857,7 +2203,7 @@ module Epoch_data = struct
  
    let table_name = "epoch_data"
  
@@ -1646,7 +1687,7 @@ index 8b90db5952..313b424f55 100644
        (t : Mina_base.Epoch_data.Value.t) =
      let open Deferred.Result.Let_syntax in
      let Mina_base.Epoch_ledger.Poly.{ hash; total_currency } =
-@@ -1847,9 +2188,9 @@ module Epoch_data = struct
+@@ -1885,9 +2231,9 @@ module Epoch_data = struct
        ; epoch_length
        }
  
@@ -1658,7 +1699,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1887,22 +2228,22 @@ module User_command = struct
+@@ -1925,22 +2271,22 @@ module User_command = struct
  
      let table_name = "user_commands"
  
@@ -1687,7 +1728,7 @@ index 8b90db5952..313b424f55 100644
          (t : Signed_command.t) =
        let open Deferred.Result.Let_syntax in
        let%bind fee_payer_id =
-@@ -1915,8 +2256,9 @@ module User_command = struct
+@@ -1953,8 +2299,9 @@ module User_command = struct
        in
        { fee_payer_id; receiver_id }
  
@@ -1699,7 +1740,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let transaction_hash = Transaction_hash.hash_command (Signed_command t) in
        match%bind find (module Conn) ~transaction_hash ~v1_transaction_hash with
-@@ -1940,7 +2282,7 @@ module User_command = struct
+@@ -1978,7 +2325,7 @@ module User_command = struct
            in
            (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
            Conn.find
@@ -1708,7 +1749,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -1967,7 +2309,7 @@ module User_command = struct
+@@ -2005,7 +2352,7 @@ module User_command = struct
                  |> txn_hash_to_base58_check ~v1_transaction_hash
              }
  
@@ -1717,7 +1758,7 @@ index 8b90db5952..313b424f55 100644
          ?(v1_transaction_hash = false) (user_cmd : Extensional.User_command.t) =
        let open Deferred.Result.Let_syntax in
        match%bind
-@@ -1987,7 +2329,7 @@ module User_command = struct
+@@ -2025,7 +2372,7 @@ module User_command = struct
              Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
            in
            Conn.find
@@ -1726,7 +1767,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2025,21 +2367,22 @@ module User_command = struct
+@@ -2063,21 +2410,22 @@ module User_command = struct
  
      let table_name = "zkapp_commands"
  
@@ -1754,7 +1795,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let zkapp_command = Zkapp_command.to_simple ps in
        let%bind zkapp_fee_payer_body_id =
-@@ -2108,11 +2451,12 @@ module Internal_command = struct
+@@ -2146,11 +2494,12 @@ module Internal_command = struct
  
    let table_name = "internal_commands"
  
@@ -1771,7 +1812,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.int
           (Mina_caqti.select_cols ~select:"id" ~table_name
              ~tannot:(function
-@@ -2121,13 +2465,13 @@ module Internal_command = struct
+@@ -2159,13 +2508,13 @@ module Internal_command = struct
        ( txn_hash_to_base58_check ~v1_transaction_hash transaction_hash
        , command_type )
  
@@ -1788,7 +1829,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false)
        (internal_cmd : Extensional.Internal_command.t) =
      let open Deferred.Result.Let_syntax in
-@@ -2144,7 +2488,7 @@ module Internal_command = struct
+@@ -2182,7 +2531,7 @@ module Internal_command = struct
            Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
          in
          Conn.find
@@ -1797,7 +1838,7 @@ index 8b90db5952..313b424f55 100644
               (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                  ~tannot:(function
                    | "command_type" -> Some "internal_command_type" | _ -> None
-@@ -2189,10 +2533,10 @@ module Fee_transfer = struct
+@@ -2227,10 +2576,10 @@ module Fee_transfer = struct
        in
        Ok { kind; receiver_id; fee; hash }
      in
@@ -1810,7 +1851,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Fee_transfer.Single.t)
        (kind : [ `Normal | `Via_coinbase ]) =
      let open Deferred.Result.Let_syntax in
-@@ -2211,7 +2555,7 @@ module Fee_transfer = struct
+@@ -2249,7 +2598,7 @@ module Fee_transfer = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1819,7 +1860,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2239,10 +2583,10 @@ module Coinbase = struct
+@@ -2277,10 +2626,10 @@ module Coinbase = struct
      let decode (_, receiver_id, amount, hash) =
        Ok { receiver_id; amount; hash }
      in
@@ -1832,7 +1873,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Coinbase.t) =
      let open Deferred.Result.Let_syntax in
      let transaction_hash = Transaction_hash.hash_coinbase t in
-@@ -2260,7 +2604,7 @@ module Coinbase = struct
+@@ -2298,7 +2647,7 @@ module Coinbase = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1841,7 +1882,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2292,14 +2636,14 @@ module Block_and_internal_command = struct
+@@ -2330,14 +2679,14 @@ module Block_and_internal_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; int; string; option string ]
  
@@ -1859,7 +1900,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_internal_commands
                   (block_id,
                   internal_command_id,
-@@ -2317,11 +2661,11 @@ module Block_and_internal_command = struct
+@@ -2355,11 +2704,11 @@ module Block_and_internal_command = struct
        ; failure_reason
        }
  
@@ -1874,7 +1915,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.string
           {sql| SELECT 'exists' FROM blocks_internal_commands
                 WHERE block_id = $1
-@@ -2331,7 +2675,7 @@ module Block_and_internal_command = struct
+@@ -2369,7 +2718,7 @@ module Block_and_internal_command = struct
           |sql} )
        (block_id, internal_command_id, sequence_no, secondary_sequence_no)
  
@@ -1883,7 +1924,7 @@ index 8b90db5952..313b424f55 100644
        ~internal_command_id ~sequence_no ~secondary_sequence_no ~status
        ~failure_reason =
      let open Deferred.Result.Let_syntax in
-@@ -2348,12 +2692,12 @@ module Block_and_internal_command = struct
+@@ -2386,12 +2735,12 @@ module Block_and_internal_command = struct
            ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
            ~status ~failure_reason
  
@@ -1899,7 +1940,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_internal_commands
-@@ -2382,13 +2726,13 @@ module Block_and_signed_command = struct
+@@ -2420,13 +2769,13 @@ module Block_and_signed_command = struct
  
    let table_name = "blocks_user_commands"
  
@@ -1916,7 +1957,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_user_commands
                   (block_id,
                   user_command_id,
-@@ -2399,8 +2743,8 @@ module Block_and_signed_command = struct
+@@ -2437,8 +2786,8 @@ module Block_and_signed_command = struct
           |sql} )
        { block_id; user_command_id; sequence_no; status; failure_reason }
  
@@ -1927,7 +1968,7 @@ index 8b90db5952..313b424f55 100644
      let status_str, failure_reason =
        match status with
        | Applied ->
-@@ -2413,13 +2757,13 @@ module Block_and_signed_command = struct
+@@ -2451,13 +2800,13 @@ module Block_and_signed_command = struct
        (module Conn)
        ~block_id ~user_command_id ~sequence_no ~status:status_str ~failure_reason
  
@@ -1945,7 +1986,7 @@ index 8b90db5952..313b424f55 100644
             Caqti_type.string
             {sql| SELECT 'exists' FROM blocks_user_commands
                   WHERE block_id = $1
-@@ -2435,11 +2779,12 @@ module Block_and_signed_command = struct
+@@ -2473,11 +2822,12 @@ module Block_and_signed_command = struct
            (module Conn)
            ~block_id ~user_command_id ~sequence_no ~status ~failure_reason
  
@@ -1961,7 +2002,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_user_commands
-@@ -2460,7 +2805,8 @@ module Zkapp_account_update_failures = struct
+@@ -2498,7 +2848,8 @@ module Zkapp_account_update_failures = struct
  
    let table_name = "zkapp_account_update_failures"
  
@@ -1971,7 +2012,7 @@ index 8b90db5952..313b424f55 100644
      let failures =
        List.map failures ~f:Transaction_status.Failure.to_string |> Array.of_list
      in
-@@ -2471,9 +2817,9 @@ module Zkapp_account_update_failures = struct
+@@ -2509,9 +2860,9 @@ module Zkapp_account_update_failures = struct
        (module Conn)
        { index; failures }
  
@@ -1983,7 +2024,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name
              ~cols:[ "index"; "failures" ] ) )
        id
-@@ -2495,7 +2841,7 @@ module Block_and_zkapp_command = struct
+@@ -2533,7 +2884,7 @@ module Block_and_zkapp_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; string; option Mina_caqti.array_int_typ ]
  
@@ -1992,7 +2033,7 @@ index 8b90db5952..313b424f55 100644
        ~zkapp_command_id ~sequence_no ~status
        ~(failure_reasons : Transaction_status.Failure.Collection.Display.t option)
        =
-@@ -2516,8 +2862,7 @@ module Block_and_zkapp_command = struct
+@@ -2554,8 +2905,7 @@ module Block_and_zkapp_command = struct
      in
      Mina_caqti.select_insert_into_cols
        ~select:
@@ -2002,7 +2043,7 @@ index 8b90db5952..313b424f55 100644
        ~table_name
        ~cols:
          ( [ "block_id"
-@@ -2537,21 +2882,22 @@ module Block_and_zkapp_command = struct
+@@ -2575,21 +2925,22 @@ module Block_and_zkapp_command = struct
        (module Conn)
        { block_id; zkapp_command_id; sequence_no; status; failure_reasons_ids }
  
@@ -2030,7 +2071,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2575,7 +2921,7 @@ module Zkapp_account = struct
+@@ -2613,7 +2964,7 @@ module Zkapp_account = struct
  
    let table_name = "zkapp_accounts"
  
@@ -2039,7 +2080,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let ({ app_state
           ; verification_key
-@@ -2621,9 +2967,9 @@ module Zkapp_account = struct
+@@ -2659,9 +3010,9 @@ module Zkapp_account = struct
        ; zkapp_uri_id
        }
  
@@ -2051,7 +2092,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -2664,11 +3010,31 @@ module Accounts_accessed = struct
+@@ -2702,11 +3053,31 @@ module Accounts_accessed = struct
  
    let table_name = "accounts_accessed"
  
@@ -2086,7 +2127,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s
-@@ -2679,72 +3045,71 @@ module Accounts_accessed = struct
+@@ -2717,72 +3088,71 @@ module Accounts_accessed = struct
              comma_cols table_name ) )
        (block_id, account_identifier_id)
  
@@ -2216,7 +2257,7 @@ index 8b90db5952..313b424f55 100644
        (accounts : (int * Account.t) list) =
      let%map results =
        Deferred.List.map accounts ~f:(fun account ->
-@@ -2752,10 +3117,10 @@ module Accounts_accessed = struct
+@@ -2790,10 +3160,10 @@ module Accounts_accessed = struct
      in
      Result.all results
  
@@ -2229,7 +2270,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~select:comma_cols ~table_name
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2772,30 +3137,30 @@ module Accounts_created = struct
+@@ -2810,30 +3180,30 @@ module Accounts_created = struct
  
    let table_name = "accounts_created"
  
@@ -2267,7 +2308,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT block_id, account_identifier_id, creation_fee
                 FROM accounts_created
                 WHERE block_id = ?
-@@ -2861,18 +3226,19 @@ module Block = struct
+@@ -2899,18 +3269,19 @@ module Block = struct
           "SELECT id FROM blocks WHERE state_hash = ?" )
        (State_hash.to_base58_check state_hash)
  
@@ -2293,7 +2334,7 @@ index 8b90db5952..313b424f55 100644
        ~constraint_constants ~protocol_state ~staged_ledger_diff
        ~protocol_version ~proposed_protocol_version ~hash ~v1_transaction_hash =
      let open Deferred.Result.Let_syntax in
-@@ -2973,7 +3339,7 @@ module Block = struct
+@@ -3011,7 +3382,7 @@ module Block = struct
          let blockchain_state = Protocol_state.blockchain_state protocol_state in
          let%bind block_id =
            Conn.find
@@ -2302,7 +2343,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "chain_status" ->
-@@ -3293,7 +3659,7 @@ module Block = struct
+@@ -3331,7 +3702,7 @@ module Block = struct
  
    (* NB: this batching logic an lead to partial writes; it is acceptable to be used with the
       migration tool, but not acceptable to be used with the archive node in its current form *)
@@ -2311,7 +2352,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (blocks : Extensional.Block.t list) =
      let open Deferred.Result.Let_syntax in
      (* zkapps are currently unsupported in the batch implementation of this function *)
-@@ -3355,9 +3721,7 @@ module Block = struct
+@@ -3393,9 +3764,7 @@ module Block = struct
      in
  
      (* we don't need to specify all types here, just the ones that sql may infer incorrectly *)
@@ -2322,7 +2363,7 @@ index 8b90db5952..313b424f55 100644
        | Bool ->
            Some "BOOL"
        | Int ->
-@@ -3370,39 +3734,36 @@ module Block = struct
+@@ -3408,39 +3777,36 @@ module Block = struct
            Some "BIGINT"
        | Float ->
            Some "FLOAT"
@@ -2381,7 +2422,7 @@ index 8b90db5952..313b424f55 100644
        match typ with
        | Bool ->
            Bool.to_string value
-@@ -3430,45 +3791,30 @@ module Block = struct
+@@ -3468,45 +3834,30 @@ module Block = struct
            (* we are ignoring the enum annotation in this context because it's not always valid to apply *)
            (* NOTE: we assume enum values do not contain special characters (eg "'") *)
            "'" ^ value ^ "'"
@@ -2449,7 +2490,7 @@ index 8b90db5952..313b424f55 100644
      in
      let render_row (type a) (typ : a Caqti_type.t) (value : a) : string =
        "(" ^ String.concat ~sep:"," (render_type typ value) ^ ")"
-@@ -3519,8 +3865,8 @@ module Block = struct
+@@ -3557,8 +3908,8 @@ module Block = struct
          in
          let%map entries =
            Conn.collect_list
@@ -2460,7 +2501,7 @@ index 8b90db5952..313b424f55 100644
                 query )
              ()
          in
-@@ -3538,7 +3884,7 @@ module Block = struct
+@@ -3576,7 +3927,7 @@ module Block = struct
            String.concat ~sep:"," @@ List.map ~f:(render_row typ) values
          in
          Conn.collect_list
@@ -2469,7 +2510,7 @@ index 8b90db5952..313b424f55 100644
               (sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table
                  fields_sql values_sql ) )
            () )
-@@ -3890,7 +4236,7 @@ module Block = struct
+@@ -3928,7 +4279,7 @@ module Block = struct
        let ids_sql = String.concat ~sep:"," ids in
        let parent_ids_sql = String.concat ~sep:"," parent_ids in
        Conn.exec
@@ -2478,7 +2519,7 @@ index 8b90db5952..313b424f55 100644
             (sprintf
                "UPDATE %s AS b SET parent_id = data.parent_id FROM (SELECT \
                 unnest(array[%s]) as id, unnest(array[%s]) as parent_id) AS \
-@@ -4041,7 +4387,7 @@ module Block = struct
+@@ -4079,7 +4430,7 @@ module Block = struct
  
      return ()
  
@@ -2487,7 +2528,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (block : Extensional.Block.t) =
      let open Deferred.Result.Let_syntax in
      let%bind block_id =
-@@ -4100,7 +4446,7 @@ module Block = struct
+@@ -4138,7 +4489,7 @@ module Block = struct
                  Some id )
            in
            Conn.find
@@ -2496,7 +2537,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "sub_window_densities" ->
-@@ -4258,18 +4604,19 @@ module Block = struct
+@@ -4296,18 +4647,19 @@ module Block = struct
      in
      return block_id
  
@@ -2520,7 +2561,7 @@ index 8b90db5952..313b424f55 100644
      (* derive query from type `t` *)
      let concat = String.concat ~sep:"," in
      let columns_with_id = concat ("id" :: Fields.names) in
-@@ -4278,8 +4625,8 @@ module Block = struct
+@@ -4316,8 +4668,8 @@ module Block = struct
      in
      let columns = concat Fields.names in
      Conn.collect_list
@@ -2531,7 +2572,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| WITH RECURSIVE chain AS (
-@@ -4303,39 +4650,42 @@ module Block = struct
+@@ -4341,39 +4693,42 @@ module Block = struct
              columns_with_id b_columns_with_id columns ) )
        (end_block_id, start_block_id)
  
@@ -2588,7 +2629,7 @@ index 8b90db5952..313b424f55 100644
           {sql| UPDATE blocks SET chain_status='orphaned'
                 WHERE height = $2
                 AND state_hash <> $1
-@@ -4343,7 +4693,7 @@ module Block = struct
+@@ -4381,7 +4736,7 @@ module Block = struct
        (state_hash, height)
  
    (* update chain_status for blocks now known to be canonical or orphaned *)
@@ -2597,7 +2638,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      match%bind get_highest_canonical_block_opt (module Conn) () with
      | None ->
-@@ -4415,7 +4765,7 @@ module Block = struct
+@@ -4453,7 +4808,7 @@ module Block = struct
            Deferred.Result.return ()
  
    let delete_if_older_than ?height ?num_blocks ?timestamp
@@ -2606,7 +2647,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let%bind height =
        match (height, num_blocks) with
-@@ -4424,7 +4774,7 @@ module Block = struct
+@@ -4462,7 +4817,7 @@ module Block = struct
        | None, Some num_blocks -> (
            match%map
              Conn.find_opt
@@ -2615,7 +2656,7 @@ index 8b90db5952..313b424f55 100644
                   "SELECT MAX(height) FROM blocks" )
                ()
            with
-@@ -4440,8 +4790,8 @@ module Block = struct
+@@ -4478,8 +4833,8 @@ module Block = struct
        let%bind () =
          (* Delete user commands from old blocks. *)
          Conn.exec
@@ -2626,7 +2667,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM user_commands\n\
                WHERE id IN\n\
                (SELECT user_command_id FROM blocks_user_commands\n\
-@@ -4452,8 +4802,8 @@ module Block = struct
+@@ -4490,8 +4845,8 @@ module Block = struct
        let%bind () =
          (* Delete old blocks. *)
          Conn.exec
@@ -2637,7 +2678,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
                ?" )
            (height, timestamp)
-@@ -4461,7 +4811,7 @@ module Block = struct
+@@ -4499,7 +4854,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned internal commands. *)
          Conn.exec
@@ -2646,7 +2687,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM internal_commands\n\
                WHERE id NOT IN\n\
                (SELECT internal_commands.id FROM internal_commands\n\
-@@ -4472,7 +4822,7 @@ module Block = struct
+@@ -4510,7 +4865,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned snarked ledger hashes. *)
          Conn.exec
@@ -2655,7 +2696,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM snarked_ledger_hashes\n\
                WHERE id NOT IN\n\
                (SELECT snarked_ledger_hash_id FROM blocks)" )
-@@ -4481,7 +4831,7 @@ module Block = struct
+@@ -4519,7 +4874,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned public keys. *)
          Conn.exec
@@ -2664,7 +2705,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM public_keys\n\
                WHERE id NOT IN (SELECT fee_payer_id FROM user_commands)\n\
                AND id NOT IN (SELECT source_id FROM user_commands)\n\
-@@ -4531,8 +4881,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4569,8 +4924,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              ()
          | Some acct_id ->
              Token_owners.add_if_doesn't_exist token_id acct_id ) ;
@@ -2675,7 +2716,7 @@ index 8b90db5952..313b424f55 100644
          let%bind res =
            let open Deferred.Result.Let_syntax in
            let%bind () = Conn.start () in
-@@ -4543,7 +4893,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4581,7 +4936,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              O1trace.thread "archive_processor.add_block"
              @@ fun () ->
              Metrics.time ~label:"add_block"
@@ -2684,7 +2725,7 @@ index 8b90db5952..313b424f55 100644
            in
            (* if an existing block has a parent hash that's for the block just added,
               set its parent id
-@@ -4598,8 +4948,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4636,8 +4991,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                      ] ;
                  let%bind.Deferred.Result () = Conn.start () in
                  match%bind
@@ -2695,7 +2736,7 @@ index 8b90db5952..313b424f55 100644
                        Accounts_accessed.add_accounts_if_don't_exist
                          (module Conn)
                          block_id accounts_accessed )
-@@ -4624,8 +4974,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4662,8 +5017,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                            , `Int (List.length accounts_accessed) )
                          ] ;
                      match%bind
@@ -2706,7 +2747,7 @@ index 8b90db5952..313b424f55 100644
                            Accounts_created.add_accounts_created_if_don't_exist
                              (module Conn)
                              block_id accounts_created )
-@@ -4762,8 +5112,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
+@@ -4800,8 +5155,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
              With_hash.{ data = block; hash = the_hash }
            in
            let add_accounts () =
@@ -2717,7 +2758,7 @@ index 8b90db5952..313b424f55 100644
                  let%bind.Deferred.Result genesis_block_id =
                    Block.add_if_doesn't_exist
                      (module Conn)
-@@ -4906,7 +5256,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
+@@ -4944,7 +5299,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
            Strict_pipe.Writer.write extensional_block_writer extensional_block )
      ]
    in

--- a/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
+++ b/buildkite/scripts/caqti-upgrade-plus-archive-init-speedup.patch
@@ -803,7 +803,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -586,32 +750,59 @@ module Protocol_versions = struct
+@@ -586,13 +750,37 @@ module Protocol_versions = struct
  
    let table_name = "protocol_versions"
  
@@ -844,43 +844,10 @@ index 8b90db5952..313b424f55 100644
 +        in
 +        Hashtbl.add_exn t_to_id ~key:t ~data:new_id ;
 +        new_id
- 
--  let find (module Conn : CONNECTION) ~transaction ~network ~patch =
-+  let find (module Conn : Mina_caqti.CONNECTION) ~transaction ~network ~patch =
-     Conn.find
--      (Caqti_request.find
--         Caqti_type.(tup3 int int int)
-+      (find_req
-+         Caqti_type.(t3 int int int)
-          Caqti_type.int
-          (Mina_caqti.select_cols ~select:"id" ~table_name ~cols:Fields.names ()) )
-       (transaction, network, patch)
- 
--  let find_txn_version (module Conn : CONNECTION) ~transaction =
--    Conn.collect_list
--      (Caqti_request.collect Caqti_type.int Caqti_type.int
--         {sql| SELECT id FROM protocol_versions WHERE transaction = ?
--        |sql} )
--      transaction
-+  let find_by_txn_version (module Conn : Mina_caqti.CONNECTION) ~transaction =
-+    let%map t_to_id = load_copy (module Conn) in
-+    let matching_ids =
-+      Hashtbl.fold ~init:[]
-+        ~f:(fun ~key ~data acc ->
-+          if Int.(key.transaction = transaction) then data :: acc else acc )
-+        t_to_id
-+    in
-+    Ok matching_ids
- 
--  let load (module Conn : CONNECTION) id =
-+  let load (module Conn : Mina_caqti.CONNECTION) id =
-     Conn.find
--      (Caqti_request.find Caqti_type.int typ
-+      (find_req Caqti_type.int typ
-          (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
-       id
  end
-@@ -646,23 +837,81 @@ module Zkapp_permissions = struct
+ 
+ module Zkapp_permissions = struct
+@@ -625,23 +813,81 @@ module Zkapp_permissions = struct
      in
      Caqti_type.enum ~encode ~decode "zkapp_auth_required_type"
  
@@ -979,7 +946,7 @@ index 8b90db5952..313b424f55 100644
  
    let typ =
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-@@ -682,14 +931,58 @@ module Zkapp_permissions = struct
+@@ -661,9 +907,51 @@ module Zkapp_permissions = struct
        ; auth_required_typ
        ]
  
@@ -1029,18 +996,10 @@ index 8b90db5952..313b424f55 100644
 +
 +  let add_if_doesn't_exist (module Conn : Mina_caqti.CONNECTION)
 +      (perms : Permissions.t) =
-     let txn_version =
-       Mina_numbers.Txn_version.to_int @@ snd perms.set_verification_key
-     in
-     let%bind versions =
--      Protocol_versions.find_txn_version (module Conn) ~transaction:txn_version
-+      Protocol_versions.find_by_txn_version
-+        (module Conn)
-+        ~transaction:txn_version
-     in
-     ( match versions with
-     | Ok [] ->
-@@ -720,16 +1013,21 @@ module Zkapp_permissions = struct
+     let value =
+       { edit_state = perms.edit_state
+       ; send = perms.send
+@@ -682,16 +970,21 @@ module Zkapp_permissions = struct
        ; set_timing = perms.set_timing
        }
      in
@@ -1071,7 +1030,7 @@ index 8b90db5952..313b424f55 100644
  end
  
  module Zkapp_timing_info = struct
-@@ -748,7 +1046,7 @@ module Zkapp_timing_info = struct
+@@ -710,7 +1003,7 @@ module Zkapp_timing_info = struct
  
    let table_name = "zkapp_timing_info"
  
@@ -1080,7 +1039,7 @@ index 8b90db5952..313b424f55 100644
        (timing_info : Account_update.Update.Timing_info.t) =
      let initial_minimum_balance =
        Currency.Balance.to_string timing_info.initial_minimum_balance
-@@ -778,9 +1076,9 @@ module Zkapp_timing_info = struct
+@@ -740,9 +1033,9 @@ module Zkapp_timing_info = struct
        (module Conn)
        value
  
@@ -1092,7 +1051,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -792,16 +1090,16 @@ module Zkapp_uri = struct
+@@ -754,16 +1047,16 @@ module Zkapp_uri = struct
  
    let table_name = "zkapp_uris"
  
@@ -1112,7 +1071,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "value" ]) )
        id
  end
-@@ -834,7 +1132,7 @@ module Zkapp_updates = struct
+@@ -796,7 +1089,7 @@ module Zkapp_updates = struct
  
    let table_name = "zkapp_updates"
  
@@ -1121,7 +1080,7 @@ index 8b90db5952..313b424f55 100644
        (update : Account_update.Update.t) =
      let open Deferred.Result.Let_syntax in
      let%bind app_state_id =
-@@ -892,9 +1190,9 @@ module Zkapp_updates = struct
+@@ -854,9 +1147,9 @@ module Zkapp_updates = struct
        (module Conn)
        value
  
@@ -1133,7 +1092,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -909,7 +1207,7 @@ module Zkapp_balance_bounds = struct
+@@ -871,7 +1164,7 @@ module Zkapp_balance_bounds = struct
  
    let table_name = "zkapp_balance_bounds"
  
@@ -1142,7 +1101,7 @@ index 8b90db5952..313b424f55 100644
        (balance_bounds :
          Currency.Balance.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let balance_lower_bound = Currency.Balance.to_string balance_bounds.lower in
-@@ -920,9 +1218,9 @@ module Zkapp_balance_bounds = struct
+@@ -882,9 +1175,9 @@ module Zkapp_balance_bounds = struct
        (module Conn)
        value
  
@@ -1154,7 +1113,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -937,7 +1235,7 @@ module Zkapp_nonce_bounds = struct
+@@ -899,7 +1192,7 @@ module Zkapp_nonce_bounds = struct
  
    let table_name = "zkapp_nonce_bounds"
  
@@ -1163,7 +1122,7 @@ index 8b90db5952..313b424f55 100644
        (nonce_bounds :
          Mina_numbers.Account_nonce.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -949,9 +1247,9 @@ module Zkapp_nonce_bounds = struct
+@@ -911,9 +1204,9 @@ module Zkapp_nonce_bounds = struct
        (module Conn)
        value
  
@@ -1175,7 +1134,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -984,7 +1282,7 @@ module Zkapp_account_precondition = struct
+@@ -946,7 +1239,7 @@ module Zkapp_account_precondition = struct
  
    let table_name = "zkapp_account_precondition"
  
@@ -1184,7 +1143,7 @@ index 8b90db5952..313b424f55 100644
        (acct : Zkapp_precondition.Account.t) =
      let open Deferred.Result.Let_syntax in
      let%bind balance_id =
-@@ -1033,9 +1331,9 @@ module Zkapp_account_precondition = struct
+@@ -995,9 +1288,9 @@ module Zkapp_account_precondition = struct
        (module Conn)
        value
  
@@ -1196,7 +1155,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1050,7 +1348,7 @@ module Zkapp_token_id_bounds = struct
+@@ -1012,7 +1305,7 @@ module Zkapp_token_id_bounds = struct
  
    let table_name = "zkapp_token_id_bounds"
  
@@ -1205,7 +1164,7 @@ index 8b90db5952..313b424f55 100644
        (token_id_bounds :
          Token_id.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let token_id_lower_bound = token_id_bounds.lower |> Token_id.to_string in
-@@ -1061,9 +1359,9 @@ module Zkapp_token_id_bounds = struct
+@@ -1023,9 +1316,9 @@ module Zkapp_token_id_bounds = struct
        (module Conn)
        value
  
@@ -1217,7 +1176,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1078,7 +1376,7 @@ module Zkapp_timestamp_bounds = struct
+@@ -1040,7 +1333,7 @@ module Zkapp_timestamp_bounds = struct
  
    let table_name = "zkapp_timestamp_bounds"
  
@@ -1226,7 +1185,7 @@ index 8b90db5952..313b424f55 100644
        (timestamp_bounds :
          Block_time.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let timestamp_lower_bound =
-@@ -1093,9 +1391,9 @@ module Zkapp_timestamp_bounds = struct
+@@ -1055,9 +1348,9 @@ module Zkapp_timestamp_bounds = struct
        (module Conn)
        value
  
@@ -1238,7 +1197,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1110,7 +1408,7 @@ module Zkapp_length_bounds = struct
+@@ -1072,7 +1365,7 @@ module Zkapp_length_bounds = struct
  
    let table_name = "zkapp_length_bounds"
  
@@ -1247,7 +1206,7 @@ index 8b90db5952..313b424f55 100644
        (length_bounds :
          Unsigned.uint32 Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let length_lower_bound = Unsigned.UInt32.to_int64 length_bounds.lower in
-@@ -1121,9 +1419,9 @@ module Zkapp_length_bounds = struct
+@@ -1083,9 +1376,9 @@ module Zkapp_length_bounds = struct
        (module Conn)
        value
  
@@ -1259,7 +1218,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1138,7 +1436,7 @@ module Zkapp_amount_bounds = struct
+@@ -1100,7 +1393,7 @@ module Zkapp_amount_bounds = struct
  
    let table_name = "zkapp_amount_bounds"
  
@@ -1268,7 +1227,7 @@ index 8b90db5952..313b424f55 100644
        (amount_bounds :
          Currency.Amount.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
      let amount_lower_bound = Currency.Amount.to_string amount_bounds.lower in
-@@ -1149,9 +1447,9 @@ module Zkapp_amount_bounds = struct
+@@ -1111,9 +1404,9 @@ module Zkapp_amount_bounds = struct
        (module Conn)
        value
  
@@ -1280,7 +1239,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1166,7 +1464,7 @@ module Zkapp_global_slot_bounds = struct
+@@ -1128,7 +1421,7 @@ module Zkapp_global_slot_bounds = struct
  
    let table_name = "zkapp_global_slot_bounds"
  
@@ -1289,7 +1248,7 @@ index 8b90db5952..313b424f55 100644
        (global_slot_bounds :
          Mina_numbers.Global_slot_since_genesis.t
          Mina_base.Zkapp_precondition.Closed_interval.t ) =
-@@ -1184,38 +1482,104 @@ module Zkapp_global_slot_bounds = struct
+@@ -1146,38 +1439,104 @@ module Zkapp_global_slot_bounds = struct
        (module Conn)
        value
  
@@ -1407,7 +1366,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1224,10 +1588,10 @@ module Timing_info = struct
+@@ -1186,10 +1545,10 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1420,7 +1379,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1236,8 +1600,9 @@ module Timing_info = struct
+@@ -1198,8 +1557,9 @@ module Timing_info = struct
           |sql} )
        account_identifier_id
  
@@ -1432,7 +1391,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let slot_to_int64 x =
        Mina_numbers.Global_slot_since_genesis.to_uint32 x
-@@ -1268,65 +1633,46 @@ module Timing_info = struct
+@@ -1230,65 +1590,46 @@ module Timing_info = struct
            ; vesting_increment = zero
            }
      in
@@ -1514,7 +1473,7 @@ index 8b90db5952..313b424f55 100644
             "SELECT id FROM snarked_ledger_hashes WHERE value = ?" )
          hash
      with
-@@ -1334,13 +1680,13 @@ module Snarked_ledger_hash = struct
+@@ -1296,13 +1637,13 @@ module Snarked_ledger_hash = struct
          return id
      | None ->
          Conn.find
@@ -1531,7 +1490,7 @@ index 8b90db5952..313b424f55 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  end
-@@ -1355,7 +1701,7 @@ module Zkapp_epoch_ledger = struct
+@@ -1317,7 +1658,7 @@ module Zkapp_epoch_ledger = struct
  
    let table_name = "zkapp_epoch_ledger"
  
@@ -1540,7 +1499,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_ledger : _ Epoch_ledger.Poly.t) =
      let open Deferred.Result.Let_syntax in
      let%bind hash_id =
-@@ -1374,9 +1720,9 @@ module Zkapp_epoch_ledger = struct
+@@ -1336,9 +1677,9 @@ module Zkapp_epoch_ledger = struct
        (module Conn)
        value
  
@@ -1552,7 +1511,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1398,7 +1744,7 @@ module Zkapp_epoch_data = struct
+@@ -1360,7 +1701,7 @@ module Zkapp_epoch_data = struct
  
    let table_name = "zkapp_epoch_data"
  
@@ -1561,7 +1520,7 @@ index 8b90db5952..313b424f55 100644
        (epoch_data : Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.t) =
      let open Deferred.Result.Let_syntax in
      let%bind epoch_ledger_id =
-@@ -1434,9 +1780,9 @@ module Zkapp_epoch_data = struct
+@@ -1396,9 +1737,9 @@ module Zkapp_epoch_data = struct
        (module Conn)
        value
  
@@ -1573,7 +1532,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1460,7 +1806,7 @@ module Zkapp_network_precondition = struct
+@@ -1422,7 +1763,7 @@ module Zkapp_network_precondition = struct
  
    let table_name = "zkapp_network_precondition"
  
@@ -1582,7 +1541,7 @@ index 8b90db5952..313b424f55 100644
        (ps : Mina_base.Zkapp_precondition.Protocol_state.t) =
      let open Deferred.Result.Let_syntax in
      let%bind snarked_ledger_hash_id =
-@@ -1509,9 +1855,9 @@ module Zkapp_network_precondition = struct
+@@ -1471,9 +1812,9 @@ module Zkapp_network_precondition = struct
        (module Conn)
        value
  
@@ -1594,7 +1553,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1545,7 +1891,7 @@ module Zkapp_events = struct
+@@ -1507,7 +1848,7 @@ module Zkapp_events = struct
       7. use "M'" and the list of list of field_ids to compute the list of field_array_ids
       8. insert the list of field_arrays
    *)
@@ -1603,7 +1562,7 @@ index 8b90db5952..313b424f55 100644
        (events : Account_update.Body.Events'.t) =
      let open Deferred.Result.Let_syntax in
      let%bind field_array_id_list =
-@@ -1601,9 +1947,9 @@ module Zkapp_events = struct
+@@ -1563,9 +1904,9 @@ module Zkapp_events = struct
        (module Conn)
        field_array_id_list
  
@@ -1615,7 +1574,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]) )
        id
  end
-@@ -1652,7 +1998,7 @@ module Zkapp_account_update_body = struct
+@@ -1614,7 +1955,7 @@ module Zkapp_account_update_body = struct
  
    let table_name = "zkapp_account_update_body"
  
@@ -1624,7 +1583,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let account_identifier = Account_id.create body.public_key body.token_id in
-@@ -1753,9 +2099,9 @@ module Zkapp_account_update_body = struct
+@@ -1715,9 +2056,9 @@ module Zkapp_account_update_body = struct
        (module Conn)
        value
  
@@ -1636,7 +1595,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1768,7 +2114,7 @@ module Zkapp_account_update = struct
+@@ -1730,7 +2071,7 @@ module Zkapp_account_update = struct
  
    let table_name = "zkapp_account_update"
  
@@ -1645,7 +1604,7 @@ index 8b90db5952..313b424f55 100644
        (account_update : Account_update.Simple.t) =
      let open Deferred.Result.Let_syntax in
      let%bind body_id =
-@@ -1784,9 +2130,9 @@ module Zkapp_account_update = struct
+@@ -1746,9 +2087,9 @@ module Zkapp_account_update = struct
        (module Conn)
        value
  
@@ -1657,7 +1616,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1806,7 +2152,7 @@ module Zkapp_fee_payer_body = struct
+@@ -1768,7 +2109,7 @@ module Zkapp_fee_payer_body = struct
  
    let table_name = "zkapp_fee_payer_body"
  
@@ -1666,7 +1625,7 @@ index 8b90db5952..313b424f55 100644
        (body : Account_update.Body.Fee_payer.t) =
      let open Deferred.Result.Let_syntax in
      let%bind public_key_id =
-@@ -1828,9 +2174,9 @@ module Zkapp_fee_payer_body = struct
+@@ -1790,9 +2131,9 @@ module Zkapp_fee_payer_body = struct
        (module Conn)
        value
  
@@ -1678,7 +1637,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1857,7 +2203,7 @@ module Epoch_data = struct
+@@ -1819,7 +2160,7 @@ module Epoch_data = struct
  
    let table_name = "epoch_data"
  
@@ -1687,7 +1646,7 @@ index 8b90db5952..313b424f55 100644
        (t : Mina_base.Epoch_data.Value.t) =
      let open Deferred.Result.Let_syntax in
      let Mina_base.Epoch_ledger.Poly.{ hash; total_currency } =
-@@ -1885,9 +2231,9 @@ module Epoch_data = struct
+@@ -1847,9 +2188,9 @@ module Epoch_data = struct
        ; epoch_length
        }
  
@@ -1699,7 +1658,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1925,22 +2271,22 @@ module User_command = struct
+@@ -1887,22 +2228,22 @@ module User_command = struct
  
      let table_name = "user_commands"
  
@@ -1728,7 +1687,7 @@ index 8b90db5952..313b424f55 100644
          (t : Signed_command.t) =
        let open Deferred.Result.Let_syntax in
        let%bind fee_payer_id =
-@@ -1953,8 +2299,9 @@ module User_command = struct
+@@ -1915,8 +2256,9 @@ module User_command = struct
        in
        { fee_payer_id; receiver_id }
  
@@ -1740,7 +1699,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let transaction_hash = Transaction_hash.hash_command (Signed_command t) in
        match%bind find (module Conn) ~transaction_hash ~v1_transaction_hash with
-@@ -1978,7 +2325,7 @@ module User_command = struct
+@@ -1940,7 +2282,7 @@ module User_command = struct
            in
            (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
            Conn.find
@@ -1749,7 +1708,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2005,7 +2352,7 @@ module User_command = struct
+@@ -1967,7 +2309,7 @@ module User_command = struct
                  |> txn_hash_to_base58_check ~v1_transaction_hash
              }
  
@@ -1758,7 +1717,7 @@ index 8b90db5952..313b424f55 100644
          ?(v1_transaction_hash = false) (user_cmd : Extensional.User_command.t) =
        let open Deferred.Result.Let_syntax in
        match%bind
-@@ -2025,7 +2372,7 @@ module User_command = struct
+@@ -1987,7 +2329,7 @@ module User_command = struct
              Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
            in
            Conn.find
@@ -1767,7 +1726,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2063,21 +2410,22 @@ module User_command = struct
+@@ -2025,21 +2367,22 @@ module User_command = struct
  
      let table_name = "zkapp_commands"
  
@@ -1795,7 +1754,7 @@ index 8b90db5952..313b424f55 100644
        let open Deferred.Result.Let_syntax in
        let zkapp_command = Zkapp_command.to_simple ps in
        let%bind zkapp_fee_payer_body_id =
-@@ -2146,11 +2494,12 @@ module Internal_command = struct
+@@ -2108,11 +2451,12 @@ module Internal_command = struct
  
    let table_name = "internal_commands"
  
@@ -1812,7 +1771,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.int
           (Mina_caqti.select_cols ~select:"id" ~table_name
              ~tannot:(function
-@@ -2159,13 +2508,13 @@ module Internal_command = struct
+@@ -2121,13 +2465,13 @@ module Internal_command = struct
        ( txn_hash_to_base58_check ~v1_transaction_hash transaction_hash
        , command_type )
  
@@ -1829,7 +1788,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false)
        (internal_cmd : Extensional.Internal_command.t) =
      let open Deferred.Result.Let_syntax in
-@@ -2182,7 +2531,7 @@ module Internal_command = struct
+@@ -2144,7 +2488,7 @@ module Internal_command = struct
            Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
          in
          Conn.find
@@ -1838,7 +1797,7 @@ index 8b90db5952..313b424f55 100644
               (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                  ~tannot:(function
                    | "command_type" -> Some "internal_command_type" | _ -> None
-@@ -2227,10 +2576,10 @@ module Fee_transfer = struct
+@@ -2189,10 +2533,10 @@ module Fee_transfer = struct
        in
        Ok { kind; receiver_id; fee; hash }
      in
@@ -1851,7 +1810,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Fee_transfer.Single.t)
        (kind : [ `Normal | `Via_coinbase ]) =
      let open Deferred.Result.Let_syntax in
-@@ -2249,7 +2598,7 @@ module Fee_transfer = struct
+@@ -2211,7 +2555,7 @@ module Fee_transfer = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1860,7 +1819,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2277,10 +2626,10 @@ module Coinbase = struct
+@@ -2239,10 +2583,10 @@ module Coinbase = struct
      let decode (_, receiver_id, amount, hash) =
        Ok { receiver_id; amount; hash }
      in
@@ -1873,7 +1832,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (t : Coinbase.t) =
      let open Deferred.Result.Let_syntax in
      let transaction_hash = Transaction_hash.hash_coinbase t in
-@@ -2298,7 +2647,7 @@ module Coinbase = struct
+@@ -2260,7 +2604,7 @@ module Coinbase = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -1882,7 +1841,7 @@ index 8b90db5952..313b424f55 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2330,14 +2679,14 @@ module Block_and_internal_command = struct
+@@ -2292,14 +2636,14 @@ module Block_and_internal_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; int; string; option string ]
  
@@ -1900,7 +1859,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_internal_commands
                   (block_id,
                   internal_command_id,
-@@ -2355,11 +2704,11 @@ module Block_and_internal_command = struct
+@@ -2317,11 +2661,11 @@ module Block_and_internal_command = struct
        ; failure_reason
        }
  
@@ -1915,7 +1874,7 @@ index 8b90db5952..313b424f55 100644
           Caqti_type.string
           {sql| SELECT 'exists' FROM blocks_internal_commands
                 WHERE block_id = $1
-@@ -2369,7 +2718,7 @@ module Block_and_internal_command = struct
+@@ -2331,7 +2675,7 @@ module Block_and_internal_command = struct
           |sql} )
        (block_id, internal_command_id, sequence_no, secondary_sequence_no)
  
@@ -1924,7 +1883,7 @@ index 8b90db5952..313b424f55 100644
        ~internal_command_id ~sequence_no ~secondary_sequence_no ~status
        ~failure_reason =
      let open Deferred.Result.Let_syntax in
-@@ -2386,12 +2735,12 @@ module Block_and_internal_command = struct
+@@ -2348,12 +2692,12 @@ module Block_and_internal_command = struct
            ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
            ~status ~failure_reason
  
@@ -1940,7 +1899,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_internal_commands
-@@ -2420,13 +2769,13 @@ module Block_and_signed_command = struct
+@@ -2382,13 +2726,13 @@ module Block_and_signed_command = struct
  
    let table_name = "blocks_user_commands"
  
@@ -1957,7 +1916,7 @@ index 8b90db5952..313b424f55 100644
           {sql| INSERT INTO blocks_user_commands
                   (block_id,
                   user_command_id,
-@@ -2437,8 +2786,8 @@ module Block_and_signed_command = struct
+@@ -2399,8 +2743,8 @@ module Block_and_signed_command = struct
           |sql} )
        { block_id; user_command_id; sequence_no; status; failure_reason }
  
@@ -1968,7 +1927,7 @@ index 8b90db5952..313b424f55 100644
      let status_str, failure_reason =
        match status with
        | Applied ->
-@@ -2451,13 +2800,13 @@ module Block_and_signed_command = struct
+@@ -2413,13 +2757,13 @@ module Block_and_signed_command = struct
        (module Conn)
        ~block_id ~user_command_id ~sequence_no ~status:status_str ~failure_reason
  
@@ -1986,7 +1945,7 @@ index 8b90db5952..313b424f55 100644
             Caqti_type.string
             {sql| SELECT 'exists' FROM blocks_user_commands
                   WHERE block_id = $1
-@@ -2473,11 +2822,12 @@ module Block_and_signed_command = struct
+@@ -2435,11 +2779,12 @@ module Block_and_signed_command = struct
            (module Conn)
            ~block_id ~user_command_id ~sequence_no ~status ~failure_reason
  
@@ -2002,7 +1961,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_user_commands
-@@ -2498,7 +2848,8 @@ module Zkapp_account_update_failures = struct
+@@ -2460,7 +2805,8 @@ module Zkapp_account_update_failures = struct
  
    let table_name = "zkapp_account_update_failures"
  
@@ -2012,7 +1971,7 @@ index 8b90db5952..313b424f55 100644
      let failures =
        List.map failures ~f:Transaction_status.Failure.to_string |> Array.of_list
      in
-@@ -2509,9 +2860,9 @@ module Zkapp_account_update_failures = struct
+@@ -2471,9 +2817,9 @@ module Zkapp_account_update_failures = struct
        (module Conn)
        { index; failures }
  
@@ -2024,7 +1983,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name
              ~cols:[ "index"; "failures" ] ) )
        id
-@@ -2533,7 +2884,7 @@ module Block_and_zkapp_command = struct
+@@ -2495,7 +2841,7 @@ module Block_and_zkapp_command = struct
      Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
        Caqti_type.[ int; int; int; string; option Mina_caqti.array_int_typ ]
  
@@ -2033,7 +1992,7 @@ index 8b90db5952..313b424f55 100644
        ~zkapp_command_id ~sequence_no ~status
        ~(failure_reasons : Transaction_status.Failure.Collection.Display.t option)
        =
-@@ -2554,8 +2905,7 @@ module Block_and_zkapp_command = struct
+@@ -2516,8 +2862,7 @@ module Block_and_zkapp_command = struct
      in
      Mina_caqti.select_insert_into_cols
        ~select:
@@ -2043,7 +2002,7 @@ index 8b90db5952..313b424f55 100644
        ~table_name
        ~cols:
          ( [ "block_id"
-@@ -2575,21 +2925,22 @@ module Block_and_zkapp_command = struct
+@@ -2537,21 +2882,22 @@ module Block_and_zkapp_command = struct
        (module Conn)
        { block_id; zkapp_command_id; sequence_no; status; failure_reasons_ids }
  
@@ -2071,7 +2030,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2613,7 +2964,7 @@ module Zkapp_account = struct
+@@ -2575,7 +2921,7 @@ module Zkapp_account = struct
  
    let table_name = "zkapp_accounts"
  
@@ -2080,7 +2039,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let ({ app_state
           ; verification_key
-@@ -2659,9 +3010,9 @@ module Zkapp_account = struct
+@@ -2621,9 +2967,9 @@ module Zkapp_account = struct
        ; zkapp_uri_id
        }
  
@@ -2092,7 +2051,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -2702,11 +3053,31 @@ module Accounts_accessed = struct
+@@ -2664,11 +3010,31 @@ module Accounts_accessed = struct
  
    let table_name = "accounts_accessed"
  
@@ -2127,7 +2086,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| SELECT %s
-@@ -2717,72 +3088,71 @@ module Accounts_accessed = struct
+@@ -2679,72 +3045,71 @@ module Accounts_accessed = struct
              comma_cols table_name ) )
        (block_id, account_identifier_id)
  
@@ -2257,7 +2216,7 @@ index 8b90db5952..313b424f55 100644
        (accounts : (int * Account.t) list) =
      let%map results =
        Deferred.List.map accounts ~f:(fun account ->
-@@ -2790,10 +3160,10 @@ module Accounts_accessed = struct
+@@ -2752,10 +3117,10 @@ module Accounts_accessed = struct
      in
      Result.all results
  
@@ -2270,7 +2229,7 @@ index 8b90db5952..313b424f55 100644
           (Mina_caqti.select_cols ~select:comma_cols ~table_name
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2810,30 +3180,30 @@ module Accounts_created = struct
+@@ -2772,30 +3137,30 @@ module Accounts_created = struct
  
    let table_name = "accounts_created"
  
@@ -2308,7 +2267,7 @@ index 8b90db5952..313b424f55 100644
           {sql| SELECT block_id, account_identifier_id, creation_fee
                 FROM accounts_created
                 WHERE block_id = ?
-@@ -2899,18 +3269,19 @@ module Block = struct
+@@ -2861,18 +3226,19 @@ module Block = struct
           "SELECT id FROM blocks WHERE state_hash = ?" )
        (State_hash.to_base58_check state_hash)
  
@@ -2334,7 +2293,7 @@ index 8b90db5952..313b424f55 100644
        ~constraint_constants ~protocol_state ~staged_ledger_diff
        ~protocol_version ~proposed_protocol_version ~hash ~v1_transaction_hash =
      let open Deferred.Result.Let_syntax in
-@@ -3011,7 +3382,7 @@ module Block = struct
+@@ -2973,7 +3339,7 @@ module Block = struct
          let blockchain_state = Protocol_state.blockchain_state protocol_state in
          let%bind block_id =
            Conn.find
@@ -2343,7 +2302,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "chain_status" ->
-@@ -3331,7 +3702,7 @@ module Block = struct
+@@ -3293,7 +3659,7 @@ module Block = struct
  
    (* NB: this batching logic an lead to partial writes; it is acceptable to be used with the
       migration tool, but not acceptable to be used with the archive node in its current form *)
@@ -2352,7 +2311,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (blocks : Extensional.Block.t list) =
      let open Deferred.Result.Let_syntax in
      (* zkapps are currently unsupported in the batch implementation of this function *)
-@@ -3393,9 +3764,7 @@ module Block = struct
+@@ -3355,9 +3721,7 @@ module Block = struct
      in
  
      (* we don't need to specify all types here, just the ones that sql may infer incorrectly *)
@@ -2363,7 +2322,7 @@ index 8b90db5952..313b424f55 100644
        | Bool ->
            Some "BOOL"
        | Int ->
-@@ -3408,39 +3777,36 @@ module Block = struct
+@@ -3370,39 +3734,36 @@ module Block = struct
            Some "BIGINT"
        | Float ->
            Some "FLOAT"
@@ -2422,7 +2381,7 @@ index 8b90db5952..313b424f55 100644
        match typ with
        | Bool ->
            Bool.to_string value
-@@ -3468,45 +3834,30 @@ module Block = struct
+@@ -3430,45 +3791,30 @@ module Block = struct
            (* we are ignoring the enum annotation in this context because it's not always valid to apply *)
            (* NOTE: we assume enum values do not contain special characters (eg "'") *)
            "'" ^ value ^ "'"
@@ -2490,7 +2449,7 @@ index 8b90db5952..313b424f55 100644
      in
      let render_row (type a) (typ : a Caqti_type.t) (value : a) : string =
        "(" ^ String.concat ~sep:"," (render_type typ value) ^ ")"
-@@ -3557,8 +3908,8 @@ module Block = struct
+@@ -3519,8 +3865,8 @@ module Block = struct
          in
          let%map entries =
            Conn.collect_list
@@ -2501,7 +2460,7 @@ index 8b90db5952..313b424f55 100644
                 query )
              ()
          in
-@@ -3576,7 +3927,7 @@ module Block = struct
+@@ -3538,7 +3884,7 @@ module Block = struct
            String.concat ~sep:"," @@ List.map ~f:(render_row typ) values
          in
          Conn.collect_list
@@ -2510,7 +2469,7 @@ index 8b90db5952..313b424f55 100644
               (sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table
                  fields_sql values_sql ) )
            () )
-@@ -3928,7 +4279,7 @@ module Block = struct
+@@ -3890,7 +4236,7 @@ module Block = struct
        let ids_sql = String.concat ~sep:"," ids in
        let parent_ids_sql = String.concat ~sep:"," parent_ids in
        Conn.exec
@@ -2519,7 +2478,7 @@ index 8b90db5952..313b424f55 100644
             (sprintf
                "UPDATE %s AS b SET parent_id = data.parent_id FROM (SELECT \
                 unnest(array[%s]) as id, unnest(array[%s]) as parent_id) AS \
-@@ -4079,7 +4430,7 @@ module Block = struct
+@@ -4041,7 +4387,7 @@ module Block = struct
  
      return ()
  
@@ -2528,7 +2487,7 @@ index 8b90db5952..313b424f55 100644
        ?(v1_transaction_hash = false) (block : Extensional.Block.t) =
      let open Deferred.Result.Let_syntax in
      let%bind block_id =
-@@ -4138,7 +4489,7 @@ module Block = struct
+@@ -4100,7 +4446,7 @@ module Block = struct
                  Some id )
            in
            Conn.find
@@ -2537,7 +2496,7 @@ index 8b90db5952..313b424f55 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "sub_window_densities" ->
-@@ -4296,18 +4647,19 @@ module Block = struct
+@@ -4258,18 +4604,19 @@ module Block = struct
      in
      return block_id
  
@@ -2561,7 +2520,7 @@ index 8b90db5952..313b424f55 100644
      (* derive query from type `t` *)
      let concat = String.concat ~sep:"," in
      let columns_with_id = concat ("id" :: Fields.names) in
-@@ -4316,8 +4668,8 @@ module Block = struct
+@@ -4278,8 +4625,8 @@ module Block = struct
      in
      let columns = concat Fields.names in
      Conn.collect_list
@@ -2572,7 +2531,7 @@ index 8b90db5952..313b424f55 100644
           typ
           (sprintf
              {sql| WITH RECURSIVE chain AS (
-@@ -4341,39 +4693,42 @@ module Block = struct
+@@ -4303,39 +4650,42 @@ module Block = struct
              columns_with_id b_columns_with_id columns ) )
        (end_block_id, start_block_id)
  
@@ -2629,7 +2588,7 @@ index 8b90db5952..313b424f55 100644
           {sql| UPDATE blocks SET chain_status='orphaned'
                 WHERE height = $2
                 AND state_hash <> $1
-@@ -4381,7 +4736,7 @@ module Block = struct
+@@ -4343,7 +4693,7 @@ module Block = struct
        (state_hash, height)
  
    (* update chain_status for blocks now known to be canonical or orphaned *)
@@ -2638,7 +2597,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      match%bind get_highest_canonical_block_opt (module Conn) () with
      | None ->
-@@ -4453,7 +4808,7 @@ module Block = struct
+@@ -4415,7 +4765,7 @@ module Block = struct
            Deferred.Result.return ()
  
    let delete_if_older_than ?height ?num_blocks ?timestamp
@@ -2647,7 +2606,7 @@ index 8b90db5952..313b424f55 100644
      let open Deferred.Result.Let_syntax in
      let%bind height =
        match (height, num_blocks) with
-@@ -4462,7 +4817,7 @@ module Block = struct
+@@ -4424,7 +4774,7 @@ module Block = struct
        | None, Some num_blocks -> (
            match%map
              Conn.find_opt
@@ -2656,7 +2615,7 @@ index 8b90db5952..313b424f55 100644
                   "SELECT MAX(height) FROM blocks" )
                ()
            with
-@@ -4478,8 +4833,8 @@ module Block = struct
+@@ -4440,8 +4790,8 @@ module Block = struct
        let%bind () =
          (* Delete user commands from old blocks. *)
          Conn.exec
@@ -2667,7 +2626,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM user_commands\n\
                WHERE id IN\n\
                (SELECT user_command_id FROM blocks_user_commands\n\
-@@ -4490,8 +4845,8 @@ module Block = struct
+@@ -4452,8 +4802,8 @@ module Block = struct
        let%bind () =
          (* Delete old blocks. *)
          Conn.exec
@@ -2678,7 +2637,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
                ?" )
            (height, timestamp)
-@@ -4499,7 +4854,7 @@ module Block = struct
+@@ -4461,7 +4811,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned internal commands. *)
          Conn.exec
@@ -2687,7 +2646,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM internal_commands\n\
                WHERE id NOT IN\n\
                (SELECT internal_commands.id FROM internal_commands\n\
-@@ -4510,7 +4865,7 @@ module Block = struct
+@@ -4472,7 +4822,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned snarked ledger hashes. *)
          Conn.exec
@@ -2696,7 +2655,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM snarked_ledger_hashes\n\
                WHERE id NOT IN\n\
                (SELECT snarked_ledger_hash_id FROM blocks)" )
-@@ -4519,7 +4874,7 @@ module Block = struct
+@@ -4481,7 +4831,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned public keys. *)
          Conn.exec
@@ -2705,7 +2664,7 @@ index 8b90db5952..313b424f55 100644
               "DELETE FROM public_keys\n\
                WHERE id NOT IN (SELECT fee_payer_id FROM user_commands)\n\
                AND id NOT IN (SELECT source_id FROM user_commands)\n\
-@@ -4569,8 +4924,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4531,8 +4881,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              ()
          | Some acct_id ->
              Token_owners.add_if_doesn't_exist token_id acct_id ) ;
@@ -2716,7 +2675,7 @@ index 8b90db5952..313b424f55 100644
          let%bind res =
            let open Deferred.Result.Let_syntax in
            let%bind () = Conn.start () in
-@@ -4581,7 +4936,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4543,7 +4893,7 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
              O1trace.thread "archive_processor.add_block"
              @@ fun () ->
              Metrics.time ~label:"add_block"
@@ -2725,7 +2684,7 @@ index 8b90db5952..313b424f55 100644
            in
            (* if an existing block has a parent hash that's for the block just added,
               set its parent id
-@@ -4636,8 +4991,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4598,8 +4948,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                      ] ;
                  let%bind.Deferred.Result () = Conn.start () in
                  match%bind
@@ -2736,7 +2695,7 @@ index 8b90db5952..313b424f55 100644
                        Accounts_accessed.add_accounts_if_don't_exist
                          (module Conn)
                          block_id accounts_accessed )
-@@ -4662,8 +5017,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+@@ -4624,8 +4974,8 @@ let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
                            , `Int (List.length accounts_accessed) )
                          ] ;
                      match%bind
@@ -2747,7 +2706,7 @@ index 8b90db5952..313b424f55 100644
                            Accounts_created.add_accounts_created_if_don't_exist
                              (module Conn)
                              block_id accounts_created )
-@@ -4800,8 +5155,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
+@@ -4762,8 +5112,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
              With_hash.{ data = block; hash = the_hash }
            in
            let add_accounts () =
@@ -2758,7 +2717,7 @@ index 8b90db5952..313b424f55 100644
                  let%bind.Deferred.Result genesis_block_id =
                    Block.add_if_doesn't_exist
                      (module Conn)
-@@ -4944,7 +5299,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
+@@ -4906,7 +5256,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
            Strict_pipe.Writer.write extensional_block_writer extensional_block )
      ]
    in

--- a/buildkite/scripts/caqti-upgrade.patch
+++ b/buildkite/scripts/caqti-upgrade.patch
@@ -257,7 +257,25 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -689,7 +690,7 @@ module Zkapp_permissions = struct
+@@ -596,22 +597,22 @@ module Protocol_versions = struct
+ 
+   let find (module Conn : CONNECTION) ~transaction ~network ~patch =
+     Conn.find
+-      (Caqti_request.find
+-         Caqti_type.(tup3 int int int)
++      (find_req
++         Caqti_type.(t3 int int int)
+          Caqti_type.int
+          (Mina_caqti.select_cols ~select:"id" ~table_name ~cols:Fields.names ()) )
+       (transaction, network, patch)
+ 
+   let find_txn_version (module Conn : CONNECTION) ~transaction =
+     Conn.collect_list
+-      (Caqti_request.collect Caqti_type.int Caqti_type.int
++      (collect_req Caqti_type.int Caqti_type.int
+          {sql| SELECT id FROM protocol_versions WHERE transaction = ?
+         |sql} )
+       transaction
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -266,7 +284,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -742,7 +743,7 @@ module Zkapp_timing_info = struct
+@@ -727,7 +728,7 @@ module Zkapp_permissions = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -275,7 +293,16 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -763,7 +764,7 @@ module Zkapp_uri = struct
+@@ -780,7 +781,7 @@ module Zkapp_timing_info = struct
+ 
+   let load (module Conn : CONNECTION) id =
+     Conn.find
+-      (Caqti_request.find Caqti_type.int typ
++      (find_req Caqti_type.int typ
+          (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
+       id
+ end
+@@ -801,7 +802,7 @@ module Zkapp_uri = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -284,7 +311,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "value" ]) )
        id
  end
-@@ -856,7 +857,7 @@ module Zkapp_updates = struct
+@@ -894,7 +895,7 @@ module Zkapp_updates = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -293,7 +320,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -884,7 +885,7 @@ module Zkapp_balance_bounds = struct
+@@ -922,7 +923,7 @@ module Zkapp_balance_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -302,7 +329,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -913,7 +914,7 @@ module Zkapp_nonce_bounds = struct
+@@ -951,7 +952,7 @@ module Zkapp_nonce_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -311,7 +338,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -997,7 +998,7 @@ module Zkapp_account_precondition = struct
+@@ -1035,7 +1036,7 @@ module Zkapp_account_precondition = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -320,7 +347,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1025,7 +1026,7 @@ module Zkapp_token_id_bounds = struct
+@@ -1063,7 +1064,7 @@ module Zkapp_token_id_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -329,7 +356,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1057,7 +1058,7 @@ module Zkapp_timestamp_bounds = struct
+@@ -1095,7 +1096,7 @@ module Zkapp_timestamp_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -338,7 +365,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1085,7 +1086,7 @@ module Zkapp_length_bounds = struct
+@@ -1123,7 +1124,7 @@ module Zkapp_length_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -347,7 +374,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1113,7 +1114,7 @@ module Zkapp_amount_bounds = struct
+@@ -1151,7 +1152,7 @@ module Zkapp_amount_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -356,7 +383,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1148,7 +1149,7 @@ module Zkapp_global_slot_bounds = struct
+@@ -1186,7 +1187,7 @@ module Zkapp_global_slot_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -365,7 +392,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1177,7 +1178,7 @@ module Timing_info = struct
+@@ -1215,7 +1216,7 @@ module Timing_info = struct
        Account_identifiers.find (module Conn) account_id
      in
      Conn.find
@@ -374,7 +401,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1189,7 +1190,7 @@ module Timing_info = struct
+@@ -1227,7 +1228,7 @@ module Timing_info = struct
    let find_by_account_identifier_id_opt (module Conn : CONNECTION)
        account_identifier_id =
      Conn.find_opt
@@ -383,7 +410,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1232,7 +1233,7 @@ module Timing_info = struct
+@@ -1270,7 +1271,7 @@ module Timing_info = struct
      in
      match%bind
        Conn.find_opt
@@ -392,7 +419,7 @@ index 8b90db5952..939aaa8864 100644
             {sql| SELECT id FROM timing_info
                   WHERE account_identifier_id = ?
                   AND initial_minimum_balance = ?
-@@ -1246,7 +1247,7 @@ module Timing_info = struct
+@@ -1284,7 +1285,7 @@ module Timing_info = struct
          return id
      | None ->
          Conn.find
@@ -401,7 +428,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO timing_info
                      (account_identifier_id,initial_minimum_balance,
                       cliff_time, cliff_amount, vesting_period, vesting_increment)
-@@ -1257,13 +1258,13 @@ module Timing_info = struct
+@@ -1295,13 +1296,13 @@ module Timing_info = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -417,7 +444,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1272,13 +1273,13 @@ module Snarked_ledger_hash = struct
+@@ -1310,13 +1311,13 @@ module Snarked_ledger_hash = struct
    let find (module Conn : CONNECTION) (t : Frozen_ledger_hash.t) =
      let hash = Frozen_ledger_hash.to_base58_check t in
      Conn.find
@@ -433,7 +460,7 @@ index 8b90db5952..939aaa8864 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  
-@@ -1288,7 +1289,7 @@ module Snarked_ledger_hash = struct
+@@ -1326,7 +1327,7 @@ module Snarked_ledger_hash = struct
      let hash = Frozen_ledger_hash.to_base58_check t in
      match%bind
        Conn.find_opt
@@ -442,7 +469,7 @@ index 8b90db5952..939aaa8864 100644
             "SELECT id FROM snarked_ledger_hashes WHERE value = ?" )
          hash
      with
-@@ -1296,13 +1297,13 @@ module Snarked_ledger_hash = struct
+@@ -1334,13 +1335,13 @@ module Snarked_ledger_hash = struct
          return id
      | None ->
          Conn.find
@@ -458,7 +485,7 @@ index 8b90db5952..939aaa8864 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  end
-@@ -1338,7 +1339,7 @@ module Zkapp_epoch_ledger = struct
+@@ -1376,7 +1377,7 @@ module Zkapp_epoch_ledger = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -467,7 +494,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1398,7 +1399,7 @@ module Zkapp_epoch_data = struct
+@@ -1436,7 +1437,7 @@ module Zkapp_epoch_data = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -476,7 +503,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1473,7 +1474,7 @@ module Zkapp_network_precondition = struct
+@@ -1511,7 +1512,7 @@ module Zkapp_network_precondition = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -485,7 +512,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1565,7 +1566,7 @@ module Zkapp_events = struct
+@@ -1603,7 +1604,7 @@ module Zkapp_events = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -494,7 +521,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]) )
        id
  end
-@@ -1717,7 +1718,7 @@ module Zkapp_account_update_body = struct
+@@ -1755,7 +1756,7 @@ module Zkapp_account_update_body = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -503,7 +530,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1748,7 +1749,7 @@ module Zkapp_account_update = struct
+@@ -1786,7 +1787,7 @@ module Zkapp_account_update = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -512,7 +539,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1792,7 +1793,7 @@ module Zkapp_fee_payer_body = struct
+@@ -1830,7 +1831,7 @@ module Zkapp_fee_payer_body = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -521,7 +548,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1849,7 +1850,7 @@ module Epoch_data = struct
+@@ -1887,7 +1888,7 @@ module Epoch_data = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -530,7 +557,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1890,13 +1891,13 @@ module User_command = struct
+@@ -1928,13 +1929,13 @@ module User_command = struct
      let find (module Conn : CONNECTION) ~(transaction_hash : Transaction_hash.t)
          ~v1_transaction_hash =
        Conn.find_opt
@@ -546,7 +573,7 @@ index 8b90db5952..939aaa8864 100644
             (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
          id
  
-@@ -1940,7 +1941,7 @@ module User_command = struct
+@@ -1978,7 +1979,7 @@ module User_command = struct
            in
            (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
            Conn.find
@@ -555,7 +582,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -1987,7 +1988,7 @@ module User_command = struct
+@@ -2025,7 +2026,7 @@ module User_command = struct
              Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
            in
            Conn.find
@@ -564,7 +591,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2028,14 +2029,14 @@ module User_command = struct
+@@ -2066,14 +2067,14 @@ module User_command = struct
      let find_opt (module Conn : CONNECTION)
          ~(transaction_hash : Transaction_hash.t) =
        Conn.find_opt
@@ -581,7 +608,7 @@ index 8b90db5952..939aaa8864 100644
          @@ Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names )
          id
  
-@@ -2111,8 +2112,8 @@ module Internal_command = struct
+@@ -2149,8 +2150,8 @@ module Internal_command = struct
    let find_opt (module Conn : CONNECTION) ~(v1_transaction_hash : bool)
        ~(transaction_hash : Transaction_hash.t) ~(command_type : string) =
      Conn.find_opt
@@ -592,7 +619,7 @@ index 8b90db5952..939aaa8864 100644
           Caqti_type.int
           (Mina_caqti.select_cols ~select:"id" ~table_name
              ~tannot:(function
-@@ -2123,7 +2124,7 @@ module Internal_command = struct
+@@ -2161,7 +2162,7 @@ module Internal_command = struct
  
    let load (module Conn : CONNECTION) ~(id : int) =
      Conn.find
@@ -601,7 +628,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  
-@@ -2144,7 +2145,7 @@ module Internal_command = struct
+@@ -2182,7 +2183,7 @@ module Internal_command = struct
            Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
          in
          Conn.find
@@ -610,7 +637,7 @@ index 8b90db5952..939aaa8864 100644
               (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                  ~tannot:(function
                    | "command_type" -> Some "internal_command_type" | _ -> None
-@@ -2189,7 +2190,7 @@ module Fee_transfer = struct
+@@ -2227,7 +2228,7 @@ module Fee_transfer = struct
        in
        Ok { kind; receiver_id; fee; hash }
      in
@@ -619,7 +646,7 @@ index 8b90db5952..939aaa8864 100644
      Caqti_type.custom ~encode ~decode rep
  
    let add_if_doesn't_exist (module Conn : CONNECTION)
-@@ -2211,7 +2212,7 @@ module Fee_transfer = struct
+@@ -2249,7 +2250,7 @@ module Fee_transfer = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -628,7 +655,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2239,7 +2240,7 @@ module Coinbase = struct
+@@ -2277,7 +2278,7 @@ module Coinbase = struct
      let decode (_, receiver_id, amount, hash) =
        Ok { receiver_id; amount; hash }
      in
@@ -637,7 +664,7 @@ index 8b90db5952..939aaa8864 100644
      Caqti_type.custom ~encode ~decode rep
  
    let add_if_doesn't_exist (module Conn : CONNECTION)
-@@ -2260,7 +2261,7 @@ module Coinbase = struct
+@@ -2298,7 +2299,7 @@ module Coinbase = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -646,7 +673,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2299,7 +2300,7 @@ module Block_and_internal_command = struct
+@@ -2337,7 +2338,7 @@ module Block_and_internal_command = struct
        Option.map ~f:Transaction_status.Failure.to_string failure_reason
      in
      Conn.exec
@@ -655,7 +682,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| INSERT INTO blocks_internal_commands
                   (block_id,
                   internal_command_id,
-@@ -2320,8 +2321,8 @@ module Block_and_internal_command = struct
+@@ -2358,8 +2359,8 @@ module Block_and_internal_command = struct
    let find (module Conn : CONNECTION) ~block_id ~internal_command_id
        ~sequence_no ~secondary_sequence_no =
      Conn.find_opt
@@ -666,7 +693,7 @@ index 8b90db5952..939aaa8864 100644
           Caqti_type.string
           {sql| SELECT 'exists' FROM blocks_internal_commands
                 WHERE block_id = $1
-@@ -2352,8 +2353,8 @@ module Block_and_internal_command = struct
+@@ -2390,8 +2391,8 @@ module Block_and_internal_command = struct
        ~sequence_no ~secondary_sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -677,7 +704,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_internal_commands
-@@ -2388,7 +2389,7 @@ module Block_and_signed_command = struct
+@@ -2426,7 +2427,7 @@ module Block_and_signed_command = struct
        Option.map ~f:Transaction_status.Failure.to_string failure_reason
      in
      Conn.exec
@@ -686,7 +713,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| INSERT INTO blocks_user_commands
                   (block_id,
                   user_command_id,
-@@ -2418,8 +2419,8 @@ module Block_and_signed_command = struct
+@@ -2456,8 +2457,8 @@ module Block_and_signed_command = struct
      let open Deferred.Result.Let_syntax in
      match%bind
        Conn.find_opt
@@ -697,7 +724,7 @@ index 8b90db5952..939aaa8864 100644
             Caqti_type.string
             {sql| SELECT 'exists' FROM blocks_user_commands
                   WHERE block_id = $1
-@@ -2438,8 +2439,8 @@ module Block_and_signed_command = struct
+@@ -2476,8 +2477,8 @@ module Block_and_signed_command = struct
    let load (module Conn : CONNECTION) ~block_id ~user_command_id ~sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -708,7 +735,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_user_commands
-@@ -2473,7 +2474,7 @@ module Zkapp_account_update_failures = struct
+@@ -2511,7 +2512,7 @@ module Zkapp_account_update_failures = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -717,7 +744,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name
              ~cols:[ "index"; "failures" ] ) )
        id
-@@ -2516,8 +2517,7 @@ module Block_and_zkapp_command = struct
+@@ -2554,8 +2555,7 @@ module Block_and_zkapp_command = struct
      in
      Mina_caqti.select_insert_into_cols
        ~select:
@@ -727,7 +754,7 @@ index 8b90db5952..939aaa8864 100644
        ~table_name
        ~cols:
          ( [ "block_id"
-@@ -2540,8 +2540,8 @@ module Block_and_zkapp_command = struct
+@@ -2578,8 +2578,8 @@ module Block_and_zkapp_command = struct
    let load (module Conn : CONNECTION) ~block_id ~zkapp_command_id ~sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -738,7 +765,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id"; "zkapp_command_id"; "sequence_no" ]
-@@ -2551,7 +2551,7 @@ module Block_and_zkapp_command = struct
+@@ -2589,7 +2589,7 @@ module Block_and_zkapp_command = struct
    let all_from_block (module Conn : CONNECTION) ~block_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.collect_list
@@ -747,7 +774,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2623,7 +2623,7 @@ module Zkapp_account = struct
+@@ -2661,7 +2661,7 @@ module Zkapp_account = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -756,7 +783,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -2667,8 +2667,8 @@ module Accounts_accessed = struct
+@@ -2705,8 +2705,8 @@ module Accounts_accessed = struct
    let find_opt (module Conn : CONNECTION) ~block_id ~account_identifier_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find_opt
@@ -767,7 +794,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s
-@@ -2739,7 +2739,7 @@ module Accounts_accessed = struct
+@@ -2777,7 +2777,7 @@ module Accounts_accessed = struct
            }
          in
          Mina_caqti.select_insert_into_cols
@@ -776,7 +803,7 @@ index 8b90db5952..939aaa8864 100644
            ~table_name ~cols:(Fields.names, typ)
            (module Conn)
            account_accessed
-@@ -2755,7 +2755,7 @@ module Accounts_accessed = struct
+@@ -2793,7 +2793,7 @@ module Accounts_accessed = struct
    let all_from_block (module Conn : CONNECTION) block_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.collect_list
@@ -785,7 +812,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols ~select:comma_cols ~table_name
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2780,7 +2780,7 @@ module Accounts_created = struct
+@@ -2818,7 +2818,7 @@ module Accounts_created = struct
      in
      let creation_fee = Currency.Fee.to_string creation_fee in
      Mina_caqti.select_insert_into_cols
@@ -794,7 +821,7 @@ index 8b90db5952..939aaa8864 100644
        ~table_name ~cols:(Fields.names, typ)
        (module Conn)
        { block_id; account_identifier_id; creation_fee }
-@@ -2795,7 +2795,7 @@ module Accounts_created = struct
+@@ -2833,7 +2833,7 @@ module Accounts_created = struct
  
    let all_from_block (module Conn : CONNECTION) block_id =
      Conn.collect_list
@@ -803,7 +830,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT block_id, account_identifier_id, creation_fee
                 FROM accounts_created
                 WHERE block_id = ?
-@@ -2861,14 +2861,14 @@ module Block = struct
+@@ -2899,14 +2899,14 @@ module Block = struct
           "SELECT id FROM blocks WHERE state_hash = ?" )
        (State_hash.to_base58_check state_hash)
  
@@ -821,7 +848,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name:"blocks" ~cols:Fields.names) )
        id
  
-@@ -2973,7 +2973,7 @@ module Block = struct
+@@ -3011,7 +3011,7 @@ module Block = struct
          let blockchain_state = Protocol_state.blockchain_state protocol_state in
          let%bind block_id =
            Conn.find
@@ -830,7 +857,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "chain_status" ->
-@@ -3355,9 +3355,7 @@ module Block = struct
+@@ -3393,9 +3393,7 @@ module Block = struct
      in
  
      (* we don't need to specify all types here, just the ones that sql may infer incorrectly *)
@@ -841,7 +868,7 @@ index 8b90db5952..939aaa8864 100644
        | Bool ->
            Some "BOOL"
        | Int ->
-@@ -3370,39 +3368,36 @@ module Block = struct
+@@ -3408,39 +3406,36 @@ module Block = struct
            Some "BIGINT"
        | Float ->
            Some "FLOAT"
@@ -900,7 +927,7 @@ index 8b90db5952..939aaa8864 100644
        match typ with
        | Bool ->
            Bool.to_string value
-@@ -3430,45 +3425,30 @@ module Block = struct
+@@ -3468,45 +3463,30 @@ module Block = struct
            (* we are ignoring the enum annotation in this context because it's not always valid to apply *)
            (* NOTE: we assume enum values do not contain special characters (eg "'") *)
            "'" ^ value ^ "'"
@@ -968,7 +995,7 @@ index 8b90db5952..939aaa8864 100644
      in
      let render_row (type a) (typ : a Caqti_type.t) (value : a) : string =
        "(" ^ String.concat ~sep:"," (render_type typ value) ^ ")"
-@@ -3519,8 +3499,8 @@ module Block = struct
+@@ -3557,8 +3537,8 @@ module Block = struct
          in
          let%map entries =
            Conn.collect_list
@@ -979,7 +1006,7 @@ index 8b90db5952..939aaa8864 100644
                 query )
              ()
          in
-@@ -3538,7 +3518,7 @@ module Block = struct
+@@ -3576,7 +3556,7 @@ module Block = struct
            String.concat ~sep:"," @@ List.map ~f:(render_row typ) values
          in
          Conn.collect_list
@@ -988,7 +1015,7 @@ index 8b90db5952..939aaa8864 100644
               (sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table
                  fields_sql values_sql ) )
            () )
-@@ -3890,7 +3870,7 @@ module Block = struct
+@@ -3928,7 +3908,7 @@ module Block = struct
        let ids_sql = String.concat ~sep:"," ids in
        let parent_ids_sql = String.concat ~sep:"," parent_ids in
        Conn.exec
@@ -997,7 +1024,7 @@ index 8b90db5952..939aaa8864 100644
             (sprintf
                "UPDATE %s AS b SET parent_id = data.parent_id FROM (SELECT \
                 unnest(array[%s]) as id, unnest(array[%s]) as parent_id) AS \
-@@ -4100,7 +4080,7 @@ module Block = struct
+@@ -4138,7 +4118,7 @@ module Block = struct
                  Some id )
            in
            Conn.find
@@ -1006,7 +1033,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "sub_window_densities" ->
-@@ -4261,8 +4241,8 @@ module Block = struct
+@@ -4299,8 +4279,8 @@ module Block = struct
    let set_parent_id_if_null (module Conn : CONNECTION) ~parent_hash
        ~(parent_id : int) =
      Conn.exec
@@ -1017,7 +1044,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| UPDATE blocks SET parent_id = ?
                 WHERE parent_hash = ?
                 AND parent_id IS NULL
-@@ -4278,8 +4258,8 @@ module Block = struct
+@@ -4316,8 +4296,8 @@ module Block = struct
      in
      let columns = concat Fields.names in
      Conn.collect_list
@@ -1028,7 +1055,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| WITH RECURSIVE chain AS (
-@@ -4305,37 +4285,37 @@ module Block = struct
+@@ -4343,37 +4323,37 @@ module Block = struct
  
    let get_highest_canonical_block_opt (module Conn : CONNECTION) =
      Conn.find_opt
@@ -1075,7 +1102,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| UPDATE blocks SET chain_status='orphaned'
                 WHERE height = $2
                 AND state_hash <> $1
-@@ -4424,7 +4404,7 @@ module Block = struct
+@@ -4462,7 +4442,7 @@ module Block = struct
        | None, Some num_blocks -> (
            match%map
              Conn.find_opt
@@ -1084,7 +1111,7 @@ index 8b90db5952..939aaa8864 100644
                   "SELECT MAX(height) FROM blocks" )
                ()
            with
-@@ -4440,8 +4420,8 @@ module Block = struct
+@@ -4478,8 +4458,8 @@ module Block = struct
        let%bind () =
          (* Delete user commands from old blocks. *)
          Conn.exec
@@ -1095,7 +1122,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM user_commands\n\
                WHERE id IN\n\
                (SELECT user_command_id FROM blocks_user_commands\n\
-@@ -4452,8 +4432,8 @@ module Block = struct
+@@ -4490,8 +4470,8 @@ module Block = struct
        let%bind () =
          (* Delete old blocks. *)
          Conn.exec
@@ -1106,7 +1133,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
                ?" )
            (height, timestamp)
-@@ -4461,7 +4441,7 @@ module Block = struct
+@@ -4499,7 +4479,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned internal commands. *)
          Conn.exec
@@ -1115,7 +1142,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM internal_commands\n\
                WHERE id NOT IN\n\
                (SELECT internal_commands.id FROM internal_commands\n\
-@@ -4472,7 +4452,7 @@ module Block = struct
+@@ -4510,7 +4490,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned snarked ledger hashes. *)
          Conn.exec
@@ -1124,7 +1151,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM snarked_ledger_hashes\n\
                WHERE id NOT IN\n\
                (SELECT snarked_ledger_hash_id FROM blocks)" )
-@@ -4481,7 +4461,7 @@ module Block = struct
+@@ -4519,7 +4499,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned public keys. *)
          Conn.exec
@@ -1133,7 +1160,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM public_keys\n\
                WHERE id NOT IN (SELECT fee_payer_id FROM user_commands)\n\
                AND id NOT IN (SELECT source_id FROM user_commands)\n\
-@@ -4906,7 +4886,13 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
+@@ -4944,7 +4924,13 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
            Strict_pipe.Writer.write extensional_block_writer extensional_block )
      ]
    in

--- a/buildkite/scripts/caqti-upgrade.patch
+++ b/buildkite/scripts/caqti-upgrade.patch
@@ -257,25 +257,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -596,22 +597,22 @@ module Protocol_versions = struct
- 
-   let find (module Conn : CONNECTION) ~transaction ~network ~patch =
-     Conn.find
--      (Caqti_request.find
--         Caqti_type.(tup3 int int int)
-+      (find_req
-+         Caqti_type.(t3 int int int)
-          Caqti_type.int
-          (Mina_caqti.select_cols ~select:"id" ~table_name ~cols:Fields.names ()) )
-       (transaction, network, patch)
- 
-   let find_txn_version (module Conn : CONNECTION) ~transaction =
-     Conn.collect_list
--      (Caqti_request.collect Caqti_type.int Caqti_type.int
-+      (collect_req Caqti_type.int Caqti_type.int
-          {sql| SELECT id FROM protocol_versions WHERE transaction = ?
-         |sql} )
-       transaction
+@@ -689,7 +690,7 @@ module Zkapp_permissions = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -284,7 +266,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -727,7 +728,7 @@ module Zkapp_permissions = struct
+@@ -742,7 +743,7 @@ module Zkapp_timing_info = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -293,16 +275,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -780,7 +781,7 @@ module Zkapp_timing_info = struct
- 
-   let load (module Conn : CONNECTION) id =
-     Conn.find
--      (Caqti_request.find Caqti_type.int typ
-+      (find_req Caqti_type.int typ
-          (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
-       id
- end
-@@ -801,7 +802,7 @@ module Zkapp_uri = struct
+@@ -763,7 +764,7 @@ module Zkapp_uri = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -311,7 +284,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "value" ]) )
        id
  end
-@@ -894,7 +895,7 @@ module Zkapp_updates = struct
+@@ -856,7 +857,7 @@ module Zkapp_updates = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -320,7 +293,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -922,7 +923,7 @@ module Zkapp_balance_bounds = struct
+@@ -884,7 +885,7 @@ module Zkapp_balance_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -329,7 +302,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -951,7 +952,7 @@ module Zkapp_nonce_bounds = struct
+@@ -913,7 +914,7 @@ module Zkapp_nonce_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -338,7 +311,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1035,7 +1036,7 @@ module Zkapp_account_precondition = struct
+@@ -997,7 +998,7 @@ module Zkapp_account_precondition = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -347,7 +320,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1063,7 +1064,7 @@ module Zkapp_token_id_bounds = struct
+@@ -1025,7 +1026,7 @@ module Zkapp_token_id_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -356,7 +329,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1095,7 +1096,7 @@ module Zkapp_timestamp_bounds = struct
+@@ -1057,7 +1058,7 @@ module Zkapp_timestamp_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -365,7 +338,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1123,7 +1124,7 @@ module Zkapp_length_bounds = struct
+@@ -1085,7 +1086,7 @@ module Zkapp_length_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -374,7 +347,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1151,7 +1152,7 @@ module Zkapp_amount_bounds = struct
+@@ -1113,7 +1114,7 @@ module Zkapp_amount_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -383,7 +356,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1186,7 +1187,7 @@ module Zkapp_global_slot_bounds = struct
+@@ -1148,7 +1149,7 @@ module Zkapp_global_slot_bounds = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -392,7 +365,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1215,7 +1216,7 @@ module Timing_info = struct
+@@ -1177,7 +1178,7 @@ module Timing_info = struct
        Account_identifiers.find (module Conn) account_id
      in
      Conn.find
@@ -401,7 +374,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1227,7 +1228,7 @@ module Timing_info = struct
+@@ -1189,7 +1190,7 @@ module Timing_info = struct
    let find_by_account_identifier_id_opt (module Conn : CONNECTION)
        account_identifier_id =
      Conn.find_opt
@@ -410,7 +383,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT account_identifier_id, initial_minimum_balance,
                        cliff_time, cliff_amount,
                        vesting_period, vesting_increment
-@@ -1270,7 +1271,7 @@ module Timing_info = struct
+@@ -1232,7 +1233,7 @@ module Timing_info = struct
      in
      match%bind
        Conn.find_opt
@@ -419,7 +392,7 @@ index 8b90db5952..939aaa8864 100644
             {sql| SELECT id FROM timing_info
                   WHERE account_identifier_id = ?
                   AND initial_minimum_balance = ?
-@@ -1284,7 +1285,7 @@ module Timing_info = struct
+@@ -1246,7 +1247,7 @@ module Timing_info = struct
          return id
      | None ->
          Conn.find
@@ -428,7 +401,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO timing_info
                      (account_identifier_id,initial_minimum_balance,
                       cliff_time, cliff_amount, vesting_period, vesting_increment)
-@@ -1295,13 +1296,13 @@ module Timing_info = struct
+@@ -1257,13 +1258,13 @@ module Timing_info = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -444,7 +417,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1310,13 +1311,13 @@ module Snarked_ledger_hash = struct
+@@ -1272,13 +1273,13 @@ module Snarked_ledger_hash = struct
    let find (module Conn : CONNECTION) (t : Frozen_ledger_hash.t) =
      let hash = Frozen_ledger_hash.to_base58_check t in
      Conn.find
@@ -460,7 +433,7 @@ index 8b90db5952..939aaa8864 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  
-@@ -1326,7 +1327,7 @@ module Snarked_ledger_hash = struct
+@@ -1288,7 +1289,7 @@ module Snarked_ledger_hash = struct
      let hash = Frozen_ledger_hash.to_base58_check t in
      match%bind
        Conn.find_opt
@@ -469,7 +442,7 @@ index 8b90db5952..939aaa8864 100644
             "SELECT id FROM snarked_ledger_hashes WHERE value = ?" )
          hash
      with
-@@ -1334,13 +1335,13 @@ module Snarked_ledger_hash = struct
+@@ -1296,13 +1297,13 @@ module Snarked_ledger_hash = struct
          return id
      | None ->
          Conn.find
@@ -485,7 +458,7 @@ index 8b90db5952..939aaa8864 100644
           "SELECT value FROM snarked_ledger_hashes WHERE id = ?" )
        id
  end
-@@ -1376,7 +1377,7 @@ module Zkapp_epoch_ledger = struct
+@@ -1338,7 +1339,7 @@ module Zkapp_epoch_ledger = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -494,7 +467,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1436,7 +1437,7 @@ module Zkapp_epoch_data = struct
+@@ -1398,7 +1399,7 @@ module Zkapp_epoch_data = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -503,7 +476,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1511,7 +1512,7 @@ module Zkapp_network_precondition = struct
+@@ -1473,7 +1474,7 @@ module Zkapp_network_precondition = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -512,7 +485,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1603,7 +1604,7 @@ module Zkapp_events = struct
+@@ -1565,7 +1566,7 @@ module Zkapp_events = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -521,7 +494,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]) )
        id
  end
-@@ -1755,7 +1756,7 @@ module Zkapp_account_update_body = struct
+@@ -1717,7 +1718,7 @@ module Zkapp_account_update_body = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -530,7 +503,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1786,7 +1787,7 @@ module Zkapp_account_update = struct
+@@ -1748,7 +1749,7 @@ module Zkapp_account_update = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -539,7 +512,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1830,7 +1831,7 @@ module Zkapp_fee_payer_body = struct
+@@ -1792,7 +1793,7 @@ module Zkapp_fee_payer_body = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -548,7 +521,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1887,7 +1888,7 @@ module Epoch_data = struct
+@@ -1849,7 +1850,7 @@ module Epoch_data = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -557,7 +530,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -1928,13 +1929,13 @@ module User_command = struct
+@@ -1890,13 +1891,13 @@ module User_command = struct
      let find (module Conn : CONNECTION) ~(transaction_hash : Transaction_hash.t)
          ~v1_transaction_hash =
        Conn.find_opt
@@ -573,7 +546,7 @@ index 8b90db5952..939aaa8864 100644
             (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
          id
  
-@@ -1978,7 +1979,7 @@ module User_command = struct
+@@ -1940,7 +1941,7 @@ module User_command = struct
            in
            (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
            Conn.find
@@ -582,7 +555,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2025,7 +2026,7 @@ module User_command = struct
+@@ -1987,7 +1988,7 @@ module User_command = struct
              Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
            in
            Conn.find
@@ -591,7 +564,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "command_type" -> Some "user_command_type" | _ -> None )
-@@ -2066,14 +2067,14 @@ module User_command = struct
+@@ -2028,14 +2029,14 @@ module User_command = struct
      let find_opt (module Conn : CONNECTION)
          ~(transaction_hash : Transaction_hash.t) =
        Conn.find_opt
@@ -608,7 +581,7 @@ index 8b90db5952..939aaa8864 100644
          @@ Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names )
          id
  
-@@ -2149,8 +2150,8 @@ module Internal_command = struct
+@@ -2111,8 +2112,8 @@ module Internal_command = struct
    let find_opt (module Conn : CONNECTION) ~(v1_transaction_hash : bool)
        ~(transaction_hash : Transaction_hash.t) ~(command_type : string) =
      Conn.find_opt
@@ -619,7 +592,7 @@ index 8b90db5952..939aaa8864 100644
           Caqti_type.int
           (Mina_caqti.select_cols ~select:"id" ~table_name
              ~tannot:(function
-@@ -2161,7 +2162,7 @@ module Internal_command = struct
+@@ -2123,7 +2124,7 @@ module Internal_command = struct
  
    let load (module Conn : CONNECTION) ~(id : int) =
      Conn.find
@@ -628,7 +601,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  
-@@ -2182,7 +2183,7 @@ module Internal_command = struct
+@@ -2144,7 +2145,7 @@ module Internal_command = struct
            Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
          in
          Conn.find
@@ -637,7 +610,7 @@ index 8b90db5952..939aaa8864 100644
               (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                  ~tannot:(function
                    | "command_type" -> Some "internal_command_type" | _ -> None
-@@ -2227,7 +2228,7 @@ module Fee_transfer = struct
+@@ -2189,7 +2190,7 @@ module Fee_transfer = struct
        in
        Ok { kind; receiver_id; fee; hash }
      in
@@ -646,7 +619,7 @@ index 8b90db5952..939aaa8864 100644
      Caqti_type.custom ~encode ~decode rep
  
    let add_if_doesn't_exist (module Conn : CONNECTION)
-@@ -2249,7 +2250,7 @@ module Fee_transfer = struct
+@@ -2211,7 +2212,7 @@ module Fee_transfer = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -655,7 +628,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2277,7 +2278,7 @@ module Coinbase = struct
+@@ -2239,7 +2240,7 @@ module Coinbase = struct
      let decode (_, receiver_id, amount, hash) =
        Ok { receiver_id; amount; hash }
      in
@@ -664,7 +637,7 @@ index 8b90db5952..939aaa8864 100644
      Caqti_type.custom ~encode ~decode rep
  
    let add_if_doesn't_exist (module Conn : CONNECTION)
-@@ -2298,7 +2299,7 @@ module Coinbase = struct
+@@ -2260,7 +2261,7 @@ module Coinbase = struct
            Public_key.add_if_doesn't_exist (module Conn) pk
          in
          Conn.find
@@ -673,7 +646,7 @@ index 8b90db5952..939aaa8864 100644
               {sql| INSERT INTO internal_commands
                      (command_type, receiver_id, fee, hash)
                     VALUES (?::internal_command_type, ?, ?, ?)
-@@ -2337,7 +2338,7 @@ module Block_and_internal_command = struct
+@@ -2299,7 +2300,7 @@ module Block_and_internal_command = struct
        Option.map ~f:Transaction_status.Failure.to_string failure_reason
      in
      Conn.exec
@@ -682,7 +655,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| INSERT INTO blocks_internal_commands
                   (block_id,
                   internal_command_id,
-@@ -2358,8 +2359,8 @@ module Block_and_internal_command = struct
+@@ -2320,8 +2321,8 @@ module Block_and_internal_command = struct
    let find (module Conn : CONNECTION) ~block_id ~internal_command_id
        ~sequence_no ~secondary_sequence_no =
      Conn.find_opt
@@ -693,7 +666,7 @@ index 8b90db5952..939aaa8864 100644
           Caqti_type.string
           {sql| SELECT 'exists' FROM blocks_internal_commands
                 WHERE block_id = $1
-@@ -2390,8 +2391,8 @@ module Block_and_internal_command = struct
+@@ -2352,8 +2353,8 @@ module Block_and_internal_command = struct
        ~sequence_no ~secondary_sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -704,7 +677,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_internal_commands
-@@ -2426,7 +2427,7 @@ module Block_and_signed_command = struct
+@@ -2388,7 +2389,7 @@ module Block_and_signed_command = struct
        Option.map ~f:Transaction_status.Failure.to_string failure_reason
      in
      Conn.exec
@@ -713,7 +686,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| INSERT INTO blocks_user_commands
                   (block_id,
                   user_command_id,
-@@ -2456,8 +2457,8 @@ module Block_and_signed_command = struct
+@@ -2418,8 +2419,8 @@ module Block_and_signed_command = struct
      let open Deferred.Result.Let_syntax in
      match%bind
        Conn.find_opt
@@ -724,7 +697,7 @@ index 8b90db5952..939aaa8864 100644
             Caqti_type.string
             {sql| SELECT 'exists' FROM blocks_user_commands
                   WHERE block_id = $1
-@@ -2476,8 +2477,8 @@ module Block_and_signed_command = struct
+@@ -2438,8 +2439,8 @@ module Block_and_signed_command = struct
    let load (module Conn : CONNECTION) ~block_id ~user_command_id ~sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -735,7 +708,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s FROM blocks_user_commands
-@@ -2511,7 +2512,7 @@ module Zkapp_account_update_failures = struct
+@@ -2473,7 +2474,7 @@ module Zkapp_account_update_failures = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -744,7 +717,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name
              ~cols:[ "index"; "failures" ] ) )
        id
-@@ -2554,8 +2555,7 @@ module Block_and_zkapp_command = struct
+@@ -2516,8 +2517,7 @@ module Block_and_zkapp_command = struct
      in
      Mina_caqti.select_insert_into_cols
        ~select:
@@ -754,7 +727,7 @@ index 8b90db5952..939aaa8864 100644
        ~table_name
        ~cols:
          ( [ "block_id"
-@@ -2578,8 +2578,8 @@ module Block_and_zkapp_command = struct
+@@ -2540,8 +2540,8 @@ module Block_and_zkapp_command = struct
    let load (module Conn : CONNECTION) ~block_id ~zkapp_command_id ~sequence_no =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find
@@ -765,7 +738,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id"; "zkapp_command_id"; "sequence_no" ]
-@@ -2589,7 +2589,7 @@ module Block_and_zkapp_command = struct
+@@ -2551,7 +2551,7 @@ module Block_and_zkapp_command = struct
    let all_from_block (module Conn : CONNECTION) ~block_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.collect_list
@@ -774,7 +747,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols ~table_name ~select:comma_cols
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2661,7 +2661,7 @@ module Zkapp_account = struct
+@@ -2623,7 +2623,7 @@ module Zkapp_account = struct
  
    let load (module Conn : CONNECTION) id =
      Conn.find
@@ -783,7 +756,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
        id
  end
-@@ -2705,8 +2705,8 @@ module Accounts_accessed = struct
+@@ -2667,8 +2667,8 @@ module Accounts_accessed = struct
    let find_opt (module Conn : CONNECTION) ~block_id ~account_identifier_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.find_opt
@@ -794,7 +767,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| SELECT %s
-@@ -2777,7 +2777,7 @@ module Accounts_accessed = struct
+@@ -2739,7 +2739,7 @@ module Accounts_accessed = struct
            }
          in
          Mina_caqti.select_insert_into_cols
@@ -803,7 +776,7 @@ index 8b90db5952..939aaa8864 100644
            ~table_name ~cols:(Fields.names, typ)
            (module Conn)
            account_accessed
-@@ -2793,7 +2793,7 @@ module Accounts_accessed = struct
+@@ -2755,7 +2755,7 @@ module Accounts_accessed = struct
    let all_from_block (module Conn : CONNECTION) block_id =
      let comma_cols = String.concat Fields.names ~sep:"," in
      Conn.collect_list
@@ -812,7 +785,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols ~select:comma_cols ~table_name
              ~cols:[ "block_id" ] () ) )
        block_id
-@@ -2818,7 +2818,7 @@ module Accounts_created = struct
+@@ -2780,7 +2780,7 @@ module Accounts_created = struct
      in
      let creation_fee = Currency.Fee.to_string creation_fee in
      Mina_caqti.select_insert_into_cols
@@ -821,7 +794,7 @@ index 8b90db5952..939aaa8864 100644
        ~table_name ~cols:(Fields.names, typ)
        (module Conn)
        { block_id; account_identifier_id; creation_fee }
-@@ -2833,7 +2833,7 @@ module Accounts_created = struct
+@@ -2795,7 +2795,7 @@ module Accounts_created = struct
  
    let all_from_block (module Conn : CONNECTION) block_id =
      Conn.collect_list
@@ -830,7 +803,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| SELECT block_id, account_identifier_id, creation_fee
                 FROM accounts_created
                 WHERE block_id = ?
-@@ -2899,14 +2899,14 @@ module Block = struct
+@@ -2861,14 +2861,14 @@ module Block = struct
           "SELECT id FROM blocks WHERE state_hash = ?" )
        (State_hash.to_base58_check state_hash)
  
@@ -848,7 +821,7 @@ index 8b90db5952..939aaa8864 100644
           (Mina_caqti.select_cols_from_id ~table_name:"blocks" ~cols:Fields.names) )
        id
  
-@@ -3011,7 +3011,7 @@ module Block = struct
+@@ -2973,7 +2973,7 @@ module Block = struct
          let blockchain_state = Protocol_state.blockchain_state protocol_state in
          let%bind block_id =
            Conn.find
@@ -857,7 +830,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "chain_status" ->
-@@ -3393,9 +3393,7 @@ module Block = struct
+@@ -3355,9 +3355,7 @@ module Block = struct
      in
  
      (* we don't need to specify all types here, just the ones that sql may infer incorrectly *)
@@ -868,7 +841,7 @@ index 8b90db5952..939aaa8864 100644
        | Bool ->
            Some "BOOL"
        | Int ->
-@@ -3408,39 +3406,36 @@ module Block = struct
+@@ -3370,39 +3368,36 @@ module Block = struct
            Some "BIGINT"
        | Float ->
            Some "FLOAT"
@@ -927,7 +900,7 @@ index 8b90db5952..939aaa8864 100644
        match typ with
        | Bool ->
            Bool.to_string value
-@@ -3468,45 +3463,30 @@ module Block = struct
+@@ -3430,45 +3425,30 @@ module Block = struct
            (* we are ignoring the enum annotation in this context because it's not always valid to apply *)
            (* NOTE: we assume enum values do not contain special characters (eg "'") *)
            "'" ^ value ^ "'"
@@ -995,7 +968,7 @@ index 8b90db5952..939aaa8864 100644
      in
      let render_row (type a) (typ : a Caqti_type.t) (value : a) : string =
        "(" ^ String.concat ~sep:"," (render_type typ value) ^ ")"
-@@ -3557,8 +3537,8 @@ module Block = struct
+@@ -3519,8 +3499,8 @@ module Block = struct
          in
          let%map entries =
            Conn.collect_list
@@ -1006,7 +979,7 @@ index 8b90db5952..939aaa8864 100644
                 query )
              ()
          in
-@@ -3576,7 +3556,7 @@ module Block = struct
+@@ -3538,7 +3518,7 @@ module Block = struct
            String.concat ~sep:"," @@ List.map ~f:(render_row typ) values
          in
          Conn.collect_list
@@ -1015,7 +988,7 @@ index 8b90db5952..939aaa8864 100644
               (sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table
                  fields_sql values_sql ) )
            () )
-@@ -3928,7 +3908,7 @@ module Block = struct
+@@ -3890,7 +3870,7 @@ module Block = struct
        let ids_sql = String.concat ~sep:"," ids in
        let parent_ids_sql = String.concat ~sep:"," parent_ids in
        Conn.exec
@@ -1024,7 +997,7 @@ index 8b90db5952..939aaa8864 100644
             (sprintf
                "UPDATE %s AS b SET parent_id = data.parent_id FROM (SELECT \
                 unnest(array[%s]) as id, unnest(array[%s]) as parent_id) AS \
-@@ -4138,7 +4118,7 @@ module Block = struct
+@@ -4100,7 +4080,7 @@ module Block = struct
                  Some id )
            in
            Conn.find
@@ -1033,7 +1006,7 @@ index 8b90db5952..939aaa8864 100644
                 (Mina_caqti.insert_into_cols ~returning:"id" ~table_name
                    ~tannot:(function
                      | "sub_window_densities" ->
-@@ -4299,8 +4279,8 @@ module Block = struct
+@@ -4261,8 +4241,8 @@ module Block = struct
    let set_parent_id_if_null (module Conn : CONNECTION) ~parent_hash
        ~(parent_id : int) =
      Conn.exec
@@ -1044,7 +1017,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| UPDATE blocks SET parent_id = ?
                 WHERE parent_hash = ?
                 AND parent_id IS NULL
-@@ -4316,8 +4296,8 @@ module Block = struct
+@@ -4278,8 +4258,8 @@ module Block = struct
      in
      let columns = concat Fields.names in
      Conn.collect_list
@@ -1055,7 +1028,7 @@ index 8b90db5952..939aaa8864 100644
           typ
           (sprintf
              {sql| WITH RECURSIVE chain AS (
-@@ -4343,37 +4323,37 @@ module Block = struct
+@@ -4305,37 +4285,37 @@ module Block = struct
  
    let get_highest_canonical_block_opt (module Conn : CONNECTION) =
      Conn.find_opt
@@ -1102,7 +1075,7 @@ index 8b90db5952..939aaa8864 100644
           {sql| UPDATE blocks SET chain_status='orphaned'
                 WHERE height = $2
                 AND state_hash <> $1
-@@ -4462,7 +4442,7 @@ module Block = struct
+@@ -4424,7 +4404,7 @@ module Block = struct
        | None, Some num_blocks -> (
            match%map
              Conn.find_opt
@@ -1111,7 +1084,7 @@ index 8b90db5952..939aaa8864 100644
                   "SELECT MAX(height) FROM blocks" )
                ()
            with
-@@ -4478,8 +4458,8 @@ module Block = struct
+@@ -4440,8 +4420,8 @@ module Block = struct
        let%bind () =
          (* Delete user commands from old blocks. *)
          Conn.exec
@@ -1122,7 +1095,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM user_commands\n\
                WHERE id IN\n\
                (SELECT user_command_id FROM blocks_user_commands\n\
-@@ -4490,8 +4470,8 @@ module Block = struct
+@@ -4452,8 +4432,8 @@ module Block = struct
        let%bind () =
          (* Delete old blocks. *)
          Conn.exec
@@ -1133,7 +1106,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
                ?" )
            (height, timestamp)
-@@ -4499,7 +4479,7 @@ module Block = struct
+@@ -4461,7 +4441,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned internal commands. *)
          Conn.exec
@@ -1142,7 +1115,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM internal_commands\n\
                WHERE id NOT IN\n\
                (SELECT internal_commands.id FROM internal_commands\n\
-@@ -4510,7 +4490,7 @@ module Block = struct
+@@ -4472,7 +4452,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned snarked ledger hashes. *)
          Conn.exec
@@ -1151,7 +1124,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM snarked_ledger_hashes\n\
                WHERE id NOT IN\n\
                (SELECT snarked_ledger_hash_id FROM blocks)" )
-@@ -4519,7 +4499,7 @@ module Block = struct
+@@ -4481,7 +4461,7 @@ module Block = struct
        let%bind () =
          (* Delete orphaned public keys. *)
          Conn.exec
@@ -1160,7 +1133,7 @@ index 8b90db5952..939aaa8864 100644
               "DELETE FROM public_keys\n\
                WHERE id NOT IN (SELECT fee_payer_id FROM user_commands)\n\
                AND id NOT IN (SELECT source_id FROM user_commands)\n\
-@@ -4944,7 +4924,13 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
+@@ -4906,7 +4886,13 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
            Strict_pipe.Writer.write extensional_block_writer extensional_block )
      ]
    in

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -593,6 +593,27 @@ module Protocol_versions = struct
       ~table_name ~cols:(Fields.names, typ)
       (module Conn)
       t
+
+  let find (module Conn : CONNECTION) ~transaction ~network ~patch =
+    Conn.find
+      (Caqti_request.find
+         Caqti_type.(tup3 int int int)
+         Caqti_type.int
+         (Mina_caqti.select_cols ~select:"id" ~table_name ~cols:Fields.names ()) )
+      (transaction, network, patch)
+
+  let find_txn_version (module Conn : CONNECTION) ~transaction =
+    Conn.collect_list
+      (Caqti_request.collect Caqti_type.int Caqti_type.int
+         {sql| SELECT id FROM protocol_versions WHERE transaction = ?
+        |sql} )
+      transaction
+
+  let load (module Conn : CONNECTION) id =
+    Conn.find
+      (Caqti_request.find Caqti_type.int typ
+         (Mina_caqti.select_cols_from_id ~table_name ~cols:Fields.names) )
+      id
 end
 
 module Zkapp_permissions = struct

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -86,6 +86,7 @@ let extract_accounts_exn = function
   | { Runtime_config.Ledger.base = Accounts accounts
     ; balances = []
     ; add_genesis_winner = None
+    ; _
     } ->
       accounts
   | _ ->


### PR DESCRIPTION
Currently the archive node breaks when adding genesis accounts if there isn't a protocol version that matches the transaction version used by those accounts. This seems wholly unnecessary, and leads to nasty hacks like #15471 (where we add a fake `X.4611686018427387903.4611686018427387903` version).

This PR deletes the unnecessary check.