### PR TITLE
Clean up noisy logging, remove `Inline_test_quiet_logs` from `Bootstrap_controller`

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -714,6 +714,20 @@ let%test_module "Bootstrap_controller tests" =
 
     let logger = Logger.null ()
 
+    let () =
+      (* Disable log messages from best_tip_diff logger. *)
+      Logger.Consumer_registry.register ~commit_id:Mina_version.commit_id
+        ~id:Logger.Logger_id.best_tip_diff ~processor:(Logger.Processor.raw ())
+        ~transport:
+          (Logger.Transport.create
+             ( module struct
+               type t = unit
+
+               let transport () _ = ()
+             end )
+             () )
+        ()
+
     let trust_system =
       let s = Trust_system.null () in
       don't_wait_for

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -1,5 +1,4 @@
 (* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
 open Core
 open Async
 open Mina_base

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -712,7 +712,7 @@ let%test_module "Bootstrap_controller tests" =
     let max_frontier_length =
       Transition_frontier.global_max_length Genesis_constants.For_unit_tests.t
 
-    let logger = Logger.create ()
+    let logger = Logger.null ()
 
     let trust_system =
       let s = Trust_system.null () in
@@ -731,7 +731,7 @@ let%test_module "Bootstrap_controller tests" =
     let compile_config = Mina_compile_config.For_unit_tests.t
 
     module Context = struct
-      let logger = Logger.create ()
+      let logger = logger
 
       let precomputed_values = precomputed_values
 

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -82,6 +82,7 @@ end) : sig
   val create :
        max_batch_size:int
     -> stop:unit Deferred.t
+    -> logger:Logger.t
     -> trust_system:Trust_system.t
     -> get:(Peer.t -> Key.t list -> Result.t list Deferred.Or_error.t)
     -> knowledge_context:Knowledge_context.t Broadcast_pipe.Reader.t
@@ -951,7 +952,7 @@ end = struct
   let mark_preferred t peer ~now =
     Useful_peers.Preferred_heap.add t.useful_peers.all_preferred (peer, now)
 
-  let create ~max_batch_size ~stop ~trust_system ~get ~knowledge_context
+  let create ~max_batch_size ~stop ~logger ~trust_system ~get ~knowledge_context
       ~knowledge ~peers ~preferred =
     let%map all_peers = peers () in
     let pipe ~name c =
@@ -972,7 +973,7 @@ end = struct
       ; useful_peers = Useful_peers.create ~all_peers ~preferred
       ; get
       ; max_batch_size
-      ; logger = Logger.create ()
+      ; logger
       ; trust_system
       ; downloading = Key.Table.create ()
       ; stop

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -98,7 +98,7 @@ let setup (type n) ~context:(module Context : CONTEXT)
         }
     }
   in
-  let get_node_status _ = failwith "unimplemented" in
+  let get_node_status _ = Deferred.Or_error.error_string "unimplemented" in
   let peer_networks =
     Vect.map2 peers states ~f:(fun peer state ->
         let trust_system = Trust_system.null () in

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1155,7 +1155,8 @@ let run_catchup ~context:(module Context : CONTEXT) ~trust_system ~verifier
               | None ->
                   `Some [] ) )
     in
-    Downloader.create ~stop ~trust_system ~preferred:[] ~max_batch_size:5
+    Downloader.create ~stop ~trust_system ~logger ~preferred:[]
+      ~max_batch_size:5
       ~get:(fun peer hs ->
         let sec =
           let sec_per_block =

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -420,7 +420,7 @@ let glue_sync_ledger :
     Sl_downloader.create ~preferred ~max_batch_size:100
       ~peers:(fun () -> peers t)
       ~knowledge_context:root_hash_r ~knowledge ~stop:global_stop
-      ~trust_system:t.trust_system
+      ~logger:t.logger ~trust_system:t.trust_system
       ~get:(fun (peer : Peer.t) qs ->
         List.iter qs ~f:(fun (h, _) ->
             if

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -312,7 +312,7 @@ module T = struct
     in
     let%bind () =
       Statement_scanner_with_proofs.check_invariants ~constraint_constants
-        scan_state ~statement_check:(`Full get_state)
+        ~logger scan_state ~statement_check:(`Full get_state)
         ~verifier:{ Statement_scanner_proof_verifier.logger; verifier }
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~last_proof_statement
@@ -327,7 +327,7 @@ module T = struct
     return t
 
   let of_scan_state_and_ledger_unchecked
-      ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+      ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~logger
       ~last_proof_statement ~ledger ~scan_state ~pending_coinbase_collection
       ~first_pass_ledger_target =
     let open Deferred.Or_error.Let_syntax in
@@ -340,8 +340,8 @@ module T = struct
       |> Deferred.return
     in
     let%bind () =
-      Statement_scanner.check_invariants ~constraint_constants scan_state
-        ~statement_check:`Partial ~verifier:()
+      Statement_scanner.check_invariants ~constraint_constants ~logger
+        scan_state ~statement_check:`Partial ~verifier:()
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~last_proof_statement
         ~registers_end:
@@ -405,11 +405,12 @@ module T = struct
       (of_scan_state_and_ledger ~logger ~get_state ~verifier)
 
   let of_scan_state_pending_coinbases_and_snarked_ledger_unchecked
-      ~constraint_constants ~scan_state ~snarked_ledger ~snarked_local_state
-      ~expected_merkle_root ~pending_coinbases ~get_state =
+      ~constraint_constants ~logger ~scan_state ~snarked_ledger
+      ~snarked_local_state ~expected_merkle_root ~pending_coinbases ~get_state =
     of_scan_state_pending_coinbases_and_snarked_ledger' ~constraint_constants
       ~pending_coinbases ~scan_state ~snarked_ledger ~snarked_local_state
-      ~expected_merkle_root ~get_state of_scan_state_and_ledger_unchecked
+      ~expected_merkle_root ~get_state
+      (of_scan_state_and_ledger_unchecked ~logger)
 
   let copy
       { scan_state; ledger; constraint_constants; pending_coinbase_collection }
@@ -1144,7 +1145,7 @@ module T = struct
         [%log internal] "Verify_scan_state_after_apply" ;
         O1trace.thread "verify_scan_state_after_apply" (fun () ->
             Deferred.(
-              verify_scan_state_after_apply ~constraint_constants
+              verify_scan_state_after_apply ~constraint_constants ~logger
                 ~first_pass_ledger_end
                 ~second_pass_ledger_end:
                   (Frozen_ledger_hash.of_ledger_hash

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -312,6 +312,7 @@ val of_scan_state_pending_coinbases_and_snarked_ledger :
 
 val of_scan_state_pending_coinbases_and_snarked_ledger_unchecked :
      constraint_constants:Genesis_constants.Constraint_constants.t
+  -> logger:Logger.t
   -> scan_state:Scan_state.t
   -> snarked_ledger:Ledger.t
   -> snarked_local_state:Mina_state.Local_state.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -328,8 +328,6 @@ end) =
 struct
   module Fold = Parallel_scan.State.Make_foldable (Deferred)
 
-  let logger = lazy (Logger.create ())
-
   module Timer = struct
     module Info = struct
       module Time_span = struct
@@ -356,15 +354,15 @@ struct
         }
     end
 
-    type t = Info.t String.Table.t
+    type t = { table : Info.t String.Table.t; logger : Logger.t }
 
-    let create () : t = String.Table.create ()
+    let create ~logger () : t = { table = String.Table.create (); logger }
 
     let time (t : t) label f =
       let start = Time.now () in
       let x = f () in
       let elapsed = Time.(diff (now ()) start) in
-      Hashtbl.update t label ~f:(function
+      Hashtbl.update t.table label ~f:(function
         | None ->
             Info.singleton elapsed
         | Some acc ->
@@ -372,23 +370,22 @@ struct
       x
 
     let log label (t : t) =
-      let logger = Lazy.force logger in
-      [%log debug]
+      [%log' debug t.logger]
         ~metadata:
-          (List.map (Hashtbl.to_alist t) ~f:(fun (k, info) ->
+          (List.map (Hashtbl.to_alist t.table) ~f:(fun (k, info) ->
                (k, Info.to_yojson info) ) )
         "%s timing" label
   end
 
   (*TODO: fold over the pending_coinbase tree and validate the statements?*)
-  let scan_statement ~constraint_constants
+  let scan_statement ~constraint_constants ~logger
       ({ scan_state = tree; previous_incomplete_zkapp_updates = _ } : t)
       ~statement_check ~verifier :
       ( Transaction_snark.Statement.t
       , [ `Error of Error.t | `Empty ] )
       Deferred.Result.t =
     let open Deferred.Or_error.Let_syntax in
-    let timer = Timer.create () in
+    let timer = Timer.create ~logger () in
     let yield_occasionally =
       let f = Staged.unstage (Async.Scheduler.yield_every ~n:50) in
       fun () -> f () |> Deferred.map ~f:Or_error.return
@@ -556,8 +553,8 @@ struct
     | Error e ->
         Deferred.return (Error (`Error e))
 
-  let check_invariants t ~constraint_constants ~statement_check ~verifier
-      ~error_prefix
+  let check_invariants t ~constraint_constants ~logger ~statement_check
+      ~verifier ~error_prefix
       ~(last_proof_statement : Transaction_snark.Statement.t option)
       ~(registers_end :
          ( Frozen_ledger_hash.t
@@ -595,7 +592,8 @@ struct
     in
     match%map
       O1trace.sync_thread "validate_transaction_snark_scan_state" (fun () ->
-          scan_statement t ~constraint_constants ~statement_check ~verifier )
+          scan_statement t ~constraint_constants ~logger ~statement_check
+            ~verifier )
     with
     | Error (`Error e) ->
         Error e

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -53,6 +53,7 @@ module Make_statement_scanner (Verifier : sig
 end) : sig
   val scan_statement :
        constraint_constants:Genesis_constants.Constraint_constants.t
+    -> logger:Logger.t
     -> t
     -> statement_check:
          [ `Full of State_hash.t -> Mina_state.Protocol_state.value Or_error.t
@@ -65,6 +66,7 @@ end) : sig
   val check_invariants :
        t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> logger:Logger.t
     -> statement_check:
          [ `Full of State_hash.t -> Mina_state.Protocol_state.value Or_error.t
          | `Partial ]

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -58,7 +58,7 @@ let construct_staged_ledger_at_root ~(precomputed_values : Precomputed_values.t)
   let%bind staged_ledger =
     Staged_ledger.of_scan_state_pending_coinbases_and_snarked_ledger_unchecked
       ~snarked_local_state:local_state ~snarked_ledger:mask ~scan_state
-      ~constraint_constants:precomputed_values.constraint_constants
+      ~constraint_constants:precomputed_values.constraint_constants ~logger
       ~pending_coinbases
       ~expected_merkle_root:(Staged_ledger_hash.ledger_hash staged_ledger_hash)
       ~get_state


### PR DESCRIPTION
This PR tweaks the loggers used in the systems supporting the `Bootstrap_controller` unit tests, allowing us to turn back on verbose output without flooding the unit test output with noise. This PR is part of an effort to make the timings of all unit tests more visible.