### PR TITLE
Remove some unused `bin_io` derivations from `Transition_frontier`

### DIFF
--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -5,40 +5,6 @@ type full = Full
 
 type lite = Lite
 
-[@@@alert "-deprecated"]
-
-module Dummy_binable1 (T : sig
-  type 'a t
-end) =
-  Binable.Of_binable1
-    (struct
-      type 'a t = unit [@@deriving bin_io_unversioned]
-    end)
-    (struct
-      type 'a t = 'a T.t
-
-      let to_binable _ = ()
-
-      let of_binable _ = assert false
-    end)
-
-module Dummy_binable2 (T : sig
-  type (_, _) t
-end) =
-  Binable.Of_binable2
-    (struct
-      type (_, _) t = unit [@@deriving bin_io_unversioned]
-    end)
-    (struct
-      type ('a, 'b) t = ('a, 'b) T.t
-
-      let to_binable _ = ()
-
-      let of_binable _ = assert false
-    end)
-
-[@@@alert "+deprecated"]
-
 module Node = struct
   type 'a t =
     | Full : Breadcrumb.t -> full t

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -40,18 +40,9 @@ end) =
 [@@@alert "+deprecated"]
 
 module Node = struct
-  [%%versioned_binable
-  module Stable = struct
-    module V3 = struct
-      type 'a t =
-        | Full : Breadcrumb.t -> full t
-        | Lite : Mina_block.Validated.Stable.V2.t -> lite t
-
-      include Dummy_binable1 (struct
-        type nonrec 'a t = 'a t
-      end)
-    end
-  end]
+  type 'a t =
+    | Full : Breadcrumb.t -> full t
+    | Lite : Mina_block.Validated.Stable.V2.t -> lite t
 end
 
 module Node_list = struct
@@ -187,28 +178,12 @@ module Root_transition = struct
   end
 end
 
-module T = struct
-  [%%versioned_binable
-  module Stable = struct
-    module V2 = struct
-      type ('repr, 'mutant) t =
-        | New_node : 'repr Node.Stable.V3.t -> ('repr, unit) t
-        | Root_transitioned : 'repr Root_transition.t -> ('repr, State_hash.t) t
-        | Best_tip_changed : State_hash.t -> (_, State_hash.t) t
-
-      include Dummy_binable2 (struct
-        type nonrec ('a, 'b) t = ('a, 'b) t
-      end)
-    end
-  end]
-end
-
-type ('repr, 'mutant) t = ('repr, 'mutant) T.t =
+type ('repr, 'mutant) t =
   | New_node : 'repr Node.t -> ('repr, unit) t
   | Root_transitioned : 'repr Root_transition.t -> ('repr, State_hash.t) t
   | Best_tip_changed : State_hash.t -> (_, State_hash.t) t
 
-type ('repr, 'mutant) diff = ('repr, 'mutant) T.t
+type ('repr, 'mutant) diff = ('repr, 'mutant) t
 
 let name : type repr mutant. (repr, mutant) t -> string = function
   | Root_transitioned _ ->

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -227,53 +227,7 @@ module Lite = struct
   type 'mutant t = (lite, 'mutant) diff
 
   module E = struct
-    module Binable_arg = struct
-      [%%versioned
-      module Stable = struct
-        [@@@no_toplevel_latest_type]
-
-        module V3 = struct
-          type t = Lite_binable.Stable.V3.t
-
-          let to_latest = Fn.id
-        end
-      end]
-    end
-
-    [%%versioned_binable
-    module Stable = struct
-      [@@@no_toplevel_latest_type]
-
-      module V3 = struct
-        type t = E : (lite, 'mutant) diff -> t [@@unboxed]
-
-        module T_nonbinable = struct
-          type nonrec t = t
-
-          let to_binable = function
-            | E (New_node (Lite x)) ->
-                (New_node x : Binable_arg.Stable.V3.t)
-            | E (Root_transitioned x) ->
-                Root_transitioned x
-            | E (Best_tip_changed x) ->
-                Best_tip_changed x
-
-          let of_binable = function
-            | (New_node x : Binable_arg.Stable.V3.t) ->
-                E (New_node (Lite x))
-            | Root_transitioned x ->
-                E (Root_transitioned x)
-            | Best_tip_changed x ->
-                E (Best_tip_changed x)
-        end
-
-        include Binable.Of_binable (Binable_arg.Stable.V3) (T_nonbinable)
-
-        let to_latest = Fn.id
-      end
-    end]
-
-    include (Stable.Latest : module type of Stable.Latest)
+    type t = E : (lite, 'mutant) diff -> t [@@unboxed]
   end
 end
 

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -207,22 +207,6 @@ let to_lite (type mutant) (diff : (full, mutant) t) : (lite, mutant) t =
   | Best_tip_changed b ->
       Best_tip_changed b
 
-module Lite_binable = struct
-  [%%versioned
-  module Stable = struct
-    [@@@no_toplevel_latest_type]
-
-    module V3 = struct
-      type t =
-        | New_node of Mina_block.Validated.Stable.V2.t
-        | Root_transitioned of Root_transition.Lite.Stable.V4.t
-        | Best_tip_changed of State_hash.Stable.V1.t
-
-      let to_latest = Fn.id
-    end
-  end]
-end
-
 module Lite = struct
   type 'mutant t = (lite, 'mutant) diff
 

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -21,14 +21,9 @@ type lite = Lite
  *  transition frontier and the persistent transition frontier.
  *)
 module Node : sig
-  [%%versioned:
-  module Stable : sig
-    module V3 : sig
-      type 'a t =
-        | Full : Breadcrumb.t -> full t
-        | Lite : Mina_block.Validated.Stable.V2.t -> lite t
-    end
-  end]
+  type 'a t =
+    | Full : Breadcrumb.t -> full t
+    | Lite : Mina_block.Validated.t -> lite t
 end
 
 module Node_list : sig

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -132,12 +132,7 @@ module Lite : sig
   type 'mutant t = (lite, 'mutant) diff
 
   module E : sig
-    [%%versioned:
-    module Stable : sig
-      module V3 : sig
-        type t = E : (lite, 'mutant) diff -> t [@@unboxed]
-      end
-    end]
+    type t = E : (lite, 'mutant) diff -> t [@@unboxed]
   end
 end
 

--- a/src/lib/transition_frontier/frontier_base/root_data.ml
+++ b/src/lib/transition_frontier/frontier_base/root_data.ml
@@ -29,18 +29,11 @@ module Common = struct
 end
 
 module Historical = struct
-  [%%versioned
-  module Stable = struct
-    module V3 = struct
-      type t =
-        { transition : Mina_block.Validated.Stable.V2.t
-        ; common : Common.Stable.V2.t
-        ; staged_ledger_target_ledger_hash : Ledger_hash.Stable.V1.t
-        }
-
-      let to_latest = Fn.id
-    end
-  end]
+  type t =
+    { transition : Mina_block.Validated.t
+    ; common : Common.t
+    ; staged_ledger_target_ledger_hash : Ledger_hash.t
+    }
 
   let transition t = t.transition
 

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -5,15 +5,7 @@ open Mina_base
  * were available on a breadcrumb in the transition frontier when this was
  * created. *)
 module Historical : sig
-  module Stable : sig
-    module V3 : sig
-      type t
-    end
-
-    module Latest = V3
-  end
-
-  type t = Stable.Latest.t
+  type t
 
   val transition : t -> Mina_block.Validated.t
 

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -5,12 +5,15 @@ open Mina_base
  * were available on a breadcrumb in the transition frontier when this was
  * created. *)
 module Historical : sig
-  [%%versioned:
   module Stable : sig
     module V3 : sig
       type t
     end
-  end]
+
+    module Latest = V3
+  end
+
+  type t = Stable.Latest.t
 
   val transition : t -> Mina_block.Validated.t
 


### PR DESCRIPTION
This PR removes some dead code depending on `bin_io` from the `Transition_frontier` libraries.