### PR TITLE
Move wire check to the tx validation logic

### DIFF
--- a/src/lib/mina_base/test/zkapp_command_test.ml
+++ b/src/lib/mina_base/test/zkapp_command_test.ml
@@ -119,9 +119,10 @@ end = struct
   let full = deriver @@ Fd.o ()
 
   let json_roundtrip_dummy () =
+    let dummy = Lazy.force dummy in
     [%test_eq: t] dummy (dummy |> Fd.to_json full |> Fd.of_json full)
 
   let full_circuit () =
     Run_in_thread.block_on_async_exn
-    @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full dummy
+    @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full (Lazy.force dummy)
 end

--- a/src/lib/mina_base/test/zkapp_command_test.ml
+++ b/src/lib/mina_base/test/zkapp_command_test.ml
@@ -119,10 +119,9 @@ end = struct
   let full = deriver @@ Fd.o ()
 
   let json_roundtrip_dummy () =
-    let dummy = Lazy.force dummy in
     [%test_eq: t] dummy (dummy |> Fd.to_json full |> Fd.of_json full)
 
   let full_circuit () =
     Run_in_thread.block_on_async_exn
-    @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full (Lazy.force dummy)
+    @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full dummy
 end

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1570,20 +1570,21 @@ let arg_query_string x =
   Fields_derivers_zkapps.Test.Loop.json_to_string_gql @@ to_json x
 
 let dummy =
-  let account_update : Account_update.t =
-    { body = Account_update.Body.dummy
-    ; authorization = Control.dummy_of_tag Signature
-    }
-  in
-  let fee_payer : Account_update.Fee_payer.t =
-    { body = Account_update.Body.Fee_payer.dummy
-    ; authorization = Signature.dummy
-    }
-  in
-  { fee_payer
-  ; account_updates = Call_forest.cons account_update []
-  ; memo = Signed_command_memo.empty
-  }
+  lazy
+    (let account_update : Account_update.t =
+       { body = Account_update.Body.dummy
+       ; authorization = Control.dummy_of_tag Signature
+       }
+     in
+     let fee_payer : Account_update.Fee_payer.t =
+       { body = Account_update.Body.Fee_payer.dummy
+       ; authorization = Signature.dummy
+       }
+     in
+     { fee_payer
+     ; account_updates = Call_forest.cons account_update []
+     ; memo = Signed_command_memo.empty
+     } )
 
 module Make_update_group (Input : sig
   type global_state

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -707,12 +707,6 @@ module T = struct
           end
         end]
 
-        let check (t : t) : unit =
-          List.iter t.account_updates ~f:(fun p ->
-              assert (
-                Account_update.May_use_token.equal
-                  p.elt.account_update.body.may_use_token No ) )
-
         let of_graphql_repr (t : Graphql_repr.t) : t =
           { fee_payer = t.fee_payer
           ; memo = t.memo
@@ -808,7 +802,7 @@ module T = struct
           (struct
             type nonrec t = t
 
-            let of_binable t = Wire.check t ; of_wire t
+            let of_binable t = of_wire t
 
             let to_binable = to_wire
           end)
@@ -1576,21 +1570,20 @@ let arg_query_string x =
   Fields_derivers_zkapps.Test.Loop.json_to_string_gql @@ to_json x
 
 let dummy =
-  lazy
-    (let account_update : Account_update.t =
-       { body = Account_update.Body.dummy
-       ; authorization = Control.dummy_of_tag Signature
-       }
-     in
-     let fee_payer : Account_update.Fee_payer.t =
-       { body = Account_update.Body.Fee_payer.dummy
-       ; authorization = Signature.dummy
-       }
-     in
-     { fee_payer
-     ; account_updates = Call_forest.cons account_update []
-     ; memo = Signed_command_memo.empty
-     } )
+  let account_update : Account_update.t =
+    { body = Account_update.Body.dummy
+    ; authorization = Control.dummy_of_tag Signature
+    }
+  in
+  let fee_payer : Account_update.Fee_payer.t =
+    { body = Account_update.Body.Fee_payer.dummy
+    ; authorization = Signature.dummy
+    }
+  in
+  { fee_payer
+  ; account_updates = Call_forest.cons account_update []
+  ; memo = Signed_command_memo.empty
+  }
 
 module Make_update_group (Input : sig
   type global_state


### PR DESCRIPTION
Problem: this check is the only one we perform in this layer, seemingly for no good reason.

Solution: move the check to where all of the other zkapp command checks reside.

P.S. this refactoring makes analysis of the code easier, because all tx-related checks are now located in a single place.

Explain how you tested your changes:
* Tested on mainnet via custom build

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None