### PR TITLE
Memoize transaction related hashes

### DIFF
--- a/src/app/cli/src/init/test_ledger_application.ml
+++ b/src/app/cli/src/init/test_ledger_application.ml
@@ -136,10 +136,14 @@ let apply_txs ~action_elements ~event_elements ~constraint_constants
   in
   let zkapps' =
     List.map zkapps ~f:(fun tx ->
-        { With_status.data =
-            Mina_transaction.Transaction.Command (User_command.Zkapp_command tx)
-        ; status = Applied
-        } )
+        ( { With_status.data =
+              Mina_transaction.Transaction.Command
+                (User_command.Zkapp_command tx)
+          ; status = Applied
+          }
+        , Option.some
+          @@ Ledger.precompute_transaction_hashes (User_command.Zkapp_command tx)
+        ) )
   in
   let accounts_accessed =
     List.fold_left ~init:Account_id.Set.empty zkapps ~f:(fun set txn ->

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -17,6 +17,7 @@ module type Inputs_intf = sig
        and type account_id := Account_id.t
        and type account_id_set := Account_id.Set.t
        and type parent := Base.t
+       and type derived_token_ids_t := Token_id.t Account_id.Map.t
 
   val mask_to_base : Mask.Attached.t -> Base.t
 end

--- a/src/lib/merkle_mask/maskable_merkle_tree.mli
+++ b/src/lib/merkle_mask/maskable_merkle_tree.mli
@@ -13,6 +13,7 @@ module type Inputs_intf = sig
        and type account_id := Account_id.t
        and type account_id_set := Account_id.Set.t
        and type parent := Base.t
+       and type derived_token_ids_t := Token_id.t Account_id.Map.t
 
   val mask_to_base : Mask.Attached.t -> Base.t
 end
@@ -33,3 +34,4 @@ module Make (I : Inputs_intf) :
      and type unattached_mask := I.Mask.t
      and type attached_mask := I.Mask.Attached.t
      and type accumulated_t := I.Mask.accumulated_t
+     and type derived_token_ids_t := I.Token_id.t I.Account_id.Map.t

--- a/src/lib/merkle_mask/maskable_merkle_tree_intf.mli
+++ b/src/lib/merkle_mask/maskable_merkle_tree_intf.mli
@@ -10,6 +10,8 @@ module type S = sig
 
   type accumulated_t
 
+  type derived_token_ids_t
+
   (* registering a mask makes it an active child of the parent Merkle tree
      - reads to the mask that fail are delegated to the parent
      - writes to the parent notify the child mask
@@ -19,7 +21,10 @@ module type S = sig
     ?accumulated:accumulated_t -> t -> unattached_mask -> attached_mask
 
   val unsafe_preload_accounts_from_parent :
-    attached_mask -> account_id list -> unit
+       attached_mask
+    -> derived_token_ids:derived_token_ids_t
+    -> account_id list
+    -> unit
 
   (** raises an exception if mask is not registered *)
   val unregister_mask_exn :

--- a/src/lib/merkle_mask/masking_merkle_tree.mli
+++ b/src/lib/merkle_mask/masking_merkle_tree.mli
@@ -10,3 +10,4 @@ module Make (I : Inputs_intf.S) :
      and type account_id := I.Account_id.t
      and type account_id_set := I.Account_id.Set.t
      and type location := I.Location.t
+     and type derived_token_ids_t := I.Token_id.t I.Account_id.Map.t

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.mli
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.mli
@@ -27,8 +27,10 @@ module type S = sig
 
   module Addr = Location.Addr
 
+  type derived_token_ids_t
+
   (** create a mask with no parent *)
-  val create : depth:int -> unit -> t
+  val create : ?derived_token_ids:derived_token_ids_t -> depth:int -> unit -> t
 
   val get_uuid : t -> Uuid.t
 
@@ -51,6 +53,8 @@ module type S = sig
     exception
       Dangling_parent_reference of
         Uuid.t * (* Location where null was set*) string
+
+    val derived_token_ids : t -> derived_token_ids_t
 
     (** get hash from mask, if present, else from its parent *)
     val get_hash : t -> Addr.t -> hash option
@@ -85,7 +89,8 @@ module type S = sig
        from parent on each lookup. I.e. these accounts will be cached in mask and accessing
        them during processing of a transaction won't use disk I/O.
     *)
-    val unsafe_preload_accounts_from_parent : t -> account_id list -> unit
+    val unsafe_preload_accounts_from_parent :
+      t -> derived_token_ids:derived_token_ids_t -> account_id list -> unit
 
     val to_accumulated : t -> accumulated_t
 

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -26,7 +26,12 @@ module Make_events (Inputs : sig
   val deriver_name : string
 end) =
 struct
-  type t = Event.t list [@@deriving compare, sexp]
+  module T = struct
+    type t = Event.t list [@@deriving compare, sexp]
+  end
+
+  include T
+  include Comparable.Make (T)
 
   let empty_hash =
     Hash_prefix_create.salt Inputs.salt_phrase |> Random_oracle.digest
@@ -119,12 +124,13 @@ module Actions = struct
     let salt_phrase = "MinaZkappActionStateEmptyElt" in
     Hash_prefix_create.salt salt_phrase |> Random_oracle.digest
 
-  let push_events (acc : Field.t) (events : t) : Field.t =
-    push_hash acc (hash events)
+  let push_events_hash ~(acc : Field.t) (events_hash : Field.t) : Field.t =
+    push_hash acc events_hash
 
-  let push_events_checked (x : Field.Var.t) (e : var) : Field.Var.t =
+  let push_events_hash_checked ~(acc : Field.Var.t) (e : Field.Var.t) :
+      Field.Var.t =
     Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_actions
-      [| x; Data_as_hash.hash e |]
+      [| acc; e |]
 end
 
 module Zkapp_uri = struct

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -145,7 +145,8 @@ module Ledger_inner = struct
        and type account_id_set := Account_id.Set.t
        and type hash := Hash.t
        and type location := Location_at_depth.t
-       and type parent := Any_ledger.M.t =
+       and type parent := Any_ledger.M.t
+       and type derived_token_ids_t := Token_id.t Account_id.Map.t =
   Merkle_mask.Masking_merkle_tree.Make (struct
     include Inputs
     module Base = Any_ledger.M
@@ -166,6 +167,7 @@ module Ledger_inner = struct
        and type unattached_mask := Mask.t
        and type attached_mask := Mask.Attached.t
        and type accumulated_t := Mask.accumulated_t
+       and type derived_token_ids_t := Token_id.t Account_id.Map.t
        and type t := Any_ledger.M.t =
   Merkle_mask.Maskable_merkle_tree.Make (struct
     include Inputs
@@ -228,7 +230,8 @@ module Ledger_inner = struct
       This should *NOT* be used to create a ledger for other purposes.
   *)
   let create_masked (t : t) : t =
-    let mask = Mask.create ~depth:(depth t) () in
+    let derived_token_ids = Mask.Attached.derived_token_ids t in
+    let mask = Mask.create ~derived_token_ids ~depth:(depth t) () in
     (* We don't register the mask here. This is only used in transaction logic,
        where we don't want to unregister. Transaction logic is also
        synchronous, so we don't need to worry that our mask will be reparented.

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -41,6 +41,7 @@ module Mask :
      and type hash := Ledger_hash.t
      and type location := Location.t
      and type parent := Any_ledger.M.t
+     and type derived_token_ids_t := Token_id.t Account_id.Map.t
 
 module Maskable :
   Merkle_mask.Maskable_merkle_tree_intf.S
@@ -57,6 +58,7 @@ module Maskable :
      and type unattached_mask := Mask.t
      and type attached_mask := Mask.Attached.t
      and type accumulated_t := Mask.accumulated_t
+     and type derived_token_ids_t := Token_id.t Account_id.Map.t
      and type t := Any_ledger.M.t
 
 include
@@ -75,6 +77,7 @@ include
      and type attached_mask = Mask.Attached.t
      and type unattached_mask = Mask.t
      and type accumulated_t = Mask.accumulated_t
+     and type derived_token_ids_t := Token_id.t Account_id.Map.t
 
 (* We override the type of unregister_mask_exn that comes from
    Merkle_mask.Maskable_merkle_tree_intf.S because at this level callers aren't
@@ -83,7 +86,10 @@ include
 val unregister_mask_exn : loc:string -> Mask.Attached.t -> Mask.t
 
 val unsafe_preload_accounts_from_parent :
-  Mask.Attached.t -> Account_id.t list -> unit
+     Mask.Attached.t
+  -> derived_token_ids:Token_id.t Account_id.Map.t
+  -> Account_id.t list
+  -> unit
 
 (* The maskable ledger is t = Mask.Attached.t because register/unregister
  * work off of this type *)

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -702,7 +702,7 @@ let get_snarked_ledger_full t state_hash_opt =
                       (State_hash.to_base58_check state_hash)
               in
               let apply_first_pass =
-                Ledger.apply_transaction_first_pass
+                Ledger.apply_transaction_first_pass ?precomputed:None
                   ~constraint_constants:
                     t.config.precomputed_values.constraint_constants
               in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -360,6 +360,7 @@ module T = struct
     let open Deferred.Or_error.Let_syntax in
     let apply_first_pass =
       Ledger.apply_transaction_first_pass ~constraint_constants
+        ?precomputed:None
     in
     let apply_second_pass = Ledger.apply_transaction_second_pass in
     let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
@@ -512,7 +513,8 @@ module T = struct
     else Ok constraint_constants.coinbase_amount
 
   let apply_single_transaction_first_pass ~constraint_constants ~global_slot
-      ledger (pending_coinbase_stack_state : Stack_state_with_init_stack.t)
+      ?precomputed ledger
+      (pending_coinbase_stack_state : Stack_state_with_init_stack.t)
       txn_with_status (txn_state_view : Zkapp_precondition.Protocol_state.View.t)
       :
       ( Pre_statement.t * Stack_state_with_init_stack.t
@@ -539,8 +541,8 @@ module T = struct
     in
     let%map partially_applied_transaction =
       to_staged_ledger_or_error
-        (Ledger.apply_transaction_first_pass ~constraint_constants ~global_slot
-           ~txn_state_view ledger txn )
+        (Ledger.apply_transaction_first_pass ?precomputed ~constraint_constants
+           ~global_slot ~txn_state_view ledger txn )
     in
     let target_ledger_hash = Ledger.merkle_root ledger in
     ( { Pre_statement.partially_applied_transaction
@@ -562,7 +564,7 @@ module T = struct
       } )
 
   let apply_single_transaction_second_pass ~constraint_constants
-      ~connecting_ledger ledger state_and_body_hash ~global_slot
+      ~connecting_ledger ?precomputed ledger state_and_body_hash ~global_slot
       (pre_stmt : Pre_statement.t) =
     let open Result.Let_syntax in
     let empty_local_state = Mina_state.Local_state.empty () in
@@ -574,7 +576,7 @@ module T = struct
     in
     let%bind applied_txn =
       to_staged_ledger_or_error
-        (Ledger.apply_transaction_second_pass ledger
+        (Ledger.apply_transaction_second_pass ?precomputed ledger
            pre_stmt.partially_applied_transaction )
     in
     let second_pass_ledger_target_hash = Ledger.merkle_root ledger in
@@ -633,7 +635,7 @@ module T = struct
   let apply_transactions_first_pass ~yield ~constraint_constants ~global_slot
       ledger init_pending_coinbase_stack_state ts current_state_view =
     let open Deferred.Result.Let_syntax in
-    let apply pending_coinbase_stack_state txn =
+    let apply pending_coinbase_stack_state (txn, precomputed) =
       match
         List.find (Transaction.public_keys txn.With_status.data) ~f:(fun pk ->
             Option.is_none (Signature_lib.Public_key.decompress pk) )
@@ -641,8 +643,9 @@ module T = struct
       | Some pk ->
           Error (Staged_ledger_error.Invalid_public_key pk)
       | None ->
-          apply_single_transaction_first_pass ~constraint_constants ~global_slot
-            ledger pending_coinbase_stack_state txn current_state_view
+          apply_single_transaction_first_pass ?precomputed ~constraint_constants
+            ~global_slot ledger pending_coinbase_stack_state txn
+            current_state_view
     in
     let%map res_rev, pending_coinbase_stack_state =
       Mina_stdlib.Deferred.Result.List.fold ts
@@ -660,10 +663,12 @@ module T = struct
       ledger state_and_body_hash pre_stmts =
     let open Deferred.Result.Let_syntax in
     let connecting_ledger = Ledger.merkle_root ledger in
-    Mina_stdlib.Deferred.Result.List.map pre_stmts ~f:(fun pre_stmt ->
+    Mina_stdlib.Deferred.Result.List.map pre_stmts
+      ~f:(fun (pre_stmt, precomputed) ->
         let%bind result =
           apply_single_transaction_second_pass ~constraint_constants
-            ~connecting_ledger ~global_slot ledger state_and_body_hash pre_stmt
+            ~connecting_ledger ~global_slot ?precomputed ledger
+            state_and_body_hash pre_stmt
           |> Deferred.return
         in
         let%map () = yield () in
@@ -702,10 +707,17 @@ module T = struct
           in
           apply_first_pass ~yield current_stack2 ts
     in
+    let all_precomputed =
+      List.map ~f:snd ts
+      @ Option.value_map ~default:[] ~f:(List.map ~f:snd) ts_opt
+    in
+    let pre_stmts_with_precomputed =
+      List.zip_exn (pre_stmts1 @ pre_stmts2) all_precomputed
+    in
     let first_pass_ledger_end = Ledger.merkle_root ledger in
     let%map txns_with_witnesses =
       apply_transactions_second_pass ~constraint_constants ~yield ~global_slot
-        ledger state_and_body_hash (pre_stmts1 @ pre_stmts2)
+        ledger state_and_body_hash pre_stmts_with_precomputed
     in
     (txns_with_witnesses, updated_stack1, updated_stack2, first_pass_ledger_end)
 
@@ -827,7 +839,7 @@ module T = struct
     let open Deferred.Result.Let_syntax in
     let coinbase_exists txns =
       List.fold_until ~init:false txns
-        ~f:(fun acc t ->
+        ~f:(fun acc (t, _) ->
           match t.With_status.data with
           | Transaction.Coinbase _ ->
               Stop true
@@ -1022,7 +1034,8 @@ module T = struct
     let new_ledger = Ledger.register_mask t.ledger new_mask in
     let transactions, works, commands_count, coinbases = pre_diff_info in
     let accounts_accessed =
-      List.fold_left ~init:Account_id.Set.empty transactions ~f:(fun set txn ->
+      List.fold_left ~init:Account_id.Set.empty transactions
+        ~f:(fun set (txn, _) ->
           Account_id.Set.(
             union set
               (of_list (Transaction.accounts_referenced txn.With_status.data))) )
@@ -1041,7 +1054,9 @@ module T = struct
             | _ ->
                 false
           in
-          let zk_app_count = List.count ~f:is_zkapp transactions in
+          let zk_app_count =
+            List.count ~f:(Fn.compose is_zkapp fst) transactions
+          in
           if zk_app_count > zkapp_cmd_limit_hardcap then
             Deferred.Result.fail
               (Staged_ledger_error.ZkApps_exceed_limit
@@ -1212,9 +1227,20 @@ module T = struct
           (Float.of_int
              (List.length (Scan_state.all_work_statements_exn t.scan_state)) ) )
 
-  let forget_prediff_info ((a : Transaction.Valid.t With_status.t list), b, c, d)
-      =
-    (List.map ~f:(With_status.map ~f:Transaction.forget) a, b, c, d)
+  let transform_prediff_info ?precomputed
+      ((a : Transaction.Valid.t With_status.t list), b, c, d) =
+    let a' =
+      match precomputed with
+      | None ->
+          List.map
+            ~f:(fun tx -> (With_status.map tx ~f:Transaction.forget, None))
+            a
+      | Some pc_list ->
+          List.map2_exn
+            ~f:(fun tx pc -> (With_status.map tx ~f:Transaction.forget, Some pc))
+            a pc_list
+    in
+    (a', b, c, d)
 
   let check_commands ledger ~verifier (cs : User_command.t With_status.t list) =
     let open Deferred.Or_error.Let_syntax in
@@ -1248,8 +1274,8 @@ module T = struct
                  (Error.of_string "batch verification failed") ) ) )
 
   let apply ?skip_verification ~constraint_constants ~global_slot t
-      ~get_completed_work (witness : Staged_ledger_diff.t) ~logger ~verifier
-      ~current_state_view ~state_and_body_hash ~coinbase_receiver
+      ~get_completed_work ?precomputed (witness : Staged_ledger_diff.t) ~logger
+      ~verifier ~current_state_view ~state_and_body_hash ~coinbase_receiver
       ~supercharge_coinbase ~zkapp_cmd_limit_hardcap =
     let open Deferred.Result.Let_syntax in
     let work = Staged_ledger_diff.completed_works witness in
@@ -1281,7 +1307,7 @@ module T = struct
         ~skip_verification:
           ([%equal: [ `All | `Proofs ] option] skip_verification (Some `All))
         ~constraint_constants ~global_slot t
-        (forget_prediff_info prediff)
+        (transform_prediff_info ?precomputed prediff)
         ~logger ~current_state_view ~state_and_body_hash
         ~log_prefix:"apply_diff" ~zkapp_cmd_limit_hardcap
     in
@@ -1302,7 +1328,7 @@ module T = struct
     in
     res
 
-  let apply_diff_unchecked ~constraint_constants ~global_slot t
+  let apply_diff_unchecked ~constraint_constants ~global_slot t ?precomputed
       (sl_diff : Staged_ledger_diff.With_valid_signatures_and_proofs.t) ~logger
       ~current_state_view ~state_and_body_hash ~coinbase_receiver
       ~supercharge_coinbase ~zkapp_cmd_limit_hardcap =
@@ -1314,7 +1340,7 @@ module T = struct
       |> Deferred.return
     in
     apply_diff t
-      (forget_prediff_info prediff)
+      (transform_prediff_info ?precomputed prediff)
       ~constraint_constants ~global_slot ~logger ~current_state_view
       ~state_and_body_hash ~log_prefix:"apply_diff_unchecked"
       ~zkapp_cmd_limit_hardcap
@@ -2795,6 +2821,7 @@ let%test_module "staged ledger tests" =
             let do_snarked_ledger_transition proof_opt =
               let apply_first_pass =
                 Ledger.apply_transaction_first_pass ~constraint_constants
+                  ?precomputed:None
               in
               let apply_second_pass = Ledger.apply_transaction_second_pass in
               let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -194,6 +194,7 @@ val apply :
   -> get_completed_work:
        (   Transaction_snark_work.Statement.t
         -> Transaction_snark_work.Checked.t option )
+  -> ?precomputed:Ledger.precomputed_t list
   -> Staged_ledger_diff.t
   -> logger:Logger.t
   -> verifier:Verifier.t
@@ -220,6 +221,7 @@ val apply_diff_unchecked :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> global_slot:Mina_numbers.Global_slot_since_genesis.t
   -> t
+  -> ?precomputed:Ledger.precomputed_t list
   -> Staged_ledger_diff.With_valid_signatures_and_proofs.t
   -> logger:Logger.t
   -> current_state_view:Zkapp_precondition.Protocol_state.View.t
@@ -366,7 +368,7 @@ module Test_helpers : sig
     -> is_new_stack:bool
     -> Ledger.t
     -> Pending_coinbase.t
-    -> Transaction.t With_status.t list
+    -> (Transaction.t With_status.t * Ledger.precomputed_t option) list
     -> Zkapp_precondition.Protocol_state.View.t
     -> Frozen_ledger_hash.t * Frozen_ledger_hash.t
     -> ( bool

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -966,7 +966,8 @@ module Make (Inputs : Inputs_intf) = struct
     ; new_frame : Stack_frame.t
     }
 
-  let get_next_account_update (current_forest : Stack_frame.t)
+  let get_next_account_update ~lookup_precomputed_token_id
+      (current_forest : Stack_frame.t)
       (* The stack for the most recent zkApp *)
         (call_stack : Call_stack.t) (* The partially-completed parent stacks *)
       : get_next_account_update_result =
@@ -1047,12 +1048,16 @@ module Make (Inputs : Inputs_intf) = struct
           (Stack_frame.if_ remainder_of_current_forest_empty
              ~then_:newly_popped_frame ~else_:remainder_of_current_forest_frame )
         ~else_:
-          (let caller =
-             Account_id.derive_token_id
-               ~owner:(Account_update.account_id account_update)
-           and caller_caller = caller_id in
-           Stack_frame.make ~calls:account_update_forest ~caller ~caller_caller
-          )
+          (let owner = Account_update.account_id account_update in
+           let caller =
+             match lookup_precomputed_token_id owner with
+             | Some tid ->
+                 tid
+             | None ->
+                 Account_id.derive_token_id ~owner
+           in
+           Stack_frame.make ~calls:account_update_forest ~caller
+             ~caller_caller:caller_id )
     in
     { account_update
     ; caller_id
@@ -1083,8 +1088,31 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (([ s1; s2; s3; s4; s5 ] : _ Pickles_types.Vector.t), last_action_slot)
 
+  (** Type holding zkapp transaction-related data that is dependent only on a transaction
+      (and not ledger)
+  *)
+  type zkapp_precomputed_t =
+    { all_account_updates :
+        ( Account_update.t
+        , Zkapp_command.Digest.Account_update.t
+        , Zkapp_command.Digest.Forest.t )
+        Zkapp_command.Call_forest.t
+    ; init_account_update_result : get_next_account_update_result
+    ; tx_commitment_on_start : Inputs.Transaction_commitment.t
+    ; full_commitment_on_start : Inputs.Transaction_commitment.t
+    }
+
+  (** Type holding transaction-related data that is dependent only on a transaction
+      (and not ledger)
+  *)
+  type precomputed_t =
+    { lookup_derived_token_id : Account_id.t -> Token_id.t option
+    ; zkapp_precomputed : zkapp_precomputed_t
+    }
+
   let apply ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~(is_start : [ `Yes of _ Start_data.t | `No | `Compute of _ Start_data.t ])
+      ?(precomputed : precomputed_t option)
       (h :
         (< global_state : Global_state.t
          ; transaction_commitment : Transaction_commitment.t
@@ -1163,9 +1191,23 @@ module Make (Inputs : Inputs_intf) = struct
           ; new_frame = remaining
           ; new_call_stack = call_stack
           } =
-        with_label ~label:"get next account update" (fun () ->
-            (* TODO: Make the stack frame hashed inside of the local state *)
-            get_next_account_update to_pop call_stack )
+        match (precomputed, is_start) with
+        | ( Some { zkapp_precomputed = { init_account_update_result; _ }; _ }
+          , `Yes _ )
+        | ( Some { zkapp_precomputed = { init_account_update_result; _ }; _ }
+          , `Compute _ ) ->
+            init_account_update_result
+        | _ ->
+            let lookup_precomputed_token_id =
+              Option.value_map ~default:(Fn.const None)
+                ~f:(fun { lookup_derived_token_id; _ } ->
+                  lookup_derived_token_id )
+                precomputed
+            in
+            with_label ~label:"get next account update" (fun () ->
+                (* TODO: Make the stack frame hashed inside of the local state *)
+                get_next_account_update ~lookup_precomputed_token_id to_pop
+                  call_stack )
       in
       let local_state =
         with_label ~label:"token owner not caller" (fun () ->
@@ -1193,14 +1235,18 @@ module Make (Inputs : Inputs_intf) = struct
             ( local_state.transaction_commitment
             , local_state.full_transaction_commitment )
         | `Yes start_data | `Compute start_data ->
-            let tx_commitment_on_start =
-              Transaction_commitment.commitment
-                ~account_updates:(Stack_frame.calls remaining)
-            in
-            let full_tx_commitment_on_start =
-              Transaction_commitment.full_commitment ~account_update
-                ~memo_hash:start_data.memo_hash
-                ~commitment:tx_commitment_on_start
+            let tx_commitment_on_start, full_commitment_on_start =
+              match precomputed with
+              | Some { zkapp_precomputed = p; _ } ->
+                  (p.tx_commitment_on_start, p.full_commitment_on_start)
+              | None ->
+                  let commitment =
+                    Transaction_commitment.commitment
+                      ~account_updates:(Stack_frame.calls remaining)
+                  in
+                  ( commitment
+                  , Transaction_commitment.full_commitment ~account_update
+                      ~memo_hash:start_data.memo_hash ~commitment )
             in
             let tx_commitment =
               Transaction_commitment.if_ is_start' ~then_:tx_commitment_on_start
@@ -1208,7 +1254,7 @@ module Make (Inputs : Inputs_intf) = struct
             in
             let full_tx_commitment =
               Transaction_commitment.if_ is_start'
-                ~then_:full_tx_commitment_on_start
+                ~then_:full_commitment_on_start
                 ~else_:local_state.full_transaction_commitment
             in
             (tx_commitment, full_tx_commitment)
@@ -1968,7 +2014,7 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (global_state, local_state)
 
-  let step h state = apply ~is_start:`No h state
+  let step = apply ~is_start:`No
 
-  let start start_data h state = apply ~is_start:(`Yes start_data) h state
+  let start start_data = apply ~is_start:(`Yes start_data)
 end

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -864,7 +864,9 @@ module Make_str (A : Wire_types.Concrete) = struct
 
           let is_empty x = run_checked (Account_update.Actions.is_empty_var x)
 
-          let push_events = Account_update.Actions.push_events_checked
+          let push_events_hash = Account_update.Actions.push_events_hash_checked
+
+          let hash = Data_as_hash.hash
         end
 
         module Zkapp_uri = struct

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -478,7 +478,7 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
       (* STEP 5 *)
       (*Validate transactions against the protocol state associated with the transaction*)
       let apply_first_pass =
-        Ledger.apply_transaction_first_pass
+        Ledger.apply_transaction_first_pass ?precomputed:None
           ~constraint_constants:Context.constraint_constants
       in
       let apply_second_pass = Ledger.apply_transaction_second_pass in


### PR DESCRIPTION
Some hashes that are computed during staged ledger application are dependent only on a transaction itself. These hashes could be precomputed before staged ledger application, to minimize time of block creation.

Main change revolves around introducing and using the following two types:

```ocaml
type zkapp_precomputed_t =
    { all_account_updates :
        ( Account_update.t
        , Zkapp_command.Digest.Account_update.t
        , Zkapp_command.Digest.Forest.t )
        Zkapp_command.Call_forest.t
    ; init_account_update_result : get_next_account_update_result
    ; tx_commitment_on_start : Inputs.Transaction_commitment.t
    ; full_commitment_on_start : Inputs.Transaction_commitment.t
    ; lookup_actions_hash : Actions.t -> Field.t option
    }

type precomputed_t =
    { memo_hash : Random_oracle.Digest.t
    ; derived_token_ids : Token_id.t Account_id.Map.t
    ; zkapp_precomputed : zkapp_precomputed_t option
    }
```

Type `precomputed_t` contains data that is dependent only on a transaction (and not on the ledger to which it is to be applied). It contains some hashes either in direct form (as `memo_hash`) or indirect form (as `all_account_updates`, for computation of which some hashing is used deep inside the function call).

_TODO_ this PR lacks a change to block producer to keep `precomputed_t` in transaction pool and use for block creation.

As measured by `mina ledger test apply` benchmark, this PR improves performance of staged ledger diff application by some 27% (measured together with #15784, #15980, #16055).

Explain how you tested your changes:
* [x] Ran a benchmark
* [ ] Ran CI/nightly tests

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? 

* Closes #14752
