### PR TITLE
Handle non-existent accounts in preload

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -547,8 +547,9 @@ module Make (Inputs : Inputs_intf.S) = struct
         (Account_id.derive_token_id ~owner:account_id)
         account_id
 
-    (* a write writes only to the mask, parent is not involved need to update
-       both account and hash pieces of the mask *)
+    (* a write writes only to the mask, parent is not involved
+
+       need to update both account and hash pieces of the mask *)
     let set t location account =
       assert_is_attached t ;
       set_account_unsafe t location account ;


### PR DESCRIPTION
Problem: account preloading is not able to preserve information about some accounts not existing in ledger, which invites future repetitive lookups to DB during staged ledger application.

Solution: keep a set of non-existent accounts for masks populated on preload.

Impact: after preload underlying ledger is guaranteed not to be queried.

Explain how you tested your changes:
* [x] measured performance via #14582

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None