### PR TITLE
[berkeley] Add setup stage to integration tests

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -68,7 +68,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let min_resulting_blocks = 12
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let receiver =

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -68,9 +68,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let min_resulting_blocks = 12
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -70,7 +70,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -26,7 +26,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; block_producers = [ { node_name = "node"; account_name = "node-key" } ]
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -26,9 +26,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; block_producers = [ { node_name = "node"; account_name = "node-key" } ]
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -28,7 +28,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -32,7 +32,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -32,9 +32,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -34,7 +34,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -60,7 +60,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; proof_config = { proof_config_default with fork = Some fork_config }
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let all_mina_nodes = Network.all_mina_nodes network in
     let%bind () =

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -62,7 +62,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -60,9 +60,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; proof_config = { proof_config_default with fork = Some fork_config }
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -32,7 +32,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -30,9 +30,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -30,7 +30,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     [%log info] "gossip_consistency test: starting..." ;

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -212,7 +212,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -210,7 +210,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let constraint_constants =
       Genesis_constants.Constraint_constants.compiled

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -210,9 +210,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -46,7 +46,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -44,9 +44,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   (* this test is the medium bootstrap test *)
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -44,7 +44,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   (* this test is the medium bootstrap test *)
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -60,7 +60,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -62,7 +62,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -60,9 +60,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -33,9 +33,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -33,7 +33,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -35,7 +35,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Network in

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -72,7 +72,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -70,7 +70,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let tx_delay_ms = 5000
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let num_slots = slot_chain_end + 2 in

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -70,9 +70,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let tx_delay_ms = 5000
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -326,7 +326,7 @@ let main inputs =
     in
     Monitor.try_with ~here:[%here] ~extract_exn:false (fun () ->
         let open Malleable_error.Let_syntax in
-        let setup = T.setup () in
+        let%bind.Deferred setup = T.setup () in
         let%bind network, dsl =
           let lift ?exit_code =
             Deferred.bind ~f:(Malleable_error.or_hard_error ?exit_code)

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -326,6 +326,7 @@ let main inputs =
     in
     Monitor.try_with ~here:[%here] ~extract_exn:false (fun () ->
         let open Malleable_error.Let_syntax in
+        let setup = T.setup () in
         let%bind network, dsl =
           let lift ?exit_code =
             Deferred.bind ~f:(Malleable_error.or_hard_error ?exit_code)
@@ -399,7 +400,7 @@ let main inputs =
         let%bind () = Malleable_error.List.iter non_seed_pods ~f:start_print in
         [%log info] "Daemons started" ;
         [%log trace] "executing test" ;
-        T.run network dsl )
+        T.run network dsl setup )
   in
   let exit_reason, test_result =
     match monitor_test_result with

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -252,7 +252,8 @@ let main inputs =
     (module Test (Test_inputs) : Intf.Test.S
       with type network = Engine.Network.t
        and type node = Engine.Network.Node.t
-       and type dsl = Dsl.t )
+       and type dsl = Dsl.t
+       and type network_config = Engine.Network_config.t )
   in
   (*
     (module Test (Test_inputs)
@@ -326,7 +327,7 @@ let main inputs =
     in
     Monitor.try_with ~here:[%here] ~extract_exn:false (fun () ->
         let open Malleable_error.Let_syntax in
-        let%bind.Deferred setup = T.setup () in
+        let%bind.Deferred setup = T.setup network_config in
         let%bind network, dsl =
           let lift ?exit_code =
             Deferred.bind ~f:(Malleable_error.or_hard_error ?exit_code)

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -103,7 +103,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -183,6 +183,21 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     sign_all { fee_payer; account_updates = call_forest; memo }
 
+  let wait_for_zkapp t ~logger ~has_failures zkapp_command =
+    let open Malleable_error.Let_syntax in
+    let with_timeout =
+      let soft_slots = 3 in
+      let soft_timeout = Network_time_span.Slots soft_slots in
+      let hard_timeout = Network_time_span.Slots (soft_slots * 2) in
+      Wait_condition.with_timeouts ~soft_timeout ~hard_timeout
+    in
+    let%map () =
+      wait_for t @@ with_timeout
+      @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures
+           ~zkapp_command
+    in
+    [%log info] "zkApp transaction included in transition frontier"
+
   let config =
     let open Test_config in
     { default with
@@ -501,20 +516,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       , failed_update_vk_signature_2
       , update_vk_proof )
     in
-    let with_timeout =
-      let soft_slots = 3 in
-      let soft_timeout = Network_time_span.Slots soft_slots in
-      let hard_timeout = Network_time_span.Slots (soft_slots * 2) in
-      Wait_condition.with_timeouts ~soft_timeout ~hard_timeout
-    in
-    let wait_for_zkapp ~has_failures zkapp_command =
-      let%map () =
-        wait_for t @@ with_timeout
-        @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures
-             ~zkapp_command
-      in
-      [%log info] "zkApp transaction included in transition frontier"
-    in
+    let wait_for_zkapp = wait_for_zkapp ~logger t in
 
     let%bind () =
       section "Send a zkApp to create a zkApp account"

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -101,9 +101,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let logger = Logger.create ()
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Async.Deferred.return ()
+  let setup (_network_config : network_config) = Async.Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -71,10 +71,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type dsl = Dsl.t
 
-  let `VK vk, `Prover prover =
-    Transaction_snark.For_tests.create_trivial_snapp
-      ~constraint_constants:Genesis_constants.Constraint_constants.compiled ()
-
   let update_vk (vk : Side_loaded_verification_key.t) : Account_update.t =
     let body (vk : Side_loaded_verification_key.t) : Account_update.Body.t =
       { Account_update.Body.dummy with

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -101,7 +101,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let logger = Logger.create ()
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let%bind () =
       section_hard "Wait for nodes to initialize"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -120,9 +120,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ~amount ~fee ~nonce ~memo ~valid_until ~raw_signature node_uri
         |> Malleable_error.ignore_m
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -122,7 +122,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -120,7 +120,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ~amount ~fee ~nonce ~memo ~valid_until ~raw_signature node_uri
         |> Malleable_error.ignore_m
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let block_producer_nodes =

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -86,9 +86,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ~sender_pub_key ~receiver_pub_key ~amount:Currency.Amount.one ~fee
         >>| ignore )
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -86,7 +86,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ~sender_pub_key ~receiver_pub_key ~amount:Currency.Amount.one ~fee
         >>| ignore )
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let block_producer_nodes =

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -88,7 +88,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -35,7 +35,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type setup = unit
 
-  let setup () = ()
+  let setup () = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -33,7 +33,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; num_archive_nodes = 1
     }
 
-  let run network t =
+  type setup = unit
+
+  let setup () = ()
+
+  let run network t () =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -33,9 +33,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; num_archive_nodes = 1
     }
 
+  type network_config = Engine.Network_config.t
+
   type setup = unit
 
-  let setup () = Deferred.return ()
+  let setup (_network_config : network_config) = Deferred.return ()
 
   let run network t () =
     let open Malleable_error.Let_syntax in

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -103,6 +103,8 @@ module Network_config = struct
 
   let network_keypair name t = Map.find t.genesis_keypairs name
 
+  let constraint_constants t = t.constants.constraints
+
   let terraform_config_to_assoc t =
     let[@warning "-8"] (`Assoc assoc : Yojson.Safe.t) =
       terraform_config_to_yojson t

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -101,6 +101,8 @@ module Network_config = struct
     }
   [@@deriving to_yojson]
 
+  let network_keypair name t = Map.find t.genesis_keypairs name
+
   let terraform_config_to_assoc t =
     let[@warning "-8"] (`Assoc assoc : Yojson.Safe.t) =
       terraform_config_to_yojson t

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -344,7 +344,7 @@ module Test = struct
 
     type setup
 
-    val setup : unit -> setup
+    val setup : unit -> setup Deferred.t
 
     val run : network -> dsl -> setup -> unit Malleable_error.t
   end

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -344,9 +344,11 @@ module Test = struct
 
     val config : Test_config.t
 
+    type network_config
+
     type setup
 
-    val setup : unit -> setup Deferred.t
+    val setup : network_config -> setup Deferred.t
 
     val run : network -> dsl -> setup -> unit Malleable_error.t
   end
@@ -358,4 +360,5 @@ module Test = struct
       with type network = Inputs.Engine.Network.t
        and type node = Inputs.Engine.Network.Node.t
        and type dsl = Inputs.Dsl.t
+       and type network_config = Inputs.Engine.Network_config.t
 end

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -342,7 +342,11 @@ module Test = struct
 
     val config : Test_config.t
 
-    val run : network -> dsl -> unit Malleable_error.t
+    type setup
+
+    val setup : unit -> setup
+
+    val run : network -> dsl -> setup -> unit Malleable_error.t
   end
 
   (* NB: until the DSL is actually implemented, a test just takes in the engine

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -40,6 +40,8 @@ module Engine = struct
       -> test_config:Test_config.t
       -> images:Test_config.Container_images.t
       -> t
+
+    val network_keypair : string -> t -> Network_keypair.t option
   end
 
   module type Network_intf = sig

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -42,6 +42,8 @@ module Engine = struct
       -> t
 
     val network_keypair : string -> t -> Network_keypair.t option
+
+    val constraint_constants : t -> Genesis_constants.Constraint_constants.t
   end
 
   module type Network_intf = sig


### PR DESCRIPTION
This PR modifies the integration test framework to run a `setup` function for each test before initialising the network. This PR also then lifts the expensive zkApp proving setup logic into these setup functions, so that integration tests don't spawn a network until the transactions are ready to be sent to it.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them