### PR TITLE
Remove dependency on extlib

### DIFF
--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -26,7 +26,6 @@
    ppx_inline_test.config
    async_unix
    stdio
-   extlib
    sexp_diff_kernel
    ;; local libraries
    key_gen

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -28,7 +28,6 @@
   core.uuid
   core_kernel
   core_kernel.uuid
-  extlib
   integers
   rocks
   sexplib0

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -5,7 +5,6 @@
  (libraries
    ;; opam libraries
    core
-   extlib
    sexplib0
    bin_prot.shape
    base.base_internalhash_types

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -11,7 +11,6 @@
    async_kernel
    base.caml
    sexplib0
-   extlib
    async_unix
    ;;local libraries
    bounded_types

--- a/src/lib/transition_frontier/persistent_frontier/sync.ml
+++ b/src/lib/transition_frontier/persistent_frontier/sync.ml
@@ -3,7 +3,7 @@ open Async_kernel
 (* TODO: *new* convert into an extension *)
 type t = { worker : Worker.t; buffer : Diff_buffer.t }
 
-let buffer t = DynArray.to_list t.buffer.diff_array
+let buffer t = Diff_buffer.Rev_dyn_array.to_list t.buffer.diff_array
 
 (* NB: the persistent frontier must remain open as
  * long as the synchronization is using it *)


### PR DESCRIPTION
This fixes #1471. We only depended on `extlib` for `DynArray`, and none of the uses actually required a `DynArray`.


Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them