### PR TITLE
[Rosetta] Replace new line with space instead of empty string in GraphQL

### DIFF
--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -26,7 +26,7 @@ let graphql_error_to_string e =
 let query query_obj uri =
   let variables_string = Yojson.Basic.to_string query_obj#variables in
   let body_string =
-    String.substr_replace_all ~pattern:"\n" ~with_:""
+    String.substr_replace_all ~pattern:"\n" ~with_:" "
     @@ Printf.sprintf {|{"query": "%s", "variables": %s}|} query_obj#query
          variables_string
   in


### PR DESCRIPTION
This pull request replaces new line characters with spaces instead of empty strings in Rosetta's GraphQL client. This change ensures that the resulting string does not contain any newline characters and that words are separated by a space, thus fixing an existing issue where some words were wrongfully joined.