### PR TITLE
Add `protocolState` GraphQL query for JSON and Base64 encoded protocol state

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -5498,6 +5498,29 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "Encoding",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "JSON",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BASE64",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "VrfEvaluationInput",
           "description": "The witness to a vrf evaluation",
@@ -15337,6 +15360,34 @@
               "description":
                 "The signature kind that this daemon instance is using",
               "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "protocolState",
+              "description":
+                "Get the current protocol state, optionally encoded in Base64",
+              "args": [
+                {
+                  "name": "encoding",
+                  "description": "Encoding format (JSON or BASE64)",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "Encoding",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2618,8 +2618,7 @@ module Queries = struct
                     Mina_state.Protocol_state.Value.Stable.V2.bin_t.writer
                     protocol_state
                   |> Base64.encode_exn
-              | Some `JSON 
-              | None ->
+              | Some `JSON | None ->
                   (* Default to JSON if no encoding is specified *)
                   Mina_state.Protocol_state.value_to_yojson protocol_state
                   |> Yojson.Safe.to_string

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2613,14 +2613,12 @@ module Queries = struct
             in
             let encoded =
               match encoding_opt with
-              | Some `JSON ->
-                  Mina_state.Protocol_state.value_to_yojson protocol_state
-                  |> Yojson.Safe.to_string
               | Some `BASE64 ->
                   Bin_prot.Writer.to_string
                     Mina_state.Protocol_state.Value.Stable.V2.bin_t.writer
                     protocol_state
                   |> Base64.encode_exn
+              | Some `JSON 
               | None ->
                   (* Default to JSON if no encoding is specified *)
                   Mina_state.Protocol_state.value_to_yojson protocol_state

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2591,6 +2591,45 @@ module Queries = struct
             (* Prefix string to disambiguate *)
             "other network: " ^ s )
 
+  let protocol_state =
+    io_field "protocolState"
+      ~doc:"Get the current protocol state, optionally encoded in Base64"
+      ~typ:(non_null string)
+      ~args:
+        Arg.
+          [ arg "encoding" ~doc:"Encoding format (JSON or BASE64)"
+              ~typ:
+                (enum "Encoding"
+                   ~values:
+                     [ enum_value "JSON" ~value:`JSON
+                     ; enum_value "BASE64" ~value:`BASE64
+                     ] )
+          ]
+      ~resolve:(fun { ctx = mina; _ } () encoding_opt ->
+        match Mina_lib.best_tip mina with
+        | `Active best_tip ->
+            let protocol_state =
+              Transition_frontier.Breadcrumb.protocol_state best_tip
+            in
+            let encoded =
+              match encoding_opt with
+              | Some `JSON ->
+                  Mina_state.Protocol_state.value_to_yojson protocol_state
+                  |> Yojson.Safe.to_string
+              | Some `BASE64 ->
+                  Bin_prot.Writer.to_string
+                    Mina_state.Protocol_state.Value.Stable.V2.bin_t.writer
+                    protocol_state
+                  |> Base64.encode_exn
+              | None ->
+                  (* Default to JSON if no encoding is specified *)
+                  Mina_state.Protocol_state.value_to_yojson protocol_state
+                  |> Yojson.Safe.to_string
+            in
+            return (Ok encoded)
+        | `Bootstrapping ->
+            return (Error "Node is bootstrapping") )
+
   let commands =
     [ sync_status
     ; daemon_status
@@ -2628,6 +2667,7 @@ module Queries = struct
     ; blockchain_verification_key
     ; network_id
     ; signature_kind
+    ; protocol_state
     ]
 
   module Itn = struct


### PR DESCRIPTION
## Description:
This PR adds a new GraphQL query `protocolState` to retrieve the current protocol state. The query allows clients to fetch the protocol state in either JSON or Base64 encoded format.

Addressing the request for https://github.com/MinaProtocol/mina/issues/15825

## Key changes:

1. Added a new field protocolState to the GraphQL schema
1. Implemented resolver for the protocolState query
1. Added option to return the protocol state as JSON or Base64 encoded

The new query provides the following functionality:

- Retrieves the current protocol state from the best tip of the blockchain
- Allows clients to specify the desired encoding format (JSON or Base64)
- Returns the full Mina_state.Protocol_state.Value.Stable.V2.t type

This addition enables clients to:

- Extract consensus data for consensus rules checking
- Access the full protocol state structure for various applications
- Efficiently transfer the protocol state data in a compact format when needed

Usage example:
```graphql
query {
  protocolState(encoding: JSON)
}
```
or
```graphql
query {
  protocolState(encoding: BASE64)
}
```

Example outputs:

```
{
  "data": {
    "protocolState": "{\"previous_state_hash\":\"3NKh6pK1JcVAy1DGuCDDjnaNsAYc6xHWsevfkXpk3ko7B9jBUTkS\",\"body\":{\"genesis_state_hash\":\"3NKh6pK1JcVAy1DGuCDDjnaNsAYc6xHWsevfkXpk3ko7B9jBUTkS\",\"blockchain_state\":{\"staged_ledger_hash\":{\"non_snark\":{\"ledger_hash\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"aux_hash\":\"UDRUFHSvxUAtV8sh7gzMVPqpbd46roG1wzWR6dYvB6RunPihom\",\"pending_coinbase_aux\":\"WAAeUjUnP9Q2JiabhJzJozcjiEmkZe8ob4cfFKSuq6pQSNmHh7\"},\"pending_coinbase_hash\":\"2n1oswjtfucMHFY4nPewXvU42b6ife5dfNK9dPb2FTmrheHcNHTC\"},\"genesis_ledger_hash\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"ledger_proof_statement\":{\"source\":{\"first_pass_ledger\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"second_pass_ledger\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"pending_coinbase_stack\":{\"data\":\"4QNrZFBTDQCPfEZqBZsaPYx8qdaNFv1nebUyCUsQW9QUJqyuD3un\",\"state\":{\"init\":\"4Yx5U3t3EYQycZ91yj4478bHkLwGkhDHnPbCY9TxgUk69SQityej\",\"curr\":\"4Yx5U3t3EYQycZ91yj4478bHkLwGkhDHnPbCY9TxgUk69SQityej\"}},\"local_state\":{\"stack_frame\":\"0x0641662E94D68EC970D0AFC059D02729BBF4A2CD88C548CCD9FB1E26E570C66C\",\"call_stack\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"transaction_commitment\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"full_transaction_commitment\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"excess\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]},\"supply_increase\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]},\"ledger\":\"jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd\",\"success\":true,\"account_update_index\":\"0\",\"failure_status_tbl\":[],\"will_succeed\":true}},\"target\":{\"first_pass_ledger\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"second_pass_ledger\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"pending_coinbase_stack\":{\"data\":\"4QNrZFBTDQCPfEZqBZsaPYx8qdaNFv1nebUyCUsQW9QUJqyuD3un\",\"state\":{\"init\":\"4Yx5U3t3EYQycZ91yj4478bHkLwGkhDHnPbCY9TxgUk69SQityej\",\"curr\":\"4Yx5U3t3EYQycZ91yj4478bHkLwGkhDHnPbCY9TxgUk69SQityej\"}},\"local_state\":{\"stack_frame\":\"0x0641662E94D68EC970D0AFC059D02729BBF4A2CD88C548CCD9FB1E26E570C66C\",\"call_stack\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"transaction_commitment\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"full_transaction_commitment\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"excess\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]},\"supply_increase\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]},\"ledger\":\"jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd\",\"success\":true,\"account_update_index\":\"0\",\"failure_status_tbl\":[],\"will_succeed\":true}},\"connecting_ledger_left\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"connecting_ledger_right\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"supply_increase\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]},\"fee_excess\":[{\"token\":\"wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf\",\"amount\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]}},{\"token\":\"wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf\",\"amount\":{\"magnitude\":\"0\",\"sgn\":[\"Pos\"]}}],\"sok_digest\":null},\"timestamp\":\"1721242541000\",\"body_reference\":\"36bda176656cc3be96c3d317db7b4ac06fdbc7f4eedcd6efdd20e28143d67421\"},\"consensus_state\":{\"blockchain_length\":\"1\",\"epoch_count\":\"0\",\"min_window_density\":\"6\",\"sub_window_densities\":[\"1\",\"2\",\"2\"],\"last_vrf_output\":\"39cyg4ZmMtnb_aFUIerNAoAJV8qtkfOpq0zFzPspjgM=\",\"total_currency\":\"23166005000060590\",\"curr_global_slot_since_hard_fork\":{\"slot_number\":\"0\",\"slots_per_epoch\":\"576\"},\"global_slot_since_genesis\":\"0\",\"staking_epoch_data\":{\"ledger\":{\"hash\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"total_currency\":\"23166005000060590\"},\"seed\":\"2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA\",\"start_checkpoint\":\"3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x\",\"lock_checkpoint\":\"3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x\",\"epoch_length\":\"1\"},\"next_epoch_data\":{\"ledger\":{\"hash\":\"jw9eWMn1vD6VwtD9scc72uHTt21yvWSmD1z3VZ1G9QcEuC7Q9LK\",\"total_currency\":\"23166005000060590\"},\"seed\":\"2vafPBQ3zQdHUEDDnFGuiNvJz7s2MhTLJgSzQSnu5fnZavT27cms\",\"start_checkpoint\":\"3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x\",\"lock_checkpoint\":\"3NKh6pK1JcVAy1DGuCDDjnaNsAYc6xHWsevfkXpk3ko7B9jBUTkS\",\"epoch_length\":\"2\"},\"has_ancestor_in_same_checkpoint_window\":true,\"block_stake_winner\":\"B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg\",\"block_creator\":\"B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg\",\"coinbase_receiver\":\"B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg\",\"supercharge_coinbase\":true},\"constants\":{\"k\":\"24\",\"slots_per_epoch\":\"576\",\"slots_per_sub_window\":\"2\",\"grace_period_slots\":\"180\",\"delta\":\"0\",\"genesis_state_timestamp\":\"1721242541000\"}}}"
  }
}
```
```
{
  "data": {
    "protocolState": "VsFzhD5NohQvFAy/nadwNXzusPnOGAN1GLDRBOBJeSpWwXOEPk2iFC8UDL+dp3A1fO6w+c4YA3UYsNEE4El5KgbpHzp07Mwlt+uBkWgOEPP1V9JJycVcU1rGOmdQHLoeIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAquqbAVCs5W0kmXi8fwJUKwR6GHD+zahkVJsRjrPFRRcG6R86dOzMJbfrgZFoDhDz9VfSScnFXFNaxjpnUBy6HgbpHzp07Mwlt+uBkWgOEPP1V9JJycVcU1rGOmdQHLoeBukfOnTszCW364GRaA4Q8/VX0knJxVxTWsY6Z1Acuh41udUeXXx0FFb4ZyBzEkGoKAJzz8bCFmj9e8bFh9DMHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABsxnDlJh772cxIxYjNovS7KSfQWcCv0HDJjtaULmZBBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAEG6R86dOzMJbfrgZFoDhDz9VfSScnFXFNaxjpnUBy6HgbpHzp07Mwlt+uBkWgOEPP1V9JJycVcU1rGOmdQHLoeNbnVHl18dBRW+GcgcxJBqCgCc8/GwhZo/XvGxYfQzB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbMZw5SYe+9nMSMWIzaL0uykn0FnAr9BwyY7WlC5mQQYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAABBukfOnTszCW364GRaA4Q8/VX0knJxVxTWsY6Z1Acuh4G6R86dOzMJbfrgZFoDhDz9VfSScnFXFNaxjpnUBy6HgAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/MjbDMKQAQAAIDa9oXZlbMO+lsPTF9t7SsBv28f07tzW790g4oFD1nQhAQAGAwECAiDf1zKDhmYy2dv9oVQh6s0CgAlXyq2R86mrTMXM+ymOA/yuvuTaW01SAAAA/kACAAAG6R86dOzMJbfrgZFoDhDz9VfSScnFXFNaxjpnUBy6HvyuvuTaW01SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEG6R86dOzMJbfrgZFoDhDz9VfSScnFXFNaxjpnUBy6HvyuvuTaW01SAESVsMogaq1Q/ljOj2NmKOWpeocuN/HWg1JpQc4Ome0oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABWwXOEPk2iFC8UDL+dp3A1fO6w+c4YA3UYsNEE4El5KgIBD0jGW9JfhfPk6k7+vrdbeXvXQ2A74EtOrYRWmLdr0zEAD0jGW9JfhfPk6k7+vrdbeXvXQ2A74EtOrYRWmLdr0zEAD0jGW9JfhfPk6k7+vrdbeXvXQ2A74EtOrYRWmLdr0zEAARj+QAIC/rQAAPzI2wzCkAEAAA=="
  }
}
```