### PR TITLE
add coverage gather for archive related tests

### DIFF
--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -8,6 +8,8 @@ let Network = ../Constants/Network.dhall
 
 let RunWithPostgres = ./RunWithPostgres.dhall
 
+let key = "patch-archive-test"
+
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)
         ->  Command.build
@@ -20,10 +22,10 @@ in  { step =
                     "./src/test/archive/sample_db/archive_db.sql"
                     Artifacts.Type.FunctionalTestSuite
                     (None Network.Type)
-                    "./scripts/patch-archive-test.sh"
+                    "./scripts/patch-archive-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
                 ]
               , label = "Archive: Patch Archive test"
-              , key = "patch-archive-test"
+              , key = key
               , target = Size.Large
               , depends_on = dependsOn
               }

--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -22,7 +22,7 @@ in  { step =
                     "./src/test/archive/sample_db/archive_db.sql"
                     Artifacts.Type.FunctionalTestSuite
                     (None Network.Type)
-                    "./scripts/patch-archive-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
+                    "./scripts/patch-archive-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Patch Archive test"
               , key = key

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -8,6 +8,8 @@ let RunWithPostgres = ./RunWithPostgres.dhall
 
 let Network = ../Constants/Network.dhall
 
+let key = "replayer-test"
+
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)
         ->  Command.build
@@ -18,10 +20,10 @@ in  { step =
                     "./src/test/archive/sample_db/archive_db.sql"
                     Artifacts.Type.Archive
                     (None Network.Type)
-                    "./buildkite/scripts/replayer-test.sh"
+                    "./buildkite/scripts/replayer-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
                 ]
               , label = "Archive: Replayer test"
-              , key = "replayer-test"
+              , key = key
               , target = Size.Large
               , depends_on = dependsOn
               }

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -18,9 +18,9 @@ in  { step =
                 [ RunWithPostgres.runInDockerWithPostgresConn
                     ([] : List Text)
                     "./src/test/archive/sample_db/archive_db.sql"
-                    Artifacts.Type.Archive
+                    Artifacts.Type.FunctionalTestSuite
                     (None Network.Type)
-                    "./buildkite/scripts/replayer-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
+                    "./buildkite/scripts/replayer-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Replayer test"
               , key = key

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -90,6 +90,8 @@ let minimalDirtyWhen =
       , S.exactly "buildkite/src/Constants/ContainerImages" "dhall"
       , S.exactly "buildkite/src/Command/HardforkPackageGeneration" "dhall"
       , S.exactly "buildkite/src/Command/MinaArtifact" "dhall"
+      , S.exactly "buildkite/src/Command/PatchArchiveTest" "dhall"
+      , S.exactly "buildkite/src/Command/ReplayerTest" "dhall"
       , S.strictlyStart (S.contains "buildkite/src/Jobs/Release/MinaArtifact")
       , S.strictlyStart (S.contains "dockerfiles/stages")
       , S.exactly "scripts/debian/build" "sh"

--- a/buildkite/src/Jobs/Test/ReplayerTest.dhall
+++ b/buildkite/src/Jobs/Test/ReplayerTest.dhall
@@ -21,7 +21,7 @@ let dependsOn =
         Dockers.Type.Bullseye
         (None Network.Type)
         Profiles.Type.Standard
-        Artifacts.Type.Archive
+        Artifacts.Type.FunctionalTestSuite
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
Added sub steps for patch archive and replayer tests which sends coverage data to coveralls