### PR TITLE
Kimchi-bindings/wasm: stop using nightly and rm ft get_mut_unchecked

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,11 +4,11 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 { toolchainBase = "codaprotocol/ci-toolchain-base:v3"
 , minaToolchainBullseye =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:fee11e64a54fd8f026c4632fed7b7b9835b8262a037cdb156deb61d3d0aac8b2"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:8dc3a721b2be119db98a45970c21249f7ed9a95a75f2b330d7c0f37cdafcc99a"
 , minaToolchainBookworm =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:fee11e64a54fd8f026c4632fed7b7b9835b8262a037cdb156deb61d3d0aac8b2"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:8dc3a721b2be119db98a45970c21249f7ed9a95a75f2b330d7c0f37cdafcc99a"
 , minaToolchain =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:fee11e64a54fd8f026c4632fed7b7b9835b8262a037cdb156deb61d3d0aac8b2"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:8dc3a721b2be119db98a45970c21249f7ed9a95a75f2b330d7c0f37cdafcc99a"
 , elixirToolchain = "elixir:1.10-alpine"
 , nodeToolchain = "node:14.13.1-stretch-slim"
 , ubuntu2004 = "ubuntu:20.04"

--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -24,9 +24,6 @@ ARG GO_CAPNP_VERSION=v3.0.0-alpha.5
 # - src/lib/crypto/kimchi_bindings/stubs/rust-toolchain.toml
 # - src/lib/crypto/proof-systems/rust-toolchain.toml
 ARG RUST_VERSION=1.72
-# Nightly Rust Version used for WebAssembly builds
-# - src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml
-ARG RUST_NIGHTLY=2023-09-01
 # wasm-pack version
 ARG WASM_PACK_VERSION=v0.12.1
 
@@ -97,7 +94,6 @@ RUN curl -sL \
 RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/lib/
 
 # --- Rust install via rustup-init to a given RUST_VERSION
-# --- Additionally, install RUST_NIGHTLY via rustup
 # For more about rustup-init see: https://github.com/rust-lang/rustup/blob/master/README.md
 # As opposed to introducing another shell script here (that mostly just determines the platform)
 # we just download the binary for the only platform we care about in this docker environment
@@ -106,7 +102,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf -o /tmp/rustup-init \
   https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
   && chmod +x /tmp/rustup-init \
   && /tmp/rustup-init -y --default-toolchain "${RUST_VERSION}" --profile minimal --component rust-src --target wasm32-unknown-unknown \
-  && $HOME/.cargo/bin/rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal --component rust-src --target wasm32-unknown-unknown --no-self-update \
   && rm /tmp/rustup-init
 USER root
 

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -9,6 +9,7 @@ let
     };
   toolchainHashes = {
     "1.72" = "sha256-dxE7lmCFWlq0nl/wKcmYvpP9zqQbBitAQgZ1zx9Ooik=";
+    # FIXME: REMOVEME
     "nightly-2023-09-01" =
       "sha256-zek9JAnRaoX8V0U2Y5ssXVe9tvoQ0ERGXfUCUGYdrMA=";
     # copy the placeholder line with the correct toolchain name when adding a new toolchain

--- a/src/lib/crypto/kimchi_bindings/js/node_js/build.sh
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 if [[ -z "${PLONK_WASM_NODEJS-}" ]]; then
     export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
     # The version should stay in line with the one in kimchi_bindings/wasm/rust-toolchain.toml
-    rustup run nightly-2023-09-01 wasm-pack build --target nodejs --out-dir ../js/node_js ../../wasm -- -Z build-std=panic_abort,std --features nodejs
+    rustup run 1.72 wasm-pack build --target nodejs --out-dir ../js/node_js ../../wasm -- --features nodejs
 else
     cp "$PLONK_WASM_NODEJS"/* -R .
 fi

--- a/src/lib/crypto/kimchi_bindings/js/web/build.sh
+++ b/src/lib/crypto/kimchi_bindings/js/web/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 if [[ -z "${PLONK_WASM_WEB-}" ]]; then
     export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
     # The version should stay in line with the one in kimchi_bindings/wasm/rust-toolchain.toml
-    rustup run nightly-2023-09-01 wasm-pack build --target web --out-dir ../js/web ../../wasm -- -Z build-std=panic_abort,std
+    rustup run 1.72 wasm-pack build --target web --out-dir ../js/web ../../wasm
 else
     cp "$PLONK_WASM_WEB"/* -R .
 fi

--- a/src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml
@@ -3,4 +3,4 @@
 # This should stay in line with the versions in
 # - kimchi_bindings/js/node_js/build.sh
 # - kimchi_bindings/js/web/build.sh
-channel = "nightly-2023-09-01" # roughly matches 1.72
+channel = "1.72"

--- a/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(get_mut_unchecked)]
 //! The Marlin_plonk_stubs crate exports some functionalities
 //! and structures from the following the Rust crates to OCaml:
 //!


### PR DESCRIPTION
Attempt to stop using nightly for wasm.

cc @martyall 

---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
