### PR TITLE
Use public names for `fields_derivers.zkapps` and `mina_base.import`

### DIFF
--- a/src/app/delegation_verify/dune
+++ b/src/app/delegation_verify/dune
@@ -27,7 +27,7 @@
    uptime_service
    currency
    ledger_proof
-   mina_base_import
+   mina_base.import
    mina_state
    mina_wire_types
    consensus

--- a/src/app/disk_caching_stats/dune
+++ b/src/app/disk_caching_stats/dune
@@ -1,7 +1,7 @@
 (executable
  (name disk_caching_stats)
  (libraries pickles pickles_types pickles.backend snark_params crypto_params network_pool mina_base
-            signature_lib one_or_two currency ledger_proof mina_state mina_base_import mina_wire_types
+            signature_lib one_or_two currency ledger_proof mina_state mina_base.import mina_wire_types
             mina_numbers random_oracle random_oracle_input kimchi_pasta_basic data_hash_lib with_hash
             kimchi_pasta mina_ledger transaction_snark_scan_state mina_transaction_logic transaction_snark
             sgn snark_profiler_lib genesis_constants digestif bigarray-compat

--- a/src/app/snark_work_debugger/dune
+++ b/src/app/snark_work_debugger/dune
@@ -28,7 +28,7 @@
    currency
    mina_ledger
    signature_lib
-   mina_base_import
+   mina_base.import
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_here ppx_custom_printf ppx_version ppx_mina ppx_let ppx_deriving_yojson ppx_sexp_conv ppx_optcomp))

--- a/src/lib/integration_test_cloud_engine/dune
+++ b/src/lib/integration_test_cloud_engine/dune
@@ -48,7 +48,7 @@
   genesis_constants
   genesis_ledger_helper
   logger
-  mina_base_import
+  mina_base.import
   signature_lib
   currency
   mina_version

--- a/src/lib/integration_test_local_engine/dune
+++ b/src/lib/integration_test_local_engine/dune
@@ -48,7 +48,7 @@
   genesis_constants
   genesis_ledger_helper
   logger
-  mina_base_import
+  mina_base.import
   signature_lib
   currency
   mina_version

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -28,7 +28,7 @@
    base58_check
    direction
    codable
-   mina_base_import
+   mina_base.import
    mina_numbers
    mina_stdlib
    data_hash_lib

--- a/src/lib/o1js_stub/dune
+++ b/src/lib/o1js_stub/dune
@@ -41,7 +41,7 @@
   data_hash_lib
   hash_prefixes
   fields_derivers
-  fields_derivers_zkapps
+  fields_derivers.zkapps
   genesis_constants
   mina_numbers
   mina_signature_kind

--- a/src/lib/transaction_logic/test/dune
+++ b/src/lib/transaction_logic/test/dune
@@ -21,7 +21,7 @@
    kimchi_backend.pasta.basic
    bounded_types
    mina_base
-   mina_base_import
+   mina_base.import
    mina_base_test_helpers
    mina_ledger
    mina_ledger_test_helpers

--- a/src/lib/transaction_logic/test/transaction_logic/dune
+++ b/src/lib/transaction_logic/test/transaction_logic/dune
@@ -21,7 +21,7 @@
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    mina_base
-   mina_base_import
+   mina_base.import
    mina_base_test_helpers
    mina_transaction
    mina_transaction_logic


### PR DESCRIPTION
For libraries `fields_derivers.zkapps` and `mina_base.import` always use public name in other libraries' dependencies.

This change doesn't affect dune compilation, but allows to always distinguish nonconsensus libraries from their consensus "originals", even if the profile check is not performed.

This in turn reduces number of concerns involved in dependency analysis.

Explain how you tested your changes:
* It compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None