### PR TITLE
Pickles/test : moved content from tests to test

### DIFF
--- a/src/lib/pickles/test/main.ml
+++ b/src/lib/pickles/test/main.ml
@@ -3,6 +3,6 @@ let () =
     Test_impls.tests @ Test_opt_sponge.tests @ Test_plonk_curve_ops.tests
     @ Test_sponge.tests @ Test_step.tests @ Test_scalar_challenge.tests
     @ Test_side_loaded_verification_key.tests @ Test_step_verifier.tests
-    @ Test_wrap.tests @ Test_wrap_hack.tests
+    @ Test_wrap.tests @ Test_wrap_hack.tests @ Test_ro.tests
   in
   Alcotest.run "Pickles" tests

--- a/src/lib/pickles/test/test_ro.ml
+++ b/src/lib/pickles/test/test_ro.ml
@@ -5,10 +5,16 @@ let test_bits_random_oracle_consistency_check () =
     "01000001101110001111111100011000011000100010100011010010110110010011101101101000001110001110100101010100001000001110101110111010"
   in
   let exp_output =
-    List.map (fun i -> i = '1') (List.of_seq (String.to_seq exp_output_str))
+    List.init (String.length exp_output_str) ~f:(fun i ->
+        Char.equal exp_output_str.[i] '1' )
   in
   let output = Pickles.Ro.bits_random_oracle ~length:128 s in
-  assert (List.for_all2 Bool.equal exp_output output)
+  assert (
+    match List.for_all2 ~f:Bool.equal exp_output output with
+    | Ok bool ->
+        bool
+    | _ ->
+        false )
 
 let () =
   let open Alcotest in
@@ -18,3 +24,11 @@ let () =
             test_bits_random_oracle_consistency_check
         ] )
     ]
+
+let tests =
+  let open Alcotest in
+  [ ( "test random oracle"
+    , [ test_case "test random oracle" `Quick
+          test_bits_random_oracle_consistency_check
+      ] )
+  ]

--- a/src/lib/pickles/tests/dune
+++ b/src/lib/pickles/tests/dune
@@ -1,3 +1,0 @@
-(tests
- (names test_ro)
- (libraries alcotest core_kernel pickles))


### PR DESCRIPTION
For some reasons there were two directories for
the pickles test and tests. We remove tests and move it's unique file.
Note that we also need to modify a bit the tests, because we use base instead of the standard lib
