### PR TITLE
More aggressive refactor of bootstrap controller

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -511,14 +511,14 @@ let main_loop ~context:(module Context : CONTEXT) ~trust_system ~verifier
                    cycle_result = "failed to download and construct scan state"
                  } )
         | Ok res ->
+            let%bind () =
+              Trust_system.(
+                record t.trust_system logger sender
+                  Actions.
+                    ( Fulfilled_request
+                    , Some ("Received valid scan state from peer", []) ))
+            in
             return (Ok res)
-      in
-      let%bind () =
-        Trust_system.(
-          record t.trust_system logger sender
-            Actions.
-              ( Fulfilled_request
-              , Some ("Received valid scan state from peer", []) ))
       in
       let best_seen_block_with_hash, _ = t.best_seen_transition in
       let consensus_state =

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -633,20 +633,20 @@ let main_loop ~context:(module Context : CONTEXT) ~trust_system ~verifier
             Gauge.set Bootstrap.num_of_root_snarked_ledger_retargeted
               (Float.of_int t.num_of_root_snarked_ledger_retargeted)) ;
           (* step 2. Download scan state and pending coinbases. *)
+          let%bind.Deferred.Result stage_2 =
+            download_scan_state_and_pending_coinbases t stage_1
+          in
+          (* step 3. Construct staged ledger from snarked ledger, scan state
+             and pending coinbases. *)
+          (* Construct the staged ledger before constructing the transition
+           * frontier in order to verify the scan state we received.
+           * TODO: reorganize the code to avoid doing this twice (#3480) *)
           let%bind.Deferred.Result ({ scan_state
                                     ; pending_coinbases = pending_coinbase
                                     ; new_root
                                     ; protocol_states
                                     }
                                      : Stages.stage_3 ) =
-            let%bind.Deferred.Result stage_2 =
-              download_scan_state_and_pending_coinbases t stage_1
-            in
-            (* step 3. Construct staged ledger from snarked ledger, scan state
-               and pending coinbases. *)
-            (* Construct the staged ledger before constructing the transition
-             * frontier in order to verify the scan state we received.
-             * TODO: reorganize the code to avoid doing this twice (#3480) *)
             construct_root_staged_ledger t stage_2
           in
           (* step 4. Synchronize consensus local state if necessary *)

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -520,16 +520,16 @@ let main_loop ~context:(module Context : CONTEXT) ~trust_system ~verifier
             in
             return (Ok res)
       in
-      let best_seen_block_with_hash, _ = t.best_seen_transition in
-      let consensus_state =
-        With_hash.data best_seen_block_with_hash
-        |> Mina_block.header |> Mina_block.Header.protocol_state
-        |> Protocol_state.consensus_state
-      in
       (* step 4. Synchronize consensus local state if necessary *)
       let%bind.Deferred.Result () =
         use_time_deferred (set_local_state_sync_time t.cycle_stats)
           ~f:(fun () ->
+            let best_seen_block_with_hash, _ = t.best_seen_transition in
+            let consensus_state =
+              With_hash.data best_seen_block_with_hash
+              |> Mina_block.header |> Mina_block.Header.protocol_state
+              |> Protocol_state.consensus_state
+            in
             match
               Consensus.Hooks.required_local_state_sync
                 ~constants:precomputed_values.consensus_constants

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -383,6 +383,9 @@ let download_snarked_ledger ({ context = (module Context); _ } as t)
       let%map _, (_, sender) = Sync_ledger.Db.valid_tree root_sync_ledger in
       t.ledger_sync_state <- Ledger_sync_finished ;
       Sync_ledger.Db.destroy root_sync_ledger ;
+      Mina_metrics.(
+        Gauge.set Bootstrap.num_of_root_snarked_ledger_retargeted
+          (Float.of_int t.num_of_root_snarked_ledger_retargeted)) ;
       ({ temp_persistent_root_instance; sender } : Stages.stage_1) )
 
 let download_scan_state_and_pending_coinbases
@@ -799,9 +802,6 @@ let main_loop ~context:(module Context : CONTEXT) ~trust_system ~verifier
               ~f:(fun stage_0 ->
                 (* step 1. download snarked_ledger *)
                 let%bind stage_1 = download_snarked_ledger t stage_0 in
-                Mina_metrics.(
-                  Gauge.set Bootstrap.num_of_root_snarked_ledger_retargeted
-                    (Float.of_int t.num_of_root_snarked_ledger_retargeted)) ;
                 (* step 2. Download scan state and pending coinbases. *)
                 let%bind.Deferred.Result stage_2 =
                   download_scan_state_and_pending_coinbases t stage_1


### PR DESCRIPTION
This PR builds upon  #15921 and #15922, with a series of commits incrementally splitting up bootstrap controller into stages.

Importantly, this refactor also lifts the pipe logic out of any of the individual stages, in preparation for the pipes to be lifted out of this module entirely.

This refactor makes the core control flow approximately
```ocaml
(* step 1. download snarked_ledger *)
let%bind stage_1 = download_snarked_ledger t stage_0 in
(* step 2. Download scan state and pending coinbases. *)
let%bind.Deferred.Result stage_2 =
  download_scan_state_and_pending_coinbases t stage_1
in
(* step 3. Construct staged ledger from snarked ledger, scan state
   and pending coinbases. *)
(* Construct the staged ledger before constructing the transition
 * frontier in order to verify the scan state we received.
 * TODO: reorganize the code to avoid doing this twice (#3480) *)
let%bind stage_3 = construct_root_staged_ledger t stage_2 in
(* step 4. Synchronize consensus local state if necessary *)
let%bind.Deferred.Result () =
  synchronize_consensus_local_state t consensus_local_state
in
(* step 5. Close the old frontier and reload a new one from disk. *)
let%map res =
  close_and_reload_frontier t ~consensus_local_state ~persistent_root
    ~persistent_frontier ~catchup_mode stage_3
in
```
(with some slight adjustments for resource management), where `t` is a `Bootstrap_controller.t` and `stage_0` is the initialisation state. From this point, it should be natural to rework the transition router's surrounding logic to be roughly
```ocaml
let bootstrap_controller = Bootstrap_controller.create ... in
don't_wait_for
  (Reader.iter boostrap_controller_reader
    ~f:(Boostrap_controller.handle_incoming_transition bootstrap_controller) ) ;
let%bind (new_frontier, collected_transitions) =
  Boostrap_controller.run boostrap_controller ...
in
...
```
and thus start unwinding some of the pipe spaghetti there.

_**Reviewer note:** this refactor may be easier to review commit by commit to check for correctness. Even without this, the logical flow is more consistent when reviewing with 'ignore whitespace changes' enabled._