### PR TITLE
Rename constructor Proof_level.{None -> No_check}

### DIFF
--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -9,7 +9,7 @@ let%test_module "Archive node unit tests" =
   ( module struct
     let logger = Logger.create ()
 
-    let proof_level = Genesis_constants.Proof_level.None
+    let proof_level = Genesis_constants.Proof_level.No_check
 
     let precomputed_values =
       { (Lazy.force Precomputed_values.for_unit_tests) with proof_level }

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -350,14 +350,14 @@ let%snarkydef_ step ~(logger : Logger.t)
   in
   let txn_snark_must_verify =
     match proof_level with
-    | Check | None ->
+    | Check | No_check ->
         Boolean.false_
     | Full ->
         txn_snark_must_verify
   in
   let prev_must_verify =
     match proof_level with
-    | Check | None ->
+    | Check | No_check ->
         Boolean.false_
     | Full ->
         Boolean.not is_base_case

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -1,9 +1,15 @@
 open Core_kernel
 
 module Proof_level = struct
-  type t = Full | Check | None [@@deriving bin_io_unversioned, equal]
+  type t = Full | Check | No_check [@@deriving bin_io_unversioned, equal]
 
-  let to_string = function Full -> "full" | Check -> "check" | None -> "none"
+  let to_string = function
+    | Full ->
+        "full"
+    | Check ->
+        "check"
+    | No_check ->
+        "none"
 
   let of_string = function
     | "full" ->
@@ -11,7 +17,7 @@ module Proof_level = struct
     | "check" ->
         Check
     | "none" ->
-        None
+        No_check
     | s ->
         failwithf "unrecognised proof level %s" s ()
 end

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -791,8 +791,8 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
               Genesis_constants.Proof_level.Full
           | Check ->
               Check
-          | None ->
-              None)
+          | No_check ->
+              No_check)
       ; Some compiled_proof_level
       ]
   in
@@ -818,9 +818,9 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
   in
   let%bind () =
     match (proof_level, compiled_proof_level) with
-    | _, Full | (Check | None), _ ->
+    | _, Full | (Check | No_check), _ ->
         return ()
-    | Full, ((Check | None) as compiled) ->
+    | Full, ((Check | No_check) as compiled) ->
         let str = Genesis_constants.Proof_level.to_string in
         [%log fatal]
           "Proof level $proof_level is not compatible with compile-time proof \

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -492,8 +492,8 @@ let runtime_config_of_constraint_constants
           Some Full
       | Check ->
           Some Check
-      | None ->
-          Some None )
+      | No_check ->
+          Some No_check )
   ; sub_windows_per_window = Some constraint_constants.sub_windows_per_window
   ; ledger_depth = Some constraint_constants.ledger_depth
   ; work_delay = Some constraint_constants.work_delay

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -68,8 +68,8 @@ let%test_module "Epoch ledger sync tests" =
         match%map
           Genesis_ledger_helper.init_from_config_file
             ~genesis_dir:(make_dirname "genesis_dir")
-            ~constraint_constants ~genesis_constants ~logger ~proof_level:None
-            runtime_config ~cli_proof_level:None
+            ~constraint_constants ~genesis_constants ~logger
+            ~proof_level:No_check runtime_config ~cli_proof_level:None
         with
         | Ok (precomputed_values, _) ->
             precomputed_values

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -203,7 +203,7 @@ module Worker_state = struct
 
             let set_itn_logger_data ~daemon_port:_ = ()
           end : S )
-    | None ->
+    | No_check ->
         Deferred.return
           ( module struct
             module Transaction_snark = Transaction_snark

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -916,14 +916,14 @@ end
 
 module Proof_keys = struct
   module Level = struct
-    type t = Full | Check | None [@@deriving bin_io_unversioned, equal]
+    type t = Full | Check | No_check [@@deriving bin_io_unversioned, equal]
 
     let to_string = function
       | Full ->
           "full"
       | Check ->
           "check"
-      | None ->
+      | No_check ->
           "none"
 
     let of_string str =
@@ -933,7 +933,7 @@ module Proof_keys = struct
       | "check" ->
           Ok Check
       | "none" ->
-          Ok None
+          Ok No_check
       | _ ->
           Error "Expected one of 'full', 'check', or 'none'"
 
@@ -954,7 +954,7 @@ module Proof_keys = struct
             "Runtime_config.Proof_keys.Level.of_json_layout: Expected the \
              field 'level' to contain a string"
 
-    let gen = Quickcheck.Generator.of_list [ Full; Check; None ]
+    let gen = Quickcheck.Generator.of_list [ Full; Check; No_check ]
   end
 
   module Transaction_capacity = struct

--- a/src/lib/snark_worker/debug.ml
+++ b/src/lib/snark_worker/debug.ml
@@ -10,7 +10,7 @@ module Inputs = struct
       match proof_level with
       | Genesis_constants.Proof_level.Full ->
           failwith "Unable to handle proof-level=Full"
-      | Check | None ->
+      | Check | No_check ->
           Deferred.unit
 
     let worker_wait_time = 0.5

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -41,7 +41,7 @@ module Inputs = struct
 
                 let proof_level = proof_level
               end) : S )
-        | Check | None ->
+        | Check | No_check ->
             None
       in
       Deferred.return { m; cache = Cache.create (); proof_level }
@@ -273,7 +273,7 @@ module Inputs = struct
                                       w.first_pass_ledger ) ) ) )
               | Merge (_, proof1, proof2) ->
                   process (fun () -> M.merge ~sok_digest proof1 proof2) ) )
-      | Check | None ->
+      | Check | No_check ->
           (* Use a dummy proof. *)
           let stmt =
             match single with

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -14,7 +14,7 @@ let command =
             (Command.Arg_type.of_alist_exn
                [ ("Full", Genesis_constants.Proof_level.Full)
                ; ("Check", Check)
-               ; ("None", None)
+               ; ("None", No_check)
                ] ) )
      in
      fun () ->

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -42,7 +42,7 @@ let create ~logger:_ ?enable_internal_tracing:_ ?internal_trace_filename:_
                ( Blockchain_snark.Blockchain.state snark
                , Blockchain_snark.Blockchain.proof snark ) ) )
         |> Deferred.Or_error.map ~f:Or_error.return
-    | Check | None ->
+    | Check | No_check ->
         Deferred.Or_error.return (Ok ())
   in
   let verify_transaction_snarks ts =
@@ -53,7 +53,7 @@ let create ~logger:_ ?enable_internal_tracing:_ ?internal_trace_filename:_
             result |> Deferred.map ~f:Or_error.return
         | Error e ->
             failwith (Error.to_string_hum e) )
-    | Check | None ->
+    | Check | No_check ->
         (* Don't check if the proof has default sok, becasue they were probably not
            intended to be checked. If it has some value then check that against the
            message passed.
@@ -99,7 +99,7 @@ let verify_commands { proof_level; _ }
     list
     Deferred.Or_error.t =
   match proof_level with
-  | Check | None ->
+  | Check | No_check ->
       List.map cs ~f:(fun c ->
           match Common.check c with
           | `Valid c ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -202,7 +202,7 @@ module Worker_state = struct
                Itn_logger.set_data ~process_kind:"verifier" ~daemon_port
            end in
           (module M : S) )
-    | Check | None ->
+    | Check | No_check ->
         Deferred.return
         @@ ( module struct
              let verify_commands tagged_commands =


### PR DESCRIPTION
Using widely used `None `for name of constructor lead to an issue when `~proof_level` parameter changed its type and compiler left it unnoticed.

Explain how you tested your changes:
* Code compiles

Resurrection of #16105

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None