### PR TITLE
Move static resources https://github.com/MinaProtocol/mina-resources 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ src/libp2p_ipc/libp2p_ipc.capnp.go
 src/libp2p_ipc/libp2p_ipc_capnp.ml
 src/libp2p_ipc/libp2p_ipc_capnp.mli
 maintenance/*.dot
-maintenance/*.png
 
 scripts/mina-local-network/genesis_ledger.json
 scripts/mina-local-network/annotated_ledger.json
@@ -65,8 +64,6 @@ automation/scripts/service_keys
 automation/scripts/genesis_ledger.json
 automation/scripts/annotated_ledger.json
 
-automation/Digraph.gv
-automation/Digraph.gv.png
 automation/**/__pycache__/**
 
 automation/nightly-logs
@@ -75,7 +72,6 @@ automation/daemon.json
 
 automation/discord_webhook_url.txt
 automation/*-accounts.csv
-automation/block_tree.gv.png
 automation/gcloud-keyfile.json
 automation/services/watchdog/check_libp2p/check_libp2p
 

--- a/README-branching.md
+++ b/README-branching.md
@@ -38,7 +38,7 @@ The relationship between the branches is as presented: `master ‚äÜ compatible ‚ä
 - When merely a new feature is introduced, it should aim at the exact target branch. This place depends on the feature, e.g. `compatible` for softfork features, `develop` for more experimental/next release, etc. And then the merged feature is back-propagated downstream (to the right).
 
 
-![Illustration of the branching strategy](docs/res/branching_flow_david_wong.png)
+![Illustration of the branching strategy](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/branching_flow_david_wong.png)
 
 
 

--- a/automation/scripts/github_branch_autosync/README.md
+++ b/automation/scripts/github_branch_autosync/README.md
@@ -31,19 +31,6 @@ It is prepared to receive github webhook payload json on new commit to specified
     
     c) if there are not conflicts : start buildkite pipeline (TBD) to verify changes. If they passes merge pr and exit
 
-##### Examples:
-
-###### No conflict 
-
-![No conflict](./docs/res/CASE1.jpg)
-
-###### Conflict
-
-![Conflict](./docs/res/CASE2.jpg)
-
-###### Update sync branch while on conflict
-
-![Update branch while conflict](./docs/res/CASE3.jpg)
 
 # Configuration
 

--- a/automation/scripts/github_branch_autosync/docs/res/CASE1.jpg
+++ b/automation/scripts/github_branch_autosync/docs/res/CASE1.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87bb8575ed49da4b98d0494f2117d85b2ef922f2c74c821b3c62110b3e879774
-size 33159

--- a/automation/scripts/github_branch_autosync/docs/res/CASE2.jpg
+++ b/automation/scripts/github_branch_autosync/docs/res/CASE2.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcd36ff4f1257411a7c08b4b861964aaa3e61e77568f986cb9dcf94a76cca1bf
-size 41727

--- a/automation/scripts/github_branch_autosync/docs/res/CASE3.jpg
+++ b/automation/scripts/github_branch_autosync/docs/res/CASE3.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b52e0ad98bf3c366495ef08172b82a3a40cecd25e5901b33311f07435cc7c07
-size 38677

--- a/docs/block-producer.md
+++ b/docs/block-producer.md
@@ -4,4 +4,4 @@
 ## Block production Scheduling
 [block-production-scheduling]: #block-production-scheduling
 
-![](res/block_production_fsm.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/block_production_fsm.png)

--- a/docs/res/all_data_structures.dot.png
+++ b/docs/res/all_data_structures.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fed6771190a9b063246074bbfe3b1fc0ba4240fdc41abcf026d5bc449ca4f9b8
-size 415306

--- a/docs/res/block_production_fsm.dot.png
+++ b/docs/res/block_production_fsm.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:711ca84bf2ef3c9392759edf01b175fa51d26e1d46511d46534bfada4aca0716
-size 42609

--- a/docs/res/branching_flow.png
+++ b/docs/res/branching_flow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01ab798f7a179a1f7d527f6b3d2f13d8371b90746796bcf0f01d0d8e1508514d
-size 21897

--- a/docs/res/branching_flow_david_wong.png
+++ b/docs/res/branching_flow_david_wong.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:641f257d41678a6fdd305d357cb56c5e5ec0cc11cf702363341a066514a5277b
-size 38814

--- a/docs/res/consensus_hooks.dot.png
+++ b/docs/res/consensus_hooks.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:855eb770681c13327e850e7a2ef07dbb166c1d4af7bf14ea159aa2d116018816
-size 79307

--- a/docs/res/ledger_builder_data_structures.dot.png
+++ b/docs/res/ledger_builder_data_structures.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93c9fe78a218a36e913663a7ec220af4a24a00608d4f06cad640ff1142c7635e
-size 50891

--- a/docs/res/ledgers_in_frontier.png
+++ b/docs/res/ledgers_in_frontier.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d6295baa768a9a344f756c84c2b7d57fab2510c6ca949cef79922348f15df8d
-size 35314

--- a/docs/res/ledgers_in_frontier.tex.png
+++ b/docs/res/ledgers_in_frontier.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:010d9139b473b6674d90e98175984a40458b3e7e78bd82f71d70df8122aacec1
-size 32831

--- a/docs/res/tracing-example.png
+++ b/docs/res/tracing-example.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a90046bac9bd997affa180b5b6ca6a4c65da9b1b25b2380263c0a23fb636e0b
-size 13970

--- a/docs/res/transition_frontier_controller.dot.png
+++ b/docs/res/transition_frontier_controller.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83406a6f8cc5c4b56ead39bb833b7447c862792a05ed155d36a8c76777b9059a
-size 117735

--- a/docs/testnet-guardian-runbook.md
+++ b/docs/testnet-guardian-runbook.md
@@ -50,7 +50,7 @@ Some strings to look for: `Received a block`, `apply_diff block info`, `Number o
 
 Publish the multiaddresses of the seed nodes on `#QA-net details` channel for the rest of the team to connect to the QA-net.
 Seeds nodes can be looked up here: https://console.cloud.google.com/compute. Usually there are two seed nodes per tesnet, click on the seed node instance to go to the page that has details about the instance required to ssh into it.
-<img src="res/gcloud_ssh.png" alt="ssh info" width="300"/>
+<img src="https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/gcloud_ssh.png" alt="ssh info" width="300"/>
 
 `docker exec -it <container> /bin/bash` into coda-daemon container and follow [this](#multiaddress) to get the multiaddress of the node. These are then published on the website (https://codaprotocol.com/docs/getting-started) for users to connect to the testnet.
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -20,7 +20,7 @@ Each row corresponds to a "task" as created by either `O1trace.trace_task` or
 it works by doing one `trace_task` per call, and the `trace-tool` knows how
 to collapse them all into one row.
 
-![screenshot of trace-viewer showing nested measure calls](./res/tracing-example.png)
+![screenshot of trace-viewer showing nested measure calls](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/tracing-example.png)
 
 In the screenshot, the top green bar represents the root of a recurring task.
 The bars underneath it each correspond to a `measure` call - which can be nested.

--- a/helm/zkapps-dashboard/_img/architecture.svg
+++ b/helm/zkapps-dashboard/_img/architecture.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f766fef012941b8e58c370906a885cbb0ae50d62008e45c848eab1e3607c798
-size 336563

--- a/helm/zkapps-dashboard/_img/light_bulb.svg
+++ b/helm/zkapps-dashboard/_img/light_bulb.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9177173339b242f338bbb80bc3a2b0b077683c06e8aa2b65452cbf17d7d1165
-size 1355

--- a/rfcs/0009-transition-frontier-controller.md
+++ b/rfcs/0009-transition-frontier-controller.md
@@ -258,7 +258,7 @@ flow of the full system in an attempt to make it very easy to trace data flow.
 
 Consult the following diagram:
 
-![](../docs/res/transition_frontier_controller.dot.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/transition_frontier_controller.dot.png)
 
 Blue arrows represent pipes and asynchronous boundaries of the system. Each
 arrow is annotated with the behavior when overflow of the pipe occurs.

--- a/rfcs/0010-decompose-ledger-builder.md
+++ b/rfcs/0010-decompose-ledger-builder.md
@@ -11,9 +11,9 @@ The staged ledger has been suffering from scope creep for some time now. As we a
 ## Detailed design
 [detailed-design]: #detailed-design
 
-[Full architecture](../docs/res/all_data_structures.dot.png)
+[Full architecture](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/all_data_structures.dot.png)
 
-![](../docs/res/ledger_builder_data_structures.dot.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/ledger_builder_data_structures.dot.png)
 
 ### `Merkle_ledger`
 

--- a/rfcs/0028-frontier-synchronization.md
+++ b/rfcs/0028-frontier-synchronization.md
@@ -15,7 +15,7 @@ This design centers around a new synchronization cycle for the frontier which cr
 
 #### Diagram
 
-![](res/frontier_synchronization.conv.tex.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/rfcs/res/frontier_synchronization.conv.tex.png)
 
 #### Frontier Synchronization Cycle
 

--- a/rfcs/0032-automated-validation.md
+++ b/rfcs/0032-automated-validation.md
@@ -31,11 +31,11 @@ From the list of validation queries, the automated validation can solve for othe
 
 Below is a diagram which displays how the system is initialized given the validation queries and resource database. From the information computed during this initialization, the automated validation service can create the various processes and external resources (such as log sinks on google cloud) necessary to perform the requested validations on the requested resources.
 
-![](./res/automated_validation_init_architecture.conv.tex.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/automated_validation_init_architecture.conv.tex.png)
 
 The following diagram shows the runtime architecture of the processes in the system once initialization has been completed. Note how this diagram shows that statistics may consume multiple providers, and validations may consume multiple statistics.
 
-![](./res/automated_validation_runtime_architecture.conv.tex.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/automated_validation_runtime_architecture.conv.tex.png)
 
 #### Resources
 [detailed-design-architecture-resources]: #detailed-design-architecture-resources

--- a/rfcs/0034-reduce-scan-state-memory-usage.md
+++ b/rfcs/0034-reduce-scan-state-memory-usage.md
@@ -37,11 +37,11 @@ ScanState &\triangleq TreeStructureOverhead \\
 
 For convenience, I have created a [python script](res/scan_state_memory_usage.py) which computes the scan state size in relation to the scan state depth and delay. As per [scan\_state\_constants.ml](https://github.com/MinaProtocol/mina/blob/8f4f05b50764a09fb748a590a7c50cd89bbed94d/src/lib/snark_params/scan_state_constants.ml), the scan state depth is computed by `1 + ceil(log2(MaxUserCommandsPerBlock + 2))`, and the maximum number of user commands per a block is set by `MaxTPS * W / 1000` (where `W` is the length of a slot in ms). Thus, at block windows of 30 seconds and a target `MaxTPS` of 1, the scan state depth would be `1 + ceil(log2((1 * 30000 / 1000) + 2)) == 1 + ceil(log2(32)) == 6`, and at 3 minute block windows, it would be `1 + ceil(log2((1 * 180000 / 1000) + 2)) == 1 + ceil(log2(182)) == 9`. The number of trees in a scan state is effected by both the depth of the scan state and the scan state delay. Scan state delay is a parameter which we will select closer to mainnet launch based on how many active snark workers we expect to be online (as well as the ratio of transaction snark proving time to slot length). Below is a graph of what the scan state size would be at various parameterizations of delay, for both 30 second slots and 3 minute slots.
 
-![](res/scan_state_memory_usage.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/scan_state_memory_usage.png)
 
 For convenience, the 30 second (depth 6) graph is shown alone below so that the values are easier to inspect.
 
-![](res/scan_state_memory_usage_depth_6.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/scan_state_memory_usage_depth_6.png)
 
 [Raw CSV data](res/scan_state_memory_usage.csv)
 

--- a/rfcs/0044-node-status-and-node-error-backend.md
+++ b/rfcs/0044-node-status-and-node-error-backend.md
@@ -18,7 +18,7 @@ We need a backend for node staus/error systems. Candidates for the backend inclu
 
 Google Cloud Loggind provides storage and data searching/visualization of logs. It provides a handy command line sdk tool. But unfortunately there's no official support for ocaml binding. The architecture of the Google Cloud Logging is depicted as following: 
 
-![](res/gcloud_logging.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/gcloud_logging.png)
 
 For the frontend, each nodes would have 2 command line options to allow them to sed node status/error reports to any specific url: `--node-status-url URL` and `--node-error-url URL`. By default users would send their reports to our backend. They could change the destination by providing their own destination `URL` to the command options. Those setting could also be changed in the daemon.json file for the corresponding field.
 
@@ -56,7 +56,7 @@ In summary, we need to setup a micro-service for each corresponding system and w
 
 The AWS stack provides the log storage and data searching/visualization.
 
-![](res/aws_stack.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/aws_stack.png)
 
 Like the diagram shown above, we would setup a public Kenesis firehose data stream where the mina client can push to. And this Kenesis data stream would be connected to the S3 bucket, the OpenSearch and Kibana. (Splunk and Redshift are potential  tools that we could utilize but we would not use them in this project.)
 

--- a/rfcs/0049-protocol-testing.md
+++ b/rfcs/0049-protocol-testing.md
@@ -122,7 +122,7 @@ Some of the metrics we want can be expressed as unit benchmarks, which are easy 
 
 Below is a diagram of the proposed testing architecture, showing a high level dataflow of the components involved in executing tests. Details are left abstract over where the tests will be running for now as the architecture is intended to remain the same, primarily swapping out the orchestra backend to change testing environments.
 
-![](res/abstract_testing_architecture.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/abstract_testing_architecture.png)
 
 ##### Orchestrator/Orchestra
 

--- a/rfcs/0053-hard-fork-package-generation.md
+++ b/rfcs/0053-hard-fork-package-generation.md
@@ -68,7 +68,7 @@ The hard fork package will be generated in a buildkite pipeline. The buildkite p
 
 Here is a diagram of the various buildkite jobs required to generate the hard fork package:
 
-![](res/hard-fork-package-generation-buildkite-pipeline.dot.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/hard-fork-package-generation-buildkite-pipeline.dot.png)
 
 The `build_daemon` job will build the daemon with the correct compile time configuration for mainnet (`mainnet.mlh`). The hard fork specific configuration will be provided via a static runtime configuration that is bundled with the hard fork release.
 

--- a/rfcs/res/abstract_testing_architecture.conv.tex.png
+++ b/rfcs/res/abstract_testing_architecture.conv.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e8669ecef8bc52dd0d445eec3ab3c1fa7b4293379ec35b171280d747d71eaa5
-size 32583

--- a/rfcs/res/abstract_testing_architecture.png
+++ b/rfcs/res/abstract_testing_architecture.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba64d381f60f2ce66efabca90cc94cbcf8bbe1da3b4e7819307027b569c42698
-size 136352

--- a/rfcs/res/abstract_testing_architecture.tex.png
+++ b/rfcs/res/abstract_testing_architecture.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eef39e5735b98d5169e9b2c908771228dcafce5d036aca1a3c943fb5a3b5f2d6
-size 61975

--- a/rfcs/res/automated_validation_init_architecture.conv.tex.png
+++ b/rfcs/res/automated_validation_init_architecture.conv.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3a0466fded671be07f15d050c688fdd183de9802812bc71a177d6a6afa07f1a
-size 30434

--- a/rfcs/res/automated_validation_runtime_architecture.conv.tex.png
+++ b/rfcs/res/automated_validation_runtime_architecture.conv.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6463fbfc189411326b2fff9a8143748e11384de9d1efb7f955efcc3472df9b0
-size 49390

--- a/rfcs/res/aws_stack.png
+++ b/rfcs/res/aws_stack.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0ee9d7877ef541b0b262dba9897aaac740a04f0769d1be9ed7dc48e5b32511d
-size 166374

--- a/rfcs/res/frontier_synchronization.conv.tex.png
+++ b/rfcs/res/frontier_synchronization.conv.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e24b4d2d25bbcac234c479d95cf7cdb71b4b938e06e0b478ec3a096c2e4e509
-size 70915

--- a/rfcs/res/gcloud_logging.png
+++ b/rfcs/res/gcloud_logging.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce8073f1610882f76be219069de7ddbfaa1f9477c8c05f5aa28b2add1e5751ad
-size 179973

--- a/src/app/zkapp_test_transaction/README.md
+++ b/src/app/zkapp_test_transaction/README.md
@@ -281,7 +281,7 @@ mutation MyMutation {
 }
 ```
 
-Send the generated graphQL object to the local daemon via GraphiQL interface at http://localhost:3085/graphql ![Screenshot](res/deploy-zkapp.png)
+Send the generated graphQL object to the local daemon via GraphiQL interface at http://localhost:3085/graphql ![Screenshot](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/deploy-zkapp.png)
 
 
 After the transaction is sent and included in a block, a new zkapp account with the verification of the test smart contract gets created. The account information can be queried through the graphQL `account` query.
@@ -345,7 +345,7 @@ Query result:
   }
 }
 ```
-![Screenshot](res/account-after-deploy.png)
+![Screenshot](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/account-after-deploy.png)
 
 #### 2. Update zkapp state
 
@@ -544,7 +544,7 @@ Result of the query
   }
 }
 ```
-![Screenshot](res/account-after-state-update.png)
+![Screenshot](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/account-after-state-update.png)
 
 #### 3. Update Account Permissions
 
@@ -770,4 +770,4 @@ Result of the query
   }
 }
 ```
-![Screenshot](res/account-after-setting-permissions.png)
+![Screenshot](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/account-after-setting-permissions.png)

--- a/src/app/zkapp_test_transaction/res/account-after-deploy.png
+++ b/src/app/zkapp_test_transaction/res/account-after-deploy.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8551e0030deda0ecc1c05eb7f7573d332f52a87596f81c7d8a86541ed90862e
-size 174569

--- a/src/app/zkapp_test_transaction/res/account-after-setting-permissions.png
+++ b/src/app/zkapp_test_transaction/res/account-after-setting-permissions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a625fc186a8bc3a936afacacf75ffbf8d4fd4433f8f3037c60982505aa53ebec
-size 132817

--- a/src/app/zkapp_test_transaction/res/account-after-state-update.png
+++ b/src/app/zkapp_test_transaction/res/account-after-state-update.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c2e3a5b9214d8c440c3ddb1542e84da73585147ae9b9d5dc97328d6cddf0fa2
-size 95053

--- a/src/app/zkapp_test_transaction/res/deploy-zkapp.png
+++ b/src/app/zkapp_test_transaction/res/deploy-zkapp.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:213ff797bf4f124edd0d22acb48cde32407a926d99143e766da776742e7521af
-size 235474

--- a/src/lib/transition_frontier/README.md
+++ b/src/lib/transition_frontier/README.md
@@ -85,7 +85,7 @@ The persistent frontier is an on-disk, limited representation of a frontier, alo
 
 The persistent frontier receives a notification every time diffs are applied to the full frontier. When this notification is received, the persistent frontier writes any diffs that were applied into a diff buffer. At a later point in time, this diff buffer is flushed, and all of the recorded diffs are performed against the persistent frontier's database. All diffs are processed in the buffer, but the auxiliary root data stored in the persistent frontier is only updated 1 time per flush.
 
-![](./res/persistent_frontier_concurrency.dot.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/persistent_frontier_concurrency.dot.png)
 
 #### Diff Buffer Flush Rules
 
@@ -126,7 +126,7 @@ TODO
 
 The transition frontier combines together the full frontier, persistent frontier, root history, and extensions into a single interface. It configures the root history to contain at most `2*k` previous roots, giving a total span of `3*k` blocks in the chains stored at any given time. This is done so that nodes can serve bootstrap requests (proofs of finality) to nodes within `2*k` blocks of the best tip.
 
-![](./res/transition_frontier_diagram.conv.tex.png)
+![](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/transition_frontier_diagram.conv.tex.png)
 
 ## Code Directory
 

--- a/src/lib/transition_frontier/res/persistent_frontier_concurrency.dot.png
+++ b/src/lib/transition_frontier/res/persistent_frontier_concurrency.dot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:002fd1840aa4d1bda5bf8ed92c36fdad6675e09612925a0bff09eff544b40f88
-size 34174

--- a/src/lib/transition_frontier/res/transition_frontier_diagram.conv.tex.png
+++ b/src/lib/transition_frontier/res/transition_frontier_diagram.conv.tex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be62ccc188f329d88a7a1af752ad52185da999b380c20395e0c5e1506b5dd872
-size 12821


### PR DESCRIPTION
Due to issues with LFS quota, we are moving all static resources like various images  to new repo: 
`https://github.com/MinaProtocol/mina-resources` and moving all references to new repository