### PR TITLE
Omit verbose git info in snark keys header

### DIFF
--- a/docs/specs/types_and_structures/serialized_key.md
+++ b/docs/specs/types_and_structures/serialized_key.md
@@ -9,7 +9,7 @@ Table of Contents
     * [`constraint_constants`](#constraint_constants)
       * [`transaction_capacity`](#transaction_capacity)
       * [`fork`](#fork)
-    * [`commits`](#commits)
+    * [`commit`](#commits)
   * [Example](#example)
 * [`body`](#body)
   * Verifier key
@@ -68,12 +68,8 @@ Here is an example of `json` field in human-readable format.  The details are di
         "account_creation_fee": "1000000000",
         "fork": {}
     },
-    "commits": {
-        "mina": "29b90544308c4db199640062508af3789867ce03",
-        "marlin": "[DIRTY]29b90544308c4db199640062508af3789867ce03"
-    },
+    "commit": "29b90544308c4db199640062508af3789867ce03",
     "length": 2130,
-    "commit_date": "2021-02-17T10:52:33-08:00",
     "constraint_system_hash": "a6cec912699b70258202f2ed855cc0ef",
     "identifying_hash": "a6cec912699b70258202f2ed855cc0ef"
 }
@@ -86,9 +82,8 @@ Here is an example of `json` field in human-readable format.  The details are di
 | `header_version`         | `Number` | Version number for keyfile header format |
 | `kind`                   | `Object` | Description of key stored in this file |
 | `constraint_constants`   | `Object` | Constraint system constants |
-| `commits`                | `Object` | Unique build identifiers |
+| `commit`                 | `String` | Git commit of mina source |
 | `length`                 | `Number` | Length of entire keyfile (including header) |
-| `commit_data`            | `String` | Commit date of `mina` blockchain version (corresponds to hashes in `commits`) |
 | `constraint_system_hash` | `String` | MD5 hash digest hex of all constraints comprising the zk proof system |
 | `identifying_hash`       | `String` | Alias for `constraint_system_hash` |
 
@@ -132,13 +127,6 @@ To help ensure no download errors have occurred, the `length` field should match
 | `previous_length`      | `Number` | Height |
 | `genesis_slot` | `Number` | Slot |
 
-### `commits`
-
-| Field   | Type     | Description |
-| - | - | - |
-| `mina`   | `String` | Githash uniquely identifying `mina` blockchain build (e.g. `"29b90544308c4db199640062508af3789867ce03"`) |
-| `marlin` | `String` | Githash uniquely identifying `marlin` library build (e.g. `"[DIRTY]29b90544308c4db199640062508af3789867ce03"`) |
-
 ## Example
 [example]: #example
 
@@ -146,7 +134,7 @@ This is an example of what the entire header looks like on disk.
 
 ```
 MINA_SNARK_KEYS\n
-{"header_version":1,"kind":{"type":"step-verification-key","identifier":"blockchain-snark-step"},"constraint_constants":{"sub_windows_per_window":11,"ledger_depth":20,"work_delay":2,"block_window_duration_ms":180000,"transaction_capacity":{"two_to_the":7},"pending_coinbase_depth":5,"coinbase_amount":"720000000000","supercharged_coinbase_factor":2,"account_creation_fee":"1000000000","fork":{}},"commits":{"mina":"29b90544308c4db199640062508af3789867ce03","marlin":"[DIRTY]29b90544308c4db199640062508af3789867ce03"},"length":      2130,"commit_date":"2021-02-17T10:52:33-08:00","constraint_system_hash":"a6cec912699b70258202f2ed855cc0ef","identifying_hash":"a6cec912699b70258202f2ed855cc0ef"}\n
+{"header_version":1,"kind":{"type":"step-verification-key","identifier":"blockchain-snark-step"},"constraint_constants":{"sub_windows_per_window":11,"ledger_depth":20,"work_delay":2,"block_window_duration_ms":180000,"transaction_capacity":{"two_to_the":7},"pending_coinbase_depth":5,"coinbase_amount":"720000000000","supercharged_coinbase_factor":2,"account_creation_fee":"1000000000","fork":{}},"commit":"29b90544308c4db199640062508af3789867ce03","length":      2130,"constraint_system_hash":"a6cec912699b70258202f2ed855cc0ef","identifying_hash":"a6cec912699b70258202f2ed855cc0ef"}\n
 ```
 
 # `body`

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -487,13 +487,7 @@ end) : S = struct
       ~constraint_constants:
         (Genesis_constants.Constraint_constants.to_snark_keys_header
            constraint_constants )
-      ~commits:
-        { commits =
-            { mina = Mina_version.commit_id
-            ; marlin = Mina_version.marlin_commit_id
-            }
-        ; commit_date = Mina_version.commit_date
-        }
+      ~commit:Mina_version.commit_id
       ~choices:(fun ~self ->
         [ rule ~proof_level ~constraint_constants T.tag self ] )
 

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -371,7 +371,7 @@ struct
            (module Nat.Add.Intf with type n = max_proofs_verified)
       -> name:string
       -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-      -> ?commits:Snark_keys_header.Commits.With_date.t
+      -> ?commit:string
       -> public_input:
            ( var
            , value
@@ -402,7 +402,7 @@ struct
          { step_storable; step_vk_storable; wrap_storable; wrap_vk_storable }
        ~proof_cache ?disk_keys ?override_wrap_domain ?override_wrap_main
        ?(num_chunks = 1) ~branches:(module Branches) ~max_proofs_verified ~name
-       ?constraint_constants ?commits ~public_input ~auxiliary_typ ~choices () ->
+       ?constraint_constants ?commit ~public_input ~auxiliary_typ ~choices () ->
     let snark_keys_header kind constraint_system_hash =
       let constraint_constants : Snark_keys_header.Constraint_constants.t =
         match constraint_constants with
@@ -421,20 +421,11 @@ struct
             ; fork = None
             }
       in
-      let (commits, commit_date) : Snark_keys_header.Commits.t * string =
-        match commits with
-        | Some { commits; commit_date } ->
-            (commits, commit_date)
-        | None ->
-            ( { mina = "[NOT SPECIFIED]"; marlin = "[NOT SPECIFIED]" }
-            , "[UNKNOWN]" )
-      in
       { Snark_keys_header.header_version = Snark_keys_header.header_version
       ; kind
       ; constraint_constants
-      ; commits
+      ; commit = Option.value ~default:"[NOT SPECIFIED]" commit
       ; length = (* This is a dummy, it gets filled in on read/write. *) 0
-      ; commit_date
       ; constraint_system_hash
       ; identifying_hash =
           (* TODO: Proper identifying hash. *)
@@ -1009,7 +1000,7 @@ let compile_with_wrap_main_override_promise :
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commits:Snark_keys_header.Commits.With_date.t
+    -> ?commit:string
     -> choices:
          (   self:(var, value, max_proofs_verified, branches) Tag.t
           -> ( prev_varss
@@ -1044,7 +1035,7 @@ let compile_with_wrap_main_override_promise :
  fun ?self ?(cache = []) ?(storables = Storables.default) ?proof_cache
      ?disk_keys ?override_wrap_domain ?override_wrap_main ?num_chunks
      ~public_input ~auxiliary_typ ~branches ~max_proofs_verified ~name
-     ?constraint_constants ?commits ~choices () ->
+     ?constraint_constants ?commit ~choices () ->
   let self =
     match self with
     | None ->
@@ -1113,7 +1104,7 @@ let compile_with_wrap_main_override_promise :
     M.compile ~self ~proof_cache ~cache ~storables ?disk_keys
       ?override_wrap_domain ?override_wrap_main ?num_chunks ~branches
       ~max_proofs_verified ~name ~public_input ~auxiliary_typ
-      ?constraint_constants ?commits
+      ?constraint_constants ?commit
       ~choices:(fun ~self -> conv_irs (choices ~self))
       ()
   in

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -305,7 +305,7 @@ val compile_with_wrap_main_override_promise :
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
   -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-  -> ?commits:Snark_keys_header.Commits.With_date.t
+  -> ?commit:string
   -> choices:
        (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
         -> ( 'prev_varss

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -188,9 +188,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
               ; account_creation_fee = Unsigned.UInt64.of_int 0
               ; fork = None
               }
-          ; commits = { mina = ""; marlin = "" }
+          ; commit = ""
           ; length = 0
-          ; commit_date = ""
           ; constraint_system_hash = ""
           ; identifying_hash = ""
           }
@@ -314,19 +313,19 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ?commits ~choices () =
+      ~max_proofs_verified ~name ?constraint_constants ?commit ~choices () =
     compile_with_wrap_main_override_promise ?self ?cache ?storables ?proof_cache
       ?disk_keys ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~branches ~max_proofs_verified ~name ?constraint_constants ?commits
+      ~branches ~max_proofs_verified ~name ?constraint_constants ?commit
       ~choices ()
 
   let compile ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ?commits ~choices () =
+      ~max_proofs_verified ~name ?constraint_constants ?commit ~choices () =
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-        ~max_proofs_verified ~name ?constraint_constants ?commits ~choices ()
+        ~max_proofs_verified ~name ?constraint_constants ?commit ~choices ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -1008,9 +1007,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 Snark_keys_header.header_version
             ; kind
             ; constraint_constants
-            ; commits = { mina = "[NOT SPECIFIED]"; marlin = "[NOT SPECIFIED]" }
+            ; commit = "[NOT SPECIFIED]"
             ; length = (* This is a dummy, it gets filled in on read/write. *) 0
-            ; commit_date = "UNKNOWN"
             ; constraint_system_hash
             ; identifying_hash =
                 (* TODO: Proper identifying hash. *)

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -395,7 +395,7 @@ module type S = sig
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commits:Snark_keys_header.Commits.With_date.t
+    -> ?commit:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss
@@ -452,7 +452,7 @@ module type S = sig
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commits:Snark_keys_header.Commits.With_date.t
+    -> ?commit:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss

--- a/src/lib/snark_keys_header/snark_keys_header.ml
+++ b/src/lib/snark_keys_header/snark_keys_header.ml
@@ -123,18 +123,6 @@ module Constraint_constants = struct
   [@@deriving yojson, sexp, ord, equal]
 end
 
-module Commits = struct
-  (** Commit identifiers *)
-  type t = { mina : string; marlin : string }
-  [@@deriving yojson, sexp, ord, equal]
-
-  module With_date = struct
-    type commits = t
-
-    type t = { commits : commits; commit_date : string }
-  end
-end
-
 let header_version = 1
 
 (** Header contents *)
@@ -142,9 +130,8 @@ type t =
   { header_version : int
   ; kind : Kind.t
   ; constraint_constants : Constraint_constants.t
-  ; commits : Commits.t
+  ; commit : string
   ; length : int
-  ; commit_date : string
   ; constraint_system_hash : string
   ; identifying_hash : string
   }
@@ -239,12 +226,8 @@ let%test_module "Check parsing of header" =
           ; account_creation_fee = Unsigned.UInt64.of_int 1
           ; fork = None
           }
-      ; commits =
-          { mina = "7e1fb2cd9138af1d0f24e78477efd40a2a0fcd07"
-          ; marlin = "75836c41fc4947acce9c938da1b2f506843e90ed"
-          }
+      ; commit = "7e1fb2cd9138af1d0f24e78477efd40a2a0fcd07"
       ; length = 4096
-      ; commit_date = "2020-01-01 00:00:00.000000Z"
       ; constraint_system_hash = "ABCDEF1234567890"
       ; identifying_hash = "ABCDEF1234567890"
       }

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3318,13 +3318,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       ~constraint_constants:
         (Genesis_constants.Constraint_constants.to_snark_keys_header
            constraint_constants )
-      ~commits:
-        { commits =
-            { mina = Mina_version.commit_id
-            ; marlin = Mina_version.marlin_commit_id
-            }
-        ; commit_date = Mina_version.commit_date
-        }
+      ~commit:Mina_version.commit_id
       ~choices:(fun ~self ->
         let zkapp_command x =
           Base.Zkapp_command_snark.rule ~constraint_constants ~proof_level x


### PR DESCRIPTION
Use only git commit

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None