### PR TITLE
Fix promotion job PUBLISH misuse

### DIFF
--- a/buildkite/scripts/promote-docker.sh
+++ b/buildkite/scripts/promote-docker.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 CLEAR='\033[0m'
 RED='\033[0;31m'
+PUBLISH=0
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--name) NAME="$2"; shift;;
@@ -45,7 +46,7 @@ docker pull ${GCR_REPO}/${NAME}:${VERSION}
 
 source buildkite/scripts/export-git-env-vars.sh
 
-if [[ -v PUBLISH ]]; then
+if [[ $PUBLISH == 1 ]]; then
   TARGET_REPO=docker.io/minaprotocol
   docker tag ${GCR_REPO}/${NAME}:${VERSION} ${TARGET_REPO}/${NAME}:${TAG}
   docker push "${TARGET_REPO}/${NAME}:${TAG}"


### PR DESCRIPTION
Fixes promotion job logic.

PUBLISH flag controls whether we push docker image to gcr or docker.io. We were testing existance of PUBLISH variable only, which looks like and issue as  if we don't want to publish to docker.io we set PUBLISH=0. However, code check only if variable is set not its value. Therefore we promote it to docker.io even if our target was gcr.io. This pr fixes is by comparing PUBLISH value