### PR TITLE
Specialize more `Typ.t`s in `Pickles.Composition_types`

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
+++ b/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
@@ -38,35 +38,21 @@ module Scalar_challenge : sig
   module Stable = Scalar_challenge.Stable
 
   type 'f t = 'f Kimchi_types.scalar_challenge = { inner : 'f }
-
-  val to_yojson : ('f -> Yojson.Safe.t) -> 'f t -> Yojson.Safe.t
-
-  val of_yojson :
-       (Yojson.Safe.t -> 'f Ppx_deriving_yojson_runtime.error_or)
-    -> Yojson.Safe.t
-    -> 'f t Ppx_deriving_yojson_runtime.error_or
-
-  val t_of_sexp :
-    (Ppx_sexp_conv_lib.Sexp.t -> 'f) -> Ppx_sexp_conv_lib.Sexp.t -> 'f t
-
-  val sexp_of_t :
-    ('f -> Ppx_sexp_conv_lib.Sexp.t) -> 'f t -> Ppx_sexp_conv_lib.Sexp.t
-
-  val compare : ('f -> 'f -> int) -> 'f t -> 'f t -> int
-
-  val equal : ('f -> 'f -> bool) -> 'f t -> 'f t -> bool
-
-  val hash_fold_t :
-       (Base_internalhash_types.state -> 'f -> Base_internalhash_types.state)
-    -> Base_internalhash_types.state
-    -> 'f t
-    -> Base_internalhash_types.state
+  [@@deriving yojson, sexp, compare, equal, hash]
 
   val create : 'a -> 'a t
 
+  module Make_typ (Impl : Snarky_backendless.Snark_intf.Run) : sig
+    val typ : ('a, 'b) Impl.Typ.t -> ('a t, 'b t) Impl.Typ.t
+  end
+
   val typ :
-       ('a, 'b, 'c) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 end

--- a/src/lib/crypto/kimchi_backend/common/scalar_challenge.ml
+++ b/src/lib/crypto/kimchi_backend/common/scalar_challenge.ml
@@ -10,9 +10,25 @@ end]
 
 let create t = { inner = t }
 
-let typ f =
-  let there { inner = x } = x in
-  let back x = create x in
-  Snarky_backendless.Typ.(transport_var (transport f ~there ~back) ~there ~back)
+module Make_typ (Impl : Snarky_backendless.Snark_intf.Run) = struct
+  let typ f =
+    let there { inner = x } = x in
+    let back x = create x in
+    Impl.Typ.(transport_var (transport f ~there ~back) ~there ~back)
+end
+
+include Make_typ (Kimchi_pasta_snarky_backend.Step_impl)
+
+include (
+  struct
+    include Make_typ (Kimchi_pasta_snarky_backend.Wrap_impl)
+
+    let wrap_typ = typ
+  end :
+    sig
+      val wrap_typ :
+           ('var, 'value) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+        -> ('var t, 'value t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    end )
 
 let map { inner = x } ~f = create (f x)

--- a/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
+++ b/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
@@ -12,8 +12,16 @@ type 'f t = 'f Kimchi_types.scalar_challenge = { inner : 'f }
 
 val create : 'a -> 'a t
 
+module Make_typ (Impl : Snarky_backendless.Snark_intf.Run) : sig
+  val typ : ('a, 'b) Impl.Typ.t -> ('a t, 'b t) Impl.Typ.t
+end
+
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
-  -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+     ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+  -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+val wrap_typ :
+     ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+  -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
 val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/src/lib/pickles/composition_types/bulletproof_challenge.ml
+++ b/src/lib/pickles/composition_types/bulletproof_challenge.ml
@@ -17,6 +17,14 @@ let map { prechallenge } ~f = { prechallenge = f prechallenge }
 let typ chal =
   let there = pack in
   let back = unpack in
-  let open Snarky_backendless in
+  let open Kimchi_pasta_snarky_backend.Step_impl in
   Typ.transport ~there ~back (Kimchi_backend_common.Scalar_challenge.typ chal)
+  |> Typ.transport_var ~there ~back
+
+let wrap_typ chal =
+  let there = pack in
+  let back = unpack in
+  let open Kimchi_pasta_snarky_backend.Wrap_impl in
+  Typ.transport ~there ~back
+    (Kimchi_backend_common.Scalar_challenge.wrap_typ chal)
   |> Typ.transport_var ~there ~back

--- a/src/lib/pickles/composition_types/bulletproof_challenge.mli
+++ b/src/lib/pickles/composition_types/bulletproof_challenge.mli
@@ -19,8 +19,13 @@ val unpack : 'a -> 'a t
 val map : 'a t -> f:('a -> 'b) -> 'b t
 
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
+     ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
   -> ( 'a Kimchi_backend_common.Scalar_challenge.t t
-     , 'b Kimchi_backend_common.Scalar_challenge.t t
-     , 'c )
-     Snarky_backendless.Typ.t
+     , 'b Kimchi_backend_common.Scalar_challenge.t t )
+     Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+val wrap_typ :
+     ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+  -> ( 'a Kimchi_backend_common.Scalar_challenge.t t
+     , 'b Kimchi_backend_common.Scalar_challenge.t t )
+     Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -172,7 +172,9 @@ struct
     let to_field = to_field_constant ~endo:Endo.scalar (module Scalar)
   end
 
-  let typ : (t, Constant.t) Typ.t = SC.typ Challenge.typ
+  let typ : (t, Constant.t) Typ.t =
+    let module Typ = SC.Make_typ (Impl) in
+    Typ.typ Challenge.typ
 
   let num_bits = 128
 


### PR DESCRIPTION
This PR builds upon #16353, allowing us to extend the efforts from PR #16352 for the `Bulletproof_challenge.typ`.