### PR TITLE
Do not override env vars in build-hardfork-package.sh

### DIFF
--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -4,24 +4,29 @@ set -eo pipefail
 
 ([ -z ${CONFIG_JSON_GZ_URL+x} ] || [ -z ${NETWORK_NAME+x} ] || [ -z ${MINA_DEB_CODENAME+x} ]) && echo "required env vars were not provided" && exit 1
 
-# Set the DUNE_PROFILE from the NETWORK_NAME. For now, these are 1-1, but in the future, this may need to be a case statement
-case "${NETWORK_NAME}" in
-  mainnet)
-    DUNE_PROFILE=mainnet
-    ;;
-  devnet|berkeley)
-    DUNE_PROFILE=devnet
-    ;;
-  *)
-    echo "unrecognized network name: ${NETWORK_NAME}"
-    exit 1
-    ;;
-esac
-export DUNE_PROFILE
+if [ -z ${DUNE_PROFILE+x} ]; then
+  # Set the DUNE_PROFILE from the NETWORK_NAME. For now, these are 1-1,
+  # but in the future, this may need to be a case statement
+  case "${NETWORK_NAME}" in
+    mainnet)
+      DUNE_PROFILE=mainnet
+      ;;
+    devnet|berkeley)
+      DUNE_PROFILE=devnet
+      ;;
+    *)
+      echo "unrecognized network name: ${NETWORK_NAME}"
+      exit 1
+      ;;
+  esac
+  export DUNE_PROFILE
+fi
 
-# Set the base network config for ./scripts/hardfork/create_runtime_config.sh
-export FORKING_FROM_CONFIG_JSON="genesis_ledgers/${NETWORK_NAME}.json"
-[ ! -f "${FORKING_FROM_CONFIG_JSON}" ] && echo "${NETWORK_NAME} is not a known network name; check for existing network configs in 'genesis_ledgers/'" && exit 1
+if [ -z ${FORKING_FROM_CONFIG_JSON+x} ]; then
+  # Set the base network config for ./scripts/hardfork/create_runtime_config.sh
+  export FORKING_FROM_CONFIG_JSON="genesis_ledgers/${NETWORK_NAME}.json"
+fi
+[ ! -f "${FORKING_FROM_CONFIG_JSON}" ] && echo "genesis ledger ${FORKING_FROM_CONFIG_JSON} was not found" && exit 1
 
 source ~/.profile
 

--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -47,7 +47,7 @@ echo "--- Migrate accounts to new network format"
 # NB: we use sed here instead of jq, because jq is extremely slow at processing this file
 sed -i -e 's/"set_verification_key": "signature"/"set_verification_key": {"auth": "signature", "txn_version": "2"}/' config.json
 
-case "${NETWORK_NAME}" in
+case "${DUNE_PROFILE}" in
   mainnet)
     MINA_BUILD_MAINNET=true ./buildkite/scripts/build-artifact.sh
     ;;

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -105,6 +105,8 @@ let hardforkPipeline : DebianVersions.DebVersion -> Pipeline.Config.Type =
                   debVersion
                   [ "NETWORK_NAME=\$NETWORK_NAME"
                   , "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL"
+                  , "DUNE_PROFILE=\$DUNE_PROFILE"
+                  , "FORKING_FROM_CONFIG_JSON=\$FORKING_FROM_CONFIG_JSON"
                   , "AWS_ACCESS_KEY_ID"
                   , "AWS_SECRET_ACCESS_KEY"
                   , "MINA_BRANCH=\$BUILDKITE_BRANCH"
@@ -135,7 +137,12 @@ let hardforkPipeline : DebianVersions.DebVersion -> Pipeline.Config.Type =
             commands = [
                 Cmd.runInDocker Cmd.Docker::{ 
                   image = "gcr.io/o1labs-192920/mina-daemon:\${BUILDKITE_COMMIT:0:7}-${DebianVersions.lowerName debVersion}-${network}"
-                , extraEnv = [ "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL",  "NETWORK_NAME=\$NETWORK_NAME" ]
+                , extraEnv =
+                    [ "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL"
+                    , "NETWORK_NAME=\$NETWORK_NAME" 
+                    , "DUNE_PROFILE=\$DUNE_PROFILE"
+                    , "FORKING_FROM_CONFIG_JSON=\$FORKING_FROM_CONFIG_JSON"
+                    ]
                 -- an account with this balance seems present in many ledgers?
                 } "curl \$CONFIG_JSON_GZ_URL > config.json.gz && gunzip config.json.gz && sed -e '0,/20.000001/{s/20.000001/20.01/}' -i config.json && ! (mina-verify-packaged-fork-config \$NETWORK_NAME config.json /workdir/verification)"
             ]
@@ -149,7 +156,12 @@ let hardforkPipeline : DebianVersions.DebVersion -> Pipeline.Config.Type =
             commands = [
                 Cmd.runInDocker Cmd.Docker::{
                   image = "gcr.io/o1labs-192920/mina-daemon:\${BUILDKITE_COMMIT:0:7}-${DebianVersions.lowerName debVersion}-${network}"
-                , extraEnv = [ "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL",  "NETWORK_NAME=\$NETWORK_NAME" ]
+                , extraEnv =
+                    [ "CONFIG_JSON_GZ_URL=\$CONFIG_JSON_GZ_URL"
+                    , "NETWORK_NAME=\$NETWORK_NAME" 
+                    , "DUNE_PROFILE=\$DUNE_PROFILE"
+                    , "FORKING_FROM_CONFIG_JSON=\$FORKING_FROM_CONFIG_JSON"
+                    ]
                 } "curl \$CONFIG_JSON_GZ_URL > config.json.gz && gunzip config.json.gz && mina-verify-packaged-fork-config \$NETWORK_NAME config.json /workdir/verification"
             ]
             , label = "Verify packaged artifacts"

--- a/scripts/create_hardfork_deb.sh
+++ b/scripts/create_hardfork_deb.sh
@@ -48,9 +48,13 @@ for ledger_tarball in $LEDGER_TARBALLS; do
 done
 
 # Overwrite outdated ledgers that are being updated by the hardfork (backing up the outdated ledgers)
-mv "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.old.json"
+if [ -f "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json" ]; then
+  mv "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.old.json"
+fi
 cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json"
-mv "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.json" "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.old.json"
+if [ -f "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.json" ]; then
+  mv "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.json" "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.old.json"
+fi
 cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/etc/mina/rosetta/genesis_ledgers/${NETWORK_NAME}.json"
 
 build_deb "${NETWORK_TAG}"

--- a/scripts/create_hardfork_deb.sh
+++ b/scripts/create_hardfork_deb.sh
@@ -9,7 +9,7 @@ LEDGER_TARBALLS=$(realpath -s $LEDGER_TARBALLS)
 NETWORK_TAG="mina-${NETWORK_NAME}-hardfork"
 
 case "${NETWORK_NAME}" in 
-  mainnet)
+  mainnet|mainnet-pre-hf-dry-run)
     SIGNATURE_KIND=mainnet
     SEEDS_LIST=mina-seed-lists/mainnet_seeds.txt
     CONTROL_FILE_DESCRIPTION='Mina Protocol Client and Daemon'

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -58,8 +58,11 @@ case "${DUNE_PROFILE}" in
     MINA_DEB_NAME="mina-berkeley"
     DEB_SUFFIX=""
    ;;
+  mainnet)
+    MINA_DEB_NAME="mina-berkeley"
+    DEB_SUFFIX=""
+   ;;
   *)
-
     # use dune profile as suffix but replace underscore to dashes so deb builder won't complain
     _SUFFIX=${DUNE_PROFILE//_/-}
     MINA_DEB_NAME="mina-berkeley-${_SUFFIX}"

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -187,7 +187,9 @@ copy_common_daemon_configs() {
   cp ../genesis_ledgers/devnet.json "${BUILDDIR}/var/lib/coda/devnet.json"
   cp ../genesis_ledgers/berkeley.json "${BUILDDIR}/var/lib/coda/berkeley.json"
   # Set the default configuration based on Network name ($1)
-  cp ../genesis_ledgers/${1}.json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
+  if [ -f "../genesis_ledgers/${1}.json" ]; then
+    cp ../genesis_ledgers/${1}.json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
+  fi
   cp ../scripts/hardfork/create_runtime_config.sh "${BUILDDIR}/usr/local/bin/mina-hf-create-runtime-config"
   cp ../scripts/mina-verify-packaged-fork-config "${BUILDDIR}/usr/local/bin/mina-verify-packaged-fork-config"
   # Update the mina.service with a new default PEERS_URL based on Seed List URL $3


### PR DESCRIPTION

Explain your changes:
* Allow `DUNE_PROFILE` and `FORKING_FROM_CONFIG_JSON` to be set via CI env vars for package building CI.

Explain how you tested your changes:
* [ ] run the hardfork pipeline

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None