### PR TITLE
Skip publishing dockers on PR 

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -99,8 +99,8 @@ let generateStep =
                       ++  " --deb-build-flags ${BuildFlags.lowerName
                                                   spec.build_flags}"
 
-                else  " echo In order to ensure storage optimization, skipping publishing docker as this is not essential one or publishing is disabled . Docker publish setting is set ${DockerPublish.show
-                                                                                                                                                                                            spec.docker_publish}."
+                else  " echo In order to ensure storage optimization, skipping publishing docker as this is not essential one or publishing is disabled . Docker publish setting is set to  ${DockerPublish.show
+                                                                                                                                                                                                spec.docker_publish}."
 
           let remoteRepoCmds =
                 [ Cmd.run

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -99,8 +99,8 @@ let generateStep =
                       ++  " --deb-build-flags ${BuildFlags.lowerName
                                                   spec.build_flags}"
 
-                else  " echo skipping publishing docker as this is not essential one or publishing is disabled (Docker publish setting is ${DockerPublish.show
-                                                                                                                                              spec.docker_publish}). This is to ensure storage optimization"
+                else  " echo In order to ensure storage optimization, skipping publishing docker as this is not essential one or publishing is disabled . Docker publish setting is set ${DockerPublish.show
+                                                                                                                                                                                            spec.docker_publish}."
 
           let remoteRepoCmds =
                 [ Cmd.run

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -53,7 +53,7 @@ let ReleaseSpec =
           , deb_version = "\\\${MINA_DEB_VERSION}"
           , deb_profile = Profiles.Type.Standard
           , build_flags = BuildFlags.Type.None
-          , docker_publish = DockerPublish.Type.Disabled
+          , docker_publish = DockerPublish.Type.Essential
           , deb_repo = DebianRepo.Type.PackagesO1Test
           , no_cache = False
           , step_key = "daemon-standard-docker-image"
@@ -99,7 +99,8 @@ let generateStep =
                       ++  " --deb-build-flags ${BuildFlags.lowerName
                                                   spec.build_flags}"
 
-                else  " echo skipping publishing docker as this is not essential one. This is to ensure storage optimization"
+                else  " echo skipping publishing docker as this is not essential one or publishing is disabled (Docker publish setting is ${DockerPublish.show
+                                                                                                                                              spec.docker_publish}). This is to ensure storage optimization"
 
           let remoteRepoCmds =
                 [ Cmd.run

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -99,7 +99,7 @@ let generateStep =
                       ++  " --deb-build-flags ${BuildFlags.lowerName
                                                   spec.build_flags}"
 
-                else  " echo skipping "
+                else  " echo skipping publishing docker as this is not essential one. This is to ensure storage optimization"
 
           let remoteRepoCmds =
                 [ Cmd.run

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -22,6 +22,8 @@ let DebianVersions = ../Constants/DebianVersions.dhall
 
 let DebianRepo = ../Constants/DebianRepo.dhall
 
+let DockerPublish = ../Constants/DockerPublish.dhall
+
 let DebianChannel = ../Constants/DebianChannel.dhall
 
 let Profiles = ../Constants/Profiles.dhall
@@ -149,6 +151,8 @@ let docker_step
                   spec.buildFlags
                   step_dep_name
 
+          let docker_publish = DockerPublish.Type.Essential
+
           in  merge
                 { Daemon =
                     Prelude.List.map
@@ -164,6 +168,7 @@ let docker_step
                             , deb_profile = spec.profile
                             , build_flags = spec.buildFlags
                             , deb_repo = DebianRepo.Type.Local
+                            , docker_publish = docker_publish
                             , step_key =
                                 "daemon-${Network.lowerName
                                             n}-${DebianVersions.lowerName
@@ -184,6 +189,7 @@ let docker_step
                         "${DebianVersions.lowerName spec.debVersion}"
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
+                    , docker_publish = docker_publish
                     , deb_repo = DebianRepo.Type.Local
                     , step_key =
                         "batch-txn-${DebianVersions.lowerName
@@ -199,6 +205,7 @@ let docker_step
                         "${DebianVersions.lowerName spec.debVersion}"
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
+                    , docker_publish = docker_publish
                     , deb_repo = DebianRepo.Type.Local
                     , step_key =
                         "archive-${DebianVersions.lowerName
@@ -220,6 +227,7 @@ let docker_step
                                 "${DebianVersions.lowerName spec.debVersion}"
                             , deb_profile = spec.profile
                             , build_flags = spec.buildFlags
+                            , docker_publish = docker_publish
                             , deb_repo = DebianRepo.Type.Local
                             , step_key =
                                 "rosetta-${Network.lowerName
@@ -234,6 +242,7 @@ let docker_step
                     , deps = deps
                     , service = Artifacts.Type.ZkappTestTransaction
                     , build_flags = spec.buildFlags
+                    , docker_publish = docker_publish
                     , deb_repo = DebianRepo.Type.Local
                     , deb_profile = spec.profile
                     , deb_codename =
@@ -252,6 +261,7 @@ let docker_step
                     , deb_codename =
                         "${DebianVersions.lowerName spec.debVersion}"
                     , build_flags = spec.buildFlags
+                    , docker_publish = docker_publish
                     , deb_repo = DebianRepo.Type.Local
                     , deb_profile = spec.profile
                     , step_key =

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -14,7 +14,7 @@ let isEssential =
             , BatchTxn = False
             , Rosetta = True
             , ZkappTestTransaction = False
-            , FunctionalTestSuite = False
+            , FunctionalTestSuite = True
             , Toolchain = True
             , ItnOrchestrator = False
             }

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -1,0 +1,46 @@
+let Artifacts = ./Artifacts.dhall
+
+let DockerPublish
+    : Type
+    = < Enabled | Disabled | Essential >
+
+let isEssential =
+          \(service : Artifacts.Type)
+      ->  merge
+            { Daemon = True
+            , LogProc = False
+            , Archive = True
+            , TestExecutive = False
+            , BatchTxn = False
+            , Rosetta = True
+            , ZkappTestTransaction = False
+            , FunctionalTestSuite = False
+            , Toolchain = True
+            , ItnOrchestrator = False
+            }
+            service
+
+let shouldPublish =
+          \(publish : DockerPublish)
+      ->  \(service : Artifacts.Type)
+      ->  merge
+            { Disabled = False
+            , Enabled = True
+            , Essential = isEssential service
+            }
+            publish
+
+let show =
+          \(publish : DockerPublish)
+      ->  merge
+            { Enabled = "Enabled"
+            , Disabled = "Disabled"
+            , Essential = "Essential"
+            }
+            publish
+
+in  { Type = DockerPublish
+    , shouldPublish = shouldPublish
+    , isEssential = isEssential
+    , show = show
+    }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
@@ -1,14 +1,14 @@
-let S = ../../Lib/SelectFiles.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let Artifacts = ../../Constants/Artifacts.dhall
+
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
-let DockerImage = ../../Command/DockerImage.dhall
+let S = ../../Lib/SelectFiles.dhall
 
-let Artifacts = ../../Constants/Artifacts.dhall
+let DockerImage = ../../Command/DockerImage.dhall
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
@@ -1,14 +1,14 @@
-let S = ../../Lib/SelectFiles.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let Artifacts = ../../Constants/Artifacts.dhall
+
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
-let DockerImage = ../../Command/DockerImage.dhall
+let S = ../../Lib/SelectFiles.dhall
 
-let Artifacts = ../../Constants/Artifacts.dhall
+let DockerImage = ../../Command/DockerImage.dhall
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Pipeline/Mode.dhall
+++ b/buildkite/src/Pipeline/Mode.dhall
@@ -11,4 +11,8 @@ let capitalName =
           \(pipelineMode : Mode)
       ->  merge { PullRequest = "PullRequest", Stable = "Stable" } pipelineMode
 
-in  { Type = Mode, capitalName = capitalName }
+let isStable =
+          \(pipelineMode : Mode)
+      ->  merge { PullRequest = False, Stable = True } pipelineMode
+
+in  { Type = Mode, capitalName = capitalName, isStable = isStable }


### PR DESCRIPTION
In order to preserve cost of our gcr.io, but also avoid lengthy docker push operation, this PR avoid pushing non essential dockers to gcr.io. What is essential or not can be configured, as well as hard switches Enabled all or Disabled all. 

As a result only daemon,archive,rosetta and functional_test_suite (until https://github.com/MinaProtocol/mina/pull/16608 is not merged) dockers will be pushed to gcr.io all others can be build using `!ci-docker-me` pipeline. 