### PR TITLE
Simplify snarky `Typ.t`, removing unnecessary type parameters

### DIFF
--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -11,23 +11,13 @@ module Make
     (Inputs : Intf.Step_main_inputs.S
                 with type Impl.field = Backend.Tick.Field.t
                  and type Impl.Bigint.t = Backend.Tick.Bigint.t
-                 and type ( 'var
-                          , 'value
-                          , 'aux
-                          , 'field
-                          , 'checked )
-                          Impl.Internal_Basic.Typ.typ' =
+                 and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value
-                  , 'aux
-                  , 'field
-                  , 'checked )
+                  , 'aux )
                   Step_main_inputs.Impl.Internal_Basic.Typ.typ'
-                 and type ('var, 'value, 'checked) Impl.Internal_Basic.Typ.typ =
-                  ( 'var
-                  , 'value
-                  , 'checked )
-                  Step_main_inputs.Impl.Internal_Basic.Typ.typ
+                 and type ('var, 'value) Impl.Internal_Basic.Typ.typ =
+                  ('var, 'value) Step_main_inputs.Impl.Internal_Basic.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tock.Field.t) =
 struct
   open Inputs

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -11,15 +11,23 @@ module Make
     (Inputs : Intf.Step_main_inputs.S
                 with type Impl.field = Backend.Tick.Field.t
                  and type Impl.Bigint.t = Backend.Tick.Bigint.t
-                 and type ('var, 'value, 'aux, 'field, 'checked) Impl.Typ.typ' =
+                 and type ( 'var
+                          , 'value
+                          , 'aux
+                          , 'field
+                          , 'checked )
+                          Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value
                   , 'aux
                   , 'field
                   , 'checked )
-                  Step_main_inputs.Impl.Typ.typ'
-                 and type ('var, 'value, 'field, 'checked) Impl.Typ.typ =
-                  ('var, 'value, 'field, 'checked) Step_main_inputs.Impl.Typ.typ
+                  Step_main_inputs.Impl.Internal_Basic.Typ.typ'
+                 and type ('var, 'value, 'checked) Impl.Internal_Basic.Typ.typ =
+                  ( 'var
+                  , 'value
+                  , 'checked )
+                  Step_main_inputs.Impl.Internal_Basic.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tock.Field.t) =
 struct
   open Inputs

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -49,23 +49,13 @@ module Make
     (Inputs : Intf.Wrap_main_inputs.S
                 with type Impl.field = Backend.Tock.Field.t
                  and type Impl.Bigint.t = Backend.Tock.Bigint.t
-                 and type ( 'var
-                          , 'value
-                          , 'aux
-                          , 'field
-                          , 'checked )
-                          Impl.Internal_Basic.Typ.typ' =
+                 and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value
-                  , 'aux
-                  , 'field
-                  , 'checked )
+                  , 'aux )
                   Wrap_main_inputs.Impl.Internal_Basic.Typ.typ'
-                 and type ('var, 'value, 'checked) Impl.Internal_Basic.Typ.typ =
-                  ( 'var
-                  , 'value
-                  , 'checked )
-                  Wrap_main_inputs.Impl.Internal_Basic.Typ.typ
+                 and type ('var, 'value) Impl.Internal_Basic.Typ.typ =
+                  ('var, 'value) Wrap_main_inputs.Impl.Internal_Basic.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tick.Field.t) =
 struct
   open Inputs

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -49,15 +49,23 @@ module Make
     (Inputs : Intf.Wrap_main_inputs.S
                 with type Impl.field = Backend.Tock.Field.t
                  and type Impl.Bigint.t = Backend.Tock.Bigint.t
-                 and type ('var, 'value, 'aux, 'field, 'checked) Impl.Typ.typ' =
+                 and type ( 'var
+                          , 'value
+                          , 'aux
+                          , 'field
+                          , 'checked )
+                          Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value
                   , 'aux
                   , 'field
                   , 'checked )
-                  Wrap_main_inputs.Impl.Typ.typ'
-                 and type ('var, 'value, 'field, 'checked) Impl.Typ.typ =
-                  ('var, 'value, 'field, 'checked) Wrap_main_inputs.Impl.Typ.typ
+                  Wrap_main_inputs.Impl.Internal_Basic.Typ.typ'
+                 and type ('var, 'value, 'checked) Impl.Internal_Basic.Typ.typ =
+                  ( 'var
+                  , 'value
+                  , 'checked )
+                  Wrap_main_inputs.Impl.Internal_Basic.Typ.typ
                  and type Inner_curve.Constant.Scalar.t = Backend.Tick.Field.t) =
 struct
   open Inputs


### PR DESCRIPTION
This PR builds on https://github.com/o1-labs/snarky/pull/856, updating the snarky submodule to pull in the simplifications there.

This also adapts the aliasing in a couple of functors, so that the OCaml typechecker can harmonise the type aliases in strengthened module types that snarky generates. This was caused by a corresponding signature tweak in snarky's `Snark_intf` to better respect the order of strengthening.