### PR TITLE
Granular nix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 The docs for the Mina Protocol website are published on [docs.minaprotocol.com](https://docs.minaprotocol.com/).
 
 The docs repository is [https://github.com/o1-labs/docs2/](https://github.com/o1-labs/docs2/).
+Hey

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,3 @@
 The docs for the Mina Protocol website are published on [docs.minaprotocol.com](https://docs.minaprotocol.com/).
 
 The docs repository is [https://github.com/o1-labs/docs2/](https://github.com/o1-labs/docs2/).
-Hey

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,51 @@
 {
   "nodes": {
+    "describe-dune": {
+      "inputs": {
+        "flake-utils": [
+          "utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721075915,
+        "narHash": "sha256-pj6C9Y9FP1VKLTtQFAJuaUbxxXvvIZ+kRN3K/9O5Rts=",
+        "owner": "o1-labs",
+        "repo": "describe-dune",
+        "rev": "9aba48884359f9828a3ca68a7b91bf06c0ab8d16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "describe-dune",
+        "type": "github"
+      }
+    },
+    "dune-nix": {
+      "inputs": {
+        "flake-utils": [
+          "utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722325092,
+        "narHash": "sha256-xH6agZYx4TAjdGb5VfDuHcBjuW1VRJmAFtC9bnNTa8k=",
+        "owner": "o1-labs",
+        "repo": "dune-nix",
+        "rev": "f3f459223cab3dc81e74407a85c6e6f464cc9b4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "dune-nix",
+        "type": "github"
+      }
+    },
     "flake-buildkite-pipeline": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -376,6 +422,8 @@
     },
     "root": {
       "inputs": {
+        "describe-dune": "describe-dune",
+        "dune-nix": "dune-nix",
         "flake-buildkite-pipeline": "flake-buildkite-pipeline",
         "flake-compat": "flake-compat",
         "flockenzeit": "flockenzeit",

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722325092,
-        "narHash": "sha256-xH6agZYx4TAjdGb5VfDuHcBjuW1VRJmAFtC9bnNTa8k=",
+        "lastModified": 1722602583,
+        "narHash": "sha256-FwqfasHSL68pEMCtqbV/UvIcAOrV2fH3VDfJ6Hzr478=",
         "owner": "o1-labs",
         "repo": "dune-nix",
-        "rev": "f3f459223cab3dc81e74407a85c6e6f464cc9b4f",
+        "rev": "5866c3e8e101059b5476de34f0d7630280ad2cca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721075915,
-        "narHash": "sha256-pj6C9Y9FP1VKLTtQFAJuaUbxxXvvIZ+kRN3K/9O5Rts=",
+        "lastModified": 1724407960,
+        "narHash": "sha256-pUKTVMYEtsD1AGlHFTdPourowt+tJ3htKhRu7VALFzc=",
         "owner": "o1-labs",
         "repo": "describe-dune",
-        "rev": "9aba48884359f9828a3ca68a7b91bf06c0ab8d16",
+        "rev": "be828239c05671209e979f9d5c2e3094e3be7a46",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722602583,
-        "narHash": "sha256-FwqfasHSL68pEMCtqbV/UvIcAOrV2fH3VDfJ6Hzr478=",
+        "lastModified": 1724418497,
+        "narHash": "sha256-HjTh7o02QhGXmbxmpE5HRWei3H/pyh/NKCMCnucDaYs=",
         "owner": "o1-labs",
         "repo": "dune-nix",
-        "rev": "5866c3e8e101059b5476de34f0d7630280ad2cca",
+        "rev": "26dc164a4c3976888e13eabd73a210b78505820f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -317,7 +317,8 @@
           # Granular nix
           inherit (ocamlPackages)
             src exes all all-tested pkgs all-exes files tested info
-            dune-description base-libs;
+            dune-description base-libs external-libs;
+          # ^ TODO move elsewhere, external-libs isn't a package
           # TODO consider the following: inherit (ocamlPackages) default;
           granular = ocamlPackages.default;
           default = ocamlPackages.mina;

--- a/flake.nix
+++ b/flake.nix
@@ -76,18 +76,6 @@
               command "nix-shell"
             }.
           '';
-      # Only get the ocaml stuff, to reduce the amount of unnecessary rebuilds
-      ocaml-src = with inputs.nix-filter.lib;
-        filter {
-          root = ./.;
-          include = [
-            (inDirectory "src")
-            "dune"
-            "dune-project"
-            "./graphql_schema.json"
-            "opam.export"
-          ];
-        };
     in {
       overlays = {
         misc = import ./nix/misc.nix;
@@ -97,7 +85,6 @@
         ocaml = pkgs: prev: {
           ocamlPackages_mina = requireSubmodules (import ./nix/ocaml.nix {
             inherit inputs pkgs;
-            src = ocaml-src;
           });
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,14 @@
   inputs.opam-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.opam-nix.inputs.opam-repository.follows = "opam-repository";
 
+  inputs.dune-nix.url = "github:o1-labs/dune-nix";
+  inputs.dune-nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.dune-nix.inputs.flake-utils.follows = "utils";
+
+  inputs.describe-dune.url = "github:o1-labs/describe-dune";
+  inputs.describe-dune.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.describe-dune.inputs.flake-utils.follows = "utils";
+
   inputs.o1-opam-repository.url = "github:o1-labs/opam-repository";
   inputs.o1-opam-repository.flake = false;
 
@@ -83,9 +91,8 @@
         go = import ./nix/go.nix;
         javascript = import ./nix/javascript.nix;
         ocaml = pkgs: prev: {
-          ocamlPackages_mina = requireSubmodules (import ./nix/ocaml.nix {
-            inherit inputs pkgs;
-          });
+          ocamlPackages_mina =
+            requireSubmodules (import ./nix/ocaml.nix { inherit inputs pkgs; });
         };
       };
 
@@ -307,6 +314,13 @@
           inherit (ocamlPackages)
             mina devnet mainnet mina_tests mina-ocaml-format mina_client_sdk
             test_executive with-instrumentation;
+          # Granular nix
+          inherit (ocamlPackages)
+            src exes all all-tested pkgs all-exes files tested info
+            dune-description base-libs;
+          # TODO consider the following: inherit (ocamlPackages) default;
+          granular = ocamlPackages.default;
+          default = ocamlPackages.mina;
           inherit (pkgs)
             libp2p_helper kimchi_bindings_stubs snarky_js leaderboard validation
             trace-tool zkapp-cli;
@@ -314,7 +328,6 @@
             mina-image-slim mina-image-full mina-archive-image-full
             mina-image-instr-full;
           mina-deb = debianPackages.mina;
-          default = mina;
         };
 
         # Pure dev shell, from which you can build Mina yourself manually, or hack on it.

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -100,6 +100,40 @@ const handler = async (event, req) => {
       }
     }
 
+    // Mina CI Build section (nix-based)
+    else if (
+      // we are creating the comment
+      req.body.action == "created" &&
+      // and this is actually a pull request
+      req.body.issue.pull_request &&
+      req.body.issue.pull_request.url &&
+      // and the comment contents is exactly the slug we are looking for
+      req.body.comment.body == "!ci-nix-me"
+    ) {
+      const orgData = await getRequest(req.body.sender.organizations_url);
+      // and the comment author is part of the core team
+      if (
+          orgData.data.filter((org) => org.login == "MinaProtocol").length > 0
+      ) {
+        const prData = await getRequest(req.body.issue.pull_request.url);
+        const buildkite = await runBuild(
+          {
+            sender: req.body.sender,
+            pull_request: prData.data,
+          },
+          "mina-nix-experimental",
+          {}
+        );
+        return [buildkite];
+      } else {
+        // NB: Users that are 'privately' a member of the org will not be able to trigger CI jobs
+        return [
+          "comment author is not (publically) a member of the core team",
+          "comment author is not (publically) a member of the core team",
+        ];
+      }
+    }
+
     // Mina CI Build section
     else if (
       // we are creating the comment

--- a/nix/README.md
+++ b/nix/README.md
@@ -617,3 +617,156 @@ Before running any `dune` commands.
 Alternatively, you can just run your commands inside `nix develop
 --ignore-environment mina`, which unsets all the outside environment variables,
 resulting in a more reproducible but less convenient environment.
+
+# Granular nix
+
+A new way to build Mina with nix goes by the catchname "granular nix". It's granular because it relies on splitting the task of building the Mina project to building each opam package defined by Mina in isolation (instead of invoking `dune build` for the whole filetree).
+
+This has a benefit of allowing caching of artifacts and test results.
+
+## Build methodology
+
+Dune files are analyzed by the [o1-labs/describe-dune](https://github.com/o1-labs/describe-dune) tool. Libraries, executables, tests and generated files, along with their mutual dependencies (as present by dune files) are extracted.
+
+After that, dependencies between all of the units (libraries, executables, tests) and files are determined. Then a greedy algorithm attempts to "upgrade" each library/executable dependency to a package dependency. It ends with an error if it fails. But if it succeeds, it comes up with a dependency tree (that can be plotted with `nix build mina#info.deps-graph`) that allows compilation of project's Ocaml code to be executed package-by-package.
+
+Then packages are compiled one by one using `dune`, with dependencies of a package built before it and then provided to the package via `OCAMLPATH` environment variable. Code of each package is isolated from its dependencies and packages that depend on it.
+
+## New nix derivations
+
+There is a bunch of new derivations available using nix flake for Mina repository.
+In subsections there are some examples and the full list of new derivations.
+
+A note on building process and treatment of packages. All of the code is build on a package level. That is, for compilation units (executables, libraries, tests) that are assigned to a package, they are compiled with `dune build --only-packages <package>`. Any of dependencies are pre-built the same way and are provided to `dune` via `OCAMLPATH`.
+
+For compilation units that have no package defined, a synthetic package name is generated. Path to dune directory with these units is quoted by replacing `.` with `__` and `/` with `-` in the package path, and also prepending and appending the resulting string with `__`. E.g. for path `src/test/command_line_tests` a synthetic package `__src-test-command_line_tests__` is generated. Such synthetic packages are built with `dune build <path-to-dune-directory>` (isolation is ensured by filtering out all of irrelevant Ocaml sources).
+
+## Examples
+
+CLI commands below assume to be executed from a directory with Mina repository checked out and `./nix/pin.sh` executed.
+
+| Description | Command |
+|--------------|-------------|
+| Build all Ocaml code, run same tests as in `unit-test.sh` | `nix build mina#granular` |
+| Build all Ocaml code and run all unit tests | `nix build mina#all-tested` |
+| Build all Ocaml code without running tests | `nix build mina#all` |
+| Build `mina_lib` package | `nix build mina#pkgs.mina_lib` |
+| Build `mina_net2` package and run its tests | `nix build mina#tested.mina_net2` |
+| Build `validate_keypair` executable | `nix build mina#exes.validate_keypair` |
+| Run tests from `src/lib/staged_ledger/test` | `nix build mina#tested.__src-lib-staged_ledger-test__` |
+| Plot dependencies of package `mina_lib` | `nix build mina#info.deps-graphs.mina_lib` |
+| Plot dependency graph of Mina repository | `nix build mina#info.deps-graph` |
+| Extract json description of dependencies | `nix build mina#info.deps` |
+
+Dependency description generated via `nix build mina#info.deps --out-link deps.json` is useful for investigation of depencies in a semi-automated way. E.g. to check which executables implicitly depend on `mina_lib`, just run the following `jq` command:
+
+```bash
+$ jq '[.units | to_entries | .[] | { key: .key, value: [ .value.exe? | to_entries? | .[]? | select(.value.pkgs? | contains(["mina_lib"])?) | .key ] } | select (.value != []) | .key ]' <deps.json
+[
+  "__src-app-batch_txn_tool__",
+  "__src-app-graphql_schema_dump__",
+  "__src-app-test_executive__",
+  "cli",
+  "zkapp_test_transaction"
+]
+```
+
+## Combined derivations
+
+Derivations that combine all packages: all of the Ocaml code is built, three options vary in which unit tests are executed.
+
+- `#all`
+  - builds all the Ocaml code discovered in the dune root (libraries, executables, tests)
+  - tests aren't executed
+- `#granular`
+  - `#all` + running all of tests except for tests in `src/app` (behavior similar to `buildkite/scripts/unit-test.sh`)
+- `#all-tested`
+  - `#all` + running all discovered tests
+  - discovery of tests is done by finding `test` stanzas and libraries with `inline_tests` stanza
+
+## Individual compilation units
+
+These allow every package to be compiled/tested in isolation, without requiring all of the other packages to be built (except for dependencies, of course).
+
+- `#pkgs.<package>`
+  - takes sources of the package and builds it with `dune build <package>`
+  - all library dependencies are provided via `OCAMLPATH`
+  - derivation contains everything from the `_build` directory
+- `#src.pkgs.<package>`
+  - show sources of a package (and some relevant files, like `dune` from the parent directory), as filtered for building the `#pkgs.<package>`
+- `#files.<path>`
+  - build all file rules in the `<path>` used by stanzas in other directories
+  - defined only for generated files that are used outside `<path>/dune` scope
+- `#src.files.<path>`
+  - source director used for building `#files.<path>`
+- `#tested.<package>`
+  - same as `#pkgs.<package>`, but also runs tests for the package
+  - note that tests for package's dependencies aren't executed
+
+There are also a few derivations that help build a particular executable. These are merely shortcuts for building a package with an executable and then copying the executable to another directory.
+
+- `#all-exes.<package>.<exe>`
+  - builds a derivation with a single file `bin/<exe>` that is executable with name `<exe>` from package `<package>`
+  - when a public name is available, `<exe>` stands for executable's public name (and private name otherwise)
+- `#exes.<exe>`
+  - shortcut for `#all-exes.<package>.<exe>`
+  - if `<exe>` is defined for multiple packages, error is printed
+  - if `<exe>` is defined in a single package `<pkg>`, it's same as `#all-exes.<pkg>.<exe>`
+
+## Metadata/debug information
+
+- `#info.src`
+  - mapping from dune directory path `dir` to metadata related to files outside of dune directory that is needed for compilation
+  - in particular the following fields:
+     - `subdirs`, containing list of file paths (relative to the `dir`) that contain dune files with compilation units
+     - `file_deps`, containing list of file paths from other dirs which should be included into source when compiling units from `dir` (e.g. some top-level `dune` files which use `env` stanza)
+     - `file_outs`, containing a mapping from absolute path of a file generated by some `rule` stanza of the dune file to type of this file output (for type being one of `promote`, `standard` and `fallback`)
+- `#info.exe`
+  - mapping from executable path (in format like `src/app/archive/archive.exe`) to an object with fields `name` and `package`
+  - `package` field contains name of the package that declares the executable
+  - `name` is either `public_name` of executable (if defined) or simply `name`
+- `#info.package`
+  - mapping from package name to an object containing information about all of the units defined by the package
+  - object schema is the following:
+     ```
+     { exe | lib | test : { public_name: string (optional), name: string, src: string, type: exe | lib | test, deps: [string] }
+     ```
+  - this object contains raw data extracted from dune files
+  - `deps` contains opam library names exactly as defined by dune (ppx-related libraries are concatenated to `libraries`)
+- `#info.separated-libs`
+  - when there is a package-to-package circular dependency, this would be a non-empty object in the format similar to `#info.deps` containing information about edges in dependency graph that form a cycle
+  - useful for debugging when an error `Package ${pkg} has separated lib dependency to packages` which may occur after future edits to dune files
+- `#info.deps`
+  - mapping from files and units to their dependencies
+  - external dependencies (defined outside of repository) are ignored
+  - schema:
+     ```
+     { files: { <path> : { exes: { <package> : [<exe>] } } },
+       units: { <package> : { exe | lib | test : { <name> : { 
+          exes: { <package> : <exe> },
+          files: [<dune dir path>],
+          libs: { <package> : [<lib name>] },
+          pkgs: [ <package> ]
+       } } 
+     }
+     ```
+- `#dune-description`
+  - raw description of dune files as parsed by  [o1-labs/describe-dune](https://github.com/o1-labs/describe-dune) tool
+- `#base-libs`
+  - a derivation that builds an opam repo-like file structure with all of the dependencies from `opam.export` (plus some extra opam packages for building)
+
+## Dependency graphs
+
+- `#info.deps-graph`
+  - generates a dot graph of all of Mina packages (a huge one)
+  - see [example ](https://drive.google.com/file/d/1G_8REbd4-rKJpWBkNOFI4P6_3sWAp2io/view?usp=sharing)(after generating an svg with `nix build mina#info.deps-graph --out-link all.dot && dot -Tsvg -o all.svg all.dot`)
+- `#info.deps-graphs.<package>`
+  - plots package dependencies for the `<package>`
+
+Here's example of graph for `mina_wire_types` package:
+
+![Dependencies of mina_wire_types](https://storage.googleapis.com/o1labs-doc-images/mina_wire_types_dep_diagram.png)
+
+Note that there are a few details of this graph. Graph generated for a package `p` displays may omit some of transitive dependencies of a dependency package if they're formed by units on which `p` has no dependency itself. And dependencies `A -> B` and `B -> C` do not always imply `A -> C`: package `B` may have a test dependent on package `C`, but `A` doesn't depend on that tests, only libraries it uses.
+
+True meaning of this graph is that one can build package by package following edges backwards, building all of the units of a package all at once on each step. Interpretation of a graph for dependency analysis is handy, just it's useful to keep in mind certain details.

--- a/nix/README.md
+++ b/nix/README.md
@@ -729,7 +729,7 @@ There are also a few derivations that help build a particular executable. These 
   - mapping from package name to an object containing information about all of the units defined by the package
   - object schema is the following:
      ```
-     { exe | lib | test : { public_name: string (optional), name: string, src: string, type: exe | lib | test, deps: [string] }
+     { exe | lib | test : { name:  { public_name: string (optional), name: string, src: string, type: exe | lib | test, deps: [string] } }
      ```
   - this object contains raw data extracted from dune files
   - `deps` contains opam library names exactly as defined by dune (ppx-related libraries are concatenated to `libraries`)

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -1,5 +1,5 @@
 # A set defining OCaml parts&dependencies of Minaocamlnix
-{ inputs, src, ... }@args:
+{ inputs, ... }@args:
 let
   opam-nix = inputs.opam-nix.lib.${pkgs.system};
 
@@ -13,7 +13,7 @@ let
 
   repos = with inputs; [ o1-opam-repository opam-repository ];
 
-  export = opam-nix.importOpam "${src}/opam.export";
+  export = opam-nix.importOpam ../opam.export;
 
   # Dependencies required by every Mina package:
   # Packages which are `installed` in the export.
@@ -131,8 +131,18 @@ let
       mina-dev = pkgs.stdenv.mkDerivation ({
         pname = "mina";
         version = "dev";
-        # Prevent unnecessary rebuilds on non-source changes
-        inherit src;
+        # Only get the ocaml stuff, to reduce the amount of unnecessary rebuilds
+        src = with inputs.nix-filter.lib;
+          filter {
+            root = ./..;
+            include = [
+              (inDirectory "src")
+              "dune"
+              "dune-project"
+              "./graphql_schema.json"
+              "opam.export"
+            ];
+          };
 
         withFakeOpam = false;
 

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -4,9 +4,6 @@ let
   opam-nix = inputs.opam-nix.lib.${pkgs.system};
 
   inherit (args) pkgs;
-
-  inherit (builtins) filterSource path;
-
   inherit (pkgs.lib)
     hasPrefix last getAttrs filterAttrs optionalAttrs makeBinPath optionalString
     escapeShellArg;
@@ -68,6 +65,15 @@ let
         rocksdb_stubs = super.rocksdb_stubs.overrideAttrs {
           MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
         };
+
+        # This is needed because
+        # - lld package is not wrapped to pick up the correct linker flags
+        # - bintools package also includes as which is incompatible with gcc
+        lld_wrapped = pkgs.writeShellScriptBin "ld.lld"
+          ''${pkgs.llvmPackages.bintools}/bin/ld.lld "$@"'';
+
+        core =
+          super.core.overrideAttrs { propagatedBuildInputs = [ pkgs.tzdata ]; };
       };
 
   scope =
@@ -85,15 +91,144 @@ let
     [ zlib bzip2 gmp openssl libffi ]
     ++ lib.optional (!(stdenv.isDarwin && stdenv.isAarch64)) jemalloc;
 
+  dune-nix = inputs.dune-nix.lib.${pkgs.system};
+
+  base-libs = dune-nix.squashOpamNixDeps scope.ocaml.version
+    (pkgs.lib.attrVals (builtins.attrNames implicit-deps) scope);
+
+  dune-description = pkgs.stdenv.mkDerivation {
+    pname = "dune-description";
+    version = "dev";
+    src = pkgs.lib.sources.sourceFilesBySuffices ../src [
+      "dune"
+      "dune-project"
+      ".inc"
+      ".opam"
+    ];
+    phases = [ "unpackPhase" "buildPhase" ];
+    buildPhase = ''
+      files=$(ls)
+      mkdir src
+      mv $files src
+      cp ${../dune} dune
+      cp ${../dune-project} dune-project
+      ${
+        inputs.describe-dune.defaultPackage.${pkgs.system}
+      }/bin/describe-dune > $out
+    '';
+  };
+
+  duneDescLoaded = builtins.fromJSON (builtins.readFile dune-description);
+  info = dune-nix.info duneDescLoaded;
+  allDeps = dune-nix.allDeps info;
+  commonOverrides = {
+    DUNE_PROFILE = "dev";
+    buildInputs = [ base-libs ] ++ external-libs;
+    nativeBuildInputs = [ ];
+  };
+  packageHasSrcApp =
+    dune-nix.packageHasUnit ({ src, ... }: pkgs.lib.hasPrefix "src/app/" src);
+  sqlSchemaFiles = with inputs.nix-filter.lib;
+    filter {
+      root = ../src/app/archive;
+      include = [ (matchExt "sql") ];
+    };
+
+  granularBase =
+    dune-nix.outputs' commonOverrides ./.. allDeps info packageHasSrcApp;
+  vmOverlays = let
+    cmdLineTest = ''
+      mina --version
+      mv _build/default/src/test/command_line_tests/command_line_tests.exe tests.exe
+      chmod +x tests.exe
+      export TMPDIR=tmp # to align with janestreet core library
+      mkdir -p $TMPDIR
+      export MINA_LIBP2P_PASS="naughty blue worm"
+      export MINA_PRIVKEY_PASS="naughty blue worm"
+      ./tests.exe --mina-path mina
+    '';
+  in [
+    (dune-nix.testWithVm { } "mina_net2" [ pkgs.libp2p_helper ])
+    (dune-nix.testWithVm { } "__src-lib-mina_net2-tests__"
+      [ pkgs.libp2p_helper ])
+    (self:
+      dune-nix.testWithVm' cmdLineTest { } "__src-test-command_line_tests__" [
+        self.pkgs.cli
+        pkgs.libp2p_helper
+      ] self)
+    (dune-nix.testWithVm { } "__src-lib-staged_ledger-test__" [ ])
+  ];
+  granularCustom = _: super:
+    let
+      makefileTest = pkg:
+        let src = info.pseudoPackages."${pkg}";
+        in dune-nix.makefileTest ./.. pkg src;
+      marlinPlonkStubs = {
+        MARLIN_PLONK_STUBS = "${pkgs.kimchi_bindings_stubs}";
+      };
+      childProcessesTester = pkgs.writeShellScriptBin "mina-tester.sh"
+        (builtins.readFile ../src/lib/child_processes/tester.sh);
+      withLibp2pHelper = (s: {
+        nativeBuildInputs = s.nativeBuildInputs ++ [ pkgs.libp2p_helper ];
+      });
+    in {
+      pkgs.mina_version = super.pkgs.mina_version.overrideAttrs {
+        MINA_COMMIT_SHA1 = inputs.self.sourceInfo.rev or "<dirty>";
+      };
+      pkgs.kimchi_bindings =
+        super.pkgs.kimchi_bindings.overrideAttrs marlinPlonkStubs;
+      pkgs.kimchi_types =
+        super.pkgs.kimchi_types.overrideAttrs marlinPlonkStubs;
+      pkgs.pasta_bindings =
+        super.pkgs.pasta_bindings.overrideAttrs marlinPlonkStubs;
+      pkgs.libp2p_ipc = super.pkgs.libp2p_ipc.overrideAttrs (s: {
+        GO_CAPNP_STD = "${pkgs.go-capnproto2.src}/std";
+        nativeBuildInputs = s.nativeBuildInputs ++ [ pkgs.capnproto ];
+      });
+      pkgs.bindings_js = super.pkgs.bindings_js.overrideAttrs {
+        PLONK_WASM_NODEJS = "${pkgs.plonk_wasm}/nodejs";
+        PLONK_WASM_WEB = "${pkgs.plonk_wasm}/web";
+      };
+      files.src-lib-crypto-kimchi_bindings-js-node_js =
+        super.files.src-lib-crypto-kimchi_bindings-js-node_js.overrideAttrs {
+          PLONK_WASM_NODEJS = "${pkgs.plonk_wasm}/nodejs";
+        };
+      files.src-lib-crypto-kimchi_bindings-js-web =
+        super.files.src-lib-crypto-kimchi_bindings-js-web.overrideAttrs {
+          PLONK_WASM_WEB = "${pkgs.plonk_wasm}/web";
+        };
+      pkgs.__src-lib-ppx_mina-tests__ =
+        makefileTest "__src-lib-ppx_mina-tests__" super;
+      pkgs.__src-lib-ppx_version-test__ =
+        makefileTest "__src-lib-ppx_version-test__" super;
+      tested.child_processes = super.tested.child_processes.overrideAttrs
+        (s: { buildInputs = s.buildInputs ++ [ childProcessesTester ]; });
+      tested.block_storage =
+        super.tested.block_storage.overrideAttrs withLibp2pHelper;
+      tested.mina_lib = super.tested.mina_lib.overrideAttrs withLibp2pHelper;
+      tested.mina_lib_tests =
+        super.tested.mina_lib_tests.overrideAttrs withLibp2pHelper;
+      tested.archive_lib = super.tested.archive_lib.overrideAttrs (s: {
+        buildInputs = s.buildInputs ++ [ pkgs.ephemeralpg ];
+        preBuild = ''
+          export MINA_TEST_POSTGRES="$(pg_tmp -w 1200)"
+          ( cd ${sqlSchemaFiles} && psql "$MINA_TEST_POSTGRES" < create_schema.sql >/dev/null )
+        '';
+      });
+    };
+
+  # We merge overlays in a cutsom way because pkgs.lib.composeManyExtensions
+  # uses `//` for update instead of recursiveUpdate
+  granularOverlay = self: _:
+    let
+      base = granularBase self;
+      overlays = [ granularCustom ] ++ vmOverlays;
+    in builtins.foldl' (super: f: pkgs.lib.recursiveUpdate super (f self super))
+    base overlays;
+
   overlay = self: super:
     let
       ocaml-libs = builtins.attrValues (getAttrs installedPackageNames self);
-
-      # This is needed because
-      # - lld package is not wrapped to pick up the correct linker flags
-      # - bintools package also includes as which is incompatible with gcc
-      lld_wrapped = pkgs.writeShellScriptBin "ld.lld"
-        ''${pkgs.llvmPackages.bintools}/bin/ld.lld "$@"'';
 
       # Make a script wrapper around a binary, setting all the necessary environment variables and adding necessary tools to PATH.
       # Also passes the version information to the executable.
@@ -164,7 +299,7 @@ let
           self.dune
           self.ocamlfind
           self.odoc
-          lld_wrapped
+          self.lld_wrapped
           pkgs.capnproto
           pkgs.removeReferencesTo
           pkgs.fd
@@ -321,5 +456,8 @@ let
       mina-ocaml-format = runMinaCheck { name = "ocaml-format"; } ''
         dune exec --profile=dev src/app/reformat/reformat.exe -- -path . -check
       '';
+
+      inherit dune-description base-libs;
     };
-in scope.overrideScope' overlay
+in scope.overrideScope'
+(pkgs.lib.composeManyExtensions ([ overlay granularOverlay ]))

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -137,6 +137,8 @@ let
   granularBase =
     dune-nix.outputs' commonOverrides ./.. allDeps info packageHasSrcApp;
   vmOverlays = let
+    commit = inputs.self.sourceInfo.rev or "<dirty>";
+    commitShort = builtins.substring 0 8 commit;
     cmdLineTest = ''
       mina --version
       mv _build/default/src/test/command_line_tests/command_line_tests.exe tests.exe
@@ -145,6 +147,9 @@ let
       mkdir -p $TMPDIR
       export MINA_LIBP2P_PASS="naughty blue worm"
       export MINA_PRIVKEY_PASS="naughty blue worm"
+      export MINA_KEYS_PATH=genesis_ledgers
+      mkdir -p $MINA_KEYS_PATH
+      echo '{"ledger":{"accounts":[]}}' > $MINA_KEYS_PATH/config_${commitShort}.json
       ./tests.exe --mina-path mina
     '';
   in [

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -457,7 +457,7 @@ let
         dune exec --profile=dev src/app/reformat/reformat.exe -- -path . -check
       '';
 
-      inherit dune-description base-libs;
+      inherit dune-description base-libs external-libs;
     };
 in scope.overrideScope'
 (pkgs.lib.composeManyExtensions ([ overlay granularOverlay ]))

--- a/src/lib/crypto_params/gen/dune
+++ b/src/lib/crypto_params/gen/dune
@@ -31,7 +31,7 @@
    mina_metrics.none
    logger.fake
  )
- (forbidden_libraries node_config)
+ (forbidden_libraries mina_node_config)
  (preprocess
   (pps ppx_version ppx_bin_prot ppxlib.metaquot))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/dummy_values/gen_values/dune
+++ b/src/lib/dummy_values/gen_values/dune
@@ -23,7 +23,7 @@
    mina_metrics.none
    logger.fake
  )
- (forbidden_libraries node_config protocol_version)
+ (forbidden_libraries mina_node_config protocol_version)
  (preprocess
   (pps ppx_version ppx_jane ppxlib.metaquot))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
_This PR is ought to be rebased after the following PRs are merged: #15510_ 

This PR updates `flake.nix`, `nix/ocaml.nix` to integrate [o1-labs/dune-nix](https://github.com/o1-labs/dune-nix) library into the repository.

This adds a family of derivations that allow:

1. Building any Mina library/executable in isolation from rest of the code
2. Running unit tests
3. Extract useful information about internal dependencies of Mina's Ocaml packages

Crucially, it allows Mina to be built package-by-package, caching build/test results for code that didn't change. This brings CI run (similar to `buildkite/scripts/unit-test.sh`) to be shortened from ~40 minutes to something between 2 minutes and 17 minutes (depending on how deep the changes are).

# Build methodology

Dune files are analyzed by the [o1-labs/describe-dune](https://github.com/o1-labs/describe-dune) tool. Libraries, executables, tests and generated files, along with their mutual dependencies (as present by dune files) are extracted.

After that, dependencies between all of the units (libraries, executables, tests) and files are determined. Then a greedy algorithm attempts to "upgrade" each library/executable dependency to a package dependency. It ends with an error if it fails. But if it succeeds, it comes up with a dependency tree (that can be plotted with `nix build mina#info.deps-graph`) that allows compilation of project's Ocaml code to be executed package-by-package.

Then packages are compiled one by one using `dune`, with dependencies of a package built before it and then provided to the package via `OCAMLPATH` environment variable. Code of each package is isolated from its dependencies and packages that depend on it.

# New nix derivations

There is a bunch of new derivations available using nix flake for Mina repository.
In subsections there are some examples and the full list of new derivations.

A note on building process and treatment of packages. All of the code is build on a package level. That is, for compilation units (executables, libraries, tests) that are assigned to a package, they are compiled with `dune build --only-packages <package>`. Any of dependencies are pre-built the same way and are provided to `dune` via `OCAMLPATH`.

For compilation units that have no package defined, a synthetic package name is generated. Path to dune directory with these units is quoted by replacing `.` with `__` and `/` with `-` in the package path, and also prepending and appending the resulting string with `__`. E.g. for path `src/test/command_line_tests` a synthetic package `__src-test-command_line_tests__` is generated. Such synthetic packages are built with `dune build <path-to-dune-directory>` (isolation is ensured by filtering out all of irrelevant Ocaml sources).

## Examples

CLI commands below assume to be executed from a directory with Mina repository checked out and `./nix/pin.sh` executed.

| Description | Command |
|--------------|-------------|
| Build all Ocaml code, run same tests as in `unit-test.sh` | `nix build mina#granular` |
| Build all Ocaml code and run all unit tests | `nix build mina#all-tested` |
| Build all Ocaml code without running tests | `nix build mina#all` |
| Build `mina_lib` package | `nix build mina#pkgs.mina_lib` |
| Build `mina_net2` package and run its tests | `nix build mina#tested.mina_net2` |
| Build `validate_keypair` executable | `nix build mina#exes.validate_keypair` |
| Run tests from `src/lib/staged_ledger/test` | `nix build mina#tested.__src-lib-staged_ledger-test__` |
| Plot dependencies of package `mina_lib` | `nix build mina#info.deps-graphs.mina_lib` |
| Plot dependency graph of Mina repository | `nix build mina#info.deps-graph` |
| Extract json description of dependencies | `nix build mina#info.deps` |

Dependency description generated via `nix build mina#info.deps --out-link deps.json` is useful for investigation of depencies in a semi-automated way. E.g. to check which executables implicitly depend on `mina_lib`, just run the following `jq` command:

```bash
$ jq '[.units | to_entries | .[] | { key: .key, value: [ .value.exe? | to_entries? | .[]? | select(.value.pkgs? | contains(["mina_lib"])?) | .key ] } | select (.value != []) | .key ]' <deps.json
[
  "__src-app-batch_txn_tool__",
  "__src-app-graphql_schema_dump__",
  "__src-app-test_executive__",
  "cli",
  "zkapp_test_transaction"
]
```

## Combined derivations

Derivations that combine all packages: all of the Ocaml code is built, three options vary in which unit tests are executed.

- `#all`
  - builds all the Ocaml code discovered in the dune root (libraries, executables, tests)
  - tests aren't executed
- `#granular`
  - `#all` + running all of tests except for tests in `src/app` (behavior similar to `buildkite/scripts/unit-test.sh`)
- `#all-tested`
  - `#all` + running all discovered tests
  - discovery of tests is done by finding `test` stanzas and libraries with `inline_tests` stanza

## Individual compilation units

These allow every package to be compiled/tested in isolation, without requiring all of the other packages to be built (except for dependencies, of course).

- `#pkgs.<package>`
  - takes sources of the package and builds it with `dune build <package>`
  - all library dependencies are provided via `OCAMLPATH`
  - derivation contains everything from the `_build` directory
- `#src.pkgs.<package>`
  - show sources of a package (and some relevant files, like `dune` from the parent directory), as filtered for building the `#pkgs.<package>`
- `#files.<path>`
  - build all file rules in the `<path>` used by stanzas in other directories
  - defined only for generated files that are used outside `<path>/dune` scope
- `#src.files.<path>`
  - source director used for building `#files.<path>`
- `#tested.<package>`
  - same as `#pkgs.<package>`, but also runs tests for the package
  - note that tests for package's dependencies aren't executed

There are also a few derivations that help build a particular executable. These are merely shortcuts for building a package with an executable and then copying the executable to another directory.

- `#all-exes.<package>.<exe>`
  - builds a derivation with a single file `bin/<exe>` that is executable with name `<exe>` from package `<package>`
  - when a public name is available, `<exe>` stands for executable's public name (and private name otherwise)
- `#exes.<exe>`
  - shortcut for `#all-exes.<package>.<exe>`
  - if `<exe>` is defined for multiple packages, error is printed
  - if `<exe>` is defined in a single package `<pkg>`, it's same as `#all-exes.<pkg>.<exe>`

## Metadata/debug information

- `#info.src`
  - mapping from dune directory path `dir` to metadata related to files outside of dune directory that is needed for compilation
  - in particular the following fields:
     - `subdirs`, containing list of file paths (relative to the `dir`) that contain dune files with compilation units
     - `file_deps`, containing list of file paths from other dirs which should be included into source when compiling units from `dir` (e.g. some top-level `dune` files which use `env` stanza)
     - `file_outs`, containing a mapping from absolute path of a file generated by some `rule` stanza of the dune file to type of this file output (for type being one of `promote`, `standard` and `fallback`)
- `#info.exe`
  - mapping from executable path (in format like `src/app/archive/archive.exe`) to an object with fields `name` and `package`
  - `package` field contains name of the package that declares the executable
  - `name` is either `public_name` of executable (if defined) or simply `name`
- `#info.package`
  - mapping from package name to an object containing information about all of the units defined by the package
  - object schema is the following:
     ```
     { exe | lib | test : { name:  { public_name: string (optional), name: string, src: string, type: exe | lib | test, deps: [string] } }
     ```
  - this object contains raw data extracted from dune files
  - `deps` contains opam library names exactly as defined by dune (ppx-related libraries are concatenated to `libraries`)
- `#info.separated-libs`
  - when there is a package-to-package circular dependency, this would be a non-empty object in the format similar to `#info.deps` containing information about edges in dependency graph that form a cycle
  - useful for debugging when an error `Package ${pkg} has separated lib dependency to packages` which may occur after future edits to dune files
- `#info.deps`
  - mapping from files and units to their dependencies
  - external dependencies (defined outside of repository) are ignored
  - schema:
     ```
     { files: { <path> : { exes: { <package> : [<exe>] } } },
       units: { <package> : { exe | lib | test : { <name> : { 
          exes: { <package> : <exe> },
          files: [<dune dir path>],
          libs: { <package> : [<lib name>] },
          pkgs: [ <package> ]
       } } 
     }
     ```
- `#dune-description`
  - raw description of dune files as parsed by  [o1-labs/describe-dune](https://github.com/o1-labs/describe-dune) tool
- `#base-libs`
  - a derivation that builds an opam repo-like file structure with all of the dependencies from `opam.export` (plus some extra opam packages for building)

## Dependency graphs

- `#info.deps-graph`
  - generates a dot graph of all of Mina packages (a huge one)
  - see [example ](https://drive.google.com/file/d/1G_8REbd4-rKJpWBkNOFI4P6_3sWAp2io/view?usp=sharing)(after generating an svg with `nix build mina#info.deps-graph --out-link all.dot && dot -Tsvg -o all.svg all.dot`)
- `#info.deps-graphs.<package>`
  - plots package dependencies for the `<package>`

Here's example of graph for `mina_wire_types` package:

![Dependencies of mina_wire_types](https://storage.googleapis.com/o1labs-doc-images/mina_wire_types_dep_diagram.png)

Note that there are a few details of this graph. Graph generated for a package `p` displays may omit some of transitive dependencies of a dependency package if they're formed by units on which `p` has no dependency itself. And dependencies `A -> B` and `B -> C` do not always imply `A -> C`: package `B` may have a test dependent on package `C`, but `A` doesn't depend on that tests, only libraries it uses.

True meaning of this graph is that one can build package by package following edges backwards, building all of the units of a package all at once on each step. Interpretation of a graph for dependency analysis is handy, just it's useful to keep in mind certain details.

# Testing

Via CI:

* Created a branch out of this, merged an unrelated PR
* Posted a comment `!ci-nix-me`
* Observed build completed
* Checked that the build succeeded

Manually:

* Changed some code of tests for some packages
* Ran `nix build mina#tested.<pkg>`, observed failures
* Reverted the change, observed build success

Also, to check the caching:

* Changed some files of packages that are at various depth of the dependency stack
* Ran `nix build mina#granular`
* Confirmed that only necessary packages are rebuilt and have their tests executed
* Confirmed the total build/test time to vary in relation to depth of a change

# Future work

Some work items are left for future:

- Start checking that generated files with `promote` propagation are generated the same way they appear in repository
- Generate Docker images and post their URLs in form of a PR comment after `!ci-nix-me` call
- Optimize nix flake "warm-up": rewrite parts of `dune-nix` from nix to Ocaml (processing is inefficient in the current form)
- Improve UX on handling build jobs that failed (upload separate logs to the Buildkite job)

# Checklist

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None