### PR TITLE
Update hardcoded genesis timestamp in alerts to 3.0.0 genesis timestamp

### DIFF
--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -193,7 +193,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${rule_filter}) >= 15 * 180
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Transition_frontier_best_tip_slot_time_sec ${rule_filter}) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -203,7 +203,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec ${rule_filter}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work ${rule_filter}) != 0
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Snark_work_useful_snark_work_received_time_sec ${rule_filter}) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work ${rule_filter}) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -213,7 +213,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec ${rule_filter}) >= 2 * 180
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Transaction_pool_useful_transactions_received_time_sec ${rule_filter}) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -269,7 +269,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec ${rule_filter}) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1717545600) - Coda_Transition_frontier_best_tip_slot_time_sec ${rule_filter}) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -580,7 +580,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/LongFork-e65e5ad7437f4f4dbac201abbf9ace81"
 
   - alert: OldBestTip
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 15 * 180
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 15 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -590,7 +590,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/OldBestTip-8afa955101b642bd8356edfd0b03b640"
 
   - alert: NoNewSnarks
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},${synced_status_filter}} ) != 0
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Snark_work_useful_snark_work_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180 and max by (testnet) (Coda_Snark_work_pending_snark_work {${berkeley_testnet},${synced_status_filter}} ) != 0
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: critical
@@ -600,7 +600,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/NoNewSnarks-f86d27c81af54954b2fb61378bff9d4d"
 
   - alert: NoNewTransactions
-    expr: min by (testnet) ((time() - 1609459200) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180
+    expr: min by (testnet) ((time() - 1717545600) - Coda_Transaction_pool_useful_transactions_received_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 2 * 180
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning
@@ -650,7 +650,7 @@ groups:
       runbook: "https://www.notion.so/minaprotocol/HighBlockGossipLatency-2096501c7cf34032b44e903ec1a4d79c"
 
   - alert: SomewhatOldBestTip
-    expr: count by (testnet) (((time() - 1609459200) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 8 * 180) > 1
+    expr: count by (testnet) (((time() - 1717545600) - Coda_Transition_frontier_best_tip_slot_time_sec {${berkeley_testnet},${synced_status_filter}} ) >= 8 * 180) > 1
     labels:
       testnet: "{{ $labels.testnet }}"
       severity: warning


### PR DESCRIPTION
Set the hard coded genesis timestamp in mainnet alerts to `1717545600`, which is `2024 June 05 00:00 UTC`.