### PR TITLE
Split `Pickles.Composition_types.Spec.ETyp.t` according to backend

### DIFF
--- a/src/lib/pickles/composition_types/spec.mli
+++ b/src/lib/pickles/composition_types/spec.mli
@@ -130,17 +130,25 @@ val wrap_typ :
      T.t
   -> ('e, 'd) Wrap_impl.Typ.t
 
-module ETyp : sig
-  type ('var, 'value, 'f) t =
+module Make_ETyp (Impl : sig
+  module Typ : sig
+    type ('var, 'value) t
+  end
+end) : sig
+  type ('var, 'value) t =
     | T :
-        ('inner, 'value, 'f) Snarky_backendless.Typ.t
-        * ('inner -> 'var)
-        * ('var -> 'inner)
-        -> ('var, 'value, 'f) t
+        ('inner, 'value) Impl.Typ.t * ('inner -> 'var) * ('var -> 'inner)
+        -> ('var, 'value) t
 end
 
+module Step_etyp :
+    module type of Make_ETyp (Kimchi_pasta_snarky_backend.Step_impl)
+
+module Wrap_etyp :
+    module type of Make_ETyp (Kimchi_pasta_snarky_backend.Wrap_impl)
+
 val packed_typ :
-     ('b, 'c, Step_impl.Field.Constant.t) ETyp.t
+     ('b, 'c) Step_etyp.t
   -> ( 'd
      , 'e
      , < bool1 : bool
@@ -162,10 +170,10 @@ val packed_typ :
        ; field2 : 'b
        ; .. > )
      T.t
-  -> ('e, 'd, Step_impl.Field.Constant.t) ETyp.t
+  -> ('e, 'd) Step_etyp.t
 
 val wrap_packed_typ :
-     ('b, 'c, Wrap_impl.Field.Constant.t) ETyp.t
+     ('b, 'c) Wrap_etyp.t
   -> ( 'd
      , 'e
      , < bool1 : bool
@@ -187,7 +195,7 @@ val wrap_packed_typ :
        ; field2 : 'b
        ; .. > )
      T.t
-  -> ('e, 'd, Wrap_impl.Field.Constant.t) ETyp.t
+  -> ('e, 'd) Wrap_etyp.t
 
 val pack :
      'f impl

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -7,94 +7,116 @@ let rough_domains =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { Domains.h = d }
 
-let domains_impl (type field gates) ?feature_flags
-    (module Impl : Snarky_backendless.Snark_intf.Run
-      with type field = field
-       and type R1CS_constraint_system.t = ( field
-                                           , gates )
-                                           Kimchi_backend_common
-                                           .Plonk_constraint_system
-                                           .t ) (typ, conv, _conv_inv)
-    (return_typ, _ret_conv, ret_conv_inv) main =
-  let main x () = Promise.map ~f:ret_conv_inv (main (conv x)) in
+module Make (Env : sig
+  type field
 
-  let domains2 sys =
-    let open Domain in
-    (* Compute the domain required for the lookup tables *)
-    let lookup_table_length_log2 =
-      match feature_flags with
-      | None ->
-          0
-      | Some feature_flags ->
-          let { Pickles_types.Plonk_types.Features.range_check0
-              ; range_check1
-              ; foreign_field_add =
-                  _
-                  (* Does not use lookup tables, therefore we do
-                     not need in the computation *)
-              ; foreign_field_mul
-              ; xor
-              ; rot
-              ; lookup
-              ; runtime_tables
-              } =
-            feature_flags
-          in
-          let combined_lookup_table_length =
-            let range_check_table_used =
-              range_check0 || range_check1 || foreign_field_mul || rot
+  type gates
+end)
+(Impl : Snarky_backendless.Snark_intf.Run
+          with type field = Env.field
+           and type R1CS_constraint_system.t =
+            ( Env.field
+            , Env.gates )
+            Kimchi_backend_common.Plonk_constraint_system.t) =
+struct
+  let domains_impl ?feature_flags (typ, conv, _conv_inv)
+      (return_typ, _ret_conv, ret_conv_inv) main =
+    let main x () = Promise.map ~f:ret_conv_inv (main (conv x)) in
+
+    let domains2 sys =
+      let open Domain in
+      (* Compute the domain required for the lookup tables *)
+      let lookup_table_length_log2 =
+        match feature_flags with
+        | None ->
+            0
+        | Some feature_flags ->
+            let { Pickles_types.Plonk_types.Features.range_check0
+                ; range_check1
+                ; foreign_field_add =
+                    _
+                    (* Does not use lookup tables, therefore we do
+                       not need in the computation *)
+                ; foreign_field_mul
+                ; xor
+                ; rot
+                ; lookup
+                ; runtime_tables
+                } =
+              feature_flags
             in
-            let xor_table_used = xor in
-            (if range_check_table_used then Int.pow 2 12 else 0)
-            + (if xor_table_used then Int.pow 2 8 else 0)
-            + ( if lookup then (
+            let combined_lookup_table_length =
+              let range_check_table_used =
+                range_check0 || range_check1 || foreign_field_mul || rot
+              in
+              let xor_table_used = xor in
+              (if range_check_table_used then Int.pow 2 12 else 0)
+              + (if xor_table_used then Int.pow 2 8 else 0)
+              + ( if lookup then (
+                  Kimchi_backend_common.Plonk_constraint_system
+                  .finalize_fixed_lookup_tables sys ;
+                  Kimchi_backend_common.Plonk_constraint_system
+                  .get_concatenated_fixed_lookup_table_size sys )
+                else 0 )
+              +
+              if runtime_tables then (
                 Kimchi_backend_common.Plonk_constraint_system
-                .finalize_fixed_lookup_tables sys ;
+                .finalize_runtime_lookup_tables sys ;
                 Kimchi_backend_common.Plonk_constraint_system
-                .get_concatenated_fixed_lookup_table_size sys )
-              else 0 )
-            +
-            if runtime_tables then (
-              Kimchi_backend_common.Plonk_constraint_system
-              .finalize_runtime_lookup_tables sys ;
-              Kimchi_backend_common.Plonk_constraint_system
-              .get_concatenated_runtime_lookup_table_size sys )
-            else 0
-          in
+                .get_concatenated_runtime_lookup_table_size sys )
+              else 0
+            in
 
-          Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
+            Int.ceil_log2 (combined_lookup_table_length + zk_rows + 1)
+      in
+      let public_input_size =
+        Set_once.get_exn
+          (Impl.R1CS_constraint_system.get_public_input_size sys)
+          [%here]
+      in
+      let rows =
+        zk_rows + public_input_size
+        + Impl.R1CS_constraint_system.get_rows_len sys
+      in
+      { Domains.h =
+          Pow_2_roots_of_unity
+            Int.(max lookup_table_length_log2 (ceil_log2 rows))
+      }
     in
-    let public_input_size =
-      Set_once.get_exn
-        (Impl.R1CS_constraint_system.get_public_input_size sys)
-        [%here]
+    let constraint_builder =
+      Impl.constraint_system_manual ~input_typ:typ ~return_typ
     in
-    let rows =
-      zk_rows + public_input_size + Impl.R1CS_constraint_system.get_rows_len sys
-    in
-    { Domains.h =
-        Pow_2_roots_of_unity Int.(max lookup_table_length_log2 (ceil_log2 rows))
-    }
-  in
-  let constraint_builder =
-    Impl.constraint_system_manual ~input_typ:typ ~return_typ
-  in
-  let%map.Promise res = constraint_builder.run_circuit main in
-  let constraint_system = constraint_builder.finish_computation res in
-  domains2 constraint_system
+    let%map.Promise res = constraint_builder.run_circuit main in
+    let constraint_system = constraint_builder.finish_computation res in
+    domains2 constraint_system
+end
 
 let domains ?feature_flags (Spec.Step_etyp.T (typ, conv, conv_inv))
     (Spec.Step_etyp.T (return_typ, ret_conv, ret_conv_inv)) main =
-  domains_impl ?feature_flags
-    (module Impls.Step)
-    (typ, conv, conv_inv)
+  let module Domains_impl =
+    Make
+      (struct
+        type field = Impls.Step.field
+
+        type nonrec gates = Kimchi_bindings.Protocol.Gates.Vector.Fp.t
+      end)
+      (Impls.Step)
+  in
+  Domains_impl.domains_impl ?feature_flags (typ, conv, conv_inv)
     (return_typ, ret_conv, ret_conv_inv)
     main
 
 let wrap_domains ?feature_flags (Spec.Wrap_etyp.T (typ, conv, conv_inv))
     (Spec.Wrap_etyp.T (return_typ, ret_conv, ret_conv_inv)) main =
-  domains_impl ?feature_flags
-    (module Impls.Wrap)
-    (typ, conv, conv_inv)
+  let module Domains_impl =
+    Make
+      (struct
+        type field = Impls.Wrap.field
+
+        type nonrec gates = Kimchi_bindings.Protocol.Gates.Vector.Fq.t
+      end)
+      (Impls.Wrap)
+  in
+  Domains_impl.domains_impl ?feature_flags (typ, conv, conv_inv)
     (return_typ, ret_conv, ret_conv_inv)
     main

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -5,15 +5,15 @@
 
 val domains :
      ?feature_flags:bool Pickles_types.Plonk_types.Features.t
-  -> (module Snarky_backendless.Snark_intf.Run
-        with type field = 'field
-         and type R1CS_constraint_system.t = ( 'field
-                                             , 'gates )
-                                             Kimchi_backend_common
-                                             .Plonk_constraint_system
-                                             .t )
-  -> ('a, 'b, 'field) Import.Spec.ETyp.t
-  -> ('c, 'd, 'field) Import.Spec.ETyp.t
+  -> ('a, 'b) Import.Spec.Step_etyp.t
+  -> ('c, 'd) Import.Spec.Step_etyp.t
+  -> ('a -> 'c Promise.t)
+  -> Import.Domains.t Promise.t
+
+val wrap_domains :
+     ?feature_flags:bool Pickles_types.Plonk_types.Features.t
+  -> ('a, 'b) Import.Spec.Wrap_etyp.t
+  -> ('c, 'd) Import.Spec.Wrap_etyp.t
   -> ('a -> 'c Promise.t)
   -> Import.Domains.t Promise.t
 

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -163,7 +163,7 @@ module Step = struct
         spec
     in
     let typ = Typ.transport typ ~there:to_data ~back:of_data in
-    Spec.ETyp.T (typ, (fun x -> of_data (f x)), fun x -> f_inv (to_data x))
+    Spec.Step_etyp.T (typ, (fun x -> of_data (f x)), fun x -> f_inv (to_data x))
 
   module Async_promise = Async_generic (Promise)
 end
@@ -271,7 +271,7 @@ module Wrap = struct
         ~there:(In_circuit.to_data ~option_map:Option.map)
         ~back:(In_circuit.of_data ~option_map:Option.map)
     in
-    Spec.ETyp.T
+    Spec.Wrap_etyp.T
       ( typ
       , (fun x -> In_circuit.of_data ~option_map:Opt.map (f x))
       , fun x -> f_inv (In_circuit.to_data ~option_map:Opt.map x) )

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -81,9 +81,8 @@ module Step : sig
   val input :
        proofs_verified:'proofs_verified Nat.t
     -> ( 'proofs_verified statement_var
-       , 'proofs_verified statement
-       , Impl.field )
-       Import.Spec.ETyp.t
+       , 'proofs_verified statement )
+       Import.Spec.Step_etyp.t
 
   module Async_promise : module type of Async_generic (Promise)
 end
@@ -169,7 +168,6 @@ module Wrap : sig
            , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
            Pickles_types.Vector.t
          , Composition_types.Branch_data.t )
-         Import.Types.Wrap.Statement.In_circuit.t
-       , Wrap_impl.field )
-       Import.Spec.ETyp.t
+         Import.Types.Wrap.Statement.In_circuit.t )
+       Import.Spec.Wrap_etyp.t
 end

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -219,7 +219,6 @@ let create
     in
     let%bind.Promise () = chain_to in
     Fix_domains.domains ~feature_flags:actual_feature_flags
-      (module Impls.Step)
       (T (Impls.Step.Typ.unit, Fn.id, Fn.id))
       etyp main
   in

--- a/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
@@ -15,16 +15,14 @@ let add_constraint c = assert_ { basic = T c; annotation = None }
 let add_plonk_constraint c = assert_ { basic = T c; annotation = None }
 
 let etyp_unit =
-  Composition_types.Spec.ETyp.T
+  Composition_types.Spec.Step_etyp.T
     (Pickles.Impls.Step.Typ.unit, Core_kernel.Fn.id, Core_kernel.Fn.id)
 
 let log2_size ~feature_flags main =
   let main' () = main () ; Promise.return () in
   let domains =
     Promise.block_on_async_exn (fun () ->
-        Pickles__Fix_domains.domains ~feature_flags
-          (module Pickles.Impls.Step)
-          etyp_unit etyp_unit main' )
+        Pickles__Fix_domains.domains ~feature_flags etyp_unit etyp_unit main' )
   in
   Pickles_base.Domain.log2_size domains.h
 

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -48,8 +48,7 @@ struct
     Timer.clock __LOC__ ;
     let%bind.Promise main = Lazy.force main in
     let t =
-      Fix_domains.domains
-        (module Impls.Wrap)
+      Fix_domains.wrap_domains
         (Impls.Wrap.input ~feature_flags ())
         (T (Impls.Wrap.Typ.unit, Fn.id, Fn.id))
         (fun input -> Promise.return (main input))


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16358, splitting the unified implementation of `Pickles.Composition_types.Spec.ETyp.t` according to the corresponding backends. This PR unpicks the last major use of the generalized `Typ.t` from snarky.