### PR TITLE
Do not derive sexp for the scan state

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -235,14 +235,12 @@ module T = struct
   type t =
     { scan_state : Scan_state.t
     ; ledger :
-        ((* Invariant: this is the ledger after having applied all the
-             transactions in the above state. *)
-         Ledger.attached_mask
-        [@sexp.opaque] )
+        (* Invariant: this is the ledger after having applied all the
+            transactions in the above state. *)
+        Ledger.attached_mask
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     ; pending_coinbase_collection : Pending_coinbase.t
     }
-  [@@deriving sexp]
 
   let proof_txns_with_state_hashes t =
     Scan_state.latest_ledger_proof t.scan_state

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -5,13 +5,13 @@ open Mina_transaction
 open Signature_lib
 module Ledger = Mina_ledger.Ledger
 
-type t [@@deriving sexp]
+type t
 
 module Scan_state : sig
   [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving sexp]
+      type t
 
       val hash : t -> Staged_ledger_hash.Aux_hash.t
     end

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -166,7 +166,6 @@ module Stable = struct
           Transaction_with_witness.Stable.V2.t list
           * [ `Border_block_continued_in_the_next_tree of bool ]
       }
-    [@@deriving sexp]
 
     let to_latest = Fn.id
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -7,7 +7,7 @@ module Ledger = Mina_ledger.Ledger
 [%%versioned:
 module Stable : sig
   module V2 : sig
-    type t [@@deriving sexp]
+    type t
 
     val hash : t -> Staged_ledger_hash.Aux_hash.t
   end


### PR DESCRIPTION
This use of deriving is not used, so no point in having it.

Explain how you tested your changes:
* [x] Code compiles

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None