### PR TITLE
add soft fail to RosettaIntegrationTests

### DIFF
--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -1,3 +1,5 @@
+let B = ../../External/Buildkite.dhall
+
 let Cmd = ../../Lib/Cmds.dhall
 
 let S = ../../Lib/SelectFiles.dhall
@@ -19,6 +21,8 @@ let Dockers = ../../Constants/DockerVersions.dhall
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let RunWithPostgres = ../../Command/RunWithPostgres.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 let dirtyWhen =
       [ S.strictlyStart (S.contains "src")
@@ -59,6 +63,7 @@ in  Pipeline.build
               ]
             , label = "Rosetta integration tests Bullseye"
             , key = "rosetta-integration-tests-bullseye"
+            , soft_fail = Some (B/SoftFail.Boolean True)
             , target = Size.Small
             , depends_on =
                 Dockers.dependsOn


### PR DESCRIPTION
Making rosetta integration tests soft fail until fixed