### PR TITLE
Use mina_version_compiled in test_executive

### DIFF
--- a/src/app/generate_keypair/dune
+++ b/src/app/generate_keypair/dune
@@ -3,7 +3,7 @@
  (name generate_keypair)
  (public_name generate_keypair)
  (modes native)
- (libraries cli_lib async core_kernel mina_version async_unix bounded_types)
+ (libraries cli_lib async core_kernel mina_version_compiled async_unix bounded_types)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_let ppx_sexp_conv))
  (flags -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/app/rosetta/ocaml-signer/dune
+++ b/src/app/rosetta/ocaml-signer/dune
@@ -24,6 +24,7 @@
    snark_params
    pickles.backend
    secrets
+   mina_version_compiled
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps

--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -62,7 +62,9 @@
   cache_dir
   snarky.backendless
   bounded_types
-  block_time)
+  block_time
+  mina_version_compiled
+ )
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/validate_keypair/dune
+++ b/src/app/validate_keypair/dune
@@ -9,7 +9,7 @@
    async
    async_unix
    ;; local libraries
-   mina_version
+   mina_version_compiled
    bounded_types
    cli_lib
  )


### PR DESCRIPTION
Problem: `test_executive` uses wrong version of `mina_version` virtual package, for that reason `[UNKNOWN]` was used in generation of testnet id instead of short commit id.

Explain how you tested your changes:
* [ ] Confirm successful execution of intg tests

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None