### PR TITLE
Use stable nixpkgs version (23.11)

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,10 +4,10 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:30a7f05b78a7331964443a3002fcb9a2ba2d859cda7d57a95f366c25131c1e70",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:424165d26583ad7a56e03dbc91ba0e83249f37068dd4f47b6263703d56ea4bf2",
-  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:424165d26583ad7a56e03dbc91ba0e83249f37068dd4f47b6263703d56ea4bf2",
-  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:424165d26583ad7a56e03dbc91ba0e83249f37068dd4f47b6263703d56ea4bf2",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:a2363c26b7ebceba98c5a82dddbbe5d42455abf59307f3d6cdcdf4b5a19b69c9",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:158ae36aed9de54ef5da39f7c98b2c9ba5d519c4c419c9c4109005a23675f539",
+  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:158ae36aed9de54ef5da39f7c98b2c9ba5d519c4c419c9c4109005a23675f539",
+  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:158ae36aed9de54ef5da39f7c98b2c9ba5d519c4c419c9c4109005a23675f539",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:12ffd0a9016819c720687f440c7a46b8815f8d3ad06d306d342ee5f8dd4375f5",
   elixirToolchain = "elixir:1.10-alpine",
   nodeToolchain = "node:14.13.1-stretch-slim",

--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     "nixpkgs-mozilla": {
       "flake": false,
       "locked": {
-        "lastModified": 1664789696,
-        "narHash": "sha256-UGWJHQShiwLCr4/DysMVFrYdYYHcOqAOVsWNUu+l6YU=",
+        "lastModified": 1704373101,
+        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "80627b282705101e7b38e19ca6e8df105031b072",
+        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
         "type": "github"
       },
       "original": {
@@ -263,16 +263,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1670837426,
-        "narHash": "sha256-VGm7k7R+zxZa5oZXGT/79SUlihzFxeWVcPmIn0k1y+8=",
+        "lastModified": 1713180868,
+        "narHash": "sha256-5CSnPSCEWeUmrFiLuYIQIPQzPrpCB8x3VhE+oXLRO3k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
+        "rev": "140546acf30a8212a03a88ded8506413fa3b5d21",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-23.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -292,11 +292,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1670004517,
-        "narHash": "sha256-7SffiN2S9pVfOoBCcEdY/iJe28p/eiRqVLXG7/8Jb3I=",
+        "lastModified": 1712645768,
+        "narHash": "sha256-9dUh8nElGtC74Q4gIDV6DM0FKgF1oXh0PUkCxdbp+sg=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "b12b7fcd6f9ea0a8a939c05c68a95525f0d80af6",
+        "rev": "464863fba44c7ecc50bd1a2967274482a2c33daf",
         "type": "github"
       },
       "original": {
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665671715,
-        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   };
 
   inputs.utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11-small";
 
   inputs.mix-to-nix.url = "github:serokell/mix-to-nix";
   inputs.nix-npm-buildPackage.url = "github:serokell/nix-npm-buildpackage";

--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,7 @@
     } // utils.lib.eachDefaultSystem (system:
       let
 	rocksdbOverlay = pkgs: prev:
-          if builtins.elem system [ "aarch64-darwin" "x86_64-darwin" ] then
+          if prev.stdenv.isDarwin then
             { rocksdb-mina = pkgs.rocksdb; }
           else { rocksdb-mina = pkgs.rocksdb511; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -263,7 +263,7 @@
       let
 	rocksdbOverlay = pkgs: prev:
           if builtins.elem system [ "aarch64-darwin" "x86_64-darwin" ] then
-            { rockdb-mina = pkgs.rocksdb; }
+            { rocksdb-mina = pkgs.rocksdb; }
           else { rocksdb-mina = pkgs.rocksdb511; };
 
         # nixpkgs with all relevant overlays applied

--- a/flake.nix
+++ b/flake.nix
@@ -261,6 +261,11 @@
         };
     } // utils.lib.eachDefaultSystem (system:
       let
+	rocksdbOverlay = pkgs: prev:
+          if builtins.elem system [ "aarch64-darwin" "x86_64-darwin" ] then
+            { rockdb-mina = pkgs.rocksdb; }
+          else { rocksdb-mina = pkgs.rocksdb511; };
+
         # nixpkgs with all relevant overlays applied
         pkgs = nixpkgs.legacyPackages.${system}.extend
           (nixpkgs.lib.composeManyExtensions ([
@@ -274,7 +279,7 @@
                   nodejs = pkgs.nodejs-16_x;
                 };
             })
-          ] ++ builtins.attrValues self.overlays));
+          ] ++ builtins.attrValues self.overlays ++ [ rocksdbOverlay ] ));
 
         checks = import ./nix/checks.nix inputs pkgs;
 

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -5,7 +5,7 @@ final: prev: {
   go-capnproto2 = final.buildGo119Module rec {
     pname = "capnpc-go";
     version = "v3.0.0-alpha.5";
-    vendorSha256 = "sha256-oZ6fUUpAsBS5hvl2+eqWsE3i0lwJzXeVaH2OiqWJQyY=";
+    vendorHash = "sha256-oZ6fUUpAsBS5hvl2+eqWsE3i0lwJzXeVaH2OiqWJQyY=";
     # Don't understand the problem, but it seems to build fine without examples
     excludedPackages = [ "./example/books/ex1" "./example/books/ex2" "./example/hashes" ];
     src = final.fetchFromGitHub {
@@ -36,7 +36,7 @@ final: prev: {
     version = "0.1";
     src = ../src/app/libp2p_helper/src;
     doCheck = false; # TODO: tests hang
-    vendorSha256 = let hashes = final.lib.importJSON ./libp2p_helper.json; in
+    vendorHash = let hashes = final.lib.importJSON ./libp2p_helper.json; in
     # sanity check, to make sure the fixed output drv doesn't keep working
       # when the inputs change
       if builtins.hashFile "sha256" ../src/app/libp2p_helper/src/go.mod
@@ -86,6 +86,6 @@ final: prev: {
       rev = "9a8ba09359482898580bb35c3aa86896364b14ce";
       sha256 = "sha256-3Lk5pa6fAeHGCmDjhaUjUoASxN6ozTD9e2+0wDH7hGs=";
     };
-    vendorSha256 = "sha256-lCBAsCNtorEu0WRZRLEMEaNyjtVIdJSAZg3icrpHIsQ=";
+    vendorHash = "sha256-lCBAsCNtorEu0WRZRLEMEaNyjtVIdJSAZg3icrpHIsQ=";
   };
 }

--- a/nix/impure-shell.nix
+++ b/nix/impure-shell.nix
@@ -12,7 +12,7 @@ pkgs.mkShell {
     postgresql.out
     sodium-static.out
     sodium-static.dev
-    go_1_18
+    go_1_21
     capnproto
     zlib.dev
     bzip2.dev
@@ -23,6 +23,7 @@ pkgs.mkShell {
     rosetta-cli
   ];
   OPAMSWITCH = "mina";
+  MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
   shellHook = ''
     eval $(opam env)
     if ! opam switch list --short 2>&1 | grep -w mina 2>&1 > /dev/null; then

--- a/nix/misc.nix
+++ b/nix/misc.nix
@@ -48,7 +48,7 @@ final: prev: {
       outputs = [ "out" ];
 
       nativeBuildInputs = with final; [ which perl ];
-      buildInputs = with final; [ google-gflags ];
+      buildInputs = with final; [ gflags ];
 
       postPatch = ''
         # Hack to fix typos

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -160,7 +160,7 @@ let
         ] ++ ocaml-libs;
 
         # todo: slimmed rocksdb
-        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
+        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
         GO_CAPNP_STD = "${pkgs.go-capnproto2.src}/std";
 
         # this is used to retrieve the path of the built static library
@@ -280,7 +280,7 @@ let
         version = "mainnet";
         DUNE_PROFILE = "mainnet";
         # For compatibility with Docker build
-        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
+        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
       });
 
       mainnet = wrapMina self.mainnet-pkg { };
@@ -289,7 +289,7 @@ let
         version = "devnet";
         DUNE_PROFILE = "devnet";
         # For compatibility with Docker build
-        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
+        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
       });
 
       devnet = wrapMina self.devnet-pkg { };

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -158,7 +158,7 @@ let
         ] ++ ocaml-libs;
 
         # todo: slimmed rocksdb
-        MINA_ROCKSDB = "${pkgs.rocksdb}/lib/librocksdb.a";
+        MINA_ROCKSDB = "${pkgs.rocksdb511}/lib/librocksdb.a";
         GO_CAPNP_STD = "${pkgs.go-capnproto2.src}/std";
 
         # this is used to retrieve the path of the built static library

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -21,7 +21,8 @@ let
 
   # Packages which are `installed` in the export.
   # These are all the transitive ocaml dependencies of Mina.
-  export-installed = opam-nix.opamListToQuery export.installed;
+  export-installed = builtins.removeAttrs
+    (opam-nix.opamListToQuery export.installed) ["check_opam_switch"];
 
   # Extra packages which are not in opam.export but useful for development, such as an LSP server.
   extra-packages = with implicit-deps; {
@@ -45,7 +46,8 @@ let
   implicit-deps = export-installed // external-packages;
 
   # Pins from opam.export
-  pins = builtins.mapAttrs (name: pkg: { inherit name; } // pkg) export.package.section;
+  pins = builtins.mapAttrs (name: pkg: { inherit name; } // pkg)
+    (builtins.removeAttrs export.package.section ["check_opam_switch"]);
 
   scope = opam-nix.applyOverlays opam-nix.__overlays
     (opam-nix.defsToScope pkgs { }

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -174,11 +174,18 @@ in
       cargoLock.lockFile = lock;
       cargoLock.outputHashes = narHashesFromCargoLock lock;
 
+      # Without this env variable, wasm pack attempts to create cache dir in root
+      # which leads to permissions issue
+      WASM_PACK_CACHE = ".wasm-pack-cache";
+
       # Work around https://github.com/rust-lang/wg-cargo-std-aware/issues/23
       # Want to run after cargoSetupPostUnpackHook
       prePatch = ''
         chmod +w $NIX_BUILD_TOP/cargo-vendor-dir
-        ln -sf ${final.kimchi-rust-std-deps}/*/ $NIX_BUILD_TOP/cargo-vendor-dir
+        for name in ''$(ls ${final.kimchi-rust-std-deps}); do
+          dest="$NIX_BUILD_TOP/cargo-vendor-dir/$name"
+          [ -e "$dest" ] || ln -s ${final.kimchi-rust-std-deps}/$name "$dest"
+        done
         chmod -w $NIX_BUILD_TOP/cargo-vendor-dir
       '';
 

--- a/nix/update-libp2p-hashes.sh
+++ b/nix/update-libp2p-hashes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
-printf '{"go.mod":"%s","go.sum":"%s","vendorSha256":"%s"}' \
+printf '{"go.mod":"%s","go.sum":"%s","vendorHash":"%s"}' \
 "$(sha256sum src/app/libp2p_helper/src/go.mod | cut -d\  -f1)" \
 "$(sha256sum src/app/libp2p_helper/src/go.sum | cut -d\  -f1)" \
 "$1" \

--- a/nix/vend/default.nix
+++ b/nix/vend/default.nix
@@ -14,7 +14,7 @@ buildGoModule {
     sha256 = "112p9dz9by2h2m3jha2bv1bvzn2a86bpg1wphgmf9gksjpwy835l";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   meta = with lib; {
     homepage = "https://github.com/c00w/vend";

--- a/opam.export
+++ b/opam.export
@@ -85,7 +85,6 @@ installed: [
   "conf-libffi.2.0.0"
   "conf-libssl.2"
   "conf-m4.1"
-  "conf-openssl.1"
   "conf-perl.1"
   "conf-pkg-config.1.1"
   "conf-postgresql.1"
@@ -448,6 +447,7 @@ Rpc_parallel offers an API to define various workers and protocols,
     "ppx_jane" {>= "v0.13" & < "v0.15"}
     "sexplib" {>= "v0.13" & < "v0.15"}
     "dune" {>= "2.0.0"}
+    "ctypes"
   ]
   build: ["dune" "build" "-p" name "-j" jobs]
   dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"

--- a/src/external/ocaml-rocksdb/rocks_options.ml
+++ b/src/external/ocaml-rocksdb/rocks_options.ml
@@ -85,12 +85,6 @@ module BlockBasedTableOptions =
     let set_block_cache =
       create_setter "set_block_cache" Cache.t
 
-    (* extern void rocksdb_block_based_options_set_block_cache_compressed( *)
-    (*     rocksdb_block_based_table_options_t* options, *)
-    (*     rocksdb_cache_t* block_cache_compressed); *)
-    let set_block_cache_compressed =
-      create_setter "set_block_cache_compressed" Cache.t
-
     (* extern void rocksdb_block_based_options_set_whole_key_filtering( *)
     (*     rocksdb_block_based_table_options_t*, unsigned char); *)
     let set_whole_key_filtering =


### PR DESCRIPTION
Problem: some old unstable nixpkgs is used in flake.nix, which is potentially insecure.

Solution: bump the version of nixpkgs, and a few more flakes.


Explain how you tested your changes:
* [x] Test build on MacOS Arm
* [x] Test build on MacOS x86
* [x] Test build on Linux

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None