### PR TITLE
Vendored dependencies 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,4 +16,4 @@
 	url = https://github.com/MinaProtocol/c-reference-signer.git
 [submodule "src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors"]
 	path = src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors
-	url = git@github.com:MinaProtocol/kimchi-stubs-vendors.git
+	url = https://github.com/MinaProtocol/kimchi-stubs-vendors.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "src/external/c-reference-signer"]
 	path = src/external/c-reference-signer
 	url = https://github.com/MinaProtocol/c-reference-signer.git
+[submodule "src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors"]
+	path = src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors
+	url = git@github.com:MinaProtocol/kimchi-stubs-vendors.git

--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -58,9 +58,6 @@ _build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --confi
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
 
-echo "--- New genesis config"
-cat new_config.json
-
 existing_files=$(aws s3 ls s3://snark-keys.o1test.net/ | awk '{print $4}')
 for file in hardfork_ledgers/*; do
   filename=$(basename "$file")
@@ -75,6 +72,9 @@ for file in hardfork_ledgers/*; do
     aws s3 cp --acl public-read "$file" s3://snark-keys.o1test.net/
   fi
 done
+
+echo "--- New genesis config"
+cat new_config.json
 
 echo "--- Build hardfork package for Debian ${MINA_DEB_CODENAME}"
 RUNTIME_CONFIG_JSON=new_config.json LEDGER_TARBALLS="$(echo hardfork_ledgers/*.tar.gz)" ./scripts/create_hardfork_deb.sh

--- a/src/lib/crypto/dune
+++ b/src/lib/crypto/dune
@@ -1,0 +1,1 @@
+(data_only_dirs proof-systems)

--- a/src/lib/crypto/kimchi_bindings/stubs/.cargo/config
+++ b/src/lib/crypto/kimchi_bindings/stubs/.cargo/config
@@ -1,2 +1,8 @@
 [build]
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "kimchi-stubs-vendors"

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -1,10 +1,11 @@
 ;; src/ contains no dune-related files
+;; kimchi-stubs-vendors contains the vendors for Kimchi stubs
 
-(data_only_dirs src)
+(data_only_dirs src kimchi-stubs-vendors)
 
 ;; Ignore target if it exists locally
 
-(dirs :standard \ target)
+(dirs :standard .cargo \ target)
 
 ;; we first create a `dune-build-root` file that contains the dune workspace root
 

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -55,6 +55,7 @@
   Cargo.toml
   rust-toolchain.toml
   (source_tree src)
+  (source_tree kimchi-stubs-vendors)
   (source_tree .cargo)
   (source_tree ../../proof-systems)
   (env_var MARLIN_PLONK_STUBS))
@@ -154,6 +155,7 @@
   Cargo.toml
   rust-toolchain.toml
   (source_tree src)
+  (source_tree kimchi-stubs-vendors)
   (source_tree .cargo)
   (source_tree ../../proof-systems)
   (env_var MARLIN_PLONK_STUBS))

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -69,7 +69,7 @@
     (setenv
      RUSTFLAGS
      %{read:rustflags.sexp}
-     (run cargo build --release --frozen)))
+     (run cargo build --release --locked)))
    (run
     cp
     %{read:dune-build-root}/cargo_kimchi_stubs/release/libwires_15_stubs.a
@@ -168,7 +168,7 @@
    (setenv
     CARGO_TARGET_DIR
     "%{read:dune-build-root}/cargo_kimchi_bindgen"
-    (run cargo run %{targets} --frozen))
+    (run cargo run %{targets} --locked))
    (run ocamlformat -i %{targets}))))
 
 ;; this is used by nix

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -66,7 +66,7 @@
     (setenv
      RUSTFLAGS
      %{read:rustflags.sexp}
-     (run cargo build --release)))
+     (run cargo build --release --frozen)))
    (run
     cp
     %{read:dune-build-root}/cargo_kimchi_stubs/release/libwires_15_stubs.a

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -55,6 +55,7 @@
   Cargo.toml
   rust-toolchain.toml
   (source_tree src)
+  (source_tree .cargo)
   (source_tree ../../proof-systems)
   (env_var MARLIN_PLONK_STUBS))
  (locks /cargo-lock) ;; lock for rustup
@@ -153,6 +154,7 @@
   Cargo.toml
   rust-toolchain.toml
   (source_tree src)
+  (source_tree .cargo)
   (source_tree ../../proof-systems)
   (env_var MARLIN_PLONK_STUBS))
  (locks /cargo-lock) ;; lock for rustup

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -163,7 +163,7 @@
    (setenv
     CARGO_TARGET_DIR
     "%{read:dune-build-root}/cargo_kimchi_bindgen"
-    (run cargo run %{targets}))
+    (run cargo run %{targets} --frozen))
    (run ocamlformat -i %{targets}))))
 
 ;; this is used by nix

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -69,7 +69,7 @@
     (setenv
      RUSTFLAGS
      %{read:rustflags.sexp}
-     (run cargo build --release --locked)))
+     (run cargo build --release --offline)))
    (run
     cp
     %{read:dune-build-root}/cargo_kimchi_stubs/release/libwires_15_stubs.a
@@ -168,7 +168,7 @@
    (setenv
     CARGO_TARGET_DIR
     "%{read:dune-build-root}/cargo_kimchi_bindgen"
-    (run cargo run %{targets} --locked))
+    (run cargo run %{targets} --offline))
    (run ocamlformat -i %{targets}))))
 
 ;; this is used by nix


### PR DESCRIPTION
We were exposed to supply chain attacks because our Rust dependencies were not pinned. This PR fixes that by pinning the kimchi stubs dependencies and also incorporating all vendored dependencies available in proof-systems.
 
Explain your changes:
* Vendored all Kimchi stubs dependencies to a separate repository (i.e., [`kimchi-stubs-vendors`](https://github.com/MinaProtocol/kimchi-stubs-vendors)).
* Incorporated the `kimchi-stubs-vendors` repository as a dependency through git submodules.
* Updated the Kimchi stubs dune script with proper instructions to use the vendored dependencies.
* Pulled in all the vendored dependencies available in `proof-systems:berkeley`.

Explain how you tested your changes:
* Verified that our build scripts no longer downloads crates from remote sources, both on CI and locally.  
* Ensured that Cargo always compiles the pinned dependencies available in our vendored submodules, both on CI and locally.  
* Checked that the version of the dependencies that Cargo builds matches exactly what we specify in `Cargo.toml`.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #15623
