### PR TITLE
Pass BUILDKITE_BRANCH env variable to ensure correct debian version

### DIFF
--- a/buildkite/scripts/build-release.sh
+++ b/buildkite/scripts/build-release.sh
@@ -14,7 +14,7 @@ echo " Includes mina daemon, archive-node, rosetta, generate keypair for devnet"
 
 
 echo "--- Prepare debian packages"
-./scripts/debian/build.sh $@
+./scripts/debian/build.sh -b "$BUILDKIE_BRANCH" $@
 
 echo "--- Git diff after build is complete:"
 git diff --exit-code -- .

--- a/buildkite/scripts/build-release.sh
+++ b/buildkite/scripts/build-release.sh
@@ -14,7 +14,7 @@ echo " Includes mina daemon, archive-node, rosetta, generate keypair for devnet"
 
 
 echo "--- Prepare debian packages"
-./scripts/debian/build.sh -b "$BUILDKIE_BRANCH" $@
+BRANCH_NAME="$BUILDKIE_BRANCH" ./scripts/debian/build.sh $@
 
 echo "--- Git diff after build is complete:"
 git diff --exit-code -- .

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -15,7 +15,6 @@ function find_most_recent_numeric_tag() {
 }
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
-export GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 export PROJECT="mina"
@@ -26,8 +25,9 @@ export BUILD_URL=${BUILDKITE_BUILD_URL}
 set -u
 
 export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
-[[ -n "$BUILDKITE_BRANCH" ]] && export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
- 
+[[ -n "$BUILDKITE_BRANCH" ]] && export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g') || export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+
+
 export RELEASE=unstable
 
 if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -6,11 +6,7 @@ set -eox pipefail
 
 # In case of running this script on detached head, script has difficulties in finding out
 # what is the current 
-while [[ "$#" -gt 0 ]]; do case $1 in
-  -b|--branch-name) BRANCH_NAME_OPT="-b $2"; shift;;
-  *) echo "Unknown parameter passed: $1"; exit 1;;
-esac; shift; done
-
+[[ -n "$BRANCH_NAME" ]] && export BRANCH_NAME_OPT="-b $BRANCH_NAME"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 source ${SCRIPTPATH}/../export-git-env-vars.sh "$BRANCH_NAME_OPT"

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -4,8 +4,16 @@
 
 set -eox pipefail
 
+# In case of running this script on detached head, script has difficulties in finding out
+# what is the current 
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -b|--branch-name) BRANCH_NAME_OPT="-b $2"; shift;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-source ${SCRIPTPATH}/../export-git-env-vars.sh
+source ${SCRIPTPATH}/../export-git-env-vars.sh "$BRANCH_NAME_OPT"
 
 echo "after export"
 

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -4,12 +4,15 @@
 
 set -eox pipefail
 
-# In case of running this script on detached head, script has difficulties in finding out
-# what is the current 
-[[ -n "$BRANCH_NAME" ]] && export BRANCH_NAME_OPT="-b $BRANCH_NAME"
-
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-source ${SCRIPTPATH}/../export-git-env-vars.sh "$BRANCH_NAME_OPT"
+
+# In case of running this script on detached head, script has difficulties in finding out
+# what is the current branch.
+if [[ -n "$BRANCH_NAME" ]]; then 
+  source ${SCRIPTPATH}/../export-git-env-vars.sh -b $BRANCH_NAME
+else
+  source ${SCRIPTPATH}/../export-git-env-vars.sh
+fi 
 
 echo "after export"
 

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -5,11 +5,6 @@ set -x
 
 # In case of running this script on detached head, script has difficulties in finding out
 # what is the current 
-while [[ "$#" -gt 0 ]]; do case $1 in
-  -b|--branch-name) BRANCH_NAME="$2"; shift;;
-  *) echo "Unknown parameter passed: $1"; exit 1;;
-esac; shift; done
-
 echo "Exporting Git Variables: "
 
 git fetch
@@ -27,7 +22,6 @@ function find_most_recent_numeric_tag() {
 export GITHASH=$(git rev-parse --short=7 HEAD)
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 
-export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 [[ -n "$BRANCH_NAME" ]] && export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g') || export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 
 export GITTAG=$(find_most_recent_numeric_tag HEAD)

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -euo pipefail
-
 set -x
+
+
+# In case of running this script on detached head, script has difficulties in finding out
+# what is the current 
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -b|--branch-name) BRANCH_NAME="$2"; shift;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
 
 echo "Exporting Git Variables: "
 
@@ -19,7 +26,9 @@ function find_most_recent_numeric_tag() {
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
+
 export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+[[ -n "$BRANCH_NAME" ]] && export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
 
 export GITTAG=$(find_most_recent_numeric_tag HEAD)
 

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -28,7 +28,7 @@ export GITHASH=$(git rev-parse --short=7 HEAD)
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 
 export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
-[[ -n "$BRANCH_NAME" ]] && export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
+[[ -n "$BRANCH_NAME" ]] && export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g') || export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 
 export GITTAG=$(find_most_recent_numeric_tag HEAD)
 


### PR DESCRIPTION
In some cases when building debian packages on buildkite agent below command return HEAD instead of actual branch name (like develop etc):

```
export GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
```
It is still under investigation why since at first look it depends on agent state (we couldn't reproduce it locally nor on agent after failure detection)

Another observation is that it could be unstable almost from long time ago, since in buildkite/scripts/export-git-env-vars.sh file we set GITBRANCH to be equal to BUILDKITE_BRANCH (if exists) after we calculate GITBRANCH.



