### PR TITLE
Use `Global_slot_since_genesis` for stop slots

### DIFF
--- a/src/app/best_tip_merger/best_tip_merger.ml
+++ b/src/app/best_tip_merger/best_tip_merger.ml
@@ -231,7 +231,8 @@ module Compact_display = struct
                     ; global_slot =
                         Mina_state.Protocol_state.consensus_state
                           t.state.protocol_state
-                        |> Consensus.Data.Consensus_state.curr_global_slot
+                        |> Consensus.Data.Consensus_state
+                           .global_slot_since_genesis
                     }
                 in
                 { state; peers = Set.length t.peer_ids } ) )

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -116,10 +116,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Time.Span.of_ms @@ float_of_int (num_slots * window_ms))
     in
     let slot_tx_end =
-      Mina_numbers.Global_slot_since_hard_fork.of_int slot_tx_end
+      Mina_numbers.Global_slot_since_genesis.of_int slot_tx_end
     in
     let slot_chain_end =
-      Mina_numbers.Global_slot_since_hard_fork.of_int slot_chain_end
+      Mina_numbers.Global_slot_since_genesis.of_int slot_chain_end
     in
     let%bind () =
       section_hard "spawn transaction sending"
@@ -160,8 +160,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section "blocks produced before slot_tx_end"
         ( ok_if_true "only empty blocks were produced before slot_tx_end"
         @@ List.exists blocks ~f:(fun block ->
-               Mina_numbers.Global_slot_since_hard_fork.(
-                 block.slot < slot_tx_end)
+               Mina_numbers.Global_slot_since_genesis.(
+                 block.slot_since_genesis < slot_tx_end)
                && ( block.command_transaction_count <> 0
                   || block.snark_work_count <> 0
                   || Currency.Amount.(block.coinbase <> zero) ) ) )
@@ -173,13 +173,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                Printf.sprintf
                  "non-empty block after slot_tx_end. block slot since genesis: \
                   %s, txn count: %d, snark work count: %d, coinbase: %s"
-                 (Mina_numbers.Global_slot_since_hard_fork.to_string block.slot)
+                 (Mina_numbers.Global_slot_since_genesis.to_string
+                    block.slot_since_genesis )
                  block.command_transaction_count block.snark_work_count
                  (Currency.Amount.to_string block.coinbase)
              in
              ok_if_true msg
-               ( Mina_numbers.Global_slot_since_hard_fork.(
-                   block.slot < slot_tx_end)
+               ( Mina_numbers.Global_slot_since_genesis.(
+                   block.slot_since_genesis < slot_tx_end)
                || block.command_transaction_count = 0
                   && block.snark_work_count = 0
                   && Currency.Amount.(block.coinbase = zero) ) ) )
@@ -188,13 +189,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section "blocks produced before slot_chain_end"
         ( ok_if_true "no block produced before slot_chain_end"
         @@ List.exists blocks ~f:(fun block ->
-               Mina_numbers.Global_slot_since_hard_fork.(
-                 block.slot < slot_chain_end) ) )
+               Mina_numbers.Global_slot_since_genesis.(
+                 block.slot_since_genesis < slot_chain_end) ) )
     in
     section "no blocks produced after slot_chain_end"
       ( ok_if_true "blocks produced after slot_chain_end"
       @@ not
       @@ List.exists blocks ~f:(fun block ->
-             Mina_numbers.Global_slot_since_hard_fork.(
-               block.slot >= slot_chain_end) ) )
+             Mina_numbers.Global_slot_since_genesis.(
+               block.slot_since_genesis >= slot_chain_end) ) )
 end

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2396,10 +2396,11 @@ module Queries = struct
                         let global_slot =
                           Mina_state.Protocol_state.consensus_state
                             protocol_state
-                          |> Consensus.Data.Consensus_state.curr_global_slot
+                          |> Consensus.Data.Consensus_state
+                             .global_slot_since_genesis
                         in
                         if
-                          Mina_numbers.Global_slot_since_hard_fork.( < )
+                          Mina_numbers.Global_slot_since_genesis.( < )
                             global_slot stop_slot
                         then return breadcrumb
                         else

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -49,7 +49,7 @@ val empty :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t
   -> time_controller:Block_time.Controller.t
-  -> slot_tx_end:Mina_numbers.Global_slot_since_hard_fork.t option
+  -> slot_tx_end:Mina_numbers.Global_slot_since_genesis.t option
   -> t
 
 (** How many transactions are currently in the pool *)

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -390,7 +390,7 @@ module type Transaction_resource_pool_intf = sig
     -> pool_max_size:int
     -> verifier:Verifier.t
     -> genesis_constants:Genesis_constants.t
-    -> slot_tx_end:Mina_numbers.Global_slot_since_hard_fork.t option
+    -> slot_tx_end:Mina_numbers.Global_slot_since_genesis.t option
     -> Config.t
 
   val member : t -> Transaction_hash.User_command_with_valid_signature.t -> bool

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -288,7 +288,7 @@ struct
               *)
         ; verifier : (Verifier.t[@sexp.opaque])
         ; genesis_constants : Genesis_constants.t
-        ; slot_tx_end : Mina_numbers.Global_slot_since_hard_fork.t option
+        ; slot_tx_end : Mina_numbers.Global_slot_since_genesis.t option
         }
       [@@deriving sexp_of]
 
@@ -3127,13 +3127,9 @@ let%test_module _ =
 
     let%test_unit "transactions added before slot_tx_end are accepted" =
       Thread_safe.block_on_async_exn (fun () ->
-          let curr_slot =
-            Mina_numbers.(
-              Global_slot_since_hard_fork.of_uint32
-              @@ Global_slot_since_genesis.to_uint32 @@ current_global_slot ())
-          in
+          let curr_slot = current_global_slot () in
           let slot_tx_end =
-            Mina_numbers.Global_slot_since_hard_fork.(succ @@ succ curr_slot)
+            Mina_numbers.Global_slot_since_genesis.(succ @@ succ curr_slot)
           in
           let%bind t = setup_test ~slot_tx_end () in
           assert_pool_txs t [] ;
@@ -3141,26 +3137,18 @@ let%test_module _ =
 
     let%test_unit "transactions added at slot_tx_end are rejected" =
       Thread_safe.block_on_async_exn (fun () ->
-          let curr_slot =
-            Mina_numbers.(
-              Global_slot_since_hard_fork.of_uint32
-              @@ Global_slot_since_genesis.to_uint32 @@ current_global_slot ())
-          in
+          let curr_slot = current_global_slot () in
           let%bind t = setup_test ~slot_tx_end:curr_slot () in
           assert_pool_txs t [] ;
           add_commands t independent_cmds >>| assert_pool_apply [] )
 
     let%test_unit "transactions added after slot_tx_end are rejected" =
       Thread_safe.block_on_async_exn (fun () ->
-          let curr_slot =
-            Mina_numbers.(
-              Global_slot_since_hard_fork.of_uint32
-              @@ Global_slot_since_genesis.to_uint32 @@ current_global_slot ())
-          in
+          let curr_slot = current_global_slot () in
           let slot_tx_end =
             Option.value_exn
             @@ Mina_numbers.(
-                 Global_slot_since_hard_fork.(
+                 Global_slot_since_genesis.(
                    sub curr_slot @@ Global_slot_span.of_int 1))
           in
           let%bind t = setup_test ~slot_tx_end () in

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1587,7 +1587,7 @@ let make_fork_config ~staged_ledger ~global_slot ~state_hash ~blockchain_length
 
 let slot_tx_end_or_default, slot_chain_end_or_default =
   let f compile get_runtime t =
-    Option.map ~f:Mina_numbers.Global_slot_since_hard_fork.of_int
+    Option.map ~f:Mina_numbers.Global_slot_since_genesis.of_int
     @@ Option.value_map t.daemon ~default:compile ~f:(fun daemon ->
            Option.merge compile ~f:(fun _c r -> r) @@ get_runtime daemon )
   in


### PR DESCRIPTION
This PR is the correct fix for the consistency issue 'fixed' in https://github.com/minaprotocol/mina/pull/15503. The global slot since hard fork was incorrectly used in the original PR https://github.com/MinaProtocol/mina/pull/14516; we fix the issue by using the global slot since genesis instead, so that an emergency hard-fork post-berkeley will not force us to use an unrepresentative stop slot.