### PR TITLE
[master] Remove hard-coded assumption that test runners have 16 cores

### DIFF
--- a/buildkite/scripts/fuzzy-zkapp-test.sh
+++ b/buildkite/scripts/fuzzy-zkapp-test.sh
@@ -21,7 +21,7 @@ export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
 # skip running all of the tests that have already succeeded, since dune will
 # only retry those tests that failed.
 echo "--- Run fuzzy zkapp tests"
-time dune exec "${path}" --profile="${profile}" -j16 -- --timeout "${timeout}" --individual-test-timeout "${individual_test_timeout}" --seed "${RANDOM}"
+time dune exec "${path}" --profile="${profile}" -- --timeout "${timeout}" --individual-test-timeout "${individual_test_timeout}" --seed "${RANDOM}"
 STATUS=$?
 if [ "$STATUS" -ne 0 ]; then
   ./scripts/link-coredumps.sh && exit "$STATUS"

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -20,10 +20,10 @@ export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
 time make build
 
 echo "--- Build all targets"
-dune build "${path}" --profile="${profile}" -j16
+dune build "${path}" --profile="${profile}"
 
 echo "--- Check for changes to verification keys"
-time dune runtest "src/app/print_blockchain_snark_vk" --profile="${profile}" -j16
+time dune runtest "src/app/print_blockchain_snark_vk" --profile="${profile}"
 
 # Turn on the proof-cache assertion, so that CI will fail if the proofs need to
 # be updated.
@@ -33,8 +33,8 @@ export ERROR_ON_PROOF=true
 # skip running all of the tests that have already succeeded, since dune will
 # only retry those tests that failed.
 echo "--- Run unit tests"
-time dune runtest "${path}" --profile="${profile}" -j16 || \
+time dune runtest "${path}" --profile="${profile}" || \
 (./scripts/link-coredumps.sh && \
  echo "--- Retrying failed unit tests" && \
- time dune runtest "${path}" --profile="${profile}" -j16 || \
+ time dune runtest "${path}" --profile="${profile}" || \
  (./scripts/link-coredumps.sh && false))


### PR DESCRIPTION
This PR removes the explicit parallelism argument passed to dune in CI. Allowing dune to automatically detect how many cores are available is likely to have better performance.