### PR TITLE
Fail the compatibility test if the docker execution fails

### DIFF
--- a/buildkite/scripts/check-compatibility.sh
+++ b/buildkite/scripts/check-compatibility.sh
@@ -2,8 +2,7 @@
 
 # start mainline branch daemon as seed, see if PR branch daemon can sync to it
 
-# don't exit if docker download fails
-set +e
+set -eox pipefail
 
 function get_shas {
   SHAS=$(git log -n 10 --format="%h" --abbrev=7 --no-merges)


### PR DESCRIPTION
This PR fixes the 'compatiblity test' so that it doesn't hang in an infinite loop if starting the container fails.

See e.g. [this hung test](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/35269#01920a82-e1d3-46b3-ac23-e7136824ee86).