### PR TITLE
Fix: don't use step feature_flags for wrap evaluations

### DIFF
--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -264,7 +264,7 @@ let wrap_main
                   let ty =
                     Plonk_types.All_evals.typ
                       (module Impl)
-                      ~num_chunks:1 feature_flags
+                      ~num_chunks:1 Plonk_types.Features.Full.none
                   in
                   Vector.typ ty Max_proofs_verified.n
                 in


### PR DESCRIPTION
This PR fixes https://github.com/o1-labs/o1js/issues/1336 (using https://github.com/o1-labs/o1js/pull/1335 as the repro case).

The underlying issue was that we were using the feature flags for the step circuit when reasoning about the contents of the wrap proofs. In particular,
* when the circuit uses a feature
* and it uses recursion
* then it expects that feature to be used by the wrap proof that it recurses over (even though wrap never uses any custom gates).

This PR fixes that by hard-coding `Features.Full.none`.