### PR TITLE
Update snarky for generalized `Run_state`

### DIFF
--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -175,6 +175,7 @@ module Pasta : sig
     module Proof = Kimchi_pasta.Pallas_based_plonk.Proof
     module Proving_key = Kimchi_pasta.Pallas_based_plonk.Proving_key
     module Oracles = Kimchi_pasta.Pallas_based_plonk.Oracles
+    module Run_state = Kimchi_pasta.Pallas_based_plonk.Run_state
   end
 
   (* module Pasta = Kimchi_pasta.Pasta *)
@@ -204,5 +205,6 @@ module Pasta : sig
     module Proof = Kimchi_pasta.Vesta_based_plonk.Proof
     module Proving_key = Kimchi_pasta.Vesta_based_plonk.Proving_key
     module Oracles = Kimchi_pasta.Vesta_based_plonk.Oracles
+    module Run_state = Kimchi_pasta.Vesta_based_plonk.Run_state
   end
 end

--- a/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.ml
@@ -15,6 +15,7 @@ module Pallas_based_plonk = struct
   module Proof = Pallas_based_plonk.Proof
   module Proving_key = Pallas_based_plonk.Proving_key
   module Oracles = Pallas_based_plonk.Oracles
+  module Run_state = Pallas_based_plonk.Run_state
 end
 
 module Vesta_based_plonk = struct
@@ -32,6 +33,7 @@ module Vesta_based_plonk = struct
   module Proof = Vesta_based_plonk.Proof
   module Proving_key = Vesta_based_plonk.Proving_key
   module Oracles = Vesta_based_plonk.Oracles
+  module Run_state = Vesta_based_plonk.Run_state
 end
 
 module Pasta = struct

--- a/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.mli
+++ b/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.mli
@@ -15,6 +15,7 @@ module Pallas_based_plonk : sig
   module Proof = Pallas_based_plonk.Proof
   module Proving_key = Pallas_based_plonk.Proving_key
   module Oracles = Pallas_based_plonk.Oracles
+  module Run_state = Pallas_based_plonk.Run_state
 end
 
 module Vesta_based_plonk : sig
@@ -32,6 +33,7 @@ module Vesta_based_plonk : sig
   module Proof = Vesta_based_plonk.Proof
   module Proving_key = Vesta_based_plonk.Proving_key
   module Oracles = Vesta_based_plonk.Oracles
+  module Run_state = Vesta_based_plonk.Run_state
 end
 
 module Pasta : sig

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -178,3 +178,5 @@ module Oracles = Plonk_dlog_oracles.Make (struct
     let create_with_public_evals = with_lagrange create_with_public_evals
   end
 end)
+
+module Run_state = Kimchi_pasta_snarky_backend.Pallas_based_plonk.Run_state

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -176,3 +176,5 @@ module Oracles = Plonk_dlog_oracles.Make (struct
     let create_with_public_evals = with_lagrange create_with_public_evals
   end
 end)
+
+module Run_state = Kimchi_pasta_snarky_backend.Vesta_based_plonk.Run_state

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
@@ -40,6 +40,8 @@ module Vesta_based_plonk = struct
       (struct
         let params = poseidon_params
       end)
+
+  module Run_state = Snarky_backendless.Run_state
 end
 
 module Pallas_based_plonk = struct
@@ -70,6 +72,8 @@ module Pallas_based_plonk = struct
       (struct
         let params = poseidon_params
       end)
+
+  module Run_state = Snarky_backendless.Run_state
 end
 
 module Step_impl = Snarky_backendless.Snark.Run.Make (Vesta_based_plonk)

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -464,9 +464,7 @@ struct
             T
               ( Typ
                   { typ with
-                    check =
-                      (fun _ ->
-                        Snarky_backendless.Checked_runner.Simple.return () )
+                    check = (fun _ -> Impl.Internal_Basic.Checked.return ())
                   }
               , (fun _ -> f constant_var)
               , f' )

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -11,6 +11,8 @@ module Make
     (Inputs : Intf.Step_main_inputs.S
                 with type Impl.field = Backend.Tick.Field.t
                  and type Impl.Bigint.t = Backend.Tick.Bigint.t
+                 and type 'a Impl.Internal_Basic.Checked.t =
+                  'a Step_main_inputs.Impl.Internal_Basic.Checked.t
                  and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -49,6 +49,8 @@ module Make
     (Inputs : Intf.Wrap_main_inputs.S
                 with type Impl.field = Backend.Tock.Field.t
                  and type Impl.Bigint.t = Backend.Tock.Bigint.t
+                 and type 'a Impl.Internal_Basic.Checked.t =
+                  'a Wrap_main_inputs.Impl.Internal_Basic.Checked.t
                  and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =
                   ( 'var
                   , 'value


### PR DESCRIPTION
This PR updates snarky to https://github.com/o1-labs/snarky/pull/858, allowing us to pass a `Run_state` implementation from rust.