### PR TITLE
Add more of `Pickles_types` to `Mina_wire_types`

### DIFF
--- a/src/lib/mina_wire_types/pickles_types.ml
+++ b/src/lib/mina_wire_types/pickles_types.ml
@@ -52,20 +52,6 @@ module Plonk_types = struct
     end
   end
 
-  module Openings = struct
-    module Bulletproof = struct
-      module V1 = struct
-        type ('g, 'fq) t =
-          { lr : ('g * 'g) array
-          ; z_1 : 'fq
-          ; z_2 : 'fq
-          ; delta : 'g
-          ; challenge_polynomial_commitment : 'g
-          }
-      end
-    end
-  end
-
   module Evals = struct
     module V2 = struct
       type 'a t =
@@ -111,6 +97,63 @@ module Plonk_types = struct
         { evals :
             ('f_multi * 'f_multi, 'f_multi * 'f_multi) With_public_input.V1.t
         ; ft_eval1 : 'f
+        }
+    end
+  end
+
+  module Openings = struct
+    module Bulletproof = struct
+      module V1 = struct
+        type ('g, 'fq) t =
+          { lr : ('g * 'g) array
+          ; z_1 : 'fq
+          ; z_2 : 'fq
+          ; delta : 'g
+          ; challenge_polynomial_commitment : 'g
+          }
+      end
+    end
+
+    module V2 = struct
+      type ('g, 'fq, 'fqv) t =
+        { proof : ('g, 'fq) Bulletproof.V1.t
+        ; evals : ('fqv * 'fqv) Evals.V2.t
+        ; ft_eval1 : 'fq
+        }
+    end
+  end
+
+  module Poly_comm = struct
+    module Without_degree_bound = struct
+      module V1 = struct
+        type 'g t = 'g array
+      end
+    end
+  end
+
+  module Messages = struct
+    module Lookup = struct
+      module V1 = struct
+        type 'g t = { sorted : 'g array; aggreg : 'g; runtime : 'g option }
+      end
+    end
+
+    module V2 = struct
+      type 'g t =
+        { w_comm :
+            ('g Poly_comm.Without_degree_bound.V1.t, Nat.fifteen) Vector.t
+        ; z_comm : 'g Poly_comm.Without_degree_bound.V1.t
+        ; t_comm : 'g Poly_comm.Without_degree_bound.V1.t
+        ; lookup : 'g Poly_comm.Without_degree_bound.V1.t Lookup.V1.t option
+        }
+    end
+  end
+
+  module Proof = struct
+    module V2 = struct
+      type ('g, 'fq, 'fqv) t =
+        { messages : 'g Messages.V2.t
+        ; openings : ('g, 'fq, 'fqv) Openings.V2.t
         }
     end
   end

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -1361,6 +1361,10 @@ module Openings = struct
   module Stable = struct
     module V2 = struct
       type ('g, 'fq, 'fqv) t =
+            ( 'g
+            , 'fq
+            , 'fqv )
+            Mina_wire_types.Pickles_types.Plonk_types.Openings.V2.t =
         { proof : ('g, 'fq) Bulletproof.Stable.V1.t
         ; evals : ('fqv * 'fqv) Evals.Stable.V2.t
         ; ft_eval1 : 'fq
@@ -1431,6 +1435,7 @@ module Messages = struct
 
       module V1 = struct
         type 'g t =
+              'g Mina_wire_types.Pickles_types.Plonk_types.Messages.Lookup.V1.t =
           { sorted : 'g Bounded_types.ArrayN16.Stable.V1.t
           ; aggreg : 'g
           ; runtime : 'g option
@@ -1486,7 +1491,7 @@ module Messages = struct
     [@@@no_toplevel_latest_type]
 
     module V2 = struct
-      type 'g t =
+      type 'g t = 'g Mina_wire_types.Pickles_types.Plonk_types.Messages.V2.t =
         { w_comm : 'g Without_degree_bound.Stable.V1.t Columns_vec.Stable.V1.t
         ; z_comm : 'g Without_degree_bound.Stable.V1.t
         ; t_comm : 'g Without_degree_bound.Stable.V1.t
@@ -1548,6 +1553,7 @@ module Proof = struct
 
     module V2 = struct
       type ('g, 'fq, 'fqv) t =
+            ('g, 'fq, 'fqv) Mina_wire_types.Pickles_types.Plonk_types.Proof.V2.t =
         { messages : 'g Messages.Stable.V2.t
         ; openings : ('g, 'fq, 'fqv) Openings.Stable.V2.t
         }

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -138,7 +138,9 @@ module Messages : sig
   module Lookup : sig
     module Stable : sig
       module V1 : sig
-        type 'g t = { sorted : 'g array; aggreg : 'g; runtime : 'g option }
+        type 'g t =
+              'g Mina_wire_types.Pickles_types.Plonk_types.Messages.Lookup.V1.t =
+          { sorted : 'g array; aggreg : 'g; runtime : 'g option }
         [@@deriving fields, sexp, compare, yojson, hash, equal, hlist]
       end
     end
@@ -171,7 +173,7 @@ module Messages : sig
           - [lookup] contains the commitments to the polynomials involved the
             lookup arguments.
       *)
-      type 'g t =
+      type 'g t = 'g Mina_wire_types.Pickles_types.Plonk_types.Messages.V2.t =
         { w_comm : 'g Poly_comm.Without_degree_bound.t Columns_vec.t
         ; z_comm : 'g Poly_comm.Without_degree_bound.t
         ; t_comm : 'g Poly_comm.Without_degree_bound.t
@@ -352,6 +354,10 @@ module Openings : sig
   module Stable : sig
     module V2 : sig
       type ('g, 'fq, 'fqv) t =
+            ( 'g
+            , 'fq
+            , 'fqv )
+            Mina_wire_types.Pickles_types.Plonk_types.Openings.V2.t =
         { proof : ('g, 'fq) Bulletproof.t
         ; evals : ('fqv * 'fqv) Evals.t
         ; ft_eval1 : 'fq
@@ -366,6 +372,7 @@ module Proof : sig
   module Stable : sig
     module V2 : sig
       type ('g, 'fq, 'fqv) t =
+            ('g, 'fq, 'fqv) Mina_wire_types.Pickles_types.Plonk_types.Proof.V2.t =
         { messages : 'g Messages.Stable.V2.t
         ; openings : ('g, 'fq, 'fqv) Openings.t
         }


### PR DESCRIPTION
This PR expands the number of serialised types tracked in `Mina_wire_types` to cover proofs from `Pickles_types`.