### PR TITLE
Do not derive `hash` for Account_id.t

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -76,14 +76,16 @@ end
 (* Unlike other modules here, `Token_owners` does not correspond with a database table *)
 module Token_owners = struct
   (* hash table of token owners, updated for each block *)
-  let owner_tbl : Account_id.t Token_id.Table.t = Token_id.Table.create ()
+  let owner_tbl : Account_id.t Token_id.Map.t ref = ref Token_id.Map.empty
 
   let add_if_doesn't_exist token_id owner =
-    match Token_id.Table.add owner_tbl ~key:token_id ~data:owner with
-    | `Ok | `Duplicate ->
+    match Token_id.Map.add !owner_tbl ~key:token_id ~data:owner with
+    | `Ok tbl' ->
+        owner_tbl := tbl'
+    | `Duplicate ->
         ()
 
-  let find_owner token_id = Token_id.Table.find owner_tbl token_id
+  let find_owner token_id = Token_id.Map.find !owner_tbl token_id
 end
 
 module Token = struct

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -71,29 +71,29 @@ module First_pass_ledger_hashes = struct
 
   module T = struct
     type t = Ledger_hash.Stable.Latest.t * int
-    [@@deriving bin_io_unversioned, compare, sexp, hash]
+    [@@deriving bin_io_unversioned, compare, sexp]
   end
 
   include T
-  include Hashable.Make_binable (T)
+  include Comparable.Make_binable (T)
 
-  let hash_set = Hash_set.create ()
+  let set = ref Set.empty
 
   let add =
     let count = ref 0 in
     fun ledger_hash ->
-      Base.Hash_set.add hash_set (ledger_hash, !count) ;
+      set := Base.Set.add !set (ledger_hash, !count) ;
       incr count
 
   let find ledger_hash =
-    Base.Hash_set.find hash_set ~f:(fun (hash, _n) ->
+    Base.Set.find !set ~f:(fun (hash, _n) ->
         Ledger_hash.equal hash ledger_hash )
 
   (* once we find a snarked ledger hash corresponding to a ledger hash, don't need to store earlier ones *)
   let flush_older_than ndx =
-    let elts = Base.Hash_set.to_list hash_set in
+    let elts = Base.Set.to_list !set in
     List.iter elts ~f:(fun ((_hash, n) as elt) ->
-        if n < ndx then Base.Hash_set.remove hash_set elt )
+        if Int.(n < ndx) then set := Base.Set.remove !set elt )
 
   let get_last_snarked_hash, set_last_snarked_hash =
     let last_snarked_hash = ref Ledger_hash.empty_hash in
@@ -148,7 +148,7 @@ let create_replayer_checkpoint ~ledger ~start_slot_since_genesis :
     }
   in
   let first_pass_ledger_hashes =
-    let elts = Base.Hash_set.to_list First_pass_ledger_hashes.hash_set in
+    let elts = Base.Set.to_list !First_pass_ledger_hashes.set in
     List.sort elts ~compare:(fun (_h1, n1) (_h2, n2) -> Int.compare n1 n2)
     |> List.map ~f:(fun (h, _n) -> h)
   in

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -99,7 +99,7 @@ module type Protocol_state = sig
   type consensus_state_var
 
   module Poly : sig
-    type ('state_hash, 'body) t [@@deriving equal, hash, sexp, to_yojson]
+    type ('state_hash, 'body) t [@@deriving equal, sexp, to_yojson]
   end
 
   module Body : sig
@@ -480,7 +480,7 @@ module type S = sig
         [%%versioned:
         module Stable : sig
           module V2 : sig
-            type t [@@deriving hash, equal, compare, sexp, yojson]
+            type t [@@deriving equal, compare, sexp, yojson]
           end
         end]
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -905,7 +905,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       module Stable = struct
         module V1 = struct
           type t = Mina_base.State_hash.Stable.V1.t option
-          [@@deriving sexp, compare, hash, to_yojson]
+          [@@deriving sexp, compare, to_yojson]
 
           let to_latest = Fn.id
         end
@@ -916,7 +916,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       include Mina_base.Epoch_data
 
       module Make (Lock_checkpoint : sig
-        type t [@@deriving sexp, compare, hash, to_yojson]
+        type t [@@deriving sexp, compare, to_yojson]
 
         val typ : (Mina_base.State_hash.var, t) Typ.t
 
@@ -936,7 +936,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             , Lock_checkpoint.t
             , Length.t )
             Poly.t
-          [@@deriving sexp, compare, hash, to_yojson]
+          [@@deriving sexp, compare, to_yojson]
         end
 
         let typ : (var, Value.t) Typ.t =
@@ -1013,7 +1013,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 , Lock_checkpoint.Stable.V1.t
                 , Length.Stable.V1.t )
                 Poly.Stable.V1.t
-              [@@deriving sexp, compare, equal, hash, yojson]
+              [@@deriving sexp, compare, equal, yojson]
 
               let to_latest = Fn.id
             end
@@ -1038,7 +1038,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 , Lock_checkpoint.Stable.V1.t
                 , Length.Stable.V1.t )
                 Poly.Stable.V1.t
-              [@@deriving sexp, compare, equal, hash, yojson]
+              [@@deriving sexp, compare, equal, yojson]
 
               let to_latest = Fn.id
             end
@@ -1672,7 +1672,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               ; coinbase_receiver : 'pk
               ; supercharge_coinbase : 'bool
               }
-            [@@deriving sexp, equal, compare, hash, yojson, fields, hlist]
+            [@@deriving sexp, equal, compare, yojson, fields, hlist]
           end
         end]
       end
@@ -1692,7 +1692,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               , bool
               , Public_key.Compressed.Stable.V1.t )
               Poly.Stable.V1.t
-            [@@deriving sexp, equal, compare, hash, yojson]
+            [@@deriving sexp, equal, compare, yojson]
 
             let to_latest = Fn.id
           end

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -8,7 +8,7 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
   module Stable = struct
     module V2 = struct
       type t = Transaction_snark.Stable.V2.t
-      [@@deriving compare, equal, sexp, yojson, hash]
+      [@@deriving compare, equal, sexp, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -2,14 +2,14 @@ open Core_kernel
 open Mina_base
 
 module type S = sig
-  type t [@@deriving compare, equal, sexp, yojson, hash]
+  type t [@@deriving compare, equal, sexp, yojson]
 
   [%%versioned:
   module Stable : sig
     [@@@no_toplevel_latest_type]
 
     module V2 : sig
-      type nonrec t = t [@@deriving compare, equal, sexp, yojson, hash]
+      type nonrec t = t [@@deriving compare, equal, sexp, yojson]
 
       val to_latest : t -> t
     end

--- a/src/lib/merkle_ledger/graphviz.ml
+++ b/src/lib/merkle_ledger/graphviz.ml
@@ -77,9 +77,8 @@ module Make (Inputs : Intf.Graphviz.I) :
             let target : target =
               if
                 not
-                @@ Hash_set.mem
-                     ( List.init ~f:empty_hash ledger_depth
-                     |> Hash.Hash_set.of_list )
+                @@ Set.mem
+                     (List.init ~f:empty_hash ledger_depth |> Hash.Set.of_list)
                      current_hash
               then (
                 Queue.enqueue jobs

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -10,7 +10,7 @@ module type LOCATION = sig
   end
 
   type t = Generic of Bigstring.t | Account of Addr.t | Hash of Addr.t
-  [@@deriving sexp, hash, compare]
+  [@@deriving sexp, compare]
 
   val is_generic : t -> bool
 
@@ -65,9 +65,7 @@ module type Key = sig
 
   val to_string : t -> string
 
-  include Hashable.S_binable with type t := t
-
-  include Comparable.S with type t := t
+  include Comparable.S_binable with type t := t
 end
 
 module type Token_id = sig
@@ -81,8 +79,6 @@ module type Token_id = sig
   with type Latest.t = t
 
   val default : t
-
-  include Hashable.S_binable with type t := t
 
   include Comparable.S_binable with type t := t
 end
@@ -107,9 +103,7 @@ module type Account_id = sig
 
   val derive_token_id : owner:t -> token_id
 
-  include Hashable.S_binable with type t := t
-
-  include Comparable.S with type t := t
+  include Comparable.S_binable with type t := t
 end
 
 module type Balance = sig
@@ -139,11 +133,11 @@ module type Account = sig
 end
 
 module type Hash = sig
-  type t [@@deriving bin_io, compare, equal, sexp, yojson]
+  type t [@@deriving bin_io, equal, sexp, yojson]
 
   val to_base58_check : t -> string
 
-  include Hashable.S_binable with type t := t
+  include Comparable.S_binable with type t := t
 
   type account
 
@@ -266,7 +260,7 @@ module Inputs = struct
   module type DATABASE = sig
     include Intf
 
-    module Location_binable : Hashable.S_binable with type t := Location.t
+    module Location_binable : Comparable.S_binable with type t := Location.t
 
     module Kvdb : Key_value_database with type config := string
 
@@ -304,7 +298,7 @@ module Ledger = struct
     module Path : Merkle_path.S with type hash := hash
 
     module Location : sig
-      type t [@@deriving sexp, compare, hash]
+      type t [@@deriving sexp, compare]
 
       include Comparable.S with type t := t
     end

--- a/src/lib/merkle_ledger/location_intf.mli
+++ b/src/lib/merkle_ledger/location_intf.mli
@@ -12,7 +12,7 @@ module type S = sig
   end
 
   type t = Generic of Bigstring.t | Account of Addr.t | Hash of Addr.t
-  [@@deriving sexp, hash, compare]
+  [@@deriving sexp, compare]
 
   val is_generic : t -> bool
 

--- a/src/lib/merkle_ledger/util.ml
+++ b/src/lib/merkle_ledger/util.ml
@@ -1,7 +1,7 @@
 module type Inputs_intf = sig
   module Location : Location_intf.S
 
-  module Location_binable : Hashable.S_binable with type t := Location.t
+  module Location_binable : Comparable.S_binable with type t := Location.t
 
   module Key : Intf.Key
 

--- a/src/lib/merkle_ledger/util.mli
+++ b/src/lib/merkle_ledger/util.mli
@@ -1,7 +1,7 @@
 module type Inputs_intf = sig
   module Location : Location_intf.S
 
-  module Location_binable : Hashable.S_binable with type t := Location.t
+  module Location_binable : Comparable.S_binable with type t := Location.t
 
   module Key : Intf.Key
 

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -22,16 +22,16 @@ module Location_binable = struct
       | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
       | Account of Location.Addr.Stable.Latest.t
       | Hash of Location.Addr.Stable.Latest.t
-    [@@deriving bin_io_unversioned, hash, sexp, compare]
+    [@@deriving bin_io_unversioned, sexp, compare]
   end
 
   type t = Arg.t =
     | Generic of Merkle_ledger.Location.Bigstring.t
     | Account of Location.Addr.t
     | Hash of Location.Addr.t
-  [@@deriving hash, sexp, compare]
+  [@@deriving sexp, compare]
 
-  include Hashable.Make_binable (Arg) [@@deriving sexp, compare, hash, yojson]
+  include Comparable.Make_binable (Arg) [@@deriving sexp, compare, yojson]
 end
 
 module Inputs = struct

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -547,16 +547,16 @@ Make (struct
         | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
         | Account of Location.Addr.Stable.Latest.t
         | Hash of Location.Addr.Stable.Latest.t
-      [@@deriving bin_io_unversioned, hash, sexp, compare]
+      [@@deriving bin_io_unversioned, sexp, compare]
     end
 
     type t = Arg.t =
       | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
       | Account of Location.Addr.Stable.Latest.t
       | Hash of Location.Addr.Stable.Latest.t
-    [@@deriving hash, sexp, compare]
+    [@@deriving sexp, compare]
 
-    include Hashable.Make_binable (Arg) [@@deriving sexp, compare, hash, yojson]
+    include Comparable.Make_binable (Arg) [@@deriving sexp, compare, yojson]
   end
 
   module Inputs = struct

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -11,10 +11,10 @@ end
 module Account = struct
   (* want bin_io, not available with Account.t *)
   type t = Mina_base.Account.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp, equal, compare, hash, yojson]
+  [@@deriving bin_io_unversioned, sexp, equal, compare, yojson]
 
   type key = Mina_base.Account.Key.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp, equal, compare, hash]
+  [@@deriving bin_io_unversioned, sexp, equal, compare]
 
   (* use Account items needed *)
   let empty = Mina_base.Account.empty
@@ -40,7 +40,7 @@ module Receipt = Mina_base.Receipt
 
 module Hash = struct
   module T = struct
-    type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
+    type t = Md5.t [@@deriving sexp, compare, bin_io_unversioned, equal]
   end
 
   include T
@@ -53,7 +53,7 @@ module Hash = struct
     let version_byte = Base58_check.Version_bytes.ledger_test_hash
   end)
 
-  include Hashable.Make_binable (T)
+  include Comparable.Make_binable (T)
 
   (* to prevent pre-image attack,
    * important impossible to create an account such that (merge a b = hash_account account) *)
@@ -151,7 +151,7 @@ module Key = struct
   module Stable = struct
     module V1 = struct
       type t = Mina_base.Account.Key.Stable.V1.t
-      [@@deriving sexp, equal, compare, hash]
+      [@@deriving sexp, equal, compare]
 
       let to_latest = Fn.id
     end
@@ -166,8 +166,7 @@ module Key = struct
   let gen_keys num_keys =
     Quickcheck.random_value (Quickcheck.Generator.list_with_length num_keys gen)
 
-  include Hashable.Make_binable (Stable.Latest)
-  include Comparable.Make (Stable.Latest)
+  include Comparable.Make_binable (Stable.Latest)
 end
 
 module Token_id = Mina_base.Token_id
@@ -177,14 +176,13 @@ module Account_id = struct
   module Stable = struct
     module V2 = struct
       type t = Mina_base.Account_id.Stable.V2.t
-      [@@deriving sexp, equal, compare, hash]
+      [@@deriving sexp, equal, compare]
 
       let to_latest = Fn.id
     end
   end]
 
-  include Hashable.Make_binable (Stable.Latest)
-  include Comparable.Make (Stable.Latest)
+  include Comparable.Make_binable (Stable.Latest)
 
   let create = Mina_base.Account_id.create
 

--- a/src/lib/merkle_mask/inputs_intf.mli
+++ b/src/lib/merkle_mask/inputs_intf.mli
@@ -21,8 +21,6 @@ module type S = sig
   module Location : Merkle_ledger.Location_intf.S
 
   module Location_binable : sig
-    include Core_kernel.Hashable.S_binable with type t := Location.t
-
     include Core_kernel.Comparable.S_binable with type t := Location.t
   end
 

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -221,7 +221,7 @@ module Poly = struct
         ; permissions : 'permissions
         ; zkapp : 'zkapp_opt
         }
-      [@@deriving sexp, equal, compare, hash, yojson, fields, hlist, annot]
+      [@@deriving sexp, equal, compare, yojson, fields, hlist, annot]
 
       let to_latest = Fn.id
     end
@@ -263,7 +263,7 @@ module Binable_arg = struct
         ; permissions : Permissions.Stable.V2.t
         ; zkapp : Zkapp_account.Stable.V2.t option
         }
-      [@@deriving sexp, equal, hash, compare, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       let to_latest = Fn.id
 
@@ -290,7 +290,7 @@ module Stable = struct
       ; permissions : Permissions.Stable.V2.t
       ; zkapp : Zkapp_account.Stable.V2.t option
       }
-    [@@deriving sexp, equal, hash, compare, yojson, hlist, fields]
+    [@@deriving sexp, equal, compare, yojson, hlist, fields]
 
     include
       Binable.Of_binable_without_uuid

--- a/src/lib/mina_base/account_id.ml
+++ b/src/lib/mina_base/account_id.ml
@@ -46,7 +46,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Pickles.Backend.Tick.Field.Stable.V1.t
-        [@@deriving sexp, equal, compare, hash]
+        [@@deriving sexp, equal, compare]
 
         let to_yojson (t : t) : Yojson.Safe.t = `String (to_string t)
 
@@ -62,7 +62,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
     module Binables = struct
       include Comparable.Make_binable (Stable.Latest)
-      include Hashable.Make_binable (Stable.Latest)
     end
 
     include Binables
@@ -109,7 +108,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Stable = struct
     module V2 = struct
       type t = Public_key.Compressed.Stable.V1.t * Digest.Stable.V1.t
-      [@@deriving sexp, equal, compare, hash, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       let to_latest = Fn.id
     end
@@ -140,7 +139,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
     (key, tid)
 
   include Comparable.Make_binable (Stable.Latest)
-  include Hashable.Make_binable (Stable.Latest)
 
   let to_input ((key, tid) : t) =
     Random_oracle.Input.Chunked.append

--- a/src/lib/mina_base/account_id_intf.ml
+++ b/src/lib/mina_base/account_id_intf.ml
@@ -6,7 +6,7 @@ module type S = sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type t [@@deriving sexp, equal, compare, hash, yojson]
+        type t [@@deriving sexp, equal, compare, yojson]
       end
     end]
 
@@ -19,8 +19,6 @@ module type S = sig
     (* so we can easily import these into Token_id *)
     module Binables : sig
       include Comparable_binable with type t := t
-
-      include Hashable_binable with type t := t
     end
 
     include module type of Binables
@@ -61,7 +59,7 @@ module type S = sig
   [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving sexp, equal, compare, hash, yojson]
+      type t [@@deriving sexp, equal, compare, yojson]
     end
   end]
 
@@ -83,9 +81,7 @@ module type S = sig
 
   val gen : t Quickcheck.Generator.t
 
-  include Comparable.S with type t := t
-
-  include Hashable.S_binable with type t := t
+  include Comparable.S_binable with type t := t
 
   type var
 

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -26,7 +26,7 @@ module Authorization_kind = struct
         | Signature
         | Proof of (Field.t[@version_asserted])
         | None_given
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -145,7 +145,7 @@ module May_use_token = struct
             *)
         | Inherit_from_parent
             (** Inherit the token permission available to the parent. *)
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -521,7 +521,7 @@ module Update = struct
           ; vesting_period : Global_slot_span.Stable.V1.t
           ; vesting_increment : Amount.Stable.V1.t
           }
-        [@@deriving annot, compare, equal, sexp, hash, yojson, hlist, fields]
+        [@@deriving annot, compare, equal, sexp, yojson, hlist, fields]
 
         let to_latest = Fn.id
       end
@@ -686,7 +686,7 @@ module Update = struct
         ; timing : Timing_info.Stable.V1.t Set_or_keep.Stable.V1.t
         ; voting_for : State_hash.Stable.V1.t Set_or_keep.Stable.V1.t
         }
-      [@@deriving annot, compare, equal, sexp, hash, yojson, fields, hlist]
+      [@@deriving annot, compare, equal, sexp, yojson, fields, hlist]
 
       let to_latest = Fn.id
     end
@@ -936,8 +936,7 @@ module Account_precondition = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Zkapp_precondition.Account.Stable.V2.t
-      [@@deriving sexp, yojson, hash]
+      type t = Zkapp_precondition.Account.Stable.V2.t [@@deriving sexp, yojson]
 
       let (_ :
             ( t
@@ -1013,7 +1012,7 @@ module Preconditions = struct
             Mina_numbers.Global_slot_since_genesis.Stable.V1.t
             Zkapp_precondition.Numeric.Stable.V1.t
         }
-      [@@deriving annot, sexp, equal, yojson, hash, hlist, compare, fields]
+      [@@deriving annot, sexp, equal, yojson, hlist, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -1097,7 +1096,7 @@ module Body = struct
           Pickles.Backend.Tick.Field.Stable.V1.t
           Bounded_types.ArrayN16.Stable.V1.t
           list
-        [@@deriving sexp, equal, hash, compare, yojson]
+        [@@deriving sexp, equal, compare, yojson]
 
         let to_latest = Fn.id
       end
@@ -1125,7 +1124,7 @@ module Body = struct
           ; may_use_token : May_use_token.Stable.V1.t
           ; authorization_kind : Authorization_kind.Stable.V1.t
           }
-        [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, sexp, equal, yojson, compare, fields]
 
         let to_latest = Fn.id
       end
@@ -1183,7 +1182,7 @@ module Body = struct
           ; may_use_token : May_use_token.Stable.V1.t
           ; authorization_kind : Authorization_kind.Stable.V1.t
           }
-        [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, sexp, equal, yojson, compare, fields]
 
         let to_latest = Fn.id
       end
@@ -1209,7 +1208,7 @@ module Body = struct
         ; may_use_token : May_use_token.Stable.V1.t
         ; authorization_kind : Authorization_kind.Stable.V1.t
         }
-      [@@deriving annot, sexp, equal, yojson, hash, hlist, compare, fields]
+      [@@deriving annot, sexp, equal, yojson, hlist, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -1306,7 +1305,7 @@ module Body = struct
                 [@name "validUntil"]
           ; nonce : Account_nonce.Stable.V1.t
           }
-        [@@deriving annot, sexp, equal, yojson, hash, compare, hlist, fields]
+        [@@deriving annot, sexp, equal, yojson, compare, hlist, fields]
 
         let to_latest = Fn.id
       end
@@ -1653,7 +1652,7 @@ module T = struct
           { body : Body.Graphql_repr.Stable.V1.t
           ; authorization : Control.Stable.V2.t
           }
-        [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, sexp, equal, yojson, compare, fields]
 
         let to_latest = Fn.id
       end
@@ -1676,7 +1675,7 @@ module T = struct
           { body : Body.Simple.Stable.V1.t
           ; authorization : Control.Stable.V2.t
           }
-        [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, sexp, equal, yojson, compare, fields]
 
         let to_latest = Fn.id
       end
@@ -1689,7 +1688,7 @@ module T = struct
       (** A account_update to a zkApp transaction *)
       type t = Mina_wire_types.Mina_base.Account_update.V1.t =
         { body : Body.Stable.V1.t; authorization : Control.Stable.V2.t }
-      [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+      [@@deriving annot, sexp, equal, yojson, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -1715,9 +1714,6 @@ module T = struct
 
   let quickcheck_generator : t Quickcheck.Generator.t = gen
 
-  let quickcheck_observer : t Quickcheck.Observer.t =
-    Quickcheck.Observer.of_hash (module Stable.Latest)
-
   let quickcheck_shrinker : t Quickcheck.Shrinker.t =
     Quickcheck.Shrinker.empty ()
 
@@ -1741,7 +1737,7 @@ module Fee_payer = struct
         { body : Body.Fee_payer.Stable.V1.t
         ; authorization : Signature.Stable.V1.t
         }
-      [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
+      [@@deriving annot, sexp, equal, yojson, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -1754,9 +1750,6 @@ module Fee_payer = struct
     { body; authorization }
 
   let quickcheck_generator : t Quickcheck.Generator.t = gen
-
-  let quickcheck_observer : t Quickcheck.Observer.t =
-    Quickcheck.Observer.of_hash (module Stable.Latest)
 
   let quickcheck_shrinker : t Quickcheck.Shrinker.t =
     Quickcheck.Shrinker.empty ()

--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -19,7 +19,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; amount : Currency.Amount.Stable.V1.t
         ; fee_transfer : Fee_transfer.Stable.V1.t option
         }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
 

--- a/src/lib/mina_base/coinbase_fee_transfer.ml
+++ b/src/lib/mina_base/coinbase_fee_transfer.ml
@@ -16,7 +16,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         { receiver_pk : Public_key.Compressed.Stable.V1.t
         ; fee : Currency.Fee.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, yojson, hash]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
 

--- a/src/lib/mina_base/coinbase_fee_transfer_intf.ml
+++ b/src/lib/mina_base/coinbase_fee_transfer_intf.ml
@@ -9,7 +9,7 @@ module type Full = sig
         { receiver_pk : Public_key.Compressed.Stable.V1.t
         ; fee : Currency.Fee.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, yojson, hash]
+      [@@deriving sexp, compare, equal, yojson]
     end
   end]
 

--- a/src/lib/mina_base/coinbase_intf.ml
+++ b/src/lib/mina_base/coinbase_intf.ml
@@ -11,7 +11,7 @@ module type Full = sig
         ; amount : Currency.Amount.Stable.V1.t
         ; fee_transfer : Fee_transfer.Stable.V1.t option
         }
-      [@@deriving sexp, bin_io, compare, equal, version, hash, yojson]
+      [@@deriving sexp, bin_io, compare, equal, version, yojson]
     end
 
     module Latest = V1
@@ -23,7 +23,7 @@ module type Full = sig
     ; amount : Currency.Amount.t
     ; fee_transfer : Fee_transfer.t option
     }
-  [@@deriving sexp, compare, equal, hash, yojson]
+  [@@deriving sexp, compare, equal, yojson]
 
   include Codable.Base58_check_intf with type t := t
 

--- a/src/lib/mina_base/digest_intf.ml
+++ b/src/lib/mina_base/digest_intf.ml
@@ -34,11 +34,6 @@ module type S = sig
       val compare : t -> t -> int
 
       val equal : t -> t -> bool
-
-      val hash_fold_t :
-        Base_internalhash_types.state -> t -> Base_internalhash_types.state
-
-      val hash : t -> int
     end
 
     module Latest = V1
@@ -57,11 +52,6 @@ module type S = sig
   val compare : t -> t -> int
 
   val equal : t -> t -> bool
-
-  val hash_fold_t :
-    Base_internalhash_types.state -> t -> Base_internalhash_types.state
-
-  val hash : t -> int
 end
 
 module type S_checked = sig

--- a/src/lib/mina_base/epoch_data.ml
+++ b/src/lib/mina_base/epoch_data.ml
@@ -25,7 +25,7 @@ module Poly = struct
         ; lock_checkpoint : 'lock_checkpoint
         ; epoch_length : 'length
         }
-      [@@deriving annot, hlist, sexp, equal, compare, hash, yojson, fields]
+      [@@deriving annot, hlist, sexp, equal, compare, yojson, fields]
     end
   end]
 end
@@ -64,13 +64,13 @@ module Value = struct
         , State_hash.Stable.V1.t
         , Length.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
   end]
 end
 
-type t = Value.Stable.V1.t [@@deriving sexp, compare, equal, hash, yojson]
+type t = Value.Stable.V1.t [@@deriving sexp, compare, equal, yojson]
 
 include Comparable.Make (Value.Stable.V1)

--- a/src/lib/mina_base/epoch_ledger.ml
+++ b/src/lib/mina_base/epoch_ledger.ml
@@ -22,7 +22,7 @@ module Value = struct
     module V1 = struct
       type t =
         (Frozen_ledger_hash0.Stable.V1.t, Amount.Stable.V1.t) Poly.Stable.V1.t
-      [@@deriving sexp, equal, compare, hash, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -44,7 +44,7 @@ module Poly = struct
         ; fee_token_r : 'token
         ; fee_excess_r : 'fee
         }
-      [@@deriving compare, equal, hash, sexp, hlist]
+      [@@deriving compare, equal, sexp, hlist]
 
       let to_yojson token_to_yojson fee_to_yojson
           { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
@@ -107,7 +107,7 @@ module Stable = struct
       ( Token_id.Stable.V2.t
       , (Fee.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving compare, equal, hash, sexp, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     let to_latest = Fn.id
   end
@@ -119,7 +119,7 @@ type ('token, 'fee) poly = ('token, 'fee) Poly.t =
   ; fee_token_r : 'token
   ; fee_excess_r : 'fee
   }
-[@@deriving compare, equal, hash, sexp]
+[@@deriving compare, equal, sexp]
 
 let poly_to_yojson = Poly.to_yojson
 

--- a/src/lib/mina_base/fee_transfer.ml
+++ b/src/lib/mina_base/fee_transfer.ml
@@ -21,7 +21,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; fee : Currency.Fee.Stable.V1.t
           ; fee_token : Token_id.Stable.V2.t
           }
-        [@@deriving sexp, compare, equal, yojson, hash]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
 
@@ -67,7 +67,7 @@ module Make_str (A : Wire_types.Concrete) = struct
   module Stable = struct
     module V2 = struct
       type t = Single.Stable.V2.t One_or_two.Stable.V1.t
-      [@@deriving sexp, compare, equal, yojson, hash]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -78,7 +78,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     ; fee : Currency.Fee.t
     ; fee_token : Token_id.t
     }
-  [@@deriving sexp, compare, yojson, hash]
+  [@@deriving sexp, compare, yojson]
 
   let to_singles = Fn.id
 

--- a/src/lib/mina_base/fee_transfer_intf.ml
+++ b/src/lib/mina_base/fee_transfer_intf.ml
@@ -10,7 +10,7 @@ module type Full = sig
           ; fee : Currency.Fee.Stable.V1.t
           ; fee_token : Token_id.Stable.V2.t
           }
-        [@@deriving bin_io, sexp, compare, equal, yojson, version, hash]
+        [@@deriving bin_io, sexp, compare, equal, yojson, version]
       end
 
       module Latest = V2
@@ -21,7 +21,7 @@ module type Full = sig
       ; fee : Currency.Fee.t
       ; fee_token : Token_id.t
       }
-    [@@deriving sexp, compare, yojson, hash]
+    [@@deriving sexp, compare, yojson]
 
     include Comparable.S with type t := t
 
@@ -54,20 +54,20 @@ module type Full = sig
   module Stable : sig
     module V2 : sig
       type t = private Single.Stable.V2.t One_or_two.Stable.V1.t
-      [@@deriving bin_io, sexp, compare, equal, yojson, version, hash]
+      [@@deriving bin_io, sexp, compare, equal, yojson, version]
     end
 
     module Latest = V2
   end
 
-  type t = Stable.Latest.t [@@deriving sexp, compare, yojson, hash]
+  type t = Stable.Latest.t [@@deriving sexp, compare, yojson]
 
   type single = Single.t = private
     { receiver_pk : Public_key.Compressed.t
     ; fee : Currency.Fee.t
     ; fee_token : Token_id.t
     }
-  [@@deriving sexp, compare, yojson, hash]
+  [@@deriving sexp, compare, yojson]
 
   include Comparable.S with type t := t
 

--- a/src/lib/mina_base/fee_with_prover.ml
+++ b/src/lib/mina_base/fee_with_prover.ml
@@ -8,7 +8,7 @@ module Stable = struct
       { fee : Currency.Fee.Stable.V1.t
       ; prover : Public_key.Compressed.Stable.V1.t
       }
-    [@@deriving sexp, yojson, hash]
+    [@@deriving sexp, yojson]
 
     let to_latest = Fn.id
 

--- a/src/lib/mina_base/ledger_hash0.ml
+++ b/src/lib/mina_base/ledger_hash0.ml
@@ -15,7 +15,7 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
-      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
+      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare]
     end
 
     include T
@@ -24,8 +24,7 @@ module Stable = struct
 
     [%%define_from_scope to_yojson, of_yojson]
 
-    include Comparable.Make (T)
-    include Hashable.Make_binable (T)
+    include Comparable.Make_binable (T)
   end
 end]
 

--- a/src/lib/mina_base/ledger_hash_intf0.ml
+++ b/src/lib/mina_base/ledger_hash_intf0.ml
@@ -9,13 +9,11 @@ module type S = sig
     [@@@no_toplevel_latest_type]
 
     module V1 : sig
-      type t = Field.t [@@deriving sexp, compare, hash, yojson]
+      type t = Field.t [@@deriving sexp, compare, yojson]
 
       val to_latest : t -> t
 
-      include Comparable.S with type t := t
-
-      include Hashable_binable with type t := t
+      include Comparable.S_binable with type t := t
     end
   end]
 end

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -14,7 +14,7 @@ module Poly = struct
             , 'amount )
             Mina_wire_types.Mina_base.Payment_payload.Poly.V2.t =
         { receiver_pk : 'public_key; amount : 'amount }
-      [@@deriving equal, sexp, hash, yojson, compare, hlist]
+      [@@deriving equal, sexp, yojson, compare, hlist]
     end
 
     module V1 = struct
@@ -26,7 +26,7 @@ module Poly = struct
         ; token_id : 'token_id
         ; amount : 'amount
         }
-      [@@deriving equal, sexp, hash, yojson, compare, hlist]
+      [@@deriving equal, sexp, yojson, compare, hlist]
     end
   end]
 end
@@ -36,7 +36,7 @@ module Stable = struct
   module V2 = struct
     type t =
       (Public_key.Compressed.Stable.V1.t, Amount.Stable.V1.t) Poly.Stable.V2.t
-    [@@deriving equal, sexp, hash, compare, yojson]
+    [@@deriving equal, sexp, compare, yojson]
 
     let to_latest = Fn.id
   end
@@ -49,7 +49,7 @@ module Stable = struct
       , Token_id.Stable.V1.t
       , Amount.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving equal, sexp, hash, compare, yojson]
+    [@@deriving equal, sexp, compare, yojson]
 
     (* don't need to coerce old payments to new ones *)
     let to_latest _ = failwith "Not implemented"

--- a/src/lib/mina_base/payment_payload.mli
+++ b/src/lib/mina_base/payment_payload.mli
@@ -7,12 +7,11 @@ module Poly : sig
         , 'amount )
         Mina_wire_types.Mina_base.Payment_payload.Poly.V2.t =
     { receiver_pk : 'public_key; amount : 'amount }
-  [@@deriving equal, sexp, hash, yojson]
+  [@@deriving equal, sexp, yojson]
 
   module Stable : sig
     module V2 : sig
-      type ('pk, 'amount) t
-      [@@deriving bin_io, equal, sexp, hash, yojson, version]
+      type ('pk, 'amount) t [@@deriving bin_io, equal, sexp, yojson, version]
     end
 
     module V1 : sig
@@ -22,7 +21,7 @@ module Poly : sig
         ; token_id : 'token_id
         ; amount : 'amount
         }
-      [@@deriving bin_io, equal, sexp, hash, yojson, version]
+      [@@deriving bin_io, equal, sexp, yojson, version]
     end
 
     module Latest = V2
@@ -37,7 +36,7 @@ module Stable : sig
       ( Public_key.Compressed.Stable.V1.t
       , Currency.Amount.Stable.V1.t )
       Poly.Stable.V2.t
-    [@@deriving compare, equal, sexp, hash, compare, yojson]
+    [@@deriving compare, equal, sexp, compare, yojson]
   end
 
   module V1 : sig
@@ -48,7 +47,7 @@ module Stable : sig
       , Token_id.Stable.V1.t
       , Currency.Amount.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving compare, equal, sexp, hash, compare, yojson]
+    [@@deriving compare, equal, sexp, compare, yojson]
 
     val to_latest : t -> Latest.t
   end

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -28,7 +28,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
               , 'signature )
               Mina_wire_types.Mina_base.Signed_command.Poly.V1.t =
           { payload : 'payload; signer : 'pk; signature : 'signature }
-        [@@deriving compare, sexp, hash, yojson, equal]
+        [@@deriving compare, sexp, yojson, equal]
       end
     end]
   end
@@ -52,19 +52,18 @@ module Make_str (_ : Wire_types.Concrete) = struct
         , Public_key.Stable.V1.t
         , Signature.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving compare, sexp, hash, yojson]
+      [@@deriving compare, sexp, yojson]
 
       let to_latest = Fn.id
 
       module T = struct
         (* can't use nonrec + deriving *)
-        type typ = t [@@deriving compare, sexp, hash]
+        type typ = t [@@deriving compare, sexp]
 
-        type t = typ [@@deriving compare, sexp, hash]
+        type t = typ [@@deriving compare, sexp]
       end
 
       include Comparable.Make (T)
-      include Hashable.Make (T)
 
       let account_access_statuses ({ payload; _ } : t) status =
         Payload.account_access_statuses payload status
@@ -82,7 +81,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         , Public_key.Stable.V1.t
         , Signature.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving compare, sexp, hash, yojson]
+      [@@deriving compare, sexp, yojson]
 
       let to_latest ({ payload; signer; signature } : t) : Latest.t =
         let payload : Signed_command_payload.t =
@@ -375,7 +374,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     [%%versioned
     module Stable = struct
       module V2 = struct
-        type t = Stable.V2.t [@@deriving sexp, equal, yojson, hash]
+        type t = Stable.V2.t [@@deriving sexp, equal, yojson]
 
         let to_latest = Stable.V2.to_latest
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -77,14 +77,12 @@ module type Gen_intf = sig
 end
 
 module type S = sig
-  type t [@@deriving sexp, yojson, hash]
+  type t [@@deriving sexp, yojson]
 
   (* type of signed commands, pre-Berkeley hard fork *)
   type t_v1
 
   include Comparable.S with type t := t
-
-  include Hashable.S with type t := t
 
   val signature : t -> Signature.t
 
@@ -130,8 +128,7 @@ module type S = sig
   module With_valid_signature : sig
     module Stable : sig
       module Latest : sig
-        type nonrec t
-        [@@deriving sexp, equal, bin_io, yojson, version, compare, hash]
+        type nonrec t [@@deriving sexp, equal, bin_io, yojson, version, compare]
 
         include Gen_intf with type t := t
       end
@@ -139,7 +136,7 @@ module type S = sig
       module V2 = Latest
     end
 
-    type t = Stable.Latest.t [@@deriving sexp, yojson, compare, hash]
+    type t = Stable.Latest.t [@@deriving sexp, yojson, compare]
 
     include Gen_intf with type t := t
 
@@ -222,7 +219,7 @@ module type Full = sig
               , 'signature )
               Mina_wire_types.Mina_base.Signed_command.Poly.V1.t =
           { payload : 'payload; signer : 'pk; signature : 'signature }
-        [@@deriving sexp, hash, yojson, equal, compare]
+        [@@deriving sexp, yojson, equal, compare]
       end
     end]
   end
@@ -237,15 +234,13 @@ module type Full = sig
         , Public_key.Stable.Latest.t
         , Signature.Stable.Latest.t )
         Poly.Stable.V1.t
-      [@@deriving sexp, hash, version]
+      [@@deriving sexp, version]
 
       val to_yojson : t -> Yojson.Safe.t
 
       val of_yojson : Yojson.Safe.t -> (t, string) result
 
       include Comparable.S with type t := t
-
-      include Hashable.S with type t := t
 
       val account_access_statuses :
            t
@@ -261,7 +256,7 @@ module type Full = sig
         , Public_key.Stable.V1.t
         , Signature.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving compare, sexp, hash, yojson]
+      [@@deriving compare, sexp, yojson]
 
       val to_latest : t -> Latest.t
     end

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -45,7 +45,7 @@ module Common = struct
           ; valid_until : 'global_slot
           ; memo : 'memo
           }
-        [@@deriving compare, equal, sexp, hash, yojson, hlist]
+        [@@deriving compare, equal, sexp, yojson, hlist]
       end
 
       module V1 = struct
@@ -59,7 +59,7 @@ module Common = struct
           ; valid_until : 'global_slot
           ; memo : 'memo
           }
-        [@@deriving compare, equal, sexp, hash, yojson, hlist]
+        [@@deriving compare, equal, sexp, yojson, hlist]
       end
     end]
   end
@@ -74,7 +74,7 @@ module Common = struct
         , Global_slot_since_genesis.Stable.V1.t
         , Memo.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving compare, equal, sexp, yojson]
 
       let to_latest = Fn.id
     end
@@ -90,7 +90,7 @@ module Common = struct
         , Global_slot_legacy.Stable.V1.t
         , Memo.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving compare, equal, sexp, yojson]
 
       let to_latest _ = failwith "Not implemented"
     end
@@ -179,7 +179,7 @@ module Body = struct
       type t = Mina_wire_types.Mina_base.Signed_command_payload.Body.V2.t =
         | Payment of Payment_payload.Stable.V2.t
         | Stake_delegation of Stake_delegation.Stable.V2.t
-      [@@deriving sexp, compare, equal, sexp, hash, yojson]
+      [@@deriving sexp, compare, equal, sexp, yojson]
 
       let to_latest = Fn.id
     end
@@ -193,7 +193,7 @@ module Body = struct
       (* omitting token commands, none were ever created
          such omission doesn't affect serialization/Base58Check of payments, delegations
       *)
-      [@@deriving sexp, compare, equal, sexp, hash, yojson]
+      [@@deriving sexp, compare, equal, sexp, yojson]
 
       let to_latest _ = failwith "Not implemented"
     end
@@ -241,7 +241,7 @@ module Poly = struct
             , 'body )
             Mina_wire_types.Mina_base.Signed_command_payload.Poly.V1.t =
         { common : 'common; body : 'body }
-      [@@deriving equal, sexp, hash, yojson, compare, hlist]
+      [@@deriving equal, sexp, yojson, compare, hlist]
 
       let of_latest common_latest body_latest { common; body } =
         let open Result.Let_syntax in
@@ -255,7 +255,7 @@ end
 module Stable = struct
   module V2 = struct
     type t = (Common.Stable.V2.t, Body.Stable.V2.t) Poly.Stable.V1.t
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     let to_latest = Fn.id
   end
@@ -264,7 +264,7 @@ module Stable = struct
     [@@@with_all_version_tags]
 
     type t = (Common.Stable.V1.t, Body.Stable.V1.t) Poly.Stable.V1.t
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     (* don't need to coerce old transactions to newer version *)
     let to_latest _ = failwith "Not implemented"

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -18,21 +18,21 @@ module Body : sig
   type t = Mina_wire_types.Mina_base.Signed_command_payload.Body.V2.t =
     | Payment of Payment_payload.t
     | Stake_delegation of Stake_delegation.t
-  [@@deriving equal, sexp, hash, yojson]
+  [@@deriving equal, sexp, yojson]
 
   [%%versioned:
   module Stable : sig
     [@@@no_toplevel_latest_type]
 
     module V2 : sig
-      type nonrec t = t [@@deriving compare, equal, sexp, hash, yojson]
+      type nonrec t = t [@@deriving compare, equal, sexp, yojson]
     end
 
     module V1 : sig
       type t =
         | Payment of Payment_payload.Stable.V1.t
         | Stake_delegation of Stake_delegation.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving compare, equal, sexp, yojson]
     end
   end]
 
@@ -61,7 +61,7 @@ module Common : sig
           ; valid_until : 'global_slot
           ; memo : 'memo
           }
-        [@@deriving equal, sexp, hash, yojson]
+        [@@deriving equal, sexp, yojson]
       end
 
       module V1 : sig
@@ -73,7 +73,7 @@ module Common : sig
           ; valid_until : 'global_slot
           ; memo : 'memo
           }
-        [@@deriving compare, equal, sexp, hash, yojson, hlist]
+        [@@deriving compare, equal, sexp, yojson, hlist]
       end
     end]
   end
@@ -88,7 +88,7 @@ module Common : sig
         , Mina_numbers.Global_slot_since_genesis.Stable.V1.t
         , Signed_command_memo.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving compare, equal, sexp, yojson]
     end
 
     module V1 : sig
@@ -100,7 +100,7 @@ module Common : sig
         , Mina_numbers.Global_slot_legacy.Stable.V1.t
         , Signed_command_memo.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving compare, equal, sexp, yojson]
     end
   end]
 
@@ -137,7 +137,7 @@ module Poly : sig
             , 'body )
             Mina_wire_types.Mina_base.Signed_command_payload.Poly.V1.t =
         { common : 'common; body : 'body }
-      [@@deriving equal, sexp, hash, yojson, compare, hlist]
+      [@@deriving equal, sexp, yojson, compare, hlist]
 
       val of_latest :
            ('common1 -> ('common2, 'err) Result.t)
@@ -152,14 +152,14 @@ end
 module Stable : sig
   module V2 : sig
     type t = (Common.Stable.V2.t, Body.Stable.V2.t) Poly.Stable.V1.t
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
   end
 
   module V1 : sig
     [@@@with_all_version_tags]
 
     type t = (Common.Stable.V1.t, Body.Stable.V1.t) Poly.Stable.V1.t
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     val to_latest : t -> Latest.t
   end

--- a/src/lib/mina_base/staged_ledger_hash.ml
+++ b/src/lib/mina_base/staged_ledger_hash.ml
@@ -23,7 +23,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Bounded_types.String.Stable.V1.t
-        [@@deriving sexp, equal, compare, hash]
+        [@@deriving sexp, equal, compare]
 
         let to_latest = Fn.id
 
@@ -107,7 +107,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Bounded_types.String.Stable.V1.t
-        [@@deriving sexp, equal, compare, hash]
+        [@@deriving sexp, equal, compare]
 
         let to_latest = Fn.id
 
@@ -154,13 +154,13 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; aux_hash : Aux_hash.Stable.V1.t
           ; pending_coinbase_aux : Pending_coinbase_aux.Stable.V1.t
           }
-        [@@deriving sexp, equal, compare, hash, yojson, fields]
+        [@@deriving sexp, equal, compare, yojson, fields]
 
         let to_latest = Fn.id
       end
     end]
 
-    type value = t [@@deriving sexp, compare, hash, yojson]
+    type value = t [@@deriving sexp, compare, yojson]
 
     let dummy : t Lazy.t =
       lazy
@@ -230,7 +230,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           { non_snark : 'non_snark
           ; pending_coinbase_hash : 'pending_coinbase_hash
           }
-        [@@deriving sexp, equal, compare, hash, yojson, hlist]
+        [@@deriving sexp, equal, compare, yojson, hlist]
       end
     end]
   end
@@ -247,7 +247,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         ( Non_snark.Stable.V1.t
         , Pending_coinbase.Hash_versioned.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving sexp, equal, compare, hash, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       let to_latest = Fn.id
     end
@@ -255,11 +255,9 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   type ('a, 'b) t_ = ('a, 'b) Poly.t
 
-  type value = t [@@deriving sexp, equal, compare, hash]
+  type value = t [@@deriving sexp, equal, compare]
 
   type var = (Non_snark.var, Pending_coinbase.Hash.var) t_
-
-  include Hashable.Make (Stable.Latest)
 
   let ledger_hash ({ non_snark; _ } : t) = Non_snark.ledger_hash non_snark
 

--- a/src/lib/mina_base/staged_ledger_hash_intf.ml
+++ b/src/lib/mina_base/staged_ledger_hash_intf.ml
@@ -2,11 +2,9 @@ module type Full = sig
   open Core_kernel
   open Snark_params.Tick
 
-  type t [@@deriving sexp, equal, compare, hash, yojson]
+  type t [@@deriving sexp, equal, compare, yojson]
 
-  include Hashable with type t := t
-
-  type value [@@deriving sexp, equal, compare, hash]
+  type value [@@deriving sexp, equal, compare]
 
   type var
 
@@ -26,7 +24,7 @@ module type Full = sig
   module Stable : sig
     module V1 : sig
       type nonrec t = t
-      [@@deriving bin_io, sexp, equal, compare, hash, yojson, version]
+      [@@deriving bin_io, sexp, equal, compare, yojson, version]
     end
 
     module Latest : module type of V1
@@ -38,7 +36,7 @@ module type Full = sig
     module Stable : sig
       module V1 : sig
         type nonrec t = t
-        [@@deriving bin_io, sexp, equal, compare, hash, yojson, version]
+        [@@deriving bin_io, sexp, equal, compare, yojson, version]
       end
 
       module Latest : module type of V1
@@ -69,7 +67,7 @@ module type Full = sig
     module Stable : sig
       module V1 : sig
         type nonrec t = t
-        [@@deriving bin_io, sexp, equal, compare, hash, yojson, version]
+        [@@deriving bin_io, sexp, equal, compare, yojson, version]
       end
 
       module Latest : module type of V1

--- a/src/lib/mina_base/stake_delegation.ml
+++ b/src/lib/mina_base/stake_delegation.ml
@@ -10,7 +10,7 @@ module Stable = struct
 
     type t = Mina_wire_types.Mina_base.Stake_delegation.V2.t =
       | Set_delegate of { new_delegate : Public_key.Compressed.Stable.V1.t }
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     let to_latest = Fn.id
   end
@@ -23,7 +23,7 @@ module Stable = struct
           { delegator : Public_key.Compressed.Stable.V1.t
           ; new_delegate : Public_key.Compressed.Stable.V1.t
           }
-    [@@deriving compare, equal, sexp, hash, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     let to_latest (Set_delegate { delegator = _; new_delegate }) =
       V2.Set_delegate { new_delegate }

--- a/src/lib/mina_base/token_id.ml
+++ b/src/lib/mina_base/token_id.ml
@@ -6,7 +6,7 @@ module Legacy_token = Mina_numbers.Nat.Make64 ()
 module Stable = struct
   module V2 = struct
     type t = Account_id.Digest.Stable.V1.t
-    [@@deriving sexp, yojson, equal, compare, hash]
+    [@@deriving sexp, yojson, equal, compare]
 
     let to_latest = Fn.id
   end

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -8,14 +8,14 @@ module Poly = struct
             ('u, 's) Mina_wire_types.Mina_base.User_command.Poly.V2.t =
         | Signed_command of 'u
         | Zkapp_command of 's
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
 
     module V1 = struct
       type ('u, 's) t = Signed_command of 'u | Snapp_command of 's
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest : _ t -> _ V2.t = function
         | Signed_command x ->
@@ -78,7 +78,7 @@ module Stable = struct
   module V2 = struct
     type t =
       (Signed_command.Stable.V2.t, Zkapp_command.Stable.V1.t) Poly.Stable.V2.t
-    [@@deriving sexp, compare, equal, hash, yojson]
+    [@@deriving sexp, compare, equal, yojson]
 
     let to_latest = Fn.id
   end
@@ -132,7 +132,7 @@ module Zero_one_or_two = struct
   module Stable = struct
     module V1 = struct
       type 'a t = [ `Zero | `One of 'a | `Two of 'a * 'a ]
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
     end
   end]
 end
@@ -145,7 +145,7 @@ module Verifiable = struct
         ( Signed_command.Stable.V2.t
         , Zkapp_command.Verifiable.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -308,7 +308,7 @@ module Valid = struct
         ( Signed_command.With_valid_signature.Stable.V2.t
         , Zkapp_command.Valid.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -457,7 +457,7 @@ let check_well_formedness ~(genesis_constants : Genesis_constants.t) t :
   if List.is_empty errs then Ok () else Error errs
 
 type fee_payer_summary_t = Signature.t * Account.key * int
-[@@deriving yojson, hash]
+[@@deriving hash, yojson]
 
 let fee_payer_summary : t -> fee_payer_summary_t = function
   | Zkapp_command cmd ->

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -21,7 +21,7 @@ module Call_forest = struct
               With_stack_hash.Stable.V1.t
               list
           }
-        [@@deriving sexp, compare, equal, hash, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
@@ -211,7 +211,7 @@ module Call_forest = struct
       module Stable = struct
         module V1 = struct
           type t = Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
-          [@@deriving sexp, compare, equal, hash, yojson]
+          [@@deriving sexp, compare, equal, yojson]
 
           let to_latest = Fn.id
         end
@@ -223,7 +223,7 @@ module Call_forest = struct
       module Stable = struct
         module V1 = struct
           type t = Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
-          [@@deriving sexp, compare, equal, hash, yojson]
+          [@@deriving sexp, compare, equal, yojson]
 
           let to_latest = Fn.id
         end
@@ -235,7 +235,7 @@ module Call_forest = struct
       module Stable = struct
         module V1 = struct
           type t = Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
-          [@@deriving sexp, compare, equal, hash, yojson]
+          [@@deriving sexp, compare, equal, yojson]
 
           let to_latest = Fn.id
         end
@@ -339,7 +339,7 @@ module Call_forest = struct
         , 'digest )
         With_stack_hash.Stable.V1.t
         list
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -525,7 +525,7 @@ module Call_forest = struct
           , Digest.Account_update.Stable.V1.t
           , Digest.Forest.Stable.V1.t )
           Stable.V1.t
-        [@@deriving sexp, compare, equal, hash, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
@@ -575,7 +575,7 @@ module Call_forest = struct
           , Digest.Account_update.Stable.V1.t
           , Digest.Forest.Stable.V1.t )
           Stable.V1.t
-        [@@deriving sexp, compare, equal, hash, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
@@ -634,7 +634,7 @@ module Graphql_repr = struct
         ; account_updates : Account_update.Graphql_repr.Stable.V1.t list
         ; memo : Signed_command_memo.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -651,7 +651,7 @@ module Simple = struct
         ; account_updates : Account_update.Simple.Stable.V1.t list
         ; memo : Signed_command_memo.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -684,7 +684,7 @@ module T = struct
             Call_forest.Stable.V1.t
         ; memo : Signed_command_memo.Stable.V1.t
         }
-      [@@deriving annot, sexp, compare, equal, hash, yojson, fields]
+      [@@deriving annot, sexp, compare, equal, yojson, fields]
 
       let to_latest = Fn.id
 
@@ -701,7 +701,7 @@ module T = struct
                   Call_forest.Stable.V1.t
               ; memo : Signed_command_memo.Stable.V1.t
               }
-            [@@deriving sexp, compare, equal, hash, yojson]
+            [@@deriving sexp, compare, equal, yojson]
 
             let to_latest = Fn.id
           end
@@ -1038,7 +1038,7 @@ module Verifiable : sig
             Call_forest.With_hashes_and_data.Stable.V1.t
         ; memo : Signed_command_memo.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       val to_latest : t -> t
     end
@@ -1108,7 +1108,7 @@ end = struct
             Call_forest.With_hashes_and_data.Stable.V1.t
         ; memo : Signed_command_memo.Stable.V1.t
         }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
@@ -1166,7 +1166,7 @@ end = struct
   let create ({ fee_payer; account_updates; memo } : T.t) ~failed ~find_vk :
       t Or_error.t =
     With_return.with_return (fun { return } ->
-        let tbl = Account_id.Table.create () in
+        let tbl = ref Account_id.Map.empty in
         let vks_overridden =
           (* Keep track of the verification keys that have been set so far
              during this transaction.
@@ -1227,8 +1227,9 @@ end = struct
                   in
                   match prioritized_vk with
                   | Some prioritized_vk ->
-                      Account_id.Table.update tbl account_id ~f:(fun _ ->
-                          With_hash.hash prioritized_vk ) ;
+                      tbl :=
+                        Account_id.Map.update !tbl account_id ~f:(fun _ ->
+                            With_hash.hash prioritized_vk ) ;
                       (* return the updated overrides *)
                       vks_overridden := vks_overriden' ;
                       (p, Some prioritized_vk)
@@ -1449,7 +1450,7 @@ module type Valid_intf = sig
   module Stable : sig
     module V1 : sig
       type t = private { zkapp_command : T.Stable.V1.t }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
     end
   end]
 
@@ -1481,7 +1482,7 @@ struct
     module Stable = struct
       module V1 = struct
         type t = Zkapp_basic.F.Stable.V1.t
-        [@@deriving sexp, compare, equal, hash, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
@@ -1493,7 +1494,7 @@ struct
     module V1 = struct
       type t = Mina_wire_types.Mina_base.Zkapp_command.Valid.V1.t =
         { zkapp_command : S.V1.t }
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -15,7 +15,7 @@ module Closed_interval = struct
       type 'a t =
             'a Mina_wire_types.Mina_base.Zkapp_precondition.Closed_interval.V1.t =
         { lower : 'a; upper : 'a }
-      [@@deriving annot, sexp, equal, compare, hash, yojson, hlist, fields]
+      [@@deriving annot, sexp, equal, compare, yojson, hlist, fields]
     end
   end]
 
@@ -155,7 +155,7 @@ module Numeric = struct
   module Stable = struct
     module V1 = struct
       type 'a t = 'a Closed_interval.Stable.V1.t Or_ignore.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
     end
   end]
 
@@ -464,7 +464,7 @@ module Account = struct
         ; proved_state : bool Eq_data.Stable.V1.t
         ; is_new : bool Eq_data.Stable.V1.t
         }
-      [@@deriving annot, hlist, sexp, equal, yojson, hash, compare, fields]
+      [@@deriving annot, hlist, sexp, equal, yojson, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -790,7 +790,7 @@ module Protocol_state = struct
           , State_hash.Stable.V1.t Hash.Stable.V1.t
           , Length.Stable.V1.t Numeric.Stable.V1.t )
           Poly.Stable.V1.t
-        [@@deriving sexp, equal, yojson, hash, compare]
+        [@@deriving sexp, equal, yojson, compare]
 
         let to_latest = Fn.id
       end
@@ -948,7 +948,7 @@ module Protocol_state = struct
           ; staking_epoch_data : 'epoch_data
           ; next_epoch_data : 'epoch_data
           }
-        [@@deriving annot, hlist, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, hlist, sexp, equal, yojson, compare, fields]
       end
     end]
   end
@@ -963,7 +963,7 @@ module Protocol_state = struct
         , Currency.Amount.Stable.V1.t Numeric.Stable.V1.t
         , Epoch_data.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -1064,7 +1064,7 @@ module Protocol_state = struct
             , Length.Stable.V1.t )
             Epoch_data.Poly.Stable.V1.t )
           Poly.Stable.V1.t
-        [@@deriving sexp, equal, yojson, hash, compare]
+        [@@deriving sexp, equal, yojson, compare]
 
         let to_latest = Fn.id
       end
@@ -1343,7 +1343,7 @@ module Valid_while = struct
   module Stable = struct
     module V1 = struct
       type t = Global_slot_since_genesis.Stable.V1.t Numeric.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -1378,7 +1378,7 @@ module Account_type = struct
   module Stable = struct
     module V1 = struct
       type t = User | Zkapp | None | Any
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -1491,7 +1491,7 @@ module Other = struct
           ; account_transition : 'account_transition
           ; account_vk : 'vk
           }
-        [@@deriving hlist, sexp, equal, yojson, hash, compare]
+        [@@deriving hlist, sexp, equal, yojson, compare]
       end
     end]
   end
@@ -1504,7 +1504,7 @@ module Other = struct
         , Account_state.Stable.V1.t Transition.Stable.V1.t
         , F.Stable.V1.t Hash.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -1559,7 +1559,7 @@ module Poly = struct
         ; fee_payer : 'pk
         ; protocol_state_predicate : 'protocol_state
         }
-      [@@deriving hlist, sexp, equal, yojson, hash, compare]
+      [@@deriving hlist, sexp, equal, yojson, compare]
 
       let to_latest = Fn.id
     end
@@ -1580,7 +1580,7 @@ module Stable = struct
       , Other.Stable.V2.t
       , Public_key.Compressed.Stable.V1.t Eq_data.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving sexp, equal, yojson, hash, compare]
+    [@@deriving sexp, equal, yojson, compare]
 
     let to_latest = Fn.id
   end

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -754,7 +754,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
             let%map zkapp_account_id =
               Quickcheck.Generator.of_list zkapp_account_ids
             in
-            match Account_id.Table.find account_state_tbl zkapp_account_id with
+            match Account_id.Map.find !account_state_tbl zkapp_account_id with
             | None ->
                 failwith "gen_account_update_body: fail to find zkapp account"
             | Some (_, `Fee_payer)
@@ -767,7 +767,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
                 acct
           else
             let accts =
-              Account_id.Table.filteri account_state_tbl
+              Account_id.Map.filteri !account_state_tbl
                 ~f:(fun ~key:_ ~data:(_, role) ->
                   match (authorization_tag, role) with
                   | _, `Fee_payer ->
@@ -782,13 +782,13 @@ let gen_account_update_body_components (type a b c d) ?global_slot
                       Option.is_none required_balance_change
                   | _, `Ordinary_participant ->
                       true )
-              |> Account_id.Table.data
+              |> Account_id.Map.data
             in
             Quickcheck.Generator.of_list accts >>| fst
       | Some account_id ->
           (*get the latest state of the account*)
           let acct =
-            Account_id.Table.find_exn account_state_tbl account_id |> fst
+            Account_id.Map.find_exn !account_state_tbl account_id |> fst
           in
           if zkapp_account && Option.is_none acct.zkapp then
             failwith
@@ -825,9 +825,9 @@ let gen_account_update_body_components (type a b c d) ?global_slot
     | None ->
         (* fee payer *)
         true
-    | Some hash_set ->
+    | Some set ->
         (* other account_updates *)
-        not @@ Hash_set.mem hash_set account_id
+        not @@ Set.mem !set account_id
   in
   let%bind account_precondition =
     f_account_precondition ~first_use_of_account account
@@ -971,29 +971,30 @@ let gen_account_update_body_components (type a b c d) ?global_slot
            in
            Some { zk with app_state; action_state; proved_state }
    in
-   Account_id.Table.update account_state_tbl (Account.identifier account)
-     ~f:(function
-     | None ->
-         (* new entry in table *)
-         ( { account with
-             balance =
-               add_balance_and_balance_change account.balance balance_change
-           ; nonce = nonce_incr account.nonce
-           ; delegate = delegate account
-           ; zkapp = zkapp account
-           }
-         , if token_account then `New_token_account else `New_account )
-     | Some (updated_account, role) ->
-         (* update entry in table *)
-         ( { updated_account with
-             balance =
-               add_balance_and_balance_change updated_account.balance
-                 balance_change
-           ; nonce = nonce_incr updated_account.nonce
-           ; delegate = delegate updated_account
-           ; zkapp = zkapp updated_account
-           }
-         , role ) ) ) ;
+   account_state_tbl :=
+     Account_id.Map.update !account_state_tbl (Account.identifier account)
+       ~f:(function
+       | None ->
+           (* new entry in table *)
+           ( { account with
+               balance =
+                 add_balance_and_balance_change account.balance balance_change
+             ; nonce = nonce_incr account.nonce
+             ; delegate = delegate account
+             ; zkapp = zkapp account
+             }
+           , if token_account then `New_token_account else `New_account )
+       | Some (updated_account, role) ->
+           (* update entry in table *)
+           ( { updated_account with
+               balance =
+                 add_balance_and_balance_change updated_account.balance
+                   balance_change
+             ; nonce = nonce_incr updated_account.nonce
+             ; delegate = delegate updated_account
+             ; zkapp = zkapp updated_account
+             }
+           , role ) ) ) ;
   { Account_update_body_components.public_key
   ; update =
       ( if new_account then
@@ -1061,7 +1062,7 @@ let gen_account_update_from ?(no_account_precondition = false)
     Account_update_body_components.to_typical_account_update body_components
   in
   let account_id = Account_id.create body.public_key body.token_id in
-  Hash_set.add account_ids_seen account_id ;
+  account_ids_seen := Account_id.Set.add !account_ids_seen account_id ;
   return { Account_update.Simple.body; authorization }
 
 (* takes an account id, if we want to sign this data *)
@@ -1131,8 +1132,8 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t )
-    ?account_state_tbl ~ledger ?protocol_state_view ?vk ?available_public_keys
-    ~genesis_constants
+    ?(account_state_tbl = ref Account_id.Map.empty) ~ledger ?protocol_state_view
+    ?vk ?available_public_keys ~genesis_constants
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) () =
   let open Quickcheck.Let_syntax in
   let fee_payer_pk =
@@ -1145,22 +1146,20 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
      a Map would be more principled, but threading that map through the code
      adds complexity
   *)
-  let account_state_tbl =
-    Option.value account_state_tbl ~default:(Account_id.Table.create ())
-  in
   if not limited then
     (* make sure all ledger keys are in the keymap *)
     List.iter (Lazy.force ledger_accounts) ~f:(fun acct ->
         let acct_id = Account.identifier acct in
         (*Initialize account states*)
-        Account_id.Table.update account_state_tbl acct_id ~f:(function
-          | None ->
-              if Account_id.equal acct_id fee_payer_acct_id then
-                (acct, `Fee_payer)
-              else (acct, `Ordinary_participant)
-          | Some a ->
-              a ) ) ;
-  List.iter (Account_id.Table.keys account_state_tbl) ~f:(fun id ->
+        account_state_tbl :=
+          Account_id.Map.update !account_state_tbl acct_id ~f:(function
+            | None ->
+                if Account_id.equal acct_id fee_payer_acct_id then
+                  (acct, `Fee_payer)
+                else (acct, `Ordinary_participant)
+            | Some a ->
+                a ) ) ;
+  List.iter (Account_id.Map.keys !account_state_tbl) ~f:(fun id ->
       let pk = Account_id.public_key id in
       if Option.is_none (Signature_lib.Public_key.Compressed.Map.find keymap pk)
       then
@@ -1183,7 +1182,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
         let ledger_account_list =
           Account_id.Set.union_list
             [ ledger_account_ids
-            ; Account_id.Set.of_hashtbl_keys account_state_tbl
+            ; Account_id.Set.of_map_keys !account_state_tbl
             ]
           |> Account_id.Set.to_list
         in
@@ -1204,7 +1203,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   (* account ids seen, to generate receipt chain hash precondition only if
      a account_update with a given account id has not been encountered before
   *)
-  let account_ids_seen = Account_id.Hash_set.create () in
+  let account_ids_seen = ref Account_id.Set.empty in
   let%bind num_zkapp_command = Int.gen_uniform_incl 1 max_account_updates in
   let%bind fee_payer =
     gen_fee_payer ?global_slot ?fee_range ?failure
@@ -1213,15 +1212,15 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
       ~genesis_constants ()
   in
   let zkapp_account_ids =
-    Account_id.Table.filteri account_state_tbl ~f:(fun ~key:_ ~data:(a, role) ->
+    Account_id.Map.filteri !account_state_tbl ~f:(fun ~key:_ ~data:(a, role) ->
         match role with
         | `Fee_payer | `New_account | `New_token_account ->
             false
         | `Ordinary_participant ->
             Option.is_some a.zkapp )
-    |> Account_id.Table.keys
+    |> Account_id.Map.keys
   in
-  Hash_set.add account_ids_seen fee_payer_acct_id ;
+  account_ids_seen := Set.add !account_ids_seen fee_payer_acct_id ;
   let mk_forest ps =
     List.map ps ~f:(fun p -> { With_stack_hash.elt = p; stack_hash = () })
   in
@@ -1550,16 +1549,17 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     in
     Receipt.Zkapp_command_elt.Zkapp_command_commitment full_txn_commitment
   in
-  Account_id.Table.update account_state_tbl fee_payer_acct_id ~f:(function
-    | None ->
-        failwith "Expected fee payer account id to be in table"
-    | Some (account, _) ->
-        let receipt_chain_hash =
-          Receipt.Chain_hash.cons_zkapp_command_commitment
-            Mina_numbers.Index.zero receipt_elt
-            account.Account.receipt_chain_hash
-        in
-        ({ account with receipt_chain_hash }, `Fee_payer) ) ;
+  account_state_tbl :=
+    Account_id.Map.update !account_state_tbl fee_payer_acct_id ~f:(function
+      | None ->
+          failwith "Expected fee payer account id to be in table"
+      | Some (account, _) ->
+          let receipt_chain_hash =
+            Receipt.Chain_hash.cons_zkapp_command_commitment
+              Mina_numbers.Index.zero receipt_elt
+              account.Account.receipt_chain_hash
+          in
+          ({ account with receipt_chain_hash }, `Fee_payer) ) ;
   let account_updates =
     Zkapp_command.Call_forest.to_account_updates
       zkapp_command_dummy_authorizations.account_updates
@@ -1569,20 +1569,21 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
       match Account_update.authorization account_update with
       | Control.Proof _ | Control.Signature _ ->
           let acct_id = Account_update.account_id account_update in
-          Account_id.Table.update account_state_tbl acct_id ~f:(function
-            | None ->
-                failwith
-                  "Expected other account_update account id to be in table"
-            | Some (account, role) ->
-                let receipt_chain_hash =
-                  let account_update_index =
-                    Mina_numbers.Index.of_int (ndx + 1)
+          account_state_tbl :=
+            Account_id.Map.update !account_state_tbl acct_id ~f:(function
+              | None ->
+                  failwith
+                    "Expected other account_update account id to be in table"
+              | Some (account, role) ->
+                  let receipt_chain_hash =
+                    let account_update_index =
+                      Mina_numbers.Index.of_int (ndx + 1)
+                    in
+                    Receipt.Chain_hash.cons_zkapp_command_commitment
+                      account_update_index receipt_elt
+                      account.Account.receipt_chain_hash
                   in
-                  Receipt.Chain_hash.cons_zkapp_command_commitment
-                    account_update_index receipt_elt
-                    account.Account.receipt_chain_hash
-                in
-                ({ account with receipt_chain_hash }, role) )
+                  ({ account with receipt_chain_hash }, role) )
       | Control.None_given ->
           () ) ;
   zkapp_command_dummy_authorizations
@@ -1598,26 +1599,28 @@ let gen_list_of_zkapp_command_from ?global_slot ?failure ?max_account_updates
   let account_state_tbl =
     match account_state_tbl with
     | None ->
-        let tbl = Account_id.Table.create () in
+        let tbl = ref Account_id.Map.empty in
         let accounts = Ledger.to_list_sequential ledger in
         List.iter accounts ~f:(fun acct ->
             let acct_id = Account.identifier acct in
-            Account_id.Table.update tbl acct_id ~f:(function
-              | None ->
-                  (acct, `Ordinary_participant)
-              | Some a ->
-                  a ) ) ;
+            tbl :=
+              Account_id.Map.update !tbl acct_id ~f:(function
+                | None ->
+                    (acct, `Ordinary_participant)
+                | Some a ->
+                    a ) ) ;
         List.iter fee_payer_keypairs ~f:(fun fee_payer_keypair ->
             let acct_id =
               Account_id.create
                 (Signature_lib.Public_key.compress fee_payer_keypair.public_key)
                 Token_id.default
             in
-            Account_id.Table.update tbl acct_id ~f:(function
-              | None ->
-                  failwith "fee_payer not in ledger"
-              | Some (a, _) ->
-                  (a, `Fee_payer) ) ) ;
+            tbl :=
+              Account_id.Map.update !tbl acct_id ~f:(function
+                | None ->
+                    failwith "fee_payer not in ledger"
+                | Some (a, _) ->
+                    (a, `Fee_payer) ) ) ;
         tbl
     | Some tbl ->
         tbl
@@ -1676,7 +1679,7 @@ let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
 
 let gen_max_cost_zkapp_command_from ?memo ?fee_range
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
-    ~(account_state_tbl : (Account.t * role) Account_id.Table.t) ~vk
+    ~(account_state_tbl : (Account.t * role) Account_id.Map.t ref) ~vk
     ~(genesis_constants : Genesis_constants.t) () =
   let open Quickcheck.Generator.Let_syntax in
   let%bind memo =
@@ -1687,7 +1690,7 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
         Signed_command_memo.gen
   in
   let zkapp_accounts =
-    Account_id.Table.data account_state_tbl
+    Account_id.Map.data !account_state_tbl
     |> List.filter_map ~f:(fun ((a, role) : Account.t * role) ->
            match role with
            | `Ordinary_participant ->
@@ -1722,7 +1725,7 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
   in
   let fee_payer_id = Account_id.create fee_payer_pk Token_id.default in
   let fee_payer_account, _ =
-    Account_id.Table.find_exn account_state_tbl fee_payer_id
+    Account_id.Map.find_exn !account_state_tbl fee_payer_id
   in
   let%map fee =
     Option.value_map fee_range
@@ -1732,11 +1735,12 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
   let fee_payer =
     mk_fee_payer ~fee ~pk:fee_payer_pk ~nonce:fee_payer_account.nonce
   in
-  Account_id.Table.change account_state_tbl fee_payer_id ~f:(function
-    | None ->
-        None
-    | Some (a, role) ->
-        Some ({ a with nonce = Account.Nonce.succ a.nonce }, role) ) ;
+  account_state_tbl :=
+    Account_id.Map.change !account_state_tbl fee_payer_id ~f:(function
+      | None ->
+          None
+      | Some (a, role) ->
+          Some ({ a with nonce = Account.Nonce.succ a.nonce }, role) ) ;
   Zkapp_command.of_simple { fee_payer; account_updates; memo }
 
 let%test_module _ =
@@ -1808,7 +1812,6 @@ let%test_module _ =
             (list_with_length 100
                (gen_zkapp_command_from ~genesis_constants ~constraint_constants
                   ~fee_payer_keypair ~keymap ~no_token_accounts:true
-                  ~account_state_tbl:(Account_id.Table.create ())
                   ~generate_new_accounts:false ~ledger () ) )
             ~size:100
             ~random:(Splittable_random.State.create Random.State.default))
@@ -1835,7 +1838,6 @@ let%test_module _ =
                       ; min_new_zkapp_balance = of_mina_string_exn "50"
                       ; max_new_zkapp_balance = of_mina_string_exn "100"
                       }
-                  ~account_state_tbl:(Account_id.Table.create ())
                   ~generate_new_accounts:false ~ledger () ) )
             ~size:100
             ~random:(Splittable_random.State.create Random.State.default))

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -69,7 +69,7 @@ val gen_zkapp_command_from :
   -> fee_payer_keypair:Signature_lib.Keypair.t
   -> keymap:
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t
-  -> ?account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> ?account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
@@ -89,7 +89,7 @@ val gen_list_of_zkapp_command_from :
   -> fee_payer_keypairs:Signature_lib.Keypair.t list
   -> keymap:
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t
-  -> ?account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> ?account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
@@ -104,7 +104,7 @@ val gen_max_cost_zkapp_command_from :
      ?memo:string
   -> ?fee_range:Currency.Fee.t * Currency.Fee.t
   -> fee_payer_keypair:Signature_lib.Keypair.t
-  -> account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
   -> genesis_constants:Genesis_constants.t
   -> unit

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1309,9 +1309,11 @@ module Mutations = struct
                       List.map ids ~f:(fun id ->
                           (id, (Utils.account_of_id id ledger, role)) )
                     in
-                    Account_id.Table.of_alist_exn
-                      ( get_account fee_payer_ids `Fee_payer
-                      @ get_account zkapp_account_ids `Ordinary_participant )
+                    ref
+                    @@ Account_id.Map.of_alist_exn
+                         ( get_account fee_payer_ids `Fee_payer
+                         @ get_account zkapp_account_ids `Ordinary_participant
+                         )
                   in
                   let tm_next = Time.add (Time.now ()) wait_span in
                   don't_wait_for

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -608,7 +608,7 @@ let work_statement =
       ; field "workId" ~doc:"Unique identifier for a snark work"
           ~typ:(non_null int)
           ~args:Arg.[]
-          ~resolve:(fun _ w -> Transaction_snark.Statement.hash w)
+          ~resolve:(fun _ -> Transaction_snark_work.statement_hash)
       ] )
 
 let pending_work =

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -13,7 +13,7 @@ module Ledger_inner = struct
         | Generic of Location.Bigstring.Stable.Latest.t
         | Account of Location_at_depth.Addr.Stable.Latest.t
         | Hash of Location_at_depth.Addr.Stable.Latest.t
-      [@@deriving bin_io_unversioned, hash, sexp, compare]
+      [@@deriving bin_io_unversioned, sexp, compare]
     end
 
     type t = Arg.t =
@@ -22,8 +22,7 @@ module Ledger_inner = struct
       | Hash of Location_at_depth.Addr.t
     [@@deriving hash, sexp, compare]
 
-    include Comparable.Make_binable (Arg)
-    include Hashable.Make_binable (Arg) [@@deriving sexp, compare, hash, yojson]
+    include Comparable.Make_binable (Arg) [@@deriving sexp, compare, yojson]
   end
 
   module Kvdb : Intf.Key_value_database with type config := string =
@@ -36,20 +35,20 @@ module Ledger_inner = struct
   module Hash = struct
     module Arg = struct
       type t = Ledger_hash.Stable.Latest.t
-      [@@deriving sexp, compare, hash, bin_io_unversioned]
+      [@@deriving sexp, compare, bin_io_unversioned]
     end
 
     [%%versioned
     module Stable = struct
       module V1 = struct
         type t = Ledger_hash.Stable.V1.t
-        [@@deriving sexp, compare, hash, equal, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let (_ : (t, Arg.t) Type_equal.t) = Type_equal.T
 
         let to_latest = Fn.id
 
-        include Hashable.Make_binable (Arg)
+        include Comparable.Make_binable (Arg)
 
         let to_base58_check = Ledger_hash.to_base58_check
 

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -40,7 +40,7 @@ module Poly = struct
         ; timestamp : 'time
         ; body_reference : 'body_reference
         }
-      [@@deriving sexp, fields, equal, compare, hash, yojson, hlist]
+      [@@deriving sexp, fields, equal, compare, yojson, hlist]
     end
   end]
 end
@@ -76,7 +76,7 @@ module Value = struct
         , Fee_excess.Stable.V1.t
         , unit )
         Poly.Stable.V2.t
-      [@@deriving sexp, equal, compare, hash, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -40,7 +40,7 @@ module Poly : sig
         ; timestamp : 'time
         ; body_reference : 'body_reference
         }
-      [@@deriving sexp, fields, equal, compare, hash, yojson, hlist]
+      [@@deriving sexp, fields, equal, compare, yojson, hlist]
     end
   end]
 end
@@ -60,7 +60,7 @@ module Value : sig
         , Fee_excess.Stable.V1.t
         , unit )
         Poly.Stable.V2.t
-      [@@deriving sexp, equal, compare, hash, yojson]
+      [@@deriving sexp, equal, compare, yojson]
 
       val to_latest : t -> t
     end

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -29,7 +29,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       module V1 = struct
         type ('state_hash, 'body) t = ('state_hash, 'body) A.Poly.V1.t =
           { previous_state_hash : 'state_hash; body : 'body }
-        [@@deriving equal, ord, hash, sexp, yojson, hlist]
+        [@@deriving equal, ord, sexp, yojson, hlist]
       end
     end]
   end
@@ -62,7 +62,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; consensus_state : 'consensus_state
             ; constants : 'constants
             }
-          [@@deriving sexp, equal, compare, yojson, hash, version, hlist]
+          [@@deriving sexp, equal, compare, yojson, version, hlist]
         end
       end]
     end
@@ -77,7 +77,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             , Consensus.Data.Consensus_state.Value.Stable.V2.t
             , Protocol_constants_checked.Value.Stable.V1.t )
             Poly.Stable.V1.t
-          [@@deriving equal, ord, bin_io, hash, sexp, yojson, version]
+          [@@deriving equal, ord, bin_io, sexp, yojson, version]
 
           let to_latest = Fn.id
         end
@@ -190,13 +190,11 @@ module Make_str (A : Wire_types.Concrete) = struct
       module V2 = struct
         type t =
           (State_hash.Stable.V1.t, Body.Value.Stable.V2.t) Poly.Stable.V1.t
-        [@@deriving sexp, hash, compare, equal, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
     end]
-
-    include Hashable.Make (Stable.Latest)
   end
 
   type value = Value.t [@@deriving sexp, yojson]

--- a/src/lib/mina_state/protocol_state_intf.ml
+++ b/src/lib/mina_state/protocol_state_intf.ml
@@ -9,7 +9,7 @@ module type Full = sig
       module V1 : sig
         type ('state_hash, 'body) t =
           { previous_state_hash : 'state_hash; body : 'body }
-        [@@deriving equal, ord, hash, sexp, to_yojson]
+        [@@deriving equal, ord, sexp, to_yojson]
       end
     end]
   end
@@ -39,7 +39,7 @@ module type Full = sig
             , Consensus.Data.Consensus_state.Value.Stable.V2.t
             , Protocol_constants_checked.Value.Stable.V1.t )
             Poly.Stable.V1.t
-          [@@deriving equal, ord, bin_io, hash, sexp, yojson, version]
+          [@@deriving equal, ord, bin_io, sexp, yojson, version]
         end
       end]
     end
@@ -82,8 +82,6 @@ module type Full = sig
         [@@deriving sexp, compare, equal, yojson]
       end
     end]
-
-    include Hashable.S with type t := t
   end
 
   type value = Value.t [@@deriving sexp, yojson]

--- a/src/lib/mina_state/registers.ml
+++ b/src/lib/mina_state/registers.ml
@@ -15,7 +15,7 @@ module Stable = struct
       ; pending_coinbase_stack : 'pending_coinbase_stack
       ; local_state : 'local_state
       }
-    [@@deriving compare, equal, hash, sexp, yojson, hlist, fields]
+    [@@deriving compare, equal, sexp, yojson, hlist, fields]
   end
 end]
 
@@ -50,12 +50,12 @@ module Value = struct
     , Pending_coinbase.Stack.t
     , Local_state.t )
     Stable.Latest.t
-  [@@deriving compare, equal, sexp, yojson, hash]
+  [@@deriving compare, equal, sexp, yojson]
 
   let connected t t' =
     let module Without_pending_coinbase_stack = struct
       type t = (Frozen_ledger_hash.t, unit, Local_state.t) Stable.Latest.t
-      [@@deriving compare, equal, sexp, yojson, hash]
+      [@@deriving compare, equal, sexp, yojson]
     end in
     Without_pending_coinbase_stack.equal
       { t with pending_coinbase_stack = () }

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -38,7 +38,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           type t =
             | Base of Pending_coinbase.Stack_versioned.Stable.V1.t
             | Merge
-          [@@deriving sexp, hash, compare, equal, yojson]
+          [@@deriving sexp, compare, equal, yojson]
 
           let to_latest = Fn.id
         end
@@ -51,7 +51,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         module V1 = struct
           type 'pending_coinbase t =
             { source : 'pending_coinbase; target : 'pending_coinbase }
-          [@@deriving sexp, hash, compare, equal, fields, yojson, hlist]
+          [@@deriving sexp, compare, equal, fields, yojson, hlist]
 
           let to_latest pending_coinbase { source; target } =
             { source = pending_coinbase source
@@ -69,14 +69,14 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     type 'pending_coinbase poly = 'pending_coinbase Poly.t =
       { source : 'pending_coinbase; target : 'pending_coinbase }
-    [@@deriving sexp, hash, compare, equal, fields, yojson]
+    [@@deriving sexp, compare, equal, fields, yojson]
 
     (* State of the coinbase stack for the current transaction snark *)
     [%%versioned
     module Stable = struct
       module V1 = struct
         type t = Pending_coinbase.Stack_versioned.Stable.V1.t Poly.Stable.V1.t
-        [@@deriving sexp, hash, compare, equal, yojson]
+        [@@deriving sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end
@@ -96,8 +96,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         (Pending_coinbase.Stack.var_to_input source)
         (Pending_coinbase.Stack.var_to_input target)
 
-    include Hashable.Make_binable (Stable.Latest)
-    include Comparable.Make (Stable.Latest)
+    include Comparable.Make_binable (Stable.Latest)
   end
 
   module Poly = struct
@@ -134,7 +133,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
-        [@@deriving compare, equal, hash, sexp, yojson, hlist]
+        [@@deriving compare, equal, sexp, yojson, hlist]
       end
     end]
 
@@ -196,7 +195,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         , unit
         , Local_state.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving compare, equal, hash, sexp, yojson]
+      [@@deriving compare, equal, sexp, yojson]
 
       let to_latest = Fn.id
     end
@@ -350,7 +349,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           , Sok_message.Digest.Stable.V1.t
           , Local_state.Stable.V1.t )
           Poly.Stable.V2.t
-        [@@deriving compare, equal, hash, sexp, yojson]
+        [@@deriving compare, equal, sexp, yojson]
 
         let to_latest = Fn.id
       end
@@ -531,7 +530,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       ; local_state_ledger_source : 'a
       ; local_state_ledger_target : 'a
       }
-    [@@deriving compare, equal, hash, sexp, yojson, hlist]
+    [@@deriving compare, equal, sexp, yojson, hlist]
 
     let of_statement (s : _ Poly.t) : _ t =
       let local_state_ledger
@@ -683,8 +682,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       }
       : t )
 
-  include Hashable.Make_binable (Stable.Latest)
-  include Comparable.Make (Stable.Latest)
+  include Comparable.Make_binable (Stable.Latest)
 
   let gen =
     let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -12,7 +12,7 @@ module type Full = sig
           type t =
             | Base of Pending_coinbase.Stack_versioned.Stable.V1.t
             | Merge
-          [@@deriving sexp, hash, compare, equal, yojson]
+          [@@deriving sexp, compare, equal, yojson]
         end
       end]
     end
@@ -23,7 +23,7 @@ module type Full = sig
         module V1 : sig
           type 'pending_coinbase t =
             { source : 'pending_coinbase; target : 'pending_coinbase }
-          [@@deriving compare, equal, fields, hash, sexp, yojson]
+          [@@deriving compare, equal, fields, sexp, yojson]
 
           val to_latest :
                ('pending_coinbase -> 'pending_coinbase')
@@ -39,13 +39,13 @@ module type Full = sig
 
     type 'pending_coinbase poly = 'pending_coinbase Poly.t =
       { source : 'pending_coinbase; target : 'pending_coinbase }
-    [@@deriving sexp, hash, compare, equal, fields, yojson]
+    [@@deriving sexp, compare, equal, fields, yojson]
 
     [%%versioned:
     module Stable : sig
       module V1 : sig
         type t = Pending_coinbase.Stack_versioned.Stable.V1.t Poly.Stable.V1.t
-        [@@deriving compare, equal, hash, sexp, yojson]
+        [@@deriving compare, equal, sexp, yojson]
       end
     end]
 
@@ -87,7 +87,7 @@ module type Full = sig
           ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
-        [@@deriving compare, equal, hash, sexp, yojson]
+        [@@deriving compare, equal, sexp, yojson]
       end
     end]
 
@@ -123,7 +123,7 @@ module type Full = sig
       ; local_state_ledger_source : 'a
       ; local_state_ledger_target : 'a
       }
-    [@@deriving compare, equal, hash, sexp, yojson]
+    [@@deriving compare, equal, sexp, yojson]
 
     val of_statement :
          ( 'a
@@ -155,7 +155,7 @@ module type Full = sig
         , unit
         , Local_state.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving compare, equal, hash, sexp, yojson]
+      [@@deriving compare, equal, sexp, yojson]
     end
   end]
 
@@ -203,7 +203,7 @@ module type Full = sig
           , Sok_message.Digest.Stable.V1.t
           , Local_state.Stable.V1.t )
           Poly.Stable.V2.t
-        [@@deriving compare, equal, hash, sexp, yojson]
+        [@@deriving compare, equal, sexp, yojson]
       end
     end]
 
@@ -252,7 +252,5 @@ module type Full = sig
 
   val snarked_ledger_hash : ('ledger_hash, _, _, _, _, _) Poly.t -> 'ledger_hash
 
-  include Hashable.S_binable with type t := t
-
-  include Comparable.S with type t := t
+  include Comparable.S_binable with type t := t
 end

--- a/src/lib/network_pool/priced_proof.ml
+++ b/src/lib/network_pool/priced_proof.ml
@@ -8,12 +8,12 @@ module Stable = struct
   module V1 = struct
     type 'proof t = 'proof Mina_wire_types.Network_pool.Priced_proof.V1.t =
       { proof : 'proof; fee : Fee_with_prover.Stable.V1.t }
-    [@@deriving compare, fields, sexp, yojson, hash, equal]
+    [@@deriving compare, fields, sexp, yojson, equal]
   end
 end]
 
 type 'proof t = 'proof Stable.Latest.t =
   { proof : 'proof; fee : Fee_with_prover.t }
-[@@deriving compare, fields, sexp, yojson, hash, equal]
+[@@deriving compare, fields, sexp, yojson, equal]
 
 let map t ~f = { t with proof = f t.proof }

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -332,7 +332,7 @@ struct
         let log_and_punish ?(punish = true) statement e =
           let metadata =
             [ ("error", Error_json.error_to_yojson e)
-            ; ("work_id", `Int (Transaction_snark.Statement.hash statement))
+            ; ("work_id", `Int (Transaction_snark_work.statement_hash statement))
             ]
             @ metadata
           in
@@ -545,7 +545,7 @@ module Diff_versioned = struct
             * Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp, to_yojson, hash]
+      [@@deriving compare, sexp, to_yojson]
 
       let to_latest = Fn.id
     end
@@ -556,7 +556,7 @@ module Diff_versioned = struct
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson, hash]
+  [@@deriving compare, sexp, to_yojson]
 end
 
 (* Only show stdout for failed inline tests. *)

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -87,7 +87,7 @@ module Diff_versioned : sig
             * Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp, hash]
+      [@@deriving compare, sexp]
     end
   end]
 end

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -28,7 +28,7 @@ module Make
   type t = Mina_wire_types.Network_pool.Snark_pool.Diff_versioned.V2.t =
     | Add_solved_work of Work.t * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson, hash]
+  [@@deriving compare, sexp, to_yojson]
 
   type verified = t [@@deriving compare, sexp, to_yojson]
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -60,6 +60,7 @@ module Compressed = struct
 
       include T
       include Hashable.Make_binable (T)
+      include Comparable.Make_binable (T)
 
       let gen =
         let open Quickcheck.Generator.Let_syntax in
@@ -69,8 +70,8 @@ module Compressed = struct
   end]
 
   module Poly = Poly
-  include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
+  include Comparable.Make_binable (Stable.Latest)
   include Stable.Latest.Base58
 
   let to_string = to_base58_check

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -45,6 +45,8 @@ module Compressed : sig
       include Codable.S with type t := t
 
       include Hashable.S_binable with type t := t
+
+      include Comparable.S_binable with type t := t
     end
   end]
 
@@ -54,9 +56,9 @@ module Compressed : sig
 
   val empty : t
 
-  include Comparable.S with type t := t
-
   include Hashable.S_binable with type t := t
+
+  include Comparable.S_binable with type t := t
 
   val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -85,7 +85,7 @@ module T = struct
               %s"
             (List.map ts ~f:(fun (_p, s, m) ->
                  ( s
-                 , Transaction_snark.Statement.hash s
+                 , Transaction_snark_work.statement_hash s
                  , Yojson.Safe.to_string
                    @@ Public_key.Compressed.to_yojson m.prover ) ) )
             (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err))
@@ -168,7 +168,7 @@ module T = struct
               [ ( "work_id"
                 , `List
                     (List.map proofs ~f:(fun (_, s, _) ->
-                         `Int (Transaction_snark.Statement.hash s) ) ) )
+                         `Int (Transaction_snark_work.statement_hash s) ) ) )
               ; ("time", `Float time_ms)
               ]
             "Verification in apply_diff for work $work_id took $time ms" ;

--- a/src/lib/syncable_ledger/test/test.ml
+++ b/src/lib/syncable_ledger/test/test.ml
@@ -13,7 +13,7 @@ end
 
 module type Input_intf = sig
   module Root_hash : sig
-    type t [@@deriving bin_io, compare, hash, sexp, compare, yojson]
+    type t [@@deriving bin_io, compare, sexp, compare, yojson]
 
     val equal : t -> t -> bool
   end
@@ -196,7 +196,7 @@ module Db = struct
           | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
           | Account of Location.Addr.Stable.Latest.t
           | Hash of Location.Addr.Stable.Latest.t
-        [@@deriving bin_io_unversioned, hash, sexp, compare]
+        [@@deriving bin_io_unversioned, sexp, compare]
       end
 
       type t = Arg.t =
@@ -205,8 +205,7 @@ module Db = struct
         | Hash of Location.Addr.t
       [@@deriving hash, sexp, compare]
 
-      include Hashable.Make_binable (Arg) [@@deriving
-                                            sexp, compare, hash, yojson]
+      include Comparable.Make_binable (Arg) [@@deriving sexp, compare, yojson]
     end
 
     module Base_ledger_inputs = struct

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -9,7 +9,7 @@ module Poly = struct
         | Command of 'command
         | Fee_transfer of Fee_transfer.Stable.V2.t
         | Coinbase of Coinbase.Stable.V1.t
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
 
@@ -30,13 +30,12 @@ module Valid = struct
   module Stable = struct
     module V2 = struct
       type t = User_command.Valid.Stable.V2.t Poly.Stable.V2.t
-      [@@deriving sexp, compare, equal, hash, yojson]
+      [@@deriving sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end
   end]
 
-  include Hashable.Make (Stable.Latest)
   include Comparable.Make (Stable.Latest)
 end
 
@@ -44,13 +43,12 @@ end
 module Stable = struct
   module V2 = struct
     type t = User_command.Stable.V2.t Poly.Stable.V2.t
-    [@@deriving sexp, compare, equal, hash, yojson]
+    [@@deriving sexp, compare, equal, yojson]
 
     let to_latest = Fn.id
   end
 end]
 
-include Hashable.Make (Stable.Latest)
 include Comparable.Make (Stable.Latest)
 
 type 'command t_ = 'command Poly.t =

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2635,7 +2635,7 @@ module For_tests = struct
             } )
 
     let gen () : t Quickcheck.Generator.t =
-      let tbl = Public_key.Compressed.Hash_set.create () in
+      let tbl = ref Public_key.Compressed.Set.empty in
       let open Quickcheck.Generator in
       let open Let_syntax in
       let rec go acc n =
@@ -2643,9 +2643,9 @@ module For_tests = struct
         else
           let%bind kp =
             filter Keypair.gen ~f:(fun kp ->
-                not (Hash_set.mem tbl (Public_key.compress kp.public_key)) )
+                not (Set.mem !tbl (Public_key.compress kp.public_key)) )
           and amount = Int64.gen_incl min_init_balance max_init_balance in
-          Hash_set.add tbl (Public_key.compress kp.public_key) ;
+          tbl := Set.add !tbl (Public_key.compress kp.public_key) ;
           go ((kp, amount) :: acc) (n - 1)
       in
       go [] num_accounts

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -264,7 +264,7 @@ module Local_state = struct
           , Mina_numbers.Index.Stable.V1.t
           , Transaction_status.Failure.Collection.Stable.V1.t )
           Stable.V1.t
-        [@@deriving equal, compare, hash, yojson, sexp]
+        [@@deriving equal, compare, yojson, sexp]
 
         let to_latest = Fn.id
       end

--- a/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
+++ b/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
@@ -99,7 +99,6 @@ let generate_zkapp_commands_and_apply_them_consecutively_5_times ~successful
   let ledger, fee_payer_keypairs, keymap =
     mk_ledgers_and_fee_payers ~num_of_fee_payers:5 ()
   in
-  let account_state_tbl = Account_id.Table.create () in
   let global_slot = Mina_numbers.Global_slot_since_genesis.one in
   let test i random =
     let zkapp_command_dummy_auths =
@@ -107,7 +106,7 @@ let generate_zkapp_commands_and_apply_them_consecutively_5_times ~successful
         (Mina_generators.Zkapp_command_generators.gen_zkapp_command_from
            ~constraint_constants:U.constraint_constants
            ~genesis_constants:U.genesis_constants ~global_slot
-           ~protocol_state_view:U.genesis_state_view ~account_state_tbl
+           ~protocol_state_view:U.genesis_state_view
            ~fee_payer_keypair:fee_payer_keypairs.(i) ~max_account_updates
            ~keymap ~ledger ~vk () )
     in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -49,8 +49,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = [ `Base | `Merge ]
-        [@@deriving compare, equal, hash, sexp, yojson]
+        type t = [ `Base | `Merge ] [@@deriving compare, equal, sexp, yojson]
 
         let to_latest = Fn.id
       end
@@ -67,7 +66,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     module Stable = struct
       module V2 = struct
         type t = Pickles.Proof.Proofs_verified_2.Stable.V2.t
-        [@@deriving yojson, compare, equal, sexp, hash]
+        [@@deriving yojson, compare, equal, sexp]
 
         let to_latest = Fn.id
       end
@@ -81,7 +80,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         { statement : Mina_state.Snarked_ledger_state.With_sok.Stable.V2.t
         ; proof : Proof.Stable.V2.t
         }
-      [@@deriving compare, equal, fields, sexp, version, yojson, hash]
+      [@@deriving compare, equal, fields, sexp, version, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -17,7 +17,7 @@ module type Full = sig
   [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving compare, equal, sexp, yojson, hash]
+      type t [@@deriving compare, equal, sexp, yojson]
     end
   end]
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -95,7 +95,7 @@ module Job_view = struct
     end in
     let statement_to_yojson (s : Transaction_snark.Statement.t) =
       `Assoc
-        [ ("Work_id", `Int (Transaction_snark.Statement.hash s))
+        [ ("Work_id", `Int (Transaction_snark_work.statement_hash s))
         ; ("Source", R.to_yojson s.source)
         ; ("Target", R.to_yojson s.target)
         ; ( "Fee Excess"

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -2,21 +2,20 @@ open Core_kernel
 open Currency
 open Signature_lib
 
+(* Hash derived from binio serialization, to be used only for information printouts *)
+val statement_hash : Transaction_snark.Statement.t -> int
+
 module Statement : sig
   type t = Transaction_snark.Statement.t One_or_two.t
   [@@deriving compare, sexp, yojson, equal]
 
   include Comparable.S with type t := t
 
-  include Hashable.S with type t := t
-
   module Stable : sig
     module V2 : sig
       type t [@@deriving bin_io, compare, sexp, version, yojson, equal]
 
-      include Comparable.S with type t := t
-
-      include Hashable.S_binable with type t := t
+      include Comparable.S_binable with type t := t
     end
   end
   with type V2.t = t

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -33,26 +33,27 @@ module Test_inputs = struct
 
       module V2 = struct
         type t = Transaction_snark.Statement.Stable.V2.t One_or_two.Stable.V1.t
-        [@@deriving hash, compare, sexp]
+        [@@deriving compare, sexp]
 
         let to_latest = Fn.id
       end
     end]
 
-    module Work = Hashable.Make_binable (Stable.Latest)
+    module Work = Comparable.Make_binable (Stable.Latest)
 
-    type t = Currency.Fee.t Work.Table.t
+    type t = Currency.Fee.t Work.Map.t ref
 
-    let get_completed_work (t : t) = Work.Table.find t
+    let get_completed_work (t : t) = Work.Map.find !t
 
-    let create () = Work.Table.create ()
+    let create () = ref Work.Map.empty
 
     let add_snark t ~work ~fee =
-      Work.Table.update t work ~f:(function
-        | None ->
-            fee
-        | Some fee' ->
-            Currency.Fee.min fee fee' )
+      t :=
+        Work.Map.update !t work ~f:(function
+          | None ->
+              fee
+          | Some fee' ->
+              Currency.Fee.min fee fee' )
   end
 
   module Staged_ledger = struct

--- a/src/lib/work_selector/test.ml
+++ b/src/lib/work_selector/test.ml
@@ -114,13 +114,14 @@ struct
           |> Or_error.ok_exn )
           (Currency.Fee.of_nanomina_int_exn 2)
       in
-      (sl, pool)
+      (sl, !pool)
     in
     Quickcheck.test g
       ~sexp_of:
         [%sexp_of:
-          (int, Fee.t) Lib.Work_spec.t list * Fee.t T.Snark_pool.Work.Table.t]
-      ~trials:100 ~f:(fun (sl, snark_pool) ->
+          (int, Fee.t) Lib.Work_spec.t list * Fee.t T.Snark_pool.Work.Map.t]
+      ~trials:100 ~f:(fun (sl, init_snark_pool) ->
+        let snark_pool = ref init_snark_pool in
         Async.Thread_safe.block_on_async_exn (fun () ->
             let open Deferred.Let_syntax in
             let%bind work_state = init_state sl reassignment_wait logger in

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -18,7 +18,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
     module Seen_key = struct
       module T = struct
         type t = Transaction_snark.Statement.t One_or_two.t
-        [@@deriving compare, sexp, to_yojson, hash]
+        [@@deriving compare, sexp, to_yojson]
       end
 
       include T


### PR DESCRIPTION
These definitions litter the codebase, but aren't used actively or in any way that is crucial.

All usages of hash tables are replaced with map-based approach.

The only functional change is in snark work hash printouts. They are derived from hash, and calculation of this hash changed in this PR. This isn't a braking change, because these are only used for informational purposes (e.g. logging). However if there are simultaneously two Mina nodes running version with this PR and without, they snark work ids will differ. 

Explain how you tested your changes:
* [x] Project compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None