### PR TITLE
Remove inline_test_quiet_logs package declaration

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -59,7 +59,6 @@
 (package (name heap_usage))
 (package (name hex))
 (package (name immutable_array))
-(package (name inline_test_quiet_logs))
 (package (name integers_stubs_js))
 (package (name integration_test_local_engine))
 (package (name integration_test_lib))


### PR DESCRIPTION
This package must have been removed without deleting the declaration in the `dune-project`. It currently produces a build error, this PR will fix it.