### PR TITLE
Specialize `Typ.t`s in `Pickles_types`

### DIFF
--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -9,8 +9,6 @@ open Core_kernel
 module Step_impl = Kimchi_pasta_snarky_backend.Step_impl
 module Wrap_impl = Kimchi_pasta_snarky_backend.Wrap_impl
 
-type 'f impl = 'f Spec.impl
-
 let index_to_field_elements =
   Pickles_base.Side_loaded_verification_key.index_to_field_elements
 
@@ -150,8 +148,7 @@ module Wrap = struct
               ; Plonk_types.Features.typ
                   ~feature_flags:(Plonk_types.Features.of_full feature_flags)
                   bool
-              ; Opt.typ Step_impl.Boolean.typ uses_lookups
-                  ~dummy:dummy_scalar_challenge
+              ; Opt.typ uses_lookups ~dummy:dummy_scalar_challenge
                   (Scalar_challenge.typ scalar_challenge)
               ]
               ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
@@ -607,8 +604,7 @@ module Wrap = struct
       ; use : Opt.Flag.t
       }
 
-    let opt_spec (type f) ((module Impl) : f impl)
-        { zero = { value; var }; use } =
+    let opt_spec { zero = { value; var }; use } =
       Spec.T.Opt
         { inner = Struct [ Scalar Challenge ]
         ; flag = use
@@ -616,7 +612,6 @@ module Wrap = struct
             [ Kimchi_backend_common.Scalar_challenge.create value.challenge ]
         ; dummy2 =
             [ Kimchi_backend_common.Scalar_challenge.create var.challenge ]
-        ; bool = (module Impl.Boolean)
         }
   end
 
@@ -774,7 +769,7 @@ module Wrap = struct
           ; Vector (B Bulletproof_challenge, Backend.Tick.Rounds.n)
           ; Vector (B Branch_data, Nat.N1.n)
           ; feature_flags_spec
-          ; Lookup_parameters.opt_spec impl lookup
+          ; Lookup_parameters.opt_spec lookup
           ]
 
       (** Convert a statement (as structured data) into the flat data-based representation. *)

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -610,8 +610,7 @@ module Wrap : sig
       }
 
     val opt_spec :
-         'f Spec.impl
-      -> ('a, 'b, 'c, 'd) t
+         ('a, 'b, 'c, 'd) t
       -> ( ('a Scalar_challenge.t * unit) Hlist.HlistId.t option
          , ( ('b Scalar_challenge.t * unit) Hlist.HlistId.t
            , 'f Snarky_backendless.Cvar.t

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -291,7 +291,7 @@ struct
     let rec typ :
         type var value env.
         env Typ_record.typ -> (value, var, env) T.t -> (var, value) Impl.Typ.t =
-      let open Snarky_backendless.Typ in
+      let open Impl.Typ in
       fun t spec ->
         match[@warning "-45"] spec with
         | B spec ->
@@ -304,7 +304,7 @@ struct
             array ~length:n (typ t spec)
         | Struct [] ->
             let open Hlist.HlistId in
-            transport (unit ()) ~there:(fun [] -> ()) ~back:(fun () -> [])
+            transport unit ~there:(fun [] -> ()) ~back:(fun () -> [])
             |> transport_var ~there:(fun [] -> ()) ~back:(fun () -> [])
         | Struct (spec :: specs) ->
             let open Hlist.HlistId in
@@ -324,20 +324,20 @@ struct
         | Opt_unflagged { inner; flag; dummy1; dummy2 } -> (
             match flag with
             | Opt.Flag.No ->
-                let open Snarky_backendless.Typ in
-                unit ()
-                |> Snarky_backendless.Typ.transport
+                let open Impl.Typ in
+                unit
+                |> Impl.Typ.transport
                      ~there:(function Some _ -> assert false | None -> ())
                      ~back:(fun () -> None)
-                |> Snarky_backendless.Typ.transport_var
+                |> Impl.Typ.transport_var
                      ~there:(function Some _ -> assert false | None -> ())
                      ~back:(fun _ -> None)
             | Opt.Flag.(Yes | Maybe) ->
                 typ t inner
-                |> Snarky_backendless.Typ.transport
+                |> Impl.Typ.transport
                      ~there:(function Some x -> x | None -> dummy1)
                      ~back:(fun x -> Some x)
-                |> Snarky_backendless.Typ.transport_var
+                |> Impl.Typ.transport_var
                      ~there:(function Some x -> x | None -> dummy2)
                      ~back:(fun x -> Some x) )
         | Constant (x, assert_eq, spec) ->
@@ -350,8 +350,8 @@ struct
               in
               typ.var_of_fields (fields, aux)
             in
-            let open Snarky_backendless.Typ in
-            unit ()
+            let open Impl.Typ in
+            unit
             |> transport ~there:(fun y -> assert_eq x y) ~back:(fun () -> x)
             |> transport_var ~there:(fun _ -> ()) ~back:(fun () -> constant_var)
     in
@@ -370,7 +370,7 @@ struct
            (Impl.Field.Constant.t, env) ETyp_record.etyp
         -> (value, var, env) T.t
         -> (var, value, Impl.Field.Constant.t) ETyp.t =
-      let open Snarky_backendless.Typ in
+      let open Impl.Typ in
       fun e spec ->
         match[@warning "-45"] spec with
         | B spec ->
@@ -389,7 +389,7 @@ struct
             let there [] = () in
             let back () = [] in
             T
-              ( transport (unit ()) ~there ~back |> transport_var ~there ~back
+              ( transport unit ~there ~back |> transport_var ~there ~back
               , Fn.id
               , Fn.id )
         | Struct (spec :: specs) ->
@@ -429,8 +429,8 @@ struct
             let f_inv = function None -> f_inv dummy2 | Some x -> f_inv x in
             let typ =
               typ
-              |> Snarky_backendless.Typ.transport
-                   ~there:(Option.value ~default:dummy1) ~back:(fun x -> Some x)
+              |> Impl.Typ.transport ~there:(Option.value ~default:dummy1)
+                   ~back:(fun x -> Some x)
             in
             T (typ, f, f_inv)
         | Constant (x, _assert_eq, spec) ->

--- a/src/lib/pickles/composition_types/spec.mli
+++ b/src/lib/pickles/composition_types/spec.mli
@@ -30,14 +30,6 @@ type (_, _, _) basic =
         )
         basic
 
-module type Bool_intf = sig
-  type var
-
-  val true_ : var
-
-  val false_ : var
-end
-
 (** Compound types. These are built from Basic types described above *)
 module rec T : sig
   type (_, _, _) t =
@@ -66,7 +58,6 @@ module rec T : sig
         ; flag : Pickles_types.Opt.Flag.t
         ; dummy1 : 'a1
         ; dummy2 : 'a2
-        ; bool : (module Bool_intf with type var = 'bool)
         }
         -> ( 'a1 option
            , ('a2, 'bool) Pickles_types.Opt.t

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -154,7 +154,6 @@ let typ (type n avar aval) ~feature_flags ~num_chunks
            (module Impl)
            ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16) )
     ; Plonk_types.All_evals.typ ~num_chunks
-        (module Impl)
         (* Assume we have lookup iff we have runtime tables *)
         feature_flags
     ; Vector.typ (Vector.typ Field.typ Tick.Rounds.n) max_proofs_verified

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -259,8 +259,7 @@ let step_main :
       local_signature_length local_branches_length feature_flags_and_num_chunks
   in
   let module Prev_typ =
-    H4.Typ (Impls.Step) (Typ_with_max_proofs_verified)
-      (Per_proof_witness.No_app_state)
+    H4.Typ (Typ_with_max_proofs_verified) (Per_proof_witness.No_app_state)
       (Per_proof_witness.Constant.No_app_state)
       (struct
         let f = Fn.id

--- a/src/lib/pickles/test/test_wrap.ml
+++ b/src/lib/pickles/test/test_wrap.ml
@@ -153,9 +153,7 @@ let run_recursive_proof_test (actual_feature_flags : Plonk_types.Features.flags)
      for use in the circuit *)
   and evals =
     constant
-      (Plonk_types.All_evals.typ ~num_chunks:1
-         (module Impls.Step)
-         full_features )
+      (Plonk_types.All_evals.typ ~num_chunks:1 full_features)
       { evals =
           { public_input = x_hat_evals; evals = proof.proof.openings.evals }
       ; ft_eval1 = proof.proof.openings.ft_eval1

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -321,7 +321,7 @@ let wrap_main
             with_label __LOC__ (fun () ->
                 let typ =
                   let module T =
-                    H1.Typ (Impls.Wrap) (Nat) (Challenges_vector)
+                    H1.Wrap_typ (Nat) (Challenges_vector)
                       (Challenges_vector.Constant)
                       (struct
                         let f (type n) (n : n Nat.t) =

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -455,7 +455,7 @@ let wrap_main
           let openings_proof =
             let shift = Shifts.tick1 in
             exists
-              (Plonk_types.Openings.Bulletproof.typ
+              (Plonk_types.Openings.Bulletproof.wrap_typ
                  ( Typ.transport Wrap_verifier.Other_field.Packed.typ
                      ~there:(fun x ->
                        (* When storing, make it a shifted value *)

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -355,9 +355,8 @@ let wrap_main
                 let evals =
                   let ty =
                     let ty =
-                      Plonk_types.All_evals.typ
-                        (module Impl)
-                        ~num_chunks:1 Plonk_types.Features.Full.none
+                      Plonk_types.All_evals.wrap_typ ~num_chunks:1
+                        Plonk_types.Features.Full.none
                     in
                     Vector.typ ty Max_proofs_verified.n
                   in
@@ -485,9 +484,7 @@ let wrap_main
             let messages =
               with_label __LOC__ (fun () ->
                   exists
-                    (Plonk_types.Messages.typ
-                       (module Impl)
-                       Inner_curve.typ ~bool:Boolean.typ feature_flags
+                    (Plonk_types.Messages.wrap_typ Inner_curve.typ feature_flags
                        ~dummy:Inner_curve.Params.one
                        ~commitment_lengths:
                          (Commitment_lengths.default ~num_chunks) )

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -34,9 +34,7 @@ let typ : (Checked.t, Constant.t) Typ.t =
   let shift = Shifted_value.Type2.Shift.create (module Tock.Field) in
   Typ.of_hlistable ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_to_hlist:Constant.to_hlist ~value_of_hlist:Constant.of_hlist
-    [ Plonk_types.Messages.typ
-        (module Impl)
-        Inner_curve.typ Plonk_types.Features.Full.none ~bool:Boolean.typ
+    [ Plonk_types.Messages.typ Inner_curve.typ Plonk_types.Features.Full.none
         ~dummy:Inner_curve.Params.one
         ~commitment_lengths:
           (Commitment_lengths.default

--- a/src/lib/pickles/wrap_verifier.mli
+++ b/src/lib/pickles/wrap_verifier.mli
@@ -24,10 +24,7 @@ module Other_field : sig
     type t = Impls.Wrap.Other_field.t
 
     val typ :
-      ( Impls.Wrap.Impl.Field.t
-      , Backend.Tick.Field.t
-      , Impls.Wrap_impl.Internal_Basic.Field.t )
-      Snarky_backendless.Typ.t
+      (Impls.Wrap.Impl.Field.t, Backend.Tick.Field.t) Impls.Wrap_impl.Typ.t
   end
 end
 

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -33,6 +33,7 @@
   bin_prot.shape
   ;; local libraries
   kimchi_types
+  kimchi_pasta_snarky_backend
   snarky.backendless
   tuple_lib
   ppx_version.runtime

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -158,21 +158,24 @@ module H1 = struct
       match (xs, ys) with [], [] -> [] | x :: xs, y :: ys -> (x, y) :: f xs ys
   end
 
-  module Typ (Impl : sig
-    type field
-  end)
-  (F : T1)
-  (Var : T1)
-  (Val : T1) (C : sig
-    val f : 'a F.t -> ('a Var.t, 'a Val.t, Impl.field) Snarky_backendless.Typ.t
-  end) =
+  module Wrap_typ
+      (F : T1)
+      (Var : T1)
+      (Val : T1) (C : sig
+        val f :
+             'a F.t
+          -> ('a Var.t, 'a Val.t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+      end) =
   struct
     let rec f :
         type xs.
            xs T(F).t
-        -> (xs T(Var).t, xs T(Val).t, Impl.field) Snarky_backendless.Typ.t =
+        -> ( xs T(Var).t
+           , xs T(Val).t )
+           Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t =
       let transport, transport_var, tuple2, unit =
-        Snarky_backendless.Typ.(transport, transport_var, tuple2, unit)
+        Kimchi_pasta_snarky_backend.Wrap_impl.Typ.
+          (transport, transport_var, tuple2, unit)
       in
       fun ts ->
         match ts with
@@ -187,7 +190,7 @@ module H1 = struct
                  ~back:(fun (x, xs) -> x :: xs)
         | [] ->
             let there _ = () in
-            transport (unit ()) ~there ~back:(fun () : _ T(Val).t -> [])
+            transport unit ~there ~back:(fun () : _ T(Val).t -> [])
             |> transport_var ~there ~back:(fun () : _ T(Var).t -> [])
   end
 end

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -239,40 +239,6 @@ module H2 = struct
           let y = C.f x in
           y :: f xs
   end
-
-  module Typ (Impl : sig
-    type field
-
-    module Typ : sig
-      type ('var, 'value) t = ('var, 'value, field) Snarky_backendless.Typ.t
-    end
-  end) =
-  struct
-    let transport, transport_var, tuple2, unit =
-      Snarky_backendless.Typ.(transport, transport_var, tuple2, unit)
-
-    let rec f :
-        type vars values.
-           (vars, values) T(Impl.Typ).t
-        -> ( vars H1.T(Id).t
-           , values H1.T(Id).t
-           , Impl.field )
-           Snarky_backendless.Typ.t =
-     fun ts ->
-      match ts with
-      | [] ->
-          let there _ = () in
-          transport (unit ()) ~there ~back:(fun () : _ H1.T(Id).t -> [])
-          |> transport_var ~there ~back:(fun () : _ H1.T(Id).t -> [])
-      | t :: ts ->
-          transport
-            (tuple2 t (f ts))
-            ~there:(fun (x :: xs : _ H1.T(Id).t) -> (x, xs))
-            ~back:(fun (x, xs) -> x :: xs)
-          |> transport_var
-               ~there:(fun (x :: xs : _ H1.T(Id).t) -> (x, xs))
-               ~back:(fun (x, xs) -> x :: xs)
-  end
 end
 
 module H3_2 = struct
@@ -820,46 +786,6 @@ module H6 = struct
         (a1, a2, a3, a4, a5, a6) T(F).t -> (a1, n) Length.t -> (a2, n) Length.t
         =
      fun xs n -> match (xs, n) with [], Z -> Z | _ :: xs, S n -> S (f xs n)
-  end
-
-  module Typ (Impl : sig
-    type field
-  end)
-  (F : T6)
-  (Var : T4)
-  (Val : T4) (C : sig
-    val f :
-         ('var, 'value, 'ret_var, 'ret_value, 'n1, 'n2) F.t
-      -> ( ('var, 'ret_var, 'n1, 'n2) Var.t
-         , ('value, 'ret_value, 'n1, 'n2) Val.t
-         , Impl.field )
-         Snarky_backendless.Typ.t
-  end) =
-  struct
-    let transport, transport_var, tuple2, unit =
-      Snarky_backendless.Typ.(transport, transport_var, tuple2, unit)
-
-    let rec f :
-        type vars values ret_vars ret_values ns1 ns2.
-           (vars, values, ret_vars, ret_values, ns1, ns2) T(F).t
-        -> ( (vars, ret_vars, ns1, ns2) H4.T(Var).t
-           , (values, ret_values, ns1, ns2) H4.T(Val).t
-           , Impl.field )
-           Snarky_backendless.Typ.t =
-     fun ts ->
-      match ts with
-      | [] ->
-          let there _ = () in
-          transport (unit ()) ~there ~back:(fun () : _ H4.T(Val).t -> [])
-          |> transport_var ~there ~back:(fun () : _ H4.T(Var).t -> [])
-      | t :: ts ->
-          transport
-            (tuple2 (C.f t) (f ts))
-            ~there:(fun (x :: xs : _ H4.T(Val).t) -> (x, xs))
-            ~back:(fun (x, xs) -> x :: xs)
-          |> transport_var
-               ~there:(fun (x :: xs : _ H4.T(Var).t) -> (x, xs))
-               ~back:(fun (x, xs) -> x :: xs)
   end
 end
 

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -647,35 +647,32 @@ module H4 = struct
      fun xs n -> match (xs, n) with [], Z -> Z | _ :: xs, S n -> S (f xs n)
   end
 
-  module Typ (Impl : sig
-    type field
-  end)
-  (F : T4)
-  (Var : T3)
-  (Val : T3) (C : sig
-    val f :
-         ('var, 'value, 'n1, 'n2) F.t
-      -> ( ('var, 'n1, 'n2) Var.t
-         , ('value, 'n1, 'n2) Val.t
-         , Impl.field )
-         Snarky_backendless.Typ.t
-  end) =
+  module Typ
+      (F : T4)
+      (Var : T3)
+      (Val : T3) (C : sig
+        val f :
+             ('var, 'value, 'n1, 'n2) F.t
+          -> ( ('var, 'n1, 'n2) Var.t
+             , ('value, 'n1, 'n2) Val.t )
+             Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+      end) =
   struct
     let transport, transport_var, tuple2, unit =
-      Snarky_backendless.Typ.(transport, transport_var, tuple2, unit)
+      Kimchi_pasta_snarky_backend.Step_impl.Typ.
+        (transport, transport_var, tuple2, unit)
 
     let rec f :
         type vars values ns1 ns2.
            (vars, values, ns1, ns2) T(F).t
         -> ( (vars, ns1, ns2) H3.T(Var).t
-           , (values, ns1, ns2) H3.T(Val).t
-           , Impl.field )
-           Snarky_backendless.Typ.t =
+           , (values, ns1, ns2) H3.T(Val).t )
+           Kimchi_pasta_snarky_backend.Step_impl.Typ.t =
      fun ts ->
       match ts with
       | [] ->
           let there _ = () in
-          transport (unit ()) ~there ~back:(fun () : _ H3.T(Val).t -> [])
+          transport unit ~there ~back:(fun () : _ H3.T(Val).t -> [])
           |> transport_var ~there ~back:(fun () : _ H3.T(Var).t -> [])
       | t :: ts ->
           transport

--- a/src/lib/pickles_types/hlist.mli
+++ b/src/lib/pickles_types/hlist.mli
@@ -327,21 +327,21 @@ module H1 : sig
       element. See {!Snarky_backendless.Typ} and its documentation for more
       information.
   *)
-  module Typ : functor
-    (Impl : sig
-       type field
-     end)
+  module Wrap_typ : functor
     (A : T1)
     (Var : T1)
     (Val : T1)
     (_ : sig
        val f :
-         'a A.t -> ('a Var.t, 'a Val.t, Impl.field) Snarky_backendless.Typ.t
+            'a A.t
+         -> ('a Var.t, 'a Val.t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
      end)
     -> sig
     val f :
          'xs T(A).t
-      -> ('xs T(Var).t, 'xs T(Val).t, Impl.field) Snarky_backendless.Typ.t
+      -> ( 'xs T(Var).t
+         , 'xs T(Val).t )
+         Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
   end
 end
 

--- a/src/lib/pickles_types/hlist.mli
+++ b/src/lib/pickles_types/hlist.mli
@@ -772,9 +772,6 @@ module H4 : sig
 
   (** See {!H1.Typ}. *)
   module Typ : functor
-    (Impl : sig
-       type field
-     end)
     (A : T4)
     (Var : T3)
     (Val : T3)
@@ -782,36 +779,15 @@ module H4 : sig
        val f :
             ('var, 'value, 'n1, 'n2) A.t
          -> ( ('var, 'n1, 'n2) Var.t
-            , ('value, 'n1, 'n2) Val.t
-            , Impl.field )
-            Snarky_backendless.Typ.t
+            , ('value, 'n1, 'n2) Val.t )
+            Kimchi_pasta_snarky_backend.Step_impl.Typ.t
      end)
     -> sig
-    val transport :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> there:('d -> 'b)
-      -> back:('b -> 'd)
-      -> ('a, 'd, 'c) Snarky_backendless.Typ.t
-
-    val transport_var :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> there:('d -> 'a)
-      -> back:('a -> 'd)
-      -> ('d, 'b, 'c) Snarky_backendless.Typ.t
-
-    val tuple2 :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> ('d, 'e, 'c) Snarky_backendless.Typ.t
-      -> ('a * 'd, 'b * 'e, 'c) Snarky_backendless.Typ.t
-
-    val unit : unit -> (unit, unit, 'a) Snarky_backendless.Typ.t
-
     val f :
          ('vars, 'values, 'ns1, 'ns2) T(A).t
       -> ( ('vars, 'ns1, 'ns2) H3.T(Var).t
-         , ('values, 'ns1, 'ns2) H3.T(Val).t
-         , Impl.field )
-         Snarky_backendless.Typ.t
+         , ('values, 'ns1, 'ns2) H3.T(Val).t )
+         Kimchi_pasta_snarky_backend.Step_impl.Typ.t
   end
 end
 

--- a/src/lib/pickles_types/hlist.mli
+++ b/src/lib/pickles_types/hlist.mli
@@ -400,24 +400,6 @@ module H2 : sig
     -> sig
     val f : ('a, 'b) T(A).t -> ('a, 'b) T(B).t
   end
-
-  (** See {!H1.Typ}. *)
-  module Typ : functor
-    (Impl : sig
-       type field
-
-       module Typ : sig
-         type ('var, 'value) t = ('var, 'value, field) Snarky_backendless.Typ.t
-       end
-     end)
-    -> sig
-    val f :
-         ('vars, 'values) T(Impl.Typ).t
-      -> ( 'vars H1.T(Id).t
-         , 'values H1.T(Id).t
-         , Impl.field )
-         Snarky_backendless.Typ.t
-  end
 end
 
 (** Data type of heterogeneous lists whose content type varies over two type
@@ -926,50 +908,6 @@ module H6 : sig
          ('a1, 'a2, 'a3, 'a4, 'a5, 'a6) T(A).t
       -> ('a1, 'n) Length.t
       -> ('a2, 'n) Length.t
-  end
-
-  (** See {!H1.Typ}. *)
-  module Typ : functor
-    (Impl : sig
-       type field
-     end)
-    (A : T6)
-    (Var : T4)
-    (Val : T4)
-    (_ : sig
-       val f :
-            ('var, 'value, 'ret_var, 'ret_value, 'n1, 'n2) A.t
-         -> ( ('var, 'ret_var, 'n1, 'n2) Var.t
-            , ('value, 'ret_value, 'n1, 'n2) Val.t
-            , Impl.field )
-            Snarky_backendless.Typ.t
-     end)
-    -> sig
-    val transport :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> there:('d -> 'b)
-      -> back:('b -> 'd)
-      -> ('a, 'd, 'c) Snarky_backendless.Typ.t
-
-    val transport_var :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> there:('d -> 'a)
-      -> back:('a -> 'd)
-      -> ('d, 'b, 'c) Snarky_backendless.Typ.t
-
-    val tuple2 :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> ('d, 'e, 'c) Snarky_backendless.Typ.t
-      -> ('a * 'd, 'b * 'e, 'c) Snarky_backendless.Typ.t
-
-    val unit : unit -> (unit, unit, 'a) Snarky_backendless.Typ.t
-
-    val f :
-         ('vars, 'values, 'ret_vars, 'ret_values, 'ns1, 'ns2) T(A).t
-      -> ( ('vars, 'ret_vars, 'ns1, 'ns2) H4.T(Var).t
-         , ('values, 'ret_values, 'ns1, 'ns2) H4.T(Val).t
-         , Impl.field )
-         Snarky_backendless.Typ.t
   end
 end
 

--- a/src/lib/pickles_types/opt.ml
+++ b/src/lib/pickles_types/opt.ml
@@ -73,90 +73,103 @@ let map t ~f =
 let iter t ~f =
   match t with Nothing -> () | Just x -> f x | Maybe (_, x) -> f x
 
-open Snarky_backendless
+module Typ (Impl : Snarky_backendless.Snark_intf.Run) = struct
+  open Impl
 
-let some_typ (type a a_var f bool_var) (t : (a_var, a, f) Typ.t) :
-    ((a_var, bool_var) t, a option, f) Typ.t =
-  Typ.transport t ~there:(fun x -> Option.value_exn x) ~back:Option.return
-  |> Typ.transport_var
-       ~there:(function
-         | Just x ->
-             x
-         | Maybe _ | Nothing ->
-             failwith "Opt.some_typ: expected Just" )
-       ~back:(fun x -> Just x)
+  let some_typ (type a a_var) (t : (a_var, a) Typ.t) :
+      ((a_var, Boolean.var) t, a option) Typ.t =
+    Typ.transport t ~there:(fun x -> Option.value_exn x) ~back:Option.return
+    |> Typ.transport_var
+         ~there:(function
+           | Just x ->
+               x
+           | Maybe _ | Nothing ->
+               failwith "Opt.some_typ: expected Just" )
+         ~back:(fun x -> Just x)
 
-let none_typ (type a a_var f bool) () : ((a_var, bool) t, a option, f) Typ.t =
-  Typ.transport (Typ.unit ())
-    ~there:(fun _ -> ())
-    ~back:(fun () : _ Option.t -> None)
-  |> Typ.transport_var
-       ~there:(function
-         | Nothing ->
-             ()
-         | Maybe _ | Just _ ->
-             failwith "Opt.none_typ: expected Nothing" )
-       ~back:(fun () : _ t -> Nothing)
+  let none_typ (type a a_var bool) () : ((a_var, bool) t, a option) Typ.t =
+    Typ.transport Typ.unit
+      ~there:(fun _ -> ())
+      ~back:(fun () : _ Option.t -> None)
+    |> Typ.transport_var
+         ~there:(function
+           | Nothing ->
+               ()
+           | Maybe _ | Just _ ->
+               failwith "Opt.none_typ: expected Nothing" )
+         ~back:(fun () : _ t -> Nothing)
 
-let maybe_typ (type a a_var bool_var f)
-    (bool_typ : (bool_var, bool, f) Snarky_backendless.Typ.t) ~(dummy : a)
-    (a_typ : (a_var, a, f) Typ.t) : ((a_var, bool_var) t, a option, f) Typ.t =
-  Typ.transport
-    (Typ.tuple2 bool_typ a_typ)
-    ~there:(fun (t : a option) ->
-      match t with None -> (false, dummy) | Some x -> (true, x) )
-    ~back:(fun (b, x) -> if b then Some x else None)
-  |> Typ.transport_var
-       ~there:(fun (t : (a_var, _) t) ->
-         match t with
-         | Maybe (b, x) ->
-             (b, x)
-         | Nothing | Just _ ->
-             failwith "Opt.maybe_typ: expected Maybe" )
-       ~back:(fun (b, x) -> Maybe (b, x))
+  let maybe_typ (type a a_var) ~(dummy : a) (a_typ : (a_var, a) Typ.t) :
+      ((a_var, Boolean.var) t, a option) Typ.t =
+    Typ.transport
+      (Typ.tuple2 Boolean.typ a_typ)
+      ~there:(fun (t : a option) ->
+        match t with None -> (false, dummy) | Some x -> (true, x) )
+      ~back:(fun (b, x) -> if b then Some x else None)
+    |> Typ.transport_var
+         ~there:(fun (t : (a_var, _) t) ->
+           match t with
+           | Maybe (b, x) ->
+               (b, x)
+           | Nothing | Just _ ->
+               failwith "Opt.maybe_typ: expected Maybe" )
+         ~back:(fun (b, x) -> Maybe (b, x))
 
-let constant_layout_typ (type a a_var f) (bool_typ : _ Typ.t) ~true_ ~false_
-    (flag : Flag.t) (a_typ : (a_var, a, f) Typ.t) ~(dummy : a)
-    ~(dummy_var : a_var) =
-  let (Typ bool_typ) = bool_typ in
-  let bool_typ : _ Typ.t =
-    let check =
-      (* No need to boolean constrain in the No or Yes case *)
-      match flag with
-      | No | Yes ->
-          fun _ -> Checked_runner.Simple.return ()
-      | Maybe ->
-          bool_typ.check
+  let constant_layout_typ (type a a_var) (flag : Flag.t)
+      (a_typ : (a_var, a) Typ.t) ~(dummy : a) ~(dummy_var : a_var) =
+    let (Typ bool_typ) = Boolean.typ in
+    let bool_typ : _ Typ.t =
+      let check =
+        (* No need to boolean constrain in the No or Yes case *)
+        match flag with
+        | No | Yes ->
+            fun _ -> Impl.Internal_Basic.Checked.return ()
+        | Maybe ->
+            bool_typ.check
+      in
+      Typ { bool_typ with check }
     in
-    Typ { bool_typ with check }
-  in
-  Typ.transport
-    (Typ.tuple2 bool_typ a_typ)
-    ~there:(fun (t : a option) ->
-      match t with None -> (false, dummy) | Some x -> (true, x) )
-    ~back:(fun (b, x) -> if b then Some x else None)
-  |> Typ.transport_var
-       ~there:(fun (t : (a_var, _) t) ->
-         match t with
-         | Maybe (b, x) ->
-             (b, x)
-         | Nothing ->
-             (false_, dummy_var)
-         | Just x ->
-             (true_, x) )
-       ~back:(fun (b, x) ->
-         match flag with No -> Nothing | Yes -> Just x | Maybe -> Maybe (b, x)
-         )
+    Typ.transport
+      (Typ.tuple2 bool_typ a_typ)
+      ~there:(fun (t : a option) ->
+        match t with None -> (false, dummy) | Some x -> (true, x) )
+      ~back:(fun (b, x) -> if b then Some x else None)
+    |> Typ.transport_var
+         ~there:(fun (t : (a_var, _) t) ->
+           match t with
+           | Maybe (b, x) ->
+               (b, x)
+           | Nothing ->
+               (Boolean.false_, dummy_var)
+           | Just x ->
+               (Boolean.true_, x) )
+         ~back:(fun (b, x) ->
+           match flag with
+           | No ->
+               Nothing
+           | Yes ->
+               Just x
+           | Maybe ->
+               Maybe (b, x) )
 
-let typ (type a a_var f) bool_typ (flag : Flag.t) (a_typ : (a_var, a, f) Typ.t)
-    ~(dummy : a) =
-  match flag with
-  | Yes ->
-      some_typ a_typ
-  | No ->
-      none_typ ()
-  | Maybe ->
-      maybe_typ bool_typ ~dummy a_typ
+  let typ (type a a_var) (flag : Flag.t) (a_typ : (a_var, a) Typ.t) ~(dummy : a)
+      =
+    match flag with
+    | Yes ->
+        some_typ a_typ
+    | No ->
+        none_typ ()
+    | Maybe ->
+        maybe_typ ~dummy a_typ
+end
+
+module Step = Typ (Kimchi_pasta_snarky_backend.Step_impl)
+module Wrap = Typ (Kimchi_pasta_snarky_backend.Wrap_impl)
+include Step
+
+let wrap_constant_layout_typ = Wrap.constant_layout_typ
+
+let wrap_typ = Wrap.typ
 
 module Early_stop_sequence = struct
   (* A sequence that should be considered to have stopped at

--- a/src/lib/pickles_types/opt.mli
+++ b/src/lib/pickles_types/opt.mli
@@ -75,22 +75,34 @@ module Flag : sig
   val ( ||| ) : t -> t -> t
 end
 
+module Step_impl := Kimchi_pasta_snarky_backend.Step_impl
+module Wrap_impl := Kimchi_pasta_snarky_backend.Wrap_impl
+
 val constant_layout_typ :
-     ('b, bool, 'f) Snarky_backendless.Typ.t
-  -> true_:'b
-  -> false_:'b
-  -> Flag.t
-  -> ('a_var, 'a, 'f) Snarky_backendless.Typ.t
+     Flag.t
+  -> ('a_var, 'a) Step_impl.Typ.t
   -> dummy:'a
   -> dummy_var:'a_var
-  -> (('a_var, 'b) t, 'a option, 'f) Snarky_backendless.Typ.t
+  -> (('a_var, Step_impl.Boolean.var) t, 'a option) Step_impl.Typ.t
 
 val typ :
-     ('b, bool, 'f) Snarky_backendless.Typ.t
-  -> Flag.t
-  -> ('a_var, 'a, 'f) Snarky_backendless.Typ.t
+     Flag.t
+  -> ('a_var, 'a) Step_impl.Typ.t
   -> dummy:'a
-  -> (('a_var, 'b) t, 'a option, 'f) Snarky_backendless.Typ.t
+  -> (('a_var, Step_impl.Boolean.var) t, 'a option) Step_impl.Typ.t
+
+val wrap_constant_layout_typ :
+     Flag.t
+  -> ('a_var, 'a) Wrap_impl.Typ.t
+  -> dummy:'a
+  -> dummy_var:'a_var
+  -> (('a_var, Wrap_impl.Boolean.var) t, 'a option) Wrap_impl.Typ.t
+
+val wrap_typ :
+     Flag.t
+  -> ('a_var, 'a) Wrap_impl.Typ.t
+  -> dummy:'a
+  -> (('a_var, Wrap_impl.Boolean.var) t, 'a option) Wrap_impl.Typ.t
 
 (** A sequence that should be considered to have stopped at
        the first occurence of {!Flag.No} *)

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -367,18 +367,17 @@ module Features = struct
         ; runtime_tables
         } =
     (* TODO: This should come from snarky. *)
-    let constant (type var value)
-        (typ : (var, value, _) Snarky_backendless.Typ.t) (x : value) : var =
+    let module Impl = Kimchi_pasta_snarky_backend.Step_impl in
+    let constant (type var value) (typ : (var, value) Impl.Typ.t) (x : value) :
+        var =
       let (Typ typ) = typ in
       let fields, aux = typ.value_to_fields x in
-      let fields =
-        Array.map ~f:(fun x -> Snarky_backendless.Cvar.Constant x) fields
-      in
+      let fields = Array.map ~f:(fun x -> Impl.Field.constant x) fields in
       typ.var_of_fields (fields, aux)
     in
     let constant_typ ~there value =
-      let open Snarky_backendless.Typ in
-      unit ()
+      let open Impl.Typ in
+      unit
       |> transport ~there ~back:(fun () -> value)
       |> transport_var ~there:(fun _ -> ()) ~back:(fun () -> constant bool value)
     in
@@ -394,7 +393,7 @@ module Features = struct
       | Opt.Flag.Maybe ->
           bool
     in
-    Snarky_backendless.Typ.of_hlistable
+    Impl.Typ.of_hlistable
       [ bool_typ_of_flag range_check0
       ; bool_typ_of_flag range_check1
       ; bool_typ_of_flag foreign_field_add

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -1349,7 +1349,14 @@ module Openings = struct
     end]
 
     let typ fq g ~length =
-      let open Snarky_backendless.Typ in
+      let open Kimchi_pasta_snarky_backend.Step_impl.Typ in
+      of_hlistable
+        [ array ~length (g * g); fq; fq; g; g ]
+        ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+        ~value_of_hlist:of_hlist
+
+    let wrap_typ fq g ~length =
+      let open Kimchi_pasta_snarky_backend.Wrap_impl.Typ in
       of_hlistable
         [ array ~length (g * g); fq; fq; g; g ]
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -84,9 +84,9 @@ module Features : sig
     -> 'a t
 
   val typ :
-       ('var, bool, 'f) Snarky_backendless.Typ.t
+       ('var, bool) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
     -> feature_flags:options
-    -> ('var t, bool t, 'f) Snarky_backendless.Typ.t
+    -> ('var t, bool t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
 
   val none : options
 

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -337,18 +337,16 @@ module Openings : sig
     end]
 
     val typ :
-         ( 'a
-         , 'b
-         , 'c
-         , (unit, 'c) Snarky_backendless.Checked_runner.Simple.t )
-         Snarky_backendless.Types.Typ.typ
-      -> ( 'd
-         , 'e
-         , 'c
-         , (unit, 'c) Snarky_backendless.Checked_runner.Simple.t )
-         Snarky_backendless.Types.Typ.typ
+         ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+      -> ('d, 'e) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
       -> length:int
-      -> (('d, 'a) t, ('e, 'b) t, 'c) Snarky_backendless.Typ.t
+      -> (('d, 'a) t, ('e, 'b) t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+    val wrap_typ :
+         ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+      -> ('d, 'e) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+      -> length:int
+      -> (('d, 'a) t, ('e, 'b) t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
   end
 
   module Stable : sig

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -203,18 +203,22 @@ module Messages : sig
   end
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('a, 'b, 'f) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
     -> Opt.Flag.t Features.Full.t
     -> dummy:'b
     -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
-    -> bool:('c, bool, 'f) Snarky_backendless.Typ.t
-    -> ( ( 'a
-         , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )
-         In_circuit.t
-       , 'b t
-       , 'f )
-       Snarky_backendless.Typ.t
+    -> ( ('a, Kimchi_pasta_snarky_backend.Step_impl.Boolean.var) In_circuit.t
+       , 'b t )
+       Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> Opt.Flag.t Features.Full.t
+    -> dummy:'b
+    -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
+    -> ( ('a, Kimchi_pasta_snarky_backend.Wrap_impl.Boolean.var) In_circuit.t
+       , 'b t )
+       Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 end
 
 module Evals : sig
@@ -442,17 +446,28 @@ module All_evals : sig
   val map : ('a, 'b) t -> f1:('a -> 'c) -> f2:('b -> 'd) -> ('c, 'd) t
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> num_chunks:int
+       num_chunks:int
     -> Opt.Flag.t Features.Full.t
-    -> ( ( 'f Snarky_backendless.Cvar.t
-         , 'f Snarky_backendless.Cvar.t array
-         , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )
+    -> ( ( Kimchi_pasta_snarky_backend.Step_impl.Field.t
+         , Kimchi_pasta_snarky_backend.Step_impl.Field.t array
+         , Kimchi_pasta_snarky_backend.Step_impl.Boolean.var )
          In_circuit.t
-       , ('f, 'f array) t
-       , 'f
-       , (unit, 'f) Snarky_backendless.Checked_runner.Simple.t )
-       Snarky_backendless.Types.Typ.typ
+       , ( Kimchi_pasta_snarky_backend.Step_impl.Field.Constant.t
+         , Kimchi_pasta_snarky_backend.Step_impl.Field.Constant.t array )
+         t )
+       Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       num_chunks:int
+    -> Opt.Flag.t Features.Full.t
+    -> ( ( Kimchi_pasta_snarky_backend.Wrap_impl.Field.t
+         , Kimchi_pasta_snarky_backend.Wrap_impl.Field.t array
+         , Kimchi_pasta_snarky_backend.Wrap_impl.Boolean.var )
+         In_circuit.t
+       , ( Kimchi_pasta_snarky_backend.Wrap_impl.Field.Constant.t
+         , Kimchi_pasta_snarky_backend.Wrap_impl.Field.Constant.t array )
+         t )
+       Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 end
 
 (** Shifts, related to the permutation argument in Plonk *)

--- a/src/lib/pickles_types/plonk_verification_key_evals.ml
+++ b/src/lib/pickles_types/plonk_verification_key_evals.ml
@@ -54,7 +54,7 @@ let map2 t1 t2 ~f =
   }
 
 let typ g =
-  Snarky_backendless.Typ.of_hlistable
+  Kimchi_pasta_snarky_backend.Step_impl.Typ.of_hlistable
     [ Vector.typ g Plonk_types.Permuts.n
     ; Vector.typ g Plonk_types.Columns.n
     ; g
@@ -170,33 +170,6 @@ module Step = struct
     ; lookup_selector_ffmul =
         f_opt t1.lookup_selector_ffmul t2.lookup_selector_ffmul
     }
-
-  let typ g g_opt =
-    Snarky_backendless.Typ.of_hlistable
-      [ Vector.typ g Plonk_types.Permuts.n
-      ; Vector.typ g Plonk_types.Columns.n
-      ; g
-      ; g
-      ; g
-      ; g
-      ; g
-      ; g
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; Vector.typ g_opt Plonk_types.Lookup_sorted_minus_1.n
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ; g_opt
-      ]
-      ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
-      ~value_of_hlist:of_hlist
 
   let forget_optional_commitments
       { sigma_comm

--- a/src/lib/pickles_types/plonk_verification_key_evals.mli
+++ b/src/lib/pickles_types/plonk_verification_key_evals.mli
@@ -33,8 +33,8 @@ type 'comm t = 'comm Stable.Latest.t =
 [@@deriving sexp, equal, compare, hash, yojson, hlist]
 
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
-  -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+     ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+  -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
 
 (** [map t ~f] applies [f] to all elements of type ['a] within record [t] and
     returns the result. In particular, [f] is applied to the elements of
@@ -69,14 +69,6 @@ module Step : sig
     ; lookup_selector_ffmul : 'opt_comm
     }
   [@@deriving sexp, equal, compare, hash, yojson, hlist]
-
-  val typ :
-       ('comm_var, 'comm_value, 'c) Snarky_backendless.Typ.t
-    -> ('opt_comm_var, 'opt_comm_value, 'c) Snarky_backendless.Typ.t
-    -> ( ('comm_var, 'opt_comm_var) t
-       , ('comm_value, 'opt_comm_value) t
-       , 'c )
-       Snarky_backendless.Typ.t
 
   val map :
        ('comm1, 'opt_comm1) t


### PR DESCRIPTION
This PR specializes many of the `Typ.t`s from `Pickles_types`. This builds upon #16354, moving closer towards the goal of entirely separated instances of `Typ.t` for the different snarky instances (specifically those for step and wrap in pickles).