### PR TITLE
[berkeley] Fix entrypoint.d warning on startup: don't allow hidden scripts, and don't include `.` and `..` as scripts

### DIFF
--- a/dockerfiles/scripts/daemon-entrypoint.sh
+++ b/dockerfiles/scripts/daemon-entrypoint.sh
@@ -12,7 +12,7 @@ INPUT_ARGS="$@"
 declare -a VERBOSE_LOG_FILES=('mina-stderr.log' '.mina-config/mina-prover.log' '.mina-config/mina-verifier.log')
 
 # Attempt to execute or source custom entrypoint scripts accordingly
-for script in /entrypoint.d/* /entrypoint.d/.*; do
+for script in /entrypoint.d/*; do
   if [[ "$( basename "${script}")" == *mina-env ]]; then
     source "${script}"
   elif [[ -f "${script}" ]] && [[ ! -x "${script}" ]]; then


### PR DESCRIPTION
This PR removes a pattern that would handle (hidden) scripts which start with `.`, ensuring that all scripts are easily visible with `ls`. This logic also includes the directories `.` and `..`, giving us the annoying message
```
[ERROR] Entrypoint script /entrypoint.d/.. is not a regular file, ignoring
```
at every docker startup.