### PR TITLE
[berkeley] Make libp2p_keypair CLI argument optional again

### DIFF
--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -49,7 +49,7 @@ module Config = struct
     ; pubsub_v1 : pubsub_topic_mode_t
     ; pubsub_v0 : pubsub_topic_mode_t
     ; validation_queue_size : int
-    ; mutable keypair : Mina_net2.Keypair.t
+    ; mutable keypair : Mina_net2.Keypair.t option
     ; all_peers_seen_metric : bool
     ; known_private_ip_nets : Core.Unix.Cidr.t list
     }
@@ -244,7 +244,14 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
       with
       | Ok (Ok net2) -> (
           let open Mina_net2 in
-          let me = config.keypair in
+          (* Make an ephemeral keypair for this session TODO: persist in the config dir *)
+          let%bind me =
+            match config.keypair with
+            | Some kp ->
+                return kp
+            | None ->
+                Mina_net2.generate_random_keypair net2
+          in
           let my_peer_id = Keypair.to_peer_id me |> Peer.Id.to_string in
           Logger.append_to_global_metadata
             [ ("peer_id", `String my_peer_id)

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -244,7 +244,9 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
       with
       | Ok (Ok net2) -> (
           let open Mina_net2 in
-          (* Make an ephemeral keypair for this session TODO: persist in the config dir *)
+          (* Make an ephemeral keypair for this session.
+             TODO(15495): persist in the config dir.
+          *)
           let%bind me =
             match config.keypair with
             | Some kp ->

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -252,7 +252,9 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
             | Some kp ->
                 return kp
             | None ->
-                Mina_net2.generate_random_keypair net2
+                let%map kp = Mina_net2.generate_random_keypair net2 in
+                config.keypair <- Some kp ;
+                kp
           in
           let my_peer_id = Keypair.to_peer_id me |> Peer.Id.to_string in
           Logger.append_to_global_metadata

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -356,11 +356,12 @@ module Itn = struct
               |> Unsigned.UInt16.of_int )
         ; field "peerId"
             ~args:Arg.[]
-            ~doc:"Peer id" ~typ:(non_null string)
+            ~doc:"Peer id" ~typ:string
             ~resolve:(fun { ctx = (_ : bool), mina; _ } _ ->
               Mina_lib.config mina
               |> fun Mina_lib.Config.{ gossip_net_params; _ } ->
-              Mina_net2.Keypair.to_peer_id gossip_net_params.keypair )
+              Option.map ~f:Mina_net2.Keypair.to_peer_id
+                gossip_net_params.keypair )
         ; field "isBlockProducer"
             ~args:Arg.[]
             ~doc:"Is the node a block producer" ~typ:(non_null bool)

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -229,7 +229,7 @@ let%test_module "Epoch ledger sync tests" =
           ; max_connections = Cli_lib.Default.max_connections
           ; validation_queue_size = Cli_lib.Default.validation_queue_size
           ; isolate = false
-          ; keypair = libp2p_keypair
+          ; keypair = Some libp2p_keypair
           ; all_peers_seen_metric = false
           ; known_private_ip_nets = []
           ; time_controller


### PR DESCRIPTION
This PR makes the `--libp2p-keypair` CLI argument optional, to avoid the irritating setup steps when first running a Mina node.

This option was added to ensure persistence will interact correctly with bitswap: if a node restarts, the network's knowledge of its persisted data will be preserved, and it doesn't need to re-advertise the contents of its store. However,
* bitswap is currently enabled, so this annoyance is for nothing, and
* if persistence *isn't* enabled for the node, re-using the libp2p keypair will mislead the network into believing that it has data that it doesn't.

After some discussion, it appears that
* converting the flag back to optional immediately does no harm and improves UX considerably, and
* we can solve the issues properly by persisting the libp2p keypair alongside the data, so that we have the correct behaviour both with and without persistence enabled.

It would be best to make this change for the mainnet berkeley release candidate, to ensure that the upgrade is as smooth and easy for node operators as possible.