### PR TITLE
fixing error message for node logging

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -75,7 +75,7 @@ let assert_filehash_equal ~file ~hash ~logger =
   else
     let%map () = Unix.rename ~src:file ~dst:(file ^ ".incorrect-hash") in
     [%log error]
-      "Verification failure: downloaded $file and expected SHA3-256 = $hash \
+      "Verification failure: downloaded $path and expected SHA3-256 = $expected_hash \
        but it had $computed_hash"
       ~metadata:
         [ ("path", `String file)


### PR DESCRIPTION
This PR fixes the error logging when an s3 hash is logged with the expected s3 hash when starting up a node.