### PR TITLE
publish standalone snark worker

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -49,5 +49,6 @@ dune build "--profile=${DUNE_PROFILE}" $INSTRUMENTED_PARAM \
   src/app/disk_caching_stats/disk_caching_stats.exe \
   src/app/heap_usage/heap_usage.exe \
   src/app/zkapp_limits/zkapp_limits.exe \
+  src/lib/snark_worker/standalone/run_snark_worker.exe \
   src/test/command_line_tests/command_line_tests.exe \
   src/test/archive/patch_archive_test/patch_archive_test.exe

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -146,7 +146,7 @@ copy_common_daemon_configs() {
   cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/mina-create-genesis"
   cp ./default/src/app/generate_keypair/generate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-generate-keypair"
   cp ./default/src/app/validate_keypair/validate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-validate-keypair"
-
+  cp ./default/src/lib/snark_worker/standalone/run_snark_worker.exe "${BUILDDIR}/usr/local/bin/mina-standalone-snark-worker"
   # Copy signature-based Binaries (based on signature type $2 passed into the function)
   cp ./default/src/app/cli/src/mina_${2}_signatures.exe "${BUILDDIR}/usr/local/bin/mina"
 


### PR DESCRIPTION
Publish "src/lib/snark_worker/standalone/run_snark_worker.exe" in mina-daemon debian package. App will be built using two profiles (mainnet,devnet) and  placed in mina-devnet and mina-mainnet debian packages. 

App will be automatically added to dockers (daemon and rosetta) as we are installing debian while building docker