### PR TITLE
Migration end at any block

### DIFF
--- a/src/app/berkeley_migration/sql.ml
+++ b/src/app/berkeley_migration/sql.ml
@@ -79,8 +79,9 @@ module Mainnet = struct
 
     let id_from_state_hash (module Conn : CONNECTION) state_hash =
       Conn.find
-        (Caqti_request.find Caqti_type.string Caqti_type.int
-           {sql| SELECT id
+        (Caqti_request.find Caqti_type.string
+           Caqti_type.(tup2 int int)
+           {sql| SELECT id, height
                  FROM blocks
                  WHERE state_hash = ?
          |sql} )
@@ -122,11 +123,18 @@ module Mainnet = struct
            "UPDATE blocks SET chain_status='canonical' WHERE id = ?" )
         id
 
+    let mark_as_pending (module Conn : CONNECTION) id =
+      Conn.exec
+        (Caqti_request.exec Caqti_type.int
+           "UPDATE blocks SET chain_status = 'pending' where id = ?" )
+        id
+
     let get_highest_canonical_block (module Conn : CONNECTION) =
       Conn.find
-        (Caqti_request.find Caqti_type.unit Caqti_type.int
-           "SELECT id FROM blocks WHERE chain_status='canonical' ORDER BY \
-            height DESC LIMIT 1" )
+        (Caqti_request.find Caqti_type.unit
+           Caqti_type.(tup2 int int)
+           "SELECT id, height FROM blocks WHERE chain_status='canonical' ORDER \
+            BY height DESC LIMIT 1" )
 
     let get_subchain (module Conn : CONNECTION) ~start_block_id ~end_block_id =
       (* derive query from type `t` *)


### PR DESCRIPTION
Explain your changes:
This PR modifies the berkeley_migration app so that it only migrate up to the fork block (instead of migrating all the canonical blocks). And it would mark the blocks after the fork block to be pending so that it's convenient for the `berkeley_migration_verifier` app to only focus on the canonical blocks up to the fork point

Explain how you tested your changes:
I've tested this with umt data

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
