### PR TITLE
replacing writable bucket with ro bucket in ci for ledger tarball

### DIFF
--- a/buildkite/scripts/build-hardfork-package.sh
+++ b/buildkite/scripts/build-hardfork-package.sh
@@ -58,18 +58,18 @@ _build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --confi
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
 
-existing_files=$(aws s3 ls s3://snark-keys.o1test.net/ | awk '{print $4}')
+existing_files=$(aws s3 ls s3://snark-keys-ro.o1test.net/ | awk '{print $4}')
 for file in hardfork_ledgers/*; do
   filename=$(basename "$file")
   
   if echo "$existing_files" | grep -q "$filename"; then
     echo "Info: $filename already exists in the bucket, packaging it instead."
     oldhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
-    aws s3 cp "s3://snark-keys.o1test.net/$filename" "$file"
+    aws s3 cp "s3://snark-keys-ro.o1test.net/$filename" "$file"
     newhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
     sed -i "s/$oldhash/$newhash/g" new_config.json 
   else
-    aws s3 cp --acl public-read "$file" s3://snark-keys.o1test.net/
+    aws s3 cp --acl public-read "$file" s3://snark-keys-ro.o1test.net/
   fi
 done
 

--- a/docs/uploading-genesis-proofs.md
+++ b/docs/uploading-genesis-proofs.md
@@ -47,4 +47,4 @@ Pull requests on CI will run the ['Build Mina daemon debian package' job](https:
   - `_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file PATH/TO/YOUR/config.json`
 * upload the generated ledger and proof files to S3
   - You will need the access keys for the `snark-keys` bucket, and the `aws` tool installed to use this command
-  - `aws s3 sync --exclude "*" --include "genesis_*" --acl public-read /tmp/coda_cache_dir/genesis_* s3://snark-keys.o1test.net/`
+  - `aws s3 sync --exclude "*" --include "genesis_*" --acl public-read /tmp/coda_cache_dir/genesis_* s3://snark-keys-ro.o1test.net/`

--- a/scripts/publish-pvkeys.sh
+++ b/scripts/publish-pvkeys.sh
@@ -12,7 +12,7 @@ else
     genfiles=("${KEYDIR}"*)
     if [ ${#genfiles[@]} -gt 0 ]; then
         ls -l ${KEYDIR}
-        aws s3 sync --acl public-read ${KEYDIR} s3://snark-keys.o1test.net/
+        aws s3 sync --acl public-read ${KEYDIR} s3://snark-keys-ro.o1test.net/
     else
         echo "No build time generated keys found."
     fi

--- a/scripts/upload-genesis.sh
+++ b/scripts/upload-genesis.sh
@@ -7,6 +7,6 @@ if [ -z "$AWS_ACCESS_KEY_ID" ]; then
     echo "WARNING: AWS_ACCESS_KEY_ID is missing, not uploading files for genesis"
 else
     if ls -l ${GENESIS_DIR}genesis_*; then
-        aws s3 sync --exclude "*" --include "genesis_*" --acl public-read ${GENESIS_DIR} s3://snark-keys.o1test.net/
+        aws s3 sync --exclude "*" --include "genesis_*" --acl public-read ${GENESIS_DIR} s3://snark-keys-ro.o1test.net/
     fi
 fi


### PR DESCRIPTION
We have allocated a new read only bucket for the ledger tarball in CI. This is to prevent the file from accidentally being overwritten by another process pushing to the bucket. The approach here was to simply find and replace the old link. I still have to sanity check if this is correct and would appreciate feedback from @dkijania.