### PR TITLE
[Archive single node test] Implement archive test with mocked daemon

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -52,4 +52,5 @@ dune build "--profile=${DUNE_PROFILE}" $INSTRUMENTED_PARAM \
   src/app/zkapp_limits/zkapp_limits.exe \
   src/lib/snark_worker/standalone/run_snark_worker.exe \
   src/test/command_line_tests/command_line_tests.exe \
-  src/test/archive/patch_archive_test/patch_archive_test.exe
+  src/test/archive/patch_archive_test/patch_archive_test.exe \
+  src/test/archive/archive_node_tests/archive_node_tests.exe

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -1,0 +1,32 @@
+let Artifacts = ../Constants/Artifacts.dhall
+
+let Command = ./Base.dhall
+
+let Size = ./Size.dhall
+
+let Network = ../Constants/Network.dhall
+
+let RunWithPostgres = ./RunWithPostgres.dhall
+
+let key = "archive-node-test"
+
+in  { step =
+            \(dependsOn : List Command.TaggedKey.Type)
+        ->  Command.build
+              Command.Config::{
+              , commands =
+                [ RunWithPostgres.runInDockerWithPostgresConn
+                    [ "ARCHIVE_TEST_APP=mina-archive-node-test"
+                    , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
+                    ]
+                    "./src/test/archive/sample_db/archive_db.sql"
+                    Artifacts.Type.FunctionalTestSuite
+                    (None Network.Type)
+                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                ]
+              , label = "Archive: Node Test"
+              , key = key
+              , target = Size.Large
+              , depends_on = dependsOn
+              }
+    }

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -17,7 +17,7 @@ in  { step =
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
                     , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
                     ]
-                    "/etc/mina/test/archive/sample_db/archive_db.sql"
+                    "src/test/archive/sample_db/archive_db.sql"
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -15,7 +15,7 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInDockerWithPostgresConn
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
-                    , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
+                    , "MINA_TEST_NETWORK_DATA=/etc/mina/test/archive/sample_db"
                     ]
                     "src/test/archive/sample_db/archive_db.sql"
                     ( Artifacts.fullDockerTag

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -17,7 +17,7 @@ in  { step =
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
                     , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
                     ]
-                    "./src/test/archive/sample_db/archive_db.sql"
+                    "NETWORK_DATA_FOLDER=\\\$NETWORK_DATA_FOLDER ./src/test/archive/sample_db/archive_db.sql"
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -23,7 +23,7 @@ in  { step =
                         , artifact = Artifacts.Type.FunctionalTestSuite
                         }
                     )
-                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                    "MINA_TEST_POSTGRES_URI=\\\$POSTGRES_URI ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -14,14 +14,16 @@ in  { step =
               Command.Config::{
               , commands =
                 [ RunWithPostgres.runInDockerWithPostgresConn
-                    [ "ARCHIVE_TEST_APP=mina-archive-node-test" ]
-                    "./src/test/archive/sample_db/archive_db.sql"
+                    [ "ARCHIVE_TEST_APP=mina-archive-node-test"
+                    , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
+                    ]
+                    "/etc/mina/test/archive/sample_db/archive_db.sql"
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite
                         }
                     )
-                    "NETWORK_DATA_FOLDER=./src/test/archive/sample_db ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -6,6 +6,8 @@ let Size = ./Size.dhall
 
 let RunWithPostgres = ./RunWithPostgres.dhall
 
+let BuildFlags = ../Constants/BuildFlags.dhall
+
 let key = "archive-node-test"
 
 in  { step =
@@ -21,6 +23,7 @@ in  { step =
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite
+                        , buildFlags = BuildFlags.Type.Instrumented
                         }
                     )
                     "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -23,7 +23,7 @@ in  { step =
                         , artifact = Artifacts.Type.FunctionalTestSuite
                         }
                     )
-                    "MINA_TEST_POSTGRES_URI=\\\$POSTGRES_URI ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -21,7 +21,7 @@ in  { step =
                         , artifact = Artifacts.Type.FunctionalTestSuite
                         }
                     )
-                    "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                    "NETWORK_DATA_FOLDER=./src/test/archive/sample_db ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -14,16 +14,14 @@ in  { step =
               Command.Config::{
               , commands =
                 [ RunWithPostgres.runInDockerWithPostgresConn
-                    [ "ARCHIVE_TEST_APP=mina-archive-node-test"
-                    , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
-                    ]
-                    "NETWORK_DATA_FOLDER=\\\$NETWORK_DATA_FOLDER ./src/test/archive/sample_db/archive_db.sql"
+                    [ "ARCHIVE_TEST_APP=mina-archive-node-test" ]
+                    "./src/test/archive/sample_db/archive_db.sql"
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite
                         }
                     )
-                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
+                    "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db ./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -4,8 +4,6 @@ let Command = ./Base.dhall
 
 let Size = ./Size.dhall
 
-let Network = ../Constants/Network.dhall
-
 let RunWithPostgres = ./RunWithPostgres.dhall
 
 let key = "archive-node-test"
@@ -20,8 +18,11 @@ in  { step =
                     , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
                     ]
                     "./src/test/archive/sample_db/archive_db.sql"
-                    Artifacts.Type.FunctionalTestSuite
-                    (None Network.Type)
+                    ( Artifacts.fullDockerTag
+                        Artifacts.Tag::{
+                        , artifact = Artifacts.Type.FunctionalTestSuite
+                        }
+                    )
                     "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Archive: Node Test"

--- a/buildkite/src/Command/RunWithPostgres.dhall
+++ b/buildkite/src/Command/RunWithPostgres.dhall
@@ -26,8 +26,9 @@ let runInDockerWithPostgresConn
 
           let dbName = "archive"
 
-          let pg_conn =
-                "postgres://${user}:${password}@localhost:${port}/${dbName}"
+          let pg_uri = "postgres://${user}:${password}@localhost:${port}"
+
+          let pg_conn = "${pg_uri}/${dbName}"
 
           let envVars =
                 Text/concatMap
@@ -37,6 +38,7 @@ let runInDockerWithPostgresConn
                       , "POSTGRES_USER=${user}"
                       , "POSTGRES_PASSWORD=${password}"
                       , "POSTGRES_DB=${dbName}"
+                      , "POSTGRES_URI=${pg_uri}"
                       , "PG_CONN=${pg_conn}"
                       ]
                     # environment

--- a/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
@@ -19,7 +19,7 @@ let Dockers = ../../Constants/DockerVersions.dhall
 let dependsOn =
       Dockers.dependsOn
         Dockers.Type.Bullseye
-        (None Network.Type)
+        Network.Type.Berkeley
         Profiles.Type.Standard
         Artifacts.Type.FunctionalTestSuite
 

--- a/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
@@ -1,0 +1,44 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let ArchiveNodeTest = ../../Command/ArchiveNodeTest.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Dockers = ../../Constants/DockerVersions.dhall
+
+let dependsOn =
+      Dockers.dependsOn
+        Dockers.Type.Bullseye
+        (None Network.Type)
+        Profiles.Type.Standard
+        Artifacts.Type.FunctionalTestSuite
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "src")
+          , S.exactly "scripts/patch-archive-test" "sh"
+          , S.exactly "buildkite/src/Jobs/Test/ArchiveNodeTest" "dhall"
+          , S.exactly "buildkite/src/Command/ArchiveNodeTest" "dhall"
+          ]
+        , path = "Test"
+        , name = "ArchiveNodeTest"
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps = [ ArchiveNodeTest.step dependsOn ]
+      }

--- a/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
@@ -12,8 +12,14 @@ let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
+let buildFlags = ../../Constants/BuildFlags.dhall
+
 let dependsOn =
-      Dockers.dependsOn Dockers.DepsSpec::{ artifact = Artifacts.Type.Rosetta }
+      Dockers.dependsOn
+        Dockers.DepsSpec::{
+        , artifact = Artifacts.Type.FunctionalTestSuite
+        , buildFlags = buildFlags.Type.Instrumented
+        }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
@@ -8,20 +8,12 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let ArchiveNodeTest = ../../Command/ArchiveNodeTest.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
-let Network = ../../Constants/Network.dhall
-
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let dependsOn =
-      Dockers.dependsOn
-        Dockers.Type.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
-        Artifacts.Type.FunctionalTestSuite
+      Dockers.dependsOn Dockers.DepsSpec::{ artifact = Artifacts.Type.Rosetta }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/changes/16329.md
+++ b/changes/16329.md
@@ -1,0 +1,1 @@
+Implemented component test for archive node. We are sending precomputed blocks from mocked daemon to an archive node and finally running replayer against it.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -291,6 +291,11 @@ build_functional_test_suite_deb() {
     "${BUILDDIR}/usr/local/bin/mina-zkapp-limits"
   cp ./default/src/test/archive/patch_archive_test/patch_archive_test.exe \
     "${BUILDDIR}/usr/local/bin/mina-patch-archive-test"
+  cp ./default/src/test/archive/archive_node_tests/archive_node_tests.exe \
+    "${BUILDDIR}/usr/local/bin/mina-archive-node-test"
+
+  mkdir -p ${BUILDDIR}/etc/mina/test/archive/sample_db
+  rsync -Huav ../src/test/archive/sample_db* "${BUILDDIR}/etc/mina/test/archive"
 
   build_deb mina-test-suite
 

--- a/scripts/tests/archive-node-test.sh
+++ b/scripts/tests/archive-node-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+# test archive node on known archive db
+
+NETWORK_DATA_FOLDER=${NETWORK_DATA_FOLDER:-src/test/archive/sample_db}
+ARCHIVE_TEST_APP=${ARCHIVE_TEST_APP:-_build/default/src/test/archive/archive_node_tests/archive_node_tests.exe}
+POSTGRES_URI=${POSTGRES_URI:-"postgres://postgres:postgres@localhost:5432"}
+
+echo "Running archive node test"
+$ARCHIVE_TEST_APP

--- a/scripts/tests/archive-node-test.sh
+++ b/scripts/tests/archive-node-test.sh
@@ -5,7 +5,9 @@ set -x
 
 NETWORK_DATA_FOLDER=${NETWORK_DATA_FOLDER:-src/test/archive/sample_db}
 ARCHIVE_TEST_APP=${ARCHIVE_TEST_APP:-_build/default/src/test/archive/archive_node_tests/archive_node_tests.exe}
-POSTGRES_URI=${POSTGRES_URI:-"postgres://postgres:postgres@localhost:5432"}
+# This env var is used in the test app
+# shellcheck disable=SC2034
+MINA_TEST_POSTGRES_URI=${POSTGRES_URI:-"postgres://postgres:postgres@localhost:5432"}
 
 echo "Running archive node test"
 $ARCHIVE_TEST_APP

--- a/scripts/tests/archive-node-test.sh
+++ b/scripts/tests/archive-node-test.sh
@@ -10,4 +10,4 @@ ARCHIVE_TEST_APP=${ARCHIVE_TEST_APP:-_build/default/src/test/archive/archive_nod
 MINA_TEST_POSTGRES_URI=${POSTGRES_URI:-"postgres://postgres:postgres@localhost:5432"}
 
 echo "Running archive node test"
-$ARCHIVE_TEST_APP
+MINA_TEST_POSTGRES_URI=$MINA_TEST_POSTGRES_URI $ARCHIVE_TEST_APP

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -29,7 +29,7 @@ module ArchivePrecomputedBlocksFromDaemon = struct
     let open Deferred.Let_syntax in
     let daemon = Daemon.default in
     let archive_uri = test_data.archive.config.postgres_uri in
-    let output = Filename.temp_dir "precomputed_blocks" "" in
+    let output = test_data.temp_dir in
     let%bind precomputed_blocks =
       Network_data.untar_precomputed_blocks test_data.network_data output
     in

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -1,0 +1,85 @@
+open Async
+open Core
+open Mina_automation
+open Mina_automation_runner
+open Mina_automation_fixture.Archive
+
+(**
+ * Test the basic functionality of the mina archive with mocked deamon
+ *)
+
+(* asserts count of archive blocked (we are skipping genesis block) *)
+let assert_archived_blocks ~archive_uri ~expected =
+  let connection = Psql.Conn_str archive_uri in
+  let%bind actual_blocks_count =
+    Psql.run_command ~connection "Select count(*) from blocks where height > 0"
+  in
+  let actual_blocks_count =
+    actual_blocks_count |> String.strip |> Int.of_string
+  in
+  if Int.( <> ) actual_blocks_count expected then
+    failwithf "Invalid number of archive blocks. Actual (%d) vs Expected (%d)"
+      actual_blocks_count expected ()
+  else Deferred.unit
+
+module ArchivePrecomputedBlocksFromDaemon = struct
+  type t = Mina_automation_fixture.Archive.after_bootstrap
+
+  let test_case (test_data : t) =
+    let open Deferred.Let_syntax in
+    let daemon = Daemon.default in
+    let archive_uri = test_data.archive.config.postgres_uri in
+    let output = Filename.temp_dir "precomputed_blocks" "" in
+    let%bind precomputed_blocks =
+      Network_data.untar_precomputed_blocks test_data.network_data output
+    in
+    let precomputed_blocks =
+      List.map precomputed_blocks ~f:(fun file -> output ^ "/" ^ file)
+    in
+    Archive.Process.start_logging test_data.archive ;
+    let%bind () =
+      Daemon.dispatch_blocks daemon
+        ~archive_address:test_data.archive.config.server_port
+        ~format:Archive_blocks.Precomputed precomputed_blocks
+    in
+
+    let%bind () =
+      assert_archived_blocks ~archive_uri
+        ~expected:(List.length precomputed_blocks)
+    in
+    let connection = Psql.Conn_str archive_uri in
+    let%bind latest_state_hash =
+      Psql.run_command ~connection
+        "select state_hash from blocks WHERE id=(SELECT max(id) FROM blocks) \
+         LIMIT 1"
+    in
+    let output_ledger = output ^ "/output_ledger.json" in
+    let replayer = Replayer.default in
+    let%bind _ =
+      Replayer.run replayer ~archive_uri
+        ~input_config:
+          (Network_data.replayer_input_file_path test_data.network_data)
+        ~target_state_hash:latest_state_hash ~interval_checkpoint:10
+        ~output_ledger ()
+    in
+    let output_ledger = Replayer.Output.of_json_file_exn output_ledger in
+    assert (
+      String.equal output_ledger.target_epoch_ledgers_state_hash
+        latest_state_hash ) ;
+    Deferred.Or_error.return Mina_automation_fixture.Intf.Passed
+end
+
+let () =
+  Backtrace.elide := false ;
+  Async.Scheduler.set_record_backtraces true
+
+let () =
+  let open Alcotest in
+  run "Test archive node."
+    [ ( "precomputed blocks"
+      , [ test_case "The mina daemon works in background mode" `Quick
+            (Runner.run_blocking
+               ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
+                          (ArchivePrecomputedBlocksFromDaemon) ) )
+        ] )
+    ]

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -17,7 +17,7 @@ let assert_archived_blocks ~archive_uri ~expected =
   let actual_blocks_count =
     match actual_blocks_count with
     | Ok count ->
-        Int.of_string count
+        count |> String.strip |> Int.of_string 
     | Error err ->
         failwith ("Failed to query blocks count: " ^ Error.to_string_hum err)
   in

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -39,6 +39,7 @@ module ArchivePrecomputedBlocksFromDaemon = struct
     in
     let precomputed_blocks =
       List.map precomputed_blocks ~f:(fun file -> output ^ "/" ^ file)
+      |> List.filter ~f:(fun file -> String.is_suffix file ~suffix:".json")
     in
     Archive.Process.start_logging test_data.archive ;
     let%bind () =

--- a/src/test/archive/archive_node_tests/dune
+++ b/src/test/archive/archive_node_tests/dune
@@ -1,0 +1,21 @@
+(tests
+ (names archive_node_tests)
+ (libraries
+   ;; opam libraries
+   async_kernel
+   core_kernel
+   ppx_inline_test.config
+   async
+   core
+   async_unix
+   stdio
+   alcotest
+   cmdliner
+   ;; mina libraries
+   mina_automation
+   mina_automation.fixture
+   mina_automation.runner
+ )
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_jane ppx_compare))
+)

--- a/src/test/mina_automation/daemon.ml
+++ b/src/test/mina_automation/daemon.ml
@@ -148,8 +148,8 @@ let archive_blocks t ~archive_address ~(format : Archive_blocks.format) blocks =
         ]
       @ blocks )
 
-let dispatch_blocks t ~archive_address ~(format : Archive_blocks.format)
-    ?(sleep = 5) blocks =
+let archive_blocks_from_files t ~archive_address
+    ~(format : Archive_blocks.format) ?(sleep = 5) blocks =
   Deferred.List.iter blocks ~f:(fun block ->
       Core.Unix.sleep sleep ;
       archive_blocks t ~archive_address ~format [ block ] () >>| ignore )

--- a/src/test/mina_automation/daemon.ml
+++ b/src/test/mina_automation/daemon.ml
@@ -151,8 +151,8 @@ let archive_blocks t ~archive_address ~(format : Archive_blocks.format) blocks =
 let archive_blocks_from_files t ~archive_address
     ~(format : Archive_blocks.format) ?(sleep = 5) blocks =
   Deferred.List.iter blocks ~f:(fun block ->
-      Core.Unix.sleep sleep ;
-      archive_blocks t ~archive_address ~format [ block ] () >>| ignore )
+      let%bind _ = archive_blocks t ~archive_address ~format [ block ] () in
+      after (Time.Span.of_sec (Float.of_int sleep)) )
 
 let default = Executor.default
 

--- a/src/test/mina_automation/executor.ml
+++ b/src/test/mina_automation/executor.ml
@@ -128,7 +128,7 @@ module Make (P : AppPaths) = struct
     | AutoDetect -> (
         match%bind Sys.file_exists PathFinder.built_name with
         | `Yes ->
-            f_local ~args ~prefix:PathFinder.built_name ?env ()
+            f_local ~args ~prefix:"" ?env ()
         | _ -> (
             match%bind
               Deferred.List.find_map
@@ -144,7 +144,7 @@ module Make (P : AppPaths) = struct
     | Debian ->
         f_debian ~args ~prefix:"" ?env ()
     | Local ->
-        f_local ~args ~prefix:PathFinder.built_name ?env ()
+        f_local ~args ~prefix:"" ?env ()
     | Docker ctx ->
         f_docker ~args ~ctx ()
 

--- a/src/test/mina_automation/fixture/archive.ml
+++ b/src/test/mina_automation/fixture/archive.ml
@@ -84,7 +84,7 @@ module Make_FixtureWithBootstrap (M : TestCaseWithBootstrap) :
     [%log info] "Tearing down archive" ;
     let%bind _ = Archive.Process.force_kill t.archive in
     let%bind.Deferred () =
-      Mina_stdlib_unix.File_system.remove_dir @@ t.network_data.folder
+      Mina_stdlib_unix.File_system.remove_dir @@ t.temp_dir
     in
     [%log info] "Archive teardown completed" ;
     Deferred.Or_error.ok_unit

--- a/src/test/mina_automation/fixture/archive.ml
+++ b/src/test/mina_automation/fixture/archive.ml
@@ -23,7 +23,13 @@ let read_postgres_uri_from_env_var () =
       uri
   | None ->
       failwith "Environment variable MINA_TEST_POSTGRES_URI is not set"
+      
+(** [setup_connection ~network_data] sets up a connection to the PostgreSQL database
+  and creates a configuration for the Archive service.
 
+  @param network_data The network data containing the genesis ledger path.
+  @return A deferred Archive.Config.t value with the configuration for the Archive service.
+*)
 let setup_connection ~network_data ~postgres_uri ?(server_port = 3030)
     ?(prefix = "random_db") () =
   let open Deferred.Let_syntax in
@@ -44,6 +50,15 @@ module Make_FixtureWithBootstrap (M : TestCaseWithBootstrap) :
 
   let test_case = M.test_case
 
+  
+  (** 
+    Sets up the archive by performing the following steps:
+    1. Retrieves the network data folder path from the environment variable "NETWORK_DATA_FOLDER".
+    2. Creates network data using the retrieved folder path.
+    3. Sets up a connection using the created network data.
+
+    @return A record containing the started archive and the network data.
+  *)
   let setup () =
     let open Deferred.Or_error.Let_syntax in
     let network_data = read_network_data_from_env_var () in
@@ -84,6 +99,13 @@ module Make_FixtureWithoutBootstrap (M : TestCaseWithoutBootstrap) :
   (* The test case should handle the connection and any necessary setup. *)
   let test_case = M.test_case
 
+  (** 
+    Sets up the network data and configuration for the archive.
+
+    @return A record containing the configuration and network data.
+
+    @raise Sys_error if the environment variable "NETWORK_DATA_FOLDER" is not set.
+  *)
   let setup () =
     let open Deferred.Or_error.Let_syntax in
     let network_data = read_network_data_from_env_var () in

--- a/src/test/mina_automation/fixture/archive.ml
+++ b/src/test/mina_automation/fixture/archive.ml
@@ -30,7 +30,7 @@ let read_postgres_uri_from_env_var () =
       uri
   | None ->
       failwith "Environment variable MINA_TEST_POSTGRES_URI is not set"
-      
+
 (** [setup_connection ~network_data] sets up a connection to the PostgreSQL database
   and creates a configuration for the Archive service.
 

--- a/src/test/mina_automation/fixture/archive.mli
+++ b/src/test/mina_automation/fixture/archive.mli
@@ -2,10 +2,16 @@ open Mina_automation
 open Intf
 
 type after_bootstrap =
-  { archive : Archive.Process.t; network_data : Network_data.t }
+  { archive : Archive.Process.t
+  ; network_data : Network_data.t
+  ; temp_dir : string
+  }
 
 type before_bootstrap =
-  { config : Archive.Config.t; network_data : Network_data.t }
+  { config : Archive.Config.t
+  ; network_data : Network_data.t
+  ; temp_dir : string
+  }
 
 module type TestCaseWithBootstrap = TestCase with type t = after_bootstrap
 

--- a/src/test/mina_automation/network_data.ml
+++ b/src/test/mina_automation/network_data.ml
@@ -51,4 +51,4 @@ let untar_precomputed_blocks t output =
   let precomputed_blocks_zip = precomputed_blocks_zip t in
   let%bind _ = Utils.untar ~archive:precomputed_blocks_zip ~output in
   let%bind array = Sys.readdir output in
-  Deferred.return (Array.to_list array |> Utils.dedup_and_sort_archive_files)
+  Deferred.return (Array.to_list array |> Utils.sort_archive_files)

--- a/src/test/mina_automation/psql.ml
+++ b/src/test/mina_automation/psql.ml
@@ -68,6 +68,13 @@ let create_credential_arg ~connection =
   @ value_or_empty "-U" credentials.user
   @ value_or_empty "-d" credentials.db
 
+(** [run_command ~connection command] runs a SQL command using psql with the given connection. 
+  The command is executed in the current directory, and the output is stripped of leading and trailing whitespace.
+
+  @param connection The connection string or credentials to connect to the PostgreSQL database.
+  @param command The SQL command to execute.
+  @return A deferred string containing the output of the command.
+*)
 let run_command ~connection command =
   let creds = create_credential_arg ~connection in
   Util.run_cmd_exn "." psql (creds @ [ "-c"; command; "-t" ]) >>| String.strip

--- a/src/test/mina_automation/psql.ml
+++ b/src/test/mina_automation/psql.ml
@@ -68,16 +68,22 @@ let create_credential_arg ~connection =
   @ value_or_empty "-U" credentials.user
   @ value_or_empty "-d" credentials.db
 
-(** [run_command ~connection command] runs a SQL command using psql with the given connection. 
+(** [run_command_exn ~connection command] runs a SQL command using psql with the given connection. 
   The command is executed in the current directory, and the output is stripped of leading and trailing whitespace.
+  It raises an exception if the command fails.
 
   @param connection The connection string or credentials to connect to the PostgreSQL database.
   @param command The SQL command to execute.
   @return A deferred string containing the output of the command.
 *)
-let run_command ~connection command =
+let run_command_exn ~connection command =
   let creds = create_credential_arg ~connection in
   Util.run_cmd_exn "." psql (creds @ [ "-c"; command; "-t" ]) >>| String.strip
+
+let run_command ~connection command =
+  let creds = create_credential_arg ~connection in
+  Util.run_cmd_or_error "." psql (creds @ [ "-c"; command ])
+  >>| Result.map ~f:String.strip
 
 let run_script ~connection ~db script =
   let creds = create_credential_arg ~connection in

--- a/src/test/mina_automation/psql.ml
+++ b/src/test/mina_automation/psql.ml
@@ -51,7 +51,11 @@ let create_credential_arg ~connection =
         let host = uri |> Uri.host in
         let port = uri |> Uri.port in
         let db = uri |> Uri.path in
-        let db = if String.is_empty db then None else Some db in
+        (* Db part of Uri is presented as path therefore it includes leading '/',
+           which need to be removed *)
+        let db =
+          if String.is_empty db then None else Some (String.drop_prefix db 1)
+        in
         { Credentials.password; user; host; db; port }
     | Credentials credentials ->
         credentials
@@ -66,7 +70,7 @@ let create_credential_arg ~connection =
 
 let run_command ~connection command =
   let creds = create_credential_arg ~connection in
-  Util.run_cmd_exn "." psql (creds @ [ "-c"; command ])
+  Util.run_cmd_exn "." psql (creds @ [ "-c"; command; "-t" ]) >>| String.strip
 
 let run_script ~connection ~db script =
   let creds = create_credential_arg ~connection in

--- a/src/test/mina_automation/psql.ml
+++ b/src/test/mina_automation/psql.ml
@@ -68,6 +68,11 @@ let create_credential_arg ~connection =
   @ value_or_empty "-U" credentials.user
   @ value_or_empty "-d" credentials.db
 
+let run_command ~connection command =
+  let creds = create_credential_arg ~connection in
+  Util.run_cmd_or_error "." psql (creds @ [ "-c"; command; "-t" ])
+  >>| Result.map ~f:String.strip
+
 (** [run_command_exn ~connection command] runs a SQL command using psql with the given connection. 
   The command is executed in the current directory, and the output is stripped of leading and trailing whitespace.
   It raises an exception if the command fails.
@@ -76,14 +81,6 @@ let create_credential_arg ~connection =
   @param command The SQL command to execute.
   @return A deferred string containing the output of the command.
 *)
-let run_command_exn ~connection command =
-  let creds = create_credential_arg ~connection in
-  Util.run_cmd_exn "." psql (creds @ [ "-c"; command; "-t" ]) >>| String.strip
-
-let run_command ~connection command =
-  let creds = create_credential_arg ~connection in
-  Util.run_cmd_or_error "." psql (creds @ [ "-c"; command ])
-  >>| Result.map ~f:String.strip
 
 let run_script ~connection ~db script =
   let creds = create_credential_arg ~connection in

--- a/src/test/mina_automation/replayer.ml
+++ b/src/test/mina_automation/replayer.ml
@@ -75,8 +75,10 @@ let default = Executor.AutoDetect
 
 type t = Executor.t
 
-let run t ~archive_uri ~input_config ~interval_checkpoint
+let run t ~archive_uri ~input_config ~interval_checkpoint ?target_state_hash
     ?checkpoint_output_folder ?checkpoint_file_prefix ~output_ledger =
+  let config_folder = Filename.temp_dir "replayer" "" in
+  let input_file = Filename.of_parts [ config_folder; "replayer_input.json" ] in
   let checkpoint_output_folder =
     match checkpoint_output_folder with
     | Some checkpoint_output_folder ->
@@ -91,11 +93,23 @@ let run t ~archive_uri ~input_config ~interval_checkpoint
     | None ->
         []
   in
+  let () =
+    match target_state_hash with
+    | None ->
+        let config =
+          Yojson.Safe.from_file input_config
+          |> InputConfig.of_yojson |> Result.ok_or_failwith
+        in
+        InputConfig.to_yojson_file config input_file
+    | Some hash ->
+        let config = InputConfig.of_checkpoint_file input_config (Some hash) in
+        InputConfig.to_yojson_file config input_file
+  in
   let args =
     [ "--archive-uri"
     ; archive_uri
     ; "--input-file"
-    ; input_config
+    ; input_file
     ; "--checkpoint-interval"
     ; string_of_int interval_checkpoint
     ; "--output-file"

--- a/src/test/mina_automation/utils.ml
+++ b/src/test/mina_automation/utils.ml
@@ -11,15 +11,21 @@ let sed ~search ~replacement ~input =
 let untar ~archive ~output =
   Util.run_cmd_exn "." "tar" [ "-xf"; archive; "-C"; output ]
 
+let precomputed_blocks_comparator left right =
+  let scan_height name = Scanf.sscanf name "%_s@-%d-%_s" Fn.id in
+  let left_height = scan_height left in
+  let right_height = scan_height right in
+  Int.compare left_height right_height
+
+let sort_archive_files files : string list =
+  files
+  |> List.sort ~compare:(fun left right ->
+         precomputed_blocks_comparator left right )
+
 let dedup_and_sort_archive_files files : string list =
   files
   |> List.dedup_and_sort ~compare:(fun left right ->
-         let scan_height name = Scanf.sscanf name "%_s@-%d-%_s" Fn.id in
-
-         let left_height = scan_height left in
-         let right_height = scan_height right in
-
-         Int.compare left_height right_height )
+         precomputed_blocks_comparator left right )
 
 let force_kill process =
   Process.send_signal process Core.Signal.kill ;


### PR DESCRIPTION
Introducing quick component test for archive node with mocked daemon which simulates sending precomputed blocks. Test scenario is easy:

- start archive node with runtime config (so genesis block will be included at startup)
- use mina advanced archive-blocks to send precomputed blocks to archive node
- validate all blocks are archived
- run replayer for consistency check

While developing thte test i introduced new mini framework for defining test case with setup i and tear down)

Test operates on new tiny framework for running tests with common setup and tear down linked in (https://github.com/MinaProtocol/mina/pull/16329)
