### PR TITLE
allow instrumentation sigterm in archive node

### DIFF
--- a/src/app/archive/cli/dune
+++ b/src/app/archive/cli/dune
@@ -19,5 +19,5 @@
    block_time
    mina_version
  )
- (instrumentation (backend bisect_ppx))
+ (instrumentation (backend bisect_ppx --bisect-sigterm))
  (preprocess (pps ppx_version ppx_jane ppx_mina)))

--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -5,7 +5,7 @@
  (modules archive)
  (modes native)
  (libraries archive_cli async async_unix core_kernel base mina_version bounded_types)
- (instrumentation (backend bisect_ppx))
+ (instrumentation (backend bisect_ppx --bisect-sigterm))
  (preprocess (pps ppx_version)))
 
 (executable
@@ -15,7 +15,7 @@
  (modules archive_testnet_signatures)
  (modes native)
  (libraries archive_cli mina_signature_kind.testnet async async_unix core_kernel base mina_version bounded_types)
- (instrumentation (backend bisect_ppx))
+ (instrumentation (backend bisect_ppx --bisect-sigterm))
  (preprocess (pps ppx_version)))
 
 (executable
@@ -25,5 +25,5 @@
  (modules archive_mainnet_signatures)
  (modes native)
  (libraries archive_cli mina_signature_kind.mainnet async async_unix core_kernel base mina_version bounded_types)
- (instrumentation (backend bisect_ppx))
+ (instrumentation (backend bisect_ppx --bisect-sigterm))
  (preprocess (pps ppx_version)))

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -77,5 +77,5 @@
  )
  (inline_tests (flags -verbose -show-counts))
  (modes native)
- (instrumentation (backend bisect_ppx))
+ (instrumentation (backend bisect_ppx --bisect-sigterm))
  (preprocess (pps ppx_mina ppx_version ppx_jane ppx_custom_printf ppx_deriving_yojson h_list.ppx)))


### PR DESCRIPTION
Add flag to support sigterm command from bisect ppx. This is required to generate coverage on sigterm command when using instrumented archive. See details here: 
https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#sigterm-handling

Main problem is that we need to fetch instrumentation artifacts from running archive node. Usually when we stop archive process it won't generate coverage files unless process support 'coverage' sigterm