### PR TITLE
Use public library names

### DIFF
--- a/src/app/berkeley_migration/dune
+++ b/src/app/berkeley_migration/dune
@@ -39,7 +39,7 @@
    mina_wire_types
    one_or_two
    protocol_version
-   runtime_config
+   mina_runtime_config
    signature_lib
    unsigned_extended
    with_hash

--- a/src/app/berkeley_migration/dune
+++ b/src/app/berkeley_migration/dune
@@ -25,7 +25,7 @@
    archive_lib
    block_time
    consensus
-   consensus_vrf
+   consensus.vrf
    currency
    genesis_constants
    genesis_ledger_helper
@@ -44,6 +44,7 @@
    unsigned_extended
    with_hash
    cli_lib
+   mina_version
    )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/berkeley_migration_verifier/dune
+++ b/src/app/berkeley_migration_verifier/dune
@@ -39,7 +39,7 @@
    mina_wire_types
    one_or_two
    protocol_version
-   runtime_config
+   mina_runtime_config
    signature_lib
    unsigned_extended
    with_hash

--- a/src/app/berkeley_migration_verifier/dune
+++ b/src/app/berkeley_migration_verifier/dune
@@ -25,7 +25,7 @@
    archive_lib
    block_time
    consensus
-   consensus_vrf
+   consensus.vrf
    currency
    genesis_constants
    genesis_ledger_helper

--- a/src/app/disk_caching_stats/dune
+++ b/src/app/disk_caching_stats/dune
@@ -2,7 +2,7 @@
  (name disk_caching_stats)
  (libraries pickles pickles_types pickles.backend snark_params crypto_params network_pool mina_base
             signature_lib one_or_two currency ledger_proof mina_state mina_base.import mina_wire_types
-            mina_numbers random_oracle random_oracle_input kimchi_pasta_basic data_hash_lib with_hash
+            mina_numbers random_oracle random_oracle_input kimchi_pasta.basic data_hash_lib with_hash
             kimchi_pasta mina_ledger transaction_snark_scan_state mina_transaction_logic transaction_snark
             sgn snark_profiler_lib genesis_constants digestif bigarray-compat
             ; --

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -18,7 +18,7 @@
    uri
    async.async_command
    ;; local libraries
-   consensus_vrf
+   consensus.vrf
    mina_wire_types
    bounded_types
    mina_base

--- a/src/app/ledger_export_bench/dune
+++ b/src/app/ledger_export_bench/dune
@@ -7,7 +7,7 @@
    core_kernel
    yojson
    ; mina libraries
-   runtime_config)
+   mina_runtime_config)
  ; the -w list here should be the same as in src/dune
  (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -69,7 +69,7 @@
    kimchi_pasta.basic
    internal_tracing
    mina_networking
-   runtime_config
+   mina_runtime_config
  )
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_register_event))

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
@@ -44,5 +44,5 @@
    promise
    kimchi_backend_common
    ppx_version.runtime
-   kimchi_gadgets_test_runner
+   kimchi_backend.gadgets_test_runner
 ))

--- a/src/lib/crypto/kimchi_bindings/js/test/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/dune
@@ -16,7 +16,7 @@
    kimchi_backend_common
    kimchi_pasta
    kimchi_pasta.basic
-   kimchi_pasta_constraint_system
+   kimchi_pasta.constraint_system
    mina_metrics.none
    run_in_thread.fake
    snarky.backendless

--- a/src/lib/crypto/kimchi_bindings/js/test/nodejs/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/nodejs/dune
@@ -10,7 +10,7 @@
   pasta_bindings
   js_of_ocaml
   bindings_js
-  node_backend
+  bindings_js.node_backend
   logger.fake
   pasta_bindings.backend.none)
  (link_deps ../../node_js/plonk_wasm.js ../../node_js/plonk_wasm_bg.wasm)

--- a/src/lib/crypto/kimchi_bindings/js/test/web/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/web/dune
@@ -8,7 +8,7 @@
   kimchi_bindings
   js_of_ocaml
   bindings_js
-  web_backend
+  bindings_js.web_backend
   logger.fake
   pasta_bindings.backend.none)
  (link_deps ../../web/plonk_wasm.js ../../web/plonk_wasm_bg.wasm)

--- a/src/lib/crypto/snarky_tests/dune
+++ b/src/lib/crypto/snarky_tests/dune
@@ -36,7 +36,7 @@
   kimchi_backend
   kimchi_pasta
   kimchi_pasta.basic
-  kimchi_pasta_constraint_system
+  kimchi_pasta.constraint_system
   bitstring_lib
   snarky.intf
   pickles.backend

--- a/src/lib/integration_test_cloud_engine/dune
+++ b/src/lib/integration_test_cloud_engine/dune
@@ -60,7 +60,7 @@
   file_system
   pickles
   pickles_types
-  backend
+  pickles.backend
   kimchi_pasta
   kimchi_pasta.basic
   with_hash

--- a/src/lib/integration_test_local_engine/dune
+++ b/src/lib/integration_test_local_engine/dune
@@ -60,7 +60,7 @@
   file_system
   pickles
   pickles_types
-  backend
+  pickles.backend
   kimchi_pasta
   kimchi_pasta.basic
   with_hash

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -67,5 +67,5 @@
    o1trace
    mina_net2
    internal_tracing
-   runtime_config
+   mina_runtime_config
 ))

--- a/src/lib/mina_base/test/helpers/dune
+++ b/src/lib/mina_base/test/helpers/dune
@@ -1,4 +1,5 @@
 (library
+ (public_name mina_base.test_helpers)
  (name mina_base_test_helpers)
  (libraries
   ;; opam libraries

--- a/src/lib/mina_ledger/test/helpers/dune
+++ b/src/lib/mina_ledger/test/helpers/dune
@@ -15,7 +15,7 @@
   kimchi_pasta
   kimchi_pasta.basic
   mina_base
-  mina_base_test_helpers
+  mina_base.test_helpers
   mina_ledger
   mina_numbers
   monad_lib

--- a/src/lib/mina_lib/tests/dune
+++ b/src/lib/mina_lib/tests/dune
@@ -43,7 +43,7 @@
    block_time
    pipe_lib
    signature_lib
-   runtime_config
+   mina_runtime_config
    trust_system
    protocol_version
    transition_frontier_base

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -77,7 +77,7 @@
    kimchi_backend_common
    kimchi_pasta
    kimchi_pasta.basic
-   genesis_ledger
+   coda_genesis_ledger
    staged_ledger_diff
    mina_wire_types
  )

--- a/src/lib/network_pool/test/dune
+++ b/src/lib/network_pool/test/dune
@@ -19,7 +19,7 @@
   data_hash_lib
   genesis_constants
   bounded_types
-  genesis_ledger
+  coda_genesis_ledger
   logger
   mina_base
   mina_base.import

--- a/src/lib/o1js_stub/dune
+++ b/src/lib/o1js_stub/dune
@@ -62,7 +62,7 @@
   bindings_js
   integers_stubs_js
   zarith_stubs_js
-  node_backend
+  bindings_js.node_backend
   ;; js-specific overrides ;;
   cache_dir.fake
   digestif.ocaml

--- a/src/lib/pickles/test/chunked_circuits/dune
+++ b/src/lib/pickles/test/chunked_circuits/dune
@@ -35,7 +35,6 @@
   sponge
   pickles
   pickles.pseudo
-  composition_types
   pickles.limb_vector
   pickles_base
   kimchi_backend

--- a/src/lib/pickles/test/optional_custom_gates/dune
+++ b/src/lib/pickles/test/optional_custom_gates/dune
@@ -35,7 +35,6 @@
   sponge
   pickles
   pickles.pseudo
-  composition_types
   pickles.limb_vector
   pickles_base
   kimchi_backend

--- a/src/lib/pickles/test/optional_custom_gates/test_gadgets/dune
+++ b/src/lib/pickles/test/optional_custom_gates/test_gadgets/dune
@@ -35,7 +35,6 @@
   sponge
   pickles
   pickles.pseudo
-  composition_types
   pickles.limb_vector
   pickles_base
   kimchi_backend

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -45,7 +45,7 @@
    mina_compile_config
    mina_state
    transaction_protocol_state
-   ppx_version_runtime
+   ppx_version.runtime
  )
  (preprocess
   (pps

--- a/src/lib/staged_ledger/test/dune
+++ b/src/lib/staged_ledger/test/dune
@@ -14,7 +14,7 @@
   ;; local libraries
   genesis_constants
   mina_base
-  mina_base_test_helpers
+  mina_base.test_helpers
   mina_generators
   mina_ledger
   mina_ledger_test_helpers

--- a/src/lib/test_genesis_ledger/dune
+++ b/src/lib/test_genesis_ledger/dune
@@ -1,7 +1,7 @@
 (library
  (public_name test_genesis_ledger)
  (name test_genesis_ledger)
- (libraries genesis_ledger core_kernel genesis_constants)
+ (libraries coda_genesis_ledger core_kernel genesis_constants)
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp ppx_let)))

--- a/src/lib/transaction_logic/test/dune
+++ b/src/lib/transaction_logic/test/dune
@@ -22,7 +22,7 @@
    bounded_types
    mina_base
    mina_base.import
-   mina_base_test_helpers
+   mina_base.test_helpers
    mina_ledger
    mina_ledger_test_helpers
    mina_transaction

--- a/src/lib/transaction_logic/test/transaction_logic/dune
+++ b/src/lib/transaction_logic/test/transaction_logic/dune
@@ -22,7 +22,7 @@
    kimchi_pasta.basic
    mina_base
    mina_base.import
-   mina_base_test_helpers
+   mina_base.test_helpers
    mina_transaction
    mina_transaction_logic
    mina_numbers

--- a/src/lib/transaction_snark/test/account_timing/dune
+++ b/src/lib/transaction_snark/test/account_timing/dune
@@ -21,7 +21,7 @@
    transaction_snark
    snark_params
    data_hash_lib
-   genesis_proof
+   coda_genesis_proof
    bounded_types
    mina_ledger
    mina_base

--- a/src/lib/transaction_snark/test/account_timing/dune
+++ b/src/lib/transaction_snark/test/account_timing/dune
@@ -42,7 +42,7 @@
    test_util
    consensus
    one_or_two
-   genesis_ledger
+   coda_genesis_ledger
    snarky.backendless
    mina_transaction_logic
    mina_wire_types

--- a/src/lib/transaction_snark/test/transaction_union/dune
+++ b/src/lib/transaction_snark/test/transaction_union/dune
@@ -34,7 +34,7 @@
    test_util
    consensus
    one_or_two
-   genesis_ledger
+   coda_genesis_ledger
    sexplib0
    quickcheck_lib
    mina_transaction

--- a/src/lib/transition_frontier/tests/dune
+++ b/src/lib/transition_frontier/tests/dune
@@ -30,8 +30,8 @@
    consensus
    data_hash_lib
    block_time
-   full_frontier
-   frontier_base
+   transition_frontier_full_frontier
+   transition_frontier_base
    transition_frontier
    protocol_version
    yojson

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -55,7 +55,7 @@
    internal_tracing
    transition_frontier_extensions
    staged_ledger_diff
-   runtime_config
+   mina_runtime_config
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_mina ppx_version ppx_jane)))

--- a/src/lib/vrf_lib/tests/dune
+++ b/src/lib/vrf_lib/tests/dune
@@ -24,7 +24,7 @@
    snarky.backendless
    bitstring_lib
    crypto_params
-   backend
+   pickles.backend
    kimchi_backend
    kimchi_bindings
    kimchi_types


### PR DESCRIPTION
Use `public_name` of different libraries instead of `name` when referring from dependencies of libraries corresponding to other packages.

Makes dune dependencies cleaner, also allows findlib-based installation.

Explain how you tested your changes:
* Mina compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None