### PR TITLE
Fix generator for transaction_pool tests

### DIFF
--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1443,32 +1443,33 @@ let inner_query =
        Fields_derivers_zkapps.(inner_query (deriver @@ Derivers.o ())) )
 
 module For_tests = struct
-  let replace_vks t vk =
+  let replace_vk vk (p : Account_update.t) =
+    { p with
+      body =
+        { p.body with
+          update =
+            { p.body.update with
+              verification_key =
+                (* replace dummy vks in vk Setting *)
+                ( match p.body.update.verification_key with
+                | Set _vk ->
+                    Set vk
+                | Keep ->
+                    Keep )
+            }
+        ; authorization_kind =
+            (* replace dummy vk hashes in authorization kind *)
+            ( match p.body.authorization_kind with
+            | Proof _vk_hash ->
+                Proof (With_hash.hash vk)
+            | ak ->
+                ak )
+        }
+    }
+
+  let replace_vks (t : t) vk =
     { t with
-      account_updates =
-        Call_forest.map t.account_updates ~f:(fun (p : Account_update.t) ->
-            { p with
-              body =
-                { p.body with
-                  update =
-                    { p.body.update with
-                      verification_key =
-                        (* replace dummy vks in vk Setting *)
-                        ( match p.body.update.verification_key with
-                        | Set _vk ->
-                            Set vk
-                        | Keep ->
-                            Keep )
-                    }
-                ; authorization_kind =
-                    (* replace dummy vk hashes in authorization kind *)
-                    ( match p.body.authorization_kind with
-                    | Proof _vk_hash ->
-                        Proof (With_hash.hash vk)
-                    | ak ->
-                        ak )
-                }
-            } )
+      account_updates = Call_forest.map t.account_updates ~f:(replace_vk vk)
     }
 end
 

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1127,7 +1127,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     ?(no_token_accounts = false) ?(limited = false)
     ?(generate_new_accounts = true) ?failure
     ?(max_account_updates = max_account_updates)
-    ?(max_token_updates = max_token_updates)
+    ?(max_token_updates = max_token_updates) ?(map_account_update = ident)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t )
@@ -1535,8 +1535,9 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   let zkapp_command_dummy_authorizations : Zkapp_command.t =
     { fee_payer
     ; account_updates =
-        account_updates
-        |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
+        Zkapp_command.Call_forest.map
+          ~f:(Fn.compose map_account_update Account_update.of_simple)
+          account_updates
         |> Zkapp_command.Call_forest.accumulate_hashes_predicated
     ; memo
     }

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -66,6 +66,7 @@ val gen_zkapp_command_from :
   -> ?failure:failure
   -> ?max_account_updates:int
   -> ?max_token_updates:int
+  -> ?map_account_update:(Account_update.t -> Account_update.t)
   -> fee_payer_keypair:Signature_lib.Keypair.t
   -> keymap:
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2113,33 +2113,26 @@ let%test_module _ =
               Mina_generators.Zkapp_command_generators.gen_zkapp_command_from
                 ~max_token_updates:1 ~keymap ~account_state_tbl
                 ~fee_payer_keypair ~ledger:best_tip_ledger ~constraint_constants
-                ~genesis_constants ()
-            in
-            let zkapp_command =
-              { zkapp_command with
-                account_updates =
-                  Zkapp_command.Call_forest.map zkapp_command.account_updates
-                    ~f:(fun (p : Account_update.t) ->
-                      { p with
-                        body =
-                          { p.body with
-                            preconditions =
-                              { p.body.preconditions with
-                                account =
-                                  ( match p.body.preconditions.account.nonce with
-                                  | Zkapp_basic.Or_ignore.Check n as c
-                                    when Zkapp_precondition.Numeric.(
-                                           is_constant Tc.nonce c) ->
-                                      Zkapp_precondition.Account.nonce n.lower
-                                  | _ ->
-                                      Zkapp_precondition.Account.accept )
-                              }
-                          }
-                      } )
-              }
-            in
-            let zkapp_command_valid_vk_hashes =
-              Zkapp_command.For_tests.replace_vks zkapp_command vk
+                ~genesis_constants
+                ~map_account_update:(fun (p : Account_update.t) ->
+                  Zkapp_command.For_tests.replace_vk vk
+                    { p with
+                      body =
+                        { p.body with
+                          preconditions =
+                            { p.body.preconditions with
+                              account =
+                                ( match p.body.preconditions.account.nonce with
+                                | Zkapp_basic.Or_ignore.Check n as c
+                                  when Zkapp_precondition.Numeric.(
+                                         is_constant Tc.nonce c) ->
+                                    Zkapp_precondition.Account.nonce n.lower
+                                | _ ->
+                                    Zkapp_precondition.Account.accept )
+                            }
+                        }
+                    } )
+                ()
             in
             let valid_zkapp_command =
               Or_error.ok_exn
@@ -2150,7 +2143,7 @@ let%test_module _ =
                         ~location_of_account:
                           (Mina_ledger.Ledger.location_of_account
                              best_tip_ledger ) )
-                   zkapp_command_valid_vk_hashes )
+                   zkapp_command )
             in
             User_command.Zkapp_command valid_zkapp_command
           in


### PR DESCRIPTION
**Problem**: previous generator was modifying zkapp commands after computing call forest hashes, which essentially rendered transactions incorrect, though didn't fail the test immediately.

**Solution**: rearrange modifications so that call forest hashes are computed after modifications to account updates take place.

While the issue didn't cause any test to fail, after some unrelated change some tests of transaction_pool started failing. Another branch will also contain a "regression" unit tests that fails before the fix and succeeds after. That regression tests will essentially recompute call forest hashes and compare them to original hashes.


Explain how you tested your changes:
* [x] A regression unit tests specifically targeting the discovered issue is added in another PR #16279 it passes

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None