### PR TITLE
Default to `BUILDKITE_BUILD_URL` for package info when available

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -3,7 +3,7 @@ set -euox pipefail
 
 
 
-BUILD_URL=${BUILD_URL:-"local build from '$(hostname)' host"}
+BUILD_URL=${BUILD_URL:-${BUILDKITE_BUILD_URL:-"local build from '$(hostname)' host"}}
 MINA_DEB_CODENAME=${MINA_DEB_CODENAME:-"bullseye"}
 MINA_DEB_VERSION=${MINA_DEB_VERSION:-"0.0.0-experimental"}
 MINA_DEB_RELEASE=${MINA_DEB_RELEASE:-"unstable"}


### PR DESCRIPTION
PR https://github.com/MinaProtocol/mina/pull/15899 added an out-of-sync, broken copy of `buildkite/scripts/export-git-env-vars.sh` at `scripts/export-git-env-vars.sh` that we use for debian builds. As a result, all of the debian descriptions have stopped containing the host URL, instead now taking the form
```
Built from 012abcf by local build from '0123456789ab' host
```

This PR uses `BUILDKITE_BUILD_URL` as the primary fallback for `BUILD_URL`, to mitigate the harm caused by this error while it's being fixed.