### PR TITLE
remove broken fold functions from rocksdb

### DIFF
--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -184,23 +184,6 @@ module type Key_value_database = sig
 
   (** An association list, sorted by key *)
   val to_alist : t -> (Bigstring.t * Bigstring.t) list
-
-  val foldi :
-       t
-    -> init:'a
-    -> f:(int -> 'a -> key:Bigstring.t -> data:Bigstring.t -> 'a)
-    -> 'a
-
-  val fold_until :
-       t
-    -> init:'a
-    -> f:
-         (   'a
-          -> key:Bigstring.t
-          -> data:Bigstring.t
-          -> ('a, 'b) Continue_or_stop.t )
-    -> finish:('a -> 'b)
-    -> 'b
 end
 
 module type Storage_locations = sig

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -128,17 +128,6 @@ struct
   let remove t ~key = Bigstring_frozen.Table.remove t.table key
 
   let make_checkpoint _ _ = ()
-
-  let foldi t ~init ~f =
-    let i = ref (-1) in
-    let f ~key ~data accum = incr i ; f !i accum ~key ~data in
-    Bigstring_frozen.Table.fold t.table ~init ~f
-
-  (* Relying on {!val:to_alist} is probably enough for testing purposes. *)
-  let fold_until t ~init ~f ~finish =
-    let f accum (key, data) = f accum ~key ~data in
-    let alist = to_alist t in
-    List.fold_until alist ~init ~f ~finish
 end
 
 module Storage_locations : Intf.Storage_locations = struct

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -78,45 +78,6 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
   in
   loop []
 
-let foldi :
-       t
-    -> init:'a
-    -> f:(int -> 'a -> key:Bigstring.t -> data:Bigstring.t -> 'a)
-    -> 'a =
- fun t ~init ~f ->
-  let iterator = Rocks.Iterator.create t.db in
-  let rec loop i accum =
-    if Rocks.Iterator.is_valid iterator then (
-      let key = copy_bigstring (Rocks.Iterator.get_key iterator) in
-      let data = copy_bigstring (Rocks.Iterator.get_value iterator) in
-      Rocks.Iterator.next iterator ;
-      loop (i + 1) (f i accum ~key ~data) )
-    else accum
-  in
-  loop 0 init
-
-let fold_until :
-       t
-    -> init:'a
-    -> f:
-         (   'a
-          -> key:Bigstring.t
-          -> data:Bigstring.t
-          -> ('a, 'b) Continue_or_stop.t )
-    -> finish:('a -> 'b)
-    -> 'b =
- fun t ~init ~f ~finish ->
-  let iterator = Rocks.Iterator.create t.db in
-  let rec loop accum =
-    if Rocks.Iterator.is_valid iterator then (
-      let key = copy_bigstring (Rocks.Iterator.get_key iterator) in
-      let data = copy_bigstring (Rocks.Iterator.get_value iterator) in
-      Rocks.Iterator.next iterator ;
-      match f accum ~key ~data with Stop _ -> accum | Continue v -> loop v )
-    else accum
-  in
-  finish @@ loop init
-
 let to_bigstring = Bigstring.of_string
 
 let%test_unit "get_batch" =

--- a/src/lib/rocksdb/database.mli
+++ b/src/lib/rocksdb/database.mli
@@ -8,7 +8,7 @@ type t = { uuid : uuid; db : (Rocks.t[@sexp.opaque]) } [@@deriving sexp]
 
 type db := t
 
-(** [create dirname] creates a database contained in [dirname]. 
+(** [create dirname] creates a database contained in [dirname].
 
     @param dirname will be created if it does not exist
  *)
@@ -21,7 +21,7 @@ val get_batch : t -> keys:key list -> data option list
 val set : t -> key:key -> data:data -> unit
 
 (** Any key present both in [remove_keys] and [key_data_pairs] will be absent
-    from the database. 
+    from the database.
 
     @param remove_keys defaults to [[]]
 *)
@@ -39,19 +39,6 @@ val make_checkpoint : t -> string -> unit
 val create_checkpoint : t -> string -> t
 
 val get_uuid : t -> uuid
-
-val foldi :
-     t
-  -> init:'a
-  -> f:(int -> 'a -> key:Bigstring.t -> data:Bigstring.t -> 'a)
-  -> 'a
-
-val fold_until :
-     t
-  -> init:'a
-  -> f:('a -> key:Bigstring.t -> data:Bigstring.t -> ('a, 'b) Continue_or_stop.t)
-  -> finish:('a -> 'b)
-  -> 'b
 
 module Batch : sig
   type t = Rocks.WriteBatch.t


### PR DESCRIPTION
I noticed these functions always behave as if the DB is empty, which only hasn't been a problem because we also don't use them. So this pr removes them from the module signature.