### PR TITLE
 Change semantics of `fire_if_not_already_fired` to match its name

### DIFF
--- a/src/lib/mina_net2/validation_callback.ml
+++ b/src/lib/mina_net2/validation_callback.ml
@@ -136,9 +136,6 @@ let await_exn ~block_window_duration cb =
       result
 
 let fire_if_not_already_fired cb result =
-  if not (is_expired cb) then (
-    if Ivar.is_full cb.signal then
-      [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-    Ivar.fill cb.signal result )
+  if not (is_expired cb) then Ivar.fill_if_empty cb.signal result
 
 let set_message_type t x = t.message_type <- x


### PR DESCRIPTION
This PR fixes the behaviour of `Mina_net2.Validation_callback.fire_if_not_already_fired`, making it match its name.

This bug was re-introduced [here](https://github.com/MinaProtocol/mina/pull/7483) after originally appearing as [a typo](https://github.com/MinaProtocol/mina/pull/6924/files#diff-2844302d4a5657da64729bc73c995310d1bdc1159acdbb6e6b9e38a30aa37719R60) in PR #6924.

We've seen this bug crash a node on devnet recently (Ivar log message [here](https://console.cloud.google.com/logs/query;aroundTime=2024-09-26T14:15:20.272Z;cursorTimestamp=2024-09-26T14:28:18.513122331Z;duration=PT1H;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22o1labs-192920%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22mina-devnet-infra-2%22%0Aresource.labels.namespace_name%3D%22devnet%22%0Aresource.labels.pod_name%3D%22devnet-whale-3-7c8fcbd4b-qlmdd%22%0Aresource.labels.container_name%3D%22mina%22%0Atimestamp%3D%222024-09-26T14:28:18.513122331Z%22%0AinsertId%3D%22uphgbo2e5mwsa1j6%22?project=o1labs-192920) with the subsequent exception raised [here](https://console.cloud.google.com/logs/query;aroundTime=2024-09-26T14:15:20.272Z;cursorTimestamp=2024-09-26T14:28:18.513590356Z;duration=PT1H;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22o1labs-192920%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22mina-devnet-infra-2%22%0Aresource.labels.namespace_name%3D%22devnet%22%0Aresource.labels.pod_name%3D%22devnet-whale-3-7c8fcbd4b-qlmdd%22%0Aresource.labels.container_name%3D%22mina%22%0Atimestamp%3D%222024-09-26T14:28:18.513590356Z%22%0AinsertId%3D%22k0wegoprl5blz308%22?project=o1labs-192920)).