### PR TITLE
Remove redundant fields from compile config type

### DIFF
--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -4,11 +4,6 @@
 (*END src/config/ledger_depth/small.mlh*)
 
 
-(*BEGIN src/config/curve/medium.mlh*)
-[%%define curve_size 255]
-(*END src/config/curve/medium.mlh*)
-
-
 (*BEGIN src/config/coinbase/standard.mlh*)
 [%%define coinbase "20"]
 (*END src/config/coinbase/standard.mlh*)

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -1,10 +1,5 @@
 [%%define ledger_depth 35]
 
-(*BEGIN src/config/curve/medium.mlh*)
-[%%define curve_size 255]
-(*END src/config/curve/medium.mlh*)
-
-
 (*BEGIN src/config/coinbase/realistic.mlh*)
 [%%define coinbase "720"]
 (*END src/config/coinbase/realistic.mlh*)

--- a/src/config/lightnet.mlh
+++ b/src/config/lightnet.mlh
@@ -1,10 +1,5 @@
 [%%define ledger_depth 35]
 
-(*BEGIN src/config/curve/medium.mlh*)
-[%%define curve_size 255]
-(*END src/config/curve/medium.mlh*)
-
-
 (*BEGIN src/config/coinbase/realistic.mlh*)
 [%%define coinbase "720"]
 (*END src/config/coinbase/realistic.mlh*)

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -1,10 +1,5 @@
 [%%define ledger_depth 35]
 
-(*BEGIN src/config/curve/medium.mlh*)
-[%%define curve_size 255]
-(*END src/config/curve/medium.mlh*)
-
-
 (*BEGIN src/config/coinbase/realistic.mlh*)
 [%%define coinbase "720"]
 (*END src/config/coinbase/realistic.mlh*)

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -8,12 +8,10 @@ open Core_kernel
 
 module Inputs = struct
   type t =
-    { curve_size : int
-    ; default_snark_worker_fee_string : string
+    { default_snark_worker_fee_string : string
     ; minimum_user_command_fee_string : string
     ; itn_features : bool
     ; compaction_interval_ms : int option
-    ; block_window_duration_ms : int
     ; vrf_poll_interval_ms : int
     ; network_id : string
     ; zkapp_cmd_limit : int option
@@ -26,12 +24,10 @@ module Inputs = struct
 end
 
 type t =
-  { curve_size : int
-  ; default_snark_worker_fee : Currency.Fee.t
+  { default_snark_worker_fee : Currency.Fee.t
   ; minimum_user_command_fee : Currency.Fee.t
   ; itn_features : bool
   ; compaction_interval : Time.Span.t option
-  ; block_window_duration : Time.Span.t
   ; vrf_poll_interval : Time.Span.t
   ; network_id : string
   ; zkapp_cmd_limit : int option
@@ -43,8 +39,7 @@ type t =
 [@@deriving sexp_of]
 
 let make (inputs : Inputs.t) =
-  { curve_size = inputs.curve_size
-  ; default_snark_worker_fee =
+  { default_snark_worker_fee =
       Currency.Fee.of_mina_string_exn inputs.default_snark_worker_fee_string
   ; minimum_user_command_fee =
       Currency.Fee.of_mina_string_exn inputs.minimum_user_command_fee_string
@@ -53,8 +48,6 @@ let make (inputs : Inputs.t) =
       Option.map
         ~f:(fun x -> Float.of_int x |> Time.Span.of_ms)
         inputs.compaction_interval_ms
-  ; block_window_duration =
-      Float.of_int inputs.block_window_duration_ms |> Time.Span.of_ms
   ; vrf_poll_interval =
       Float.of_int inputs.vrf_poll_interval_ms |> Time.Span.of_ms
   ; rpc_handshake_timeout = Time.Span.of_sec inputs.rpc_handshake_timeout_sec
@@ -68,8 +61,7 @@ let make (inputs : Inputs.t) =
 
 let to_yojson t =
   `Assoc
-    [ ("curve_size", `Int t.curve_size)
-    ; ( "default_snark_worker_fee"
+    [ ( "default_snark_worker_fee"
       , Currency.Fee.to_yojson t.default_snark_worker_fee )
     ; ( "minimum_user_command_fee"
       , Currency.Fee.to_yojson t.minimum_user_command_fee )
@@ -78,7 +70,6 @@ let to_yojson t =
       , Option.value_map ~default:`Null
           ~f:(fun x -> `Float (Time.Span.to_ms x))
           t.compaction_interval )
-    ; ("block_window_duration", `Float (Time.Span.to_ms t.block_window_duration))
     ; ("vrf_poll_interval", `Float (Time.Span.to_ms t.vrf_poll_interval))
     ; ( "rpc_handshake_timeout"
       , `Float (Time.Span.to_sec t.rpc_handshake_timeout) )
@@ -97,12 +88,10 @@ let to_yojson t =
 module Compiled = struct
   let t : t =
     let (inputs : Inputs.t) =
-      { curve_size = Node_config.curve_size
-      ; default_snark_worker_fee_string = Node_config.default_snark_worker_fee
+      { default_snark_worker_fee_string = Node_config.default_snark_worker_fee
       ; minimum_user_command_fee_string = Node_config.minimum_user_command_fee
       ; itn_features = Node_config.itn_features
       ; compaction_interval_ms = Node_config.compaction_interval
-      ; block_window_duration_ms = Node_config.block_window_duration
       ; vrf_poll_interval_ms = Node_config.vrf_poll_interval
       ; network_id = Node_config.network
       ; zkapp_cmd_limit = Node_config.zkapp_cmd_limit
@@ -118,15 +107,12 @@ end
 module For_unit_tests = struct
   let t : t =
     let inputs : Inputs.t =
-      { curve_size = Node_config_for_unit_tests.curve_size
-      ; default_snark_worker_fee_string =
+      { default_snark_worker_fee_string =
           Node_config_for_unit_tests.default_snark_worker_fee
       ; minimum_user_command_fee_string =
           Node_config_for_unit_tests.minimum_user_command_fee
       ; itn_features = Node_config_for_unit_tests.itn_features
       ; compaction_interval_ms = Node_config_for_unit_tests.compaction_interval
-      ; block_window_duration_ms =
-          Node_config_for_unit_tests.block_window_duration
       ; vrf_poll_interval_ms = Node_config_for_unit_tests.vrf_poll_interval
       ; rpc_handshake_timeout_sec =
           Node_config_for_unit_tests.rpc_handshake_timeout_sec

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1500,7 +1500,11 @@ let create ~commit_id ?wallets (config : Config.t) =
   let constraint_constants = config.precomputed_values.constraint_constants in
   let consensus_constants = config.precomputed_values.consensus_constants in
   let compile_config = config.precomputed_values.compile_config in
-  let block_window_duration = config.compile_config.block_window_duration in
+  let block_window_duration =
+    Float.of_int
+      config.precomputed_values.constraint_constants.block_window_duration_ms
+    |> Time.Span.of_ms
+  in
   let monitor = Option.value ~default:(Monitor.create ()) config.monitor in
   Async.Scheduler.within' ~monitor (fun () ->
       let set_itn_data (type t) (module M : Itn_settable with type t = t) (t : t)

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -198,7 +198,10 @@ let%test_module "Epoch ledger sync tests" =
           ~consensus_constants ~time_controller ~logger
           ~frontier_broadcast_pipe:frontier_broadcast_pipe_r ~on_remote_push
           ~log_gossip_heard:false
-          ~block_window_duration:compile_config.block_window_duration
+          ~block_window_duration:
+            ( Float.of_int
+                precomputed_values.constraint_constants.block_window_duration_ms
+            |> Time.Span.of_ms )
       in
       let snark_remote_sink =
         let config =
@@ -211,7 +214,11 @@ let%test_module "Epoch ledger sync tests" =
             ~consensus_constants ~time_controller ~logger
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r ~on_remote_push
             ~log_gossip_heard:false
-            ~block_window_duration:compile_config.block_window_duration
+            ~block_window_duration:
+              ( Float.of_int
+                  precomputed_values.constraint_constants
+                    .block_window_duration_ms
+              |> Time.Span.of_ms )
         in
         snark_remote_sink
       in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -568,7 +568,10 @@ let%test_module "random set test" =
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
+      Float.of_int
+        Genesis_constants.For_unit_tests.Constraint_constants.t
+          .block_window_duration_ms
+      |> Time.Span.of_ms
 
     (* SNARK work is rejected if the prover doesn't have an account and the fee
        is below the account creation fee. So, just to make generating valid SNARK

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -20,7 +20,10 @@ let%test_module "network pool test" =
     let time_controller = Block_time.Controller.basic ~logger
 
     let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
+      Float.of_int
+        Genesis_constants.For_unit_tests.Constraint_constants.t
+          .block_window_duration_ms
+      |> Time.Span.of_ms
 
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1643,7 +1643,10 @@ let%test_module _ =
     let num_extra_keys = 30
 
     let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
+      Float.of_int
+        Genesis_constants.For_unit_tests.Constraint_constants.t
+          .block_window_duration_ms
+      |> Time.Span.of_ms
 
     (* keys that can be used when generating new accounts *)
     let extra_keys =

--- a/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
+++ b/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
@@ -7,8 +7,6 @@ include Node_config_version
 
 let (ledger_depth : int) = (10 : int)
 
-let (curve_size : int) = (255 : int)
-
 let (coinbase : string) = ("20" : string)
 
 let (k : int) = (24 : int)

--- a/src/lib/node_config/intf/node_config_intf.mli
+++ b/src/lib/node_config/intf/node_config_intf.mli
@@ -11,8 +11,6 @@ module type S = sig
 
   val ledger_depth : int
 
-  val curve_size : int
-
   val coinbase : string
 
   val k : int

--- a/src/lib/node_config/node_config.ml
+++ b/src/lib/node_config/node_config.ml
@@ -10,8 +10,6 @@ include Node_config_version
 
 [%%inject "ledger_depth", ledger_depth]
 
-[%%inject "curve_size", curve_size]
-
 [%%inject "coinbase", coinbase]
 
 [%%inject "k", k]

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1949,10 +1949,7 @@ module Constants : Constants_intf = struct
     in
     let compile_config =
       { a.compile_config with
-        block_window_duration =
-          constraint_constants.block_window_duration_ms |> Float.of_int
-          |> Time.Span.of_ms
-      ; network_id =
+        network_id =
           Option.value ~default:a.compile_config.network_id
             Option.(b.daemon >>= fun d -> d.network_id)
       }

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -88,7 +88,10 @@ let%test_module "transaction_status" =
     let pool_max_size = precomputed_values.genesis_constants.txpool_max_size
 
     let block_window_duration =
-      Mina_compile_config.For_unit_tests.t.block_window_duration
+      Float.of_int
+        Genesis_constants.For_unit_tests.Constraint_constants.t
+          .block_window_duration_ms
+      |> Time.Span.of_ms
 
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -46,8 +46,7 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 (* add a breadcrumb and perform post processing *)
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
     ~processed_transition_writer ~only_if_present ~time_controller ~source
-    ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t)
-    ~block_window_duration:_ (*TODO remove unused var*) =
+    ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t) =
   let module Inclusion_time = Mina_metrics.Block_latency.Inclusion_time in
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
@@ -284,7 +283,6 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
         add_and_finalize ~logger ~frontier ~catchup_scheduler
           ~processed_transition_writer ~only_if_present:false ~time_controller
           ~source:`Gossip breadcrumb ~precomputed_values ~valid_cb
-          ~block_window_duration:compile_config.block_window_duration
       in
       ( match result with
       | Ok () ->
@@ -378,8 +376,6 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                               let%map result =
                                 add_and_finalize ~logger ~only_if_present:true
                                   ~source:`Catchup ~valid_cb b
-                                  ~block_window_duration:
-                                    compile_config.block_window_duration
                               in
                               Internal_tracing.with_state_hash state_hash
                               @@ fun () ->
@@ -443,8 +439,6 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                     match%map
                       add_and_finalize ~logger ~only_if_present:false
                         ~source:`Internal breadcrumb ~valid_cb:None
-                        ~block_window_duration:
-                          compile_config.block_window_duration
                     with
                     | Ok () ->
                         [%log internal] "Breadcrumb_integrated" ;


### PR DESCRIPTION
- The field `curve_size` isn't being used anywhere in the codebase, so remove the field and definitions in `mlh` files
- Fixes #16108 