### PR TITLE
Bitswap: rename `deleteXX` to `removeXX`, add tag to IPC

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_delete.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_delete.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"codanet"
+	"errors"
+
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+func ClearRootDownloadState(bs BitswapState, root root) {
+	rootStates := bs.RootDownloadStates()
+	state, has := rootStates[root]
+	if !has {
+		return
+	}
+	nodeParams := bs.NodeDownloadParams()
+	delete(rootStates, root)
+	state.allDescendants.ForEach(func(c cid.Cid) error {
+		np, hasNp := nodeParams[c]
+		if hasNp {
+			delete(np, root)
+			if len(np) == 0 {
+				delete(nodeParams, c)
+			}
+		}
+		return nil
+	})
+	state.cancelF()
+}
+
+func DeleteRoot(bs BitswapState, root BitswapBlockLink) (BitswapDataTag, error) {
+	if err := bs.SetStatus(root, codanet.Deleting); err != nil {
+		return 255, err
+	}
+	var tag BitswapDataTag
+	{
+		// Determining tag of root being deleted
+		state, has := bs.RootDownloadStates()[root]
+		if has {
+			tag = state.getTag()
+		} else {
+			err := bs.ViewBlock(root, func(b []byte) error {
+				_, fullBlockData, err := ReadBitswapBlock(b)
+				if err != nil {
+					return err
+				}
+				if len(fullBlockData) < 5 {
+					return errors.New("root block is too short")
+				}
+				tag = BitswapDataTag(fullBlockData[4])
+				return nil
+			})
+			if err != nil {
+				return 255, err
+			}
+		}
+	}
+	ClearRootDownloadState(bs, root)
+	descendantMap := map[[32]byte]struct{}{root: {}}
+	allDescendants := []BitswapBlockLink{root}
+	viewBlockF := func(b []byte) error {
+		links, _, err := ReadBitswapBlock(b)
+		if err == nil {
+			for _, l := range links {
+				var l2 BitswapBlockLink
+				copy(l2[:], l[:])
+				_, has := descendantMap[l2]
+				if !has {
+					descendantMap[l2] = struct{}{}
+					allDescendants = append(allDescendants, l2)
+				}
+			}
+		}
+		return err
+	}
+	for i := 0; i < len(allDescendants); i++ {
+		block := allDescendants[i]
+		if err := bs.ViewBlock(block, viewBlockF); err != nil && err != (ipld.ErrNotFound{Cid: codanet.BlockHashToCid(block)}) {
+			return tag, err
+		}
+	}
+	if err := bs.DeleteBlocks(allDescendants); err != nil {
+		return tag, err
+	}
+	return tag, bs.DeleteStatus(root)
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
@@ -10,7 +10,6 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -140,7 +139,7 @@ func kickStartRootDownload(root_ BitswapBlockLink, tag BitswapDataTag, bs Bitswa
 		copy(rootBlock, b)
 		return nil
 	}
-	if err := bs.ViewBlock(root_, rootBlockViewF); err != nil && err != (ipld.ErrNotFound{Cid: codanet.BlockHashToCid(root_)}) {
+	if err := bs.ViewBlock(root_, rootBlockViewF); err != nil && !isBlockNotFound(root_, err) {
 		handleError(err)
 		return
 	}
@@ -316,7 +315,7 @@ func processDownloadedBlock(block blocks.Block, bs BitswapState) {
 			b, _ := blocks.NewBlockWithCid(blockBytes, childId)
 			blocksToProcess = append(blocksToProcess, b)
 		} else {
-			if err != (ipld.ErrNotFound{Cid: codanet.BlockHashToCid(link)}) {
+			if !isBlockNotFound(link, err) {
 				// we still schedule blocks for downloading
 				// this case should rarely happen in practice
 				bitswapLogger.Warnf("Failed to retrieve block %s from storage: %s", childId, err)

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
@@ -86,7 +86,7 @@ type BitswapState interface {
 	DepthIndices() DepthIndices
 	NewSession(downloadTimeout time.Duration) (BlockRequester, context.CancelFunc)
 	RegisterDeadlineTracker(root, time.Duration)
-	SendResourceUpdate(type_ ipc.ResourceUpdateType, root root)
+	SendResourceUpdate(type_ ipc.ResourceUpdateType, tag BitswapDataTag, root root)
 	CheckInvariants()
 }
 
@@ -109,7 +109,7 @@ func kickStartRootDownload(root_ BitswapBlockLink, tag BitswapDataTag, bs Bitswa
 		bitswapLogger.Debugf("Skipping download request for %s due to status: %s", codanet.BlockHashToCidSuffix(root_), err)
 		status, err := bs.GetStatus(root_)
 		if err == nil && status == codanet.Full {
-			bs.SendResourceUpdate(ipc.ResourceUpdateType_added, root_)
+			bs.SendResourceUpdate(ipc.ResourceUpdateType_added, tag, root_)
 		}
 		return
 	}
@@ -280,8 +280,8 @@ func processDownloadedBlock(block blocks.Block, bs BitswapState) {
 	newParams, malformed := processDownloadedBlockStep(oldPs, block, rps, bs.MaxBlockSize(), depthIndices, bs.DataConfig())
 	for root, err := range malformed {
 		bitswapLogger.Warnf("Block %s of root %s is malformed: %s", id, codanet.BlockHashToCidSuffix(root), err)
-		ClearRootDownloadState(bs, root)
-		bs.SendResourceUpdate(ipc.ResourceUpdateType_broken, root)
+		DeleteRoot(bs, root)
+		bs.SendResourceUpdate(ipc.ResourceUpdateType_broken, rps[root].getTag(), root)
 	}
 
 	blocksToProcess := make([]blocks.Block, 0)
@@ -338,7 +338,7 @@ func processDownloadedBlock(block blocks.Block, bs BitswapState) {
 				bitswapLogger.Warnf("Failed to update status of fully downloaded root %s: %s", root, err)
 			}
 			ClearRootDownloadState(bs, root)
-			bs.SendResourceUpdate(ipc.ResourceUpdateType_added, root)
+			bs.SendResourceUpdate(ipc.ResourceUpdateType_added, rootState.tag, root)
 		}
 	}
 	for _, b := range blocksToProcess {

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader_test.go
@@ -670,7 +670,7 @@ func (bs *testBitswapState) RegisterDeadlineTracker(root_ root, downloadTimeout 
 		downloadTimeout time.Duration
 	}{root: root_, downloadTimeout: downloadTimeout})
 }
-func (bs *testBitswapState) SendResourceUpdate(type_ ipc.ResourceUpdateType, root root) {
+func (bs *testBitswapState) SendResourceUpdate(type_ ipc.ResourceUpdateType, _tag BitswapDataTag, root root) {
 	type1, has := bs.resourceUpdates[root]
 	if has && type1 != type_ {
 		panic("duplicate resource update")

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_msg.go
@@ -27,12 +27,12 @@ func (m AddResourcePush) handle(app *app) {
 	}
 }
 
-type DeleteResourcePushT = ipc.Libp2pHelperInterface_DeleteResource
-type DeleteResourcePush DeleteResourcePushT
+type RemoveResourcePushT = ipc.Libp2pHelperInterface_RemoveResource
+type RemoveResourcePush RemoveResourcePushT
 
-func fromDeleteResourcePush(m ipcPushMessage) (pushMessage, error) {
-	i, err := m.DeleteResource()
-	return DeleteResourcePush(i), err
+func fromRemoveResourcePush(m ipcPushMessage) (pushMessage, error) {
+	i, err := m.RemoveResource()
+	return RemoveResourcePush(i), err
 }
 
 func extractRootBlockList(l ipc.RootBlockId_List) ([]root, error) {
@@ -52,14 +52,14 @@ func extractRootBlockList(l ipc.RootBlockId_List) ([]root, error) {
 	return ids, nil
 }
 
-func (m DeleteResourcePush) handle(app *app) {
-	idsM, err := DeleteResourcePushT(m).Ids()
+func (m RemoveResourcePush) handle(app *app) {
+	idsM, err := RemoveResourcePushT(m).Ids()
 	var links []root
 	if err == nil {
 		links, err = extractRootBlockList(idsM)
 	}
 	if err != nil {
-		app.P2p.Logger.Errorf("DeleteResourcePush.handle: error %s", err)
+		app.P2p.Logger.Errorf("RemoveResourcePush.handle: error %s", err)
 		return
 	}
 	app.bitswapCtx.deleteCmds <- bitswapDeleteCmd{links}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
@@ -71,12 +71,12 @@ func getRootIds(ids ipc.RootBlockId_List) ([]BitswapBlockLink, error) {
 	return links, nil
 }
 
-func deleteResource(n testNode, root root) error {
+func removeResource(n testNode, root root) error {
 	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
 	if err != nil {
 		return err
 	}
-	m, err := ipc.NewRootLibp2pHelperInterface_DeleteResource(seg)
+	m, err := ipc.NewRootLibp2pHelperInterface_RemoveResource(seg)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func deleteResource(n testNode, root root) error {
 	if err != nil {
 		return err
 	}
-	DeleteResourcePush(m).handle(n.node)
+	RemoveResourcePush(m).handle(n.node)
 	return nil
 }
 
@@ -393,7 +393,7 @@ func (conf bitswapTestConfig) execute(nodes []testNode, delayBeforeDownload bool
 			if !resourceReplicated[ni] {
 				continue
 			}
-			err = deleteResource(nodes[ni], roots[ni])
+			err = removeResource(nodes[ni], roots[ni])
 			if err != nil {
 				return fmt.Errorf("Error removing own resources: %v", err)
 			}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
@@ -15,7 +15,6 @@ import (
 
 	capnp "capnproto.org/go/capnp/v3"
 	"github.com/ipfs/go-cid"
-	ipld "github.com/ipfs/go-ipld-format"
 	multihash "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/blake2b"
@@ -189,7 +188,7 @@ func confirmBlocksNotInStorage(bs *BitswapCtx, resource []byte) error {
 		})
 		if err == nil {
 			return fmt.Errorf("block %s wasn't deleted", codanet.BlockHashToCidSuffix(h))
-		} else if err != (ipld.ErrNotFound{Cid: codanet.BlockHashToCid(h)}) {
+		} else if !isBlockNotFound(h, err) {
 			return err
 		}
 	}

--- a/src/app/libp2p_helper/src/libp2p_helper/error.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/error.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"codanet"
 	"fmt"
 
 	"github.com/go-errors/errors"
+	ipld "github.com/ipfs/go-ipld-format"
 )
 
 // TODO: wrap these in a new type, encode them differently in the rpc mainloop
@@ -47,4 +49,8 @@ func needsConfigure() error {
 
 func needsDHT() error {
 	return badRPC(errors.New("helper not yet joined to pubsub"))
+}
+
+func isBlockNotFound(block BitswapBlockLink, err error) bool {
+	return err == ipld.ErrNotFound{Cid: codanet.BlockHashToCid(block)}
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/incoming_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/incoming_msg.go
@@ -34,7 +34,7 @@ var rpcRequestExtractors = map[ipc.Libp2pHelperInterface_RpcRequest_Which]extrac
 
 var pushMesssageExtractors = map[ipc.Libp2pHelperInterface_PushMessage_Which]extractPushMessage{
 	ipc.Libp2pHelperInterface_PushMessage_Which_addResource:      fromAddResourcePush,
-	ipc.Libp2pHelperInterface_PushMessage_Which_deleteResource:   fromDeleteResourcePush,
+	ipc.Libp2pHelperInterface_PushMessage_Which_removeResource:   fromRemoveResourcePush,
 	ipc.Libp2pHelperInterface_PushMessage_Which_downloadResource: fromDownloadResourcePush,
 	ipc.Libp2pHelperInterface_PushMessage_Which_validation:       fromValidationPush,
 	ipc.Libp2pHelperInterface_PushMessage_Which_heartbeatPeer:    fromHeartbeatPeerPush,

--- a/src/app/libp2p_helper/src/libp2p_helper/msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/msg.go
@@ -395,7 +395,7 @@ func mkStreamMessageReceivedUpcall(streamIdx uint64, data []byte) *capnp.Message
 	})
 }
 
-func mkResourceUpdatedUpcall(type_ ipc.ResourceUpdateType, rootIds []root) *capnp.Message {
+func mkResourceUpdatedUpcall(type_ ipc.ResourceUpdateType, tag BitswapDataTag, rootIds []root) *capnp.Message {
 	return mkPushMsg(func(m ipc.DaemonInterface_PushMessage) {
 		im, err := m.NewResourceUpdated()
 		panicOnErr(err)
@@ -403,6 +403,7 @@ func mkResourceUpdatedUpcall(type_ ipc.ResourceUpdateType, rootIds []root) *capn
 			panic("too many root ids in a single upcall")
 		}
 		im.SetType(type_)
+		im.SetTag(uint8(tag))
 		mIds, err := im.NewIds(int32(len(rootIds)))
 		panicOnErr(err)
 		for i, rootId := range rootIds {

--- a/src/lib/mina_net2/libp2p_helper.ml
+++ b/src/lib/mina_net2/libp2p_helper.ml
@@ -221,8 +221,7 @@ let handle_incoming_message t msg ~handle_push_message =
               handle_push_message t (DaemonInterface.PushMessage.get push_msg) )
           )
   | Undefined n ->
-      Libp2p_ipc.undefined_union ~context:"DaemonInterface.Message" n ;
-      Deferred.unit
+      Libp2p_ipc.undefined_union ~context:"DaemonInterface.Message" n
 
 let spawn ?(allow_multiple_instances = false) ~logger ~pids ~conf_dir
     ~handle_push_message () =

--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -332,7 +332,7 @@ struct Libp2pHelperInterface {
     result @1 :ValidationResult;
   }
 
-  struct DeleteResource {
+  struct RemoveResource {
     ids @0 :List(RootBlockId);
   }
 
@@ -420,7 +420,7 @@ struct Libp2pHelperInterface {
     union {
       validation @1 :Libp2pHelperInterface.Validation;
       addResource @2 :Libp2pHelperInterface.AddResource;
-      deleteResource @3 :Libp2pHelperInterface.DeleteResource;
+      removeResource @3 :Libp2pHelperInterface.RemoveResource;
       downloadResource @4 :Libp2pHelperInterface.DownloadResource;
       heartbeatPeer @5 :Libp2pHelperInterface.HeartbeatPeer;
     }
@@ -475,6 +475,7 @@ struct DaemonInterface {
   struct ResourceUpdate {
     type @0 :ResourceUpdateType;
     ids @1 :List(RootBlockId);
+    tag @2 :UInt8;
   }
 
   struct PushMessage {

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -265,39 +265,39 @@ let push_message_to_outgoing_message request =
     Builder.Libp2pHelperInterface.Message.(
       builder_op push_message_set_builder request)
 
-      let create_remove_resource_push_message ~ids =
-        let ids =
-          List.map ids ~f:(fun id ->
-              build'
-                (module Builder.RootBlockId)
-                Builder.RootBlockId.(op blake2b_hash_set id) )
-        in
+let create_remove_resource_push_message ~ids =
+  let ids =
+    List.map ids ~f:(fun id ->
         build'
-          (module Builder.Libp2pHelperInterface.PushMessage)
-          Builder.Libp2pHelperInterface.PushMessage.(
-            builder_op header_set_builder (create_push_message_header ())
-            *> reader_op remove_resource_set_reader
-                 (build
-                    (module Builder.Libp2pHelperInterface.RemoveResource)
-                    Builder.Libp2pHelperInterface.RemoveResource.(
-                      list_op ids_set_list ids) ))
-      
-      let create_download_resource_push_message ~tag ~ids =
-        let ids =
-          List.map ids ~f:(fun id ->
-              build'
-                (module Builder.RootBlockId)
-                Builder.RootBlockId.(op blake2b_hash_set id) )
-        in
+          (module Builder.RootBlockId)
+          Builder.RootBlockId.(op blake2b_hash_set id) )
+  in
+  build'
+    (module Builder.Libp2pHelperInterface.PushMessage)
+    Builder.Libp2pHelperInterface.PushMessage.(
+      builder_op header_set_builder (create_push_message_header ())
+      *> reader_op remove_resource_set_reader
+           (build
+              (module Builder.Libp2pHelperInterface.RemoveResource)
+              Builder.Libp2pHelperInterface.RemoveResource.(
+                list_op ids_set_list ids) ))
+
+let create_download_resource_push_message ~tag ~ids =
+  let ids =
+    List.map ids ~f:(fun id ->
         build'
-          (module Builder.Libp2pHelperInterface.PushMessage)
-          Builder.Libp2pHelperInterface.PushMessage.(
-            builder_op header_set_builder (create_push_message_header ())
-            *> reader_op download_resource_set_reader
-                 (build
-                    (module Builder.Libp2pHelperInterface.DownloadResource)
-                    Builder.Libp2pHelperInterface.DownloadResource.(
-                      op tag_set_exn tag *> list_op ids_set_list ids) ))
+          (module Builder.RootBlockId)
+          Builder.RootBlockId.(op blake2b_hash_set id) )
+  in
+  build'
+    (module Builder.Libp2pHelperInterface.PushMessage)
+    Builder.Libp2pHelperInterface.PushMessage.(
+      builder_op header_set_builder (create_push_message_header ())
+      *> reader_op download_resource_set_reader
+           (build
+              (module Builder.Libp2pHelperInterface.DownloadResource)
+              Builder.Libp2pHelperInterface.DownloadResource.(
+                op tag_set_exn tag *> list_op ids_set_list ids) ))
 
 let create_add_resource_push_message ~tag ~data =
   build'

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -265,6 +265,40 @@ let push_message_to_outgoing_message request =
     Builder.Libp2pHelperInterface.Message.(
       builder_op push_message_set_builder request)
 
+      let create_remove_resource_push_message ~ids =
+        let ids =
+          List.map ids ~f:(fun id ->
+              build'
+                (module Builder.RootBlockId)
+                Builder.RootBlockId.(op blake2b_hash_set id) )
+        in
+        build'
+          (module Builder.Libp2pHelperInterface.PushMessage)
+          Builder.Libp2pHelperInterface.PushMessage.(
+            builder_op header_set_builder (create_push_message_header ())
+            *> reader_op remove_resource_set_reader
+                 (build
+                    (module Builder.Libp2pHelperInterface.RemoveResource)
+                    Builder.Libp2pHelperInterface.RemoveResource.(
+                      list_op ids_set_list ids) ))
+      
+      let create_download_resource_push_message ~tag ~ids =
+        let ids =
+          List.map ids ~f:(fun id ->
+              build'
+                (module Builder.RootBlockId)
+                Builder.RootBlockId.(op blake2b_hash_set id) )
+        in
+        build'
+          (module Builder.Libp2pHelperInterface.PushMessage)
+          Builder.Libp2pHelperInterface.PushMessage.(
+            builder_op header_set_builder (create_push_message_header ())
+            *> reader_op download_resource_set_reader
+                 (build
+                    (module Builder.Libp2pHelperInterface.DownloadResource)
+                    Builder.Libp2pHelperInterface.DownloadResource.(
+                      op tag_set_exn tag *> list_op ids_set_list ids) ))
+
 let create_add_resource_push_message ~tag ~data =
   build'
     (module Builder.Libp2pHelperInterface.PushMessage)

--- a/src/libp2p_ipc/libp2p_ipc.mli
+++ b/src/libp2p_ipc/libp2p_ipc.mli
@@ -36,7 +36,7 @@ module Subscription_id : sig
   val create : unit -> t
 end
 
-val undefined_union : context:string -> int -> unit
+val undefined_union : context:string -> int -> 'a
 
 val unsafe_parse_peer_id : peer_id -> Peer.Id.t
 
@@ -96,6 +96,11 @@ val create_validation_push_message :
   -> push_message
 
 val create_add_resource_push_message : tag:int -> data:string -> push_message
+
+val create_download_resource_push_message :
+  tag:int -> ids:string list -> push_message
+
+val create_remove_resource_push_message : ids:string list -> push_message
 
 val create_heartbeat_peer_push_message : peer_id:Peer.Id.t -> push_message
 


### PR DESCRIPTION
This PR renames a number of methods with names `deleteXX` to `removeXX`.

It also adds a functions `create_download_resource_push_message` and `create_remove_resource_push_message` that will later be used for organization of IPC between Ocaml's bit-catchup algrotihm code and Libp2p's functions exposing Biytswap functionality. 