### PR TITLE
adding network id field to the daemon

### DIFF
--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -93,8 +93,8 @@ cat <<EOF >"$MINA_CONFIG_FILE"
 {
   "genesis": { "genesis_state_timestamp": "$CURRENT_TIME" },
   "proof": { "block_window_duration_ms": 20000 },
+  "daemon": { "network_id": "${MINA_NETWORK}" },
   "ledger": {
-    "name": "${MINA_NETWORK}",
     "accounts": [
       { "pk": "${BLOCK_PRODUCER_PUB_KEY}", "balance": "1000000", "delegate": null, "sk": null },
       { "pk": "${SNARK_PRODUCER_PK}", "balance": "2000000", "delegate": "${BLOCK_PRODUCER_PUB_KEY}", "sk": null },

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -634,6 +634,7 @@ let runtime_config_of_precomputed_values (precomputed_values : Genesis_proof.t)
               Some precomputed_values.genesis_constants.zkapp_cmd_limit_hardcap
           ; slot_tx_end = None
           ; slot_chain_end = None
+          ; network_id = None
           }
     ; genesis =
         Some

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -129,6 +129,7 @@ module Network_config = struct
          ; txpool_max_size
          ; slot_tx_end
          ; slot_chain_end
+         ; network_id
          }
           : Test_config.t ) =
       test_config
@@ -242,6 +243,7 @@ module Network_config = struct
             ; zkapp_cmd_limit_hardcap = None
             ; slot_tx_end
             ; slot_chain_end
+            ; network_id
             }
       ; genesis =
           Some

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -80,6 +80,7 @@ type t =
   ; txpool_max_size : int
   ; slot_tx_end : int option
   ; slot_chain_end : int option
+  ; network_id : string option
   }
 
 let proof_config_default : Runtime_config.Proof_keys.t =
@@ -130,6 +131,7 @@ let default =
   ; txpool_max_size = 3000
   ; slot_tx_end = None
   ; slot_chain_end = None
+  ; network_id = None
   }
 
 let transaction_capacity_log_2 (config : t) =

--- a/src/lib/integration_test_local_engine/mina_docker.ml
+++ b/src/lib/integration_test_local_engine/mina_docker.ml
@@ -67,6 +67,7 @@ module Network_config = struct
          ; txpool_max_size
          ; slot_tx_end
          ; slot_chain_end
+         ; network_id
          ; _
          }
           : Test_config.t ) =
@@ -166,6 +167,7 @@ module Network_config = struct
             ; zkapp_cmd_limit_hardcap = None
             ; slot_tx_end
             ; slot_chain_end
+            ; network_id
             }
       ; genesis =
           Some

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2569,8 +2569,8 @@ module Queries = struct
         let configured_name =
           let open Option.Let_syntax in
           let cfg = Mina_lib.runtime_config mina in
-          let%bind ledger = cfg.ledger in
-          ledger.name
+          let%bind daemon = cfg.daemon in
+          daemon.network_id
         in
         "mina:"
         ^ Option.value ~default:Mina_compile_config.network_id configured_name

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -473,6 +473,7 @@ module Json_layout = struct
       ; zkapp_cmd_limit_hardcap : int option [@default None]
       ; slot_tx_end : int option [@default None]
       ; slot_chain_end : int option [@default None]
+      ; network_id : string option [@default None]
       }
     [@@deriving yojson, fields]
 
@@ -1220,6 +1221,7 @@ module Daemon = struct
     ; zkapp_cmd_limit_hardcap : int option [@default None]
     ; slot_tx_end : int option [@default None]
     ; slot_chain_end : int option [@default None]
+    ; network_id : string option [@default None]
     }
   [@@deriving bin_io_unversioned]
 
@@ -1259,6 +1261,7 @@ module Daemon = struct
     ; slot_tx_end = opt_fallthrough ~default:t1.slot_tx_end t2.slot_tx_end
     ; slot_chain_end =
         opt_fallthrough ~default:t1.slot_chain_end t2.slot_chain_end
+    ; network_id = opt_fallthrough ~default:t1.network_id t2.network_id
     }
 
   let gen =
@@ -1282,6 +1285,7 @@ module Daemon = struct
     ; zkapp_cmd_limit_hardcap = Some zkapp_cmd_limit_hardcap
     ; slot_tx_end = None
     ; slot_chain_end = None
+    ; network_id = None
     }
 end
 


### PR DESCRIPTION
This is a pr that adds the network id field to the daemon. It's purpose is to ensure the correct output result from a fork config, such that the networkId graphql endpoint is correct.