### PR TITLE
Adding infra-eng-reviewers owner to .github folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@
 /dockerfiles/ @MinaProtocol/infra-eng-reviewers
 /scripts/ @MinaProtocol/infra-eng-reviewers @MinaProtocol/protocol-eng-reviewers
 /Makefile @MinaProtocol/infra-eng-reviewers
+/.github/ @MinaProtocol/infra-eng-reviewers
 /src/config/dev.mlh @MinaProtocol/infra-eng-reviewers @MinaProtocol/protocol-eng-reviewers
 /CODE_OF_CONDUCT.md @bkase
 /CONTRIBUTING.md @MinaProtocol/product-eng-reviewers


### PR DESCRIPTION
Adding MF `infra-eng-reviewers` team as owner to .github folder to prevent vulnerability attack as reported on hackenproof.