### PR TITLE
[TESTING; DO NOT MERGE] Use dune cache for unit tests

### DIFF
--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -25,7 +25,12 @@ let buildTestCmd
                 Command.Config::{
                 , commands =
                     RunInToolchain.runInToolchain
-                      [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
+                      [ "DUNE_INSTRUMENT_WITH=bisect_ppx"
+                      , "COVERALLS_TOKEN"
+                      , "DUNE_CACHE"
+                      , "DUNE_CACHE_STORAGE_MODE"
+                      , "XDG_CACHE_HOME"
+                      ]
                       "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev"
                 , label = "${profile} unit-tests"
                 , key = command_key

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -61,5 +61,5 @@ in  Pipeline.build
                 , PipelineTag.Type.Stable
                 ]
               }
-      , steps = [ buildTestCmd "dev" "src/lib" Size.XLarge ]
+      , steps = [ buildTestCmd "dev" "src/lib" Size.QA ]
       }

--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -71,11 +71,11 @@ let module =
                         = if docker.useBash then "/bin/bash" else "/bin/sh"
 
                     in  { line =
-                            "docker run -it --rm --entrypoint ${entrypoint} --init --volume /var/secrets:/var/secrets --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${      if docker.privileged
+                            "docker run -it --rm --entrypoint ${entrypoint} --init --volume /var/dune-cache:/var/dune-cache --volume /var/secrets:/var/secrets --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${      if docker.privileged
 
-                                                                                                                                                                                                                then  " --privileged"
+                                                                                                                                                                                                                                                         then  " --privileged"
 
-                                                                                                                                                                                                                else  ""} ${docker.image} -c '${inner.line}'"
+                                                                                                                                                                                                                                                         else  ""} ${docker.image} -c '${inner.line}'"
                         , readable =
                             Optional/map
                               Text
@@ -142,7 +142,7 @@ let tests =
       let dockerExample =
               assert
             :     { line =
-                      "docker run -it --rm --entrypoint /bin/bash --init --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello'"
+                      "docker run -it --rm --entrypoint /bin/bash --init --volume /var/dune-cache:/var/dune-cache --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello'"
                   , readable = Some "Docker@foo/bar:tag ( echo hello )"
                   }
               ===  M.inDocker


### PR DESCRIPTION
This PR uses a shared `dune-cache` for the dev unit tests, to allow us to skip re-runs for unit tests whose dependencies haven't changed.

This experiment is running on the QA buildkite agent to avoid any adverse effects to the other runners.