### PR TITLE
adding graphql query for snarked ledger

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -9891,16 +9891,6 @@
         },
         {
           "kind": "SCALAR",
-          "name": "JSON",
-          "description": "Arbitrary JSON",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
           "name": "PrecomputedBlockProof",
           "description": "Base-64 encoded proof",
           "fields": null,
@@ -9937,6 +9927,16 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "JSON",
+          "description": "Arbitrary JSON",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -11512,6 +11512,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ProtocolState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkLedger",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
Explain your changes:
* I added a snarkLedger object to the block object in graphql. The idea is to emulate the snark leger export functionality in the daemon rpc calls in graphql.

Explain how you tested your changes:
* I need some additional assistance testing this. Despite my best efforts, I can't seem to get a block height of greater than size one on my local network. Ideally this query would be run on a network with a reasonably large snark ledger, along with a unit test. If anyone can walk me through doing this, or help me get my local network set up that would be a huge help.

<img width="1233" alt="Screenshot 2024-05-06 at 8 40 31 PM" src="https://github.com/MinaProtocol/mina/assets/23268748/0f383d6e-529e-4166-8de2-c850bb19a3b0">


Ch=
- [ ] Does this close issues? List them
hopefully closes #12706 
