### PR TITLE
Remove some unused code in snark-related modules

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -381,18 +381,12 @@ let%snarkydef_ step ~(logger : Logger.t)
     ; proof_must_verify = txn_snark_must_verify
     } )
 
-module Statement = struct
-  type t = Protocol_state.Value.t
-
-  let to_field_elements (t : t) : Tick.Field.t array =
-    [| (Protocol_state.hashes t).state_hash |]
-end
-
-module Statement_var = struct
-  type t = Protocol_state.Value.t Data_as_hash.t
-end
-
-type tag = (Statement_var.t, Statement.t, Nat.N2.n, Nat.N1.n) Pickles.Tag.t
+type tag =
+  ( Protocol_state.Value.t Data_as_hash.t
+  , Protocol_state.Value.t
+  , Nat.N2.n
+  , Nat.N1.n )
+  Pickles.Tag.t
 
 let typ = Data_as_hash.typ ~hash:(fun t -> (Protocol_state.hashes t).state_hash)
 
@@ -448,8 +442,6 @@ module type S = sig
 
   val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
 end
-
-let verify ts ~key = Pickles.verify (module Nat.N2) (module Statement) key ts
 
 let constraint_system_digests ~proof_level ~constraint_constants () =
   let digest = Tick.R1CS_constraint_system.digest in

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -20,11 +20,6 @@ type tag =
   , Nat.N1.n )
   Pickles.Tag.t
 
-val verify :
-     (Protocol_state.Value.t * Proof.t) list
-  -> key:Pickles.Verification_key.t
-  -> unit Or_error.t Async.Deferred.t
-
 val check :
      Witness.t
   -> ?handler:

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -383,56 +383,6 @@ module Make_str (A : Wire_types.Concrete) = struct
       Poly.typ Frozen_ledger_hash.typ Currency.Amount.Signed.typ
         Pending_coinbase.Stack.typ Fee_excess.typ Sok_message.Digest.typ
         Local_state.typ
-
-    let to_input ({ sok_digest; _ } as t : t) =
-      let input =
-        let input_without_sok = to_input { t with sok_digest = () } in
-        Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
-          [| Sok_message.Digest.to_input sok_digest; input_without_sok |]
-      in
-      if !top_hash_logging_enabled then
-        Format.eprintf
-          !"Generating unchecked top hash from:@.%{sexp: Tick.Field.t \
-            Random_oracle.Input.Chunked.t}@."
-          input ;
-      input
-
-    let to_field_elements t = Random_oracle.pack_input (to_input t)
-
-    module Checked = struct
-      type t = var
-
-      module Checked_without_sok = Checked
-
-      let to_input ({ sok_digest; _ } as t : t) =
-        let open Tick in
-        let open Checked.Let_syntax in
-        let%bind input_without_sok =
-          Checked_without_sok.to_input { t with sok_digest = () }
-        in
-        let input =
-          Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
-            [| Sok_message.Digest.Checked.to_input sok_digest
-             ; input_without_sok
-            |]
-        in
-        let%map () =
-          as_prover
-            As_prover.(
-              if !top_hash_logging_enabled then
-                let%map input = Random_oracle.read_typ' input in
-                Format.eprintf
-                  !"Generating checked top hash from:@.%{sexp: Field.t \
-                    Random_oracle.Input.Chunked.t}@."
-                  input
-              else return ())
-        in
-        input
-
-      let to_field_elements t =
-        let open Tick.Checked.Let_syntax in
-        Tick.Run.run_checked (to_input t >>| Random_oracle.Checked.pack_input)
-    end
   end
 
   let option lab =

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -223,22 +223,7 @@ module type Full = sig
       , Local_state.Checked.t )
       Poly.t
 
-    open Tick
-
-    val typ : (var, t) Typ.t
-
-    val to_input : t -> Field.t Random_oracle.Input.Chunked.t
-
-    val to_field_elements : t -> Field.t array
-
-    module Checked : sig
-      type t = var
-
-      val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t Checked.t
-
-      (* This is actually a checked function. *)
-      val to_field_elements : var -> Field.Var.t array
-    end
+    val typ : (var, t) Tick.Typ.t
   end
 
   val gen : t Quickcheck.Generator.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1854,7 +1854,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   [ correct_coinbase_target_stack; valid_init_state ] ) )
 
       let main ?(witness : Witness.t option) (spec : Spec.t)
-          ~constraint_constants (statement : Statement.With_sok.Checked.t) =
+          ~constraint_constants (statement : Statement.With_sok.var) =
         let open Impl in
         run_checked (dummy_constraints ()) ;
         let ( ! ) x = Option.value_exn x in
@@ -3053,7 +3053,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           pc: Pending_coinbase_stack_state.t
     *)
     let%snarkydef_ main ~constraint_constants
-        (statement : Statement.With_sok.Checked.t) =
+        (statement : Statement.With_sok.var) =
       let%bind () = dummy_constraints () in
       let%bind (module Shifted) = Tick.Inner_curve.Checked.Shifted.create () in
       let%bind t =
@@ -3199,7 +3199,7 @@ module Make_str (A : Wire_types.Concrete) = struct
        verify_transition tock_vk _ s1 s2 pending_coinbase_stack12.source, pending_coinbase_stack12.target is true
        verify_transition tock_vk _ s2 s3 pending_coinbase_stack23.source, pending_coinbase_stack23.target is true
     *)
-    let%snarkydef_ main (s : Statement.With_sok.Checked.t) =
+    let%snarkydef_ main (s : Statement.With_sok.var) =
       let%bind s1, s2 =
         exists
           Typ.(Statement.With_sok.typ * Statement.With_sok.typ)
@@ -3302,7 +3302,7 @@ module Make_str (A : Wire_types.Concrete) = struct
   open Pickles_types
 
   type tag =
-    ( Statement.With_sok.Checked.t
+    ( Statement.With_sok.var
     , Statement.With_sok.t
     , Nat.N2.n
     , Nat.N5.n )
@@ -3508,23 +3508,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             transaction = Transaction_union.of_transaction t
           }
           init_stack pending_coinbase_stack_state handler
-
-  let verify (ts : (t * _) list) ~key =
-    if
-      List.for_all ts ~f:(fun ({ statement; _ }, message) ->
-          Sok_message.Digest.equal
-            (Sok_message.digest message)
-            statement.sok_digest )
-    then
-      Pickles.verify
-        (module Nat.N2)
-        (module Statement.With_sok)
-        key
-        (List.map ts ~f:(fun ({ statement; proof }, _) -> (statement, proof)))
-    else
-      Async.return
-        (Or_error.error_string
-           "Transaction_snark.verify: Mismatched sok_message" )
 
   let constraint_system_digests ~constraint_constants () =
     let digest = Tick.R1CS_constraint_system.digest in

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -34,16 +34,11 @@ module type Full = sig
   open Pickles_types
 
   type tag =
-    ( Statement.With_sok.Checked.t
+    ( Statement.With_sok.var
     , Statement.With_sok.t
     , Nat.N2.n
     , Nat.N5.n )
     Pickles.Tag.t
-
-  val verify :
-       (t * Sok_message.t) list
-    -> key:Pickles.Verification_key.t
-    -> unit Or_error.t Async.Deferred.t
 
   module Verification : sig
     module type S = sig


### PR DESCRIPTION
Removes some code which was unused:

* Function `Transaction_state.verify`
* Function `Blockchain_state.verify`
* Function `to_input` and module `Checked` from  `Snarked_ledger_state.Statement.With_sok`

Code was written but never used. More importantly, implementation of `Snarked_ledger_state.Statement.With_sok.to_input` (and transitively `Transaction_state.verify`) didn't agree with `verify` function exposed by `Proof` module (which used `to_field_elements` derived from `typ` instead of `to_input`).

PR removes a function that was unused before #16201, where it was used and the new code become unexpectedly incorrect.

Explain how you tested your changes:
* [x] Code compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None