### PR TITLE
Refactor transition router

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -205,10 +205,7 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
       in
       let sender = Envelope.Incoming.remote_sender_exn incoming_transition in
       Transition_cache.add transition_graph ~parent:previous_state_hash
-        ( Envelope.Incoming.map
-            ~f:(fun x -> Transition_cache.Block x)
-            incoming_transition
-        , vc ) ;
+        (Envelope.Incoming.map ~f:(fun x -> `Block x) incoming_transition, vc) ;
       (* TODO: Efficiently limiting the number of green threads in #1337 *)
       if
         worth_getting_root t

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -8,6 +8,7 @@ module Sync_ledger = Mina_ledger.Sync_ledger
 open Mina_state
 open Pipe_lib.Strict_pipe
 open Network_peer
+module Transition_cache = Transition_cache
 
 module type CONTEXT = sig
   val logger : Logger.t
@@ -192,7 +193,8 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
   let response_writer = Sync_ledger.Db.answer_writer root_sync_ledger in
   Mina_networking.glue_sync_ledger ~preferred t.network query_reader
     response_writer ;
-  Reader.iter sync_ledger_reader ~f:(fun (`Block incoming_transition, _) ->
+  Reader.iter sync_ledger_reader
+    ~f:(fun (`Block incoming_transition, `Valid_cb vc) ->
       let (transition, _) : Mina_block.initial_valid_block =
         Envelope.Incoming.data incoming_transition
       in
@@ -203,7 +205,10 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
       in
       let sender = Envelope.Incoming.remote_sender_exn incoming_transition in
       Transition_cache.add transition_graph ~parent:previous_state_hash
-        incoming_transition ;
+        ( Envelope.Incoming.map
+            ~f:(fun x -> Transition_cache.Block x)
+            incoming_transition
+        , vc ) ;
       (* TODO: Efficiently limiting the number of green threads in #1337 *)
       if
         worth_getting_root t
@@ -224,6 +229,9 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
       else Deferred.unit )
 
 let external_transition_compare ~context:(module Context : CONTEXT) =
+  let get_consensus_state =
+    Fn.compose Protocol_state.consensus_state Mina_block.Header.protocol_state
+  in
   Comparable.lift
     (fun existing candidate ->
       (* To prevent the logger to spam a lot of messsages, the logger input is set to null *)
@@ -237,7 +245,7 @@ let external_transition_compare ~context:(module Context : CONTEXT) =
         @@ Consensus.Hooks.select ~context:(module Context) ~existing ~candidate
       then -1
       else 1 )
-    ~f:(With_hash.map ~f:Mina_block.consensus_state)
+    ~f:(With_hash.map ~f:get_consensus_state)
 
 (** The entry point function for bootstrap controller. When bootstrap finished
     it would return a transition frontier with the root breadcrumb and a list
@@ -253,9 +261,8 @@ let external_transition_compare ~context:(module Context : CONTEXT) =
     5. Close the old frontier and reload a new one from disk.
  *)
 let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
-    ~consensus_local_state ~transition_reader ~best_seen_transition
-    ~persistent_root ~persistent_frontier ~initial_root_transition ~catchup_mode
-    =
+    ~consensus_local_state ~transition_reader ~preferred_peers ~persistent_root
+    ~persistent_frontier ~initial_root_transition ~catchup_mode =
   let open Context in
   O1trace.thread "bootstrap" (fun () ->
       let genesis_constants =
@@ -318,17 +325,8 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                Sync_ledger.Db.create temp_snarked_ledger ~logger ~trust_system
              in
              don't_wait_for
-               (sync_ledger t
-                  ~preferred:
-                    ( Option.to_list best_seen_transition
-                    |> List.filter_map ~f:(fun x ->
-                           match Envelope.Incoming.sender x with
-                           | Local ->
-                               None
-                           | Remote r ->
-                               Some r ) )
-                  ~root_sync_ledger ~transition_graph ~sync_ledger_reader
-                  ~genesis_constants ) ;
+               (sync_ledger t ~preferred:preferred_peers ~root_sync_ledger
+                  ~transition_graph ~sync_ledger_reader ~genesis_constants ) ;
              (* We ignore the resulting ledger returned here since it will always
                 * be the same as the ledger we started with because we are syncing
                 * a db ledger. *)
@@ -641,17 +639,20 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                 in
                 let filtered_collected_transitions =
                   List.filter collected_transitions
-                    ~f:(fun incoming_transition ->
+                    ~f:(fun (incoming_transition, _) ->
                       let transition =
                         Envelope.Incoming.data incoming_transition
-                        |> Mina_block.Validation.block_with_hash
+                        |> Transition_cache.header_with_hash
                       in
                       Consensus.Hooks.equal_select_status `Take
                       @@ Consensus.Hooks.select
                            ~context:(module Context)
                            ~existing:root_consensus_state
                            ~candidate:
-                             (With_hash.map ~f:Mina_block.consensus_state
+                             (With_hash.map
+                                ~f:
+                                  (Fn.compose Protocol_state.consensus_state
+                                     Mina_block.Header.protocol_state )
                                 transition ) )
                 in
                 [%log debug] "Sorting filtered transitions by consensus state"
@@ -661,9 +662,9 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                       List.sort filtered_collected_transitions
                         ~compare:
                           (Comparable.lift
-                             ~f:
-                               (Fn.compose Mina_block.Validation.block_with_hash
-                                  Envelope.Incoming.data )
+                             ~f:(fun (x, _) ->
+                               Transition_cache.header_with_hash
+                               @@ Envelope.Incoming.data x )
                              (external_transition_compare
                                 ~context:(module Context) ) ) )
                 in
@@ -820,27 +821,27 @@ let%test_module "Bootstrap_controller tests" =
                     Strict_pipe.Writer.write sync_ledger_writer
                       ( `Block
                           (downcast_breadcrumb ~sender:other.peer breadcrumb)
-                      , `Vallid_cb None ) )
+                      , `Valid_cb None ) )
               in
               Strict_pipe.Writer.close sync_ledger_writer ;
               sync_deferred ) ;
           let expected_transitions =
             List.map branch
               ~f:
-                (Fn.compose Mina_block.Validation.block_with_hash
-                   (Fn.compose Mina_block.Validated.remember
-                      Transition_frontier.Breadcrumb.validated_transition ) )
+                (Fn.compose
+                   (With_hash.map ~f:Mina_block.header)
+                   (Fn.compose Mina_block.Validation.block_with_hash
+                      (Fn.compose Mina_block.Validated.remember
+                         Transition_frontier.Breadcrumb.validated_transition ) ) )
           in
           let saved_transitions =
             Transition_cache.data transition_graph
-            |> List.map
-                 ~f:
-                   (Fn.compose Mina_block.Validation.block_with_hash
-                      Envelope.Incoming.data )
+            |> List.map ~f:(fun (x, _) ->
+                   Transition_cache.header_with_hash @@ Envelope.Incoming.data x )
           in
           let module E = struct
             module T = struct
-              type t = Mina_block.t State_hash.With_state_hashes.t
+              type t = Mina_block.Header.t State_hash.With_state_hashes.t
               [@@deriving sexp]
 
               let compare = external_transition_compare ~context:(module Context)
@@ -872,35 +873,39 @@ let%test_module "Bootstrap_controller tests" =
       Block_time.Timeout.await_exn time_controller ~timeout_duration
         (run
            ~context:(module Context)
-           ~trust_system ~verifier ~network:my_net.network
-           ~best_seen_transition:None
+           ~trust_system ~verifier ~network:my_net.network ~preferred_peers:[]
            ~consensus_local_state:my_net.state.consensus_local_state
            ~transition_reader ~persistent_root ~persistent_frontier
            ~catchup_mode:`Normal ~initial_root_transition )
 
     let assert_transitions_increasingly_sorted ~root
-        (incoming_transitions :
-          Mina_block.initial_valid_block Envelope.Incoming.t list ) =
-      let root = Transition_frontier.Breadcrumb.block root in
+        (incoming_transitions : Transition_cache.element list) =
+      let root =
+        Transition_frontier.Breadcrumb.block root |> Mina_block.header
+      in
       ignore
         ( List.fold_result ~init:root incoming_transitions
             ~f:(fun max_acc incoming_transition ->
-              let With_hash.{ data = transition; _ }, _ =
-                Envelope.Incoming.data incoming_transition
+              let With_hash.{ data = header; _ } =
+                Transition_cache.header_with_hash
+                  (Envelope.Incoming.data @@ fst incoming_transition)
+              in
+              let header_len h =
+                Mina_block.Header.protocol_state h
+                |> Protocol_state.consensus_state
+                |> Consensus.Data.Consensus_state.blockchain_length
               in
               let open Result.Let_syntax in
               let%map () =
                 Result.ok_if_true
-                  Mina_numbers.Length.(
-                    Mina_block.blockchain_length max_acc
-                    <= Mina_block.blockchain_length transition)
+                  Mina_numbers.Length.(header_len max_acc <= header_len header)
                   ~error:
                     (Error.of_string
                        "The blocks are not sorted in increasing order" )
               in
-              transition )
+              header )
           |> Or_error.ok_exn
-          : Mina_block.t )
+          : Mina_block.Header.t )
 
     let%test_unit "sync with one node after receiving a transition" =
       Quickcheck.test ~trials:1

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -1,6 +1,7 @@
 open Async_kernel
 open Pipe_lib
 open Network_peer
+module Transition_cache = Transition_cache
 
 module type CONTEXT = sig
   val logger : Logger.t
@@ -39,12 +40,9 @@ val run :
        ( [ `Block of Mina_block.initial_valid_block Envelope.Incoming.t ]
        * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Strict_pipe.Reader.t
-  -> best_seen_transition:
-       Mina_block.initial_valid_block Envelope.Incoming.t option
+  -> preferred_peers:Network_peer.Peer.t list
   -> persistent_root:Transition_frontier.Persistent_root.t
   -> persistent_frontier:Transition_frontier.Persistent_frontier.t
   -> initial_root_transition:Mina_block.Validated.t
   -> catchup_mode:[ `Normal | `Super ]
-  -> ( Transition_frontier.t
-     * Mina_block.initial_valid_block Envelope.Incoming.t list )
-     Deferred.t
+  -> (Transition_frontier.t * Transition_cache.element list) Deferred.t

--- a/src/lib/bootstrap_controller/transition_cache.ml
+++ b/src/lib/bootstrap_controller/transition_cache.ml
@@ -2,29 +2,69 @@ open Mina_base
 open Core
 open Network_peer
 
+type initial_valid_block_or_header =
+  | Block of Mina_block.initial_valid_block
+  | Header of Mina_block.initial_valid_header
+
+type element =
+  initial_valid_block_or_header Envelope.Incoming.t
+  * Mina_net2.Validation_callback.t option
+
+let header_with_hash e =
+  match e with
+  | Block b ->
+      With_hash.map ~f:Mina_block.header
+      @@ Mina_block.Validation.block_with_hash b
+  | Header h ->
+      Mina_block.Validation.header_with_hash h
+
 (* Cache represents a graph. The key is a State_hash, which is the node in
    the graph, and the value is the children transitions of the node *)
 
-type t =
-  Mina_block.initial_valid_block Envelope.Incoming.t list State_hash.Table.t
+type t = element list State_hash.Table.t
 
 let create () = State_hash.Table.create ()
+
+let state_hash e =
+  State_hash.With_state_hashes.state_hash @@ header_with_hash
+  @@ Envelope.Incoming.data e
+
+let logger = Logger.create ()
+
+let merge (old_env, old_vc) (new_env, new_vc) =
+  let old_b = Envelope.Incoming.data old_env in
+  let vc =
+    match (old_vc, new_vc) with
+    | Some _, Some _ ->
+        [%log warn] "Received gossip on $state_hash twice"
+          ~metadata:
+            [ ("state_hash", State_hash.to_yojson @@ state_hash old_env) ] ;
+        old_vc
+    | None, Some _ ->
+        new_vc
+    | _ ->
+        old_vc
+  in
+  ( Envelope.Incoming.map new_env ~f:(fun new_b ->
+        match new_b with Block _ -> new_b | _ -> old_b )
+  , vc )
 
 let add (t : t) ~parent new_child =
   State_hash.Table.update t parent ~f:(function
     | None ->
         [ new_child ]
     | Some children ->
-        if
-          List.mem children new_child ~equal:(fun e1 e2 ->
-              let state_hash e =
-                Envelope.Incoming.data e
-                |> Mina_block.Validation.block_with_hash
-                |> State_hash.With_state_hashes.state_hash
-              in
-              State_hash.equal (state_hash e1) (state_hash e2) )
-        then children
-        else new_child :: children )
+        let children', b =
+          List.fold children ~init:([], false) ~f:(fun (acc, b) child ->
+              if
+                (not b)
+                && State_hash.equal
+                     (state_hash @@ fst child)
+                     (state_hash @@ fst new_child)
+              then (merge child new_child :: acc, true)
+              else (acc, b) )
+        in
+        if b then children' else new_child :: children )
 
 let data t =
   let collected_transitions = State_hash.Table.data t |> List.concat in

--- a/src/lib/bootstrap_controller/transition_cache.ml
+++ b/src/lib/bootstrap_controller/transition_cache.ml
@@ -56,6 +56,16 @@ let add (t : t) ~parent new_child =
     | Some children ->
         let children', b =
           List.fold children ~init:([], false) ~f:(fun (acc, b) child ->
+              (* If state hash was already among children, existing child is
+                 merged with the new transition.
+                 It's needed to maintain consistency about transitions that may
+                 come from gossip or other ways; we want to preserve some
+                 validation callback (and we don't expect two gossips for the
+                 same).
+                 Also, if we received a block after receiving a header
+                 (possible when we'll simultaneously support both old and new
+                 gossip topics), we want to preserve a block because it's more
+                 than a header. *)
               if
                 (not b)
                 && State_hash.equal

--- a/src/lib/bootstrap_controller/transition_cache.ml
+++ b/src/lib/bootstrap_controller/transition_cache.ml
@@ -3,8 +3,8 @@ open Core
 open Network_peer
 
 type initial_valid_block_or_header =
-  | Block of Mina_block.initial_valid_block
-  | Header of Mina_block.initial_valid_header
+  [ `Block of Mina_block.initial_valid_block
+  | `Header of Mina_block.initial_valid_header ]
 
 type element =
   initial_valid_block_or_header Envelope.Incoming.t
@@ -12,10 +12,10 @@ type element =
 
 let header_with_hash e =
   match e with
-  | Block b ->
+  | `Block b ->
       With_hash.map ~f:Mina_block.header
       @@ Mina_block.Validation.block_with_hash b
-  | Header h ->
+  | `Header h ->
       Mina_block.Validation.header_with_hash h
 
 (* Cache represents a graph. The key is a State_hash, which is the node in
@@ -46,7 +46,7 @@ let merge (old_env, old_vc) (new_env, new_vc) =
         old_vc
   in
   ( Envelope.Incoming.map new_env ~f:(fun new_b ->
-        match new_b with Block _ -> new_b | _ -> old_b )
+        match new_b with `Block _ -> new_b | _ -> old_b )
   , vc )
 
 let add (t : t) ~parent new_child =

--- a/src/lib/bootstrap_controller/transition_cache.mli
+++ b/src/lib/bootstrap_controller/transition_cache.mli
@@ -1,14 +1,21 @@
 open Mina_base
 open Network_peer
 
+type initial_valid_block_or_header =
+  | Block of Mina_block.initial_valid_block
+  | Header of Mina_block.initial_valid_header
+
+val header_with_hash :
+  initial_valid_block_or_header -> Mina_block.Header.with_hash
+
+type element =
+  initial_valid_block_or_header Envelope.Incoming.t
+  * Mina_net2.Validation_callback.t option
+
 type t
 
 val create : unit -> t
 
-val add :
-     t
-  -> parent:State_hash.t
-  -> Mina_block.initial_valid_block Envelope.Incoming.t
-  -> unit
+val add : t -> parent:State_hash.t -> element -> unit
 
-val data : t -> Mina_block.initial_valid_block Envelope.Incoming.t list
+val data : t -> element list

--- a/src/lib/bootstrap_controller/transition_cache.mli
+++ b/src/lib/bootstrap_controller/transition_cache.mli
@@ -2,8 +2,8 @@ open Mina_base
 open Network_peer
 
 type initial_valid_block_or_header =
-  | Block of Mina_block.initial_valid_block
-  | Header of Mina_block.initial_valid_header
+  [ `Block of Mina_block.initial_valid_block
+  | `Header of Mina_block.initial_valid_header ]
 
 val header_with_hash :
   initial_valid_block_or_header -> Mina_block.Header.with_hash

--- a/src/lib/mina_block/header.ml
+++ b/src/lib/mina_block/header.ml
@@ -116,6 +116,12 @@ module Make_str (A : Wire_types.Concrete) = struct
       Protocol_version.compatible_with_daemon (current_protocol_version body)
     in
     { valid_current; valid_next; matches_daemon }
+
+  type with_hash = t State_hash.With_state_hashes.t [@@deriving sexp]
+
+  let blockchain_length h =
+    protocol_state h |> Mina_state.Protocol_state.consensus_state
+    |> Consensus.Data.Consensus_state.blockchain_length
 end
 
 include Wire_types.Make (Make_sig) (Make_str)

--- a/src/lib/mina_block/header_intf.ml
+++ b/src/lib/mina_block/header_intf.ml
@@ -13,6 +13,8 @@ module type Full = sig
 
   type t = Stable.Latest.t [@@deriving sexp, to_yojson]
 
+  type with_hash = t State_hash.With_state_hashes.t [@@deriving sexp]
+
   val create :
        protocol_state:Protocol_state.Value.t
     -> protocol_state_proof:Proof.t
@@ -36,4 +38,6 @@ module type Full = sig
     { valid_current : bool; valid_next : bool; matches_daemon : bool }
 
   val protocol_version_status : t -> protocol_version_status
+
+  val blockchain_length : t -> Mina_numbers.Length.t
 end

--- a/src/lib/mina_block/mina_block.ml
+++ b/src/lib/mina_block/mina_block.ml
@@ -12,7 +12,11 @@ type fully_invalid_block = Validation.fully_invalid_with_block
 
 type initial_valid_block = Validation.initial_valid_with_block
 
+type initial_valid_header = Validation.initial_valid_with_header
+
 type almost_valid_block = Validation.almost_valid_with_block
+
+type almost_valid_header = Validation.almost_valid_with_header
 
 type fully_valid_block = Validation.fully_valid_with_block
 
@@ -57,10 +61,7 @@ let handle_dropped_transition ?pipe_name ?valid_cb ~logger block =
     ~f:(Fn.flip Mina_net2.Validation_callback.fire_if_not_already_fired `Reject)
     valid_cb
 
-let blockchain_length block =
-  block |> Block.header |> Header.protocol_state
-  |> Mina_state.Protocol_state.consensus_state
-  |> Consensus.Data.Consensus_state.blockchain_length
+let blockchain_length block = block |> Block.header |> Header.blockchain_length
 
 let consensus_state =
   Fn.compose Protocol_state.consensus_state

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -22,6 +22,8 @@ end
 
 let validation (_, v) = v
 
+let header_with_hash (b, _) = b
+
 let block_with_hash (b, _) = b
 
 let block (b, _) = With_hash.data b

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -24,6 +24,8 @@ end
 val validation :
   ('a, 'b, 'c, 'd, 'e, 'f, 'g) with_block -> ('a, 'b, 'c, 'd, 'e, 'f, 'g) t
 
+val header_with_hash : _ with_header -> Header.with_hash
+
 val block_with_hash : _ with_block -> Block.with_hash
 
 val block : _ with_block -> Block.t

--- a/src/lib/mina_block/validation_types.ml
+++ b/src/lib/mina_block/validation_types.ml
@@ -131,6 +131,46 @@ type almost_valid_with_block =
   , [ `Protocol_versions ] * unit Truth.true_t )
   with_block
 
+type ( 'time_received
+     , 'genesis_state
+     , 'proof
+     , 'delta_block_chain
+     , 'frontier_dependencies
+     , 'staged_ledger_diff
+     , 'protocol_versions )
+     with_header =
+  Header.with_hash
+  * ( 'time_received
+    , 'genesis_state
+    , 'proof
+    , 'delta_block_chain
+    , 'frontier_dependencies
+    , 'staged_ledger_diff
+    , 'protocol_versions )
+    t
+
+type initial_valid_with_header =
+  ( [ `Time_received ] * unit Truth.true_t
+  , [ `Genesis_state ] * unit Truth.true_t
+  , [ `Proof ] * unit Truth.true_t
+  , [ `Delta_block_chain ]
+    * State_hash.t Mina_stdlib.Nonempty_list.t Truth.true_t
+  , [ `Frontier_dependencies ] * unit Truth.false_t
+  , [ `Staged_ledger_diff ] * unit Truth.false_t
+  , [ `Protocol_versions ] * unit Truth.true_t )
+  with_header
+
+type almost_valid_with_header =
+  ( [ `Time_received ] * unit Truth.true_t
+  , [ `Genesis_state ] * unit Truth.true_t
+  , [ `Proof ] * unit Truth.true_t
+  , [ `Delta_block_chain ]
+    * State_hash.t Mina_stdlib.Nonempty_list.t Truth.true_t
+  , [ `Frontier_dependencies ] * unit Truth.true_t
+  , [ `Staged_ledger_diff ] * unit Truth.false_t
+  , [ `Protocol_versions ] * unit Truth.true_t )
+  with_header
+
 type fully_valid_with_block = Block.with_hash * fully_valid
 
 let fully_invalid : fully_invalid =

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -28,4 +28,5 @@
    with_hash
    genesis_constants
    consensus
+   bootstrap_controller
 ))

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -28,5 +28,4 @@
    with_hash
    genesis_constants
    consensus
-   bootstrap_controller
 ))

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -78,7 +78,17 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     Transition_handler.Unprocessed_transition_cache.create ~logger
       ~cache_exceptions
   in
-  List.iter collected_transitions ~f:(fun t ->
+  let collected_transitions =
+    List.filter_map collected_transitions ~f:(fun (x, vc) ->
+        let open Network_peer.Envelope.Incoming in
+        match data x with
+        | Bootstrap_controller.Transition_cache.Block b ->
+            Some (map x ~f:(const b), vc)
+        | _ ->
+            (* TODO: handle headers too *)
+            None )
+  in
+  List.iter collected_transitions ~f:(fun (t, vc) ->
       (* since the cache was just built, it's safe to assume
        * registering these will not fail, so long as there
        * are no duplicates in the list *)
@@ -87,9 +97,9 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
           unprocessed_transition_cache t
       in
       Strict_pipe.Writer.write primary_transition_writer
-        (`Block block_cached, `Valid_cb None) ) ;
+        (`Block block_cached, `Valid_cb vc) ) ;
   let initial_state_hashes =
-    List.map collected_transitions ~f:(fun envelope ->
+    List.map collected_transitions ~f:(fun (envelope, _) ->
         Network_peer.Envelope.Incoming.data envelope
         |> Validation.block_with_hash
         |> Mina_base.State_hash.With_state_hashes.state_hash )

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -82,7 +82,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     List.filter_map collected_transitions ~f:(fun (x, vc) ->
         let open Network_peer.Envelope.Incoming in
         match data x with
-        | Bootstrap_controller.Transition_cache.Block b ->
+        | `Block b ->
             Some (map x ~f:(const b), vc)
         | _ ->
             (* TODO: handle headers too *)

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -85,7 +85,8 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
         | `Block b ->
             Some (map x ~f:(const b), vc)
         | _ ->
-            (* TODO: handle headers too *)
+            (* TODO: handle headers too (headers can't be actually received at
+               this point, so this TODO is safe to be left for future.) *)
             None )
   in
   List.iter collected_transitions ~f:(fun (t, vc) ->

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -109,6 +109,11 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
     Strict_pipe.create ~name:"transition frontier: producer transition"
       Synchronous
   in
+  (* No block production happens when bootstrap is running. The
+     [producer_transition_writer_ref] pipe was created just to substitute a
+     value for the type and was never actually used. It could have been read
+     only by the transition frontier controller, and it's not running when
+     bootstrap controller is active *)
   producer_transition_writer_ref := Some producer_transition_writer ;
   Broadcast_pipe.Writer.write frontier_w (Some frontier) |> don't_wait_for ;
   let new_verified_transition_reader =
@@ -547,7 +552,7 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
           ~pipe_name:name ~logger ?valid_cb )
       ()
   in
-  (* Ref is None when bootstrap is in progress and Some writer when it's catch-up.query
+  (* Ref is None when bootstrap is in progress and Some writer when it's catch-up.
      In fact, we don't expect any produced blocks during bootstrap (possible only in rare case
      of race condition between bootstrap and block creation) *)
   let producer_transition_writer_ref = ref None in

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -433,8 +433,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
                 ]
               "Network best tip is recent enough to catchup to (best_tip with \
                $length); syncing local state and starting participation" ;
-            let f x = Bootstrap_controller.Transition_cache.Block x in
-            [ (Envelope.Incoming.map ~f best_tip, None) ]
+            [ (Envelope.Incoming.map ~f:(fun x -> `Block x) best_tip, None) ]
         | None ->
             [%log info]
               "Successfully loaded frontier, but failed downloaded best tip \


### PR DESCRIPTION
This PR rebases the following commit of [this PR](https://github.com/MinaProtocol/mina/pull/12534) :

[Refactor Transition_router](https://github.com/MinaProtocol/mina/pull/12534/commits/fbc8bf0ff093b07283d08ab64ddba0598d0b394d)

1. Simplify transition_router: remove unnecessary reader refs
2. Do not ignore validation_callbacks for transition gossips received
   during bootstrap
3. Add support for header gossip collection during boostrap