### PR TITLE
Stop using `hash` / `Hashable` for ledger tests and zkApp generators

### DIFF
--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -442,7 +442,6 @@ module Make (Inputs : Intf.Inputs.DATABASE) = struct
     module Account_id = Account_id
     module Balance = Balance
     module Location = Location
-    module Location_binable = Location_binable
     module Account = Account
     module Hash = Hash
 

--- a/src/lib/merkle_ledger/graphviz.ml
+++ b/src/lib/merkle_ledger/graphviz.ml
@@ -77,9 +77,8 @@ module Make (Inputs : Intf.Graphviz.I) :
             let target : target =
               if
                 not
-                @@ Hash_set.mem
-                     ( List.init ~f:empty_hash ledger_depth
-                     |> Hash.Hash_set.of_list )
+                @@ List.mem ~equal:Hash.equal
+                     (List.init ~f:empty_hash ledger_depth)
                      current_hash
               then (
                 Queue.enqueue jobs

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -266,8 +266,6 @@ module Inputs = struct
   module type DATABASE = sig
     include Intf
 
-    module Location_binable : Hashable.S_binable with type t := Location.t
-
     module Kvdb : Key_value_database with type config := string
 
     module Storage_locations : Storage_locations

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -65,8 +65,6 @@ module type Key = sig
 
   val to_string : t -> string
 
-  include Hashable.S_binable with type t := t
-
   include Comparable.S with type t := t
 end
 
@@ -81,8 +79,6 @@ module type Token_id = sig
   with type Latest.t = t
 
   val default : t
-
-  include Hashable.S_binable with type t := t
 
   include Comparable.S_binable with type t := t
 end
@@ -106,8 +102,6 @@ module type Account_id = sig
   val create : key -> token_id -> t
 
   val derive_token_id : owner:t -> token_id
-
-  include Hashable.S_binable with type t := t
 
   include Comparable.S with type t := t
 end
@@ -142,8 +136,6 @@ module type Hash = sig
   type t [@@deriving bin_io, compare, equal, sexp, yojson]
 
   val to_base58_check : t -> string
-
-  include Hashable.S_binable with type t := t
 
   type account
 

--- a/src/lib/merkle_ledger/util.ml
+++ b/src/lib/merkle_ledger/util.ml
@@ -1,8 +1,6 @@
 module type Inputs_intf = sig
   module Location : Location_intf.S
 
-  module Location_binable : Hashable.S_binable with type t := Location.t
-
   module Key : Intf.Key
 
   module Token_id : Intf.Token_id

--- a/src/lib/merkle_ledger/util.mli
+++ b/src/lib/merkle_ledger/util.mli
@@ -1,8 +1,6 @@
 module type Inputs_intf = sig
   module Location : Location_intf.S
 
-  module Location_binable : Hashable.S_binable with type t := Location.t
-
   module Key : Intf.Key
 
   module Token_id : Intf.Token_id

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -11,10 +11,10 @@ end
 module Account = struct
   (* want bin_io, not available with Account.t *)
   type t = Mina_base.Account.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp, equal, compare, hash, yojson]
+  [@@deriving bin_io_unversioned, sexp, equal, compare, yojson]
 
   type key = Mina_base.Account.Key.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp, equal, compare, hash]
+  [@@deriving bin_io_unversioned, sexp, equal, compare]
 
   (* use Account items needed *)
   let empty = Mina_base.Account.empty
@@ -40,7 +40,7 @@ module Receipt = Mina_base.Receipt
 
 module Hash = struct
   module T = struct
-    type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
+    type t = Md5.t [@@deriving sexp, compare, bin_io_unversioned, equal]
   end
 
   include T
@@ -52,8 +52,6 @@ module Hash = struct
 
     let version_byte = Base58_check.Version_bytes.ledger_test_hash
   end)
-
-  include Hashable.Make_binable (T)
 
   (* to prevent pre-image attack,
    * important impossible to create an account such that (merge a b = hash_account account) *)
@@ -151,7 +149,7 @@ module Key = struct
   module Stable = struct
     module V1 = struct
       type t = Mina_base.Account.Key.Stable.V1.t
-      [@@deriving sexp, equal, compare, hash]
+      [@@deriving sexp, equal, compare]
 
       let to_latest = Fn.id
     end
@@ -166,7 +164,6 @@ module Key = struct
   let gen_keys num_keys =
     Quickcheck.random_value (Quickcheck.Generator.list_with_length num_keys gen)
 
-  include Hashable.Make_binable (Stable.Latest)
   include Comparable.Make (Stable.Latest)
 end
 
@@ -177,13 +174,12 @@ module Account_id = struct
   module Stable = struct
     module V2 = struct
       type t = Mina_base.Account_id.Stable.V2.t
-      [@@deriving sexp, equal, compare, hash]
+      [@@deriving sexp, equal, compare]
 
       let to_latest = Fn.id
     end
   end]
 
-  include Hashable.Make_binable (Stable.Latest)
   include Comparable.Make (Stable.Latest)
 
   let create = Mina_base.Account_id.create

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -692,7 +692,6 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     include Merkle_ledger.Util.Make (struct
       module Location = Location
-      module Location_binable = Location_binable
       module Key = Key
       module Token_id = Token_id
       module Account_id = Account_id

--- a/src/lib/mina_base/account_id_intf.ml
+++ b/src/lib/mina_base/account_id_intf.ml
@@ -61,7 +61,7 @@ module type S = sig
   [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving sexp, equal, compare, hash, yojson]
+      type t [@@deriving sexp, equal, compare, yojson]
     end
   end]
 
@@ -84,8 +84,6 @@ module type S = sig
   val gen : t Quickcheck.Generator.t
 
   include Comparable.S with type t := t
-
-  include Hashable.S_binable with type t := t
 
   type var
 

--- a/src/lib/mina_base/zkapp_basic.ml
+++ b/src/lib/mina_base/zkapp_basic.ml
@@ -361,7 +361,6 @@ end
 module F = Pickles.Backend.Tick.Field
 
 module F_map = struct
-  include Hashable.Make (F)
   include Comparable.Make (F)
 end
 

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1166,7 +1166,7 @@ end = struct
   let create ({ fee_payer; account_updates; memo } : T.t) ~failed ~find_vk :
       t Or_error.t =
     With_return.with_return (fun { return } ->
-        let tbl = Account_id.Table.create () in
+        let tbl = ref Account_id.Map.empty in
         let vks_overridden =
           (* Keep track of the verification keys that have been set so far
              during this transaction.
@@ -1227,8 +1227,9 @@ end = struct
                   in
                   match prioritized_vk with
                   | Some prioritized_vk ->
-                      Account_id.Table.update tbl account_id ~f:(fun _ ->
-                          With_hash.hash prioritized_vk ) ;
+                      tbl :=
+                        Account_id.Map.update !tbl account_id ~f:(fun _ ->
+                            With_hash.hash prioritized_vk ) ;
                       (* return the updated overrides *)
                       vks_overridden := vks_overriden' ;
                       (p, Some prioritized_vk)

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -827,7 +827,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
         true
     | Some hash_set ->
         (* other account_updates *)
-        not @@ Hash_set.mem hash_set account_id
+        not @@ Set.mem !hash_set account_id
   in
   let%bind account_precondition =
     f_account_precondition ~first_use_of_account account
@@ -1062,7 +1062,7 @@ let gen_account_update_from ?(no_account_precondition = false)
     Account_update_body_components.to_typical_account_update body_components
   in
   let account_id = Account_id.create body.public_key body.token_id in
-  Hash_set.add account_ids_seen account_id ;
+  account_ids_seen := Set.add !account_ids_seen account_id ;
   return { Account_update.Simple.body; authorization }
 
 (* takes an account id, if we want to sign this data *)
@@ -1198,7 +1198,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   (* account ids seen, to generate receipt chain hash precondition only if
      a account_update with a given account id has not been encountered before
   *)
-  let account_ids_seen = Account_id.Hash_set.create () in
+  let account_ids_seen = ref Account_id.Set.empty in
   let%bind num_zkapp_command = Int.gen_uniform_incl 1 max_account_updates in
   let%bind fee_payer =
     gen_fee_payer ?global_slot ?fee_range ?failure
@@ -1215,7 +1215,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
             Option.is_some a.zkapp )
     |> Account_id.Map.keys
   in
-  Hash_set.add account_ids_seen fee_payer_acct_id ;
+  account_ids_seen := Set.add !account_ids_seen fee_payer_acct_id ;
   let mk_forest ps =
     List.map ps ~f:(fun p -> { With_stack_hash.elt = p; stack_hash = () })
   in

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -754,7 +754,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
             let%map zkapp_account_id =
               Quickcheck.Generator.of_list zkapp_account_ids
             in
-            match Account_id.Table.find account_state_tbl zkapp_account_id with
+            match Account_id.Map.find !account_state_tbl zkapp_account_id with
             | None ->
                 failwith "gen_account_update_body: fail to find zkapp account"
             | Some (_, `Fee_payer)
@@ -767,7 +767,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
                 acct
           else
             let accts =
-              Account_id.Table.filteri account_state_tbl
+              Account_id.Map.filteri !account_state_tbl
                 ~f:(fun ~key:_ ~data:(_, role) ->
                   match (authorization_tag, role) with
                   | _, `Fee_payer ->
@@ -782,13 +782,13 @@ let gen_account_update_body_components (type a b c d) ?global_slot
                       Option.is_none required_balance_change
                   | _, `Ordinary_participant ->
                       true )
-              |> Account_id.Table.data
+              |> Account_id.Map.data
             in
             Quickcheck.Generator.of_list accts >>| fst
       | Some account_id ->
           (*get the latest state of the account*)
           let acct =
-            Account_id.Table.find_exn account_state_tbl account_id |> fst
+            Account_id.Map.find_exn !account_state_tbl account_id |> fst
           in
           if zkapp_account && Option.is_none acct.zkapp then
             failwith
@@ -971,29 +971,30 @@ let gen_account_update_body_components (type a b c d) ?global_slot
            in
            Some { zk with app_state; action_state; proved_state }
    in
-   Account_id.Table.update account_state_tbl (Account.identifier account)
-     ~f:(function
-     | None ->
-         (* new entry in table *)
-         ( { account with
-             balance =
-               add_balance_and_balance_change account.balance balance_change
-           ; nonce = nonce_incr account.nonce
-           ; delegate = delegate account
-           ; zkapp = zkapp account
-           }
-         , if token_account then `New_token_account else `New_account )
-     | Some (updated_account, role) ->
-         (* update entry in table *)
-         ( { updated_account with
-             balance =
-               add_balance_and_balance_change updated_account.balance
-                 balance_change
-           ; nonce = nonce_incr updated_account.nonce
-           ; delegate = delegate updated_account
-           ; zkapp = zkapp updated_account
-           }
-         , role ) ) ) ;
+   account_state_tbl :=
+     Account_id.Map.update !account_state_tbl (Account.identifier account)
+       ~f:(function
+       | None ->
+           (* new entry in table *)
+           ( { account with
+               balance =
+                 add_balance_and_balance_change account.balance balance_change
+             ; nonce = nonce_incr account.nonce
+             ; delegate = delegate account
+             ; zkapp = zkapp account
+             }
+           , if token_account then `New_token_account else `New_account )
+       | Some (updated_account, role) ->
+           (* update entry in table *)
+           ( { updated_account with
+               balance =
+                 add_balance_and_balance_change updated_account.balance
+                   balance_change
+             ; nonce = nonce_incr updated_account.nonce
+             ; delegate = delegate updated_account
+             ; zkapp = zkapp updated_account
+             }
+           , role ) ) ) ;
   { Account_update_body_components.public_key
   ; update =
       ( if new_account then
@@ -1131,8 +1132,8 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t )
-    ?account_state_tbl ~ledger ?protocol_state_view ?vk ?available_public_keys
-    ~genesis_constants
+    ?(account_state_tbl = ref Account_id.Map.empty) ~ledger ?protocol_state_view
+    ?vk ?available_public_keys ~genesis_constants
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) () =
   let open Quickcheck.Let_syntax in
   let fee_payer_pk =
@@ -1140,27 +1141,20 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   in
   let fee_payer_acct_id = Account_id.create fee_payer_pk Token_id.default in
   let ledger_accounts = lazy (Ledger.to_list_sequential ledger) in
-  (* table of public keys to accounts, updated when generating each account_update
-
-     a Map would be more principled, but threading that map through the code
-     adds complexity
-  *)
-  let account_state_tbl =
-    Option.value account_state_tbl ~default:(Account_id.Table.create ())
-  in
   if not limited then
     (* make sure all ledger keys are in the keymap *)
     List.iter (Lazy.force ledger_accounts) ~f:(fun acct ->
         let acct_id = Account.identifier acct in
         (*Initialize account states*)
-        Account_id.Table.update account_state_tbl acct_id ~f:(function
-          | None ->
-              if Account_id.equal acct_id fee_payer_acct_id then
-                (acct, `Fee_payer)
-              else (acct, `Ordinary_participant)
-          | Some a ->
-              a ) ) ;
-  List.iter (Account_id.Table.keys account_state_tbl) ~f:(fun id ->
+        account_state_tbl :=
+          Account_id.Map.update !account_state_tbl acct_id ~f:(function
+            | None ->
+                if Account_id.equal acct_id fee_payer_acct_id then
+                  (acct, `Fee_payer)
+                else (acct, `Ordinary_participant)
+            | Some a ->
+                a ) ) ;
+  List.iter (Account_id.Map.keys !account_state_tbl) ~f:(fun id ->
       let pk = Account_id.public_key id in
       if Option.is_none (Signature_lib.Public_key.Compressed.Map.find keymap pk)
       then
@@ -1183,7 +1177,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
         let ledger_account_list =
           Account_id.Set.union_list
             [ ledger_account_ids
-            ; Account_id.Set.of_hashtbl_keys account_state_tbl
+            ; Account_id.Set.of_map_keys !account_state_tbl
             ]
           |> Account_id.Set.to_list
         in
@@ -1213,13 +1207,13 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
       ~genesis_constants ()
   in
   let zkapp_account_ids =
-    Account_id.Table.filteri account_state_tbl ~f:(fun ~key:_ ~data:(a, role) ->
+    Account_id.Map.filteri !account_state_tbl ~f:(fun ~key:_ ~data:(a, role) ->
         match role with
         | `Fee_payer | `New_account | `New_token_account ->
             false
         | `Ordinary_participant ->
             Option.is_some a.zkapp )
-    |> Account_id.Table.keys
+    |> Account_id.Map.keys
   in
   Hash_set.add account_ids_seen fee_payer_acct_id ;
   let mk_forest ps =
@@ -1550,16 +1544,17 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     in
     Receipt.Zkapp_command_elt.Zkapp_command_commitment full_txn_commitment
   in
-  Account_id.Table.update account_state_tbl fee_payer_acct_id ~f:(function
-    | None ->
-        failwith "Expected fee payer account id to be in table"
-    | Some (account, _) ->
-        let receipt_chain_hash =
-          Receipt.Chain_hash.cons_zkapp_command_commitment
-            Mina_numbers.Index.zero receipt_elt
-            account.Account.receipt_chain_hash
-        in
-        ({ account with receipt_chain_hash }, `Fee_payer) ) ;
+  account_state_tbl :=
+    Account_id.Map.update !account_state_tbl fee_payer_acct_id ~f:(function
+      | None ->
+          failwith "Expected fee payer account id to be in table"
+      | Some (account, _) ->
+          let receipt_chain_hash =
+            Receipt.Chain_hash.cons_zkapp_command_commitment
+              Mina_numbers.Index.zero receipt_elt
+              account.Account.receipt_chain_hash
+          in
+          ({ account with receipt_chain_hash }, `Fee_payer) ) ;
   let account_updates =
     Zkapp_command.Call_forest.to_account_updates
       zkapp_command_dummy_authorizations.account_updates
@@ -1569,20 +1564,21 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
       match Account_update.authorization account_update with
       | Control.Proof _ | Control.Signature _ ->
           let acct_id = Account_update.account_id account_update in
-          Account_id.Table.update account_state_tbl acct_id ~f:(function
-            | None ->
-                failwith
-                  "Expected other account_update account id to be in table"
-            | Some (account, role) ->
-                let receipt_chain_hash =
-                  let account_update_index =
-                    Mina_numbers.Index.of_int (ndx + 1)
+          account_state_tbl :=
+            Account_id.Map.update !account_state_tbl acct_id ~f:(function
+              | None ->
+                  failwith
+                    "Expected other account_update account id to be in table"
+              | Some (account, role) ->
+                  let receipt_chain_hash =
+                    let account_update_index =
+                      Mina_numbers.Index.of_int (ndx + 1)
+                    in
+                    Receipt.Chain_hash.cons_zkapp_command_commitment
+                      account_update_index receipt_elt
+                      account.Account.receipt_chain_hash
                   in
-                  Receipt.Chain_hash.cons_zkapp_command_commitment
-                    account_update_index receipt_elt
-                    account.Account.receipt_chain_hash
-                in
-                ({ account with receipt_chain_hash }, role) )
+                  ({ account with receipt_chain_hash }, role) )
       | Control.None_given ->
           () ) ;
   zkapp_command_dummy_authorizations
@@ -1598,26 +1594,28 @@ let gen_list_of_zkapp_command_from ?global_slot ?failure ?max_account_updates
   let account_state_tbl =
     match account_state_tbl with
     | None ->
-        let tbl = Account_id.Table.create () in
+        let tbl = ref Account_id.Map.empty in
         let accounts = Ledger.to_list_sequential ledger in
         List.iter accounts ~f:(fun acct ->
             let acct_id = Account.identifier acct in
-            Account_id.Table.update tbl acct_id ~f:(function
-              | None ->
-                  (acct, `Ordinary_participant)
-              | Some a ->
-                  a ) ) ;
+            tbl :=
+              Account_id.Map.update !tbl acct_id ~f:(function
+                | None ->
+                    (acct, `Ordinary_participant)
+                | Some a ->
+                    a ) ) ;
         List.iter fee_payer_keypairs ~f:(fun fee_payer_keypair ->
             let acct_id =
               Account_id.create
                 (Signature_lib.Public_key.compress fee_payer_keypair.public_key)
                 Token_id.default
             in
-            Account_id.Table.update tbl acct_id ~f:(function
-              | None ->
-                  failwith "fee_payer not in ledger"
-              | Some (a, _) ->
-                  (a, `Fee_payer) ) ) ;
+            tbl :=
+              Account_id.Map.update !tbl acct_id ~f:(function
+                | None ->
+                    failwith "fee_payer not in ledger"
+                | Some (a, _) ->
+                    (a, `Fee_payer) ) ) ;
         tbl
     | Some tbl ->
         tbl
@@ -1676,7 +1674,7 @@ let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
 
 let gen_max_cost_zkapp_command_from ?memo ?fee_range
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
-    ~(account_state_tbl : (Account.t * role) Account_id.Table.t) ~vk
+    ~(account_state_tbl : (Account.t * role) Account_id.Map.t ref) ~vk
     ~(genesis_constants : Genesis_constants.t) () =
   let open Quickcheck.Generator.Let_syntax in
   let%bind memo =
@@ -1687,7 +1685,7 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
         Signed_command_memo.gen
   in
   let zkapp_accounts =
-    Account_id.Table.data account_state_tbl
+    Account_id.Map.data !account_state_tbl
     |> List.filter_map ~f:(fun ((a, role) : Account.t * role) ->
            match role with
            | `Ordinary_participant ->
@@ -1722,7 +1720,7 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
   in
   let fee_payer_id = Account_id.create fee_payer_pk Token_id.default in
   let fee_payer_account, _ =
-    Account_id.Table.find_exn account_state_tbl fee_payer_id
+    Account_id.Map.find_exn !account_state_tbl fee_payer_id
   in
   let%map fee =
     Option.value_map fee_range
@@ -1732,11 +1730,12 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range
   let fee_payer =
     mk_fee_payer ~fee ~pk:fee_payer_pk ~nonce:fee_payer_account.nonce
   in
-  Account_id.Table.change account_state_tbl fee_payer_id ~f:(function
-    | None ->
-        None
-    | Some (a, role) ->
-        Some ({ a with nonce = Account.Nonce.succ a.nonce }, role) ) ;
+  account_state_tbl :=
+    Account_id.Map.change !account_state_tbl fee_payer_id ~f:(function
+      | None ->
+          None
+      | Some (a, role) ->
+          Some ({ a with nonce = Account.Nonce.succ a.nonce }, role) ) ;
   Zkapp_command.of_simple { fee_payer; account_updates; memo }
 
 let%test_module _ =
@@ -1808,7 +1807,6 @@ let%test_module _ =
             (list_with_length 100
                (gen_zkapp_command_from ~genesis_constants ~constraint_constants
                   ~fee_payer_keypair ~keymap ~no_token_accounts:true
-                  ~account_state_tbl:(Account_id.Table.create ())
                   ~generate_new_accounts:false ~ledger () ) )
             ~size:100
             ~random:(Splittable_random.State.create Random.State.default))
@@ -1835,7 +1833,6 @@ let%test_module _ =
                       ; min_new_zkapp_balance = of_mina_string_exn "50"
                       ; max_new_zkapp_balance = of_mina_string_exn "100"
                       }
-                  ~account_state_tbl:(Account_id.Table.create ())
                   ~generate_new_accounts:false ~ledger () ) )
             ~size:100
             ~random:(Splittable_random.State.create Random.State.default))

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -69,7 +69,7 @@ val gen_zkapp_command_from :
   -> fee_payer_keypair:Signature_lib.Keypair.t
   -> keymap:
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t
-  -> ?account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> ?account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
@@ -89,7 +89,7 @@ val gen_list_of_zkapp_command_from :
   -> fee_payer_keypairs:Signature_lib.Keypair.t list
   -> keymap:
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t
-  -> ?account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> ?account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> ledger:Mina_ledger.Ledger.t
   -> ?protocol_state_view:Zkapp_precondition.Protocol_state.View.t
   -> ?vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
@@ -104,7 +104,7 @@ val gen_max_cost_zkapp_command_from :
      ?memo:string
   -> ?fee_range:Currency.Fee.t * Currency.Fee.t
   -> fee_payer_keypair:Signature_lib.Keypair.t
-  -> account_state_tbl:(Account.t * role) Account_id.Table.t
+  -> account_state_tbl:(Account.t * role) Account_id.Map.t ref
   -> vk:(Side_loaded_verification_key.t, State_hash.t) With_hash.Stable.V1.t
   -> genesis_constants:Genesis_constants.t
   -> unit

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -145,12 +145,14 @@ let rec wait_until_zkapps_deployed ?(deployed = false) ~scheduler_tbl ~mina
 
 let insert_account_queue ~account_queue ~account_queue_size ~account_state_tbl
     id =
-  let a = Account_id.Table.find_and_remove account_state_tbl id in
-  Queue.enqueue account_queue (Option.value_exn a) ;
+  let a = Account_id.Map.find_exn !account_state_tbl id in
+  account_state_tbl := Account_id.Map.remove !account_state_tbl id ;
+  Queue.enqueue account_queue a ;
   if Queue.length account_queue > account_queue_size then
     let a, role = Queue.dequeue_exn account_queue in
-    Account_id.Table.add_exn account_state_tbl ~key:(Account.identifier a)
-      ~data:(a, role)
+    account_state_tbl :=
+      Account_id.Map.add_exn !account_state_tbl ~key:(Account.identifier a)
+        ~data:(a, role)
   else ()
 
 let send_zkapps ~(genesis_constants : Genesis_constants.t)
@@ -213,7 +215,7 @@ let send_zkapps ~(genesis_constants : Genesis_constants.t)
       | Some (ledger, _) ->
           let number_of_accounts_generated =
             let f = function _, `New_account -> true | _ -> false in
-            Account_id.Table.count ~f account_state_tbl
+            Account_id.Map.count ~f !account_state_tbl
             + Queue.count ~f account_queue
           in
           let generate_new_accounts =

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1328,9 +1328,11 @@ module Mutations = struct
                       List.map ids ~f:(fun id ->
                           (id, (Utils.account_of_id id ledger, role)) )
                     in
-                    Account_id.Table.of_alist_exn
-                      ( get_account fee_payer_ids `Fee_payer
-                      @ get_account zkapp_account_ids `Ordinary_participant )
+                    ref
+                    @@ Account_id.Map.of_alist_exn
+                         ( get_account fee_payer_ids `Fee_payer
+                         @ get_account zkapp_account_ids `Ordinary_participant
+                         )
                   in
                   let tm_next = Time.add (Time.now ()) wait_span in
                   don't_wait_for

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -332,22 +332,24 @@ struct
 
     module Vk_refcount_table = struct
       type t =
-        { verification_keys :
-            (int * Verification_key_wire.t) Zkapp_basic.F_map.Table.t
-        ; account_id_to_vks : int Zkapp_basic.F_map.Map.t Account_id.Table.t
-        ; vk_to_account_ids : int Account_id.Map.t Zkapp_basic.F_map.Table.t
+        { mutable verification_keys :
+            (int * Verification_key_wire.t) Zkapp_basic.F_map.Map.t
+        ; mutable account_id_to_vks :
+            int Zkapp_basic.F_map.Map.t Account_id.Map.t
+        ; mutable vk_to_account_ids :
+            int Account_id.Map.t Zkapp_basic.F_map.Map.t
         }
 
       let create () =
-        { verification_keys = Zkapp_basic.F_map.Table.create ()
-        ; account_id_to_vks = Account_id.Table.create ()
-        ; vk_to_account_ids = Zkapp_basic.F_map.Table.create ()
+        { verification_keys = Zkapp_basic.F_map.Map.empty
+        ; account_id_to_vks = Account_id.Map.empty
+        ; vk_to_account_ids = Zkapp_basic.F_map.Map.empty
         }
 
-      let find_vk (t : t) = Hashtbl.find t.verification_keys
+      let find_vk (t : t) = Map.find t.verification_keys
 
       let find_vks_by_account_id (t : t) account_id =
-        match Hashtbl.find t.account_id_to_vks account_id with
+        match Map.find t.account_id_to_vks account_id with
         | None ->
             []
         | Some vks ->
@@ -365,18 +367,21 @@ struct
             | Some count ->
                 count + 1 )
         in
-        Hashtbl.update t.verification_keys vk.hash ~f:(function
-          | None ->
-              (1, vk)
-          | Some (count, vk) ->
-              (count + 1, vk) ) ;
-        Hashtbl.update t.account_id_to_vks account_id
-          ~f:(inc_map ~default_map:Zkapp_basic.F_map.Map.empty vk.hash) ;
-        Hashtbl.update t.vk_to_account_ids vk.hash
-          ~f:(inc_map ~default_map:Account_id.Map.empty account_id) ;
+        t.verification_keys <-
+          Map.update t.verification_keys vk.hash ~f:(function
+            | None ->
+                (1, vk)
+            | Some (count, vk) ->
+                (count + 1, vk) ) ;
+        t.account_id_to_vks <-
+          Map.update t.account_id_to_vks account_id
+            ~f:(inc_map ~default_map:Zkapp_basic.F_map.Map.empty vk.hash) ;
+        t.vk_to_account_ids <-
+          Map.update t.vk_to_account_ids vk.hash
+            ~f:(inc_map ~default_map:Account_id.Map.empty account_id) ;
         Mina_metrics.(
           Gauge.set Transaction_pool.vk_refcount_table_size
-            (Float.of_int (Zkapp_basic.F_map.Table.length t.verification_keys)))
+            (Float.of_int (Zkapp_basic.F_map.Map.length t.verification_keys)))
 
       let dec (t : t) ~account_id ~vk_hash =
         let open Option.Let_syntax in
@@ -385,18 +390,21 @@ struct
           let map' = Map.change map key ~f:(Option.bind ~f:dec) in
           if Map.is_empty map' then None else Some map'
         in
-        Hashtbl.change t.verification_keys vk_hash
-          ~f:
-            (Option.bind ~f:(fun (count, value) ->
-                 let%map count' = dec count in
-                 (count', value) ) ) ;
-        Hashtbl.change t.account_id_to_vks account_id
-          ~f:(Option.bind ~f:(dec_map vk_hash)) ;
-        Hashtbl.change t.vk_to_account_ids vk_hash
-          ~f:(Option.bind ~f:(dec_map account_id)) ;
+        t.verification_keys <-
+          Map.change t.verification_keys vk_hash
+            ~f:
+              (Option.bind ~f:(fun (count, value) ->
+                   let%map count' = dec count in
+                   (count', value) ) ) ;
+        t.account_id_to_vks <-
+          Map.change t.account_id_to_vks account_id
+            ~f:(Option.bind ~f:(dec_map vk_hash)) ;
+        t.vk_to_account_ids <-
+          Map.change t.vk_to_account_ids vk_hash
+            ~f:(Option.bind ~f:(dec_map account_id)) ;
         Mina_metrics.(
           Gauge.set Transaction_pool.vk_refcount_table_size
-            (Float.of_int (Zkapp_basic.F_map.Table.length t.verification_keys)))
+            (Float.of_int (Zkapp_basic.F_map.Map.length t.verification_keys)))
 
       let lift_common (t : t) table_modify cmd =
         User_command.extract_vks cmd

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2097,7 +2097,7 @@ let%test_module _ =
                     Mina_ledger.Ledger.get best_tip_ledger loc )
                in
                (id, (state, `Fee_payer)) )
-        |> Account_id.Table.of_alist_exn
+        |> Account_id.Map.of_alist_exn |> ref
       in
       let rec go n cmds =
         let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/syncable_ledger/test/test.ml
+++ b/src/lib/syncable_ledger/test/test.ml
@@ -13,7 +13,7 @@ end
 
 module type Input_intf = sig
   module Root_hash : sig
-    type t [@@deriving bin_io, compare, hash, sexp, compare, yojson]
+    type t [@@deriving bin_io, compare, sexp, compare, yojson]
 
     val equal : t -> t -> bool
   end

--- a/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
+++ b/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
@@ -99,7 +99,7 @@ let generate_zkapp_commands_and_apply_them_consecutively_5_times ~successful
   let ledger, fee_payer_keypairs, keymap =
     mk_ledgers_and_fee_payers ~num_of_fee_payers:5 ()
   in
-  let account_state_tbl = Account_id.Table.create () in
+  let account_state_tbl = ref Account_id.Map.empty in
   let global_slot = Mina_numbers.Global_slot_since_genesis.one in
   let test i random =
     let zkapp_command_dummy_auths =


### PR DESCRIPTION
This PR redoes a subset of the changes in #15999, split into separate commits for each meaningful change.

Unlike #15999, this PR does not have any user-facing functional changes. However, we should expect a slight speed-up of the modified systems, since `Map` is nearly always faster than `HashMap` for types involving field elements.

If needed, this PR can be split up along commit lines; every commit compiles and is self-contained.