### PR TITLE
Build rosetta mainnet/devnet docker

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -224,9 +224,10 @@ let docker_step
                             , build_flags = spec.buildFlags
                             , deb_repo = DebianRepo.Type.Local
                             , step_key =
-                                "rosetta-${DebianVersions.lowerName
-                                             spec.debVersion}${BuildFlags.toLabelSegment
-                                                                 spec.buildFlags}-docker-image"
+                                "rosetta-${Network.lowerName
+                                             n}-${DebianVersions.lowerName
+                                                    spec.debVersion}${BuildFlags.toLabelSegment
+                                                                        spec.buildFlags}-docker-image"
                             }
                       )
                       spec.networks

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -209,21 +209,27 @@ let docker_step
                     }
                   ]
                 , Rosetta =
-                  [ DockerImage.ReleaseSpec::{
-                    , deps = deps
-                    , service = "mina-rosetta"
-                    , network = "berkeley"
-                    , build_flags = spec.buildFlags
-                    , deb_repo = DebianRepo.Type.Local
-                    , deb_profile = spec.profile
-                    , deb_codename =
-                        "${DebianVersions.lowerName spec.debVersion}"
-                    , step_key =
-                        "rosetta-${DebianVersions.lowerName
-                                     spec.debVersion}${BuildFlags.toLabelSegment
-                                                         spec.buildFlags}-docker-image"
-                    }
-                  ]
+                    Prelude.List.map
+                      Network.Type
+                      DockerImage.ReleaseSpec.Type
+                      (     \(n : Network.Type)
+                        ->  DockerImage.ReleaseSpec::{
+                            , deps = deps
+                            , service =
+                                Artifacts.dockerName Artifacts.Type.Rosetta
+                            , network = Network.lowerName n
+                            , deb_codename =
+                                "${DebianVersions.lowerName spec.debVersion}"
+                            , deb_profile = spec.profile
+                            , build_flags = spec.buildFlags
+                            , deb_repo = DebianRepo.Type.Local
+                            , step_key =
+                                "rosetta-${DebianVersions.lowerName
+                                             spec.debVersion}${BuildFlags.toLabelSegment
+                                                                 spec.buildFlags}-docker-image"
+                            }
+                      )
+                      spec.networks
                 , ZkappTestTransaction =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -71,7 +71,7 @@ in  Pipeline.build
             , depends_on =
                 Dockers.dependsOn
                   Dockers.Type.Bullseye
-                  (None Network.Type)
+                  (Some Network.Type.Devnet)
                   Profiles.Type.Standard
                   Artifacts.Type.Rosetta
             }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -71,7 +71,7 @@ in  Pipeline.build
             , depends_on =
                 Dockers.dependsOn
                   Dockers.Type.Bullseye
-                  (Some Network.Type.Devnet)
+                  (Some Network.Type.Berkeley)
                   Profiles.Type.Standard
                   Artifacts.Type.Rosetta
             }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
@@ -66,7 +66,7 @@ in  Pipeline.build
             , depends_on =
                 Dockers.dependsOn
                   Dockers.Type.Bullseye
-                  (None Network.Type)
+                  (Some Network.Type.Devnet)
                   Profiles.Type.Standard
                   Artifacts.Type.Rosetta
             }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
@@ -66,7 +66,7 @@ in  Pipeline.build
             , depends_on =
                 Dockers.dependsOn
                   Dockers.Type.Bullseye
-                  (Some Network.Type.Devnet)
+                  (Some Network.Type.Berkeley)
                   Profiles.Type.Standard
                   Artifacts.Type.Rosetta
             }

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -28,6 +28,9 @@ if [ $# -eq 0 ]
     build_daemon_berkeley_deb
     build_daemon_mainnet_deb
     build_daemon_devnet_deb
+    build_rosetta_berkeley_deb
+    build_rosetta_mainnet_deb
+    build_rosetta_devnet_deb
     build_test_executive_deb
     build_functional_test_suite_deb
     build_zkapp_test_transaction_deb


### PR DESCRIPTION
Builds two versions of rosetta docker for mainnet and devnet networks (previously was build only for berkeley network)