### PR TITLE
Use network_id from runtime config in Graphql

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2672,7 +2672,13 @@ module Queries = struct
       ~args:Arg.[]
       ~resolve:(fun { ctx = mina; _ } () ->
         let cfg = Mina_lib.config mina in
-        "mina:" ^ cfg.compile_config.network_id )
+        let runtime_cfg = Mina_lib.runtime_config mina in
+        let network_id =
+          Option.value ~default:cfg.compile_config.network_id
+          @@ let%bind.Option daemon = runtime_cfg.daemon in
+             daemon.network_id
+        in
+        "mina:" ^ network_id )
 
   let signature_kind =
     field "signatureKind"


### PR DESCRIPTION
Problem: value from compile time config was always used, although such a field existed in runtime config as well and was expected to be used.

Solution: use value from runtime config when present.

Explain how you tested your changes:
* [ ] launch a Mina node, check `networkID` graphql's output

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?
  - Release 3.0.2 has `networkID` returning `mina:testnet` on a mainnet build