### PR TITLE
Maintain concurrent switches locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ automation/services/watchdog/check_libp2p/check_libp2p
 *.terraform.lock.hcl
 *gcloud-keyfile.json*
 _opam
+opam_switches
 
 target
 ./release

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,8 @@ ocaml_word_size: switch
 # This check is disabled in the pure nix environment (that does not use opam).
 check_opam_switch: switch
 ifneq ($(DISABLE_CHECK_OPAM_SWITCH), true)
-    ifeq (, $(shell which check_opam_switch))
-	$(warning The check_opam_switch binary was not found in the PATH.)
-	$(error The current opam switch should likely be updated by running: "opam switch import opam.export")
-    else
-	check_opam_switch opam.export
-    endif
+	@which check_opam_switch 2>/dev/null >/dev/null || ( echo "The check_opam_switch binary was not found in the PATH, try: opam switch import opam.export" >&2 && exit 1 )
+	@check_opam_switch opam.export
 endif
 
 ocaml_checks: switch ocaml_version ocaml_word_size check_opam_switch

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(DUNE_PROFILE),)
 DUNE_PROFILE := dev
 endif
 
-ifeq ($(OPAMSWITCH)$(IN_NIX_SHELL),)
+ifeq ($(OPAMSWITCH)$(IN_NIX_SHELL)$(CI)$(BUILDKITE),)
 # Sometimes opam replaces these env variables in shell with
 # an explicit mention of a particular switch (dereferenced from the value)
 OPAM_SWITCH_PREFIX := $(PWD)/_opam

--- a/dune
+++ b/dune
@@ -3,4 +3,4 @@
  (mode promote)
  (action (with-stdout-to graphql_schema.json (run %{exe:src/app/graphql_schema_dump/graphql_schema_dump.exe}))))
 
-(data_only_dirs opam_switches)
+(dirs :standard \ opam_switches)

--- a/dune
+++ b/dune
@@ -2,3 +2,5 @@
  (targets graphql_schema.json)
  (mode promote)
  (action (with-stdout-to graphql_schema.json (run %{exe:src/app/graphql_schema_dump/graphql_schema_dump.exe}))))
+
+(data_only_dirs opam_switches)

--- a/scripts/update-opam-switch.sh
+++ b/scripts/update-opam-switch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/.."
+
+# Don't do anything if we're in a nix shell
+[[ "$IN_NIX_SHELL" == "" ]] || exit 0
+
+sum="$(cksum opam.export | grep -oE '^\S*')"
+switch_dir=opam_switches/"$sum"
+rm -Rf _opam
+if [[ ! -d "$switch_dir" ]]; then
+  opam switch import --switch . opam.export
+  mkdir -p opam_switches
+  mv _opam "$switch_dir"
+fi
+ln -s "$switch_dir" _opam

--- a/scripts/update-opam-switch.sh
+++ b/scripts/update-opam-switch.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR/.."
 
 # Don't do anything if we're in a nix shell
-[[ "$IN_NIX_SHELL" == "" ]] || exit 0
+[[ "$IN_NIX_SHELL$CI$BUILDKITE" == "" ]] || exit 0
 
 sum="$(cksum opam.export | grep -oE '^\S*')"
 switch_dir=opam_switches/"$sum"

--- a/scripts/update-opam-switch.sh
+++ b/scripts/update-opam-switch.sh
@@ -10,7 +10,9 @@ sum="$(cksum opam.export | grep -oE '^\S*')"
 switch_dir=opam_switches/"$sum"
 rm -Rf _opam
 if [[ ! -d "$switch_dir" ]]; then
-  opam switch import --switch . opam.export
+  opam switch import -y --switch . opam.export
+  opam pin -y add src/external/ocaml-sodium
+  opam pin -y add src/external/coda_base58
   mkdir -p opam_switches
   mv _opam "$switch_dir"
 fi


### PR DESCRIPTION
**Problem:** when different branches contain different opam.export files, managing corresponding switches when jumping between branches becomes burdensome.

**Solution:** use local switch functionality of opam to maintain _opam as a symlink to a switch that exactly matches opam.export. Update it autmatically when running `make build` and other commands.

**Explain how you tested your changes:**

1. Took a fresh Ubuntu (where mina wasn't ever built before)
2. Executed `apt install opam libgmp-dev liblmdb-dev libpq-dev pkg-config liblmdb0 liblmdb-dev libssl-dev libffi-dev` from root user
3. Checked out mina repository at branch `georgeee/makefile-opam-switch`, synchronized submodules
4. `opam init --bare`
5. `make ocaml_checks` (takes a while to build the switch)
6. `git apply test.patch`
7. `make ocaml_checks` (takes a while to build the switch)
8. `git apply -R test.patch` 
9. `make ocaml_checks` (no switch is re-build, finishes immediately)
10. `git apply test.patch` 
11. `make ocaml_checks` (no switch is re-build, finishes immediately)

Command `make ocaml_checks` was used for reason of demonstration simplicity. It asserts that a correct version of compiler was used and that switch contains all of the packages from `opam.export` with correct versions.
It could be demonstrated with make build, but that would require setting up a bunch of additional dependencies (`capnproto`, `postgresql`, `rustup`, `rocksdb`) which would complicate the demonstration.

In the testing the following `test.patch` file was used: [URL](https://drive.google.com/file/d/1RRYcDIGAkOviQh87qPq0I7Eq03M-51dn/view?usp=drive_link).

**Checklist:**

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None