### PR TITLE
pass BRANCH_NAME to export-git-env-vars script properly

### DIFF
--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -9,7 +9,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 # In case of running this script on detached head, script has difficulties in finding out
 # what is the current branch.
 if [[ -n "$BRANCH_NAME" ]]; then 
-  source ${SCRIPTPATH}/../export-git-env-vars.sh -b $BRANCH_NAME
+  BRANCH_NAME="$BRANCH_NAME" source ${SCRIPTPATH}/../export-git-env-vars.sh
 else
   source ${SCRIPTPATH}/../export-git-env-vars.sh
 fi 


### PR DESCRIPTION
Another slight adjustment for HEAD issue which is hard to track but easy to patch post mortem