### PR TITLE
ignore any leading/trailing whitespace in the peerlist

### DIFF
--- a/src/lib/mina_net2/multiaddr.ml
+++ b/src/lib/mina_net2/multiaddr.ml
@@ -39,6 +39,7 @@ let valid_as_peer t =
 
 let of_file_contents contents : t list =
   String.split ~on:'\n' contents
+  |> List.map ~f:String.strip
   |> List.filter ~f:(fun s ->
          if valid_as_peer s then true
          else if String.is_empty s then false


### PR DESCRIPTION

Explain your changes:
* maps `String.strip` over the lines of the peerlist file

Explain how you tested your changes:
* ~~I haven't been able to get a locally compiled node to run, but I've confirmed that adding spaces to the peer list without this change does change the error message and with this change no longer changes the error message.~~
* I've used this branch to run a node using a peerlist with trailing spaces

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #15696 
