### PR TITLE
Meaningful error message in case of failed GQL zkApp command (stale verification key case).

### DIFF
--- a/src/lib/mina_graphql/zkapps.ml
+++ b/src/lib/mina_graphql/zkapps.ml
@@ -3,6 +3,18 @@ open Async
 open Mina_transaction
 
 let send_zkapp_command mina zkapp_command =
+  let replace_error_message error_msg =
+    (* Define the pattern to match and the replacement message *)
+    let pattern =
+      Re2.create_exn "Verification_failed \\(Invalid_proof \"In progress\"\\)"
+    in
+    let replacement =
+      "Stale verification key detected. Please make sure that deployed \
+       verification key reflects zkApp changes."
+    in
+    (* Replace the matched pattern with the replacement message *)
+    Re2.replace_exn pattern ~f:(fun _ -> replacement) error_msg
+  in
   match Mina_commands.setup_and_submit_zkapp_command mina zkapp_command with
   | `Active f -> (
       match%map f with
@@ -20,8 +32,9 @@ let send_zkapp_command mina zkapp_command =
           in
           Ok cmd_with_hash
       | Error e ->
-          Error
-            (sprintf "Couldn't send zkApp command: %s" (Error.to_string_hum e))
+          let original_error_msg = Error.to_string_hum e in
+          let meaningful_error_msg = replace_error_message original_error_msg in
+          Error (sprintf "Couldn't send zkApp command: %s" meaningful_error_msg)
       )
   | `Bootstrapping ->
       return (Error "Daemon is bootstrapping")

--- a/src/lib/mina_graphql/zkapps.ml
+++ b/src/lib/mina_graphql/zkapps.ml
@@ -1,9 +1,10 @@
 open Core
 open Async
 open Mina_transaction
+open Re2
 
 let send_zkapp_command mina zkapp_command =
-  let replace_error_message error_msg =
+  let update_error_message error_msg =
     (* Define the pattern to match and the replacement message *)
     let pattern =
       Re2.create_exn "Verification_failed \\(Invalid_proof \"In progress\"\\)"
@@ -33,8 +34,7 @@ let send_zkapp_command mina zkapp_command =
           Ok cmd_with_hash
       | Error e ->
           let original_error_msg = Error.to_string_hum e in
-          let meaningful_error_msg = replace_error_message original_error_msg in
-          Error (sprintf "Couldn't send zkApp command: %s" meaningful_error_msg)
-      )
+          let updated_error_msg = update_error_message original_error_msg in
+          Error (sprintf "Couldn't send zkApp command: %s" updated_error_msg) )
   | `Bootstrapping ->
       return (Error "Daemon is bootstrapping")


### PR DESCRIPTION
To provide more information to the end users instead of the:

```log
Couldn't send zkApp command: (Verification_failed (Invalid_proof "In progress"))
```