### PR TITLE
Fixing Debian Package Naming in the CI

### DIFF
--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -15,7 +15,7 @@ function find_most_recent_numeric_tag() {
 }
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
-export GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+export GITBRANCH=$(git rev-parse --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 export PROJECT="mina"

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -15,7 +15,7 @@ function find_most_recent_numeric_tag() {
 }
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
-export GITBRANCH=$(git rev-parse --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+export GITBRANCH=$(BUILDKITE_BRANCH)
 
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 export PROJECT="mina"


### PR DESCRIPTION
I noticed some UB in this nightly build:
https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/2519#0191f332-f37f-4bf0-acb7-03f3bd475e1f/975

seems like the focal package is built with the name HEAD instead of develop
```
Built mina-logproc_3.0.1-beta1-HEAD-7a3ad2b.deb | 24s
-- | --
  | Building archive deb | 18s
  | Built mina-archive_3.0.1-beta1-HEAD-7a3ad2b.deb | 19s
  | Built mina-batch-txn_3.0.1-beta1-HEAD-7a3ad2b.deb | 0s
  | Built mina-test-executive_3.0.1-beta1-HEAD-7a3ad2b.deb | 21s
  | Building devnet rosetta deb | 0s
  | Built mina-rosetta-devnet_3.0.1-beta1-HEAD-7a3ad2b.deb | 17s
  | Building Mina Berkeley ZkApp test transaction tool: | 0s
  | Built mina-zkapp-test-transaction_3.0.1-beta1-HEAD-7a3ad2b.deb | 5s
  | Git diff after build is complete: | 23s
  | Copy debians to gs

```
the expected would be for example: `Built mina-archive_3.0.1-beta1-develop-7a3ad2b.deb`

this is due to this being called when the branch is in a detached state:
https://github.com/MinaProtocol/mina/blob/develop/scripts/export-git-env-vars.sh#L22


```bash 
➜  mina-nix git:(sai/fix-deb-naming) ✗ git checkout origin/develop
Note: switching to 'origin/develop'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 7a3ad2b4b1 Merge pull request #16046 from MinaProtocol/sai/fix-nightly
➜  mina-nix git:(7a3ad2b4b1) ✗ git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g'
HEAD

```

I've modified the package name to just use the buildkite branch name, since this is simply for package tagging and should be consistent across all jobs.