### PR TITLE
Remove mistaken use of `--no-merges` in compatibility test

### DIFF
--- a/buildkite/scripts/check-compatibility.sh
+++ b/buildkite/scripts/check-compatibility.sh
@@ -6,7 +6,7 @@
 set +e
 
 function get_shas {
-  SHAS=$(git log -n 10 --format="%h" --abbrev=7 --no-merges)
+  SHAS=$(git log -n 10 --format="%h" --abbrev=7 --first-parent)
 }
 
 function image_tag {


### PR DESCRIPTION
This PR removes the use of the `--no-merges` flag for the compatibility test, since it's essentially never what we want.