### PR TITLE
make fuzzy test be size of medium

### DIFF
--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -51,6 +51,6 @@ Pipeline.build
         mode = PipelineMode.Type.Stable
       },
     steps = [
-      buildTestCmd "dev" "src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.exe" 4200 150 Size.Small
+      buildTestCmd "dev" "src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.exe" 4200 150 Size.Medium
     ]
   }


### PR DESCRIPTION
Explain your changes:
Make fuzzy zkapp test of size medium

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
