### PR TITLE
Relax functor lint rules in ppx_version

### DIFF
--- a/src/lib/ppx_version/lint_version_syntax.ml
+++ b/src/lib/ppx_version/lint_version_syntax.ml
@@ -3,6 +3,7 @@
 open Core_kernel
 open Ppxlib
 open Versioned_util
+module StringSet = Set.Make (String)
 
 let name = "enforce_version_syntax"
 
@@ -74,8 +75,10 @@ let is_versioned_module_inc_decl inc_decl =
   | _ ->
       false
 
-let versioned_in_functor_error loc =
-  (loc, "Cannot use versioned extension within a functor body")
+let versioned_in_functor_error loc bad_modules =
+  ( loc
+  , "Cannot use types from functor arguments in versioned module: "
+    ^ String.concat ~sep:", " (StringSet.to_list bad_modules) )
 
 let include_stable_latest_error loc = (loc, "Cannot include Stable.Latest")
 
@@ -84,6 +87,7 @@ type accumulator =
   ; in_include : bool
   ; in_versioned_ext : bool
   ; module_path : string list
+  ; functor_args : StringSet.t
   ; errors : (Location.t * string) list
   }
 
@@ -237,14 +241,18 @@ let lint_ast =
       let acc' =
         match expr.pmod_desc with
         (* don't match special case of functor with () argument *)
-        | Pmod_functor (Named _, body) ->
+        | Pmod_functor (Named ({ txt = Some name; _ }, _), body) ->
             (* Don't match special case of functor called [Make_str].
                This convention is used when using the [mina_wire_types] library framework.
             *)
             let in_functor =
               match acc.module_path with "Make_str" :: _ -> false | _ -> true
             in
-            self#module_expr body { acc with in_functor }
+            self#module_expr body
+              { acc with
+                in_functor
+              ; functor_args = StringSet.add acc.functor_args name
+              }
         | Pmod_apply
             ( { pmod_desc =
                   Pmod_apply
@@ -405,7 +413,15 @@ let lint_ast =
             | Nonrecursive ->
                 no_errors_fun
             | Recursive ->
-                if acc.in_functor then validate_neither_bin_io_nor_version
+                if acc.in_functor then
+                  let used_modules =
+                    List.fold_right ~init:StringSet.empty
+                      ~f:Versioned_util.collect_types#type_declaration
+                      type_decls
+                  in
+                  let bad_modules = Set.inter used_modules acc.functor_args in
+                  if Set.is_empty bad_modules then validate_version_if_bin_io
+                  else validate_neither_bin_io_nor_version
                 else validate_version_if_bin_io
           in
           let deriving_errors =
@@ -417,7 +433,14 @@ let lint_ast =
         when acc.in_functor
              && String.length name.txt >= 9
              && String.equal (String.sub name.txt ~pos:0 ~len:9) "versioned" ->
-          acc_with_accum_errors acc [ versioned_in_functor_error name.loc ]
+          let used_modules =
+            Versioned_util.collect_types#payload _payload StringSet.empty
+          in
+          let bad_modules = Set.inter used_modules acc.functor_args in
+          if Set.is_empty bad_modules then acc
+          else
+            acc_with_accum_errors acc
+              [ versioned_in_functor_error name.loc bad_modules ]
       | Pstr_extension ((name, PStr [ stri ]), _attrs)
         when String.length name.txt >= 9
              && String.equal (String.sub name.txt ~pos:0 ~len:9) "versioned" ->
@@ -454,6 +477,7 @@ let lint_impl str =
       ; in_include = false
       ; in_versioned_ext = false
       ; module_path = []
+      ; functor_args = StringSet.empty
       ; errors = []
       }
   in

--- a/src/lib/ppx_version/test/bad_versioned_in_functor.ml
+++ b/src/lib/ppx_version/test/bad_versioned_in_functor.ml
@@ -2,12 +2,13 @@
 
 open Core_kernel
 
-module Functor (X : sig end) = struct
+module Functor (X : sig type x end) = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
       type t = string
 
+      type x = X.x
       let to_latest = Fn.id
     end
   end]

--- a/src/lib/ppx_version/test/bad_versioned_in_nested_functor.ml
+++ b/src/lib/ppx_version/test/bad_versioned_in_nested_functor.ml
@@ -2,7 +2,7 @@ open Core_kernel
 
 (* deriving bin_io in nested functor body *)
 
-module Functor (X : sig end) (Y : sig
+module Functor (X : sig type t end) (Y : sig
   val _y : int
 end) =
 struct
@@ -10,6 +10,8 @@ struct
   module Stable = struct
     module V1 = struct
       type t = string [@@deriving bin_io]
+
+      type x = X.t
 
       let to_latest = Fn.id
     end

--- a/src/lib/ppx_version/test/versioned_good.ml
+++ b/src/lib/ppx_version/test/versioned_good.ml
@@ -208,3 +208,16 @@ module M13 = struct
     end
   end]
 end
+
+module Functor (X : sig type x val foo :int end) = struct
+  type x = X.x
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = string
+      let to_latest =
+        let _ = X.foo
+        in Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -82,8 +82,8 @@ let collect_types : StringSet.t Ast_traverse.fold =
     match l with
     | Lident s ->
         StringSet.add acc s
-    | Ldot (m, s) ->
-        lident m (StringSet.add acc s)
+    | Ldot (m, _) ->
+        lident m acc
     | Lapply (l1, l2) ->
         lident l1 (lident l2 acc)
   in

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -74,3 +74,37 @@ let jane_street_library_modules = [ "Uuid" ]
 
 let jane_street_modules =
   [ "Core"; "Core_kernel" ] @ jane_street_library_modules
+
+module StringSet = Set.Make (String)
+
+let collect_types : StringSet.t Ast_traverse.fold =
+  let rec lident l acc =
+    match l with
+    | Lident s ->
+        StringSet.add acc s
+    | Ldot (m, s) ->
+        lident m (StringSet.add acc s)
+    | Lapply (l1,l2) ->
+        lident l1 (lident l2 acc)
+  in
+
+  object (self)
+    inherit [StringSet.t] Ast_traverse.fold as super
+
+    method! core_type_desc ct acc =
+      match ct with
+      | Ptyp_constr (l, types) ->
+          let acc' = lident l.txt acc in
+          List.fold_right ~f:self#core_type ~init:acc' types
+      | _ ->
+          super#core_type_desc ct acc
+
+    method! module_expr_desc desc acc =
+      match desc with
+      | Pmod_ident l ->
+          lident l.txt acc
+      | _ ->
+          super#module_expr_desc desc acc
+
+    method! module_substitution ms acc = lident ms.pms_manifest.txt acc
+  end

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -84,7 +84,7 @@ let collect_types : StringSet.t Ast_traverse.fold =
         StringSet.add acc s
     | Ldot (m, s) ->
         lident m (StringSet.add acc s)
-    | Lapply (l1,l2) ->
+    | Lapply (l1, l2) ->
         lident l1 (lident l2 acc)
   in
 


### PR DESCRIPTION
Quoting from the original [README](https://github.com/o1-labs/ppx_version/tree/master)

> One linter rule is that stable-versioned modules cannot be contained in the result of a functor application. The reason is that the types might depend on the functor arguments, so that distinct functor applications yield different types with different serializations. Functors that take no module arguments are allowed to return stable-versioned modules.

This rule makes the following code illegal:

```ocaml
module Functor (X : sig type x val foo :int end) = struct
  type x = X.x
  
  let f = g X.foo
  
  [%%versioned
  module Stable = struct
    module V1 = struct
      type t = string
      let to_latest =  Fn.id
    end
  end]
end
```

This turns out to be overly conservative and can cause problems when writing/refactoring harmless code. Take for example  [zkapp_command.ml](https://github.com/MinaProtocol/mina/blob/martin/force-signature_kind-to-toplevel/src/lib/mina_base/zkapp_command.ml) where you have versioned modules nested inside the top level. If you wanted to change `Call_forest` to a functor, you can't. Even if the functor's argument doesn't appear at all in the versioned module.

This PR changes the linting rule to enforce that it is only illegal _if you access_ a functor's argument directly in types defined wia `%%versioned` extension **if you are outside of an expression**. I figure that it's allowed in an expression because AFAIK we are only using this as a method to version types for coherent serialization
