### PR TITLE
WIP

### DIFF
--- a/buildkite/scripts/build-release.sh
+++ b/buildkite/scripts/build-release.sh
@@ -2,19 +2,20 @@
 
 set -eo pipefail
 
+source "./buildkite/scripts/export-git-env-vars.sh"
+
 ([ -z ${DUNE_PROFILE+x} ] || [ -z ${MINA_DEB_CODENAME+x} ]) && echo "required env vars were not provided" && exit 1
 
 source ~/.profile
 
+echo "--- Bundle all packages for Debian ${MINA_DEB_CODENAME}"
 ./buildkite/scripts/build-artifact.sh
 
-echo "--- Bundle all packages for Debian ${MINA_DEB_CODENAME}"
 echo " Includes mina daemon, archive-node, rosetta, generate keypair for devnet"
 [[ ${MINA_BUILD_MAINNET} ]] && echo " MINA_BUILD_MAINNET is true so this includes the mainnet and devnet packages for mina-daemon as well"
 
-
 echo "--- Prepare debian packages"
-BRANCH_NAME="$BUILDKITE_BRANCH" ./scripts/debian/build.sh $@
+./scripts/debian/build.sh $@
 
 echo "--- Git diff after build is complete:"
 git diff --exit-code -- .

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -1,65 +1,14 @@
 #!/bin/bash
 
-echo "Exporting Variables: "
+# This script should be never run outside buildkite agent
 
-export MINA_REPO="https://github.com/MinaProtocol/mina.git"
+source ./scripts/export-git-env-vars.sh
 
-function find_most_recent_numeric_tag() {
-    # We use the --prune flag because we've had problems with buildkite agents getting conflicting results here
-    git fetch --tags --prune --prune-tags --force
-    TAG=$(git describe --always --abbrev=0 $1 | sed 's!/!-!g; s!_!-!g; s!#!-!g')
-    if [[ $TAG != [0-9]* ]]; then
-        TAG=$(find_most_recent_numeric_tag $TAG~)
-    fi
-    echo $TAG
-}
+# Always prefer buildkite branch even if ./scripts/export-git-env-vars.sh 
+# calculate GITBRANCH on its own
+export GITBRANCH=$BUILDKITE_BRANCH 
 
-export GITHASH=$(git rev-parse --short=7 HEAD)
-
-export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
-export PROJECT="mina"
-
-set +u
-export BUILD_NUM=${BUILDKITE_BUILD_NUM}
+export BUILD_NUM=${BUILDKITE_BUILD_NUMBER}
 export BUILD_URL=${BUILDKITE_BUILD_URL}
-set -u
 
-export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
-if [[ -n "$BUILDKITE_BRANCH" ]]; then
-   export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
-else
-   export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
-fi
-
-
-
-export RELEASE=unstable
-
-if [ "${BUILDKITE_REPO}" != "${MINA_REPO}" ]; then 
-  # Abort if `BUILDKITE_REPO` doesn't have the expected format
-  echo ${BUILDKITE_REPO} | grep -P '^.*github.com[:\/](.*)\.git$' > /dev/null || \
-      (echo "BUILDKITE_REPO does not have the expected format" && false)
-
-  # We don't want to allow some operations on fork repository which should be done on main repo only. 
-  # Publish to docker hub or publish to unstable debian channel should be exclusive to main repo as it can override 
-  # packages from main repo (by using the same commit and the same branch from forked repository)
-
-  # We don't want to use tags (as this can replace our dockers/debian packages). Instead we are using repo name
-  # For example: for given repo 'https://github.com/dkijania/mina.git' we convert it to 'dkijania_mina' 
-  export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e 's/^.*github.com[:\/]\(.*\)\.git$/\1/' -e 's/\//-/')
-  export THIS_COMMIT_TAG=""
-
-else
-  # GITTAG is the closest tagged commit to this commit, while THIS_COMMIT_TAG only has a value when the current commit is tagged
-  export GITTAG=$(find_most_recent_numeric_tag HEAD)
-fi
-
-
-export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
-export MINA_DOCKER_TAG="$(echo "${MINA_DEB_VERSION}-${MINA_DEB_CODENAME}" | sed 's!/!-!g; s!_!-!g')"
-export RELEASE=unstable
-
-echo "Publishing on release channel \"${RELEASE}\""
-[[ -n ${THIS_COMMIT_TAG} ]] && export MINA_COMMIT_TAG="${THIS_COMMIT_TAG}"
-
-export MINA_DEB_RELEASE="${RELEASE}"
+source ./buildkite/scripts/handle-fork.sh

--- a/buildkite/scripts/handle-fork.sh
+++ b/buildkite/scripts/handle-fork.sh
@@ -11,4 +11,18 @@ else
     git fetch mina
     export REMOTE="mina"
     export FORK=1
+
+    # Abort if `BUILDKITE_REPO` doesn't have the expected format
+    echo ${BUILDKITE_REPO} | grep -P '^.*github.com[:\/](.*)\.git$' > /dev/null || \
+      (echo "BUILDKITE_REPO does not have the expected format" && false)
+
+    # We don't want to allow some operations on fork repository which should be done on main repo only. 
+    # Publish to docker hub or publish to unstable debian channel should be exclusive to main repo as it can override 
+    # packages from main repo (by using the same commit and the same branch from forked repository)
+
+    # We don't want to use tags (as this can replace our dockers/debian packages). Instead we are using repo name
+    # For example: for given repo 'https://github.com/dkijania/mina.git' we convert it to 'dkijania_mina' 
+    export GITTAG=1.0.0$(echo ${BUILDKITE_REPO} | sed -e 's/^.*github.com[:\/]\(.*\)\.git$/\1/' -e 's/\//-/')
+    export THIS_COMMIT_TAG=""
+    export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
 fi

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -6,18 +6,10 @@ set -eox pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-# In case of running this script on detached head, script has difficulties in finding out
-# what is the current branch.
-if [[ -n "$BRANCH_NAME" ]]; then 
-  BRANCH_NAME="$BRANCH_NAME" source ${SCRIPTPATH}/../export-git-env-vars.sh
-else
-  source ${SCRIPTPATH}/../export-git-env-vars.sh
-fi 
-
-echo "after export"
+source ${SCRIPTPATH}/../export-git-env-vars.sh
 
 source ${SCRIPTPATH}/builder-helpers.sh
-  
+
 if [ $# -eq 0 ]
   then
     echo "No arguments supplied. Building all known debian packages"

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-set -euo pipefail
-set -x
-
-
-# In case of running this script on detached head, script has difficulties in finding out
-# what is the current 
-echo "Exporting Git Variables: "
-
-git fetch
+set -euox pipefail
 
 function find_most_recent_numeric_tag() {
     # We use the --prune flag because we've had problems with buildkite agents getting conflicting results here
@@ -20,19 +12,10 @@ function find_most_recent_numeric_tag() {
 }
 
 export GITHASH=$(git rev-parse --short=7 HEAD)
-export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
-
-if [[ -n "$BRANCH_NAME" ]]; then
-   export GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
-else
-   export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
-fi
-
+export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 export GITTAG=$(find_most_recent_numeric_tag HEAD)
 
 export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
+export MINA_DEB_RELEASE="unstable"
+export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
 export MINA_DOCKER_TAG="$(echo "${MINA_DEB_VERSION}-${MINA_DEB_CODENAME}" | sed 's!/!-!g; s!_!-!g')"
-
-[[ -n ${THIS_COMMIT_TAG} ]] && export MINA_COMMIT_TAG="${THIS_COMMIT_TAG}"
-
-echo "after commit tag"

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -15,7 +15,15 @@ export GITHASH=$(git rev-parse --short=7 HEAD)
 export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 export GITTAG=$(find_most_recent_numeric_tag HEAD)
 
+export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
+[[ -n ${THIS_COMMIT_TAG} ]] && export MINA_COMMIT_TAG="${THIS_COMMIT_TAG}"
+
 export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
-export MINA_DEB_RELEASE="unstable"
+export RELEASE=unstable
+export MINA_DEB_RELEASE="${RELEASE}"
 export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
 export MINA_DOCKER_TAG="$(echo "${MINA_DEB_VERSION}-${MINA_DEB_CODENAME}" | sed 's!/!-!g; s!_!-!g')"
+
+export MINA_REPO="https://github.com/MinaProtocol/mina.git"
+export PROJECT="mina"
+


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
