### PR TITLE
Specialize `Pickles.Composition_types.Branch_data`

### DIFF
--- a/src/lib/pickles/composition_types/branch_data.ml
+++ b/src/lib/pickles/composition_types/branch_data.ml
@@ -98,13 +98,17 @@ module Make_str (A : Wire_types.Concrete) = struct
       + pack (Pickles_types.Vector.to_list proofs_verified_mask)
   end
 
-  let packed_typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) =
-    Impl.Typ.transport Impl.Typ.field
-      ~there:(pack (module Impl))
-      ~back:(unpack (module Impl))
-
   open Kimchi_pasta_snarky_backend
+
+  let packed_typ =
+    Step_impl.Typ.transport Step_impl.Typ.field
+      ~there:(pack (module Step_impl))
+      ~back:(unpack (module Step_impl))
+
+  let wrap_packed_typ =
+    Wrap_impl.Typ.transport Wrap_impl.Typ.field
+      ~there:(pack (module Wrap_impl))
+      ~back:(unpack (module Wrap_impl))
 
   let typ
       ~(* We actually only need it to be less than 252 bits in order to pack

--- a/src/lib/pickles/composition_types/branch_data.ml
+++ b/src/lib/pickles/composition_types/branch_data.ml
@@ -104,22 +104,49 @@ module Make_str (A : Wire_types.Concrete) = struct
       ~there:(pack (module Impl))
       ~back:(unpack (module Impl))
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+  open Kimchi_pasta_snarky_backend
+
+  let typ
       ~(* We actually only need it to be less than 252 bits in order to pack
           the whole branch_data struct safely, but it's cheapest to check that it's
           under 16 bits *)
-      (assert_16_bits : Impl.Field.t -> unit) : (f Checked.t, t) Impl.Typ.t =
-    let open Impl in
+      (assert_16_bits : Step_impl.Field.t -> unit) :
+      (_ Checked.t, t) Step_impl.Typ.t =
+    let open Step_impl in
     let proofs_verified_mask :
-        (f Proofs_verified.Prefix_mask.Checked.t, Proofs_verified.t) Typ.t =
-      Proofs_verified.Prefix_mask.typ (module Impl)
+        (_ Proofs_verified.Prefix_mask.Checked.t, Proofs_verified.t) Typ.t =
+      Proofs_verified.Prefix_mask.typ
     in
     let domain_log2 : (Field.t, Domain_log2.t) Typ.t =
       let (Typ t) =
         Typ.transport Field.typ
           ~there:(fun (x : char) -> Field.Constant.of_int (Char.to_int x))
-          ~back:(Domain_log2.of_field_exn (module Impl))
+          ~back:(Domain_log2.of_field_exn (module Step_impl))
+      in
+      let check (x : Field.t) = make_checked (fun () -> assert_16_bits x) in
+      Typ { t with check }
+    in
+    Typ.of_hlistable
+      [ proofs_verified_mask; domain_log2 ]
+      ~value_of_hlist:of_hlist ~value_to_hlist:to_hlist
+      ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
+
+  let wrap_typ
+      ~(* We actually only need it to be less than 252 bits in order to pack
+          the whole branch_data struct safely, but it's cheapest to check that it's
+          under 16 bits *)
+      (assert_16_bits : Wrap_impl.Field.t -> unit) :
+      (_ Checked.t, t) Wrap_impl.Typ.t =
+    let open Wrap_impl in
+    let proofs_verified_mask :
+        (_ Proofs_verified.Prefix_mask.Checked.t, Proofs_verified.t) Typ.t =
+      Proofs_verified.Prefix_mask.wrap_typ
+    in
+    let domain_log2 : (Field.t, Domain_log2.t) Typ.t =
+      let (Typ t) =
+        Typ.transport Field.typ
+          ~there:(fun (x : char) -> Field.Constant.of_int (Char.to_int x))
+          ~back:(Domain_log2.of_field_exn (module Wrap_impl))
       in
       let check (x : Field.t) = make_checked (fun () -> assert_16_bits x) in
       Typ { t with check }

--- a/src/lib/pickles/composition_types/branch_data_intf.ml
+++ b/src/lib/pickles/composition_types/branch_data_intf.ml
@@ -46,9 +46,9 @@ module type S = sig
        assert_16_bits:(Impls.Wrap_impl.Field.t -> unit)
     -> (Impls.Wrap_impl.Field.Constant.t Checked.t, t) Impls.Wrap_impl.Typ.t
 
-  val packed_typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('f Snarky_backendless.Cvar.t, t, 'f) Snarky_backendless.Typ.t
+  val packed_typ : (Impls.Step_impl.Field.t, t) Impls.Step_impl.Typ.t
+
+  val wrap_packed_typ : (Impls.Wrap_impl.Field.t, t) Impls.Wrap_impl.Typ.t
 
   val length_in_bits : int
 

--- a/src/lib/pickles/composition_types/branch_data_intf.ml
+++ b/src/lib/pickles/composition_types/branch_data_intf.ml
@@ -36,10 +36,15 @@ module type S = sig
       -> 'f Snarky_backendless.Cvar.t
   end
 
+  module Impls := Kimchi_pasta_snarky_backend
+
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> assert_16_bits:('f Snarky_backendless.Cvar.t -> unit)
-    -> ('f Checked.t, t, 'f) Snarky_backendless.Typ.t
+       assert_16_bits:(Impls.Step_impl.Field.t -> unit)
+    -> (Impls.Step_impl.Field.Constant.t Checked.t, t) Impls.Step_impl.Typ.t
+
+  val wrap_typ :
+       assert_16_bits:(Impls.Wrap_impl.Field.t -> unit)
+    -> (Impls.Wrap_impl.Field.Constant.t Checked.t, t) Impls.Wrap_impl.Typ.t
 
   val packed_typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -493,7 +493,7 @@ module Step =
             | Bool ->
                 Boolean.typ
             | Branch_data ->
-                Branch_data.typ (module Impl) ~assert_16_bits
+                Branch_data.typ ~assert_16_bits
             | Digest ->
                 Digest.typ
             | Challenge ->
@@ -590,7 +590,7 @@ module Wrap =
             | Bool ->
                 Boolean.typ
             | Branch_data ->
-                Branch_data.typ (module Impl) ~assert_16_bits
+                Branch_data.wrap_typ ~assert_16_bits
             | Digest ->
                 Digest.typ
             | Challenge ->

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -542,7 +542,7 @@ module Step =
           | Challenge ->
               T (Challenge.typ, Fn.id, Fn.id)
           | Branch_data ->
-              T (Branch_data.packed_typ (module Impl), Fn.id, Fn.id)
+              T (Branch_data.packed_typ, Fn.id, Fn.id)
           | Bulletproof_challenge ->
               let typ =
                 let there bp_challenge =
@@ -639,7 +639,7 @@ module Wrap =
           | Challenge ->
               T (Challenge.typ, Fn.id, Fn.id)
           | Branch_data ->
-              T (Branch_data.packed_typ (module Impl), Fn.id, Fn.id)
+              T (Branch_data.wrap_packed_typ, Fn.id, Fn.id)
           | Bulletproof_challenge ->
               let typ =
                 let there bp_challenge =

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -139,7 +139,6 @@ let typ (type n avar aval) ~feature_flags ~num_chunks
     =
   let module Sc = Scalar_challenge in
   let open Impls.Step in
-  let open Step_main_inputs in
   let open Step_verifier in
   Impls.Step.Typ.of_hlistable ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:Constant.to_hlist ~value_of_hlist:Constant.of_hlist
@@ -150,9 +149,7 @@ let typ (type n avar aval) ~feature_flags ~num_chunks
         ~dummy_scalar_challenge:(Sc.create Limb_vector.Challenge.Constant.zero)
         (Shifted_value.Type1.typ Field.typ)
         Impls.Step.Typ.unit Digest.typ
-        (Branch_data.typ
-           (module Impl)
-           ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16) )
+        (Branch_data.typ ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16))
     ; Plonk_types.All_evals.typ ~num_chunks
         (* Assume we have lookup iff we have runtime tables *)
         feature_flags

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -347,8 +347,8 @@ let typ : (Checked.t, t) Impls.Step.Typ.t =
   let open Step_main_inputs in
   let open Impl in
   Typ.of_hlistable
-    [ Pickles_base.Proofs_verified.One_hot.typ (module Impls.Step)
-    ; Pickles_base.Proofs_verified.One_hot.typ (module Impls.Step)
+    [ Pickles_base.Proofs_verified.One_hot.typ
+    ; Pickles_base.Proofs_verified.One_hot.typ
     ; Plonk_verification_key_evals.typ Inner_curve.typ
     ]
     ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist

--- a/src/lib/pickles/test/test_wrap.ml
+++ b/src/lib/pickles/test/test_wrap.ml
@@ -123,7 +123,6 @@ let run_recursive_proof_test (actual_feature_flags : Plonk_types.Features.flags)
      once for the wrap circuit.  It was decided not to use a functor for this. *)
   let deferred_values_typ =
     let open Impls.Step in
-    let open Step_main_inputs in
     let open Step_verifier in
     Import.Types.Wrap.Proof_state.Deferred_values.In_circuit.typ
       ~feature_flags:full_features ~challenge:Challenge.typ
@@ -133,7 +132,6 @@ let run_recursive_proof_test (actual_feature_flags : Plonk_types.Features.flags)
            Limb_vector.Challenge.Constant.zero )
       (Shifted_value.Type1.typ Field.typ)
       (Import.Branch_data.typ
-         (module Impl)
          ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16) )
   in
 

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -93,13 +93,18 @@ module Prefix_mask = struct
     | [ true; false ] ->
         invalid_arg "Prefix_mask.back: invalid mask [false; true]"
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) :
-      (f Checked.t, proofs_verified) Impl.Typ.t =
-    let open Impl in
-    let module Vector_typ = Pickles_types.Vector.Make_typ (Impl) in
+  open Kimchi_pasta_snarky_backend
+
+  let typ : (_ Checked.t, proofs_verified) Step_impl.Typ.t =
+    let open Step_impl in
     Typ.transport
-      (Vector_typ.typ Boolean.typ Pickles_types.Nat.N2.n)
+      (Pickles_types.Vector.typ Boolean.typ Pickles_types.Nat.N2.n)
+      ~there ~back
+
+  let wrap_typ : (_ Checked.t, proofs_verified) Wrap_impl.Typ.t =
+    let open Wrap_impl in
+    Wrap_impl.Typ.transport
+      (Pickles_types.Vector.wrap_typ Boolean.typ Pickles_types.Nat.N2.n)
       ~there ~back
 end
 
@@ -138,10 +143,13 @@ module One_hot = struct
     in
     Random_oracle_input.Chunked.packeds (Array.map one_hot ~f:(fun b -> (b, 1)))
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) :
-      (f Checked.t, proofs_verified) Impl.Typ.t =
-    let module M = One_hot_vector.Make (Impl) in
-    let open Impl in
-    Typ.transport (M.typ Pickles_types.Nat.N3.n) ~there ~back
+  open Kimchi_pasta_snarky_backend
+
+  let typ : (_ Checked.t, proofs_verified) Step_impl.Typ.t =
+    let module M = One_hot_vector.Make (Step_impl) in
+    Step_impl.Typ.transport (M.typ Pickles_types.Nat.N3.n) ~there ~back
+
+  let wrap_typ : (_ Checked.t, proofs_verified) Wrap_impl.Typ.t =
+    let module M = One_hot_vector.Make (Wrap_impl) in
+    Wrap_impl.Typ.transport (M.typ Pickles_types.Nat.N3.n) ~there ~back
 end

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -35,9 +35,11 @@ module One_hot : sig
 
   val to_input : zero:'a -> one:'a -> t -> 'a Random_oracle_input.Chunked.t
 
-  val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('f Checked.t, t, 'f) Snarky_backendless.Typ.t
+  open Kimchi_pasta_snarky_backend
+
+  val typ : (Step_impl.Field.Constant.t Checked.t, t) Step_impl.Typ.t
+
+  val wrap_typ : (Wrap_impl.Field.Constant.t Checked.t, t) Wrap_impl.Typ.t
 end
 
 type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
@@ -54,11 +56,9 @@ module Prefix_mask : sig
 
   val back : bool vec2 -> t
 
-  val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ( 'f Checked.t
-       , t
-       , 'f
-       , (unit, 'f) Snarky_backendless.Checked_runner.Simple.t )
-       Snarky_backendless__.Types.Typ.t
+  open Kimchi_pasta_snarky_backend
+
+  val typ : (Step_impl.Field.Constant.t Checked.t, t) Step_impl.Typ.t
+
+  val wrap_typ : (Wrap_impl.Field.Constant.t Checked.t, t) Wrap_impl.Typ.t
 end


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16357, using the concretized versions of `Typ.t`s to give concrete types to `Pickles.Composition_types.Branch_data`, and remove their dependency on the generalized `Typ.t` from snarky.