### PR TITLE
Port BRANCH_NAME fix from compatible

### DIFF
--- a/buildkite/scripts/build-release.sh
+++ b/buildkite/scripts/build-release.sh
@@ -14,7 +14,7 @@ echo " Includes mina daemon, archive-node, rosetta, generate keypair for berkele
 
 
 echo "--- Prepare debian packages"
-./scripts/debian/build.sh $@
+BRANCH_NAME="$BUILDKIE_BRANCH" ./scripts/debian/build.sh $@
 
 echo "--- Git diff after build is complete:"
 git diff --exit-code -- .

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -15,7 +15,6 @@ function find_most_recent_numeric_tag() {
 }
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
-export GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
 export PROJECT="mina"
@@ -26,8 +25,14 @@ export BUILD_URL=${BUILDKITE_BUILD_URL}
 set -u
 
 export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
-[[ -n "$BUILDKITE_BRANCH" ]] && export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
- 
+if [[ -n "$BUILDKITE_BRANCH" ]]; then
+   export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
+else
+   export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+fi
+
+
+
 export RELEASE=unstable
 
 if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -5,7 +5,14 @@
 set -eox pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-source ${SCRIPTPATH}/../export-git-env-vars.sh
+
+# In case of running this script on detached head, script has difficulties in finding out
+# what is the current branch.
+if [[ -n "$BRANCH_NAME" ]]; then 
+  BRANCH_NAME="$BRANCH_NAME" source ${SCRIPTPATH}/../export-git-env-vars.sh
+else
+  source ${SCRIPTPATH}/../export-git-env-vars.sh
+fi 
 
 echo "after export"
 

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
-
 set -x
 
+
+# In case of running this script on detached head, script has difficulties in finding out
+# what is the current 
 echo "Exporting Git Variables: "
 
 git fetch
@@ -19,7 +21,12 @@ function find_most_recent_numeric_tag() {
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
 export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
-export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" |  sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+
+if [[ -n "$BRANCH_NAME" ]]; then
+   export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
+else
+   export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+fi
 
 export GITTAG=$(find_most_recent_numeric_tag HEAD)
 


### PR DESCRIPTION
Use BUILDKITE_BRANCH when calculating debian name as git rev-name can return random tag/branch