### PR TITLE
[o1js] Custom deriver type for Int64 / BalanceChange

### DIFF
--- a/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
+++ b/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
@@ -355,11 +355,15 @@ module Make (Schema : Graphql_intf.Schema) = struct
         ~of_string:sign_of_string
     in
     let ( !. ) = ( !. ) ~t_fields_annots:Currency.Signed_poly.t_fields_annots in
-    Currency.Signed_poly.Fields.make_creator obj ~magnitude:!.amount
-      ~sgn:!.sign_deriver
-    |> finish "BalanceChange"
-         ~t_toplevel_annots:Currency.Signed_poly.t_toplevel_annots
-    |> Fields_derivers_js.Js_layout.(of_layout @@ leaf_type (Custom "Int64"))
+    let balance_change obj =
+      Currency.Signed_poly.Fields.make_creator obj ~magnitude:!.amount
+        ~sgn:!.sign_deriver
+      |> finish "BalanceChange"
+           ~t_toplevel_annots:Currency.Signed_poly.t_toplevel_annots
+    in
+    needs_custom_js
+      ~js_type:(js_leaf (Custom "BalanceChange"))
+      ~name:"BalanceChange" balance_change obj
 
   let to_json obj x = !(obj#to_json) @@ !(obj#contramap) x
 

--- a/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
+++ b/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
@@ -355,8 +355,8 @@ module Make (Schema : Graphql_intf.Schema) = struct
         ~of_string:sign_of_string
     in
     let ( !. ) = ( !. ) ~t_fields_annots:Currency.Signed_poly.t_fields_annots in
-    let balance_change obj =
-      Currency.Signed_poly.Fields.make_creator obj ~magnitude:!.amount
+    let balance_change obj' =
+      Currency.Signed_poly.Fields.make_creator obj' ~magnitude:!.amount
         ~sgn:!.sign_deriver
       |> finish "BalanceChange"
            ~t_toplevel_annots:Currency.Signed_poly.t_toplevel_annots

--- a/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
+++ b/src/lib/fields_derivers_zkapps/fields_derivers_zkapps.ml
@@ -359,6 +359,7 @@ module Make (Schema : Graphql_intf.Schema) = struct
       ~sgn:!.sign_deriver
     |> finish "BalanceChange"
          ~t_toplevel_annots:Currency.Signed_poly.t_toplevel_annots
+    |> Fields_derivers_js.Js_layout.(of_layout @@ leaf_type (Custom "Int64"))
 
   let to_json obj x = !(obj#to_json) @@ !(obj#contramap) x
 


### PR DESCRIPTION
companion of https://github.com/o1-labs/o1js/pull/1749

Note: this PR doesn't change the format of the `balanceChange` field, but adds a hint to that type that we need to change some of the automatically derived defaults on the JS type (that will be autogenerated using this deriver).

In this case, we want to modify the defining constraints of the  `balanceChange` type such that it can never be `{ magnitude: 0, sgn: Negative }`. We want to prevent this case because it implies a non-unique representation of 0, which can lead to unexpected vulnerabilities.

With the existing deriver, the balance change type would just be composed from its parts, a `UInt64` and a `Bool`. By adding the `needs_custom_js` annotation, the generated TS code allows us to provide customization of the composed type.