### PR TITLE
Use concrete snarky implementations for `Vector.typ` and friends

### DIFF
--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -385,7 +385,7 @@ module Wrap = struct
 
       let wrap_typ g1 chal ~length =
         Wrap_impl.Typ.of_hlistable
-          [ g1; Vector.typ chal length ]
+          [ g1; Vector.wrap_typ chal length ]
           ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
           ~value_of_hlist:of_hlist
     end
@@ -1332,7 +1332,7 @@ module Step = struct
         (((_, _) Vector.t, _) t, ((_, _) Vector.t, _) t) Wrap_impl.Typ.t =
       let per_proof _ = Per_proof.wrap_typ fq ~assert_16_bits in
       let unfinalized_proofs =
-        Vector.typ' (Vector.map proofs_verified ~f:per_proof)
+        Vector.wrap_typ' (Vector.map proofs_verified ~f:per_proof)
       in
       let messages_for_next_step_proof =
         Spec.wrap_typ fq ~assert_16_bits (B Spec.Digest)

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -281,6 +281,8 @@ struct
   type 'env is_boolean =
     | Is_boolean : < bool2 : Impl.Boolean.var ; .. > is_boolean
 
+  module Vector_typ = Vector.Make_typ (Impl)
+
   let typ (type other_field other_field_var) ~assert_16_bits
       (field : (other_field_var, other_field) Impl.Typ.t) t =
     let module Typ_record = struct
@@ -303,7 +305,7 @@ struct
         | Scalar chal ->
             Basic.scalar_typ (t.typ chal)
         | Vector (spec, n) ->
-            Vector.typ (typ t is_boolean spec) n
+            Vector_typ.typ (typ t is_boolean spec) n
         | Array (spec, n) ->
             array ~length:n (typ t is_boolean spec)
         | Struct [] ->
@@ -386,7 +388,7 @@ struct
             T (Basic.scalar_typ typ, Sc.map ~f, Sc.map ~f:f_inv)
         | Vector (spec, n) ->
             let (T (typ, f, f_inv)) = etyp e is_boolean spec in
-            T (Vector.typ typ n, Vector.map ~f, Vector.map ~f:f_inv)
+            T (Vector_typ.typ typ n, Vector.map ~f, Vector.map ~f:f_inv)
         | Array (spec, n) ->
             let (T (typ, f, f_inv)) = etyp e is_boolean spec in
             T (array ~length:n typ, Array.map ~f, Array.map ~f:f_inv)

--- a/src/lib/pickles/test/test_wrap_hack.ml
+++ b/src/lib/pickles/test/test_wrap_hack.ml
@@ -31,7 +31,7 @@ let test_hash_messages_for_next_wrap_proof (type n) (n : n Nat.t) () =
     ~equal:Field.Constant.equal
     (Composition_types.Wrap.Proof_state.Messages_for_next_wrap_proof.wrap_typ
        Wrap_main_inputs.Inner_curve.typ
-       (Vector.typ Field.typ Backend.Tock.Rounds.n)
+       (Vector.wrap_typ Field.typ Backend.Tock.Rounds.n)
        ~length:n )
     Field.typ
     (fun t ->

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -314,7 +314,7 @@ let wrap_main
           in
           let prev_step_accs =
             with_label __LOC__ (fun () ->
-                exists (Vector.typ Inner_curve.typ Max_proofs_verified.n)
+                exists (Vector.wrap_typ Inner_curve.typ Max_proofs_verified.n)
                   ~request:(fun () -> Req.Step_accs) )
           in
           let old_bp_chals =
@@ -325,8 +325,8 @@ let wrap_main
                       (Challenges_vector.Constant)
                       (struct
                         let f (type n) (n : n Nat.t) =
-                          Vector.typ
-                            (Vector.typ Field.typ Backend.Tock.Rounds.n)
+                          Vector.wrap_typ
+                            (Vector.wrap_typ Field.typ Backend.Tock.Rounds.n)
                             n
                       end)
                   in
@@ -358,7 +358,7 @@ let wrap_main
                       Plonk_types.All_evals.wrap_typ ~num_chunks:1
                         Plonk_types.Features.Full.none
                     in
-                    Vector.typ ty Max_proofs_verified.n
+                    Vector.wrap_typ ty Max_proofs_verified.n
                   in
                   exists ty ~request:(fun () -> Req.Evals)
                 in
@@ -368,7 +368,7 @@ let wrap_main
                       Wrap_verifier.all_possible_domains ()
                     in
                     let wrap_domain_indices =
-                      exists (Vector.typ Field.typ Max_proofs_verified.n)
+                      exists (Vector.wrap_typ Field.typ Max_proofs_verified.n)
                         ~request:(fun () -> Req.Wrap_domain_indices)
                     in
                     Vector.map wrap_domain_indices ~f:(fun index ->

--- a/src/lib/pickles_base/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles_base/one_hot_vector/one_hot_vector.ml
@@ -26,8 +26,10 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
 
   let of_vector_unsafe = Fn.id
 
+  module Vector_typ = Vector.Make_typ (Impl)
+
   let typ (n : 'n Nat.t) : ('n t, Constant.t) Typ.t =
-    let (Typ typ) = Vector.typ Boolean.typ n in
+    let (Typ typ) = Vector_typ.typ Boolean.typ n in
     let typ : _ Typ.t =
       Typ
         { typ with

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -97,8 +97,9 @@ module Prefix_mask = struct
       (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) :
       (f Checked.t, proofs_verified) Impl.Typ.t =
     let open Impl in
+    let module Vector_typ = Pickles_types.Vector.Make_typ (Impl) in
     Typ.transport
-      (Pickles_types.Vector.typ Boolean.typ Pickles_types.Nat.N2.n)
+      (Vector_typ.typ Boolean.typ Pickles_types.Nat.N2.n)
       ~there ~back
 end
 

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -1242,7 +1242,7 @@ module Evals = struct
     let lookup_sorted =
       let lookups_per_row_3 = opt lookups_per_row_3 in
       let lookups_per_row_4 = opt lookups_per_row_4 in
-      Vector.typ'
+      Vector.wrap_typ'
         [ lookups_per_row_3
         ; lookups_per_row_3
         ; lookups_per_row_3
@@ -1251,10 +1251,10 @@ module Evals = struct
         ]
     in
     Typ.of_hlistable
-      [ Vector.typ e Columns.n
-      ; Vector.typ e Columns.n
+      [ Vector.wrap_typ e Columns.n
+      ; Vector.wrap_typ e Columns.n
       ; e
-      ; Vector.typ e Permuts_minus_1.n
+      ; Vector.wrap_typ e Permuts_minus_1.n
       ; e
       ; e
       ; e
@@ -1584,7 +1584,7 @@ module Messages = struct
 
     let wrap_typ e ~lookups_per_row_4 ~runtime_tables ~dummy =
       Wrap_impl.Typ.of_hlistable
-        [ Vector.typ e Lookup_sorted_minus_1.n
+        [ Vector.wrap_typ e Lookup_sorted_minus_1.n
         ; Opt.wrap_typ lookups_per_row_4 e ~dummy
         ; e
         ; Opt.wrap_typ runtime_tables e ~dummy
@@ -1677,7 +1677,7 @@ module Messages = struct
         (wo [ 1 ])
     in
     of_hlistable
-      [ Vector.typ (wo w_lens) Columns.n; wo [ z ]; wo [ t ]; lookup ]
+      [ Vector.wrap_typ (wo w_lens) Columns.n; wo [ z ]; wo [ t ]; lookup ]
       ~var_to_hlist:In_circuit.to_hlist ~var_of_hlist:In_circuit.of_hlist
       ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 end

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -113,17 +113,41 @@ module With_length (N : Nat.Intf) : S with type 'a t = ('a, N.n) vec
 
 (** {1 Snarky related functions } *)
 
+module Make_typ (Impl : Snarky_backendless.Snark_intf.Run) : sig
+  (** [typ v t_n] creates a snarky [Typ.t] for a vector of the length [t_n] and
+    sets the contents of each cell to [v] *)
+  val typ :
+    ('a, 'b) Impl.Typ.t -> 'd Nat.nat -> (('a, 'd) vec, ('b, 'd) vec) Impl.Typ.t
+
+  (** Builds a Snarky type from a type [('a, 'n) t]*)
+  val typ' :
+       (('var, 'value) Impl.Typ.t, 'n) t
+    -> (('var, 'n) t, ('value, 'n) t) Impl.Typ.t
+end
+
 (** [typ v t_n] creates a snarky [Typ.t] for a vector of the length [t_n] and
     sets the contents of each cell to [v] *)
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
+     ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
   -> 'd Nat.nat
-  -> (('a, 'd) vec, ('b, 'd) vec, 'c) Snarky_backendless.Typ.t
+  -> (('a, 'd) vec, ('b, 'd) vec) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
 
 (** Builds a Snarky type from a type [('a, 'n) t]*)
 val typ' :
-     (('var, 'value, 'f) Snarky_backendless.Typ.t, 'n) t
-  -> (('var, 'n) t, ('value, 'n) t, 'f) Snarky_backendless.Typ.t
+     (('var, 'value) Kimchi_pasta_snarky_backend.Step_impl.Typ.t, 'n) t
+  -> (('var, 'n) t, ('value, 'n) t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+(** [wrap_typ v t_n] creates a snarky [Typ.t] for a vector of the length [t_n] and
+    sets the contents of each cell to [v] *)
+val wrap_typ :
+     ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+  -> 'd Nat.nat
+  -> (('a, 'd) vec, ('b, 'd) vec) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+
+(** Builds a Snarky type from a type [('a, 'n) t]*)
+val wrap_typ' :
+     (('var, 'value) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t, 'n) t
+  -> (('var, 'n) t, ('value, 'n) t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
 (** {1 Common interface of vectors } *)
 


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16355, continuing its work by removing the dependency on `Snarky_backendless.Typ` from `Vector.typ` and its downstream `Typ.t`s.