### PR TITLE
Update proof-systems: external prover randomness & regression tests

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -88,13 +88,14 @@ pub fn caml_pasta_fp_plonk_proof_create(
     // Release the runtime lock so that other threads can run using it while we generate the proof.
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fq>::setup();
-        let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+        let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
             &group_map,
             witness,
             &runtime_tables,
             index,
             prev,
             None,
+            &mut rand::rngs::OsRng,
         )
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
@@ -153,13 +154,14 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
     // Release the runtime lock so that other threads can run using it while we generate the proof.
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fq>::setup();
-        let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+        let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
             &group_map,
             witness,
             &runtime_tables,
             index,
             prev,
             None,
+            &mut rand::rngs::OsRng,
         )
         .map_err(|e| ocaml::Error::Error(e.into()))?;
 
@@ -281,13 +283,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let public_input = witness[0][0];
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &runtime_tables,
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
 
@@ -444,13 +447,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_foreign_field_mul(
     let (endo_q, _endo_r) = endos::<Pallas>();
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (
@@ -510,13 +514,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check(
     let (endo_q, _endo_r) = endos::<Pallas>();
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (
@@ -582,13 +587,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_range_check0(
     let (endo_q, _endo_r) = endos::<Pallas>();
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (
@@ -707,13 +713,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let public_input = witness[0][0];
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (
@@ -795,13 +802,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let public_input = (witness[0][0], witness[0][1]);
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (
@@ -888,13 +896,14 @@ pub fn caml_pasta_fp_plonk_proof_example_with_rot(
     let index = ProverIndex::<Vesta, OpeningProof<Vesta>>::create(cs, endo_q, srs.0);
     let group_map = <Vesta as CommitmentCurve>::Map::setup();
     let public_input = (witness[0][0], witness[0][1]);
-    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
+    let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge, _>(
         &group_map,
         witness,
         &[],
         &index,
         vec![],
         None,
+        &mut rand::rngs::OsRng,
     )
     .unwrap();
     (

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -87,7 +87,16 @@ pub fn caml_pasta_fq_plonk_proof_create(
         let proof = ProverProof::create_recursive::<
             DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
             DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
-        >(&group_map, witness, &runtime_tables, index, prev, None)
+            _,
+        >(
+            &group_map,
+            witness,
+            &runtime_tables,
+            index,
+            prev,
+            None,
+            &mut rand::rngs::OsRng,
+        )
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
     })

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
@@ -708,7 +708,9 @@ macro_rules! impl_proof {
                     let maybe_proof = ProverProof::create_recursive::<
                         DefaultFqSponge<_, PlonkSpongeConstantsKimchi>,
                         DefaultFrSponge<_, PlonkSpongeConstantsKimchi>,
-                        >(&group_map, witness, &rust_runtime_tables, index, prev, None);
+                        _>(&group_map, witness, &rust_runtime_tables, index, prev, None,
+                           &mut rand::rngs::OsRng
+                    );
                     (maybe_proof, public_input)
                 });
 


### PR DESCRIPTION
https://github.com/o1-labs/proof-systems/pull/2598 introduces serialization tests into `proof-systems`. For that it was necessary to make kimchi prover take `rng` explicitly (Instead of taking `&mut rand::rngs::OsRng` internally), this is merely a semantic change.

This PR propagates this semantics to `mina` and updates to the new version of proof-systems.