### PR TITLE
[CI/Master] Rename copy_control_file -> create_control_file

### DIFF
--- a/scripts/deb-builder-helpers.sh
+++ b/scripts/deb-builder-helpers.sh
@@ -300,7 +300,7 @@ build_daemon_deb() {
     echo "------------------------------------------------------------"
     echo "--- Building testnet signatures deb without keys:"
 
-    copy_control_file mina-devnet "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Devnet Network'
+    create_control_file mina-devnet "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Devnet Network'
 
     copy_common_daemon_configs devnet testnet 'seed-lists/devnet_seeds.txt'
 


### PR DESCRIPTION
Another fix for master CI, looks like after update to newest master and fix for mainnet signature there was another issue lurking in the shadows. If we are using mainnet signatures then we are also building devnet package, but for this we are using non-existing method. This PR fixes it 