### PR TITLE
[berkeley] Fix duplicated txn Rosetta

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -338,7 +338,8 @@ module Sql = struct
         typ
         [%string
           {|
-         SELECT u.id,
+         SELECT DISTINCT ON (u.id)
+                u.id,
                 %{fields},
                 pk_payer.value as fee_payer,
                 pk_source.value as source,


### PR DESCRIPTION
Failed user transactions were reported in duplicate. Fixed SQL query with `DISTINCT ON` user transaction id.