### PR TITLE
[berkeley] Remove stop-slots from compile config

### DIFF
--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -35,5 +35,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -47,5 +47,3 @@
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
 [%%define zkapp_cmd_limit 24]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/fork.mlh
+++ b/src/config/fork.mlh
@@ -2,5 +2,3 @@
 [%%undef fork_state_hash]
 [%%undef fork_global_slot_since_genesis]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/fork_at_3757.mlh
+++ b/src/config/fork_at_3757.mlh
@@ -2,5 +2,3 @@
 [%%define fork_state_hash "3NKR3QYJ7qwxiGgX39umahgdT8BH5yXBQwQtpYZdvodCXcsndK7f"]
 [%%define fork_global_slot_since_genesis 12796]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -32,5 +32,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -32,5 +32,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/integration_tests.mlh
+++ b/src/config/integration_tests.mlh
@@ -6,6 +6,3 @@
    snark keys, a valid genesis proof, etc. *)
 [%%import "/src/config/proof_level/none.mlh"]
 [%%undef zkapp_cmd_limit]
-
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/lightnet.mlh
+++ b/src/config/lightnet.mlh
@@ -47,5 +47,3 @@
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -47,5 +47,3 @@
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
 [%%define zkapp_cmd_limit 24]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/nonconsensus_mainnet.mlh
+++ b/src/config/nonconsensus_mainnet.mlh
@@ -3,5 +3,3 @@
 [%%undef consensus_mechanism]
 [%%undef compaction_interval]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -32,5 +32,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -32,5 +32,3 @@
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -32,5 +32,3 @@
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -33,5 +33,3 @@
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -33,5 +33,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -34,5 +34,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -34,5 +34,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -32,5 +32,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -34,5 +34,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -46,5 +46,3 @@
 [%%define compaction_interval 360000]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -34,5 +34,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -35,5 +35,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 0]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -34,5 +34,3 @@
 [%%undef compaction_interval]
 [%%define vrf_poll_interval 5000]
 [%%undef zkapp_cmd_limit]
-[%%undef slot_tx_end]
-[%%undef slot_chain_end]

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -67,7 +67,7 @@ let max_event_elements = 100
 
 let max_action_elements = 100
 
-[%%inject "network_id", network]
+let network_id = "testnet"
 
 [%%ifndef zkapp_cmd_limit]
 
@@ -84,27 +84,3 @@ let zkapp_cmd_limit = Some zkapp_cmd_limit
 let zkapp_cmd_limit_hardcap = 128
 
 let zkapps_disabled = false
-
-[%%ifndef slot_tx_end]
-
-let slot_tx_end : int option = None
-
-[%%else]
-
-[%%inject "slot_tx_end", slot_tx_end]
-
-let slot_tx_end = Some slot_tx_end
-
-[%%endif]
-
-[%%ifndef slot_chain_end]
-
-let slot_chain_end : int option = None
-
-[%%else]
-
-[%%inject "slot_chain_end", slot_chain_end]
-
-let slot_chain_end = Some slot_chain_end
-
-[%%endif]

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1586,13 +1586,13 @@ let make_fork_config ~staged_ledger ~global_slot ~state_hash ~blockchain_length
     ~proof:(Proof_keys.make ~fork ()) ()
 
 let slot_tx_end_or_default, slot_chain_end_or_default =
-  let f compile get_runtime t =
-    Option.map ~f:Mina_numbers.Global_slot_since_hard_fork.of_int
-    @@ Option.value_map t.daemon ~default:compile ~f:(fun daemon ->
-           Option.merge compile ~f:(fun _c r -> r) @@ get_runtime daemon )
+  let f get_runtime t =
+    let open Option.Let_syntax in
+    let%bind daemon = t.daemon in
+    let%map slot = get_runtime daemon in
+    Mina_numbers.Global_slot_since_hard_fork.of_int slot
   in
-  ( f Mina_compile_config.slot_tx_end (fun d -> d.slot_tx_end)
-  , f Mina_compile_config.slot_chain_end (fun d -> d.slot_chain_end) )
+  (f (fun d -> d.slot_tx_end), f (fun d -> d.slot_chain_end))
 
 module Test_configs = struct
   let bootstrap =


### PR DESCRIPTION
This PR removes the stop slots from the compile config.

These caused a previous issue where a release was baked expecting it to use the compile config, where CI is not set up to do so. Instead, we remove the options so that they are only injected in the correct location: in the runtime config that we provide for the network.