### PR TITLE
Demote some unnecessary logs at startup to Debug

### DIFF
--- a/src/lib/exit_handlers/exit_handlers.ml
+++ b/src/lib/exit_handlers/exit_handlers.ml
@@ -25,7 +25,7 @@ let register_handler ~logger ~description (f : unit -> unit) =
 (* register a Deferred.t thunk to be called at Async shutdown; log registration and execution *)
 let register_async_shutdown_handler ~logger ~description
     (f : unit -> unit Deferred.t) =
-  [%log info] "Registering async shutdown handler: $description"
+  [%log debug] "Registering async shutdown handler: $description"
     ~metadata:[ ("description", `String description) ] ;
   let logging_thunk () =
     [%log info] "Running async shutdown handler: $description"

--- a/src/lib/mina_lib/conf_dir.ml
+++ b/src/lib/mina_lib/conf_dir.ml
@@ -18,7 +18,7 @@ let check_and_set_lockfile ~logger conf_dir =
                 return (Writer.writef writer "%d\n" (Pid.to_int pid)) ) )
       with
       | Ok () ->
-          [%log info] "Created daemon lockfile $lockfile"
+          [%log debug] "Created daemon lockfile $lockfile"
             ~metadata:[ ("lockfile", `String lockfile) ] ;
           Exit_handlers.register_async_shutdown_handler ~logger
             ~description:"Remove daemon lockfile" (fun () ->


### PR DESCRIPTION
This PR tweaks the log level of some messages from `Info` to `Debug`. These messages show on every startup, and have never been useful info for a node operator.