### PR TITLE
Remove c-reference-signer submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,9 +11,6 @@
 	path = src/external/prometheus
 	url = https://github.com/MinaProtocol/prometheus.git
     branch = master
-[submodule "src/external/c-reference-signer"]
-	path = src/external/c-reference-signer
-	url = https://github.com/MinaProtocol/c-reference-signer.git
 [submodule "src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors"]
 	path = src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors
 	url = https://github.com/MinaProtocol/kimchi-stubs-vendors.git

--- a/src/app/delegation_backend/scripts/build.sh
+++ b/src/app/delegation_backend/scripts/build.sh
@@ -6,19 +6,22 @@ if [[ "$OUT" == "" ]]; then
   OUT="$PWD/result"
 fi
 
-ref_signer="$PWD/../../external/c-reference-signer"
 
-mkdir -p "$OUT"/{headers,bin}
-rm -f "$OUT"/libmina_signer.so # Otherwise re-building without clean causes permissions issue
-if [[ "$LIB_MINA_SIGNER" == "" ]]; then
+mkdir -p "$OUT"/bin
+rm -Rf "$OUT/c-reference-signer" "$OUT/headers" "$OUT"/libmina_signer.so # Otherwise re-building without clean causes permissions issue
+if [[ "$PKG_MINA_SIGNER" == "" ]]; then
   # No nix
-  cp -R "$ref_signer" "$OUT"
+
+  # Hack to avoid one extra submodule
+  git clone -b v1.0.0 --depth 1 https://github.com/MinaProtocol/c-reference-signer.git "$OUT/c-reference-signer"
   make -C "$OUT/c-reference-signer" clean libmina_signer.so
   cp "$OUT/c-reference-signer/libmina_signer.so" "$OUT"
+  mkdir -p "$OUT/headers"
+  cp "$ref_signer"/*.h "$OUT/headers"
 else
-  cp "$LIB_MINA_SIGNER" "$OUT"/libmina_signer.so
+  ln -s "$PKG_MINA_SIGNER"/lib/libmina_signer.so "$OUT"/libmina_signer.so
+  ln -s "$PKG_MINA_SIGNER"/headers "$OUT"/headers
 fi
-cp "$ref_signer"/*.h "$OUT/headers"
 
 case "$1" in
   test)

--- a/src/app/delegation_backend/shell.nix
+++ b/src/app/delegation_backend/shell.nix
@@ -8,9 +8,9 @@ let
 in {
   devEnv = stdenv.mkDerivation {
     name = "dev";
-    buildInputs = [ stdenv go_1_18 glibc minaSigner ];
+    buildInputs = [ stdenv go_1_19 glibc minaSigner ];
     shellHook = ''
-      export LIB_MINA_SIGNER=${minaSigner}/lib/libmina_signer.so
+      export PKG_MINA_SIGNER=${minaSigner}
       return
     '';
   };


### PR DESCRIPTION
Removes a submodule containing c-reference-signer.

Part of this change was accidentally merged as part #15551 (taken from another PR #15510).

Explain how you tested your changes:
* delegation app compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None