### PR TITLE
Fix `epochDelegateAccount` GraphQL command to match its description

### DIFF
--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -1352,8 +1352,8 @@ module AccountObj = struct
                        |> Ledger.location_of_account staking_ledger
                        >>= Ledger.get staking_ledger
                      with
-                     | Some delegate_account ->
-                         let delegate_key = delegate_account.public_key in
+                     | Some account ->
+                         let%bind delegate_key = account.delegate in
                          Some (get_best_ledger_account_pk mina delegate_key)
                      | None ->
                          [%log' warn (Mina_lib.top_level_logger mina)]
@@ -1367,10 +1367,10 @@ module AccountObj = struct
                          Ledger.Db.index_of_account_exn staking_ledger
                            account_id
                        in
-                       let delegate_account =
+                       let account =
                          Ledger.Db.get_at_index_exn staking_ledger index
                        in
-                       let delegate_key = delegate_account.public_key in
+                       let%bind delegate_key = account.delegate in
                        Some (get_best_ledger_account_pk mina delegate_key)
                      with e ->
                        [%log' warn (Mina_lib.top_level_logger mina)]


### PR DESCRIPTION
This PR fixes `epochDelegateAccount` so that its behaviour matches the description, returning the account from the staking ledger to which this account has delegated. It has been broken since its inception in https://github.com/MinaProtocol/mina/pull/3904, where its behaviour has been to always return the same account from the current staking ledger.