### PR TITLE
move bitswap_tag from staged_ledger_diff to mina_net2

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -364,6 +364,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 in
                 let body_reference =
                   Staged_ledger_diff.Body.compute_reference
+                    ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
                     (Body.create @@ Staged_ledger_diff.forget diff)
                 in
                 let blockchain_state =

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -483,7 +483,11 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
   let body = Block.body block in
   let apply_start_time = Core.Time.now () in
   let body_ref_from_header = Blockchain_state.body_reference blockchain_state in
-  let body_ref_computed = Staged_ledger_diff.Body.compute_reference body in
+  let body_ref_computed =
+    Staged_ledger_diff.Body.compute_reference
+      ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
+      body
+  in
   let%bind.Deferred.Result () =
     if Blake2.equal body_ref_computed body_ref_from_header then
       Deferred.Result.return ()

--- a/src/lib/mina_net2/bitswap_tag.ml
+++ b/src/lib/mina_net2/bitswap_tag.ml
@@ -1,0 +1,2 @@
+type t = Body [@@deriving enum]
+(* In future: | EpochLedger |... *)

--- a/src/lib/mina_net2/libp2p_helper.ml
+++ b/src/lib/mina_net2/libp2p_helper.ml
@@ -361,10 +361,8 @@ let send_validation ~validation_id ~validation_result =
       (Libp2p_ipc.create_validation_push_message ~validation_id
          ~validation_result )
 
-let send_add_resource ~tag ~body =
-  let open Staged_ledger_diff in
-  let tag = Body.Tag.to_enum tag in
-  let data = Body.to_binio_bigstring body |> Bigstring.to_string in
+let send_add_resource ~tag ~data =
+  let tag = Bitswap_tag.to_enum tag in
   send_push ~name:"AddResource"
     ~msg:(Libp2p_ipc.create_add_resource_push_message ~tag ~data)
 

--- a/src/lib/mina_net2/libp2p_helper.mli
+++ b/src/lib/mina_net2/libp2p_helper.mli
@@ -33,11 +33,7 @@ val send_validation :
   -> t
   -> unit
 
-val send_add_resource :
-     tag:Staged_ledger_diff.Body.Tag.t
-  -> body:Staged_ledger_diff.Body.t
-  -> t
-  -> unit
+val send_add_resource : tag:Bitswap_tag.t -> data:string -> t -> unit
 
 val send_heartbeat : peer_id:Network_peer.Peer.Id.t -> t -> unit
 

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -7,6 +7,7 @@ module Libp2p_stream = Libp2p_stream
 module Multiaddr = Multiaddr
 module Validation_callback = Validation_callback
 module Sink = Sink
+module Bitswap_tag = Bitswap_tag
 
 exception
   Libp2p_helper_died_unexpectedly = Libp2p_helper

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -111,6 +111,7 @@ end
 
 module Validation_callback = Validation_callback
 module Sink = Sink
+module Bitswap_tag = Bitswap_tag
 
 module For_tests : sig
   module Helper = Libp2p_helper

--- a/src/lib/staged_ledger_diff/body.ml
+++ b/src/lib/staged_ledger_diff/body.ml
@@ -6,12 +6,6 @@ module Make_sig (A : Wire_types.Types.S) = struct
 end
 
 module Make_str (A : Wire_types.Concrete) = struct
-  (* TODO Consider moving to a different location. as in future this won't be only about block body *)
-  module Tag = struct
-    type t = Body [@@deriving enum]
-    (* In future: | EpochLedger |... *)
-  end
-
   [%%versioned
   module Stable = struct
     module V1 = struct
@@ -66,19 +60,19 @@ module Make_str (A : Wire_types.Concrete) = struct
     ignore (Stable.V1.bin_write_t buf ~pos:0 b : int) ;
     buf
 
-  let serialize_with_len_and_tag b =
+  let serialize_with_len_and_tag ~tag b =
     let len = Stable.V1.bin_size_t b in
     let bs' = Bigstring.create (len + 5) in
     ignore (Stable.V1.bin_write_t bs' ~pos:5 b : int) ;
-    Bigstring.set_uint8_exn ~pos:4 bs' (Tag.to_enum Body) ;
+    Bigstring.set_uint8_exn ~pos:4 bs' tag ;
     Bigstring.set_uint32_le_exn ~pos:0 bs' (len + 1) ;
     bs'
 
-  let compute_reference =
+  let compute_reference ~tag =
     Fn.compose snd
     @@ Fn.compose
          (Bitswap_block.blocks_of_data ~max_block_size:262144)
-         serialize_with_len_and_tag
+         (serialize_with_len_and_tag ~tag)
 end
 
 include Wire_types.Make (Make_sig) (Make_str)

--- a/src/lib/staged_ledger_diff/body_intf.ml
+++ b/src/lib/staged_ledger_diff/body_intf.ml
@@ -1,9 +1,4 @@
 module type Full = sig
-  (* TODO Consider moving to a different location. as in future this won't be only about block body *)
-  module Tag : sig
-    type t = Body [@@deriving enum]
-  end
-
   [%%versioned:
   module Stable : sig
     [@@@no_toplevel_latest_type]
@@ -21,5 +16,5 @@ module type Full = sig
 
   val to_binio_bigstring : t -> Core_kernel.Bigstring.t
 
-  val compute_reference : t -> Consensus.Body_reference.t
+  val compute_reference : tag:int -> t -> Consensus.Body_reference.t
 end

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -2,4 +2,6 @@ include Diff
 module Body = Body
 module Bitswap_block = Bitswap_block
 
-let genesis_body_reference = Body.compute_reference (Body.create empty_diff)
+let genesis_body_reference =
+  (* Tag Body is fixed to integer value 0 *)
+  Body.compute_reference ~tag:0 (Body.create empty_diff)

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -437,7 +437,10 @@ module For_tests = struct
         Blockchain_state.create_value
           ~timestamp:(Block_time.now @@ Block_time.Controller.basic ~logger)
           ~staged_ledger_hash:next_staged_ledger_hash ~genesis_ledger_hash
-          ~body_reference:(Body.compute_reference body)
+          ~body_reference:
+            (Body.compute_reference
+               ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
+               body )
           ~ledger_proof_statement
       in
       let previous_state_hashes =


### PR DESCRIPTION
Refactoring needed for https://github.com/MinaProtocol/mina/pull/16361. Moving bitswap_tag to mina_net2 is necessary to unblock one of test in mina_lmdb_storage