### PR TITLE
Rework `Pickles.Composition_types.Spec` to handle distinct snarky instances

### DIFF
--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -1293,19 +1293,13 @@ module Step = struct
 
       let typ fq ~assert_16_bits =
         let open In_circuit in
-        Spec.typ
-          (module Step_impl)
-          fq ~assert_16_bits
-          (spec Backend.Tock.Rounds.n)
+        Spec.typ fq ~assert_16_bits (spec Backend.Tock.Rounds.n)
         |> Step_impl.Typ.transport ~there:to_data ~back:of_data
         |> Step_impl.Typ.transport_var ~there:to_data ~back:of_data
 
       let wrap_typ fq ~assert_16_bits =
         let open In_circuit in
-        Spec.typ
-          (module Wrap_impl)
-          fq ~assert_16_bits
-          (spec Backend.Tock.Rounds.n)
+        Spec.wrap_typ fq ~assert_16_bits (spec Backend.Tock.Rounds.n)
         |> Wrap_impl.Typ.transport ~there:to_data ~back:of_data
         |> Wrap_impl.Typ.transport_var ~there:to_data ~back:of_data
     end
@@ -1346,7 +1340,7 @@ module Step = struct
         Vector.typ' (Vector.map proofs_verified ~f:per_proof)
       in
       let messages_for_next_step_proof =
-        Spec.typ (module Wrap_impl) fq ~assert_16_bits (B Spec.Digest)
+        Spec.wrap_typ fq ~assert_16_bits (B Spec.Digest)
       in
       Wrap_impl.Typ.of_hlistable
         [ unfinalized_proofs; messages_for_next_step_proof ]

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -235,11 +235,9 @@ let typ (type field other_field other_field_var) ~assert_16_bits
     (field : (other_field_var, other_field) Impl.Typ.t) t =
   let module C = Common (Impl) in
   let module Typ_record = struct
-    type ('f, 'env) typ =
+    type 'env typ =
       { typ :
-          'var 'value.
-             ('value, 'var, 'env) basic
-          -> ('var, 'value, 'f) Snarky_backendless.Typ.t
+          'var 'value. ('value, 'var, 'env) basic -> ('var, 'value) Impl.Typ.t
       }
   end in
   let typ_basic =
@@ -269,10 +267,8 @@ let typ (type field other_field other_field_var) ~assert_16_bits
     { Typ_record.typ }
   in
   let rec typ :
-      type f var value env.
-         (f, env) Typ_record.typ
-      -> (value, var, env) T.t
-      -> (var, value, f) Snarky_backendless.Typ.t =
+      type var value env.
+      env Typ_record.typ -> (value, var, env) T.t -> (var, value) Impl.Typ.t =
     let open Snarky_backendless.Typ in
     fun t spec ->
       match[@warning "-45"] spec with

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -152,12 +152,6 @@ let rec pack :
   | Constant (x, _, inner) ->
       pack ~zero ~one p inner (Some x) t
 
-type ('f, 'env) typ =
-  { typ :
-      'var 'value.
-      ('value, 'var, 'env) basic -> ('var, 'value, 'f) Snarky_backendless.Typ.t
-  }
-
 module ETyp = struct
   type ('var, 'value, 'f) t =
     | T :
@@ -330,9 +324,17 @@ let pack (type f) ((module Impl) as impl : f impl) t =
 let typ (type field other_field other_field_var) ~assert_16_bits
     (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
     (field : (other_field_var, other_field) Impl.Typ.t) t =
+  let module C = Common (Impl) in
+  let module Typ_record = struct
+    type ('f, 'env) typ =
+      { typ :
+          'var 'value.
+             ('value, 'var, 'env) basic
+          -> ('var, 'value, 'f) Snarky_backendless.Typ.t
+      }
+  end in
   let typ_basic =
     let open Impl in
-    let module C = Common (Impl) in
     let open C in
     let typ :
         type a b.
@@ -355,11 +357,11 @@ let typ (type field other_field other_field_var) ~assert_16_bits
       | Bulletproof_challenge ->
           Bulletproof_challenge.typ Challenge.typ
     in
-    { typ }
+    { Typ_record.typ }
   in
   let rec typ :
       type f var value env.
-         (f, env) typ
+         (f, env) Typ_record.typ
       -> (value, var, env) T.t
       -> (var, value, f) Snarky_backendless.Typ.t =
     let open Snarky_backendless.Typ in

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -233,87 +233,132 @@ let pack (type f) ((module Impl) as impl : f impl) t =
 module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
   module C = Common (Impl)
 
-  let typ_basic (type other_field other_field_var) ~assert_16_bits
-      (field : (other_field_var, other_field) Impl.Typ.t) =
-    let typ_basic :
-        type a b.
-           (a, b, ((other_field, other_field_var, 'e) C.Env.t as 'e)) basic
-        -> (b, a) Impl.Typ.t =
+  module Basic : sig
+    val typ_basic :
+         assert_16_bits:(Impl.Field.t -> unit)
+      -> ('other_field_var, 'other_field) Impl.Typ.t
+      -> ( 'a
+         , 'b
+         , < bool1 : bool
+           ; bool2 : Impl.Boolean.var
+           ; branch_data1 : Branch_data.t
+           ; branch_data2 : Impl.field Branch_data.Checked.t
+           ; bulletproof_challenge1 :
+               C.Challenge.Constant.t Sc.t Bulletproof_challenge.t
+           ; bulletproof_challenge2 : C.Challenge.t Sc.t Bulletproof_challenge.t
+           ; challenge1 : C.Challenge.Constant.t
+           ; challenge2 : C.Challenge.t
+           ; digest1 : C.Digest.Constant.t
+           ; digest2 : C.Digest.t
+           ; field1 : 'other_field
+           ; field2 : 'other_field_var
+           ; .. > )
+         basic
+      -> ('b, 'a) Impl.Typ.t
+
+    val packed_typ_basic :
+         ('other_field_var, 'other_field, Impl.Field.Constant.t) ETyp.t
+      -> ( 'a
+         , 'b
+         , < bool1 : bool
+           ; bool2 : Impl.Boolean.var
+           ; branch_data1 : Branch_data.t
+           ; branch_data2 : C.Digest.t
+           ; bulletproof_challenge1 :
+               C.Challenge.Constant.t Sc.t Bulletproof_challenge.t
+           ; bulletproof_challenge2 : C.Digest.t Sc.t Bulletproof_challenge.t
+           ; challenge1 : C.Challenge.Constant.t
+           ; challenge2 : C.Digest.t
+           ; digest1 : C.Digest.Constant.t
+           ; digest2 : C.Digest.t
+           ; field1 : 'other_field
+           ; field2 : 'other_field_var
+           ; .. > )
+         basic
+      -> ('b, 'a, Impl.Field.Constant.t) ETyp.t
+  end = struct
+    let typ_basic (type other_field other_field_var) ~assert_16_bits
+        (field : (other_field_var, other_field) Impl.Typ.t) =
+      let typ_basic :
+          type a b.
+             (a, b, ((other_field, other_field_var, 'e) C.Env.t as 'e)) basic
+          -> (b, a) Impl.Typ.t =
+        let open Impl in
+        let open C in
+        fun basic ->
+          match basic with
+          | Unit ->
+              Typ.unit
+          | Field ->
+              field
+          | Bool ->
+              Boolean.typ
+          | Branch_data ->
+              Branch_data.typ (module Impl) ~assert_16_bits
+          | Digest ->
+              Digest.typ
+          | Challenge ->
+              Challenge.typ
+          | Bulletproof_challenge ->
+              Bulletproof_challenge.typ Challenge.typ
+      in
+      typ_basic
+
+    let packed_typ_basic (type other_field other_field_var)
+        (field : (other_field_var, other_field, Impl.Field.Constant.t) ETyp.t) =
       let open Impl in
       let open C in
-      fun basic ->
-        match basic with
+      let module Env = struct
+        type ('other_field, 'other_field_var, 'a) t =
+          < field1 : 'other_field
+          ; field2 : 'other_field_var
+          ; bool1 : bool
+          ; bool2 : Boolean.var
+          ; digest1 : Digest.Constant.t
+          ; digest2 : Field.t
+          ; challenge1 : Challenge.Constant.t
+          ; challenge2 : (* Challenge.t *) Field.t
+          ; bulletproof_challenge1 :
+              Challenge.Constant.t Sc.t Bulletproof_challenge.t
+          ; bulletproof_challenge2 : Field.t Sc.t Bulletproof_challenge.t
+          ; branch_data1 : Branch_data.t
+          ; branch_data2 : Field.t
+          ; .. >
+          as
+          'a
+      end in
+      let etyp :
+          type a b.
+             (a, b, ((other_field, other_field_var, 'e) Env.t as 'e)) basic
+          -> (b, a, field) ETyp.t = function
         | Unit ->
-            Typ.unit
+            T (Typ.unit, Fn.id, Fn.id)
         | Field ->
             field
         | Bool ->
-            Boolean.typ
-        | Branch_data ->
-            Branch_data.typ (module Impl) ~assert_16_bits
+            T (Boolean.typ, Fn.id, Fn.id)
         | Digest ->
-            Digest.typ
+            T (Digest.typ, Fn.id, Fn.id)
         | Challenge ->
-            Challenge.typ
+            T (Challenge.typ, Fn.id, Fn.id)
+        | Branch_data ->
+            T (Branch_data.packed_typ (module Impl), Fn.id, Fn.id)
         | Bulletproof_challenge ->
-            Bulletproof_challenge.typ Challenge.typ
-    in
-    typ_basic
-
-  let packed_typ_basic (type other_field other_field_var)
-      (field : (other_field_var, other_field, Impl.Field.Constant.t) ETyp.t) =
-    let open Impl in
-    let open C in
-    let module Env = struct
-      type ('other_field, 'other_field_var, 'a) t =
-        < field1 : 'other_field
-        ; field2 : 'other_field_var
-        ; bool1 : bool
-        ; bool2 : Boolean.var
-        ; digest1 : Digest.Constant.t
-        ; digest2 : Field.t
-        ; challenge1 : Challenge.Constant.t
-        ; challenge2 : (* Challenge.t *) Field.t
-        ; bulletproof_challenge1 :
-            Challenge.Constant.t Sc.t Bulletproof_challenge.t
-        ; bulletproof_challenge2 : Field.t Sc.t Bulletproof_challenge.t
-        ; branch_data1 : Branch_data.t
-        ; branch_data2 : Field.t
-        ; .. >
-        as
-        'a
-    end in
-    let etyp :
-        type a b.
-           (a, b, ((other_field, other_field_var, 'e) Env.t as 'e)) basic
-        -> (b, a, field) ETyp.t = function
-      | Unit ->
-          T (Typ.unit, Fn.id, Fn.id)
-      | Field ->
-          field
-      | Bool ->
-          T (Boolean.typ, Fn.id, Fn.id)
-      | Digest ->
-          T (Digest.typ, Fn.id, Fn.id)
-      | Challenge ->
-          T (Challenge.typ, Fn.id, Fn.id)
-      | Branch_data ->
-          T (Branch_data.packed_typ (module Impl), Fn.id, Fn.id)
-      | Bulletproof_challenge ->
-          let typ =
-            let there bp_challenge =
-              let { Sc.inner = pre } =
-                Bulletproof_challenge.pack bp_challenge
+            let typ =
+              let there bp_challenge =
+                let { Sc.inner = pre } =
+                  Bulletproof_challenge.pack bp_challenge
+                in
+                pre
               in
-              pre
+              let back pre = Bulletproof_challenge.unpack { Sc.inner = pre } in
+              Typ.transport Challenge.typ ~there ~back
+              |> Typ.transport_var ~there ~back
             in
-            let back pre = Bulletproof_challenge.unpack { Sc.inner = pre } in
-            Typ.transport Challenge.typ ~there ~back
-            |> Typ.transport_var ~there ~back
-          in
-          T (typ, Fn.id, Fn.id)
-    in
-    etyp
+            T (typ, Fn.id, Fn.id)
+      in
+      etyp
+  end
 
   let typ (type other_field other_field_var) ~assert_16_bits
       (field : (other_field_var, other_field) Impl.Typ.t) t =
@@ -390,7 +435,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
             |> transport ~there:(fun y -> assert_eq x y) ~back:(fun () -> x)
             |> transport_var ~there:(fun _ -> ()) ~back:(fun () -> constant_var)
     in
-    typ { typ = (fun basic -> typ_basic ~assert_16_bits field basic) } t
+    typ { typ = (fun basic -> Basic.typ_basic ~assert_16_bits field basic) } t
 
   let packed_typ (type other_field other_field_var)
       (field : (other_field_var, other_field, Impl.Field.Constant.t) ETyp.t) t =
@@ -492,7 +537,9 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
               , (fun _ -> f constant_var)
               , f' )
     in
-    etyp { ETyp_record.etyp = (fun basic -> packed_typ_basic field basic) } t
+    etyp
+      { ETyp_record.etyp = (fun basic -> Basic.packed_typ_basic field basic) }
+      t
 end
 
 module Step = Make (Kimchi_pasta_snarky_backend.Step_impl)

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -338,16 +338,16 @@ let typ (type field other_field other_field_var) ~assert_16_bits
   in
   typ typ_basic t
 
-let packed_typ impl field t =
+let packed_typ (type field other_field other_field_var)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
+    (field : (other_field_var, other_field, field) ETyp.t) t =
   let module ETyp_record = struct
     type ('f, 'env) etyp =
       { etyp :
           'var 'value. ('value, 'var, 'env) basic -> ('var, 'value, 'f) ETyp.t
       }
   end in
-  let packed_typ_basic (type field other_field other_field_var)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
-      (field : (other_field_var, other_field, field) ETyp.t) =
+  let packed_typ_basic =
     let open Impl in
     let module Digest = D.Make (Impl) in
     let module Challenge = Limb_vector.Challenge.Make (Impl) in
@@ -491,4 +491,4 @@ let packed_typ impl field t =
             , (fun _ -> f constant_var)
             , f' )
   in
-  etyp (packed_typ_basic impl field) t
+  etyp packed_typ_basic t

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -327,36 +327,36 @@ let pack (type f) ((module Impl) as impl : f impl) t =
     ~one:(`Packed_bits (Field.one, 1))
     None
 
-let typ_basic (type field other_field other_field_var)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
-    ~assert_16_bits (field : (other_field_var, other_field) Impl.Typ.t) =
-  let open Impl in
-  let module C = Common (Impl) in
-  let open C in
-  let typ :
-      type a b.
-         (a, b, ((other_field, other_field_var, 'e) Env.t as 'e)) basic
-      -> (b, a) Impl.Typ.t =
-   fun basic ->
-    match basic with
-    | Unit ->
-        Typ.unit
-    | Field ->
-        field
-    | Bool ->
-        Boolean.typ
-    | Branch_data ->
-        Branch_data.typ (module Impl) ~assert_16_bits
-    | Digest ->
-        Digest.typ
-    | Challenge ->
-        Challenge.typ
-    | Bulletproof_challenge ->
-        Bulletproof_challenge.typ Challenge.typ
-  in
-  { typ }
-
 let typ ~assert_16_bits impl field t =
+  let typ_basic (type field other_field other_field_var)
+      (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
+      ~assert_16_bits (field : (other_field_var, other_field) Impl.Typ.t) =
+    let open Impl in
+    let module C = Common (Impl) in
+    let open C in
+    let typ :
+        type a b.
+           (a, b, ((other_field, other_field_var, 'e) Env.t as 'e)) basic
+        -> (b, a) Impl.Typ.t =
+     fun basic ->
+      match basic with
+      | Unit ->
+          Typ.unit
+      | Field ->
+          field
+      | Bool ->
+          Boolean.typ
+      | Branch_data ->
+          Branch_data.typ (module Impl) ~assert_16_bits
+      | Digest ->
+          Digest.typ
+      | Challenge ->
+          Challenge.typ
+      | Bulletproof_challenge ->
+          Bulletproof_challenge.typ Challenge.typ
+    in
+    { typ }
+  in
   let rec typ :
       type f var value env.
          (f, env) typ

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -327,10 +327,10 @@ let pack (type f) ((module Impl) as impl : f impl) t =
     ~one:(`Packed_bits (Field.one, 1))
     None
 
-let typ ~assert_16_bits impl field t =
-  let typ_basic (type field other_field other_field_var)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
-      ~assert_16_bits (field : (other_field_var, other_field) Impl.Typ.t) =
+let typ (type field other_field other_field_var) ~assert_16_bits
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
+    (field : (other_field_var, other_field) Impl.Typ.t) t =
+  let typ_basic =
     let open Impl in
     let module C = Common (Impl) in
     let open C in
@@ -425,7 +425,7 @@ let typ ~assert_16_bits impl field t =
           |> transport ~there:(fun y -> assert_eq x y) ~back:(fun () -> x)
           |> transport_var ~there:(fun _ -> ()) ~back:(fun () -> constant_var)
   in
-  typ (typ_basic ~assert_16_bits impl field) t
+  typ typ_basic t
 
 let packed_typ_basic (type field other_field other_field_var)
     (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -231,8 +231,6 @@ let pack (type f) ((module Impl) as impl : f impl) t =
     None
 
 module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
-  module C = Common (Impl)
-
   module Basic : sig
     val typ_basic :
          assert_16_bits:(Impl.Field.t -> unit)
@@ -244,12 +242,13 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
            ; branch_data1 : Branch_data.t
            ; branch_data2 : Impl.field Branch_data.Checked.t
            ; bulletproof_challenge1 :
-               C.Challenge.Constant.t Sc.t Bulletproof_challenge.t
-           ; bulletproof_challenge2 : C.Challenge.t Sc.t Bulletproof_challenge.t
-           ; challenge1 : C.Challenge.Constant.t
-           ; challenge2 : C.Challenge.t
-           ; digest1 : C.Digest.Constant.t
-           ; digest2 : C.Digest.t
+               Common(Impl).Challenge.Constant.t Sc.t Bulletproof_challenge.t
+           ; bulletproof_challenge2 :
+               Common(Impl).Challenge.t Sc.t Bulletproof_challenge.t
+           ; challenge1 : Common(Impl).Challenge.Constant.t
+           ; challenge2 : Common(Impl).Challenge.t
+           ; digest1 : Common(Impl).Digest.Constant.t
+           ; digest2 : Common(Impl).Digest.t
            ; field1 : 'other_field
            ; field2 : 'other_field_var
            ; .. > )
@@ -263,20 +262,23 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
          , < bool1 : bool
            ; bool2 : Impl.Boolean.var
            ; branch_data1 : Branch_data.t
-           ; branch_data2 : C.Digest.t
+           ; branch_data2 : Common(Impl).Digest.t
            ; bulletproof_challenge1 :
-               C.Challenge.Constant.t Sc.t Bulletproof_challenge.t
-           ; bulletproof_challenge2 : C.Digest.t Sc.t Bulletproof_challenge.t
-           ; challenge1 : C.Challenge.Constant.t
-           ; challenge2 : C.Digest.t
-           ; digest1 : C.Digest.Constant.t
-           ; digest2 : C.Digest.t
+               Common(Impl).Challenge.Constant.t Sc.t Bulletproof_challenge.t
+           ; bulletproof_challenge2 :
+               Common(Impl).Digest.t Sc.t Bulletproof_challenge.t
+           ; challenge1 : Common(Impl).Challenge.Constant.t
+           ; challenge2 : Common(Impl).Digest.t
+           ; digest1 : Common(Impl).Digest.Constant.t
+           ; digest2 : Common(Impl).Digest.t
            ; field1 : 'other_field
            ; field2 : 'other_field_var
            ; .. > )
          basic
       -> ('b, 'a, Impl.Field.Constant.t) ETyp.t
   end = struct
+    module C = Common (Impl)
+
     let typ_basic (type other_field other_field_var) ~assert_16_bits
         (field : (other_field_var, other_field) Impl.Typ.t) =
       let typ_basic :

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -231,9 +231,10 @@ let pack (type f) ((module Impl) as impl : f impl) t =
     None
 
 module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
+  module C = Common (Impl)
+
   let typ (type other_field other_field_var) ~assert_16_bits
       (field : (other_field_var, other_field) Impl.Typ.t) t =
-    let module C = Common (Impl) in
     let module Typ_record = struct
       type 'env typ =
         { typ :
@@ -345,8 +346,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
     end in
     let packed_typ_basic =
       let open Impl in
-      let module Digest = D.Make (Impl) in
-      let module Challenge = Limb_vector.Challenge.Make (Impl) in
+      let open C in
       let module Env = struct
         type ('other_field, 'other_field_var, 'a) t =
           < field1 : 'other_field

--- a/src/lib/pickles/composition_types/spec.mli
+++ b/src/lib/pickles/composition_types/spec.mli
@@ -82,37 +82,62 @@ module rec T : sig
     | Constant : 'a * ('a -> 'a -> unit) * ('a, 'b, 'env) t -> ('a, 'b, 'env) t
 end
 
+module Step_impl := Kimchi_pasta_snarky_backend.Step_impl
+module Wrap_impl := Kimchi_pasta_snarky_backend.Wrap_impl
+
 val typ :
-     assert_16_bits:('a Snarky_backendless.Cvar.t -> unit)
-  -> 'a impl
-  -> ( 'b
-     , 'c
-     , 'a
-     , (unit, 'a) Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
-     Snarky_backendless.Types.Typ.t
+     assert_16_bits:(Step_impl.Field.t -> unit)
+  -> ('b, 'c) Step_impl.Typ.t
   -> ( 'd
      , 'e
      , < bool1 : bool
-       ; bool2 :
-           'a Snarky_backendless.Cvar.t Snarky_backendless.Snark_intf.Boolean0.t
+       ; bool2 : Step_impl.Boolean.var
        ; branch_data1 : Branch_data.t
-       ; branch_data2 : 'a Branch_data.Checked.t
+       ; branch_data2 : Step_impl.Field.Constant.t Branch_data.Checked.t
        ; bulletproof_challenge1 :
            Limb_vector.Challenge.Constant.t
            Kimchi_backend_common.Scalar_challenge.t
            Bulletproof_challenge.t
        ; bulletproof_challenge2 :
-           'a Limb_vector.Challenge.t Kimchi_backend_common.Scalar_challenge.t
+           Step_impl.Field.Constant.t Limb_vector.Challenge.t
+           Kimchi_backend_common.Scalar_challenge.t
            Bulletproof_challenge.t
        ; challenge1 : Limb_vector.Challenge.Constant.t
-       ; challenge2 : 'a Limb_vector.Challenge.t
+       ; challenge2 : Step_impl.Field.Constant.t Limb_vector.Challenge.t
        ; digest1 : Digest.Constant.t
-       ; digest2 : 'a Snarky_backendless.Cvar.t
+       ; digest2 : Step_impl.Field.t
        ; field1 : 'c
        ; field2 : 'b
        ; .. > )
      T.t
-  -> ('e, 'd, 'a) Snarky_backendless.Typ.t
+  -> ('e, 'd) Step_impl.Typ.t
+
+val wrap_typ :
+     assert_16_bits:(Wrap_impl.Field.t -> unit)
+  -> ('b, 'c) Wrap_impl.Typ.t
+  -> ( 'd
+     , 'e
+     , < bool1 : bool
+       ; bool2 : Wrap_impl.Boolean.var
+       ; branch_data1 : Branch_data.t
+       ; branch_data2 : Wrap_impl.Field.Constant.t Branch_data.Checked.t
+       ; bulletproof_challenge1 :
+           Limb_vector.Challenge.Constant.t
+           Kimchi_backend_common.Scalar_challenge.t
+           Bulletproof_challenge.t
+       ; bulletproof_challenge2 :
+           Wrap_impl.Field.Constant.t Limb_vector.Challenge.t
+           Kimchi_backend_common.Scalar_challenge.t
+           Bulletproof_challenge.t
+       ; challenge1 : Limb_vector.Challenge.Constant.t
+       ; challenge2 : Wrap_impl.Field.Constant.t Limb_vector.Challenge.t
+       ; digest1 : Digest.Constant.t
+       ; digest2 : Wrap_impl.Field.t
+       ; field1 : 'c
+       ; field2 : 'b
+       ; .. > )
+     T.t
+  -> ('e, 'd) Wrap_impl.Typ.t
 
 module ETyp : sig
   type ('var, 'value, 'f) t =
@@ -124,31 +149,54 @@ module ETyp : sig
 end
 
 val packed_typ :
-     'a impl
-  -> ('b, 'c, 'a) ETyp.t
+     ('b, 'c, Step_impl.Field.Constant.t) ETyp.t
   -> ( 'd
      , 'e
      , < bool1 : bool
-       ; bool2 :
-           'a Snarky_backendless.Cvar.t Snarky_backendless.Snark_intf.Boolean0.t
+       ; bool2 : Step_impl.Boolean.var
        ; branch_data1 : Branch_data.t
-       ; branch_data2 : 'a Snarky_backendless.Cvar.t
+       ; branch_data2 : Step_impl.Field.t
        ; bulletproof_challenge1 :
            Limb_vector.Challenge.Constant.t
            Kimchi_backend_common.Scalar_challenge.t
            Bulletproof_challenge.t
        ; bulletproof_challenge2 :
-           'a Snarky_backendless.Cvar.t Kimchi_backend_common.Scalar_challenge.t
+           Step_impl.Field.t Kimchi_backend_common.Scalar_challenge.t
            Bulletproof_challenge.t
        ; challenge1 : Limb_vector.Challenge.Constant.t
-       ; challenge2 : 'a Snarky_backendless.Cvar.t
+       ; challenge2 : Step_impl.Field.t
        ; digest1 : Digest.Constant.t
-       ; digest2 : 'a Snarky_backendless.Cvar.t
+       ; digest2 : Step_impl.Field.t
        ; field1 : 'c
        ; field2 : 'b
        ; .. > )
      T.t
-  -> ('e, 'd, 'a) ETyp.t
+  -> ('e, 'd, Step_impl.Field.Constant.t) ETyp.t
+
+val wrap_packed_typ :
+     ('b, 'c, Wrap_impl.Field.Constant.t) ETyp.t
+  -> ( 'd
+     , 'e
+     , < bool1 : bool
+       ; bool2 : Wrap_impl.Boolean.var
+       ; branch_data1 : Branch_data.t
+       ; branch_data2 : Wrap_impl.Field.t
+       ; bulletproof_challenge1 :
+           Limb_vector.Challenge.Constant.t
+           Kimchi_backend_common.Scalar_challenge.t
+           Bulletproof_challenge.t
+       ; bulletproof_challenge2 :
+           Wrap_impl.Field.t Kimchi_backend_common.Scalar_challenge.t
+           Bulletproof_challenge.t
+       ; challenge1 : Limb_vector.Challenge.Constant.t
+       ; challenge2 : Wrap_impl.Field.t
+       ; digest1 : Digest.Constant.t
+       ; digest2 : Wrap_impl.Field.t
+       ; field1 : 'c
+       ; field2 : 'b
+       ; .. > )
+     T.t
+  -> ('e, 'd, Wrap_impl.Field.Constant.t) ETyp.t
 
 val pack :
      'f impl

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -154,7 +154,6 @@ module Step = struct
     let spec = spec proofs_verified Tock.Rounds.n in
     let (T (typ, f, f_inv)) =
       Spec.packed_typ
-        (module Impl)
         (T
            ( Shifted_value.Type2.typ Other_field.typ_unchecked
            , (fun (Shifted_value.Type2.Shifted_value x as t) ->
@@ -258,8 +257,7 @@ module Wrap = struct
     in
     let open Types.Wrap.Statement in
     let (T (typ, f, f_inv)) =
-      Spec.packed_typ
-        (module Impl)
+      Spec.wrap_packed_typ
         (T
            ( Shifted_value.Type1.typ fp
            , (fun (Shifted_value x as t) ->


### PR DESCRIPTION
This PR converts the generalized helpers in `Pickles.Composition_types.Spec` to functors, instantiating them by default with the step and wrap snarky instances for pickles.

This allows for more straightfoward manipulation of the `Typ.t`s for each instance, which in turn allows for integration with the rust snarky backend.