### PR TITLE
Constants loader

### DIFF
--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -38,22 +38,29 @@ let command_run =
            "int Delete blocks that are more than n blocks lower than the \
             maximum seen block."
      in
-     let runtime_config_opt =
-       Option.map runtime_config_file ~f:(fun file ->
-           Yojson.Safe.from_file file |> Runtime_config.of_yojson
-           |> Result.ok_or_failwith )
-     in
      fun () ->
        let logger = Logger.create () in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
+       let open Deferred.Let_syntax in
+       let%bind constants =
+         Runtime_config.Constants.load_constants ~logger
+           (Option.to_list runtime_config_file)
+       in
+       let%bind runtime_config_opt =
+         match runtime_config_file with
+         | None ->
+             return None
+         | Some file -> Deferred.Or_error.(
+             Runtime_config.Json_loader.load_config_files ~logger [file] >>=
+             Genesis_ledger_helper.init_from_config_file ~logger ~constants
+             >>| fun (a,_) -> Option.some a
+          ) |> Deferred.Or_error.ok_exn
        in
        Stdout_log.setup log_json log_level ;
        [%log info] "Starting archive process; built with commit $commit"
          ~metadata:[ ("commit", `String Mina_version.commit_id) ] ;
        Archive_lib.Processor.setup_server ~metrics_server_port ~logger
-         ~genesis_constants ~constraint_constants
+         ~genesis_constants:(Runtime_config.Constants.genesis_constants constants)
+         ~constraint_constants:(Runtime_config.Constants.constraint_constants constants)
          ~postgres_address:postgres.value
          ~server_port:
            (Option.value server_port.value ~default:server_port.default)

--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -51,10 +51,9 @@ let command_run =
              return None
          | Some file ->
              Deferred.Or_error.(
-               Runtime_config.Json_loader.load_config_files ~logger [ file ]
-               >>= Genesis_ledger_helper.init_from_config_file ~logger
-                     ~constants
-               >>| fun (a, _) -> Option.some a)
+               Genesis_ledger_helper.Config_loader.load_config_files ~logger
+                 [ file ]
+               >>| fun a -> Option.some @@ fst a)
              |> Deferred.Or_error.ok_exn
        in
        Stdout_log.setup log_json log_level ;

--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -49,18 +49,22 @@ let command_run =
          match runtime_config_file with
          | None ->
              return None
-         | Some file -> Deferred.Or_error.(
-             Runtime_config.Json_loader.load_config_files ~logger [file] >>=
-             Genesis_ledger_helper.init_from_config_file ~logger ~constants
-             >>| fun (a,_) -> Option.some a
-          ) |> Deferred.Or_error.ok_exn
+         | Some file ->
+             Deferred.Or_error.(
+               Runtime_config.Json_loader.load_config_files ~logger [ file ]
+               >>= Genesis_ledger_helper.init_from_config_file ~logger
+                     ~constants
+               >>| fun (a, _) -> Option.some a)
+             |> Deferred.Or_error.ok_exn
        in
        Stdout_log.setup log_json log_level ;
        [%log info] "Starting archive process; built with commit $commit"
          ~metadata:[ ("commit", `String Mina_version.commit_id) ] ;
        Archive_lib.Processor.setup_server ~metrics_server_port ~logger
-         ~genesis_constants:(Runtime_config.Constants.genesis_constants constants)
-         ~constraint_constants:(Runtime_config.Constants.constraint_constants constants)
+         ~genesis_constants:
+           (Runtime_config.Constants.genesis_constants constants)
+         ~constraint_constants:
+           (Runtime_config.Constants.constraint_constants constants)
          ~postgres_address:postgres.value
          ~server_port:
            (Option.value server_port.value ~default:server_port.default)

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -8,10 +8,10 @@ let main ~config_file ~archive_uri ~precomputed ~extensional ~success_file
     ~failure_file ~log_successes ~files () =
   let%bind config =
     let logger = Logger.create () in
-    Runtime_config.Constants_loader.load_constants ~logger config_file
+    Runtime_config.Constants.load_constants ~logger config_file
   in
-  let genesis_constants = config.genesis_constants in
-  let constraint_constants = config.constraint_constants in
+  let genesis_constants = Runtime_config.Constants.genesis_constants config in
+  let constraint_constants = Runtime_config.Constants.constraint_constants config in
   let output_file_line path =
     match path with
     | Some path ->

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -4,8 +4,14 @@ open Core_kernel
 open Async
 open Archive_lib
 
-let main ~genesis_constants ~constraint_constants ~archive_uri ~precomputed
-    ~extensional ~success_file ~failure_file ~log_successes ~files () =
+let main ~config_file ~archive_uri ~precomputed ~extensional ~success_file
+    ~failure_file ~log_successes ~files () =
+  let%bind config =
+    let logger = Logger.create () in
+    Runtime_config.Constants_loader.load_constants ~logger config_file
+  in
+  let genesis_constants = config.genesis_constants in
+  let constraint_constants = config.constraint_constants in
   let output_file_line path =
     match path with
     | Some path ->
@@ -99,10 +105,6 @@ let main ~genesis_constants ~constraint_constants ~archive_uri ~precomputed
 
 let () =
   Command.(
-    let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-    let constraint_constants =
-      Genesis_constants.Compiled.constraint_constants
-    in
     run
       (let open Let_syntax in
       async ~summary:"Write blocks to an archive database"
@@ -133,6 +135,7 @@ let () =
                "true/false Whether to log messages for files that were \
                 processed successfully"
              (Flag.optional_with_default true Param.bool)
+         and config_file = Cli_lib.Flag.conf_file
          and files = Param.anon Anons.(sequence ("FILES" %: Param.string)) in
-         main ~genesis_constants ~constraint_constants ~archive_uri ~precomputed
-           ~extensional ~success_file ~failure_file ~log_successes ~files )))
+         main ~config_file ~archive_uri ~precomputed ~extensional ~success_file
+           ~failure_file ~log_successes ~files )))

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -11,7 +11,9 @@ let main ~config_file ~archive_uri ~precomputed ~extensional ~success_file
     Runtime_config.Constants.load_constants ~logger config_file
   in
   let genesis_constants = Runtime_config.Constants.genesis_constants config in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let output_file_line path =
     match path with
     | Some path ->

--- a/src/app/archive_blocks/dune
+++ b/src/app/archive_blocks/dune
@@ -24,6 +24,7 @@
    bounded_types
    genesis_constants
    archive_lib
+   cli_lib
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_mina ppx_let ppx_hash ppx_compare ppx_sexp_conv)))

--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -160,14 +160,13 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
   let open Logger in
   let logger = Logger.create () in
   let%bind minimum_user_command_fee =
-    let%map genesis_constants =
-      let%map conf =
-        Runtime_config.Constants.load_constants ~logger config_file
-      in
-      Runtime_config.Constants.genesis_constants conf
+    let%map conf =
+      Runtime_config.Constants.load_constants ~logger config_file
     in
-    Option.value ~default:genesis_constants.minimum_user_command_fee
-      minimum_user_command_fee_opt
+    Option.value
+      ~default:
+        (Runtime_config.Constants.genesis_constants conf)
+          .minimum_user_command_fee minimum_user_command_fee_opt
   in
   let limit_level =
     let slot_limit =

--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -154,11 +154,19 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
     ~origin_sender_secret_key_path
     ~(origin_sender_secret_key_pw_option : string option)
     ~returner_secret_key_path ~(returner_secret_key_pw_option : string option)
-    ~graphql_target_node_option ~minimum_user_command_fee () =
+    ~graphql_target_node_option ~minimum_user_command_fee_opt ~config_file () =
   let open Deferred.Let_syntax in
   (* define the rate limiting function *)
   let open Logger in
   let logger = Logger.create () in
+  let%bind minimum_user_command_fee =
+    let%map genesis_constants =
+      let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+      Runtime_config.Constants.genesis_constants conf
+    in
+    Option.value ~default:genesis_constants.minimum_user_command_fee
+      minimum_user_command_fee_opt
+  in
   let limit_level =
     let slot_limit =
       Float.(
@@ -310,8 +318,6 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
   return ()
 
 let output_there_and_back_cmds =
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let compile_config = Mina_compile_config.Compiled.t in
   let open Command.Let_syntax in
   Command.async
     ~summary:
@@ -390,23 +396,19 @@ let output_there_and_back_cmds =
             transactions, if this is not present then we use the env var \
             MINA_PRIVKEY_PASS"
          (optional string)
+     and config_file = Cli_lib.Flag.conf_file
      and graphql_target_node_option =
        flag "--graphql-target-node" ~aliases:[ "graphql-target-node" ]
          ~doc:
            "URL The graphql node to send graphl commands to.  must be in \
             format `<ip>:<port>`.  default is `127.0.0.1:3085`"
          (optional string)
-     and minimum_user_command_fee =
-       let default = compile_config.default_transaction_fee in
-       Cli_lib.Flag.fee_common
-         ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee
-         ~default_transaction_fee:default
-     in
+     and minimum_user_command_fee_opt = Cli_lib.Flag.fee_common in
      there_and_back_again ~num_txn_per_acct ~txns_per_block ~txn_fee_option
        ~slot_time ~fill_rate ~rate_limit ~rate_limit_level ~rate_limit_interval
        ~origin_sender_secret_key_path ~origin_sender_secret_key_pw_option
        ~returner_secret_key_path ~returner_secret_key_pw_option
-       ~graphql_target_node_option ~minimum_user_command_fee )
+       ~graphql_target_node_option ~minimum_user_command_fee_opt ~config_file )
 
 let () =
   Command.run

--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -154,20 +154,10 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
     ~origin_sender_secret_key_path
     ~(origin_sender_secret_key_pw_option : string option)
     ~returner_secret_key_path ~(returner_secret_key_pw_option : string option)
-    ~graphql_target_node_option ~minimum_user_command_fee_opt ~config_file () =
+    ~graphql_target_node_option ~minimum_user_command_fee ~logger () =
   let open Deferred.Let_syntax in
   (* define the rate limiting function *)
   let open Logger in
-  let logger = Logger.create () in
-  let%bind minimum_user_command_fee =
-    let%map conf =
-      Runtime_config.Constants.load_constants ~logger config_file
-    in
-    Option.value
-      ~default:
-        (Runtime_config.Constants.genesis_constants conf)
-          .minimum_user_command_fee minimum_user_command_fee_opt
-  in
   let limit_level =
     let slot_limit =
       Float.(
@@ -405,11 +395,24 @@ let output_there_and_back_cmds =
             format `<ip>:<port>`.  default is `127.0.0.1:3085`"
          (optional string)
      and minimum_user_command_fee_opt = Cli_lib.Flag.fee_common in
-     there_and_back_again ~num_txn_per_acct ~txns_per_block ~txn_fee_option
-       ~slot_time ~fill_rate ~rate_limit ~rate_limit_level ~rate_limit_interval
-       ~origin_sender_secret_key_path ~origin_sender_secret_key_pw_option
-       ~returner_secret_key_path ~returner_secret_key_pw_option
-       ~graphql_target_node_option ~minimum_user_command_fee_opt ~config_file )
+     fun () ->
+       let open Deferred.Let_syntax in
+       let logger = Logger.create () in
+       let%bind minimum_user_command_fee =
+         let%map conf =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in
+         Option.value
+           ~default:
+             (Runtime_config.Constants.genesis_constants conf)
+               .minimum_user_command_fee minimum_user_command_fee_opt
+       in
+       there_and_back_again ~num_txn_per_acct ~txns_per_block ~txn_fee_option
+         ~slot_time ~fill_rate ~rate_limit ~rate_limit_level
+         ~rate_limit_interval ~origin_sender_secret_key_path
+         ~origin_sender_secret_key_pw_option ~returner_secret_key_path
+         ~returner_secret_key_pw_option ~graphql_target_node_option
+         ~minimum_user_command_fee ~logger () )
 
 let () =
   Command.run

--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -161,7 +161,9 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
   let logger = Logger.create () in
   let%bind minimum_user_command_fee =
     let%map genesis_constants =
-      let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+      let%map conf =
+        Runtime_config.Constants.load_constants ~logger config_file
+      in
       Runtime_config.Constants.genesis_constants conf
     in
     Option.value ~default:genesis_constants.minimum_user_command_fee

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1600,8 +1600,8 @@ let internal_commands ~itn_features logger =
         (let open Command.Let_syntax in
         let%map_open config_file = Cli_lib.Flag.conf_file in
         fun () ->
-          let open Deferred.Let_syntax in
           let logger = Logger.create () in
+          let open Deferred.Let_syntax in
           let%bind constraint_constants, proof_level =
             let%map conf =
               Runtime_config.Constants.load_constants ~logger config_file
@@ -1609,7 +1609,6 @@ let internal_commands ~itn_features logger =
             Runtime_config.Constants.
               (constraint_constants conf, proof_level conf)
           in
-          let logger = Logger.create () in
           Parallel.init_master () ;
           match%bind Reader.read_sexp (Lazy.force Reader.stdin) with
           | `Ok sexp ->
@@ -1854,16 +1853,9 @@ let internal_commands ~itn_features logger =
           let logger = Logger.create () in
           let conf_dir = Mina_lib.Conf_dir.compute_conf_dir conf_dir in
           let cli_proof_level = Genesis_constants.Proof_level.Full in
-          let%bind constants =
-            Runtime_config.Constants.load_constants ~cli_proof_level ~logger
-              config_file
-          in
           let%bind precomputed_values, _ =
-            Deferred.Or_error.(
-              Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
-                config_file
-              >>= Genesis_ledger_helper.init_from_config_file ?genesis_dir
-                    ~logger ~constants)
+            load_config_files ~logger ~conf_dir ~genesis_dir ~cli_proof_level
+              ~itn_features config_file
             |> Deferred.Or_error.ok_exn
           in
           let pids = Child_processes.Termination.create_pid_table () in

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -49,16 +49,20 @@ let plugin_flag =
          times"
   else Command.Param.return []
 
-let load_config_files ~logger ~genesis_constants ~constraint_constants ~conf_dir
-    ~genesis_dir ~cli_proof_level ~proof_level (config_files : string list) =
+let load_config_files ~logger ~conf_dir ~genesis_dir ~itn_features
+    ?cli_proof_level (config_files : string list) =
   let open Deferred.Or_error.Let_syntax in
   let genesis_dir = Option.value ~default:(conf_dir ^/ "genesis") genesis_dir in
+  let%bind.Deferred constants =
+    Runtime_config.Constants.load_constants ~conf_dir ?cli_proof_level
+      ~itn_features ~logger config_files
+  in
   let%bind config =
     Runtime_config.Json_loader.load_config_files ~conf_dir ~logger config_files
   in
   match%bind.Deferred
-    Genesis_ledger_helper.init_from_config_file ~cli_proof_level ~genesis_dir
-      ~logger ~genesis_constants ~constraint_constants ~proof_level config
+    Genesis_ledger_helper.init_from_config_file ~genesis_dir ~logger ~constants
+      config
   with
   | Ok a ->
       return a
@@ -93,7 +97,7 @@ let load_config_files ~logger ~genesis_constants ~constraint_constants ~conf_dir
         ~metadata ;
       Error.raise err
 
-let setup_daemon logger ~itn_features ~default_snark_worker_fee =
+let setup_daemon logger ~itn_features =
   let open Command.Let_syntax in
   let open Cli_lib.Arg_type in
   let receiver_key_warning = Cli_lib.Default.receiver_key_warning in
@@ -262,8 +266,7 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
       ~doc:
         (sprintf
            "FEE Amount a worker wants to get compensated for generating a \
-            snark proof (default: %d)"
-           (Currency.Fee.to_nanomina_int default_snark_worker_fee) )
+            snark proof" )
       (optional txn_fee)
   and work_reassignment_wait =
     flag "--work-reassignment-wait"
@@ -686,22 +689,15 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
         in
         let pids = Child_processes.Termination.create_pid_table () in
         let mina_initialization_deferred () =
-          let genesis_constants =
-            Genesis_constants.Compiled.genesis_constants
-          in
-          let constraint_constants =
-            Genesis_constants.Compiled.constraint_constants
-          in
-          let compile_config = Mina_compile_config.Compiled.t in
           let%bind precomputed_values, config =
-            load_config_files ~logger ~conf_dir ~genesis_dir
-              ~proof_level:Genesis_constants.Compiled.proof_level config_files
-              ~genesis_constants ~constraint_constants ~cli_proof_level
+            load_config_files ~logger ~conf_dir ~genesis_dir ?cli_proof_level
+              ~itn_features config_files
             |> Deferred.Or_error.ok_exn
           in
-
-          constraint_constants.block_window_duration_ms |> Float.of_int
-          |> Time.Span.of_ms |> Mina_metrics.initialize_all ;
+          let constraint_constants = precomputed_values.consensus_constants in
+          let compile_config = precomputed_values.compile_config in
+          constraint_constants.block_window_duration_ms |> Block_time.Span.to_ms
+          |> Float.of_int64 |> Time.Span.of_ms |> Mina_metrics.initialize_all ;
 
           let module DC = Runtime_config.Daemon in
           (* The explicit typing here is necessary to prevent type inference from specializing according
@@ -1378,12 +1374,9 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
         let () = Mina_plugins.init_plugins ~logger mina plugins in
         return mina )
 
-let daemon logger =
-  let compile_config = Mina_compile_config.Compiled.t in
+let daemon logger ~itn_features =
   Command.async ~summary:"Mina daemon"
-    (Command.Param.map
-       (setup_daemon logger ~itn_features:compile_config.itn_features
-          ~default_snark_worker_fee:compile_config.default_snark_worker_fee )
+    (Command.Param.map (setup_daemon logger ~itn_features)
        ~f:(fun setup_daemon () ->
          (* Immediately disable updating the time offset. *)
          Block_time.Controller.disable_setting_offset () ;
@@ -1392,7 +1385,7 @@ let daemon logger =
          [%log info] "Daemon ready. Clients can now connect" ;
          Async.never () ) )
 
-let replay_blocks logger =
+let replay_blocks ~itn_features logger =
   let replay_flag =
     let open Command.Param in
     flag "--blocks-filename" ~aliases:[ "-blocks-filename" ] (required string)
@@ -1403,11 +1396,9 @@ let replay_blocks logger =
     flag "--format" ~aliases:[ "-format" ] (optional string)
       ~doc:"json|sexp The format to read lines of the file in (default: json)"
   in
-  let compile_config = Mina_compile_config.Compiled.t in
   Command.async ~summary:"Start mina daemon with blocks replayed from a file"
     (Command.Param.map3 replay_flag read_kind
-       (setup_daemon logger ~itn_features:compile_config.itn_features
-          ~default_snark_worker_fee:compile_config.default_snark_worker_fee )
+       (setup_daemon logger ~itn_features)
        ~f:(fun blocks_filename read_kind setup_daemon () ->
          (* Enable updating the time offset. *)
          Block_time.Controller.enable_setting_offset () ;
@@ -1599,34 +1590,39 @@ let snark_hashes =
       let json = Cli_lib.Flag.json in
       fun () -> if json then Core.printf "[]\n%!"]
 
-let internal_commands logger =
+let internal_commands ~itn_features logger =
   [ ( Snark_worker.Intf.command_name
-    , Snark_worker.command ~proof_level:Genesis_constants.Compiled.proof_level
-        ~constraint_constants:Genesis_constants.Compiled.constraint_constants
-        ~commit_id:Mina_version.commit_id )
+    , Snark_worker.command ~commit_id:Mina_version.commit_id )
   ; ("snark-hashes", snark_hashes)
   ; ( "run-prover"
     , Command.async
         ~summary:"Run prover on a sexp provided on a single line of stdin"
-        (Command.Param.return (fun () ->
-             let logger = Logger.create () in
-             let constraint_constants =
-               Genesis_constants.Compiled.constraint_constants
-             in
-             let proof_level = Genesis_constants.Compiled.proof_level in
-             Parallel.init_master () ;
-             match%bind Reader.read_sexp (Lazy.force Reader.stdin) with
-             | `Ok sexp ->
-                 let%bind conf_dir = Unix.mkdtemp "/tmp/mina-prover" in
-                 [%log info] "Prover state being logged to %s" conf_dir ;
-                 let%bind prover =
-                   Prover.create ~commit_id:Mina_version.commit_id ~logger
-                     ~proof_level ~constraint_constants
-                     ~pids:(Pid.Table.create ()) ~conf_dir ()
-                 in
-                 Prover.prove_from_input_sexp prover sexp >>| ignore
-             | `Eof ->
-                 failwith "early EOF while reading sexp" ) ) )
+        (let open Command.Let_syntax in
+        let%map_open config_file = Cli_lib.Flag.conf_file in
+        fun () ->
+          let open Deferred.Let_syntax in
+          let logger = Logger.create () in
+          let%bind constraint_constants, proof_level =
+            let%map conf =
+              Runtime_config.Constants.load_constants ~logger config_file
+            in
+            Runtime_config.Constants.
+              (constraint_constants conf, proof_level conf)
+          in
+          let logger = Logger.create () in
+          Parallel.init_master () ;
+          match%bind Reader.read_sexp (Lazy.force Reader.stdin) with
+          | `Ok sexp ->
+              let%bind conf_dir = Unix.mkdtemp "/tmp/mina-prover" in
+              [%log info] "Prover state being logged to %s" conf_dir ;
+              let%bind prover =
+                Prover.create ~commit_id:Mina_version.commit_id ~logger
+                  ~proof_level ~constraint_constants ~pids:(Pid.Table.create ())
+                  ~conf_dir ()
+              in
+              Prover.prove_from_input_sexp prover sexp >>| ignore
+          | `Eof ->
+              failwith "early EOF while reading sexp") )
   ; ( "run-snark-worker-single"
     , Command.async
         ~summary:"Run snark-worker on a sexp provided on a single line of stdin"
@@ -1634,14 +1630,18 @@ let internal_commands logger =
         let%map_open filename =
           flag "--file" (required string)
             ~doc:"File containing the s-expression of the snark work to execute"
-        in
+        and config_file = Cli_lib.Flag.conf_file in
+
         fun () ->
           let open Deferred.Let_syntax in
           let logger = Logger.create () in
-          let constraint_constants =
-            Genesis_constants.Compiled.constraint_constants
+          let%bind constraint_constants, proof_level =
+            let%map conf =
+              Runtime_config.Constants.load_constants ~logger config_file
+            in
+            Runtime_config.Constants.
+              (constraint_constants conf, proof_level conf)
           in
-          let proof_level = Genesis_constants.Compiled.proof_level in
           Parallel.init_master () ;
           match%bind
             Reader.with_file filename ~f:(fun reader ->
@@ -1688,14 +1688,17 @@ let internal_commands logger =
         and limit =
           flag "--limit" ~aliases:[ "-limit" ] (optional int)
             ~doc:"limit the number of proofs taken from the file"
-        in
+        and config_file = Cli_lib.Flag.conf_file in
         fun () ->
           let open Async in
           let logger = Logger.create () in
-          let constraint_constants =
-            Genesis_constants.Compiled.constraint_constants
+          let%bind constraint_constants, proof_level =
+            let%map conf =
+              Runtime_config.Constants.load_constants ~logger config_file
+            in
+            Runtime_config.Constants.
+              (constraint_constants conf, proof_level conf)
           in
-          let proof_level = Genesis_constants.Compiled.proof_level in
           Parallel.init_master () ;
           let%bind conf_dir = Unix.mkdtemp "/tmp/mina-verifier" in
           let mode =
@@ -1831,18 +1834,12 @@ let internal_commands logger =
               () ) ;
           Deferred.return ()) )
   ; ("dump-type-shapes", dump_type_shapes)
-  ; ("replay-blocks", replay_blocks logger)
+  ; ("replay-blocks", replay_blocks ~itn_features logger)
   ; ("audit-type-shapes", audit_type_shapes)
   ; ( "test-genesis-block-generation"
     , Command.async ~summary:"Generate a genesis proof"
         (let open Command.Let_syntax in
-        let%map_open config_files =
-          flag "--config-file" ~aliases:[ "config-file" ]
-            ~doc:
-              "PATH path to a configuration file (overrides MINA_CONFIG_FILE, \
-               default: <config_dir>/daemon.json). Pass multiple times to \
-               override fields from earlier config files"
-            (listed string)
+        let%map_open config_file = Cli_lib.Flag.conf_dir
         and conf_dir = Cli_lib.Flag.conf_dir
         and genesis_dir =
           flag "--genesis-ledger-dir" ~aliases:[ "genesis-ledger-dir" ]
@@ -1856,17 +1853,18 @@ let internal_commands logger =
           Parallel.init_master () ;
           let logger = Logger.create () in
           let conf_dir = Mina_lib.Conf_dir.compute_conf_dir conf_dir in
-          let genesis_constants =
-            Genesis_constants.Compiled.genesis_constants
+          let cli_proof_level = Genesis_constants.Proof_level.Full in
+          let config_file = Option.to_list config_file in
+          let%bind constants =
+            Runtime_config.Constants.load_constants ~cli_proof_level ~logger
+              config_file
           in
-          let constraint_constants =
-            Genesis_constants.Compiled.constraint_constants
-          in
-          let proof_level = Genesis_constants.Proof_level.Full in
           let%bind precomputed_values, _ =
-            load_config_files ~logger ~conf_dir ~genesis_dir ~genesis_constants
-              ~constraint_constants ~proof_level config_files
-              ~cli_proof_level:None
+            Deferred.Or_error.(
+              Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
+                config_file
+              >>= Genesis_ledger_helper.init_from_config_file ?genesis_dir
+                    ~logger ~constants)
             |> Deferred.Or_error.ok_exn
           in
           let pids = Child_processes.Termination.create_pid_table () in
@@ -1875,7 +1873,7 @@ let internal_commands logger =
                realistic test.
             *)
             Prover.create ~commit_id:Mina_version.commit_id ~logger ~pids
-              ~conf_dir ~proof_level
+              ~conf_dir ~proof_level:precomputed_values.proof_level
               ~constraint_constants:precomputed_values.constraint_constants ()
           in
           match%bind
@@ -1895,13 +1893,14 @@ let internal_commands logger =
 
 let mina_commands logger ~itn_features =
   [ ("accounts", Client.accounts)
-  ; ("daemon", daemon logger)
+  ; ("daemon", daemon ~itn_features logger)
   ; ("client", Client.client)
   ; ("advanced", Client.advanced ~itn_features)
   ; ("ledger", Client.ledger)
   ; ("libp2p", Client.libp2p)
   ; ( "internal"
-    , Command.group ~summary:"Internal commands" (internal_commands logger) )
+    , Command.group ~summary:"Internal commands"
+        (internal_commands ~itn_features logger) )
   ; (Parallel.worker_command_name, Parallel.worker_command)
   ; ("transaction-snark-profiler", Transaction_snark_profiler.command)
   ]
@@ -1939,11 +1938,13 @@ let () =
    | [| _mina_exe; version |] when is_version_cmd version ->
        Mina_version.print_version ()
    | _ ->
-       let compile_config = Mina_compile_config.Compiled.t in
+       let itn_features =
+         Sys.getenv "MINA_ITN_FEATURES"
+         |> Option.value_map ~default:false ~f:bool_of_string
+       in
        Command.run
          (Command.group ~summary:"Mina" ~preserve_subcommand_order:()
-            (mina_commands logger ~itn_features:compile_config.itn_features) )
-  ) ;
+            (mina_commands logger ~itn_features) ) ) ;
   Core.exit 0
 
 let linkme = ()

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1839,7 +1839,7 @@ let internal_commands ~itn_features logger =
   ; ( "test-genesis-block-generation"
     , Command.async ~summary:"Generate a genesis proof"
         (let open Command.Let_syntax in
-        let%map_open config_file = Cli_lib.Flag.conf_dir
+        let%map_open config_file = Cli_lib.Flag.conf_file
         and conf_dir = Cli_lib.Flag.conf_dir
         and genesis_dir =
           flag "--genesis-ledger-dir" ~aliases:[ "genesis-ledger-dir" ]
@@ -1854,7 +1854,6 @@ let internal_commands ~itn_features logger =
           let logger = Logger.create () in
           let conf_dir = Mina_lib.Conf_dir.compute_conf_dir conf_dir in
           let cli_proof_level = Genesis_constants.Proof_level.Full in
-          let config_file = Option.to_list config_file in
           let%bind constants =
             Runtime_config.Constants.load_constants ~cli_proof_level ~logger
               config_file

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -49,54 +49,6 @@ let plugin_flag =
          times"
   else Command.Param.return []
 
-let load_config_files ~logger ~conf_dir ~genesis_dir ~itn_features
-    ?cli_proof_level (config_files : string list) =
-  let open Deferred.Or_error.Let_syntax in
-  let genesis_dir = Option.value ~default:(conf_dir ^/ "genesis") genesis_dir in
-  let%bind.Deferred constants =
-    Runtime_config.Constants.load_constants ~conf_dir ?cli_proof_level
-      ~itn_features ~logger config_files
-  in
-  let%bind config =
-    Runtime_config.Json_loader.load_config_files ~conf_dir ~logger config_files
-  in
-  match%bind.Deferred
-    Genesis_ledger_helper.init_from_config_file ~genesis_dir ~logger ~constants
-      config
-  with
-  | Ok a ->
-      return a
-  | Error err ->
-      let ( json_config
-          , `Accounts_omitted
-              ( `Genesis genesis_accounts_omitted
-              , `Staking staking_accounts_omitted
-              , `Next next_accounts_omitted ) ) =
-        Runtime_config.to_yojson_without_accounts config
-      in
-      let append_accounts_omitted s =
-        Option.value_map
-          ~f:(fun i -> List.cons (s ^ "_accounts_omitted", `Int i))
-          ~default:Fn.id
-      in
-      let metadata =
-        append_accounts_omitted "genesis" genesis_accounts_omitted
-        @@ append_accounts_omitted "staking" staking_accounts_omitted
-        @@ append_accounts_omitted "next" next_accounts_omitted []
-        @ [ ("config", json_config)
-          ; ( "name"
-            , `String
-                (Option.value ~default:"not provided"
-                   (let%bind.Option ledger = config.ledger in
-                    Option.first_some ledger.name ledger.hash ) ) )
-          ; ("error", Error_json.error_to_yojson err)
-          ]
-      in
-      [%log info]
-        "Initializing with runtime configuration. Ledger source: $name"
-        ~metadata ;
-      Error.raise err
-
 let setup_daemon logger ~itn_features =
   let open Command.Let_syntax in
   let open Cli_lib.Arg_type in
@@ -690,8 +642,8 @@ let setup_daemon logger ~itn_features =
         let pids = Child_processes.Termination.create_pid_table () in
         let mina_initialization_deferred () =
           let%bind precomputed_values, config =
-            load_config_files ~logger ~conf_dir ~genesis_dir ?cli_proof_level
-              ~itn_features config_files
+            Genesis_ledger_helper.Config_loader.load_config_files ~logger
+              ~conf_dir ?genesis_dir ?cli_proof_level ~itn_features config_files
             |> Deferred.Or_error.ok_exn
           in
           let constraint_constants = precomputed_values.consensus_constants in
@@ -1854,8 +1806,8 @@ let internal_commands ~itn_features logger =
           let conf_dir = Mina_lib.Conf_dir.compute_conf_dir conf_dir in
           let cli_proof_level = Genesis_constants.Proof_level.Full in
           let%bind precomputed_values, _ =
-            load_config_files ~logger ~conf_dir ~genesis_dir ~cli_proof_level
-              ~itn_features config_file
+            Genesis_ledger_helper.Config_loader.load_config_files ~logger
+              ~conf_dir ?genesis_dir ~cli_proof_level ~itn_features config_file
             |> Deferred.Or_error.ok_exn
           in
           let pids = Child_processes.Termination.create_pid_table () in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -530,12 +530,13 @@ let send_payment_graphql =
          let open Deferred.Let_syntax in
          let%bind compile_config =
            let logger = Logger.create () in
-           let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+           let%map conf =
+             Runtime_config.Constants.load_constants ~logger config_file
+           in
            Runtime_config.Constants.compile_config conf
          in
          let fee =
-           Option.value ~default:compile_config.default_transaction_fee
-             fee
+           Option.value ~default:compile_config.default_transaction_fee fee
          in
          let%map response =
            let input =
@@ -571,12 +572,13 @@ let delegate_stake_graphql =
          let open Deferred.Let_syntax in
          let%bind compile_config =
            let logger = Logger.create () in
-           let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
-            Runtime_config.Constants.compile_config conf
+           let%map conf =
+             Runtime_config.Constants.load_constants ~logger config_file
+           in
+           Runtime_config.Constants.compile_config conf
          in
          let fee =
-           Option.value ~default:compile_config.default_transaction_fee
-             fee
+           Option.value ~default:compile_config.default_transaction_fee fee
          in
          let%map response =
            Graphql_client.query_exn
@@ -839,7 +841,9 @@ let hash_ledger =
        let open Deferred.Let_syntax in
        let%bind constraint_constants =
          let logger = Logger.create () in
-         let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+         let%map conf =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in
          Runtime_config.Constants.constraint_constants conf
        in
        let process_accounts accounts =
@@ -954,9 +958,11 @@ let constraint_system_digests =
     (let%map_open config_file = Cli_lib.Flag.conf_file in
      fun () ->
        let open Deferred.Let_syntax in
-       let%bind (constraint_constants, proof_level) =
+       let%bind constraint_constants, proof_level =
          let logger = Logger.create () in
-         let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+         let%map conf =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in
          Runtime_config.Constants.(constraint_constants conf, proof_level conf)
        in
        let all =
@@ -1644,8 +1650,10 @@ let generate_libp2p_keypair_do privkey_path ~config_file =
     (* FIXME: I'd like to accumulate messages into this logger and only dump them out in failure paths. *)
     let logger = Logger.null () in
     let%bind compile_config =
-      let%map conf = Runtime_config.Constants.load_constants ~logger config_file
-      in Runtime_config.Constants.compile_config conf 
+      let%map conf =
+        Runtime_config.Constants.load_constants ~logger config_file
+      in
+      Runtime_config.Constants.compile_config conf
     in
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-generate-libp2p-keypair" ~f:(fun tmpd ->
@@ -1682,10 +1690,12 @@ let dump_libp2p_keypair_do privkey_path ~config_file =
     (let open Deferred.Let_syntax in
     let logger = Logger.null () in
     let%bind compile_config =
-      let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+      let%map conf =
+        Runtime_config.Constants.load_constants ~logger config_file
+      in
       Runtime_config.Constants.compile_config conf
-
     in
+
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-dump-libp2p-keypair" ~f:(fun tmpd ->
         match%bind
@@ -2340,10 +2350,13 @@ let test_ledger_application =
      Cli_lib.Exceptions.handle_nicely
      @@ fun () ->
      let open Deferred.Let_syntax in
-     let%bind (genesis_constants, constraint_constants) =
+     let%bind genesis_constants, constraint_constants =
        let logger = Logger.create () in
-       let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
-       Runtime_config.Constants.(genesis_constants conf, constraint_constants conf)
+       let%map conf =
+         Runtime_config.Constants.load_constants ~logger config_file
+       in
+       Runtime_config.Constants.
+         (genesis_constants conf, constraint_constants conf)
      in
      let first_partition_slots =
        Option.value ~default:128 first_partition_slots
@@ -2385,10 +2398,13 @@ let itn_create_accounts =
            (privkey_path, key_prefix, num_accounts, fee, amount, config_file)
          ->
         let open Deferred.Let_syntax in
-        let%bind (genesis_constants, constraint_constants) =
+        let%bind genesis_constants, constraint_constants =
           let logger = Logger.create () in
-          let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
-          Runtime_config.Constants.(genesis_constants conf, constraint_constants conf)
+          let%map conf =
+            Runtime_config.Constants.load_constants ~logger config_file
+          in
+          Runtime_config.Constants.
+            (genesis_constants conf, constraint_constants conf)
         in
         let args' = (privkey_path, key_prefix, num_accounts, fee, amount) in
         let genesis_constants = genesis_constants in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -869,11 +869,7 @@ let hash_ledger =
              process_accounts accounts )
        else
          let json = Yojson.Safe.from_file ledger_file in
-         match
-           Result.(
-             Runtime_config.Json_layout.Accounts.of_yojson json
-             >>= Runtime_config.Accounts.of_json_layout)
-         with
+         match Runtime_config.Accounts.of_yojson json with
          | Ok runtime_accounts ->
              let accounts =
                lazy (Genesis_ledger_helper.Accounts.to_full runtime_accounts)
@@ -936,11 +932,7 @@ let currency_in_ledger =
              process_accounts accounts )
        else
          let json = Yojson.Safe.from_file ledger_file in
-         match
-           Result.(
-             Runtime_config.Json_layout.Accounts.of_yojson json
-             >>= Runtime_config.Accounts.of_json_layout)
-         with
+         match Runtime_config.Accounts.of_yojson json with
          | Ok runtime_accounts ->
              let accounts =
                Genesis_ledger_helper.Accounts.to_full runtime_accounts

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1846,17 +1846,11 @@ let compile_time_constants =
        let%map ({ consensus_constants; _ } as precomputed_values) =
          let logger = Logger.create () in
          let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
-         let%bind constants =
-           Runtime_config.Constants.load_constants ~logger config_file
-         in
-         let%map config, _ =
-           Deferred.Or_error.(
-             Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
-               config_file
-             >>= Genesis_ledger_helper.init_from_config_file ~logger ~constants)
-           |> Deferred.Or_error.ok_exn
-         in
-         config
+         Deferred.Or_error.(
+           Genesis_ledger_helper.Config_loader.load_config_files ~conf_dir
+             ~logger config_file
+           >>| fst)
+         |> Deferred.Or_error.ok_exn
        in
        let all_constants =
          `Assoc

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -172,9 +172,9 @@ let command =
            (String.concat !incompatible_flags ~sep:", ") ;
          exit 1 ) ) ;
      let repeats = Option.value repeats ~default:1 in
-     let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+     let genesis_constants = Genesis_constants.Compiled_.genesis_constants in
      let constraint_constants =
-       Genesis_constants.Compiled.constraint_constants
+       Genesis_constants.Compiled_.constraint_constants
      in
      let proof_level = Genesis_constants.Proof_level.Full in
      if witness_only then

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -13,9 +13,7 @@ let get_filenames =
 let verify_snark_work ~verify_transaction_snarks ~proof ~message =
   verify_transaction_snarks [ (proof, message) ]
 
-let config_flag =
-  let open Command.Param in
-  flag "--config-file" ~doc:"FILE config file" (optional string)
+let config_flag = Cli_lib.Flag.conf_file
 
 let keyspace_flag =
   let open Command.Param in
@@ -44,31 +42,12 @@ let timestamp =
   let open Command.Param in
   anon ("timestamp" %: string)
 
-let instantiate_verify_functions ~logger ~genesis_constants
-    ~constraint_constants ~proof_level ~cli_proof_level = function
-  | None ->
-      Deferred.return
-        (Verifier.verify_functions ~constraint_constants ~proof_level ())
-  | Some config_file ->
-      let%bind.Deferred precomputed_values =
-        let%bind.Deferred.Or_error config =
-          Runtime_config.Json_loader.load_config_files ~logger [ config_file ]
-        in
-        Genesis_ledger_helper.init_from_config_file ~logger ~proof_level
-          ~constraint_constants ~genesis_constants config ~cli_proof_level
-      in
-      let%map.Deferred precomputed_values =
-        match precomputed_values with
-        | Ok (precomputed_values, _) ->
-            Deferred.return precomputed_values
-        | Error _ ->
-            Output.display_error "fail to read config file" ;
-            exit 4
-      in
-      let constraint_constants =
-        Precomputed_values.constraint_constants precomputed_values
-      in
-      Verifier.verify_functions ~constraint_constants ~proof_level:Full ()
+let instantiate_verify_functions ~logger config_file =
+  let open Deferred.Let_syntax in
+  let%map { constraint_constants; _ } =
+    Genesis_ledger_helper.Config_loader.load_config ~logger config_file
+  in
+  Verifier.verify_functions ~constraint_constants ~proof_level:Full ()
 
 module Make_verifier (Source : Submission.Data_source) = struct
   let verify_transaction_snarks = Source.verify_transaction_snarks
@@ -139,7 +118,7 @@ module Make_verifier (Source : Submission.Data_source) = struct
     |> Deferred.Or_error.all_unit
 end
 
-let filesystem_command =
+let filesystem_command ~logger =
   Command.async ~summary:"Verify submissions and block read from the filesystem"
     Command.Let_syntax.(
       let%map_open block_dir = block_dir_flag
@@ -147,16 +126,10 @@ let filesystem_command =
       and no_checks = no_checks_flag
       and config_file = config_flag in
       fun () ->
-        let logger = Logger.create () in
-        let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
-        in
-        let proof_level = Genesis_constants.Compiled.proof_level in
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file ~genesis_constants
-            ~constraint_constants ~proof_level ~cli_proof_level:None
+          instantiate_verify_functions ~logger config_file
         in
+
         let submission_paths = get_filenames inputs in
         let module V = Make_verifier (struct
           include Submission.Filesystem
@@ -175,7 +148,7 @@ let filesystem_command =
             Output.display_error @@ Error.to_string_hum e ;
             exit 1)
 
-let cassandra_command =
+let cassandra_command ~logger =
   Command.async ~summary:"Verify submissions and block read from Cassandra"
     Command.Let_syntax.(
       let%map_open cqlsh = cassandra_executable_flag
@@ -186,15 +159,8 @@ let cassandra_command =
       and period_end = timestamp in
       fun () ->
         let open Deferred.Let_syntax in
-        let logger = Logger.create () in
-        let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
-        in
-        let proof_level = Genesis_constants.Compiled.proof_level in
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file ~genesis_constants
-            ~constraint_constants ~proof_level ~cli_proof_level:None
+          instantiate_verify_functions ~logger config_file
         in
         let module V = Make_verifier (struct
           include Submission.Cassandra
@@ -217,22 +183,15 @@ let cassandra_command =
             Output.display_error @@ Error.to_string_hum e ;
             exit 1)
 
-let stdin_command =
+let stdin_command ~logger =
   Command.async
     ~summary:"Verify submissions and blocks read from standard input"
     Command.Let_syntax.(
       let%map_open config_file = config_flag and no_checks = no_checks_flag in
       fun () ->
         let open Deferred.Let_syntax in
-        let logger = Logger.create () in
-        let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
-        in
-        let proof_level = Genesis_constants.Compiled.proof_level in
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file ~genesis_constants
-            ~constraint_constants ~proof_level ~cli_proof_level:None
+          instantiate_verify_functions ~logger config_file
         in
         let module V = Make_verifier (struct
           include Submission.Stdin
@@ -249,11 +208,12 @@ let stdin_command =
             exit 1)
 
 let command =
+  let logger = Logger.create () in
   Command.group
     ~summary:"A tool for verifying JSON payload submitted by the uptime service"
-    [ ("fs", filesystem_command)
-    ; ("cassandra", cassandra_command)
-    ; ("stdin", stdin_command)
+    [ ("fs", filesystem_command ~logger)
+    ; ("cassandra", cassandra_command ~logger)
+    ; ("stdin", stdin_command ~logger)
     ]
 
 let () = Async.Command.run command

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -42,10 +42,10 @@ let timestamp =
   let open Command.Param in
   anon ("timestamp" %: string)
 
-let instantiate_verify_functions ~logger config_file =
+let instantiate_verify_functions ~logger ~cli_proof_level config_file =
   let open Deferred.Let_syntax in
   let%map constants =
-    Runtime_config.Constants.load_constants ~logger config_file
+    Runtime_config.Constants.load_constants ~logger ~cli_proof_level config_file
   in
   let constraint_constants =
     Runtime_config.Constants.constraint_constants constants
@@ -130,7 +130,7 @@ let filesystem_command ~logger =
       and config_file = config_flag in
       fun () ->
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file
+          instantiate_verify_functions ~logger ~cli_proof_level:None config_file
         in
 
         let submission_paths = get_filenames inputs in
@@ -163,7 +163,7 @@ let cassandra_command ~logger =
       fun () ->
         let open Deferred.Let_syntax in
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file
+          instantiate_verify_functions ~logger ~cli_proof_level:None config_file
         in
         let module V = Make_verifier (struct
           include Submission.Cassandra
@@ -194,7 +194,7 @@ let stdin_command ~logger =
       fun () ->
         let open Deferred.Let_syntax in
         let%bind.Deferred verify_blockchain_snarks, verify_transaction_snarks =
-          instantiate_verify_functions ~logger config_file
+          instantiate_verify_functions ~logger ~cli_proof_level:None config_file
         in
         let module V = Make_verifier (struct
           include Submission.Stdin

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -210,8 +210,7 @@ let stdin_command ~logger =
             Output.display_error @@ Error.to_string_hum e ;
             exit 1)
 
-let command =
-  let logger = Logger.create () in
+let command ~logger =
   Command.group
     ~summary:"A tool for verifying JSON payload submitted by the uptime service"
     [ ("fs", filesystem_command ~logger)
@@ -219,4 +218,6 @@ let command =
     ; ("stdin", stdin_command ~logger)
     ]
 
-let () = Async.Command.run command
+let () =
+  let logger = Logger.create () in
+  Async.Command.run @@ command ~logger

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -44,9 +44,8 @@ let timestamp =
 
 let instantiate_verify_functions ~logger config_file =
   let open Deferred.Let_syntax in
-  let%map { constraint_constants; _ } =
-    Genesis_ledger_helper.Config_loader.load_config ~logger config_file
-  in
+  let%map constants = Runtime_config.Constants.load_constants ~logger config_file in
+  let constraint_constants = Runtime_config.Constants.constraint_constants constants in
   Verifier.verify_functions ~constraint_constants ~proof_level:Full ()
 
 module Make_verifier (Source : Submission.Data_source) = struct

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -44,8 +44,12 @@ let timestamp =
 
 let instantiate_verify_functions ~logger config_file =
   let open Deferred.Let_syntax in
-  let%map constants = Runtime_config.Constants.load_constants ~logger config_file in
-  let constraint_constants = Runtime_config.Constants.constraint_constants constants in
+  let%map constants =
+    Runtime_config.Constants.load_constants ~logger config_file
+  in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants constants
+  in
   Verifier.verify_functions ~constraint_constants ~proof_level:Full ()
 
 module Make_verifier (Source : Submission.Data_source) = struct

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -848,14 +848,12 @@ let () =
     (let%map_open config_file = Cli_lib.Flag.conf_file in
      fun () ->
        let open Async.Deferred.Let_syntax in
-       let%map config =
+       let%map genesis_constants, constraint_constants =
          let logger = Logger.create () in
-         Runtime_config.Constants.load_constants ~logger config_file
-       in
-       let genesis_constants =
-         Runtime_config.Constants.genesis_constants config
-       in
-       let constraint_constants =
-         Runtime_config.Constants.constraint_constants config
+         let%map config =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in
+         Runtime_config.Constants.
+           (genesis_constants config, constraint_constants config)
        in
        main { genesis_constants; constraint_constants } () )

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -852,6 +852,10 @@ let () =
          let logger = Logger.create () in
          Runtime_config.Constants.load_constants ~logger config_file
        in
-       let genesis_constants =   Runtime_config.Constants.genesis_constants config in
-       let constraint_constants =Runtime_config.Constants.constraint_constants config in
+       let genesis_constants =
+         Runtime_config.Constants.genesis_constants config
+       in
+       let constraint_constants =
+         Runtime_config.Constants.constraint_constants config
+       in
        main { genesis_constants; constraint_constants } () )

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -721,21 +721,21 @@ let compute_ram_usage ~config (sizes : size_params) =
   in
   Printf.printf "TOTAL: %fGB\n" (format_gb total_size)
 
-let () =
+let main config () =
   Async.Thread_safe.block_on_async_exn
   @@ fun () ->
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
-  let config = { constraint_constants; genesis_constants } in
   let%bind.Async_kernel.Deferred _, generated_zkapps =
     let num_updates = 1 in
-    Snark_profiler_lib.create_ledger_and_zkapps ~genesis_constants
-      ~constraint_constants ~min_num_updates:num_updates
-      ~num_proof_updates:num_updates ~max_num_updates:num_updates ()
+    Snark_profiler_lib.create_ledger_and_zkapps
+      ~genesis_constants:config.genesis_constants
+      ~constraint_constants:config.constraint_constants
+      ~min_num_updates:num_updates ~num_proof_updates:num_updates
+      ~max_num_updates:num_updates ()
   in
   let%map.Async_kernel.Deferred vk =
     let `VK vk, `Prover _ =
-      Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+      Transaction_snark.For_tests.create_trivial_snapp
+        ~constraint_constants:config.constraint_constants ()
     in
     vk
   in
@@ -836,3 +836,22 @@ let () =
          *. Time.Span.to_ns ledger_proof_serial_times.read )
      in
      Time.Span.(zkapps + snark_works) )
+
+let () =
+  Command.run
+  @@
+  let open Command.Let_syntax in
+  Async.Command.async
+    ~summary:
+      "Estimate the memory usage of the daemon in the fully saturated max-cost \
+       transaction environment"
+    (let%map_open config_file = Cli_lib.Flag.conf_file in
+     fun () ->
+       let open Async.Deferred.Let_syntax in
+       let%map config =
+         let logger = Logger.create () in
+         Runtime_config.Constants.load_constants ~logger config_file
+       in
+       let genesis_constants =   Runtime_config.Constants.genesis_constants config in
+       let constraint_constants =Runtime_config.Constants.constraint_constants config in
+       main { genesis_constants; constraint_constants } () )

--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -43,10 +43,17 @@ let main ~genesis_constants ~constraint_constants () =
   Async.return ()
 
 let () =
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
-  Command.(
-    run
-      (async ~summary:"Print heap usage of selected Mina data structures"
-         (let%map.Command () = Let_syntax.return () in
-          main ~genesis_constants ~constraint_constants ) ))
+  Command.run
+  @@
+  let open Command.Let_syntax in
+  Command.async ~summary:"Print heap usage of selected Mina data structures"
+    (let%map_open config_file = Cli_lib.Flag.conf_file in
+     fun () ->
+       let open Deferred.Let_syntax in
+       let%bind config =
+         let logger = Logger.create () in
+         Runtime_config.Constants.load_constants ~logger config_file
+       in
+       let genesis_constants = Runtime_config.Constants.genesis_constants config in
+       let constraint_constants = Runtime_config.Constants.constraint_constants config in
+       main ~genesis_constants ~constraint_constants () )

--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -54,6 +54,10 @@ let () =
          let logger = Logger.create () in
          Runtime_config.Constants.load_constants ~logger config_file
        in
-       let genesis_constants = Runtime_config.Constants.genesis_constants config in
-       let constraint_constants = Runtime_config.Constants.constraint_constants config in
+       let genesis_constants =
+         Runtime_config.Constants.genesis_constants config
+       in
+       let constraint_constants =
+         Runtime_config.Constants.constraint_constants config
+       in
        main ~genesis_constants ~constraint_constants () )

--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -50,14 +50,12 @@ let () =
     (let%map_open config_file = Cli_lib.Flag.conf_file in
      fun () ->
        let open Deferred.Let_syntax in
-       let%bind config =
+       let%bind genesis_constants, constraint_constants =
          let logger = Logger.create () in
-         Runtime_config.Constants.load_constants ~logger config_file
-       in
-       let genesis_constants =
-         Runtime_config.Constants.genesis_constants config
-       in
-       let constraint_constants =
-         Runtime_config.Constants.constraint_constants config
+         let%map config =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in
+         Runtime_config.Constants.
+           (genesis_constants config, constraint_constants config)
        in
        main ~genesis_constants ~constraint_constants () )

--- a/src/app/print_blockchain_snark_vk/dune
+++ b/src/app/print_blockchain_snark_vk/dune
@@ -1,9 +1,9 @@
 (executable
  (name print_blockchain_snark_vk)
  (libraries
-   blockchain_snark genesis_constants)
+   blockchain_snark genesis_constants mina_runtime_config)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (preprocess (pps ppx_version ppx_let)))
 
 (rule
  (deps print_blockchain_snark_vk.exe)

--- a/src/app/print_blockchain_snark_vk/print_blockchain_snark_vk.ml
+++ b/src/app/print_blockchain_snark_vk/print_blockchain_snark_vk.ml
@@ -6,9 +6,11 @@ let () =
       let open Async.Deferred.Let_syntax in
       let%bind constraint_constants =
         let logger = Logger.null () in
-        let%map conf = Runtime_config.Constants.load_constants ~logger
-          (Option.to_list config_file)
-        in Runtime_config.Constants.constraint_constants conf
+        let%map conf =
+          Runtime_config.Constants.load_constants ~logger
+            (Option.to_list config_file)
+        in
+        Runtime_config.Constants.constraint_constants conf
       in
       let () = Format.eprintf "Generating transaction snark circuit..@." in
       let module Transaction_snark_instance = Transaction_snark.Make (struct

--- a/src/app/print_blockchain_snark_vk/print_blockchain_snark_vk.ml
+++ b/src/app/print_blockchain_snark_vk/print_blockchain_snark_vk.ml
@@ -2,10 +2,17 @@ open Core_kernel
 
 let () =
   Async.Thread_safe.block_on_async_exn (fun () ->
+      let config_file = Sys.getenv_opt "MINA_CONFIG_FILE" in
+      let open Async.Deferred.Let_syntax in
+      let%bind constraint_constants =
+        let logger = Logger.null () in
+        let%map conf = Runtime_config.Constants.load_constants ~logger
+          (Option.to_list config_file)
+        in Runtime_config.Constants.constraint_constants conf
+      in
       let () = Format.eprintf "Generating transaction snark circuit..@." in
       let module Transaction_snark_instance = Transaction_snark.Make (struct
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
+        let constraint_constants = constraint_constants
 
         let proof_level = Genesis_constants.Proof_level.Full
       end) in
@@ -13,8 +20,7 @@ let () =
       let before = Time.now () in
       let module Blockchain_snark_instance =
       Blockchain_snark.Blockchain_snark_state.Make (struct
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
+        let constraint_constants = constraint_constants
 
         let proof_level = Genesis_constants.Proof_level.Full
 

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -639,9 +639,11 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
         ~transport:(Logger_file_system.evergrowing ~log_filename)
         () ) ;
   let logger = Logger.create () in
-  let%bind (constraint_constants, proof_level) =
-    let%map conf = Runtime_config.Constants.load_constants ~cli_proof_level ~logger
-      config_file in
+  let%bind constraint_constants, proof_level =
+    let%map conf =
+      Runtime_config.Constants.load_constants ~cli_proof_level ~logger
+        config_file
+    in
     Runtime_config.Constants.(constraint_constants conf, proof_level conf)
   in
   let json = Yojson.Safe.from_file input_file in

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -631,21 +631,13 @@ let write_replayer_checkpoint ~logger ~ledger ~last_global_slot_since_genesis
 let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
     ~checkpoint_interval ~checkpoint_output_folder_opt ~checkpoint_file_prefix
     ~genesis_dir_opt ~log_json ~log_level ~log_filename ~file_log_level
-    ~config_file ~cli_proof_level () =
+    ~constraint_constants ~proof_level ~logger () =
   Cli_lib.Stdout_log.setup log_json log_level ;
   Option.iter log_filename ~f:(fun log_filename ->
       Logger.Consumer_registry.register ~id:"default"
         ~processor:(Logger.Processor.raw ~log_level:file_log_level ())
         ~transport:(Logger_file_system.evergrowing ~log_filename)
         () ) ;
-  let logger = Logger.create () in
-  let%bind constraint_constants, proof_level =
-    let%map conf =
-      Runtime_config.Constants.load_constants ~cli_proof_level ~logger
-        config_file
-    in
-    Runtime_config.Constants.(constraint_constants conf, proof_level conf)
-  in
   let json = Yojson.Safe.from_file input_file in
   let input =
     match input_of_yojson json with
@@ -1732,7 +1724,19 @@ let () =
          and log_level = Cli_lib.Flag.Log.level
          and file_log_level = Cli_lib.Flag.Log.file_log_level
          and log_filename = Cli_lib.Flag.Log.file in
-         main ~input_file ~output_file_opt ~archive_uri ~checkpoint_interval
-           ~continue_on_error ~checkpoint_output_folder_opt
-           ~checkpoint_file_prefix ~genesis_dir_opt ~log_json ~log_level
-           ~file_log_level ~log_filename ~config_file ~cli_proof_level:Full )))
+         fun () ->
+           let open Deferred.Let_syntax in
+           let logger = Logger.create () in
+           let%bind constraint_constants, proof_level =
+             let%map conf =
+               Runtime_config.Constants.load_constants ~cli_proof_level:Full
+                 ~logger config_file
+             in
+             Runtime_config.Constants.
+               (constraint_constants conf, proof_level conf)
+           in
+           main ~input_file ~output_file_opt ~archive_uri ~checkpoint_interval
+             ~continue_on_error ~checkpoint_output_folder_opt
+             ~checkpoint_file_prefix ~genesis_dir_opt ~log_json ~log_level
+             ~file_log_level ~log_filename ~constraint_constants ~proof_level
+             ~logger () )))

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -631,7 +631,7 @@ let write_replayer_checkpoint ~logger ~ledger ~last_global_slot_since_genesis
 let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
     ~checkpoint_interval ~checkpoint_output_folder_opt ~checkpoint_file_prefix
     ~genesis_dir_opt ~log_json ~log_level ~log_filename ~file_log_level
-    ~constraint_constants ~proof_level () =
+    ~config_file ~cli_proof_level () =
   Cli_lib.Stdout_log.setup log_json log_level ;
   Option.iter log_filename ~f:(fun log_filename ->
       Logger.Consumer_registry.register ~id:"default"
@@ -639,6 +639,11 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
         ~transport:(Logger_file_system.evergrowing ~log_filename)
         () ) ;
   let logger = Logger.create () in
+  let%bind (constraint_constants, proof_level) =
+    let%map conf = Runtime_config.Constants.load_constants ~cli_proof_level ~logger
+      config_file in
+    Runtime_config.Constants.(constraint_constants conf, proof_level conf)
+  in
   let json = Yojson.Safe.from_file input_file in
   let input =
     match input_of_yojson json with
@@ -1683,8 +1688,6 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                 exit 1 ) ) )
 
 let () =
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
-  let proof_level = Genesis_constants.Proof_level.Full in
   Command.(
     run
       (let open Let_syntax in
@@ -1722,6 +1725,7 @@ let () =
            Param.flag "--checkpoint-file-prefix"
              ~doc:"string Checkpoint file prefix (default: 'replayer')"
              Param.(optional_with_default "replayer" string)
+         and config_file = Cli_lib.Flag.conf_file
          and log_json = Cli_lib.Flag.Log.json
          and log_level = Cli_lib.Flag.Log.level
          and file_log_level = Cli_lib.Flag.Log.file_log_level
@@ -1729,4 +1733,4 @@ let () =
          main ~input_file ~output_file_opt ~archive_uri ~checkpoint_interval
            ~continue_on_error ~checkpoint_output_folder_opt
            ~checkpoint_file_prefix ~genesis_dir_opt ~log_json ~log_level
-           ~file_log_level ~log_filename ~constraint_constants ~proof_level )))
+           ~file_log_level ~log_filename ~config_file ~cli_proof_level:Full )))

--- a/src/app/rosetta/lib/commands_common.ml
+++ b/src/app/rosetta/lib/commands_common.ml
@@ -208,8 +208,11 @@ module User_command_info = struct
                 let open Mina_base.Signed_command_memo in
                 base58_check |> of_base58_check_exn |> to_string_hum
               in
-              if String.is_empty memo then None
-              else Some (`Assoc [ ("memo", `String memo) ])
+              let nonce = ("nonce", `Int (Unsigned.UInt32.to_int info.nonce)) in
+              Some
+                (`Assoc
+                  ( if String.is_empty memo then [ nonce ]
+                  else [ nonce; ("memo", `String memo) ] ) )
             with _ -> None )
     ; related_transactions = []
     }

--- a/src/app/rosetta/lib/commands_common.ml
+++ b/src/app/rosetta/lib/commands_common.ml
@@ -208,11 +208,8 @@ module User_command_info = struct
                 let open Mina_base.Signed_command_memo in
                 base58_check |> of_base58_check_exn |> to_string_hum
               in
-              let nonce = ("nonce", `Int (Unsigned.UInt32.to_int info.nonce)) in
-              Some
-                (`Assoc
-                  ( if String.is_empty memo then [ nonce ]
-                  else [ nonce; ("memo", `String memo) ] ) )
+              if String.is_empty memo then None
+              else Some (`Assoc [ ("memo", `String memo) ])
             with _ -> None )
     ; related_transactions = []
     }

--- a/src/app/rosetta/lib/dune
+++ b/src/app/rosetta/lib/dune
@@ -52,6 +52,7 @@
   mina_numbers
   mina_transaction
   mina_version
+  cli_lib
  )
  (preprocessor_deps
   ../../../graphql-ppx-config.inc

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -176,15 +176,15 @@ let command =
   fun () ->
     let logger = Logger.create () in
     Cli.logger_setup log_json log_level ;
-    let%bind (genesis_constants, constraint_constants) =
-      let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
-      Runtime_config.Constants.(genesis_constants conf, constraint_constants conf)
+    let%bind genesis_constants, constraint_constants =
+      let%map conf =
+        Runtime_config.Constants.load_constants ~logger config_file
+      in
+      Runtime_config.Constants.
+        (genesis_constants conf, constraint_constants conf)
     in
-    let account_creation_fee = constraint_constants.account_creation_fee
-    in
-    let minimum_user_command_fee =
-      genesis_constants.minimum_user_command_fee
-    in
+    let account_creation_fee = constraint_constants.account_creation_fee in
+    let minimum_user_command_fee = genesis_constants.minimum_user_command_fee in
     let pool =
       lazy
         (let open Deferred.Result.Let_syntax in

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -153,7 +153,7 @@ let server_handler ~pool ~graphql_uri ~logger ~minimum_user_command_fee
       [%log warn] ~metadata "Error response: $error" ;
       respond_500 error
 
-let command ~minimum_user_command_fee ~account_creation_fee =
+let command =
   let open Command.Let_syntax in
   let%map_open archive_uri =
     flag "--archive-uri" ~aliases:[ "archive-uri" ]
@@ -171,11 +171,20 @@ let command ~minimum_user_command_fee ~account_creation_fee =
   and port =
     flag "--port" ~aliases:[ "port" ] ~doc:"Port to expose Rosetta server"
       (required int)
-  in
+  and config_file = Cli_lib.Flag.conf_file in
   let open Deferred.Let_syntax in
   fun () ->
     let logger = Logger.create () in
     Cli.logger_setup log_json log_level ;
+    let%bind (genesis_constants, constraint_constants) =
+      let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+      Runtime_config.Constants.(genesis_constants conf, constraint_constants conf)
+    in
+    let account_creation_fee = constraint_constants.account_creation_fee
+    in
+    let minimum_user_command_fee =
+      genesis_constants.minimum_user_command_fee
+    in
     let pool =
       lazy
         (let open Deferred.Result.Let_syntax in

--- a/src/app/rosetta/lib/search.ml
+++ b/src/app/rosetta/lib/search.ml
@@ -381,10 +381,7 @@ module Sql = struct
                 [%string "u.command_type = 'delegation'"]
             | `Fee_payer_dec
             | `Account_creation_fee_via_payment
-            | `Account_creation_fee_via_fee_payer
             | `Account_creation_fee_via_fee_receiver
-            | `Create_token
-            | `Mint_tokens
             | `Zkapp_fee_payer_dec
             | `Zkapp_balance_update
             | `Fee_receiver_inc
@@ -691,13 +688,10 @@ module Sql = struct
           | `Account_creation_fee_via_fee_receiver ->
               "ac.creation_fee IS NOT NULL"
           | `Account_creation_fee_via_payment
-          | `Account_creation_fee_via_fee_payer
           | `Payment_source_dec
           | `Payment_receiver_inc
           | `Fee_payment
           | `Delegate_change
-          | `Create_token
-          | `Mint_tokens
           | `Zkapp_fee_payer_dec
           | `Zkapp_balance_update ->
               "FALSE" )
@@ -893,14 +887,11 @@ module Sql = struct
           | `Fee_receiver_inc
           | `Coinbase_inc
           | `Account_creation_fee_via_payment
-          | `Account_creation_fee_via_fee_payer
           | `Account_creation_fee_via_fee_receiver
           | `Payment_source_dec
           | `Payment_receiver_inc
           | `Fee_payment
-          | `Delegate_change
-          | `Create_token
-          | `Mint_tokens ->
+          | `Delegate_change ->
               "FALSE" )
       in
       let filters =

--- a/src/app/rosetta/lib/search.ml
+++ b/src/app/rosetta/lib/search.ml
@@ -381,7 +381,10 @@ module Sql = struct
                 [%string "u.command_type = 'delegation'"]
             | `Fee_payer_dec
             | `Account_creation_fee_via_payment
+            | `Account_creation_fee_via_fee_payer
             | `Account_creation_fee_via_fee_receiver
+            | `Create_token
+            | `Mint_tokens
             | `Zkapp_fee_payer_dec
             | `Zkapp_balance_update
             | `Fee_receiver_inc
@@ -688,10 +691,13 @@ module Sql = struct
           | `Account_creation_fee_via_fee_receiver ->
               "ac.creation_fee IS NOT NULL"
           | `Account_creation_fee_via_payment
+          | `Account_creation_fee_via_fee_payer
           | `Payment_source_dec
           | `Payment_receiver_inc
           | `Fee_payment
           | `Delegate_change
+          | `Create_token
+          | `Mint_tokens
           | `Zkapp_fee_payer_dec
           | `Zkapp_balance_update ->
               "FALSE" )
@@ -887,11 +893,14 @@ module Sql = struct
           | `Fee_receiver_inc
           | `Coinbase_inc
           | `Account_creation_fee_via_payment
+          | `Account_creation_fee_via_fee_payer
           | `Account_creation_fee_via_fee_receiver
           | `Payment_source_dec
           | `Payment_receiver_inc
           | `Fee_payment
-          | `Delegate_change ->
+          | `Delegate_change
+          | `Create_token
+          | `Mint_tokens ->
               "FALSE" )
       in
       let filters =

--- a/src/app/rosetta/rosetta.ml
+++ b/src/app/rosetta/rosetta.ml
@@ -2,9 +2,5 @@ open Lib.Rosetta
 open Async
 
 let () =
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
-    (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
-          ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )
+    (Command.async ~summary:"Run Rosetta process on top of Mina" command)

--- a/src/app/rosetta/rosetta_mainnet_signatures.ml
+++ b/src/app/rosetta/rosetta_mainnet_signatures.ml
@@ -2,9 +2,5 @@ open Lib.Rosetta
 open Async
 
 let () =
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
-    (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
-          ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )
+    (Command.async ~summary:"Run Rosetta process on top of Mina" command)

--- a/src/app/rosetta/rosetta_testnet_signatures.ml
+++ b/src/app/rosetta/rosetta_testnet_signatures.ml
@@ -2,9 +2,5 @@ open Lib.Rosetta
 open Async
 
 let () =
-  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
-    (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
-          ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )
+    (Command.async ~summary:"Run Rosetta process on top of Mina" command)

--- a/src/app/runtime_genesis_ledger/dune
+++ b/src/app/runtime_genesis_ledger/dune
@@ -24,6 +24,7 @@
    coda_genesis_ledger
    consensus
    mina_base
+   mina_lib
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_mina ppx_version ppx_let ppx_deriving_yojson)))

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -92,17 +92,11 @@ let main ~config_file ~genesis_dir ~hash_output_file () =
   let%bind config =
     let logger = Logger.create () in
     let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
-    let%bind constants =
-      Runtime_config.Constants.load_constants ~logger config_file
-    in
-    let%map config, _ =
-      Deferred.Or_error.(
-        Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
-          config_file
-        >>= Genesis_ledger_helper.init_from_config_file ~logger ~constants)
-      |> Deferred.Or_error.ok_exn
-    in
-    config
+    Deferred.Or_error.(
+      Genesis_ledger_helper.Config_loader.load_config_files ~logger ~conf_dir
+        config_file
+      >>| fst)
+    |> Deferred.Or_error.ok_exn
   in
   if
     Option.(

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -88,36 +88,48 @@ let extract_accounts_exn = function
   | _ ->
       failwith "Wrong ledger supplied"
 
-let load_config_exn ~logger config_file =
-  let%map config =
-    Deferred.Or_error.ok_exn
-    @@ Runtime_config.Json_loader.load_config_files ~logger [ config_file ]
+let main ~config_file ~genesis_dir ~hash_output_file () =
+  let%bind config =
+    let logger = Logger.create () in
+    let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
+    let%bind constants =
+      Runtime_config.Constants.load_constants ~logger config_file
+    in
+    let%map config, _ =
+      Deferred.Or_error.(
+        Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
+          config_file
+        >>= Genesis_ledger_helper.init_from_config_file ~logger ~constants)
+      |> Deferred.Or_error.ok_exn
+    in
+    config
   in
   if
     Option.(
-      is_some config.daemon || is_some config.genesis
-      || Option.value_map ~default:false ~f:is_dirty_proof config.proof)
+      is_some config.runtime_config.daemon
+      || is_some config.runtime_config.genesis
+      || Option.value_map ~default:false ~f:is_dirty_proof
+           config.runtime_config.proof)
   then failwith "Runtime config has unexpected fields" ;
-  let ledger = Option.value_exn ~message:"No ledger provided" config.ledger in
-  let staking_ledger =
-    let%map.Option { staking; _ } = config.epoch_data in
-    staking.ledger
+  let accounts, staking_accounts_opt, next_accounts_opt =
+    let ledger =
+      Option.value_exn ~message:"No ledger provided"
+        config.runtime_config.ledger
+    in
+    let staking_ledger =
+      let%map.Option { staking; _ } = config.runtime_config.epoch_data in
+      staking.ledger
+    in
+    let next_ledger =
+      let%bind.Option { next; _ } = config.runtime_config.epoch_data in
+      let%map.Option { ledger; _ } = next in
+      ledger
+    in
+    ( extract_accounts_exn ledger
+    , Option.map ~f:extract_accounts_exn staking_ledger
+    , Option.map ~f:extract_accounts_exn next_ledger )
   in
-  let next_ledger =
-    let%bind.Option { next; _ } = config.epoch_data in
-    let%map.Option { ledger; _ } = next in
-    ledger
-  in
-  ( extract_accounts_exn ledger
-  , Option.map ~f:extract_accounts_exn staking_ledger
-  , Option.map ~f:extract_accounts_exn next_ledger )
-
-let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~config_file ~genesis_dir ~hash_output_file () =
-  let logger = Logger.create () in
-  let%bind accounts, staking_accounts_opt, next_accounts_opt =
-    load_config_exn ~logger config_file
-  in
+  let constraint_constants = config.constraint_constants in
   let ledger = load_ledger ~constraint_constants accounts in
   let staking_ledger : Ledger.t =
     Option.value_map ~default:ledger
@@ -136,7 +148,6 @@ let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~contents:(Yojson.Safe.to_string (Hash_json.to_yojson hash_json))
 
 let () =
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
     (Command.async
        ~summary:
@@ -146,9 +157,7 @@ let () =
        Command.(
          let open Let_syntax in
          let open Command.Param in
-         let%map config_file =
-           flag "--config-file" ~doc:"PATH path to the JSON configuration file"
-             (required string)
+         let%map config_file = Cli_lib.Flag.conf_file
          and genesis_dir =
            flag "--genesis-dir"
              ~doc:
@@ -163,4 +172,4 @@ let () =
                "PATH path to the file where the hashes of the ledgers are to \
                 be saved"
          in
-         main ~constraint_constants ~config_file ~genesis_dir ~hash_output_file) )
+         main ~config_file ~genesis_dir ~hash_output_file) )

--- a/src/app/snark_work_debugger/snark_work_debugger.ml
+++ b/src/app/snark_work_debugger/snark_work_debugger.ml
@@ -37,12 +37,14 @@ let cmd =
       let%map path =
         let open Command.Param in
         flag "--spec" ~doc:"PATH Spec path" (required string)
-      in
+      and config_file = Cli_lib.Flag.conf_file in
       fun () ->
-        let constraint_constants =
-          Genesis_constants.Compiled.constraint_constants
+        let open Deferred.Let_syntax in
+        let%bind (constraint_constants, proof_level) =
+          let logger = Logger.create () in
+          let%map constants =Runtime_config.Constants.load_constants ~logger config_file
+      in  (Runtime_config.Constants.constraint_constants constants, Runtime_config.Constants.proof_level constants)
         in
-        let proof_level = Genesis_constants.Compiled.proof_level in
         Obj.magic (main path ~constraint_constants ~proof_level))
 
 let () = Command.run cmd

--- a/src/app/snark_work_debugger/snark_work_debugger.ml
+++ b/src/app/snark_work_debugger/snark_work_debugger.ml
@@ -40,10 +40,13 @@ let cmd =
       and config_file = Cli_lib.Flag.conf_file in
       fun () ->
         let open Deferred.Let_syntax in
-        let%bind (constraint_constants, proof_level) =
+        let%bind constraint_constants, proof_level =
           let logger = Logger.create () in
-          let%map constants =Runtime_config.Constants.load_constants ~logger config_file
-      in  (Runtime_config.Constants.constraint_constants constants, Runtime_config.Constants.proof_level constants)
+          let%map constants =
+            Runtime_config.Constants.load_constants ~logger config_file
+          in
+          ( Runtime_config.Constants.constraint_constants constants
+          , Runtime_config.Constants.proof_level constants )
         in
         Obj.magic (main path ~constraint_constants ~proof_level))
 

--- a/src/app/snark_work_debugger/snark_work_debugger.ml
+++ b/src/app/snark_work_debugger/snark_work_debugger.ml
@@ -45,8 +45,8 @@ let cmd =
           let%map constants =
             Runtime_config.Constants.load_constants ~logger config_file
           in
-          ( Runtime_config.Constants.constraint_constants constants
-          , Runtime_config.Constants.proof_level constants )
+          Runtime_config.Constants.
+            (constraint_constants constants, proof_level constants)
         in
         Obj.magic (main path ~constraint_constants ~proof_level))
 

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -269,7 +269,6 @@ let main inputs =
    *)
   let logger = Logger.create () in
   let%bind config =
-    let logger = Logger.create () in
     Runtime_config.Constants.load_constants ~logger inputs.config_file
   in
   let constants : Test_config.constants =

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -283,8 +283,12 @@ let main inputs =
       }
     in
     { genesis_constants =
-        { (Runtime_config.Constants.genesis_constants config) with protocol; txpool_max_size = 3000 }
-    ; constraint_constants = Runtime_config.Constants.constraint_constants config
+        { (Runtime_config.Constants.genesis_constants config) with
+          protocol
+        ; txpool_max_size = 3000
+        }
+    ; constraint_constants =
+        Runtime_config.Constants.constraint_constants config
     ; compile_config = Runtime_config.Constants.compile_config config
     }
   in

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -30,6 +30,7 @@ type inputs =
   ; mina_image : string
   ; archive_image : string option
   ; debug : bool
+  ; config_file : string list
   }
 
 let validate_inputs ~logger inputs (test_config : Test_config.t) :
@@ -267,9 +268,13 @@ let main inputs =
    *   Exec.execute ~logger ~engine_cli_inputs ~images (module Test (Engine))
    *)
   let logger = Logger.create () in
+  let%bind config =
+    let logger = Logger.create () in
+    Runtime_config.Constants.load_constants ~logger inputs.config_file
+  in
   let constants : Test_config.constants =
     let protocol =
-      { Genesis_constants.Compiled.genesis_constants.protocol with
+      { (Runtime_config.Constants.genesis_constants config).protocol with
         k = 20
       ; delta = 0
       ; slots_per_epoch = 3 * 8 * 20
@@ -278,12 +283,9 @@ let main inputs =
       }
     in
     { genesis_constants =
-        { Genesis_constants.Compiled.genesis_constants with
-          protocol
-        ; txpool_max_size = 3000
-        }
-    ; constraint_constants = Genesis_constants.Compiled.constraint_constants
-    ; compile_config = Mina_compile_config.Compiled.t
+        { (Runtime_config.Constants.genesis_constants config) with protocol; txpool_max_size = 3000 }
+    ; constraint_constants = Runtime_config.Constants.constraint_constants config
+    ; compile_config = Runtime_config.Constants.compile_config config
     }
   in
   let images =
@@ -473,6 +475,14 @@ let debug_arg =
   in
   Arg.(value & flag & info [ "debug"; "d" ] ~doc)
 
+let config_file_arg =
+  let doc = "The path to the node configuration file." in
+  let env = Arg.env_var "MINA_CONFIG_FILE" ~doc in
+  Arg.(
+    value
+      ( opt (some string) None
+      & info [ "config-file" ] ~env ~docv:"MINA_CONFIG_FILE" ~doc ))
+
 let help_term = Term.(ret @@ const (`Help (`Plain, None)))
 
 let engine_cmd ((engine_name, (module Engine)) : engine) =
@@ -488,12 +498,19 @@ let engine_cmd ((engine_name, (module Engine)) : engine) =
     Term.(const wrap_cli_inputs $ Engine.Network_config.Cli_inputs.term)
   in
   let inputs_term =
-    let cons_inputs test_inputs test mina_image archive_image debug =
-      { test_inputs; test; mina_image; archive_image; debug }
+    let cons_inputs test_inputs test mina_image archive_image debug config_file
+        =
+      { test_inputs
+      ; test
+      ; mina_image
+      ; archive_image
+      ; debug
+      ; config_file = Option.to_list config_file
+      }
     in
     Term.(
       const cons_inputs $ test_inputs_with_cli_inputs_arg $ test_arg
-      $ mina_image_arg $ archive_image_arg $ debug_arg)
+      $ mina_image_arg $ archive_image_arg $ debug_arg $ config_file_arg)
   in
   let term = Term.(const start $ inputs_term) in
   (term, info)

--- a/src/app/zkapp_limits/dune
+++ b/src/app/zkapp_limits/dune
@@ -11,6 +11,8 @@
    mina_base
    genesis_constants
    bounded_types
+   mina_runtime_config
+   cli_lib
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_mina ppx_custom_printf ppx_let ppx_hash ppx_compare ppx_sexp_conv)))

--- a/src/app/zkapp_limits/zkapp_limits.ml
+++ b/src/app/zkapp_limits/zkapp_limits.ml
@@ -2,7 +2,7 @@
 open Core_kernel
 open Async
 
-let main ({ genesis_constants; _ } : Runtime_config.Constants_loader.t) =
+let main (genesis_constants : Genesis_constants.t) =
   let cost_limit = genesis_constants.zkapp_transaction_cost_limit in
   let max_event_elements = genesis_constants.max_event_elements in
   let max_action_elements = genesis_constants.max_action_elements in
@@ -37,8 +37,10 @@ let () =
     (let%map_open config_file = Cli_lib.Flag.conf_file in
      fun () ->
        let open Deferred.Let_syntax in
-       let%map config =
+       let%map genesis_constants =
          let logger = Logger.create () in
-         Runtime_config.Constants_loader.load_constants ~logger config_file
+         let%map config =
+           Runtime_config.Constants.load_constants ~logger config_file
+         in  Runtime_config.Constants.genesis_constants config
        in
-       main config )
+       main genesis_constants )

--- a/src/app/zkapp_limits/zkapp_limits.ml
+++ b/src/app/zkapp_limits/zkapp_limits.ml
@@ -41,6 +41,7 @@ let () =
          let logger = Logger.create () in
          let%map config =
            Runtime_config.Constants.load_constants ~logger config_file
-         in  Runtime_config.Constants.genesis_constants config
+         in
+         Runtime_config.Constants.genesis_constants config
        in
        main genesis_constants )

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -338,7 +338,7 @@ let test_zkapp_with_genesis_ledger_main ~logger keyfile zkapp_keyfile
     Runtime_config.Constants.load_constants ~logger config_file
   in
   let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
-  let%map config, _ =
+  let%bind config, _ =
     Deferred.Or_error.(
       Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
         config_file

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -46,10 +46,9 @@ let get_second_pass_ledger_mask ~ledger ~constraint_constants ~global_slot
 
 let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t) ~config
     ~proof_level =
-  let genesis_constants, constraint_constants = 
-     (Runtime_config.Constants.genesis_constants config
-     , Runtime_config.Constants.constraint_constants config
-     )
+  let genesis_constants, constraint_constants =
+    ( Runtime_config.Constants.genesis_constants config
+    , Runtime_config.Constants.constraint_constants config )
   in
   let ledger = Ledger.create ~depth:constraint_constants.ledger_depth () in
   let _v =
@@ -340,8 +339,7 @@ let test_zkapp_with_genesis_ledger_main ~logger keyfile zkapp_keyfile
   let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
   let%bind config, _ =
     Deferred.Or_error.(
-      Runtime_config.Json_loader.load_config_files ~conf_dir ~logger
-        config_file
+      Runtime_config.Json_loader.load_config_files ~conf_dir ~logger config_file
       >>= Genesis_ledger_helper.init_from_config_file ~logger ~constants)
     |> Deferred.Or_error.ok_exn
   in
@@ -385,7 +383,9 @@ let create_zkapp_account ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     Transaction_snark.For_tests.deploy_snapp
       ~permissions:Permissions.user_default ~constraint_constants spec
@@ -434,7 +434,9 @@ let upgrade_zkapp ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants
@@ -523,7 +525,9 @@ let update_state ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants
@@ -567,7 +571,9 @@ let update_zkapp_uri ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants
@@ -613,7 +619,9 @@ let update_action_state ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants
@@ -657,7 +665,9 @@ let update_token_symbol ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants
@@ -702,7 +712,9 @@ let update_snapp ~logger debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     Runtime_config.Constants.load_constants ~logger ~cli_proof_level:Full
       config_file
   in
-  let constraint_constants = Runtime_config.Constants.constraint_constants config in
+  let constraint_constants =
+    Runtime_config.Constants.constraint_constants config
+  in
   let%bind zkapp_command =
     let `VK vk, `Prover prover =
       Lazy.force @@ vk_and_prover ~constraint_constants

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -333,14 +333,12 @@ let test_zkapp_with_genesis_ledger_main ~logger keyfile zkapp_keyfile
   let open Deferred.Let_syntax in
   let%bind keypair = Util.fee_payer_keypair_of_file keyfile in
   let%bind zkapp_kp = Util.snapp_keypair_of_file zkapp_keyfile in
-  let%bind constants =
-    Runtime_config.Constants.load_constants ~logger config_file
-  in
   let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
-  let%bind config, _ =
+  let%bind config =
     Deferred.Or_error.(
-      Runtime_config.Json_loader.load_config_files ~conf_dir ~logger config_file
-      >>= Genesis_ledger_helper.init_from_config_file ~logger ~constants)
+      Genesis_ledger_helper.Config_loader.load_config_files ~logger ~conf_dir
+        config_file
+      >>| fst)
     |> Deferred.Or_error.ok_exn
   in
   let ledger =

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -47,8 +47,8 @@ let get_second_pass_ledger_mask ~ledger ~constraint_constants ~global_slot
 let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t) ~config
     ~proof_level =
   let genesis_constants, constraint_constants =
-    ( Runtime_config.Constants.genesis_constants config
-    , Runtime_config.Constants.constraint_constants config )
+    Runtime_config.Constants.
+      (genesis_constants config, constraint_constants config)
   in
   let ledger = Ledger.create ~depth:constraint_constants.ledger_depth () in
   let _v =

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -53,12 +53,12 @@ module Flags = struct
 end
 
 let create_zkapp_account =
-  let create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-      ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo () =
+  let create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+      ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      create_zkapp_account ~debug ~sender ~sender_nonce ~fee ~fee_payer
-        ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo
+      create_zkapp_account ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+        ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -81,24 +81,24 @@ let create_zkapp_account =
          Param.flag "--zkapp-account-key"
            ~doc:"KEYFILE Private key file for the zkApp account to be created"
            Param.(required string)
+       and config_file = Cli_lib.Flag.conf_file
        and amount = Flags.amount in
        let fee = Option.value ~default:Flags.default_fee fee in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-         ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo ))
+       create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+         ~fee_payer_nonce ~zkapp_keyfile ~amount ~memo ~config_file ))
 
 let upgrade_zkapp =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-      ~verification_key ~zkapp_uri ~auth ~constraint_constants
-      ~genesis_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+      ~verification_key ~zkapp_uri ~auth ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      upgrade_zkapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-        ~verification_key ~zkapp_uri ~auth ~constraint_constants
-        ~genesis_constants
+      upgrade_zkapp ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+        ~verification_key ~zkapp_uri ~auth ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -119,6 +119,7 @@ let upgrade_zkapp =
        and zkapp_uri_str =
          Param.flag "--zkapp-uri" ~doc:"URI the URI for the zkApp account"
            Param.(optional string)
+       and config_file = Cli_lib.Flag.conf_file
        and auth =
          Param.flag "--auth"
            ~doc:
@@ -126,29 +127,24 @@ let upgrade_zkapp =
               to change the verification key"
            Param.(required string)
        in
+       let logger = Logger.create () in
        let fee = Option.value ~default:Flags.default_fee fee in
        let auth = Util.auth_of_string auth in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
        let zkapp_uri = Zkapp_basic.Set_or_keep.of_option zkapp_uri_str in
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~verification_key ~zkapp_uri ~auth ~constraint_constants
-         ~genesis_constants ))
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+         ~verification_key ~zkapp_uri ~auth ~config_file ))
 
 let transfer_funds_one_receiver =
-  let create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-      ~fee_payer_nonce ~memo ~receiver ~amount ~genesis_constants
-      ~constraint_constants () =
+  let create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+      ~fee_payer_nonce ~memo ~receiver ~amount ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer
-        ~fee_payer_nonce ~memo ~genesis_constants ~constraint_constants
+      transfer_funds ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+        ~fee_payer_nonce ~memo ~config_file
         ~receivers:(Deferred.return [ (receiver, amount) ])
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
@@ -174,29 +170,24 @@ let transfer_funds_one_receiver =
          Param.flag "--receiver"
            ~doc:"PUBLIC_KEY the public key of the receiver"
            Param.(required public_key_compressed)
+       and config_file = Cli_lib.Flag.conf_file
        and amount = Flags.amount in
        let fee = Option.value ~default:Flags.default_fee fee in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwithf "Fee must at least be %s"
            (Currency.Fee.to_mina_string Flags.min_fee)
            () ;
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-       create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-         ~fee_payer_nonce ~memo ~receiver ~amount ~genesis_constants
-         ~constraint_constants ))
+       create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+         ~fee_payer_nonce ~memo ~receiver ~amount ~config_file ))
 
 let transfer_funds =
-  let create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-      ~fee_payer_nonce ~memo ~receivers ~genesis_constants ~constraint_constants
-      () =
+  let create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+      ~fee_payer_nonce ~memo ~receivers ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer
-        ~fee_payer_nonce ~memo ~receivers ~genesis_constants
-        ~constraint_constants
+      transfer_funds ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+        ~fee_payer_nonce ~memo ~receivers ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -257,7 +248,7 @@ let transfer_funds =
        and sender_nonce =
          Param.flag "--sender-nonce" ~doc:"NN Nonce of the sender account"
            Param.(required txn_nonce)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwithf "Fee must at least be %s"
@@ -265,21 +256,17 @@ let transfer_funds =
            () ;
        let max_keys = 10 in
        let receivers = read_key_and_amount max_keys in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-       create_command ~debug ~sender ~sender_nonce ~fee ~fee_payer
-         ~fee_payer_nonce ~memo ~receivers ~genesis_constants
-         ~constraint_constants ))
+       let logger = Logger.create () in
+       create_command ~logger ~debug ~sender ~sender_nonce ~fee ~fee_payer
+         ~fee_payer_nonce ~memo ~receivers ~config_file ))
 
 let update_state =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
-      ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+      ~app_state ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
-        ~genesis_constants ~constraint_constants
+      update_state ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+        ~app_state ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -299,26 +286,23 @@ let update_state =
              "String(hash)|Integer(field element) a list of 8 elements that \
               represent the zkApp state (Use empty string for no-op)"
            Param.(listed string)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~app_state ~genesis_constants ~constraint_constants ))
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+         ~app_state ~config_file ))
 
 let update_zkapp_uri =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri
-      ~auth ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+      ~zkapp_uri ~auth ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_zkapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
-        ~zkapp_uri ~auth ~genesis_constants ~constraint_constants
+      update_zkapp_uri ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+        ~zkapp_uri ~auth ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -342,27 +326,24 @@ let update_zkapp_uri =
              "Proof|Signature|Either|None Current authorization in the account \
               to change the zkApp URI"
            Param.(required string)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
+       let logger = Logger.create () in
        let auth = Util.auth_of_string auth in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
-         ~zkapp_uri ~auth ~genesis_constants ~constraint_constants ))
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+         ~zkapp_uri ~auth ~config_file ))
 
 let update_action_state =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-      ~action_state ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+      ~action_state ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_action_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-        ~action_state ~genesis_constants ~constraint_constants
+      update_action_state ~logger ~debug ~keyfile ~fee ~nonce ~memo
+        ~zkapp_keyfile ~action_state ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -404,31 +385,28 @@ let update_action_state =
              optional_with_default []
                (Arg_type.comma_separated ~allow_empty:false
                   ~strip_whitespace:true string ))
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
+       let logger = Logger.create () in
        let action_state =
          List.filter_map
            ~f:(fun s -> if List.is_empty s then None else Some (Array.of_list s))
            [ action_state0; action_state1; action_state2; action_state3 ]
        in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~action_state ~genesis_constants ~constraint_constants ))
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+         ~action_state ~config_file ))
 
 let update_token_symbol =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
-      ~token_symbol ~auth ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+      ~token_symbol ~auth ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
-        ~token_symbol ~auth ~genesis_constants ~constraint_constants
+      update_token_symbol ~logger ~debug ~keyfile ~fee ~nonce ~memo
+        ~snapp_keyfile ~token_symbol ~auth ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -452,27 +430,24 @@ let update_token_symbol =
              "Proof|Signature|Either|None Current authorization in the account \
               to change the token symbol"
            Param.(required string)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
        let auth = Util.auth_of_string auth in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
-         ~token_symbol ~auth ~genesis_constants ~constraint_constants ))
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+         ~token_symbol ~auth ~config_file ))
 
 let update_permissions =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-      ~snapp_update ~current_auth ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+      ~snapp_update ~current_auth ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_snapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-        ~snapp_update ~current_auth ~genesis_constants ~constraint_constants
+      update_snapp ~logger debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+        ~snapp_update ~current_auth ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -533,7 +508,7 @@ let update_permissions =
              "Proof|Signature|Either|None Current authorization in the account \
               to change permissions"
            Param.(required string)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
        let permissions : Permissions.t Zkapp_basic.Set_or_keep.t =
          Zkapp_basic.Set_or_keep.Set
@@ -555,25 +530,22 @@ let update_permissions =
            }
        in
        let snapp_update = { Account_update.Update.dummy with permissions } in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~genesis_constants ~constraint_constants ~snapp_update
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+         ~config_file ~snapp_update
          ~current_auth:(Util.auth_of_string current_auth) ))
 
 let update_timings =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-      ~snapp_update ~current_auth ~genesis_constants ~constraint_constants () =
+  let create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+      ~snapp_update ~current_auth ~config_file () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
-      update_snapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-        ~snapp_update ~current_auth ~genesis_constants ~constraint_constants
+      update_snapp ~logger debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+        ~snapp_update ~current_auth ~config_file
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -610,7 +582,7 @@ let update_timings =
              "Proof|Signature|Either|None Current authorization in the account \
               to change permissions"
            Param.(required string)
-       in
+       and config_file = Cli_lib.Flag.conf_file in
        let fee = Option.value ~default:Flags.default_fee fee in
        let timing =
          Zkapp_basic.Set_or_keep.Set
@@ -627,16 +599,13 @@ let update_timings =
              : Account_update.Update.Timing_info.value )
        in
        let snapp_update = { Account_update.Update.dummy with timing } in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
-       in
-       let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+       let logger = Logger.create () in
        if Currency.Fee.(fee < Flags.min_fee) then
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~snapp_update ~genesis_constants ~constraint_constants
+       create_command ~logger ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
+         ~snapp_update ~config_file
          ~current_auth:(Util.auth_of_string current_auth) ))
 
 let test_zkapp_with_genesis_ledger =
@@ -656,13 +625,10 @@ let test_zkapp_with_genesis_ledger =
          Param.flag "--zkapp-account-key"
            ~doc:"KEYFILE Private key file to create a new zkApp account"
            Param.(required string)
-       and config_file =
-         Param.flag "--config-file" ~aliases:[ "config-file" ]
-           ~doc:
-             "PATH path to a configuration file consisting the genesis ledger"
-           Param.(required string)
-       in
-       test_zkapp_with_genesis_ledger_main keyfile zkapp_keyfile config_file ))
+       and config_file = Cli_lib.Flag.conf_file in
+       let logger = Logger.create () in
+       test_zkapp_with_genesis_ledger_main ~logger keyfile zkapp_keyfile
+         config_file ))
 
 let txn_commands =
   [ ("create-zkapp-account", create_zkapp_account)

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -230,16 +230,18 @@ module Vrf = struct
         flag "--total-stake"
           ~doc:"AMOUNT The total balance of all accounts in the epoch ledger"
           (optional int)
-      in
+      and config_file = Flag.conf_file in
       Exceptions.handle_nicely
       @@ fun () ->
       let env = Secrets.Keypair.env in
-      let constraint_constants =
-        Genesis_constants.Compiled.constraint_constants
+      let open Deferred.Let_syntax in
+      let%bind constraint_constants =
+        let logger = Logger.create () in
+        let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+        Runtime_config.Constants.constraint_constants conf
       in
       if Option.is_some (Sys.getenv env) then
         eprintf "Using password from environment variable %s\n" env ;
-      let open Deferred.Let_syntax in
       (* TODO-someday: constraint constants from config file. *)
       let%bind () =
         let password =
@@ -297,17 +299,19 @@ module Vrf = struct
          \"epochSeed\": _, \"delegatorIndex\": _} JSON message objects read on \
          stdin"
       (let open Command.Let_syntax in
-      let%map_open privkey_path = Flag.privkey_read_path in
+      let%map_open privkey_path = Flag.privkey_read_path
+      and config_file = Flag.conf_file in
       Exceptions.handle_nicely
       @@ fun () ->
-      let constraint_constants =
-        Genesis_constants.Compiled.constraint_constants
-      in
       let env = Secrets.Keypair.env in
       if Option.is_some (Sys.getenv env) then
         eprintf "Using password from environment variable %s\n" env ;
       let open Deferred.Let_syntax in
-      (* TODO-someday: constraint constants from config file. *)
+      let%bind constraint_constants =
+        let logger = Logger.create () in
+        let%map conf = Runtime_config.Constants.load_constants ~logger config_file
+        in Runtime_config.Constants.constraint_constants conf
+      in
       let%bind () =
         let password =
           lazy
@@ -362,11 +366,15 @@ module Vrf = struct
          totalStake: 1000000000}. The threshold is not checked against a \
          ledger; this should be done manually to confirm whether threshold_met \
          in the output corresponds to an actual won block."
-      ( Command.Param.return @@ Exceptions.handle_nicely
+      (let open Command.Let_syntax in
+      let%map_open config_file = Flag.conf_file in
+      Exceptions.handle_nicely
       @@ fun () ->
       let open Deferred.Let_syntax in
-      let constraint_constants =
-        Genesis_constants.Compiled.constraint_constants
+      let%bind constraint_constants =
+        let logger = Logger.create () in
+        let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+        Runtime_config.Constants.constraint_constants conf
       in
       (* TODO-someday: constraint constants from config file. *)
       let lexbuf = Lexing.from_channel In_channel.stdin in
@@ -399,7 +407,7 @@ module Vrf = struct
                      (Error_json.error_to_yojson err) ) ;
                 `Repeat () )
       in
-      exit 0 )
+      exit 0)
 
   let command_group =
     Command.group ~summary:"Commands for vrf evaluations"

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -237,7 +237,9 @@ module Vrf = struct
       let open Deferred.Let_syntax in
       let%bind constraint_constants =
         let logger = Logger.create () in
-        let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+        let%map conf =
+          Runtime_config.Constants.load_constants ~logger config_file
+        in
         Runtime_config.Constants.constraint_constants conf
       in
       if Option.is_some (Sys.getenv env) then
@@ -309,8 +311,10 @@ module Vrf = struct
       let open Deferred.Let_syntax in
       let%bind constraint_constants =
         let logger = Logger.create () in
-        let%map conf = Runtime_config.Constants.load_constants ~logger config_file
-        in Runtime_config.Constants.constraint_constants conf
+        let%map conf =
+          Runtime_config.Constants.load_constants ~logger config_file
+        in
+        Runtime_config.Constants.constraint_constants conf
       in
       let%bind () =
         let password =
@@ -373,7 +377,9 @@ module Vrf = struct
       let open Deferred.Let_syntax in
       let%bind constraint_constants =
         let logger = Logger.create () in
-        let%map conf = Runtime_config.Constants.load_constants ~logger config_file in
+        let%map conf =
+          Runtime_config.Constants.load_constants ~logger config_file
+        in
         Runtime_config.Constants.constraint_constants conf
       in
       (* TODO-someday: constraint constants from config file. *)

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -33,6 +33,15 @@ let conf_dir =
   flag "--config-directory" ~aliases:[ "config-directory" ]
     ~doc:"DIR Configuration directory" (optional string)
 
+let conf_file =
+  let open Command.Param in
+  flag "--config-file" ~aliases:[ "config-file" ]
+    ~doc:
+      "PATH path to a configuration file (overrides MINA_CONFIG_FILE, default: \
+       <config_dir>/daemon.json). Pass multiple times to override fields from \
+       earlier config files"
+    (listed string)
+
 module Doc_builder = struct
   type 'value t =
     { type_name : string
@@ -343,32 +352,24 @@ end
 
 type signed_command_common =
   { sender : Signature_lib.Public_key.Compressed.t
-  ; fee : Currency.Fee.t
+  ; fee : Currency.Fee.t option
   ; nonce : Mina_base.Account.Nonce.t option
   ; memo : string option
   }
 
-let fee_common ~default_transaction_fee ~minimum_user_command_fee :
-    Currency.Fee.t Command.Param.t =
+let fee_common : Currency.Fee.t option Command.Param.t =
   Command.Param.flag "--fee" ~aliases:[ "fee" ]
-    ~doc:
-      (Printf.sprintf
-         "FEE Amount you are willing to pay to process the transaction \
-          (default: %s) (minimum: %s)"
-         (Currency.Fee.to_mina_string default_transaction_fee)
-         (Currency.Fee.to_mina_string minimum_user_command_fee) )
-    (Command.Param.optional_with_default default_transaction_fee
-       Arg_type.txn_fee )
+    ~doc:"FEE Amount you are willing to pay to process the transaction"
+    (Command.Param.optional Arg_type.txn_fee)
 
-let signed_command_common ~default_transaction_fee ~minimum_user_command_fee :
-    signed_command_common Command.Param.t =
+let signed_command_common : signed_command_common Command.Param.t =
   let open Command.Let_syntax in
   let open Arg_type in
   let%map_open sender =
     flag "--sender" ~aliases:[ "sender" ]
       (required public_key_compressed)
       ~doc:"PUBLICKEY Public key from which you want to send the transaction"
-  and fee = fee_common ~default_transaction_fee ~minimum_user_command_fee
+  and fee = fee_common
   and nonce =
     flag "--nonce" ~aliases:[ "nonce" ]
       ~doc:
@@ -401,15 +402,10 @@ module Signed_command = struct
     flag "--amount" ~aliases:[ "amount" ]
       ~doc:"VALUE Payment amount you want to send" (required txn_amount)
 
-  let fee ~default_transaction_fee ~minimum_user_command_fee =
+  let fee =
     let open Command.Param in
     flag "--fee" ~aliases:[ "fee" ]
-      ~doc:
-        (Printf.sprintf
-           "FEE Amount you are willing to pay to process the transaction \
-            (default: %s) (minimum: %s)"
-           (Currency.Fee.to_mina_string default_transaction_fee)
-           (Currency.Fee.to_mina_string minimum_user_command_fee) )
+      ~doc:"FEE Amount you are willing to pay to process the transaction"
       (optional txn_fee)
 
   let valid_until =

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -12,6 +12,8 @@ val privkey_read_path : string Command.Param.t
 
 val conf_dir : string option Command.Param.t
 
+val conf_file : string list Command.Param.t
+
 module Types : sig
   type 'a with_name = { name : string; value : 'a }
 
@@ -81,20 +83,14 @@ end
 
 type signed_command_common =
   { sender : Signature_lib.Public_key.Compressed.t
-  ; fee : Currency.Fee.t
+  ; fee : Currency.Fee.t option
   ; nonce : Mina_base.Account.Nonce.t option
   ; memo : string option
   }
 
-val fee_common :
-     default_transaction_fee:Currency.Fee.t
-  -> minimum_user_command_fee:Currency.Fee.t
-  -> Currency.Fee.t Command.Param.t
+val fee_common : Currency.Fee.t option Command.Param.t
 
-val signed_command_common :
-     default_transaction_fee:Currency.Fee.t
-  -> minimum_user_command_fee:Currency.Fee.t
-  -> signed_command_common Command.Param.t
+val signed_command_common : signed_command_common Command.Param.t
 
 module Signed_command : sig
   val hd_index : Mina_numbers.Hd_index.t Command.Param.t
@@ -103,10 +99,7 @@ module Signed_command : sig
 
   val amount : Currency.Amount.t Command.Param.t
 
-  val fee :
-       default_transaction_fee:Currency.Fee.t
-    -> minimum_user_command_fee:Currency.Fee.t
-    -> Currency.Fee.t option Command.Param.t
+  val fee : Currency.Fee.t option Command.Param.t
 
   val valid_until :
     Mina_numbers.Global_slot_since_genesis.t option Command.Param.t

--- a/src/lib/crypto/snarky_tests/dune
+++ b/src/lib/crypto/snarky_tests/dune
@@ -68,4 +68,5 @@
   blockchain_snark
   transaction_snark
   genesis_constants
+  mina_runtime_config
   core))

--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -664,14 +664,17 @@ let api_tests =
   ]
 
 let () =
-Async.Thread_safe.block_on_async_exn @@ fun () ->
+  Async.Thread_safe.block_on_async_exn
+  @@ fun () ->
   let range_checks =
     List.map ~f:QCheck_alcotest.to_alcotest [ RangeCircuits.test_range_gates ]
   in
   let logger = Logger.create () in
-  let%map.Async.Deferred constraint_constants = 
-      let%map.Async.Deferred config = Runtime_config.Constants.load_constants ~logger []
-      in Runtime_config.Constants.constraint_constants config 
+  let%map.Async.Deferred constraint_constants =
+    let%map.Async.Deferred config =
+      Runtime_config.Constants.load_constants ~logger []
+    in
+    Runtime_config.Constants.constraint_constants config
   in
   Alcotest.run "Simple snarky tests"
     [ ("outside of circuit tests before", outside_circuit_tests)

--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -604,14 +604,12 @@ module Protocol_circuits = struct
   (* Full because we want to be sure nothing changes *)
   let proof_level = Genesis_constants.Proof_level.Full
 
-  let constraint_constants = Genesis_constants.Compiled.constraint_constants
-
   let print_hash print expected digest : unit =
     if print then (
       Format.printf "expected:\n%s\n" expected ;
       Format.printf "obtained:\n%s\n" digest )
 
-  let blockchain () : unit =
+  let blockchain ~constraint_constants () : unit =
     let expected = "36786c300e37c2a2f1341ad6374aa113" in
     let digest =
       Blockchain_snark.Blockchain_snark_state.constraint_system_digests
@@ -626,7 +624,7 @@ module Protocol_circuits = struct
     assert digests_match ;
     ()
 
-  let transaction () : unit =
+  let transaction ~constraint_constants () : unit =
     let expected1 = "b8879f677f622a1d86648030701f43e1" in
     let expected2 = "740db2397b0b01806a48f061a2e2b063" in
     let digest =
@@ -651,9 +649,9 @@ module Protocol_circuits = struct
     assert check ;
     ()
 
-  let tests =
-    [ ("test blockchain circuit", `Quick, blockchain)
-    ; ("test transaction circuit", `Quick, transaction)
+  let tests ~constraint_constants =
+    [ ("test blockchain circuit", `Quick, blockchain ~constraint_constants)
+    ; ("test transaction circuit", `Quick, transaction ~constraint_constants)
     ]
 end
 
@@ -666,8 +664,14 @@ let api_tests =
   ]
 
 let () =
+Async.Thread_safe.block_on_async_exn @@ fun () ->
   let range_checks =
     List.map ~f:QCheck_alcotest.to_alcotest [ RangeCircuits.test_range_gates ]
+  in
+  let logger = Logger.create () in
+  let%map.Async.Deferred constraint_constants = 
+      let%map.Async.Deferred config = Runtime_config.Constants.load_constants ~logger []
+      in Runtime_config.Constants.constraint_constants config 
   in
   Alcotest.run "Simple snarky tests"
     [ ("outside of circuit tests before", outside_circuit_tests)
@@ -675,7 +679,7 @@ let () =
     ; ("circuit tests", circuit_tests)
     ; ("As_prover tests", As_prover_circuits.as_prover_tests)
     ; ("range checks", range_checks)
-    ; ("protocol circuits", Protocol_circuits.tests)
+    ; ("protocol circuits", Protocol_circuits.tests ~constraint_constants)
     ; ("improper calls", Improper_calls.tests)
       (* We run the pure functions before and after other tests,
          because we've had bugs in the past where it would only work after the global state was initialized by an API function

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -434,7 +434,7 @@ end
 
 module For_unit_tests = Make (Node_config_for_unit_tests)
 
-module Compiled : sig
+module Compiled_ : sig
   val genesis_constants : t
 
   val constraint_constants : Constraint_constants.t

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -666,7 +666,7 @@ module Genesis_proof = struct
         return None
 
   let generate_inputs ~runtime_config ~proof_level ~ledger ~genesis_epoch_data
-      ~constraint_constants ~blockchain_proof_system_id
+      ~constraint_constants ~blockchain_proof_system_id ~compile_config
       ~(genesis_constants : Genesis_constants.t) =
     let consensus_constants =
       Consensus.Constants.create ~constraint_constants
@@ -682,6 +682,7 @@ module Genesis_proof = struct
     { Genesis_proof.Inputs.runtime_config
     ; constraint_constants
     ; proof_level
+    ; compile_config
     ; blockchain_proof_system_id
     ; genesis_ledger = ledger
     ; genesis_epoch_data
@@ -708,6 +709,7 @@ module Genesis_proof = struct
              ; consensus_constants = inputs.consensus_constants
              ; constraint_constants = inputs.constraint_constants
              ; genesis_body_reference = inputs.genesis_body_reference
+             ; compile_config = inputs.compile_config
              }
     | _ ->
         Deferred.return (Genesis_proof.create_values_no_proof inputs)
@@ -769,6 +771,7 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
     Runtime_config.Constants.constraint_constants constants
   in
   let proof_level = Runtime_config.Constants.proof_level constants in
+  let compile_config = Runtime_config.Constants.compile_config constants in
   let genesis_constants =
     Runtime_config.Constants.genesis_constants constants
   in
@@ -801,7 +804,7 @@ let inputs_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
   let proof_inputs =
     Genesis_proof.generate_inputs ~runtime_config:config ~proof_level
       ~ledger:genesis_ledger ~constraint_constants ~genesis_constants
-      ~blockchain_proof_system_id ~genesis_epoch_data
+      ~compile_config ~blockchain_proof_system_id ~genesis_epoch_data
   in
   (proof_inputs, config)
 

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -8,6 +8,7 @@ module Inputs = struct
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     ; proof_level : Genesis_constants.Proof_level.t
     ; genesis_constants : Genesis_constants.t
+    ; compile_config : Mina_compile_config.t
     ; genesis_ledger : Genesis_ledger.Packed.t
     ; genesis_epoch_data : Consensus.Genesis_epoch_data.t
     ; genesis_body_reference : Consensus.Body_reference.t
@@ -85,6 +86,7 @@ module T = struct
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     ; genesis_constants : Genesis_constants.t
     ; proof_level : Genesis_constants.Proof_level.t
+    ; compile_config : Mina_compile_config.t
     ; genesis_ledger : Genesis_ledger.Packed.t
     ; genesis_epoch_data : Consensus.Genesis_epoch_data.t
     ; genesis_body_reference : Consensus.Body_reference.t
@@ -223,6 +225,7 @@ let create_values_no_proof (t : Inputs.t) =
   ; constraint_constants = t.constraint_constants
   ; proof_level = t.proof_level
   ; genesis_constants = t.genesis_constants
+  ; compile_config = t.compile_config
   ; genesis_ledger = t.genesis_ledger
   ; genesis_epoch_data = t.genesis_epoch_data
   ; genesis_body_reference = t.genesis_body_reference
@@ -240,6 +243,7 @@ let to_inputs (t : t) : Inputs.t =
   ; constraint_constants = t.constraint_constants
   ; proof_level = t.proof_level
   ; genesis_constants = t.genesis_constants
+  ; compile_config = t.compile_config
   ; genesis_ledger = t.genesis_ledger
   ; genesis_epoch_data = t.genesis_epoch_data
   ; genesis_body_reference = t.genesis_body_reference

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -128,7 +128,7 @@ let to_yojson t =
     ]
 
 (*TODO: Delete this module and read in a value from the environment*)
-module Compiled = struct
+module Compiled_ = struct
   let t : t =
     let (inputs : Inputs.t) =
       { curve_size = Node_config.curve_size

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -36,11 +36,6 @@ let%test_module "Epoch ledger sync tests" =
 
     let dir_prefix = "sync_test_data"
 
-    let genesis_constants = Genesis_constants.For_unit_tests.t
-
-    let constraint_constants =
-      Genesis_constants.For_unit_tests.Constraint_constants.t
-
     let make_dirname s =
       let open Core in
       let uuid = Uuid_unix.create () |> Uuid.to_string in
@@ -68,8 +63,9 @@ let%test_module "Epoch ledger sync tests" =
         match%map
           Genesis_ledger_helper.init_from_config_file
             ~genesis_dir:(make_dirname "genesis_dir")
-            ~constraint_constants ~genesis_constants ~logger ~proof_level:None
-            runtime_config ~cli_proof_level:None
+            ~constants:
+              (Runtime_config.Constants.magic_for_unit_tests runtime_config)
+            ~logger runtime_config
         with
         | Ok (precomputed_values, _) ->
             precomputed_values

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -61,7 +61,7 @@ let%test_module "Epoch ledger sync tests" =
           }
         in
         match%map
-          Genesis_ledger_helper.init_from_config_file
+          Genesis_ledger_helper.Config_loader.init_from_config_file
             ~genesis_dir:(make_dirname "genesis_dir")
             ~constants:
               (Runtime_config.Constants.magic_for_unit_tests runtime_config)

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -46,7 +46,7 @@ let%test_module "Epoch ledger sync tests" =
         let runtime_config : Runtime_config.t =
           { daemon = None
           ; genesis = None
-          ; proof = None
+          ; proof = Some { Runtime_config.Proof_keys.default with level = None }
           ; ledger =
               Some
                 { base = Named "test"

--- a/src/lib/precomputed_values/precomputed_values.ml
+++ b/src/lib/precomputed_values/precomputed_values.ml
@@ -43,4 +43,5 @@ let for_unit_tests =
     ; protocol_state_with_hashes
     ; constraint_system_digests = hashes
     ; proof_data = None
+    ; compile_config = Mina_compile_config.For_unit_tests.t
     })

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1902,30 +1902,14 @@ module Constants : Constants_intf = struct
         block_window_duration =
           constraint_constants.block_window_duration_ms |> Float.of_int
           |> Time.Span.of_ms
-      ; zkapp_proof_update_cost =
-          Option.value ~default:a.compile_config.zkapp_proof_update_cost
-            Option.(b.daemon >>= fun d -> d.zkapp_proof_update_cost)
-      ; zkapp_signed_single_update_cost =
-          Option.value ~default:a.compile_config.zkapp_signed_single_update_cost
-            Option.(b.daemon >>= fun d -> d.zkapp_signed_single_update_cost)
-      ; zkapp_signed_pair_update_cost =
-          Option.value ~default:a.compile_config.zkapp_signed_pair_update_cost
-            Option.(b.daemon >>= fun d -> d.zkapp_signed_pair_update_cost)
-      ; zkapp_transaction_cost_limit =
-          Option.value ~default:a.compile_config.zkapp_transaction_cost_limit
-            Option.(b.daemon >>= fun d -> d.zkapp_transaction_cost_limit)
-      ; max_event_elements =
-          Option.value ~default:a.compile_config.max_event_elements
-            Option.(b.daemon >>= fun d -> d.max_event_elements)
-      ; max_action_elements =
-          Option.value ~default:a.compile_config.max_action_elements
-            Option.(b.daemon >>= fun d -> d.max_action_elements)
-      ; zkapp_cmd_limit_hardcap =
-          Option.value ~default:a.compile_config.zkapp_cmd_limit_hardcap
-            Option.(b.daemon >>= fun d -> d.zkapp_cmd_limit_hardcap)
-      ; minimum_user_command_fee =
-          Option.value ~default:a.compile_config.minimum_user_command_fee
-            Option.(b.daemon >>= fun d -> d.minimum_user_command_fee)
+      ; zkapp_proof_update_cost = genesis_constants.zkapp_proof_update_cost
+      ; zkapp_signed_single_update_cost = genesis_constants.zkapp_signed_single_update_cost
+      ; zkapp_signed_pair_update_cost = genesis_constants.zkapp_signed_pair_update_cost
+      ; zkapp_transaction_cost_limit = genesis_constants.zkapp_transaction_cost_limit
+      ; max_event_elements = genesis_constants.max_event_elements
+      ; max_action_elements = genesis_constants.max_action_elements
+      ; zkapp_cmd_limit_hardcap = genesis_constants.zkapp_cmd_limit_hardcap
+      ; minimum_user_command_fee = genesis_constants.minimum_user_command_fee
       ; network_id =
           Option.value ~default:a.compile_config.network_id
             Option.(b.daemon >>= fun d -> d.network_id)

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1825,32 +1825,19 @@ module Constants : Constants_intf = struct
       }
     in
     let constraint_constants =
-      let fork : Genesis_constants.Fork_constants.t option =
-        let%map.Option a = a.constraint_constants.fork in
-        { Genesis_constants.Fork_constants.state_hash =
-            Option.value ~default:a.state_hash
-              Option.(
-                b.proof
-                >>= fun x ->
-                x.fork
-                >>| fun x -> Pickles.Backend.Tick.Field.of_string x.state_hash)
-        ; blockchain_length =
-            Option.value ~default:a.blockchain_length
-              Option.(
-                b.proof
-                >>= fun x ->
-                x.fork
-                >>| fun x -> Mina_numbers.Length.of_int x.blockchain_length)
-        ; global_slot_since_genesis =
-            Option.value ~default:a.global_slot_since_genesis
-              Option.(
-                b.proof
-                >>= fun x ->
-                x.fork
-                >>| fun x ->
-                Mina_numbers.Global_slot_since_genesis.of_int
-                  x.global_slot_since_genesis)
-        }
+      let fork =
+        let a = a.constraint_constants.fork in
+        let b =
+          let%map.Option f = Option.(b.proof >>= fun x -> x.fork) in
+          { Genesis_constants.Fork_constants.state_hash =
+              Pickles.Backend.Tick.Field.of_string f.state_hash
+          ; blockchain_length = Mina_numbers.Length.of_int f.blockchain_length
+          ; global_slot_since_genesis =
+              Mina_numbers.Global_slot_since_genesis.of_int
+                f.global_slot_since_genesis
+          }
+        in
+        Option.first_some b a
       in
       { a.constraint_constants with
         sub_windows_per_window =

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1733,10 +1733,14 @@ module type Constants_intf = sig
 
   val genesis_constants : constants -> Genesis_constants.t
 
-  val constraint_constants : constants -> Genesis_constants.Constraint_constants.t
+  val constraint_constants :
+    constants -> Genesis_constants.Constraint_constants.t
+
   val proof_level : constants -> Genesis_constants.Proof_level.t
+
   val compile_config : constants -> Mina_compile_config.t
-  
+
+  val magic_for_unit_tests : t -> constants
 end
 
 module Constants : Constants_intf = struct
@@ -1748,8 +1752,11 @@ module Constants : Constants_intf = struct
     }
 
   let genesis_constants t = t.genesis_constants
+
   let constraint_constants t = t.constraint_constants
+
   let proof_level t = t.proof_level
+
   let compile_config t = t.compile_config
 
   let combine (a : constants) (b : t) : constants =
@@ -1892,8 +1899,9 @@ module Constants : Constants_intf = struct
     in
     let compile_config =
       { a.compile_config with
-        block_window_duration = 
-          constraint_constants.block_window_duration_ms |> Float.of_int |> Time.Span.of_ms
+        block_window_duration =
+          constraint_constants.block_window_duration_ms |> Float.of_int
+          |> Time.Span.of_ms
       ; zkapp_proof_update_cost =
           Option.value ~default:a.compile_config.zkapp_proof_update_cost
             Option.(b.daemon >>= fun d -> d.zkapp_proof_update_cost)
@@ -1938,7 +1946,8 @@ module Constants : Constants_intf = struct
     let constants =
       let compile_constants =
         { genesis_constants = Genesis_constants.Compiled_.genesis_constants
-        ; constraint_constants = Genesis_constants.Compiled_.constraint_constants
+        ; constraint_constants =
+            Genesis_constants.Compiled_.constraint_constants
         ; proof_level = Genesis_constants.Compiled_.proof_level
         ; compile_config = Mina_compile_config.Compiled_.t
         }
@@ -1954,4 +1963,15 @@ module Constants : Constants_intf = struct
       }
     in
     constants
+
+  let magic_for_unit_tests t =
+    let compile_constants =
+      { genesis_constants = Genesis_constants.For_unit_tests.t
+      ; constraint_constants =
+          Genesis_constants.For_unit_tests.Constraint_constants.t
+      ; proof_level = Genesis_constants.For_unit_tests.Proof_level.t
+      ; compile_config = Mina_compile_config.For_unit_tests.t
+      }
+    in
+    combine compile_constants t
 end

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1903,9 +1903,12 @@ module Constants : Constants_intf = struct
           constraint_constants.block_window_duration_ms |> Float.of_int
           |> Time.Span.of_ms
       ; zkapp_proof_update_cost = genesis_constants.zkapp_proof_update_cost
-      ; zkapp_signed_single_update_cost = genesis_constants.zkapp_signed_single_update_cost
-      ; zkapp_signed_pair_update_cost = genesis_constants.zkapp_signed_pair_update_cost
-      ; zkapp_transaction_cost_limit = genesis_constants.zkapp_transaction_cost_limit
+      ; zkapp_signed_single_update_cost =
+          genesis_constants.zkapp_signed_single_update_cost
+      ; zkapp_signed_pair_update_cost =
+          genesis_constants.zkapp_signed_pair_update_cost
+      ; zkapp_transaction_cost_limit =
+          genesis_constants.zkapp_transaction_cost_limit
       ; max_event_elements = genesis_constants.max_event_elements
       ; max_action_elements = genesis_constants.max_action_elements
       ; zkapp_cmd_limit_hardcap = genesis_constants.zkapp_cmd_limit_hardcap

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -978,6 +978,14 @@ module Proof_keys = struct
     type t = Log_2 of int | Txns_per_second_x10 of int
     [@@deriving bin_io_unversioned]
 
+    let log2 = function Log_2 i -> Some i | Txns_per_second_x10 _ -> None
+
+    let txns_per_second_x10 = function
+      | Log_2 _ ->
+          None
+      | Txns_per_second_x10 i ->
+          Some i
+
     let to_json_layout : t -> Json_layout.Proof_keys.Transaction_capacity.t =
       function
       | Log_2 i ->
@@ -1709,4 +1717,241 @@ module Json_loader : Json_loader_intf = struct
                 ; ("error", `String err)
                 ] ;
             failwithf "Could not parse configuration file: %s" err () )
+end
+
+module type Constants_intf = sig
+  type constants
+
+  val load_constants :
+       ?conf_dir:string
+    -> ?commit_id_short:string
+    -> ?itn_features:bool
+    -> ?cli_proof_level:Genesis_constants.Proof_level.t
+    -> logger:Logger.t
+    -> string list
+    -> constants Deferred.t
+
+  val genesis_constants : constants -> Genesis_constants.t
+
+  val constraint_constants : constants -> Genesis_constants.Constraint_constants.t
+  val proof_level : constants -> Genesis_constants.Proof_level.t
+  val compile_config : constants -> Mina_compile_config.t
+  
+end
+
+module Constants : Constants_intf = struct
+  type constants =
+    { genesis_constants : Genesis_constants.t
+    ; constraint_constants : Genesis_constants.Constraint_constants.t
+    ; proof_level : Genesis_constants.Proof_level.t
+    ; compile_config : Mina_compile_config.t
+    }
+
+  let genesis_constants t = t.genesis_constants
+  let constraint_constants t = t.constraint_constants
+  let proof_level t = t.proof_level
+  let compile_config t = t.compile_config
+
+  let combine (a : constants) (b : t) : constants =
+    let genesis_constants =
+      { Genesis_constants.protocol =
+          { k =
+              Option.value ~default:a.genesis_constants.protocol.k
+                Option.(b.genesis >>= fun g -> g.k)
+          ; delta =
+              Option.value ~default:a.genesis_constants.protocol.delta
+                Option.(b.genesis >>= fun g -> g.delta)
+          ; slots_per_epoch =
+              Option.value ~default:a.genesis_constants.protocol.slots_per_epoch
+                Option.(b.genesis >>= fun g -> g.slots_per_epoch)
+          ; slots_per_sub_window =
+              Option.value
+                ~default:a.genesis_constants.protocol.slots_per_sub_window
+                Option.(b.genesis >>= fun g -> g.slots_per_sub_window)
+          ; grace_period_slots =
+              Option.value
+                ~default:a.genesis_constants.protocol.grace_period_slots
+                Option.(b.genesis >>= fun g -> g.grace_period_slots)
+          ; genesis_state_timestamp =
+              Option.value
+                ~default:a.genesis_constants.protocol.genesis_state_timestamp
+                Option.(
+                  b.genesis
+                  >>= fun g ->
+                  g.genesis_state_timestamp
+                  >>| Genesis_constants.genesis_timestamp_of_string
+                  >>| Genesis_constants.of_time)
+          }
+      ; txpool_max_size =
+          Option.value ~default:a.genesis_constants.txpool_max_size
+            Option.(b.daemon >>= fun d -> d.txpool_max_size)
+      ; num_accounts =
+          Option.first_some
+            Option.(b.ledger >>= fun l -> l.num_accounts)
+            a.genesis_constants.num_accounts
+      ; zkapp_proof_update_cost =
+          Option.value ~default:a.genesis_constants.zkapp_proof_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_proof_update_cost)
+      ; zkapp_signed_single_update_cost =
+          Option.value
+            ~default:a.genesis_constants.zkapp_signed_single_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_signed_single_update_cost)
+      ; zkapp_signed_pair_update_cost =
+          Option.value
+            ~default:a.genesis_constants.zkapp_signed_pair_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_signed_pair_update_cost)
+      ; zkapp_transaction_cost_limit =
+          Option.value ~default:a.genesis_constants.zkapp_transaction_cost_limit
+            Option.(b.daemon >>= fun d -> d.zkapp_transaction_cost_limit)
+      ; max_event_elements =
+          Option.value ~default:a.genesis_constants.max_event_elements
+            Option.(b.daemon >>= fun d -> d.max_event_elements)
+      ; max_action_elements =
+          Option.value ~default:a.genesis_constants.max_action_elements
+            Option.(b.daemon >>= fun d -> d.max_action_elements)
+      ; zkapp_cmd_limit_hardcap =
+          Option.value ~default:a.genesis_constants.zkapp_cmd_limit_hardcap
+            Option.(b.daemon >>= fun d -> d.zkapp_cmd_limit_hardcap)
+      ; minimum_user_command_fee =
+          Option.value ~default:a.genesis_constants.minimum_user_command_fee
+            Option.(b.daemon >>= fun d -> d.minimum_user_command_fee)
+      }
+    in
+    let constraint_constants =
+      let fork : Genesis_constants.Fork_constants.t option =
+        let%map.Option a = a.constraint_constants.fork in
+        { Genesis_constants.Fork_constants.state_hash =
+            Option.value ~default:a.state_hash
+              Option.(
+                b.proof
+                >>= fun x ->
+                x.fork
+                >>| fun x -> Pickles.Backend.Tick.Field.of_string x.state_hash)
+        ; blockchain_length =
+            Option.value ~default:a.blockchain_length
+              Option.(
+                b.proof
+                >>= fun x ->
+                x.fork
+                >>| fun x -> Mina_numbers.Length.of_int x.blockchain_length)
+        ; global_slot_since_genesis =
+            Option.value ~default:a.global_slot_since_genesis
+              Option.(
+                b.proof
+                >>= fun x ->
+                x.fork
+                >>| fun x ->
+                Mina_numbers.Global_slot_since_genesis.of_int
+                  x.global_slot_since_genesis)
+        }
+      in
+      { a.constraint_constants with
+        sub_windows_per_window =
+          Option.value ~default:a.constraint_constants.sub_windows_per_window
+            Option.(b.proof >>= fun p -> p.sub_windows_per_window)
+      ; ledger_depth =
+          Option.value ~default:a.constraint_constants.ledger_depth
+            Option.(b.proof >>= fun p -> p.ledger_depth)
+      ; work_delay =
+          Option.value ~default:a.constraint_constants.work_delay
+            Option.(b.proof >>= fun p -> p.work_delay)
+      ; block_window_duration_ms =
+          Option.value ~default:a.constraint_constants.block_window_duration_ms
+            Option.(b.proof >>= fun p -> p.block_window_duration_ms)
+      ; transaction_capacity_log_2 =
+          Option.value
+            ~default:a.constraint_constants.transaction_capacity_log_2
+            Option.(
+              b.proof
+              >>= fun p ->
+              p.transaction_capacity >>= Proof_keys.Transaction_capacity.log2)
+      ; coinbase_amount =
+          Option.value ~default:a.constraint_constants.coinbase_amount
+            Option.(b.proof >>= fun p -> p.coinbase_amount)
+      ; supercharged_coinbase_factor =
+          Option.value
+            ~default:a.constraint_constants.supercharged_coinbase_factor
+            Option.(b.proof >>= fun p -> p.supercharged_coinbase_factor)
+      ; account_creation_fee =
+          Option.value ~default:a.constraint_constants.account_creation_fee
+            Option.(b.proof >>= fun p -> p.account_creation_fee)
+      ; fork
+      }
+    in
+    let proof_level =
+      let coerce_proof_level = function
+        | Proof_keys.Level.Full ->
+            Genesis_constants.Proof_level.Full
+        | Check ->
+            Genesis_constants.Proof_level.Check
+        | None ->
+            Genesis_constants.Proof_level.None
+      in
+      Option.value ~default:Genesis_constants.Proof_level.None
+        Option.(b.proof >>= fun p -> p.level >>| coerce_proof_level)
+    in
+    let compile_config =
+      { a.compile_config with
+        block_window_duration = 
+          constraint_constants.block_window_duration_ms |> Float.of_int |> Time.Span.of_ms
+      ; zkapp_proof_update_cost =
+          Option.value ~default:a.compile_config.zkapp_proof_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_proof_update_cost)
+      ; zkapp_signed_single_update_cost =
+          Option.value ~default:a.compile_config.zkapp_signed_single_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_signed_single_update_cost)
+      ; zkapp_signed_pair_update_cost =
+          Option.value ~default:a.compile_config.zkapp_signed_pair_update_cost
+            Option.(b.daemon >>= fun d -> d.zkapp_signed_pair_update_cost)
+      ; zkapp_transaction_cost_limit =
+          Option.value ~default:a.compile_config.zkapp_transaction_cost_limit
+            Option.(b.daemon >>= fun d -> d.zkapp_transaction_cost_limit)
+      ; max_event_elements =
+          Option.value ~default:a.compile_config.max_event_elements
+            Option.(b.daemon >>= fun d -> d.max_event_elements)
+      ; max_action_elements =
+          Option.value ~default:a.compile_config.max_action_elements
+            Option.(b.daemon >>= fun d -> d.max_action_elements)
+      ; zkapp_cmd_limit_hardcap =
+          Option.value ~default:a.compile_config.zkapp_cmd_limit_hardcap
+            Option.(b.daemon >>= fun d -> d.zkapp_cmd_limit_hardcap)
+      ; minimum_user_command_fee =
+          Option.value ~default:a.compile_config.minimum_user_command_fee
+            Option.(b.daemon >>= fun d -> d.minimum_user_command_fee)
+      ; network_id =
+          Option.value ~default:a.compile_config.network_id
+            Option.(b.daemon >>= fun d -> d.network_id)
+      }
+    in
+    { genesis_constants; constraint_constants; proof_level; compile_config }
+
+  (* Use this function if you don't need/want the ledger configuration *)
+  let load_constants ?conf_dir ?commit_id_short ?itn_features ?cli_proof_level
+      ~logger config_files =
+    Deferred.Or_error.ok_exn
+    @@
+    let open Deferred.Or_error.Let_syntax in
+    let%map json =
+      Json_loader.load_config_files ?conf_dir ?commit_id_short ~logger
+        config_files
+    in
+    let constants =
+      let compile_constants =
+        { genesis_constants = Genesis_constants.Compiled_.genesis_constants
+        ; constraint_constants = Genesis_constants.Compiled_.constraint_constants
+        ; proof_level = Genesis_constants.Compiled_.proof_level
+        ; compile_config = Mina_compile_config.Compiled_.t
+        }
+      in
+      let cs = combine compile_constants json in
+      { cs with
+        proof_level = Option.value ~default:cs.proof_level cli_proof_level
+      ; compile_config =
+          { cs.compile_config with
+            itn_features =
+              Option.value ~default:cs.compile_config.itn_features itn_features
+          }
+      }
+    in
+    constants
 end

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -365,14 +365,14 @@ module Make (Inputs : Intf.Inputs_intf) :
         let logger =
           Logger.create () ~metadata:[ ("process", `String "Snark Worker") ]
         in
-        let%bind.Deferred constants =
-          Runtime_config.Constants.load_constants ?conf_dir ?cli_proof_level
-            ~logger config_file
+        let%bind.Deferred constraint_constants, proof_level =
+          let%map.Deferred config =
+            Runtime_config.Constants.load_constants ?conf_dir ?cli_proof_level
+              ~logger config_file
+          in
+          Runtime_config.Constants.
+            (constraint_constants config, proof_level config)
         in
-        let constraint_constants =
-          Runtime_config.Constants.constraint_constants constants
-        in
-        let proof_level = Runtime_config.Constants.proof_level constants in
         Option.value_map ~default:() conf_dir ~f:(fun conf_dir ->
             let logrotate_max_size = 1024 * 10 in
             let logrotate_num_rotate = 1 in

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -154,8 +154,6 @@ module type S0 = sig
 
   val command_from_rpcs :
        commit_id:string
-    -> proof_level:Genesis_constants.Proof_level.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> (module Rpcs_versioned_S with type Work.ledger_proof = ledger_proof)
     -> Command.t
 
@@ -173,9 +171,5 @@ module type S = sig
   module Rpcs_versioned :
     Rpcs_versioned_S with type Work.ledger_proof = ledger_proof
 
-  val command :
-       commit_id:string
-    -> proof_level:Genesis_constants.Proof_level.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> Command.t
+  val command : commit_id:string -> Command.t
 end

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -23,10 +23,12 @@ let command =
        let open Deferred.Let_syntax in
        let%bind constraint_constants, proof_level =
          let logger = Logger.create () in
-         let%map conf = Runtime_config.Constants.load_constants ~cli_proof_level ~logger config_file in
-           ( Runtime_config.Constants.constraint_constants conf
-           , Runtime_config.Constants.proof_level conf
-           )
+         let%map conf =
+           Runtime_config.Constants.load_constants ~cli_proof_level ~logger
+             config_file
+         in
+         ( Runtime_config.Constants.constraint_constants conf
+         , Runtime_config.Constants.proof_level conf )
        in
        let%bind worker_state =
          Prod.Worker_state.create ~constraint_constants ~proof_level ()

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -27,8 +27,7 @@ let command =
            Runtime_config.Constants.load_constants ~cli_proof_level ~logger
              config_file
          in
-         ( Runtime_config.Constants.constraint_constants conf
-         , Runtime_config.Constants.proof_level conf )
+         Runtime_config.Constants.(constraint_constants conf, proof_level conf)
        in
        let%bind worker_state =
          Prod.Worker_state.create ~constraint_constants ~proof_level ()

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -8,7 +8,8 @@ let command =
     (let%map_open spec =
        flag "--spec-sexp" ~doc:""
          (required (sexp_conv Prod.single_spec_of_sexp))
-     and proof_level =
+     and config_file = Cli_lib.Flag.conf_file
+     and cli_proof_level =
        flag "--proof-level" ~doc:""
          (optional_with_default Genesis_constants.Proof_level.Full
             (Command.Arg_type.of_alist_exn
@@ -19,8 +20,13 @@ let command =
      in
      fun () ->
        let open Async in
-       let constraint_constants =
-         Genesis_constants.Compiled.constraint_constants
+       let open Deferred.Let_syntax in
+       let%bind constraint_constants, proof_level =
+         let logger = Logger.create () in
+         let%map conf = Runtime_config.Constants.load_constants ~cli_proof_level ~logger config_file in
+           ( Runtime_config.Constants.constraint_constants conf
+           , Runtime_config.Constants.proof_level conf
+           )
        in
        let%bind worker_state =
          Prod.Worker_state.create ~constraint_constants ~proof_level ()

--- a/src/test/command_line_tests/config.ml
+++ b/src/test/command_line_tests/config.ml
@@ -29,7 +29,8 @@ module ConfigDirs = struct
   let generate_keys t =
     let open Deferred.Let_syntax in
     let%map () =
-      Init.Client.generate_libp2p_keypair_do (libp2p_keypair_folder t) ()
+      Init.Client.generate_libp2p_keypair_do (libp2p_keypair_folder t)
+        ~config_file:[] ()
     in
     ()
 


### PR DESCRIPTION
### NOTE to reviewer
90% of this PR involves changing executables to take a `--config-files` cli arg and to use the same loading function instead of invoking `*_constants.Compiled.t` directly to supply these values. The math is roughly 

```
(+/- n LOC per executable) x (a ton of executables) = a large diff
```

All of the important changes in this PR are in `runtime_config.ml` and `genesis_ledger_helper.ml`, start there. You will see that all other changes are switching an executable to use these new `load` methods, and it always looks the same.

## Background
In previous work we removed all/as much direct access to `*_constants.Compiled.t` as possible throughout the codebase (with the exception being the `For_unit_tests` variant). We were able to push those all the way to the various executable entrypoints, but we were still using the compiled config directly

## The problem
- Invoking the compile config directly across many files doesn't provide an easy transition to json-only config
- `Mina_cli_entrypoint` and a few other executables allow you to take a `--config-file` parameter and apply the json config to the compile time constants. Most executables do not allow this.
- We have (at least) two different implicit kinds of config  (i.e. you will not find these types anywhere, but they are implied):


```ocaml
(* Common in exectuables that we use as tests, benchmarks, etc *)
type constants = 
  { genesis_constants : Genesis_constants.t
  ; constraint_constants : Genesis_constants.Constraint_constants.t
  ; proof_level : Genesis_constants.Proof_level.t
  ; compile_config : Mina_compile_config.t
```

```ocaml
(* less commonly required, e.g. you find in it `Mina_cli_entrypoint`, `Archive.Archive_cli`, things that aren't tests or tools *)
type config = 
  { constants : constants
  ; daemon : Runtime_ledger.Daemon.t (* has overlap with compile_config *)
  ; ledger : Runtime_config.Ledger.t
  ; epoch_data : Runtime_config.Epoch_data.t
  }
  ```
Most executables only requires the `constants` config, so we don't want to require the above `config` type in places where no ledger is required. We need to separate these cases in the type system.

## The Solution
- Introduce a `Runtime_config.Constants` module to manage the `constants` type above and manage loading and applying the json config file for these values.
- Force the use of `Runtime_config.Constants.load_constants` as the only way we can load these values into our system, and use this standard loader everywhere. This means removing all direct usage of `*_constants.Compiled.t`
- Add a `--config-file` option to all CLI contexts, or create this context it if it didn't exist before