### PR TITLE
Update snarky for backend-specific constraints

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/tests/test_lookup_table_constraint_kind.ml
+++ b/src/lib/crypto/kimchi_backend/common/tests/test_lookup_table_constraint_kind.ml
@@ -14,7 +14,7 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 module Tick = Kimchi_backend.Pasta.Vesta_based_plonk
 module Impl = Snarky_backendless.Snark.Run.Make (Tick)
 
-let add_constraint c = Impl.assert_ { basic = T c; annotation = None }
+let add_constraint c = Impl.assert_ (T c)
 
 (* Verify finalize_and_get_gates *)
 let test_finalize_and_get_gates_with_lookup_tables () =

--- a/src/lib/crypto/kimchi_backend/common/tests/test_lookup_table_constraint_kind.ml
+++ b/src/lib/crypto/kimchi_backend/common/tests/test_lookup_table_constraint_kind.ml
@@ -14,7 +14,7 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 module Tick = Kimchi_backend.Pasta.Vesta_based_plonk
 module Impl = Snarky_backendless.Snark.Run.Make (Tick)
 
-let add_constraint c = Impl.assert_ (T c)
+let add_constraint c = Impl.assert_ c
 
 (* Verify finalize_and_get_gates *)
 let test_finalize_and_get_gates_with_lookup_tables () =
@@ -35,11 +35,11 @@ let test_finalize_and_get_gates_with_lookup_tables () =
   in
   let () =
     Tick.R1CS_constraint_system.(
-      add_constraint cs (T (AddFixedLookupTable { id = 1l; data = xor_table })))
+      add_constraint cs (AddFixedLookupTable { id = 1l; data = xor_table }))
   in
   let () =
     Tick.R1CS_constraint_system.(
-      add_constraint cs (T (AddFixedLookupTable { id = 2l; data = and_table })))
+      add_constraint cs (AddFixedLookupTable { id = 2l; data = and_table }))
   in
   let () = Tick.R1CS_constraint_system.set_primary_input_size cs 1 in
   let _gates, lts, _rt =
@@ -57,9 +57,8 @@ let test_finalize_and_get_gates_with_runtime_table_cfg () =
   let () =
     Tick.R1CS_constraint_system.(
       add_constraint cs
-        (T
-           (AddRuntimeTableCfg
-              { id = 1l; first_column = indexed_runtime_table_cfg } ) ))
+        (AddRuntimeTableCfg
+           { id = 1l; first_column = indexed_runtime_table_cfg } ))
   in
   let () = Tick.R1CS_constraint_system.set_primary_input_size cs 1 in
   let _aux = Tick.R1CS_constraint_system.set_auxiliary_input_size cs 1 in
@@ -435,7 +434,7 @@ let test_cannot_finalize_twice_the_fixed_lookup_tables () =
   let () =
     Tick.R1CS_constraint_system.(
       add_constraint cs
-        (T (AddFixedLookupTable { id = 1l; data = [| indexes; values |] })))
+        (AddFixedLookupTable { id = 1l; data = [| indexes; values |] }))
   in
   let () = Tick.R1CS_constraint_system.finalize_fixed_lookup_tables cs in
   Alcotest.check_raises "Finalize a second time the fixed lookup tables"
@@ -449,7 +448,7 @@ let test_cannot_finalize_twice_the_runtime_table_cfgs () =
   let cs = Tick.R1CS_constraint_system.create () in
   let () =
     Tick.R1CS_constraint_system.(
-      add_constraint cs (T (AddRuntimeTableCfg { id = 1l; first_column })))
+      add_constraint cs (AddRuntimeTableCfg { id = 1l; first_column }))
   in
   let () = Tick.R1CS_constraint_system.finalize_runtime_lookup_tables cs in
   Alcotest.check_raises

--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -89,28 +89,25 @@ let rot_aux ?(check64 = false) (word : Circuit.Field.t) (bits : int)
   with_label "rot64_gate" (fun () ->
       (* Set up Rot64 gate *)
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Rot64
-                 { word
-                 ; rotated
-                 ; excess
-                 ; bound_limb0 = of_bits bound 52 64
-                 ; bound_limb1 = of_bits bound 40 52
-                 ; bound_limb2 = of_bits bound 28 40
-                 ; bound_limb3 = of_bits bound 16 28
-                 ; bound_crumb0 = of_bits bound 14 16
-                 ; bound_crumb1 = of_bits bound 12 14
-                 ; bound_crumb2 = of_bits bound 10 12
-                 ; bound_crumb3 = of_bits bound 8 10
-                 ; bound_crumb4 = of_bits bound 6 8
-                 ; bound_crumb5 = of_bits bound 4 6
-                 ; bound_crumb6 = of_bits bound 2 4
-                 ; bound_crumb7 = of_bits bound 0 2
-                 ; two_to_rot = Common.bignum_bigint_to_field big_2_pow_rot
-                 } )
-        } ) ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Rot64
+              { word
+              ; rotated
+              ; excess
+              ; bound_limb0 = of_bits bound 52 64
+              ; bound_limb1 = of_bits bound 40 52
+              ; bound_limb2 = of_bits bound 28 40
+              ; bound_limb3 = of_bits bound 16 28
+              ; bound_crumb0 = of_bits bound 14 16
+              ; bound_crumb1 = of_bits bound 12 14
+              ; bound_crumb2 = of_bits bound 10 12
+              ; bound_crumb3 = of_bits bound 8 10
+              ; bound_crumb4 = of_bits bound 6 8
+              ; bound_crumb5 = of_bits bound 4 6
+              ; bound_crumb6 = of_bits bound 2 4
+              ; bound_crumb7 = of_bits bound 0 2
+              ; two_to_rot = Common.bignum_bigint_to_field big_2_pow_rot
+              } ) ) ) ;
 
   (* Next row *)
   Range_check.bits64 shifted ;
@@ -211,15 +208,9 @@ let bxor ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
     if length = 0 then (
       with_label "xor_zero_check" (fun () ->
           assert_
-            { annotation = Some __LOC__
-            ; basic =
-                Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-                  (Raw
-                     { kind = Zero
-                     ; values = [| in1; in2; out |]
-                     ; coeffs = [||]
-                     } )
-            } ) ;
+            (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+               (Raw { kind = Zero; values = [| in1; in2; out |]; coeffs = [||] })
+            ) ) ;
       Field.Assert.equal Field.zero in1 ;
       Field.Assert.equal Field.zero in2 ;
       Field.Assert.equal Field.zero out ;
@@ -251,27 +242,24 @@ let bxor ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
       with_label "xor_gate" (fun () ->
           (* Set up Xor gate *)
           assert_
-            { annotation = Some __LOC__
-            ; basic =
-                Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-                  (Xor
-                     { in1
-                     ; in2
-                     ; out
-                     ; in1_0
-                     ; in1_1
-                     ; in1_2
-                     ; in1_3
-                     ; in2_0
-                     ; in2_1
-                     ; in2_2
-                     ; in2_3
-                     ; out_0
-                     ; out_1
-                     ; out_2
-                     ; out_3
-                     } )
-            } ) ;
+            (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+               (Xor
+                  { in1
+                  ; in2
+                  ; out
+                  ; in1_0
+                  ; in1_1
+                  ; in1_2
+                  ; in1_3
+                  ; in2_0
+                  ; in2_1
+                  ; in2_2
+                  ; in2_3
+                  ; out_0
+                  ; out_1
+                  ; out_2
+                  ; out_3
+                  } ) ) ) ;
 
       let next_in1 = as_prover_next_var in1 in1_0 in1_1 in1_2 in1_3 len_xor in
       let next_in2 = as_prover_next_var in2 in2_0 in2_1 in2_2 in2_3 len_xor in
@@ -405,17 +393,14 @@ let band ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
   (* Constrain AND as 2 * and = sum - xor *)
   with_label "and_equation" (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Basic
-                 { l = (Field.Constant.one, sum)
-                 ; r = (neg_one, xor_output)
-                 ; o = (neg_two, and_output)
-                 ; m = Field.Constant.zero
-                 ; c = Field.Constant.zero
-                 } )
-        } ) ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Basic
+              { l = (Field.Constant.one, sum)
+              ; r = (neg_one, xor_output)
+              ; o = (neg_two, and_output)
+              ; m = Field.Constant.zero
+              ; c = Field.Constant.zero
+              } ) ) ) ;
 
   and_output
 

--- a/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/bitwise.ml
@@ -89,25 +89,24 @@ let rot_aux ?(check64 = false) (word : Circuit.Field.t) (bits : int)
   with_label "rot64_gate" (fun () ->
       (* Set up Rot64 gate *)
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Rot64
-              { word
-              ; rotated
-              ; excess
-              ; bound_limb0 = of_bits bound 52 64
-              ; bound_limb1 = of_bits bound 40 52
-              ; bound_limb2 = of_bits bound 28 40
-              ; bound_limb3 = of_bits bound 16 28
-              ; bound_crumb0 = of_bits bound 14 16
-              ; bound_crumb1 = of_bits bound 12 14
-              ; bound_crumb2 = of_bits bound 10 12
-              ; bound_crumb3 = of_bits bound 8 10
-              ; bound_crumb4 = of_bits bound 6 8
-              ; bound_crumb5 = of_bits bound 4 6
-              ; bound_crumb6 = of_bits bound 2 4
-              ; bound_crumb7 = of_bits bound 0 2
-              ; two_to_rot = Common.bignum_bigint_to_field big_2_pow_rot
-              } ) ) ) ;
+        (Rot64
+           { word
+           ; rotated
+           ; excess
+           ; bound_limb0 = of_bits bound 52 64
+           ; bound_limb1 = of_bits bound 40 52
+           ; bound_limb2 = of_bits bound 28 40
+           ; bound_limb3 = of_bits bound 16 28
+           ; bound_crumb0 = of_bits bound 14 16
+           ; bound_crumb1 = of_bits bound 12 14
+           ; bound_crumb2 = of_bits bound 10 12
+           ; bound_crumb3 = of_bits bound 8 10
+           ; bound_crumb4 = of_bits bound 6 8
+           ; bound_crumb5 = of_bits bound 4 6
+           ; bound_crumb6 = of_bits bound 2 4
+           ; bound_crumb7 = of_bits bound 0 2
+           ; two_to_rot = Common.bignum_bigint_to_field big_2_pow_rot
+           } ) ) ;
 
   (* Next row *)
   Range_check.bits64 shifted ;
@@ -208,9 +207,7 @@ let bxor ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
     if length = 0 then (
       with_label "xor_zero_check" (fun () ->
           assert_
-            (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-               (Raw { kind = Zero; values = [| in1; in2; out |]; coeffs = [||] })
-            ) ) ;
+            (Raw { kind = Zero; values = [| in1; in2; out |]; coeffs = [||] }) ) ;
       Field.Assert.equal Field.zero in1 ;
       Field.Assert.equal Field.zero in2 ;
       Field.Assert.equal Field.zero out ;
@@ -242,24 +239,23 @@ let bxor ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
       with_label "xor_gate" (fun () ->
           (* Set up Xor gate *)
           assert_
-            (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-               (Xor
-                  { in1
-                  ; in2
-                  ; out
-                  ; in1_0
-                  ; in1_1
-                  ; in1_2
-                  ; in1_3
-                  ; in2_0
-                  ; in2_1
-                  ; in2_2
-                  ; in2_3
-                  ; out_0
-                  ; out_1
-                  ; out_2
-                  ; out_3
-                  } ) ) ) ;
+            (Xor
+               { in1
+               ; in2
+               ; out
+               ; in1_0
+               ; in1_1
+               ; in1_2
+               ; in1_3
+               ; in2_0
+               ; in2_1
+               ; in2_2
+               ; in2_3
+               ; out_0
+               ; out_1
+               ; out_2
+               ; out_3
+               } ) ) ;
 
       let next_in1 = as_prover_next_var in1 in1_0 in1_1 in1_2 in1_3 len_xor in
       let next_in2 = as_prover_next_var in2 in2_0 in2_1 in2_2 in2_3 len_xor in
@@ -393,14 +389,13 @@ let band ?(len_xor = 4) (input1 : Circuit.Field.t) (input2 : Circuit.Field.t)
   (* Constrain AND as 2 * and = sum - xor *)
   with_label "and_equation" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Basic
-              { l = (Field.Constant.one, sum)
-              ; r = (neg_one, xor_output)
-              ; o = (neg_two, and_output)
-              ; m = Field.Constant.zero
-              ; c = Field.Constant.zero
-              } ) ) ) ;
+        (Basic
+           { l = (Field.Constant.one, sum)
+           ; r = (neg_one, xor_output)
+           ; o = (neg_two, and_output)
+           ; m = Field.Constant.zero
+           ; c = Field.Constant.zero
+           } ) ) ;
 
   and_output
 

--- a/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml.disabled
+++ b/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml.disabled
@@ -746,21 +746,20 @@ let sum_setup (type f) (module Circuit : Snark_intf.Run with type field = f)
       assert_
         { annotation = Some __LOC__
         ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (ForeignFieldAdd
-                 { left_input_lo = left_input0
-                 ; left_input_mi = left_input1
-                 ; left_input_hi = left_input2
-                 ; right_input_lo = right_input0
-                 ; right_input_mi = right_input1
-                 ; right_input_hi = right_input2
-                 ; field_overflow
-                 ; carry
-                 ; foreign_field_modulus0
-                 ; foreign_field_modulus1
-                 ; foreign_field_modulus2
-                 ; sign
-                 } )
+            ForeignFieldAdd
+              { left_input_lo = left_input0
+              ; left_input_mi = left_input1
+              ; left_input_hi = left_input2
+              ; right_input_lo = right_input0
+              ; right_input_mi = right_input1
+              ; right_input_hi = right_input2
+              ; field_overflow
+              ; carry
+              ; foreign_field_modulus0
+              ; foreign_field_modulus1
+              ; foreign_field_modulus2
+              ; sign
+              }
         } ) ;
 
   (* Return the result *)
@@ -775,12 +774,11 @@ let result_row (type f) (module Circuit : Snark_intf.Run with type field = f)
       assert_
         { annotation = Some __LOC__
         ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Raw
-                 { kind = Zero
-                 ; values = [| result0; result1; result2 |]
-                 ; coeffs = [||]
-                 } )
+            Raw
+              { kind = Zero
+              ; values = [| result0; result1; result2 |]
+              ; coeffs = [||]
+              }
         } )
 
 (* Gadget to check the supplied value is a valid foreign field element for the
@@ -1393,36 +1391,35 @@ let mul (type f) (module Circuit : Snark_intf.Run with type field = f)
       assert_
         { annotation = Some __LOC__
         ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (ForeignFieldMul
-                 { (* Current row *) left_input0
-                 ; left_input1
-                 ; left_input2
-                 ; right_input0
-                 ; right_input1
-                 ; right_input2
-                 ; carry1_lo
-                 ; carry1_hi
-                 ; carry0
-                 ; quotient0
-                 ; quotient1
-                 ; quotient2
-                 ; quotient_bound_carry
-                 ; product1_hi_1
-                 ; (* Next row *) remainder0
-                 ; remainder1
-                 ; remainder2
-                 ; quotient_bound01
-                 ; quotient_bound2
-                 ; product1_lo
-                 ; product1_hi_0
-                 ; (* Coefficients *) foreign_field_modulus0
-                 ; foreign_field_modulus1
-                 ; foreign_field_modulus2
-                 ; neg_foreign_field_modulus0
-                 ; neg_foreign_field_modulus1
-                 ; neg_foreign_field_modulus2
-                 } )
+            ForeignFieldMul
+              { (* Current row *) left_input0
+              ; left_input1
+              ; left_input2
+              ; right_input0
+              ; right_input1
+              ; right_input2
+              ; carry1_lo
+              ; carry1_hi
+              ; carry0
+              ; quotient0
+              ; quotient1
+              ; quotient2
+              ; quotient_bound_carry
+              ; product1_hi_1
+              ; (* Next row *) remainder0
+              ; remainder1
+              ; remainder2
+              ; quotient_bound01
+              ; quotient_bound2
+              ; product1_lo
+              ; product1_hi_0
+              ; (* Coefficients *) foreign_field_modulus0
+              ; foreign_field_modulus1
+              ; foreign_field_modulus2
+              ; neg_foreign_field_modulus0
+              ; neg_foreign_field_modulus1
+              ; neg_foreign_field_modulus2
+              }
         } ) ;
   Element.Standard.of_limbs (remainder0, remainder1, remainder2)
 

--- a/src/lib/crypto/kimchi_backend/gadgets/generic.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/generic.ml
@@ -1,5 +1,3 @@
-open Core_kernel
-
 open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
 module Circuit = Kimchi_pasta_snarky_backend.Step_impl
@@ -22,17 +20,14 @@ let add (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic add gate *)
   with_label "generic_add_gadget" (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Basic
-                 { l = (Field.Constant.one, left_input)
-                 ; r = (Field.Constant.one, right_input)
-                 ; o = (neg_one, sum)
-                 ; m = Field.Constant.zero
-                 ; c = Field.Constant.zero
-                 } )
-        } ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Basic
+              { l = (Field.Constant.one, left_input)
+              ; r = (Field.Constant.one, right_input)
+              ; o = (neg_one, sum)
+              ; m = Field.Constant.zero
+              ; c = Field.Constant.zero
+              } ) ) ;
       sum )
 
 (* Generic subtraction gate gadget *)
@@ -53,17 +48,14 @@ let sub (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic sub gate *)
   with_label "generic_sub_gadget" (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Basic
-                 { l = (Field.Constant.one, left_input)
-                 ; r = (neg_one, right_input)
-                 ; o = (neg_one, difference)
-                 ; m = Field.Constant.zero
-                 ; c = Field.Constant.zero
-                 } )
-        } ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Basic
+              { l = (Field.Constant.one, left_input)
+              ; r = (neg_one, right_input)
+              ; o = (neg_one, difference)
+              ; m = Field.Constant.zero
+              ; c = Field.Constant.zero
+              } ) ) ;
       difference )
 
 (* Generic multiplication gate gadget *)
@@ -82,17 +74,14 @@ let mul (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic mul gate *)
   with_label "generic_mul_gadget" (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Basic
-                 { l = (Field.Constant.zero, left_input)
-                 ; r = (Field.Constant.zero, right_input)
-                 ; o = (neg_one, prod)
-                 ; m = Field.Constant.one
-                 ; c = Field.Constant.zero
-                 } )
-        } ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Basic
+              { l = (Field.Constant.zero, left_input)
+              ; r = (Field.Constant.zero, right_input)
+              ; o = (neg_one, prod)
+              ; m = Field.Constant.one
+              ; c = Field.Constant.zero
+              } ) ) ;
       prod )
 
 (*********)

--- a/src/lib/crypto/kimchi_backend/gadgets/generic.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/generic.ml
@@ -20,14 +20,13 @@ let add (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic add gate *)
   with_label "generic_add_gadget" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Basic
-              { l = (Field.Constant.one, left_input)
-              ; r = (Field.Constant.one, right_input)
-              ; o = (neg_one, sum)
-              ; m = Field.Constant.zero
-              ; c = Field.Constant.zero
-              } ) ) ;
+        (Basic
+           { l = (Field.Constant.one, left_input)
+           ; r = (Field.Constant.one, right_input)
+           ; o = (neg_one, sum)
+           ; m = Field.Constant.zero
+           ; c = Field.Constant.zero
+           } ) ;
       sum )
 
 (* Generic subtraction gate gadget *)
@@ -48,14 +47,13 @@ let sub (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic sub gate *)
   with_label "generic_sub_gadget" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Basic
-              { l = (Field.Constant.one, left_input)
-              ; r = (neg_one, right_input)
-              ; o = (neg_one, difference)
-              ; m = Field.Constant.zero
-              ; c = Field.Constant.zero
-              } ) ) ;
+        (Basic
+           { l = (Field.Constant.one, left_input)
+           ; r = (neg_one, right_input)
+           ; o = (neg_one, difference)
+           ; m = Field.Constant.zero
+           ; c = Field.Constant.zero
+           } ) ;
       difference )
 
 (* Generic multiplication gate gadget *)
@@ -74,14 +72,13 @@ let mul (left_input : Circuit.Field.t) (right_input : Circuit.Field.t) :
   (* Set up generic mul gate *)
   with_label "generic_mul_gadget" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Basic
-              { l = (Field.Constant.zero, left_input)
-              ; r = (Field.Constant.zero, right_input)
-              ; o = (neg_one, prod)
-              ; m = Field.Constant.one
-              ; c = Field.Constant.zero
-              } ) ) ;
+        (Basic
+           { l = (Field.Constant.zero, left_input)
+           ; r = (Field.Constant.zero, right_input)
+           ; o = (neg_one, prod)
+           ; m = Field.Constant.one
+           ; c = Field.Constant.zero
+           } ) ;
       prod )
 
 (*********)

--- a/src/lib/crypto/kimchi_backend/gadgets/lookup.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/lookup.ml
@@ -12,16 +12,15 @@ let three_12bit (v0 : Circuit.Field.t) (v1 : Circuit.Field.t)
   let open Circuit in
   with_label "triple_lookup" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (Lookup
-              { w0 = Field.one
-              ; w1 = v0
-              ; w2 = Field.zero
-              ; w3 = v1
-              ; w4 = Field.zero
-              ; w5 = v2
-              ; w6 = Field.zero
-              } ) ) ) ;
+        (Lookup
+           { w0 = Field.one
+           ; w1 = v0
+           ; w2 = Field.zero
+           ; w3 = v1
+           ; w4 = Field.zero
+           ; w5 = v2
+           ; w6 = Field.zero
+           } ) ) ;
   ()
 
 (* Check that one value is at most X bits (at most 12), default is 12.

--- a/src/lib/crypto/kimchi_backend/gadgets/lookup.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/lookup.ml
@@ -12,19 +12,16 @@ let three_12bit (v0 : Circuit.Field.t) (v1 : Circuit.Field.t)
   let open Circuit in
   with_label "triple_lookup" (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (Lookup
-                 { w0 = Field.one
-                 ; w1 = v0
-                 ; w2 = Field.zero
-                 ; w3 = v1
-                 ; w4 = Field.zero
-                 ; w5 = v2
-                 ; w6 = Field.zero
-                 } )
-        } ) ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (Lookup
+              { w0 = Field.one
+              ; w1 = v0
+              ; w2 = Field.zero
+              ; w3 = v1
+              ; w4 = Field.zero
+              ; w5 = v2
+              ; w6 = Field.zero
+              } ) ) ) ;
   ()
 
 (* Check that one value is at most X bits (at most 12), default is 12.

--- a/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
@@ -47,26 +47,25 @@ let range_check0 ~(label : string) ?(is_compact : bool = false)
   (* Create RangeCheck0 gate *)
   with_label label (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (RangeCheck0
-              { (* Current row *) v0
-              ; v0p0
-              ; v0p1
-              ; v0p2
-              ; v0p3
-              ; v0p4
-              ; v0p5
-              ; v0c0
-              ; v0c1
-              ; v0c2
-              ; v0c3
-              ; v0c4
-              ; v0c5
-              ; v0c6
-              ; v0c7
-              ; (* Coefficients *)
-                compact
-              } ) ) )
+        (RangeCheck0
+           { (* Current row *) v0
+           ; v0p0
+           ; v0p1
+           ; v0p2
+           ; v0p3
+           ; v0p4
+           ; v0p5
+           ; v0c0
+           ; v0c1
+           ; v0c2
+           ; v0c3
+           ; v0c4
+           ; v0c5
+           ; v0c6
+           ; v0c7
+           ; (* Coefficients *)
+             compact
+           } ) )
 
 (* Helper to create RangeCheck1 gate *)
 let range_check1 ~(label : string) (v0p0 : Circuit.Field.t)
@@ -107,39 +106,38 @@ let range_check1 ~(label : string) (v0p0 : Circuit.Field.t)
   (* Create RangeCheck0 gate *)
   with_label label (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (RangeCheck1
-              { (* Current row *) v2
-              ; v12
-              ; v2c0
-              ; v2p0
-              ; v2p1
-              ; v2p2
-              ; v2p3
-              ; v2c1
-              ; v2c2
-              ; v2c3
-              ; v2c4
-              ; v2c5
-              ; v2c6
-              ; v2c7
-              ; v2c8
-              ; (* Next row *) v2c9
-              ; v2c10
-              ; v2c11
-              ; v0p0
-              ; v0p1
-              ; v1p0
-              ; v1p1
-              ; v2c12
-              ; v2c13
-              ; v2c14
-              ; v2c15
-              ; v2c16
-              ; v2c17
-              ; v2c18
-              ; v2c19
-              } ) ) )
+        (RangeCheck1
+           { (* Current row *) v2
+           ; v12
+           ; v2c0
+           ; v2p0
+           ; v2p1
+           ; v2p2
+           ; v2p3
+           ; v2c1
+           ; v2c2
+           ; v2c3
+           ; v2c4
+           ; v2c5
+           ; v2c6
+           ; v2c7
+           ; v2c8
+           ; (* Next row *) v2c9
+           ; v2c10
+           ; v2c11
+           ; v0p0
+           ; v0p1
+           ; v1p0
+           ; v1p1
+           ; v2c12
+           ; v2c13
+           ; v2c14
+           ; v2c15
+           ; v2c16
+           ; v2c17
+           ; v2c18
+           ; v2c19
+           } ) )
 
 (* 64-bit range-check gadget - checks v0 \in [0, 2^64) *)
 let bits64 (v0 : Circuit.Field.t) =

--- a/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/range_check.ml
@@ -47,29 +47,26 @@ let range_check0 ~(label : string) ?(is_compact : bool = false)
   (* Create RangeCheck0 gate *)
   with_label label (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (RangeCheck0
-                 { (* Current row *) v0
-                 ; v0p0
-                 ; v0p1
-                 ; v0p2
-                 ; v0p3
-                 ; v0p4
-                 ; v0p5
-                 ; v0c0
-                 ; v0c1
-                 ; v0c2
-                 ; v0c3
-                 ; v0c4
-                 ; v0c5
-                 ; v0c6
-                 ; v0c7
-                 ; (* Coefficients *)
-                   compact
-                 } )
-        } )
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (RangeCheck0
+              { (* Current row *) v0
+              ; v0p0
+              ; v0p1
+              ; v0p2
+              ; v0p3
+              ; v0p4
+              ; v0p5
+              ; v0c0
+              ; v0c1
+              ; v0c2
+              ; v0c3
+              ; v0c4
+              ; v0c5
+              ; v0c6
+              ; v0c7
+              ; (* Coefficients *)
+                compact
+              } ) ) )
 
 (* Helper to create RangeCheck1 gate *)
 let range_check1 ~(label : string) (v0p0 : Circuit.Field.t)
@@ -110,42 +107,39 @@ let range_check1 ~(label : string) (v0p0 : Circuit.Field.t)
   (* Create RangeCheck0 gate *)
   with_label label (fun () ->
       assert_
-        { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (RangeCheck1
-                 { (* Current row *) v2
-                 ; v12
-                 ; v2c0
-                 ; v2p0
-                 ; v2p1
-                 ; v2p2
-                 ; v2p3
-                 ; v2c1
-                 ; v2c2
-                 ; v2c3
-                 ; v2c4
-                 ; v2c5
-                 ; v2c6
-                 ; v2c7
-                 ; v2c8
-                 ; (* Next row *) v2c9
-                 ; v2c10
-                 ; v2c11
-                 ; v0p0
-                 ; v0p1
-                 ; v1p0
-                 ; v1p1
-                 ; v2c12
-                 ; v2c13
-                 ; v2c14
-                 ; v2c15
-                 ; v2c16
-                 ; v2c17
-                 ; v2c18
-                 ; v2c19
-                 } )
-        } )
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (RangeCheck1
+              { (* Current row *) v2
+              ; v12
+              ; v2c0
+              ; v2p0
+              ; v2p1
+              ; v2p2
+              ; v2p3
+              ; v2c1
+              ; v2c2
+              ; v2c3
+              ; v2c4
+              ; v2c5
+              ; v2c6
+              ; v2c7
+              ; v2c8
+              ; (* Next row *) v2c9
+              ; v2c10
+              ; v2c11
+              ; v0p0
+              ; v0p1
+              ; v1p0
+              ; v1p1
+              ; v2c12
+              ; v2c13
+              ; v2c14
+              ; v2c15
+              ; v2c16
+              ; v2c17
+              ; v2c18
+              ; v2c19
+              } ) ) )
 
 (* 64-bit range-check gadget - checks v0 \in [0, 2^64) *)
 let bits64 (v0 : Circuit.Field.t) =

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -169,6 +169,7 @@ module Pasta : sig
     module R1CS_constraint_system =
       Kimchi_pasta.Pallas_based_plonk.R1CS_constraint_system
 
+    module Constraint = Kimchi_pasta.Pallas_based_plonk.Constraint
     module Rounds_vector = Kimchi_pasta.Pallas_based_plonk.Rounds_vector
     module Rounds = Kimchi_pasta.Pallas_based_plonk.Rounds
     module Keypair = Kimchi_pasta.Pallas_based_plonk.Keypair
@@ -199,6 +200,7 @@ module Pasta : sig
     module Verification_key = Kimchi_pasta.Vesta_based_plonk.Verification_key
     module R1CS_constraint_system =
       Kimchi_pasta.Vesta_based_plonk.R1CS_constraint_system
+    module Constraint = Kimchi_pasta.Vesta_based_plonk.Constraint
     module Rounds_vector = Kimchi_pasta.Vesta_based_plonk.Rounds_vector
     module Rounds = Kimchi_pasta.Vesta_based_plonk.Rounds
     module Keypair = Kimchi_pasta.Vesta_based_plonk.Keypair

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -31,6 +31,9 @@ module type Full = sig
 
   type gates
 
+  type constraint_ =
+    (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
+
   include
     With_accessors
       with type t = (fp, gates) Kimchi_backend_common.Plonk_constraint_system.t

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -33,7 +33,9 @@ module type Full = sig
 
   module Constraint : sig
     type t =
-      (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
+      ( fp Snarky_backendless.Cvar.t
+      , fp )
+      Kimchi_pasta_snarky_backend.Plonk_constraint_system.Plonk_constraint.basic
     [@@deriving sexp]
 
     val boolean : fp Snarky_backendless.Cvar.t -> t
@@ -61,10 +63,7 @@ module type Full = sig
     With_accessors
       with type t = (fp, gates) Kimchi_backend_common.Plonk_constraint_system.t
 
-  val add_constraint :
-       t
-    -> (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
-    -> unit
+  val add_constraint : t -> Constraint.t -> unit
 
   val compute_witness :
     t -> (int -> fp) -> fp array array * fp Kimchi_types.runtime_table array

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -36,8 +36,7 @@ module type Full = sig
       with type t = (fp, gates) Kimchi_backend_common.Plonk_constraint_system.t
 
   val add_constraint :
-       ?label:string
-    -> t
+       t
     -> (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
     -> unit
 

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -31,8 +31,31 @@ module type Full = sig
 
   type gates
 
-  type constraint_ =
-    (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
+  module Constraint : sig
+    type t =
+      (fp Snarky_backendless.Cvar.t, fp) Snarky_backendless.Constraint.basic
+    [@@deriving sexp]
+
+    val boolean : fp Snarky_backendless.Cvar.t -> t
+
+    val equal :
+      fp Snarky_backendless.Cvar.t -> fp Snarky_backendless.Cvar.t -> t
+
+    val r1cs :
+         fp Snarky_backendless.Cvar.t
+      -> fp Snarky_backendless.Cvar.t
+      -> fp Snarky_backendless.Cvar.t
+      -> t
+
+    val square :
+      fp Snarky_backendless.Cvar.t -> fp Snarky_backendless.Cvar.t -> t
+
+    val eval : t -> (fp Snarky_backendless.Cvar.t -> fp) -> bool
+
+    val log_constraint : t -> (fp Snarky_backendless.Cvar.t -> fp) -> string
+  end
+
+  type constraint_ = Constraint.t
 
   include
     With_accessors

--- a/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.ml
@@ -9,6 +9,7 @@ module Pallas_based_plonk = struct
 
   module Verification_key = Pallas_based_plonk.Verification_key
   module R1CS_constraint_system = Pallas_based_plonk.R1CS_constraint_system
+  module Constraint = R1CS_constraint_system.Constraint
   module Rounds_vector = Pallas_based_plonk.Rounds_vector
   module Rounds = Pallas_based_plonk.Rounds
   module Keypair = Pallas_based_plonk.Keypair
@@ -27,6 +28,7 @@ module Vesta_based_plonk = struct
 
   module Verification_key = Vesta_based_plonk.Verification_key
   module R1CS_constraint_system = Vesta_based_plonk.R1CS_constraint_system
+  module Constraint = R1CS_constraint_system.Constraint
   module Rounds_vector = Vesta_based_plonk.Rounds_vector
   module Rounds = Vesta_based_plonk.Rounds
   module Keypair = Vesta_based_plonk.Keypair

--- a/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.mli
+++ b/src/lib/crypto/kimchi_backend/pasta/kimchi_pasta.mli
@@ -9,6 +9,7 @@ module Pallas_based_plonk : sig
 
   module Verification_key = Pallas_based_plonk.Verification_key
   module R1CS_constraint_system = Pallas_based_plonk.R1CS_constraint_system
+  module Constraint = R1CS_constraint_system.Constraint
   module Rounds_vector = Pallas_based_plonk.Rounds_vector
   module Rounds = Pallas_based_plonk.Rounds
   module Keypair = Pallas_based_plonk.Keypair
@@ -27,6 +28,7 @@ module Vesta_based_plonk : sig
 
   module Verification_key = Vesta_based_plonk.Verification_key
   module R1CS_constraint_system = Vesta_based_plonk.R1CS_constraint_system
+  module Constraint = R1CS_constraint_system.Constraint
   module Rounds_vector = Vesta_based_plonk.Rounds_vector
   module Rounds = Vesta_based_plonk.Rounds
   module Keypair = Vesta_based_plonk.Keypair

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -34,6 +34,8 @@ end
 module R1CS_constraint_system =
   Kimchi_pasta_constraint_system.Pallas_constraint_system
 
+module Constraint = R1CS_constraint_system.Constraint
+
 let lagrange (srs : Kimchi_bindings.Protocol.SRS.Fq.t) domain_log2 :
     _ Kimchi_types.poly_comm array =
   let domain_size = Int.pow 2 domain_log2 in

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -33,6 +33,8 @@ end
 module R1CS_constraint_system =
   Kimchi_pasta_constraint_system.Vesta_constraint_system
 
+module Constraint = R1CS_constraint_system.Constraint
+
 let lagrange srs domain_log2 : _ Kimchi_types.poly_comm array =
   let domain_size = Int.pow 2 domain_log2 in
   Kimchi_bindings.Protocol.SRS.Fp.lagrange_commitments_whole_domain srs

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
@@ -41,7 +41,11 @@ module Vesta_based_plonk = struct
         let params = poseidon_params
       end)
 
-  module Run_state = Snarky_backendless.Run_state
+  module Run_state = struct
+    include Snarky_backendless.Run_state
+
+    type nonrec t = Field.t t
+  end
 end
 
 module Pallas_based_plonk = struct
@@ -73,7 +77,11 @@ module Pallas_based_plonk = struct
         let params = poseidon_params
       end)
 
-  module Run_state = Snarky_backendless.Run_state
+  module Run_state = struct
+    include Snarky_backendless.Run_state
+
+    type nonrec t = Field.t t
+  end
 end
 
 module Step_impl = Snarky_backendless.Snark.Run.Make (Vesta_based_plonk)

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
@@ -43,11 +43,11 @@ module Vesta_based_plonk = struct
 
   module Constraint = R1CS_constraint_system.Constraint
 
-  module Run_state = struct
-    include Snarky_backendless.Run_state
+  module Run_state = Snarky_backendless.Run_state.Make (struct
+    type field = Field.t
 
-    type nonrec t = Field.t t
-  end
+    type constraint_ = Constraint.t
+  end)
 end
 
 module Pallas_based_plonk = struct
@@ -81,11 +81,11 @@ module Pallas_based_plonk = struct
 
   module Constraint = R1CS_constraint_system.Constraint
 
-  module Run_state = struct
-    include Snarky_backendless.Run_state
+  module Run_state = Snarky_backendless.Run_state.Make (struct
+    type field = Field.t
 
-    type nonrec t = Field.t t
-  end
+    type constraint_ = Constraint.t
+  end)
 end
 
 module Step_impl = Snarky_backendless.Snark.Run.Make (Vesta_based_plonk)

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
@@ -5,6 +5,8 @@ module Intf = Intf
 module Plonk_constraint_system = Plonk_constraint_system
 module Scale_round = Scale_round
 
+module type Snark_intf = Plonk_constraint_system.Snark_intf
+
 module Bigint256 =
   Bigint.Make
     (Pasta_bindings.BigInt256)

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/kimchi_pasta_snarky_backend.ml
@@ -41,6 +41,8 @@ module Vesta_based_plonk = struct
         let params = poseidon_params
       end)
 
+  module Constraint = R1CS_constraint_system.Constraint
+
   module Run_state = struct
     include Snarky_backendless.Run_state
 
@@ -76,6 +78,8 @@ module Pallas_based_plonk = struct
       (struct
         let params = poseidon_params
       end)
+
+  module Constraint = R1CS_constraint_system.Constraint
 
   module Run_state = struct
     include Snarky_backendless.Run_state

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
@@ -146,176 +146,223 @@ end
 
 (** The PLONK constraints. *)
 module Plonk_constraint = struct
-  open Core_kernel
-
-  (** A PLONK constraint (or gate) can be [Basic], [Poseidon], [EC_add_complete], [EC_scale], [EC_endoscale], [EC_endoscalar], [RangeCheck0], [RangeCheck1], [Xor] *)
   module T = struct
-    type ('v, 'f) t =
-      | Basic of { l : 'f * 'v; r : 'f * 'v; o : 'f * 'v; m : 'f; c : 'f }
-          (** the Poseidon state is an array of states (and states are arrays of size 3). *)
-      | Poseidon of { state : 'v array array }
-      | EC_add_complete of
-          { p1 : 'v * 'v
-          ; p2 : 'v * 'v
-          ; p3 : 'v * 'v
-          ; inf : 'v
-          ; same_x : 'v
-          ; slope : 'v
-          ; inf_z : 'v
-          ; x21_inv : 'v
+    open Core_kernel
+
+    type ('field_var, 'fp) basic =
+      | Boolean of 'field_var
+      | Equal of 'field_var * 'field_var
+      | Square of 'field_var * 'field_var
+      | R1CS of 'field_var * 'field_var * 'field_var
+      | Basic of
+          { l : 'fp * 'field_var
+          ; r : 'fp * 'field_var
+          ; o : 'fp * 'field_var
+          ; m : 'fp
+          ; c : 'fp
           }
-      | EC_scale of { state : 'v Scale_round.t array }
+          (** the Poseidon state is an array of states (and states are arrays of size 3). *)
+      | Poseidon of { state : 'field_var array array }
+      | EC_add_complete of
+          { p1 : 'field_var * 'field_var
+          ; p2 : 'field_var * 'field_var
+          ; p3 : 'field_var * 'field_var
+          ; inf : 'field_var
+          ; same_x : 'field_var
+          ; slope : 'field_var
+          ; inf_z : 'field_var
+          ; x21_inv : 'field_var
+          }
+      | EC_scale of { state : 'field_var Scale_round.t array }
       | EC_endoscale of
-          { state : 'v Endoscale_round.t array; xs : 'v; ys : 'v; n_acc : 'v }
-      | EC_endoscalar of { state : 'v Endoscale_scalar_round.t array }
+          { state : 'field_var Endoscale_round.t array
+          ; xs : 'field_var
+          ; ys : 'field_var
+          ; n_acc : 'field_var
+          }
+      | EC_endoscalar of { state : 'field_var Endoscale_scalar_round.t array }
       | Lookup of
-          { w0 : 'v; w1 : 'v; w2 : 'v; w3 : 'v; w4 : 'v; w5 : 'v; w6 : 'v }
+          { w0 : 'field_var
+          ; w1 : 'field_var
+          ; w2 : 'field_var
+          ; w3 : 'field_var
+          ; w4 : 'field_var
+          ; w5 : 'field_var
+          ; w6 : 'field_var
+          }
       | RangeCheck0 of
-          { v0 : 'v (* Value to constrain to 88-bits *)
-          ; v0p0 : 'v (* MSBs *)
-          ; v0p1 : 'v (* vpX are 12-bit plookup chunks *)
-          ; v0p2 : 'v
-          ; v0p3 : 'v
-          ; v0p4 : 'v
-          ; v0p5 : 'v
-          ; v0c0 : 'v (* vcX are 2-bit crumbs *)
-          ; v0c1 : 'v
-          ; v0c2 : 'v
-          ; v0c3 : 'v
-          ; v0c4 : 'v
-          ; v0c5 : 'v
-          ; v0c6 : 'v
-          ; v0c7 : 'v (* LSBs *)
+          { v0 : 'field_var (* Value to constrain to 88-bits *)
+          ; v0p0 : 'field_var (* MSBs *)
+          ; v0p1 : 'field_var (* vpX are 12-bit plookup chunks *)
+          ; v0p2 : 'field_var
+          ; v0p3 : 'field_var
+          ; v0p4 : 'field_var
+          ; v0p5 : 'field_var
+          ; v0c0 : 'field_var (* vcX are 2-bit crumbs *)
+          ; v0c1 : 'field_var
+          ; v0c2 : 'field_var
+          ; v0c3 : 'field_var
+          ; v0c4 : 'field_var
+          ; v0c5 : 'field_var
+          ; v0c6 : 'field_var
+          ; v0c7 : 'field_var (* LSBs *)
           ; (* Coefficients *)
-            compact : 'f
+            compact : 'fp
                 (* Limbs mode coefficient: 0 (standard 3-limb) or 1 (compact 2-limb) *)
           }
       | RangeCheck1 of
           { (* Current row *)
-            v2 : 'v (* Value to constrain to 88-bits *)
-          ; v12 : 'v (* Optional value used in compact 2-limb mode *)
-          ; v2c0 : 'v (* MSBs, 2-bit crumb *)
-          ; v2p0 : 'v (* vpX are 12-bit plookup chunks *)
-          ; v2p1 : 'v
-          ; v2p2 : 'v
-          ; v2p3 : 'v
-          ; v2c1 : 'v (* vcX are 2-bit crumbs *)
-          ; v2c2 : 'v
-          ; v2c3 : 'v
-          ; v2c4 : 'v
-          ; v2c5 : 'v
-          ; v2c6 : 'v
-          ; v2c7 : 'v
-          ; v2c8 : 'v (* LSBs *)
-          ; (* Next row *) v2c9 : 'v
-          ; v2c10 : 'v
-          ; v2c11 : 'v
-          ; v0p0 : 'v
-          ; v0p1 : 'v
-          ; v1p0 : 'v
-          ; v1p1 : 'v
-          ; v2c12 : 'v
-          ; v2c13 : 'v
-          ; v2c14 : 'v
-          ; v2c15 : 'v
-          ; v2c16 : 'v
-          ; v2c17 : 'v
-          ; v2c18 : 'v
-          ; v2c19 : 'v
+            v2 : 'field_var (* Value to constrain to 88-bits *)
+          ; v12 : 'field_var (* Optional value used in compact 2-limb mode *)
+          ; v2c0 : 'field_var (* MSBs, 2-bit crumb *)
+          ; v2p0 : 'field_var (* vpX are 12-bit plookup chunks *)
+          ; v2p1 : 'field_var
+          ; v2p2 : 'field_var
+          ; v2p3 : 'field_var
+          ; v2c1 : 'field_var (* vcX are 2-bit crumbs *)
+          ; v2c2 : 'field_var
+          ; v2c3 : 'field_var
+          ; v2c4 : 'field_var
+          ; v2c5 : 'field_var
+          ; v2c6 : 'field_var
+          ; v2c7 : 'field_var
+          ; v2c8 : 'field_var (* LSBs *)
+          ; (* Next row *) v2c9 : 'field_var
+          ; v2c10 : 'field_var
+          ; v2c11 : 'field_var
+          ; v0p0 : 'field_var
+          ; v0p1 : 'field_var
+          ; v1p0 : 'field_var
+          ; v1p1 : 'field_var
+          ; v2c12 : 'field_var
+          ; v2c13 : 'field_var
+          ; v2c14 : 'field_var
+          ; v2c15 : 'field_var
+          ; v2c16 : 'field_var
+          ; v2c17 : 'field_var
+          ; v2c18 : 'field_var
+          ; v2c19 : 'field_var
           }
       | Xor of
-          { in1 : 'v
-          ; in2 : 'v
-          ; out : 'v
-          ; in1_0 : 'v
-          ; in1_1 : 'v
-          ; in1_2 : 'v
-          ; in1_3 : 'v
-          ; in2_0 : 'v
-          ; in2_1 : 'v
-          ; in2_2 : 'v
-          ; in2_3 : 'v
-          ; out_0 : 'v
-          ; out_1 : 'v
-          ; out_2 : 'v
-          ; out_3 : 'v
+          { in1 : 'field_var
+          ; in2 : 'field_var
+          ; out : 'field_var
+          ; in1_0 : 'field_var
+          ; in1_1 : 'field_var
+          ; in1_2 : 'field_var
+          ; in1_3 : 'field_var
+          ; in2_0 : 'field_var
+          ; in2_1 : 'field_var
+          ; in2_2 : 'field_var
+          ; in2_3 : 'field_var
+          ; out_0 : 'field_var
+          ; out_1 : 'field_var
+          ; out_2 : 'field_var
+          ; out_3 : 'field_var
           }
       | ForeignFieldAdd of
-          { left_input_lo : 'v
-          ; left_input_mi : 'v
-          ; left_input_hi : 'v
-          ; right_input_lo : 'v
-          ; right_input_mi : 'v
-          ; right_input_hi : 'v
-          ; field_overflow : 'v
-          ; carry : 'v
-          ; (* Coefficients *) foreign_field_modulus0 : 'f
-          ; foreign_field_modulus1 : 'f
-          ; foreign_field_modulus2 : 'f
-          ; sign : 'f
+          { left_input_lo : 'field_var
+          ; left_input_mi : 'field_var
+          ; left_input_hi : 'field_var
+          ; right_input_lo : 'field_var
+          ; right_input_mi : 'field_var
+          ; right_input_hi : 'field_var
+          ; field_overflow : 'field_var
+          ; carry : 'field_var
+          ; (* Coefficients *) foreign_field_modulus0 : 'fp
+          ; foreign_field_modulus1 : 'fp
+          ; foreign_field_modulus2 : 'fp
+          ; sign : 'fp
           }
       | ForeignFieldMul of
-          { left_input0 : 'v
-          ; left_input1 : 'v
-          ; left_input2 : 'v
-          ; right_input0 : 'v
-          ; right_input1 : 'v
-          ; right_input2 : 'v
-          ; remainder01 : 'v
-          ; remainder2 : 'v
-          ; quotient0 : 'v
-          ; quotient1 : 'v
-          ; quotient2 : 'v
-          ; quotient_hi_bound : 'v
-          ; product1_lo : 'v
-          ; product1_hi_0 : 'v
-          ; product1_hi_1 : 'v
-          ; carry0 : 'v
-          ; carry1_0 : 'v
-          ; carry1_12 : 'v
-          ; carry1_24 : 'v
-          ; carry1_36 : 'v
-          ; carry1_48 : 'v
-          ; carry1_60 : 'v
-          ; carry1_72 : 'v
-          ; carry1_84 : 'v
-          ; carry1_86 : 'v
-          ; carry1_88 : 'v
-          ; carry1_90 : 'v
-          ; (* Coefficients *) foreign_field_modulus2 : 'f
-          ; neg_foreign_field_modulus0 : 'f
-          ; neg_foreign_field_modulus1 : 'f
-          ; neg_foreign_field_modulus2 : 'f
+          { left_input0 : 'field_var
+          ; left_input1 : 'field_var
+          ; left_input2 : 'field_var
+          ; right_input0 : 'field_var
+          ; right_input1 : 'field_var
+          ; right_input2 : 'field_var
+          ; remainder01 : 'field_var
+          ; remainder2 : 'field_var
+          ; quotient0 : 'field_var
+          ; quotient1 : 'field_var
+          ; quotient2 : 'field_var
+          ; quotient_hi_bound : 'field_var
+          ; product1_lo : 'field_var
+          ; product1_hi_0 : 'field_var
+          ; product1_hi_1 : 'field_var
+          ; carry0 : 'field_var
+          ; carry1_0 : 'field_var
+          ; carry1_12 : 'field_var
+          ; carry1_24 : 'field_var
+          ; carry1_36 : 'field_var
+          ; carry1_48 : 'field_var
+          ; carry1_60 : 'field_var
+          ; carry1_72 : 'field_var
+          ; carry1_84 : 'field_var
+          ; carry1_86 : 'field_var
+          ; carry1_88 : 'field_var
+          ; carry1_90 : 'field_var
+          ; (* Coefficients *) foreign_field_modulus2 : 'fp
+          ; neg_foreign_field_modulus0 : 'fp
+          ; neg_foreign_field_modulus1 : 'fp
+          ; neg_foreign_field_modulus2 : 'fp
           }
       | Rot64 of
           { (* Current row *)
-            word : 'v
-          ; rotated : 'v
-          ; excess : 'v
-          ; bound_limb0 : 'v
-          ; bound_limb1 : 'v
-          ; bound_limb2 : 'v
-          ; bound_limb3 : 'v
-          ; bound_crumb0 : 'v
-          ; bound_crumb1 : 'v
-          ; bound_crumb2 : 'v
-          ; bound_crumb3 : 'v
-          ; bound_crumb4 : 'v
-          ; bound_crumb5 : 'v
-          ; bound_crumb6 : 'v
-          ; bound_crumb7 : 'v
-          ; (* Coefficients *) two_to_rot : 'f (* Rotation scalar 2^rot *)
+            word : 'field_var
+          ; rotated : 'field_var
+          ; excess : 'field_var
+          ; bound_limb0 : 'field_var
+          ; bound_limb1 : 'field_var
+          ; bound_limb2 : 'field_var
+          ; bound_limb3 : 'field_var
+          ; bound_crumb0 : 'field_var
+          ; bound_crumb1 : 'field_var
+          ; bound_crumb2 : 'field_var
+          ; bound_crumb3 : 'field_var
+          ; bound_crumb4 : 'field_var
+          ; bound_crumb5 : 'field_var
+          ; bound_crumb6 : 'field_var
+          ; bound_crumb7 : 'field_var
+          ; (* Coefficients *) two_to_rot : 'fp (* Rotation scalar 2^rot *)
           }
-      | AddFixedLookupTable of { id : int32; data : 'f array array }
-      | AddRuntimeTableCfg of { id : int32; first_column : 'f array }
+      | AddFixedLookupTable of { id : int32; data : 'fp array array }
+      | AddRuntimeTableCfg of { id : int32; first_column : 'fp array }
       | Raw of
-          { kind : Kimchi_gate_type.t; values : 'v array; coeffs : 'f array }
+          { kind : Kimchi_gate_type.t
+          ; values : 'field_var array
+          ; coeffs : 'fp array
+          }
     [@@deriving sexp]
+  end
 
-    (** map t *)
-    let map (type a b f) (t : (a, f) t) ~(f : a -> b) =
+  include T
+
+  module Make (Fp : Field.S) = struct
+    open Core_kernel
+    include T
+
+    type t = (Fp.t Snarky_backendless.Cvar.t, Fp.t) basic [@@deriving sexp]
+
+    let equal x y = Equal (x, y)
+
+    let boolean x = Boolean x
+
+    let r1cs a b c = R1CS (a, b, c)
+
+    let square a c = Square (a, c)
+
+    let map (t : t) ~f =
       let fp (x, y) = (f x, f y) in
       match t with
+      | Boolean v ->
+          Boolean (f v)
+      | Equal (v1, v2) ->
+          Equal (f v1, f v2)
+      | R1CS (v1, v2, v3) ->
+          R1CS (f v1, f v2, f v3)
+      | Square (a, c) ->
+          Square (f a, f c)
       | Basic { l; r; o; m; c } ->
           let p (x, y) = (x, f y) in
           Basic { l = p l; r = p r; o = p o; m; c }
@@ -630,20 +677,37 @@ module Plonk_constraint = struct
       | Raw { kind; values; coeffs } ->
           Raw { kind; values = Array.map ~f values; coeffs }
 
-    (** [eval (module F) get_variable gate] checks that [gate]'s polynomial is
-        satisfied by the assignments given by [get_variable].
-        Warning: currently only implemented for the [Basic] gate.
-    *)
-    let eval (type v f)
-        (module F : Snarky_backendless.Field_intf.S with type t = f)
-        (eval_one : v -> f) (t : (v, f) t) =
+    let log_constraint (basic : t) get_value =
+      match basic with
+      | Boolean var ->
+          Format.(asprintf "Boolean %s" (Fp.to_string (get_value var)))
+      | Equal (var1, var2) ->
+          Format.(
+            asprintf "Equal %s %s"
+              (Fp.to_string (get_value var1))
+              (Fp.to_string (get_value var2)))
+      | Square (var1, var2) ->
+          Format.(
+            asprintf "Square %s %s"
+              (Fp.to_string (get_value var1))
+              (Fp.to_string (get_value var2)))
+      | R1CS (var1, var2, var3) ->
+          Format.(
+            asprintf "R1CS %s %s %s"
+              (Fp.to_string (get_value var1))
+              (Fp.to_string (get_value var2))
+              (Fp.to_string (get_value var3)))
+      | _ ->
+          Format.asprintf !"%{sexp:(Fp.t, Fp.t) basic}" (map basic ~f:get_value)
+
+    let eval (t : t) (eval_one : _ -> Fp.t) =
       match t with
       (* cl * vl + cr * vr + co * vo + m * vl*vr + c = 0 *)
       | Basic { l = cl, vl; r = cr, vr; o = co, vo; m; c } ->
           let vl = eval_one vl in
           let vr = eval_one vr in
           let vo = eval_one vo in
-          let open F in
+          let open Fp in
           let res =
             List.reduce_exn ~f:add
               [ mul cl vl; mul cr vr; mul co vo; mul m (mul vl vr); c ]
@@ -652,11 +716,16 @@ module Plonk_constraint = struct
       | _ ->
           true
   end
+end
 
-  include T
+module type Snark_intf = sig
+  type field
 
-  (* Adds our constraint enum to the list of constraints handled by Snarky. *)
-  include Snarky_backendless.Constraint.Add_kind (T)
+  include
+    Snarky_backendless.Snark_intf.Run
+      with type field := field
+       and type Constraint.t =
+        (field Snarky_backendless.Cvar.t, field) Plonk_constraint.basic
 end
 
 module Internal_var = Core_kernel.Unique_id.Int ()
@@ -825,8 +894,7 @@ module Make
   type nonrec t = (Fp.t, Gates.t) t
 
   module Constraint : sig
-    type t =
-      (Fp.t Snarky_backendless.Cvar.t, Fp.t) Snarky_backendless.Constraint.basic
+    type t = (Fp.t Snarky_backendless.Cvar.t, Fp.t) Plonk_constraint.basic
     [@@deriving sexp]
 
     val boolean : Fp.t Snarky_backendless.Cvar.t -> t
@@ -903,45 +971,7 @@ module Make
   val to_json : t -> string
 end = struct
   open Core_kernel
-
-  module Constraint = struct
-    include Snarky_backendless.Constraint.T
-
-    type t =
-      (Fp.t Snarky_backendless.Cvar.t, Fp.t) Snarky_backendless.Constraint.t
-    [@@deriving sexp]
-
-    let m = (module Fp : Snarky_intf.Field.S with type t = Fp.t)
-
-    let log_constraint (basic : t) get_value =
-      let open Snarky_backendless.Constraint in
-      match basic with
-      | Boolean var ->
-          Format.(asprintf "Boolean %s" (Fp.to_string (get_value var)))
-      | Equal (var1, var2) ->
-          Format.(
-            asprintf "Equal %s %s"
-              (Fp.to_string (get_value var1))
-              (Fp.to_string (get_value var2)))
-      | Square (var1, var2) ->
-          Format.(
-            asprintf "Square %s %s"
-              (Fp.to_string (get_value var1))
-              (Fp.to_string (get_value var2)))
-      | R1CS (var1, var2, var3) ->
-          Format.(
-            asprintf "R1CS %s %s %s"
-              (Fp.to_string (get_value var1))
-              (Fp.to_string (get_value var2))
-              (Fp.to_string (get_value var3)))
-      | _ ->
-          Format.asprintf
-            !"%{sexp:(Fp.t, Fp.t) Snarky_backendless.Constraint.basic}"
-            (Snarky_backendless.Constraint.Basic.map basic ~f:get_value)
-
-    let eval basic get_value =
-      Snarky_backendless.Constraint.Basic.eval m get_value basic
-  end
+  module Constraint = Plonk_constraint.Make (Fp)
 
   type constraint_ = Constraint.t
 
@@ -1473,11 +1503,7 @@ end = struct
             (Fp.one, `Var res) )
 
   (** Adds a constraint to the constraint system. *)
-  let add_constraint sys
-      (constr :
-        ( Fp.t Snarky_backendless.Cvar.t
-        , Fp.t )
-        Snarky_backendless.Constraint.basic ) =
+  let add_constraint sys (constr : Constraint.t) =
     let red = reduce_lincom sys in
     (* reduce any [Cvar.t] to a single internal variable *)
     let reduce_to_v (x : Fp.t Snarky_backendless.Cvar.t) : V.t =
@@ -1504,7 +1530,7 @@ end = struct
               x )
     in
     match constr with
-    | Snarky_backendless.Constraint.Square (v1, v2) -> (
+    | Square (v1, v2) -> (
         match (red v1, red v2) with
         | (sl, `Var xl), (so, `Var xo) ->
             (* (sl * xl)^2 = so * xo
@@ -1525,7 +1551,7 @@ end = struct
               sys
         | (sl, `Constant), (so, `Constant) ->
             assert (Fp.(equal (square sl) so)) )
-    | Snarky_backendless.Constraint.R1CS (v1, v2, v3) -> (
+    | R1CS (v1, v2, v3) -> (
         match (red v1, red v2, red v3) with
         | (s1, `Var x1), (s2, `Var x2), (s3, `Var x3) ->
             (* s1 x1 * s2 x2 = s3 x3
@@ -1562,7 +1588,7 @@ end = struct
               sys
         | (s1, `Constant), (s2, `Constant), (s3, `Constant) ->
             assert (Fp.(equal s3 Fp.(s1 * s2))) )
-    | Snarky_backendless.Constraint.Boolean v -> (
+    | Boolean v -> (
         let s, x = red v in
         match x with
         | `Var x ->
@@ -1572,7 +1598,7 @@ end = struct
               sys
         | `Constant ->
             assert (Fp.(equal s (s * s))) )
-    | Snarky_backendless.Constraint.Equal (v1, v2) -> (
+    | Equal (v1, v2) -> (
         let (s1, x1), (s2, x2) = (red v1, red v2) in
         match (x1, x2) with
         | `Var x1, `Var x2 ->
@@ -1617,7 +1643,7 @@ end = struct
                 Hashtbl.set sys.cached_constants ~key:ratio ~data:x2 )
         | `Constant, `Constant ->
             assert (Fp.(equal s1 s2)) )
-    | Plonk_constraint.T (Basic { l; r; o; m; c }) ->
+    | Basic { l; r; o; m; c } ->
         (* 0
            = l.s * l.x
            + r.s * r.x
@@ -1681,7 +1707,7 @@ end = struct
        state = [ x , x  , x ], [ y, y, y ], ... ]
                  i=0, perm^   i=1, perm^
     *)
-    | Plonk_constraint.T (Poseidon { state }) ->
+    | Poseidon { state } ->
         (* reduce the state *)
         let reduce_state sys (s : Fp.t Snarky_backendless.Cvar.t array array) :
             V.t array array =
@@ -1762,8 +1788,7 @@ end = struct
               failwith "incorrect number of states given"
         in
         process_5_states_at_a_time ~round:0 (Array.to_list state)
-    | Plonk_constraint.T
-        (EC_add_complete { p1; p2; p3; inf; same_x; slope; inf_z; x21_inv }) ->
+    | EC_add_complete { p1; p2; p3; inf; same_x; slope; inf_z; x21_inv } ->
         let reduce_curve_point (x, y) = (reduce_to_v x, reduce_to_v y) in
 
         (*
@@ -1792,7 +1817,7 @@ end = struct
           |]
         in
         add_row sys vars CompleteAdd [||]
-    | Plonk_constraint.T (EC_scale { state }) ->
+    | EC_scale { state } ->
         let i = ref 0 in
         (*
  0   1   2   3   4   5   6   7   8   9   10  11  12  13  14
@@ -1845,7 +1870,7 @@ end = struct
           ~f:(fun round -> add_ecscale_round round ; incr i)
           (Array.map state ~f:(Scale_round.map ~f:reduce_to_v)) ;
         ()
-    | Plonk_constraint.T (EC_endoscale { state; xs; ys; n_acc }) ->
+    | EC_endoscale { state; xs; ys; n_acc } ->
         (* Reduce state. *)
         let state = Array.map state ~f:(Endoscale_round.map ~f:reduce_to_v) in
         (* Add round function. *)
@@ -1891,8 +1916,7 @@ end = struct
           |]
         in
         add_row sys vars Zero [||]
-    | Plonk_constraint.T
-        (EC_endoscalar { state : 'v Endoscale_scalar_round.t array }) ->
+    | EC_endoscalar { state : 'v Endoscale_scalar_round.t array } ->
         (* Add round function. *)
         let add_endoscale_scalar_round (round : V.t Endoscale_scalar_round.t) =
           let row =
@@ -1919,7 +1943,7 @@ end = struct
           ~f:
             (Fn.compose add_endoscale_scalar_round
                (Endoscale_scalar_round.map ~f:reduce_to_v) )
-    | Plonk_constraint.T (Lookup { w0; w1; w2; w3; w4; w5; w6 }) ->
+    | Lookup { w0; w1; w2; w3; w4; w5; w6 } ->
         (* table ID *)
         let red_w0 = reduce_to_v w0 in
         (* idx1 *)
@@ -1952,25 +1976,24 @@ end = struct
         sys.runtime_lookups_rev <-
           lookup3 :: lookup2 :: lookup1 :: sys.runtime_lookups_rev ;
         add_row sys vars Lookup [||]
-    | Plonk_constraint.T
-        (RangeCheck0
-          { v0
-          ; v0p0
-          ; v0p1
-          ; v0p2
-          ; v0p3
-          ; v0p4
-          ; v0p5
-          ; v0c0
-          ; v0c1
-          ; v0c2
-          ; v0c3
-          ; v0c4
-          ; v0c5
-          ; v0c6
-          ; v0c7
-          ; compact
-          } ) ->
+    | RangeCheck0
+        { v0
+        ; v0p0
+        ; v0p1
+        ; v0p2
+        ; v0p3
+        ; v0p4
+        ; v0p5
+        ; v0c0
+        ; v0c1
+        ; v0c2
+        ; v0c3
+        ; v0c4
+        ; v0c5
+        ; v0c6
+        ; v0c7
+        ; compact
+        } ->
         (*
         //! 0   1   2   3   4   5   6   7   8   9  10  11  12  13  14
         //! v vp0 vp1 vp2 vp3 vp4 vp5 vc0 vc1 vc2 vc3 vc4 vc5 vc6 vc7
@@ -1995,39 +2018,38 @@ end = struct
         in
         let coeff = if Fp.equal compact Fp.one then Fp.one else Fp.zero in
         add_row sys vars RangeCheck0 [| coeff |]
-    | Plonk_constraint.T
-        (RangeCheck1
-          { (* Current row *) v2
-          ; v12
-          ; v2c0
-          ; v2p0
-          ; v2p1
-          ; v2p2
-          ; v2p3
-          ; v2c1
-          ; v2c2
-          ; v2c3
-          ; v2c4
-          ; v2c5
-          ; v2c6
-          ; v2c7
-          ; v2c8
-          ; (* Next row *) v2c9
-          ; v2c10
-          ; v2c11
-          ; v0p0
-          ; v0p1
-          ; v1p0
-          ; v1p1
-          ; v2c12
-          ; v2c13
-          ; v2c14
-          ; v2c15
-          ; v2c16
-          ; v2c17
-          ; v2c18
-          ; v2c19
-          } ) ->
+    | RangeCheck1
+        { (* Current row *) v2
+        ; v12
+        ; v2c0
+        ; v2p0
+        ; v2p1
+        ; v2p2
+        ; v2p3
+        ; v2c1
+        ; v2c2
+        ; v2c3
+        ; v2c4
+        ; v2c5
+        ; v2c6
+        ; v2c7
+        ; v2c8
+        ; (* Next row *) v2c9
+        ; v2c10
+        ; v2c11
+        ; v0p0
+        ; v0p1
+        ; v1p0
+        ; v1p1
+        ; v2c12
+        ; v2c13
+        ; v2c14
+        ; v2c15
+        ; v2c16
+        ; v2c17
+        ; v2c18
+        ; v2c19
+        } ->
         (*
         //!       0      1      2     3    4    5    6     7     8     9    10    11    12   13     14
         //! Curr: v2   v12   v2c0  v2p0 v2p1 v2p2 v2p3  v2c1  v2c2  v2c3  v2c4  v2c5  v2c6 v2c7   v2c8
@@ -2071,24 +2093,23 @@ end = struct
         in
         add_row sys vars_curr RangeCheck1 [||] ;
         add_row sys vars_next Zero [||]
-    | Plonk_constraint.T
-        (Xor
-          { in1
-          ; in2
-          ; out
-          ; in1_0
-          ; in1_1
-          ; in1_2
-          ; in1_3
-          ; in2_0
-          ; in2_1
-          ; in2_2
-          ; in2_3
-          ; out_0
-          ; out_1
-          ; out_2
-          ; out_3
-          } ) ->
+    | Xor
+        { in1
+        ; in2
+        ; out
+        ; in1_0
+        ; in1_1
+        ; in1_2
+        ; in1_3
+        ; in2_0
+        ; in2_1
+        ; in2_2
+        ; in2_3
+        ; out_0
+        ; out_1
+        ; out_2
+        ; out_3
+        } ->
         (* | Column |          Curr    | Next (gadget responsibility) |
            | ------ | ---------------- | ---------------------------- |
            |      0 | copy     `in1`   | copy     `in1'`              |
@@ -2129,21 +2150,20 @@ end = struct
            For that, the first coefficient is 1 and the rest will be zero.
            This will be included in the gadget for a chain of Xors, not here.*)
         add_row sys curr_row Xor16 [||]
-    | Plonk_constraint.T
-        (ForeignFieldAdd
-          { left_input_lo
-          ; left_input_mi
-          ; left_input_hi
-          ; right_input_lo
-          ; right_input_mi
-          ; right_input_hi
-          ; field_overflow
-          ; carry
-          ; (* Coefficients *) foreign_field_modulus0
-          ; foreign_field_modulus1
-          ; foreign_field_modulus2
-          ; sign
-          } ) ->
+    | ForeignFieldAdd
+        { left_input_lo
+        ; left_input_mi
+        ; left_input_hi
+        ; right_input_lo
+        ; right_input_mi
+        ; right_input_hi
+        ; field_overflow
+        ; carry
+        ; (* Coefficients *) foreign_field_modulus0
+        ; foreign_field_modulus1
+        ; foreign_field_modulus2
+        ; sign
+        } ->
         (*
         //! | Gate   | `ForeignFieldAdd`        | Circuit/gadget responsibility  |
         //! | ------ | ------------------------ | ------------------------------ |
@@ -2189,40 +2209,39 @@ end = struct
            ; foreign_field_modulus2
            ; sign
           |]
-    | Plonk_constraint.T
-        (ForeignFieldMul
-          { left_input0
-          ; left_input1
-          ; left_input2
-          ; right_input0
-          ; right_input1
-          ; right_input2
-          ; remainder01
-          ; remainder2
-          ; quotient0
-          ; quotient1
-          ; quotient2
-          ; quotient_hi_bound
-          ; product1_lo
-          ; product1_hi_0
-          ; product1_hi_1
-          ; carry0
-          ; carry1_0
-          ; carry1_12
-          ; carry1_24
-          ; carry1_36
-          ; carry1_48
-          ; carry1_60
-          ; carry1_72
-          ; carry1_84
-          ; carry1_86
-          ; carry1_88
-          ; carry1_90
-          ; (* Coefficients *) foreign_field_modulus2
-          ; neg_foreign_field_modulus0
-          ; neg_foreign_field_modulus1
-          ; neg_foreign_field_modulus2
-          } ) ->
+    | ForeignFieldMul
+        { left_input0
+        ; left_input1
+        ; left_input2
+        ; right_input0
+        ; right_input1
+        ; right_input2
+        ; remainder01
+        ; remainder2
+        ; quotient0
+        ; quotient1
+        ; quotient2
+        ; quotient_hi_bound
+        ; product1_lo
+        ; product1_hi_0
+        ; product1_hi_1
+        ; carry0
+        ; carry1_0
+        ; carry1_12
+        ; carry1_24
+        ; carry1_36
+        ; carry1_48
+        ; carry1_60
+        ; carry1_72
+        ; carry1_84
+        ; carry1_86
+        ; carry1_88
+        ; carry1_90
+        ; (* Coefficients *) foreign_field_modulus2
+        ; neg_foreign_field_modulus0
+        ; neg_foreign_field_modulus1
+        ; neg_foreign_field_modulus2
+        } ->
         (*
           | col | `ForeignFieldMul`       | `Zero`                     |
           | --- | ----------------------- | -------------------------- |
@@ -2287,25 +2306,24 @@ end = struct
            ; neg_foreign_field_modulus2
           |] ;
         add_row sys vars_next Zero [||]
-    | Plonk_constraint.T
-        (Rot64
-          { word
-          ; rotated
-          ; excess
-          ; bound_limb0
-          ; bound_limb1
-          ; bound_limb2
-          ; bound_limb3
-          ; bound_crumb0
-          ; bound_crumb1
-          ; bound_crumb2
-          ; bound_crumb3
-          ; bound_crumb4
-          ; bound_crumb5
-          ; bound_crumb6
-          ; bound_crumb7
-          ; (* Coefficients *) two_to_rot
-          } ) ->
+    | Rot64
+        { word
+        ; rotated
+        ; excess
+        ; bound_limb0
+        ; bound_limb1
+        ; bound_limb2
+        ; bound_limb3
+        ; bound_crumb0
+        ; bound_crumb1
+        ; bound_crumb2
+        ; bound_crumb3
+        ; bound_crumb4
+        ; bound_crumb5
+        ; bound_crumb6
+        ; bound_crumb7
+        ; (* Coefficients *) two_to_rot
+        } ->
         (*
         //! | Gate   | `Rot64`             | `RangeCheck0` gadgets (designer's duty)                   |
         //! | ------ | ------------------- | --------------------------------------------------------- |
@@ -2346,7 +2364,7 @@ end = struct
           |]
         in
         add_row sys vars_curr Rot64 [| two_to_rot |]
-    | Plonk_constraint.T (AddFixedLookupTable { id; data }) -> (
+    | AddFixedLookupTable { id; data } -> (
         match sys.fixed_lookup_tables with
         | Unfinalized_fixed_lookup_tables_rev fixed_lookup_tables ->
             let lt : Fp.t Kimchi_types.lookup_table list =
@@ -2357,7 +2375,7 @@ end = struct
             failwith
               "Trying to add a fixed lookup tables when it has been already \
                finalized" )
-    | Plonk_constraint.T (AddRuntimeTableCfg { id; first_column }) -> (
+    | AddRuntimeTableCfg { id; first_column } -> (
         match sys.runtime_tables_cfg with
         | Unfinalized_runtime_tables_cfg_rev runtime_tables_cfg ->
             let rt_cfg : Fp.t Kimchi_types.runtime_table_cfg list =
@@ -2368,7 +2386,7 @@ end = struct
             failwith
               "Trying to add a runtime table configuration  it has been \
                already finalized" )
-    | Plonk_constraint.T (Raw { kind; values; coeffs }) ->
+    | Raw { kind; values; coeffs } ->
         let values =
           Array.init 15 ~f:(fun i ->
               (* Insert [None] if the index is beyond the end of the [values]
@@ -2377,8 +2395,4 @@ end = struct
               Option.try_with (fun () -> reduce_to_v values.(i)) )
         in
         add_row sys values kind coeffs
-    | constr ->
-        failwithf "Unhandled constraint %s"
-          Obj.(Extension_constructor.name (Extension_constructor.of_val constr))
-          ()
 end

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
@@ -856,8 +856,7 @@ module Make
   val finalize_runtime_lookup_tables : t -> unit
 
   val add_constraint :
-       ?label:string
-    -> t
+       t
     -> ( Fp.t Snarky_backendless.Cvar.t
        , Fp.t )
        Snarky_backendless.Constraint.basic
@@ -1412,7 +1411,7 @@ end = struct
             (Fp.one, `Var res) )
 
   (** Adds a constraint to the constraint system. *)
-  let add_constraint ?label:_ sys
+  let add_constraint sys
       (constr :
         ( Fp.t Snarky_backendless.Cvar.t
         , Fp.t )

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
@@ -722,7 +722,22 @@ module Plonk_constraint = struct
               [ mul cl vl; mul cr vr; mul co vo; mul m (mul vl vr); c ]
           in
           equal zero res
-      | _ ->
+      | Poseidon _
+      | EC_add_complete _
+      | EC_scale _
+      | EC_endoscale _
+      | EC_endoscalar _
+      | Lookup _
+      | RangeCheck0 _
+      | RangeCheck1 _
+      | Xor _
+      | ForeignFieldAdd _
+      | ForeignFieldMul _
+      | Rot64 _
+      | AddFixedLookupTable _
+      | AddRuntimeTableCfg _
+      | Raw _ ->
+          (* Skip validation *)
           true
   end
 end

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
@@ -702,6 +702,15 @@ module Plonk_constraint = struct
 
     let eval (t : t) (eval_one : _ -> Fp.t) =
       match t with
+      | Boolean v ->
+          let x = eval_one v in
+          Fp.(equal x zero || equal x one)
+      | Equal (v1, v2) ->
+          Fp.equal (eval_one v1) (eval_one v2)
+      | R1CS (v1, v2, v3) ->
+          Fp.(equal (mul (eval_one v1) (eval_one v2)) (eval_one v3))
+      | Square (a, c) ->
+          Fp.equal (Fp.square (eval_one a)) (eval_one c)
       (* cl * vl + cr * vr + co * vo + m * vl*vr + c = 0 *)
       | Basic { l = cl, vl; r = cr, vr; o = co, vo; m; c } ->
           let vl = eval_one vl in

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/plonk_constraint_system.ml
@@ -824,6 +824,9 @@ module Make
 
   type nonrec t = (Fp.t, Gates.t) t
 
+  type constraint_ =
+    (Fp.t Snarky_backendless.Cvar.t, Fp.t) Snarky_backendless.Constraint.basic
+
   val create : unit -> t
 
   val get_public_input_size : t -> int Set_once.t
@@ -882,6 +885,9 @@ module Make
   val to_json : t -> string
 end = struct
   open Core_kernel
+
+  type constraint_ =
+    (Fp.t Snarky_backendless.Cvar.t, Fp.t) Snarky_backendless.Constraint.basic
 
   (* Used by compute_witness to build the runtime tables from the Lookup
      constraint *)

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -161,8 +161,6 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let equal_var = Field.Checked.equal
 
-    let m = Snark_params.Tick.m
-
     let make_checked = Snark_params.Tick.make_checked
 
     let var_to_bits_ (t : var) = Field.Checked.unpack ~length:length_in_bits t
@@ -195,7 +193,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       make_checked (fun () ->
           let _, _, actual_packed =
             Pickles.Scalar_challenge.to_field_checked' ~num_bits:length_in_bits
-              m
+              (module Run)
               (Kimchi_backend_common.Scalar_challenge.create t)
           in
           actual_packed )
@@ -209,7 +207,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let%bind actual = image_from_bits_unsafe t in
       with_label "range_check" (fun () -> Field.Checked.Assert.equal actual t)
 
-    let seal x = make_checked (fun () -> Pickles.Util.seal Tick.m x)
+    let seal x = make_checked (fun () -> Pickles.Util.seal (module Run) x)
 
     let modulus_as_field =
       lazy (Fn.apply_n_times ~n:length_in_bits Field.(mul (of_int 2)) Field.one)

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -163,7 +163,8 @@ module Token_symbol = struct
     let%bind actual =
       make_checked (fun () ->
           let _, _, actual_packed =
-            Pickles.Scalar_challenge.to_field_checked' ~num_bits m
+            Pickles.Scalar_challenge.to_field_checked' ~num_bits
+              (module Run)
               (Kimchi_backend_common.Scalar_challenge.create t)
           in
           actual_packed )

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -10,6 +10,10 @@ module Make_checked
 struct
   open Snark_params.Tick
 
+  let m =
+    (module Run : Kimchi_pasta_snarky_backend.Snark_intf
+      with type field = Run.field )
+
   type var = Field.Var.t
 
   let () = assert (Int.(N.length_in_bits < Field.size_in_bits))
@@ -33,7 +37,8 @@ struct
 
   let range_check' (t : var) =
     let _, _, actual_packed =
-      Pickles.Scalar_challenge.to_field_checked' ~num_bits:N.length_in_bits m
+      Pickles.Scalar_challenge.to_field_checked' ~num_bits:N.length_in_bits
+        (module Run)
         (Kimchi_backend_common.Scalar_challenge.create t)
     in
     actual_packed

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -5,9 +5,9 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 let seal i = Tuple_lib.Double.map ~f:(Util.seal i)
 
 let add_fast (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
-      with type field = f ) ?(check_finite = true) ((x1, y1) as p1)
-    ((x2, y2) as p2) : Impl.Field.t * Impl.Field.t =
+    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
+    ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
+    Impl.Field.t * Impl.Field.t =
   let p1 = seal (module Impl) p1 in
   let p2 = seal (module Impl) p2 in
   let open Impl in
@@ -45,13 +45,11 @@ let add_fast (type f)
   let p3 = (x3, y3) in
   with_label "add_fast" (fun () ->
       assert_
-        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-           (EC_add_complete
-              { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } ) ) ;
+        (EC_add_complete { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv }) ;
       p3 )
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl
@@ -121,9 +119,7 @@ struct
         }
         :: !rounds_rev
     done ;
-    assert_
-      (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-         (EC_scale { state = Array.of_list_rev !rounds_rev }) ) ;
+    assert_ (EC_scale { state = Array.of_list_rev !rounds_rev }) ;
     (* TODO: Return n_acc ? *)
     !acc
 
@@ -193,9 +189,7 @@ struct
         }
         :: !rounds_rev
     done ;
-    assert_
-      (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-         (EC_scale { state = Array.of_list_rev !rounds_rev }) ) ;
+    assert_ (EC_scale { state = Array.of_list_rev !rounds_rev }) ;
     Field.Assert.equal !n_acc scalar ;
     let bits_lsb =
       let bs = Array.map bits_msb ~f:Boolean.Unsafe.of_cvar in

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -5,9 +5,9 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 let seal i = Tuple_lib.Double.map ~f:(Util.seal i)
 
 let add_fast (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-    ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
-    Impl.Field.t * Impl.Field.t =
+    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
+      with type field = f ) ?(check_finite = true) ((x1, y1) as p1)
+    ((x2, y2) as p2) : Impl.Field.t * Impl.Field.t =
   let p1 = seal (module Impl) p1 in
   let p2 = seal (module Impl) p2 in
   let open Impl in
@@ -51,7 +51,7 @@ let add_fast (type f)
       p3 )
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -45,12 +45,9 @@ let add_fast (type f)
   let p3 = (x3, y3) in
   with_label "add_fast" (fun () ->
       assert_
-        { Snarky_backendless.Constraint.annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (EC_add_complete
-                 { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } )
-        } ;
+        (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+           (EC_add_complete
+              { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } ) ) ;
       p3 )
 
 module Make
@@ -125,11 +122,8 @@ struct
         :: !rounds_rev
     done ;
     assert_
-      { Snarky_backendless.Constraint.annotation = Some __LOC__
-      ; basic =
-          Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-            (EC_scale { state = Array.of_list_rev !rounds_rev })
-      } ;
+      (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+         (EC_scale { state = Array.of_list_rev !rounds_rev }) ) ;
     (* TODO: Return n_acc ? *)
     !acc
 
@@ -200,11 +194,8 @@ struct
         :: !rounds_rev
     done ;
     assert_
-      { Snarky_backendless.Constraint.annotation = Some __LOC__
-      ; basic =
-          Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-            (EC_scale { state = Array.of_list_rev !rounds_rev })
-      } ;
+      (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+         (EC_scale { state = Array.of_list_rev !rounds_rev }) ) ;
     Field.Assert.equal !n_acc scalar ;
     let bits_lsb =
       let bs = Array.map bits_msb ~f:Boolean.Unsafe.of_cvar in

--- a/src/lib/pickles/plonk_curve_ops.mli
+++ b/src/lib/pickles/plonk_curve_ops.mli
@@ -1,12 +1,13 @@
 val add_fast :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+     (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> ?check_finite:bool
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) : sig
   type var := Impl.field Snarky_backendless.Cvar.t
 

--- a/src/lib/pickles/plonk_curve_ops.mli
+++ b/src/lib/pickles/plonk_curve_ops.mli
@@ -1,13 +1,12 @@
 val add_fast :
-     (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+     (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> ?check_finite:bool
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) : sig
   type var := Impl.field Snarky_backendless.Cvar.t
 

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -118,12 +118,8 @@ let to_field_checked' (type f) ?(num_bits = num_bits)
   done ;
   with_label __LOC__ (fun () ->
       assert_
-        Snarky_backendless.Constraint.
-          { annotation = Some __LOC__
-          ; basic =
-              Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
-                T (EC_endoscalar { state = Array.of_list_rev !state }))
-          } ) ;
+        Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
+          T (EC_endoscalar { state = Array.of_list_rev !state })) ) ;
   (!a, !b, !n)
 
 let to_field_checked (type f) ?num_bits
@@ -257,17 +253,14 @@ struct
     let xs, ys = !acc in
     with_label __LOC__ (fun () ->
         assert_
-          { annotation = Some __LOC__
-          ; basic =
-              Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
-                T
-                  (EC_endoscale
-                     { xs
-                     ; ys
-                     ; n_acc = !n_acc
-                     ; state = Array.of_list_rev !rounds_rev
-                     } ))
-          } ) ;
+          Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
+            T
+              (EC_endoscale
+                 { xs
+                 ; ys
+                 ; n_acc = !n_acc
+                 ; state = Array.of_list_rev !rounds_rev
+                 } )) ) ;
     with_label __LOC__ (fun () -> Field.Assert.equal !n_acc scalar) ;
     !acc
 

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -10,8 +10,8 @@ let num_bits = 128
 
 (* Has the side effect of checking that [scalar] fits in 128 bits. *)
 let to_field_checked' (type f) ?(num_bits = num_bits)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-    { SC.inner = (scalar : Impl.Field.t) } =
+    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
+      with type field = f ) { SC.inner = (scalar : Impl.Field.t) } =
   let open Impl in
   let neg_one = Field.Constant.(negate one) in
   let a_func = function
@@ -123,8 +123,9 @@ let to_field_checked' (type f) ?(num_bits = num_bits)
   (!a, !b, !n)
 
 let to_field_checked (type f) ?num_bits
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) ~endo
-    ({ SC.inner = (scalar : Impl.Field.t) } as s) =
+    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
+      with type field = f ) ~endo ({ SC.inner = (scalar : Impl.Field.t) } as s)
+    =
   let open Impl in
   let a, b, n = to_field_checked' ?num_bits (module Impl) s in
   Field.Assert.equal n scalar ;
@@ -147,7 +148,7 @@ let to_field_constant (type f) ~endo
   F.((!a * endo) + !b)
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
     (Challenge : Challenge.S with module Impl := Impl) (Endo : sig
       val base : Impl.Field.Constant.t

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -16,8 +16,7 @@ val to_field_constant :
 *)
 val to_field_checked' :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
      * 'f Snarky_backendless.Cvar.t
@@ -25,14 +24,13 @@ val to_field_checked' :
 
 val to_field_checked :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> endo:'f
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
 
 module Make : functor
-  (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
+  (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
   (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
   (Challenge : Import.Challenge.S with module Impl := Impl)
   (_ : sig

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -16,7 +16,8 @@ val to_field_constant :
 *)
 val to_field_checked' :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
      * 'f Snarky_backendless.Cvar.t
@@ -24,13 +25,14 @@ val to_field_checked' :
 
 val to_field_checked :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> endo:'f
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
 
 module Make : functor
-  (Impl : Snarky_backendless.Snark_intf.Run)
+  (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
   (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
   (Challenge : Import.Challenge.S with module Impl := Impl)
   (_ : sig

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -1,5 +1,5 @@
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint) (B : sig
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf) (B : sig
       open Impl
 
       val params : field Sponge.Params.t
@@ -46,8 +46,7 @@ struct
         in
         t.(0) <- init ;
         (let open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint in
-        with_label __LOC__ (fun () ->
-            Impl.assert_ (T (Poseidon { state = t })) )) ;
+        with_label __LOC__ (fun () -> Impl.assert_ (Poseidon { state = t }))) ;
         t.(Int.(Array.length t - 1)) )
 
   let add_assign ~state i x =

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -47,10 +47,7 @@ struct
         t.(0) <- init ;
         (let open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint in
         with_label __LOC__ (fun () ->
-            Impl.assert_
-              { basic = T (Poseidon { state = t })
-              ; annotation = Some "plonk-poseidon"
-              } )) ;
+            Impl.assert_ (T (Poseidon { state = t })) )) ;
         t.(Int.(Array.length t - 1)) )
 
   let add_assign ~state i x =

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -1,5 +1,5 @@
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run) (B : sig
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint) (B : sig
       open Impl
 
       val params : field Sponge.Params.t

--- a/src/lib/pickles/sponge_inputs.mli
+++ b/src/lib/pickles/sponge_inputs.mli
@@ -10,7 +10,7 @@
 *)
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint) (_ : sig
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf) (_ : sig
       (** The parameters of the permutation *)
       val params : Impl.field Sponge.Params.t
 

--- a/src/lib/pickles/sponge_inputs.mli
+++ b/src/lib/pickles/sponge_inputs.mli
@@ -10,7 +10,7 @@
 *)
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run) (_ : sig
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint) (_ : sig
       (** The parameters of the permutation *)
       val params : Impl.field Sponge.Params.t
 

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -11,6 +11,7 @@ module Make
     (Inputs : Intf.Step_main_inputs.S
                 with type Impl.field = Backend.Tick.Field.t
                  and type Impl.Bigint.t = Backend.Tick.Bigint.t
+                 and type Impl.Constraint.t = Backend.Tick.Constraint.t
                  and type 'a Impl.Internal_Basic.Checked.t =
                   'a Step_main_inputs.Impl.Internal_Basic.Checked.t
                  and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -34,22 +34,19 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  (Kimchi_backend_common.Plonk_constraint_system
-                   .Plonk_constraint
-                   .T
-                     (Raw
-                        { kind = Generic
-                        ; values =
-                            [| fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                            |]
-                        ; coeffs = [||]
-                        } ) ) ;
+                  (Raw
+                     { kind = Generic
+                     ; values =
+                         [| fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                         |]
+                     ; coeffs = [||]
+                     } ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -34,25 +34,22 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  { basic =
-                      Kimchi_backend_common.Plonk_constraint_system
-                      .Plonk_constraint
-                      .T
-                        (Raw
-                           { kind = Generic
-                           ; values =
-                               [| fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                               |]
-                           ; coeffs = [||]
-                           } )
-                  ; annotation = Some __LOC__
-                  } ;
+                  (Kimchi_backend_common.Plonk_constraint_system
+                   .Plonk_constraint
+                   .T
+                     (Raw
+                        { kind = Generic
+                        ; values =
+                            [| fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                            |]
+                        ; coeffs = [||]
+                        } ) ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/chunked_circuits/chunks4.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks4.ml
@@ -35,22 +35,19 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  (Kimchi_backend_common.Plonk_constraint_system
-                   .Plonk_constraint
-                   .T
-                     (Raw
-                        { kind = Generic
-                        ; values =
-                            [| fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                            |]
-                        ; coeffs = [||]
-                        } ) ) ;
+                  (Raw
+                     { kind = Generic
+                     ; values =
+                         [| fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                         |]
+                     ; coeffs = [||]
+                     } ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/chunked_circuits/chunks4.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks4.ml
@@ -35,25 +35,22 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  { basic =
-                      Kimchi_backend_common.Plonk_constraint_system
-                      .Plonk_constraint
-                      .T
-                        (Raw
-                           { kind = Generic
-                           ; values =
-                               [| fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                               |]
-                           ; coeffs = [||]
-                           } )
-                  ; annotation = Some __LOC__
-                  } ;
+                  (Kimchi_backend_common.Plonk_constraint_system
+                   .Plonk_constraint
+                   .T
+                     (Raw
+                        { kind = Generic
+                        ; values =
+                            [| fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                            |]
+                        ; coeffs = [||]
+                        } ) ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/chunked_circuits/chunks8.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks8.ml
@@ -35,22 +35,19 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  (Kimchi_backend_common.Plonk_constraint_system
-                   .Plonk_constraint
-                   .T
-                     (Raw
-                        { kind = Generic
-                        ; values =
-                            [| fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                             ; fresh_zero
-                            |]
-                        ; coeffs = [||]
-                        } ) ) ;
+                  (Raw
+                     { kind = Generic
+                     ; values =
+                         [| fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                          ; fresh_zero
+                         |]
+                     ; coeffs = [||]
+                     } ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/chunked_circuits/chunks8.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks8.ml
@@ -35,25 +35,22 @@ let test () =
                 *)
                 let fresh_zero = fresh_zero () in
                 Impl.assert_
-                  { basic =
-                      Kimchi_backend_common.Plonk_constraint_system
-                      .Plonk_constraint
-                      .T
-                        (Raw
-                           { kind = Generic
-                           ; values =
-                               [| fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                                ; fresh_zero
-                               |]
-                           ; coeffs = [||]
-                           } )
-                  ; annotation = Some __LOC__
-                  } ;
+                  (Kimchi_backend_common.Plonk_constraint_system
+                   .Plonk_constraint
+                   .T
+                     (Raw
+                        { kind = Generic
+                        ; values =
+                            [| fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                             ; fresh_zero
+                            |]
+                        ; coeffs = [||]
+                        } ) ) ;
                 { previous_proof_statements = []
                 ; public_output = ()
                 ; auxiliary_output = ()

--- a/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
+++ b/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
@@ -6,7 +6,7 @@ let () = Pickles.Backend.Tick.Keypair.set_urs_info []
 
 let () = Pickles.Backend.Tock.Keypair.set_urs_info []
 
-let add_constraint c = assert_ { basic = c; annotation = None }
+let add_constraint c = assert_ c
 
 let add_plonk_constraint c =
   add_constraint

--- a/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
+++ b/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
@@ -8,9 +8,7 @@ let () = Pickles.Backend.Tock.Keypair.set_urs_info []
 
 let add_constraint c = assert_ c
 
-let add_plonk_constraint c =
-  add_constraint
-    (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T c)
+let add_plonk_constraint c = add_constraint c
 
 let fresh_int i = exists Field.typ ~compute:(fun () -> Field.Constant.of_int i)
 

--- a/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
@@ -10,9 +10,9 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
 open Pickles.Impls.Step
 
-let add_constraint c = assert_ { basic = T c; annotation = None }
+let add_constraint c = assert_ (T c)
 
-let add_plonk_constraint c = assert_ { basic = T c; annotation = None }
+let add_plonk_constraint c = add_constraint c
 
 let etyp_unit =
   Composition_types.Spec.Step_etyp.T

--- a/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_fix_domains.ml
@@ -10,7 +10,7 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
 open Pickles.Impls.Step
 
-let add_constraint c = assert_ (T c)
+let add_constraint c = assert_ c
 
 let add_plonk_constraint c = add_constraint c
 

--- a/src/lib/pickles/test/optional_custom_gates/test_gadgets/pickles_optional_custom_gates_circuits.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_gadgets/pickles_optional_custom_gates_circuits.ml
@@ -4,9 +4,7 @@ open Pickles.Impls.Step
 
 let add_constraint c = assert_ c
 
-let add_plonk_constraint c =
-  add_constraint
-    (Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T c)
+let add_plonk_constraint c = add_constraint c
 
 let fresh_int i = exists Field.typ ~compute:(fun () -> Field.Constant.of_int i)
 

--- a/src/lib/pickles/test/optional_custom_gates/test_gadgets/pickles_optional_custom_gates_circuits.ml
+++ b/src/lib/pickles/test/optional_custom_gates/test_gadgets/pickles_optional_custom_gates_circuits.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Pickles_types
 open Pickles.Impls.Step
 
-let add_constraint c = assert_ { basic = c; annotation = None }
+let add_constraint c = assert_ c
 
 let add_plonk_constraint c =
   add_constraint

--- a/src/lib/pickles/test/test_plonk_curve_ops.ml
+++ b/src/lib/pickles/test/test_plonk_curve_ops.ml
@@ -8,7 +8,7 @@
 *)
 
 module Test_make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
     (G : Pickles__Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl

--- a/src/lib/pickles/test/test_plonk_curve_ops.ml
+++ b/src/lib/pickles/test/test_plonk_curve_ops.ml
@@ -8,7 +8,7 @@
 *)
 
 module Test_make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Pickles__Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl

--- a/src/lib/pickles/test/test_scalar_challenge.ml
+++ b/src/lib/pickles/test/test_scalar_challenge.ml
@@ -10,7 +10,7 @@ module SC = Pickles__Import.Scalar_challenge
 module Scalar_challenge = Pickles__Scalar_challenge
 
 module Test_make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
     (G : Pickles__Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
     (Challenge : Pickles__Import.Challenge.S with module Impl := Impl)
     (Endo : sig

--- a/src/lib/pickles/test/test_scalar_challenge.ml
+++ b/src/lib/pickles/test/test_scalar_challenge.ml
@@ -10,7 +10,7 @@ module SC = Pickles__Import.Scalar_challenge
 module Scalar_challenge = Pickles__Scalar_challenge
 
 module Test_make
-    (Impl : Snarky_backendless.Snark_intf.Run_with_constraint)
+    (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Pickles__Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
     (Challenge : Pickles__Import.Challenge.S with module Impl := Impl)
     (Endo : sig

--- a/src/lib/pickles/util.ml
+++ b/src/lib/pickles/util.ml
@@ -48,8 +48,7 @@ let rec absorb :
 let ones_vector :
     type f n.
        first_zero:f Snarky_backendless.Cvar.t
-    -> (module Snarky_backendless.Snark_intf.Run_with_constraint
-          with type field = f )
+    -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
     -> n Nat.t
     -> (f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t, n) Vector.t =
  fun ~first_zero (module Impl) n ->
@@ -69,8 +68,8 @@ let ones_vector :
   go Boolean.true_ 0 n
 
 let seal (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
-      with type field = f ) (x : Impl.Field.t) : Impl.Field.t =
+    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
+    (x : Impl.Field.t) : Impl.Field.t =
   let open Impl in
   match Field.to_constant_and_terms x with
   | None, [ (x, i) ] when Field.Constant.(equal x one) ->
@@ -82,8 +81,8 @@ let seal (type f)
       Field.Assert.equal x y ; y
 
 let lowest_128_bits (type f) ~constrain_low_bits ~assert_128_bits
-    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
-      with type field = f ) x =
+    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f) x
+    =
   let open Impl in
   let pow2 =
     (* 2 ^ n *)

--- a/src/lib/pickles/util.ml
+++ b/src/lib/pickles/util.ml
@@ -48,7 +48,8 @@ let rec absorb :
 let ones_vector :
     type f n.
        first_zero:f Snarky_backendless.Cvar.t
-    -> (module Snarky_backendless.Snark_intf.Run with type field = f)
+    -> (module Snarky_backendless.Snark_intf.Run_with_constraint
+          with type field = f )
     -> n Nat.t
     -> (f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t, n) Vector.t =
  fun ~first_zero (module Impl) n ->
@@ -68,8 +69,8 @@ let ones_vector :
   go Boolean.true_ 0 n
 
 let seal (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-    (x : Impl.Field.t) : Impl.Field.t =
+    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
+      with type field = f ) (x : Impl.Field.t) : Impl.Field.t =
   let open Impl in
   match Field.to_constant_and_terms x with
   | None, [ (x, i) ] when Field.Constant.(equal x one) ->
@@ -81,7 +82,8 @@ let seal (type f)
       Field.Assert.equal x y ; y
 
 let lowest_128_bits (type f) ~constrain_low_bits ~assert_128_bits
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) x =
+    (module Impl : Snarky_backendless.Snark_intf.Run_with_constraint
+      with type field = f ) x =
   let open Impl in
   let pow2 =
     (* 2 ^ n *)

--- a/src/lib/pickles/util.mli
+++ b/src/lib/pickles/util.mli
@@ -13,23 +13,20 @@ val absorb :
 val ones_vector :
   'f 'n.
      first_zero:'f Snarky_backendless.Cvar.t
-  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> 'n Pickles_types.Nat.t
   -> ( 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
      , 'n )
      Pickles_types.Vector.t
 
 val seal :
-     (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+     (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t
 
 val lowest_128_bits :
      constrain_low_bits:bool
   -> assert_128_bits:('f Snarky_backendless.Cvar.t -> unit)
-  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
-        with type field = 'f )
+  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t

--- a/src/lib/pickles/util.mli
+++ b/src/lib/pickles/util.mli
@@ -13,20 +13,23 @@ val absorb :
 val ones_vector :
   'f 'n.
      first_zero:'f Snarky_backendless.Cvar.t
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> 'n Pickles_types.Nat.t
   -> ( 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
      , 'n )
      Pickles_types.Vector.t
 
 val seal :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+     (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t
 
 val lowest_128_bits :
      constrain_low_bits:bool
   -> assert_128_bits:('f Snarky_backendless.Cvar.t -> unit)
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> (module Snarky_backendless.Snark_intf.Run_with_constraint
+        with type field = 'f )
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -49,6 +49,7 @@ module Make
     (Inputs : Intf.Wrap_main_inputs.S
                 with type Impl.field = Backend.Tock.Field.t
                  and type Impl.Bigint.t = Backend.Tock.Bigint.t
+                 and type Impl.Constraint.t = Backend.Tock.Constraint.t
                  and type 'a Impl.Internal_Basic.Checked.t =
                   'a Wrap_main_inputs.Impl.Internal_Basic.Checked.t
                  and type ('var, 'value, 'aux) Impl.Internal_Basic.Typ.typ' =

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -1421,14 +1421,13 @@ struct
                 (* 0 = - acc' + y + pt_n_acc *)
                 let open Field.Constant in
                 assert_
-                  (T
-                     (Basic
-                        { l = (one, y)
-                        ; r = (one, pt_n_acc)
-                        ; o = (negate one, acc')
-                        ; m = zero
-                        ; c = zero
-                        } ) ) ;
+                  (Basic
+                     { l = (one, y)
+                     ; r = (one, pt_n_acc)
+                     ; o = (negate one, acc')
+                     ; m = zero
+                     ; c = zero
+                     } ) ;
                 acc' )
         | [] ->
             failwith "empty list" )

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -1420,17 +1420,14 @@ struct
                 (* 0 = - acc' + y + pt_n_acc *)
                 let open Field.Constant in
                 assert_
-                  { annotation = None
-                  ; basic =
-                      T
-                        (Basic
-                           { l = (one, y)
-                           ; r = (one, pt_n_acc)
-                           ; o = (negate one, acc')
-                           ; m = zero
-                           ; c = zero
-                           } )
-                  } ;
+                  (T
+                     (Basic
+                        { l = (one, y)
+                        ; r = (one, pt_n_acc)
+                        ; o = (negate one, acc')
+                        ; m = zero
+                        ; c = zero
+                        } ) ) ;
                 acc' )
         | [] ->
             failwith "empty list" )

--- a/src/lib/snarky_group_map/checked_map.ml
+++ b/src/lib/snarky_group_map/checked_map.ml
@@ -37,8 +37,9 @@ module Aux (Impl : Snarky_backendless.Snark_intf.Run) = struct
     (sqrt_exn (Field.if_ is_square ~then_:x ~else_:(Field.scale x m)), is_square)
 end
 
-let wrap (type f) ((module Impl) : f Snarky_backendless.Snark0.m) ~potential_xs
-    ~y_squared =
+let wrap (type f)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    ~potential_xs ~y_squared =
   let open Impl in
   let module A = Aux (Impl) in
   let open A in
@@ -55,7 +56,7 @@ let wrap (type f) ((module Impl) : f Snarky_backendless.Snark0.m) ~potential_xs
       , Field.((x1_is_first * y1) + (x2_is_first * y2) + (x3_is_first * y3)) ) )
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run_with_constraint) (P : sig
+    (M : Snarky_backendless.Snark_intf.Run) (P : sig
       val params : M.field Group_map.Params.t
     end) =
 struct

--- a/src/lib/snarky_group_map/checked_map.ml
+++ b/src/lib/snarky_group_map/checked_map.ml
@@ -55,7 +55,7 @@ let wrap (type f) ((module Impl) : f Snarky_backendless.Snark0.m) ~potential_xs
       , Field.((x1_is_first * y1) + (x2_is_first * y2) + (x3_is_first * y3)) ) )
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run) (P : sig
+    (M : Snarky_backendless.Snark_intf.Run_with_constraint) (P : sig
       val params : M.field Group_map.Params.t
     end) =
 struct

--- a/src/lib/snarky_group_map/checked_map.mli
+++ b/src/lib/snarky_group_map/checked_map.mli
@@ -8,7 +8,7 @@ val wrap :
   -> ('input -> 'f Cvar.t * 'f Cvar.t) Staged.t
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run) (Params : sig
+    (M : Snarky_backendless.Snark_intf.Run_with_constraint) (Params : sig
       val params : M.field Group_map.Params.t
     end) : sig
   val to_group : M.Field.t -> M.Field.t * M.Field.t

--- a/src/lib/snarky_group_map/checked_map.mli
+++ b/src/lib/snarky_group_map/checked_map.mli
@@ -2,13 +2,13 @@ open Core_kernel
 open Snarky_backendless
 
 val wrap :
-     'f Snark.m
+     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
   -> potential_xs:('input -> 'f Cvar.t * 'f Cvar.t * 'f Cvar.t)
   -> y_squared:(x:'f Cvar.t -> 'f Cvar.t)
   -> ('input -> 'f Cvar.t * 'f Cvar.t) Staged.t
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run_with_constraint) (Params : sig
+    (M : Snarky_backendless.Snark_intf.Run) (Params : sig
       val params : M.field Group_map.Params.t
     end) : sig
   val to_group : M.Field.t -> M.Field.t * M.Field.t

--- a/src/lib/snarky_group_map/snarky_group_map.ml
+++ b/src/lib/snarky_group_map/snarky_group_map.ml
@@ -29,9 +29,8 @@ module Checked = struct
 
   let wrap = Checked_map.wrap
 
-  let to_group (type f)
-      (module M : Snark_intf.Run_with_constraint with type field = f) ~params t
-      =
+  let to_group (type f) (module M : Snark_intf.Run with type field = f) ~params
+      t =
     let module G =
       Checked_map.Make
         (M)

--- a/src/lib/snarky_group_map/snarky_group_map.ml
+++ b/src/lib/snarky_group_map/snarky_group_map.ml
@@ -29,8 +29,9 @@ module Checked = struct
 
   let wrap = Checked_map.wrap
 
-  let to_group (type f) (module M : Snark_intf.Run with type field = f) ~params
-      t =
+  let to_group (type f)
+      (module M : Snark_intf.Run_with_constraint with type field = f) ~params t
+      =
     let module G =
       Checked_map.Make
         (M)

--- a/src/lib/snarky_group_map/snarky_group_map.mli
+++ b/src/lib/snarky_group_map/snarky_group_map.mli
@@ -23,7 +23,7 @@ module Checked : sig
     -> ('input -> 'f Cvar.t * 'f Cvar.t) Core_kernel.Staged.t
 
   val to_group :
-       (module Snark_intf.Run with type field = 'f)
+       (module Snark_intf.Run_with_constraint with type field = 'f)
     -> params:'f Params.t
     -> 'f Cvar.t
     -> 'f Cvar.t * 'f Cvar.t

--- a/src/lib/snarky_group_map/snarky_group_map.mli
+++ b/src/lib/snarky_group_map/snarky_group_map.mli
@@ -17,13 +17,13 @@ module Checked : sig
   open Snarky_backendless
 
   val wrap :
-       'f Snark.m
+       (module Snark_intf.Run with type field = 'f)
     -> potential_xs:('input -> 'f Cvar.t * 'f Cvar.t * 'f Cvar.t)
     -> y_squared:(x:'f Cvar.t -> 'f Cvar.t)
     -> ('input -> 'f Cvar.t * 'f Cvar.t) Core_kernel.Staged.t
 
   val to_group :
-       (module Snark_intf.Run_with_constraint with type field = 'f)
+       (module Snark_intf.Run with type field = 'f)
     -> params:'f Params.t
     -> 'f Cvar.t
     -> 'f Cvar.t * 'f Cvar.t


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16448, pulling in the changes in https://github.com/o1-labs/snarky/pull/859 to allow us to feed the constraints cleanly through the FFI to the o1rs backend.