### PR TITLE
Remove unused block window duration arguments

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1205,7 +1205,6 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
               ; time_controller
               ; pubsub_v1
               ; pubsub_v0
-              ; block_window_duration = compile_config.block_window_duration
               }
           in
           let net_config =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1612,14 +1612,12 @@ let generate_libp2p_keypair_do privkey_path =
     (let open Deferred.Let_syntax in
     (* FIXME: I'd like to accumulate messages into this logger and only dump them out in failure paths. *)
     let logger = Logger.null () in
-    let compile_config = Mina_compile_config.Compiled.t in
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-generate-libp2p-keypair" ~f:(fun tmpd ->
         match%bind
           Mina_net2.create ~logger ~conf_dir:tmpd ~all_peers_seen_metric:false
             ~pids:(Child_processes.Termination.create_pid_table ())
-            ~on_peer_connected:ignore ~on_peer_disconnected:ignore
-            ~block_window_duration:compile_config.block_window_duration ()
+            ~on_peer_connected:ignore ~on_peer_disconnected:ignore ()
         with
         | Ok net ->
             let%bind me = Mina_net2.generate_random_keypair net in
@@ -1646,14 +1644,12 @@ let dump_libp2p_keypair_do privkey_path =
   Deferred.ignore_m
     (let open Deferred.Let_syntax in
     let logger = Logger.null () in
-    let compile_config = Mina_compile_config.Compiled.t in
     (* Using the helper only for keypair generation requires no state. *)
     File_system.with_temp_dir "mina-dump-libp2p-keypair" ~f:(fun tmpd ->
         match%bind
           Mina_net2.create ~logger ~conf_dir:tmpd ~all_peers_seen_metric:false
             ~pids:(Child_processes.Termination.create_pid_table ())
-            ~on_peer_connected:ignore ~on_peer_disconnected:ignore
-            ~block_window_duration:compile_config.block_window_duration ()
+            ~on_peer_connected:ignore ~on_peer_disconnected:ignore ()
         with
         | Ok net ->
             let%bind () = Mina_net2.shutdown net in

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -52,7 +52,6 @@ module Config = struct
     ; mutable keypair : Mina_net2.Keypair.t option
     ; all_peers_seen_metric : bool
     ; known_private_ip_nets : Core.Unix.Cidr.t list
-    ; block_window_duration : Time.Span.t
     }
   [@@deriving make]
 end
@@ -220,8 +219,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
         ctx first_peer_ivar high_connectivity_ivar ~added_seeds ~pids
         ~on_unexpected_termination
         ~sinks:
-          (Message.Any_sinks (sinksM, (sink_block, sink_tx, sink_snark_work)))
-        ~block_window_duration =
+          (Message.Any_sinks (sinksM, (sink_block, sink_tx, sink_snark_work))) =
       let module Sinks = (val sinksM) in
       let ctr = ref 0 in
       let record_peer_connection () =
@@ -258,7 +256,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
                   ~all_peers_seen_metric:config.all_peers_seen_metric
                   ~on_peer_connected:(fun _ -> record_peer_connection ())
                   ~on_peer_disconnected:ignore ~logger:config.logger ~conf_dir
-                  ~pids ~block_window_duration () ) )
+                  ~pids () ) )
       with
       | Ok (Ok net2) -> (
           let open Mina_net2 in
@@ -629,7 +627,6 @@ module Make (Rpc_interface : RPC_INTERFACE) :
             create_libp2p ~allow_multiple_instances config rpc_handlers
               first_peer_ivar high_connectivity_ivar ~added_seeds ~pids
               ~on_unexpected_termination:restart_libp2p ~sinks
-              ~block_window_duration:config.block_window_duration
           in
           on_libp2p_create libp2p ; Deferred.ignore_m libp2p
         and restart_libp2p () = don't_wait_for (start_libp2p ()) in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1866,7 +1866,6 @@ let create ~commit_id ?wallets (config : Config.t) =
               ; consensus_constants
               ; genesis_constants = config.precomputed_values.genesis_constants
               ; constraint_constants
-              ; block_window_duration
               }
           in
           let sinks = (block_sink, tx_remote_sink, snark_remote_sink) in

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -185,7 +185,6 @@ let%test_module "Epoch ledger sync tests" =
           ; consensus_constants
           ; genesis_constants = precomputed_values.genesis_constants
           ; constraint_constants
-          ; block_window_duration = compile_config.block_window_duration
           }
       in
       let _transaction_pool, tx_remote_sink, _tx_local_sink =
@@ -273,7 +272,6 @@ let%test_module "Epoch ledger sync tests" =
           ; time_controller
           ; pubsub_v1
           ; pubsub_v0
-          ; block_window_duration = compile_config.block_window_duration
           }
         in
         Mina_networking.Gossip_net.(

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -94,7 +94,6 @@ type t =
   ; mutable banned_ips : Unix.Inet_addr.t list
   ; peer_connected_callback : string -> unit
   ; peer_disconnected_callback : string -> unit
-  ; block_window_duration : Time.Span.t
   }
 
 let banned_ips t = t.banned_ips
@@ -383,8 +382,7 @@ let handle_push_message t push_message =
               upon
                 (O1trace.thread "validate_libp2p_gossip" (fun () ->
                      Subscription.handle_and_validate sub ~validation_expiration
-                       ~sender ~data
-                       ~block_window_duration:t.block_window_duration ) )
+                       ~sender ~data ) )
                 (function
                   | `Validation_timeout ->
                       [%log' warn t.logger]
@@ -545,8 +543,7 @@ let handle_push_message t push_message =
       Libp2p_ipc.undefined_union ~context:"DaemonInterface.PushMessage" n
 
 let create ?(allow_multiple_instances = false) ~all_peers_seen_metric ~logger
-    ~pids ~conf_dir ~on_peer_connected ~on_peer_disconnected
-    ~block_window_duration () =
+    ~pids ~conf_dir ~on_peer_connected ~on_peer_disconnected () =
   let open Deferred.Or_error.Let_syntax in
   let push_message_handler =
     ref (fun _msg ->
@@ -577,7 +574,6 @@ let create ?(allow_multiple_instances = false) ~all_peers_seen_metric ~logger
     ; peer_disconnected_callback =
         (fun peer_id -> on_peer_disconnected (Peer.Id.unsafe_of_string peer_id))
     ; protocol_handlers = Hashtbl.create (module String)
-    ; block_window_duration
     }
   in
   (push_message_handler := fun msg -> handle_push_message t msg) ;

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -139,7 +139,6 @@ val create :
   -> conf_dir:string
   -> on_peer_connected:(Peer.Id.t -> unit)
   -> on_peer_disconnected:(Peer.Id.t -> unit)
-  -> block_window_duration:Time.Span.t
   -> unit
   -> t Deferred.Or_error.t
 

--- a/src/lib/mina_net2/subscription.ml
+++ b/src/lib/mina_net2/subscription.ml
@@ -50,7 +50,7 @@ let unsubscribe ~helper sub =
   else Deferred.Or_error.error_string "already unsubscribed"
 
 let handle_and_validate sub ~validation_expiration ~(sender : Peer.t)
-    ~data:raw_data ~block_window_duration =
+    ~data:raw_data =
   let open Libp2p_ipc.Reader.ValidationResult in
   let wrap_message data =
     if
@@ -65,9 +65,7 @@ let handle_and_validate sub ~validation_expiration ~(sender : Peer.t)
         Validation_callback.create validation_expiration
       in
       let%bind () = sub.validator (wrap_message data) validation_callback in
-      match%map
-        Validation_callback.await ~block_window_duration validation_callback
-      with
+      match%map Validation_callback.await validation_callback with
       | Some `Accept ->
           `Validation_result Accept
       | Some `Reject ->

--- a/src/lib/mina_net2/subscription.mli
+++ b/src/lib/mina_net2/subscription.mli
@@ -29,7 +29,6 @@ val handle_and_validate :
   -> validation_expiration:Time_ns.t
   -> sender:Peer.t
   -> data:string
-  -> block_window_duration:Time.Span.t
   -> [ `Validation_result of Libp2p_ipc.validation_result
      | `Validation_timeout
      | `Decoding_error of Error.t ]

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -543,8 +543,7 @@ let%test_module "all-ipc test" =
       let%bind node =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String local_name) ])
-          ~conf_dir ~pids ~on_peer_connected ~on_peer_disconnected
-          ~block_window_duration ()
+          ~conf_dir ~pids ~on_peer_connected ~on_peer_disconnected ()
         >>| Or_error.ok_exn
       in
       let%bind kp_a =

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -78,9 +78,6 @@ let%test_module "all-ipc test" =
     let bob_status =
       "This is major Tom to ground control\nI'm stepping through the door"
 
-    let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
-
     type messages =
       { topic_a_msg_1 : string
       ; topic_a_msg_2 : string

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -11,9 +11,6 @@ let%test_module "Mina network tests" =
 
     let pids = Child_processes.Termination.create_pid_table ()
 
-    let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
-
     let setup_two_nodes network_id =
       let%bind a_tmp = Unix.mkdtemp "p2p_helper_test_a" in
       let%bind b_tmp = Unix.mkdtemp "p2p_helper_test_b" in
@@ -22,21 +19,21 @@ let%test_module "Mina network tests" =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "a") ])
           ~conf_dir:a_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
+          ~on_peer_disconnected:Fn.ignore ()
         >>| Or_error.ok_exn
       in
       let%bind b =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "b") ])
           ~conf_dir:b_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
+          ~on_peer_disconnected:Fn.ignore ()
         >>| Or_error.ok_exn
       in
       let%bind c =
         create ~all_peers_seen_metric:false
           ~logger:(Logger.extend logger [ ("name", `String "c") ])
           ~conf_dir:c_tmp ~pids ~on_peer_connected:Fn.ignore
-          ~on_peer_disconnected:Fn.ignore ~block_window_duration ()
+          ~on_peer_disconnected:Fn.ignore ()
         >>| Or_error.ok_exn
       in
       let%bind kp_a = generate_random_keypair a in

--- a/src/lib/mina_net2/validation_callback.mli
+++ b/src/lib/mina_net2/validation_callback.mli
@@ -11,11 +11,9 @@ val create_without_expiration : unit -> t
 
 val is_expired : t -> bool
 
-val await :
-  block_window_duration:Time.Span.t -> t -> validation_result option Deferred.t
+val await : t -> validation_result option Deferred.t
 
-val await_exn :
-  block_window_duration:Time.Span.t -> t -> validation_result Deferred.t
+val await_exn : t -> validation_result Deferred.t
 
 (** May return a deferred that never resolves, in the case of callbacks without expiration. *)
 val await_timeout : t -> unit Deferred.t

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -185,7 +185,6 @@ end)
         ~unwrap:(function
           | Diff m -> m | _ -> failwith "unexpected message type" )
         ~trace_label:Resource_pool.label ~logger resource_pool
-        ~block_window_duration
     in
     let local_r, local_w, _ =
       Local_sink.create
@@ -193,7 +192,6 @@ end)
         ~unwrap:(function
           | Diff m -> m | _ -> failwith "unexpected message type" )
         ~trace_label:Resource_pool.label ~logger resource_pool
-        ~block_window_duration
     in
     log_rate_limiter_occasionally network_pool remote_rl ;
     (*priority: Transition frontier diffs > local diffs > incoming diffs*)

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -23,7 +23,6 @@ type block_sink_config =
   ; consensus_constants : Consensus.Constants.t
   ; genesis_constants : Genesis_constants.t
   ; constraint_constants : Genesis_constants.Constraint_constants.t
-  ; block_window_duration : Time.Span.t
   }
 
 type t =
@@ -37,7 +36,6 @@ type t =
       ; consensus_constants : Consensus.Constants.t
       ; genesis_constants : Genesis_constants.t
       ; constraint_constants : Genesis_constants.Constraint_constants.t
-      ; block_window_duration : Time.Span.t
       }
   | Void
 
@@ -59,7 +57,6 @@ let push sink (b_or_h, `Time_received tm, `Valid_cb cb) =
       ; consensus_constants
       ; genesis_constants
       ; constraint_constants
-      ; block_window_duration
       } ->
       O1trace.sync_thread "handle_block_gossip"
       @@ fun () ->
@@ -105,9 +102,7 @@ let push sink (b_or_h, `Time_received tm, `Valid_cb cb) =
           :: txs_meta ) ;
       [%log internal] "External_block_received" ;
       don't_wait_for
-        ( match%map
-            Mina_net2.Validation_callback.await ~block_window_duration cb
-          with
+        ( match%map Mina_net2.Validation_callback.await cb with
         | Some `Accept ->
             let processing_time_span =
               Time.diff
@@ -238,7 +233,6 @@ let create
     ; consensus_constants
     ; genesis_constants
     ; constraint_constants
-    ; block_window_duration
     } =
   let rate_limiter =
     Network_pool.Rate_limiter.create
@@ -260,7 +254,6 @@ let create
       ; consensus_constants
       ; genesis_constants
       ; constraint_constants
-      ; block_window_duration
       } )
 
 let void = Void

--- a/src/lib/transition_handler/block_sink.mli
+++ b/src/lib/transition_handler/block_sink.mli
@@ -1,6 +1,5 @@
 open Network_peer
 open Mina_base
-open Core_kernel
 
 type Structured_log_events.t +=
   | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
@@ -26,7 +25,6 @@ type block_sink_config =
   ; consensus_constants : Consensus.Constants.t
   ; genesis_constants : Genesis_constants.t
   ; constraint_constants : Genesis_constants.Constraint_constants.t
-  ; block_window_duration : Time.Span.t
   }
 
 val create :

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -172,7 +172,6 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
       | Ok _ | Error `Parent_missing_from_frontier ->
           [%log internal] "Schedule_catchup" ;
           Catchup_scheduler.watch_header catchup_scheduler ~valid_cb
-            ~block_window_duration:compile_config.block_window_duration
             ~header_with_hash ;
           return ()
       | Error `Not_selected_over_frontier_root ->
@@ -240,8 +239,7 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
                 in
                 Catchup_scheduler.watch catchup_scheduler ~timeout_duration
                   ~cached_transition:cached_initially_validated_transition
-                  ~valid_cb
-                  ~block_window_duration:compile_config.block_window_duration ;
+                  ~valid_cb ;
                 return (Error ()) )
       in
       (* TODO: only access parent in transition frontier once (already done in call to validate dependencies) #2485 *)


### PR DESCRIPTION
_part 2 of #16173_ 

Argument `block_window_duration` was unnecessarily introduced in one of recent refactorings, by accident.

This PR essentially removes `~block_window_duration:_ (*TODO remove*)` in `validation_callback.ml` and propagates the change up the function calls.