### PR TITLE
Pipeless initial validator

### DIFF
--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -344,9 +344,9 @@ module type Transition_router_intf = sig
          * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
          Strict_pipe.Reader.t
     -> producer_transition_reader:breadcrumb Strict_pipe.Reader.t
-    -> most_recent_valid_block:
-         Mina_block.initial_valid_block Broadcast_pipe.Reader.t
-         * Mina_block.initial_valid_block Broadcast_pipe.Writer.t
+    -> get_most_recent_valid_block:(unit -> Mina_block.initial_valid_block)
+    -> most_recent_valid_block_writer:
+         Mina_block.initial_valid_block Broadcast_pipe.Writer.t
     -> get_completed_work:
          (   Transaction_snark_work.Statement.t
           -> Transaction_snark_work.Checked.t option )

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -335,9 +335,9 @@ module type Transition_router_intf = sig
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root_location:string
     -> persistent_frontier_location:string
-    -> frontier_broadcast_pipe:
-         transition_frontier option Pipe_lib.Broadcast_pipe.Reader.t
-         * transition_frontier option Pipe_lib.Broadcast_pipe.Writer.t
+    -> get_current_frontier:(unit -> transition_frontier option)
+    -> frontier_broadcast_writer:
+         transition_frontier option Pipe_lib.Broadcast_pipe.Writer.t
     -> network_transition_reader:
          ( [ `Transition of Mina_block.t Envelope.Incoming.t ]
          * [ `Time_received of Block_time.t ]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2019,9 +2019,9 @@ let create ~commit_id ?wallets (config : Config.t) =
               ~consensus_local_state:config.consensus_local_state
               ~persistent_root_location:config.persistent_root_location
               ~persistent_frontier_location:config.persistent_frontier_location
-              ~frontier_broadcast_pipe:
-                (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
-              ~catchup_mode ~network_transition_reader:block_reader
+              ~get_current_frontier
+              ~frontier_broadcast_writer:frontier_broadcast_pipe_w ~catchup_mode
+              ~network_transition_reader:block_reader
               ~producer_transition_reader ~get_most_recent_valid_block
               ~most_recent_valid_block_writer
               ~get_completed_work:

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -234,18 +234,18 @@ end
 
 let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
     ~precomputed_values =
+  let genesis_state_hash =
+    (Precomputed_values.genesis_state_hashes precomputed_values).state_hash
+  in
+  let genesis_constants =
+    Precomputed_values.genesis_constants precomputed_values
+  in
+  let rejected_blocks_logger =
+    Logger.create ~id:Logger.Logger_id.rejected_blocks ()
+  in
+  let duplicate_checker = Duplicate_block_detector.create () in
   stage (fun ~transition_env ~time_received ~valid_cb ->
-      let genesis_state_hash =
-        (Precomputed_values.genesis_state_hashes precomputed_values).state_hash
-      in
-      let genesis_constants =
-        Precomputed_values.genesis_constants precomputed_values
-      in
-      let rejected_blocks_logger =
-        Logger.create ~id:Logger.Logger_id.rejected_blocks ()
-      in
       let open Deferred.Let_syntax in
-      let duplicate_checker = Duplicate_block_detector.create () in
       if Ivar.is_full initialization_finish_signal then (
         let blockchain_length =
           Envelope.Incoming.data transition_env

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib.Strict_pipe
 open Mina_base
 open Mina_state
 open Signature_lib
@@ -233,8 +232,8 @@ module Duplicate_block_detector = struct
           [%log error] ~metadata msg )
 end
 
-let validate ~logger ~trust_system ~verifier ~valid_transition_writer
-    ~initialization_finish_signal ~precomputed_values =
+let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
+    ~precomputed_values =
   stage (fun ~transition_env ~time_received ~valid_cb ->
       let genesis_state_hash =
         (Precomputed_values.genesis_state_hashes precomputed_values).state_hash
@@ -288,30 +287,37 @@ let validate ~logger ~trust_system ~verifier ~valid_transition_writer
                 >>= defer validate_protocol_versions)
             with
             | Ok verified_transition ->
-                Writer.write valid_transition_writer
-                  ( `Block
-                      (Envelope.Incoming.wrap ~data:verified_transition ~sender)
-                  , `Valid_cb valid_cb ) ;
                 Mina_metrics.Transition_frontier.update_max_blocklength_observed
                   blockchain_length ;
                 Queue.enqueue Transition_frontier.validated_blocks
                   ( State_hash.With_state_hashes.state_hash transition_with_hash
                   , sender
                   , time_received ) ;
-                return ()
+                return
+                  (Ok
+                     ( `Block
+                         (Envelope.Incoming.wrap ~data:verified_transition
+                            ~sender )
+                     , `Valid_cb valid_cb ) )
             | Error error ->
                 Mina_net2.Validation_callback.fire_if_not_already_fired valid_cb
                   `Reject ;
-                Interruptible.uninterruptible
-                @@ handle_validation_error ~logger ~rejected_blocks_logger
-                     ~time_received ~trust_system ~sender ~transition_with_hash
-                     ~delta:genesis_constants.protocol.delta error
+                let%map () =
+                  Interruptible.uninterruptible
+                  @@ handle_validation_error ~logger ~rejected_blocks_logger
+                       ~time_received ~trust_system ~sender
+                       ~transition_with_hash
+                       ~delta:genesis_constants.protocol.delta error
+                in
+                Error ()
           in
           Interruptible.force computation )
         else Deferred.Result.fail () )
         >>| function
-        | Ok () ->
-            ()
+        | Ok (Ok res) ->
+            Ok res
+        | Ok (Error ()) ->
+            Error ()
         | Error () ->
             let state_hash =
               ( Envelope.Incoming.data transition_env
@@ -329,20 +335,6 @@ let validate ~logger ~trust_system ~verifier ~valid_transition_writer
               ]
             in
             [%log error] ~metadata
-              "Dropping blocks because libp2p validation expired" )
-      else Deferred.unit )
-
-let run ~logger ~trust_system ~verifier ~transition_reader
-    ~valid_transition_writer ~initialization_finish_signal ~precomputed_values =
-  let validate =
-    unstage
-      (validate ~logger ~trust_system ~verifier ~valid_transition_writer
-         ~initialization_finish_signal ~precomputed_values )
-  in
-  O1trace.background_thread "initially_validate_blocks" (fun () ->
-      Reader.iter transition_reader
-        ~f:(fun
-             ( `Transition transition_env
-             , `Time_received time_received
-             , `Valid_cb valid_cb )
-           -> validate ~transition_env ~time_received ~valid_cb ) )
+              "Dropping blocks because libp2p validation expired" ;
+            Error () )
+      else Deferred.Result.fail () )

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -233,142 +233,116 @@ module Duplicate_block_detector = struct
           [%log error] ~metadata msg )
 end
 
+let validate ~logger ~trust_system ~verifier ~valid_transition_writer
+    ~initialization_finish_signal ~precomputed_values =
+  stage (fun ~transition_env ~time_received ~valid_cb ->
+      let genesis_state_hash =
+        (Precomputed_values.genesis_state_hashes precomputed_values).state_hash
+      in
+      let genesis_constants =
+        Precomputed_values.genesis_constants precomputed_values
+      in
+      let rejected_blocks_logger =
+        Logger.create ~id:Logger.Logger_id.rejected_blocks ()
+      in
+      let open Deferred.Let_syntax in
+      let duplicate_checker = Duplicate_block_detector.create () in
+      if Ivar.is_full initialization_finish_signal then (
+        let blockchain_length =
+          Envelope.Incoming.data transition_env
+          |> Mina_block.blockchain_length |> Mina_numbers.Length.to_int
+        in
+        Mina_metrics.Transition_frontier
+        .update_max_unvalidated_blocklength_observed blockchain_length ;
+        ( if not (Mina_net2.Validation_callback.is_expired valid_cb) then (
+          let transition_with_hash =
+            Envelope.Incoming.data transition_env
+            |> With_hash.of_data
+                 ~hash_data:
+                   (Fn.compose Protocol_state.hashes
+                      (Fn.compose Header.protocol_state Mina_block.header) )
+          in
+          Duplicate_block_detector.check ~precomputed_values
+            ~rejected_blocks_logger ~time_received duplicate_checker logger
+            transition_with_hash ;
+          let sender = Envelope.Incoming.sender transition_env in
+          let computation =
+            let open Interruptible.Let_syntax in
+            let defer f x =
+              Interruptible.uninterruptible @@ Deferred.return (f x)
+            in
+            let%bind () =
+              Interruptible.lift Deferred.unit
+                (Mina_net2.Validation_callback.await_timeout valid_cb)
+            in
+            match%bind
+              let open Interruptible.Result.Let_syntax in
+              Validation.(
+                wrap transition_with_hash
+                |> defer
+                     (validate_time_received ~precomputed_values ~time_received)
+                >>= defer (validate_genesis_protocol_state ~genesis_state_hash)
+                >>= Fn.compose Interruptible.uninterruptible
+                      (validate_single_proof ~verifier ~genesis_state_hash)
+                >>= defer validate_delta_block_chain
+                >>= defer validate_protocol_versions)
+            with
+            | Ok verified_transition ->
+                Writer.write valid_transition_writer
+                  ( `Block
+                      (Envelope.Incoming.wrap ~data:verified_transition ~sender)
+                  , `Valid_cb valid_cb ) ;
+                Mina_metrics.Transition_frontier.update_max_blocklength_observed
+                  blockchain_length ;
+                Queue.enqueue Transition_frontier.validated_blocks
+                  ( State_hash.With_state_hashes.state_hash transition_with_hash
+                  , sender
+                  , time_received ) ;
+                return ()
+            | Error error ->
+                Mina_net2.Validation_callback.fire_if_not_already_fired valid_cb
+                  `Reject ;
+                Interruptible.uninterruptible
+                @@ handle_validation_error ~logger ~rejected_blocks_logger
+                     ~time_received ~trust_system ~sender ~transition_with_hash
+                     ~delta:genesis_constants.protocol.delta error
+          in
+          Interruptible.force computation )
+        else Deferred.Result.fail () )
+        >>| function
+        | Ok () ->
+            ()
+        | Error () ->
+            let state_hash =
+              ( Envelope.Incoming.data transition_env
+              |> Mina_block.header |> Header.protocol_state
+              |> Protocol_state.hashes )
+                .state_hash
+            in
+            let metadata =
+              [ ("state_hash", State_hash.to_yojson state_hash)
+              ; ( "time_received"
+                , `String
+                    (Time.to_string_abs
+                       (Block_time.to_time_exn time_received)
+                       ~zone:Time.Zone.utc ) )
+              ]
+            in
+            [%log error] ~metadata
+              "Dropping blocks because libp2p validation expired" )
+      else Deferred.unit )
+
 let run ~logger ~trust_system ~verifier ~transition_reader
     ~valid_transition_writer ~initialization_finish_signal ~precomputed_values =
-  let genesis_state_hash =
-    (Precomputed_values.genesis_state_hashes precomputed_values).state_hash
+  let validate =
+    unstage
+      (validate ~logger ~trust_system ~verifier ~valid_transition_writer
+         ~initialization_finish_signal ~precomputed_values )
   in
-  let genesis_constants =
-    Precomputed_values.genesis_constants precomputed_values
-  in
-  let rejected_blocks_logger =
-    Logger.create ~id:Logger.Logger_id.rejected_blocks ()
-  in
-  let open Deferred.Let_syntax in
-  let duplicate_checker = Duplicate_block_detector.create () in
   O1trace.background_thread "initially_validate_blocks" (fun () ->
       Reader.iter transition_reader
         ~f:(fun
              ( `Transition transition_env
              , `Time_received time_received
              , `Valid_cb valid_cb )
-           ->
-          let state_hash =
-            ( Envelope.Incoming.data transition_env
-            |> Mina_block.header |> Header.protocol_state
-            |> Protocol_state.hashes )
-              .state_hash
-          in
-          Internal_tracing.Context_call.with_call_id ~tag:"initial_validation"
-          @@ fun () ->
-          Internal_tracing.with_state_hash state_hash
-          @@ fun () ->
-          [%log internal] "Initial_validation" ;
-          if Ivar.is_full initialization_finish_signal then (
-            let blockchain_length =
-              Envelope.Incoming.data transition_env
-              |> Mina_block.blockchain_length |> Mina_numbers.Length.to_int
-            in
-            Mina_metrics.Transition_frontier
-            .update_max_unvalidated_blocklength_observed blockchain_length ;
-            ( if not (Mina_net2.Validation_callback.is_expired valid_cb) then (
-              let transition_with_hash =
-                Envelope.Incoming.data transition_env
-                |> With_hash.of_data
-                     ~hash_data:
-                       (Fn.compose Protocol_state.hashes
-                          (Fn.compose Header.protocol_state Mina_block.header) )
-              in
-              Duplicate_block_detector.check ~precomputed_values
-                ~rejected_blocks_logger ~time_received duplicate_checker logger
-                transition_with_hash ;
-              let sender = Envelope.Incoming.sender transition_env in
-              let computation =
-                let open Interruptible.Let_syntax in
-                let defer f x =
-                  Interruptible.uninterruptible @@ Deferred.return (f x)
-                in
-                let%bind () =
-                  Interruptible.lift Deferred.unit
-                    (Mina_net2.Validation_callback.await_timeout valid_cb)
-                in
-                match%bind
-                  let open Interruptible.Result.Let_syntax in
-                  Validation.(
-                    wrap transition_with_hash
-                    |> defer
-                         (validate_time_received ~precomputed_values
-                            ~time_received )
-                    >>= defer
-                          (validate_genesis_protocol_state ~genesis_state_hash)
-                    >>= Fn.compose Interruptible.uninterruptible
-                          (validate_single_proof ~verifier ~genesis_state_hash)
-                    >>= defer validate_delta_block_chain
-                    >>= defer validate_protocol_versions)
-                with
-                | Ok verified_transition ->
-                    [%log internal] "Initial_validation_done" ;
-                    Writer.write valid_transition_writer
-                      ( `Block
-                          (Envelope.Incoming.wrap ~data:verified_transition
-                             ~sender )
-                      , `Valid_cb valid_cb ) ;
-                    Mina_metrics.Transition_frontier
-                    .update_max_blocklength_observed blockchain_length ;
-                    Queue.enqueue Transition_frontier.validated_blocks
-                      ( State_hash.With_state_hashes.state_hash
-                          transition_with_hash
-                      , sender
-                      , time_received ) ;
-                    return ()
-                | Error error ->
-                    Internal_tracing.with_state_hash state_hash
-                    @@ fun () ->
-                    [%log internal] "Failure"
-                      ~metadata:
-                        [ ( "reason"
-                          , `String
-                              ( "Failed initial validation: "
-                              ^ Sexp.to_string
-                                  ([%sexp_of: validation_error] error) ) )
-                        ] ;
-                    Mina_net2.Validation_callback.fire_if_not_already_fired
-                      valid_cb `Reject ;
-                    Interruptible.uninterruptible
-                    @@ handle_validation_error ~logger ~rejected_blocks_logger
-                         ~time_received ~trust_system ~sender
-                         ~transition_with_hash
-                         ~delta:genesis_constants.protocol.delta error
-              in
-              Interruptible.force computation )
-            else Deferred.Result.fail () )
-            >>| function
-            | Ok () ->
-                ()
-            | Error () ->
-                let state_hash =
-                  ( Envelope.Incoming.data transition_env
-                  |> Mina_block.header |> Header.protocol_state
-                  |> Protocol_state.hashes )
-                    .state_hash
-                in
-                Internal_tracing.with_state_hash state_hash
-                @@ fun () ->
-                [%log internal] "Failure"
-                  ~metadata:
-                    [ ("reason", `String "Validation callback expired") ] ;
-                let metadata =
-                  [ ("state_hash", State_hash.to_yojson state_hash)
-                  ; ( "time_received"
-                    , `String
-                        (Time.to_string_abs
-                           (Block_time.to_time_exn time_received)
-                           ~zone:Time.Zone.utc ) )
-                  ]
-                in
-                [%log error] ~metadata
-                  "Dropping blocks because libp2p validation expired" )
-          else (
-            [%log internal] "Failure"
-              ~metadata:[ ("reason", `String "Node still initializing") ] ;
-            Deferred.unit ) ) )
+           -> validate ~transition_env ~time_received ~valid_cb ) )

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -575,9 +575,28 @@ let run ?(sync_local_state = true) ~context:(module Context : CONTEXT)
               ~valid_cb ~pipe_name:name ~logger )
           ()
       in
-      Initial_validator.run ~logger ~trust_system ~verifier
-        ~transition_reader:network_transition_reader ~valid_transition_writer
-        ~initialization_finish_signal ~precomputed_values ;
+      let () =
+        let initial_validate =
+          unstage
+            (Initial_validator.validate ~logger ~trust_system ~verifier
+               ~initialization_finish_signal ~precomputed_values )
+        in
+        O1trace.background_thread "initially_validate_blocks" (fun () ->
+            Pipe_lib.Strict_pipe.Reader.iter network_transition_reader
+              ~f:(fun
+                   ( `Transition transition_env
+                   , `Time_received time_received
+                   , `Valid_cb valid_cb )
+                 ->
+                match%map
+                  initial_validate ~transition_env ~time_received ~valid_cb
+                with
+                | Ok valid_transition ->
+                    Pipe_lib.Strict_pipe.Writer.write valid_transition_writer
+                      valid_transition
+                | Error () ->
+                    () ) )
+      in
       let persistent_frontier =
         Transition_frontier.Persistent_frontier.create ~logger ~verifier
           ~time_controller ~directory:persistent_frontier_location

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -514,10 +514,9 @@ let run ?(sync_local_state = true) ~context:(module Context : CONTEXT)
     ~consensus_local_state ~persistent_root_location
     ~persistent_frontier_location
     ~frontier_broadcast_pipe:(frontier_r, frontier_w) ~network_transition_reader
-    ~producer_transition_reader
-    ~most_recent_valid_block:
-      (most_recent_valid_block_reader, most_recent_valid_block_writer)
-    ~get_completed_work ~catchup_mode ~notify_online () =
+    ~producer_transition_reader ~get_most_recent_valid_block
+    ~most_recent_valid_block_writer ~get_completed_work ~catchup_mode
+    ~notify_online () =
   let open Context in
   [%log info] "Starting transition router" ;
   let initialization_finish_signal = Ivar.create () in
@@ -609,9 +608,7 @@ let run ?(sync_local_state = true) ~context:(module Context : CONTEXT)
              let incoming_transition =
                Envelope.Incoming.data enveloped_transition
              in
-             let current_transition =
-               Broadcast_pipe.Reader.peek most_recent_valid_block_reader
-             in
+             let current_transition = get_most_recent_valid_block () in
              if
                Consensus.Hooks.equal_select_status `Take
                  (Consensus.Hooks.select

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -512,8 +512,8 @@ let wait_till_genesis ~logger ~time_controller
 let run ?(sync_local_state = true) ~context:(module Context : CONTEXT)
     ~trust_system ~verifier ~network ~is_seed ~is_demo_mode ~time_controller
     ~consensus_local_state ~persistent_root_location
-    ~persistent_frontier_location
-    ~frontier_broadcast_pipe:(frontier_r, frontier_w) ~network_transition_reader
+    ~persistent_frontier_location ~get_current_frontier
+    ~frontier_broadcast_writer:frontier_w ~network_transition_reader
     ~producer_transition_reader ~get_most_recent_valid_block
     ~most_recent_valid_block_writer ~get_completed_work ~catchup_mode
     ~notify_online () =
@@ -632,7 +632,7 @@ let run ?(sync_local_state = true) ~context:(module Context : CONTEXT)
                   let incoming_transition =
                     Envelope.Incoming.data enveloped_transition
                   in
-                  match Broadcast_pipe.Reader.peek frontier_r with
+                  match get_current_frontier () with
                   | Some frontier ->
                       if
                         is_transition_for_bootstrap


### PR DESCRIPTION
This PR performs a small refactor on the `Initial_validator` library, turning it into a helper function `Initial_validator.validate` called directly from the pipe in `Transition_validator`, instead of running it as a sub-process.