### PR TITLE
force block_window_duration to top level

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -784,17 +784,8 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
               ~genesis_constants ~constraint_constants ~cli_proof_level
           in
 
-          (* TODO consider moving elsewhere *)
-          let duration =
-            constraint_constants.block_window_duration_ms |> Float.of_int
-            |> Time.Span.of_ms
-          in
-          Mina_metrics.Transition_frontier.TPS_30min.initialize duration ;
-          Mina_metrics.Block_latency.Gossip_slots.initialize duration ;
-          Mina_metrics.Block_latency.Gossip_time.initialize duration ;
-          Mina_metrics.Block_latency.Inclusion_time.initialize duration ;
-          Mina_metrics.Block_latency.Validation_acceptance_time.initialize
-            duration ;
+          constraint_constants.block_window_duration_ms |> Float.of_int
+          |> Time.Span.of_ms |> Mina_metrics.initialize_all ;
 
           let rev_daemon_configs =
             List.rev_filter_map config_jsons

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1290,6 +1290,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
               ; time_controller
               ; pubsub_v1
               ; pubsub_v0
+              ; block_window_duration = compile_config.block_window_duration
               }
           in
           let net_config =

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -783,6 +783,19 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
               ~proof_level:Genesis_constants.Compiled.proof_level config_files
               ~genesis_constants ~constraint_constants ~cli_proof_level
           in
+
+          (* TODO consider moving elsewhere *)
+          let duration =
+            constraint_constants.block_window_duration_ms |> Float.of_int
+            |> Time.Span.of_ms
+          in
+          Mina_metrics.Transition_frontier.TPS_30min.initialize duration ;
+          Mina_metrics.Block_latency.Gossip_slots.initialize duration ;
+          Mina_metrics.Block_latency.Gossip_time.initialize duration ;
+          Mina_metrics.Block_latency.Inclusion_time.initialize duration ;
+          Mina_metrics.Block_latency.Validation_acceptance_time.initialize
+            duration ;
+
           let rev_daemon_configs =
             List.rev_filter_map config_jsons
               ~f:(fun (config_file, config_json) ->

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1612,12 +1612,14 @@ let generate_libp2p_keypair_do privkey_path =
     (let open Deferred.Let_syntax in
     (* FIXME: I'd like to accumulate messages into this logger and only dump them out in failure paths. *)
     let logger = Logger.null () in
+    let compile_config = Mina_compile_config.Compiled.t in
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-generate-libp2p-keypair" ~f:(fun tmpd ->
         match%bind
           Mina_net2.create ~logger ~conf_dir:tmpd ~all_peers_seen_metric:false
             ~pids:(Child_processes.Termination.create_pid_table ())
-            ~on_peer_connected:ignore ~on_peer_disconnected:ignore ()
+            ~on_peer_connected:ignore ~on_peer_disconnected:ignore
+            ~block_window_duration:compile_config.block_window_duration ()
         with
         | Ok net ->
             let%bind me = Mina_net2.generate_random_keypair net in
@@ -1644,12 +1646,14 @@ let dump_libp2p_keypair_do privkey_path =
   Deferred.ignore_m
     (let open Deferred.Let_syntax in
     let logger = Logger.null () in
+    let compile_config = Mina_compile_config.Compiled.t in
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-dump-libp2p-keypair" ~f:(fun tmpd ->
         match%bind
           Mina_net2.create ~logger ~conf_dir:tmpd ~all_peers_seen_metric:false
             ~pids:(Child_processes.Termination.create_pid_table ())
-            ~on_peer_connected:ignore ~on_peer_disconnected:ignore ()
+            ~on_peer_connected:ignore ~on_peer_disconnected:ignore
+            ~block_window_duration:compile_config.block_window_duration ()
         with
         | Ok net ->
             let%bind () = Mina_net2.shutdown net in

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -17,6 +17,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 type Structured_log_events.t += Bootstrap_complete
@@ -712,6 +714,8 @@ let%test_module "Bootstrap_controller tests" =
 
     let constraint_constants = precomputed_values.constraint_constants
 
+    let compile_config = Mina_compile_config.For_unit_tests.t
+
     module Context = struct
       let logger = Logger.create ()
 
@@ -721,6 +725,8 @@ let%test_module "Bootstrap_controller tests" =
         Genesis_constants.For_unit_tests.Constraint_constants.t
 
       let consensus_constants = precomputed_values.consensus_constants
+
+      let compile_config = compile_config
     end
 
     let verifier =
@@ -769,7 +775,8 @@ let%test_module "Bootstrap_controller tests" =
         let%bind fake_network =
           Fake_network.Generator.(
             gen ~precomputed_values ~verifier ~max_frontier_length
-              [ fresh_peer; fresh_peer ] ~use_super_catchup:false)
+              ~compile_config [ fresh_peer; fresh_peer ]
+              ~use_super_catchup:false)
         in
         let%map make_branch =
           Transition_frontier.Breadcrumb.For_tests.gen_seq ~precomputed_values
@@ -899,7 +906,7 @@ let%test_module "Bootstrap_controller tests" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup:false
+            ~use_super_catchup:false ~compile_config
             [ fresh_peer
             ; peer_with_branch
                 ~frontier_branch_size:((max_frontier_length * 2) + 2)

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -10,6 +10,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 type Structured_log_events.t += Bootstrap_complete [@@deriving register_event]

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -14,6 +14,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 (* There must be at least 2 peers to create a network *)
@@ -298,7 +300,7 @@ module Generator = struct
 
   let gen ?(logger = Logger.null ()) ~precomputed_values ~verifier
       ~max_frontier_length ~use_super_catchup
-      (configs : (peer_config, 'n num_peers) Gadt_lib.Vect.t) =
+      (configs : (peer_config, 'n num_peers) Gadt_lib.Vect.t) ~compile_config =
     (* TODO: Pass in *)
     let module Context = struct
       let logger = logger
@@ -310,6 +312,8 @@ module Generator = struct
 
       let consensus_constants =
         precomputed_values.Precomputed_values.consensus_constants
+
+      let compile_config = compile_config
     end in
     let open Quickcheck.Generator.Let_syntax in
     let%map states =

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -10,6 +10,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 (* There must be at least 2 peers to create a network *)
@@ -98,5 +100,6 @@ module Generator : sig
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> (peer_config, 'n num_peers) Vect.t
+    -> compile_config:Mina_compile_config.t
     -> 'n num_peers t Generator.t
 end

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -52,6 +52,7 @@ module Config = struct
     ; mutable keypair : Mina_net2.Keypair.t option
     ; all_peers_seen_metric : bool
     ; known_private_ip_nets : Core.Unix.Cidr.t list
+    ; block_window_duration : Time.Span.t
     }
   [@@deriving make]
 end
@@ -219,7 +220,8 @@ module Make (Rpc_interface : RPC_INTERFACE) :
         ctx first_peer_ivar high_connectivity_ivar ~added_seeds ~pids
         ~on_unexpected_termination
         ~sinks:
-          (Message.Any_sinks (sinksM, (sink_block, sink_tx, sink_snark_work))) =
+          (Message.Any_sinks (sinksM, (sink_block, sink_tx, sink_snark_work)))
+        ~block_window_duration =
       let module Sinks = (val sinksM) in
       let ctr = ref 0 in
       let record_peer_connection () =
@@ -256,7 +258,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
                   ~all_peers_seen_metric:config.all_peers_seen_metric
                   ~on_peer_connected:(fun _ -> record_peer_connection ())
                   ~on_peer_disconnected:ignore ~logger:config.logger ~conf_dir
-                  ~pids () ) )
+                  ~pids ~block_window_duration () ) )
       with
       | Ok (Ok net2) -> (
           let open Mina_net2 in
@@ -628,6 +630,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
             create_libp2p ~allow_multiple_instances config rpc_handlers
               first_peer_ivar high_connectivity_ivar ~added_seeds ~pids
               ~on_unexpected_termination:restart_libp2p ~sinks
+              ~block_window_duration:config.block_window_duration
           in
           on_libp2p_create libp2p ; Deferred.ignore_m libp2p
         and restart_libp2p () = don't_wait_for (start_libp2p ()) in

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -68,4 +68,5 @@
    mina_net2
    internal_tracing
    mina_runtime_config
+   mina_compile_config
 ))

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -9,6 +9,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network

--- a/src/lib/ledger_catchup/ledger_catchup.mli
+++ b/src/lib/ledger_catchup/ledger_catchup.mli
@@ -13,6 +13,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 module Catchup_jobs : sig

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -15,6 +15,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 (** [Ledger_catchup] is a procedure that connects a foreign external transition
@@ -880,6 +882,8 @@ let%test_module "Ledger_catchup tests" =
 
     let constraint_constants = precomputed_values.constraint_constants
 
+    let compile_config = Mina_compile_config.For_unit_tests.t
+
     let trust_system = Trust_system.null ()
 
     let time_controller = Block_time.Controller.basic ~logger
@@ -901,6 +905,8 @@ let%test_module "Ledger_catchup tests" =
       let constraint_constants = constraint_constants
 
       let consensus_constants = precomputed_values.consensus_constants
+
+      let compile_config = compile_config
     end
 
     let downcast_transition transition =
@@ -1025,6 +1031,7 @@ let%test_module "Ledger_catchup tests" =
           in
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
+            ~compile_config:Mina_compile_config.For_unit_tests.t
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:peer_branch_size
             ])
@@ -1046,6 +1053,7 @@ let%test_module "Ledger_catchup tests" =
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
+            ~compile_config:Mina_compile_config.For_unit_tests.t
             [ fresh_peer; peer_with_branch ~frontier_branch_size:1 ])
         ~f:(fun network ->
           let open Fake_network in
@@ -1061,6 +1069,7 @@ let%test_module "Ledger_catchup tests" =
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
+            ~compile_config:Mina_compile_config.For_unit_tests.t
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:(max_frontier_length * 2)
             ])

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -16,6 +16,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 (** [Ledger_catchup] is a procedure that connects a foreign external transition
@@ -1433,6 +1435,8 @@ let%test_module "Ledger_catchup tests" =
 
     let use_super_catchup = true
 
+    let compile_config = Mina_compile_config.For_unit_tests.t
+
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
@@ -1448,6 +1452,8 @@ let%test_module "Ledger_catchup tests" =
       let constraint_constants = constraint_constants
 
       let consensus_constants = precomputed_values.consensus_constants
+
+      let compile_config = compile_config
     end
 
     (* let mock_verifier =
@@ -1626,7 +1632,7 @@ let%test_module "Ledger_catchup tests" =
             Int.gen_incl (max_frontier_length / 2) (max_frontier_length - 1)
           in
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
+            ~use_super_catchup ~compile_config
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:peer_branch_size
             ])
@@ -1646,7 +1652,7 @@ let%test_module "Ledger_catchup tests" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
+            ~use_super_catchup ~compile_config
             [ fresh_peer; peer_with_branch ~frontier_branch_size:1 ])
         ~f:(fun network ->
           let open Fake_network in
@@ -1662,7 +1668,7 @@ let%test_module "Ledger_catchup tests" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
+            ~use_super_catchup ~compile_config
             [ fresh_peer; peer_with_branch ~frontier_branch_size:1 ])
         ~f:(fun network ->
           let open Fake_network in
@@ -1679,7 +1685,7 @@ let%test_module "Ledger_catchup tests" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
+            ~use_super_catchup ~compile_config
             [ fresh_peer
             ; peer_with_branch
                 ~frontier_branch_size:((max_frontier_length * 3) + 1)
@@ -1757,7 +1763,7 @@ let%test_module "Ledger_catchup tests" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
+            ~use_super_catchup ~compile_config
             [ fresh_peer
               (* ; peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) *)
             ; peer_with_branch_custom_rpc

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -13,6 +13,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 module type Transition_handler_validator_intf = sig

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -42,6 +42,8 @@ module type CONTEXT = sig
   val zkapp_cmd_limit : int option ref
 
   val compaction_interval : Time.Span.t option
+
+  val compile_config : Mina_compile_config.t
 end
 
 exception Snark_worker_error of int

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -100,6 +100,8 @@ let%test_module "Epoch ledger sync tests" =
 
         let time_controller = time_controller
 
+        let compile_config = Mina_compile_config.For_unit_tests.t
+
         let commit_id = "not specified for unit test"
 
         let vrf_poll_interval =
@@ -183,6 +185,7 @@ let%test_module "Epoch ledger sync tests" =
           ; consensus_constants
           ; genesis_constants = precomputed_values.genesis_constants
           ; constraint_constants
+          ; block_window_duration = compile_config.block_window_duration
           }
       in
       let _transaction_pool, tx_remote_sink, _tx_local_sink =
@@ -197,6 +200,7 @@ let%test_module "Epoch ledger sync tests" =
           ~consensus_constants ~time_controller ~logger
           ~frontier_broadcast_pipe:frontier_broadcast_pipe_r ~on_remote_push
           ~log_gossip_heard:false
+          ~block_window_duration:compile_config.block_window_duration
       in
       let snark_remote_sink =
         let config =
@@ -209,6 +213,7 @@ let%test_module "Epoch ledger sync tests" =
             ~consensus_constants ~time_controller ~logger
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r ~on_remote_push
             ~log_gossip_heard:false
+            ~block_window_duration:compile_config.block_window_duration
         in
         snark_remote_sink
       in
@@ -268,6 +273,7 @@ let%test_module "Epoch ledger sync tests" =
           ; time_controller
           ; pubsub_v1
           ; pubsub_v0
+          ; block_window_duration = compile_config.block_window_duration
           }
         in
         Mina_networking.Gossip_net.(

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -563,3 +563,5 @@ module Archive : sig
   val create_archive_server :
     ?forward_uri:Uri.t -> port:int -> logger:Logger.t -> unit -> t Deferred.t
 end
+
+val initialize_all : Time.Span.t -> unit

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -3,10 +3,6 @@ open Async_kernel
 
 val time_offset_sec : float
 
-module type CONTEXT = sig
-  val block_window_duration : Time.Span.t
-end
-
 module Counter : sig
   type t
 
@@ -125,15 +121,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time (Context : CONTEXT) : sig
+    module Validation_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time (Context : CONTEXT) : sig
+    module Processing_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time (Context : CONTEXT) : sig
+    module Rejection_time : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -147,15 +143,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time (Context : CONTEXT) : sig
+    module Validation_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time (Context : CONTEXT) : sig
+    module Processing_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time (Context : CONTEXT) : sig
+    module Rejection_time : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -169,15 +165,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time (Context : CONTEXT) : sig
+    module Validation_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time (Context : CONTEXT) : sig
+    module Processing_time : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time (Context : CONTEXT) : sig
+    module Rejection_time : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -428,6 +424,8 @@ module Transition_frontier : sig
     val update : float -> unit
 
     val clear : unit -> unit
+
+    val initialize : Core_kernel.Time.Span.t -> unit
   end
 
   val recently_finalized_staged_txns : Gauge.t
@@ -484,36 +482,44 @@ module Block_latency : sig
     val upload_to_gcloud_blocks : Gauge.t
   end
 
-  module Gossip_slots (Context : CONTEXT) : sig
+  module Gossip_slots : sig
     val v : Gauge.t
 
     val update : float -> unit
 
     val clear : unit -> unit
+
+    val initialize : Core_kernel.Time.Span.t -> unit
   end
 
-  module Gossip_time (Context : CONTEXT) : sig
+  module Gossip_time : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit
 
     val clear : unit -> unit
+
+    val initialize : Core_kernel.Time.Span.t -> unit
   end
 
-  module Inclusion_time (Context : CONTEXT) : sig
+  module Inclusion_time : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit
 
     val clear : unit -> unit
+
+    val initialize : Core_kernel.Time.Span.t -> unit
   end
 
-  module Validation_acceptance_time (Context : CONTEXT) : sig
+  module Validation_acceptance_time : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit
 
     val clear : unit -> unit
+
+    val initialize : Core_kernel.Time.Span.t -> unit
   end
 end
 

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -3,6 +3,10 @@ open Async_kernel
 
 val time_offset_sec : float
 
+module type CONTEXT = sig
+  val block_window_duration : Time.Span.t
+end
+
 module Counter : sig
   type t
 
@@ -121,15 +125,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time : sig
+    module Validation_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time : sig
+    module Processing_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time : sig
+    module Rejection_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -143,15 +147,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time : sig
+    module Validation_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time : sig
+    module Processing_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time : sig
+    module Rejection_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -165,15 +169,15 @@ module Network : sig
 
     val received : Counter.t
 
-    module Validation_time : sig
+    module Validation_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Processing_time : sig
+    module Processing_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
 
-    module Rejection_time : sig
+    module Rejection_time (Context : CONTEXT) : sig
       val update : Time.Span.t -> unit
     end
   end
@@ -480,7 +484,7 @@ module Block_latency : sig
     val upload_to_gcloud_blocks : Gauge.t
   end
 
-  module Gossip_slots : sig
+  module Gossip_slots (Context : CONTEXT) : sig
     val v : Gauge.t
 
     val update : float -> unit
@@ -488,7 +492,7 @@ module Block_latency : sig
     val clear : unit -> unit
   end
 
-  module Gossip_time : sig
+  module Gossip_time (Context : CONTEXT) : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit
@@ -496,7 +500,7 @@ module Block_latency : sig
     val clear : unit -> unit
   end
 
-  module Inclusion_time : sig
+  module Inclusion_time (Context : CONTEXT) : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit
@@ -504,7 +508,7 @@ module Block_latency : sig
     val clear : unit -> unit
   end
 
-  module Validation_acceptance_time : sig
+  module Validation_acceptance_time (Context : CONTEXT) : sig
     val v : Gauge.t
 
     val update : Time.Span.t -> unit

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -581,3 +581,5 @@ module Archive = struct
    fun ?forward_uri:_ ~port:_ ~logger:_ _ ->
     failwith "No metrics server available"
 end
+
+let initialize_all = Fn.ignore

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -3,6 +3,10 @@ open Async_kernel
 
 let time_offset_sec = 1609459200.
 
+module type CONTEXT = sig
+  val block_window_duration : Time.Span.t
+end
+
 module Counter = struct
   type t = unit
 
@@ -131,15 +135,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time = struct
+    module Validation_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time = struct
+    module Processing_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time = struct
+    module Rejection_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -153,15 +157,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time = struct
+    module Validation_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time = struct
+    module Processing_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time = struct
+    module Rejection_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -175,15 +179,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time = struct
+    module Validation_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time = struct
+    module Processing_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time = struct
+    module Rejection_time (Context : CONTEXT) = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -492,7 +496,7 @@ module Block_latency = struct
     let upload_to_gcloud_blocks : Gauge.t = ()
   end
 
-  module Gossip_slots = struct
+  module Gossip_slots (Context : CONTEXT) = struct
     let v : Gauge.t = ()
 
     let update : float -> unit = fun _ -> ()
@@ -500,7 +504,7 @@ module Block_latency = struct
     let clear : unit -> unit = fun _ -> ()
   end
 
-  module Gossip_time = struct
+  module Gossip_time (Context : CONTEXT) = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()
@@ -508,7 +512,7 @@ module Block_latency = struct
     let clear : unit -> unit = fun _ -> ()
   end
 
-  module Inclusion_time = struct
+  module Inclusion_time (Context : CONTEXT) = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()
@@ -516,7 +520,7 @@ module Block_latency = struct
     let clear : unit -> unit = fun _ -> ()
   end
 
-  module Validation_acceptance_time = struct
+  module Validation_acceptance_time (Context : CONTEXT) = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -3,10 +3,6 @@ open Async_kernel
 
 let time_offset_sec = 1609459200.
 
-module type CONTEXT = sig
-  val block_window_duration : Time.Span.t
-end
-
 module Counter = struct
   type t = unit
 
@@ -135,15 +131,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time (Context : CONTEXT) = struct
+    module Validation_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time (Context : CONTEXT) = struct
+    module Processing_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time (Context : CONTEXT) = struct
+    module Rejection_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -157,15 +153,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time (Context : CONTEXT) = struct
+    module Validation_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time (Context : CONTEXT) = struct
+    module Processing_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time (Context : CONTEXT) = struct
+    module Rejection_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -179,15 +175,15 @@ module Network = struct
 
     let received : Counter.t = ()
 
-    module Validation_time (Context : CONTEXT) = struct
+    module Validation_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Processing_time (Context : CONTEXT) = struct
+    module Processing_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
 
-    module Rejection_time (Context : CONTEXT) = struct
+    module Rejection_time = struct
       let update : Time.Span.t -> unit = Fn.ignore
     end
   end
@@ -440,6 +436,8 @@ module Transition_frontier = struct
     let update : float -> unit = fun _ -> ()
 
     let clear : unit -> unit = fun _ -> ()
+
+    let initialize = Fn.ignore
   end
 
   let recently_finalized_staged_txns : Gauge.t = ()
@@ -496,36 +494,44 @@ module Block_latency = struct
     let upload_to_gcloud_blocks : Gauge.t = ()
   end
 
-  module Gossip_slots (Context : CONTEXT) = struct
+  module Gossip_slots = struct
     let v : Gauge.t = ()
 
     let update : float -> unit = fun _ -> ()
 
     let clear : unit -> unit = fun _ -> ()
+
+    let initialize = Fn.ignore
   end
 
-  module Gossip_time (Context : CONTEXT) = struct
+  module Gossip_time = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()
 
     let clear : unit -> unit = fun _ -> ()
+
+    let initialize = Fn.ignore
   end
 
-  module Inclusion_time (Context : CONTEXT) = struct
+  module Inclusion_time = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()
 
     let clear : unit -> unit = fun _ -> ()
+
+    let initialize = Fn.ignore
   end
 
-  module Validation_acceptance_time (Context : CONTEXT) = struct
+  module Validation_acceptance_time = struct
     let v : Gauge.t = ()
 
     let update : Time.Span.t -> unit = fun _ -> ()
 
     let clear : unit -> unit = fun _ -> ()
+
+    let initialize = Fn.ignore
   end
 end
 

--- a/src/lib/mina_metrics/prometheus_metrics/metric_generators.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/metric_generators.ml
@@ -13,9 +13,9 @@ end
 module type Bucketed_average_spec_intf = sig
   include Metric_spec_intf
 
-  val bucket_interval : Core.Time.Span.t -> Core.Time.Span.t
+  val bucket_interval : Time.Span.t -> Time.Span.t
 
-  val num_buckets : Core.Time.Span.t -> int
+  val num_buckets : Time.Span.t -> int
 
   val render_average : (float * int) list -> float
 end
@@ -49,7 +49,7 @@ module type Moving_average_metric_intf = sig
 
   val v : Gauge.t
 
-  val initialize : Core.Time.Span.t -> unit
+  val initialize : Time.Span.t -> unit
 end
 
 module Moving_bucketed_average (Spec : Bucketed_average_spec_intf) :
@@ -96,7 +96,7 @@ module Moving_bucketed_average (Spec : Bucketed_average_spec_intf) :
 end
 
 module Moving_time_average (Spec : Time_average_spec_intf) :
-  Moving_average_metric_intf with type datum := Core.Time.Span.t = struct
+  Moving_average_metric_intf with type datum := Time.Span.t = struct
   include Moving_bucketed_average (struct
     include Spec
 
@@ -117,5 +117,5 @@ module Moving_time_average (Spec : Time_average_spec_intf) :
       total_sum /. Float.of_int count_sum
   end)
 
-  let update span = update (Core.Time.Span.to_sec span)
+  let update span = update (Time.Span.to_sec span)
 end

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -435,9 +435,9 @@ module Network = struct
     Counter.v "messages_received" ~help ~namespace ~subsystem
 
   module Delay_time_spec (Context : CONTEXT) = struct
-    let tick_interval = Context.block_window_duration
-
-    let rolling_interval = Time.Span.scale Context.block_window_duration 20.0
+    let intervals =
+      Intervals.make ~rolling_interval:Context.block_window_duration
+        ~tick_interval:Context.block_window_duration
   end
 
   module Block = struct
@@ -459,49 +459,52 @@ module Network = struct
       let help = "# of blocks received" in
       Counter.v "received" ~help ~namespace ~subsystem
 
-    module Validation_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    let validation_time_is_initialized = ref false
 
-          let subsystem = subsystem
+    let processing_time_is_initialized = ref false
 
-          let name = "validation_time"
+    let rejection_time_is_initialized = ref false
 
-          let help =
-            "average time, in ms, for blocks to be validated and rebroadcasted"
-        end)
-        ()
+    module Validation_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-    module Processing_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+      let subsystem = subsystem
 
-          let subsystem = subsystem
+      let name = "validation_time"
 
-          let name = "processing_time"
+      let help =
+        "average time, in ms, for blocks to be validated and rebroadcasted"
 
-          let help =
-            "average time, in ms, for blocks to be accepted after the OCaml \
-             process receives it"
-        end)
-        ()
+      let is_initialized = validation_time_is_initialized
+    end)
 
-    module Rejection_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    module Processing_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-          let subsystem = subsystem
+      let subsystem = subsystem
 
-          let name = "rejection_time"
+      let name = "processing_time"
 
-          let help =
-            "average time, in ms, for blocks to be rejected after the OCaml \
-             process receives it"
-        end)
-        ()
+      let help =
+        "average time, in ms, for blocks to be accepted after the OCaml \
+         process receives it"
+
+      let is_initialized = processing_time_is_initialized
+    end)
+
+    module Rejection_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
+
+      let subsystem = subsystem
+
+      let name = "rejection_time"
+
+      let help =
+        "average time, in ms, for blocks to be rejected after the OCaml \
+         process receives it"
+
+      let is_initialized = rejection_time_is_initialized
+    end)
   end
 
   module Snark_work = struct
@@ -523,50 +526,52 @@ module Network = struct
       let help = "# of snark work received" in
       Counter.v "received" ~help ~namespace ~subsystem
 
-    module Validation_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    let validation_time_is_initialized = ref false
 
-          let subsystem = subsystem
+    let processing_time_is_initialized = ref false
 
-          let name = "validation_time"
+    let rejection_time_is_initialized = ref false
 
-          let help =
-            "average delay, in ms, for snark work to be validated and \
-             rebroadcasted"
-        end)
-        ()
+    module Validation_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-    module Processing_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+      let subsystem = subsystem
 
-          let subsystem = subsystem
+      let name = "validation_time"
 
-          let name = "processing_time"
+      let help =
+        "average delay, in ms, for snark work to be validated and rebroadcasted"
 
-          let help =
-            "average delay, in ms, for snark work to be accepted after the \
-             OCaml process receives it"
-        end)
-        ()
+      let is_initialized = validation_time_is_initialized
+    end)
 
-    module Rejection_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    module Processing_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-          let subsystem = subsystem
+      let subsystem = subsystem
 
-          let name = "rejection_time"
+      let name = "processing_time"
 
-          let help =
-            "average time, in ms, for snark work to be rejected after the \
-             OCaml process receives it"
-        end)
-        ()
+      let help =
+        "average delay, in ms, for snark work to be accepted after the OCaml \
+         process receives it"
+
+      let is_initialized = processing_time_is_initialized
+    end)
+
+    module Rejection_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
+
+      let subsystem = subsystem
+
+      let name = "rejection_time"
+
+      let help =
+        "average time, in ms, for snark work to be rejected after the OCaml \
+         process receives it"
+
+      let is_initialized = rejection_time_is_initialized
+    end)
   end
 
   module Transaction = struct
@@ -588,50 +593,53 @@ module Network = struct
       let help = "# of transactions received" in
       Counter.v "received" ~help ~namespace ~subsystem
 
-    module Validation_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    let validation_time_is_initialized = ref false
 
-          let subsystem = subsystem
+    let processing_time_is_initialized = ref false
 
-          let name = "validation_time"
+    let rejection_time_is_initialized = ref false
 
-          let help =
-            "average delay, in ms, for transactions to be validated and \
-             rebroadcasted"
-        end)
-        ()
+    module Validation_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-    module Processing_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+      let subsystem = subsystem
 
-          let subsystem = subsystem
+      let name = "validation_time"
 
-          let name = "processing_time"
+      let help =
+        "average delay, in ms, for transactions to be validated and \
+         rebroadcasted"
 
-          let help =
-            "average delay, in ms, for transactions to be accepted after the \
-             OCaml process receives it"
-        end)
-        ()
+      let is_initialized = validation_time_is_initialized
+    end)
 
-    module Rejection_time (Context : CONTEXT) =
-      Moving_time_average
-        (struct
-          include Delay_time_spec (Context)
+    module Processing_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
 
-          let subsystem = subsystem
+      let subsystem = subsystem
 
-          let name = "rejection_time"
+      let name = "processing_time"
 
-          let help =
-            "average time, in ms, for transactions to be rejected after the \
-             OCaml process receives it"
-        end)
-        ()
+      let help =
+        "average delay, in ms, for transactions to be accepted after the OCaml \
+         process receives it"
+
+      let is_initialized = processing_time_is_initialized
+    end)
+
+    module Rejection_time (Context : CONTEXT) = Moving_time_average (struct
+      include Delay_time_spec (Context)
+
+      let subsystem = subsystem
+
+      let name = "rejection_time"
+
+      let help =
+        "average time, in ms, for transactions to be rejected after the OCaml \
+         process receives it"
+
+      let is_initialized = rejection_time_is_initialized
+    end)
   end
 
   let rpc_requests_received : Counter.t =
@@ -1275,28 +1283,27 @@ module Transition_frontier = struct
     let help = "total # of staged txns that have been finalized" in
     Counter.v "finalized_staged_txns" ~help ~namespace ~subsystem
 
-  module TPS_30min =
-    Moving_bucketed_average
-      (struct
-        let bucket_interval = Core.Time.Span.of_min 3.0
+  let tps_30min_is_initialized = ref false
 
-        let num_buckets = 10
+  module TPS_30min = Moving_bucketed_average (struct
+    let bucket_interval = Core.Time.Span.of_min 3.0
 
-        let render_average buckets =
-          let total =
-            List.fold buckets ~init:0.0 ~f:(fun acc (n, _) -> acc +. n)
-          in
-          total /. Core.Time.Span.(of_min 30.0 |> to_sec)
+    let num_buckets = 10
 
-        let subsystem = subsystem
+    let render_average buckets =
+      let total = List.fold buckets ~init:0.0 ~f:(fun acc (n, _) -> acc +. n) in
+      total /. Core.Time.Span.(of_min 30.0 |> to_sec)
 
-        let name = "tps_30min"
+    let subsystem = subsystem
 
-        let help =
-          "moving average for transaction per second, the rolling interval is \
-           set to 30 min"
-      end)
-      ()
+    let name = "tps_30min"
+
+    let help =
+      "moving average for transaction per second, the rolling interval is set \
+       to 30 min"
+
+    let is_initialized = tps_30min_is_initialized
+  end)
 
   let recently_finalized_staged_txns : Gauge.t =
     let help =
@@ -1443,79 +1450,84 @@ module Block_latency = struct
   end
 
   module Latency_time_spec (Context : CONTEXT) = struct
-    let tick_interval = Time.Span.scale Context.block_window_duration 0.5
-
-    let rolling_interval = Time.Span.scale Context.block_window_duration 20.0
+    let intervals =
+      Intervals.make
+        ~tick_interval:(Time.Span.scale Context.block_window_duration 0.5)
+        ~rolling_interval:(Time.Span.scale Context.block_window_duration 20.0)
   end
 
-  module Gossip_slots (Context : CONTEXT) =
-    Moving_bucketed_average
-      (struct
-        let bucket_interval = Time.Span.scale Context.block_window_duration 0.5
+  let gossip_slots_is_initialized = ref false
 
-        let num_buckets = 40
+  module Gossip_slots (Context : CONTEXT) = Moving_bucketed_average (struct
+    let bucket_interval = Time.Span.scale Context.block_window_duration 0.5
 
-        let subsystem = subsystem
+    let num_buckets = 40
 
-        let name = "gossip_slots"
+    let subsystem = subsystem
 
-        let help =
-          "average delay, in slots, after which produced blocks are received"
+    let name = "gossip_slots"
 
-        let render_average buckets =
-          let total_sum, count_sum =
-            List.fold buckets ~init:(0.0, 0)
-              ~f:(fun (total_sum, count_sum) (total, count) ->
-                (total_sum +. total, count_sum + count) )
-          in
-          total_sum /. Float.of_int count_sum
-      end)
-      ()
+    let help =
+      "average delay, in slots, after which produced blocks are received"
 
-  module Gossip_time (Context : CONTEXT) =
-    Moving_time_average
-      (struct
-        include Latency_time_spec (Context)
+    let render_average buckets =
+      let total_sum, count_sum =
+        List.fold buckets ~init:(0.0, 0)
+          ~f:(fun (total_sum, count_sum) (total, count) ->
+            (total_sum +. total, count_sum + count) )
+      in
+      total_sum /. Float.of_int count_sum
 
-        let subsystem = subsystem
+    let is_initialized = gossip_slots_is_initialized
+  end)
 
-        let name = "gossip_time"
+  let gossip_time_is_initialized = ref false
 
-        let help =
-          "average delay, in seconds, after which produced blocks are received"
-      end)
-      ()
+  module Gossip_time (Context : CONTEXT) = Moving_time_average (struct
+    include Latency_time_spec (Context)
 
-  module Inclusion_time (Context : CONTEXT) =
-    Moving_time_average
-      (struct
-        include Latency_time_spec (Context)
+    let subsystem = subsystem
 
-        let subsystem = subsystem
+    let name = "gossip_time"
 
-        let name = "inclusion_time"
+    let help =
+      "average delay, in seconds, after which produced blocks are received"
 
-        let help =
-          "average delay, in seconds, after which produced blocks are included \
-           into our frontier"
-      end)
-      ()
+    let is_initialized = gossip_time_is_initialized
+  end)
+
+  let inclusion_time_is_initialized = ref false
+
+  module Inclusion_time (Context : CONTEXT) = Moving_time_average (struct
+    include Latency_time_spec (Context)
+
+    let subsystem = subsystem
+
+    let name = "inclusion_time"
+
+    let help =
+      "average delay, in seconds, after which produced blocks are included \
+       into our frontier"
+
+    let is_initialized = inclusion_time_is_initialized
+  end)
+
+  let validation_acceptance_time_is_initialized = ref false
 
   module Validation_acceptance_time (Context : CONTEXT) =
-    Moving_time_average
-      (struct
-        include Latency_time_spec (Context)
+  Moving_time_average (struct
+    include Latency_time_spec (Context)
 
-        let subsystem = subsystem
+    let subsystem = subsystem
 
-        let name = "validation_acceptance_time"
+    let name = "validation_acceptance_time"
 
-        let help =
-          "average delay, in seconds, between the time blocks are initially \
-           received from the libp2p_helper, and when they are accepted as \
-           valid"
-      end)
-      ()
+    let help =
+      "average delay, in seconds, between the time blocks are initially \
+       received from the libp2p_helper, and when they are accepted as valid"
+
+    let is_initialized = validation_acceptance_time_is_initialized
+  end)
 end
 
 module Rejected_blocks = struct

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1755,3 +1755,10 @@ module Archive = struct
     ; gauge_metrics = Hashtbl.create (module String)
     }
 end
+
+let initialize_all block_window_duration =
+  Transition_frontier.TPS_30min.initialize block_window_duration ;
+  Block_latency.Gossip_slots.initialize block_window_duration ;
+  Block_latency.Gossip_time.initialize block_window_duration ;
+  Block_latency.Inclusion_time.initialize block_window_duration ;
+  Block_latency.Validation_acceptance_time.initialize block_window_duration

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -465,6 +465,16 @@ module Network = struct
 
     let rejection_time_is_initialized = ref false
 
+    module Gauge_map = Metric_map (struct
+      type t = Gauge.t
+
+      let subsystem = subsystem
+
+      let v = Gauge.v
+    end)
+
+    let block_table = Gauge_map.of_alist_exn []
+
     module Validation_time (Context : CONTEXT) = Moving_time_average (struct
       include Delay_time_spec (Context)
 
@@ -474,6 +484,8 @@ module Network = struct
 
       let help =
         "average time, in ms, for blocks to be validated and rebroadcasted"
+
+      let v = Gauge_map.add block_table ~name ~help
 
       let is_initialized = validation_time_is_initialized
     end)
@@ -489,6 +501,8 @@ module Network = struct
         "average time, in ms, for blocks to be accepted after the OCaml \
          process receives it"
 
+      let v = Gauge_map.add block_table ~name ~help
+
       let is_initialized = processing_time_is_initialized
     end)
 
@@ -502,6 +516,8 @@ module Network = struct
       let help =
         "average time, in ms, for blocks to be rejected after the OCaml \
          process receives it"
+
+      let v = Gauge_map.add block_table ~name ~help
 
       let is_initialized = rejection_time_is_initialized
     end)
@@ -532,6 +548,16 @@ module Network = struct
 
     let rejection_time_is_initialized = ref false
 
+    module Gauge_map = Metric_map (struct
+      type t = Gauge.t
+
+      let subsystem = subsystem
+
+      let v = Gauge.v
+    end)
+
+    let snark_work_table = Gauge_map.of_alist_exn []
+
     module Validation_time (Context : CONTEXT) = Moving_time_average (struct
       include Delay_time_spec (Context)
 
@@ -541,6 +567,8 @@ module Network = struct
 
       let help =
         "average delay, in ms, for snark work to be validated and rebroadcasted"
+
+      let v = Gauge_map.add snark_work_table ~name ~help
 
       let is_initialized = validation_time_is_initialized
     end)
@@ -556,6 +584,8 @@ module Network = struct
         "average delay, in ms, for snark work to be accepted after the OCaml \
          process receives it"
 
+      let v = Gauge_map.add snark_work_table ~name ~help
+
       let is_initialized = processing_time_is_initialized
     end)
 
@@ -569,6 +599,8 @@ module Network = struct
       let help =
         "average time, in ms, for snark work to be rejected after the OCaml \
          process receives it"
+
+      let v = Gauge_map.add snark_work_table ~name ~help
 
       let is_initialized = rejection_time_is_initialized
     end)
@@ -599,6 +631,16 @@ module Network = struct
 
     let rejection_time_is_initialized = ref false
 
+    module Gauge_map = Metric_map (struct
+      type t = Gauge.t
+
+      let subsystem = subsystem
+
+      let v = Gauge.v
+    end)
+
+    let transaction_table = Gauge_map.of_alist_exn []
+
     module Validation_time (Context : CONTEXT) = Moving_time_average (struct
       include Delay_time_spec (Context)
 
@@ -609,6 +651,8 @@ module Network = struct
       let help =
         "average delay, in ms, for transactions to be validated and \
          rebroadcasted"
+
+      let v = Gauge_map.add transaction_table ~name ~help
 
       let is_initialized = validation_time_is_initialized
     end)
@@ -624,6 +668,8 @@ module Network = struct
         "average delay, in ms, for transactions to be accepted after the OCaml \
          process receives it"
 
+      let v = Gauge_map.add transaction_table ~name ~help
+
       let is_initialized = processing_time_is_initialized
     end)
 
@@ -637,6 +683,8 @@ module Network = struct
       let help =
         "average time, in ms, for transactions to be rejected after the OCaml \
          process receives it"
+
+      let v = Gauge_map.add transaction_table ~name ~help
 
       let is_initialized = rejection_time_is_initialized
     end)
@@ -1285,6 +1333,16 @@ module Transition_frontier = struct
 
   let tps_30min_is_initialized = ref false
 
+  module Gauge_map = Metric_map (struct
+    type t = Gauge.t
+
+    let subsystem = subsystem
+
+    let v = Gauge.v
+  end)
+
+  let transaction_frontier_table = Gauge_map.of_alist_exn []
+
   module TPS_30min = Moving_bucketed_average (struct
     let bucket_interval = Core.Time.Span.of_min 3.0
 
@@ -1301,6 +1359,8 @@ module Transition_frontier = struct
     let help =
       "moving average for transaction per second, the rolling interval is set \
        to 30 min"
+
+    let v = Gauge_map.add transaction_frontier_table ~name ~help
 
     let is_initialized = tps_30min_is_initialized
   end)
@@ -1458,6 +1518,16 @@ module Block_latency = struct
 
   let gossip_slots_is_initialized = ref false
 
+  module Gauge_map = Metric_map (struct
+    type t = Gauge.t
+
+    let subsystem = subsystem
+
+    let v = Gauge.v
+  end)
+
+  let block_latency_table = Gauge_map.of_alist_exn []
+
   module Gossip_slots (Context : CONTEXT) = Moving_bucketed_average (struct
     let bucket_interval = Time.Span.scale Context.block_window_duration 0.5
 
@@ -1478,6 +1548,8 @@ module Block_latency = struct
       in
       total_sum /. Float.of_int count_sum
 
+    let v = Gauge_map.add block_latency_table ~name ~help
+
     let is_initialized = gossip_slots_is_initialized
   end)
 
@@ -1492,6 +1564,8 @@ module Block_latency = struct
 
     let help =
       "average delay, in seconds, after which produced blocks are received"
+
+    let v = Gauge_map.add block_latency_table ~name ~help
 
     let is_initialized = gossip_time_is_initialized
   end)
@@ -1509,6 +1583,8 @@ module Block_latency = struct
       "average delay, in seconds, after which produced blocks are included \
        into our frontier"
 
+    let v = Gauge_map.add block_latency_table ~name ~help
+
     let is_initialized = inclusion_time_is_initialized
   end)
 
@@ -1525,6 +1601,8 @@ module Block_latency = struct
     let help =
       "average delay, in seconds, between the time blocks are initially \
        received from the libp2p_helper, and when they are accepted as valid"
+
+    let v = Gauge_map.add block_latency_table ~name ~help
 
     let is_initialized = validation_acceptance_time_is_initialized
   end)

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -139,6 +139,7 @@ val create :
   -> conf_dir:string
   -> on_peer_connected:(Peer.Id.t -> unit)
   -> on_peer_disconnected:(Peer.Id.t -> unit)
+  -> block_window_duration:Time.Span.t
   -> unit
   -> t Deferred.Or_error.t
 

--- a/src/lib/mina_net2/subscription.ml
+++ b/src/lib/mina_net2/subscription.ml
@@ -50,7 +50,7 @@ let unsubscribe ~helper sub =
   else Deferred.Or_error.error_string "already unsubscribed"
 
 let handle_and_validate sub ~validation_expiration ~(sender : Peer.t)
-    ~data:raw_data =
+    ~data:raw_data ~block_window_duration =
   let open Libp2p_ipc.Reader.ValidationResult in
   let wrap_message data =
     if
@@ -65,7 +65,9 @@ let handle_and_validate sub ~validation_expiration ~(sender : Peer.t)
         Validation_callback.create validation_expiration
       in
       let%bind () = sub.validator (wrap_message data) validation_callback in
-      match%map Validation_callback.await validation_callback with
+      match%map
+        Validation_callback.await ~block_window_duration validation_callback
+      with
       | Some `Accept ->
           `Validation_result Accept
       | Some `Reject ->

--- a/src/lib/mina_net2/subscription.mli
+++ b/src/lib/mina_net2/subscription.mli
@@ -29,6 +29,7 @@ val handle_and_validate :
   -> validation_expiration:Time_ns.t
   -> sender:Peer.t
   -> data:string
+  -> block_window_duration:Time.Span.t
   -> [ `Validation_result of Libp2p_ipc.validation_result
      | `Validation_timeout
      | `Decoding_error of Error.t ]

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -78,6 +78,9 @@ let%test_module "all-ipc test" =
     let bob_status =
       "This is major Tom to ground control\nI'm stepping through the door"
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     type messages =
       { topic_a_msg_1 : string
       ; topic_a_msg_2 : string
@@ -540,7 +543,8 @@ let%test_module "all-ipc test" =
       let%bind node =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String local_name) ])
-          ~conf_dir ~pids ~on_peer_connected ~on_peer_disconnected ()
+          ~conf_dir ~pids ~on_peer_connected ~on_peer_disconnected
+          ~block_window_duration ()
         >>| Or_error.ok_exn
       in
       let%bind kp_a =

--- a/src/lib/mina_net2/tests/dune
+++ b/src/lib/mina_net2/tests/dune
@@ -20,6 +20,7 @@
    network_peer
    file_system
    bounded_types
+   mina_compile_config
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version))

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -11,6 +11,9 @@ let%test_module "Mina network tests" =
 
     let pids = Child_processes.Termination.create_pid_table ()
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     let setup_two_nodes network_id =
       let%bind a_tmp = Unix.mkdtemp "p2p_helper_test_a" in
       let%bind b_tmp = Unix.mkdtemp "p2p_helper_test_b" in
@@ -19,21 +22,21 @@ let%test_module "Mina network tests" =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "a") ])
           ~conf_dir:a_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ()
+          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
         >>| Or_error.ok_exn
       in
       let%bind b =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "b") ])
           ~conf_dir:b_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ()
+          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
         >>| Or_error.ok_exn
       in
       let%bind c =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "c") ])
           ~conf_dir:c_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ()
+          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
         >>| Or_error.ok_exn
       in
       let%bind kp_a = generate_random_keypair a in

--- a/src/lib/mina_net2/validation_callback.ml
+++ b/src/lib/mina_net2/validation_callback.ml
@@ -39,15 +39,15 @@ module type Metric_intf = sig
 
   val ignored : Mina_metrics.Counter.t
 
-  module Validation_time (Context : Mina_metrics.CONTEXT) : sig
+  module Validation_time : sig
     val update : Time.Span.t -> unit
   end
 
-  module Processing_time (Context : Mina_metrics.CONTEXT) : sig
+  module Processing_time : sig
     val update : Time.Span.t -> unit
   end
 
-  module Rejection_time (Context : Mina_metrics.CONTEXT) : sig
+  module Rejection_time : sig
     val update : Time.Span.t -> unit
   end
 end
@@ -72,10 +72,7 @@ let record_timeout_metrics cb =
       Mina_metrics.Counter.inc_one M.validations_timed_out
 
 let record_validation_metrics message_type (result : validation_result)
-    validation_time processing_time ~block_window_duration =
-  let module Context = struct
-    let block_window_duration = block_window_duration
-  end in
+    validation_time processing_time ~block_window_duration:_ (*TODO remove*) =
   match metrics_of_message_type message_type with
   | None ->
       ()
@@ -84,13 +81,13 @@ let record_validation_metrics message_type (result : validation_result)
       | `Ignore ->
           Mina_metrics.Counter.inc_one M.ignored
       | `Accept ->
-          let module Validation_time = M.Validation_time (Context) in
+          let module Validation_time = M.Validation_time in
           Validation_time.update validation_time ;
-          let module Processing_time = M.Processing_time (Context) in
+          let module Processing_time = M.Processing_time in
           Processing_time.update processing_time
       | `Reject ->
           Mina_metrics.Counter.inc_one M.rejected ;
-          let module Rejection_time = M.Rejection_time (Context) in
+          let module Rejection_time = M.Rejection_time in
           Rejection_time.update processing_time )
 
 let await_timeout cb =

--- a/src/lib/mina_net2/validation_callback.ml
+++ b/src/lib/mina_net2/validation_callback.ml
@@ -32,6 +32,7 @@ let is_expired cb =
   | Some expires_at ->
       Time_ns.(now () >= expires_at)
 
+(*
 module type Metric_intf = sig
   val validations_timed_out : Mina_metrics.Counter.t
 
@@ -39,53 +40,95 @@ module type Metric_intf = sig
 
   val ignored : Mina_metrics.Counter.t
 
-  module Validation_time : sig
+  module Validation_time(Context : Mina_metrics.CONTEXT) : sig
     val update : Time.Span.t -> unit
   end
 
-  module Processing_time : sig
+  module Processing_time(Context : Mina_metrics.CONTEXT) : sig
     val update : Time.Span.t -> unit
   end
 
-  module Rejection_time : sig
+  module Rejection_time(Context : Mina_metrics.CONTEXT) : sig
     val update : Time.Span.t -> unit
   end
 end
 
-let metrics_of_message_type m : (module Metric_intf) option =
+let metrics_of_message_type m  =
   match m with
   | `Unknown ->
       None
   | `Block ->
-      Some (module Mina_metrics.Network.Block)
+      Some (Mina_metrics.Network.Block.validations_timed_out)
   | `Snark_work ->
-      Some (module Mina_metrics.Network.Snark_work)
+      Some (Mina_metrics.Network.Snark_work.validations_timed_out)
   | `Transaction ->
-      Some (module Mina_metrics.Network.Transaction)
+      Some (Mina_metrics.Network.Transaction.validations_timed_out)
+
+*)
 
 let record_timeout_metrics cb =
   Mina_metrics.(Counter.inc_one Network.validations_timed_out) ;
-  match metrics_of_message_type cb.message_type with
-  | None ->
-      ()
-  | Some (module M) ->
-      Mina_metrics.Counter.inc_one M.validations_timed_out
+  let counter =
+    match cb.message_type with
+    | `Unknown ->
+        None
+    | `Block ->
+        Some Mina_metrics.Network.Block.validations_timed_out
+    | `Snark_work ->
+        Some Mina_metrics.Network.Snark_work.validations_timed_out
+    | `Transaction ->
+        Some Mina_metrics.Network.Transaction.validations_timed_out
+  in
+  Option.iter ~f:Mina_metrics.Counter.inc_one counter
 
-let record_validation_metrics message_type (result : validation_result)
-    validation_time processing_time =
-  match metrics_of_message_type message_type with
-  | None ->
+let record_validation_metrics ~block_window_duration message_type
+    (result : validation_result) validation_time processing_time =
+  let open Mina_metrics.Network in
+  let module Context = struct
+    let block_window_duration = block_window_duration
+  end in
+  match message_type with
+  | `Unknown ->
       ()
-  | Some (module M) -> (
+  | `Block -> (
+      let module Validation_time = Block.Validation_time (Context) in
+      let module Processing_time = Block.Processing_time (Context) in
+      let module Rejection_time = Block.Rejection_time (Context) in
       match result with
       | `Ignore ->
-          Mina_metrics.Counter.inc_one M.ignored
+          Mina_metrics.Counter.inc_one Block.ignored
       | `Accept ->
-          M.Validation_time.update validation_time ;
-          M.Processing_time.update processing_time
+          Validation_time.update validation_time ;
+          Processing_time.update processing_time
       | `Reject ->
-          Mina_metrics.Counter.inc_one M.rejected ;
-          M.Rejection_time.update processing_time )
+          Mina_metrics.Counter.inc_one Block.rejected ;
+          Rejection_time.update processing_time )
+  | `Snark_work -> (
+      let module Validation_time = Snark_work.Validation_time (Context) in
+      let module Processing_time = Snark_work.Processing_time (Context) in
+      let module Rejection_time = Snark_work.Rejection_time (Context) in
+      match result with
+      | `Ignore ->
+          Mina_metrics.Counter.inc_one Block.ignored
+      | `Accept ->
+          Validation_time.update validation_time ;
+          Processing_time.update processing_time
+      | `Reject ->
+          Mina_metrics.Counter.inc_one Block.rejected ;
+          Rejection_time.update processing_time )
+  | `Transaction -> (
+      let module Validation_time = Transaction.Validation_time (Context) in
+      let module Processing_time = Transaction.Processing_time (Context) in
+      let module Rejection_time = Transaction.Rejection_time (Context) in
+      match result with
+      | `Ignore ->
+          Mina_metrics.Counter.inc_one Block.ignored
+      | `Accept ->
+          Validation_time.update validation_time ;
+          Processing_time.update processing_time
+      | `Reject ->
+          Mina_metrics.Counter.inc_one Block.rejected ;
+          Rejection_time.update processing_time )
 
 let await_timeout cb =
   if is_expired cb then Deferred.return ()
@@ -98,7 +141,7 @@ let await_timeout cb =
           ( Time_ns.Span.to_span_float_round_nearest
           @@ Time_ns.diff expires_at (Time_ns.now ()) )
 
-let await cb =
+let await ~block_window_duration cb =
   if is_expired cb then (record_timeout_metrics cb ; Deferred.return None)
   else
     match cb.expiration with
@@ -119,14 +162,18 @@ let await cb =
               Time_ns.abs_diff (Time_ns.now ()) cb.created_at
               |> Time_ns.Span.to_ms |> Time.Span.of_ms
             in
-            record_validation_metrics cb.message_type result validation_time
-              processing_time ;
+            record_validation_metrics ~block_window_duration cb.message_type
+              result validation_time processing_time ;
             Some result
         | `Timeout ->
             record_timeout_metrics cb ; None )
 
-let await_exn cb =
-  match%map await cb with None -> failwith "timeout" | Some result -> result
+let await_exn ~block_window_duration cb =
+  match%map await ~block_window_duration cb with
+  | None ->
+      failwith "timeout"
+  | Some result ->
+      result
 
 let fire_if_not_already_fired cb result =
   if not (is_expired cb) then (

--- a/src/lib/mina_net2/validation_callback.mli
+++ b/src/lib/mina_net2/validation_callback.mli
@@ -11,9 +11,11 @@ val create_without_expiration : unit -> t
 
 val is_expired : t -> bool
 
-val await : t -> validation_result option Deferred.t
+val await :
+  block_window_duration:Time.Span.t -> t -> validation_result option Deferred.t
 
-val await_exn : t -> validation_result Deferred.t
+val await_exn :
+  block_window_duration:Time.Span.t -> t -> validation_result Deferred.t
 
 (** May return a deferred that never resolves, in the case of callbacks without expiration. *)
 val await_timeout : t -> unit Deferred.t

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -42,6 +42,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 module Node_status = Node_status

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -29,6 +29,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 module Node_status = Node_status

--- a/src/lib/mina_networking/rpcs.ml
+++ b/src/lib/mina_networking/rpcs.ml
@@ -33,6 +33,8 @@ module type CONTEXT = sig
   val list_peers : unit -> Peer.t list Deferred.t
 
   val get_transition_frontier : unit -> Transition_frontier.t option
+
+  val compile_config : Mina_compile_config.t
 end
 
 type ctx = (module CONTEXT)

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -224,6 +224,7 @@ module type Network_pool_base_intf = sig
     -> logger:Logger.t
     -> log_gossip_heard:bool
     -> on_remote_push:(unit -> unit Deferred.t)
+    -> block_window_duration:Time.Span.t
     -> t * Remote_sink.t * Local_sink.t
 
   val of_resource_pool_and_diffs :
@@ -233,6 +234,7 @@ module type Network_pool_base_intf = sig
     -> tf_diffs:transition_frontier_diff Strict_pipe.Reader.t
     -> log_gossip_heard:bool
     -> on_remote_push:(unit -> unit Deferred.t)
+    -> block_window_duration:Time.Span.t
     -> t * Remote_sink.t * Local_sink.t
 
   val resource_pool : t -> resource_pool

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -26,6 +26,7 @@ module type Pool_sink = sig
     -> trace_label:string
     -> logger:Logger.t
     -> pool
+    -> block_window_duration:Time.Span.t
     -> 'wrapped_t Strict_pipe.Reader.t * t * Rate_limiter.t
 end
 
@@ -71,6 +72,7 @@ module Base
         ; throttle : unit Throttle.t
         ; on_push : unit -> unit Deferred.t
         ; log_gossip_heard : bool
+        ; block_window_duration : Time.Span.t
         }
         -> t
     | Void
@@ -143,6 +145,7 @@ module Base
         ; throttle
         ; on_push
         ; log_gossip_heard
+        ; block_window_duration
         } ->
         O1trace.sync_thread (sprintf "handle_%s_gossip" trace_label)
         @@ fun () ->
@@ -154,7 +157,10 @@ module Base
         | BC.External cb'' ->
             Diff.update_metrics env' cb'' ~log_gossip_heard ~logger ;
             don't_wait_for
-              ( match%map Mina_net2.Validation_callback.await cb'' with
+              ( match%map
+                  Mina_net2.Validation_callback.await ~block_window_duration
+                    cb''
+                with
               | None ->
                   let diff = Envelope.Incoming.data env' in
                   [%log error]
@@ -191,7 +197,7 @@ module Base
         Deferred.unit
 
   let create ?(on_push = Fn.const Deferred.unit) ?(log_gossip_heard = false)
-      ~wrap ~unwrap ~trace_label ~logger pool =
+      ~wrap ~unwrap ~trace_label ~logger pool ~block_window_duration =
     let r, writer =
       Strict_pipe.create ~name:"verified network pool diffs"
         (Buffered
@@ -217,6 +223,7 @@ module Base
         ; throttle
         ; on_push
         ; log_gossip_heard
+        ; block_window_duration
         }
     , rate_limiter )
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -570,6 +570,9 @@ let%test_module "random set test" =
 
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     (* SNARK work is rejected if the prover doesn't have an account and the fee
        is below the account creation fee. So, just to make generating valid SNARK
        work easier for testing, we set the account creation fee to 0. *)
@@ -639,6 +642,7 @@ let%test_module "random set test" =
           ~consensus_constants ~time_controller
           ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+          ~block_window_duration
         (* |>  *)
       in
       let pool = Mock_snark_pool.resource_pool mock_pool in
@@ -805,6 +809,7 @@ let%test_module "random set test" =
               ~consensus_constants ~time_controller ~logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+              ~block_window_duration
           in
           let priced_proof =
             { Priced_proof.proof =
@@ -877,6 +882,7 @@ let%test_module "random set test" =
                 ~consensus_constants ~time_controller
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+                ~block_window_duration
             in
             List.map (List.take works per_reader) ~f:create_work
             |> List.map ~f:(fun work ->
@@ -961,6 +967,7 @@ let%test_module "random set test" =
               ~constraint_constants ~consensus_constants ~time_controller
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+              ~block_window_duration
           in
           let resource_pool = Mock_snark_pool.resource_pool network_pool in
           let%bind () =

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -22,6 +22,9 @@ let%test_module "network pool test" =
 
     let time_controller = Block_time.Controller.basic ~logger
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
@@ -61,6 +64,7 @@ let%test_module "network pool test" =
               ~consensus_constants ~time_controller
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+              ~block_window_duration
           in
           let%bind () =
             Mocks.Transition_frontier.refer_statements tf [ work ]
@@ -115,6 +119,7 @@ let%test_module "network pool test" =
             ~consensus_constants ~time_controller
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
             ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+            ~block_window_duration
         in
         List.map (List.take works per_reader) ~f:create_work
         |> List.map ~f:(fun work ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1641,6 +1641,9 @@ let%test_module _ =
 
     let num_extra_keys = 30
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     (* keys that can be used when generating new accounts *)
     let extra_keys =
       Array.init num_extra_keys ~f:(fun _ -> Signature_lib.Keypair.create ())
@@ -1922,6 +1925,7 @@ let%test_module _ =
         Test.create ~config ~logger ~constraint_constants ~consensus_constants
           ~time_controller ~frontier_broadcast_pipe:frontier_pipe_r
           ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+          ~block_window_duration
       in
       let txn_pool = Test.resource_pool pool_ in
       let%map () = Async.Scheduler.yield_until_no_jobs_remain () in

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -14,6 +14,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 module type Inputs_intf = sig

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -87,6 +87,9 @@ let%test_module "transaction_status" =
 
     let pool_max_size = precomputed_values.genesis_constants.txpool_max_size
 
+    let block_window_duration =
+      Mina_compile_config.For_unit_tests.t.block_window_duration
+
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
@@ -124,6 +127,7 @@ let%test_module "transaction_status" =
           ~consensus_constants:precomputed_values.consensus_constants
           ~time_controller ~logger ~frontier_broadcast_pipe
           ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
+          ~block_window_duration
       in
       don't_wait_for
       @@ Linear_pipe.iter (Transaction_pool.broadcasts transaction_pool)

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -11,6 +11,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -60,9 +60,6 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       O1trace.sync_thread "handle_block_gossip"
       @@ fun () ->
       let%bind () = on_push () in
-      let module Metrics_Context = struct
-        let block_window_duration = block_window_duration
-      end in
       Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
       let state = Envelope.Incoming.data e in
       let state_hash =
@@ -102,7 +99,7 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
             in
             let module Validation_acceptance_time =
               Mina_metrics.Block_latency.Validation_acceptance_time
-                (Metrics_Context) in
+            in
             Validation_acceptance_time.update processing_time_span
         | Some _ ->
             ()
@@ -192,11 +189,9 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
           (Consensus.Data.Consensus_time.of_time_exn
              ~constants:consensus_constants tm )
       in
-      let module Gossip_slots =
-        Mina_metrics.Block_latency.Gossip_slots (Metrics_Context) in
+      let module Gossip_slots = Mina_metrics.Block_latency.Gossip_slots in
       Gossip_slots.update (Float.of_int (tm_slot - tn_production_slot)) ;
-      let module Gossip_time =
-        Mina_metrics.Block_latency.Gossip_time (Metrics_Context) in
+      let module Gossip_time = Mina_metrics.Block_latency.Gossip_time in
       Gossip_time.update
         Block_time.(Span.to_time_span @@ diff tm tn_production_time) ;
       Deferred.unit

--- a/src/lib/transition_handler/block_sink.mli
+++ b/src/lib/transition_handler/block_sink.mli
@@ -1,5 +1,6 @@
 open Network_peer
 open Mina_base
+open Core_kernel
 
 type Structured_log_events.t +=
   | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
@@ -21,6 +22,7 @@ type block_sink_config =
   ; consensus_constants : Consensus.Constants.t
   ; genesis_constants : Genesis_constants.t
   ; constraint_constants : Genesis_constants.Constraint_constants.t
+  ; block_window_duration : Time.Span.t
   }
 
 val create :

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -25,6 +25,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 (* TODO: calculate a sensible value from postake consensus arguments *)
@@ -44,7 +46,13 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 (* add a breadcrumb and perform post processing *)
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
     ~processed_transition_writer ~only_if_present ~time_controller ~source
-    ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t) =
+    ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t)
+    ~block_window_duration =
+  let module Metrics_context = struct
+    let block_window_duration = block_window_duration
+  end in
+  let module Inclusion_time =
+    Mina_metrics.Block_latency.Inclusion_time (Metrics_context) in
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
     else Cached.invalidate_with_success cached_breadcrumb
@@ -94,8 +102,7 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
           (Consensus.Data.Consensus_time.to_time ~constants:consensus_constants
              transition_time )
       in
-      Mina_metrics.Block_latency.Inclusion_time.update
-        (Block_time.Span.to_time_span time_elapsed) ) ;
+      Inclusion_time.update (Block_time.Span.to_time_span time_elapsed) ) ;
   [%log internal] "Add_and_finalize_done" ;
   if Writer.is_closed processed_transition_writer then
     Or_error.error_string "processed transitions closed"
@@ -204,7 +211,8 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
               in
               Catchup_scheduler.watch catchup_scheduler ~timeout_duration
                 ~cached_transition:cached_initially_validated_transition
-                ~valid_cb ;
+                ~valid_cb
+                ~block_window_duration:compile_config.block_window_duration ;
               return (Error ()) )
     in
     (* TODO: only access parent in transition frontier once (already done in call to validate dependencies) #2485 *)
@@ -251,6 +259,7 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
       add_and_finalize ~logger ~frontier ~catchup_scheduler
         ~processed_transition_writer ~only_if_present:false ~time_controller
         ~source:`Gossip breadcrumb ~precomputed_values ~valid_cb
+        ~block_window_duration:compile_config.block_window_duration
     in
     ( match result with
     | Ok () ->
@@ -343,6 +352,8 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                               let%map result =
                                 add_and_finalize ~logger ~only_if_present:true
                                   ~source:`Catchup ~valid_cb b
+                                  ~block_window_duration:
+                                    compile_config.block_window_duration
                               in
                               Internal_tracing.with_state_hash state_hash
                               @@ fun () ->
@@ -406,6 +417,8 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                     match%map
                       add_and_finalize ~logger ~only_if_present:false
                         ~source:`Internal breadcrumb ~valid_cb:None
+                        ~block_window_duration:
+                          compile_config.block_window_duration
                     with
                     | Ok () ->
                         [%log internal] "Breadcrumb_integrated" ;
@@ -453,6 +466,8 @@ let%test_module "Transition_handler.Processor tests" =
 
     let trust_system = Trust_system.null ()
 
+    let compile_config = Mina_compile_config.For_unit_tests.t
+
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
@@ -468,6 +483,8 @@ let%test_module "Transition_handler.Processor tests" =
       let constraint_constants = constraint_constants
 
       let consensus_constants = precomputed_values.consensus_constants
+
+      let compile_config = compile_config
     end
 
     let downcast_breadcrumb breadcrumb =

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -47,12 +47,8 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
     ~processed_transition_writer ~only_if_present ~time_controller ~source
     ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t)
-    ~block_window_duration =
-  let module Metrics_context = struct
-    let block_window_duration = block_window_duration
-  end in
-  let module Inclusion_time =
-    Mina_metrics.Block_latency.Inclusion_time (Metrics_context) in
+    ~block_window_duration:_ (*TODO remove unused var*) =
+  let module Inclusion_time = Mina_metrics.Block_latency.Inclusion_time in
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
     else Cached.invalidate_with_success cached_breadcrumb

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -13,6 +13,8 @@ module type CONTEXT = sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
 
   val consensus_constants : Consensus.Constants.t
+
+  val compile_config : Mina_compile_config.t
 end
 
 type Structured_log_events.t += Starting_transition_frontier_controller


### PR DESCRIPTION
move all access to `Node_config.block_window_duration` to top level

This requires a sort of "hack" to prevent modules from initializing modules which require the `CONTEXT` argument more than once.

I am not an ocaml pro, but this kind of effectful module initialization does not easily lend itself to being refactored in this way -- the code seems dependent on these modules being singletons, which is no longer true. It seems like it should be avoided.