### PR TITLE
Rosetta integration test: make block producer produce more blocks

### DIFF
--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -96,7 +96,7 @@ cat <<EOF >"$MINA_CONFIG_FILE"
   "daemon": { "network_id": "${MINA_NETWORK}" },
   "ledger": {
     "accounts": [
-      { "pk": "${BLOCK_PRODUCER_PUB_KEY}", "balance": "1000000", "delegate": null, "sk": null },
+      { "pk": "${BLOCK_PRODUCER_PUB_KEY}", "balance": "600000000", "delegate": null, "sk": null },
       { "pk": "${SNARK_PRODUCER_PK}", "balance": "2000000", "delegate": "${BLOCK_PRODUCER_PUB_KEY}", "sk": null },
       { "pk": "${ZKAPP_FEE_PAYER_PUB_KEY}", "balance": "1000000", "delegate": null, "sk": null },
       { "pk": "${ZKAPP_SENDER_PUB_KEY}", "balance": "1000000", "delegate": null, "sk": null },


### PR DESCRIPTION
This PR increases the relative proportion of stake that the block producer has in the rosetta integration tests. This should speed up progress of the test, similar in principle to #14376.