### PR TITLE
Do not recompute hashes on ledger commit

### DIFF
--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -87,7 +87,8 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
 
     let get_at_index_exn (T ((module Base), t)) = Base.get_at_index_exn t
 
-    let set_batch (T ((module Base), t)) = Base.set_batch t
+    let set_batch ?hash_cache (T ((module Base), t)) =
+      Base.set_batch ?hash_cache t
 
     let set (T ((module Base), t)) = Base.set t
 

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -392,7 +392,8 @@ module Ledger = struct
 
     val set : t -> Location.t -> account -> unit
 
-    val set_batch : t -> (Location.t * account) list -> unit
+    val set_batch :
+      ?hash_cache:hash Addr.Map.t -> t -> (Location.t * account) list -> unit
 
     val get_at_index_exn : t -> int -> account
 

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -93,7 +93,8 @@ end = struct
 
   let get_at_index_exn _t = failwith "get_at_index_exn: null ledgers are empty"
 
-  let set_batch _t = failwith "set_batch: null ledgers cannot be mutated"
+  let set_batch ?hash_cache:_ _t =
+    failwith "set_batch: null ledgers cannot be mutated"
 
   let set _t = failwith "set: null ledgers cannot be mutated"
 

--- a/src/lib/merkle_ledger/util.ml
+++ b/src/lib/merkle_ledger/util.ml
@@ -57,7 +57,10 @@ module Make (Inputs : Inputs_intf) : sig
     Inputs.Base.t -> (Inputs.Location.t * Inputs.Hash.t) list -> unit
 
   val set_batch :
-    Inputs.Base.t -> (Inputs.Location.t * Inputs.Account.t) list -> unit
+       ?hash_cache:Inputs.Hash.t Inputs.Location.Addr.Map.t
+    -> Inputs.Base.t
+    -> (Inputs.Location.t * Inputs.Account.t) list
+    -> unit
 
   val set_batch_accounts :
     Inputs.Base.t -> (Inputs.Location.Addr.t * Inputs.Account.t) list -> unit
@@ -82,7 +85,18 @@ end = struct
       | addr, Some account ->
           Some (addr, account) )
 
-  let rec compute_affected_locations_and_hashes t locations_and_hashes acc =
+  let lookup_hash ?hash_cache ~compute loc =
+    let res =
+      let%bind.Option addr =
+        Option.try_with (fun () -> Inputs.Location.to_path_exn loc)
+      in
+      let%bind.Option m = hash_cache in
+      Map.find m addr
+    in
+    match res with Some x -> x | _ -> compute ()
+
+  let rec compute_affected_locations_and_hashes ?hash_cache t
+      locations_and_hashes acc =
     let ledger_depth = Inputs.ledger_depth t in
     if not @@ List.is_empty locations_and_hashes then
       let height =
@@ -103,11 +117,13 @@ end = struct
                        the hash now.
                     *)
                     let parent_hash =
-                      let left_hash, right_hash =
-                        Inputs.Location.order_siblings location hash
-                          sibling_hash
-                      in
-                      Inputs.Hash.merge ~height left_hash right_hash
+                      lookup_hash ?hash_cache parent_location
+                        ~compute:(fun () ->
+                          let left_hash, right_hash =
+                            Inputs.Location.order_siblings location hash
+                              sibling_hash
+                          in
+                          Inputs.Hash.merge ~height left_hash right_hash )
                     in
                     `Hash parent_hash
                 | Some (`Hash _) ->
@@ -125,27 +141,32 @@ end = struct
                   (* We haven't recorded the sibling, so query the ledger to get
                      the hash.
                   *)
-                  let sibling_location = Inputs.Location.sibling location in
-                  let sibling_hash = Inputs.get_hash t sibling_location in
                   let parent_hash =
-                    let left_hash, right_hash =
-                      Inputs.Location.order_siblings location hash sibling_hash
-                    in
-                    Inputs.Hash.merge ~height left_hash right_hash
+                    lookup_hash ?hash_cache key ~compute:(fun () ->
+                        let sibling_location =
+                          Inputs.Location.sibling location
+                        in
+                        let sibling_hash = Inputs.get_hash t sibling_location in
+                        let left_hash, right_hash =
+                          Inputs.Location.order_siblings location hash
+                            sibling_hash
+                        in
+                        Inputs.Hash.merge ~height left_hash right_hash )
                   in
                   (key, parent_hash) :: acc
               | `Hash parent_hash ->
                   (* We have already computed the hash above. *)
                   (key, parent_hash) :: acc )
         in
-        compute_affected_locations_and_hashes t rev_parent_locations_and_hashes
+        compute_affected_locations_and_hashes ?hash_cache t
+          rev_parent_locations_and_hashes
           (List.rev_append rev_parent_locations_and_hashes acc)
       else acc
     else acc
 
-  let set_hash_batch t locations_and_hashes =
+  let set_hash_batch ?hash_cache t locations_and_hashes =
     Inputs.set_raw_hash_batch t
-      (compute_affected_locations_and_hashes t locations_and_hashes
+      (compute_affected_locations_and_hashes ?hash_cache t locations_and_hashes
          locations_and_hashes )
 
   let compute_last_index addresses =
@@ -186,13 +207,17 @@ end = struct
 
   (* TODO: When we do batch on a database, we should add accounts, locations and hashes
      simulatenously for full atomicity. *)
-  let set_batch t locations_and_accounts =
+  let set_batch ?hash_cache t locations_and_accounts =
     set_raw_addresses t locations_and_accounts ;
     Inputs.set_raw_account_batch t locations_and_accounts ;
-    set_hash_batch t
+    set_hash_batch ?hash_cache t
     @@ List.map locations_and_accounts ~f:(fun (location, account) ->
-           ( Inputs.location_of_hash_addr (Inputs.Location.to_path_exn location)
-           , Inputs.Hash.hash_account account ) )
+           let addr = Inputs.Location.to_path_exn location in
+           let account_hash =
+             lookup_hash ?hash_cache location ~compute:(fun () ->
+                 Inputs.Hash.hash_account account )
+           in
+           (Inputs.location_of_hash_addr addr, account_hash) )
 
   let set_batch_accounts t addresses_and_accounts =
     set_batch t
@@ -208,4 +233,6 @@ end = struct
     let num_accounts = List.length accounts in
     List.(zip_exn (take addresses num_accounts) accounts)
     |> set_batch_accounts t
+
+  let set_hash_batch = set_hash_batch ?hash_cache:None
 end

--- a/src/lib/merkle_ledger/util.mli
+++ b/src/lib/merkle_ledger/util.mli
@@ -57,7 +57,10 @@ module Make (Inputs : Inputs_intf) : sig
     Inputs.Base.t -> (Inputs.Location.t * Inputs.Hash.t) list -> unit
 
   val set_batch :
-    Inputs.Base.t -> (Inputs.Location.t * Inputs.Account.t) list -> unit
+       ?hash_cache:Inputs.Hash.t Inputs.Location.Addr.Map.t
+    -> Inputs.Base.t
+    -> (Inputs.Location.t * Inputs.Account.t) list
+    -> unit
 
   val set_batch_accounts :
     Inputs.Base.t -> (Inputs.Location.Addr.t * Inputs.Account.t) list -> unit

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -244,8 +244,8 @@ module Make (Inputs : Inputs_intf) = struct
               List.iter accounts ~f:(fun account ->
                   Mask.Attached.parent_set_notify mask account ) ) )
 
-  let set_batch t locations_and_accounts =
-    Base.set_batch t locations_and_accounts ;
+  let set_batch ?hash_cache t locations_and_accounts =
+    Base.set_batch ?hash_cache t locations_and_accounts ;
     batch_notify_mask_children t (List.map locations_and_accounts ~f:snd)
 
   let set_batch_accounts t addresses_and_accounts =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -621,13 +621,14 @@ module Make (Inputs : Inputs_intf.S) = struct
       let parent = get_parent t in
       let old_root_hash = merkle_root t in
       let account_data = Map.to_alist t.maps.accounts in
+      let hash_cache = t.maps.hashes in
       t.maps <-
         { accounts = Location_binable.Map.empty
         ; hashes = Addr.Map.empty
         ; token_owners = Token_id.Map.empty
         ; locations = Account_id.Map.empty
         } ;
-      Base.set_batch parent account_data ;
+      Base.set_batch ~hash_cache parent account_data ;
       Debug_assert.debug_assert (fun () ->
           [%test_result: Hash.t]
             ~message:


### PR DESCRIPTION
Problem: recomputation of hashes is costly and is absolutely nonsensical when we commit child ledger to parent.

Solution: provide hashes map from child to parent to be used in operation of hash recomputation for the accounts being added.

This change improved performance of transaction application for 9-account-update transactions by ~20% (as measured by #14582).

Explain how you tested your changes:
* Measured performance with #14582

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None