### PR TITLE
Do not over-expose Transaction_applied

### DIFF
--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -179,7 +179,9 @@ let apply_zkapp_second_pass_unchecked_with_states ~init ledger c =
   |> Result.map ~f:(fun (account_update_applied, rev_states) ->
          let module LS = Mina_transaction_logic.Zkapp_command_logic.Local_state
          in
-         let module Applied = T.Transaction_applied.Zkapp_command_applied in
+         let module Applied =
+           Mina_transaction_logic.Transaction_applied.Zkapp_command_applied
+         in
          let states =
            match rev_states with
            | [] ->

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -563,7 +563,7 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                  (target_ledger, applied) ->
            let txn =
              With_status.data
-             @@ Mina_ledger.Ledger.Transaction_applied.transaction applied
+             @@ Mina_ledger.Ledger.transaction_of_applied applied
            in
            (* the txn was already valid before apply, we are just recasting it here after application *)
            let (`If_this_is_used_it_should_have_a_comment_justifying_it
@@ -782,7 +782,7 @@ let check_base_snarks ~genesis_constants ~constraint_constants sparse_ledger0
            ~f:(fun source_ledger (target_ledger, applied_txn) ->
              let txn =
                With_status.data
-               @@ Mina_ledger.Ledger.Transaction_applied.transaction applied_txn
+               @@ Mina_ledger.Ledger.transaction_of_applied applied_txn
              in
              (* the txn was already valid before apply, we are just recasting it here after application *)
              let (`If_this_is_used_it_should_have_a_comment_justifying_it
@@ -793,7 +793,7 @@ let check_base_snarks ~genesis_constants ~constraint_constants sparse_ledger0
                pending_coinbase_stack_target txn Pending_coinbase.Stack.empty
              in
              let supply_increase =
-               Mina_ledger.Ledger.Transaction_applied.supply_increase
+               Mina_transaction_logic.Transaction_applied.supply_increase
                  ~constraint_constants applied_txn
                |> Or_error.ok_exn
              in
@@ -844,7 +844,7 @@ let generate_base_snarks_witness ~genesis_constants ~constraint_constants
            ~f:(fun source_ledger (target_ledger, applied_txn) ->
              let txn =
                With_status.data
-               @@ Mina_ledger.Ledger.Transaction_applied.transaction applied_txn
+               @@ Mina_ledger.Ledger.transaction_of_applied applied_txn
              in
              (* the txn was already valid before apply, we are just recasting it here after application *)
              let (`If_this_is_used_it_should_have_a_comment_justifying_it
@@ -855,7 +855,7 @@ let generate_base_snarks_witness ~genesis_constants ~constraint_constants
                pending_coinbase_stack_target txn Pending_coinbase.Stack.empty
              in
              let supply_increase =
-               Mina_ledger.Ledger.Transaction_applied.supply_increase
+               Mina_transaction_logic.Transaction_applied.supply_increase
                  ~constraint_constants applied_txn
                |> Or_error.ok_exn
              in

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -361,7 +361,7 @@ let compute_statuses
   let split_transaction_statuses txns_with_statuses =
     List.partition_map txns_with_statuses ~f:(fun txn_applied ->
         let { With_status.data = txn; status } =
-          Mina_ledger.Ledger.Transaction_applied.transaction txn_applied
+          Mina_ledger.Ledger.transaction_of_applied txn_applied
         in
         match txn with
         | Transaction.Command cmd ->

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -93,7 +93,7 @@ module Scan_state : sig
     -> apply_second_pass:
          (   Ledger.t
           -> Ledger.Transaction_partially_applied.t
-          -> Ledger.Transaction_applied.t Or_error.t )
+          -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
     -> apply_first_pass_sparse_ledger:
          (   global_slot:Mina_numbers.Global_slot_since_genesis.t
           -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
@@ -121,7 +121,7 @@ module Scan_state : sig
     -> apply_second_pass:
          (   Ledger.t
           -> Ledger.Transaction_partially_applied.t
-          -> Ledger.Transaction_applied.t Or_error.t )
+          -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
     -> apply_first_pass_sparse_ledger:
          (   global_slot:Mina_numbers.Global_slot_since_genesis.t
           -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -256,87 +256,10 @@ module type S = sig
 
   type location
 
-  module Transaction_applied : sig
-    module Signed_command_applied : sig
-      module Common : sig
-        type t = Transaction_applied.Signed_command_applied.Common.t =
-          { user_command : Signed_command.t With_status.t }
-        [@@deriving sexp]
-      end
+  val transaction_of_applied :
+    Transaction_applied.t -> Transaction.t With_status.t
 
-      module Body : sig
-        type t = Transaction_applied.Signed_command_applied.Body.t =
-          | Payment of { new_accounts : Account_id.t list }
-          | Stake_delegation of
-              { previous_delegate : Public_key.Compressed.t option }
-          | Failed
-        [@@deriving sexp]
-      end
-
-      type t = Transaction_applied.Signed_command_applied.t =
-        { common : Common.t; body : Body.t }
-      [@@deriving sexp]
-    end
-
-    module Zkapp_command_applied : sig
-      type t = Transaction_applied.Zkapp_command_applied.t =
-        { accounts : (Account_id.t * Account.t option) list
-        ; command : Zkapp_command.t With_status.t
-        ; new_accounts : Account_id.t list
-        }
-      [@@deriving sexp]
-    end
-
-    module Command_applied : sig
-      type t = Transaction_applied.Command_applied.t =
-        | Signed_command of Signed_command_applied.t
-        | Zkapp_command of Zkapp_command_applied.t
-      [@@deriving sexp]
-    end
-
-    module Fee_transfer_applied : sig
-      type t = Transaction_applied.Fee_transfer_applied.t =
-        { fee_transfer : Fee_transfer.t With_status.t
-        ; new_accounts : Account_id.t list
-        ; burned_tokens : Currency.Amount.t
-        }
-      [@@deriving sexp]
-    end
-
-    module Coinbase_applied : sig
-      type t = Transaction_applied.Coinbase_applied.t =
-        { coinbase : Coinbase.t With_status.t
-        ; new_accounts : Account_id.t list
-        ; burned_tokens : Currency.Amount.t
-        }
-      [@@deriving sexp]
-    end
-
-    module Varying : sig
-      type t = Transaction_applied.Varying.t =
-        | Command of Command_applied.t
-        | Fee_transfer of Fee_transfer_applied.t
-        | Coinbase of Coinbase_applied.t
-      [@@deriving sexp]
-    end
-
-    type t = Transaction_applied.t =
-      { previous_hash : Ledger_hash.t; varying : Varying.t }
-    [@@deriving sexp]
-
-    val burned_tokens : t -> Currency.Amount.t
-
-    val supply_increase :
-         constraint_constants:Genesis_constants.Constraint_constants.t
-      -> t
-      -> Currency.Amount.Signed.t Or_error.t
-
-    val transaction : t -> Transaction.t With_status.t
-
-    val transaction_status : t -> Transaction_status.t
-
-    val new_accounts : t -> Account_id.t list
-  end
+  val status_of_applied : Transaction_applied.t -> Transaction_status.t
 
   module Global_state : sig
     type t =
@@ -760,38 +683,33 @@ module Make (L : Ledger_intf.S) :
         transaction expiry slot %{sexp: Global_slot_since_genesis.t}"
       current_global_slot valid_until
 
-  module Transaction_applied = struct
-    include Transaction_applied
+  let transaction_of_applied :
+      Transaction_applied.t -> Transaction.t With_status.t =
+   fun { varying; _ } ->
+    match varying with
+    | Command (Signed_command uc) ->
+        With_status.map uc.common.user_command ~f:(fun cmd ->
+            Transaction.Command (User_command.Signed_command cmd) )
+    | Command (Zkapp_command s) ->
+        With_status.map s.command ~f:(fun c ->
+            Transaction.Command (User_command.Zkapp_command c) )
+    | Fee_transfer f ->
+        With_status.map f.fee_transfer ~f:(fun f -> Transaction.Fee_transfer f)
+    | Coinbase c ->
+        With_status.map c.coinbase ~f:(fun c -> Transaction.Coinbase c)
 
-    let transaction : t -> Transaction.t With_status.t =
-     fun { varying; _ } ->
-      match varying with
-      | Command (Signed_command uc) ->
-          With_status.map uc.common.user_command ~f:(fun cmd ->
-              Transaction.Command (User_command.Signed_command cmd) )
-      | Command (Zkapp_command s) ->
-          With_status.map s.command ~f:(fun c ->
-              Transaction.Command (User_command.Zkapp_command c) )
-      | Fee_transfer f ->
-          With_status.map f.fee_transfer ~f:(fun f ->
-              Transaction.Fee_transfer f )
-      | Coinbase c ->
-          With_status.map c.coinbase ~f:(fun c -> Transaction.Coinbase c)
-
-    let transaction_status : t -> Transaction_status.t =
-     fun { varying; _ } ->
-      match varying with
-      | Command
-          (Signed_command { common = { user_command = { status; _ }; _ }; _ })
-        ->
-          status
-      | Command (Zkapp_command c) ->
-          c.command.status
-      | Fee_transfer f ->
-          f.fee_transfer.status
-      | Coinbase c ->
-          c.coinbase.status
-  end
+  let status_of_applied : Transaction_applied.t -> Transaction_status.t =
+   fun { varying; _ } ->
+    match varying with
+    | Command
+        (Signed_command { common = { user_command = { status; _ }; _ }; _ }) ->
+        status
+    | Command (Zkapp_command c) ->
+        c.command.status
+    | Fee_transfer f ->
+        f.fee_transfer.status
+    | Coinbase c ->
+        c.coinbase.status
 
   let get_new_accounts action pk =
     if Ledger_intf.equal_account_state action `Added then [ pk ] else []

--- a/src/lib/transaction_logic/test/helpers.ml
+++ b/src/lib/transaction_logic/test/helpers.ml
@@ -3,8 +3,10 @@ module Transaction_logic = Mina_transaction_logic.Make (Ledger)
 
 module Zk_cmd_result = struct
   type t =
-    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t * Ledger.t
+    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t
+    * Ledger.t
 
   let sexp_of_t (txn, _) =
-    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.sexp_of_t txn
+    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.sexp_of_t
+      txn
 end

--- a/src/lib/transaction_logic/test/helpers.ml
+++ b/src/lib/transaction_logic/test/helpers.ml
@@ -3,8 +3,8 @@ module Transaction_logic = Mina_transaction_logic.Make (Ledger)
 
 module Zk_cmd_result = struct
   type t =
-    Transaction_logic.Transaction_applied.Zkapp_command_applied.t * Ledger.t
+    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t * Ledger.t
 
   let sexp_of_t (txn, _) =
-    Transaction_logic.Transaction_applied.Zkapp_command_applied.sexp_of_t txn
+    Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.sexp_of_t txn
 end

--- a/src/lib/transaction_logic/test/predicates.ml
+++ b/src/lib/transaction_logic/test/predicates.ml
@@ -13,7 +13,7 @@ let result ?(with_error = Fn.const false) ~f result =
 
 let verify_account_updates ~(ledger : Helpers.Ledger.t)
     ~(txn :
-       Helpers.Transaction_logic.Transaction_applied.Zkapp_command_applied.t )
+       Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t )
     ~(f : Amount.Signed.t -> Account.t option * Account.t option -> bool)
     (account : Test_account.t) =
   let open Helpers in
@@ -81,7 +81,7 @@ let verify_balance_changes ~txn ~ledger accounts =
 
 let verify_balances_unchanged ~(ledger : Helpers.Ledger.t)
     ~(txn :
-       Helpers.Transaction_logic.Transaction_applied.Zkapp_command_applied.t )
+       Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t )
     (accounts : Test_account.t list) =
   let is_fee_payer account =
     Public_key.Compressed.equal account.Test_account.pk

--- a/src/lib/transaction_logic/test/predicates.ml
+++ b/src/lib/transaction_logic/test/predicates.ml
@@ -12,8 +12,7 @@ let result ?(with_error = Fn.const false) ~f result =
   match Result.bind result ~f with Ok b -> b | Error e -> with_error e
 
 let verify_account_updates ~(ledger : Helpers.Ledger.t)
-    ~(txn :
-       Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t )
+    ~(txn : Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t)
     ~(f : Amount.Signed.t -> Account.t option * Account.t option -> bool)
     (account : Test_account.t) =
   let open Helpers in
@@ -80,8 +79,7 @@ let verify_balance_changes ~txn ~ledger accounts =
              false ) )
 
 let verify_balances_unchanged ~(ledger : Helpers.Ledger.t)
-    ~(txn :
-       Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t )
+    ~(txn : Mina_transaction_logic.Transaction_applied.Zkapp_command_applied.t)
     (accounts : Test_account.t list) =
   let is_fee_payer account =
     Public_key.Compressed.equal account.Test_account.pk

--- a/src/lib/transaction_logic/test/zkapp_logic.ml
+++ b/src/lib/transaction_logic/test/zkapp_logic.ml
@@ -27,7 +27,7 @@ let balance_to_fee = Fn.compose Amount.to_fee Balance.to_amount
    validate them. *)
 let%test_module "Test transaction logic." =
   ( module struct
-    open Transaction_logic.Transaction_applied.Zkapp_command_applied
+    open Mina_transaction_logic.Transaction_applied.Zkapp_command_applied
 
     let run_zkapp_cmd ~fee_payer ~fee ~accounts txns =
       let open Result.Let_syntax in

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -362,7 +362,7 @@ let%test_module "account timing check" =
             stack_with_state
       in
       let supply_increase =
-        Mina_ledger.Ledger.Transaction_applied.supply_increase
+        Mina_transaction_logic.Transaction_applied.supply_increase
           ~constraint_constants txn_applied
         |> Or_error.ok_exn
       in

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -143,7 +143,7 @@ let%test_module "Transaction union tests" =
             |> Or_error.ok_exn
           in
           let supply_increase =
-            Mina_ledger.Ledger.Transaction_applied.supply_increase
+            Mina_transaction_logic.Transaction_applied.supply_increase
               ~constraint_constants applied_transaction
             |> Or_error.ok_exn
           in
@@ -518,7 +518,7 @@ let%test_module "Transaction union tests" =
                 ( Ledger.apply_user_command ~constraint_constants ledger
                     ~txn_global_slot:current_global_slot t1
                   |> Or_error.ok_exn
-                  : Ledger.Transaction_applied.Signed_command_applied.t ) ;
+                  : Mina_transaction_logic.Transaction_applied.Signed_command_applied.t ) ;
               [%test_eq: Frozen_ledger_hash.t]
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -518,7 +518,9 @@ let%test_module "Transaction union tests" =
                 ( Ledger.apply_user_command ~constraint_constants ledger
                     ~txn_global_slot:current_global_slot t1
                   |> Or_error.ok_exn
-                  : Mina_transaction_logic.Transaction_applied.Signed_command_applied.t ) ;
+                  : Mina_transaction_logic.Transaction_applied
+                    .Signed_command_applied
+                    .t ) ;
               [%test_eq: Frozen_ledger_hash.t]
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -173,7 +173,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
               let open Async.Deferred.Let_syntax in
               let applied, statement_opt =
                 if ignore_outside_snark then
-                  ( Ledger.Transaction_applied.Varying.Command
+                  ( Mina_transaction_logic.Transaction_applied.Varying.Command
                       (Zkapp_command
                          { command =
                              { With_status.status = Applied
@@ -213,8 +213,8 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                     ; connecting_ledger_right = connecting_ledger
                     ; fee_excess = Zkapp_command.fee_excess zkapp_command
                     ; supply_increase =
-                        Ledger.Transaction_applied.supply_increase
-                          ~constraint_constants applied_txn
+                        Mina_transaction_logic.Transaction_applied
+                        .supply_increase ~constraint_constants applied_txn
                         |> Or_error.ok_exn
                     ; sok_digest = ()
                     }
@@ -620,7 +620,7 @@ let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
     with
     | Ok res ->
         ( if Option.is_some expected_failure then
-          match Ledger.Transaction_applied.transaction_status res with
+          match Ledger.status_of_applied res with
           | Applied ->
               failwith
                 (sprintf "Expected Ledger.apply_transaction to fail with %s"
@@ -665,7 +665,8 @@ let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
   let supply_increase =
     Option.value_map applied_transaction ~default:Amount.Signed.zero
       ~f:(fun txn ->
-        Ledger.Transaction_applied.supply_increase ~constraint_constants txn
+        Mina_transaction_logic.Transaction_applied.supply_increase
+          ~constraint_constants txn
         |> Or_error.ok_exn )
   in
   match

--- a/src/lib/transaction_snark/transaction_validator.ml
+++ b/src/lib/transaction_snark/transaction_validator.ml
@@ -16,7 +16,9 @@ let apply_user_command ~constraint_constants ~txn_global_slot l uc =
   within_mask l ~f:(fun l' ->
       Result.map
         ~f:(fun applied_txn ->
-          applied_txn.Ledger.Transaction_applied.Signed_command_applied.common
+          applied_txn
+            .Mina_transaction_logic.Transaction_applied.Signed_command_applied
+             .common
             .user_command
             .status )
         (Ledger.apply_user_command l' ~constraint_constants ~txn_global_slot uc) )

--- a/src/lib/transaction_snark/transaction_validator.mli
+++ b/src/lib/transaction_snark/transaction_validator.mli
@@ -15,7 +15,7 @@ val apply_transactions :
   -> txn_state_view:Zkapp_precondition.Protocol_state.View.t
   -> Mina_ledger.Ledger.t
   -> Transaction.t list
-  -> Mina_ledger.Ledger.Transaction_applied.t list Or_error.t
+  -> Mina_transaction_logic.Transaction_applied.t list Or_error.t
 
 val apply_transaction_first_pass :
      constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -16,7 +16,7 @@ end]
 module Transaction_with_witness : sig
   (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
   type t =
-    { transaction_with_info : Ledger.Transaction_applied.t
+    { transaction_with_info : Mina_transaction_logic.Transaction_applied.t
     ; state_hash : State_hash.t * State_body_hash.t
     ; statement : Transaction_snark.Statement.t
     ; init_stack : Transaction_snark.Pending_coinbase_stack_state.Init_stack.t
@@ -137,7 +137,7 @@ val get_snarked_ledger_sync :
   -> apply_second_pass:
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
-        -> Ledger.Transaction_applied.t Or_error.t )
+        -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
   -> apply_first_pass_sparse_ledger:
        (   global_slot:Mina_numbers.Global_slot_since_genesis.t
         -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
@@ -162,7 +162,7 @@ val get_snarked_ledger_async :
   -> apply_second_pass:
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
-        -> Ledger.Transaction_applied.t Or_error.t )
+        -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
   -> apply_first_pass_sparse_ledger:
        (   global_slot:Mina_numbers.Global_slot_since_genesis.t
         -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
@@ -194,7 +194,7 @@ val get_staged_ledger_async :
   -> apply_second_pass:
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
-        -> Ledger.Transaction_applied.t Or_error.t )
+        -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
   -> apply_first_pass_sparse_ledger:
        (   global_slot:Mina_numbers.Global_slot_since_genesis.t
         -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t


### PR DESCRIPTION
Transaction_applied is exposed in both the top-level module and a `Make` functor. It's cleaner to just expose it once.

Explain how you tested your changes:
* [x] Code compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None