### PR TITLE
Use public name for `runtime_config`

### DIFF
--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -45,7 +45,7 @@
   kimchi_pasta.basic
   ppx_version.runtime
   gossip_net
-  runtime_config)
+  mina_runtime_config)
  (preprocess
   (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.make))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
Change to fix `!ci-nix-me`.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None