### PR TITLE
Dune: only enabling formatting for OCaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 3.1)
+(formatting (enabled_for ocaml))


### PR DESCRIPTION
See https://dune.readthedocs.io/en/stable/reference/dune-project/formatting.html\#formatting
As there is some ReasonML code.

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
