### PR TITLE
Sai/snark ledger query serialized

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6471,6 +6471,57 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "EncodedAccount",
+          "description": null,
+          "fields": [
+            {
+              "name": "account",
+              "description": "Base64 encoded account as binable wire type",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "merklePath",
+              "description": "Membership proof in the snarked ledger",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "MerklePathElement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AccountInput",
           "description": "An account with a public key and a token id",
@@ -15285,6 +15336,68 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "MembershipInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "encodedSnarkedLedgerAccountMembership",
+              "description":
+                "obtain a membership proof for an account in the snarked ledger along with the accounts full information encoded as base64 binable type",
+              "args": [
+                {
+                  "name": "stateHash",
+                  "description": "Hash of the snarked ledger to check",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "accountInfos",
+                  "description": "Token id of the account to check",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "AccountInput",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "EncodedAccount",
                       "ofType": null
                     }
                   }

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2251,44 +2251,25 @@ module Queries = struct
         ~resolve:
           (resolve_membership ~mapper:Types.SnarkedLedgerMembership.of_account)
 
-    (*
-  let encoded_snarked_ledger_accounts_membership =
-    io_field "encodedSnarkedLedgerAccountsMembership"
-      ~doc:
-        "obtain a membership proof for an account in the snarked ledger along \
-         with the account's balance, timing information, and nonce"
-      ~args:
-        Arg.
-          [ arg "accountInfos" ~doc:"Token id of the account to check"
-              ~typ:(non_null (list (non_null Types.Input.AccountInfo.arg_typ)))
-          ; arg "stateHash" ~doc:"Hash of the snarked ledger to check"
-              ~typ:(non_null string)
-          ]
-      ~typ:(non_null string)
-      ~resolve:(fun resolve_info args account_infos state_hash ->
-        let open Deferred.Let_syntax in
-        let%map memberships =
-          resolve_membership resolve_info () account_infos state_hash
-        in
-        let memberships = 
-          match memberships with
-          | Ok memberships ->
-              memberships
-          | Error err ->
-              raise (Failure err)
-        in
-        (* encode memberships to a base64 encoded string *)
-        let encoded_memberships =
-          let encoded_memberships =
-            List.map memberships ~f:(fun membership ->
-                Types.SnarkedLedgerMembership.to_yojson membership
-                |> Yojson.Safe.to_string )
-          in
-          let encoded_memberships = String.concat ~sep:"\n" encoded_memberships in
-          Base64.encode_exn encoded_memberships
-        in
-        Ok encoded_memberships )
-        *)
+    let encoded_snarked_ledger_account_membership =
+      io_field "encodedSnarkedLedgerAccountMembership"
+        ~doc:
+          "obtain a membership proof for an account in the snarked ledger \
+           along with the accounts full information encoded as base64 binable \
+           type"
+        ~args:
+          Arg.
+            [ arg "accountInfos" ~doc:"Token id of the account to check"
+                ~typ:
+                  (non_null (list (non_null Types.Input.AccountInfo.arg_typ)))
+            ; arg "stateHash" ~doc:"Hash of the snarked ledger to check"
+                ~typ:(non_null string)
+            ]
+        ~typ:
+          (non_null (list (non_null Types.SnarkedLedgerMembership.encoded_obj)))
+        ~resolve:
+          (resolve_membership
+             ~mapper:Types.SnarkedLedgerMembership.of_encoded_account )
   end
 
   let genesis_constants =

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2758,6 +2758,7 @@ module Queries = struct
     ; snark_pool
     ; pending_snark_work
     ; SnarkedLedgerMembership.snarked_ledger_account_membership
+    ; SnarkedLedgerMembership.encoded_snarked_ledger_account_membership
     ; genesis_constants
     ; time_offset
     ; validate_payment

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -772,6 +772,30 @@ let snarked_ledger_state :
       ] )
 
 module SnarkedLedgerMembership = struct
+  type encoded_account = { account : string; proof : Ledger.path }
+
+  let encoded_obj =
+    obj "EncodedAccount" ~fields:(fun _ ->
+        [ field "account"
+            ~args:Arg.[]
+            ~doc:"Base64 encoded account as binable wire type"
+            ~typ:(non_null string)
+            ~resolve:(fun _ { account; _ } -> account)
+        ; field "merklePath"
+            ~args:Arg.[]
+            ~doc:"Membership proof in the snarked ledger"
+            ~typ:(non_null (list (non_null merkle_path_element)))
+            ~resolve:(fun _ { proof; _ } -> proof)
+        ] )
+
+  let of_encoded_account (proof : Ledger.path) (account : Account.t) :
+      encoded_account =
+    let account =
+      Binable.to_string (module Account.Binable_arg.Stable.Latest) account
+      |> Base64.encode_exn
+    in
+    { account; proof }
+
   type t =
     { account_balance : Currency.Balance.t
     ; timing_info : Account_timing.t

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -779,6 +779,13 @@ module SnarkedLedgerMembership = struct
     ; proof : Ledger.path
     }
 
+  let of_account (proof : Ledger.path) (account : Account.t) : t =
+    { account_balance = account.balance
+    ; timing_info = account.timing
+    ; nonce = account.nonce
+    ; proof
+    }
+
   let obj =
     obj "MembershipInfo" ~fields:(fun _ ->
         [ field "accountBalance"


### PR DESCRIPTION
It should now be possible to encode accounts as base64 binable types in gql output.