### PR TITLE
Mina_wire_types/test: stop discarding warning

### DIFF
--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -1,8 +1,6 @@
 (** Test that wire types and original types can be used interchangeably in the
     eyes of the type system. *)
 
-[@@@warning "-34"]
-
 module WT = Mina_wire_types
 open WT.Utils
 


### PR DESCRIPTION
It seems it is not even warned while compiling.

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
