### PR TITLE
Use public name of mina_node_config.for_unit_tests

### DIFF
--- a/src/lib/mina_compile_config/dune
+++ b/src/lib/mina_compile_config/dune
@@ -1,6 +1,6 @@
 (library
  (name mina_compile_config)
  (public_name mina_compile_config)
- (libraries mina_node_config node_config_for_unit_tests core_kernel currency)
+ (libraries mina_node_config mina_node_config.for_unit_tests core_kernel currency)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_base ppx_deriving_yojson)))


### PR DESCRIPTION
Very simple change to fix nix CI (`!ci-nix-me`).

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None