### PR TITLE
Remove snark key download

### DIFF
--- a/src/config/berkeley_archive_migration.mlh
+++ b/src/config/berkeley_archive_migration.mlh
@@ -33,7 +33,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features false]

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features true]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -33,7 +33,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features false]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/lightnet.mlh
+++ b/src/config/lightnet.mlh
@@ -33,7 +33,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features true]

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -33,7 +33,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features false]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -21,7 +21,6 @@
 
 [%%define print_versioned_types false]
 
-[%%define download_snark_keys true]
 [%%define generate_genesis_proof false]
 
 [%%define test_full_epoch false]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types true]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -22,7 +22,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -23,7 +23,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -23,7 +23,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -21,7 +21,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -23,7 +23,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -32,7 +32,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define itn_features false]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -23,7 +23,6 @@
 [%%define integration_tests false]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -24,7 +24,6 @@
 [%%define integration_tests true]
 [%%define force_updates false]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -23,7 +23,6 @@
 [%%define integration_tests false]
 [%%define force_updates true]
 
-[%%define download_snark_keys false]
 [%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]

--- a/src/lib/cache_dir/native/cache_dir.ml
+++ b/src/lib/cache_dir/native/cache_dir.ml
@@ -29,8 +29,6 @@ let cache =
   ; dir brew_install_path false
   ; dir s3_install_path false
   ; dir autogen_path true
-  ; Key_cache.Spec.S3
-      { bucket_prefix = s3_keys_bucket_prefix; install_path = s3_install_path }
   ]
 
 let env_path =

--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -140,13 +140,7 @@ module Make (Inputs : Inputs_intf) = struct
             | Error _e ->
                 let urs = Inputs.Urs.create degree in
                 let (_ : (unit, Error.t) Result.t) =
-                  Key_cache.Sync.write
-                    (List.filter specs ~f:(function
-                      | On_disk _ ->
-                          true
-                      | S3 _ ->
-                          false ) )
-                    store () urs
+                  Key_cache.Sync.write specs store () urs
                 in
                 urs
           in

--- a/src/lib/crypto/kimchi_backend/common/dlog_urs.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_urs.ml
@@ -57,13 +57,7 @@ module Make (Inputs : Inputs_intf) = struct
             | Error _e ->
                 let urs = Urs.create (Unsigned.Size_t.of_int degree) in
                 let (_ : (unit, Error.t) Result.t) =
-                  Key_cache.Sync.write
-                    (List.filter specs ~f:(function
-                      | On_disk _ ->
-                          true
-                      | S3 _ ->
-                          false ) )
-                    store () urs
+                  Key_cache.Sync.write specs store () urs
                 in
                 urs
           in

--- a/src/lib/key_cache/async/key_cache_async.ml
+++ b/src/lib/key_cache/async/key_cache_async.ml
@@ -25,47 +25,6 @@ let on_disk to_string read write prefix =
   in
   { read; write }
 
-let s3 to_string read ~bucket_prefix ~install_path =
-  let read k =
-    let label = to_string k in
-    let uri_string = bucket_prefix ^/ label in
-    let file_path = install_path ^/ label in
-    let open Deferred.Or_error.Let_syntax in
-    let logger = Logger.create () in
-    [%log trace] "Downloading key to key cache"
-      ~metadata:
-        [ ("url", `String uri_string); ("local_file_path", `String file_path) ] ;
-    let%bind result =
-      Monitor.try_with_join_or_error ~here:[%here] (fun () ->
-          Process.run ~prog:"curl"
-            ~args:
-              [ "--fail"
-              ; "--silent"
-              ; "--show-error"
-              ; "-o"
-              ; file_path
-              ; uri_string
-              ]
-            ()
-          |> Deferred.Result.map_error ~f:(fun err ->
-                 [%log debug] "Could not download key to key cache"
-                   ~metadata:
-                     [ ("url", `String uri_string)
-                     ; ("local_file_path", `String file_path)
-                     ] ;
-                 err ) )
-    in
-    [%log trace] "Downloaded key to key cache"
-      ~metadata:
-        [ ("url", `String uri_string)
-        ; ("local_file_path", `String file_path)
-        ; ("result", `String result)
-        ] ;
-    read k ~path:file_path
-  in
-  let write _ _ = Deferred.Or_error.return () in
-  { read; write }
-
 module Disk_storable = struct
   include Disk_storable (Deferred.Or_error)
 
@@ -92,12 +51,8 @@ let read spec { Disk_storable.to_string; read = r; write = w } k =
       | Spec.On_disk { directory; should_write } ->
           let%map res = (on_disk to_string r w directory).read k in
           (res, if should_write then `Locally_generated else `Cache_hit)
-      | S3 _ when not (may_download ()) ->
-          Deferred.Or_error.errorf "Downloading from S3 is disabled"
-      | S3 { bucket_prefix; install_path } ->
-          let%bind.Deferred () = Unix.mkdir ~p:() install_path in
-          let%map res = (s3 to_string r ~bucket_prefix ~install_path).read k in
-          (res, `Cache_hit) )
+      | S3 _ ->
+          Deferred.Or_error.errorf "Downloading from S3 is disabled" )
 
 let write spec { Disk_storable.to_string; read = r; write = w } k v =
   let%map errs =

--- a/src/lib/key_cache/async/key_cache_async.ml
+++ b/src/lib/key_cache/async/key_cache_async.ml
@@ -50,9 +50,7 @@ let read spec { Disk_storable.to_string; read = r; write = w } k =
       match s with
       | Spec.On_disk { directory; should_write } ->
           let%map res = (on_disk to_string r w directory).read k in
-          (res, if should_write then `Locally_generated else `Cache_hit)
-      | S3 _ ->
-          Deferred.Or_error.errorf "Downloading from S3 is disabled" )
+          (res, if should_write then `Locally_generated else `Cache_hit) )
 
 let write spec { Disk_storable.to_string; read = r; write = w } k v =
   let%map errs =
@@ -64,8 +62,6 @@ let write spec { Disk_storable.to_string; read = r; write = w } k v =
                 let%bind () = Unix.mkdir ~p:() directory in
                 (on_disk to_string r w directory).write k v
               else Deferred.Or_error.return ()
-          | S3 { bucket_prefix = _; install_path = _ } ->
-              Deferred.Or_error.return ()
         in
         match%map res with Error e -> Some e | Ok () -> None )
   in

--- a/src/lib/key_cache/key_cache.ml
+++ b/src/lib/key_cache/key_cache.ml
@@ -9,9 +9,7 @@ module Spec = struct
     | S3 of { bucket_prefix : string; install_path : string }
 end
 
-[%%inject "may_download", download_snark_keys]
-
-let may_download = ref may_download
+let may_download = ref false
 
 let set_downloads_enabled b = may_download := b
 

--- a/src/lib/key_cache/key_cache.ml
+++ b/src/lib/key_cache/key_cache.ml
@@ -9,12 +9,6 @@ module Spec = struct
     | S3 of { bucket_prefix : string; install_path : string }
 end
 
-let may_download = ref false
-
-let set_downloads_enabled b = may_download := b
-
-let may_download () = !may_download
-
 module T (M : sig
   type _ t
 end) =

--- a/src/lib/key_cache/key_cache.ml
+++ b/src/lib/key_cache/key_cache.ml
@@ -4,9 +4,7 @@ open Async_kernel
 [%%import "/src/config.mlh"]
 
 module Spec = struct
-  type t =
-    | On_disk of { directory : string; should_write : bool }
-    | S3 of { bucket_prefix : string; install_path : string }
+  type t = On_disk of { directory : string; should_write : bool }
 end
 
 module T (M : sig

--- a/src/lib/key_cache/key_cache.mli
+++ b/src/lib/key_cache/key_cache.mli
@@ -7,10 +7,6 @@ module Spec : sig
     | S3 of { bucket_prefix : string; install_path : string }
 end
 
-val may_download : unit -> bool
-
-val set_downloads_enabled : bool -> unit
-
 module T (M : sig
   type _ t
 end) : sig

--- a/src/lib/key_cache/key_cache.mli
+++ b/src/lib/key_cache/key_cache.mli
@@ -2,9 +2,7 @@ open Core_kernel
 open Async_kernel
 
 module Spec : sig
-  type t =
-    | On_disk of { directory : string; should_write : bool }
-    | S3 of { bucket_prefix : string; install_path : string }
+  type t = On_disk of { directory : string; should_write : bool }
 end
 
 module T (M : sig

--- a/src/lib/key_cache/sync/key_cache_sync.ml
+++ b/src/lib/key_cache/sync/key_cache_sync.ml
@@ -50,8 +50,6 @@ let read spec { Disk_storable.to_string; read = r; write = w } k =
         | Spec.On_disk { directory; should_write } ->
             ( (on_disk to_string r w directory).read k
             , if should_write then `Locally_generated else `Cache_hit )
-        | S3 _ ->
-            (Or_error.errorf "Downloading from S3 is disabled", `Cache_hit)
       in
       let%map.Or_error res = res in
       (res, cache_hit) )
@@ -66,8 +64,6 @@ let write spec { Disk_storable.to_string; read = r; write = w } k v =
                 Unix.mkdir_p directory ;
                 (on_disk to_string r w directory).write k v )
               else Or_error.return ()
-          | S3 { bucket_prefix = _; install_path = _ } ->
-              Or_error.return ()
         in
         match res with Error e -> Some e | Ok () -> None )
   in


### PR DESCRIPTION
We no longer store snark keys in S3, so this codepath is entirely unused. This PR removes the compile-time configuration option and the logic for downloading those keys.