### PR TITLE
Send command with insufficient replace fee earlier to reduce flakiness

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -775,16 +775,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            zkapp_command_update_all )
     in
     let%bind () =
-      section_hard "Send a zkapp with an invalid proof"
-        (send_invalid_zkapp ~logger
-           (Network.Node.get_ingress_uri node)
-           zkapp_command_invalid_proof "Invalid_proof" )
-    in
-    let%bind () =
       section_hard "Send a zkapp with an insufficient replace fee"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
            zkapp_command_insufficient_replace_fee "Insufficient_replace_fee" )
+    in
+    let%bind () =
+      section_hard "Send a zkapp with an invalid proof"
+        (send_invalid_zkapp ~logger
+           (Network.Node.get_ingress_uri node)
+           zkapp_command_invalid_proof "Invalid_proof" )
     in
     let%bind () =
       section_hard "Send a zkApp transaction with an invalid nonce"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -767,6 +767,38 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            zkapp_command_insufficient_fee "Insufficient fee" )
     in
     let%bind () = wait_for t (Wait_condition.blocks_to_be_produced 1) in
+    let%bind.Deferred () =
+      (* Wait for the start of the next slot, attempting to submit all commands
+         within the same slot.
+         In particular, this has the goal of reducing flakiness around the
+         'insufficient replace fee' test, which becomes an 'invalid nonce'
+         failure if the first transaction has already been included.
+
+         Note that this *isn't* redundant with the block waiting above, because
+         the block will be produced part-way through a slot, and will further
+         take us some time to receive the message about that block production
+         due to polling.
+      *)
+      let next_slot_time =
+        let genesis_timestamp =
+          constants.genesis_constants.genesis_state_timestamp |> Int64.to_float
+          |> Time.Span.of_ms |> Time.of_span_since_epoch
+        in
+        let block_duration_ms =
+          constants.constraint_constants.block_window_duration_ms
+          |> Int.to_float
+        in
+        let current_slot_span_ms =
+          Time.(now () - genesis_timestamp) |> Time.Span.to_ms
+        in
+        let target_slot =
+          block_duration_ms /. current_slot_span_ms |> Float.iround_up_exn
+        in
+        let target_slot_span_ms = target_slot *. current_slot_span_ms in
+        Time.add genesis_timestamp target_slot_span_ms
+      in
+      after Time.(now () - next_slot_time)
+    in
     (* Won't be accepted until the previous transactions are applied *)
     let%bind () =
       section_hard "Send a zkApp transaction to update all fields"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -781,23 +781,25 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       *)
       let next_slot_time =
         let genesis_timestamp =
-          constants.genesis_constants.genesis_state_timestamp |> Int64.to_float
-          |> Time.Span.of_ms |> Time.of_span_since_epoch
+          constants.genesis_constants.protocol.genesis_state_timestamp
+          |> Int64.to_float |> Time.Span.of_ms |> Time.of_span_since_epoch
         in
         let block_duration_ms =
           constants.constraint_constants.block_window_duration_ms
           |> Int.to_float
         in
         let current_slot_span_ms =
-          Time.(now () - genesis_timestamp) |> Time.Span.to_ms
+          Time.(diff (now ()) genesis_timestamp) |> Time.Span.to_ms
         in
         let target_slot =
-          block_duration_ms /. current_slot_span_ms |> Float.iround_up_exn
+          block_duration_ms /. current_slot_span_ms |> Float.round_up
         in
-        let target_slot_span_ms = target_slot *. current_slot_span_ms in
+        let target_slot_span_ms =
+          target_slot *. current_slot_span_ms |> Time.Span.of_ms
+        in
         Time.add genesis_timestamp target_slot_span_ms
       in
-      after Time.(now () - next_slot_time)
+      after Time.(diff (now ()) next_slot_time)
     in
     (* Won't be accepted until the previous transactions are applied *)
     let%bind () =


### PR DESCRIPTION
This PR is intended to reduce the number of flakes that we see e.g. [here](https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3191#01948957-9ec5-4e88-ace9-86c63fcbc7ab), moving the command earlier in the sequence so that it is more likely to trigger the condition. This particular flake occurs when the first transaction is accepted into a block before the node processes the second transaction, causing an 'invalid nonce' error instead of hitting the replace-fee logic.

This PR also adds an unrelated change to help, attempting to schedule the transaction broadcasts to fall within the same slot, in the hopes that this further reduces flakiness.