### PR TITLE
Optimize the non-present zkapp uri hashing

### DIFF
--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -25,11 +25,6 @@ let pop_exn : t -> (Account_update.t * t) * t = function
   | _ ->
       failwith "pop_exn"
 
-let push ~account_update ~calls t =
-  Zkapp_command.Call_forest.cons ~calls account_update t
-
-let hash (t : t) = Zkapp_command.Call_forest.hash t
-
 open Snark_params.Tick.Run
 
 module Checked = struct
@@ -210,6 +205,7 @@ module Checked = struct
             } )
           : (account_update * t) * t ) )
 
+  (* TODO Consider moving out of mina_base *)
   let push
       ~account_update:
         { account_update = { hash = account_update_hash; data = account_update }

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -341,33 +341,6 @@ module Ledger_inner = struct
         Debug_assert.debug_assert (fun () ->
             [%test_eq: Ledger_hash.t] start_hash (merkle_root ledger) ) ;
         (merkle_path ledger new_loc, Account.empty)
-
-  let _handler t =
-    let open Snark_params.Tick in
-    let path_exn idx =
-      List.map (merkle_path_at_index_exn t idx) ~f:(function
-        | `Left h ->
-            h
-        | `Right h ->
-            h )
-    in
-    stage (fun (With { request; respond }) ->
-        match request with
-        | Ledger_hash.Get_element idx ->
-            let elt = get_at_index_exn t idx in
-            let path = (path_exn idx :> Random_oracle.Digest.t list) in
-            respond (Provide (elt, path))
-        | Ledger_hash.Get_path idx ->
-            let path = (path_exn idx :> Random_oracle.Digest.t list) in
-            respond (Provide path)
-        | Ledger_hash.Set (idx, account) ->
-            set_at_index_exn t idx account ;
-            respond (Provide ())
-        | Ledger_hash.Find_index pk ->
-            let index = index_of_account_exn t pk in
-            respond (Provide index)
-        | _ ->
-            unhandled )
 end
 
 include Ledger_inner


### PR DESCRIPTION
When no zkapp uri is specified, use a precomputed hash of a dummy stub.

Previous behavior involved hashing the dummy stub each time no zkapp uri was specified which is wasteful.

PR also removes some dead code, which just happened to be discovered dead during work on the PR.

Explain how you tested your changes:
* Saw improvement with `mina ledger test apply` benchmark

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None