### PR TITLE
Remove hardcoded values for `zk_rows` and `num_chunks` in Pickles code

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -202,7 +202,8 @@ module Protocol = struct
         -> int
         -> SRS.Fp.t
         -> t
-        = "caml_pasta_fp_plonk_index_create_bytecode" "caml_pasta_fp_plonk_index_create"
+        = "caml_pasta_fp_plonk_index_create_bytecode"
+          "caml_pasta_fp_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fp_plonk_index_max_degree"
 
@@ -236,7 +237,8 @@ module Protocol = struct
         -> int
         -> SRS.Fq.t
         -> t
-        = "caml_pasta_fq_plonk_index_create_bytecode" "caml_pasta_fq_plonk_index_create"
+        = "caml_pasta_fq_plonk_index_create_bytecode"
+          "caml_pasta_fq_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fq_plonk_index_max_degree"
 

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -202,8 +202,7 @@ module Protocol = struct
         -> int
         -> SRS.Fp.t
         -> t
-        = "caml_pasta_fp_plonk_index_create_bytecode"
-          "caml_pasta_fp_plonk_index_create"
+        = "caml_pasta_fp_plonk_index_create_bytecode" "caml_pasta_fp_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fp_plonk_index_max_degree"
 
@@ -237,8 +236,7 @@ module Protocol = struct
         -> int
         -> SRS.Fq.t
         -> t
-        = "caml_pasta_fq_plonk_index_create_bytecode"
-          "caml_pasta_fq_plonk_index_create"
+        = "caml_pasta_fq_plonk_index_create_bytecode" "caml_pasta_fq_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fq_plonk_index_max_degree"
 

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -412,8 +412,8 @@ struct
       }
     in
     Timer.start __LOC__ ;
-    let module Max_proofs_verified = (val max_proofs_verified : Nat.Add.Intf
-                                        with type n = max_proofs_verified)
+    let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
+                                         with type n = max_proofs_verified )
     in
     let T = Max_proofs_verified.eq in
     let choices = choices ~self in
@@ -870,7 +870,7 @@ struct
             ~f:
               (Promise.map ~f:(fun x ->
                    Plonk_verification_key_evals.map
-                     (Verification_key.commitments x) ~f:(fun x -> [| x |] ) ) )
+                     (Verification_key.commitments x) ~f:(fun x -> [| x |]) ) )
       ; wrap_vk = Lazy.map wrap_vk ~f:(Promise.map ~f:Verification_key.index)
       ; wrap_domains
       ; step_domains
@@ -957,7 +957,7 @@ module Side_loaded = struct
     in
     (* TODO: This should be the actual max width on a per proof basis *)
     let max_proofs_verified =
-      ( module Verification_key.Max_width : Nat.Intf
+      (module Verification_key.Max_width : Nat.Intf
         with type n = Verification_key.Max_width.n )
     in
     with_return (fun { return } ->
@@ -1152,9 +1152,9 @@ let compile_with_wrap_main_override_promise :
           domains
           |> Vector.reduce_exn
                ~f:(fun
-                  { h = Pow_2_roots_of_unity d1 }
-                  { h = Pow_2_roots_of_unity d2 }
-                -> { h = Pow_2_roots_of_unity (Int.max d1 d2) } )
+                    { h = Pow_2_roots_of_unity d1 }
+                    { h = Pow_2_roots_of_unity d2 }
+                  -> { h = Pow_2_roots_of_unity (Int.max d1 d2) } )
         in
         Some
           { Verify.Instance.num_chunks

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -412,8 +412,8 @@ struct
       }
     in
     Timer.start __LOC__ ;
-    let module Max_proofs_verified =
-      (val max_proofs_verified : Nat.Add.Intf with type n = max_proofs_verified)
+    let module Max_proofs_verified = (val max_proofs_verified : Nat.Add.Intf
+                                        with type n = max_proofs_verified)
     in
     let T = Max_proofs_verified.eq in
     let choices = choices ~self in
@@ -870,8 +870,7 @@ struct
             ~f:
               (Promise.map ~f:(fun x ->
                    Plonk_verification_key_evals.map
-                     (Verification_key.commitments x) ~f:(fun x -> [| x |] ) )
-              )
+                     (Verification_key.commitments x) ~f:(fun x -> [| x |] ) ) )
       ; wrap_vk = Lazy.map wrap_vk ~f:(Promise.map ~f:Verification_key.index)
       ; wrap_domains
       ; step_domains
@@ -1153,9 +1152,9 @@ let compile_with_wrap_main_override_promise :
           domains
           |> Vector.reduce_exn
                ~f:(fun
-                   { h = Pow_2_roots_of_unity d1 }
-                   { h = Pow_2_roots_of_unity d2 }
-                 -> { h = Pow_2_roots_of_unity (Int.max d1 d2) } )
+                  { h = Pow_2_roots_of_unity d1 }
+                  { h = Pow_2_roots_of_unity d2 }
+                -> { h = Pow_2_roots_of_unity (Int.max d1 d2) } )
         in
         Some
           { Verify.Instance.num_chunks

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1837,8 +1837,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 Lazy.map wrap_vk ~f:(Promise.map ~f:Verification_key.index)
             ; wrap_domains
             ; step_domains
-            ; num_chunks = 1
-            ; zk_rows = 3
+            ; num_chunks = Plonk_checks.num_chunks_by_default
+            ; zk_rows = Plonk_checks.zk_rows_by_default
             }
           in
           Types_map.add_exn self data ;

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -254,8 +254,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
         ; branches = Verification_key.Max_branches.n
         ; feature_flags =
             Plonk_types.(Features.to_full ~or_:Opt.Flag.( ||| ) feature_flags)
-        ; num_chunks = 1
-        ; zk_rows = 3
+        ; num_chunks = Plonk_checks.num_chunks_by_default
+        ; zk_rows = Plonk_checks.zk_rows_by_default
         }
 
     module Proof = struct
@@ -278,7 +278,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
       in
       (* TODO: This should be the actual max width on a per proof basis *)
       let max_proofs_verified =
-        (module Verification_key.Max_width : Nat.Intf
+        ( module Verification_key.Max_width : Nat.Intf
           with type n = Verification_key.Max_width.n )
       in
       with_return (fun { return } ->
@@ -446,7 +446,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ))
+              : Field.t * Field.t ) )
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -794,7 +794,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                           let proof_must_verify = Boolean.not is_base_case in
                           let self =
                             Field.(
-                              if_ is_base_case ~then_:zero ~else_:(one + prev))
+                              if_ is_base_case ~then_:zero ~else_:(one + prev) )
                           in
                           Promise.return
                             { Inductive_rule.previous_proof_statements =
@@ -1459,7 +1459,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               { Tick.Proof.Challenge_polynomial.commitment
                               ; challenges = Vector.to_array cs
                               } )
-                          |> to_list)
+                          |> to_list )
                         public_input proof
                     in
                     let x_hat = O.(p_eval_1 o, p_eval_2 o) in
@@ -1725,9 +1725,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
                       in
                       Common.time "wrap proof" (fun () ->
                           Impls.Wrap.generate_witness_conv
-                            ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs
-                                    ; public_inputs
-                                    } () ->
+                            ~f:(fun
+                                { Impls.Wrap.Proof_inputs.auxiliary_inputs
+                                ; public_inputs
+                                }
+                                ()
+                              ->
                               Backend.Tock.Proof.create_async
                                 ~primary:public_inputs
                                 ~auxiliary:auxiliary_inputs pk
@@ -2014,7 +2017,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ))
+              : Field.t * Field.t ) )
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -2190,7 +2193,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               Side_loaded.in_prover side_loaded_tag vk ) ;
                           let vk =
                             exists Side_loaded_verification_key.typ
-                              ~compute:(fun () -> As_prover.Ref.get vk)
+                              ~compute:(fun () -> As_prover.Ref.get vk )
                           in
                           Side_loaded.in_circuit side_loaded_tag vk ;
                           let is_base_case = Field.equal Field.zero self in
@@ -2323,7 +2326,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ))
+              : Field.t * Field.t ) )
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -2502,7 +2505,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               Side_loaded.in_prover side_loaded_tag vk ) ;
                           let vk =
                             exists Side_loaded_verification_key.typ
-                              ~compute:(fun () -> As_prover.Ref.get vk)
+                              ~compute:(fun () -> As_prover.Ref.get vk )
                           in
                           Side_loaded.in_circuit side_loaded_tag vk ;
                           let is_base_case = Field.equal Field.zero self in

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -278,7 +278,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
       in
       (* TODO: This should be the actual max width on a per proof basis *)
       let max_proofs_verified =
-        ( module Verification_key.Max_width : Nat.Intf
+        (module Verification_key.Max_width : Nat.Intf
           with type n = Verification_key.Max_width.n )
       in
       with_return (fun { return } ->
@@ -446,7 +446,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ) )
+              : Field.t * Field.t ))
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -794,7 +794,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                           let proof_must_verify = Boolean.not is_base_case in
                           let self =
                             Field.(
-                              if_ is_base_case ~then_:zero ~else_:(one + prev) )
+                              if_ is_base_case ~then_:zero ~else_:(one + prev))
                           in
                           Promise.return
                             { Inductive_rule.previous_proof_statements =
@@ -1459,7 +1459,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               { Tick.Proof.Challenge_polynomial.commitment
                               ; challenges = Vector.to_array cs
                               } )
-                          |> to_list )
+                          |> to_list)
                         public_input proof
                     in
                     let x_hat = O.(p_eval_1 o, p_eval_2 o) in
@@ -1725,12 +1725,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
                       in
                       Common.time "wrap proof" (fun () ->
                           Impls.Wrap.generate_witness_conv
-                            ~f:(fun
-                                { Impls.Wrap.Proof_inputs.auxiliary_inputs
-                                ; public_inputs
-                                }
-                                ()
-                              ->
+                            ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs
+                                    ; public_inputs
+                                    } () ->
                               Backend.Tock.Proof.create_async
                                 ~primary:public_inputs
                                 ~auxiliary:auxiliary_inputs pk
@@ -2017,7 +2014,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ) )
+              : Field.t * Field.t ))
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -2193,7 +2190,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               Side_loaded.in_prover side_loaded_tag vk ) ;
                           let vk =
                             exists Side_loaded_verification_key.typ
-                              ~compute:(fun () -> As_prover.Ref.get vk )
+                              ~compute:(fun () -> As_prover.Ref.get vk)
                           in
                           Side_loaded.in_circuit side_loaded_tag vk ;
                           let is_base_case = Field.equal Field.zero self in
@@ -2326,7 +2323,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           ignore
             ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
                 (Kimchi_backend_common.Scalar_challenge.create x)
-              : Field.t * Field.t ) )
+              : Field.t * Field.t ))
 
       module No_recursion = struct
         let[@warning "-45"] tag, _, p, Provers.[ step ] =
@@ -2505,7 +2502,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                               Side_loaded.in_prover side_loaded_tag vk ) ;
                           let vk =
                             exists Side_loaded_verification_key.typ
-                              ~compute:(fun () -> As_prover.Ref.get vk )
+                              ~compute:(fun () -> As_prover.Ref.get vk)
                           in
                           Side_loaded.in_circuit side_loaded_tag vk ;
                           let is_base_case = Field.equal Field.zero self in

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -5,9 +5,9 @@ module Scalars = Scalars
 module Domain = Domain
 module Opt = Opt
 
-let zk_rows_by_default = 3
-
 let num_chunks_by_default = 1
+
+let zk_rows_by_default = 3
 
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -5,6 +5,10 @@ module Scalars = Scalars
 module Domain = Domain
 module Opt = Opt
 
+let zk_rows_by_default = 3
+
+let num_chunks_by_default = 1
+
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Plonk_types.Shifts.t
@@ -248,7 +252,7 @@ let scalars_env (type boolean t) (module B : Bool_intf with type t = boolean)
       let next_term = ref omega_to_minus_2 in
       let omega_to_intermediate_powers =
         Array.init
-          Stdlib.(zk_rows - 3)
+          Stdlib.(zk_rows - zk_rows_by_default)
           ~f:(fun _ ->
             let term = !next_term in
             next_term := term * omega_to_minus_1 ;

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -1,10 +1,10 @@
 open Pickles_types
 
-(** The number of rows required for zero knowledge in circuits with one single chunk *)
-val zk_rows_by_default : int
-
 (** The default number of chunks in a circuit is one (< 2^16 rows) *)
 val num_chunks_by_default : int
+
+(** The number of rows required for zero knowledge in circuits with one single chunk *)
+val zk_rows_by_default : int
 
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -1,5 +1,9 @@
 open Pickles_types
 
+val zk_rows_by_default : int
+
+val num_chunks_by_default : int
+
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Pickles_types.Plonk_types.Shifts.t
@@ -93,7 +97,9 @@ val scalars_env :
   -> ('t * 't, 'a) Pickles_types.Plonk_types.Evals.In_circuit.t
   -> 't Scalars.Env.t
 
-module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : sig
+module Make
+    (Shifted_value : Pickles_types.Shifted_value.S)
+    (_ : Scalars.S) : sig
   val ft_eval0 :
        't field
     -> domain:< shifts : 't array ; .. >

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -1,7 +1,9 @@
 open Pickles_types
 
+(** The number of rows required for zero knowledge in circuits with one single chunk *)
 val zk_rows_by_default : int
 
+(** The default number of chunks in a circuit is one (< 2^16 rows) *)
 val num_chunks_by_default : int
 
 type 'field plonk_domain =

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -99,8 +99,8 @@ val scalars_env :
   -> ('t * 't, 'a) Pickles_types.Plonk_types.Evals.In_circuit.t
   -> 't Scalars.Env.t
 
-  module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : sig
-    val ft_eval0 :
+module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : sig
+  val ft_eval0 :
        't field
     -> domain:< shifts : 't array ; .. >
     -> env:'t Scalars.Env.t

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -99,10 +99,8 @@ val scalars_env :
   -> ('t * 't, 'a) Pickles_types.Plonk_types.Evals.In_circuit.t
   -> 't Scalars.Env.t
 
-module Make
-    (Shifted_value : Pickles_types.Shifted_value.S)
-    (_ : Scalars.S) : sig
-  val ft_eval0 :
+  module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : sig
+    val ft_eval0 :
        't field
     -> domain:< shifts : 't array ; .. >
     -> env:'t Scalars.Env.t

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -117,7 +117,10 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
   let g0 = Tock.Curve.(to_affine_exn one) in
   let g len = Array.create ~len g0 in
   let tick_arr len = Array.init len ~f:(fun _ -> tick ()) in
-  let lengths = Commitment_lengths.default ~num_chunks:1 (* TODO *) in
+  let lengths =
+    Commitment_lengths.default
+      ~num_chunks:Plonk_checks.num_chunks_by_default (* TODO *)
+  in
   T
     { statement =
         { proof_state =

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -354,6 +354,9 @@ let typ : (Checked.t, t) Impls.Step.Typ.t =
     ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_of_hlist:(fun _ ->
       failwith "Side_loaded_verification_key: value_of_hlist" )
-    ~value_to_hlist:(fun
-        { Poly.wrap_index; actual_wrap_domain_size; max_proofs_verified; _ } ->
+      ~value_to_hlist:(fun { Poly.wrap_index
+                           ; actual_wrap_domain_size
+                           ; max_proofs_verified
+                           ; _
+                           } ->
       [ max_proofs_verified; actual_wrap_domain_size; wrap_index ] )

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -354,9 +354,9 @@ let typ : (Checked.t, t) Impls.Step.Typ.t =
     ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_of_hlist:(fun _ ->
       failwith "Side_loaded_verification_key: value_of_hlist" )
-      ~value_to_hlist:(fun { Poly.wrap_index
-                           ; actual_wrap_domain_size
-                           ; max_proofs_verified
-                           ; _
-                           } ->
+    ~value_to_hlist:(fun { Poly.wrap_index
+                         ; actual_wrap_domain_size
+                         ; max_proofs_verified
+                         ; _
+                         } ->
       [ max_proofs_verified; actual_wrap_domain_size; wrap_index ] )

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -229,7 +229,7 @@ module Stable = struct
                    } )
               ; shifts = Common.tock_shifts ~log2_size
               ; lookup_index = None
-              ; zk_rows = 3
+              ; zk_rows = Plonk_checks.zk_rows_by_default
               } )
         in
         { Poly.max_proofs_verified
@@ -354,9 +354,6 @@ let typ : (Checked.t, t) Impls.Step.Typ.t =
     ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_of_hlist:(fun _ ->
       failwith "Side_loaded_verification_key: value_of_hlist" )
-    ~value_to_hlist:(fun { Poly.wrap_index
-                         ; actual_wrap_domain_size
-                         ; max_proofs_verified
-                         ; _
-                         } ->
+    ~value_to_hlist:(fun
+        { Poly.wrap_index; actual_wrap_domain_size; max_proofs_verified; _ } ->
       [ max_proofs_verified; actual_wrap_domain_size; wrap_index ] )

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -11,7 +11,8 @@ open Common
 (* This contains the "step" prover *)
 
 module Make
-    (A : T0) (A_value : sig
+    (A : T0)
+    (A_value : sig
       type t
     end)
     (Max_proofs_verified : Nat.Add.Intf_transparent) =
@@ -160,7 +161,7 @@ struct
         let zeta = to_field plonk0.zeta in
         let zetaw =
           Tick.Field.(
-            zeta * domain_generator ~log2_size:(Domain.log2_size domain))
+            zeta * domain_generator ~log2_size:(Domain.log2_size domain) )
         in
         let combined_evals =
           Plonk_checks.evals_of_split_evals
@@ -454,7 +455,7 @@ struct
           (module Env_bool)
           (module Env_field)
           ~domain:tock_domain ~srs_length_log2:Common.Max_degree.wrap_log2
-          ~zk_rows:3
+          ~zk_rows:Plonk_checks.zk_rows_by_default
           ~field_of_hex:(fun s ->
             Kimchi_pasta.Pasta.Bigint256.of_hex_string s
             |> Kimchi_pasta.Pasta.Fq.of_bigint )
@@ -797,7 +798,7 @@ struct
                { Tick.Proof.Challenge_polynomial.commitment
                ; challenges = Vector.to_array chals
                } )
-           |> to_list) )
+           |> to_list ) )
     in
     let%map.Promise ( (next_proof : Tick.Proof.with_public_evals)
                     , _next_statement_hashed ) =

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -11,8 +11,7 @@ open Common
 (* This contains the "step" prover *)
 
 module Make
-    (A : T0)
-    (A_value : sig
+    (A : T0) (A_value : sig
       type t
     end)
     (Max_proofs_verified : Nat.Add.Intf_transparent) =
@@ -161,7 +160,7 @@ struct
         let zeta = to_field plonk0.zeta in
         let zetaw =
           Tick.Field.(
-            zeta * domain_generator ~log2_size:(Domain.log2_size domain) )
+            zeta * domain_generator ~log2_size:(Domain.log2_size domain))
         in
         let combined_evals =
           Plonk_checks.evals_of_split_evals
@@ -798,7 +797,7 @@ struct
                { Tick.Proof.Challenge_polynomial.commitment
                ; challenges = Vector.to_array chals
                } )
-           |> to_list ) )
+           |> to_list) )
     in
     let%map.Promise ( (next_proof : Tick.Proof.with_public_evals)
                     , _next_statement_hashed ) =

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -193,8 +193,8 @@ let create
         ; num_chunks
         ; zk_rows =
             ( match num_chunks with
-            | 1 ->
-                3
+            | 1 (* cannot match with Plonk_checks.num_chunks_by_default *) ->
+                Plonk_checks.zk_rows_by_default
             | num_chunks ->
                 let permuts = 7 in
                 ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts )

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -118,7 +118,7 @@ let verify_one ~srs
           let must_verify = read Boolean.typ must_verify in
           printf "finalized: %b\n%!" finalized ;
           printf "verified: %b\n%!" verified ;
-          printf "must_verify: %b\n\n%!" must_verify) ;
+          printf "must_verify: %b\n\n%!" must_verify ) ;
   (chals, Boolean.(verified &&& finalized ||| not must_verify))
 
 (* The SNARK function corresponding to the input inductive rule. *)
@@ -266,8 +266,8 @@ let step_main :
         let f = Fn.id
       end)
   in
-  let (input_typ, output_typ)
-        : (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
+  let (input_typ, output_typ) :
+      (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
     match public_input with
     | Input typ ->
         (typ, Typ.unit)
@@ -279,8 +279,8 @@ let step_main :
   let main () : _ Types.Step.Statement.t Promise.t =
     let open Impls.Step in
     let logger = Context_logger.get () in
-    let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
-                                         with type n = max_proofs_verified )
+    let module Max_proofs_verified =
+      (val max_proofs_verified : Nat.Add.Intf with type n = max_proofs_verified)
     in
     let T = Max_proofs_verified.eq in
     let app_state = exists input_typ ~request:(fun () -> Req.App_state) in
@@ -351,7 +351,7 @@ let step_main :
               Req.Compute_prev_proof_parts previous_proof_statements )
         in
         let dlog_plonk_index =
-          let num_chunks = (* TODO *) 1 in
+          let num_chunks = (* TODO *) Plonk_checks.num_chunks_by_default in
           exists
             ~request:(fun () -> Req.Wrap_index)
             (Plonk_verification_key_evals.typ
@@ -369,7 +369,7 @@ let step_main :
             ~request:(fun () -> Req.Unfinalized_proofs)
         and messages_for_next_wrap_proof =
           exists (Vector.typ Digest.typ Max_proofs_verified.n)
-            ~request:(fun () -> Req.Messages_for_next_wrap_proof)
+            ~request:(fun () -> Req.Messages_for_next_wrap_proof )
         and actual_wrap_domains =
           exists
             (Vector.typ (Typ.Internal.ref ()) (Length.to_nat proofs_verified))

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -118,7 +118,7 @@ let verify_one ~srs
           let must_verify = read Boolean.typ must_verify in
           printf "finalized: %b\n%!" finalized ;
           printf "verified: %b\n%!" verified ;
-          printf "must_verify: %b\n\n%!" must_verify ) ;
+          printf "must_verify: %b\n\n%!" must_verify) ;
   (chals, Boolean.(verified &&& finalized ||| not must_verify))
 
 (* The SNARK function corresponding to the input inductive rule. *)
@@ -266,8 +266,8 @@ let step_main :
         let f = Fn.id
       end)
   in
-  let (input_typ, output_typ) :
-      (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
+  let (input_typ, output_typ)
+        : (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
     match public_input with
     | Input typ ->
         (typ, Typ.unit)
@@ -279,8 +279,8 @@ let step_main :
   let main () : _ Types.Step.Statement.t Promise.t =
     let open Impls.Step in
     let logger = Context_logger.get () in
-    let module Max_proofs_verified =
-      (val max_proofs_verified : Nat.Add.Intf with type n = max_proofs_verified)
+    let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
+                                         with type n = max_proofs_verified )
     in
     let T = Max_proofs_verified.eq in
     let app_state = exists input_typ ~request:(fun () -> Req.App_state) in
@@ -369,7 +369,7 @@ let step_main :
             ~request:(fun () -> Req.Unfinalized_proofs)
         and messages_for_next_wrap_proof =
           exists (Vector.typ Digest.typ Max_proofs_verified.n)
-            ~request:(fun () -> Req.Messages_for_next_wrap_proof )
+            ~request:(fun () -> Req.Messages_for_next_wrap_proof)
         and actual_wrap_domains =
           exists
             (Vector.typ (Typ.Internal.ref ()) (Length.to_nat proofs_verified))

--- a/src/lib/pickles/unfinalized.ml
+++ b/src/lib/pickles/unfinalized.ml
@@ -69,7 +69,8 @@ module Constant = struct
          Plonk_checks.scalars_env
            (module Env_bool)
            (module Env_field)
-           ~srs_length_log2:Common.Max_degree.wrap_log2 ~zk_rows:3
+           ~srs_length_log2:Common.Max_degree.wrap_log2
+           ~zk_rows:Plonk_checks.zk_rows_by_default
            ~endo:Endo.Wrap_inner_curve.base ~mds:Tock_field_sponge.params.mds
            ~field_of_hex:
              (Core_kernel.Fn.compose Tock.Field.of_bigint (fun x ->

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -197,7 +197,7 @@ module Stable = struct
              } )
         ; shifts = Common.tock_shifts ~log2_size
         ; lookup_index = None
-        ; zk_rows = 3
+        ; zk_rows = Plonk_checks.zk_rows_by_default
         }
       in
       { commitments = c; data = d; index = t }

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -41,22 +41,22 @@ let verify_heterogenous (ts : Instance.t list) =
   let _computed_bp_chals, deferred_values =
     List.map ts
       ~f:(fun
-          (T
-            ( _max_proofs_verified
-            , _statement
-            , chunking_data
-            , key
-            , _app_state
-            , T
-                { statement =
-                    { proof_state
-                    ; messages_for_next_step_proof =
-                        { old_bulletproof_challenges; _ }
-                    }
-                ; prev_evals = evals
-                ; proof = _
-                } ) )
-        ->
+           (T
+             ( _max_proofs_verified
+             , _statement
+             , chunking_data
+             , key
+             , _app_state
+             , T
+                 { statement =
+                     { proof_state
+                     ; messages_for_next_step_proof =
+                         { old_bulletproof_challenges; _ }
+                     }
+                 ; prev_evals = evals
+                 ; proof = _
+                 } ) )
+         ->
         Timer.start __LOC__ ;
         let non_chunking, expected_num_chunks =
           let expected_num_chunks =
@@ -167,15 +167,15 @@ let verify_heterogenous (ts : Instance.t list) =
   let batch_verify_inputs =
     List.map2_exn ts deferred_values
       ~f:(fun
-          (T
-            ( (module Max_proofs_verified)
-            , (module A_value)
-            , _chunking_data
-            , key
-            , app_state
-            , T t ) )
-          deferred_values
-        ->
+           (T
+             ( (module Max_proofs_verified)
+             , (module A_value)
+             , _chunking_data
+             , key
+             , app_state
+             , T t ) )
+           deferred_values
+         ->
         let prepared_statement : _ Types.Wrap.Statement.In_circuit.t =
           { messages_for_next_step_proof =
               Common.hash_messages_for_next_step_proof

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -60,8 +60,8 @@ let verify_heterogenous (ts : Instance.t list) =
         Timer.start __LOC__ ;
         let non_chunking, expected_num_chunks =
           let expected_num_chunks =
-            Option.value_map ~default:1 chunking_data ~f:(fun x ->
-                x.Instance.num_chunks )
+            Option.value_map ~default:Plonk_checks.num_chunks_by_default
+              chunking_data ~f:(fun x -> x.Instance.num_chunks )
           in
           let exception Is_chunked in
           match

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -41,22 +41,22 @@ let verify_heterogenous (ts : Instance.t list) =
   let _computed_bp_chals, deferred_values =
     List.map ts
       ~f:(fun
-           (T
-             ( _max_proofs_verified
-             , _statement
-             , chunking_data
-             , key
-             , _app_state
-             , T
-                 { statement =
-                     { proof_state
-                     ; messages_for_next_step_proof =
-                         { old_bulletproof_challenges; _ }
-                     }
-                 ; prev_evals = evals
-                 ; proof = _
-                 } ) )
-         ->
+          (T
+            ( _max_proofs_verified
+            , _statement
+            , chunking_data
+            , key
+            , _app_state
+            , T
+                { statement =
+                    { proof_state
+                    ; messages_for_next_step_proof =
+                        { old_bulletproof_challenges; _ }
+                    }
+                ; prev_evals = evals
+                ; proof = _
+                } ) )
+        ->
         Timer.start __LOC__ ;
         let non_chunking, expected_num_chunks =
           let expected_num_chunks =
@@ -117,8 +117,8 @@ let verify_heterogenous (ts : Instance.t list) =
         Timer.clock __LOC__ ;
         let deferred_values =
           let zk_rows =
-            Option.value_map ~default:3 chunking_data ~f:(fun x ->
-                x.Instance.zk_rows )
+            Option.value_map ~default:Plonk_checks.zk_rows_by_default
+              chunking_data ~f:(fun x -> x.Instance.zk_rows )
           in
           Wrap_deferred_values.expand_deferred ~evals ~zk_rows
             ~old_bulletproof_challenges ~proof_state
@@ -167,15 +167,15 @@ let verify_heterogenous (ts : Instance.t list) =
   let batch_verify_inputs =
     List.map2_exn ts deferred_values
       ~f:(fun
-           (T
-             ( (module Max_proofs_verified)
-             , (module A_value)
-             , _chunking_data
-             , key
-             , app_state
-             , T t ) )
-           deferred_values
-         ->
+          (T
+            ( (module Max_proofs_verified)
+            , (module A_value)
+            , _chunking_data
+            , key
+            , app_state
+            , T t ) )
+          deferred_values
+        ->
         let prepared_statement : _ Types.Wrap.Statement.In_circuit.t =
           { messages_for_next_step_proof =
               Common.hash_messages_for_next_step_proof

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -29,7 +29,9 @@ struct
       lazy
         (Promise.return
            (Vector.init num_choices ~f:(fun _ ->
-                let num_chunks = (* TODO *) 1 in
+                let num_chunks =
+                  (* TODO *) Plonk_checks.num_chunks_by_default
+                in
                 let g =
                   Array.init num_chunks ~f:(fun _ ->
                       Backend.Tock.Inner_curve.(to_affine_exn one) )

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -38,7 +38,9 @@ let typ : (Checked.t, Constant.t) Typ.t =
         (module Impl)
         Inner_curve.typ Plonk_types.Features.Full.none ~bool:Boolean.typ
         ~dummy:Inner_curve.Params.one
-        ~commitment_lengths:(Commitment_lengths.default ~num_chunks:1)
+        ~commitment_lengths:
+          (Commitment_lengths.default
+             ~num_chunks:Plonk_checks.num_chunks_by_default )
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)
         ( Typ.transport Other_field.typ
             ~there:(fun x ->

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -254,7 +254,9 @@ struct
                      Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t)) )
                in
                let none_sum =
-                 let num_chunks = (* TODO *) 1 in
+                 let num_chunks =
+                   (* TODO *) Plonk_checks.num_chunks_by_default
+                 in
                  Option.map is_none ~f:(fun (b : Boolean.var) ->
                      Array.init num_chunks ~f:(fun _ ->
                          Double.map Inner_curve.one ~f:(( * ) (b :> t)) ) )

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -94,7 +94,7 @@ struct
             printf
               !"%s: %{sexp:Backend.Tock.Field.t}, %{sexp:Backend.Tock.Field.t}\n\
                 %!"
-              lab (read_var x) (read_var y))
+              lab (read_var x) (read_var y) )
 
   let _print_w lab gs =
     if Import.debug then
@@ -111,7 +111,7 @@ struct
             printf "in-snark %s:%!" lab ;
             Field.Constant.print
               (Field.Constant.project (List.map ~f:(read Boolean.typ) x)) ;
-            printf "\n%!")
+            printf "\n%!" )
 
   let print_bool lab x =
     if debug then
@@ -264,8 +264,8 @@ struct
                  |> List.map ~f:(fun ((b : Boolean.var), g) ->
                         (b, Array.map g ~f:(Double.map ~f:(( * ) (b :> t)))) )
                  |> List.reduce
-                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
-                         ->
+                      ~f:(fun
+                          ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2) ->
                         ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
                         , Array.map2_exn ~f:(Double.map2 ~f:( + )) g1 g2 ) )
                  |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
@@ -277,8 +277,8 @@ struct
                         ( Boolean.Unsafe.of_cvar Field.(mul (b :> t) (b_g :> t))
                         , Array.map g ~f:(Double.map ~f:(( * ) (b :> t))) ) )
                  |> List.reduce
-                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
-                         ->
+                      ~f:(fun
+                          ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2) ->
                         ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
                         , Array.map2_exn ~f:(Double.map2 ~f:( + )) g1 g2 ) )
                  |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
@@ -331,8 +331,7 @@ struct
     |> Vector.map2
          (which_branch :> (Boolean.var, n) Vector.t)
          ~f:(fun b pts ->
-           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y))
-           )
+           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y)) )
     |> Vector.reduce_exn ~f:(Array.map2_exn ~f:(Double.map2 ~f:Field.( + )))
 
   let scaled_lagrange (type n) c
@@ -355,8 +354,7 @@ struct
     |> Vector.map2
          (which_branch :> (Boolean.var, n) Vector.t)
          ~f:(fun b pts ->
-           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y))
-           )
+           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y)) )
     |> Vector.reduce_exn ~f:(Array.map2_exn ~f:(Double.map2 ~f:Field.( + )))
 
   let lagrange_with_correction (type n) ~input_length
@@ -446,7 +444,7 @@ struct
             Field.(
               (x * x * x)
               + (constant Inner_curve.Params.a * x)
-              + constant Inner_curve.Params.b) )
+              + constant Inner_curve.Params.b ) )
         |> unstage )
     in
     fun x -> Lazy.force f x
@@ -495,8 +493,11 @@ struct
         Pcs_batch.combine_split_commitments batch
           ~reduce_with_degree_bound:(fun _ -> assert false)
           ~reduce_without_degree_bound:(fun x -> [ x ])
-          ~scale_and_add:(fun ~(acc : Curve_opt.t) ~xi
-                              (p : (Point.t array, Boolean.var) Opt.t) ->
+          ~scale_and_add:(fun
+              ~(acc : Curve_opt.t)
+              ~xi
+              (p : (Point.t array, Boolean.var) Opt.t)
+            ->
             (* match acc.non_zero, keep with
                | false, false -> acc
                | true, false -> acc
@@ -512,7 +513,7 @@ struct
                     ~else_:
                       ((* In this branch, the accumulator was zero, so there is no harm in
                           putting the potentially junk underlying point here. *)
-                       Point.underlying p ))
+                       Point.underlying p ) )
               in
               let point = ref base_point in
               for i = Array.length p - 2 downto 0 do
@@ -700,9 +701,10 @@ struct
       (m2 : (_, Scalar_challenge.t, _) Plonk.Minimal.In_circuit.t) =
     iter2 m1 m2
       ~chal:(fun c1 c2 -> Field.Assert.equal c1 c2)
-      ~scalar_chal:(fun ({ inner = t1 } : _ Import.Scalar_challenge.t)
-                        ({ inner = t2 } : Scalar_challenge.t) ->
-        Field.Assert.equal t1 t2 )
+      ~scalar_chal:(fun
+          ({ inner = t1 } : _ Import.Scalar_challenge.t)
+          ({ inner = t2 } : Scalar_challenge.t)
+        -> Field.Assert.equal t1 t2 )
 
   let index_to_field_elements ~g (m : _ Plonk_verification_key_evals.Step.t) =
     let { Plonk_verification_key_evals.Step.sigma_comm
@@ -857,14 +859,14 @@ struct
                 | `Field (Constant c, _) ->
                     First
                       ( if Field.Constant.(equal zero) c then None
-                      else if Field.Constant.(equal one) c then
-                        Some (lagrange ~domain srs i)
-                      else
-                        Some
-                          (scaled_lagrange ~domain
-                             (Inner_curve.Constant.Scalar.project
-                                (Field.Constant.unpack c) )
-                             srs i ) )
+                        else if Field.Constant.(equal one) c then
+                          Some (lagrange ~domain srs i)
+                        else
+                          Some
+                            (scaled_lagrange ~domain
+                               (Inner_curve.Constant.Scalar.project
+                                  (Field.Constant.unpack c) )
+                               srs i ) )
                 | `Field x ->
                     Second (i, x) )
           in
@@ -1426,11 +1428,11 @@ struct
 
   let _shift1 =
     Pickles_types.Shifted_value.Type1.Shift.(
-      map ~f:Field.constant (create (module Field.Constant)))
+      map ~f:Field.constant (create (module Field.Constant)) )
 
   let shift2 =
     Shifted_value.Type2.Shift.(
-      map ~f:Field.constant (create (module Field.Constant)))
+      map ~f:Field.constant (create (module Field.Constant)) )
 
   let map_plonk_to_field plonk =
     Types.Step.Proof_state.Deferred_values.Plonk.In_circuit.map_challenges
@@ -1576,7 +1578,8 @@ struct
       Plonk_checks.scalars_env
         (module Env_bool)
         (module Env_field)
-        ~srs_length_log2:Common.Max_degree.wrap_log2 ~zk_rows:3
+        ~srs_length_log2:Common.Max_degree.wrap_log2
+        ~zk_rows:Plonk_checks.zk_rows_by_default
         ~endo:(Impl.Field.constant Endo.Wrap_inner_curve.base)
         ~mds:sponge_params.mds
         ~field_of_hex:(fun s ->

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -279,8 +279,8 @@ struct
                         ( Boolean.Unsafe.of_cvar Field.(mul (b :> t) (b_g :> t))
                         , Array.map g ~f:(Double.map ~f:(( * ) (b :> t))) ) )
                  |> List.reduce
-                        ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
-                           ->
+                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
+                         ->
                         ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
                         , Array.map2_exn ~f:(Double.map2 ~f:( + )) g1 g2 ) )
                  |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -94,7 +94,7 @@ struct
             printf
               !"%s: %{sexp:Backend.Tock.Field.t}, %{sexp:Backend.Tock.Field.t}\n\
                 %!"
-              lab (read_var x) (read_var y) )
+              lab (read_var x) (read_var y))
 
   let _print_w lab gs =
     if Import.debug then
@@ -111,7 +111,7 @@ struct
             printf "in-snark %s:%!" lab ;
             Field.Constant.print
               (Field.Constant.project (List.map ~f:(read Boolean.typ) x)) ;
-            printf "\n%!" )
+            printf "\n%!")
 
   let print_bool lab x =
     if debug then
@@ -266,8 +266,8 @@ struct
                  |> List.map ~f:(fun ((b : Boolean.var), g) ->
                         (b, Array.map g ~f:(Double.map ~f:(( * ) (b :> t)))) )
                  |> List.reduce
-                      ~f:(fun
-                          ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2) ->
+                      ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
+                         ->
                         ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
                         , Array.map2_exn ~f:(Double.map2 ~f:( + )) g1 g2 ) )
                  |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
@@ -279,8 +279,8 @@ struct
                         ( Boolean.Unsafe.of_cvar Field.(mul (b :> t) (b_g :> t))
                         , Array.map g ~f:(Double.map ~f:(( * ) (b :> t))) ) )
                  |> List.reduce
-                      ~f:(fun
-                          ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2) ->
+                        ~f:(fun ((b1 : Boolean.var), g1) ((b2 : Boolean.var), g2)
+                           ->
                         ( Boolean.Unsafe.of_cvar Field.(add (b1 :> t) (b2 :> t))
                         , Array.map2_exn ~f:(Double.map2 ~f:( + )) g1 g2 ) )
                  |> fun x -> (Option.map ~f:fst x, Option.map ~f:snd x)
@@ -333,7 +333,8 @@ struct
     |> Vector.map2
          (which_branch :> (Boolean.var, n) Vector.t)
          ~f:(fun b pts ->
-           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y)) )
+           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y))
+           )
     |> Vector.reduce_exn ~f:(Array.map2_exn ~f:(Double.map2 ~f:Field.( + )))
 
   let scaled_lagrange (type n) c
@@ -356,7 +357,8 @@ struct
     |> Vector.map2
          (which_branch :> (Boolean.var, n) Vector.t)
          ~f:(fun b pts ->
-           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y)) )
+           Array.map pts ~f:(fun (x, y) -> Field.((b :> t) * x, (b :> t) * y))
+           )
     |> Vector.reduce_exn ~f:(Array.map2_exn ~f:(Double.map2 ~f:Field.( + )))
 
   let lagrange_with_correction (type n) ~input_length
@@ -446,7 +448,7 @@ struct
             Field.(
               (x * x * x)
               + (constant Inner_curve.Params.a * x)
-              + constant Inner_curve.Params.b ) )
+              + constant Inner_curve.Params.b) )
         |> unstage )
     in
     fun x -> Lazy.force f x
@@ -495,11 +497,8 @@ struct
         Pcs_batch.combine_split_commitments batch
           ~reduce_with_degree_bound:(fun _ -> assert false)
           ~reduce_without_degree_bound:(fun x -> [ x ])
-          ~scale_and_add:(fun
-              ~(acc : Curve_opt.t)
-              ~xi
-              (p : (Point.t array, Boolean.var) Opt.t)
-            ->
+          ~scale_and_add:(fun ~(acc : Curve_opt.t) ~xi
+                              (p : (Point.t array, Boolean.var) Opt.t) ->
             (* match acc.non_zero, keep with
                | false, false -> acc
                | true, false -> acc
@@ -515,7 +514,7 @@ struct
                     ~else_:
                       ((* In this branch, the accumulator was zero, so there is no harm in
                           putting the potentially junk underlying point here. *)
-                       Point.underlying p ) )
+                       Point.underlying p ))
               in
               let point = ref base_point in
               for i = Array.length p - 2 downto 0 do
@@ -703,10 +702,9 @@ struct
       (m2 : (_, Scalar_challenge.t, _) Plonk.Minimal.In_circuit.t) =
     iter2 m1 m2
       ~chal:(fun c1 c2 -> Field.Assert.equal c1 c2)
-      ~scalar_chal:(fun
-          ({ inner = t1 } : _ Import.Scalar_challenge.t)
-          ({ inner = t2 } : Scalar_challenge.t)
-        -> Field.Assert.equal t1 t2 )
+      ~scalar_chal:(fun ({ inner = t1 } : _ Import.Scalar_challenge.t)
+                        ({ inner = t2 } : Scalar_challenge.t) ->
+        Field.Assert.equal t1 t2 )
 
   let index_to_field_elements ~g (m : _ Plonk_verification_key_evals.Step.t) =
     let { Plonk_verification_key_evals.Step.sigma_comm
@@ -861,14 +859,14 @@ struct
                 | `Field (Constant c, _) ->
                     First
                       ( if Field.Constant.(equal zero) c then None
-                        else if Field.Constant.(equal one) c then
-                          Some (lagrange ~domain srs i)
-                        else
-                          Some
-                            (scaled_lagrange ~domain
-                               (Inner_curve.Constant.Scalar.project
-                                  (Field.Constant.unpack c) )
-                               srs i ) )
+                      else if Field.Constant.(equal one) c then
+                        Some (lagrange ~domain srs i)
+                      else
+                        Some
+                          (scaled_lagrange ~domain
+                             (Inner_curve.Constant.Scalar.project
+                                (Field.Constant.unpack c) )
+                             srs i ) )
                 | `Field x ->
                     Second (i, x) )
           in
@@ -1430,11 +1428,11 @@ struct
 
   let _shift1 =
     Pickles_types.Shifted_value.Type1.Shift.(
-      map ~f:Field.constant (create (module Field.Constant)) )
+      map ~f:Field.constant (create (module Field.Constant)))
 
   let shift2 =
     Shifted_value.Type2.Shift.(
-      map ~f:Field.constant (create (module Field.Constant)) )
+      map ~f:Field.constant (create (module Field.Constant)))
 
   let map_plonk_to_field plonk =
     Types.Step.Proof_state.Deferred_values.Plonk.In_circuit.map_challenges


### PR DESCRIPTION
This is part of the investigation of the chunking bug in Pickles and o1js (RFCs [here](https://github.com/o1-labs/rfcs/blob/main/0002-chunking.md) and [here](https://github.com/o1-labs/rfcs/pull/45/)).

Partially addresses https://github.com/o1-labs/o1js/issues/1806

Explain your changes:
* Substitute hardcoded values of `3` for `zk_rows` for a variables called `zk_rows_by_default`, and likewise for `1` and `num_chunks`. 
* This is to facilitate debugging and reduce error proneness. 

Explain how you tested your changes:
* It only contains cosmetic changes.
* There must still be a few places in our codebase, because the chunking tests in `o1js` still read `3` always. 

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
