### PR TITLE
Opinionated refactoring of #16415

### DIFF
--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3299,11 +3299,11 @@ let%test_module _ =
 
       let set = Array.set
 
-      let get_random_unsealed spec = Simple_account.get_random_unsealed spec
+      let get_random_unsealed ledger = Simple_account.get_random_unsealed ledger
 
-      let find_by_key_idx (spec : t) key_idx =
-        Array.findi spec ~f:(fun _idx spec ->
-            Int.equal key_idx (Simple_account.key_idx spec) )
+      let find_by_key_idx (ledger : t) key_idx =
+        Array.findi ledger ~f:(fun _idx account ->
+            Int.equal key_idx (Simple_account.key_idx account) )
     end
 
     module Simple_command = struct

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3317,43 +3317,40 @@ let%test_module _ =
         | Zkapp_blocking_send of { sender : Simple_account.t; fee : int }
       [@@deriving yojson]
 
-      let gen_zkapp_blocking_send (spec : Simple_ledger.t) =
+      let gen_zkapp_blocking_send (ledger : Simple_ledger.t) =
         let open Quickcheck.Generator.Let_syntax in
-        let%bind random_idx, account_spec =
-          Simple_ledger.get_random_unsealed spec
+        let%bind random_idx, account =
+          Simple_ledger.get_random_unsealed ledger
         in
         let new_account_spec =
-          Simple_account.apply_cmd_or_fail ~amount:0 ~fee:minimum_fee
-            account_spec
+          Simple_account.apply_cmd_or_fail ~amount:0 ~fee:minimum_fee account
         in
-        Simple_ledger.set spec random_idx new_account_spec ;
-        return (Zkapp_blocking_send { sender = account_spec; fee = minimum_fee })
+        Simple_ledger.set ledger random_idx new_account_spec ;
+        return (Zkapp_blocking_send { sender = account; fee = minimum_fee })
 
       let gen_single_from ?(lower = 5_000_000_000_000)
-          ?(higher = 10_000_000_000_000) (spec : Simple_ledger.t)
-          (idx, account_spec) =
+          ?(higher = 10_000_000_000_000) (ledger : Simple_ledger.t)
+          (idx, account) =
         let open Quickcheck.Generator.Let_syntax in
         let%bind receiver_idx =
           test_keys |> Array.mapi ~f:(fun i _ -> i) |> Quickcheck_lib.of_array
         in
         let%bind amount = Int.gen_incl lower higher in
         let new_account_spec =
-          Simple_account.apply_cmd_or_fail ~amount ~fee:minimum_fee account_spec
+          Simple_account.apply_cmd_or_fail ~amount ~fee:minimum_fee account
         in
-        Simple_ledger.set spec idx new_account_spec ;
+        Simple_ledger.set ledger idx new_account_spec ;
         return
-          (Payment
-             { sender = account_spec; fee = minimum_fee; receiver_idx; amount }
-          )
+          (Payment { sender = account; fee = minimum_fee; receiver_idx; amount })
 
       let gen_sequence ?(lower = 5_000_000_000_000)
-          ?(higher = 10_000_000_000_000) (spec : Simple_ledger.t) ~length =
+          ?(higher = 10_000_000_000_000) (ledger : Simple_ledger.t) ~length =
         let open Quickcheck.Generator.Let_syntax in
         Quickcheck_lib.init_gen_array length ~f:(fun _ ->
-            let%bind random_idx, account_spec =
-              Simple_ledger.get_random_unsealed spec
+            let%bind random_idx, account =
+              Simple_ledger.get_random_unsealed ledger
             in
-            gen_single_from ~lower ~higher spec (random_idx, account_spec) )
+            gen_single_from ~lower ~higher ledger (random_idx, account) )
 
       let sender t =
         match t with

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3528,25 +3528,23 @@ let%test_module _ =
         (sequence, !sender)
       in
       let%bind major_sequence =
-        let account_state_on_major = account_with_limited_capacity in
-        let%bind major_sequence, account_state_on_major =
-          gen_sequence_and_update_account major_sequence_length
-            account_state_on_major
+        let account = account_with_limited_capacity in
+        let%bind major_sequence, account =
+          gen_sequence_and_update_account major_sequence_length account
         in
         Simple_ledger.set major account_with_limited_capacity_idx
-          (Simple_account.seal account_state_on_major) ;
+          (Simple_account.seal account) ;
         return major_sequence
       in
       let%bind minor_sequence =
-        let account_state_on_minor =
+        let account =
           Simple_ledger.get minor account_with_limited_capacity_idx
         in
-        let%bind minor_sequence, account_state_on_minor =
-          gen_sequence_and_update_account minor_sequence_length
-            account_state_on_minor
+        let%bind minor_sequence, account =
+          gen_sequence_and_update_account minor_sequence_length account
         in
         Simple_ledger.set minor account_with_limited_capacity_idx
-          (Simple_account.seal account_state_on_minor) ;
+          (Simple_account.seal account) ;
         return minor_sequence
       in
       let major_sequence_total_cost =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3511,13 +3511,17 @@ let%test_module _ =
       let initial_balance =
         Simple_account.balance account_with_limited_capacity
       in
-      let b = Simple_account.balance account_with_limited_capacity / 2 in
+      let half_initial_balance =
+        Simple_account.balance account_with_limited_capacity / 2
+      in
 
       let gen_sequence_and_update_account len sender =
         let sender = ref sender in
         let%map sequence =
           Quickcheck_lib.init_gen_array len ~f:(fun _ ->
-              let%bind amount = Int.gen_incl 5_000_000_000_000_000 (b / len) in
+              let%bind amount =
+                Int.gen_incl 5_000_000_000_000_000 (half_initial_balance / len)
+              in
               let tx =
                 Simple_command.Payment
                   { sender = Simple_account.to_sender_info !sender

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3575,13 +3575,9 @@ let%test_module _ =
         (Simple_account.seal account_state_on_minor) ;
       Array.set major_sequence random_idx increased_tx ;
       let split_by_account (account : Simple_account.t) commands =
-        let f cmd =
-          let sender = Simple_command.sender cmd in
-          sender.key_idx = Simple_account.key_idx account
-        in
-        let cmds_from_acc = Array.filter commands ~f in
-        let others = Array.filter commands ~f:(fun x -> not (f x)) in
-        (cmds_from_acc, others)
+        Array.partition_tf commands ~f:(fun cmd ->
+            let sender = Simple_command.sender cmd in
+            sender.key_idx = Simple_account.key_idx account )
       in
       let unchanged_major_commands, major_commands_to_merge =
         split_by_account account_with_limited_capacity major_commands

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3709,7 +3709,7 @@ let%test_module _ =
       in
       return branches
 
-    let gen_commands_from_specs (sequence : Simple_command.t array) test :
+    let commands_from_specs (sequence : Simple_command.t array) test :
         User_command.Valid.t list =
       let best_tip_ledger = Option.value_exn test.txn_pool.best_tip_ledger in
       sequence
@@ -3761,9 +3761,9 @@ let%test_module _ =
               [%log info] "Input Data $data"
                 ~metadata:[ ("data", [%to_yojson: branches] input_data) ] ;
 
-              let prefix_cmds = gen_commands_from_specs prefix_commands test in
-              let minor_cmds = gen_commands_from_specs minor_commands test in
-              let major_cmds = gen_commands_from_specs major_commands test in
+              let prefix_cmds = commands_from_specs prefix_commands test in
+              let minor_cmds = commands_from_specs minor_commands test in
+              let major_cmds = commands_from_specs major_commands test in
 
               commit_commands test (prefix_cmds @ major_cmds) ;
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3781,15 +3781,14 @@ let%test_module _ =
                        let data =
                          Transaction_hash.User_command_with_valid_signature.data
                            tx
+                         |> User_command.forget_check
                        in
                        let nonce =
-                         data |> User_command.forget_check
-                         |> User_command.applicable_at_nonce
+                         data |> User_command.applicable_at_nonce
                          |> Unsigned.UInt32.to_int
                        in
                        let fee_payer_pk =
-                         data |> User_command.forget_check
-                         |> User_command.fee_payer |> Account_id.public_key
+                         data |> User_command.fee_payer |> Account_id.public_key
                        in
                        (fee_payer_pk, nonce) )
               in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3748,13 +3748,10 @@ let%test_module _ =
           Thread_safe.block_on_async_exn (fun () ->
               [%log info] "Input Data $data"
                 ~metadata:[ ("data", [%to_yojson: branches] input_data) ] ;
-
               let prefix_cmds = commands_from_specs prefix_commands test in
               let minor_cmds = commands_from_specs minor_commands test in
               let major_cmds = commands_from_specs major_commands test in
-
               commit_commands test (prefix_cmds @ major_cmds) ;
-
               Test.Resource_pool.handle_transition_frontier_diff_inner
                 ~new_commands:
                   (List.map ~f:mk_with_status (prefix_cmds @ major_cmds))
@@ -3763,7 +3760,6 @@ let%test_module _ =
                 ~best_tip_ledger:
                   (Option.value_exn test.txn_pool.best_tip_ledger)
                 test.txn_pool ;
-
               let pool_state =
                 Test.Resource_pool.get_all test.txn_pool
                 |> List.map ~f:(fun tx ->
@@ -3781,7 +3777,6 @@ let%test_module _ =
                        in
                        (fee_payer_pk, nonce) )
               in
-
               [%log info] "Pool state"
                 ~metadata:
                   [ ( "pool state"
@@ -3845,7 +3840,6 @@ let%test_module _ =
               Array.iter minor_commands ~f:(fun (spec : Simple_command.t) ->
                   let sender = Simple_command.sender spec in
                   let pk, nonce = Sender_info.to_key_and_nonce sender in
-
                   let account_spec_pair_opt =
                     Simple_ledger.find_by_key_idx major sender.key_idx
                   in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3202,10 +3202,10 @@ let%test_module _ =
               t.key_idx t.balance fee ()
           else apply_cmd fee t
         else apply_cmd (amount + fee) t
-    end
 
-    let get_random_acc (arr : Account_spec.t array) =
-      get_random_from_array (Array.filter arr ~f:(fun x -> not x.sealed))
+      let get_random_unsealed (arr : t array) =
+        get_random_from_array (Array.filter arr ~f:(fun x -> not x.sealed))
+    end
 
     let ledger_snapshot t =
       Array.mapi test_keys ~f:(fun i kp ->
@@ -3243,7 +3243,9 @@ let%test_module _ =
 
       let gen_zkapp_blocking_send (spec : Account_spec.t array) =
         let open Quickcheck.Generator.Let_syntax in
-        let%bind random_idx, account_spec = get_random_acc spec in
+        let%bind random_idx, account_spec =
+          Account_spec.get_random_unsealed spec
+        in
         let new_account_spec =
           Account_spec.apply_cmd_or_fail 0 minimum_fee account_spec
         in
@@ -3271,7 +3273,9 @@ let%test_module _ =
           ?(higher = 10_000_000_000_000) (spec : Account_spec.t array) ~length =
         let open Quickcheck.Generator.Let_syntax in
         Quickcheck_lib.init_gen_array length ~f:(fun _ ->
-            let%bind random_idx, account_spec = get_random_acc spec in
+            let%bind random_idx, account_spec =
+              Account_spec.get_random_unsealed spec
+            in
             gen_single_from ~lower ~higher spec (random_idx, account_spec) )
 
       let sender t =
@@ -3367,7 +3371,7 @@ let%test_module _ =
           (*find account in major and minor branches with the same nonces and similar balances (less than 100k mina diff)*)
           let%bind ( account_with_limited_capacity_idx
                    , account_with_limited_capacity ) =
-            get_random_acc major
+            Account_spec.get_random_unsealed major
           in
 
           let initial_nonce = account_with_limited_capacity.nonce in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3484,13 +3484,11 @@ let%test_module _ =
           =
         Simple_ledger.get_random_unsealed major
       in
-
       let initial_nonce = Simple_account.nonce account_with_limited_capacity in
       let account_state_on_major = account_with_limited_capacity in
       let account_state_on_minor =
         Simple_ledger.get minor account_with_limited_capacity_idx
       in
-
       (* find receiver which is not our selected account*)
       let%bind receiver_idx =
         test_keys
@@ -3502,7 +3500,6 @@ let%test_module _ =
                else Some i )
         |> Quickcheck_lib.of_array
       in
-
       let%bind major_sequence_length = Int.gen_incl 2 10 in
       let%bind minor_sequence_length =
         let%map minor_sequence_length = Int.gen_incl 2 4 in
@@ -3514,7 +3511,6 @@ let%test_module _ =
       let half_initial_balance =
         Simple_account.balance account_with_limited_capacity / 2
       in
-
       let gen_sequence_and_update_account len sender =
         let sender = ref sender in
         let%map sequence =
@@ -3535,7 +3531,6 @@ let%test_module _ =
         in
         (sequence, !sender)
       in
-
       let%bind major_sequence, account_state_on_major =
         gen_sequence_and_update_account major_sequence_length
           account_state_on_major
@@ -3544,16 +3539,13 @@ let%test_module _ =
         gen_sequence_and_update_account minor_sequence_length
           account_state_on_minor
       in
-
       let major_sequence_total_cost =
         Array.fold ~init:0 major_sequence ~f:(fun acc item ->
             acc + Simple_command.total_cost item )
       in
-
       let%bind i =
         Int.gen_incl 1 (minor_sequence_length - major_sequence_length)
       in
-
       let t2 =
         List.sub
           (Array.to_list minor_sequence)
@@ -3562,11 +3554,9 @@ let%test_module _ =
         |> List.fold_left ~init:0 ~f:(fun acc item ->
                acc + Simple_command.total_cost item )
       in
-
       let%bind random_idx, tx_to_increase =
         get_random_from_array major_sequence
       in
-
       let increased_tx =
         match tx_to_increase with
         | Payment { sender; receiver_idx; fee; amount } ->
@@ -3582,13 +3572,11 @@ let%test_module _ =
               "Only payments are supported in limite account capacity corner \
                case"
       in
-
       Simple_ledger.set major account_with_limited_capacity_idx
         (Simple_account.seal account_state_on_major) ;
       Simple_ledger.set minor account_with_limited_capacity_idx
         (Simple_account.seal account_state_on_minor) ;
       Array.set major_sequence random_idx increased_tx ;
-
       let split_by_account (account : Simple_account.t) commands =
         let f cmd =
           let sender = Simple_command.sender cmd in
@@ -3598,15 +3586,12 @@ let%test_module _ =
         let others = Array.filter commands ~f:(fun x -> not (f x)) in
         (cmds_from_acc, others)
       in
-
       let unchanged_major_commands, major_commands_to_merge =
         split_by_account account_with_limited_capacity major_commands
       in
-
       let unchanged_minor_commands, minor_commands_to_merge =
         split_by_account account_with_limited_capacity minor_commands
       in
-
       let%bind major_commands =
         gen_merge
           (Array.to_list major_commands_to_merge)
@@ -3619,7 +3604,6 @@ let%test_module _ =
           (Array.to_list minor_sequence)
           []
       in
-
       return
         { prefix_commands
         ; major_commands =
@@ -3665,7 +3649,6 @@ let%test_module _ =
             Simple_command.gen_single_and_update_ledger minor
               (sender_on_minor_idx, sender_on_minor) )
       in
-
       return
         { prefix_commands
         ; major_commands =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3560,34 +3560,32 @@ let%test_module _ =
             (cmds_from_acc, others)
           in
 
-          let unchanged_major_command_spec, major_command_spec_to_merge =
+          let unchanged_major_commands, major_commands_to_merge =
             split_by_account account_with_limited_capacity major_commands
           in
 
-          let unchanged_minor_command_spec, minor_command_spec_to_merge =
+          let unchanged_minor_commands, minor_commands_to_merge =
             split_by_account account_with_limited_capacity minor_commands
           in
 
           let%bind major_commands =
             gen_merge
-              (Array.to_list major_command_spec_to_merge)
+              (Array.to_list major_commands_to_merge)
               (Array.to_list major_sequence)
               []
           in
           let%bind minor_commands =
             gen_merge
-              (Array.to_list minor_command_spec_to_merge)
+              (Array.to_list minor_commands_to_merge)
               (Array.to_list minor_sequence)
               []
           in
 
           return
-            ( List.append
-                (Array.to_list unchanged_major_command_spec)
-                major_commands
+            ( List.append (Array.to_list unchanged_major_commands) major_commands
               |> List.to_array
             , List.append
-                (Array.to_list unchanged_minor_command_spec)
+                (Array.to_list unchanged_minor_commands)
                 minor_commands
               |> List.to_array ) )
         else return (major_commands, minor_commands)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3649,16 +3649,12 @@ let%test_module _ =
                        (fee_payer_pk, nonce) )
               in
 
-              let log_pool_content =
-                List.map pool_state ~f:(fun (fee_payer_pk, nonce) ->
-                    `String
-                      (Printf.sprintf
-                         !"%{sexp: Public_key.Compressed.t} : %d"
-                         fee_payer_pk nonce ) )
-              in
-
               [%log info] "Pool state"
-                ~metadata:[ ("pool state", `List log_pool_content) ] ;
+                ~metadata:
+                  [ ( "pool state"
+                    , [%to_yojson: (Public_key.Compressed.t * int) list]
+                        pool_state )
+                  ] ;
 
               let actual_nonce_opt pk nonce =
                 List.find ~f:(fun (fee_payer_pk, actual_nonce) ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3507,8 +3507,8 @@ let%test_module _ =
       let half_initial_balance =
         Simple_account.balance account_with_limited_capacity / 2
       in
-      let gen_sequence_and_update_account len sender =
-        let sender = ref sender in
+      let gen_sequence_and_update_account len account =
+        let account = ref account in
         let%map sequence =
           Quickcheck_lib.init_gen_array len ~f:(fun _ ->
               let%bind amount =
@@ -3516,16 +3516,17 @@ let%test_module _ =
               in
               let tx =
                 Simple_command.Payment
-                  { sender = Simple_account.to_sender_info !sender
+                  { sender = Simple_account.to_sender_info !account
                   ; receiver_idx
                   ; fee = minimum_fee
                   ; amount
                   }
               in
-              sender := Simple_account.apply_cmd (amount + minimum_fee) !sender ;
+              account :=
+                Simple_account.apply_cmd (amount + minimum_fee) !account ;
               return tx )
         in
-        (sequence, !sender)
+        (sequence, !account)
       in
       let%bind major_sequence =
         let account = account_with_limited_capacity in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3543,11 +3543,13 @@ let%test_module _ =
         Array.fold ~init:0 major_sequence ~f:(fun acc item ->
             acc + Simple_command.total_cost item )
       in
-      let%bind i =
+      let%bind num_suffix_commands =
         Int.gen_incl 1 (minor_sequence_length - major_sequence_length)
       in
-      let t2 =
-        Array.sub minor_sequence ~pos:(major_sequence_length - 1) ~len:i
+      let suffix_commands_total_cost =
+        Array.sub minor_sequence
+          ~pos:(major_sequence_length - 1)
+          ~len:num_suffix_commands
         |> Array.fold ~init:0 ~f:(fun acc item ->
                acc + Simple_command.total_cost item )
       in
@@ -3562,7 +3564,9 @@ let%test_module _ =
               ; receiver_idx
               ; fee
               ; amount =
-                  amount + (initial_balance - major_sequence_total_cost - t2)
+                  amount
+                  + ( initial_balance - major_sequence_total_cost
+                    - suffix_commands_total_cost )
               }
         | _ ->
             failwith

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3547,11 +3547,8 @@ let%test_module _ =
         Int.gen_incl 1 (minor_sequence_length - major_sequence_length)
       in
       let t2 =
-        List.sub
-          (Array.to_list minor_sequence)
-          ~pos:(major_sequence_length - 1)
-          ~len:i
-        |> List.fold_left ~init:0 ~f:(fun acc item ->
+        Array.sub minor_sequence ~pos:(major_sequence_length - 1) ~len:i
+        |> Array.fold ~init:0 ~f:(fun acc item ->
                acc + Simple_command.total_cost item )
       in
       let%bind random_idx, tx_to_increase =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1672,7 +1672,7 @@ let%test_module _ =
     let minimum_fee =
       Currency.Fee.to_nanomina_int genesis_constants.minimum_user_command_fee
 
-    let logger = Logger.create ()
+    let logger = Logger.null ()
 
     let time_controller = Block_time.Controller.basic ~logger
 
@@ -1940,7 +1940,7 @@ let%test_module _ =
           ~genesis_constants ~slot_tx_end ~compile_config
       in
       let pool_, _, _ =
-        Test.create ~config ~logger:(Logger.create ()) ~constraint_constants
+        Test.create ~config ~logger:(Logger.null ()) ~constraint_constants
           ~consensus_constants ~time_controller
           ~frontier_broadcast_pipe:frontier_pipe_r ~log_gossip_heard:false
           ~on_remote_push:(Fn.const Deferred.unit) ~block_window_duration

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3400,6 +3400,7 @@ let%test_module _ =
       ; minor : Simple_ledger.t
       ; major : Simple_ledger.t
       }
+    [@@deriving to_yojson]
 
     (** Main generator for prefix, minor and major sequences. This generator has a more firm grip
            on how data is generated than usual. It uses Simple_command and Simple_account modules for 
@@ -3707,24 +3708,15 @@ let%test_module _ =
         in
         return (test, branches))
         ~f:(fun ( test
-                , { prefix_commands
-                  ; major_commands
-                  ; minor_commands
-                  ; minor
-                  ; major
-                  } ) ->
+                , ( { prefix_commands
+                    ; major_commands
+                    ; minor_commands
+                    ; minor = _
+                    ; major
+                    } as input_data ) ) ->
           Thread_safe.block_on_async_exn (fun () ->
-              [%log info] "Input Data"
-                ~metadata:
-                  [ ( "prefix_commands"
-                    , [%to_yojson: Simple_command.t array] prefix_commands )
-                  ; ( "major_commands"
-                    , [%to_yojson: Simple_command.t array] major_commands )
-                  ; ( "minor_commands"
-                    , [%to_yojson: Simple_command.t array] minor_commands )
-                  ; ("minor accounts state", [%to_yojson: Simple_ledger.t] minor)
-                  ; ("major accounts state", [%to_yojson: Simple_ledger.t] major)
-                  ] ;
+              [%log info] "Input Data $data"
+                ~metadata:[ ("data", [%to_yojson: branches] input_data) ] ;
 
               let prefix_cmds = gen_commands_from_specs prefix_commands test in
               let minor_cmds = gen_commands_from_specs minor_commands test in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3541,7 +3541,7 @@ let%test_module _ =
           account_state_on_minor
       in
 
-      let b1 =
+      let major_sequence_total_cost =
         Array.fold ~init:0 major_sequence ~f:(fun acc item ->
             acc + Simple_command.total_cost item )
       in
@@ -3570,7 +3570,8 @@ let%test_module _ =
               { sender
               ; receiver_idx
               ; fee
-              ; amount = amount + (initial_balance - b1 - t2)
+              ; amount =
+                  amount + (initial_balance - major_sequence_total_cost - t2)
               }
         | _ ->
             failwith

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3391,8 +3391,8 @@ let%test_module _ =
           in
 
           let%bind major_sequence_length = Int.gen_incl 2 10 in
-          let%bind minor_sequence_length = Int.gen_incl 2 4 in
-          let minor_sequence_length =
+          let%bind minor_sequence_length =
+            let%map minor_sequence_length = Int.gen_incl 2 4 in
             minor_sequence_length + major_sequence_length + initial_nonce
           in
           let initial_balance = account_with_limited_capacity.balance in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3437,8 +3437,7 @@ let%test_module _ =
         
           On top of that one can enable/disable two special corner cases (permission change and limited capacity)
         *)
-    let gen_branches ledger ~permission_change ~limited_capacity
-        ?(sequence_max_length = 3) () =
+    let gen_branches_basic ledger ?(sequence_max_length = 3) () =
       let open Quickcheck.Generator.Let_syntax in
       let%bind prefix_length = Int.gen_incl 0 sequence_max_length in
       let%bind major_length = Int.gen_incl 0 sequence_max_length in
@@ -3455,237 +3454,224 @@ let%test_module _ =
       let%bind major_commands =
         Simple_command.gen_sequence_and_update_ledger major ~length:major_length
       in
-      let branches =
-        { prefix_commands; major_commands; minor_commands; minor; major }
+      return { prefix_commands; major_commands; minor_commands; minor; major }
+
+    (* Optional Edge Case 1: Limited Account Capacity
+
+       - In major sequence*, a transaction `T` from a specific account decreases its balance by amount `X`.
+       - In minor sequence*, the same account decreases its balance in a similar transaction `T'`, but by an amount much smaller than `X`, followed by several other transactions using the same account.
+       - The prefix ledger* contains just enough funds to process major sequence, with a small surplus.
+       - When applying *minor sequence* without the transaction `T'` (of the same nonce as the large-amount transaction `T` in major sequence),
+           the sequence becomes partially applicable, forcing the mempool logic to drop some transactions at the end of *minor sequence*.
+    *)
+    let gen_updated_branches_for_limited_capacity
+        { prefix_commands; major_commands; minor_commands; minor; major } =
+      let open Quickcheck.Generator.Let_syntax in
+      (*find account in major and minor branches with the same nonces and similar balances (less than 100k mina diff)*)
+      let%bind account_with_limited_capacity_idx, account_with_limited_capacity
+          =
+        Simple_ledger.get_random_unsealed major
       in
 
-      (* Optional Edge Case 1: Limited Account Capacity
+      let initial_nonce = Simple_account.nonce account_with_limited_capacity in
+      let account_state_on_major = account_with_limited_capacity in
+      let account_state_on_minor =
+        Simple_ledger.get minor account_with_limited_capacity_idx
+      in
 
-         - In major sequence*, a transaction `T` from a specific account decreases its balance by amount `X`.
-         - In minor sequence*, the same account decreases its balance in a similar transaction `T'`, but by an amount much smaller than `X`, followed by several other transactions using the same account.
-         - The prefix ledger* contains just enough funds to process major sequence, with a small surplus.
-         - When applying *minor sequence* without the transaction `T'` (of the same nonce as the large-amount transaction `T` in major sequence),
-             the sequence becomes partially applicable, forcing the mempool logic to drop some transactions at the end of *minor sequence*.
+      (* find receiver which is not our selected account*)
+      let%bind receiver_idx =
+        test_keys
+        |> Array.filter_mapi ~f:(fun i _ ->
+               if
+                 Int.equal i
+                   (Simple_account.key_idx account_with_limited_capacity)
+               then None
+               else Some i )
+        |> Quickcheck_lib.of_array
+      in
+
+      let%bind major_sequence_length = Int.gen_incl 2 10 in
+      let%bind minor_sequence_length =
+        let%map minor_sequence_length = Int.gen_incl 2 4 in
+        minor_sequence_length + major_sequence_length + initial_nonce
+      in
+      let initial_balance =
+        Simple_account.balance account_with_limited_capacity
+      in
+      let b = Simple_account.balance account_with_limited_capacity / 2 in
+
+      let gen_sequence_and_update_account len sender =
+        let sender = ref sender in
+        let%map sequence =
+          Quickcheck_lib.init_gen_array len ~f:(fun _ ->
+              let%bind amount = Int.gen_incl 5_000_000_000_000_000 (b / len) in
+              let tx =
+                Simple_command.Payment
+                  { sender = Simple_account.to_sender_info !sender
+                  ; receiver_idx
+                  ; fee = minimum_fee
+                  ; amount
+                  }
+              in
+              sender := Simple_account.apply_cmd (amount + minimum_fee) !sender ;
+              return tx )
+        in
+        (sequence, !sender)
+      in
+
+      let%bind major_sequence, account_state_on_major =
+        gen_sequence_and_update_account major_sequence_length
+          account_state_on_major
+      in
+      let%bind minor_sequence, account_state_on_minor =
+        gen_sequence_and_update_account minor_sequence_length
+          account_state_on_minor
+      in
+
+      let b1 =
+        Array.fold ~init:0 major_sequence ~f:(fun acc item ->
+            acc + Simple_command.total_cost item )
+      in
+
+      let%bind i =
+        Int.gen_incl 1 (minor_sequence_length - major_sequence_length)
+      in
+
+      let t2 =
+        List.sub
+          (Array.to_list minor_sequence)
+          ~pos:(major_sequence_length - 1)
+          ~len:i
+        |> List.fold_left ~init:0 ~f:(fun acc item ->
+               acc + Simple_command.total_cost item )
+      in
+
+      let%bind random_idx, tx_to_increase =
+        get_random_from_array major_sequence
+      in
+
+      let increased_tx =
+        match tx_to_increase with
+        | Payment { sender; receiver_idx; fee; amount } ->
+            Simple_command.Payment
+              { sender
+              ; receiver_idx
+              ; fee
+              ; amount = amount + (initial_balance - b1 - t2)
+              }
+        | _ ->
+            failwith
+              "Only payments are supported in limite account capacity corner \
+               case"
+      in
+
+      Simple_ledger.set major account_with_limited_capacity_idx
+        (Simple_account.seal account_state_on_major) ;
+      Simple_ledger.set minor account_with_limited_capacity_idx
+        (Simple_account.seal account_state_on_minor) ;
+      Array.set major_sequence random_idx increased_tx ;
+
+      let split_by_account (account : Simple_account.t) commands =
+        let f cmd =
+          let sender = Simple_command.sender cmd in
+          sender.key_idx = Simple_account.key_idx account
+        in
+        let cmds_from_acc = Array.filter commands ~f in
+        let others = Array.filter commands ~f:(fun x -> not (f x)) in
+        (cmds_from_acc, others)
+      in
+
+      let unchanged_major_commands, major_commands_to_merge =
+        split_by_account account_with_limited_capacity major_commands
+      in
+
+      let unchanged_minor_commands, minor_commands_to_merge =
+        split_by_account account_with_limited_capacity minor_commands
+      in
+
+      let%bind major_commands =
+        gen_merge
+          (Array.to_list major_commands_to_merge)
+          (Array.to_list major_sequence)
+          []
+      in
+      let%bind minor_commands =
+        gen_merge
+          (Array.to_list minor_commands_to_merge)
+          (Array.to_list minor_sequence)
+          []
+      in
+
+      return
+        { prefix_commands
+        ; major_commands =
+            List.append (Array.to_list unchanged_major_commands) major_commands
+            |> List.to_array
+        ; minor_commands =
+            List.append (Array.to_list unchanged_minor_commands) minor_commands
+            |> List.to_array
+        ; minor
+        ; major
+        }
+
+    (* Optional Edge Case : Permission Changes:
+
+       - In major sequence, a transaction modifies an account's permissions:
+           1. It removes the permission to maintain the nonce.
+           2. It removes the permission to send transactions.
+       - In minor sequence, there is a regular transaction involving the same account,
+           but after the permission-modifying transaction in major sequence,
+           the new transaction becomes invalid and must be dropped.
+    *)
+    let gen_updated_branches_for_permission_change
+        { prefix_commands; major_commands; minor_commands; minor; major } =
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind permission_change_cmd =
+        Simple_command.gen_zkapp_blocking_send_and_update_ledger major
+      in
+      let sender_on_major = Simple_command.sender permission_change_cmd in
+      (* We need to increase nonce so transaction has a chance to be placed in the pool.
+         Otherwise it will be dropped as we already have transaction with the same nonce from major sequence
       *)
+      let sender_index = Simple_ledger.index_of_int sender_on_major.key_idx in
+      let sender_on_minor = Simple_ledger.get minor sender_index in
+      let%bind aux_minor_cmd =
+        Quickcheck_lib.init_gen_array
+          (sender_on_major.nonce - Simple_account.nonce sender_on_minor + 1)
+          ~f:(fun _ ->
+            let sender_on_minor = Simple_ledger.get minor sender_index in
+            let sender_on_minor_idx =
+              Simple_ledger.index_of_int
+                (Simple_account.key_idx sender_on_minor)
+            in
+            Simple_command.gen_single_and_update_ledger minor
+              (sender_on_minor_idx, sender_on_minor) )
+      in
+
+      return
+        { prefix_commands
+        ; major_commands =
+            Array.append major_commands [| permission_change_cmd |]
+        ; minor_commands = Array.append minor_commands aux_minor_cmd
+        ; minor
+        ; major
+        }
+
+    let gen_branches ledger ~permission_change ~limited_capacity
+        ?sequence_max_length () =
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind branches = gen_branches_basic ledger ?sequence_max_length () in
       let%bind branches =
         if limited_capacity then
-          let gen_updated_branches_for_limited_capacity
-              { prefix_commands; major_commands; minor_commands; minor; major }
-              =
-            (*find account in major and minor branches with the same nonces and similar balances (less than 100k mina diff)*)
-            let%bind ( account_with_limited_capacity_idx
-                     , account_with_limited_capacity ) =
-              Simple_ledger.get_random_unsealed major
-            in
-
-            let initial_nonce =
-              Simple_account.nonce account_with_limited_capacity
-            in
-            let account_state_on_major = account_with_limited_capacity in
-            let account_state_on_minor =
-              Simple_ledger.get minor account_with_limited_capacity_idx
-            in
-
-            (* find receiver which is not our selected account*)
-            let%bind receiver_idx =
-              test_keys
-              |> Array.filter_mapi ~f:(fun i _ ->
-                     if
-                       Int.equal i
-                         (Simple_account.key_idx account_with_limited_capacity)
-                     then None
-                     else Some i )
-              |> Quickcheck_lib.of_array
-            in
-
-            let%bind major_sequence_length = Int.gen_incl 2 10 in
-            let%bind minor_sequence_length =
-              let%map minor_sequence_length = Int.gen_incl 2 4 in
-              minor_sequence_length + major_sequence_length + initial_nonce
-            in
-            let initial_balance =
-              Simple_account.balance account_with_limited_capacity
-            in
-            let b = Simple_account.balance account_with_limited_capacity / 2 in
-
-            let gen_sequence_and_update_account len sender =
-              let sender = ref sender in
-              let%map sequence =
-                Quickcheck_lib.init_gen_array len ~f:(fun _ ->
-                    let%bind amount =
-                      Int.gen_incl 5_000_000_000_000_000 (b / len)
-                    in
-                    let tx =
-                      Simple_command.Payment
-                        { sender = Simple_account.to_sender_info !sender
-                        ; receiver_idx
-                        ; fee = minimum_fee
-                        ; amount
-                        }
-                    in
-                    sender :=
-                      Simple_account.apply_cmd (amount + minimum_fee) !sender ;
-                    return tx )
-              in
-              (sequence, !sender)
-            in
-
-            let%bind major_sequence, account_state_on_major =
-              gen_sequence_and_update_account major_sequence_length
-                account_state_on_major
-            in
-            let%bind minor_sequence, account_state_on_minor =
-              gen_sequence_and_update_account minor_sequence_length
-                account_state_on_minor
-            in
-
-            let b1 =
-              Array.fold ~init:0 major_sequence ~f:(fun acc item ->
-                  acc + Simple_command.total_cost item )
-            in
-
-            let%bind i =
-              Int.gen_incl 1 (minor_sequence_length - major_sequence_length)
-            in
-
-            let t2 =
-              List.sub
-                (Array.to_list minor_sequence)
-                ~pos:(major_sequence_length - 1)
-                ~len:i
-              |> List.fold_left ~init:0 ~f:(fun acc item ->
-                     acc + Simple_command.total_cost item )
-            in
-
-            let%bind random_idx, tx_to_increase =
-              get_random_from_array major_sequence
-            in
-
-            let increased_tx =
-              match tx_to_increase with
-              | Payment { sender; receiver_idx; fee; amount } ->
-                  Simple_command.Payment
-                    { sender
-                    ; receiver_idx
-                    ; fee
-                    ; amount = amount + (initial_balance - b1 - t2)
-                    }
-              | _ ->
-                  failwith
-                    "Only payments are supported in limite account capacity \
-                     corner case"
-            in
-
-            Simple_ledger.set major account_with_limited_capacity_idx
-              (Simple_account.seal account_state_on_major) ;
-            Simple_ledger.set minor account_with_limited_capacity_idx
-              (Simple_account.seal account_state_on_minor) ;
-            Array.set major_sequence random_idx increased_tx ;
-
-            let split_by_account (account : Simple_account.t) commands =
-              let f cmd =
-                let sender = Simple_command.sender cmd in
-                sender.key_idx = Simple_account.key_idx account
-              in
-              let cmds_from_acc = Array.filter commands ~f in
-              let others = Array.filter commands ~f:(fun x -> not (f x)) in
-              (cmds_from_acc, others)
-            in
-
-            let unchanged_major_commands, major_commands_to_merge =
-              split_by_account account_with_limited_capacity major_commands
-            in
-
-            let unchanged_minor_commands, minor_commands_to_merge =
-              split_by_account account_with_limited_capacity minor_commands
-            in
-
-            let%bind major_commands =
-              gen_merge
-                (Array.to_list major_commands_to_merge)
-                (Array.to_list major_sequence)
-                []
-            in
-            let%bind minor_commands =
-              gen_merge
-                (Array.to_list minor_commands_to_merge)
-                (Array.to_list minor_sequence)
-                []
-            in
-
-            return
-              { prefix_commands
-              ; major_commands =
-                  List.append
-                    (Array.to_list unchanged_major_commands)
-                    major_commands
-                  |> List.to_array
-              ; minor_commands =
-                  List.append
-                    (Array.to_list unchanged_minor_commands)
-                    minor_commands
-                  |> List.to_array
-              ; minor
-              ; major
-              }
-          in
           gen_updated_branches_for_limited_capacity branches
         else return branches
       in
-
-      (* Optional Edge Case : Permission Changes:
-
-         - In major sequence, a transaction modifies an account's permissions:
-             1. It removes the permission to maintain the nonce.
-             2. It removes the permission to send transactions.
-         - In minor sequence, there is a regular transaction involving the same account,
-             but after the permission-modifying transaction in major sequence,
-             the new transaction becomes invalid and must be dropped.
-      *)
       let%bind branches =
         if permission_change then
-          let gen_updated_branches_for_permission_change
-              { prefix_commands; major_commands; minor_commands; minor; major }
-              =
-            let%bind permission_change_cmd =
-              Simple_command.gen_zkapp_blocking_send_and_update_ledger major
-            in
-            let sender_on_major = Simple_command.sender permission_change_cmd in
-            (* We need to increase nonce so transaction has a chance to be placed in the pool.
-               Otherwise it will be dropped as we already have transaction with the same nonce from major sequence
-            *)
-            let sender_index =
-              Simple_ledger.index_of_int sender_on_major.key_idx
-            in
-            let sender_on_minor = Simple_ledger.get minor sender_index in
-            let%bind aux_minor_cmd =
-              Quickcheck_lib.init_gen_array
-                ( sender_on_major.nonce
-                - Simple_account.nonce sender_on_minor
-                + 1 )
-                ~f:(fun _ ->
-                  let sender_on_minor = Simple_ledger.get minor sender_index in
-                  let sender_on_minor_idx =
-                    Simple_ledger.index_of_int
-                      (Simple_account.key_idx sender_on_minor)
-                  in
-                  Simple_command.gen_single_and_update_ledger minor
-                    (sender_on_minor_idx, sender_on_minor) )
-            in
-
-            return
-              { prefix_commands
-              ; major_commands =
-                  Array.append major_commands [| permission_change_cmd |]
-              ; minor_commands = Array.append minor_commands aux_minor_cmd
-              ; minor
-              ; major
-              }
-          in
           gen_updated_branches_for_permission_change branches
         else return branches
       in
-
       return branches
 
     let gen_commands_from_specs (sequence : Simple_command.t array) test :

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3570,7 +3570,7 @@ let%test_module _ =
               }
         | _ ->
             failwith
-              "Only payments are supported in limite account capacity corner \
+              "Only payments are supported in limited account capacity corner \
                case"
       in
       Simple_ledger.set major account_with_limited_capacity_idx

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3164,6 +3164,12 @@ let%test_module _ =
           assert_pool_txs t [] ;
           add_commands t independent_cmds >>| assert_pool_apply [] )
 
+    let get_random_from_array arr =
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind idx = Int.gen_incl 0 (Array.length arr - 1) in
+      let item = arr.(idx) in
+      return (idx, item)
+
     module Account_spec = struct
       type t = { key_idx : int; balance : int; nonce : int; sealed : bool }
       [@@deriving sexp, yojson]
@@ -3198,14 +3204,8 @@ let%test_module _ =
         else apply_cmd (amount + fee) t
     end
 
-    let get_random arr =
-      let open Quickcheck.Generator.Let_syntax in
-      let%bind idx = Int.gen_incl 0 (Array.length arr - 1) in
-      let item = arr.(idx) in
-      return (idx, item)
-
     let get_random_acc (arr : Account_spec.t array) =
-      get_random (Array.filter arr ~f:(fun x -> not x.sealed))
+      get_random_from_array (Array.filter arr ~f:(fun x -> not x.sealed))
 
     let ledger_snapshot t =
       Array.mapi test_keys ~f:(fun i kp ->
@@ -3425,7 +3425,7 @@ let%test_module _ =
                    acc + Command_spec.total_cost item )
           in
 
-          let%bind random_idx, tx_to_increase = get_random s1 in
+          let%bind random_idx, tx_to_increase = get_random_from_array s1 in
 
           let increased_tx =
             match tx_to_increase with

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3710,8 +3710,8 @@ let%test_module _ =
                 , { prefix_commands
                   ; major_commands
                   ; minor_commands
-                  ; minor = minor_account_spec
-                  ; major = major_account_spec
+                  ; minor
+                  ; major
                   } ) ->
           Thread_safe.block_on_async_exn (fun () ->
               [%log info] "Input Data"
@@ -3722,10 +3722,8 @@ let%test_module _ =
                     , [%to_yojson: Simple_command.t array] major_commands )
                   ; ( "minor_commands"
                     , [%to_yojson: Simple_command.t array] minor_commands )
-                  ; ( "minor accounts state"
-                    , [%to_yojson: Simple_ledger.t] minor_account_spec )
-                  ; ( "major accounts state"
-                    , [%to_yojson: Simple_ledger.t] major_account_spec )
+                  ; ("minor accounts state", [%to_yojson: Simple_ledger.t] minor)
+                  ; ("major accounts state", [%to_yojson: Simple_ledger.t] major)
                   ] ;
 
               let prefix_cmds = gen_commands_from_specs prefix_commands test in
@@ -3832,7 +3830,7 @@ let%test_module _ =
                   let pk, nonce = Simple_account.to_key_and_nonce sender in
 
                   let account_spec_pair_opt =
-                    Simple_ledger.find_by_key_idx major_account_spec
+                    Simple_ledger.find_by_key_idx major
                       (Simple_account.key_idx sender)
                   in
                   match account_spec_pair_opt with
@@ -3877,7 +3875,7 @@ let%test_module _ =
                                    pk nonce ) )
                           ] ;
                       assert_pool_contains pool_state (pk, nonce) ;
-                      Simple_ledger.set major_account_spec idx
+                      Simple_ledger.set major idx
                         (Simple_account.subtract_balance account_spec
                            (total_cost sender) )
                   | Some _account_spec ->


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/16415. The commits in this PR apply a series of transformations to make the code more readable and maintainable. Most notably:
* the pervasive use of the overloaded word 'spec' is removed
* `Account_spec` is renamed to `Simple_account`
* the `Account_spec.t array` pattern is encapsulated as a new `Simple_ledger` module
* `Command_spec` is renamed to `Simple_command`
* single-letter and non-descriptive variables names have been updated
* functions and generators that cause side-effects on ledgers are named to record that
* the edge-case generators are split into their own helper functions
* transactions now carry a `sender_info` struct instead of a full account
* yojson is used in place of s-expression strings masquerading as JSON
* comment formatting is fixed
* some inline functions are lifted outside as appropriate.

The goal of this PR is to modify the original so that abstractions and naming guide the reader towards an understanding of mutability, the differences between the various arrays and 'spec' concepts, and more generally the mapping between the test code and the concepts in the rest of the code. The diff with compatible can be found [here](https://github.com/MinaProtocol/mina/compare/compatible...mrmr1993/transaction_pool_tests?expand=1) for reference.