### PR TITLE
Fix bug with rocksdb fold methods

### DIFF
--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -85,6 +85,7 @@ let foldi :
     -> 'a =
  fun t ~init ~f ->
   let iterator = Rocks.Iterator.create t.db in
+  Rocks.Iterator.seek_to_first iterator ;
   let rec loop i accum =
     if Rocks.Iterator.is_valid iterator then (
       let key = copy_bigstring (Rocks.Iterator.get_key iterator) in
@@ -107,6 +108,7 @@ let fold_until :
     -> 'b =
  fun t ~init ~f ~finish ->
   let iterator = Rocks.Iterator.create t.db in
+  Rocks.Iterator.seek_to_first iterator ;
   let rec loop accum =
     if Rocks.Iterator.is_valid iterator then (
       let key = copy_bigstring (Rocks.Iterator.get_key iterator) in


### PR DESCRIPTION
I'm not certain how often this happens, but at least in some reproducible cases `foldi` and `fold_until` behave as if the database were empty. Seemingly because `Iterator.create` does not always return an iterator at the first entry. Adding this `seek_first` call seems to fix this. Computing the size of the database with a fold agrees with the length of the list returned by `to_alist` in the case where it previously consistently did not.