### PR TITLE
cherrypick - default logger for compile config should be null

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -43,7 +43,7 @@ let or_error_str ~f_ok ~error = function
   | Error e ->
       sprintf "%s\n%s\n" error (Error.to_string_hum e)
 
-let load_compile_config ?(logger = Logger.create ()) config_files =
+let load_compile_config ?(logger = Logger.null ()) config_files =
   let%map conf = Runtime_config.Constants.load_constants ~logger config_files in
   Runtime_config.Constants.compile_config conf
 


### PR DESCRIPTION
**Explain your changes:**
A minor change cherrypicked from https://github.com/MinaProtocol/mina/pull/16381/commits to suppress incorrect logging information when calling `mina client` via CLI. This issue was seen in the 3.0.4 devnet alpha1 release and the purpose of this fix is to ensure that it is fixed prior to promotion to mainnet beta.

**Explain how you tested your changes:**
This was tested via CI as well as connecting to mainnet to ensure that the mina client commands can be called successfully without viewing any extra unwanted data.