### PR TITLE
Fix 'Mina daemon is booting up' log

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -648,9 +648,7 @@ let setup_daemon logger =
                () )
           () ;
         let version_metadata = [ ("commit", `String Mina_version.commit_id) ] in
-        [%log info]
-          "Mina daemon is booting up; built with commit $commit on branch \
-           $branch"
+        [%log info] "Mina daemon is booting up; built with commit $commit"
           ~metadata:version_metadata ;
         let%bind () =
           Mina_lib.Conf_dir.check_and_set_lockfile ~logger conf_dir


### PR DESCRIPTION
Fix the log by removing the now-removed `branch` metadata item.

Tested by launching the Mina node.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None