### PR TITLE
[release/3.0.1] Add network_id to the devnet and mainnet config files

### DIFF
--- a/genesis_ledgers/devnet.json
+++ b/genesis_ledgers/devnet.json
@@ -25,5 +25,8 @@
       "hash": "jxjmYHK1tnGy5S6CDaLDTRrDbw17DmtEd6Jnw3L86QSsLm15w5g",
       "s3_data_hash": "094ceb7c580ef53be0bf2385698fd8d2faebf91fdd8542c076df649aa261b94e"
     }
+  },
+  "daemon": {
+    "network_id": "devnet"
   }
 }

--- a/genesis_ledgers/mainnet.json
+++ b/genesis_ledgers/mainnet.json
@@ -25,5 +25,8 @@
       "hash": "jwgzfxD5rEnSP3k4UiZu2569FfhJ1SRUvabfTz21e4btwBHg3jq",
       "s3_data_hash": "61323d7565130cfa4768c0333f32b2a8ea7fdfbf17065adfa48b4e9956619b44"
     }
+  },
+  "daemon": {
+    "network_id": "mainnet"
   }
 }


### PR DESCRIPTION
This PR adds the relevant fields to the config files to set the response of the `networkID` GraphQL endpoint.

Tested by running the mainnet and devnet 3.0.0 containers, and comparing the responses to those from this branch using the config files.