### PR TITLE
make snark profiler configurable again

### DIFF
--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -8,9 +8,9 @@ module Zkapp_command_segment = Transaction_snark.Zkapp_command_segment
 module Statement = Transaction_snark.Statement
 
 let constraint_constants =
-  Genesis_constants.For_unit_tests.Constraint_constants.t
+  Genesis_constants.Compiled.constraint_constants
 
-let genesis_constants = Genesis_constants.For_unit_tests.t
+let genesis_constants = Genesis_constants.Compiled.genesis_constants
 
 (* Always run tests with proof-level Full *)
 let proof_level = Genesis_constants.Proof_level.Full


### PR DESCRIPTION
When we handed off the work for this I just blindly followed this comment:

![image](https://github.com/user-attachments/assets/ba380f22-e30c-4858-b6d3-eb2057951860)

It turns out we can't do this, we need to make this utils library configurable because it supports the `transaction_snark_profiler` executable which is meant to be run with the `devnet profile. 

We can do this if we paramaterize all the functions by the `constants` arguments (like we have elsewhere). However I want to push this as a hotfix because that wasn't trivial -- it will change many files. I have filed [this follow up issue](https://github.com/MinaProtocol/mina/issues/16169) instead

