### PR TITLE
Revert publish job fix 

### DIFF
--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -59,6 +59,12 @@ for i in {1..10}; do (
     "${DEB_NAMES}"
 ) && break || scripts/clear-deb-s3-lockfile.sh; done
 
+# Verify integrity of debs on remote repo
+function verify_o1test_repo_has_package {
+  sudo apt-get update
+  ${DEBS3_SHOW} ${1} ${DEB_VERSION} $ARCH -c $DEB_CODENAME -m $DEB_RELEASE
+  return $?
+}
 
 for deb in $DEB_NAMES
 do
@@ -67,32 +73,12 @@ do
 
   DEBS3_SHOW="deb-s3 show $BUCKET_ARG $S3_REGION_ARG"
 
-  # extracting name from debian package path. E.g:
-  # _build/mina-archive_3.0.1-develop-a2a872a.deb -> mina-archive
-  deb=$(basename "$deb")
-  deb="${deb%_*}"
+  deb_split=(${deb//_/ })
+  deb="${deb_split[0]}"
+  deb=$(basename $deb)
   
-  
-  for i in {1..10}; do 
+  for i in {1..10}; do (verify_o1test_repo_has_package $deb) && break || sleep 60; done
 
-    sudo apt-get update
-    ${DEBS3_SHOW} "$deb" "${DEB_VERSION}" "${ARCH}" -c "${DEB_CODENAME}" -m "${DEB_RELEASE}"
-    LAST_VERIFY_STATUS=$?
-    
-    if [[ $LAST_VERIFY_STATUS == 0 ]]; then
-        echo "succesfully validated that package is uploaded to deb-s3"
-        break
-    fi
-    
-    sleep 60
-    i=$((i+1)) 
-  done
-
-  if [[ $LAST_VERIFY_STATUS != 0 ]]; then
-    echo "Cannot locate '$deb' in debian repo. failing job..."
-    echo "You may still try to rerun job as debian repository is known from imperfect performance"
-    exit 1
-  fi
 done
 
 


### PR DESCRIPTION
Reverting https://github.com/MinaProtocol/mina/pull/16189 as it introduced two issues:

- mina-side car has different package name in control file of debian and deb-s3 cannot find it (this issue is still present in master but currently this is silent fail)
- buster EOL - we had some luck as we never ran apt-get update on buster. After my change we did it and it caused failures.

I introduced pr which fixes above problems, but it's better not to merge them at haste. 

Buster EOL fix: https://github.com/MinaProtocol/mina/pull/16246
Mina sidecar removal: https://github.com/MinaProtocol/mina/pull/16248
