### PR TITLE
Makefile: rm check-proof-systems-submodule target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,6 @@ check-format: ocaml_checks
 check-snarky-submodule:
 	./scripts/check-snarky-submodule.sh
 
-check-proof-systems-submodule:
-	./scripts/check-proof-systems-submodule.sh
-
 #######################################
 ## Environment setup
 


### PR DESCRIPTION
The script that the target  is supposed to launch does not exist anymore.


