### PR TITLE
[Trivial] Stop using `Snarky.As_prover0` and `Snarky.Types.Typ` everywhere

### DIFF
--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -145,10 +145,9 @@ let var_to_input
 let%test_unit "value = var" =
   let compiled = Genesis_constants.For_unit_tests.t.protocol in
   let test protocol_constants =
-    let open Snarky_backendless in
     let p_var =
-      let%map p = exists typ ~compute:(As_prover0.return protocol_constants) in
-      As_prover0.read typ p
+      let%map p = exists typ ~compute:(As_prover.return protocol_constants) in
+      As_prover.read typ p
     in
     let res = Or_error.ok_exn (run_and_check p_var) in
     [%test_eq: Value.t] res protocol_constants ;

--- a/src/lib/mina_base/test/account_test.ml
+++ b/src/lib/mina_base/test/account_test.ml
@@ -274,8 +274,7 @@ let minimum_balance_checked_equal_to_unchecked () =
           ~vesting_increment:Amount.(var_of_t timing.vesting_increment)
           ~vesting_period:(global_slot_span_var timing.vesting_period)
           ~global_slot:(global_slot_since_genesis_var global_slot)
-        |> Snarky_backendless.(
-             Checked_runner.Simple.map ~f:(As_prover0.read Balance.typ))
+        |> Snark_params.Tick.(Checked.map ~f:(As_prover.read Balance.typ))
         |> Snark_params.Tick.run_and_check
       in
       [%test_eq: Balance.t Or_error.t] (Ok min_balance) min_balance_checked )

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -259,7 +259,7 @@ module Wrap = struct
     let (T (typ, f, f_inv)) =
       Spec.wrap_packed_typ
         (T
-           ( Shifted_value.Type1.typ fp
+           ( Shifted_value.Type1.wrap_typ fp
            , (fun (Shifted_value x as t) ->
                Impl.run_checked (Other_field.check x) ;
                t )

--- a/src/lib/pickles/intf.mli
+++ b/src/lib/pickles/intf.mli
@@ -46,7 +46,7 @@ module Group (Impl : Snarky_backendless.Snark_intf.Run) : sig
 
     (** Represent a point, but not necessarily on the curve and in the prime
         subgroup *)
-    val typ_unchecked : (t, Constant.t, Impl.field) Snarky_backendless.Typ.t
+    val typ_unchecked : (t, Constant.t) Impl.Typ.t
 
     (** Represent a point on the curve and in the prime subgroup *)
     val typ : (t, Constant.t) Impl.Typ.t

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -26,11 +26,7 @@ module Other_field : sig
 
   val size_in_bits : int
 
-  val typ :
-    ( t
-    , Impls.Step.Other_field.Constant.t
-    , Impls.Step.Internal_Basic.field )
-    Snarky_backendless.Typ.t
+  val typ : (t, Impls.Step.Other_field.Constant.t) Impls.Step.Typ.t
 end
 
 val assert_n_bits :

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -210,7 +210,7 @@ let wrap_main
                     ~assert_16_bits:(Wrap_verifier.assert_n_bits ~n:16)
                     (Vector.init Max_proofs_verified.n ~f:(fun _ ->
                          Plonk_types.Features.none ) )
-                    (Shifted_value.Type2.typ Field.typ)
+                    (Shifted_value.Type2.wrap_typ Field.typ)
                 in
                 exists typ ~request:(fun () -> Req.Proof_state) )
           in

--- a/src/lib/pickles_types/shifted_value.ml
+++ b/src/lib/pickles_types/shifted_value.ml
@@ -67,8 +67,12 @@ module type S = sig
   end]
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -104,7 +108,13 @@ module Type1 = struct
   let typ f =
     let there (Shifted_value x) = x in
     let back x = Shifted_value x in
-    Snarky_backendless.Typ.(
+    Kimchi_pasta_snarky_backend.Step_impl.Typ.(
+      transport_var (transport f ~there ~back) ~there ~back)
+
+  let wrap_typ f =
+    let there (Shifted_value x) = x in
+    let back x = Shifted_value x in
+    Kimchi_pasta_snarky_backend.Wrap_impl.Typ.(
       transport_var (transport f ~there ~back) ~there ~back)
 
   let map (Shifted_value x) ~f = Shifted_value (f x)
@@ -162,7 +172,13 @@ module Type2 = struct
   let typ f =
     let there (Shifted_value x) = x in
     let back x = Shifted_value x in
-    Snarky_backendless.Typ.(
+    Kimchi_pasta_snarky_backend.Step_impl.Typ.(
+      transport_var (transport f ~there ~back) ~there ~back)
+
+  let wrap_typ f =
+    let there (Shifted_value x) = x in
+    let back x = Shifted_value x in
+    Kimchi_pasta_snarky_backend.Wrap_impl.Typ.(
       transport_var (transport f ~there ~back) ~there ~back)
 
   let map (Shifted_value x) ~f = Shifted_value (f x)

--- a/src/lib/pickles_types/shifted_value.mli
+++ b/src/lib/pickles_types/shifted_value.mli
@@ -52,8 +52,12 @@ module type S = sig
   type 'f t = 'f Stable.V1.t
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -91,8 +95,12 @@ module Type1 : sig
   val equal : ('a, 'res) Sigs.rel2 -> ('a t, 'res) Sigs.rel2
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -126,8 +134,12 @@ module Type2 : sig
   val equal : ('a, 'res) Sigs.rel2 -> ('a t, 'res) Sigs.rel2
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Step_impl.Typ.t
+
+  val wrap_typ :
+       ('a, 'b) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
+    -> ('a t, 'b t) Kimchi_pasta_snarky_backend.Wrap_impl.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -67,8 +67,7 @@ let%test_module "account timing check" =
           Balance.Checked.equal checked_min_balance
             (Balance.var_of_t unchecked_min_balance)
         in
-        Snarky_backendless.As_prover0.read Tick.Boolean.typ
-          equal_balances_checked
+        As_prover.read Tick.Boolean.typ equal_balances_checked
       in
       Or_error.ok_exn @@ Tick.run_and_check equal_balances_computation
 


### PR DESCRIPTION
This PR extends https://github.com/MinaProtocol/mina/pull/16359, removing all remaining references to `As_prover0` and `Snarky.Types.Typ` everywhere. This finally allows us to make these types opaque so that they can be forwarded from rust.