### PR TITLE
Use Mainnet profile in mainnet builds

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseye.dhall
@@ -21,7 +21,7 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
             ]
-          , networks = [ Network.Type.Devnet, Network.Type.Mainnet ]
+          , networks = [ Network.Type.Mainnet ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -29,5 +29,6 @@ in  Pipeline.build
             ]
           , mode = PipelineMode.Type.Stable
           , prefix = "MinaArtifactMainnet"
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetFocal.dhall
@@ -24,7 +24,7 @@ in  Pipeline.build
             , Artifacts.Type.ZkappTestTransaction
             ]
           , debVersion = DebianVersions.DebVersion.Focal
-          , networks = [ Network.Type.Devnet, Network.Type.Mainnet ]
+          , networks = [ Network.Type.Mainnet ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -32,5 +32,6 @@ in  Pipeline.build
             ]
           , mode = PipelineMode.Type.Stable
           , prefix = "MinaArtifactMainnet"
+          , profile = Profiles.Type.Mainnet
           }
       )


### PR DESCRIPTION
Specify `mainnet` profile in mainnet CI jobs to use `DUNE_PROFILE=mainnet` when building the executables.


Explain how you tested your changes:
* [ ] CI logs reveal that the mainnet builds used `mainnet` dune profile

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?
  - mainnet dockers use executable built with `devnet` profile
