### PR TITLE
Fix Terraform tests by synthetically creating required seed peerid files

### DIFF
--- a/automation/terraform/modules/o1-testnet/files.tf
+++ b/automation/terraform/modules/o1-testnet/files.tf
@@ -15,10 +15,23 @@
 #   ]
 # }
 
+# Generate random strings for peer IDs
+resource "random_id" "peer_id" {
+  for_each = var.create_libp2p_files ? toset(local.seed_names) : []
+  byte_length = 32
+}
+
+# Create the files with the generated peer IDs
+resource "local_file" "libp2p_seed_peers" {
+  for_each = var.create_libp2p_files ? toset(local.seed_names) : []
+  filename = "${var.artifact_path}/keys/libp2p-keys/${each.key}.peerid"
+  content  = random_id.peer_id[each.key].hex
+}
+
 data "local_file" "libp2p_seed_peers" {
   for_each = toset(local.seed_names)
   filename = "${var.artifact_path}/keys/libp2p-keys/${each.key}.peerid"
-  #   depends_on = [
-  #     null_resource.block_producer_key_generation
-  #   ]
+  depends_on = [
+    local_file.libp2p_seed_peers
+  ]
 }

--- a/automation/terraform/modules/o1-testnet/inputs.tf
+++ b/automation/terraform/modules/o1-testnet/inputs.tf
@@ -30,6 +30,13 @@ variable "artifact_path" {
   default = "/tmp"
 }
 
+# Variable to control file creation
+variable "create_libp2p_files" {
+  description = "Whether to create LibP2P peer ID files"
+  type        = bool
+  default     = false
+}
+
 variable "mina_image" {
   type    = string
   default = "gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet"

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -62,6 +62,12 @@ variable "ci_artifact_path" {
   default = "/tmp"
 }
 
+variable "create_libp2p_files" {
+  type        = bool
+  description = "Whether to create LibP2P peer ID files"
+  default     = true
+}
+
 locals {
   seed_region = "us-west1"
   seed_zone   = "us-west1-b"
@@ -72,6 +78,8 @@ module "ci_testnet" {
   source = "../../modules/o1-testnet"
 
   artifact_path = var.ci_artifact_path
+
+  create_libp2p_files = var.create_libp2p_files
 
   # TODO: remove obsolete cluster_name var + cluster region
   cluster_name   = "mina-integration-west1"

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -65,7 +65,7 @@ variable "ci_artifact_path" {
 variable "create_libp2p_files" {
   type        = bool
   description = "Whether to create LibP2P peer ID files"
-  default     = true
+  default     = false
 }
 
 locals {

--- a/buildkite/scripts/terraform-test.sh
+++ b/buildkite/scripts/terraform-test.sh
@@ -5,7 +5,7 @@ function test_single_terraform_config {
     cd $1
 
     terraform init
-    terraform plan
+    terraform plan -var="create_libp2p_files=true"
 
     RET=$?
 


### PR DESCRIPTION
This PR creates the required `peerid` key files in order to make the `terraform plan` command succeed.

As the Terraform file is not applied, this fix makes the job succeed and still tells us the Terraform files are ok in terms of syntax and functionality.