### PR TITLE
Add suffix to docker version if we are building instrumented dockers

### DIFF
--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -73,6 +73,7 @@ IMAGE="--build-arg image=${IMAGE}"
       case "${DEB_BUILD_FLAGS}" in 
         *instrumented)
           DOCKER_DEB_SUFFIX="--build-arg deb_suffix=instrumented"
+          BUILD_FLAG_SUFFIX="-instrumented"
           ;;
         *)
           ;;
@@ -82,6 +83,7 @@ IMAGE="--build-arg image=${IMAGE}"
       case "${DEB_BUILD_FLAGS}" in 
         *instrumented)
           DOCKER_DEB_SUFFIX="--build-arg deb_suffix=${DEB_PROFILE}-instrumented"
+          BUILD_FLAG_SUFFIX="-instrumented"
           ;;
         *)
           DOCKER_DEB_SUFFIX="--build-arg deb_suffix=${DEB_PROFILE}"
@@ -168,10 +170,10 @@ if [[ -z "${MINA_REPO}" ]]; then
 fi
 
 DOCKER_REGISTRY="gcr.io/o1labs-192920"
-TAG="${DOCKER_REGISTRY}/${SERVICE}:${VERSION}"
+TAG="${DOCKER_REGISTRY}/${SERVICE}:${VERSION}${BUILD_FLAG_SUFFIX}"
 # friendly, predictable tag
 GITHASH=$(git rev-parse --short=7 HEAD)
-HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}"
+HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}${BUILD_FLAG_SUFFIX}"
 BUILD_NETWORK="--network=host"
 
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build


### PR DESCRIPTION
We are not distinguishing instrumented docker in CI. This PR is adding `-instrumented` suffix to a daemon and archive docker