### PR TITLE
Fix warnings in dump_blocks

### DIFF
--- a/src/app/dump_blocks/dump_blocks.ml
+++ b/src/app/dump_blocks/dump_blocks.ml
@@ -1,5 +1,4 @@
 open Core
-open Frontier_base
 open Full_frontier.For_tests
 
 (* NOTE: This type is initially instantiated as Encoding.t io, where
@@ -74,7 +73,7 @@ let output_block : type a. a -> a codec io -> unit
   fprintf channel "%s" (Enc.to_string content);
   match filename with
     | "-" -> ()
-    | s -> Out_channel.close channel
+    | _ -> Out_channel.close channel
 
 (* This executable outputs random block to stderr in sexp and json
    The output is useful for src/lib/mina_block tests when the sexp/json representation changes. *)


### PR DESCRIPTION
Fix the warning

Explain how you tested your changes:
* App compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None