### PR TITLE
Move merges cleanly check from berkeley do master

### DIFF
--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -48,9 +48,9 @@ Pipeline.build
         },
       Command.build
         Command.Config::{
-          commands = [ Cmd.run "buildkite/scripts/merges-cleanly.sh berkeley"]
-          , label = "Check merges cleanly into berkeley"
-          , key = "clean-merge-berkeley"
+          commands = [ Cmd.run "buildkite/scripts/merges-cleanly.sh master"]
+          , label = "Check merges cleanly into master"
+          , key = "clean-merge-master"
           , target = Size.Small
           , docker = Some Docker::{
               image = (../../Constants/ContainerImages.dhall).toolchainBase


### PR DESCRIPTION
Since we are not using actively berkeley branch and we are fallback to having develop,compatible,master branches, we need to also convert merges cleanly check from berkeley to master