### PR TITLE
Remove constraint_constants from currency_consumed

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -66,11 +66,8 @@ let config t = t.config
 (* Compute the total currency required from the sender to execute a command.
    Returns None in case of overflow.
 *)
-let currency_consumed_unchecked :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> User_command.t
-    -> Currency.Amount.t option =
- fun ~constraint_constants:_ cmd ->
+let currency_consumed_unchecked : User_command.t -> Currency.Amount.t option =
+ fun cmd ->
   let fee_amt = Currency.Amount.of_fee @@ User_command.fee cmd in
   let open Currency.Amount in
   let amt =
@@ -88,17 +85,14 @@ let currency_consumed_unchecked :
   in
   fee_amt + amt
 
-let currency_consumed ~constraint_constants cmd =
-  currency_consumed_unchecked ~constraint_constants
+let currency_consumed cmd =
+  currency_consumed_unchecked
     (Transaction_hash.User_command_with_valid_signature.command cmd)
 
 let currency_consumed' :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> User_command.t
-    -> (Currency.Amount.t, Command_error.t) Result.t =
- fun ~constraint_constants cmd ->
-  cmd
-  |> currency_consumed_unchecked ~constraint_constants
+    User_command.t -> (Currency.Amount.t, Command_error.t) Result.t =
+ fun cmd ->
+  cmd |> currency_consumed_unchecked
   |> Result.of_option ~error:Command_error.Overflow
 
 module For_tests = struct
@@ -180,7 +174,6 @@ module For_tests = struct
                 nonce ;
               let consumed =
                 currency_consumed_unchecked
-                  ~constraint_constants:pool.config.constraint_constants
                   (Transaction_hash.User_command_with_valid_signature.command
                      cmd )
                 |> Option.value_exn
@@ -568,14 +561,13 @@ let run :
    it. Called from revalidate and remove_lowest_fee, and when replacing
    transactions. *)
 let remove_with_dependents_exn :
-       constraint_constants:_
-    -> Transaction_hash.User_command_with_valid_signature.t
+       Transaction_hash.User_command_with_valid_signature.t
     -> Sender_local_state.t ref
     -> ( Transaction_hash.User_command_with_valid_signature.t Sequence.t
        , Update.single
        , _ )
        Writer_result.t =
- fun ~constraint_constants (* ({ constraint_constants; _ } as t) *) cmd state ->
+ fun cmd state ->
   let unchecked =
     Transaction_hash.User_command_with_valid_signature.command cmd
   in
@@ -604,7 +596,7 @@ let remove_with_dependents_exn :
         Option.value_exn
           (* safe because we check for overflow when we add commands. *)
           (let open Option.Let_syntax in
-          let%bind consumed = currency_consumed ~constraint_constants cmd' in
+          let%bind consumed = currency_consumed cmd' in
           Currency.Amount.(consumed + acc)) )
       Currency.Amount.zero drop_queue
   in
@@ -642,11 +634,7 @@ let run' t cmd x =
     x
 
 let remove_with_dependents_exn' t cmd =
-  match
-    run' t cmd
-      (remove_with_dependents_exn
-         ~constraint_constants:t.config.constraint_constants cmd )
-  with
+  match run' t cmd (remove_with_dependents_exn cmd) with
   | Ok x ->
       x
   | Error _ ->
@@ -655,14 +643,13 @@ let remove_with_dependents_exn' t cmd =
 (** Drop commands from the end of the queue until the total currency consumed is
     <= the current balance. *)
 let drop_until_sufficient_balance :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> Transaction_hash.User_command_with_valid_signature.t F_sequence.t
+       Transaction_hash.User_command_with_valid_signature.t F_sequence.t
        * Currency.Amount.t
     -> Currency.Amount.t
     -> Transaction_hash.User_command_with_valid_signature.t F_sequence.t
        * Currency.Amount.t
        * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
- fun ~constraint_constants (queue, currency_reserved) current_balance ->
+ fun (queue, currency_reserved) current_balance ->
   let rec go queue' currency_reserved' dropped_so_far =
     if Currency.Amount.(currency_reserved' <= current_balance) then
       (queue', currency_reserved', dropped_so_far)
@@ -674,9 +661,7 @@ let drop_until_sufficient_balance :
              sufficient balance"
           (F_sequence.unsnoc queue')
       in
-      let consumed =
-        Option.value_exn (currency_consumed ~constraint_constants liat)
-      in
+      let consumed = Option.value_exn (currency_consumed liat) in
       go daeh
         (Option.value_exn Currency.Amount.(currency_reserved' - consumed))
         (Sequence.append dropped_so_far @@ Sequence.singleton liat)
@@ -693,7 +678,7 @@ let revalidate :
     -> [ `Entire_pool | `Subset of Account_id.Set.t ]
     -> (Account_id.t -> Account.t)
     -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
- fun ({ config = { constraint_constants; _ }; _ } as t) ~logger scope f ->
+ fun t ~logger scope f ->
   let requires_revalidation =
     match scope with
     | `Entire_pool ->
@@ -770,14 +755,12 @@ let revalidate :
             F_sequence.foldl
               (fun c cmd ->
                 Option.value_exn
-                  Currency.Amount.(
-                    c
-                    - Option.value_exn
-                        (currency_consumed ~constraint_constants cmd)) )
+                  Currency.Amount.(c - Option.value_exn (currency_consumed cmd))
+                )
               currency_reserved drop_queue
           in
           let keep_queue', currency_reserved'', dropped_for_balance =
-            drop_until_sufficient_balance ~constraint_constants
+            drop_until_sufficient_balance
               (keep_queue, currency_reserved')
               current_balance
           in
@@ -898,7 +881,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
          , Command_error.t )
          M.t =
    fun ~config:
-         ( { constraint_constants
+         ( { constraint_constants = _
            ; consensus_constants
            ; time_controller
            ; slot_tx_end
@@ -929,9 +912,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
         Result.Let_syntax.(
           (* C5 *)
           let%bind () = check_expiry config unchecked in
-          let%bind consumed =
-            currency_consumed' ~constraint_constants unchecked
-          in
+          let%bind consumed = currency_consumed' unchecked in
           let%map () =
             (* TODO: Proper exchange rate mechanism. *)
             let fee_token = User_command.fee_token unchecked in
@@ -1058,7 +1039,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
             (* C3 *)
           in
           let%bind dropped =
-            remove_with_dependents_exn ~constraint_constants
+            remove_with_dependents_exn
               (F_sequence.head_exn drop_queue)
               by_sender
             |> M.lift
@@ -1159,7 +1140,7 @@ let add_from_backtrack :
     -> Transaction_hash.User_command_with_valid_signature.t
     -> (t, Command_error.t) Result.t =
  fun ( { config =
-           { constraint_constants
+           { constraint_constants = _
            ; consensus_constants
            ; time_controller
            ; slot_tx_end
@@ -1186,9 +1167,7 @@ let add_from_backtrack :
   let fee_payer = User_command.fee_payer unchecked in
   let fee_per_wu = User_command.fee_per_wu unchecked in
   let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
-  let consumed =
-    Option.value_exn (currency_consumed ~constraint_constants cmd)
-  in
+  let consumed = Option.value_exn (currency_consumed cmd) in
   match Map.find t.all_by_sender fee_payer with
   | None ->
       { all_by_sender =

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -151,7 +151,6 @@ module For_tests : sig
        Account_id.Map.t
 
   val currency_consumed :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> Transaction_hash.User_command_with_valid_signature.t
+       Transaction_hash.User_command_with_valid_signature.t
     -> Currency.Amount.t option
 end

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -35,8 +35,7 @@ let singleton_properties () =
           (Amount.of_nanomina_int_exn 500)
       in
       if
-        Option.value_exn (currency_consumed ~constraint_constants cmd)
-        |> Amount.to_nanomina_int > 500
+        Option.value_exn (currency_consumed cmd) |> Amount.to_nanomina_int > 500
       then
         match add_res with
         | Error (Insufficient_funds _) ->
@@ -214,9 +213,7 @@ let replacement () =
             ~common:(fun c -> { c with fee = Amount.to_fee fee })
             ~body:(fun b -> { b with amount })
         in
-        let consumed =
-          Option.value_exn (currency_consumed ~constraint_constants cmd')
-        in
+        let consumed = Option.value_exn (currency_consumed cmd') in
         let%map rest =
           go
             (Account_nonce.succ current_nonce)
@@ -293,7 +290,7 @@ let replacement () =
           ~f:(fun consumed_so_far cmd ->
             Option.value_exn
               Option.(
-                currency_consumed ~constraint_constants cmd
+                currency_consumed cmd
                 >>= fun consumed -> Amount.(consumed + consumed_so_far)) )
       in
       assert (Amount.(currency_consumed_pre_replace <= init_balance)) ;
@@ -301,12 +298,9 @@ let replacement () =
         Option.value_exn
           (let open Option.Let_syntax in
           let%bind replaced_currency_consumed =
-            currency_consumed ~constraint_constants
-            @@ List.nth_exn setup_cmds replaced_idx
+            currency_consumed @@ List.nth_exn setup_cmds replaced_idx
           in
-          let%bind replacer_currency_consumed =
-            currency_consumed ~constraint_constants replace_cmd
-          in
+          let%bind replacer_currency_consumed = currency_consumed replace_cmd in
           let%bind a =
             Amount.(currency_consumed_pre_replace - replaced_currency_consumed)
           in


### PR DESCRIPTION
This parameter is not used.

Explain how you tested your changes:
* [ ] Code compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None