### PR TITLE
Expose internal structure of Transaction_snark.t

### DIFF
--- a/src/lib/mina_wire_types/transaction_snark.ml
+++ b/src/lib/mina_wire_types/transaction_snark.ml
@@ -2,7 +2,18 @@ open Utils
 
 module Types = struct
   module type S = sig
-    module V2 : S0
+    module Proof : sig
+      module V2 : sig
+        type t = Pickles.Proof.Proofs_verified_2.V2.t
+      end
+    end
+
+    module V2 : sig
+      type t =
+        ( Mina_state.Snarked_ledger_state.With_sok.V2.t
+        , Proof.V2.t )
+        Proof_carrying_data.V1.t
+    end
   end
 end
 

--- a/src/lib/mina_wire_types/transaction_snark.mli
+++ b/src/lib/mina_wire_types/transaction_snark.mli
@@ -2,7 +2,18 @@ open Utils
 
 module Types : sig
   module type S = sig
-    module V2 : S0
+    module Proof : sig
+      module V2 : sig
+        type t = Pickles.Proof.Proofs_verified_2.V2.t
+      end
+    end
+
+    module V2 : sig
+      type t =
+        ( Mina_state.Snarked_ledger_state.With_sok.V2.t
+        , Proof.V2.t )
+        Proof_carrying_data.V1.t
+    end
   end
 end
 

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -17,7 +17,11 @@ module type Full = sig
   [%%versioned:
   module Stable : sig
     module V2 : sig
-      type t [@@deriving compare, equal, sexp, yojson, hash]
+      type t =
+        ( Mina_state.Snarked_ledger_state.With_sok.Stable.V2.t
+        , Proof.Stable.V2.t )
+        Proof_carrying_data.Stable.V1.t
+      [@@deriving compare, equal, sexp, yojson, hash]
     end
   end]
 


### PR DESCRIPTION
Expose internal structure of `Transaction_snark.t`

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
