### PR TITLE
Remove the arbitrary 30s wait in the zkapps integration test

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -767,7 +767,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            zkapp_command_insufficient_fee "Insufficient fee" )
     in
     let%bind () = wait_for t (Wait_condition.blocks_to_be_produced 1) in
-    let%bind () = Malleable_error.lift (after (Time.Span.of_sec 30.0)) in
     (* Won't be accepted until the previous transactions are applied *)
     let%bind () =
       section_hard "Send a zkApp transaction to update all fields"


### PR DESCRIPTION
This wait is the likely cause of flakiness with the message
```
ZkApp transaction failed: "Couldn't send zkApp commands: [\"Invalid_nonce\"] (in [\"internalSendZkapp\"])", but expected "Insufficient_replace_fee"
```
In particular, this delay plus an additional delay from block production, validation, and propagation, means that the transaction to be 'replaced' may have already been included in a block.