### PR TITLE
Reduce repetitions in TestBitswapSmall

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
@@ -549,7 +549,7 @@ func TestBitswapSmoke(t *testing.T) {
 }
 
 func TestBitswapSmall(t *testing.T) {
-	testBitswap(t, 20, 100, 5, 1<<16, false)
+	testBitswap(t, 20, 10, 5, 1<<16, false)
 }
 
 func TestBitswapQC(t *testing.T) {


### PR DESCRIPTION
Existing test is really long to execute. On some machines it exceeds the limit of 60 minutes.

With the reduced number of repetitions, testing is still performed, but it's ensured that libp2p unit tests take less than 30m even on slower machines.

In future we may look deeper in the test and instead of making lesser amount of repetitions either optimize the software or restructure the test.

Tests concerns only bitswap, i.e. functionality that is not activated in mainnet's Mina build.

Explain how you tested your changes:
* [x] Test passes

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None