### PR TITLE
Use headers for v1 pubsub block topic

### DIFF
--- a/src/lib/best_tip_prover/best_tip_prover.ml
+++ b/src/lib/best_tip_prover/best_tip_prover.ml
@@ -90,17 +90,22 @@ module Make (Inputs : Inputs_intf) :
   let validate_proof ~verifier ~genesis_state_hash
       (transition_with_hash : Mina_block.with_hash) :
       Mina_block.initial_valid_block Deferred.Or_error.t =
-    let%map validation =
+    let validate (b, v) =
       let open Deferred.Result.Let_syntax in
+      let h = (With_hash.map ~f:Mina_block.header b, v) in
+      Deferred.return (Validation.validate_protocol_versions h)
+      >>= Fn.compose Deferred.return
+            (Validation.validate_genesis_protocol_state ~genesis_state_hash)
+      >>= Validation.validate_single_proof ~verifier ~genesis_state_hash
+      >>| Fn.flip Validation.with_body (Mina_block.body @@ With_hash.data b)
+    in
+    let%map validation =
       Validation.wrap transition_with_hash
       |> Validation.skip_time_received_validation
            `This_block_was_not_received_via_gossip
       |> Validation.skip_delta_block_chain_validation
            `This_block_was_not_received_via_gossip
-      |> Fn.compose Deferred.return Validation.validate_protocol_versions
-      >>= Fn.compose Deferred.return
-            (Validation.validate_genesis_protocol_state ~genesis_state_hash)
-      >>= Validation.validate_single_proof ~verifier ~genesis_state_hash
+      |> validate
     in
     match validation with
     | Ok block ->

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -650,6 +650,12 @@ module Vrf_evaluation_state = struct
     poll ~logger ~vrf_evaluator ~vrf_poll_interval t
 end
 
+let validate_genesis_protocol_state_block ~genesis_state_hash (b, v) =
+  Validation.validate_genesis_protocol_state ~genesis_state_hash
+    (With_hash.map ~f:Mina_block.header b, v)
+  |> Result.map
+       ~f:(Fn.flip Validation.with_body (Mina_block.body @@ With_hash.data b))
+
 let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~trust_system ~get_completed_work ~transaction_resource_pool
     ~time_controller ~consensus_local_state ~coinbase_receiver ~frontier_reader
@@ -918,7 +924,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                            `This_block_was_not_received_via_gossip
                       |> Validation.skip_protocol_versions_validation
                            `This_block_has_valid_protocol_versions
-                      |> Validation.validate_genesis_protocol_state
+                      |> validate_genesis_protocol_state_block
                            ~genesis_state_hash:
                              (Protocol_state.genesis_state_hash
                                 ~state_hash:(Some previous_state_hash)
@@ -928,13 +934,13 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                       >>| Validation.skip_delta_block_chain_validation
                             `This_block_was_not_received_via_gossip
                       >>= Validation.validate_frontier_dependencies
+                            ~to_header:Mina_block.header
                             ~context:(module Context)
                             ~root_block:
                               ( Transition_frontier.root frontier
                               |> Breadcrumb.block_with_hash )
-                            ~get_block_by_hash:
-                              (Fn.compose
-                                 (Option.map ~f:Breadcrumb.block_with_hash)
+                            ~is_block_in_frontier:
+                              (Fn.compose Option.is_some
                                  (Transition_frontier.find frontier) )
                       |> Deferred.return
                     in
@@ -1453,19 +1459,19 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
                  `This_block_was_generated_internally
             |> Validation.skip_delta_block_chain_validation
                  `This_block_was_not_received_via_gossip
-            |> Validation.validate_genesis_protocol_state
+            |> validate_genesis_protocol_state_block
                  ~genesis_state_hash:
                    (Protocol_state.genesis_state_hash
                       ~state_hash:(Some previous_protocol_state_hash)
                       previous_protocol_state )
             >>= Validation.validate_frontier_dependencies
+                  ~to_header:Mina_block.header
                   ~context:(module Context)
                   ~root_block:
                     ( Transition_frontier.root frontier
                     |> Breadcrumb.block_with_hash )
-                  ~get_block_by_hash:
-                    (Fn.compose
-                       (Option.map ~f:Breadcrumb.block_with_hash)
+                  ~is_block_in_frontier:
+                    (Fn.compose Option.is_some
                        (Transition_frontier.find frontier) )
             |> Deferred.return
           in

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -144,16 +144,19 @@ let start_sync_job_with_peer ~sender ~root_sync_ledger
   | `Repeat ->
       `Ignored
 
+let to_consensus_state h =
+  Mina_block.Header.protocol_state h |> Protocol_state.consensus_state
+
 (** For each transition, this function would compare it with the existing one.
     If the incoming transition is better, then download the merkle list from
     that transition to its root and verify it. If we get a better root than
     the existing one, then reset the Sync_ledger's target by calling
     [start_sync_job_with_peer] function. *)
 let on_transition ({ context = (module Context); _ } as t) ~sender
-    ~root_sync_ledger ~genesis_constants candidate_transition =
+    ~root_sync_ledger ~genesis_constants candidate_header =
   let open Context in
   let candidate_consensus_state =
-    With_hash.map ~f:Mina_block.consensus_state candidate_transition
+    With_hash.map ~f:to_consensus_state candidate_header
   in
   if not @@ should_sync ~root_sync_ledger t candidate_consensus_state then
     Deferred.return `Ignored
@@ -193,36 +196,45 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
   let response_writer = Sync_ledger.Db.answer_writer root_sync_ledger in
   Mina_networking.glue_sync_ledger ~preferred t.network query_reader
     response_writer ;
-  Reader.iter sync_ledger_reader
-    ~f:(fun (`Block incoming_transition, `Valid_cb vc) ->
-      let (transition, _) : Mina_block.initial_valid_block =
-        Envelope.Incoming.data incoming_transition
+  Reader.iter sync_ledger_reader ~f:(fun (b_or_h, `Valid_cb vc) ->
+      let header_with_hash, sender, transition_cache_element =
+        match b_or_h with
+        | `Block b_env ->
+            ( Envelope.Incoming.data b_env
+              |> Mina_block.Validation.block_with_hash
+              |> With_hash.map ~f:Mina_block.header
+            , Envelope.Incoming.remote_sender_exn b_env
+            , Envelope.Incoming.map ~f:(fun x -> `Block x) b_env )
+        | `Header h_env ->
+            ( Envelope.Incoming.data h_env
+              |> Mina_block.Validation.header_with_hash
+            , Envelope.Incoming.remote_sender_exn h_env
+            , Envelope.Incoming.map ~f:(fun x -> `Header x) h_env )
       in
       let previous_state_hash =
-        With_hash.data transition |> Mina_block.header
+        With_hash.data header_with_hash
         |> Mina_block.Header.protocol_state
         |> Protocol_state.previous_state_hash
       in
-      let sender = Envelope.Incoming.remote_sender_exn incoming_transition in
       Transition_cache.add transition_graph ~parent:previous_state_hash
-        (Envelope.Incoming.map ~f:(fun x -> `Block x) incoming_transition, vc) ;
+        (transition_cache_element, vc) ;
       (* TODO: Efficiently limiting the number of green threads in #1337 *)
       if
         worth_getting_root t
-          (With_hash.map ~f:Mina_block.consensus_state transition)
+          (With_hash.map ~f:to_consensus_state header_with_hash)
       then (
         [%log trace] "Added the transition from sync_ledger_reader into cache"
           ~metadata:
             [ ( "state_hash"
               , State_hash.to_yojson
-                  (State_hash.With_state_hashes.state_hash transition) )
-            ; ( "external_transition"
-              , Mina_block.to_yojson (With_hash.data transition) )
+                  (State_hash.With_state_hashes.state_hash header_with_hash) )
+            ; ( "header"
+              , Mina_block.Header.to_yojson (With_hash.data header_with_hash) )
             ] ;
 
         Deferred.ignore_m
         @@ on_transition t ~sender ~root_sync_ledger ~genesis_constants
-             transition )
+             header_with_hash )
       else Deferred.unit )
 
 let external_transition_compare ~context:(module Context : CONTEXT) =
@@ -274,18 +286,22 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
                ( `Capacity 50
                , `Overflow
                    (Drop_head
-                      (fun ( `Block
-                               (block :
-                                 Mina_block.Validation.initial_valid_with_block
-                                 Envelope.Incoming.t )
-                           , `Valid_cb valid_cb ) ->
+                      (fun (b_or_h, `Valid_cb valid_cb) ->
+                        let hash =
+                          match b_or_h with
+                          | `Block b_env ->
+                              Envelope.Incoming.data b_env
+                              |> Mina_block.Validation.block_with_hash
+                              |> With_hash.hash
+                          | `Header h_env ->
+                              Envelope.Incoming.data h_env
+                              |> Mina_block.Validation.header_with_hash
+                              |> With_hash.hash
+                        in
                         Mina_metrics.(
                           Counter.inc_one
                             Pipe.Drop_on_overflow.bootstrap_sync_ledger) ;
-                        Mina_block.handle_dropped_transition ?valid_cb
-                          ( With_hash.hash
-                          @@ Mina_block.Validation.block_with_hash
-                          @@ Envelope.Incoming.data block )
+                        Mina_block.handle_dropped_transition ?valid_cb hash
                           ~pipe_name:sync_ledger_pipe ~logger ) ) ) )
         in
         don't_wait_for

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -37,7 +37,8 @@ val run :
   -> network:Mina_networking.t
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> transition_reader:
-       ( [ `Block of Mina_block.initial_valid_block Envelope.Incoming.t ]
+       ( [ `Block of Mina_block.initial_valid_block Envelope.Incoming.t
+         | `Header of Mina_block.initial_valid_header Envelope.Incoming.t ]
        * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Strict_pipe.Reader.t
   -> preferred_peers:Network_peer.Peer.t list

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -276,7 +276,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
           let time = Block_time.now t.time_controller in
           let module M = (val sinksM) in
           M.Block_sink.push sink_block
-            (`Transition env, `Time_received time, `Valid_cb vc) )
+            (`Block env, `Time_received time, `Valid_cb vc) )
 
     let broadcast_snark_pool_diff ?origin_topic ?nonce t diff =
       ignore origin_topic ;

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -140,7 +140,7 @@ module type GOSSIP_NET = sig
     -> 'r rpc_response Deferred.t List.t Deferred.t
 
   val broadcast_state :
-    ?origin_topic:string -> t -> Message.state_msg -> unit Deferred.t
+    ?origin_topic:string -> t -> Mina_block.t -> unit Deferred.t
 
   val broadcast_transaction_pool_diff :
        ?origin_topic:string

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -78,7 +78,7 @@ let download_seed_peer_list uri =
 
 type publish_functions =
   { publish_v0 : Message.msg -> unit Deferred.t
-  ; publish_v1_block : Message.state_msg -> unit Deferred.t
+  ; publish_v1_block : Mina_block.Header.t -> unit Deferred.t
   ; publish_v1_tx : Message.transaction_pool_diff_msg -> unit Deferred.t
   ; publish_v1_snark_work : Message.snark_pool_diff_msg -> unit Deferred.t
   }
@@ -443,7 +443,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
             let snark_bin_prot =
               Network_pool.Snark_pool.Diff_versioned.Stable.Latest.bin_t
             in
-            let block_bin_prot = Mina_block.Stable.Latest.bin_t in
+            let header_bin_prot = Mina_block.Header.Stable.Latest.bin_t in
             let unit_f _ = Deferred.unit in
             let publish_v1_impl push_impl bin_prot topic =
               match config.pubsub_v1 with
@@ -468,10 +468,10 @@ module Make (Rpc_interface : RPC_INTERFACE) :
               publish_v1_impl
                 (fun (env, vc) ->
                   Sinks.Block_sink.push sink_block
-                    ( `Transition env
+                    ( `Header env
                     , `Time_received (Block_time.now config.time_controller)
                     , `Valid_cb vc ) )
-                block_bin_prot v1_topic_block
+                header_bin_prot v1_topic_block
             in
             let map_v0_msg msg =
               match msg with
@@ -488,8 +488,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
                   match Envelope.Incoming.data env with
                   | Message.Latest.T.New_state state ->
                       Sinks.Block_sink.push sink_block
-                        ( `Transition
-                            (Envelope.Incoming.map ~f:(const state) env)
+                        ( `Block (Envelope.Incoming.map ~f:(const state) env)
                         , `Time_received (Block_time.now config.time_controller)
                         , `Valid_cb vc )
                   | Message.Latest.T.Transaction_pool_diff
@@ -952,7 +951,8 @@ module Make (Rpc_interface : RPC_INTERFACE) :
     let broadcast_state ?origin_topic t state =
       let pfs = !(t.publish_functions) in
       let%bind () =
-        guard_topic ?origin_topic v1_topic_block pfs.publish_v1_block state
+        guard_topic ?origin_topic v1_topic_block pfs.publish_v1_block
+          (Mina_block.header state)
       in
       guard_topic ?origin_topic v0_topic pfs.publish_v0 (Message.New_state state)
 

--- a/src/lib/gossip_net/message.ml
+++ b/src/lib/gossip_net/message.ml
@@ -13,8 +13,6 @@ module Master = struct
           Transaction_pool.Resource_pool.Diff.t Network_pool.With_nonce.t
     [@@deriving sexp, to_yojson]
 
-    type state_msg = Mina_block.t
-
     type snark_pool_diff_msg = Snark_pool.Resource_pool.Diff.t
 
     type transaction_pool_diff_msg = Transaction_pool.Resource_pool.Diff.t
@@ -40,8 +38,6 @@ module V2 = struct
           Transaction_pool.Diff_versioned.Stable.V2.t
           Network_pool.With_nonce.Stable.V1.t
     [@@deriving bin_io, sexp, version { rpc }]
-
-    type state_msg = Mina_block.Stable.V2.t
 
     type snark_pool_diff_msg = Snark_pool.Diff_versioned.Stable.V2.t
 
@@ -82,7 +78,8 @@ module Latest = V2
 [%%define_locally Latest.(summary)]
 
 type block_sink_msg =
-  [ `Transition of state_msg Envelope.Incoming.t ]
+  [ `Block of Mina_block.t Envelope.Incoming.t
+  | `Header of Mina_block.Header.t Envelope.Incoming.t ]
   * [ `Time_received of Block_time.t ]
   * [ `Valid_cb of Mina_net2.Validation_callback.t ]
 

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -57,6 +57,25 @@ end
     After building the breadcrumb path, [Ledger_catchup] will then send it to
     the [Processor] via writing them to catchup_breadcrumbs_writer. *)
 
+let validate_block ~genesis_state_hash (b, v) =
+  let open Mina_block.Validation in
+  let open Result.Let_syntax in
+  let h = (With_hash.map ~f:Mina_block.header b, v) in
+  validate_genesis_protocol_state ~genesis_state_hash h
+  >>= validate_protocol_versions >>= validate_delta_block_chain
+  >>| Fn.flip with_body (Mina_block.body @@ With_hash.data b)
+
+let validate_proofs_block ~verifier ~genesis_state_hash blocks =
+  let open Mina_block.Validation in
+  let open Deferred.Result.Let_syntax in
+  let f ((b, _), h) = with_body h (Mina_block.body @@ With_hash.data b) in
+  let hs =
+    List.map blocks ~f:(fun (b, v) ->
+        (With_hash.map ~f:Mina_block.header b, v) )
+  in
+  validate_proofs ~verifier ~genesis_state_hash hs
+  >>| List.zip_exn blocks >>| List.map ~f
+
 let verify_transition ~context:(module Context : CONTEXT) ~trust_system
     ~frontier ~unprocessed_transition_cache ~slot_tx_end ~slot_chain_end
     enveloped_transition =
@@ -70,10 +89,7 @@ let verify_transition ~context:(module Context : CONTEXT) ~trust_system
       transition_with_hash
       |> Mina_block.Validation.skip_time_received_validation
            `This_block_was_not_received_via_gossip
-      |> Mina_block.Validation.validate_genesis_protocol_state
-           ~genesis_state_hash
-      >>= Mina_block.Validation.validate_protocol_versions
-      >>= Mina_block.Validation.validate_delta_block_chain
+      |> validate_block ~genesis_state_hash
     in
     let enveloped_initially_validated_transition =
       Envelope.Incoming.map enveloped_transition
@@ -495,7 +511,7 @@ let verify_transitions_and_build_breadcrumbs ~context:(module Context : CONTEXT)
         |> State_hash.With_state_hashes.state_hash
       in
       match%bind
-        Mina_block.Validation.validate_proofs ~verifier ~genesis_state_hash
+        validate_proofs_block ~verifier ~genesis_state_hash
           (List.map transitions ~f:(fun t ->
                Mina_block.Validation.wrap (Envelope.Incoming.data t) ) )
       with

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -130,6 +130,25 @@ let write_graph (_ : t) =
   let _ = G.output_graph in
   ()
 
+let validate_block ~genesis_state_hash (b, v) =
+  let open Mina_block.Validation in
+  let open Result.Let_syntax in
+  let h = (With_hash.map ~f:Mina_block.header b, v) in
+  validate_genesis_protocol_state ~genesis_state_hash h
+  >>= validate_protocol_versions >>= validate_delta_block_chain
+  >>| Fn.flip with_body (Mina_block.body @@ With_hash.data b)
+
+let validate_proofs_block ~verifier ~genesis_state_hash blocks =
+  let open Mina_block.Validation in
+  let open Deferred.Result.Let_syntax in
+  let f ((b, _), h) = with_body h (Mina_block.body @@ With_hash.data b) in
+  let hs =
+    List.map blocks ~f:(fun (b, v) ->
+        (With_hash.map ~f:Mina_block.header b, v) )
+  in
+  validate_proofs ~verifier ~genesis_state_hash hs
+  >>| List.zip_exn blocks >>| List.map ~f
+
 let verify_transition ~context:(module Context : CONTEXT) ~trust_system
     ~frontier ~unprocessed_transition_cache ~slot_tx_end ~slot_chain_end
     enveloped_transition =
@@ -138,15 +157,10 @@ let verify_transition ~context:(module Context : CONTEXT) ~trust_system
   let genesis_state_hash = Transition_frontier.genesis_state_hash frontier in
   let transition_with_hash = Envelope.Incoming.data enveloped_transition in
   let cached_initially_validated_transition_result =
-    let open Result.Let_syntax in
-    let open Mina_block in
-    let%bind initially_validated_transition =
-      transition_with_hash
-      |> Validation.skip_time_received_validation
-           `This_block_was_not_received_via_gossip
-      |> Validation.validate_genesis_protocol_state ~genesis_state_hash
-      >>= Validation.validate_protocol_versions
-      >>= Validation.validate_delta_block_chain
+    let%bind.Result initially_validated_transition =
+      Mina_block.Validation.skip_time_received_validation
+        `This_block_was_not_received_via_gossip transition_with_hash
+      |> validate_block ~genesis_state_hash
     in
     let enveloped_initially_validated_transition =
       Envelope.Incoming.map enveloped_transition
@@ -523,7 +537,7 @@ module Initial_validate_batcher = struct
                    ; state_body_hash = None
                    } )
             |> Mina_block.Validation.wrap )
-        |> Mina_block.Validation.validate_proofs ~verifier ~genesis_state_hash
+        |> validate_proofs_block ~verifier ~genesis_state_hash
         >>| function
         | Ok tvs ->
             Ok (List.map tvs ~f:(fun x -> `Valid x))

--- a/src/lib/mina_block/mina_block.ml
+++ b/src/lib/mina_block/mina_block.ml
@@ -51,6 +51,10 @@ let genesis ~precomputed_values : Block.with_hash * Validation.fully_valid =
   in
   (block_with_hash, validation)
 
+let genesis_header ~precomputed_values =
+  let b, v = genesis ~precomputed_values in
+  (With_hash.map ~f:Block.header b, v)
+
 let handle_dropped_transition ?pipe_name ?valid_cb ~logger block =
   [%log warn] "Dropping state_hash $state_hash from $pipe transition pipe"
     ~metadata:

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -266,7 +266,7 @@ end
 let validate_time_received ~(precomputed_values : Precomputed_values.t)
     ~time_received (t, validation) =
   let consensus_state =
-    t |> With_hash.data |> Block.header |> Header.protocol_state
+    t |> With_hash.data |> Header.protocol_state
     |> Protocol_state.consensus_state
   in
   let constants = precomputed_values.consensus_constants in
@@ -287,7 +287,7 @@ let skip_time_received_validation `This_block_was_not_received_via_gossip
   (t, Unsafe.set_valid_time_received validation)
 
 let validate_genesis_protocol_state ~genesis_state_hash (t, validation) =
-  let state = t |> With_hash.data |> Block.header |> Header.protocol_state in
+  let state = t |> With_hash.data |> Header.protocol_state in
   if
     State_hash.equal
       (Protocol_state.genesis_state_hash state)
@@ -332,7 +332,7 @@ let validate_proofs ~verifier ~genesis_state_hash tvs =
           *)
           None
         else
-          let header = Block.header @@ With_hash.data t in
+          let header = With_hash.data t in
           Some
             (Blockchain_snark.Blockchain.create
                ~state:(Header.protocol_state header)
@@ -371,7 +371,7 @@ let extract_delta_block_chain_witness = function
       failwith "why can't this be refuted?"
 
 let validate_delta_block_chain (t, validation) =
-  let header = t |> With_hash.data |> Block.header in
+  let header = t |> With_hash.data in
   match
     Transition_chain_verifier.verify
       ~target_hash:
@@ -393,8 +393,9 @@ let skip_delta_block_chain_validation `This_block_was_not_received_via_gossip
   , Unsafe.set_valid_delta_block_chain validation
       (Mina_stdlib.Nonempty_list.singleton previous_protocol_state_hash) )
 
-let validate_frontier_dependencies ~context:(module Context : CONTEXT)
-    ~root_block ~get_block_by_hash (t, validation) =
+let validate_frontier_dependencies ~to_header
+    ~context:(module Context : CONTEXT) ~root_block ~is_block_in_frontier
+    (t, validation) =
   let module Context = struct
     include Context
 
@@ -406,7 +407,14 @@ let validate_frontier_dependencies ~context:(module Context : CONTEXT)
   end in
   let open Result.Let_syntax in
   let hash = State_hash.With_state_hashes.state_hash t in
-  let protocol_state = Fn.compose Header.protocol_state Block.header in
+  let protocol_state = Fn.compose Header.protocol_state to_header in
+  let root_consensus_state =
+    With_hash.map
+      ~f:
+        (Fn.compose Protocol_state.consensus_state
+           (Fn.compose Header.protocol_state Block.header) )
+      root_block
+  in
   let parent_hash =
     Protocol_state.previous_state_hash (protocol_state @@ With_hash.data t)
   in
@@ -415,7 +423,7 @@ let validate_frontier_dependencies ~context:(module Context : CONTEXT)
   in
   let%bind () =
     Result.ok_if_true
-      (hash |> get_block_by_hash |> Option.is_none)
+      (not @@ is_block_in_frontier hash)
       ~error:`Already_in_frontier
   in
   let%bind () =
@@ -425,13 +433,13 @@ let validate_frontier_dependencies ~context:(module Context : CONTEXT)
       ( `Take
       = Consensus.Hooks.select
           ~context:(module Context)
-          ~existing:(With_hash.map ~f:consensus_state root_block)
+          ~existing:root_consensus_state
           ~candidate:(With_hash.map ~f:consensus_state t) )
       ~error:`Not_selected_over_frontier_root
   in
   let%map () =
     Result.ok_if_true
-      (parent_hash |> get_block_by_hash |> Option.is_some)
+      (is_block_in_frontier parent_hash)
       ~error:`Parent_missing_from_frontier
   in
   (t, Unsafe.set_valid_frontier_dependencies validation)
@@ -587,7 +595,7 @@ let reset_staged_ledger_diff_validation (transition_with_hash, validation) =
 
 let validate_protocol_versions (t, validation) =
   let { Header.valid_current; valid_next; matches_daemon } =
-    t |> With_hash.data |> Block.header |> Header.protocol_version_status
+    t |> With_hash.data |> Header.protocol_version_status
   in
   if not (valid_current && valid_next) then Error `Invalid_protocol_version
   else if not matches_daemon then Error `Mismatched_protocol_version

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -24,6 +24,8 @@ let validation (_, v) = v
 
 let header_with_hash (b, _) = b
 
+let header (b, _) = With_hash.data b
+
 let block_with_hash (b, _) = b
 
 let block (b, _) = With_hash.data b
@@ -594,3 +596,11 @@ let validate_protocol_versions (t, validation) =
 let skip_protocol_versions_validation `This_block_has_valid_protocol_versions
     (t, validation) =
   (t, Unsafe.set_valid_protocol_versions validation)
+
+let with_body (header_with_hash, validation) body =
+  ( With_hash.map ~f:(fun header -> Block.create ~header ~body) header_with_hash
+  , validation )
+
+let wrap_header t : fully_invalid_with_header = (t, fully_invalid)
+
+let to_header (b, v) = (With_hash.map ~f:Block.header b, v)

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -30,7 +30,15 @@ val block_with_hash : _ with_block -> Block.with_hash
 
 val block : _ with_block -> Block.t
 
+val header : _ with_header -> Header.t
+
+val to_header :
+     ('a, 'b, 'c, 'd, 'e, 'f, 'g) with_block
+  -> ('a, 'b, 'c, 'd, 'e, 'f, 'g) with_header
+
 val wrap : Block.with_hash -> fully_invalid_with_block
+
+val wrap_header : Header.with_hash -> fully_invalid_with_header
 
 val validate_time_received :
      precomputed_values:Precomputed_values.t
@@ -382,4 +390,23 @@ val skip_protocol_versions_validation :
      , 'e
      , 'f
      , [ `Protocol_versions ] * unit Truth.true_t )
+     with_block
+
+val with_body :
+     ( 'a
+     , 'b
+     , 'c
+     , 'd
+     , 'e
+     , [ `Staged_ledger_diff ] * unit Truth.false_t
+     , 'f )
+     with_header
+  -> Staged_ledger_diff.Body.t
+  -> ( 'a
+     , 'b
+     , 'c
+     , 'd
+     , 'e
+     , [ `Staged_ledger_diff ] * unit Truth.false_t
+     , 'f )
      with_block

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -50,7 +50,7 @@ val validate_time_received :
      , 'd
      , 'e
      , 'f )
-     with_block
+     with_header
   -> ( ( [ `Time_received ] * unit Truth.true_t
        , 'a
        , 'b
@@ -58,7 +58,7 @@ val validate_time_received :
        , 'd
        , 'e
        , 'f )
-       with_block
+       with_header
      , [> `Invalid_time_received of [ `Too_early | `Too_late of int64 ] ] )
      Result.t
 
@@ -83,7 +83,7 @@ val validate_genesis_protocol_state :
      , 'd
      , 'e
      , 'f )
-     with_block
+     with_header
   -> ( ( 'a
        , [ `Genesis_state ] * unit Truth.true_t
        , 'b
@@ -91,7 +91,7 @@ val validate_genesis_protocol_state :
        , 'd
        , 'e
        , 'f )
-       with_block
+       with_header
      , [> `Invalid_genesis_protocol_state ] )
      Result.t
 
@@ -121,16 +121,16 @@ val reset_genesis_protocol_state_validation :
 val validate_proofs :
      verifier:Verifier.t
   -> genesis_state_hash:State_hash.t
-  -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_block list
-  -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_block list
+  -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_header list
+  -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_header list
      , [> `Invalid_proof of Error.t | `Verifier_error of Error.t ] )
      Deferred.Result.t
 
 val validate_single_proof :
      verifier:Verifier.t
   -> genesis_state_hash:State_hash.t
-  -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_block
-  -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_block
+  -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_header
+  -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_header
      , [> `Invalid_proof of Error.t | `Verifier_error of Error.t ] )
      Deferred.Result.t
 
@@ -160,7 +160,7 @@ val validate_delta_block_chain :
      , 'd
      , 'e
      , 'f )
-     with_block
+     with_header
   -> ( ( 'a
        , 'b
        , 'c
@@ -169,7 +169,7 @@ val validate_delta_block_chain :
        , 'd
        , 'e
        , 'f )
-       with_block
+       with_header
      , [> `Invalid_delta_block_chain_proof ] )
      Result.t
 
@@ -195,25 +195,28 @@ val skip_delta_block_chain_validation :
      with_block
 
 val validate_frontier_dependencies :
-     context:(module CONTEXT)
+     to_header:('a -> Header.t)
+  -> context:(module CONTEXT)
   -> root_block:Block.with_hash
-  -> get_block_by_hash:(State_hash.t -> Block.with_hash option)
-  -> ( 'a
-     , 'b
-     , 'c
-     , 'd
-     , [ `Frontier_dependencies ] * unit Truth.false_t
-     , 'e
-     , 'f )
-     with_block
-  -> ( ( 'a
-       , 'b
+  -> is_block_in_frontier:(Frozen_ledger_hash.t -> bool)
+  -> ('a, State_hash.State_hashes.t) With_hash.t
+     * ( 'b
        , 'c
        , 'd
-       , [ `Frontier_dependencies ] * unit Truth.true_t
        , 'e
-       , 'f )
-       with_block
+       , [ `Frontier_dependencies ] * unit Truth.false_t
+       , 'f
+       , 'g )
+       t
+  -> ( ('a, State_hash.State_hashes.t) With_hash.t
+       * ( 'b
+         , 'c
+         , 'd
+         , 'e
+         , [ `Frontier_dependencies ] * unit Truth.true_t
+         , 'f
+         , 'g )
+         t
      , [> `Already_in_frontier
        | `Not_selected_over_frontier_root
        | `Parent_missing_from_frontier ] )
@@ -240,22 +243,24 @@ val skip_frontier_dependencies_validation :
      with_block
 
 val reset_frontier_dependencies_validation :
-     ( 'a
-     , 'b
-     , 'c
-     , 'd
-     , [ `Frontier_dependencies ] * unit Truth.true_t
-     , 'e
-     , 'f )
-     with_block
-  -> ( 'a
-     , 'b
-     , 'c
-     , 'd
-     , [ `Frontier_dependencies ] * unit Truth.false_t
-     , 'e
-     , 'f )
-     with_block
+     'g
+     * ( 'a
+       , 'b
+       , 'c
+       , 'd
+       , [ `Frontier_dependencies ] * unit Truth.true_t
+       , 'e
+       , 'f )
+       t
+  -> 'g
+     * ( 'a
+       , 'b
+       , 'c
+       , 'd
+       , [ `Frontier_dependencies ] * unit Truth.false_t
+       , 'e
+       , 'f )
+       t
 
 val validate_staged_ledger_diff :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
@@ -336,22 +341,9 @@ val skip_staged_ledger_diff_validation :
      with_block
 
 val reset_staged_ledger_diff_validation :
-     ( 'a
-     , 'b
-     , 'c
-     , 'd
-     , 'e
-     , [ `Staged_ledger_diff ] * unit Truth.true_t
-     , 'f )
-     with_block
-  -> ( 'a
-     , 'b
-     , 'c
-     , 'd
-     , 'e
-     , [ `Staged_ledger_diff ] * unit Truth.false_t
-     , 'f )
-     with_block
+     'g * ('a, 'b, 'c, 'd, 'e, [ `Staged_ledger_diff ] * unit Truth.true_t, 'f) t
+  -> 'g
+     * ('a, 'b, 'c, 'd, 'e, [ `Staged_ledger_diff ] * unit Truth.false_t, 'f) t
 
 val validate_protocol_versions :
      ( 'a
@@ -361,7 +353,7 @@ val validate_protocol_versions :
      , 'e
      , 'f
      , [ `Protocol_versions ] * unit Truth.false_t )
-     with_block
+     with_header
   -> ( ( 'a
        , 'b
        , 'c
@@ -369,7 +361,7 @@ val validate_protocol_versions :
        , 'e
        , 'f
        , [ `Protocol_versions ] * unit Truth.true_t )
-       with_block
+       with_header
      , [> `Invalid_protocol_version | `Mismatched_protocol_version ] )
      Result.t
 

--- a/src/lib/mina_block/validation_types.ml
+++ b/src/lib/mina_block/validation_types.ml
@@ -149,6 +149,17 @@ type ( 'time_received
     , 'protocol_versions )
     t
 
+type fully_invalid_with_header =
+  ( [ `Time_received ] * unit Truth.false_t
+  , [ `Genesis_state ] * unit Truth.false_t
+  , [ `Proof ] * unit Truth.false_t
+  , [ `Delta_block_chain ]
+    * State_hash.t Mina_stdlib.Nonempty_list.t Truth.false_t
+  , [ `Frontier_dependencies ] * unit Truth.false_t
+  , [ `Staged_ledger_diff ] * unit Truth.false_t
+  , [ `Protocol_versions ] * unit Truth.false_t )
+  with_header
+
 type initial_valid_with_header =
   ( [ `Time_received ] * unit Truth.true_t
   , [ `Genesis_state ] * unit Truth.true_t

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -347,7 +347,7 @@ let get_status ~flag t =
   in
   let new_block_length_received =
     let open Mina_block in
-    Length.to_int @@ Mina_block.blockchain_length @@ Validation.block
+    Length.to_int @@ Mina_block.Header.blockchain_length @@ Validation.header
     @@ Pipe_lib.Broadcast_pipe.Reader.peek
          (Mina_lib.most_recent_valid_transition t)
   in

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -347,9 +347,9 @@ module type Transition_router_intf = sig
          * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
          Strict_pipe.Reader.t
     -> producer_transition_reader:breadcrumb Strict_pipe.Reader.t
-    -> get_most_recent_valid_block:(unit -> Mina_block.initial_valid_block)
+    -> get_most_recent_valid_block:(unit -> Mina_block.initial_valid_header)
     -> most_recent_valid_block_writer:
-         Mina_block.initial_valid_block Broadcast_pipe.Writer.t
+         Mina_block.initial_valid_header Broadcast_pipe.Writer.t
     -> get_completed_work:
          (   Transaction_snark_work.Statement.t
           -> Transaction_snark_work.Checked.t option )

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -306,7 +306,11 @@ module type Transition_frontier_controller_intf = sig
          Mina_block.initial_valid_block Envelope.Incoming.t list
     -> frontier:transition_frontier
     -> network_transition_reader:
-         Mina_block.initial_valid_block Envelope.Incoming.t Strict_pipe.Reader.t
+         ( [ `Block of Mina_block.t Envelope.Incoming.t
+           | `Header of Mina_block.Header.t Envelope.Incoming.t ]
+         * [ `Time_received of Block_time.t ]
+         * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
+         Strict_pipe.Reader.t
     -> producer_transition_reader:breadcrumb Strict_pipe.Reader.t
     -> clear_reader:[ `Clear ] Strict_pipe.Reader.t
     -> unit
@@ -342,7 +346,8 @@ module type Transition_router_intf = sig
     -> frontier_broadcast_writer:
          transition_frontier option Pipe_lib.Broadcast_pipe.Writer.t
     -> network_transition_reader:
-         ( [ `Transition of Mina_block.t Envelope.Incoming.t ]
+         ( [ `Block of Mina_block.t Envelope.Incoming.t
+           | `Header of Mina_block.Header.t Envelope.Incoming.t ]
          * [ `Time_received of Block_time.t ]
          * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
          Strict_pipe.Reader.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -64,7 +64,7 @@ type components =
   ; snark_pool : Network_pool.Snark_pool.t
   ; transition_frontier : Transition_frontier.t option Broadcast_pipe.Reader.t
   ; most_recent_valid_block :
-      Mina_block.initial_valid_block Broadcast_pipe.Reader.t
+      Mina_block.initial_valid_header Broadcast_pipe.Reader.t
   ; block_produced_bvar : (Transition_frontier.Breadcrumb.t, read_write) Bvar.t
   }
 
@@ -1927,7 +1927,8 @@ let create ~commit_id ?wallets (config : Config.t) =
           |> Deferred.don't_wait_for ;
           let most_recent_valid_block_reader, most_recent_valid_block_writer =
             Broadcast_pipe.create
-              ( Mina_block.genesis ~precomputed_values:config.precomputed_values
+              ( Mina_block.genesis_header
+                  ~precomputed_values:config.precomputed_values
               |> Validation.reset_frontier_dependencies_validation
               |> Validation.reset_staged_ledger_diff_validation )
           in

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -214,7 +214,7 @@ val wallets : t -> Secrets.Wallets.t
 val subscriptions : t -> Mina_subscriptions.t
 
 val most_recent_valid_transition :
-  t -> Mina_block.initial_valid_block Broadcast_pipe.Reader.t
+  t -> Mina_block.initial_valid_header Broadcast_pipe.Reader.t
 
 val block_produced_bvar :
   t -> (Transition_frontier.Breadcrumb.t, read_write) Bvar.t

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -309,7 +309,7 @@ let%test_module "Epoch ledger sync tests" =
         let notify_online () = Deferred.unit in
         let most_recent_valid_block_reader, most_recent_valid_block_writer =
           Broadcast_pipe.create
-            ( Mina_block.genesis ~precomputed_values
+            ( Mina_block.genesis_header ~precomputed_values
             |> Mina_block.Validation.reset_frontier_dependencies_validation
             |> Mina_block.Validation.reset_staged_ledger_diff_validation )
         in

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -193,6 +193,14 @@ module Instance = struct
       ~persistent_root_instance =
     let open Context in
     let open Deferred.Result.Let_syntax in
+    let validate genesis_state_hash (b, v) =
+      Validation.validate_genesis_protocol_state ~genesis_state_hash
+        (With_hash.map ~f:Mina_block.header b, v)
+      |> Result.map
+           ~f:
+             (Fn.flip Validation.with_body
+                (Mina_block.body @@ With_hash.data b) )
+    in
     let downgrade_transition transition genesis_state_hash :
         ( Mina_block.almost_valid_block
         , [ `Invalid_genesis_protocol_state ] )
@@ -201,7 +209,7 @@ module Instance = struct
       transition |> Mina_block.Validated.remember
       |> Validation.reset_staged_ledger_diff_validation
       |> Validation.reset_genesis_protocol_state_validation
-      |> Validation.validate_genesis_protocol_state ~genesis_state_hash
+      |> validate genesis_state_hash
     in
     let%bind () = Deferred.return (assert_no_sync t) in
     (* read basic information from the database *)

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -28,4 +28,5 @@
    with_hash
    genesis_constants
    consensus
+   bootstrap_controller
 ))

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -23,12 +23,17 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
   let valid_transition_pipe_capacity = 50 in
   let start_time = Time.now () in
   let f_drop_head name head valid_cb =
-    let block : Mina_block.initial_valid_block =
-      Network_peer.Envelope.Incoming.data @@ Cache_lib.Cached.peek head
+    let hashes =
+      match head with
+      | `Block b ->
+          With_hash.hash @@ Validation.block_with_hash
+          @@ Network_peer.Envelope.Incoming.data @@ Cache_lib.Cached.peek b
+      | `Header h ->
+          With_hash.hash @@ Validation.header_with_hash
+          @@ Network_peer.Envelope.Incoming.data h
     in
-    Mina_block.handle_dropped_transition
-      (Validation.block_with_hash block |> With_hash.hash)
-      ?valid_cb ~pipe_name:name ~logger
+    Mina_block.handle_dropped_transition hashes ?valid_cb ~pipe_name:name
+      ~logger
   in
   let valid_transition_reader, valid_transition_writer =
     let name = "valid transitions" in
@@ -37,7 +42,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
          ( `Capacity valid_transition_pipe_capacity
          , `Overflow
              (Drop_head
-                (fun (`Block head, `Valid_cb vc) ->
+                (fun (head, `Valid_cb vc) ->
                   Mina_metrics.(
                     Counter.inc_one
                       Pipe.Drop_on_overflow
@@ -55,7 +60,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
          ( `Capacity primary_transition_pipe_capacity
          , `Overflow
              (Drop_head
-                (fun (`Block head, `Valid_cb vc) ->
+                (fun (head, `Valid_cb vc) ->
                   Mina_metrics.(
                     Counter.inc_one
                       Pipe.Drop_on_overflow
@@ -78,31 +83,25 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     Transition_handler.Unprocessed_transition_cache.create ~logger
       ~cache_exceptions
   in
-  let collected_transitions =
-    List.filter_map collected_transitions ~f:(fun (x, vc) ->
-        let open Network_peer.Envelope.Incoming in
-        match data x with
-        | `Block b ->
-            Some (map x ~f:(const b), vc)
-        | _ ->
-            (* TODO: handle headers too (headers can't be actually received at
-               this point, so this TODO is safe to be left for future.) *)
-            None )
-  in
   List.iter collected_transitions ~f:(fun (t, vc) ->
-      (* since the cache was just built, it's safe to assume
-       * registering these will not fail, so long as there
-       * are no duplicates in the list *)
-      let block_cached =
-        Transition_handler.Unprocessed_transition_cache.register_exn
-          unprocessed_transition_cache t
+      let b_or_h =
+        match Network_peer.Envelope.Incoming.data t with
+        | `Block b ->
+            (* since the cache was just built, it's safe to assume
+             * registering these will not fail, so long as there
+             * are no duplicates in the list *)
+            `Block
+              ( Transition_handler.Unprocessed_transition_cache.register_exn
+                  unprocessed_transition_cache
+              @@ Network_peer.Envelope.Incoming.map ~f:(const b) t )
+        | `Header h ->
+            `Header (Network_peer.Envelope.Incoming.map ~f:(const h) t)
       in
-      Strict_pipe.Writer.write primary_transition_writer
-        (`Block block_cached, `Valid_cb vc) ) ;
+      Strict_pipe.Writer.write primary_transition_writer (b_or_h, `Valid_cb vc) ) ;
   let initial_state_hashes =
     List.map collected_transitions ~f:(fun (envelope, _) ->
         Network_peer.Envelope.Incoming.data envelope
-        |> Validation.block_with_hash
+        |> Bootstrap_controller.Transition_cache.header_with_hash
         |> Mina_base.State_hash.With_state_hashes.state_hash )
     |> Mina_base.State_hash.Set.of_list
   in
@@ -129,8 +128,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     ~transition_reader:network_transition_reader ~valid_transition_writer
     ~unprocessed_transition_cache ;
   Strict_pipe.Reader.iter_without_pushback valid_transition_reader
-    ~f:(fun (`Block b, `Valid_cb vc) ->
-      Strict_pipe.Writer.write primary_transition_writer (`Block b, `Valid_cb vc) )
+    ~f:(Strict_pipe.Writer.write primary_transition_writer)
   |> don't_wait_for ;
   let clean_up_catchup_scheduler = Ivar.create () in
   Transition_handler.Processor.run

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -5,8 +5,12 @@ open Pipe_lib.Strict_pipe
 open Mina_base
 open Mina_state
 
+type block_or_header =
+  [ `Block of Mina_block.t Envelope.Incoming.t
+  | `Header of Mina_block.Header.t Envelope.Incoming.t ]
+
 type stream_msg =
-  [ `Transition of Mina_block.t Envelope.Incoming.t ]
+  block_or_header
   * [ `Time_received of Block_time.t ]
   * [ `Valid_cb of Mina_net2.Validation_callback.t ]
 
@@ -41,7 +45,7 @@ type Structured_log_events.t +=
   | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
   [@@deriving register_event { msg = "Received a block from $sender" }]
 
-let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
+let push sink (b_or_h, `Time_received tm, `Valid_cb cb) =
   match sink with
   | Void ->
       Deferred.unit
@@ -61,10 +65,22 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       @@ fun () ->
       let%bind () = on_push () in
       Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
-      let state = Envelope.Incoming.data e in
+      let processing_start_time =
+        Block_time.(now time_controller |> to_time_exn)
+      in
+      let sender, header, txs_opt =
+        match b_or_h with
+        | `Block b_env ->
+            ( Envelope.Incoming.sender b_env
+            , Mina_block.header (Envelope.Incoming.data b_env)
+            , Some
+                ( Envelope.Incoming.data b_env
+                |> Mina_block.transactions ~constraint_constants ) )
+        | `Header h_env ->
+            (Envelope.Incoming.sender h_env, Envelope.Incoming.data h_env, None)
+      in
       let state_hash =
-        Mina_block.(
-          state |> header |> Header.protocol_state |> Protocol_state.hashes)
+        (Mina_block.Header.protocol_state header |> Protocol_state.hashes)
           .state_hash
       in
       Internal_tracing.Context_call.with_call_id ~tag:"block_received"
@@ -72,21 +88,22 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       Internal_tracing.with_state_hash state_hash
       @@ fun () ->
       let open Mina_transaction in
-      let txs =
-        Mina_block.transactions ~constraint_constants state
-        |> List.map ~f:Transaction.yojson_summary_with_status
+      let txs_meta =
+        Option.value_map ~default:[]
+          ~f:(fun txs ->
+            [ ( "transactions"
+              , `List (List.map ~f:Transaction.yojson_summary_with_status txs)
+              )
+            ] )
+          txs_opt
       in
       [%log internal] "@block_metadata"
         ~metadata:
-          [ ( "blockchain_length"
-            , Mina_numbers.Length.to_yojson (Mina_block.blockchain_length state)
-            )
-          ; ("transactions", `List txs)
-          ] ;
+          ( ( "blockchain_length"
+            , Mina_numbers.Length.to_yojson
+                (Mina_block.Header.blockchain_length header) )
+          :: txs_meta ) ;
       [%log internal] "External_block_received" ;
-      let processing_start_time =
-        Block_time.(now time_controller |> to_time_exn)
-      in
       don't_wait_for
         ( match%map
             Mina_net2.Validation_callback.await ~block_window_duration cb
@@ -109,25 +126,24 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       Perf_histograms.add_span ~name:"external_transition_latency"
         (Core.Time.abs_diff
            Block_time.(now time_controller |> to_time_exn)
-           Mina_block.(
-             header state |> Header.protocol_state
-             |> Protocol_state.blockchain_state |> Blockchain_state.timestamp
-             |> Block_time.to_time_exn) ) ;
+           ( Mina_block.Header.protocol_state header
+           |> Protocol_state.blockchain_state |> Blockchain_state.timestamp
+           |> Block_time.to_time_exn ) ) ;
       Mina_metrics.(Gauge.inc_one Network.new_state_received) ;
-      if log_gossip_heard then
-        [%str_log info]
-          ~metadata:[ ("external_transition", Mina_block.to_yojson state) ]
-          (Block_received
-             { state_hash =
-                 Mina_block.(
-                   header state |> Header.protocol_state
-                   |> Protocol_state.hashes)
-                   .state_hash
-             ; sender = Envelope.Incoming.sender e
-             } ) ;
+      ( if log_gossip_heard then
+        let metadata =
+          match b_or_h with
+          | `Block b_env ->
+              [ ("block", Mina_block.to_yojson @@ Envelope.Incoming.data b_env)
+              ]
+          | `Header h_env ->
+              [ ( "header"
+                , Mina_block.Header.to_yojson @@ Envelope.Incoming.data h_env )
+              ]
+        in
+        [%str_log info] ~metadata (Block_received { state_hash; sender }) ) ;
       Mina_net2.Validation_callback.set_message_type cb `Block ;
       Mina_metrics.(Counter.inc_one Network.Block.received) ;
-      let sender = Envelope.Incoming.sender e in
       let%bind () =
         match
           Network_pool.Rate_limiter.add rate_limiter sender ~now:(Time.now ())
@@ -143,28 +159,38 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
             Mina_net2.Validation_callback.fire_if_not_already_fired cb `Reject ;
             Deferred.unit
         | `Within_capacity ->
-            Writer.write writer (`Transition e, `Time_received tm, `Valid_cb cb)
+            Writer.write writer (b_or_h, `Time_received tm, `Valid_cb cb)
       in
-      let transactions = Mina_block.transactions state ~constraint_constants in
       let exists_well_formedness_errors =
-        List.exists transactions ~f:(fun txn ->
-            match
-              Mina_transaction.Transaction.check_well_formedness
-                ~genesis_constants txn.data
-            with
-            | Ok () ->
-                false
-            | Error errs ->
-                [%log warn]
-                  "Rejecting block due to one or more errors in a transaction"
-                  ~metadata:
-                    [ ( "errors"
-                      , `List
-                          (List.map errs
-                             ~f:User_command.Well_formedness_error.to_yojson )
-                      )
-                    ] ;
-                true )
+        match b_or_h with
+        | `Header _ ->
+            (* TODO make sure this check is executed at a later point when body is received *)
+            false
+        | `Block block_env ->
+            let transactions =
+              Mina_block.transactions
+                (Envelope.Incoming.data block_env)
+                ~constraint_constants
+            in
+            List.exists transactions ~f:(fun txn ->
+                match
+                  Mina_transaction.Transaction.check_well_formedness
+                    ~genesis_constants txn.data
+                with
+                | Ok () ->
+                    false
+                | Error errs ->
+                    [%log warn]
+                      "Rejecting block due to one or more errors in a \
+                       transaction"
+                      ~metadata:
+                        [ ( "errors"
+                          , `List
+                              (List.map errs
+                                 ~f:User_command.Well_formedness_error.to_yojson )
+                          )
+                        ] ;
+                    true )
       in
       if exists_well_formedness_errors then
         Mina_net2.Validation_callback.fire_if_not_already_fired cb `Reject ;
@@ -174,8 +200,8 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       in
       let tn_production_consensus_time =
         Consensus.Data.Consensus_state.consensus_time
-        @@ Protocol_state.consensus_state @@ Mina_block.Header.protocol_state
-        @@ Mina_block.header (Envelope.Incoming.data e)
+        @@ Protocol_state.consensus_state
+        @@ Mina_block.Header.protocol_state header
       in
       let tn_production_slot =
         lift_consensus_time tn_production_consensus_time

--- a/src/lib/transition_handler/block_sink.mli
+++ b/src/lib/transition_handler/block_sink.mli
@@ -6,10 +6,14 @@ type Structured_log_events.t +=
   | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
   [@@deriving register_event]
 
+type block_or_header =
+  [ `Block of Mina_block.t Envelope.Incoming.t
+  | `Header of Mina_block.Header.t Envelope.Incoming.t ]
+
 include
   Mina_net2.Sink.S_with_void
     with type msg :=
-      [ `Transition of Mina_block.t Envelope.Incoming.t ]
+      block_or_header
       * [ `Time_received of Block_time.t ]
       * [ `Valid_cb of Mina_net2.Validation_callback.t ]
 
@@ -27,7 +31,7 @@ type block_sink_config =
 
 val create :
      block_sink_config
-  -> ( [ `Transition of Mina_block.t Envelope.Incoming.t ]
+  -> ( block_or_header
      * [ `Time_received of Block_time.t ]
      * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
      Pipe_lib.Strict_pipe.Reader.t

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -194,21 +194,47 @@ let rec remove_tree t parent_hash =
       let transition, _ = Envelope.Incoming.data (Cached.peek child) in
       remove_tree t (State_hash.With_state_hashes.state_hash transition) )
 
-let watch t ~timeout_duration ~cached_transition ~valid_cb
-    ~block_window_duration =
-  let transition_with_hash, _ =
-    Envelope.Incoming.data (Cached.peek cached_transition)
-  in
-  let hash = State_hash.With_state_hashes.state_hash transition_with_hash in
-  let parent_hash =
-    With_hash.data transition_with_hash
-    |> Mina_block.header |> Header.protocol_state
-    |> Mina_state.Protocol_state.previous_state_hash
-  in
-  Internal_tracing.with_state_hash hash
+let log_block_metadata ~logger state_hash ~parent_hash =
+  Internal_tracing.with_state_hash state_hash
   @@ fun () ->
-  [%log' internal t.logger] "@block_metadata"
-    ~metadata:[ ("previous_state_hash", State_hash.to_yojson parent_hash) ] ;
+  [%log internal] "@block_metadata"
+    ~metadata:[ ("previous_state_hash", State_hash.to_yojson parent_hash) ]
+
+let get_parent_hash transition_with_hash =
+  With_hash.data transition_with_hash
+  |> Mina_block.header |> Header.protocol_state
+  |> Mina_state.Protocol_state.previous_state_hash
+
+let make_timeout t transition_with_hash duration =
+  let target_hash = get_parent_hash transition_with_hash in
+  Block_time.Timeout.create t.time_controller duration ~f:(fun _ ->
+      let forest = extract_forest t target_hash in
+      Hashtbl.remove t.parent_root_timeouts target_hash ;
+      Mina_metrics.(
+        Gauge.dec_one
+          Transition_frontier_controller.transitions_in_catchup_scheduler) ;
+      remove_tree t target_hash ;
+      [%log' info t.logger]
+        ~metadata:
+          [ ("parent_hash", Mina_base.State_hash.to_yojson target_hash)
+          ; ( "duration"
+            , `Int (Block_time.Span.to_ms duration |> Int64.to_int_trunc) )
+          ; ( "cached_transition"
+            , With_hash.data transition_with_hash |> Mina_block.to_yojson )
+          ]
+        "Timed out waiting for the parent of $cached_transition after \
+         $duration ms, signalling a catchup job" ;
+      (* it's ok to create a new thread here because the thread essentially does no work *)
+      if Writer.is_closed t.catchup_job_writer then
+        [%log' trace t.logger]
+          "catchup job pipe was closed; attempt to write to closed pipe"
+      else Writer.write t.catchup_job_writer forest )
+
+(* TODO handle possibility of receiving two gossips (one for block and another for header).
+   Existing code is safe as long as header-only gossip topic isn't actually used in the code.logger
+   I.e. this TODO has to be resolved before bit-catchup work fully lands.
+*)
+let register_validation_callback ~hash ~valid_cb ~block_window_duration t =
   Option.value_map valid_cb ~default:() ~f:(fun data ->
       match Hashtbl.add t.validation_callbacks ~key:hash ~data with
       | `Ok ->
@@ -220,31 +246,17 @@ let watch t ~timeout_duration ~cached_transition ~valid_cb
             (fun () -> Hashtbl.remove t.validation_callbacks hash)
       | `Duplicate ->
           [%log' warn t.logger] "Double validation callback for $state_hash"
-            ~metadata:[ ("state_hash", Mina_base.State_hash.to_yojson hash) ] ) ;
-  let make_timeout duration =
-    Block_time.Timeout.create t.time_controller duration ~f:(fun _ ->
-        let forest = extract_forest t parent_hash in
-        Hashtbl.remove t.parent_root_timeouts parent_hash ;
-        Mina_metrics.(
-          Gauge.dec_one
-            Transition_frontier_controller.transitions_in_catchup_scheduler) ;
-        remove_tree t parent_hash ;
-        [%log' info t.logger]
-          ~metadata:
-            [ ("parent_hash", Mina_base.State_hash.to_yojson parent_hash)
-            ; ( "duration"
-              , `Int (Block_time.Span.to_ms duration |> Int64.to_int_trunc) )
-            ; ( "cached_transition"
-              , With_hash.data transition_with_hash |> Mina_block.to_yojson )
-            ]
-          "Timed out waiting for the parent of $cached_transition after \
-           $duration ms, signalling a catchup job" ;
-        (* it's ok to create a new thread here because the thread essentially does no work *)
-        if Writer.is_closed t.catchup_job_writer then
-          [%log' trace t.logger]
-            "catchup job pipe was closed; attempt to write to closed pipe"
-        else Writer.write t.catchup_job_writer forest )
+            ~metadata:[ ("state_hash", Mina_base.State_hash.to_yojson hash) ] )
+
+let watch t ~timeout_duration ~cached_transition ~valid_cb
+    ~block_window_duration =
+  let transition_with_hash, _ =
+    Envelope.Incoming.data (Cached.peek cached_transition)
   in
+  let hash = State_hash.With_state_hashes.state_hash transition_with_hash in
+  let parent_hash = get_parent_hash transition_with_hash in
+  log_block_metadata ~logger:t.logger ~parent_hash hash ;
+  register_validation_callback ~hash ~valid_cb ~block_window_duration t ;
   match Hashtbl.find t.collected_transitions parent_hash with
   | None ->
       let remaining_time = cancel_timeout t hash in
@@ -254,7 +266,7 @@ let watch t ~timeout_duration ~cached_transition ~valid_cb
       ignore
         ( Hashtbl.add t.parent_root_timeouts ~key:parent_hash
             ~data:
-              (make_timeout
+              (make_timeout t transition_with_hash
                  (Option.fold remaining_time ~init:timeout_duration
                     ~f:(fun _ remaining_time ->
                       Block_time.Span.min remaining_time timeout_duration ) ) )
@@ -285,6 +297,28 @@ let watch t ~timeout_duration ~cached_transition ~valid_cb
         Mina_metrics.(
           Gauge.inc_one
             Transition_frontier_controller.transitions_in_catchup_scheduler)
+
+(** Handles a header received from gossip.
+    If a block corresponding to the header wasn't received yet, catchup
+    for it is triggered (and validation callback is registered to be
+    resolved when catchup receives corresponding block).
+*)
+let watch_header t ~header_with_hash ~valid_cb ~block_window_duration =
+  let hash = State_hash.With_state_hashes.state_hash header_with_hash in
+  let parent_hash =
+    With_hash.data header_with_hash
+    |> Header.protocol_state |> Mina_state.Protocol_state.previous_state_hash
+  in
+  log_block_metadata ~logger:t.logger ~parent_hash hash ;
+  match Hashtbl.find t.collected_transitions hash with
+  | None ->
+      register_validation_callback ~hash ~valid_cb ~block_window_duration t ;
+      if Writer.is_closed t.catchup_job_writer then
+        [%log' trace t.logger]
+          "catchup job pipe was closed; attempt to write to closed pipe"
+      else Writer.write t.catchup_job_writer (hash, [])
+  | _ ->
+      ()
 
 let notify t ~hash =
   if

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -110,28 +110,34 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 
 let process_transition ~context:(module Context : CONTEXT) ~trust_system
     ~verifier ~get_completed_work ~frontier ~catchup_scheduler
-    ~processed_transition_writer ~time_controller
-    ~transition:cached_initially_validated_transition ~valid_cb =
+    ~processed_transition_writer ~time_controller ~block_or_header ~valid_cb =
   let is_block_in_frontier =
     Fn.compose Option.is_some @@ Transition_frontier.find frontier
   in
   let open Context in
-  let enveloped_initially_validated_transition =
-    Cached.peek cached_initially_validated_transition
+  let header, transition_hash, transition_receipt_time, sender, validation =
+    match block_or_header with
+    | `Block cached_env ->
+        let env = Cached.peek cached_env in
+        let block, v = Envelope.Incoming.data env in
+        ( Mina_block.header @@ With_hash.data block
+        , State_hash.With_state_hashes.state_hash block
+        , Some (Envelope.Incoming.received_at env)
+        , Envelope.Incoming.sender env
+        , v )
+    | `Header env ->
+        let h, v = Envelope.Incoming.data env in
+        ( With_hash.data h
+        , State_hash.With_state_hashes.state_hash h
+        , Some (Envelope.Incoming.received_at env)
+        , Envelope.Incoming.sender env
+        , v )
   in
-  let transition_receipt_time =
-    Some
-      (Envelope.Incoming.received_at enveloped_initially_validated_transition)
+  let parent_hash =
+    Protocol_state.previous_state_hash (Header.protocol_state header)
   in
-  let sender =
-    Envelope.Incoming.sender enveloped_initially_validated_transition
-  in
-  let initially_validated_transition =
-    Envelope.Incoming.data enveloped_initially_validated_transition
-  in
-  let transition_hash, transition =
-    let t, _ = initially_validated_transition in
-    (State_hash.With_state_hashes.state_hash t, With_hash.data t)
+  let root_block =
+    Transition_frontier.(Breadcrumb.block_with_hash @@ root frontier)
   in
   let metadata = [ ("state_hash", State_hash.to_yojson transition_hash) ] in
   let state_hash = transition_hash in
@@ -140,130 +146,154 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
   [%log internal] "@block_metadata"
     ~metadata:
       [ ( "blockchain_length"
-        , Mina_numbers.Length.to_yojson
-            (Mina_block.blockchain_length transition) )
+        , Mina_numbers.Length.to_yojson (Header.blockchain_length header) )
       ] ;
   [%log internal] "Begin_external_block_processing" ;
-  Deferred.map ~f:(Fn.const ())
-    (let open Deferred.Result.Let_syntax in
-    [%log internal] "Validate_frontier_dependencies" ;
-    let%bind mostly_validated_transition =
-      let open Deferred.Let_syntax in
+  match block_or_header with
+  | `Header env -> (
+      let header_with_hash, _ = Envelope.Incoming.data env in
+      [%log internal] "Validate_frontier_dependencies" ;
+      return
+      @@
       match
         Mina_block.Validation.validate_frontier_dependencies
           ~context:(module Context)
-          ~root_block:
-            Transition_frontier.(Breadcrumb.block_with_hash @@ root frontier)
-          ~is_block_in_frontier ~to_header:Mina_block.header
-          initially_validated_transition
+          ~root_block ~is_block_in_frontier ~to_header:ident
+          (Envelope.Incoming.data env)
       with
-      | Ok t ->
-          return (Ok t)
-      | Error `Not_selected_over_frontier_root ->
-          [%log internal] "Failure"
-            ~metadata:[ ("reason", `String "Not_selected_over_frontier_root") ] ;
-          let%map () =
-            Trust_system.record_envelope_sender trust_system logger sender
-              ( Trust_system.Actions.Gossiped_invalid_transition
-              , Some
-                  ( "The transition with hash $state_hash was not selected \
-                     over the transition frontier root"
-                  , metadata ) )
-          in
-          let (_ : Mina_block.initial_valid_block Envelope.Incoming.t) =
-            Cached.invalidate_with_failure cached_initially_validated_transition
-          in
-          Error ()
-      | Error `Already_in_frontier ->
-          [%log internal] "Failure"
-            ~metadata:[ ("reason", `String "Already_in_frontier") ] ;
-          [%log warn] ~metadata
-            "Refusing to process the transition with hash $state_hash because \
-             is is already in the transition frontier" ;
-          let (_ : Mina_block.initial_valid_block Envelope.Incoming.t) =
-            Cached.invalidate_with_failure cached_initially_validated_transition
-          in
-          return (Error ())
-      | Error `Parent_missing_from_frontier -> (
+      (* TODO need more internal logging? *)
+      | Ok _ ->
+          Catchup_scheduler.watch_header catchup_scheduler ~valid_cb
+            ~block_window_duration:compile_config.block_window_duration
+            ~header_with_hash
+      | Error `Parent_missing_from_frontier ->
           [%log internal] "Schedule_catchup" ;
-          let _, validation =
-            Cached.peek cached_initially_validated_transition
-            |> Envelope.Incoming.data
-          in
-          match validation with
-          | ( _
-            , _
-            , _
-            , (`Delta_block_chain, Truth.True delta_state_hashes)
-            , _
-            , _
-            , _ ) ->
-              let timeout_duration =
-                Option.fold
-                  (Transition_frontier.find frontier
-                     (Mina_stdlib.Nonempty_list.head delta_state_hashes) )
-                  ~init:(Block_time.Span.of_ms 0L)
-                  ~f:(fun _ _ -> catchup_timeout_duration precomputed_values)
-              in
-              Catchup_scheduler.watch catchup_scheduler ~timeout_duration
-                ~cached_transition:cached_initially_validated_transition
-                ~valid_cb
-                ~block_window_duration:compile_config.block_window_duration ;
-              return (Error ()) )
-    in
-    (* TODO: only access parent in transition frontier once (already done in call to validate dependencies) #2485 *)
-    let parent_hash =
-      Protocol_state.previous_state_hash
-        (Header.protocol_state @@ Mina_block.header transition)
-    in
-    [%log internal] "Find_parent_breadcrumb" ;
-    let parent_breadcrumb = Transition_frontier.find_exn frontier parent_hash in
-    let%bind breadcrumb =
-      cached_transform_deferred_result cached_initially_validated_transition
-        ~transform_cached:(fun _ ->
-          Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
-            ~verifier ~get_completed_work ~trust_system ~transition_receipt_time
-            ~sender:(Some sender) ~parent:parent_breadcrumb
-            ~transition:mostly_validated_transition
-            (* TODO: Can we skip here? *) () )
-        ~transform_result:(function
-          | Error (`Invalid_staged_ledger_hash error)
-          | Error (`Invalid_staged_ledger_diff error) ->
-              Internal_tracing.with_state_hash state_hash
-              @@ fun () ->
-              [%log internal] "Failure"
-                ~metadata:[ ("reason", `String (Error.to_string_hum error)) ] ;
-              [%log error]
-                ~metadata:
-                  (metadata @ [ ("error", Error_json.error_to_yojson error) ])
-                "Error while building breadcrumb in the transition handler \
-                 processor: $error" ;
-              Deferred.return (Error ())
-          | Error (`Fatal_error exn) ->
-              Internal_tracing.with_state_hash state_hash
-              @@ fun () ->
-              [%log internal] "Failure"
-                ~metadata:[ ("reason", `String "Fatal error") ] ;
-              raise exn
-          | Ok breadcrumb ->
-              Deferred.return (Ok breadcrumb) )
-    in
-    Mina_metrics.(
-      Counter.inc_one
-        Transition_frontier_controller.breadcrumbs_built_by_processor) ;
-    let%map.Deferred result =
-      add_and_finalize ~logger ~frontier ~catchup_scheduler
-        ~processed_transition_writer ~only_if_present:false ~time_controller
-        ~source:`Gossip breadcrumb ~precomputed_values ~valid_cb
-        ~block_window_duration:compile_config.block_window_duration
-    in
-    ( match result with
-    | Ok () ->
-        [%log internal] "Breadcrumb_integrated"
-    | Error err ->
-        [%log internal] "Failure"
-          ~metadata:[ ("reason", `String (Error.to_string_hum err)) ] ) ;
-    Result.return result)
+          Catchup_scheduler.watch_header catchup_scheduler ~valid_cb
+            ~block_window_duration:compile_config.block_window_duration
+            ~header_with_hash
+      | _ ->
+          () )
+  | `Block cached_initially_validated_transition ->
+      Deferred.map ~f:(Fn.const ())
+      @@
+      let open Deferred.Result.Let_syntax in
+      let%bind mostly_validated_transition =
+        let open Deferred.Let_syntax in
+        let initially_validated_transition =
+          Cached.peek cached_initially_validated_transition
+          |> Envelope.Incoming.data
+        in
+        [%log internal] "Validate_frontier_dependencies" ;
+        match
+          Mina_block.Validation.validate_frontier_dependencies
+            ~context:(module Context)
+            ~root_block ~is_block_in_frontier ~to_header:Mina_block.header
+            initially_validated_transition
+        with
+        | Ok t ->
+            return (Ok t)
+        | Error `Not_selected_over_frontier_root ->
+            [%log internal] "Failure"
+              ~metadata:
+                [ ("reason", `String "Not_selected_over_frontier_root") ] ;
+            let%map () =
+              Trust_system.record_envelope_sender trust_system logger sender
+                ( Trust_system.Actions.Gossiped_invalid_transition
+                , Some
+                    ( "The transition with hash $state_hash was not selected \
+                       over the transition frontier root"
+                    , metadata ) )
+            in
+            let (_ : Mina_block.initial_valid_block Envelope.Incoming.t) =
+              Cached.invalidate_with_failure
+                cached_initially_validated_transition
+            in
+            Error ()
+        | Error `Already_in_frontier ->
+            [%log internal] "Failure"
+              ~metadata:[ ("reason", `String "Already_in_frontier") ] ;
+            [%log warn] ~metadata
+              "Refusing to process the transition with hash $state_hash \
+               because is is already in the transition frontier" ;
+            let (_ : Mina_block.initial_valid_block Envelope.Incoming.t) =
+              Cached.invalidate_with_failure
+                cached_initially_validated_transition
+            in
+            return (Error ())
+        | Error `Parent_missing_from_frontier -> (
+            [%log internal] "Schedule_catchup" ;
+            match validation with
+            | ( _
+              , _
+              , _
+              , (`Delta_block_chain, Truth.True delta_state_hashes)
+              , _
+              , _
+              , _ ) ->
+                let timeout_duration =
+                  Option.fold
+                    (Transition_frontier.find frontier
+                       (Mina_stdlib.Nonempty_list.head delta_state_hashes) )
+                    ~init:(Block_time.Span.of_ms 0L)
+                    ~f:(fun _ _ -> catchup_timeout_duration precomputed_values)
+                in
+                Catchup_scheduler.watch catchup_scheduler ~timeout_duration
+                  ~cached_transition:cached_initially_validated_transition
+                  ~valid_cb
+                  ~block_window_duration:compile_config.block_window_duration ;
+                return (Error ()) )
+      in
+      (* TODO: only access parent in transition frontier once (already done in call to validate dependencies) #2485 *)
+      [%log internal] "Find_parent_breadcrumb" ;
+      let parent_breadcrumb =
+        Transition_frontier.find_exn frontier parent_hash
+      in
+      let%bind breadcrumb =
+        cached_transform_deferred_result cached_initially_validated_transition
+          ~transform_cached:(fun _ ->
+            Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
+              ~verifier ~get_completed_work ~trust_system
+              ~transition_receipt_time ~sender:(Some sender)
+              ~parent:parent_breadcrumb ~transition:mostly_validated_transition
+              (* TODO: Can we skip here? *) () )
+          ~transform_result:(function
+            | Error (`Invalid_staged_ledger_hash error)
+            | Error (`Invalid_staged_ledger_diff error) ->
+                Internal_tracing.with_state_hash state_hash
+                @@ fun () ->
+                [%log internal] "Failure"
+                  ~metadata:[ ("reason", `String (Error.to_string_hum error)) ] ;
+                [%log error]
+                  ~metadata:
+                    (metadata @ [ ("error", Error_json.error_to_yojson error) ])
+                  "Error while building breadcrumb in the transition handler \
+                   processor: $error" ;
+                Deferred.return (Error ())
+            | Error (`Fatal_error exn) ->
+                Internal_tracing.with_state_hash state_hash
+                @@ fun () ->
+                [%log internal] "Failure"
+                  ~metadata:[ ("reason", `String "Fatal error") ] ;
+                raise exn
+            | Ok breadcrumb ->
+                Deferred.return (Ok breadcrumb) )
+      in
+      Mina_metrics.(
+        Counter.inc_one
+          Transition_frontier_controller.breadcrumbs_built_by_processor) ;
+      let%map.Deferred result =
+        add_and_finalize ~logger ~frontier ~catchup_scheduler
+          ~processed_transition_writer ~only_if_present:false ~time_controller
+          ~source:`Gossip breadcrumb ~precomputed_values ~valid_cb
+          ~block_window_duration:compile_config.block_window_duration
+      in
+      ( match result with
+      | Ok () ->
+          [%log internal] "Breadcrumb_integrated"
+      | Error err ->
+          [%log internal] "Failure"
+            ~metadata:[ ("reason", `String (Error.to_string_hum err)) ] ) ;
+      Result.return result
 
 let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
     ~time_controller ~frontier ~get_completed_work
@@ -271,7 +301,8 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
        ( [ `Block of
            ( Mina_block.initial_valid_block Envelope.Incoming.t
            , State_hash.t )
-           Cached.t ]
+           Cached.t
+         | `Header of Mina_block.initial_valid_header Envelope.Incoming.t ]
        * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Reader.t )
     ~(producer_transition_reader : Transition_frontier.Breadcrumb.t Reader.t)
@@ -436,9 +467,9 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                   Mina_metrics.(
                     Gauge.dec_one
                       Transition_frontier_controller.transitions_being_processed)
-              | `Partially_valid_transition
-                  (`Block transition, `Valid_cb valid_cb) ->
-                  process_transition ~transition ~valid_cb ) ) )
+              | `Partially_valid_transition (block_or_header, `Valid_cb valid_cb)
+                ->
+                  process_transition ~block_or_header ~valid_cb ) ) )
 
 let%test_module "Transition_handler.Processor tests" =
   ( module struct

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -112,6 +112,9 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
     ~verifier ~get_completed_work ~frontier ~catchup_scheduler
     ~processed_transition_writer ~time_controller
     ~transition:cached_initially_validated_transition ~valid_cb =
+  let is_block_in_frontier =
+    Fn.compose Option.is_some @@ Transition_frontier.find frontier
+  in
   let open Context in
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
@@ -151,10 +154,7 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
           ~context:(module Context)
           ~root_block:
             Transition_frontier.(Breadcrumb.block_with_hash @@ root frontier)
-          ~get_block_by_hash:
-            Transition_frontier.(
-              Fn.compose (Option.map ~f:Breadcrumb.block_with_hash)
-              @@ find frontier)
+          ~is_block_in_frontier ~to_header:Mina_block.header
           initially_validated_transition
       with
       | Ok t ->

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -3,7 +3,6 @@ open Core_kernel
 open Pipe_lib.Strict_pipe
 open Mina_base
 open Mina_state
-open Cache_lib
 open Mina_block
 open Network_peer
 
@@ -17,18 +16,74 @@ module type CONTEXT = sig
   val consensus_constants : Consensus.Constants.t
 end
 
+let validate_header_is_relevant ~context:(module Context : CONTEXT) ~frontier
+    ~slot_chain_end header_with_hash =
+  let open Result.Let_syntax in
+  let module Context = struct
+    include Context
+
+    let logger =
+      Logger.extend logger
+        [ ("selection_context", `String "Transition_handler.Validator") ]
+  end in
+  let transition_hash =
+    State_hash.With_state_hashes.state_hash header_with_hash
+  in
+  [%log' internal Context.logger] "Validate_transition" ;
+  let get_consensus_constants h =
+    Mina_block.Header.protocol_state h |> Protocol_state.consensus_state
+  in
+  let header_data = With_hash.data header_with_hash in
+  let block_slot =
+    Consensus.Data.Consensus_state.curr_global_slot
+    @@ Protocol_state.consensus_state
+    @@ Header.protocol_state header_data
+  in
+  let%bind () =
+    match slot_chain_end with
+    | Some slot_chain_end
+      when Mina_numbers.Global_slot_since_hard_fork.(
+             block_slot >= slot_chain_end) ->
+        [%log' internal Context.logger] "Block after slot_chain_end, rejecting" ;
+        Result.fail `Block_after_after_stop_slot
+    | None | Some _ ->
+        Result.return ()
+  in
+  let blockchain_length =
+    With_hash.data header_with_hash |> Mina_block.Header.blockchain_length
+  in
+  let root_breadcrumb = Transition_frontier.root frontier in
+  [%log' internal Context.logger] "@block_metadata"
+    ~metadata:
+      [ ("blockchain_length", Mina_numbers.Length.to_yojson blockchain_length) ] ;
+  [%log' internal Context.logger] "Check_transition_not_in_frontier" ;
+  let open Result.Let_syntax in
+  let%bind () =
+    Option.fold
+      (Transition_frontier.find frontier transition_hash)
+      ~init:Result.(Ok ())
+      ~f:(fun _ _ -> Result.Error (`In_frontier transition_hash))
+  in
+  [%log' internal Context.logger] "Check_transition_not_in_process" ;
+  Result.ok_if_true
+    (Consensus.Hooks.equal_select_status `Take
+       (Consensus.Hooks.select
+          ~context:(module Context)
+          ~existing:
+            (Transition_frontier.Breadcrumb.consensus_state_with_hashes
+               root_breadcrumb )
+          ~candidate:(With_hash.map ~f:get_consensus_constants header_with_hash) ) )
+    ~error:`Disconnected
+
 let validate_transition_is_relevant ~context:(module Context : CONTEXT)
     ~frontier ~unprocessed_transition_cache ~slot_tx_end ~slot_chain_end
     enveloped_transition =
-  let logger = Context.logger in
   let open Result.Let_syntax in
+  [%log' internal Context.logger] "Validate_transition" ;
   let transition =
     Envelope.Incoming.data enveloped_transition
     |> Mina_block.Validation.block_with_hash
   in
-  let transition_hash = State_hash.With_state_hashes.state_hash transition in
-  [%log internal] "Validate_transition" ;
-  let root_breadcrumb = Transition_frontier.root frontier in
   let transition_data = With_hash.data transition in
   let block_slot =
     Consensus.Data.Consensus_state.curr_global_slot
@@ -36,21 +91,12 @@ let validate_transition_is_relevant ~context:(module Context : CONTEXT)
     @@ Mina_block.header transition_data
   in
   let%bind () =
-    match slot_chain_end with
-    | Some slot_chain_end
-      when Mina_numbers.Global_slot_since_hard_fork.(
-             block_slot >= slot_chain_end) ->
-        [%log info] "Block after slot_chain_end, rejecting" ;
-        Result.fail `Block_after_after_stop_slot
-    | None | Some _ ->
-        Result.return ()
-  in
-  let%bind () =
     match slot_tx_end with
     | Some slot_tx_end
       when Mina_numbers.Global_slot_since_hard_fork.(block_slot >= slot_tx_end)
       ->
-        [%log info] "Block after slot_tx_end, validating it is empty" ;
+        [%log' internal Context.logger]
+          "Block after slot_tx_end, validating it is empty" ;
         let staged_ledger_diff =
           Body.staged_ledger_diff @@ body transition_data
         in
@@ -66,17 +112,10 @@ let validate_transition_is_relevant ~context:(module Context : CONTEXT)
     Envelope.Incoming.data enveloped_transition
     |> Mina_block.Validation.block |> Mina_block.blockchain_length
   in
-  [%log internal] "@block_metadata"
+  [%log' internal Context.logger] "@block_metadata"
     ~metadata:
       [ ("blockchain_length", Mina_numbers.Length.to_yojson blockchain_length) ] ;
-  [%log internal] "Check_transition_not_in_frontier" ;
-  let%bind () =
-    Option.fold
-      (Transition_frontier.find frontier transition_hash)
-      ~init:Result.(Ok ())
-      ~f:(fun _ _ -> Result.Error (`In_frontier transition_hash))
-  in
-  [%log internal] "Check_transition_not_in_process" ;
+  [%log' internal Context.logger] "Check_transition_not_in_process" ;
   let%bind () =
     Option.fold
       (Unprocessed_transition_cache.final_state unprocessed_transition_cache
@@ -84,58 +123,62 @@ let validate_transition_is_relevant ~context:(module Context : CONTEXT)
       ~init:Result.(Ok ())
       ~f:(fun _ final_state -> Result.Error (`In_process final_state))
   in
-  [%log internal] "Check_transition_can_be_connected" ;
-  let module Context = struct
-    include Context
-
-    let logger =
-      Logger.extend logger
-        [ ("selection_context", `String "Transition_handler.Validator") ]
-  end in
+  [%log' internal Context.logger] "Check_transition_can_be_connected" ;
+  let header_with_hash = With_hash.map ~f:Mina_block.header transition in
   let%map () =
-    Result.ok_if_true
-      (Consensus.Hooks.equal_select_status `Take
-         (Consensus.Hooks.select
-            ~context:(module Context)
-            ~existing:
-              (Transition_frontier.Breadcrumb.consensus_state_with_hashes
-                 root_breadcrumb )
-            ~candidate:(With_hash.map ~f:Mina_block.consensus_state transition) ) )
-      ~error:`Disconnected
+    validate_header_is_relevant
+      ~context:(module Context)
+      ~frontier ~slot_chain_end header_with_hash
   in
-  [%log internal] "Register_transition_for_processing" ;
+  [%log' internal Context.logger] "Register_transition_for_processing" ;
   (* we expect this to be Ok since we just checked the cache *)
   Unprocessed_transition_cache.register_exn unprocessed_transition_cache
     enveloped_transition
 
+let validate_transition_or_header_is_relevant
+    ~context:(module Context : CONTEXT) ~slot_tx_end ~slot_chain_end ~frontier
+    ~unprocessed_transition_cache b_or_h =
+  match b_or_h with
+  | `Block b ->
+      Result.map ~f:(fun x -> `Block x)
+      @@ validate_transition_is_relevant
+           ~context:(module Context)
+           ~slot_tx_end ~slot_chain_end ~frontier ~unprocessed_transition_cache
+           b
+  | `Header h ->
+      let header_with_hash, _ = Envelope.Incoming.data h in
+      Result.map ~f:(fun _ -> `Header h)
+      @@ validate_header_is_relevant
+           ~context:(module Context)
+           ~slot_chain_end ~frontier header_with_hash
+
 let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
-    ~frontier ~transition_reader
-    ~(valid_transition_writer :
-       ( [ `Block of
-           ( Mina_block.initial_valid_block Envelope.Incoming.t
-           , State_hash.t )
-           Cached.t ]
-         * [ `Valid_cb of Mina_net2.Validation_callback.t option ]
-       , drop_head buffered
-       , unit )
-       Writer.t ) ~unprocessed_transition_cache =
+    ~frontier ~transition_reader ~valid_transition_writer
+    ~unprocessed_transition_cache =
   let open Context in
   let module Lru = Core_extended_cache.Lru in
   let outdated_root_cache = Lru.create ~destruct:None 1000 in
   O1trace.background_thread "validate_blocks_against_frontier" (fun () ->
-      Reader.iter transition_reader
-        ~f:(fun (`Block transition_env, `Valid_cb vc) ->
-          let transition_with_hash, _ = Envelope.Incoming.data transition_env in
+      Reader.iter transition_reader ~f:(fun (b_or_h, `Valid_cb vc) ->
+          let header_with_hash, sender =
+            match b_or_h with
+            | `Block b ->
+                let block_with_hash, _ = Envelope.Incoming.data b in
+                ( With_hash.map ~f:Mina_block.header block_with_hash
+                , Envelope.Incoming.sender b )
+            | `Header h ->
+                let header_with_hash, _ = Envelope.Incoming.data h in
+                (header_with_hash, Envelope.Incoming.sender h)
+          in
+          let header = With_hash.data header_with_hash in
           let transition_hash =
-            State_hash.With_state_hashes.state_hash transition_with_hash
+            State_hash.With_state_hashes.state_hash header_with_hash
           in
           Internal_tracing.Context_call.with_call_id
             ~tag:"transition_handler_validator"
           @@ fun () ->
           Internal_tracing.with_state_hash transition_hash
           @@ fun () ->
-          let transition = With_hash.data transition_with_hash in
-          let sender = Envelope.Incoming.sender transition_env in
           let slot_tx_end =
             Runtime_config.slot_tx_end
               precomputed_values.Precomputed_values.runtime_config
@@ -144,24 +187,23 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
             Runtime_config.slot_chain_end precomputed_values.runtime_config
           in
           match
-            validate_transition_is_relevant
+            validate_transition_or_header_is_relevant
               ~context:(module Context)
               ~frontier ~unprocessed_transition_cache ~slot_tx_end
-              ~slot_chain_end transition_env
+              ~slot_chain_end b_or_h
           with
-          | Ok cached_transition ->
+          | Ok b_or_h' ->
               let%map () =
                 Trust_system.record_envelope_sender trust_system logger sender
                   ( Trust_system.Actions.Sent_useful_gossip
                   , Some
                       ( "external transition $state_hash"
                       , [ ("state_hash", State_hash.to_yojson transition_hash)
-                        ; ("transition", Mina_block.to_yojson transition)
+                        ; ("header", Mina_block.Header.to_yojson header)
                         ] ) )
               in
               let transition_time =
-                Mina_block.header transition
-                |> Mina_block.Header.protocol_state
+                Mina_block.Header.protocol_state header
                 |> Protocol_state.blockchain_state |> Blockchain_state.timestamp
                 |> Block_time.to_time_exn
               in
@@ -171,8 +213,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
                    Block_time.(now time_controller |> to_time_exn)
                    transition_time ) ;
               [%log internal] "Validate_transition_done" ;
-              Writer.write valid_transition_writer
-                (`Block cached_transition, `Valid_cb vc)
+              Writer.write valid_transition_writer (b_or_h', `Valid_cb vc)
           | Error (`In_frontier _) | Error (`In_process _) ->
               [%log internal] "Failure"
                 ~metadata:[ ("reason", `String "In_frontier or In_process") ] ;
@@ -181,21 +222,20 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
                 , Some
                     ( "external transition with state hash $state_hash"
                     , [ ("state_hash", State_hash.to_yojson transition_hash)
-                      ; ("transition", Mina_block.to_yojson transition)
+                      ; ("header", Mina_block.Header.to_yojson header)
                       ] ) )
           | Error `Disconnected ->
               [%log internal] "Failure"
                 ~metadata:[ ("reason", `String "Disconnected") ] ;
               Mina_metrics.(Counter.inc_one Rejected_blocks.worse_than_root) ;
-              let protocol_state =
-                Mina_block.Header.protocol_state (Mina_block.header transition)
-              in
+              let protocol_state = Mina_block.Header.protocol_state header in
               [%log error]
                 ~metadata:
                   [ ("state_hash", State_hash.to_yojson transition_hash)
                   ; ("reason", `String "not selected over current root")
                   ; ( "protocol_state"
-                    , Protocol_state.value_to_yojson protocol_state )
+                    , Mina_block.Header.protocol_state header
+                      |> Protocol_state.value_to_yojson )
                   ]
                 "Validation error: external transition with state hash \
                  $state_hash was rejected for reason $reason" ;
@@ -228,10 +268,8 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
                 , Some
                     ( "received transition that was not connected to our chain \
                        from $sender"
-                    , [ ( "sender"
-                        , Envelope.Sender.to_yojson
-                            (Envelope.Incoming.sender transition_env) )
-                      ; ("transition", Mina_block.to_yojson transition)
+                    , [ ("sender", Envelope.Sender.to_yojson sender)
+                      ; ("header", Mina_block.Header.to_yojson header)
                       ] ) )
           | Error `Non_empty_staged_ledger_diff_after_stop_slot ->
               [%log error]
@@ -244,7 +282,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
                     , Mina_numbers.Global_slot_since_hard_fork.to_yojson
                       @@ Consensus.Data.Consensus_state.curr_global_slot
                       @@ Protocol_state.consensus_state @@ Header.protocol_state
-                      @@ Mina_block.header @@ transition )
+                      @@ header )
                   ]
                 "Validation error: external transition with state hash \
                  $state_hash was rejected for reason $reason" ;
@@ -258,7 +296,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~time_controller
                     , Mina_numbers.Global_slot_since_hard_fork.to_yojson
                       @@ Consensus.Data.Consensus_state.curr_global_slot
                       @@ Protocol_state.consensus_state @@ Header.protocol_state
-                      @@ Mina_block.header @@ transition )
+                      @@ header )
                   ]
                 "Validation error: external transition with state hash \
                  $state_hash was rejected for reason $reason" ;

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -17,13 +17,10 @@ type validation_error =
 [@@deriving sexp_of]
 
 let handle_validation_error ~logger ~rejected_blocks_logger ~time_received
-    ~trust_system ~sender ~transition_with_hash ~delta (error : validation_error)
-    =
+    ~trust_system ~sender ~header_with_hash ~delta (error : validation_error) =
   let open Trust_system.Actions in
-  let state_hash =
-    State_hash.With_state_hashes.state_hash transition_with_hash
-  in
-  let transition = With_hash.data transition_with_hash in
+  let state_hash = State_hash.With_state_hashes.state_hash header_with_hash in
+  let header = With_hash.data header_with_hash in
   let punish action message =
     let message' =
       "external transition with state hash $state_hash"
@@ -53,11 +50,8 @@ let handle_validation_error ~logger ~rejected_blocks_logger ~time_received
     | `Invalid_proof err ->
         [ ("reason", `String "invalid proof")
         ; ( "protocol_state"
-          , Header.protocol_state (Mina_block.header transition)
-            |> Protocol_state.value_to_yojson )
-        ; ( "proof"
-          , Header.protocol_state_proof @@ Mina_block.header transition
-            |> Proof.to_yojson )
+          , Header.protocol_state header |> Protocol_state.value_to_yojson )
+        ; ("proof", Header.protocol_state_proof header |> Proof.to_yojson)
         ; ("error", Error_json.error_to_yojson err)
         ]
     | `Invalid_delta_block_chain_proof ->
@@ -87,8 +81,7 @@ let handle_validation_error ~logger ~rejected_blocks_logger ~time_received
   [%log' debug rejected_blocks_logger]
     ~metadata:
       ( ( "protocol_state"
-        , Protocol_state.Value.to_yojson
-            (Header.protocol_state (Mina_block.header transition)) )
+        , Protocol_state.Value.to_yojson (Header.protocol_state header) )
       :: metadata )
     "Validation error: external transition with state hash $state_hash was \
      rejected for reason $reason" ;
@@ -190,13 +183,15 @@ module Duplicate_block_detector = struct
   let create () = { table = Map.empty (module Blocks); latest_epoch = 0 }
 
   let check ~precomputed_values ~rejected_blocks_logger ~time_received t logger
-      external_transition_with_hash =
-    let external_transition = external_transition_with_hash.With_hash.data in
+      header_with_hash =
+    let header = header_with_hash.With_hash.data in
     let protocol_state_hash =
-      State_hash.With_state_hashes.state_hash external_transition_with_hash
+      State_hash.With_state_hashes.state_hash header_with_hash
     in
     let open Consensus.Data.Consensus_state in
-    let consensus_state = Mina_block.consensus_state external_transition in
+    let consensus_state =
+      Mina_block.Header.protocol_state header |> Protocol_state.consensus_state
+    in
     let consensus_time = consensus_time consensus_state in
     let block_producer =
       Consensus.Data.Consensus_state.block_creator consensus_state
@@ -244,27 +239,32 @@ let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
     Logger.create ~id:Logger.Logger_id.rejected_blocks ()
   in
   let duplicate_checker = Duplicate_block_detector.create () in
-  stage (fun ~transition_env ~time_received ~valid_cb ->
+  stage (fun ~b_or_h ~time_received ~valid_cb ->
+      let header, sender =
+        match b_or_h with
+        | `Block b_env ->
+            ( Mina_block.header (Envelope.Incoming.data b_env)
+            , Envelope.Incoming.sender b_env )
+        | `Header h_env ->
+            (Envelope.Incoming.data h_env, Envelope.Incoming.sender h_env)
+      in
       let open Deferred.Let_syntax in
       if Ivar.is_full initialization_finish_signal then (
         let blockchain_length =
-          Envelope.Incoming.data transition_env
-          |> Mina_block.blockchain_length |> Mina_numbers.Length.to_int
+          Mina_block.Header.blockchain_length header
+          |> Mina_numbers.Length.to_int
         in
         Mina_metrics.Transition_frontier
         .update_max_unvalidated_blocklength_observed blockchain_length ;
         ( if not (Mina_net2.Validation_callback.is_expired valid_cb) then (
-          let transition_with_hash =
-            Envelope.Incoming.data transition_env
-            |> With_hash.of_data
-                 ~hash_data:
-                   (Fn.compose Protocol_state.hashes
-                      (Fn.compose Header.protocol_state Mina_block.header) )
+          let header_hashed =
+            With_hash.of_data header
+              ~hash_data:
+                (Fn.compose Protocol_state.hashes Header.protocol_state)
           in
           Duplicate_block_detector.check ~precomputed_values
             ~rejected_blocks_logger ~time_received duplicate_checker logger
-            transition_with_hash ;
-          let sender = Envelope.Incoming.sender transition_env in
+            header_hashed ;
           let computation =
             let open Interruptible.Let_syntax in
             let defer f x =
@@ -273,9 +273,6 @@ let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
             let%bind () =
               Interruptible.lift Deferred.unit
                 (Mina_net2.Validation_callback.await_timeout valid_cb)
-            in
-            let header_hashed : Header.with_hash =
-              With_hash.map ~f:Mina_block.header transition_with_hash
             in
             match%bind
               let open Interruptible.Result.Let_syntax in
@@ -290,21 +287,29 @@ let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
                 >>= defer validate_protocol_versions)
             with
             | Ok verified_header ->
+                [%log internal] "Initial_validation_done" ;
+                let b_or_h' =
+                  match b_or_h with
+                  | `Block b_env ->
+                      `Block
+                        (Envelope.Incoming.map
+                           ~f:
+                             (Fn.compose
+                                (Mina_block.Validation.with_body verified_header)
+                                Mina_block.body )
+                           b_env )
+                  | `Header h_env ->
+                      `Header
+                        (Envelope.Incoming.map ~f:(Fn.const verified_header)
+                           h_env )
+                in
                 Mina_metrics.Transition_frontier.update_max_blocklength_observed
                   blockchain_length ;
                 Queue.enqueue Transition_frontier.validated_blocks
-                  ( State_hash.With_state_hashes.state_hash transition_with_hash
+                  ( State_hash.With_state_hashes.state_hash header_hashed
                   , sender
                   , time_received ) ;
-                let verified_block =
-                  Validation.with_body verified_header
-                    (With_hash.data transition_with_hash |> Mina_block.body)
-                in
-                return
-                  (Ok
-                     ( `Block
-                         (Envelope.Incoming.wrap ~data:verified_block ~sender)
-                     , `Valid_cb valid_cb ) )
+                return (Ok (b_or_h', `Valid_cb valid_cb))
             | Error error ->
                 Mina_net2.Validation_callback.fire_if_not_already_fired valid_cb
                   `Reject ;
@@ -312,7 +317,7 @@ let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
                   Interruptible.uninterruptible
                   @@ handle_validation_error ~logger ~rejected_blocks_logger
                        ~time_received ~trust_system ~sender
-                       ~transition_with_hash
+                       ~header_with_hash:header_hashed
                        ~delta:genesis_constants.protocol.delta error
                 in
                 Error ()
@@ -326,10 +331,7 @@ let validate ~logger ~trust_system ~verifier ~initialization_finish_signal
             Error ()
         | Error () ->
             let state_hash =
-              ( Envelope.Incoming.data transition_env
-              |> Mina_block.header |> Header.protocol_state
-              |> Protocol_state.hashes )
-                .state_hash
+              (Header.protocol_state header |> Protocol_state.hashes).state_hash
             in
             let metadata =
               [ ("state_hash", State_hash.to_yojson state_hash)

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Async_kernel
 open Pipe_lib
-open Mina_block
 open Network_peer
 open Mina_numbers
 
@@ -27,16 +26,44 @@ type Structured_log_events.t += Starting_bootstrap_controller
 let create_buffered_pipe ?name ~f () =
   Strict_pipe.create ?name (Buffered (`Capacity 50, `Overflow (Drop_head f)))
 
+let block_or_header_to_header_hashed b_or_h =
+  match b_or_h with
+  | `Block b ->
+      With_hash.map ~f:Mina_block.header @@ fst @@ Envelope.Incoming.data b
+  | `Header h ->
+      fst @@ Envelope.Incoming.data h
+
+let block_or_header_to_header_hashed_with_validation b_or_h =
+  match b_or_h with
+  | `Block b ->
+      let b', v = Envelope.Incoming.data b in
+      (With_hash.map ~f:Mina_block.header b', v)
+  | `Header h ->
+      Envelope.Incoming.data h
+
+let block_or_header_to_hash
+    (b_or_h :
+      [ `Block of
+        Mina_block.Validation.initial_valid_with_block Envelope.Incoming.t
+      | `Header of
+        Mina_block.Validation.initial_valid_with_header Envelope.Incoming.t ] )
+    =
+  With_hash.hash (block_or_header_to_header_hashed b_or_h)
+
+let to_consensus_state h =
+  Mina_block.Validation.header_with_hash h
+  |> With_hash.map
+       ~f:
+         (Fn.compose Mina_state.Protocol_state.consensus_state
+            Mina_block.Header.protocol_state )
+
 let is_transition_for_bootstrap ~context:(module Context : CONTEXT) frontier
-    new_transition =
+    new_header_hash =
   let root_consensus_state =
     Transition_frontier.root frontier
     |> Transition_frontier.Breadcrumb.consensus_state_with_hashes
   in
-  let new_consensus_state =
-    Validation.block_with_hash new_transition
-    |> With_hash.map ~f:Mina_block.consensus_state
-  in
+  let new_consensus_state = to_consensus_state new_header_hash in
   match
     Consensus.Hooks.select
       ~context:(module Context)
@@ -82,13 +109,12 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
       , transition_frontier_controller_writer ) =
     let name = "transition frontier controller pipe" in
     create_buffered_pipe ~name
-      ~f:(fun (`Block block, `Valid_cb valid_cb) ->
+      ~f:(fun (b_or_h, `Valid_cb valid_cb) ->
         Mina_metrics.(
           Counter.inc_one
             Pipe.Drop_on_overflow.router_transition_frontier_controller) ;
         Mina_block.handle_dropped_transition
-          ( With_hash.hash @@ Validation.block_with_hash
-          @@ Network_peer.Envelope.Incoming.data block )
+          (block_or_header_to_hash b_or_h)
           ?valid_cb ~pipe_name:name ~logger )
       ()
   in
@@ -143,12 +169,11 @@ let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
   let bootstrap_controller_reader, bootstrap_controller_writer =
     let name = "bootstrap controller pipe" in
     create_buffered_pipe ~name
-      ~f:(fun (`Block head, `Valid_cb valid_cb) ->
+      ~f:(fun (b_or_h, `Valid_cb valid_cb) ->
         Mina_metrics.(
           Counter.inc_one Pipe.Drop_on_overflow.router_bootstrap_controller) ;
         Mina_block.handle_dropped_transition
-          ( With_hash.hash @@ Validation.block_with_hash
-          @@ Network_peer.Envelope.Incoming.data head )
+          (block_or_header_to_hash b_or_h)
           ~pipe_name:name ~logger ?valid_cb )
       ()
   in
@@ -259,7 +284,7 @@ let download_best_tip ~context:(module Context : CONTEXT) ~notify_online
         Option.merge acc (Option.return enveloped_candidate_best_tip)
           ~f:(fun enveloped_existing_best_tip enveloped_candidate_best_tip ->
             let f x =
-              Validation.block_with_hash x
+              Mina_block.Validation.block_with_hash x
               |> With_hash.map ~f:Mina_block.consensus_state
             in
             match
@@ -276,14 +301,14 @@ let download_best_tip ~context:(module Context : CONTEXT) ~notify_online
   Option.iter res ~f:(fun best ->
       let best_tip = best.data.data in
       let best_tip_length =
-        Validation.block best_tip |> Mina_block.blockchain_length
-        |> Length.to_int
+        Mina_block.Validation.block best_tip
+        |> Mina_block.blockchain_length |> Length.to_int
       in
       Mina_metrics.Transition_frontier.update_max_blocklength_observed
         best_tip_length ;
       don't_wait_for
       @@ Broadcast_pipe.Writer.write most_recent_valid_block_writer
-      @@ Validation.to_header best_tip ) ;
+      @@ Mina_block.Validation.to_header best_tip ) ;
   Option.map res
     ~f:
       (Envelope.Incoming.map ~f:(fun (x : _ Proof_carrying_data.t) ->
@@ -402,14 +427,15 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
     when is_transition_for_bootstrap
            ~context:(module Context)
            frontier
-           (best_tip |> Envelope.Incoming.data) ->
+           ( best_tip |> Envelope.Incoming.data
+           |> Mina_block.Validation.to_header ) ->
       [%log info]
         ~metadata:
           [ ( "length"
             , `Int
                 (Unsigned.UInt32.to_int
                    ( Mina_block.blockchain_length
-                   @@ Validation.block best_tip.data ) ) )
+                   @@ Mina_block.Validation.block best_tip.data ) ) )
           ]
         "Network best tip is too new to catchup to (best_tip with $length); \
          starting bootstrap" ;
@@ -435,7 +461,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
                   , `Int
                       (Unsigned.UInt32.to_int
                          ( Mina_block.blockchain_length
-                         @@ Validation.block best_tip.data ) ) )
+                         @@ Mina_block.Validation.block best_tip.data ) ) )
                 ]
               "Network best tip is recent enough to catchup to (best_tip with \
                $length); syncing local state and starting participation" ;
@@ -571,12 +597,11 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
         let name = "valid transitions" in
         create_buffered_pipe ~name
           ~f:(fun head ->
-            let `Block block, `Valid_cb valid_cb = head in
+            let b_or_h, `Valid_cb valid_cb = head in
             Mina_metrics.(
               Counter.inc_one Pipe.Drop_on_overflow.router_valid_transitions) ;
             Mina_block.handle_dropped_transition
-              ( Network_peer.Envelope.Incoming.data block
-              |> Validation.block_with_hash |> With_hash.hash )
+              (block_or_header_to_hash b_or_h)
               ~valid_cb ~pipe_name:name ~logger )
           ()
       in
@@ -588,14 +613,9 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
         in
         O1trace.background_thread "initially_validate_blocks" (fun () ->
             Pipe_lib.Strict_pipe.Reader.iter network_transition_reader
-              ~f:(fun
-                   ( `Transition transition_env
-                   , `Time_received time_received
-                   , `Valid_cb valid_cb )
+              ~f:(fun (b_or_h, `Time_received time_received, `Valid_cb valid_cb)
                  ->
-                match%map
-                  initial_validate ~transition_env ~time_received ~valid_cb
-                with
+                match%map initial_validate ~b_or_h ~time_received ~valid_cb with
                 | Ok valid_transition ->
                     Pipe_lib.Strict_pipe.Writer.write valid_transition_writer
                       valid_transition
@@ -626,45 +646,39 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
         Strict_pipe.Reader.Fork.two valid_transition_reader
       in
       don't_wait_for
-      @@ Strict_pipe.Reader.iter valid_transition_reader1
-           ~f:(fun (`Block enveloped_transition, _) ->
-             let incoming_transition =
-               Envelope.Incoming.data enveloped_transition
+      @@ Strict_pipe.Reader.iter valid_transition_reader1 ~f:(fun (b_or_h, _) ->
+             let header_with_hash =
+               block_or_header_to_header_hashed_with_validation b_or_h
              in
-             let current_transition = get_most_recent_valid_block () in
+             let current_header_with_hash = get_most_recent_valid_block () in
              if
                Consensus.Hooks.equal_select_status `Take
                  (Consensus.Hooks.select
                     ~context:(module Context)
-                    ~existing:
-                      ( Validation.header_with_hash current_transition
-                      |> With_hash.map
-                           ~f:
-                             (Fn.compose
-                                Mina_state.Protocol_state.consensus_state
-                                Mina_block.Header.protocol_state ) )
-                    ~candidate:
-                      ( Validation.block_with_hash incoming_transition
-                      |> With_hash.map ~f:Mina_block.consensus_state ) )
+                    ~existing:(to_consensus_state current_header_with_hash)
+                    ~candidate:(to_consensus_state header_with_hash) )
              then
                (* TODO: do we need to push valid_cb? *)
                Broadcast_pipe.Writer.write most_recent_valid_block_writer
-               @@ Validation.to_header incoming_transition
+                 header_with_hash
              else Deferred.unit ) ;
       don't_wait_for
       @@ Strict_pipe.Reader.iter_without_pushback valid_transition_reader2
-           ~f:(fun (`Block enveloped_transition, `Valid_cb vc) ->
+           ~f:(fun (b_or_h, `Valid_cb vc) ->
              don't_wait_for
              @@ let%map () =
-                  let incoming_transition =
-                    Envelope.Incoming.data enveloped_transition
+                  let header_with_hash =
+                    block_or_header_to_header_hashed_with_validation b_or_h
+                  in
+                  let best_seen_transition =
+                    match b_or_h with `Block b_env -> Some b_env | _ -> None
                   in
                   match get_current_frontier () with
                   | Some frontier ->
                       if
                         is_transition_for_bootstrap
                           ~context:(module Context)
-                          frontier incoming_transition
+                          frontier header_with_hash
                       then (
                         Strict_pipe.Writer.kill !transition_writer_ref ;
                         Option.iter ~f:Strict_pipe.Writer.kill
@@ -688,12 +702,11 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
                              ~clear_reader ~transition_writer_ref
                              ~consensus_local_state ~frontier_w ~persistent_root
                              ~persistent_frontier ~initial_root_transition
-                             ~best_seen_transition:(Some enveloped_transition)
-                             ~catchup_mode )
+                             ~best_seen_transition ~catchup_mode )
                       else Deferred.unit
                   | None ->
                       Deferred.unit
                 in
                 Strict_pipe.Writer.write !transition_writer_ref
-                  (`Block enveloped_transition, `Valid_cb (Some vc)) ) ) ;
+                  (b_or_h, `Valid_cb (Some vc)) ) ) ;
   (verified_transition_reader, initialization_finish_signal)


### PR DESCRIPTION
This PR rebases the following commit of https://github.com/MinaProtocol/mina/pull/12534 :

[Use headers for v1 pubsub block topic](https://github.com/MinaProtocol/mina/pull/12534/commits/c9416b3dc82999047d081718e6d57d4c47a4cc01)

Receive headers on a new pubsub topic and propagate them all the way
through to catchup, as alternative to block.

Existing synchronization code relies heavily on full blocks becoming
available, hence a hack was made: when a valid and relevant header
enters catchup system, download of a block will be requested and only
when the full block is available, processing will continue.

---

I did my best to split in several commits but I didn't manage to make them all compile.