### PR TITLE
Polymorphize some Transaction_snark functions

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -87,14 +87,18 @@ module Make_str (A : Wire_types.Concrete) = struct
     end
   end]
 
+  module Poly = struct
+    type 'a t =
+      (Mina_state.Snarked_ledger_state.With_sok.t, 'a) Proof_carrying_data.t
+  end
+
+  module Cached = struct
+    type t = Proof_cache_tag.t Poly.t
+  end
+
   let proof t = t.Proof_carrying_data.proof
 
-  let statement
-      (t :
-        ( Mina_state.Snarked_ledger_state.With_sok.Stable.V2.t
-        , _ )
-        Proof_carrying_data.t ) =
-    { t.data with sok_digest = () }
+  let statement (t : 'a Poly.t) = { t.data with sok_digest = () }
 
   let statement_with_sok t = t.Proof_carrying_data.data
 

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -25,15 +25,24 @@ module type Full = sig
     end
   end]
 
-  val create : statement:Statement.With_sok.t -> proof:Mina_base.Proof.t -> t
+  module Poly : sig
+    type 'a t =
+      (Mina_state.Snarked_ledger_state.With_sok.t, 'a) Proof_carrying_data.t
+  end
 
-  val proof : t -> Mina_base.Proof.t
+  module Cached : sig
+    type t = Proof_cache_tag.t Poly.t
+  end
 
-  val statement : t -> Statement.t
+  val create : statement:Statement.With_sok.t -> proof:'p -> 'p Poly.t
 
-  val statement_with_sok : t -> Statement.With_sok.t
+  val proof : 'p Poly.t -> 'p
 
-  val sok_digest : t -> Sok_message.Digest.t
+  val statement : _ Poly.t -> Statement.t
+
+  val statement_with_sok : _ Poly.t -> Statement.With_sok.t
+
+  val sok_digest : _ Poly.t -> Sok_message.Digest.t
 
   open Pickles_types
 


### PR DESCRIPTION
Polymorphize some `Transaction_snark.t` functions

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
