### PR TITLE
add mina-create-config docker

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -261,7 +261,16 @@ let docker_step : Artifacts.Type -> DebianVersions.DebVersion -> Profiles.Type -
             deb_codename="${DebianVersions.lowerName debVersion}",
             step_key="test-suite-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
             network="berkeley"
-          }
+          },
+
+        CreateConfig = 
+          DockerImage.ReleaseSpec::{
+            deps=DebianVersions.dependsOn debVersion profile,
+            service="mina-create-config",
+            deb_codename="${DebianVersions.lowerName debVersion}",
+            step_key="create-config-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
+            network="berkeley"
+          },
       } artifact
 in 
 

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -266,9 +266,9 @@ let docker_step : Artifacts.Type -> DebianVersions.DebVersion -> Profiles.Type -
         CreateConfig = 
           DockerImage.ReleaseSpec::{
             deps=DebianVersions.dependsOn debVersion profile,
-            service="mina-create-config",
+            service="mina-create-genesis",
             deb_codename="${DebianVersions.lowerName debVersion}",
-            step_key="create-config-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
+            step_key="create-genesis-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
             network="berkeley"
           }
       } artifact

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -270,7 +270,7 @@ let docker_step : Artifacts.Type -> DebianVersions.DebVersion -> Profiles.Type -
             deb_codename="${DebianVersions.lowerName debVersion}",
             step_key="create-config-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
             network="berkeley"
-          },
+          }
       } artifact
 in 
 

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -263,7 +263,7 @@ let docker_step : Artifacts.Type -> DebianVersions.DebVersion -> Profiles.Type -
             network="berkeley"
           },
 
-        CreateConfig = 
+        CreateGenesis = 
           DockerImage.ReleaseSpec::{
             deps=DebianVersions.dependsOn debVersion profile,
             service="mina-create-genesis",

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -5,7 +5,7 @@ let Profiles = ./Profiles.dhall
 let Artifact : Type  = < Daemon | CreateConfig | Archive | ArchiveMigration | TestExecutive | BatchTxn | Rosetta | ZkappTestTransaction | FunctionalTestSuite >
 
 
-let AllButTests = [ Artifact.Daemon Artifact.CreateConfig , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
+let AllButTests = [ Artifact.Daemon, Artifact.CreateConfig , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
 
 let Main = [ Artifact.Daemon , Artifact.Archive , Artifact.Rosetta ]
 

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -2,10 +2,10 @@ let Prelude = ../External/Prelude.dhall
 let Text/concatSep = Prelude.Text.concatSep
 let Profiles = ./Profiles.dhall
 
-let Artifact : Type  = < Daemon | CreateConfig | Archive | ArchiveMigration | TestExecutive | BatchTxn | Rosetta | ZkappTestTransaction | FunctionalTestSuite >
+let Artifact : Type  = < Daemon | CreateGenesis | Archive | ArchiveMigration | TestExecutive | BatchTxn | Rosetta | ZkappTestTransaction | FunctionalTestSuite >
 
 
-let AllButTests = [ Artifact.Daemon, Artifact.CreateConfig , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
+let AllButTests = [ Artifact.Daemon, Artifact.CreateGenesis , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
 
 let Main = [ Artifact.Daemon , Artifact.Archive , Artifact.Rosetta ]
 
@@ -14,7 +14,7 @@ let All = AllButTests # [ Artifact.FunctionalTestSuite ]
 let capitalName = \(artifact : Artifact) ->
   merge {
     Daemon = "Daemon"
-    , CreateConfig = "CreateConfig"
+    , CreateGenesis = "CreateGenesis"
     , Archive = "Archive"
     , ArchiveMigration = "ArchiveMigration"
     , TestExecutive = "TestExecutive"
@@ -27,7 +27,7 @@ let capitalName = \(artifact : Artifact) ->
 let lowerName = \(artifact : Artifact) ->
   merge {
     Daemon = "daemon"
-    , CreateConfig = "create_config"
+    , CreateGenesis = "create_genesis"
     , Archive = "archive"
     , ArchiveMigration = "archive_migration"
     , TestExecutive = "test_executive"
@@ -40,7 +40,7 @@ let lowerName = \(artifact : Artifact) ->
 let dockerName = \(artifact : Artifact) ->
   merge {
     Daemon = "mina-daemon"
-    , CreateConfig = "mina-create-config"
+    , CreateGenesis = "mina-create-genesis"
     , Archive = "mina-archive"
     , TestExecutive = "mina-test-executive"
     , ArchiveMigration = "mina-archive-migration"
@@ -54,7 +54,7 @@ let dockerName = \(artifact : Artifact) ->
 let toDebianName = \(artifact : Artifact) ->
   merge {
     Daemon = "daemon"
-    , CreateConfig = "create_config"
+    , CreateGenesis = "create_genesis"
     , Archive = "archive"
     , ArchiveMigration  = "archive_migration"
     , TestExecutive = "test_executive"

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -2,10 +2,10 @@ let Prelude = ../External/Prelude.dhall
 let Text/concatSep = Prelude.Text.concatSep
 let Profiles = ./Profiles.dhall
 
-let Artifact : Type  = < Daemon | Archive | ArchiveMigration | TestExecutive | BatchTxn | Rosetta | ZkappTestTransaction | FunctionalTestSuite >
+let Artifact : Type  = < Daemon | CreateConfig | Archive | ArchiveMigration | TestExecutive | BatchTxn | Rosetta | ZkappTestTransaction | FunctionalTestSuite >
 
 
-let AllButTests = [ Artifact.Daemon , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
+let AllButTests = [ Artifact.Daemon Artifact.CreateConfig , Artifact.Archive , Artifact.ArchiveMigration , Artifact.BatchTxn , Artifact.TestExecutive , Artifact.Rosetta , Artifact.ZkappTestTransaction ]
 
 let Main = [ Artifact.Daemon , Artifact.Archive , Artifact.Rosetta ]
 
@@ -14,6 +14,7 @@ let All = AllButTests # [ Artifact.FunctionalTestSuite ]
 let capitalName = \(artifact : Artifact) ->
   merge {
     Daemon = "Daemon"
+    , CreateConfig = "CreateConfig"
     , Archive = "Archive"
     , ArchiveMigration = "ArchiveMigration"
     , TestExecutive = "TestExecutive"
@@ -26,6 +27,7 @@ let capitalName = \(artifact : Artifact) ->
 let lowerName = \(artifact : Artifact) ->
   merge {
     Daemon = "daemon"
+    , CreateConfig = "create_config"
     , Archive = "archive"
     , ArchiveMigration = "archive_migration"
     , TestExecutive = "test_executive"
@@ -38,6 +40,7 @@ let lowerName = \(artifact : Artifact) ->
 let dockerName = \(artifact : Artifact) ->
   merge {
     Daemon = "mina-daemon"
+    , CreateConfig = "mina-create-config"
     , Archive = "mina-archive"
     , TestExecutive = "mina-test-executive"
     , ArchiveMigration = "mina-archive-migration"
@@ -51,6 +54,7 @@ let dockerName = \(artifact : Artifact) ->
 let toDebianName = \(artifact : Artifact) ->
   merge {
     Daemon = "daemon"
+    , CreateConfig = "create_config"
     , Archive = "archive"
     , ArchiveMigration  = "archive_migration"
     , TestExecutive = "test_executive"

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-          artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.Archive, Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive ,
+          artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig, Artifacts.Type.Archive, Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive ,
                         Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction, Artifacts.Type.FunctionalTestSuite ]
         }
     )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-          artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig, Artifacts.Type.Archive, Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive ,
+          artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateGenesis, Artifacts.Type.Archive, Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive ,
                         Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction, Artifacts.Type.FunctionalTestSuite ]
         }
     )

--- a/buildkite/src/Jobs/Release/MinaArtifactBuster.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBuster.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig, Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
+            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateGenesis, Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
             debVersion = DebianVersions.DebVersion.Buster
         }
     )

--- a/buildkite/src/Jobs/Release/MinaArtifactBuster.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBuster.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
+            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig, Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
             debVersion = DebianVersions.DebVersion.Buster
         }
     )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
+            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig , Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
             debVersion = DebianVersions.DebVersion.Focal
         }
     )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
@@ -12,7 +12,7 @@ in
 Pipeline.build 
     (ArtifactPipelines.pipeline 
         ArtifactPipelines.MinaBuildSpec::{
-            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateConfig , Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
+            artifacts = [ Artifacts.Type.Daemon , Artifacts.Type.CreateGenesis , Artifacts.Type.Archive , Artifacts.Type.BatchTxn , Artifacts.Type.TestExecutive , Artifacts.Type.Rosetta , Artifacts.Type.ZkappTestTransaction ],
             debVersion = DebianVersions.DebVersion.Focal
         }
     )

--- a/dockerfiles/Dockerfile-mina-create-config
+++ b/dockerfiles/Dockerfile-mina-create-config
@@ -1,0 +1,50 @@
+ARG image=debian:bullseye-slim
+FROM ${image}
+
+# Run with `docker build --build-arg deb_version=<version>`
+ARG deb_version
+ARG deb_codename=bullseye
+ARG deb_release=unstable
+ARG deb_profile
+
+# if --build-arg deb_profile is defined, add hypen at beginning.
+ENV SUFFIX=${deb_profile:+-${deb_profile}}
+# construct mina debian package name based on network and suffix.
+# possible values:
+# - mina-archive
+# - mina-archive-lightnet etc.
+ENV MINA_DEB=mina-create-config${SUFFIX}
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo "Building image with version $deb_codename $deb_release $deb_version"
+
+COPY scripts/archive-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Dependencies
+RUN apt-get update --quiet --yes \
+    && apt-get upgrade --quiet --yes \
+    && apt-get install --quiet --yes --no-install-recommends \
+        procps \
+        curl \
+        jq \
+        dumb-init \
+        libssl1.1 \
+        libgomp1 \
+        libpq-dev \
+        gnupg2 \
+        apt-transport-https \
+        ca-certificates \
+        dnsutils \
+        tzdata \
+        apt-utils \
+        man \
+    && rm -rf /var/lib/apt/lists/*
+
+# archive-node package
+RUN echo "deb [trusted=yes] http://packages.o1test.net $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
+  && apt-get update --quiet --yes \
+  && apt-get install --quiet --yes "${MINA_DEB}=$deb_version" \
+  && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["mina-create-config"]

--- a/dockerfiles/Dockerfile-mina-create-genesis
+++ b/dockerfiles/Dockerfile-mina-create-genesis
@@ -13,7 +13,7 @@ ENV SUFFIX=${deb_profile:+-${deb_profile}}
 # possible values:
 # - mina-archive
 # - mina-archive-lightnet etc.
-ENV MINA_DEB=mina-create-config${SUFFIX}
+ENV MINA_DEB=mina-create-genesis${SUFFIX}
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
@@ -47,4 +47,4 @@ RUN echo "deb [trusted=yes] http://packages.o1test.net $deb_codename $deb_releas
   && apt-get install --quiet --yes "${MINA_DEB}=$deb_version" \
   && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["mina-create-config"]
+ENTRYPOINT ["mina-create-genesis"]

--- a/dockerfiles/Dockerfile-mina-create-genesis
+++ b/dockerfiles/Dockerfile-mina-create-genesis
@@ -7,19 +7,10 @@ ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG deb_profile
 
-# if --build-arg deb_profile is defined, add hypen at beginning.
-ENV SUFFIX=${deb_profile:+-${deb_profile}}
-# construct mina debian package name based on network and suffix.
-# possible values:
-# - mina-archive
-# - mina-archive-lightnet etc.
-ENV MINA_DEB=mina-create-genesis${SUFFIX}
+ENV MINA_DEB=mina-create-genesis
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
-
-COPY scripts/archive-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 # Dependencies
 RUN apt-get update --quiet --yes \

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -43,12 +43,12 @@ case "${MINA_DEB_CODENAME}" in
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   buster)
-    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc"
     DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)
-    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps6, mina-logproc"
     DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc1"
     ;;

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -33,19 +33,19 @@ TEST_EXECUTIVE_DEPS=", mina-logproc, python3, nodejs, yarn, google-cloud-sdk, ku
 
 case "${MINA_DEB_CODENAME}" in
   bookworm|jammy)
-    DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   buster)
-    DAEMON_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc"
+    DAEMON_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)
-    DAEMON_DEPS=", libffi6, libjemalloc1, libpq-dev, libprocps6, mina-logproc"
+    DAEMON_DEPS=", libffi6, libjemalloc1, libpq-dev, libprocps6, mina-logproc, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc1"
     ;;
   *)
@@ -147,8 +147,6 @@ copy_common_daemon_configs() {
 
   # Copy shared binaries
   cp ../src/app/libp2p_helper/result/bin/libp2p_helper "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
-  # cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/mina-logproc"
-  cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/mina-create-genesis"
   cp ./default/src/app/generate_keypair/generate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-generate-keypair"
   cp ./default/src/app/validate_keypair/validate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-validate-keypair"
 
@@ -240,6 +238,18 @@ build_logproc_deb() {
   build_deb mina-logproc
 }
 ##################################### END LOGPROC PACKAGE #######################################
+
+##################################### CREATE GENESIS PACKAGE #######################################
+build_create_genesis_deb() {
+  create_control_file mina-create-genesis "${SHARED_DEPS}, mina-logproc" 'Utility for create mina genesis config' "${SUGGESTED_DEPS}"
+
+  # Binaries
+  cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/mina-create-genesis"
+
+  build_deb mina-create-genesis
+}
+##################################### END GENESIS PACKAGE #######################################
+
 
 ##################################### GENERATE TEST_EXECUTIVE PACKAGE #######################################
 build_test_executive_deb () {

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -33,19 +33,23 @@ TEST_EXECUTIVE_DEPS=", mina-logproc, python3, nodejs, yarn, google-cloud-sdk, ku
 
 case "${MINA_DEB_CODENAME}" in
   bookworm|jammy)
-    DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc, mina-create-genesis"
+    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc, mina-create-genesis"
+    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   buster)
-    DAEMON_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps7, mina-logproc, mina-create-genesis"
+    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)
-    DAEMON_DEPS=", libffi6, libjemalloc1, libpq-dev, libprocps6, mina-logproc, mina-create-genesis"
+    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc1"
     ;;
   *)
@@ -241,7 +245,7 @@ build_logproc_deb() {
 
 ##################################### CREATE GENESIS PACKAGE #######################################
 build_create_genesis_deb() {
-  create_control_file mina-create-genesis "${SHARED_DEPS}, mina-logproc" 'Utility for create mina genesis config' "${SUGGESTED_DEPS}"
+  create_control_file mina-create-genesis "${SHARED_DEPS}${MINA_CREATE_GENESIS_DEPS}" 'Utility for create mina genesis config' "${SUGGESTED_DEPS}"
 
   # Binaries
   cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/mina-create-genesis"

--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -38,17 +38,17 @@ case "${MINA_DEB_CODENAME}" in
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    MINA_CREATE_GENESIS_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
     DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   buster)
-    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
     DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)
-    MINA_CREATE_GENESIS_DEPS=", libffi8, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    MINA_CREATE_GENESIS_DEPS=", libffi6, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
     DAEMON_DEPS="$MINA_CREATE_GENESIS_DEPS, mina-create-genesis"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc1"
     ;;

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -19,6 +19,7 @@ if [ $# -eq 0 ]
     build_test_executive_deb
     build_functional_test_suite_deb
     build_zkapp_test_transaction_deb
+    build_create_genesis_deb
 
   else 
     for i in "$@"; do

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -10,7 +10,7 @@ set +x
 CLEAR='\033[0m'
 RED='\033[0;31m'
 # Array of valid service names
-VALID_SERVICES=('mina-archive' 'mina-archive-migration' 'mina-daemon' 'mina-rosetta' 'mina-test-suite' 'mina-test-executive' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'bot' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain' 'itn-orchestrator')
+VALID_SERVICES=('mina-archive' 'mina-create-config' 'mina-archive-migration' 'mina-daemon' 'mina-rosetta' 'mina-test-suite' 'mina-test-executive' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'bot' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain' 'itn-orchestrator')
 
 function usage() {
   if [[ -n "$1" ]]; then
@@ -87,6 +87,11 @@ if [[ $(echo ${VALID_SERVICES[@]} | grep -o "$SERVICE" - | wc -w) -eq 0 ]]; then
 case "${SERVICE}" in
 mina-archive)
   DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-archive"
+  DOCKER_CONTEXT="dockerfiles/"
+  SERVICE=${SERVICE}${SERVICE_SUFFIX}
+  ;;
+mina-create-config)
+  DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-create-config"
   DOCKER_CONTEXT="dockerfiles/"
   SERVICE=${SERVICE}${SERVICE_SUFFIX}
   ;;

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -10,7 +10,7 @@ set +x
 CLEAR='\033[0m'
 RED='\033[0;31m'
 # Array of valid service names
-VALID_SERVICES=('mina-archive' 'mina-create-config' 'mina-archive-migration' 'mina-daemon' 'mina-rosetta' 'mina-test-suite' 'mina-test-executive' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'bot' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain' 'itn-orchestrator')
+VALID_SERVICES=('mina-archive' 'mina-create-genesis' 'mina-archive-migration' 'mina-daemon' 'mina-rosetta' 'mina-test-suite' 'mina-test-executive' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'bot' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain' 'itn-orchestrator')
 
 function usage() {
   if [[ -n "$1" ]]; then
@@ -90,8 +90,8 @@ mina-archive)
   DOCKER_CONTEXT="dockerfiles/"
   SERVICE=${SERVICE}${SERVICE_SUFFIX}
   ;;
-mina-create-config)
-  DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-create-config"
+mina-create-genesis)
+  DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-create-genesis"
   DOCKER_CONTEXT="dockerfiles/"
   SERVICE=${SERVICE}${SERVICE_SUFFIX}
   ;;


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
