### PR TITLE
Remove commit field for Pickles

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -487,7 +487,6 @@ end) : S = struct
       ~constraint_constants:
         (Genesis_constants.Constraint_constants.to_snark_keys_header
            constraint_constants )
-      ~commit:Mina_version.commit_id
       ~choices:(fun ~self ->
         [ rule ~proof_level ~constraint_constants T.tag self ] )
 

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -37,7 +37,6 @@
    data_hash_lib
    ppx_version.runtime
    snark_keys_header
-   mina_version
  )
  (inline_tests (flags -verbose -show-counts))
  (preprocess

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -353,7 +353,6 @@ struct
            (module Nat.Add.Intf with type n = max_proofs_verified)
       -> name:string
       -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-      -> ?commit:string
       -> public_input:
            ( var
            , value
@@ -384,7 +383,7 @@ struct
          { step_storable; step_vk_storable; wrap_storable; wrap_vk_storable }
        ~proof_cache ?disk_keys ?override_wrap_domain ?override_wrap_main
        ?(num_chunks = 1) ~branches:(module Branches) ~max_proofs_verified ~name
-       ?constraint_constants ?commit ~public_input ~auxiliary_typ ~choices () ->
+       ?constraint_constants ~public_input ~auxiliary_typ ~choices () ->
     let snark_keys_header kind constraint_system_hash =
       let constraint_constants : Snark_keys_header.Constraint_constants.t =
         match constraint_constants with
@@ -406,7 +405,6 @@ struct
       { Snark_keys_header.header_version = Snark_keys_header.header_version
       ; kind
       ; constraint_constants
-      ; commit = Option.value ~default:"[NOT SPECIFIED]" commit
       ; length = (* This is a dummy, it gets filled in on read/write. *) 0
       ; constraint_system_hash
       ; identifying_hash =
@@ -1021,7 +1019,6 @@ let compile_with_wrap_main_override_promise :
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commit:string
     -> choices:
          (   self:(var, value, max_proofs_verified, branches) Tag.t
           -> ( prev_varss
@@ -1056,7 +1053,7 @@ let compile_with_wrap_main_override_promise :
  fun ?self ?(cache = []) ?(storables = Storables.default) ?proof_cache
      ?disk_keys ?override_wrap_domain ?override_wrap_main ?num_chunks
      ~public_input ~auxiliary_typ ~branches ~max_proofs_verified ~name
-     ?constraint_constants ?commit ~choices () ->
+     ?constraint_constants ~choices () ->
   let self =
     match self with
     | None ->
@@ -1125,7 +1122,7 @@ let compile_with_wrap_main_override_promise :
     M.compile ~self ~proof_cache ~cache ~storables ?disk_keys
       ?override_wrap_domain ?override_wrap_main ?num_chunks ~branches
       ~max_proofs_verified ~name ~public_input ~auxiliary_typ
-      ?constraint_constants ?commit
+      ?constraint_constants
       ~choices:(fun ~self -> conv_irs (choices ~self))
       ()
   in

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -314,7 +314,6 @@ val compile_with_wrap_main_override_promise :
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
   -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-  -> ?commit:string
   -> choices:
        (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
         -> ( 'prev_varss

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -188,7 +188,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               ; account_creation_fee = Unsigned.UInt64.of_int 0
               ; fork = None
               }
-          ; commit = ""
           ; length = 0
           ; constraint_system_hash = ""
           ; identifying_hash = ""
@@ -317,15 +316,14 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ?commit ~choices () =
+      ~max_proofs_verified ~name ?constraint_constants ~choices () =
     compile_with_wrap_main_override_promise ?self ?cache ?storables ?proof_cache
       ?disk_keys ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~branches ~max_proofs_verified ~name ?constraint_constants ?commit
-      ~choices ()
+      ~branches ~max_proofs_verified ~name ?constraint_constants ~choices ()
 
   let compile ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ?commit ~choices () =
+      ~max_proofs_verified ~name ?constraint_constants ~choices () =
     let choices ~self =
       let choices = choices ~self in
       let rec go :
@@ -348,7 +346,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-        ~max_proofs_verified ~name ?constraint_constants ?commit ~choices ()
+        ~max_proofs_verified ~name ?constraint_constants ~choices ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -365,7 +363,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_async ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ?commit ~choices () =
+      ~max_proofs_verified ~name ?constraint_constants ~choices () =
     let choices ~self =
       let choices = choices ~self in
       let rec go :
@@ -393,7 +391,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-        ~max_proofs_verified ~name ?constraint_constants ?commit ~choices ()
+        ~max_proofs_verified ~name ?constraint_constants ~choices ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -1085,7 +1083,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 Snark_keys_header.header_version
             ; kind
             ; constraint_constants
-            ; commit = "[NOT SPECIFIED]"
             ; length = (* This is a dummy, it gets filled in on read/write. *) 0
             ; constraint_system_hash
             ; identifying_hash =

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -415,7 +415,6 @@ module type S = sig
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commit:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss
@@ -472,7 +471,6 @@ module type S = sig
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commit:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss
@@ -529,7 +527,6 @@ module type S = sig
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-    -> ?commit:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss

--- a/src/lib/snark_keys_header/snark_keys_header.ml
+++ b/src/lib/snark_keys_header/snark_keys_header.ml
@@ -130,7 +130,6 @@ type t =
   { header_version : int
   ; kind : Kind.t
   ; constraint_constants : Constraint_constants.t
-  ; commit : string
   ; length : int
   ; constraint_system_hash : string
   ; identifying_hash : string
@@ -226,7 +225,6 @@ let%test_module "Check parsing of header" =
           ; account_creation_fee = Unsigned.UInt64.of_int 1
           ; fork = None
           }
-      ; commit = "7e1fb2cd9138af1d0f24e78477efd40a2a0fcd07"
       ; length = 4096
       ; constraint_system_hash = "ABCDEF1234567890"
       ; identifying_hash = "ABCDEF1234567890"

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -68,7 +68,6 @@
    logger
    zkapp_command_builder
    snark_keys_header
-   mina_version
  )
  (preprocess
   (pps ppx_snarky ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3318,7 +3318,6 @@ module Make_str (A : Wire_types.Concrete) = struct
       ~constraint_constants:
         (Genesis_constants.Constraint_constants.to_snark_keys_header
            constraint_constants )
-      ~commit:Mina_version.commit_id
       ~choices:(fun ~self ->
         let zkapp_command x =
           Base.Zkapp_command_snark.rule ~constraint_constants ~proof_level x


### PR DESCRIPTION
Commit id was only used for snark header files. This could be safely removed.

Explain how you tested your changes:
* Pickles code compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None