### PR TITLE
Stop slots for mainnet upgrade

### DIFF
--- a/genesis_ledgers/mainnet.json
+++ b/genesis_ledgers/mainnet.json
@@ -2,6 +2,10 @@
   "genesis": {
     "genesis_state_timestamp": "2021-03-17T00:00:00Z"
   },
+  "daemon": {
+    "slot_tx_end": 564180,
+    "slot_chain_end": 564280
+  },
   "ledger": {
     "name": "mainnet",
     "accounts": [


### PR DESCRIPTION
Soft fork update to set stop-slots in mainnet config file for the upcoming berkeley upgrade.
Slot set as per the announced date **June 4, 2024**.
Setting stop-slots such that the timings match all the dry-runs and devnet upgrade schedule and as a result- 

* stop-transaction slot is **564180** (June 4th 9am UTC). This translates to 120th slot of 79th epoch. Upgraded nodes won't accept blocks with transactions at/after this slot
* stop-network slot is **564280** which is 100 slots/5hours after the stop-transaction slot (June 4th 14:00 UTC). This translates to 220th slot of 79th epoch. Upgraded nodes won't accept any blocks at or after this slot 

These calculations are based on mainnet genesis timestamp `2021-03-17 00:00:00 UTC`
Reviewer- please perform the calculation once more for sanity :)

Explain how you tested your changes:
* Ran a local seed node with `mainnet` build profile and the updated config file genesis_ledgers/mainnet.json
   cli command `mina.exe advanced runtime-config` returned the stop slots correctly
   ```
  "daemon": {
    "txpool_max_size": 3000,
    "slot_tx_end": 564180,
    "slot_chain_end": 564280
  }```

* Connected a local node to mainnet with the updated config file and the node synced. Also, checked the runtime config and it produced the same output

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #15647
