### PR TITLE
[easy/develop] Make shellcheck happier on scripts/debian/*.sh

### DIFF
--- a/scripts/debian/aptly.sh
+++ b/scripts/debian/aptly.sh
@@ -12,7 +12,6 @@ CLEAR='\033[0m'
 RED='\033[0;31m'
 
 # global variables
-declare CLI_VERSION='1.0.0';
 declare CLI_NAME='aptly.sh';
 declare PS4='debug($LINENO) ${FUNCNAME[0]:+${FUNCNAME[0]}}(): ';
 
@@ -34,28 +33,28 @@ function start_aptly() {
     local __background=$3
     local __clean=$4
     local __component=$5
-    local __repo="$__distribution-$__component"
+    local __repo="${__distribution}"-"${__component}"
     local __port=$6
 
-    if [ $__clean = 1 ]; then
+    if [ "${__clean}" = 1 ]; then
         rm -rf ~/.aptly
     fi
-    
-    aptly repo create -component $__component -distribution $__distribution  $__repo
 
-    aptly repo add $__repo $__debs
+    aptly repo create -component "${__component}" -distribution "${__distribution}"  "${__repo}"
 
-    aptly snapshot create $__component from repo $__repo
+    aptly repo add "${__repo}" "${__debs}"
 
-    aptly publish snapshot -distribution=$__distribution -skip-signing $__component
+    aptly snapshot create "${__component}" from repo "${__repo}"
 
-    if [ $__background = 1 ]; then
-        aptly serve -listen localhost:$__port &
-    else 
-        aptly serve -listen localhost:$__port
+    aptly publish snapshot -distribution="${__distribution}" -skip-signing "${__component}"
+
+    if [ "${__background}" = 1 ]; then
+        aptly serve -listen localhost:"${__port}" &
+    else
+        aptly serve -listen localhost:"${__port}"
     fi
 
-    
+
 }
 
 
@@ -91,7 +90,7 @@ function start(){
     local __clean=0
     local __component="unstable"
     local __port=$PORT
-    
+
 
     while [ ${#} -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -99,7 +98,7 @@ function start(){
             -h | --help )
                 start_help;
             ;;
-            -b | --background ) 
+            -b | --background )
                 __background=1
                 shift;
             ;;
@@ -130,13 +129,13 @@ function start(){
             ;;
         esac
     done
-    
-    start_aptly $__distribution \
-        $__debs \
-        $__background \
-        $__clean \
-        $__component \
-        $__port
+
+    start_aptly "${__distribution}" \
+        "${__debs}" \
+        "${__background}" \
+        "${__clean}" \
+        "${__component}" \
+        "${__port}"
 
 
 }
@@ -156,9 +155,9 @@ function stop_help(){
 }
 
 function stop(){
-    
+
     local __clean=0
-    
+
     while [ ${#} -gt 0 ]; do
         case $1 in
             -h | --help )
@@ -175,9 +174,9 @@ function stop(){
             ;;
         esac
     done
-    
+
     pkill aptly
-    if [ $__clean = 1 ]; then
+    if [ "${__clean}" = 1 ]; then
         rm -rf ~/.aptly
     fi
 }

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -8,16 +8,16 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # In case of running this script on detached head, script has difficulties in finding out
 # what is the current branch.
-if [[ -n "$BRANCH_NAME" ]]; then 
-  BRANCH_NAME="$BRANCH_NAME" source ${SCRIPTPATH}/../export-git-env-vars.sh
+if [[ -n "${BRANCH_NAME}" ]]; then
+  BRANCH_NAME="${BRANCH_NAME}" source "${SCRIPTPATH}"/../export-git-env-vars.sh
 else
-  source ${SCRIPTPATH}/../export-git-env-vars.sh
-fi 
+  source "${SCRIPTPATH}"/../export-git-env-vars.sh
+fi
 
 echo "after export"
 
-source ${SCRIPTPATH}/builder-helpers.sh
-  
+source "${SCRIPTPATH}"/builder-helpers.sh
+
 if [ $# -eq 0 ]
   then
     echo "No arguments supplied. Building all known debian packages"
@@ -31,13 +31,13 @@ if [ $# -eq 0 ]
     build_functional_test_suite_deb
     build_zkapp_test_transaction_deb
 
-  else 
+  else
     for i in "$@"; do
-      if [[ $(type -t "build_${i}_deb") == function ]] 
-      then 
+      if [[ $(type -t "build_${i}_deb") == function ]]
+      then
           echo "Building $i debian package"
           "build_${i}_deb"
-      else 
+      else
         echo "invalid debian package name '$i'"
         exit 1
       fi

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -63,7 +63,7 @@ if [[ -v DUNE_INSTRUMENT_WITH ]]; then
     INSTRUMENTED_SUFFIX=instrumented
     MINA_DEB_NAME="${MINA_DEB_NAME}-${INSTRUMENTED_SUFFIX}"
     DEB_SUFFIX="${DEB_SUFFIX}-${INSTRUMENTED_SUFFIX}"
-fi 
+fi
 
 BUILDDIR="deb_build"
 
@@ -123,9 +123,9 @@ build_deb() {
 
   # Build the package
   echo "------------------------------------------------------------"
-  fakeroot dpkg-deb --build "${BUILDDIR}" ${1}_${MINA_DEB_VERSION}.deb
+  fakeroot dpkg-deb --build "${BUILDDIR}" "${1}"_"${MINA_DEB_VERSION}".deb
   echo "build_deb outputs:"
-  ls -lh ${1}_*.deb
+  ls -lh "${1}"_*.deb
   echo "deleting BUILDDIR ${BUILDDIR}"
   rm -rf "${BUILDDIR}"
 
@@ -148,7 +148,7 @@ copy_common_daemon_configs() {
   cp ./default/src/app/validate_keypair/validate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-validate-keypair"
 
   # Copy signature-based Binaries (based on signature type $2 passed into the function)
-  cp ./default/src/app/cli/src/mina_${2}_signatures.exe "${BUILDDIR}/usr/local/bin/mina"
+  cp ./default/src/app/cli/src/mina_"${2}"_signatures.exe "${BUILDDIR}/usr/local/bin/mina"
 
   # Copy over Build Configs (based on $2)
   mkdir -p "${BUILDDIR}/etc/coda/build_config"
@@ -162,7 +162,7 @@ copy_common_daemon_configs() {
   cp ../genesis_ledgers/mainnet.json "${BUILDDIR}/var/lib/coda/mainnet.json"
   cp ../genesis_ledgers/devnet.json "${BUILDDIR}/var/lib/coda/devnet.json"
   # Set the default configuration based on Network name ($1)
-  cp ../genesis_ledgers/${1}.json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
+  cp ../genesis_ledgers/"${1}".json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
   cp ../scripts/hardfork/create_runtime_config.sh "${BUILDDIR}/usr/local/bin/mina-hf-create-runtime-config"
   cp ../scripts/mina-verify-packaged-fork-config "${BUILDDIR}/usr/local/bin/mina-verify-packaged-fork-config"
   # Update the mina.service with a new default PEERS_URL based on Seed List URL $3
@@ -240,7 +240,7 @@ build_functional_test_suite_deb() {
 
   mkdir -p "${BUILDDIR}/etc/mina/test/archive"
 
-  cp -r ../src/test/archive/* ${BUILDDIR}/etc/mina/test/archive/ 
+  cp -r ../src/test/archive/* "${BUILDDIR}"/etc/mina/test/archive/
 
   # Binaries
   cp ./default/src/test/command_line_tests/command_line_tests.exe "${BUILDDIR}/usr/local/bin/mina-command-line-tests"
@@ -252,11 +252,11 @@ build_functional_test_suite_deb() {
 ##################################### END TEST SUITE PACKAGE #######################################
 
 function copy_common_rosetta_configs () {
- 
-  # Copy rosetta-based Binaries 
-  cp ./default/src/app/rosetta/rosetta_${1}_signatures.exe "${BUILDDIR}/usr/local/bin/mina-rosetta"
-  cp ./default/src/app/rosetta/ocaml-signer/signer_${1}_signatures.exe "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
- 
+
+  # Copy rosetta-based Binaries
+  cp ./default/src/app/rosetta/rosetta_"${1}"_signatures.exe "${BUILDDIR}/usr/local/bin/mina-rosetta"
+  cp ./default/src/app/rosetta/ocaml-signer/signer_"${1}"_signatures.exe "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+
   mkdir -p "${BUILDDIR}/etc/mina/rosetta"
   mkdir -p "${BUILDDIR}/etc/mina/rosetta/rosetta-cli-config"
   mkdir -p "${BUILDDIR}/etc/mina/rosetta/scripts"
@@ -266,38 +266,38 @@ function copy_common_rosetta_configs () {
   cp ../src/app/rosetta/rosetta-cli-config/*.json "${BUILDDIR}/etc/mina/rosetta/rosetta-cli-config"
   cp ../src/app/rosetta/rosetta-cli-config/*.ros "${BUILDDIR}/etc/mina/rosetta/rosetta-cli-config"
   cp ./default/src/app/rosetta/indexer_test/indexer_test.exe "${BUILDDIR}/usr/local/bin/mina-rosetta-indexer-test"
- 
+
 }
 
 ##################################### ROSETTA MAINNET PACKAGE #######################################
 build_rosetta_mainnet_deb() {
- 
+
   echo "------------------------------------------------------------"
   echo "--- Building mainnet rosetta deb"
 
   create_control_file mina-rosetta-mainnet "${SHARED_DEPS}" 'Mina Protocol Rosetta Client' "${SUGGESTED_DEPS}"
 
   copy_common_rosetta_configs "mainnet"
-  
+
   build_deb mina-rosetta-mainnet
 }
 
 ##################################### ROSETTA MAINNET PACKAGE #######################################
 build_rosetta_devnet_deb() {
- 
+
   echo "------------------------------------------------------------"
   echo "--- Building devnet rosetta deb"
 
   create_control_file mina-rosetta-devnet "${SHARED_DEPS}" 'Mina Protocol Rosetta Client' "${SUGGESTED_DEPS}"
 
   copy_common_rosetta_configs "testnet"
-  
+
   build_deb mina-rosetta-devnet
 }
 
 ##################################### MAINNET PACKAGE #######################################
 build_daemon_mainnet_deb() {
- 
+
   echo "------------------------------------------------------------"
   echo "--- Building mainnet deb without keys:"
 
@@ -311,7 +311,7 @@ build_daemon_mainnet_deb() {
 
 ##################################### DEVNET PACKAGE #######################################
 build_daemon_devnet_deb() {
-  
+
   echo "------------------------------------------------------------"
   echo "--- Building testnet signatures deb without keys:"
 
@@ -337,12 +337,13 @@ build_archive_deb () {
   cp ./default/src/app/archive/archive.exe "${BUILDDIR}/usr/local/bin/mina-archive"
   cp ./default/src/app/archive_blocks/archive_blocks.exe "${BUILDDIR}/usr/local/bin/mina-archive-blocks"
   cp ./default/src/app/extract_blocks/extract_blocks.exe "${BUILDDIR}/usr/local/bin/mina-extract-blocks"
-  
+
   mkdir -p "${BUILDDIR}/etc/mina/archive"
   cp ../scripts/archive/missing-blocks-guardian.sh "${BUILDDIR}/usr/local/bin/mina-missing-blocks-guardian"
+
   cp ./default/src/app/missing_blocks_auditor/missing_blocks_auditor.exe "${BUILDDIR}/usr/local/bin/mina-missing-blocks-auditor"
   cp ./default/src/app/replayer/replayer.exe "${BUILDDIR}/usr/local/bin/mina-replayer"
-  
+
   cp ../src/app/archive/create_schema.sql "${BUILDDIR}/etc/mina/archive"
   cp ../src/app/archive/drop_tables.sql "${BUILDDIR}/etc/mina/archive"
 
@@ -360,6 +361,6 @@ build_zkapp_test_transaction_deb () {
   # Binaries
   cp ./default/src/app/zkapp_test_transaction/zkapp_test_transaction.exe "${BUILDDIR}/usr/local/bin/mina-zkapp-test-transaction"
 
-  build_deb mina-zkapp-test-transaction 
+  build_deb mina-zkapp-test-transaction
 }
 ##################################### END ZKAPP TEST TXN PACKAGE #######################################

--- a/scripts/debian/publish.sh
+++ b/scripts/debian/publish.sh
@@ -52,7 +52,7 @@ DEBS3_UPLOAD="deb-s3 upload $BUCKET_ARG $S3_REGION_ARG \
 echo "Publishing debs: ${DEB_NAMES} to Release: ${DEB_RELEASE} and Codename: ${DEB_CODENAME}"
 # Upload the deb files to s3.
 # If this fails, attempt to remove the lockfile and retry.
-for i in {1..10}; do (
+for _i in {1..10}; do (
   ${DEBS3_UPLOAD} \
     --component "${DEB_RELEASE}" \
     --codename "${DEB_CODENAME}" \
@@ -62,23 +62,21 @@ for i in {1..10}; do (
 # Verify integrity of debs on remote repo
 function verify_o1test_repo_has_package {
   sudo apt-get update
-  ${DEBS3_SHOW} ${1} ${DEB_VERSION} $ARCH -c $DEB_CODENAME -m $DEB_RELEASE
+  ${DEBS3_SHOW} "${1}" "${DEB_VERSION}" ${ARCH} -c "${DEB_CODENAME}" -m "${DEB_RELEASE}"
   return $?
 }
 
 for deb in $DEB_NAMES
 do
-  echo "Adding packages.o1test.net $DEB_CODENAME $DEB_RELEASE"
-  sudo echo "deb [trusted=yes] http://packages.o1test.net $DEB_CODENAME $DEB_RELEASE" | sudo tee /etc/apt/sources.list.d/mina.list
+  echo "Adding packages.o1test.net ${DEB_CODENAME} ${DEB_RELEASE}"
+  sudo echo "deb [trusted=yes] http://packages.o1test.net ${DEB_CODENAME} ${DEB_RELEASE}" | sudo tee /etc/apt/sources.list.d/mina.list
 
   DEBS3_SHOW="deb-s3 show $BUCKET_ARG $S3_REGION_ARG"
 
-  deb_split=(${deb//_/ })
+  deb_split=("${deb//_/ }")
   deb="${deb_split[0]}"
-  deb=$(basename $deb)
-  
-  for i in {1..10}; do (verify_o1test_repo_has_package $deb) && break || sleep 60; done
+  deb=$(basename "${deb}")
+
+  for _i in {1..10}; do (verify_o1test_repo_has_package "${deb}") && break || sleep 60; done
 
 done
-
-

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -49,8 +49,8 @@ if [[ -z "$SUITE" ]]; then NEW_SUITE=$SUITE; fi;
 function rebuild_deb() {
   rm -f "${DEB}_${VERSION}.deb"
   rm -rf "${NEW_NAME}_${NEW_VERSION}"
-    
-  wget https://s3.us-west-2.amazonaws.com/packages.o1test.net/pool/${CODENAME}/m/mi/${DEB}_${VERSION}.deb
+
+  wget https://s3.us-west-2.amazonaws.com/packages.o1test.net/pool/"${CODENAME}"/m/mi/"${DEB}"_"${VERSION}".deb
   dpkg-deb -R "${DEB}_${VERSION}.deb" "${NEW_NAME}_${NEW_VERSION}"
   sed -i 's/Version: '"${VERSION}"'/Version: '"${NEW_VERSION}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
   sed -i 's/Package: '"${DEB}"'/Package: '"${NEW_NAME}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
@@ -60,4 +60,4 @@ function rebuild_deb() {
 
 rebuild_deb
 
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version ${NEW_VERSION} --codename ${CODENAME} --release ${NEW_RELEASE}
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}"

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -13,7 +13,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
-if [ -z $PACKAGE ]; then
+if [ -z "${PACKAGE}" ]; then
   echo "No package defined. exiting.."; exit 1;
 fi
 


### PR DESCRIPTION
I use [shellcheck](https://www.shellcheck.net/) on my machine and my code editor warns me when `shellcheck` encounters an error/warning.
I would like to suggest to add shellcheck later in the CI.
Check the commit message for the errors we are still getting.

Explain your changes:
* I mostly run shellcheck on the files, and fix the error messages. I didn't do on all of them, only a few I explored.

[compatible version](https://github.com/MinaProtocol/mina/pull/16119)

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
