### PR TITLE
Introduce additional checks for dhall (deps, dirtyWhen)

### DIFF
--- a/buildkite/Makefile
+++ b/buildkite/Makefile
@@ -20,6 +20,6 @@ check_deps:
 	python3 scripts/dhall/checker.py --root ./src/Jobs deps
 
 check_dirty:
-	python3 scripts/dhall/checker.py --root ./src/Jobs dirty-when
+	python3 scripts/dhall/checker.py --root $(PWD)/src/Jobs dirty-when  --repo "$(PWD)/../"
 
 all: check_syntax lint format check_deps check_dirty

--- a/buildkite/Makefile
+++ b/buildkite/Makefile
@@ -15,3 +15,11 @@ lint:
 
 format:
 	find ./src/ -name "*.dhall" -print0 | xargs -I{} -0 -n1 bash -c 'echo "{}" && dhall --ascii format --inplace {} || exit 255'
+
+check_deps:
+	python3 scripts/dhall/checker.py --root ./src/Jobs deps
+
+check_dirty:
+	python3 scripts/dhall/checker.py --root ./src/Jobs dirty-when
+
+all: check_syntax lint format check_deps check_dirty

--- a/buildkite/scripts/dhall/checker.py
+++ b/buildkite/scripts/dhall/checker.py
@@ -1,0 +1,219 @@
+"""
+    Runs dhall checks like:
+
+    - validate if all dependencies in jobs are covered
+
+        python3 buildkite/scripts/dhall/checker.py --root ./buildkite/src/Jobs deps
+
+    - all dirtyWhen entries relates to existing files
+
+        python3 buildkite/scripts/dhall/checker.py --root ./buildkite/src/Jobs dirty-when
+
+    - print commands for given job
+
+        python3 buildkite/scripts/dhall/checker.py --root ./buildkite/src/Jobs print-cmd --job SingleNodeTest
+"""
+
+
+import argparse
+import subprocess
+import os
+from glob import glob
+import tempfile
+from pathlib import Path
+import yaml
+
+
+class CmdColors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+class PipelineInfoBuilder:
+
+    def __init__(self, temp, file):
+        with open(f"{temp}/{file}") as stream:
+            try:
+                self.pipeline = yaml.safe_load(stream)
+                self.file = file
+            except yaml.YAMLError as exc:
+                print(f"cannot parse correctly {temp}/{file}, due to {exc}")
+                exit(1)
+
+    def get_steps(self):
+        steps = []
+        for step in self.pipeline["pipeline"]["steps"]:
+            key = step["key"]
+            deps = []
+            if "depends_on" in step:
+                for dependsOn in step["depends_on"]:
+                    deps.append(dependsOn["step"])
+            commands = step["commands"]
+            steps.append(Step(key, deps, commands))
+        return steps
+
+    def get_dirty(self):
+        dirty = []
+        for dirtyWhen in self.pipeline["spec"]["dirtyWhen"]:
+            path = dirtyWhen["dir"][0] if "dir" in dirtyWhen else ""
+            exts = dirtyWhen["exts"][0] if "exts" in dirtyWhen else ""
+            strictEnd = bool(dirtyWhen["strictEnd"]) if (
+                not "strictEnd" in dirtyWhen) else False
+            strictStart = bool(dirtyWhen["strictStart"]) if (
+                not "strictStart" in dirtyWhen) else False
+            dirty.append(DirtyWhen(path=path, strictStart=strictStart,
+                         strictEnd=strictEnd, extension=exts))
+        return dirty
+
+    def build(self):
+        steps = self.get_steps()
+        dirty = self.get_dirty()
+        return PipelineInfo(self.file, self.pipeline, steps, dirty)
+
+
+class DirtyWhen:
+
+    def __init__(self, path, extension, strictStart, strictEnd):
+        self.path = path
+        self.extension = extension
+        self.strictStart = strictStart
+        self.strictEnd = strictEnd
+
+    def calculate_path(self):
+        if self.extension and self.path:
+            return glob(f"{self.path}.{self.extension}")
+        if self.strictEnd and not self.strictStart:
+            if not self.extension:
+                return glob(f"**/*/{self.path}")
+            else:
+                return glob(f"*/{self.path}.{self.extension}")
+        if self.strictStart and self.strictEnd:
+            if not self.extension:
+                return glob(f"{self.path}*")
+            else:
+                return glob(f"{self.path}.{self.extension}")
+        if self.strictStart and not self.strictEnd:
+            return glob(self.path + '.*')
+        if not self.strictStart and not self.strictEnd:
+            if not self.extension:
+                if "." in self.path:
+                    return glob(f"**/*/{self.path}", recursive=True)
+                else:
+                    return glob(f"{self.path}*")
+            else:
+                return glob(f"*.{self.extension}")
+        raise RuntimeError("invalid state dirty when")
+
+    def __str__(self):
+        return f"path: '{self.path}', exts: '{self.extension}', startStrict:{self.strictStart}, startEnd:{self.strictEnd}"
+
+
+class Step:
+
+    def __init__(self, key, deps, commands):
+        self.key = key
+        self.deps = deps
+        self.commands = commands
+
+
+class PipelineInfo:
+
+    def __init__(self, file, pipeline, steps, dirty):
+        self.file = file
+        self.pipeline = pipeline
+        self.steps = steps
+        self.dirty = dirty
+
+    def keys(self):
+        return [step.key for step in self.steps]
+
+
+parser = argparse.ArgumentParser(description='Executes mina benchmarks')
+parser.add_argument("--root", required=True,
+                    help="root folder where all dhall files resides")
+
+subparsers = parser.add_subparsers(dest="cmd")
+subparsers.add_parser('dirty-when')
+subparsers.add_parser('deps')
+run = subparsers.add_parser('print-cmd')
+run.add_argument("--job", required=True, help="job to run")
+run.add_argument("--step", required=False, help="job to run")
+
+
+args = parser.parse_args()
+tmp = tempfile.mkdtemp()
+
+print(f"Artifacts are stored in {tmp}")
+
+for file in [y for x in os.walk(args.root) for y in glob(os.path.join(x[0], '*.dhall'))]:
+    name = Path(file).stem
+    with open(f"{tmp}/{name}.yml", "w") as outfile:
+        subprocess.run(["dhall-to-yaml", "--quoted", "--file",
+                       file], stdout=outfile, check=True)
+
+
+pipelinesInfo = [PipelineInfoBuilder(tmp, file).build()
+                 for file in os.listdir(path=tmp)]
+
+if args.cmd == "deps":
+
+    keys = []
+    for pipeline in pipelinesInfo:
+        keys.extend(pipeline.keys())
+
+    failedSteps = []
+
+    for pipeline in pipelinesInfo:
+        for step in pipeline.steps:
+            for dep in step.deps:
+                if not dep in keys:
+                    failedSteps.append((pipeline, step, dep))
+
+    if any(failedSteps):
+        print("Fatal: Missing dependency resolution found:")
+        for (pipeline, step, dep) in failedSteps:
+            file = str.replace(pipeline.file, ".yml", ".dhall")
+            print(
+                f"\t{CmdColors.FAIL}[FATAL] Unresolved dependency for step '{step.key}' in '{file}' depends on non existing job '{dep}'{CmdColors.ENDC}")
+        exit(1)
+
+
+if args.cmd == "print-cmd":
+    pipeline = next(filter(lambda x: args.job in x.file, pipelinesInfo))
+
+    def get_steps():
+        if args.step:
+            return [next(filter(lambda x: args.step in x.key, pipeline.steps))]
+        else:
+            return pipeline.steps
+
+    steps = get_steps()
+
+    for step in steps:
+        for command in step.commands:
+            if not command.startswith("echo"):
+                print(command)
+
+if args.cmd == "dirty-when":
+
+    failedSteps = []
+
+    for pipeline in pipelinesInfo:
+        for dirty in pipeline.dirty:
+            if not bool(dirty.calculate_path()):
+                failedSteps.append((pipeline, dirty))
+
+    if any(failedSteps):
+        print("Fatal: Non existing dirtyWhen path detected:")
+        for (pipeline, dirty) in failedSteps:
+            file = str.replace(pipeline.file, ".yml", ".dhall")
+            print(
+                f"\t{CmdColors.FAIL}[FATAL] Unresolved dirtyWhen path  in '{file}' ('{str(dirty)}'){CmdColors.ENDC}")
+        exit(1)

--- a/buildkite/scripts/helm-ci.sh
+++ b/buildkite/scripts/helm-ci.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 
 diff=$(
-  ./buildkite/scripts/generate-diff.sh
+  ./buildkite/scripts/git/generate-diff.sh
 )
 echo "--- Generated change DIFF: ${diff}"
 

--- a/buildkite/src/Jobs/Lint/Dhall.dhall
+++ b/buildkite/src/Jobs/Lint/Dhall.dhall
@@ -54,5 +54,25 @@ in  Pipeline.build
               , image = (../../Constants/ContainerImages.dhall).toolchainBase
               }
             }
+        , Command.build
+            Command.Config::{
+            , commands = [ Cmd.run "cd buildkite && make check_deps" ]
+            , label = "Dhall: deps"
+            , key = "check-dhall-deps"
+            , target = Size.Multi
+            , docker = Some Docker::{
+              , image = (../../Constants/ContainerImages.dhall).toolchainBase
+              }
+            }
+        , Command.build
+            Command.Config::{
+            , commands = [ Cmd.run "cd buildkite && make check_dirty" ]
+            , label = "Dhall: dirtyWhen"
+            , key = "check-dhall-dirty"
+            , target = Size.Multi
+            , docker = Some Docker::{
+              , image = (../../Constants/ContainerImages.dhall).toolchainBase
+              }
+            }
         ]
       }

--- a/buildkite/src/Jobs/Lint/ValidationService.dhall
+++ b/buildkite/src/Jobs/Lint/ValidationService.dhall
@@ -75,10 +75,7 @@ in  Pipeline.build
                   (S.contains "buildkite/src/Jobs/Lint/ValidationService")
 
           in  JobSpec::{
-              , dirtyWhen =
-                [ dirtyDhallDir
-                , S.strictlyStart (S.contains ValidationService.rootPath)
-                ]
+              , dirtyWhen = [ dirtyDhallDir ]
               , path = "Lint"
               , name = "ValidationService"
               , tags = [ PipelineTag.Type.Fast, PipelineTag.Type.Lint ]

--- a/buildkite/src/Jobs/Lint/Xrefcheck.dhall
+++ b/buildkite/src/Jobs/Lint/Xrefcheck.dhall
@@ -23,7 +23,7 @@ in  Pipeline.build
       , spec = JobSpec::{
         , dirtyWhen =
           [ SelectFiles.strictly SelectFiles::{ exts = Some [ "md" ] }
-          , SelectFiles.strictly (SelectFiles.contains ".xrefcheck.yml")
+          , SelectFiles.strictly (SelectFiles.contains ".xrefcheck.yaml")
           ]
         , path = "Lint"
         , name = "Xrefcheck"

--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -40,8 +40,6 @@ in  Pipeline.build
             , label = "Deploy Testnet alert rules"
             , key = "deploy-testnet-alerts"
             , target = Size.Medium
-            , depends_on =
-              [ { name = "TestnetAlerts", key = "lint-testnet-alerts" } ]
             , docker = None Docker.Type
             , if = Some "build.env('DEPLOY_ALERTS') == 'true'"
             }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -64,7 +64,7 @@ in  Pipeline.build
                   Dockers.Type.Bullseye
                   (Some Network.Type.Berkeley)
                   Profiles.Type.Standard
-                  Artifacts.Type.Rosetta
+                  Artifacts.Type.Daemon
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
@@ -56,7 +56,7 @@ in  Pipeline.build
                   Dockers.Type.Bullseye
                   (Some Network.Type.Berkeley)
                   Profiles.Type.Standard
-                  Artifacts.Type.Rosetta
+                  Artifacts.Type.Daemon
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/TerraformNetworkTest.dhall
+++ b/buildkite/src/Jobs/Test/TerraformNetworkTest.dhall
@@ -35,8 +35,8 @@ in  Pipeline.build
       Pipeline.Config::{
       , spec =
           let unitDirtyWhen =
-                [ S.strictlyStart (S.contains "src/automation/terraform")
-                , S.strictlyStart (S.contains "src/helm")
+                [ S.strictlyStart (S.contains "automation/terraform")
+                , S.strictlyStart (S.contains "helm")
                 , S.strictlyStart
                     (S.contains "buildkite/src/Jobs/Test/TerraformNetworkTest")
                 , S.strictlyStart

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -39,18 +39,18 @@ in  Pipeline.build
           , S.strictlyStart
               (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
           , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Command/TestExecutive")
+              (S.contains "buildkite/src/Command/TestExecutive")
           , S.strictlyStart
               (S.contains "automation/terraform/modules/o1-integration")
           , S.strictlyStart
               (S.contains "automation/terraform/modules/kubernetes/testnet")
           , S.strictlyStart
               ( S.contains
-                  "automation/buildkite/script/run-test-executive-cloud"
+                  "buildkite/scripts/run-test-executive-cloud"
               )
           , S.strictlyStart
               ( S.contains
-                  "automation/buildkite/script/run-test-executive-local"
+                  "buildkite/scripts/run-test-executive-local"
               )
           ]
         , path = "Test"

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
@@ -39,7 +39,7 @@ in  Pipeline.build
           , S.strictlyStart
               (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
           , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Command/TestExecutive")
+              (S.contains "buildkite/src/Command/TestExecutive")
           , S.strictlyStart
               (S.contains "automation/terraform/modules/o1-integration")
           , S.strictlyStart

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -35,8 +35,8 @@ let jobs
 let prefixCommands =
       [ Cmd.run
           "git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt"
-      , Cmd.run "./buildkite/scripts/refresh_code.sh"
-      , Cmd.run "./buildkite/scripts/generate-diff.sh > _computed_diff.txt"
+      , Cmd.run "./buildkite/scripts/git/refresh_code.sh"
+      , Cmd.run "./buildkite/scripts/git/generate-diff.sh > _computed_diff.txt"
       ]
 
 let commands

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -33,7 +33,7 @@ let config
               [ Cmd.run "export BUILDKITE_PIPELINE_MODE=${mode}"
               , Cmd.run "export BUILDKITE_PIPELINE_FILTER=${filter}"
               , Cmd.run
-                  "./buildkite/scripts/generate-jobs.sh > buildkite/src/gen/Jobs.dhall"
+                  "./buildkite/scripts/dhall/generate-jobs.sh > buildkite/src/gen/Jobs.dhall"
               , Cmd.quietly
                   "dhall-to-yaml --quoted <<< '(./buildkite/src/Monorepo.dhall) { mode=(./buildkite/src/Pipeline/Mode.dhall).Type.${mode}, filter=(./buildkite/src/Pipeline/Filter.dhall).Type.${filter}  }' | buildkite-agent pipeline upload"
               ]


### PR DESCRIPTION
Introducing additional checks for dhall which will be used in ci but nothing prevents to use them locally. There are 3 new commands


Additionally I fixed all encountered issues with dirtyWhen and Dependencies

(all commands should be run in buildkite folder)

### check dependencies

usage: ` make check_deps`

desc: it validates that if step provides dependsOn section it is a correct and existing key of some job

### check dirtyWhen

usage: `make check_dirty`

desc: it validates that if step provides dirtyWhen section it is corresponding to existing files

### print cmd (only for local)

usage: `python3 buildkite/scripts/dhall/checker --root buildkite/src/Jobs print-cmd --job MinaArtifactFocal --step build_deb_pkg`





