### PR TITLE
Port lightnet suffix fix to release 3.0.2

### DIFF
--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -43,6 +43,18 @@ function export_suffixes () {
             ;;
         esac
         ;;
+        lightnet)
+        case "${DEB_BUILD_FLAGS}" in
+            *instrumented)
+            export DOCKER_DEB_SUFFIX="--build-arg deb_suffix=lightnet-instrumented"
+            export BUILD_FLAG_SUFFIX="lightnet-instrumented"
+            ;;
+            *)
+            export DOCKER_DEB_SUFFIX="--build-arg deb_suffix=lightnet"
+            export BUILD_FLAG_SUFFIX="-lightnet"
+            ;;
+        esac
+        ;;
         *)
         case "${DEB_BUILD_FLAGS}" in 
             *instrumented)
@@ -57,7 +69,6 @@ function export_suffixes () {
         ;;
     esac
 }
-    
 
 function export_docker_tag() {
     export_suffixes

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4737,7 +4737,8 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
   | Some runtime_config -> (
       let%bind precomputed_values =
         match%map
-          Genesis_ledger_helper.init_from_config_file ~logger ~proof_level:None
+          Genesis_ledger_helper.init_from_config_file ~logger
+            ~proof_level:Genesis_constants.Compiled.proof_level
             ~genesis_constants ~constraint_constants runtime_config
             ~cli_proof_level:None
         with


### PR DESCRIPTION
During stable run we experienced issue in archive node during some integration tests run:

```
2024-09-18 20:48:55 UTC [Info] Starting archive process; built with commit "b40ca1562f2f448ae20ecdb299c8b9da14090c28"

2024-09-18 20:48:55 UTC [Info] Initializing with runtime configuration. Ledger name: null

2024-09-18 20:48:55 UTC [Info] Using the constraint constants from the configuration file

2024-09-18 20:48:55 UTC [Fatal] Proof level "full" is not 
compatible with compile-time proof level "none"

(monitor.ml.Error
 (Failure
  "Could not get precomputed values, error: Proof level full is not compatible with compile-time proof level none")
 ("Raised at Stdlib.failwith in file \"stdlib.ml\", line 29, characters 17-33"
   "Called from Async_kernel__Deferred1.M.map.(fun) in file \"src/deferred1.ml\", line 17, characters 40-45"
   "Called from Async_kernel__Job_queue.run_job in file \"src/job_queue.ml\" (inlined), line 128, characters 2-5"   "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 169, characters 6-47"))
```

It is reproducible when passing config with proof.level = Full and running command like below

`DUNE_PROFILE=devnet dune exec  src/app/archive/archive.exe --  run -postgres-uri "postgres://postgres:password@postgres-1-icoj:5432/archive" "-server-port" "3086" "-config-file"  "config.json"
`

We synced together with Martin and looks like this commit causes the issue:
https://github.com/MinaProtocol/mina/blame/5b8924f2b55298c28f140176c1a552bfc751d958/src/app/archive/lib/processor.ml#L4740
We reverted this change partially and now it's working good. The problem was that config_file.json which was provided at the archive node startup was taken from daemon (runtime_config) and it had a proof section with proof level = full which causes that archive node was unhappy due to mismatch full / none.
