### PR TITLE
Reformat src/app/dump_blocks

### DIFF
--- a/src/app/dump_blocks/.ocamlformat
+++ b/src/app/dump_blocks/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/dump_blocks/dump_blocks.ml
+++ b/src/app/dump_blocks/dump_blocks.ml
@@ -8,10 +8,7 @@ open Full_frontier.For_tests
    Choice of the actual codec module depends on more than one CLI
    argument, which is why it must be delayed until all the CLI
    arguments are parsed. This choice is made by mk_io function below. *)
-type 'a io =
-  { encoding : 'a
-  ; filename : string
-  }
+type 'a io = { encoding : 'a; filename : string }
 
 type 'a codec = (module Encoding.S with type t = 'a)
 
@@ -41,15 +38,20 @@ let encoded_block =
   Command.Arg_type.create (fun s ->
       match String.split ~on:':' s with
       | [ encoding; filename ] ->
-          { encoding=
+          { encoding =
               ( match String.lowercase encoding with
-              | "sexp" -> Encoding.Sexp
-              | "json" -> Json
-              | "bin" | "binary" -> Binary
-              | _ -> failwith "invalid encoding" )
+              | "sexp" ->
+                  Encoding.Sexp
+              | "json" ->
+                  Json
+              | "bin" | "binary" ->
+                  Binary
+              | _ ->
+                  failwith "invalid encoding" )
           ; filename
           }
-      | _ -> failwith "invalid format" )
+      | _ ->
+          failwith "invalid format" )
 
 let () =
   let open Core_kernel in
@@ -62,18 +64,14 @@ let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
 let constraint_constants = precomputed_values.constraint_constants
 
-let output_block : type a. a -> a codec io -> unit
-  = fun content { encoding; filename } ->
+let output_block : type a. a -> a codec io -> unit =
+ fun content { encoding; filename } ->
   let module Enc : Encoding.S with type t = a = (val encoding) in
   let channel =
-    match filename with
-    | "-" -> Out_channel.stdout
-    | s -> Out_channel.create s
+    match filename with "-" -> Out_channel.stdout | s -> Out_channel.create s
   in
-  fprintf channel "%s" (Enc.to_string content);
-  match filename with
-    | "-" -> ()
-    | _ -> Out_channel.close channel
+  fprintf channel "%s" (Enc.to_string content) ;
+  match filename with "-" -> () | _ -> Out_channel.close channel
 
 (* This executable outputs random block to stderr in sexp and json
    The output is useful for src/lib/mina_block tests when the sexp/json representation changes. *)
@@ -91,75 +89,67 @@ let f (type a) ?parent (outputs : a codec io list) make_breadcrumb =
       List.iter outputs ~f:(fun output ->
           let module Enc = (val output.encoding) in
           let content =
-            Enc.of_breadcrumb
-              ?with_parent_statehash:parent
-              breadcrumb
+            Enc.of_breadcrumb ?with_parent_statehash:parent breadcrumb
           in
-          eprintf !"Randomly generated block, %s: %s\n"
+          eprintf
+            !"Randomly generated block, %s: %s\n"
             Enc.name
             (match output.filename with "-" -> "" | s -> s) ;
-          output_block content output;);
+          output_block content output ) ;
       clean_up_persistent_root ~frontier )
 
 let default_outputs =
-  [ { encoding= Encoding.Sexp; filename= "-" }
-  ; { encoding= Encoding.Json; filename= "-" }
+  [ { encoding = Encoding.Sexp; filename = "-" }
+  ; { encoding = Encoding.Json; filename = "-" }
   ]
 
 let command =
   Command.basic
     ~summary:"Transcribe between block formats or generate a random block"
     (let%map_open.Command outputs =
-       flag
-         "-o"
-         (listed encoded_block)
-         ~doc:"output <format>:<path>; formats are: sexp / json / bin; a dash (-) denotes stdout (example: -o json:-)"
+       flag "-o" (listed encoded_block)
+         ~doc:
+           "output <format>:<path>; formats are: sexp / json / bin; a dash (-) \
+            denotes stdout (example: -o json:-)"
      and input =
-       flag
-         "-i"
-         (optional encoded_block)
-         ~doc:"input <format>:<path>; formats are: sexp / json / bin; a dash (-) denotes stdin (example: -i json:-)"
+       flag "-i" (optional encoded_block)
+         ~doc:
+           "input <format>:<path>; formats are: sexp / json / bin; a dash (-) \
+            denotes stdin (example: -i json:-)"
      and full =
-       flag
-         "--full"
-         no_arg
-         ~doc:"use full blocks, not just precomputed values"
+       flag "--full" no_arg ~doc:"use full blocks, not just precomputed values"
      and parent =
-       flag
-         "--parent"
-         (optional string)
-         ~aliases:[ "--parent-statehash" ]
+       flag "--parent" (optional string) ~aliases:[ "--parent-statehash" ]
          ~doc:"statehash of the parent block"
      in
-     let outs = match outputs with
-       | [] -> default_outputs
-       | _ -> outputs
-     in
+     let outs = match outputs with [] -> default_outputs | _ -> outputs in
      let conf =
        if full then
-         Conf ( Option.map input ~f:(mk_io Block)
-              , List.map ~f:(mk_io Encoding.Block) outs)
+         Conf
+           ( Option.map input ~f:(mk_io Block)
+           , List.map ~f:(mk_io Encoding.Block) outs )
        else
-         Conf ( Option.map input ~f:(mk_io Precomputed)
-              , List.map ~f:(mk_io Encoding.Precomputed) outs)
+         Conf
+           ( Option.map input ~f:(mk_io Precomputed)
+           , List.map ~f:(mk_io Encoding.Precomputed) outs )
      in
      fun () ->
-     match conf with
-     | Conf (None, outs) ->
-        let verifier = verifier () in
-        Core_kernel.Quickcheck.test (gen_breadcrumb ~verifier ()) ~trials:1 ~f:(f ?parent outs)
-     | Conf (Some { encoding; filename }, outs)->
-        let module Enc = (val encoding) in
-        let input =
-          match filename with
-          | "-" -> In_channel.stdin
-          | s -> In_channel.create s
-        in
-        let contents =
-          In_channel.input_all input
-          |> Enc.of_string
-        in
-        List.iter outs ~f:(output_block contents))
+       match conf with
+       | Conf (None, outs) ->
+           let verifier = verifier () in
+           Core_kernel.Quickcheck.test
+             (gen_breadcrumb ~verifier ())
+             ~trials:1 ~f:(f ?parent outs)
+       | Conf (Some { encoding; filename }, outs) ->
+           let module Enc = (val encoding) in
+           let input =
+             match filename with
+             | "-" ->
+                 In_channel.stdin
+             | s ->
+                 In_channel.create s
+           in
+           let contents = In_channel.input_all input |> Enc.of_string in
+           List.iter outs ~f:(output_block contents) )
 
 let () = Command_unix.run command
-

--- a/src/app/dump_blocks/encoding.ml
+++ b/src/app/dump_blocks/encoding.ml
@@ -12,51 +12,48 @@ let block_of_breadcrumb ?with_parent_statehash breadcrumb =
   let open Mina_block in
   let block = Frontier_base.Breadcrumb.block breadcrumb in
   match with_parent_statehash with
-    | None ->
-       block
-    | Some hash ->
-       let previous_state_hash = Mina_base.State_hash.of_base58_check_exn hash in
-       let h = header block in
-       let state = Header.protocol_state h in
-       let header =
-         Header.create
-           ~protocol_state:{ state with previous_state_hash }
-           ~protocol_state_proof:(Header.protocol_state_proof h)
-           ~delta_block_chain_proof:(Header.delta_block_chain_proof h)
-           ?proposed_protocol_version_opt:(Header.proposed_protocol_version_opt h)
-           ~current_protocol_version:(Header.current_protocol_version h)
-           ()
-       in
-       Mina_block.create ~header ~body:(body block)
+  | None ->
+      block
+  | Some hash ->
+      let previous_state_hash = Mina_base.State_hash.of_base58_check_exn hash in
+      let h = header block in
+      let state = Header.protocol_state h in
+      let header =
+        Header.create
+          ~protocol_state:{ state with previous_state_hash }
+          ~protocol_state_proof:(Header.protocol_state_proof h)
+          ~delta_block_chain_proof:(Header.delta_block_chain_proof h)
+          ?proposed_protocol_version_opt:
+            (Header.proposed_protocol_version_opt h)
+          ~current_protocol_version:(Header.current_protocol_version h)
+          ()
+      in
+      Mina_block.create ~header ~body:(body block)
 
 module type S = sig
   type t
 
   val name : string
-  val of_breadcrumb : ?with_parent_statehash:string -> Frontier_base.Breadcrumb.t -> t
+
+  val of_breadcrumb :
+    ?with_parent_statehash:string -> Frontier_base.Breadcrumb.t -> t
 
   val to_string : t -> string
+
   val of_string : string -> t
 end
 
-module Sexp_block : S  with type t = Mina_block.t = struct
+module Sexp_block : S with type t = Mina_block.t = struct
   type t = Mina_block.t
 
   let name = "sexp"
 
   let of_breadcrumb = block_of_breadcrumb
 
+  let to_string b = Mina_block.sexp_of_t b |> Sexp.to_string |> append_newline
 
-  let to_string b =
-    Mina_block.sexp_of_t b
-    |> Sexp.to_string
-    |> append_newline
-
-  let of_string s =
-    Sexp.of_string s
-    |> Mina_block.t_of_sexp
+  let of_string s = Sexp.of_string s |> Mina_block.t_of_sexp
 end
-
 
 module Binary_block : S with type t = Mina_block.t = struct
   type t = Mina_block.t
@@ -84,16 +81,14 @@ let constraint_constants = precomputed_values.constraint_constants
 let precomputed_of_breadcrumb ?with_parent_statehash breadcrumb =
   let open Frontier_base in
   let block = block_of_breadcrumb ?with_parent_statehash breadcrumb in
-  let staged_ledger =
-    Transition_frontier.Breadcrumb.staged_ledger breadcrumb
-  in
+  let staged_ledger = Transition_frontier.Breadcrumb.staged_ledger breadcrumb in
   let scheduled_time =
     Mina_block.(Header.protocol_state @@ header block)
     |> Mina_state.Protocol_state.blockchain_state
     |> Mina_state.Blockchain_state.timestamp
   in
-  Mina_block.Precomputed.of_block ~logger ~constraint_constants
-    ~staged_ledger ~scheduled_time
+  Mina_block.Precomputed.of_block ~logger ~constraint_constants ~staged_ledger
+    ~scheduled_time
     (Breadcrumb.block_with_hash breadcrumb)
 
 module Sexp_precomputed : S with type t = Mina_block.Precomputed.t = struct
@@ -104,16 +99,12 @@ module Sexp_precomputed : S with type t = Mina_block.Precomputed.t = struct
   let of_breadcrumb = precomputed_of_breadcrumb
 
   let to_string b =
-    Mina_block.Precomputed.sexp_of_t b
-    |> Sexp.to_string
-    |> append_newline
+    Mina_block.Precomputed.sexp_of_t b |> Sexp.to_string |> append_newline
 
-  let of_string s =
-    Sexp.of_string s
-    |> Mina_block.Precomputed.t_of_sexp
+  let of_string s = Sexp.of_string s |> Mina_block.Precomputed.t_of_sexp
 end
 
-module Json_precomputed : S  with type t = Mina_block.Precomputed.t = struct
+module Json_precomputed : S with type t = Mina_block.Precomputed.t = struct
   type t = Mina_block.Precomputed.t
 
   let name = "json"
@@ -122,12 +113,10 @@ module Json_precomputed : S  with type t = Mina_block.Precomputed.t = struct
 
   let to_string b =
     Mina_block.Precomputed.to_yojson b
-    |> Yojson.Safe.to_string
-    |> append_newline
+    |> Yojson.Safe.to_string |> append_newline
 
   let of_string s =
-    Yojson.Safe.from_string s
-    |> Mina_block.Precomputed.of_yojson
+    Yojson.Safe.from_string s |> Mina_block.Precomputed.of_yojson
     |> Result.ok_or_failwith
 end
 
@@ -138,9 +127,7 @@ module Binary_precomputed : S with type t = Mina_block.Precomputed.t = struct
 
   let of_breadcrumb = precomputed_of_breadcrumb
 
-  let to_string =
-    Binable.to_string (module Mina_block.Precomputed.Stable.Latest)
+  let to_string = Binable.to_string (module Mina_block.Precomputed.Stable.Latest)
 
-  let of_string =
-    Binable.of_string (module Mina_block.Precomputed.Stable.Latest)
+  let of_string = Binable.of_string (module Mina_block.Precomputed.Stable.Latest)
 end


### PR DESCRIPTION
A trivial PR that adds a missing `.ocamlformat` file and runs the formatter.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None