### PR TITLE
Add (no_dynlink) to kimchi_bindings stubs

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -121,6 +121,9 @@
  (name pasta_bindings_backend_native)
  (modules pasta_bindings_backend)
  (foreign_archives wires_15_stubs)
+ (no_dynlink)
+ ; ^ Required for compilation of this library separately
+ ; from libraries that depend on it
  (c_library_flags :standard "-lpthread")
  (libraries bounded_types)
  (instrumentation


### PR DESCRIPTION
Compilation of the library as a standalone unit fails without this flag.

Explain how you tested your changes:
* Library compiles as part of granular nix approach

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None