### PR TITLE
Introduce checkpoint prefix argument to migration script

### DIFF
--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -848,7 +848,7 @@ function run_final_migration() {
 
     # sort by https://stackoverflow.com/questions/60311787/how-to-sort-by-numbers-that-are-part-of-a-filename-in-bash
     
-    migrated_replayer_output=$(find_most_recent_checkpoint $CHECKPOINT_PREFIX-checkpoint*.json)
+    migrated_replayer_output=$(find_most_recent_checkpoint $__checkpoint_prefix-checkpoint*.json)
 
     echo "Running validations for final migration: "
     echo "   mainnet-archive-uri: '$__mainnet_archive_uri'"

--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -79,18 +79,19 @@ function initial_help(){
     echo ""
     echo "Parameters:"
     echo ""
-    printf "  %-25s %s\n" "-h | --help" "show help";
-    printf "  %-25s %s\n" "-g | --genesis-ledger" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-s | --source-db" "[connection_str] connection string to database to be migrated";
-    printf "  %-25s %s\n" "-t | --target-db" "[connection_str] connection string to database which will hold migrated data";
-    printf "  %-25s %s\n" "-b | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-g  | --genesis-ledger" "[file] path to genesis ledger file";
+    printf "  %-25s %s\n" "-s  | --source-db" "[connection_str] connection string to database to be migrated";
+    printf "  %-25s %s\n" "-t  | --target-db" "[connection_str] connection string to database which will hold migrated data";
+    printf "  %-25s %s\n" "-b  | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
     printf "  %-25s %s\n" "-bs | --blocks-batch-size" "[int] number of precomputed blocks to be fetch at once from Gcloud. Bigger number like 1000 can help speed up migration process";
-    printf "  %-25s %s\n" "-n | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
-    printf "  %-25s %s\n" "-d | --delete-blocks" "[flag] delete blocks after they are processed (saves space with -sb)"
-    printf "  %-25s %s\n" "-p | --prefetch-blocks" "[flag] downloads all blocks at once instead of incrementally"
-    printf "  %-25s %s\n" "-i | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
-    printf "  %-25s %s\n" "-c | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
-    printf "  %-25s %s\n" "-l | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
+    printf "  %-25s %s\n" "-n  | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-d  | --delete-blocks" "[flag] delete blocks after they are processed (saves space with -sb)"
+    printf "  %-25s %s\n" "-p  | --prefetch-blocks" "[flag] downloads all blocks at once instead of incrementally"
+    printf "  %-25s %s\n" "-i  | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
+    printf "  %-25s %s\n" "-cp | --checkpoint-prefix" "[string] replayer checkpoint prefix. Default: $CHECKPOINT_PREFIX"
+    printf "  %-25s %s\n" "-c  | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
+    printf "  %-25s %s\n" "-l  | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
     echo ""
     echo "Example:"
     echo ""
@@ -122,6 +123,7 @@ function initial(){
     local __checkpoint_output_path='.'
     local __precomputed_blocks_local_path='.'
     local __checkpoint_interval=$CHECKPOINT_INTERVAL
+    local __checkpoint_prefix=$CHECKPOINT_PREFIX
 
     while [ ${#} -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -167,6 +169,10 @@ function initial(){
             ;;
             -i | --checkpoint-interval )
                 __checkpoint_interval=${2:?$error_message}
+                shift 2;
+            ;;
+            -cp | --checkpoint-prefix )
+                __checkpoint_prefix=${2:?$error_message}
                 shift 2;
             ;;
             -l | --precomputed-blocks-local-path )
@@ -225,7 +231,8 @@ function initial(){
         "$__network" \
         "$__checkpoint_output_path" \
         "$__precomputed_blocks_local_path" \
-        "$__checkpoint_interval"
+        "$__checkpoint_interval" \
+        "$__checkpoint_prefix"
 }
 
 function check_log_for_error() {
@@ -272,6 +279,7 @@ function run_initial_migration() {
     local __checkpoint_output_path=$9
     local __precomputed_blocks_local_path=${10}
     local __checkpoint_interval=${11}
+    local __checkpoint_prefix=${12}
     
     local __date=$(date '+%Y-%m-%d_%H_%M_%S')
     local __berkely_migration_log="berkeley_migration_$__date.log"
@@ -305,7 +313,7 @@ function run_initial_migration() {
         --archive-uri "$__migrated_archive_uri" \
         --input-file "$__config_file" \
         --checkpoint-interval "$__checkpoint_interval" \
-        --checkpoint-file-prefix "$CHECKPOINT_PREFIX" \
+        --checkpoint-file-prefix "$__checkpoint_prefix" \
         --checkpoint-output-folder "$__checkpoint_output_path" \
         --log-file "$__replayer_log"
 
@@ -313,7 +321,7 @@ function run_initial_migration() {
 
     set -e # exit immediately on errors
 
-    check_output_replayer_for_initial "$CHECKPOINT_PREFIX"
+    check_output_replayer_for_initial "$__checkpoint_prefix"
     
     mina-berkeley-migration-verifier pre-fork \
         --mainnet-archive-uri "$__mainnet_archive_uri" \
@@ -329,19 +337,20 @@ function incremental_help(){
     echo ""
     echo "Parameters:"
     echo ""
-    printf "  %-25s %s\n" "-h | --help" "show help";
-    printf "  %-25s %s\n" "-g | --genesis-ledger" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-r | --replayer-checkpoint" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-s | --source-db" "[connection_str] connection string to database to be migrated";
-    printf "  %-25s %s\n" "-t | --target-db" "[connection_str] connection string to database which will hold migrated data";
-    printf "  %-25s %s\n" "-b | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-g  | --genesis-ledger" "[file] path to genesis ledger file";
+    printf "  %-25s %s\n" "-r  | --replayer-checkpoint" "[file] path to genesis ledger file";
+    printf "  %-25s %s\n" "-s  | --source-db" "[connection_str] connection string to database to be migrated";
+    printf "  %-25s %s\n" "-t  | --target-db" "[connection_str] connection string to database which will hold migrated data";
+    printf "  %-25s %s\n" "-b  | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
     printf "  %-25s %s\n" "-bs | --blocks-batch-size" "[int] number of precomputed blocks to be fetch at once from Gcloud. Bigger number like 1000 can help speed up migration process";
-    printf "  %-25s %s\n" "-n | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
-    printf "  %-25s %s\n" "-d | --delete-blocks" "delete blocks after they are processed (saves space with -sb)"
-    printf "  %-25s %s\n" "-p | --prefetch-blocks" "downloads all blocks at once instead of incrementally"
-    printf "  %-25s %s\n" "-c | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
-    printf "  %-25s %s\n" "-i | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
-    printf "  %-25s %s\n" "-l | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
+    printf "  %-25s %s\n" "-n  | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-d  | --delete-blocks" "delete blocks after they are processed (saves space with -sb)"
+    printf "  %-25s %s\n" "-p  | --prefetch-blocks" "downloads all blocks at once instead of incrementally"
+    printf "  %-25s %s\n" "-c  | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
+    printf "  %-25s %s\n" "-i  | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
+    printf "  %-25s %s\n" "-cp | --checkpoint-prefix" "[string] replayer checkpoint prefix. Default: $CHECKPOINT_PREFIX"
+    printf "  %-25s %s\n" "-l  | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
     echo ""
     echo "Example:"
     echo ""
@@ -401,6 +410,7 @@ function incremental(){
     local __checkpoint_interval=$CHECKPOINT_INTERVAL
     local __checkpoint_output_path='.'
     local __precomputed_blocks_local_path='.'
+    local __checkpoint_prefix="$CHECKPOINT_PREFIX"
 
     while [ ${#} -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -450,6 +460,10 @@ function incremental(){
             ;;
             -c | --checkpoint-output-path )
                 __checkpoint_output_path=${2:?$error_message}
+                shift 2;
+            ;;
+            -cp | --checkpoint-prefix )
+                __checkpoint_prefix=${2:?$error_message}
                 shift 2;
             ;;
             -l | --precomputed-blocks-local-path )
@@ -511,7 +525,8 @@ function incremental(){
         "$__checkpoint_interval" \
         "$__replayer_checkpoint" \
         "$__checkpoint_output_path" \
-        "$__precomputed_blocks_local_path"
+        "$__precomputed_blocks_local_path" \
+        "$__checkpoint_prefix"
 
 }
 
@@ -528,6 +543,7 @@ function run_incremental_migration() {
     local __replayer_checkpoint=${10}
     local __checkpoint_output_path=${11}
     local __precomputed_blocks_local_path=${12}
+    local __checkpoint_prefix=${13}
 
     local __date=$(date '+%Y-%m-%d_%H%M')
     local __berkely_migration_log="berkeley_migration_$__date.log"
@@ -557,7 +573,7 @@ function run_incremental_migration() {
         --archive-uri "$__migrated_archive_uri" \
         --input-file "$__replayer_checkpoint" \
         --checkpoint-interval "$__checkpoint_interval" \
-        --checkpoint-file-prefix "$CHECKPOINT_PREFIX" \
+        --checkpoint-file-prefix "$__checkpoint_prefix" \
         --checkpoint-output-folder "$__checkpoint_output_path" \
         --log-file "$__replayer_log"
 
@@ -565,7 +581,7 @@ function run_incremental_migration() {
 
     set -e # exit immediately on errors
 
-    check_new_replayer_checkpoints_for_incremental "$CHECKPOINT_PREFIX"
+    check_new_replayer_checkpoints_for_incremental "$__checkpoint_prefix"
 
     mina-berkeley-migration-verifier pre-fork \
         --mainnet-archive-uri "$__mainnet_archive_uri" \
@@ -582,20 +598,21 @@ function final_help(){
     echo ""
     echo "Parameters:"
     echo ""
-    printf "  %-25s %s\n" "-h | --help" "show help";
-    printf "  %-25s %s\n" "-g | --genesis-ledger" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-r | --replayer-checkpoint" "[file] path to genesis ledger file";
-    printf "  %-25s %s\n" "-s | --source-db" "[connection_str] connection string to database to be migrated";
-    printf "  %-25s %s\n" "-t | --target-db" "[connection_str] connection string to database which will hold migrated data";
-    printf "  %-25s %s\n" "-b | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-g  | --genesis-ledger" "[file] path to genesis ledger file";
+    printf "  %-25s %s\n" "-r  | --replayer-checkpoint" "[file] path to genesis ledger file";
+    printf "  %-25s %s\n" "-s  | --source-db" "[connection_str] connection string to database to be migrated";
+    printf "  %-25s %s\n" "-t  | --target-db" "[connection_str] connection string to database which will hold migrated data";
+    printf "  %-25s %s\n" "-b  | --blocks-bucket" "[string] name of precomputed blocks bucket. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
     printf "  %-25s %s\n" "-bs | --blocks-batch-size" "[int] number of precomputed blocks to be fetch at once from Gcloud. Bigger number like 1000 can help speed up migration process";
-    printf "  %-25s %s\n" "-n | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
+    printf "  %-25s %s\n" "-n  | --network" "[string] network name when determining precomputed blocks. NOTICE: there is an assumption that precomputed blocks are named with format: {network}-{height}-{state_hash}.json";
     printf "  %-25s %s\n" "-fc | --fork-genesis-config" "[file] Genesis config file for the fork network. It should be provied by MF or O(1)Labs team after fork block is announced";
-    printf "  %-25s %s\n" "-d | --delete-blocks" "delete blocks after they are processed (saves space with -sb)"
-    printf "  %-25s %s\n" "-p | --prefetch-blocks" "downloads all blocks at once instead of incrementally"
-    printf "  %-25s %s\n" "-c | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
-    printf "  %-25s %s\n" "-i | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
-    printf "  %-25s %s\n" "-l | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
+    printf "  %-25s %s\n" "-d  | --delete-blocks" "delete blocks after they are processed (saves space with -sb)"
+    printf "  %-25s %s\n" "-p  | --prefetch-blocks" "downloads all blocks at once instead of incrementally"
+    printf "  %-25s %s\n" "-c  | --checkpoint-output-path" "[file] output folder for replayer checkpoints"
+    printf "  %-25s %s\n" "-cp | --checkpoint-prefix" "[string] replayer checkpoint prefix. Default: $CHECKPOINT_PREFIX"
+    printf "  %-25s %s\n" "-i  | --checkpoint-interval" "[int] replayer checkpoint interval. Default: 1000"
+    printf "  %-25s %s\n" "-l  | --precomputed-blocks-local-path" "[file] on-disk precomputed blocks location"
     echo ""
     echo "Example:"
     echo ""
@@ -627,6 +644,7 @@ function final(){
     local __fork_genesis_config=''
     local __checkpoint_output_path='.'
     local __precomputed_blocks_local_path='.'
+    local __checkpoint_prefix="$CHECKPOINT_PREFIX"
     
     while [ ${#} -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -680,6 +698,10 @@ function final(){
             ;;
             -c | --checkpoint-output-path )
                 __checkpoint_output_path=${2:?$error_message}
+                shift 2;
+            ;;
+            -cp | --checkpoint-prefix )
+                __checkpoint_prefix=${2:?error_message}
                 shift 2;
             ;;
             -l | --precomputed-blocks-local-path )
@@ -747,7 +769,8 @@ function final(){
         "$__replayer_checkpoint" \
         "$__fork_genesis_config" \
         "$__checkpoint_output_path" \
-        "$__precomputed_blocks_local_path"
+        "$__precomputed_blocks_local_path" \
+        "$__checkpoint_prefix"
 }
 
 function run_final_migration() {
@@ -764,6 +787,7 @@ function run_final_migration() {
     local __fork_genesis_config=${11}
     local __checkpoint_output_path=${12}
     local __precomputed_blocks_local_path=${13}
+    local __checkpoint_prefix=${14}
     
     local __fork_state_hash="$(jq -r .proof.fork.state_hash "$__fork_genesis_config")"
     local __date=$(date '+%Y-%m-%d_%H%M')
@@ -795,7 +819,7 @@ function run_final_migration() {
         --archive-uri "$__migrated_archive_uri" \
         --input-file "$__replayer_checkpoint" \
         --checkpoint-interval "$__checkpoint_interval" \
-        --checkpoint-file-prefix "$CHECKPOINT_PREFIX" \
+        --checkpoint-file-prefix "$__checkpoint_prefix" \
         --checkpoint-output-folder "$__checkpoint_output_path" \
         --log-file "$__replayer_log"
 
@@ -803,10 +827,10 @@ function run_final_migration() {
     set -e # exit immediately on errors
 
     check_incremental_migration_progress "$__replayer_checkpoint" "$__migrated_archive_uri" 
-    check_new_replayer_checkpoints_for_incremental "$CHECKPOINT_PREFIX"
+    check_new_replayer_checkpoints_for_incremental "$__checkpoint_prefix"
 
     # sort by https://stackoverflow.com/questions/60311787/how-to-sort-by-numbers-that-are-part-of-a-filename-in-bash
-    local migrated_replayer_output=$(find . -maxdepth 1 -name "$CHECKPOINT_PREFIX-checkpoint*.json"  | sort -Vrt - -k3,3 | head -n 1)
+    local migrated_replayer_output=$(find . -maxdepth 1 -name "${__checkpoint_prefix}-checkpoint*.json"  | sort -Vrt - -k3,3 | head -n 1)
 
     mina-berkeley-migration-verifier post-fork \
         --mainnet-archive-uri "$__mainnet_archive_uri" \

--- a/scripts/archive/migration/mina-berkeley-migration-script
+++ b/scripts/archive/migration/mina-berkeley-migration-script
@@ -773,6 +773,23 @@ function final(){
         "$__checkpoint_prefix"
 }
 
+function find_most_recent_checkpoint() {
+    
+    FILTER=$1
+    declare -A checkpoints
+
+    for i in $FILTER ; do
+      SLOT=$(cat $i | jq .start_slot_since_genesis)
+      checkpoints["$SLOT"]="$i"
+    done
+
+    for k in "${!checkpoints[@]}"
+    do
+        echo $k ',' ${checkpoints["$k"]}
+    done |
+    sort -rn | head -n 1 | cut -d',' -f2 | xargs
+}
+
 function run_final_migration() {
     local __batch_size=$1
     local __mainnet_archive_uri=$2
@@ -830,7 +847,14 @@ function run_final_migration() {
     check_new_replayer_checkpoints_for_incremental "$__checkpoint_prefix"
 
     # sort by https://stackoverflow.com/questions/60311787/how-to-sort-by-numbers-that-are-part-of-a-filename-in-bash
-    local migrated_replayer_output=$(find . -maxdepth 1 -name "${__checkpoint_prefix}-checkpoint*.json"  | sort -Vrt - -k3,3 | head -n 1)
+    
+    migrated_replayer_output=$(find_most_recent_checkpoint $CHECKPOINT_PREFIX-checkpoint*.json)
+
+    echo "Running validations for final migration: "
+    echo "   mainnet-archive-uri: '$__mainnet_archive_uri'"
+    echo "   migrated-archive-uri: '$__migrated_archive_uri'"
+    echo "   fork-genesis-config: '$__fork_genesis_config'"
+    echo "   migrated-replayer-output: '$migrated_replayer_output'"
 
     mina-berkeley-migration-verifier post-fork \
         --mainnet-archive-uri "$__mainnet_archive_uri" \


### PR DESCRIPTION
Exposing checkpoint-prefix parameter in berkeley migration script. It might be helpful when we have more that one migration on single machine (devnet and mainnet) and for some reason we would like to keep both checkpoints. This is the case for our cron job which is used for more than one network and it need to be aware of checkpoint prefixes