### PR TITLE
Fix a few bugs in `revalidate` (mini)

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -776,7 +776,7 @@ let revalidate :
                         (currency_consumed ~constraint_constants cmd)) )
               currency_reserved dropped_for_nonce
           in
-          let keep_queue', currency_reserved'', dropped_for_balance =
+          let keep_queue, currency_reserved_updated, dropped_for_balance =
             drop_until_sufficient_balance ~constraint_constants
               (retained_for_nonce, currency_reserved_partially_updated)
               current_balance
@@ -799,7 +799,7 @@ let revalidate :
                   ~f:remove_all_by_fee_and_hash_and_expiration_exn
               in
               let t''' =
-                match F_sequence.uncons keep_queue' with
+                match F_sequence.uncons keep_queue with
                 | None ->
                     { t'' with
                       all_by_sender = Map.remove t''.all_by_sender sender
@@ -812,7 +812,7 @@ let revalidate :
                     { t'' with
                       all_by_sender =
                         Map.set t''.all_by_sender ~key:sender
-                          ~data:(keep_queue', currency_reserved'')
+                          ~data:(keep_queue, currency_reserved_updated)
                     ; applicable_by_fee =
                         Map_set.insert
                           ( module Transaction_hash

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -739,14 +739,14 @@ let revalidate :
         then (
           [%log debug]
             "Account no longer has permission to send; dropping queue" ;
-          let dropped, t'' = remove_with_dependents_exn' t_initial first_cmd in
-          (t'', Sequence.append dropped_acc dropped) )
+          let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+          (t_updated, Sequence.append dropped_acc dropped) )
         else if Account_nonce.(account.nonce < first_nonce) then (
           [%log debug]
             "Current account nonce precedes first nonce in queue; dropping \
              queue" ;
-          let dropped, t'' = remove_with_dependents_exn' t_initial first_cmd in
-          (t'', Sequence.append dropped_acc dropped) )
+          let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+          (t_updated, Sequence.append dropped_acc dropped) )
         else
           (* current_nonce >= first_nonce *)
           let first_applicable_nonce_index =

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -705,7 +705,7 @@ let revalidate :
     ~f:(fun
          ~key:sender
          ~data:(queue, currency_reserved)
-         ((t', dropped_acc) as acc)
+         ((t, dropped_acc) as acc)
        ->
       if not (requires_revalidation sender) then acc
       else
@@ -792,7 +792,7 @@ let revalidate :
                 Sequence.fold tail
                   ~init:
                     (remove_all_by_fee_and_hash_and_expiration_exn
-                       (remove_applicable_exn t' head)
+                       (remove_applicable_exn t head)
                        head )
                   ~f:remove_all_by_fee_and_hash_and_expiration_exn
               in


### PR DESCRIPTION
1. Fix two similar issues originating from confusion between previous variable names `t` and `t'` (`Account no longer has permission to send` and `Current account nonce precedes first nonce in queue`)
2. Fix the issue #16397 by ensuring removal from `applicable_by_fee` is
       done only for the previous head of queue.

Explain how you tested your changes:
* [x] #16415 unit tests


## Checklist

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #16397
