### PR TITLE
Specialize pickles types instead of using snarky's `Cvar.t`s

### DIFF
--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -936,9 +936,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         include
           Basic
             with type t := Stable.Latest.t
-             and type var =
-              Pickles.Impls.Step.Impl.Internal_Basic.field
-              Snarky_backendless.Cvar.t
+             and type var = Pickles.Impls.Step.Field.t
 
         include Arithmetic_intf with type t := t
 
@@ -1197,9 +1195,6 @@ module Make_str (A : Wire_types.Concrete) = struct
         type magnitude = t [@@deriving sexp, compare]
 
         type var
-
-        (* TODO =
-           field Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t list *)
 
         val zero : t
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -207,7 +207,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let%bind actual = image_from_bits_unsafe t in
       with_label "range_check" (fun () -> Field.Checked.Assert.equal actual t)
 
-    let seal x = make_checked (fun () -> Pickles.Util.seal (module Run) x)
+    let seal x = make_checked (fun () -> Pickles.Util.Step.seal x)
 
     let modulus_as_field =
       lazy (Fn.apply_n_times ~n:length_in_bits Field.(mul (of_int 2)) Field.one)

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -10,10 +10,6 @@ module Make_checked
 struct
   open Snark_params.Tick
 
-  let m =
-    (module Run : Kimchi_pasta_snarky_backend.Snark_intf
-      with type field = Run.field )
-
   type var = Field.Var.t
 
   let () = assert (Int.(N.length_in_bits < Field.size_in_bits))
@@ -95,8 +91,8 @@ struct
 
   let gte x y =
     let open Pickles.Impls.Step in
-    let xy = Pickles.Util.seal m Field.(x - y) in
-    let yx = Pickles.Util.seal m (Field.negate xy) in
+    let xy = Pickles.Util.Step.seal Field.(x - y) in
+    let yx = Pickles.Util.Step.seal (Field.negate xy) in
     let x_gte_y = range_check_flag xy in
     let y_gte_x = range_check_flag yx in
     Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
@@ -137,7 +133,7 @@ struct
   let succ (t : var) =
     Checked.return (Field.Var.add t (Field.Var.constant Field.one))
 
-  let seal x = make_checked (fun () -> Pickles.Util.seal m x)
+  let seal x = make_checked (fun () -> Pickles.Util.Step.seal x)
 
   let add (x : var) (y : var) =
     let%bind res = seal (Field.Var.add x y) in
@@ -151,8 +147,8 @@ struct
 
   let subtract_unpacking_or_zero x y =
     let open Pickles.Impls.Step in
-    let res = Pickles.Util.seal m Field.(x - y) in
-    let neg_res = Pickles.Util.seal m (Field.negate res) in
+    let res = Pickles.Util.Step.seal Field.(x - y) in
+    let neg_res = Pickles.Util.Step.seal (Field.negate res) in
     let x_gte_y = range_check_flag res in
     let y_gte_x = range_check_flag neg_res in
     Boolean.Assert.any [ x_gte_y; y_gte_x ] ;

--- a/src/lib/pickles/composition_types/branch_data_intf.ml
+++ b/src/lib/pickles/composition_types/branch_data_intf.ml
@@ -25,26 +25,42 @@ module type S = sig
   end]
 
   module Checked : sig
-    type 'f t =
-      { proofs_verified_mask : 'f Proofs_verified.Prefix_mask.Checked.t
-      ; domain_log2 : 'f Snarky_backendless.Cvar.t
-      }
+    module Step : sig
+      open Kimchi_pasta_snarky_backend.Step_impl
 
-    val pack :
-         (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-      -> 'f t
-      -> 'f Snarky_backendless.Cvar.t
+      type field_var = Field.t
+
+      type t =
+        { proofs_verified_mask : Proofs_verified.Prefix_mask.Step.Checked.t
+        ; domain_log2 : Field.t
+        }
+
+      val pack : t -> Field.t
+    end
+
+    module Wrap : sig
+      open Kimchi_pasta_snarky_backend.Wrap_impl
+
+      type field_var = Field.t
+
+      type t =
+        { proofs_verified_mask : Proofs_verified.Prefix_mask.Wrap.Checked.t
+        ; domain_log2 : Field.t
+        }
+
+      val pack : t -> Field.t
+    end
   end
 
   module Impls := Kimchi_pasta_snarky_backend
 
   val typ :
        assert_16_bits:(Impls.Step_impl.Field.t -> unit)
-    -> (Impls.Step_impl.Field.Constant.t Checked.t, t) Impls.Step_impl.Typ.t
+    -> (Checked.Step.t, t) Impls.Step_impl.Typ.t
 
   val wrap_typ :
        assert_16_bits:(Impls.Wrap_impl.Field.t -> unit)
-    -> (Impls.Wrap_impl.Field.Constant.t Checked.t, t) Impls.Wrap_impl.Typ.t
+    -> (Checked.Wrap.t, t) Impls.Wrap_impl.Typ.t
 
   val packed_typ : (Impls.Step_impl.Field.t, t) Impls.Step_impl.Typ.t
 

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -1397,10 +1397,9 @@ module Wrap_bp_vec = Backend.Tock.Rounds_vector
 module Step_bp_vec = Backend.Tick.Rounds_vector
 
 module Challenges_vector = struct
-  type 'n t =
-    (Backend.Tock.Field.t Snarky_backendless.Cvar.t Wrap_bp_vec.t, 'n) Vector.t
+  type 'n t = (Wrap_impl.Field.t Wrap_bp_vec.t, 'n) Vector.t
 
   module Constant = struct
-    type 'n t = (Backend.Tock.Field.t Wrap_bp_vec.t, 'n) Vector.t
+    type 'n t = (Wrap_impl.Field.Constant.t Wrap_bp_vec.t, 'n) Vector.t
   end
 end

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -1373,11 +1373,10 @@ module Step : sig
 end
 
 module Challenges_vector : sig
-  type 'n t =
-    (Backend.Tock.Field.t Snarky_backendless.Cvar.t Wrap_bp_vec.t, 'n) Vector.t
+  type 'n t = (Wrap_impl.Field.t Wrap_bp_vec.t, 'n) Vector.t
 
   module Constant : sig
-    type 'n t = (Backend.Tock.Field.t Wrap_bp_vec.t, 'n) Vector.t
+    type 'n t = (Wrap_impl.Field.Constant.t Wrap_bp_vec.t, 'n) Vector.t
   end
 end
 

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -612,14 +612,9 @@ module Wrap : sig
     val opt_spec :
          ('a, 'b, 'c, 'd) t
       -> ( ('a Scalar_challenge.t * unit) Hlist.HlistId.t option
-         , ( ('b Scalar_challenge.t * unit) Hlist.HlistId.t
-           , 'f Snarky_backendless.Cvar.t
-             Snarky_backendless__Snark_intf.Boolean0.t )
-           opt
+         , (('b Scalar_challenge.t * unit) Hlist.HlistId.t, 'bool2) opt
          , < bool1 : bool
-           ; bool2 :
-               'f Snarky_backendless.Cvar.t
-               Snarky_backendless__Snark_intf.Boolean0.t
+           ; bool2 : 'bool2
            ; challenge1 : 'a
            ; challenge2 : 'b
            ; field1 : 'c
@@ -845,11 +840,7 @@ module Wrap : sig
              , 'bool2 )
              flat_repr
            , < bool1 : bool
-             ; bool2 :
-                 ('a Snarky_backendless.Cvar.t
-                  Snarky_backendless__Snark_intf.Boolean0.t
-                  as
-                  'bool2 )
+             ; bool2 : 'bool2
              ; branch_data1 : 'branch_data1
              ; branch_data2 : 'branch_data2
              ; bulletproof_challenge1 : 'bulletproof_challenge1
@@ -1173,7 +1164,7 @@ module Step : sig
                ; digest1 : 'digest1
                ; digest2 : 'digest2
                ; field1 : 'field1
-               ; field2 : ('f Snarky_backendless.Cvar.t as 'field2)
+               ; field2 : 'field2
                ; .. > )
              Spec.T.t
 
@@ -1344,21 +1335,15 @@ module Step : sig
                * ( ('j, Nat.N1.n) Vector.t
                  * ( ('e, Nat.N2.n) Vector.t
                    * ( ('e Scalar_challenge.t, Nat.N3.n) Vector.t
-                     * ( ('k, 'c) Vector.t
-                       * ( ( 'a Snarky_backendless.Cvar.t
-                             Snarky_backendless__Snark_intf.Boolean0.t
-                           , Nat.N1.n )
-                           Vector.t
-                         * unit ) ) ) ) ) )
+                     * (('k, 'c) Vector.t * (('bool2, Nat.N1.n) Vector.t * unit))
+                     ) ) ) )
                Hlist.HlistId.t
              , 'b )
              Vector.t
            * ('j * (('j, 'b) Vector.t * unit)) )
            Hlist.HlistId.t
          , < bool1 : bool
-           ; bool2 :
-               'a Snarky_backendless.Cvar.t
-               Snarky_backendless__Snark_intf.Boolean0.t
+           ; bool2 : 'bool2
            ; bulletproof_challenge1 : 'i
            ; bulletproof_challenge2 : 'k
            ; challenge1 : 'd

--- a/src/lib/pickles/composition_types/spec.ml
+++ b/src/lib/pickles/composition_types/spec.ml
@@ -6,6 +6,17 @@ module Sc = Kimchi_backend_common.Scalar_challenge
 
 type 'f impl = (module Snarky_backendless.Snark_intf.Run with type field = 'f)
 
+module type Branch_data_checked = sig
+  type field_var
+
+  type t
+
+  val pack : t -> field_var
+end
+
+type ('branch_data, 'f) branch_data =
+  (module Branch_data_checked with type field_var = 'f and type t = 'branch_data)
+
 type ('a, 'b, 'c) basic =
   | Unit : (unit, unit, < .. >) basic
   | Field
@@ -158,7 +169,11 @@ end
 module Step_etyp = Make_ETyp (Kimchi_pasta_snarky_backend.Step_impl)
 module Wrap_etyp = Make_ETyp (Kimchi_pasta_snarky_backend.Wrap_impl)
 
-module Common (Impl : Snarky_backendless.Snark_intf.Run) = struct
+module Common
+    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Branch_data_checked : Branch_data_checked
+                             with type field_var := Impl.Field.t) =
+struct
   module Digest = D.Make (Impl)
   module Challenge = Limb_vector.Challenge.Make (Impl)
   open Impl
@@ -177,17 +192,19 @@ module Common (Impl : Snarky_backendless.Snark_intf.Run) = struct
           Challenge.Constant.t Sc.t Bulletproof_challenge.t
       ; bulletproof_challenge2 : Challenge.t Sc.t Bulletproof_challenge.t
       ; branch_data1 : Branch_data.t
-      ; branch_data2 : Impl.field Branch_data.Checked.t
+      ; branch_data2 : Branch_data_checked.t
       ; .. >
       as
       'a
   end
 end
 
-let pack_basic (type field other_field other_field_var)
-    ((module Impl) : field impl) =
+let pack_basic (type field other_field other_field_var branch_data_var)
+    ((module Impl) : field impl)
+    ((module Branch_data_checked) : (branch_data_var, Impl.Field.t) branch_data)
+    =
   let open Impl in
-  let module C = Common (Impl) in
+  let module C = Common (Impl) (Branch_data_checked) in
   let open C in
   let pack :
       type a b.
@@ -210,9 +227,7 @@ let pack_basic (type field other_field other_field_var)
     | Challenge ->
         [| `Packed_bits (x, Challenge.length) |]
     | Branch_data ->
-        [| `Packed_bits
-             ( Branch_data.Checked.pack (module Impl) x
-             , Branch_data.length_in_bits )
+        [| `Packed_bits (Branch_data_checked.pack x, Branch_data.length_in_bits)
         |]
     | Bulletproof_challenge ->
         let { Sc.inner = pre } = Bulletproof_challenge.pack x in
@@ -220,15 +235,20 @@ let pack_basic (type field other_field other_field_var)
   in
   { pack }
 
-let pack (type f) ((module Impl) as impl : f impl) t =
+let pack (type f) ((module Impl) as impl : f impl) branch_data t =
   let open Impl in
-  pack (pack_basic impl) t
+  pack
+    (pack_basic impl branch_data)
+    t
     ~zero:(`Packed_bits (Field.zero, 1))
     ~one:(`Packed_bits (Field.one, 1))
     None
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run) (Basic : sig
+    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Branch_data_checked : Branch_data_checked
+                             with type field_var := Impl.Field.t)
+    (Basic : sig
       val typ_basic :
            assert_16_bits:(Impl.Field.t -> unit)
         -> ('other_field_var, 'other_field) Impl.Typ.t
@@ -237,15 +257,18 @@ module Make
            , < bool1 : bool
              ; bool2 : Impl.Boolean.var
              ; branch_data1 : Branch_data.t
-             ; branch_data2 : Impl.field Branch_data.Checked.t
+             ; branch_data2 : Branch_data_checked.t
              ; bulletproof_challenge1 :
-                 Common(Impl).Challenge.Constant.t Sc.t Bulletproof_challenge.t
+                 Common(Impl)(Branch_data_checked).Challenge.Constant.t Sc.t
+                 Bulletproof_challenge.t
              ; bulletproof_challenge2 :
-                 Common(Impl).Challenge.t Sc.t Bulletproof_challenge.t
-             ; challenge1 : Common(Impl).Challenge.Constant.t
-             ; challenge2 : Common(Impl).Challenge.t
-             ; digest1 : Common(Impl).Digest.Constant.t
-             ; digest2 : Common(Impl).Digest.t
+                 Common(Impl)(Branch_data_checked).Challenge.t Sc.t
+                 Bulletproof_challenge.t
+             ; challenge1 :
+                 Common(Impl)(Branch_data_checked).Challenge.Constant.t
+             ; challenge2 : Common(Impl)(Branch_data_checked).Challenge.t
+             ; digest1 : Common(Impl)(Branch_data_checked).Digest.Constant.t
+             ; digest2 : Common(Impl)(Branch_data_checked).Digest.t
              ; field1 : 'other_field
              ; field2 : 'other_field_var
              ; .. > )
@@ -259,15 +282,18 @@ module Make
            , < bool1 : bool
              ; bool2 : Impl.Boolean.var
              ; branch_data1 : Branch_data.t
-             ; branch_data2 : Common(Impl).Digest.t
+             ; branch_data2 : Common(Impl)(Branch_data_checked).Digest.t
              ; bulletproof_challenge1 :
-                 Common(Impl).Challenge.Constant.t Sc.t Bulletproof_challenge.t
+                 Common(Impl)(Branch_data_checked).Challenge.Constant.t Sc.t
+                 Bulletproof_challenge.t
              ; bulletproof_challenge2 :
-                 Common(Impl).Digest.t Sc.t Bulletproof_challenge.t
-             ; challenge1 : Common(Impl).Challenge.Constant.t
-             ; challenge2 : Common(Impl).Digest.t
-             ; digest1 : Common(Impl).Digest.Constant.t
-             ; digest2 : Common(Impl).Digest.t
+                 Common(Impl)(Branch_data_checked).Digest.t Sc.t
+                 Bulletproof_challenge.t
+             ; challenge1 :
+                 Common(Impl)(Branch_data_checked).Challenge.Constant.t
+             ; challenge2 : Common(Impl)(Branch_data_checked).Digest.t
+             ; digest1 : Common(Impl)(Branch_data_checked).Digest.Constant.t
+             ; digest2 : Common(Impl)(Branch_data_checked).Digest.t
              ; field1 : 'other_field
              ; field2 : 'other_field_var
              ; .. > )
@@ -475,11 +501,10 @@ struct
 end
 
 module Step =
-  Make
-    (Kimchi_pasta_snarky_backend.Step_impl)
+  Make (Kimchi_pasta_snarky_backend.Step_impl) (Branch_data.Checked.Step)
     (struct
       module Impl = Kimchi_pasta_snarky_backend.Step_impl
-      module C = Common (Impl)
+      module C = Common (Impl) (Branch_data.Checked.Step)
 
       let typ_basic (type other_field other_field_var) ~assert_16_bits
           (field : (other_field_var, other_field) Impl.Typ.t) =
@@ -571,11 +596,10 @@ module Step =
     end)
 
 module Wrap =
-  Make
-    (Kimchi_pasta_snarky_backend.Wrap_impl)
+  Make (Kimchi_pasta_snarky_backend.Wrap_impl) (Branch_data.Checked.Wrap)
     (struct
       module Impl = Kimchi_pasta_snarky_backend.Wrap_impl
-      module C = Common (Impl)
+      module C = Common (Impl) (Branch_data.Checked.Wrap)
 
       let typ_basic (type other_field other_field_var) ~assert_16_bits
           (field : (other_field_var, other_field) Impl.Typ.t) =

--- a/src/lib/pickles/composition_types/spec.mli
+++ b/src/lib/pickles/composition_types/spec.mli
@@ -1,5 +1,16 @@
 type 'f impl = (module Snarky_backendless.Snark_intf.Run with type field = 'f)
 
+module type Branch_data_checked = sig
+  type field_var
+
+  type t
+
+  val pack : t -> field_var
+end
+
+type ('branch_data, 'f) branch_data =
+  (module Branch_data_checked with type field_var = 'f and type t = 'branch_data)
+
 (** Basic types *)
 type (_, _, _) basic =
   | Unit : (unit, unit, < .. >) basic
@@ -84,7 +95,7 @@ val typ :
      , < bool1 : bool
        ; bool2 : Step_impl.Boolean.var
        ; branch_data1 : Branch_data.t
-       ; branch_data2 : Step_impl.Field.Constant.t Branch_data.Checked.t
+       ; branch_data2 : Branch_data.Checked.Step.t
        ; bulletproof_challenge1 :
            Limb_vector.Challenge.Constant.t
            Kimchi_backend_common.Scalar_challenge.t
@@ -111,7 +122,7 @@ val wrap_typ :
      , < bool1 : bool
        ; bool2 : Wrap_impl.Boolean.var
        ; branch_data1 : Branch_data.t
-       ; branch_data2 : Wrap_impl.Field.Constant.t Branch_data.Checked.t
+       ; branch_data2 : Branch_data.Checked.Wrap.t
        ; bulletproof_challenge1 :
            Limb_vector.Challenge.Constant.t
            Kimchi_backend_common.Scalar_challenge.t
@@ -199,13 +210,14 @@ val wrap_packed_typ :
 
 val pack :
      'f impl
+  -> ('branch_data_checked, 'f Snarky_backendless.Cvar.t) branch_data
   -> ( 'a
      , 'b
      , < bool1 : bool
        ; bool2 :
            'f Snarky_backendless.Cvar.t Snarky_backendless.Snark_intf.Boolean0.t
        ; branch_data1 : Branch_data.t
-       ; branch_data2 : 'f Branch_data.Checked.t
+       ; branch_data2 : 'branch_data_checked
        ; bulletproof_challenge1 :
            Limb_vector.Challenge.Constant.t
            Kimchi_backend_common.Scalar_challenge.t

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -2,7 +2,7 @@ open Backend
 open Pickles_types
 open Import
 module Impl = Impls.Step
-module One_hot_vector = One_hot_vector.Make (Impl)
+module One_hot_vector = One_hot_vector.Step
 
 (* Let F, K be the two fields (either (Fp, Fq) or (Fq, Fp)).
    Each proof over F has an accumulator state which contains

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -68,7 +68,7 @@ type ('app_state, 'max_proofs_verified, 'num_branches) t =
       , unit
       , Digest.Make(Impl).t
       , scalar_challenge Types.Bulletproof_challenge.t Types.Step_bp_vec.t
-      , Impl.field Branch_data.Checked.t )
+      , Branch_data.Checked.Step.t )
       Types.Wrap.Proof_state.In_circuit.t
         (** The accumulator state corresponding to the above proof. Contains
       - `deferred_values`: The values necessary for finishing the deferred "scalar field" computations.

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -35,7 +35,7 @@ type ('app_state, 'max_proofs_verified, 'num_branches) t =
       , Import.Digest.Make(Impl).t
       , scalar_challenge Import.Bulletproof_challenge.t
         Import.Types.Step_bp_vec.t
-      , Impl.field Import.Branch_data.Checked.t )
+      , Import.Branch_data.Checked.Step.t )
       Import.Types.Wrap.Proof_state.In_circuit.t
         (** The accumulator state corresponding to the above proof. Contains
       - `deferred_values`: The values necessary for finishing the deferred "scalar field" computations.

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -2,8 +2,7 @@
 
 open Pickles_types
 module Impl = Impls.Step
-
-module One_hot_vector : module type of One_hot_vector.Make (Impls.Step)
+module One_hot_vector = One_hot_vector.Step
 
 type challenge = Import.Challenge.Make(Impls.Step).t
 

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -2,61 +2,61 @@ open Core_kernel
 
 open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
-let seal i = Tuple_lib.Double.map ~f:(Util.seal i)
+module Make_add (Impl : Kimchi_pasta_snarky_backend.Snark_intf) = struct
+  module Utils = Util.Make (Impl)
 
-let add_fast (type f)
-    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
-    ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
-    Impl.Field.t * Impl.Field.t =
-  let p1 = seal (module Impl) p1 in
-  let p2 = seal (module Impl) p2 in
-  let open Impl in
-  let open Field.Constant in
-  let bool b = if b then one else zero in
-  let eq a b = As_prover.(equal (read_var a) (read_var b)) in
-  let same_x_bool = lazy (eq x1 x2) in
-  let ( ! ) = Lazy.force in
-  let ( !! ) = As_prover.read_var in
-  let mk f = exists Field.typ ~compute:f in
-  let same_x = mk (fun () -> bool !same_x_bool) in
-  let inf =
-    if check_finite then Field.zero
-    else mk (fun () -> bool (!same_x_bool && not (eq y1 y2)))
-  in
-  let inf_z =
-    mk (fun () ->
-        if eq y1 y2 then zero
-        else if !same_x_bool then inv (!!y2 - !!y1)
-        else zero )
-  in
-  let x21_inv =
-    mk (fun () -> if !same_x_bool then zero else inv (!!x2 - !!x1))
-  in
-  let s =
-    mk (fun () ->
-        if !same_x_bool then
-          let x1_squared = square !!x1 in
-          let y1 = !!y1 in
-          (x1_squared + x1_squared + x1_squared) / (y1 + y1)
-        else (!!y2 - !!y1) / (!!x2 - !!x1) )
-  in
-  let x3 = mk (fun () -> square !!s - (!!x1 + !!x2)) in
-  let y3 = mk (fun () -> (!!s * (!!x1 - !!x3)) - !!y1) in
-  let p3 = (x3, y3) in
-  with_label "add_fast" (fun () ->
-      assert_
-        (EC_add_complete { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv }) ;
-      p3 )
+  let seal = Tuple_lib.Double.map ~f:Utils.seal
+
+  let add_fast ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
+      Impl.Field.t * Impl.Field.t =
+    let p1 = seal p1 in
+    let p2 = seal p2 in
+    let open Impl in
+    let open Field.Constant in
+    let bool b = if b then one else zero in
+    let eq a b = As_prover.(equal (read_var a) (read_var b)) in
+    let same_x_bool = lazy (eq x1 x2) in
+    let ( ! ) = Lazy.force in
+    let ( !! ) = As_prover.read_var in
+    let mk f = exists Field.typ ~compute:f in
+    let same_x = mk (fun () -> bool !same_x_bool) in
+    let inf =
+      if check_finite then Field.zero
+      else mk (fun () -> bool (!same_x_bool && not (eq y1 y2)))
+    in
+    let inf_z =
+      mk (fun () ->
+          if eq y1 y2 then zero
+          else if !same_x_bool then inv (!!y2 - !!y1)
+          else zero )
+    in
+    let x21_inv =
+      mk (fun () -> if !same_x_bool then zero else inv (!!x2 - !!x1))
+    in
+    let s =
+      mk (fun () ->
+          if !same_x_bool then
+            let x1_squared = square !!x1 in
+            let y1 = !!y1 in
+            (x1_squared + x1_squared + x1_squared) / (y1 + y1)
+          else (!!y2 - !!y1) / (!!x2 - !!x1) )
+    in
+    let x3 = mk (fun () -> square !!s - (!!x1 + !!x2)) in
+    let y3 = mk (fun () -> (!!s * (!!x1 - !!x3)) - !!y1) in
+    let p3 = (x3, y3) in
+    with_label "add_fast" (fun () ->
+        assert_
+          (EC_add_complete
+             { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } ) ;
+        p3 )
+end
 
 module Make
     (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl
-
-  let seal = seal (module Impl)
-
-  let add_fast = add_fast (module Impl)
+  include Make_add (Impl)
 
   let bits_per_chunk = 5
 

--- a/src/lib/pickles/plonk_curve_ops.mli
+++ b/src/lib/pickles/plonk_curve_ops.mli
@@ -1,20 +1,19 @@
-val add_fast :
-     (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
-  -> ?check_finite:bool
-  -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
-  -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
-  -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
+module Make_add (Impl : Kimchi_pasta_snarky_backend.Snark_intf) : sig
+  type pair := Impl.Field.t Tuple_lib.Double.t
+
+  val seal : pair -> pair
+
+  val add_fast : ?check_finite:bool -> pair -> pair -> pair
+end
 
 module Make
     (Impl : Kimchi_pasta_snarky_backend.Snark_intf)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) : sig
-  type var := Impl.field Snarky_backendless.Cvar.t
-
-  type pair := var Tuple_lib.Double.t
+  type pair := Impl.Field.t Tuple_lib.Double.t
 
   val seal : pair -> pair
 
-  val add_fast : ?check_finite:bool -> var * var -> var * var -> var * var
+  val add_fast : ?check_finite:bool -> pair -> pair -> pair
 
   val bits_per_chunk : int
 

--- a/src/lib/pickles/pseudo/pseudo.ml
+++ b/src/lib/pickles/pseudo/pseudo.ml
@@ -4,8 +4,9 @@ module Domain = Plonk_checks.Domain
 
 module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
   open Impl
+  module One_hot_vector = One_hot_vector.Make (Impl)
 
-  type ('a, 'n) t = 'n One_hot_vector.T(Impl).t * ('a, 'n) Vector.t
+  type ('a, 'n) t = 'n One_hot_vector.t * ('a, 'n) Vector.t
 
   (* TODO: Use version in common. *)
   let seal (x : Impl.Field.t) : Impl.Field.t =
@@ -19,7 +20,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
         let y = exists Field.typ ~compute:As_prover.(fun () -> read_var x) in
         Field.Assert.equal x y ; y
 
-  let mask (type n) (bits : n One_hot_vector.T(Impl).t) xs =
+  let mask (type n) (bits : n One_hot_vector.t) xs =
     with_label __LOC__ (fun () ->
         Vector.map
           (Vector.zip (bits :> (Boolean.var, n) Vector.t) xs)
@@ -127,3 +128,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
       end
   end
 end
+
+module Step = Make (Kimchi_pasta_snarky_backend.Step_impl)
+module Wrap = Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles/pseudo/pseudo.mli
+++ b/src/lib/pickles/pseudo/pseudo.mli
@@ -6,12 +6,12 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
   (** The type parameter ['n] is the size of the vector, and ['a] is the domains
       of the vector elements. *)
   type ('a, 'n) t =
-    'n One_hot_vector.T(Impl).t * ('a, 'n) Pickles_types.Vector.t
+    'n One_hot_vector.Make(Impl).t * ('a, 'n) Pickles_types.Vector.t
 
   val seal : Impl.Field.t -> Impl.Field.t
 
   val mask :
-       'n One_hot_vector.T(Impl).t
+       'n One_hot_vector.Make(Impl).t
     -> (Impl.Field.t, 'n) Pickles_types.Vector.t
     -> Impl.Field.t
 
@@ -51,3 +51,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
       -> Impl.Field.t Plonk_checks.plonk_domain
   end
 end
+
+module Step : module type of Make (Kimchi_pasta_snarky_backend.Step_impl)
+
+module Wrap : module type of Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -154,6 +154,7 @@ module Make
     end) =
 struct
   open Impl
+  module Utils = Util.Make (Impl)
   module Scalar = G.Constant.Scalar
 
   type t = Challenge.t SC.t
@@ -170,7 +171,7 @@ struct
 
   let num_bits = 128
 
-  let seal = Util.seal (module Impl)
+  let seal = Utils.seal
 
   let endo ?(num_bits = num_bits) t { SC.inner = (scalar : Field.t) } =
     let ( !! ) = As_prover.read_var in

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -303,14 +303,11 @@ let dummy : t =
 
 module Checked = struct
   open Step_main_inputs
-  open Impl
 
   type t =
-    { max_proofs_verified :
-        Impl.field Pickles_base.Proofs_verified.One_hot.Checked.t
+    { max_proofs_verified : Pickles_base.Proofs_verified.One_hot.Checked.t
           (** The maximum of all of the [step_widths]. *)
-    ; actual_wrap_domain_size :
-        Impl.field Pickles_base.Proofs_verified.One_hot.Checked.t
+    ; actual_wrap_domain_size : Pickles_base.Proofs_verified.One_hot.Checked.t
           (** The actual domain size used by the wrap circuit. *)
     ; wrap_index : Inner_curve.t Plonk_verification_key_evals.t
           (** The plonk verification key for the 'wrapping' proof that this key

--- a/src/lib/pickles/side_loaded_verification_key.mli
+++ b/src/lib/pickles/side_loaded_verification_key.mli
@@ -43,13 +43,9 @@ end
 
 module Checked : sig
   type t =
-    { max_proofs_verified :
-        Step_main_inputs.Impl.field
-        Pickles_base.Proofs_verified.One_hot.Checked.t
+    { max_proofs_verified : Pickles_base.Proofs_verified.One_hot.Checked.t
           (** The maximum of all of the [step_widths]. *)
-    ; actual_wrap_domain_size :
-        Step_main_inputs.Impl.field
-        Pickles_base.Proofs_verified.One_hot.Checked.t
+    ; actual_wrap_domain_size : Pickles_base.Proofs_verified.One_hot.Checked.t
           (** The actual domain size used by the wrap circuit. *)
     ; wrap_index :
         Step_main_inputs.Inner_curve.t

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -13,6 +13,7 @@ module Make
     end) =
 struct
   include Make_sponge.Rounds
+  module Utils = Util.Make (Impl)
 
   let round_table start =
     let ({ round_constants; mds } : _ Sponge.Params.t) = B.params in
@@ -49,8 +50,7 @@ struct
         with_label __LOC__ (fun () -> Impl.assert_ (Poseidon { state = t }))) ;
         t.(Int.(Array.length t - 1)) )
 
-  let add_assign ~state i x =
-    state.(i) <- Util.seal (module Impl) Field.(state.(i) + x)
+  let add_assign ~state i x = state.(i) <- Utils.seal Field.(state.(i) + x)
 
   let copy = Array.copy
 end

--- a/src/lib/pickles/step_main_inputs.ml
+++ b/src/lib/pickles/step_main_inputs.ml
@@ -180,8 +180,9 @@ module Inner_curve = struct
         with module Scaling_precomputation := T.Scaling_precomputation )
 
   module Scaling_precomputation = T.Scaling_precomputation
+  module Curve_add = Plonk_curve_ops.Make_add (Impl)
 
-  let ( + ) t1 t2 = Plonk_curve_ops.add_fast (module Impl) t1 t2
+  let ( + ) t1 t2 = Curve_add.add_fast t1 t2
 
   let double t = t + t
 

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -27,6 +27,7 @@ struct
   open Impl
   module Challenge = Challenge.Make (Impl)
   module Digest = Digest.Make (Impl)
+  module Utils = Util.Make (Impl)
 
   (* Other_field.size > Field.size *)
   module Other_field = struct
@@ -81,7 +82,7 @@ struct
 
   let lowest_128_bits ~constrain_low_bits x =
     let assert_128_bits = assert_n_bits ~n:128 in
-    Util.lowest_128_bits ~constrain_low_bits ~assert_128_bits (module Impl) x
+    Utils.lowest_128_bits ~constrain_low_bits ~assert_128_bits x
 
   module Scalar_challenge =
     SC.Make (Impl) (Inner_curve) (Challenge) (Endo.Step_inner_curve)
@@ -399,7 +400,7 @@ struct
                     Field.((b :> t) * x, (b :> t) * y) ) )
             |> Vector.reduce_exn
                  ~f:(Vector.map2 ~f:(Double.map2 ~f:Field.( + )))
-            |> Vector.map ~f:(Double.map ~f:(Util.seal (module Impl)))
+            |> Vector.map ~f:(Double.map ~f:Utils.seal)
     in
     let lagrange i =
       select_curve_points ~points_for_domain:(fun d ->
@@ -671,7 +672,7 @@ struct
     fun ~(log2_size : Field.t) ->
       let domain ~max =
         let (T max_n) = Nat.of_int max in
-        let mask = ones_vector (module Impl) max_n ~first_zero:log2_size in
+        let mask = Utils.ones_vector max_n ~first_zero:log2_size in
         let log2_sizes =
           ( O.of_index log2_size ~length:(S max_n)
           , Vector.init (S max_n) ~f:Fn.id )

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -794,7 +794,7 @@ struct
 
   let domain_for_compiled (type branches)
       (domains : (Domains.t, branches) Vector.t)
-      (branch_data : Impl.field Branch_data.Checked.t) :
+      (branch_data : Branch_data.Checked.Step.t) :
       Field.t Plonk_checks.plonk_domain =
     let (T unique_domains) =
       List.map (Vector.to_list domains) ~f:Domains.h
@@ -845,7 +845,7 @@ struct
         , _
         , _
         , _
-        , Field.Constant.t Branch_data.Checked.t
+        , Branch_data.Checked.Step.t
         , _ )
         Types.Wrap.Proof_state.Deferred_values.In_circuit.t )
       { Plonk_types.All_evals.In_circuit.ft_eval1; evals } =
@@ -1175,6 +1175,7 @@ struct
       with_label "pack_statement" (fun () ->
           Spec.pack
             (module Impl)
+            (module Branch_data.Checked.Step)
             (Types.Wrap.Statement.In_circuit.spec
                (module Impl)
                lookup_parameters feature_flags )

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -484,9 +484,9 @@ struct
       ~(domain :
          [ `Known of Domain.t
          | `Side_loaded of
-           _ Composition_types.Branch_data.Proofs_verified.One_hot.Checked.t ]
-         ) ~srs ~verification_key:(m : _ Plonk_verification_key_evals.t) ~xi
-      ~sponge ~sponge_after_index
+           Composition_types.Branch_data.Proofs_verified.One_hot.Checked.t ] )
+      ~srs ~verification_key:(m : _ Plonk_verification_key_evals.t) ~xi ~sponge
+      ~sponge_after_index
       ~(public_input :
          [ `Field of Field.t | `Packed_bits of Field.t * int ] array )
       ~(sg_old : (_, Proofs_verified.n) Vector.t) ~advice

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -365,7 +365,7 @@ struct
     | _ ->
         assert false
 
-  module O = One_hot_vector.Make (Impl)
+  module O = One_hot_vector.Step
   open Tuple_lib
 
   let public_input_commitment_dynamic (type n) ~srs (which : n O.t)
@@ -635,7 +635,7 @@ struct
 
   let challenge_polynomial = Wrap_verifier.challenge_polynomial (module Field)
 
-  module Pseudo = Pseudo.Make (Impl)
+  module Pseudo = Pseudo.Step
 
   (* module Bounded = struct
        type t = { max : int; actual : Field.t }

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -48,7 +48,7 @@ val finalize_other_proof :
      , ( Impl.Field.t Import.Scalar_challenge.t Import.Bulletproof_challenge.t
        , 'c )
        Pickles_types.Vector.t
-     , Impl.Field.Constant.t Import.Branch_data.Checked.t
+     , Import.Branch_data.Checked.Step.t
      , Impl.Boolean.var )
      Import.Types.Wrap.Proof_state.Deferred_values.In_circuit.t
   -> ( Impl.Field.t
@@ -136,7 +136,7 @@ val verify :
          Composition_types.Bulletproof_challenge.t
        , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )
        Pickles_types.Vector.t
-     , Impl.field Composition_types.Branch_data.Checked.t )
+     , Composition_types.Branch_data.Checked.Step.t )
      Import.Types.Wrap.Statement.In_circuit.t
      (* statement *)
   -> Impls.Step.unfinalized_proof_var (* unfinalized *)

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -114,7 +114,6 @@ val verify :
   -> wrap_domain:
        [ `Known of Import.Domain.t
        | `Side_loaded of
-         Impl.field
          Composition_types.Branch_data.Proofs_verified.One_hot.Checked.t ]
   -> wrap_verification_key:
        Step_main_inputs.Inner_curve.t array

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -9,7 +9,7 @@ module Scalar_challenge :
       Scalar_challenge.Make (Impl) (Step_main_inputs.Inner_curve) (Challenge)
         (Endo.Step_inner_curve)
 
-module Pseudo : module type of Pseudo.Make (Impl)
+module Pseudo = Pseudo.Step
 
 module Inner_curve : sig
   type t = Step_main_inputs.Inner_curve.t

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -162,8 +162,7 @@ module For_step = struct
     ; wrap_key : inner_curve_var array Plonk_verification_key_evals.t
     ; wrap_domain :
         [ `Known of Domain.t
-        | `Side_loaded of
-          Impls.Step.field Pickles_base.Proofs_verified.One_hot.Checked.t ]
+        | `Side_loaded of Pickles_base.Proofs_verified.One_hot.Checked.t ]
     ; step_domains : [ `Known of (Domains.t, 'branches) Vector.t | `Side_loaded ]
     ; feature_flags : Opt.Flag.t Plonk_types.Features.Full.t
     ; num_chunks : int

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -100,8 +100,7 @@ module For_step : sig
         inner_curve_var array Pickles_types.Plonk_verification_key_evals.t
     ; wrap_domain :
         [ `Known of Import.Domain.t
-        | `Side_loaded of
-          Impls.Step.field Pickles_base.Proofs_verified.One_hot.Checked.t ]
+        | `Side_loaded of Pickles_base.Proofs_verified.One_hot.Checked.t ]
     ; step_domains :
         [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]

--- a/src/lib/pickles/util.ml
+++ b/src/lib/pickles/util.ml
@@ -42,66 +42,62 @@ let rec absorb :
       let t1, t2 = t in
       absorb ty1 t1 ; absorb ty2 t2
 
-(** [ones_vector (module I) ~first_zero n] returns a vector of booleans of
+module Make (Impl : Kimchi_pasta_snarky_backend.Snark_intf) = struct
+  open Impl
+
+  (** [ones_vector (module I) ~first_zero n] returns a vector of booleans of
    length n which is all ones until position [first_zero], at which it is zero,
    and zero thereafter. *)
-let ones_vector :
-    type f n.
-       first_zero:f Snarky_backendless.Cvar.t
-    -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
-    -> n Nat.t
-    -> (f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t, n) Vector.t =
- fun ~first_zero (module Impl) n ->
-  let open Impl in
-  let rec go :
-      type m. Boolean.var -> int -> m Nat.t -> (Boolean.var, m) Vector.t =
-   fun value i m ->
-    match[@warning "-45"] m with
-    | Pickles_types.Nat.Z ->
-        Pickles_types.Vector.[]
-    | Pickles_types.Nat.S m ->
-        let value =
-          Boolean.(value && not (Field.equal first_zero (Field.of_int i)))
-        in
-        Pickles_types.Vector.(value :: go value (i + 1) m)
-  in
-  go Boolean.true_ 0 n
-
-let seal (type f)
-    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f)
-    (x : Impl.Field.t) : Impl.Field.t =
-  let open Impl in
-  match Field.to_constant_and_terms x with
-  | None, [ (x, i) ] when Field.Constant.(equal x one) ->
-      Snarky_backendless.Cvar.Var i
-  | Some c, [] ->
-      Field.constant c
-  | _ ->
-      let y = exists Field.typ ~compute:As_prover.(fun () -> read_var x) in
-      Field.Assert.equal x y ; y
-
-let lowest_128_bits (type f) ~constrain_low_bits ~assert_128_bits
-    (module Impl : Kimchi_pasta_snarky_backend.Snark_intf with type field = f) x
-    =
-  let open Impl in
-  let pow2 =
-    (* 2 ^ n *)
-    let rec pow2 x i =
-      if i = 0 then x else pow2 Field.Constant.(x + x) (i - 1)
+  let ones_vector :
+      type n. first_zero:Impl.Field.t -> n Nat.t -> (Boolean.var, n) Vector.t =
+   fun ~first_zero n ->
+    let rec go :
+        type m. Boolean.var -> int -> m Nat.t -> (Boolean.var, m) Vector.t =
+     fun value i m ->
+      match[@warning "-45"] m with
+      | Pickles_types.Nat.Z ->
+          Pickles_types.Vector.[]
+      | Pickles_types.Nat.S m ->
+          let value =
+            Boolean.(value && not (Field.equal first_zero (Field.of_int i)))
+          in
+          Pickles_types.Vector.(value :: go value (i + 1) m)
     in
-    fun n -> pow2 Field.Constant.one n
-  in
-  let lo, hi =
-    exists
-      Typ.(field * field)
-      ~compute:(fun () ->
-        let lo, hi =
-          Field.Constant.unpack (As_prover.read_var x)
-          |> Fn.flip List.split_n 128
-        in
-        (Field.Constant.project lo, Field.Constant.project hi) )
-  in
-  assert_128_bits hi ;
-  if constrain_low_bits then assert_128_bits lo ;
-  Field.Assert.equal x Field.(lo + scale hi (pow2 128)) ;
-  lo
+    go Boolean.true_ 0 n
+
+  let seal (x : Impl.Field.t) : Impl.Field.t =
+    match Field.to_constant_and_terms x with
+    | None, [ (x, i) ] when Field.Constant.(equal x one) ->
+        Snarky_backendless.Cvar.Var i
+    | Some c, [] ->
+        Field.constant c
+    | _ ->
+        let y = exists Field.typ ~compute:As_prover.(fun () -> read_var x) in
+        Field.Assert.equal x y ; y
+
+  let lowest_128_bits ~constrain_low_bits ~assert_128_bits x =
+    let pow2 =
+      (* 2 ^ n *)
+      let rec pow2 x i =
+        if i = 0 then x else pow2 Field.Constant.(x + x) (i - 1)
+      in
+      fun n -> pow2 Field.Constant.one n
+    in
+    let lo, hi =
+      exists
+        Typ.(field * field)
+        ~compute:(fun () ->
+          let lo, hi =
+            Field.Constant.unpack (As_prover.read_var x)
+            |> Fn.flip List.split_n 128
+          in
+          (Field.Constant.project lo, Field.Constant.project hi) )
+    in
+    assert_128_bits hi ;
+    if constrain_low_bits then assert_128_bits lo ;
+    Field.Assert.equal x Field.(lo + scale hi (pow2 128)) ;
+    lo
+end
+
+module Step = Make (Kimchi_pasta_snarky_backend.Step_impl)
+module Wrap = Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles/util.mli
+++ b/src/lib/pickles/util.mli
@@ -10,23 +10,23 @@ val absorb :
   -> 'a
   -> unit
 
-val ones_vector :
-  'f 'n.
-     first_zero:'f Snarky_backendless.Cvar.t
-  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
-  -> 'n Pickles_types.Nat.t
-  -> ( 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
-     , 'n )
-     Pickles_types.Vector.t
+module Make (Impl : Kimchi_pasta_snarky_backend.Snark_intf) : sig
+  open Impl
 
-val seal :
-     (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
-  -> 'f Snarky_backendless.Cvar.t
-  -> 'f Snarky_backendless.Cvar.t
+  val ones_vector :
+       first_zero:Field.t
+    -> 'n Pickles_types.Nat.t
+    -> (Boolean.var, 'n) Pickles_types.Vector.t
 
-val lowest_128_bits :
-     constrain_low_bits:bool
-  -> assert_128_bits:('f Snarky_backendless.Cvar.t -> unit)
-  -> (module Kimchi_pasta_snarky_backend.Snark_intf with type field = 'f)
-  -> 'f Snarky_backendless.Cvar.t
-  -> 'f Snarky_backendless.Cvar.t
+  val seal : Field.t -> Field.t
+
+  val lowest_128_bits :
+       constrain_low_bits:bool
+    -> assert_128_bits:(Field.t -> unit)
+    -> Field.t
+    -> Field.t
+end
+
+module Step : module type of Make (Kimchi_pasta_snarky_backend.Step_impl)
+
+module Wrap : module type of Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -40,6 +40,7 @@ let pack_statement max_proofs_verified t =
   let open Types.Step in
   Spec.pack
     (module Impl)
+    (module Branch_data.Checked.Wrap)
     (Statement.spec max_proofs_verified Backend.Tock.Rounds.n)
     (Statement.to_data t)
 
@@ -193,8 +194,7 @@ let wrap_main
           let () =
             with_label __LOC__ (fun () ->
                 (* Check that the branch_data public-input is correct *)
-                Branch_data.Checked.pack
-                  (module Impl)
+                Branch_data.Checked.Wrap.pack
                   { proofs_verified_mask =
                       Vector.extend_front_exn actual_proofs_verified_mask
                         Nat.N2.n Boolean.false_

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -176,8 +176,7 @@ let wrap_main
             Wrap_verifier.One_hot_vector.of_index which_branch' ~length:branches
           in
           let actual_proofs_verified_mask =
-            Util.ones_vector
-              (module Impl)
+            Util.Wrap.ones_vector
               ~first_zero:
                 (Wrap_verifier.Pseudo.choose
                    (which_branch, step_widths)

--- a/src/lib/pickles/wrap_main_inputs.ml
+++ b/src/lib/pickles/wrap_main_inputs.ml
@@ -176,8 +176,9 @@ module Inner_curve = struct
         with module Scaling_precomputation := T.Scaling_precomputation )
 
   module Scaling_precomputation = T.Scaling_precomputation
+  module Curve_add = Plonk_curve_ops.Make_add (Impl)
 
-  let ( + ) t1 t2 = Plonk_curve_ops.add_fast (module Impl) t1 t2
+  let ( + ) t1 t2 = Curve_add.add_fast t1 t2
 
   let double t = t + t
 

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -159,7 +159,7 @@ struct
 
   let lowest_128_bits ~constrain_low_bits x =
     let assert_128_bits = assert_n_bits ~n:128 in
-    Util.lowest_128_bits ~constrain_low_bits ~assert_128_bits (module Impl) x
+    Util.Wrap.lowest_128_bits ~constrain_low_bits ~assert_128_bits x
 
   let squeeze_challenge sponge : Field.t =
     lowest_128_bits (* I think you may not have to constrain these actually *)
@@ -310,17 +310,16 @@ struct
                in
                Opt.Maybe (is_yes, sum) )
       |> Plonk_verification_key_evals.Step.map
-           ~f:(fun g -> Array.map ~f:(Double.map ~f:(Util.seal (module Impl))) g)
+           ~f:(fun g -> Array.map ~f:(Double.map ~f:Util.Wrap.seal) g)
            ~f_opt:(function
              | Opt.Nothing ->
                  Opt.Nothing
              | Opt.Maybe (b, x) ->
                  Opt.Maybe
-                   ( Boolean.Unsafe.of_cvar (Util.seal (module Impl) (b :> t))
-                   , Array.map ~f:(Double.map ~f:(Util.seal (module Impl))) x )
+                   ( Boolean.Unsafe.of_cvar (Util.Wrap.seal (b :> t))
+                   , Array.map ~f:(Double.map ~f:Util.Wrap.seal) x )
              | Opt.Just x ->
-                 Opt.Just
-                   (Array.map ~f:(Double.map ~f:(Util.seal (module Impl))) x) )
+                 Opt.Just (Array.map ~f:(Double.map ~f:Util.Wrap.seal) x) )
 
   (* TODO: Unify with the code in step_verifier *)
   let lagrange (type n)
@@ -432,8 +431,7 @@ struct
                    ~f:
                      (Array.map2_exn
                         ~f:(Double.map2 ~f:(Double.map2 ~f:Field.( + ))) )
-              |> Array.map
-                   ~f:(Double.map ~f:(Double.map ~f:(Util.seal (module Impl)))) )
+              |> Array.map ~f:(Double.map ~f:(Double.map ~f:Util.Wrap.seal)) )
 
   let _h_precomp =
     Lazy.map ~f:Inner_curve.Scaling_precomputation.create Generators.h
@@ -655,7 +653,7 @@ struct
     in
     let length = Pseudo.choose (choice, lengths) ~f:Field.of_int in
     let (T max) = Nat.of_int max in
-    Vector.to_array (ones_vector (module Impl) ~first_zero:length max)
+    Vector.to_array (Util.Wrap.ones_vector ~first_zero:length max)
 
   module Plonk = Types.Wrap.Proof_state.Deferred_values.Plonk
 
@@ -1442,10 +1440,9 @@ struct
 
   let map_plonk_to_field plonk =
     Types.Step.Proof_state.Deferred_values.Plonk.In_circuit.map_challenges
-      ~f:(Util.seal (module Impl))
-      ~scalar:scalar_to_field plonk
+      ~f:Util.Wrap.seal ~scalar:scalar_to_field plonk
     |> Types.Step.Proof_state.Deferred_values.Plonk.In_circuit.map_fields
-         ~f:(Shifted_value.Type2.map ~f:(Util.seal (module Impl)))
+         ~f:(Shifted_value.Type2.map ~f:Util.Wrap.seal)
 
   module Plonk_checks = struct
     include Plonk_checks

--- a/src/lib/pickles_base/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles_base/one_hot_vector/one_hot_vector.ml
@@ -48,3 +48,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
         in
         i )
 end
+
+module Step = Make (Kimchi_pasta_snarky_backend.Step_impl)
+module Wrap = Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles_base/one_hot_vector/one_hot_vector.mli
+++ b/src/lib/pickles_base/one_hot_vector/one_hot_vector.mli
@@ -13,27 +13,17 @@ module Constant : sig
   type t = int
 end
 
-(** Represents a one-hot vector of length ['n]. The type parameter ['f] is used
-    to encod the field the vector lives in. For instance, if we want to
-    represent the one-hot vector [0; 0; 1; 0; 0] in the finite field [F13], we
-    would use the type [(F13.t, Nat.N5) t]. To activate the third bit, we would
-    use the function [of_index] provided below.
-*)
-type ('f, 'n) t =
-  private
-  ('f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t, 'n) Vector.t
-
-(** Concrete instance of a one-hot vector using an implementation Impl
-    TODO: why don't we merge this functor with {!Make}? *)
-module T (Impl : Snarky_backendless.Snark_intf.Run) : sig
-  type nonrec 'n t = (Impl.field, 'n) t
-end
-
 (** Concrete instance of a one-hot vector with some helpers *)
 module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
   module Constant = Constant
 
-  type 'n t = 'n T(Impl).t
+  (** Represents a one-hot vector of length ['n]. The type parameter ['f] is
+      used to encode the field the vector lives in. For instance, if we want to
+      represent the one-hot vector [0; 0; 1; 0; 0] in the finite field [F13],
+      we would use the type [(F13.t, Nat.N5) t]. To activate the third bit, we
+      would use the function [of_index] provided below.
+  *)
+  type 'n t = private (Impl.Boolean.var, 'n) Vector.t
 
   (** [of_index f_idx t_n] creates a one hot vector of size [t_n] which only the
       index [f_idx] is set to [true].
@@ -49,3 +39,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
 
   val typ : 'n Nat.t -> ('n t, Constant.t) Impl.Typ.t
 end
+
+module Step : module type of Make (Kimchi_pasta_snarky_backend.Step_impl)
+
+module Wrap : module type of Make (Kimchi_pasta_snarky_backend.Wrap_impl)

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -109,14 +109,17 @@ module Prefix_mask = struct
 end
 
 module One_hot = struct
-  module Checked = struct
-    type 'f t = ('f, Pickles_types.Nat.N3.n) One_hot_vector.t
+  open Kimchi_pasta_snarky_backend
 
-    let to_input (type f) (t : f t) =
+  module Checked = struct
+    type t = (Step_impl.field, Pickles_types.Nat.N3.n) One_hot_vector.t
+
+    let to_input (t : t) =
       Random_oracle_input.Chunked.packeds
         (Array.map
-           Pickles_types.(Vector.to_array (t :> (f boolean, Nat.N3.n) Vector.t))
-           ~f:(fun b -> ((b :> f Snarky_backendless.Cvar.t), 1)) )
+           Pickles_types.(
+             Vector.to_array (t :> (Step_impl.Boolean.var, Nat.N3.n) Vector.t))
+           ~f:(fun b -> ((b :> Step_impl.Field.t), 1)) )
   end
 
   let there : proofs_verified -> int = function N0 -> 0 | N1 -> 1 | N2 -> 2
@@ -143,13 +146,7 @@ module One_hot = struct
     in
     Random_oracle_input.Chunked.packeds (Array.map one_hot ~f:(fun b -> (b, 1)))
 
-  open Kimchi_pasta_snarky_backend
-
-  let typ : (_ Checked.t, proofs_verified) Step_impl.Typ.t =
+  let typ : (Checked.t, proofs_verified) Step_impl.Typ.t =
     let module M = One_hot_vector.Make (Step_impl) in
     Step_impl.Typ.transport (M.typ Pickles_types.Nat.N3.n) ~there ~back
-
-  let wrap_typ : (_ Checked.t, proofs_verified) Wrap_impl.Typ.t =
-    let module M = One_hot_vector.Make (Wrap_impl) in
-    Wrap_impl.Typ.transport (M.typ Pickles_types.Nat.N3.n) ~there ~back
 end

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -121,7 +121,7 @@ module One_hot = struct
   open Kimchi_pasta_snarky_backend
 
   module Checked = struct
-    type t = (Step_impl.field, Pickles_types.Nat.N3.n) One_hot_vector.t
+    type t = Pickles_types.Nat.N3.n One_hot_vector.Step.t
 
     let to_input (t : t) =
       Random_oracle_input.Chunked.packeds

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -26,20 +26,17 @@ val of_int_exn : int -> t
 val to_int : t -> int
 
 module One_hot : sig
-  module Checked : sig
-    type 'f t = ('f, Pickles_types.Nat.N3.n) One_hot_vector.t
+  open Kimchi_pasta_snarky_backend
 
-    val to_input :
-      'f t -> 'f Snarky_backendless.Cvar.t Random_oracle_input.Chunked.t
+  module Checked : sig
+    type t = (Step_impl.field, Pickles_types.Nat.N3.n) One_hot_vector.t
+
+    val to_input : t -> Step_impl.Field.t Random_oracle_input.Chunked.t
   end
 
   val to_input : zero:'a -> one:'a -> t -> 'a Random_oracle_input.Chunked.t
 
-  open Kimchi_pasta_snarky_backend
-
-  val typ : (Step_impl.Field.Constant.t Checked.t, t) Step_impl.Typ.t
-
-  val wrap_typ : (Wrap_impl.Field.Constant.t Checked.t, t) Wrap_impl.Typ.t
+  val typ : (Checked.t, t) Step_impl.Typ.t
 end
 
 type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -1,3 +1,5 @@
+open Pickles_types
+
 (** Represents how many proofs are verified. Currently only [0], [1] or [2] *)
 module Stable : sig
   module V1 : sig
@@ -15,7 +17,7 @@ type t = Stable.V1.t = N0 | N1 | N2
 
 (** [of_nat_exn t_n] converts the type level natural [t_n] to the data type natural.
     Raise an exception if [t_n] represents a value above or equal to 3 *)
-val of_nat_exn : 'n Pickles_types.Nat.t -> t
+val of_nat_exn : 'n Nat.t -> t
 
 (** [of_int_exn n] converts the runtime natural [n] to the data type natural. Raise
     an exception if the value [n] is above or equal to 3 *)
@@ -29,7 +31,7 @@ module One_hot : sig
   open Kimchi_pasta_snarky_backend
 
   module Checked : sig
-    type t = (Step_impl.field, Pickles_types.Nat.N3.n) One_hot_vector.t
+    type t = (Step_impl.field, Nat.N3.n) One_hot_vector.t
 
     val to_input : t -> Step_impl.Field.t Random_oracle_input.Chunked.t
   end
@@ -39,23 +41,26 @@ module One_hot : sig
   val typ : (Checked.t, t) Step_impl.Typ.t
 end
 
-type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
+val to_bool_vec : t -> (bool, Nat.N2.n) Vector.t
 
-(** Vector of 2 elements *)
-type 'a vec2 = ('a, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+val of_bool_vec : (bool, Nat.N2.n) Vector.t -> t
 
 module Prefix_mask : sig
-  module Checked : sig
-    type 'f t = 'f boolean vec2
-  end
-
-  val there : t -> bool vec2
-
-  val back : bool vec2 -> t
-
   open Kimchi_pasta_snarky_backend
 
-  val typ : (Step_impl.Field.Constant.t Checked.t, t) Step_impl.Typ.t
+  module Step : sig
+    module Checked : sig
+      type t = (Step_impl.Boolean.var, Nat.N2.n) Vector.t
+    end
 
-  val wrap_typ : (Wrap_impl.Field.Constant.t Checked.t, t) Wrap_impl.Typ.t
+    val typ : (Checked.t, t) Step_impl.Typ.t
+  end
+
+  module Wrap : sig
+    module Checked : sig
+      type t = (Wrap_impl.Boolean.var, Nat.N2.n) Vector.t
+    end
+
+    val typ : (Checked.t, t) Wrap_impl.Typ.t
+  end
 end

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -31,7 +31,7 @@ module One_hot : sig
   open Kimchi_pasta_snarky_backend
 
   module Checked : sig
-    type t = (Step_impl.field, Nat.N3.n) One_hot_vector.t
+    type t = Pickles_types.Nat.N3.n One_hot_vector.Step.t
 
     val to_input : t -> Step_impl.Field.t Random_oracle_input.Chunked.t
   end

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -196,7 +196,7 @@ module Legacy = struct
       module Operations = struct
         open Field
 
-        let seal = Pickles.Util.seal (module Impl)
+        let seal = Pickles.Util.Step.seal
 
         let add_assign ~state i x = state.(i) <- seal (state.(i) + x)
 


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16450, changing some pickles types and utilities to use the specific implementation from the backend instead of passing around the polymorphic `Cvar.t` wrappers.

This allows us to remove the hard-coding of `Cvar.t` in snarky, in turn letting us use a replacement type defined in the rust FFI.