### PR TITLE
[CI] Disable logic which decides where to push artifacts

### DIFF
--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -27,6 +27,7 @@ set -u
 export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
 [[ -n "$BUILDKITE_BRANCH" ]] && export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g')
  
+export RELEASE=unstable
 
 if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 
   # Abort if `BUILDKITE_REPO` doesn't have the expected format
@@ -41,47 +42,10 @@ if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then
   # For example: for given repo 'https://github.com/dkijania/mina.git' we convert it to 'dkijania_mina' 
   export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e 's/^.*github.com[:\/]\(.*\)\.git$/\1/' -e 's/\//-/')
   export THIS_COMMIT_TAG=""
-  RELEASE=unstable
 
 else
   # GITTAG is the closest tagged commit to this commit, while THIS_COMMIT_TAG only has a value when the current commit is tagged
   export GITTAG=$(find_most_recent_numeric_tag HEAD)
-
-  # Determine deb repo to use
-  case $GITBRANCH in
-      berkeley|rampup|compatible|master|release/*) # whitelist of branches that can be tagged
-          case "${THIS_COMMIT_TAG}" in
-            *alpha*) # any tag including the string `alpha`
-              RELEASE=alpha ;;
-            *beta*) # any tag including the string `beta`
-              RELEASE=beta ;;
-            *berkeley*) # any tag including the string `berkeley`
-              RELEASE=berkeley ;;
-            *rampup*) # any tag including the string `rampup`
-              RELEASE=rampup ;;
-            *devnet*)
-              RELEASE=devnet ;;
-            ?*)
-              # if the tag is a version number sans any suffix, then it's a stable release
-              if grep -qP '^\d+\.\d+\.\d+$' <<< "${THIS_COMMIT_TAG}"; then
-                RELEASE=stable
-              else
-                RELEASE=unstable
-              fi ;;
-            "") # No tag
-              RELEASE="unstable" ;;
-              # real soon now:
-              # RELEASE="${GITHASH}" ;; # avoids deb-s3 concurrency issues between PRs
-            *) # The above set of cases should be exhaustive, if they're not then still set RELEASE=unstable
-              RELEASE=unstable
-              echo "git tag --points-at HEAD may have failed, falling back to unstable. Value: \"$(git tag --points-at HEAD)\""
-              ;;
-          esac ;;
-      release-automation-testing/*) # whitelist of branches that can be tagged
-          RELEASE=prerelease ;;
-      *)
-          RELEASE=unstable ;;
-  esac
 fi
 
 if [[ -n "${THIS_COMMIT_TAG}" ]]; then # If the commit is tagged
@@ -100,6 +64,6 @@ case $GITBRANCH in
       MINA_BUILD_MAINNET=false ;;
 esac
 
-echo "Publishing on release channel \"${RELEASE}\" based on branch \"${GITBRANCH}\" and tag \"${THIS_COMMIT_TAG}\""
+echo "Publishing on release channel \"${RELEASE}\""
 [[ -n ${THIS_COMMIT_TAG} ]] && export MINA_COMMIT_TAG="${THIS_COMMIT_TAG}"
 export MINA_DEB_RELEASE="${RELEASE}"

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -175,15 +175,4 @@ if [[ -z "$NOUPLOAD" ]] || [[ "$NOUPLOAD" -eq 0 ]]; then
   docker tag "${TAG}" "${HASHTAG}"
   docker push "${HASHTAG}"
 
-  echo "Release Env Var: ${DEB_RELEASE}"
-  echo "Release: ${DEB_RELEASE##*=}"
-
-  if [[ "${DEB_RELEASE##*=}" = "unstable" ]]; then
-    echo "Release is unstable: not pushing to docker hub"
-  else
-    echo "Release is public (alpha, beta, berkeley, or stable): pushing image to docker hub"
-    # tag and push to dockerhub
-    docker tag "${TAG}" "minaprotocol/${SERVICE}:${VERSION}"
-    docker push "minaprotocol/${SERVICE}:${VERSION}"
-  fi
 fi


### PR DESCRIPTION
In order to prevent unintentional releases from personal branches or nightly I removed logic which decides where to push artifacts. Now it will push debian into unstable channel and dockers to gcr. We will then rely on promotion pipeline to promote packages to other channels in a fully controlled way.

On the horizon there is one possible fork of logic when we will introduce different channel and tag for nightly releases