### PR TITLE
Make "ledger" field required in runtime config

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1011,18 +1011,14 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
           (str proof_level) (str compiled)
   in
   let%bind genesis_ledger, ledger_config, ledger_file =
-    Ledger.load ~proof_level ~genesis_dir ~logger ~constraint_constants
-      ?overwrite_version
-      (Option.value config.ledger
-         ~default:
-           { base = Named Mina_compile_config.genesis_ledger
-           ; num_accounts = None
-           ; balances = []
-           ; s3_data_hash = None
-           ; hash = None
-           ; name = None
-           ; add_genesis_winner = None
-           } )
+    match config.ledger with
+    | Some ledger ->
+        Ledger.load ~proof_level ~genesis_dir ~logger ~constraint_constants
+          ?overwrite_version ledger
+    | None ->
+        [%log fatal] "No ledger was provided in the runtime configuration" ;
+        Deferred.Or_error.errorf
+          "No ledger was provided in the runtime configuration"
   in
   [%log info] "Loaded genesis ledger from $ledger_file"
     ~metadata:[ ("ledger_file", `String ledger_file) ] ;

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -6,8 +6,6 @@
 
 let curve_size = Node_config.curve_size
 
-let genesis_ledger = Node_config.genesis_ledger
-
 let default_transaction_fee_string = Node_config.default_transaction_fee
 
 let default_snark_worker_fee_string = Node_config.default_snark_worker_fee

--- a/src/lib/mina_compile_config/mina_compile_config.mli
+++ b/src/lib/mina_compile_config/mina_compile_config.mli
@@ -1,7 +1,5 @@
 val curve_size : int
 
-val genesis_ledger : string
-
 val default_transaction_fee_string : string
 
 val default_snark_worker_fee_string : string

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -42,7 +42,16 @@ let%test_module "Epoch ledger sync tests" =
           { daemon = None
           ; genesis = None
           ; proof = None
-          ; ledger = None
+          ; ledger =
+              Some
+                { base = Named "test"
+                ; num_accounts = None
+                ; balances = []
+                ; hash = None
+                ; s3_data_hash = None
+                ; name = None
+                ; add_genesis_winner = None
+                }
           ; epoch_data = None
           }
         in

--- a/src/lib/node_config/node_config.ml
+++ b/src/lib/node_config/node_config.ml
@@ -66,8 +66,6 @@ let scan_state_transaction_capacity_log_2 =
 
 [%%inject "plugins", plugins]
 
-[%%inject "genesis_ledger", genesis_ledger]
-
 [%%inject "genesis_state_timestamp", genesis_state_timestamp]
 
 [%%inject "block_window_duration", block_window_duration]

--- a/src/lib/node_config/node_config.mli
+++ b/src/lib/node_config/node_config.mli
@@ -46,8 +46,6 @@ val supercharged_coinbase_factor : int
 
 val plugins : bool
 
-val genesis_ledger : string
-
 val genesis_state_timestamp : string
 
 val block_window_duration : int

--- a/src/lib/test_genesis_ledger/test_genesis_ledger.ml
+++ b/src/lib/test_genesis_ledger/test_genesis_ledger.ml
@@ -1,5 +1,5 @@
 include Genesis_ledger.Make (struct
-  include (val Genesis_ledger.fetch_ledger_exn Node_config.genesis_ledger)
+  include (val Genesis_ledger.fetch_ledger_exn "test")
 
   let directory = `Ephemeral
 


### PR DESCRIPTION
This PR raises an error if no configuration file has set the `ledger` field for the network, instead of falling back to a test ledger.

This removes one of the compile-time configuration variables.