### PR TITLE
[Rosetta] Remove newline characters from GraphQL query body

### DIFF
--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -26,8 +26,9 @@ let graphql_error_to_string e =
 let query query_obj uri =
   let variables_string = Yojson.Basic.to_string query_obj#variables in
   let body_string =
-    Printf.sprintf {|{"query": "%s", "variables": %s}|} query_obj#query
-      variables_string
+    String.substr_replace_all ~pattern:"\n" ~with_:""
+    @@ Printf.sprintf {|{"query": "%s", "variables": %s}|} query_obj#query
+         variables_string
   in
   let open Deferred.Result.Let_syntax in
   let headers =


### PR DESCRIPTION
This pull request removes newline characters from the GraphQL query body to ensure compatibility with proxied servers.