### PR TITLE
Push `Pickles_types` down into `Mina_wire_types`

### DIFF
--- a/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
@@ -3,12 +3,11 @@ open Kimchi_backend_common
 
 module Rounds : sig
   open Pickles_types
-
-  module Wrap : Nat.Add.Intf_transparent
+  module Wrap = Nat.N15
 
   module Wrap_vector : Vector.With_version(Wrap).S
 
-  module Step : Nat.Add.Intf_transparent
+  module Step = Nat.N16
 
   module Step_vector : Vector.With_version(Step).S
 end = struct

--- a/src/lib/mina_wire_types/dune
+++ b/src/lib/mina_wire_types/dune
@@ -9,11 +9,8 @@
     ; Keep these dependencies to an absolute minimum
     integers
     pasta_bindings
-    pickles_types
     kimchi_types
     kimchi_bindings
-    kimchi_pasta
-    kimchi_pasta.basic
     blake2
     )
   (preprocess (pps ppx_version))

--- a/src/lib/mina_wire_types/mina_base/mina_base_zkapp_state.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_zkapp_state.ml
@@ -1,5 +1,5 @@
 module V = struct
   module V1 = struct
-    type 'a t = 'a Pickles_types.Vector.Vector_8.Stable.V1.t
+    type 'a t = ('a, Pickles_types.Nat.eight) Pickles_types.Vector.t
   end
 end

--- a/src/lib/mina_wire_types/pickles/pickles.ml
+++ b/src/lib/mina_wire_types/pickles/pickles.ml
@@ -12,21 +12,22 @@ module M = struct
   end
 
   module Wrap_wire_proof = struct
-    module Columns_vec = Pickles_types.Vector.Vector_15
-    module Coefficients_vec = Pickles_types.Vector.Vector_15
-    module Quotient_polynomial_vec = Pickles_types.Vector.Vector_7
-    module Permuts_minus_1_vec = Pickles_types.Vector.Vector_6
+    type 'a columns_vec = ('a, Pickles_types.Nat.fifteen) Pickles_types.Vector.t
+
+    type 'a quotient_polynomial_vec =
+      ('a, Pickles_types.Nat.seven) Pickles_types.Vector.t
+
+    type 'a permuts_minus_1_vec =
+      ('a, Pickles_types.Nat.six) Pickles_types.Vector.t
 
     module Commitments = struct
       module V1 = struct
         type t =
-          { w_comm :
-              (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
-              Columns_vec.Stable.V1.t
+          { w_comm : (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t) columns_vec
           ; z_comm : Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
           ; t_comm :
               (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
-              Quotient_polynomial_vec.Stable.V1.t
+              quotient_polynomial_vec
           }
       end
     end
@@ -34,16 +35,11 @@ module M = struct
     module Evaluations = struct
       module V1 = struct
         type t =
-          { w :
-              (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t)
-              Columns_vec.Stable.V1.t
+          { w : (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t) columns_vec
           ; coefficients :
-              (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t)
-              Columns_vec.Stable.V1.t
+              (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t) columns_vec
           ; z : Pasta_bindings.Fq.t * Pasta_bindings.Fq.t
-          ; s :
-              (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t)
-              Permuts_minus_1_vec.Stable.V1.t
+          ; s : (Pasta_bindings.Fq.t * Pasta_bindings.Fq.t) permuts_minus_1_vec
           ; generic_selector : Pasta_bindings.Fq.t * Pasta_bindings.Fq.t
           ; poseidon_selector : Pasta_bindings.Fq.t * Pasta_bindings.Fq.t
           ; complete_add_selector : Pasta_bindings.Fq.t * Pasta_bindings.Fq.t
@@ -62,30 +58,31 @@ module M = struct
         ; bulletproof :
             ( Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
             , Pasta_bindings.Fq.t )
-            Pickles_types.Plonk_types.Openings.Bulletproof.Stable.V1.t
+            Pickles_types.Plonk_types.Openings.Bulletproof.V1.t
         }
     end
   end
 
   module Proof = struct
     type challenge_constant =
-      Pickles_limb_vector.Constant.Make(Pickles_types.Nat.N2).t
+      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
 
     type tock_affine = Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
 
-    type 'a step_bp_vec = 'a Kimchi_pasta.Basic.Rounds.Step_vector.Stable.V1.t
+    type 'a step_bp_vec = ('a, Pickles_types.Nat.sixteen) Pickles_types.Vector.t
 
     module Base = struct
       module Wrap = struct
         module V2 = struct
           type digest_constant =
-            Pickles_limb_vector.Constant.Make(Pickles_types.Nat.N4).t
+            Pickles_types.Nat.four Pickles_limb_vector.Constant.t
 
           type ('messages_for_next_wrap_proof, 'messages_for_next_step_proof) t =
             { statement :
                 ( challenge_constant
                 , challenge_constant Kimchi_types.scalar_challenge
-                , Snark_params.Tick.Field.t Pickles_types.Shifted_value.Type1.t
+                , Snark_params.Tick.Field.t
+                  Pickles_types.Shifted_value.Type1.V1.t
                 , bool
                 , 'messages_for_next_wrap_proof
                 , digest_constant
@@ -98,7 +95,7 @@ module M = struct
             ; prev_evals :
                 ( Snark_params.Tick.Field.t
                 , Snark_params.Tick.Field.t array )
-                Pickles_types.Plonk_types.All_evals.t
+                Pickles_types.Plonk_types.All_evals.V1.t
                   (* A job half-done may be worse than not done at all.
                      TODO: Migrate Plonk_types here, and actually include the
                      *wire* type, not this in-memory version.
@@ -128,7 +125,7 @@ module M = struct
 
     module Proofs_verified_2 = struct
       module V2 = struct
-        type nonrec t = (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) t
+        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
       end
     end
   end
@@ -155,7 +152,9 @@ module M = struct
           Pickles_base.Side_loaded_verification_key.Poly.V2.t
       end
 
-      module Max_width = Pickles_types.Nat.N2
+      module Max_width = struct
+        type n = Pickles_types.Nat.two
+      end
     end
 
     module Proof = struct
@@ -174,14 +173,16 @@ module Types = struct
 
       module Proofs_verified_2 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) t
+          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
         end
       end
     end
 
     module Side_loaded : sig
       module Verification_key : sig
-        module Max_width : module type of Pickles_types.Nat.N2
+        module Max_width : sig
+          type n = Pickles_types.Nat.two
+        end
 
         module V2 : sig
           type t

--- a/src/lib/mina_wire_types/pickles/pickles.mli
+++ b/src/lib/mina_wire_types/pickles/pickles.mli
@@ -7,14 +7,16 @@ module Types : sig
 
       module Proofs_verified_2 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) t
+          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
         end
       end
     end
 
     module Side_loaded : sig
       module Verification_key : sig
-        module Max_width : module type of Pickles_types.Nat.N2
+        module Max_width : sig
+          type n = Pickles_types.Nat.two
+        end
 
         module V2 : sig
           type t
@@ -64,17 +66,21 @@ module Concrete_ : sig
 
     type fq_point := Pasta_bindings.Fq.t * Pasta_bindings.Fq.t
 
-    module Columns_vec = Pickles_types.Vector.Vector_15
-    module Coefficients_vec = Pickles_types.Vector.Vector_15
-    module Quotient_polynomial_vec = Pickles_types.Vector.Vector_7
-    module Permuts_minus_1_vec = Pickles_types.Vector.Vector_6
+    type 'a columns_vec :=
+      ('a, Pickles_types.Nat.fifteen) Pickles_types.Vector.t
+
+    type 'a quotient_polynomial_vec :=
+      ('a, Pickles_types.Nat.seven) Pickles_types.Vector.t
+
+    type 'a permuts_minus_1_vec :=
+      ('a, Pickles_types.Nat.six) Pickles_types.Vector.t
 
     module Commitments : sig
       module V1 : sig
         type t =
-          { w_comm : fp_point Columns_vec.Stable.V1.t
+          { w_comm : fp_point columns_vec
           ; z_comm : fp_point
-          ; t_comm : fp_point Quotient_polynomial_vec.Stable.V1.t
+          ; t_comm : fp_point quotient_polynomial_vec
           }
       end
     end
@@ -82,10 +88,10 @@ module Concrete_ : sig
     module Evaluations : sig
       module V1 : sig
         type t =
-          { w : fq_point Columns_vec.Stable.V1.t
-          ; coefficients : fq_point Columns_vec.Stable.V1.t
+          { w : fq_point columns_vec
+          ; coefficients : fq_point columns_vec
           ; z : fq_point
-          ; s : fq_point Permuts_minus_1_vec.Stable.V1.t
+          ; s : fq_point permuts_minus_1_vec
           ; generic_selector : fq_point
           ; poseidon_selector : fq_point
           ; complete_add_selector : fq_point
@@ -104,7 +110,7 @@ module Concrete_ : sig
         ; bulletproof :
             ( fp_point
             , Pasta_bindings.Fq.t )
-            Pickles_types.Plonk_types.Openings.Bulletproof.Stable.V1.t
+            Pickles_types.Plonk_types.Openings.Bulletproof.V1.t
         }
     end
   end
@@ -112,23 +118,24 @@ module Concrete_ : sig
   module Proof : sig
     (* We define some type aliases directly *)
     type challenge_constant =
-      Pickles_limb_vector.Constant.Make(Pickles_types.Nat.N2).t
+      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
 
     type tock_affine = Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
 
-    type 'a step_bp_vec = 'a Kimchi_pasta.Basic.Rounds.Step_vector.Stable.V1.t
+    type 'a step_bp_vec = ('a, Pickles_types.Nat.sixteen) Pickles_types.Vector.t
 
     module Base : sig
       module Wrap : sig
         module V2 : sig
           type digest_constant =
-            Pickles_limb_vector.Constant.Make(Pickles_types.Nat.N4).t
+            Pickles_types.Nat.four Pickles_limb_vector.Constant.t
 
           type ('messages_for_next_wrap_proof, 'messages_for_next_step_proof) t =
             { statement :
                 ( challenge_constant
                 , challenge_constant Kimchi_types.scalar_challenge
-                , Snark_params.Tick.Field.t Pickles_types.Shifted_value.Type1.t
+                , Snark_params.Tick.Field.t
+                  Pickles_types.Shifted_value.Type1.V1.t
                 , bool
                 , 'messages_for_next_wrap_proof
                 , digest_constant
@@ -141,7 +148,7 @@ module Concrete_ : sig
             ; prev_evals :
                 ( Snark_params.Tick.Field.t
                 , Snark_params.Tick.Field.t array )
-                Pickles_types.Plonk_types.All_evals.t
+                Pickles_types.Plonk_types.All_evals.V1.t
             ; proof : Wrap_wire_proof.V1.t
             }
         end
@@ -167,7 +174,7 @@ module Concrete_ : sig
 
     module Proofs_verified_2 : sig
       module V2 : sig
-        type nonrec t = (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) t
+        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
       end
     end
   end
@@ -194,7 +201,9 @@ module Concrete_ : sig
           Pickles_base.Side_loaded_verification_key.Poly.V2.t
       end
 
-      module Max_width = Pickles_types.Nat.N2
+      module Max_width : sig
+        type n = Pickles_types.Nat.two
+      end
     end
 
     module Proof : sig

--- a/src/lib/mina_wire_types/pickles/pickles_composition_types.ml
+++ b/src/lib/mina_wire_types/pickles/pickles_composition_types.ml
@@ -60,8 +60,7 @@ module Wrap = struct
               ; gamma : 'challenge
               ; zeta : 'scalar_challenge
               ; joint_combiner : 'scalar_challenge option
-              ; feature_flags :
-                  'bool Pickles_types.Plonk_types.Features.Stable.V1.t
+              ; feature_flags : 'bool Pickles_types.Plonk_types.Features.V1.t
               }
           end
         end

--- a/src/lib/mina_wire_types/pickles/pickles_composition_types.mli
+++ b/src/lib/mina_wire_types/pickles/pickles_composition_types.mli
@@ -48,8 +48,7 @@ module Wrap : sig
               ; gamma : 'challenge
               ; zeta : 'scalar_challenge
               ; joint_combiner : 'scalar_challenge option
-              ; feature_flags :
-                  'bool Pickles_types.Plonk_types.Features.Stable.V1.t
+              ; feature_flags : 'bool Pickles_types.Plonk_types.Features.V1.t
               }
           end
         end

--- a/src/lib/mina_wire_types/pickles/pickles_limb_vector.ml
+++ b/src/lib/mina_wire_types/pickles/pickles_limb_vector.ml
@@ -3,9 +3,5 @@ module Constant = struct
     type t = Int64.t
   end
 
-  module Make (N : Pickles_types.Nat.Intf) = struct
-    module A = Pickles_types.Vector.With_length (N)
-
-    type t = Hex64.t A.t
-  end
+  type 'n t = (Hex64.t, 'n) Pickles_types.Vector.t
 end

--- a/src/lib/mina_wire_types/pickles/pickles_reduced_messages_for_next_proof_over_same_field.ml
+++ b/src/lib/mina_wire_types/pickles/pickles_reduced_messages_for_next_proof_over_same_field.ml
@@ -11,9 +11,9 @@ end
 module Wrap = struct
   module Challenges_vector = struct
     type challenge_constant =
-      Pickles_limb_vector.Constant.Make(Pickles_types.Nat.N2).t
+      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
 
-    type 'a wrap_bp_vec = 'a Kimchi_pasta.Basic.Rounds.Wrap_vector.Stable.V1.t
+    type 'a wrap_bp_vec = ('a, Pickles_types.Nat.fifteen) Pickles_types.Vector.t
 
     type t =
       challenge_constant Kimchi_types.scalar_challenge

--- a/src/lib/mina_wire_types/pickles_base.ml
+++ b/src/lib/mina_wire_types/pickles_base.ml
@@ -10,7 +10,7 @@ module Side_loaded_verification_key = struct
       type ('g, 'proofs_verified, 'vk) t =
         { max_proofs_verified : 'proofs_verified
         ; actual_wrap_domain_size : 'proofs_verified
-        ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.Stable.V2.t
+        ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.V2.t
         ; wrap_vk : 'vk option
         }
     end

--- a/src/lib/mina_wire_types/pickles_types.ml
+++ b/src/lib/mina_wire_types/pickles_types.ml
@@ -1,0 +1,132 @@
+module Nat = struct
+  type z = Z of z
+
+  type 'a s = Z | S of 'a
+
+  type _ t = Z : z t | S : 'n t -> 'n s t
+
+  type two = z s s
+
+  type four = z s s s s
+
+  type five = z s s s s s
+
+  type six = z s s s s s s
+
+  type seven = z s s s s s s s
+
+  type eight = z s s s s s s s s
+
+  type fifteen = z s s s s s s s s s s s s s s s
+
+  type sixteen = z s s s s s s s s s s s s s s s s
+end
+
+module Vector = struct
+  type ('a, _) t =
+    | [] : ('a, Nat.z) t
+    | ( :: ) : 'a * ('a, 'n) t -> ('a, 'n Nat.s) t
+end
+
+module Shifted_value = struct
+  module Type1 = struct
+    module V1 = struct
+      type 'f t = Shifted_value of 'f
+    end
+  end
+end
+
+module Plonk_types = struct
+  module Features = struct
+    module V1 = struct
+      type 'bool t =
+        { range_check0 : 'bool
+        ; range_check1 : 'bool
+        ; foreign_field_add : 'bool
+        ; foreign_field_mul : 'bool
+        ; xor : 'bool
+        ; rot : 'bool
+        ; lookup : 'bool
+        ; runtime_tables : 'bool
+        }
+    end
+  end
+
+  module Openings = struct
+    module Bulletproof = struct
+      module V1 = struct
+        type ('g, 'fq) t =
+          { lr : ('g * 'g) array
+          ; z_1 : 'fq
+          ; z_2 : 'fq
+          ; delta : 'g
+          ; challenge_polynomial_commitment : 'g
+          }
+      end
+    end
+  end
+
+  module Evals = struct
+    module V2 = struct
+      type 'a t =
+        { w : ('a, Nat.fifteen) Vector.t
+        ; coefficients : ('a, Nat.fifteen) Vector.t
+        ; z : 'a
+        ; s : ('a, Nat.six) Vector.t
+        ; generic_selector : 'a
+        ; poseidon_selector : 'a
+        ; complete_add_selector : 'a
+        ; mul_selector : 'a
+        ; emul_selector : 'a
+        ; endomul_scalar_selector : 'a
+        ; range_check0_selector : 'a option
+        ; range_check1_selector : 'a option
+        ; foreign_field_add_selector : 'a option
+        ; foreign_field_mul_selector : 'a option
+        ; xor_selector : 'a option
+        ; rot_selector : 'a option
+        ; lookup_aggregation : 'a option
+        ; lookup_table : 'a option
+        ; lookup_sorted : ('a option, Nat.five) Vector.t
+        ; runtime_lookup_table : 'a option
+        ; runtime_lookup_table_selector : 'a option
+        ; xor_lookup_selector : 'a option
+        ; lookup_gate_lookup_selector : 'a option
+        ; range_check_lookup_selector : 'a option
+        ; foreign_field_mul_lookup_selector : 'a option
+        }
+    end
+  end
+
+  module All_evals = struct
+    module With_public_input = struct
+      module V1 = struct
+        type ('f, 'f_multi) t =
+          { public_input : 'f; evals : 'f_multi Evals.V2.t }
+      end
+    end
+
+    module V1 = struct
+      type ('f, 'f_multi) t =
+        { evals :
+            ('f_multi * 'f_multi, 'f_multi * 'f_multi) With_public_input.V1.t
+        ; ft_eval1 : 'f
+        }
+    end
+  end
+end
+
+module Plonk_verification_key_evals = struct
+  module V2 = struct
+    type 'comm t =
+      { sigma_comm : ('comm, Nat.seven) Vector.t
+      ; coefficients_comm : ('comm, Nat.fifteen) Vector.t
+      ; generic_comm : 'comm
+      ; psm_comm : 'comm
+      ; complete_add_comm : 'comm
+      ; mul_comm : 'comm
+      ; emul_comm : 'comm
+      ; endomul_scalar_comm : 'comm
+      }
+  end
+end

--- a/src/lib/mina_wire_types/snark_params.ml
+++ b/src/lib/mina_wire_types/snark_params.ml
@@ -1,6 +1,6 @@
 module Tick = struct
   module Field = struct
-    type t = Kimchi_pasta_basic.Fp.t
+    type t = Pasta_bindings.Fp.t
   end
 
   module Inner_curve = struct

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -37,4 +37,5 @@
   tuple_lib
   ppx_version.runtime
   bounded_types
+  mina_wire_types
   ))

--- a/src/lib/pickles_types/nat.ml
+++ b/src/lib/pickles_types/nat.ml
@@ -1,6 +1,6 @@
-type z = Z of z
+type z = Mina_wire_types.Pickles_types.Nat.z = Z of z
 
-type 'a s = Z | S of 'a
+type 'a s = 'a Mina_wire_types.Pickles_types.Nat.s = Z | S of 'a
 
 type _ t = Z : z t | S : 'n t -> 'n s t
 

--- a/src/lib/pickles_types/nat.mli
+++ b/src/lib/pickles_types/nat.mli
@@ -3,9 +3,9 @@
 (** {1 Type definitions} *)
 
 (** [z] is uninhabited *)
-type z = Z of z
+type z = Mina_wire_types.Pickles_types.Nat.z = Z of z
 
-type 'a s = Z | S of 'a
+type 'a s = 'a Mina_wire_types.Pickles_types.Nat.s = Z | S of 'a
 
 type _ t = Z : z t | S : 'n t -> 'n s t
 

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -206,6 +206,7 @@ module Features = struct
   module Stable = struct
     module V1 = struct
       type 'bool t =
+            'bool Mina_wire_types.Pickles_types.Plonk_types.Features.V1.t =
         { range_check0 : 'bool
         ; range_check1 : 'bool
         ; foreign_field_add : 'bool
@@ -475,7 +476,7 @@ module Evals = struct
   [%%versioned
   module Stable = struct
     module V2 = struct
-      type 'a t =
+      type 'a t = 'a Mina_wire_types.Pickles_types.Plonk_types.Evals.V2.t =
         { w : 'a Columns_vec.Stable.V1.t
         ; coefficients : 'a Columns_vec.Stable.V1.t
         ; z : 'a
@@ -1231,6 +1232,12 @@ module All_evals = struct
     module Stable = struct
       module V1 = struct
         type ('f, 'f_multi) t =
+              ( 'f
+              , 'f_multi )
+              Mina_wire_types.Pickles_types.Plonk_types.All_evals
+              .With_public_input
+              .V1
+              .t =
           { public_input : 'f; evals : 'f_multi Evals.Stable.V2.t }
         [@@deriving sexp, compare, yojson, hash, equal, hlist]
       end
@@ -1276,6 +1283,7 @@ module All_evals = struct
   end]
 
   type ('f, 'f_multi) t =
+        ('f, 'f_multi) Mina_wire_types.Pickles_types.Plonk_types.All_evals.V1.t =
     { evals : ('f_multi * 'f_multi, 'f_multi * 'f_multi) With_public_input.t
     ; ft_eval1 : 'f
     }
@@ -1327,6 +1335,10 @@ module Openings = struct
     module Stable = struct
       module V1 = struct
         type ('g, 'fq) t =
+              ( 'g
+              , 'fq )
+              Mina_wire_types.Pickles_types.Plonk_types.Openings.Bulletproof.V1
+              .t =
           { lr : ('g * 'g) Bounded_types.ArrayN16.Stable.V1.t
           ; z_1 : 'fq
           ; z_2 : 'fq

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -42,6 +42,7 @@ module Features : sig
   module Stable : sig
     module V1 : sig
       type 'bool t =
+            'bool Mina_wire_types.Pickles_types.Plonk_types.Features.V1.t =
         { range_check0 : 'bool
         ; range_check1 : 'bool
         ; foreign_field_add : 'bool
@@ -266,7 +267,7 @@ module Evals : sig
       -> unit
   end
 
-  type 'a t =
+  type 'a t = 'a Mina_wire_types.Pickles_types.Plonk_types.Evals.V2.t =
     { w : 'a Columns_vec.t
     ; coefficients : 'a Columns_vec.t
     ; z : 'a
@@ -319,6 +320,10 @@ module Openings : sig
     module Stable : sig
       module V1 : sig
         type ('g, 'fq) t =
+              ( 'g
+              , 'fq )
+              Mina_wire_types.Pickles_types.Plonk_types.Openings.Bulletproof.V1
+              .t =
           { lr : ('g * 'g) array
           ; z_1 : 'fq
           ; z_2 : 'fq
@@ -380,7 +385,13 @@ end
 
 module All_evals : sig
   module With_public_input : sig
-    type ('f, 'f_multi) t = { public_input : 'f; evals : 'f_multi Evals.t }
+    type ('f, 'f_multi) t =
+          ( 'f
+          , 'f_multi )
+          Mina_wire_types.Pickles_types.Plonk_types.All_evals.With_public_input
+          .V1
+          .t =
+      { public_input : 'f; evals : 'f_multi Evals.t }
 
     module In_circuit : sig
       type ('f, 'f_multi, 'bool) t =
@@ -417,6 +428,7 @@ module All_evals : sig
   end
 
   type ('f, 'f_multi) t =
+        ('f, 'f_multi) Mina_wire_types.Pickles_types.Plonk_types.All_evals.V1.t =
     { evals : ('f_multi * 'f_multi, 'f_multi * 'f_multi) With_public_input.t
     ; ft_eval1 : 'f
     }

--- a/src/lib/pickles_types/plonk_verification_key_evals.ml
+++ b/src/lib/pickles_types/plonk_verification_key_evals.ml
@@ -5,6 +5,7 @@ module H_list = Snarky_backendless.H_list
 module Stable = struct
   module V2 = struct
     type 'comm t =
+          'comm Mina_wire_types.Pickles_types.Plonk_verification_key_evals.V2.t =
       { sigma_comm : 'comm Plonk_types.Permuts_vec.Stable.V1.t
       ; coefficients_comm : 'comm Plonk_types.Columns_vec.Stable.V1.t
       ; generic_comm : 'comm

--- a/src/lib/pickles_types/plonk_verification_key_evals.mli
+++ b/src/lib/pickles_types/plonk_verification_key_evals.mli
@@ -3,6 +3,7 @@
 module Stable : sig
   module V2 : sig
     type 'comm t =
+          'comm Mina_wire_types.Pickles_types.Plonk_verification_key_evals.V2.t =
       { sigma_comm : 'comm Plonk_types.Permuts_vec.Stable.V1.t
       ; coefficients_comm : 'comm Plonk_types.Columns_vec.Stable.V1.t
       ; generic_comm : 'comm

--- a/src/lib/pickles_types/shifted_value.ml
+++ b/src/lib/pickles_types/shifted_value.ml
@@ -95,7 +95,8 @@ module Type1 = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type 'f t = Shifted_value of 'f
+      type 'f t = 'f Mina_wire_types.Pickles_types.Shifted_value.Type1.V1.t =
+        | Shifted_value of 'f
       [@@deriving sexp, compare, equal, yojson, hash]
     end
   end]

--- a/src/lib/pickles_types/shifted_value.mli
+++ b/src/lib/pickles_types/shifted_value.mli
@@ -81,7 +81,8 @@ module Type1 : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      type 'f t = Shifted_value of 'f
+      type 'f t = 'f Mina_wire_types.Pickles_types.Shifted_value.Type1.V1.t =
+        | Shifted_value of 'f
       [@@deriving sexp, compare, equal, yojson, hash]
     end
   end]

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -7,7 +7,9 @@ type z = Nat.z
 type 'a s = 'a Nat.s
 
 module T = struct
-  type ('a, _) t = [] : ('a, z) t | ( :: ) : 'a * ('a, 'n) t -> ('a, 'n s) t
+  type ('a, 'n) t = ('a, 'n) Mina_wire_types.Pickles_types.Vector.t =
+    | [] : ('a, z) t
+    | ( :: ) : 'a * ('a, 'n) t -> ('a, 'n s) t
 end
 
 include T

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -8,7 +8,7 @@
 
 (** Encode a vector at the type level with its size *)
 module T : sig
-  type ('a, _) t =
+  type ('a, 'b) t = ('a, 'b) Mina_wire_types.Pickles_types.Vector.t =
     | [] : ('a, Nat.z) t
     | ( :: ) : 'a * ('a, 'n) t -> ('a, 'n Nat.s) t
 end


### PR DESCRIPTION
This PR moves the `Pickles_types` type definitions into the `Mina_wire_types` library.
This unblocks a dependency cycle, which in turn allows us to use concrete instances for `Typ.t`s etc. when we're communicating across the FFI boundary with rust.