### PR TITLE
Differentiate snarky `Typ.t`s between instances

### DIFF
--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -11,6 +11,15 @@ module Make
     (Inputs : Intf.Step_main_inputs.S
                 with type Impl.field = Backend.Tick.Field.t
                  and type Impl.Bigint.t = Backend.Tick.Bigint.t
+                 and type ('var, 'value, 'aux, 'field, 'checked) Impl.Typ.typ' =
+                  ( 'var
+                  , 'value
+                  , 'aux
+                  , 'field
+                  , 'checked )
+                  Step_main_inputs.Impl.Typ.typ'
+                 and type ('var, 'value, 'field, 'checked) Impl.Typ.typ =
+                  ('var, 'value, 'field, 'checked) Step_main_inputs.Impl.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tock.Field.t) =
 struct
   open Inputs

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -49,6 +49,15 @@ module Make
     (Inputs : Intf.Wrap_main_inputs.S
                 with type Impl.field = Backend.Tock.Field.t
                  and type Impl.Bigint.t = Backend.Tock.Bigint.t
+                 and type ('var, 'value, 'aux, 'field, 'checked) Impl.Typ.typ' =
+                  ( 'var
+                  , 'value
+                  , 'aux
+                  , 'field
+                  , 'checked )
+                  Wrap_main_inputs.Impl.Typ.typ'
+                 and type ('var, 'value, 'field, 'checked) Impl.Typ.typ =
+                  ('var, 'value, 'field, 'checked) Wrap_main_inputs.Impl.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tick.Field.t) =
 struct
   open Inputs


### PR DESCRIPTION
This PR builds on https://github.com/MinaProtocol/mina/pull/16371, using the snarky PR https://github.com/o1-labs/snarky/pull/847 to completely separate the `Typ.t`s from the different snarky interfaces.