### PR TITLE
Fix incorrect ledger archive hashes

### DIFF
--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -67,7 +67,7 @@ for file in hardfork_ledgers/*; do
     oldhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
     aws s3 cp "s3://snark-keys.o1test.net/$filename" "$file"
     newhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
-    sed -i 's/$oldhash/$newhash/g' new_config.json 
+    sed -i "s/$oldhash/$newhash/g" new_config.json 
   else
     aws s3 cp --acl public-read "$file" s3://snark-keys.o1test.net/
   fi

--- a/scripts/mina-verify-packaged-fork-config
+++ b/scripts/mina-verify-packaged-fork-config
@@ -156,10 +156,18 @@ function extract_ledgers() {
     "$MINA_EXE" client stop
 }
 
-extract_ledgers "$PACKAGED_DAEMON_CONFIG" "$GENESIS_LEDGER_DIR" "$workdir/packaged"
-mv -t "$workdir/ledgers-backup" /var/lib/coda/*.tar.gz
+mkdir -p "$workdir/ledgers-downloaded"
+
+mv -t "$workdir/ledgers-backup" "$GENESIS_LEDGER_DIR"/*.tar.gz
+if [ -z ${NO_TEST_LEDGER_DOWNLOAD+z} ]; then
+    # We removed all *.tar.gz from GENESIS_LEDGER_DIR (in case it's one of default paths)
+    # and expect Mina node to be able to download these from S3
+    extract_ledgers "$PACKAGED_DAEMON_CONFIG" "$workdir/ledgers-downloaded" "$workdir/downloaded"
+    rm -Rf /tmp/coda_cache_dir/*.tar.gz /tmp/s3_cache_dir/*.tar.gz
+fi
 extract_ledgers "$workdir/config-substituted.json" "$workdir/ledgers" "$workdir/reference"
-mv -t /var/lib/coda "$workdir/ledgers-backup"/*
+mv -t "$GENESIS_LEDGER_DIR" "$workdir/ledgers-backup"/*
+extract_ledgers "$PACKAGED_DAEMON_CONFIG" "$GENESIS_LEDGER_DIR" "$workdir/packaged"
 
 echo "Performing final comparisons..." >&2
 error=0
@@ -182,6 +190,12 @@ for file in "$workdir"/packaged-*.json; do
     if ! cmp "$file" "$workdir/reference-$name.json"; then
         echo "Error: $file does not match reference" >&2
         error=1
+    fi
+    if [ -z ${NO_TEST_LEDGER_DOWNLOAD+z} ]; then
+        if ! cmp "$file" "$workdir/downloaded-$name.json"; then
+            echo "Error: $file does not match downloaded" >&2
+            error=1
+        fi
     fi
 done
 


### PR DESCRIPTION
Problem: when ledgers for the fork where uploaded, wrong sha3 hashes of archives are going to be used in the config that is put into a .deb file.

Solution: replace quotes in bash.

Explain how you tested your changes:
* [ ] TODO: run pipeline

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None