### PR TITLE
Remove `apt-get update` from aptly script

### DIFF
--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -52,10 +52,6 @@ for i in "${debs[@]}"; do
    debs_with_version+=("${i}=${MINA_DEB_VERSION}")
 done
 
-# Install aptly
-$SUDO apt-get update 
-$SUDO apt-get install -y aptly
-
 # Start aptly
 source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background
 

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -59,7 +59,8 @@ source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $
 echo "Installing mina packages: $DEBS"
 echo "deb [trusted=yes] http://localhost:8080 $MINA_DEB_CODENAME unstable" | $SUDO tee /etc/apt/sources.list.d/mina.list
 
-$SUDO apt-get update --yes
+# Update apt packages for the new repo, preserving all others
+$SUDO apt-get update --yes -o Dir::Etc::sourcelist="sources.list.d/mina.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 $SUDO apt-get remove --yes "${debs[@]}"
 $SUDO apt-get install --yes --allow-downgrades "${debs_with_version[@]}"
 

--- a/buildkite/scripts/run-test-executive-local.sh
+++ b/buildkite/scripts/run-test-executive-local.sh
@@ -40,7 +40,7 @@ export DEBIAN_FRONTEND=noninteractive
 rm -f /etc/apt/sources.list.d/hashicorp.list
 
 apt-get update
-apt-get install -y git apt-transport-https ca-certificates tzdata curl
+apt-get install -y git apt-transport-https ca-certificates aptly tzdata curl
 
 TESTNET_NAME="berkeley"
 

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,11 +4,11 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 { toolchainBase = "codaprotocol/ci-toolchain-base:v3"
 , minaToolchainBullseye =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:7e1ee3c956dc2ae149994139702fa46970b17ad68890d8c6c2d358b2700d2623"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:b1816fd48deb3a67368b52597a391c60df882f4755f0d7075f02acf88b7bdf90"
 , minaToolchainBookworm =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:7e1ee3c956dc2ae149994139702fa46970b17ad68890d8c6c2d358b2700d2623"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:b1816fd48deb3a67368b52597a391c60df882f4755f0d7075f02acf88b7bdf90"
 , minaToolchain =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:7e1ee3c956dc2ae149994139702fa46970b17ad68890d8c6c2d358b2700d2623"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:b1816fd48deb3a67368b52597a391c60df882f4755f0d7075f02acf88b7bdf90"
 , elixirToolchain = "elixir:1.10-alpine"
 , nodeToolchain = "node:14.13.1-stretch-slim"
 , ubuntu2004 = "ubuntu:20.04"

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -19,6 +19,7 @@ USER root
 # afaict this is the last python dependency of any kind in CI
 RUN apt-get update --yes \
   && apt-get install --yes \
+    aptly \
     apt-transport-https \
     apt-utils \
     awscli \


### PR DESCRIPTION
This PR tweaks the uses of `apt-get update` in CI to avoid re-fetching all sources unnecessarily. In particular,
* we hoist the installation of `aptly` into the toolchain file, and
* we limit `apt-get update` to update only the local Mina repository that `aptly` generates.

This PR should improve the stability of CI, where a mirror sync can cause flakiness outside of our control.