### PR TITLE
Fix verification key update in develop

### DIFF
--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -59,6 +59,7 @@ echo "Installing mina packages: $DEBS"
 echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SUDO tee /etc/apt/sources.list.d/mina.list
 
 $SUDO apt-get update --yes
+$SUDO apt-get remove "${debs[@]}"
 $SUDO apt-get install --yes --allow-downgrades "${debs[@]}"
 
 

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -64,7 +64,7 @@ echo "Installing mina packages: $DEBS"
 echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SUDO tee /etc/apt/sources.list.d/mina.list
 
 $SUDO apt-get update --yes
-$SUDO apt-get remove "${debs[@]}"
+$SUDO apt-get remove --yes "${debs[@]}"
 $SUDO apt-get install --yes --allow-downgrades "${debs_with_version[@]}"
 
 

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -49,7 +49,7 @@ fi
 
 debs_with_version=()
 for i in "${debs[@]}"; do
-   debs_with_version+=("${i}=${MINA_DEB_VERSION}_amd64")
+   debs_with_version+=("${i}=${MINA_DEB_VERSION}")
 done
 
 # Install aptly
@@ -62,6 +62,10 @@ source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $
 # Install debians
 echo "Installing mina packages: $DEBS"
 echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SUDO tee /etc/apt/sources.list.d/mina.list
+
+for i in "${debs_with_version[@]}"; do
+   aptly package show $i
+done
 
 $SUDO apt-get update --yes
 $SUDO apt-get remove --yes "${debs[@]}"

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -49,7 +49,7 @@ fi
 
 debs_with_version=()
 for i in "${debs[@]}"; do
-   debs_with_version+=("${i}_${MINA_DEB_VERSION}")
+   debs_with_version+=("${i}_${MINA_DEB_VERSION}_amd64")
 done
 
 # Install aptly

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -49,7 +49,7 @@ fi
 
 debs_with_version=()
 for i in "${debs[@]}"; do
-   debs_with_version+=("${i}_${MINA_DEB_VERSION}_amd64")
+   debs_with_version+=("${i}=${MINA_DEB_VERSION}_amd64")
 done
 
 # Install aptly

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -63,10 +63,6 @@ source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $
 echo "Installing mina packages: $DEBS"
 echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SUDO tee /etc/apt/sources.list.d/mina.list
 
-for i in "${debs_with_version[@]}"; do
-   aptly package show $i
-done
-
 $SUDO apt-get update --yes
 $SUDO apt-get remove --yes "${debs[@]}"
 $SUDO apt-get install --yes --allow-downgrades "${debs_with_version[@]}"

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -47,6 +47,11 @@ else
   done
 fi
 
+debs_with_version=()
+for i in "${debs[@]}"; do
+   debs_with_version+=("${i}_${MINA_DEB_VERSION}")
+done
+
 # Install aptly
 $SUDO apt-get update 
 $SUDO apt-get install -y aptly
@@ -60,7 +65,7 @@ echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SU
 
 $SUDO apt-get update --yes
 $SUDO apt-get remove "${debs[@]}"
-$SUDO apt-get install --yes --allow-downgrades "${debs[@]}"
+$SUDO apt-get install --yes --allow-downgrades "${debs_with_version[@]}"
 
 
 

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -71,13 +71,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type dsl = Dsl.t
 
-  let vk, prover =
-    let `VK vk, `Prover prover =
-      Transaction_snark.For_tests.create_trivial_snapp
-        ~constraint_constants:Genesis_constants.Constraint_constants.compiled ()
-    in
-    let vk = Async.Thread_safe.block_on_async_exn (fun () -> vk) in
-    (Async.Deferred.return vk, prover)
+  let `VK vk, `Prover prover =
+    Transaction_snark.For_tests.create_trivial_snapp
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled ()
 
   let config =
     let open Test_config in
@@ -159,7 +155,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let%bind.Async.Deferred account_update2, _ =
       trivial_prover2 ~handler:Trivial_rule2.handler ()
     in
-    let zkapp_prover_and_vk = (prover, vk) in
 
     let update_vk (vk : Side_loaded_verification_key.t) : Account_update.t =
       let body (vk : Side_loaded_verification_key.t) : Account_update.Body.t =
@@ -396,22 +391,22 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let%bind invalid_update_vk_perm_proof =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_invalid_proof
+             spec_invalid_proof
       in
       let%bind invalid_update_vk_perm_impossible =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_invalid_impossible
+             spec_invalid_impossible
       in
       let%bind update_vk_perm_proof =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_proof
+             spec_proof
       in
       let%map update_vk_perm_impossible =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_impossible
+             spec_impossible
       in
       ( invalid_update_vk_perm_proof
       , invalid_update_vk_perm_impossible
@@ -464,17 +459,17 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let%bind failed_update_vk_signature_1 =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_failed_signature_1
+             spec_failed_signature_1
       in
       let%bind failed_update_vk_signature_2 =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_failed_signature_2
+             spec_failed_signature_2
       in
       let%map update_vk_proof =
         Malleable_error.lift
         @@ Transaction_snark.For_tests.update_states ~constraint_constants
-             ~zkapp_prover_and_vk spec_proof
+             spec_proof
       in
       ( failed_update_vk_signature_1
       , failed_update_vk_signature_2


### PR DESCRIPTION
Fix nightly for verification key update in nightly for develop. After last commit nightly is happy:

https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/2144

Fix was to partially revert incorrect merge from o1js-main: 

https://github.com/MinaProtocol/mina/pull/15594/commits/adf934d28f491d850c9d8e83e35a5857a74f59f6