### PR TITLE
Add basic proof_cache_tag

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -151,6 +151,7 @@
 (package (name ppx_version))
 (package (name precomputed_values))
 (package (name promise))
+(package (name proof_cache_tag))
 (package (name proof_carrying_data))
 (package (name protocol_version))
 (package (name prover))

--- a/src/lib/proof_cache_tag/dune
+++ b/src/lib/proof_cache_tag/dune
@@ -1,0 +1,12 @@
+(library
+ (public_name proof_cache_tag)
+ (virtual_modules proof_cache_tag)
+ (default_implementation proof_cache_tag.identity)
+ (libraries
+   ;; opam libraries
+   core_kernel
+   ;; local libraries
+   mina_base)
+ (preprocess
+  (pps ppx_mina ppx_version))
+ (instrumentation (backend bisect_ppx)))

--- a/src/lib/proof_cache_tag/identity/dune
+++ b/src/lib/proof_cache_tag/identity/dune
@@ -1,0 +1,12 @@
+(library
+ (public_name proof_cache_tag.identity)
+ (name proof_cache_tag_identity)
+ (implements proof_cache_tag)
+ (libraries
+   ;; opam libraries
+   core_kernel
+   ;; local libraries
+   mina_base)
+ (preprocess
+  (pps ppx_mina ppx_version))
+ (instrumentation (backend bisect_ppx)))

--- a/src/lib/proof_cache_tag/identity/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/identity/proof_cache_tag.ml
@@ -1,0 +1,19 @@
+open Core_kernel
+
+type t = Pickles.Proof.Proofs_verified_2.t
+
+type cache_db = unit
+
+let unwrap = Fn.id
+
+let generate () = Fn.id
+
+let create_db () = ()
+
+module For_tests = struct
+  let blockchain_dummy = Mina_base.Proof.blockchain_dummy
+
+  let transaction_dummy = Mina_base.Proof.transaction_dummy
+
+  let create_db () = ()
+end

--- a/src/lib/proof_cache_tag/proof_cache_tag.mli
+++ b/src/lib/proof_cache_tag/proof_cache_tag.mli
@@ -1,0 +1,17 @@
+type t
+
+type cache_db
+
+val create_db : unit -> cache_db
+
+val unwrap : t -> Mina_base.Proof.t
+
+val generate : cache_db -> Mina_base.Proof.t -> t
+
+module For_tests : sig
+  val blockchain_dummy : t lazy_t
+
+  val transaction_dummy : t lazy_t
+
+  val create_db : unit -> cache_db
+end


### PR DESCRIPTION
Add basic `proof_cache_tag`.
No cache implementation, just "identity".

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
