### PR TITLE
[compatible] reformat: ignore opam-switches - reapply 16115

### DIFF
--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -18,6 +18,7 @@ let dirs_trustlist =
   ; "proof-systems"
   ; "snarky"
   ; "_opam"
+  ; "opam_switches"
   ; ".direnv" ]
 
 let rec fold_over_files ~path ~process_path ~init ~f =


### PR DESCRIPTION
Reapply https://github.com/MinaProtocol/mina/pull/16115/

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
