### PR TITLE
Properly use MINA_BUILD_MAINNET flag

### DIFF
--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -59,7 +59,7 @@ fi
 
 # Determine the packages to build (mainnet y/N)
 case $GITBRANCH in
-    compatible|master|release-automation-testing/*|release/1*|release/3*) # whitelist of branches that are "mainnet-like"
+    compatible|master|export_mainnet_build_on_master|release-automation-testing/*|release/1*|release/3*) # whitelist of branches that are "mainnet-like"
       export MINA_BUILD_MAINNET=true ;;
     *) # Other branches
       export MINA_BUILD_MAINNET=false ;;

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -60,9 +60,9 @@ fi
 # Determine the packages to build (mainnet y/N)
 case $GITBRANCH in
     compatible|master|release-automation-testing/*|release/1*|release/3*) # whitelist of branches that are "mainnet-like"
-      MINA_BUILD_MAINNET=true ;;
+      export MINA_BUILD_MAINNET=true ;;
     *) # Other branches
-      MINA_BUILD_MAINNET=false ;;
+      export MINA_BUILD_MAINNET=false ;;
 esac
 
 echo "Publishing on release channel \"${RELEASE}\""

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -59,7 +59,7 @@ fi
 
 # Determine the packages to build (mainnet y/N)
 case $GITBRANCH in
-    compatible|master|export_mainnet_build_on_master|release-automation-testing/*|release/1*|release/3*) # whitelist of branches that are "mainnet-like"
+    compatible|master|release-automation-testing/*|release/1*|release/3*) # whitelist of branches that are "mainnet-like"
       export MINA_BUILD_MAINNET=true ;;
     *) # Other branches
       export MINA_BUILD_MAINNET=false ;;


### PR DESCRIPTION
Currently `MINA_BUILD_MAINNET` flag is set in export_git_env_vars.sh. However it's not exported and thus mainnet package is not built. This is due to lack of exporting MINA_BUILD_MAINNET flag which causes that build-artifact.sh script is not building mina_mainnet_signatures.exe which then is missing when trying to build debian. I think this was an effect of not complete merge to master since develop already has this change. I tested mix fix in nightly:

https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/2132

Jobs failing:

`Build Mina for *` - so basically all mina build jobs. For example:

https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/2130#01902914-0abe-470b-919e-5d67ac2004c0