### PR TITLE
Remove now-unnecessary `Pickles.compile` parameter `~constraint_constants`

### DIFF
--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -735,7 +735,7 @@ let () =
   in
   let%map.Async_kernel.Deferred vk =
     let `VK vk, `Prover _ =
-      Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+      Transaction_snark.For_tests.create_trivial_snapp ()
     in
     vk
   in

--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -23,7 +23,7 @@ let main ~genesis_constants ~constraint_constants () =
   in
   print_heap_usage "Zkapp_command.t" zkapp_command ;
   print_heap_usage "Pickles.Side_loaded.Proof.t" @@ zkapp_proof ~zkapp_command ;
-  let%bind verification_key = verification_key in
+  let%bind verification_key = Lazy.force verification_key in
   print_heap_usage "Mina_base.Side_loaded_verification_key.t" verification_key ;
   print_heap_usage "Dummy Pickles.Side_loaded.Proof.t" dummy_proof ;
   print_heap_usage "Dummy Mina_base.Side_loaded_verification_key.t" dummy_vk ;

--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -23,7 +23,7 @@ let main ~genesis_constants ~constraint_constants () =
   in
   print_heap_usage "Zkapp_command.t" zkapp_command ;
   print_heap_usage "Pickles.Side_loaded.Proof.t" @@ zkapp_proof ~zkapp_command ;
-  let%bind verification_key = verification_key ~constraint_constants in
+  let%bind verification_key = verification_key in
   print_heap_usage "Mina_base.Side_loaded_verification_key.t" verification_key ;
   print_heap_usage "Dummy Pickles.Side_loaded.Proof.t" dummy_proof ;
   print_heap_usage "Dummy Mina_base.Side_loaded_verification_key.t" dummy_vk ;

--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -62,9 +62,12 @@ let dummy_proof =
 let dummy_vk = Mina_base.Side_loaded_verification_key.dummy
 
 let verification_key =
-  let `VK vk, `Prover _ = Transaction_snark.For_tests.create_trivial_snapp () in
-  let%map.Async.Deferred vk = vk in
-  With_hash.data vk
+  lazy
+    (let `VK vk, `Prover _ =
+       Transaction_snark.For_tests.create_trivial_snapp ()
+     in
+     let%map.Async.Deferred vk = vk in
+     With_hash.data vk )
 
 let applied = Mina_base.Transaction_status.Applied
 

--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -61,10 +61,8 @@ let dummy_proof =
 
 let dummy_vk = Mina_base.Side_loaded_verification_key.dummy
 
-let verification_key ~constraint_constants =
-  let `VK vk, `Prover _ =
-    Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
-  in
+let verification_key =
+  let `VK vk, `Prover _ = Transaction_snark.For_tests.create_trivial_snapp () in
   let%map.Async.Deferred vk = vk in
   With_hash.data vk
 

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -123,9 +123,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ~branches:(module Pickles_types.Nat.N1)
         ~max_proofs_verified:(module Pickles_types.Nat.N0)
         ~name:"trivial1"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ -> [ Trivial_rule1.rule ])
     in
     let%bind.Async.Deferred vk1 =
@@ -137,9 +134,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ~branches:(module Pickles_types.Nat.N1)
         ~max_proofs_verified:(module Pickles_types.Nat.N0)
         ~name:"trivial2"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ -> [ Trivial_rule2.rule ])
     in
     let%bind.Async.Deferred vk2 =

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -22,9 +22,7 @@ let parse_field_element_or_hash_string s ~f =
   | Error e1 ->
       Error.raise (Error.tag ~tag:"Expected a field element" e1)
 
-let vk_and_prover ~constraint_constants =
-  lazy
-    (Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ())
+let vk_and_prover = lazy (Transaction_snark.For_tests.create_trivial_snapp ())
 
 let get_second_pass_ledger_mask ~ledger ~constraint_constants ~global_slot
     ~state_body zkapp_command =
@@ -61,9 +59,7 @@ let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t)
   let open Async.Deferred.Let_syntax in
   let%bind () =
     Option.value_map zkapp_account ~default:(Deferred.return ()) ~f:(fun pk ->
-        let `VK vk, `Prover _ =
-          Lazy.force @@ vk_and_prover ~constraint_constants
-        in
+        let `VK vk, `Prover _ = Lazy.force @@ vk_and_prover in
         let%map vk = vk in
         let id = Account_id.create pk Token_id.default in
         Ledger.get_or_create_account ledger id
@@ -183,8 +179,7 @@ let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
   in
   let%bind zkapp_command =
     Transaction_snark.For_tests.create_trivial_predicate_snapp
-      ~constraint_constants ~protocol_state_predicate spec ledger
-      ~snapp_kp:zkapp_kp
+      ~protocol_state_predicate spec ledger ~snapp_kp:zkapp_kp
   in
   printf "ZkApp transaction yojson: %s\n\n%!"
     (Zkapp_command.to_yojson zkapp_command |> Yojson.Safe.to_string) ;
@@ -424,9 +419,7 @@ let upgrade_zkapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in
@@ -506,9 +499,7 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in
@@ -546,9 +537,7 @@ let update_zkapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in
@@ -588,9 +577,7 @@ let update_action_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in
@@ -628,9 +615,7 @@ let update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in
@@ -669,9 +654,7 @@ let update_snapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~snapp_update
     }
   in
   let%bind zkapp_command =
-    let `VK vk, `Prover prover =
-      Lazy.force @@ vk_and_prover ~constraint_constants
-    in
+    let `VK vk, `Prover prover = Lazy.force @@ vk_and_prover in
     Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk:(prover, vk)
       ~constraint_constants spec
   in

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -26,9 +26,6 @@ let%test_module "Actions test" =
         ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"no actions"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ ->
           [ Zkapps_actions.initialize_rule pk_compressed
           ; Zkapps_actions.update_actions_rule pk_compressed

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -26,9 +26,6 @@ let%test_module "Add events test" =
         ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"no events"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ ->
           [ Zkapps_add_events.initialize_rule pk_compressed
           ; Zkapps_add_events.update_events_rule pk_compressed

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -24,9 +24,6 @@ let tag, _cache, _p_module, Pickles.Provers.[ prover ] =
     ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"big_circuit"
-    ~constraint_constants:
-      (Genesis_constants.Constraint_constants.to_snark_keys_header
-         constraint_constants )
     ~choices:(fun ~self:_ ->
       [ Zkapps_big_circuit.rule ~num_constraints pk_compressed ] )
 

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -71,9 +71,6 @@ let%test_module "Composability test" =
         ~branches:(module Nat.N4)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ ->
           [ Zkapps_calls.Rules.Initialize_state.rule
           ; Zkapps_calls.Rules.Update_state.rule

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -21,9 +21,6 @@ let tag, _, p_module, Pickles.Provers.[ prover ] =
     ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"empty_update"
-    ~constraint_constants:
-      (Genesis_constants.Constraint_constants.to_snark_keys_header
-         constraint_constants )
     ~choices:(fun ~self:_ -> [ Zkapps_empty_update.rule pk_compressed ])
 
 module P = (val p_module)

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -30,9 +30,6 @@ let%test_module "Initialize state test" =
         ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ ->
           [ Zkapps_initialize_state.initialize_rule pk_compressed
           ; Zkapps_initialize_state.update_state_rule pk_compressed

--- a/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
+++ b/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
@@ -19,19 +19,6 @@ struct
   open Pickles.Impls.Step
   open Pickles_types
 
-  let constraint_constants =
-    { Snark_keys_header.Constraint_constants.sub_windows_per_window = 0
-    ; ledger_depth = 0
-    ; work_delay = 0
-    ; block_window_duration_ms = 0
-    ; transaction_capacity = Log_2 0
-    ; pending_coinbase_depth = 0
-    ; coinbase_amount = Unsigned.UInt64.of_int 0
-    ; supercharged_coinbase_factor = 0
-    ; account_creation_fee = Unsigned.UInt64.of_int 0
-    ; fork = None
-    }
-
   let feature_flags =
     { Plonk_types.Features.none_bool with
       rot = true
@@ -46,7 +33,7 @@ struct
     Zkapps_examples.compile ~auxiliary_typ:Typ.unit
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
-      ~name:"custom gates" ~constraint_constants
+      ~name:"custom gates"
       ~choices:(fun ~self:_ ->
         [ { identifier = "main"
           ; prevs = []

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -545,7 +545,6 @@ let compile :
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
-    -> ?constraint_constants:_
     -> choices:
          (   self:
                ( Zkapp_statement.Checked.t
@@ -588,7 +587,7 @@ let compile :
            Deferred.t )
          H3_2.T(Pickles.Prover).t =
  fun ?self ?cache ?proof_cache ?disk_keys ?override_wrap_domain ~auxiliary_typ
-     ~branches ~max_proofs_verified ~name ?constraint_constants ~choices () ->
+     ~branches ~max_proofs_verified ~name ~choices () ->
   let vk_hash = ref None in
   let choices ~self =
     let rec go :
@@ -649,7 +648,7 @@ let compile :
     Pickles.compile_async () ?self ?cache ?proof_cache ?disk_keys
       ?override_wrap_domain ~public_input:(Output Zkapp_statement.typ)
       ~auxiliary_typ:Typ.(Prover_value.typ () * auxiliary_typ)
-      ~branches ~max_proofs_verified ~name ?constraint_constants ~choices
+      ~branches ~max_proofs_verified ~name ~choices
   in
   let () =
     vk_hash :=

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -487,9 +487,6 @@ end) : S = struct
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N2)
       ~name:"blockchain-snark"
-      ~constraint_constants:
-        (Genesis_constants.Constraint_constants.to_snark_keys_header
-           constraint_constants )
       ~choices:(fun ~self ->
         [ rule ~proof_level ~constraint_constants T.tag self ] )
 

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1750,8 +1750,7 @@ let%test_module _ =
     let constraint_constants =
       Genesis_constants.For_unit_tests.Constraint_constants.t
 
-    let `VK vk, `Prover _ =
-      Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+    let `VK vk, `Prover _ = Transaction_snark.For_tests.create_trivial_snapp ()
 
     let vk = Async.Thread_safe.block_on_async_exn (fun () -> vk)
 

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -179,7 +179,7 @@ let send_zkapps ~(genesis_constants : Genesis_constants.t)
     `Repeat (next_tm_next, counter + 1)
   in
   let `VK vk, `Prover prover =
-    Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+    Transaction_snark.For_tests.create_trivial_snapp ()
   in
   let%bind.Deferred vk = vk in
   let account_queue = Queue.create () in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1677,7 +1677,7 @@ let%test_module _ =
             () )
 
     let `VK vk, `Prover prover =
-      Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+      Transaction_snark.For_tests.create_trivial_snapp ()
 
     let vk = Async.Thread_safe.block_on_async_exn (fun () -> vk)
 

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -316,14 +316,14 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ~choices () =
+      ~max_proofs_verified ~name ~choices () =
     compile_with_wrap_main_override_promise ?self ?cache ?storables ?proof_cache
       ?disk_keys ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~branches ~max_proofs_verified ~name ?constraint_constants ~choices ()
+      ~branches ~max_proofs_verified ~name ~choices ()
 
   let compile ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ~choices () =
+      ~max_proofs_verified ~name ~choices () =
     let choices ~self =
       let choices = choices ~self in
       let rec go :
@@ -346,7 +346,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-        ~max_proofs_verified ~name ?constraint_constants ~choices ()
+        ~max_proofs_verified ~name ~choices ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -363,7 +363,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_async ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-      ~max_proofs_verified ~name ?constraint_constants ~choices () =
+      ~max_proofs_verified ~name ~choices () =
     let choices ~self =
       let choices = choices ~self in
       let rec go :
@@ -391,7 +391,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
-        ~max_proofs_verified ~name ?constraint_constants ~choices ()
+        ~max_proofs_verified ~name ~choices ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -414,7 +414,6 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss
@@ -470,7 +469,6 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss
@@ -526,7 +524,6 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'prev_varss

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -6,19 +6,6 @@ let () = Pickles.Backend.Tick.Keypair.set_urs_info []
 
 let () = Pickles.Backend.Tock.Keypair.set_urs_info []
 
-let constraint_constants =
-  { Snark_keys_header.Constraint_constants.sub_windows_per_window = 0
-  ; ledger_depth = 0
-  ; work_delay = 0
-  ; block_window_duration_ms = 0
-  ; transaction_capacity = Log_2 0
-  ; pending_coinbase_depth = 0
-  ; coinbase_amount = Unsigned.UInt64.of_int 0
-  ; supercharged_coinbase_factor = 0
-  ; account_creation_fee = Unsigned.UInt64.of_int 0
-  ; fork = None
-  }
-
 let test () =
   let tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
@@ -26,7 +13,6 @@ let test () =
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:2 ~override_wrap_domain:N1 ~name:"chunked_circuits"
-      ~constraint_constants (* TODO(mrmr1993): This was misguided.. Delete. *)
       ~choices:(fun ~self:_ ->
         [ { identifier = "2^16"
           ; prevs = []
@@ -101,7 +87,6 @@ let test () =
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N1)
       ~name:"recursion over chunks"
-      ~constraint_constants (* TODO(mrmr1993): This was misguided.. Delete. *)
       ~choices:(fun ~self:_ ->
         [ { identifier = "recurse over 2^17"
           ; prevs = [ tag ]

--- a/src/lib/pickles/test/chunked_circuits/chunks4.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks4.ml
@@ -6,19 +6,6 @@ let () = Pickles.Backend.Tick.Keypair.set_urs_info []
 
 let () = Pickles.Backend.Tock.Keypair.set_urs_info []
 
-let constraint_constants =
-  { Snark_keys_header.Constraint_constants.sub_windows_per_window = 0
-  ; ledger_depth = 0
-  ; work_delay = 0
-  ; block_window_duration_ms = 0
-  ; transaction_capacity = Log_2 0
-  ; pending_coinbase_depth = 0
-  ; coinbase_amount = Unsigned.UInt64.of_int 0
-  ; supercharged_coinbase_factor = 0
-  ; account_creation_fee = Unsigned.UInt64.of_int 0
-  ; fork = None
-  }
-
 let test () =
   let t11 = Sys.time () in
   let _tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
@@ -27,7 +14,6 @@ let test () =
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:4 ~override_wrap_domain:N1 ~name:"chunked_circuits"
-      ~constraint_constants (* TODO(mrmr1993): This was misguided.. Delete. *)
       ~choices:(fun ~self:_ ->
         [ { identifier = "2^17"
           ; prevs = []

--- a/src/lib/pickles/test/chunked_circuits/chunks8.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks8.ml
@@ -6,19 +6,6 @@ let () = Pickles.Backend.Tick.Keypair.set_urs_info []
 
 let () = Pickles.Backend.Tock.Keypair.set_urs_info []
 
-let constraint_constants =
-  { Snark_keys_header.Constraint_constants.sub_windows_per_window = 0
-  ; ledger_depth = 0
-  ; work_delay = 0
-  ; block_window_duration_ms = 0
-  ; transaction_capacity = Log_2 0
-  ; pending_coinbase_depth = 0
-  ; coinbase_amount = Unsigned.UInt64.of_int 0
-  ; supercharged_coinbase_factor = 0
-  ; account_creation_fee = Unsigned.UInt64.of_int 0
-  ; fork = None
-  }
-
 let test () =
   let t11 = Sys.time () in
   let _tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
@@ -27,7 +14,6 @@ let test () =
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:8 ~override_wrap_domain:N2 ~name:"chunked_circuits"
-      ~constraint_constants (* TODO(mrmr1993): This was misguided.. Delete. *)
       ~choices:(fun ~self:_ ->
         [ { identifier = "2^18"
           ; prevs = []

--- a/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
+++ b/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
@@ -48,19 +48,6 @@ let range_check_in_lookup_gate () =
        ; w6 = fresh_int 0
        } )
 
-let constraint_constants =
-  { Snark_keys_header.Constraint_constants.sub_windows_per_window = 0
-  ; ledger_depth = 0
-  ; work_delay = 0
-  ; block_window_duration_ms = 0
-  ; transaction_capacity = Log_2 0
-  ; pending_coinbase_depth = 0
-  ; coinbase_amount = Unsigned.UInt64.of_int 0
-  ; supercharged_coinbase_factor = 0
-  ; account_creation_fee = Unsigned.UInt64.of_int 0
-  ; fork = None
-  }
-
 let test_range_check_lookup () =
   let _tag, _cache_handle, (module Proof), Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
@@ -68,7 +55,6 @@ let test_range_check_lookup () =
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~name:"lookup range-check"
-      ~constraint_constants (* TODO(mrmr1993): This was misguided.. Delete. *)
       ~choices:(fun ~self:_ ->
         [ { identifier = "main"
           ; prevs = []

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -190,7 +190,7 @@ let create_ledger_and_zkapps ?(min_num_updates = 1) ?(num_proof_updates = 0)
     ~max_num_updates () :
     (Mina_ledger.Ledger.t * Zkapp_command.t list) Async.Deferred.t =
   let `VK verification_key, `Prover prover =
-    Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+    Transaction_snark.For_tests.create_trivial_snapp ()
   in
   let zkapp_prover_and_vk = (prover, verification_key) in
   let%bind.Async.Deferred verification_key = verification_key in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2375,7 +2375,7 @@ let%test_module "staged ledger tests" =
     let logger = Logger.null ()
 
     let `VK vk, `Prover zkapp_prover =
-      Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+      Transaction_snark.For_tests.create_trivial_snapp ()
 
     let vk = Async.Thread_safe.block_on_async_exn (fun () -> vk)
 
@@ -4791,13 +4791,11 @@ let%test_module "staged ledger tests" =
         ~setup_test:(fun _ledger (a, privkey_a, _loc_a) (b, privkey_b, _loc_b)
                     ->
           let `VK vk_a, `Prover prover_a =
-            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:0
-              ~constraint_constants ()
+            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:0 ()
           in
           let%bind.Async.Deferred vk_a = vk_a in
           let `VK vk_b, `Prover _prover_b =
-            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:1
-              ~constraint_constants ()
+            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:1 ()
           in
           let%bind.Async.Deferred vk_b = vk_b in
           let keymap =
@@ -4863,13 +4861,11 @@ let%test_module "staged ledger tests" =
         ~setup_test:(fun _ledger (a, privkey_a, _loc_a) (_b, _privkey_b, _loc_b)
                     ->
           let `VK vk_a, `Prover prover_a =
-            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:0
-              ~constraint_constants ()
+            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:0 ()
           in
           let%bind.Async.Deferred vk_a = vk_a in
           let `VK vk_b, `Prover _prover_b =
-            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:1
-              ~constraint_constants ()
+            Transaction_snark.For_tests.create_trivial_snapp ~unique_id:1 ()
           in
           let%bind.Async.Deferred vk_b = vk_b in
           let keymap =

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -32,9 +32,6 @@ let%test_module "Access permission tests" =
         ~branches:(module Nat.N1)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
-        ~constraint_constants:
-          (Genesis_constants.Constraint_constants.to_snark_keys_header
-             constraint_constants )
         ~choices:(fun ~self:_ -> [ Zkapps_empty_update.rule pk_compressed ])
 
     module P = (val p_module)

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -16,8 +16,6 @@ let%test_module "multisig_account" =
 
     let () = Transaction_snark.For_tests.set_proof_cache proof_cache
 
-    let constraint_constants = U.constraint_constants
-
     module M_of_n_predicate = struct
       type _witness = (Schnorr.Chunked.Signature.t * Public_key.t) list
 
@@ -227,9 +225,6 @@ let%test_module "multisig_account" =
                   ~max_proofs_verified:(module Nat.N2)
                     (* You have to put 2 here... *)
                   ~name:"multisig"
-                  ~constraint_constants:
-                    (Genesis_constants.Constraint_constants.to_snark_keys_header
-                       constraint_constants )
                   ~choices:(fun ~self ->
                     [ multisig_rule
                     ; { identifier = "dummy"

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -132,9 +132,6 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
               ~branches:(module Nat.N1)
               ~max_proofs_verified:(module Nat.N0)
               ~name:"ringsig"
-              ~constraint_constants:
-                (Genesis_constants.Constraint_constants.to_snark_keys_header
-                   constraint_constants )
               ~choices:(fun ~self:_ -> [ ring_sig_rule ring_member_pks ])
           in
           let vk = Pickles.Side_loaded.Verification_key.of_compiled tag in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -64,9 +64,7 @@ let pending_coinbase_state_stack ~state_body_hash ~global_slot =
       Pending_coinbase.Stack.push_state state_body_hash global_slot init_stack
   }
 
-let trivial_zkapp =
-  lazy
-    (Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ())
+let trivial_zkapp = lazy (Transaction_snark.For_tests.create_trivial_snapp ())
 
 type pass_number = Pass_1 | Pass_2
 

--- a/src/lib/transaction_snark/test/verify-simple-test/transaction_snark_tests_verify_simple_test.ml
+++ b/src/lib/transaction_snark/test/verify-simple-test/transaction_snark_tests_verify_simple_test.ml
@@ -1,11 +1,7 @@
 open Core_kernel
 open Mina_base
 
-let constraint_constants =
-  Genesis_constants.For_unit_tests.Constraint_constants.t
-
-let `VK vk, `Prover p =
-  Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+let `VK vk, `Prover p = Transaction_snark.For_tests.create_trivial_snapp ()
 
 let { With_hash.data = vk; hash = _ } =
   Async.Thread_safe.block_on_async_exn (fun () -> vk)

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -361,8 +361,7 @@ module type Full = sig
       -> Zkapp_command.t Async.Deferred.t
 
     val create_trivial_predicate_snapp :
-         constraint_constants:Genesis_constants.Constraint_constants.t
-      -> ?protocol_state_predicate:Zkapp_precondition.Protocol_state.t
+         ?protocol_state_predicate:Zkapp_precondition.Protocol_state.t
       -> snapp_kp:Signature_lib.Keypair.t
       -> Mina_transaction_logic.For_tests.Transaction_spec.t
       -> Mina_ledger.Ledger.t
@@ -383,7 +382,6 @@ module type Full = sig
 
     val create_trivial_snapp :
          ?unique_id:int
-      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> unit
       -> [> `VK of
             (Side_loaded_verification_key.t, Tick.Field.t) With_hash.t


### PR DESCRIPTION
This PR removes the uses of the parameter `~constraint_constants` from all callers of `Pickles.compile`. Now that [RFC 0039](https://github.com/MinaProtocol/mina/pull/6341) is no longer relevant and key management is done elsewhere, we can entirely remove this optional parameter.

This PR is a no-op.