### PR TITLE
Tidy up some pickles interfaces

### DIFF
--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/intf.ml
@@ -29,32 +29,28 @@ end
 module type Full = sig
   type fp
 
+  type field_var
+
   type gates
 
   module Constraint : sig
     type t =
-      ( fp Snarky_backendless.Cvar.t
+      ( field_var
       , fp )
       Kimchi_pasta_snarky_backend.Plonk_constraint_system.Plonk_constraint.basic
     [@@deriving sexp]
 
-    val boolean : fp Snarky_backendless.Cvar.t -> t
+    val boolean : field_var -> t
 
-    val equal :
-      fp Snarky_backendless.Cvar.t -> fp Snarky_backendless.Cvar.t -> t
+    val equal : field_var -> field_var -> t
 
-    val r1cs :
-         fp Snarky_backendless.Cvar.t
-      -> fp Snarky_backendless.Cvar.t
-      -> fp Snarky_backendless.Cvar.t
-      -> t
+    val r1cs : field_var -> field_var -> field_var -> t
 
-    val square :
-      fp Snarky_backendless.Cvar.t -> fp Snarky_backendless.Cvar.t -> t
+    val square : field_var -> field_var -> t
 
-    val eval : t -> (fp Snarky_backendless.Cvar.t -> fp) -> bool
+    val eval : t -> (field_var -> fp) -> bool
 
-    val log_constraint : t -> (fp Snarky_backendless.Cvar.t -> fp) -> string
+    val log_constraint : t -> (field_var -> fp) -> string
   end
 
   type constraint_ = Constraint.t

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/pallas_constraint_system.mli
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/pallas_constraint_system.mli
@@ -1,4 +1,5 @@
 include
   Intf.Full
     with type fp := Kimchi_pasta_basic.Fq.t
+    with type field_var := Kimchi_pasta_basic.Fq.t Snarky_backendless.Cvar.t
      and type gates := Kimchi_bindings.Protocol.Gates.Vector.Fq.t

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/vesta_constraint_system.mli
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/vesta_constraint_system.mli
@@ -1,4 +1,5 @@
 include
   Intf.Full
     with type fp := Kimchi_pasta_basic.Fp.t
+    with type field_var := Kimchi_pasta_basic.Fp.t Snarky_backendless.Cvar.t
      and type gates := Kimchi_bindings.Protocol.Gates.Vector.Fp.t

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -143,10 +143,8 @@ module Step = struct
 
   type 'proofs_verified statement_var =
     ( (unfinalized_proof_var, 'proofs_verified) Pickles_types.Vector.t
-    , Impl.field Snarky_backendless.Cvar.t
-    , ( Impl.field Snarky_backendless.Cvar.t
-      , 'proofs_verified )
-      Pickles_types.Vector.t )
+    , Impl.Field.t
+    , (Impl.Field.t, 'proofs_verified) Pickles_types.Vector.t )
     Import.Types.Step.Statement.t
 
   let input ~proofs_verified =

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -134,19 +134,16 @@ module Wrap : sig
          , Impl.Field.t Composition_types.Scalar_challenge.t
          , Impl.Field.t Pickles_types.Shifted_value.Type1.t
          , ( Impl.Field.t Pickles_types.Shifted_value.Type1.t
-           , Impl.Field.t
-             Snarky_backendless.Snark_intf.Boolean0.t )
+           , Impl.Field.t Snarky_backendless.Snark_intf.Boolean0.t )
            Pickles_types.Opt.t
          , ( Impl.Field.t Composition_types.Scalar_challenge.t
-           , Impl.Field.t
-             Snarky_backendless.Snark_intf.Boolean0.t )
+           , Impl.Field.t Snarky_backendless.Snark_intf.Boolean0.t )
            Pickles_types.Opt.t
          , Impl.Boolean.var
          , Impl.Field.t
          , Impl.Field.t
          , Impl.Field.t
-         , ( Impl.Field.t
-             Kimchi_backend_common.Scalar_challenge.t
+         , ( Impl.Field.t Kimchi_backend_common.Scalar_challenge.t
              Composition_types.Bulletproof_challenge.t
            , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
            Pickles_types.Vector.t

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -74,8 +74,8 @@ module Step : sig
 
   type 'proofs_verified statement_var =
     ( (unfinalized_proof_var, 'proofs_verified) Vector.t
-    , Impl.field Snarky_backendless.Cvar.t
-    , (Impl.field Snarky_backendless.Cvar.t, 'proofs_verified) Vector.t )
+    , Impl.Field.t
+    , (Impl.Field.t, 'proofs_verified) Vector.t )
     Import.Types.Step.Statement.t
 
   val input :
@@ -134,23 +134,23 @@ module Wrap : sig
          , Impl.Field.t Composition_types.Scalar_challenge.t
          , Impl.Field.t Pickles_types.Shifted_value.Type1.t
          , ( Impl.Field.t Pickles_types.Shifted_value.Type1.t
-           , Impl.field Snarky_backendless.Cvar.t
+           , Impl.Field.t
              Snarky_backendless.Snark_intf.Boolean0.t )
            Pickles_types.Opt.t
          , ( Impl.Field.t Composition_types.Scalar_challenge.t
-           , Impl.field Snarky_backendless.Cvar.t
+           , Impl.Field.t
              Snarky_backendless.Snark_intf.Boolean0.t )
            Pickles_types.Opt.t
          , Impl.Boolean.var
-         , Impl.field Snarky_backendless.Cvar.t
-         , Impl.field Snarky_backendless.Cvar.t
-         , Impl.field Snarky_backendless.Cvar.t
-         , ( Impl.field Snarky_backendless.Cvar.t
+         , Impl.Field.t
+         , Impl.Field.t
+         , Impl.Field.t
+         , ( Impl.Field.t
              Kimchi_backend_common.Scalar_challenge.t
              Composition_types.Bulletproof_challenge.t
            , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
            Pickles_types.Vector.t
-         , Impl.field Snarky_backendless.Cvar.t )
+         , Impl.Field.t )
          Import.Types.Wrap.Statement.In_circuit.t
        , ( Limb_vector.Challenge.Constant.t
          , Limb_vector.Challenge.Constant.t Composition_types.Scalar_challenge.t

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -54,8 +54,7 @@ module Make : functor
 
   val num_bits : int
 
-  val seal :
-    Impl.Field.t -> Impl.Field.t
+  val seal : Impl.Field.t -> Impl.Field.t
 
   val endo :
        ?num_bits:int

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -55,11 +55,11 @@ module Make : functor
   val num_bits : int
 
   val seal :
-    Impl.field Snarky_backendless.Cvar.t -> Impl.field Snarky_backendless.Cvar.t
+    Impl.Field.t -> Impl.Field.t
 
   val endo :
        ?num_bits:int
-    -> Impl.field Snarky_backendless.Cvar.t Tuple_lib.Double.t
+    -> Impl.Field.t Tuple_lib.Double.t
     -> Impl.Field.t Import.Scalar_challenge.t
     -> G.t
 

--- a/src/lib/pickles/side_loaded_verification_key.mli
+++ b/src/lib/pickles/side_loaded_verification_key.mli
@@ -61,9 +61,7 @@ module Checked : sig
   [@@deriving hlist, fields]
 
   val to_input :
-       t
-    -> Pasta_bindings.Fp.t Snarky_backendless.Cvar.t
-       Random_oracle_input.Chunked.t
+    t -> Step_main_inputs.Impl.Field.t Random_oracle_input.Chunked.t
 end
 
 module Vk : sig

--- a/src/lib/pickles/step_main_inputs.mli
+++ b/src/lib/pickles/step_main_inputs.mli
@@ -34,113 +34,66 @@ module Sponge : sig
 end
 
 module Inner_curve : sig
-  module Inputs : sig
-    module Impl = Impl.Impl
+  module Params : sig
+    val a : Impl.Field.Constant.t
 
-    module Params : sig
-      val a : Kimchi_pasta.Basic.Fp.t
+    val b : Impl.Field.Constant.t
 
-      val b : Kimchi_pasta.Basic.Fp.t
+    val one : Impl.Field.Constant.t * Impl.Field.Constant.t
 
-      val one : Kimchi_pasta.Basic.Fp.t * Kimchi_pasta.Basic.Fp.t
-
-      val group_size_in_bits : int
-    end
-
-    module F : sig
-      type t = Impl.Field.t
-
-      val ( * ) : t -> t -> t
-
-      val ( + ) : t -> t -> t
-
-      val ( - ) : t -> t -> t
-
-      val inv_exn : t -> t
-
-      val square : t -> t
-
-      val negate : t -> t
-
-      module Constant : sig
-        type t = Impl.Field.Constant.t
-
-        val ( * ) : t -> t -> t
-
-        val ( + ) : t -> t -> t
-
-        val ( - ) : t -> t -> t
-
-        val inv_exn : t -> t
-
-        val square : t -> t
-
-        val negate : t -> t
-      end
-
-      val assert_square : t -> t -> unit
-
-      val assert_r1cs : t -> t -> t -> unit
-    end
-
-    module Constant : sig
-      include module type of Kimchi_pasta.Pasta.Pallas.Affine
-
-      module Scalar = Impls.Wrap.Field.Constant
-
-      val scale : t -> Scalar.t -> t
-
-      val random : unit -> t
-
-      val zero : Impl.Field.Constant.t * Impl.Field.Constant.t
-
-      val ( + ) : t -> t -> t
-
-      val negate : t -> t
-
-      val to_affine_exn : 'a -> 'a
-
-      val of_affine : 'a -> 'a
-    end
+    val group_size_in_bits : int
   end
 
-  module Params = Inputs.Params
-  module Constant = Inputs.Constant
+  module Constant : sig
+    include module type of Kimchi_pasta.Pasta.Pallas.Affine
 
-  type t = Inputs.F.t * Inputs.F.t
+    module Scalar = Impls.Wrap.Field.Constant
 
-  (* val double : t -> t *)
+    val scale : t -> Scalar.t -> t
 
-  val add' :
-       div:(Inputs.F.t -> Inputs.F.t -> Inputs.F.t)
-    -> Inputs.F.t * Inputs.F.t
-    -> Inputs.F.t * Inputs.F.t
-    -> t
+    val random : unit -> t
+
+    val zero : Impl.Field.Constant.t * Impl.Field.Constant.t
+
+    val ( + ) : t -> t -> t
+
+    val negate : t -> t
+
+    val to_affine_exn : 'a -> 'a
+
+    val of_affine : 'a -> 'a
+  end
+
+  type t = Impl.Field.t * Impl.Field.t
+
+  val double : t -> t
+
+  val add' : div:(Impl.Field.t -> Impl.Field.t -> Impl.Field.t) -> t -> t -> t
 
   val add_exn : t -> t -> t
 
   val to_affine_exn : 'a -> 'a
 
-  val constant : Inputs.Constant.t -> t
+  val constant : Constant.t -> t
 
-  (* val negate : t -> t *)
+  val negate : t -> t
 
-  (* val one : t *)
+  val one : t
 
   val assert_on_curve : t -> unit
 
-  val typ_unchecked : (t, Inputs.Constant.t) Inputs.Impl.Typ.t
+  val typ_unchecked : (t, Constant.t) Impl.Typ.t
 
-  val typ : (t, Inputs.Constant.t) Inputs.Impl.Typ.t
+  val typ : (t, Constant.t) Impl.Typ.t
 
-  (* val if_ : Inputs.Impl.Boolean.var -> then_:t -> else_:t -> t *)
+  val if_ : Impl.Boolean.var -> then_:t -> else_:t -> t
 
   module Scalar : sig
-    type t = Inputs.Impl.Boolean.var Bitstring_lib.Bitstring.Lsb_first.t
+    type t = Impl.Boolean.var Bitstring_lib.Bitstring.Lsb_first.t
 
-    val of_field : Inputs.Impl.Field.t -> t
+    val of_field : Impl.Field.t -> t
 
-    val to_field : t -> Inputs.Impl.Field.t
+    val to_field : t -> Impl.Field.t
   end
 
   module type Shifted_intf = sig
@@ -154,7 +107,7 @@ module Inner_curve : sig
 
     val add : t -> inputs -> t
 
-    val if_ : Inputs.Impl.Boolean.var -> then_:t -> else_:t -> t
+    val if_ : Impl.Boolean.var -> then_:t -> else_:t -> t
   end
 
   module Shifted : functor
@@ -169,110 +122,73 @@ module Inner_curve : sig
   (* val scale : ?init:t -> t -> Scalar.t -> t *)
 
   module Window_table : sig
-    type t = Inputs.Constant.t Tuple_lib.Quadruple.t array
+    type t = Constant.t Tuple_lib.Quadruple.t array
 
     val window_size : int
 
     val windows : int
 
-    val shift_left_by_window_size : Inputs.Constant.t -> Inputs.Constant.t
+    val shift_left_by_window_size : Constant.t -> Constant.t
 
-    val create :
-      shifts:Inputs.Constant.t Core_kernel.Array.t -> Inputs.Constant.t -> t
+    val create : shifts:Constant.t Core_kernel.Array.t -> Constant.t -> t
   end
 
-  val pow2s : Inputs.Constant.t -> Inputs.Constant.t Core_kernel.Array.t
+  val pow2s : Constant.t -> Constant.t Core_kernel.Array.t
 
   module Scaling_precomputation : sig
     type t =
-      { base : Inputs.Constant.t
-      ; shifts : Inputs.Constant.t array
-      ; table : Window_table.t
-      }
+      { base : Constant.t; shifts : Constant.t array; table : Window_table.t }
 
     val group_map :
-      (   Inputs.Impl.Field.Constant.t
-       -> Inputs.Impl.Field.Constant.t * Inputs.Impl.Field.Constant.t )
+      (Impl.Field.Constant.t -> Impl.Field.Constant.t * Impl.Field.Constant.t)
       lazy_t
 
     val string_to_bits : string -> bool list
 
-    val create : Inputs.Constant.t -> t
+    val create : Constant.t -> t
   end
 
   val add_unsafe : t -> t -> t
 
   val lookup_point :
-       Inputs.Impl.Boolean.var * Inputs.Impl.Boolean.var
-    -> Inputs.Constant.t
-       * Inputs.Constant.t
-       * Inputs.Constant.t
-       * Inputs.Constant.t
-    -> Inputs.Impl.Field.t * Inputs.Impl.Field.t
+       Impl.Boolean.var * Impl.Boolean.var
+    -> Constant.t * Constant.t * Constant.t * Constant.t
+    -> t
 
   val pairs :
-       Inputs.Impl.Boolean.var list
-    -> (Inputs.Impl.Boolean.var * Inputs.Impl.Boolean.var) list
+    Impl.Boolean.var list -> (Impl.Boolean.var * Impl.Boolean.var) list
 
-  type shifted = { value : t; shift : Inputs.Constant.t }
+  type shifted = { value : t; shift : Constant.t }
 
   val unshift : shifted -> t
 
   val multiscale_known :
-       (Inputs.Impl.Boolean.var list * Scaling_precomputation.t)
-       Core_kernel.Array.t
-    -> t
+    (Impl.Boolean.var list * Scaling_precomputation.t) Core_kernel.Array.t -> t
 
-  val scale_known :
-    Scaling_precomputation.t -> Inputs.Impl.Boolean.var list -> t
+  val scale_known : Scaling_precomputation.t -> Impl.Boolean.var list -> t
 
-  val conditional_negation :
-       Inputs.Impl.Boolean.var
-    -> 'a * Inputs.Impl.Field.t
-    -> 'a * Inputs.Impl.Field.t
+  val conditional_negation : Impl.Boolean.var -> t -> t
 
-  val p_plus_q_plus_p : t -> t -> Inputs.Impl.Field.t * Inputs.Impl.Field.t
+  val p_plus_q_plus_p : t -> t -> t
 
   val scale_fast :
-       Inputs.Impl.Field.t * Inputs.F.t
-    -> [< `Plus_two_to_len_minus_1 of
-          Inputs.Impl.Boolean.var Core_kernel.Array.t ]
-    -> Inputs.F.t * Inputs.F.t
+       t
+    -> [< `Plus_two_to_len_minus_1 of Impl.Boolean.var Core_kernel.Array.t ]
+    -> t
 
-  val ( + ) :
-       Impls.Step.field Snarky_backendless.Cvar.t
-       * Impls.Step.field Snarky_backendless.Cvar.t
-    -> Impls.Step.field Snarky_backendless.Cvar.t
-       * Impls.Step.field Snarky_backendless.Cvar.t
-    -> Impls.Step.field Snarky_backendless.Cvar.t
-       * Impls.Step.field Snarky_backendless.Cvar.t
+  val ( + ) : t -> t -> t
 
-  val double :
-       Impls.Step.field Snarky_backendless.Cvar.t
-       * Impls.Step.field Snarky_backendless.Cvar.t
-    -> Impls.Step.field Snarky_backendless.Cvar.t
-       * Impls.Step.field Snarky_backendless.Cvar.t
-
-  val scale : t -> Inputs.Impl.Boolean.var list -> Inputs.F.t * Inputs.F.t
+  val scale : t -> Impl.Boolean.var list -> t
 
   val to_field_elements : 'a * 'a -> 'a list
 
-  val assert_equal :
-       Impls.Step.Field.t * Impls.Step.Field.t
-    -> Impls.Step.Field.t * Impls.Step.Field.t
-    -> unit
+  val assert_equal : t -> t -> unit
 
-  val scale_inv : t -> Inputs.Impl.Boolean.var list -> t
-
-  val negate : t -> t
-
-  val one : t
-
-  val if_ : Inputs.Impl.Boolean.var -> then_:t -> else_:t -> t
+  val scale_inv : t -> Impl.Boolean.var list -> t
 end
 
 module Ops : module type of Plonk_curve_ops.Make (Impls.Step) (Inner_curve)
 
 module Generators : sig
-  val h : (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t) lazy_t
+  val h : (Impl.Field.Constant.t * Impl.Field.Constant.t) lazy_t
 end

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -14,10 +14,7 @@ module Pseudo : module type of Pseudo.Make (Impl)
 module Inner_curve : sig
   type t = Step_main_inputs.Inner_curve.t
 
-  val typ :
-    ( t
-    , Step_main_inputs.Inner_curve.Inputs.Constant.t )
-    Step_main_inputs.Inner_curve.Inputs.Impl.Typ.t
+  val typ : (t, Step_main_inputs.Inner_curve.Constant.t) Impl.Typ.t
 end
 
 module Other_field : sig

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -1,16 +1,15 @@
-module Challenge : module type of Import.Challenge.Make (Step_main_inputs.Impl)
+module Impl := Step_main_inputs.Impl
 
-module Digest : module type of Import.Digest.Make (Step_main_inputs.Impl)
+module Challenge : module type of Import.Challenge.Make (Impl)
+
+module Digest : module type of Import.Digest.Make (Impl)
 
 module Scalar_challenge :
     module type of
-      Scalar_challenge.Make
-        (Step_main_inputs.Impl)
-        (Step_main_inputs.Inner_curve)
-        (Challenge)
+      Scalar_challenge.Make (Impl) (Step_main_inputs.Inner_curve) (Challenge)
         (Endo.Step_inner_curve)
 
-module Pseudo : module type of Pseudo.Make (Step_main_inputs.Impl)
+module Pseudo : module type of Pseudo.Make (Impl)
 
 module Inner_curve : sig
   type t = Step_main_inputs.Inner_curve.t
@@ -22,15 +21,14 @@ module Inner_curve : sig
 end
 
 module Other_field : sig
-  type t = Step_main_inputs.Impl.Other_field.t
+  type t = Impl.Other_field.t
 
   val size_in_bits : int
 
   val typ : (t, Impls.Step.Other_field.Constant.t) Impls.Step.Typ.t
 end
 
-val assert_n_bits :
-  n:int -> Pasta_bindings.Fp.t Snarky_backendless.Cvar.t -> unit
+val assert_n_bits : n:int -> Impl.Field.t -> unit
 
 val finalize_other_proof :
      (module Pickles_types.Nat.Add.Intf with type n = 'b)
@@ -40,86 +38,77 @@ val finalize_other_proof :
   -> zk_rows:int
   -> sponge:Step_main_inputs.Sponge.t
   -> prev_challenges:
-       ( (Step_main_inputs.Impl.Field.t, 'a) Pickles_types.Vector.t
-       , 'b )
-       Pickles_types.Vector.t
-  -> ( Step_main_inputs.Impl.Field.t
-     , Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-       Import.Scalar_challenge.t
-     , Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t
-     , ( Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t
-       , Step_main_inputs.Impl.Boolean.var )
+       ((Impl.Field.t, 'a) Pickles_types.Vector.t, 'b) Pickles_types.Vector.t
+  -> ( Impl.Field.t
+     , Impl.Field.t Import.Scalar_challenge.t
+     , Impl.Field.t Pickles_types.Shifted_value.Type1.t
+     , ( Impl.Field.t Pickles_types.Shifted_value.Type1.t
+       , Impl.Boolean.var )
        Composition_types.Opt.t
-     , ( Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-         Import.Scalar_challenge.t
-       , Step_main_inputs.Impl.Boolean.var )
+     , ( Impl.Field.t Import.Scalar_challenge.t
+       , Impl.Boolean.var )
        Composition_types.Opt.t
-     , ( Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-         Import.Scalar_challenge.t
-         Import.Bulletproof_challenge.t
+     , ( Impl.Field.t Import.Scalar_challenge.t Import.Bulletproof_challenge.t
        , 'c )
        Pickles_types.Vector.t
-     , Step_main_inputs.Impl.Field.Constant.t Import.Branch_data.Checked.t
-     , Step_main_inputs.Impl.Boolean.var )
+     , Impl.Field.Constant.t Import.Branch_data.Checked.t
+     , Impl.Boolean.var )
      Import.Types.Wrap.Proof_state.Deferred_values.In_circuit.t
-  -> ( Step_main_inputs.Impl.Field.t
-     , Step_main_inputs.Impl.Field.t Core_kernel.Array.t
-     , Step_main_inputs.Impl.Boolean.var )
+  -> ( Impl.Field.t
+     , Impl.Field.t Core_kernel.Array.t
+     , Impl.Boolean.var )
      Pickles_types.Plonk_types.All_evals.In_circuit.t
-  -> Step_main_inputs.Impl.Boolean.var
-     * ( Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-       , 'c )
-       Pickles_types.Vector.t
+  -> Impl.Boolean.var * (Impl.Field.t, 'c) Pickles_types.Vector.t
 
 val hash_messages_for_next_step_proof :
      index:
        Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
-  -> ('s -> Step_main_inputs.Impl.Field.t array)
+  -> ('s -> Impl.Field.t array)
   -> (   ( 'a
          , 's
          , (Inner_curve.t, 'b) Pickles_types.Vector.t
-         , ( (Step_main_inputs.Impl.Field.t, 'c) Pickles_types.Vector.t
+         , ( (Impl.Field.t, 'c) Pickles_types.Vector.t
            , 'b )
            Pickles_types.Vector.t )
          Import.Types.Step.Proof_state.Messages_for_next_step_proof.t
-      -> Step_main_inputs.Impl.Field.t )
+      -> Impl.Field.t )
      Core_kernel.Staged.t
 
 val hash_messages_for_next_step_proof_opt :
      index:
        Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
-  -> ('s -> Step_main_inputs.Impl.Field.t array)
+  -> ('s -> Impl.Field.t array)
   -> Step_main_inputs.Sponge.t
      * (   ( 'a
            , 's
            , (Inner_curve.t, 'b) Pickles_types.Vector.t
-           , ( (Step_main_inputs.Impl.Field.t, 'c) Pickles_types.Vector.t
+           , ( (Impl.Field.t, 'c) Pickles_types.Vector.t
              , 'b )
              Pickles_types.Vector.t )
            Import.Types.Step.Proof_state.Messages_for_next_step_proof.t
         -> widths:'d
         -> max_width:'e
         -> proofs_verified_mask:
-             ( Step_main_inputs.Impl.Field.t Snarky_backendless.Boolean.t
+             ( Impl.Field.t Snarky_backendless.Boolean.t
              , 'b )
              Pickles_types.Vector.t
-        -> Step_main_inputs.Impl.Field.t )
+        -> Impl.Field.t )
        Core_kernel.Staged.t
 
 (** Actual verification using cryptographic tools. Returns [true] (encoded as a
     in-circuit Boolean variable) if the verification is successful *)
 val verify :
      proofs_verified:(module Pickles_types.Nat.Add.Intf with type n = 'a)
-  -> is_base_case:Step_main_inputs.Impl.Boolean.var
+  -> is_base_case:Impl.Boolean.var
   -> sg_old:(Impls.Step.Field.t Tuple_lib.Double.t, 'a) Pickles_types.Vector.t
   -> sponge_after_index:Step_main_inputs.Sponge.t
   -> lookup_parameters:
        ( Limb_vector.Challenge.Constant.t
-       , Step_main_inputs.Impl.field Limb_vector.Challenge.t
+       , Impl.field Limb_vector.Challenge.t
        , 'b
-       , Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t )
+       , Impl.Field.t Pickles_types.Shifted_value.Type1.t )
        Composition_types.Wrap.Lookup_parameters.t
        (* lookup arguments parameters *)
   -> feature_flags:Pickles_types.Opt.Flag.t Pickles_types.Plonk_types.Features.t
@@ -128,40 +117,37 @@ val verify :
   -> wrap_domain:
        [ `Known of Import.Domain.t
        | `Side_loaded of
-         Step_main_inputs.Impl.field
+         Impl.field
          Composition_types.Branch_data.Proofs_verified.One_hot.Checked.t ]
   -> wrap_verification_key:
        Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
-  -> ( Step_main_inputs.Impl.field Limb_vector.Challenge.t
-     , Step_main_inputs.Impl.field Limb_vector.Challenge.t
-       Composition_types.Scalar_challenge.t
-     , Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t
-     , ( Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t
-       , Step_main_inputs.Impl.Boolean.var )
+  -> ( Impl.field Limb_vector.Challenge.t
+     , Impl.field Limb_vector.Challenge.t Composition_types.Scalar_challenge.t
+     , Impl.Field.t Pickles_types.Shifted_value.Type1.t
+     , ( Impl.Field.t Pickles_types.Shifted_value.Type1.t
+       , Impl.Boolean.var )
        Pickles_types.Opt.t
-     , ( Step_main_inputs.Impl.field Limb_vector.Challenge.t
-         Composition_types.Scalar_challenge.t
-       , Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-         Snarky_backendless.Snark_intf.Boolean0.t )
+     , ( Impl.field Limb_vector.Challenge.t Composition_types.Scalar_challenge.t
+       , Impl.Field.t Snarky_backendless.Snark_intf.Boolean0.t )
        Pickles_types.Opt.t
-     , Step_main_inputs.Impl.Boolean.var
-     , Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-     , Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-     , Step_main_inputs.Impl.field Snarky_backendless.Cvar.t
-     , ( Step_main_inputs.Impl.field Limb_vector.Challenge.t
+     , Impl.Boolean.var
+     , Impl.Field.t
+     , Impl.Field.t
+     , Impl.Field.t
+     , ( Impl.field Limb_vector.Challenge.t
          Kimchi_backend_common.Scalar_challenge.t
          Composition_types.Bulletproof_challenge.t
        , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
        Pickles_types.Vector.t
-     , Step_main_inputs.Impl.field Composition_types.Branch_data.Checked.t )
+     , Impl.field Composition_types.Branch_data.Checked.t )
      Import.Types.Wrap.Statement.In_circuit.t
      (* statement *)
   -> Impls.Step.unfinalized_proof_var (* unfinalized *)
-  -> Step_main_inputs.Impl.Boolean.var
+  -> Impl.Boolean.var
 
 module For_tests_only : sig
-  type field := Step_main_inputs.Impl.Field.t
+  type field := Impl.Field.t
 
   val side_loaded_domain :
        log2_size:field

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -6,9 +6,7 @@ open Backend
 (* We maintain a global hash table which stores for each inductive proof system some
    data.
 *)
-type inner_curve_var =
-  Tick.Field.t Snarky_backendless.Cvar.t
-  * Tick.Field.t Snarky_backendless.Cvar.t
+type inner_curve_var = Impls.Step.Field.t * Impls.Step.Field.t
 
 module Basic = struct
   type ('var, 'value, 'n1, 'n2) t =

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -1,8 +1,6 @@
 open Pickles_types
 
-type inner_curve_var =
-  Backend.Tick.Field.t Snarky_backendless.Cvar.t
-  * Backend.Tick.Field.t Snarky_backendless.Cvar.t
+type inner_curve_var = Impls.Step.Field.t * Impls.Step.Field.t
 
 module Basic : sig
   type ('var, 'value, 'n1, 'n2) t =

--- a/src/lib/pickles/wrap.mli
+++ b/src/lib/pickles/wrap.mli
@@ -14,23 +14,22 @@ val wrap :
          , Impls.Wrap.Impl.Field.t Composition_types.Scalar_challenge.t
          , Impls.Wrap.Impl.Field.t Pickles_types.Shifted_value.Type1.t
          , ( Impls.Wrap.Impl.Field.t Pickles_types.Shifted_value.Type1.t
-           , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-             Snarky_backendless.Snark_intf.Boolean0.t )
+           , Impls.Wrap.Impl.Field.t Snarky_backendless.Snark_intf.Boolean0.t
+           )
            Pickles_types.Opt.t
          , ( Impls.Wrap.Impl.Field.t Composition_types.Scalar_challenge.t
-           , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-             Snarky_backendless.Snark_intf.Boolean0.t )
+           , Impls.Wrap.Impl.Field.t Snarky_backendless.Snark_intf.Boolean0.t
+           )
            Pickles_types.Opt.t
          , Impls.Wrap.Impl.Boolean.var
-         , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-         , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-         , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-         , ( Impls.Wrap.Impl.field Snarky_backendless.Cvar.t
-             Kimchi_backend_common.Scalar_challenge.t
+         , Impls.Wrap.Impl.Field.t
+         , Impls.Wrap.Impl.Field.t
+         , Impls.Wrap.Impl.Field.t
+         , ( Impls.Wrap.Impl.Field.t Kimchi_backend_common.Scalar_challenge.t
              Composition_types.Bulletproof_challenge.t
            , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
            Pickles_types.Vector.t
-         , Impls.Wrap.Impl.field Snarky_backendless.Cvar.t )
+         , Impls.Wrap.Impl.Field.t )
          Import.Types.Wrap.Statement.In_circuit.t
       -> unit )
   -> typ:('a, 'b) Impls.Step.Typ.t

--- a/src/lib/pickles/wrap_verifier.mli
+++ b/src/lib/pickles/wrap_verifier.mli
@@ -1,3 +1,5 @@
+module Impl := Impls.Wrap
+
 (** Generic (polymorphic instance of [challenge_polynomial]) *)
 val challenge_polynomial :
      (module Pickles_types.Shifted_value.Field_intf with type t = 'a)
@@ -7,9 +9,9 @@ val challenge_polynomial :
 type ('a, 'a_opt) index' =
   ('a, 'a_opt) Pickles_types.Plonk_verification_key_evals.Step.t
 
-module Challenge : module type of Import.Challenge.Make (Impls.Wrap)
+module Challenge : module type of Import.Challenge.Make (Impl)
 
-module Digest : module type of Import.Digest.Make (Impls.Wrap)
+module Digest : module type of Import.Digest.Make (Impl)
 
 module Scalar_challenge :
     module type of
@@ -21,20 +23,19 @@ module Scalar_challenge :
 
 module Other_field : sig
   module Packed : sig
-    type t = Impls.Wrap.Other_field.t
+    type t = Impl.Other_field.t
 
-    val typ :
-      (Impls.Wrap.Impl.Field.t, Backend.Tick.Field.t) Impls.Wrap_impl.Typ.t
+    val typ : (Impl.Impl.Field.t, Backend.Tick.Field.t) Impls.Wrap_impl.Typ.t
   end
 end
 
-module One_hot_vector : module type of One_hot_vector.Make (Impls.Wrap)
+module One_hot_vector : module type of One_hot_vector.Make (Impl)
 
-module Pseudo : module type of Pseudo.Make (Impls.Wrap)
+module Pseudo : module type of Pseudo.Make (Impl)
 
 module Opt : sig
   include module type of
-      Opt_sponge.Make (Impls.Wrap) (Wrap_main_inputs.Sponge.Permutation)
+      Opt_sponge.Make (Impl) (Wrap_main_inputs.Sponge.Permutation)
 end
 
 val all_possible_domains :
@@ -47,8 +48,7 @@ val all_possible_domains :
 val num_possible_domains :
   Wrap_hack.Padded_length.n Pickles_types.Nat.s Pickles_types.Nat.t
 
-val assert_n_bits :
-  n:int -> Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t -> unit
+val assert_n_bits : n:int -> Impl.Field.t -> unit
 
 val incrementally_verify_proof :
      (module Pickles_types.Nat.Add.Intf with type n = 'b)
@@ -61,7 +61,7 @@ val incrementally_verify_proof :
   -> verification_key:
        ( Wrap_main_inputs.Inner_curve.t array
        , ( Wrap_main_inputs.Inner_curve.t array
-         , Impls.Wrap.Boolean.var )
+         , Impl.Boolean.var )
          Pickles_types.Opt.t )
        Pickles_types.Plonk_verification_key_evals.Step.t
   -> xi:Scalar_challenge.t
@@ -109,23 +109,17 @@ val finalize_other_proof :
   -> domain:
        < generator : Wrap_main_inputs.Impl.Field.t
        ; shifts : Wrap_main_inputs.Impl.Field.t array
-       ; vanishing_polynomial :
-              Wrap_main_inputs.Impl.field Snarky_backendless__.Cvar.t
-           -> Wrap_main_inputs.Impl.field Snarky_backendless__.Cvar.t
+       ; vanishing_polynomial : Impl.Field.t -> Impl.Field.t
        ; .. >
   -> sponge:Wrap_main_inputs.Sponge.t
   -> old_bulletproof_challenges:
        ( (Wrap_main_inputs.Impl.Field.t, 'a) Pickles_types.Vector.t
        , 'b )
        Pickles_types.Vector.t
-  -> ( Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t
-     , Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t
-       Import.Scalar_challenge.t
-     , Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t
-       Pickles_types.Shifted_value.Type2.t
-     , ( Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t
-         Import.Scalar_challenge.t
-         Import.Bulletproof_challenge.t
+  -> ( Impl.Field.t
+     , Impl.Field.t Import.Scalar_challenge.t
+     , Impl.Field.t Pickles_types.Shifted_value.Type2.t
+     , ( Impl.Field.t Import.Scalar_challenge.t Import.Bulletproof_challenge.t
        , 'c )
        Pickles_types.Vector.t )
      Import.Types.Step.Proof_state.Deferred_values.In_circuit.t
@@ -134,22 +128,20 @@ val finalize_other_proof :
      , Wrap_main_inputs.Impl.Boolean.var )
      Pickles_types.Plonk_types.All_evals.In_circuit.t
   -> Wrap_main_inputs.Impl.Boolean.var
-     * ( Wrap_main_inputs.Impl.field Snarky_backendless.Cvar.t
-       , 'c )
-       Pickles_types.Vector.t
+     * (Impl.Field.t, 'c) Pickles_types.Vector.t
 
 val choose_key :
   'n.
      'n One_hot_vector.t
   -> ( ( Wrap_main_inputs.Inner_curve.t array
        , ( Wrap_main_inputs.Inner_curve.t array
-         , Impls.Wrap.Boolean.var )
+         , Impl.Boolean.var )
          Pickles_types.Opt.t )
        index'
      , 'n )
      Pickles_types.Vector.t
   -> ( Wrap_main_inputs.Inner_curve.t array
      , ( Wrap_main_inputs.Inner_curve.t array
-       , Impls.Wrap.Boolean.var )
+       , Impl.Boolean.var )
        Pickles_types.Opt.t )
      index'


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16449, tidying up some pickles interfaces to remove spurious references to `Snarky_backendless.Cvar.t`.