### PR TITLE
[master] Use generic-multi CI for dhall lint and libp2p_helper build

### DIFF
--- a/buildkite/src/Command/Libp2pHelperBuild.dhall
+++ b/buildkite/src/Command/Libp2pHelperBuild.dhall
@@ -35,7 +35,7 @@ let cmdConfig =
                                              debVersion} ${BuildFlags.toSuffixUppercase
                                                              buildFlags}"
             , key = "libp2p-helper${BuildFlags.toLabelSegment buildFlags}"
-            , target = Size.Small
+            , target = Size.Multi
             }
 
 in  { step = cmdConfig }

--- a/buildkite/src/Jobs/Lint/Dhall.dhall
+++ b/buildkite/src/Jobs/Lint/Dhall.dhall
@@ -29,7 +29,7 @@ in  Pipeline.build
             , commands = [ Cmd.run "cd buildkite && make check_syntax" ]
             , label = "Dhall: syntax"
             , key = "check-dhall-syntax"
-            , target = Size.Small
+            , target = Size.Multi
             , docker = Some Docker::{
               , image = (../../Constants/ContainerImages.dhall).toolchainBase
               }
@@ -39,7 +39,7 @@ in  Pipeline.build
             , commands = [ Cmd.run "cd buildkite && make check_lint" ]
             , label = "Dhall: lint"
             , key = "check-dhall-lint"
-            , target = Size.Small
+            , target = Size.Multi
             , docker = Some Docker::{
               , image = (../../Constants/ContainerImages.dhall).toolchainBase
               }
@@ -49,7 +49,7 @@ in  Pipeline.build
             , commands = [ Cmd.run "cd buildkite && make check_format" ]
             , label = "Dhall: format"
             , key = "check-dhall-format"
-            , target = Size.Small
+            , target = Size.Multi
             , docker = Some Docker::{
               , image = (../../Constants/ContainerImages.dhall).toolchainBase
               }


### PR DESCRIPTION
This PR builds on https://github.com/MinaProtocol/mina/pull/16132. This enables the `generic-multi` agents for dhall lint and libp2p_helper build jobs in CI.