### PR TITLE
Remove %%versioned from Logger.t

### DIFF
--- a/src/lib/logger/fake/logger.ml
+++ b/src/lib/logger/fake/logger.ml
@@ -130,29 +130,17 @@ module Consumer_registry = struct
   let register ?commit_id:_ ~id:_ ~processor:_ ~transport:_ = not_implemented
 end
 
-[%%versioned
-module Stable = struct
-  module V1 = struct
-    type t =
-      { null : bool
-      ; metadata : Metadata.Stable.V1.t
-      ; id : Bounded_types.String.Stable.V1.t
-      }
+type t = Metadata.Stable.Latest.t [@@deriving bin_io_unversioned]
 
-    let to_latest = Fn.id
-  end
-end]
+let metadata = Fn.id
 
-let metadata t = t.metadata
+let create ?metadata:_ ?id:_ () = Metadata.empty
 
-let create ?metadata:_ ?(id = "default") () =
-  { null = false; metadata = Metadata.empty; id }
-
-let null () = { null = true; metadata = Metadata.empty; id = "default" }
+let null () = Metadata.empty
 
 let extend t _ = t
 
-let change_id { null; metadata; id = _ } ~id = { null; metadata; id }
+let change_id t ~id:_ = t
 
 let raw _ _ = not_implemented ()
 

--- a/src/lib/logger/logger.mli
+++ b/src/lib/logger/logger.mli
@@ -1,11 +1,6 @@
 open Core_kernel
 
-[%%versioned:
-module Stable : sig
-  module V1 : sig
-    type t
-  end
-end]
+type t [@@deriving bin_io]
 
 module Level : sig
   type t =

--- a/src/lib/logger/native/logger.ml
+++ b/src/lib/logger/native/logger.ml
@@ -329,18 +329,12 @@ module Consumer_registry = struct
             () )
 end
 
-[%%versioned
-module Stable = struct
-  module V1 = struct
-    type t =
-      { null : bool
-      ; metadata : Metadata.Stable.V1.t
-      ; id : Bounded_types.String.Stable.V1.t
-      }
-
-    let to_latest = Fn.id
-  end
-end]
+type t =
+  { null : bool
+  ; metadata : Metadata.Stable.Latest.t
+  ; id : Bounded_types.String.Stable.V1.t
+  }
+[@@deriving bin_io_unversioned]
 
 let metadata t = t.metadata
 

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -63,7 +63,7 @@ module Worker_state = struct
     { conf_dir : string
     ; enable_internal_tracing : bool
     ; internal_trace_filename : string option
-    ; logger : Logger.Stable.Latest.t
+    ; logger : Logger.t
     ; proof_level : Genesis_constants.Proof_level.t
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     ; commit_id : string

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -13,8 +13,7 @@ module Worker_state = struct
   end
 
   (* bin_io required by rpc_parallel *)
-  type init_arg =
-    Logger.Stable.Latest.t * Genesis_constants.Constraint_constants.t
+  type init_arg = Logger.t * Genesis_constants.Constraint_constants.t
   [@@deriving bin_io_unversioned]
 
   type t = (module S)
@@ -89,10 +88,7 @@ module Worker = struct
 end
 
 type t =
-  { connection : Worker.Connection.t
-  ; process : Process.t
-  ; logger : Logger.Stable.Latest.t
-  }
+  { connection : Worker.Connection.t; process : Process.t; logger : Logger.t }
 
 let create ~logger ~constraint_constants ~pids : t Deferred.t =
   let on_failure err =

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -66,7 +66,7 @@ module Worker_state = struct
     { conf_dir : string option
     ; enable_internal_tracing : bool
     ; internal_trace_filename : string option
-    ; logger : Logger.Stable.Latest.t
+    ; logger : Logger.t
     ; proof_level : Genesis_constants.Proof_level.t
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     ; commit_id : string
@@ -441,7 +441,7 @@ type worker =
   ; exit_or_signal : Unix.Exit_or_signal.t Deferred.Or_error.t
   }
 
-type t = { worker : worker Ivar.t ref; logger : Logger.Stable.Latest.t }
+type t = { worker : worker Ivar.t ref; logger : Logger.t }
 
 (* TODO: investigate why conf_dir wasn't being used *)
 let create ~logger ?(enable_internal_tracing = false) ?internal_trace_filename

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -76,7 +76,7 @@ module Worker_state = struct
     { constraint_constants : Genesis_constants.Constraint_constants.t
     ; consensus_constants : Consensus.Constants.Stable.Latest.t
     ; conf_dir : string
-    ; logger : Logger.Stable.Latest.t
+    ; logger : Logger.t
     ; commit_id : string
     }
   [@@deriving bin_io_unversioned]


### PR DESCRIPTION
These seem to have been introduced for serialization of logger for RPC parallel, however versionining is not needed in that context.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None