### PR TITLE
Fix Debian Buster EOL issue when publishing debian

### DIFF
--- a/automation/services/mina-bp-stats/sidecar/build.sh
+++ b/automation/services/mina-bp-stats/sidecar/build.sh
@@ -10,7 +10,7 @@ rm -rf "${BUILDDIR}"
 mkdir -p "${BUILDDIR}/DEBIAN"
 
 cat << EOF > "${BUILDDIR}/DEBIAN/control"
-Package: mina-bp-stats-sidecar
+Package: mina-sidecar
 Version: ${MINA_DEB_VERSION}
 License: Apache-2.0
 Vendor: none

--- a/automation/services/mina-bp-stats/sidecar/build.sh
+++ b/automation/services/mina-bp-stats/sidecar/build.sh
@@ -10,7 +10,7 @@ rm -rf "${BUILDDIR}"
 mkdir -p "${BUILDDIR}/DEBIAN"
 
 cat << EOF > "${BUILDDIR}/DEBIAN/control"
-Package: mina-sidecar
+Package: mina-bp-stats-sidecar
 Version: ${MINA_DEB_VERSION}
 License: Apache-2.0
 Vendor: none

--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -71,9 +71,11 @@ do
 
   for i in {1..10}; do 
 
+    set +e
     ${DEBS3_SHOW} "$deb" "${DEB_VERSION}" "${ARCH}" -c "${DEB_CODENAME}" -m "${DEB_RELEASE}"
     LAST_VERIFY_STATUS=$?
-    
+    set -eo pipefail
+
     if [[ $LAST_VERIFY_STATUS == 0 ]]; then
         echo "succesfully validated that package is uploaded to deb-s3"
         break

--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -59,11 +59,8 @@ for i in {1..10}; do (
     "${DEB_NAMES}"
 ) && break || scripts/clear-deb-s3-lockfile.sh; done
 
-
 for deb in $DEB_NAMES
 do
-  echo "Adding packages.o1test.net $DEB_CODENAME $DEB_RELEASE"
-  sudo echo "deb [trusted=yes] http://packages.o1test.net $DEB_CODENAME $DEB_RELEASE" | sudo tee /etc/apt/sources.list.d/mina.list
 
   DEBS3_SHOW="deb-s3 show $BUCKET_ARG $S3_REGION_ARG"
 
@@ -71,11 +68,9 @@ do
   # _build/mina-archive_3.0.1-develop-a2a872a.deb -> mina-archive
   deb=$(basename "$deb")
   deb="${deb%_*}"
-  
-  
+
   for i in {1..10}; do 
 
-    sudo apt-get update
     ${DEBS3_SHOW} "$deb" "${DEB_VERSION}" "${ARCH}" -c "${DEB_CODENAME}" -m "${DEB_RELEASE}"
     LAST_VERIFY_STATUS=$?
     


### PR DESCRIPTION
Debian Buster is EOL. We are using apt-get update when verifying pushed packages to debian repo. We are relying purely on deb-s3 in order to verify package is located in out repo so we can remove apt-get call from process. 

For mina-side car issue, looks like there is a name mismatch between package name in control file with debian package name. Adjusting package name in control file will solve the issue