### PR TITLE
Reduce quickcheck trials from 10,000 to 1000 for some slow tests

### DIFF
--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -728,7 +728,8 @@ let gen_accounts_and_transactions =
   (accounts_map senders, shuffled)
 
 let transactions_from_many_senders_no_nonce_gaps () =
-  Quickcheck.test gen_accounts_and_transactions ~f:(fun (account_map, txns) ->
+  Quickcheck.test ~trials:1000 gen_accounts_and_transactions
+    ~f:(fun (account_map, txns) ->
       let pool =
         pool_of_transactions ~init:empty ~account_map txns |> rem_lowest_fee 5
       in
@@ -739,7 +740,8 @@ let transactions_from_many_senders_no_nonce_gaps () =
       assert_pool_consistency pool )
 
 let revalidation_drops_nothing_unless_ledger_changed () =
-  Quickcheck.test gen_accounts_and_transactions ~f:(fun (account_map, txns) ->
+  Quickcheck.test ~trials:1000 gen_accounts_and_transactions
+    ~f:(fun (account_map, txns) ->
       let pool = pool_of_transactions ~init:empty ~account_map txns in
       let pool', dropped =
         Indexed_pool.revalidate pool ~logger `Entire_pool (fun aid ->
@@ -779,7 +781,7 @@ let apply_transactions txns accounts =
 let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
 
 let application_invalidates_applied_transactions () =
-  Quickcheck.test
+  Quickcheck.test ~trials:1000
     (let open Quickcheck.Generator.Let_syntax in
     let%bind accounts, txns = gen_accounts_and_transactions in
     (* Simulate application of some transactions in order to invalidate them. *)

--- a/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
+++ b/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
@@ -83,7 +83,8 @@ let setup =
   (global_slot, sender, receiver, amount, fee)
 
 let simple_payment () =
-  Quickcheck.test setup ~f:(fun (global_slot, sender, receiver, amount, fee) ->
+  Quickcheck.test ~trials:1000 setup
+    ~f:(fun (global_slot, sender, receiver, amount, fee) ->
       let accounts = [ sender; receiver ] in
       let txn = signed_command ~fee ~sender ~receiver amount in
       let txn_state_view = protocol_state in
@@ -99,7 +100,8 @@ let simple_payment () =
            ~txn_state_view ledger [ txn ] ) )
 
 let simple_payment_signer_different_from_fee_payer () =
-  Quickcheck.test setup ~f:(fun (global_slot, sender, receiver, amount, fee) ->
+  Quickcheck.test ~trials:1000 setup
+    ~f:(fun (global_slot, sender, receiver, amount, fee) ->
       let accounts = [ sender; receiver ] in
       let txn = signed_command ~signer:receiver ~fee ~sender ~receiver amount in
       let txn_state_view = protocol_state in


### PR DESCRIPTION
This PR builds upon #15648.

This PR reduces the runtime of some slow quickcheck unit tests by reducing the number of trials from 10,000 to 1000, with the goal of reducing the runtime of unit tests in CI.