### PR TITLE
naming sync lag variable

### DIFF
--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -7,6 +7,8 @@ open Mina_base
 (** For status *)
 let txn_count = ref 0
 
+let sync_lag = 5
+
 let get_account t (addr : Account_id.t) =
   let open Participating_state.Let_syntax in
   let%map ledger = Mina_lib.best_ledger t in
@@ -391,7 +393,7 @@ let get_status ~flag t =
       | `Synced | `Catchup ->
           if
             (Mina_lib.config t).demo_mode
-            || abs (!max_block_height - blockchain_length) < 5
+            || abs (!max_block_height - blockchain_length) < sync_lag
           then `Active `Synced
           else `Active `Catchup
     in


### PR DESCRIPTION
We update to sync status 5 blocks before the best tip block number. In the spirit of getting rid of magic numbers, I've named it. I would also like to reference it in a later PR.