### PR TITLE
[berkeley] Wait for all dependencies in the single-node integration test

### DIFF
--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -32,7 +32,9 @@ let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
 
-let dependsOn = DebianVersions.dependsOn DebianVersions.DebVersion.Bullseye Profiles.Type.Lightnet
+let dependsOn =
+  DebianVersions.dependsOn DebianVersions.DebVersion.Bullseye Profiles.Type.Lightnet
+  # DebianVersions.dependsOn DebianVersions.DebVersion.Bullseye Profiles.Type.Standard
 
 
 let buildTestCmd : Size -> Command.Type = \(cmd_target : Size) ->


### PR DESCRIPTION
This PR fixes flakes in the `single-node` integration test in CI, where it can trigger before all of its dependencies are ready.