### PR TITLE
[trivial] Transaction_snark: remove old comment reg. type constraints

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -1,17 +1,3 @@
 include
   Transaction_snark_intf.Full
     with type Stable.V2.t = Mina_wire_types.Transaction_snark.V2.t
-(*and type ( 'ledger_hash
-          , 'amount
-          , 'pending_coinbase
-          , 'fee_excess
-          , 'sok_digest
-          , 'local_state )
-          Statement.Poly.Stable.V2.t =
-  ( 'ledger_hash
-  , 'amount
-  , 'pending_coinbase
-  , 'fee_excess
-  , 'sok_digest
-  , 'local_state )
-  Mina_wire_types.Mina_state.Snarked_ledger_state.Poly.V2.t*)


### PR DESCRIPTION
It seems the file hasn't been modified since '22. I guess it is a leftover.

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
