### PR TITLE
Mirror Proof_carrying_data in Mina_wire_types

### DIFF
--- a/src/lib/mina_wire_types/proof_carrying_data.ml
+++ b/src/lib/mina_wire_types/proof_carrying_data.ml
@@ -1,0 +1,5 @@
+module V1 = struct
+  type ('a, 'p) t = { data : 'a; proof : 'p }
+end
+
+type ('a, 'p) t = ('a, 'p) V1.t = { data : 'a; proof : 'p }

--- a/src/lib/proof_carrying_data/dune
+++ b/src/lib/proof_carrying_data/dune
@@ -1,11 +1,12 @@
 (library
  (name proof_carrying_data)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_jane))
+ (preprocess (pps ppx_deriving_yojson ppx_version ppx_jane))
  (libraries
    ;; opam libraries
    core_kernel bin_prot.shape base base.caml sexplib0
    ;; local libraries
+   mina_wire_types
    ppx_version.runtime)
  (public_name proof_carrying_data)
 )

--- a/src/lib/proof_carrying_data/proof_carrying_data.ml
+++ b/src/lib/proof_carrying_data/proof_carrying_data.ml
@@ -5,7 +5,9 @@ open Core_kernel
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type ('a, 'b) t = { data : 'a; proof : 'b } [@@deriving sexp, fields]
+    type ('a, 'p) t = ('a, 'p) Mina_wire_types.Proof_carrying_data.V1.t =
+      { data : 'a; proof : 'p }
+    [@@deriving compare, equal, fields, hash, sexp, version, yojson]
   end
 end]
 


### PR DESCRIPTION
Mirror `Proof_carrying_data` in `Mina_wire_types`.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
