### PR TITLE
new dhall jobs for detecting duplicated steps and invalid jobs names

### DIFF
--- a/buildkite/Makefile
+++ b/buildkite/Makefile
@@ -16,14 +16,20 @@ lint:
 format:
 	find ./src/ -name "*.dhall" -print0 | xargs -I{} -0 -n1 bash -c 'echo "{}" && dhall --ascii format --inplace {} || exit 255'
 
-check_deps:
-	 $(eval TMP := $(shell mktemp -d))
-	scripts/dhall/dump_dhall_to_pipelines.sh src/Jobs "$(TMP)"
-	python3 scripts/dhall/checker.py --root "$(TMP)" deps
-
-check_dirty:
+dump_pipelines:
 	$(eval TMP := $(shell mktemp -d))
 	scripts/dhall/dump_dhall_to_pipelines.sh src/Jobs "$(TMP)"
+
+check_deps: dump_pipelines
+	python3 scripts/dhall/checker.py --root "$(TMP)" deps
+
+check_dirty: dump_pipelines
 	python3 scripts/dhall/checker.py --root "$(TMP)" dirty-when  --repo "$(PWD)/../"
 
-all: check_syntax lint format check_deps check_dirty
+check_dups: dump_pipelines
+	python3 scripts/dhall/checker.py --root "$(TMP)" dups
+
+check_names: dump_pipelines
+	python3 scripts/dhall/checker.py --root "$(TMP)" names
+
+all: check_syntax lint format check_deps check_dirty check_dups check_names

--- a/buildkite/src/Jobs/Lint/Dhall.dhall
+++ b/buildkite/src/Jobs/Lint/Dhall.dhall
@@ -91,5 +91,29 @@ in  Pipeline.build
             , target = Size.Multi
             , docker = None Docker.Type
             }
+        , Command.build
+            Command.Config::{
+            , commands =
+                  [ dump_pipelines_cmd ]
+                # RunInToolchain.runInToolchainBullseye
+                    ([] : List Text)
+                    "python3 ./buildkite/scripts/dhall/checker.py --root _pipelines dups"
+            , label = "Dhall: duplicates"
+            , key = "check-dhall-dups"
+            , target = Size.Multi
+            , docker = None Docker.Type
+            }
+        , Command.build
+            Command.Config::{
+            , commands =
+                  [ dump_pipelines_cmd ]
+                # RunInToolchain.runInToolchainBullseye
+                    ([] : List Text)
+                    "python3 ./buildkite/scripts/dhall/checker.py --root _pipelines names"
+            , label = "Dhall: job names"
+            , key = "check-dhall-jobs"
+            , target = Size.Multi
+            , docker = None Docker.Type
+            }
         ]
       }


### PR DESCRIPTION
Added two more dhall checks to buildkite/Makefile, which I found handy when making changes to dhall framework:

- make check_dups

Looks for duplicate names of any steps defined

- make check_names

Validates that all defined jobs respect naming constraints

Running above checks before pushing to CI helped me to find out issues without spamming (!ci-build-me) command too much