### PR TITLE
Make Transaction_snark_work.{Checked.t != t}

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1579,7 +1579,7 @@ let fetch_completed_snarks (module Context : CONTEXT) snark_pool network
       let%bind () =
         Deferred.List.iter completed_works ~f:(fun work ->
             (* proofs should be verified in apply and broadcast *)
-            let statement = Transaction_snark_work.Checked.statement work in
+            let statement = Transaction_snark_work.statement work in
             let snark =
               Network_pool.Priced_proof.
                 { proof = work.proofs

--- a/src/lib/mina_networking/rpcs.ml
+++ b/src/lib/mina_networking/rpcs.ml
@@ -874,7 +874,9 @@ module Get_completed_snarks = struct
     match (get_snark_pool (), snark_job_state ()) with
     | Some snark_pool, Some snark_state ->
         Work_selector.completed_work_statements ~snark_pool snark_state
-        |> Fn.flip List.take limit |> Option.some |> return
+        |> Fn.flip List.take limit
+        |> List.map ~f:Transaction_snark_work.forget
+        |> Option.some |> return
     | _, _ ->
         return None
 

--- a/src/lib/staged_ledger/diff_creation_log.ml
+++ b/src/lib/staged_ledger/diff_creation_log.ml
@@ -64,7 +64,7 @@ module Summary = struct
       ( Sequence.length completed_work
       , Sequence.sum
           (module Fee_Summable)
-          completed_work ~f:Transaction_snark_work.fee )
+          completed_work ~f:Transaction_snark_work.Checked.fee )
     in
     let commands =
       ( Sequence.length commands
@@ -183,7 +183,7 @@ module Detail = struct
           ; completed_work =
               ( fst x.completed_work - 1
               , Currency.Fee.sub (snd x.completed_work)
-                  (Transaction_snark_work.fee completed_work)
+                  (Transaction_snark_work.Checked.fee completed_work)
                 |> Option.value_exn )
           }
         in

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -176,64 +176,6 @@ let sum_fees xs ~f =
 let to_staged_ledger_or_error =
   Result.map_error ~f:(fun error -> Error.Unexpected error)
 
-let fee_remainder (type c) ~(to_user_command : c -> User_command.t)
-    (commands : c list) completed_works coinbase_fee =
-  let open Result.Let_syntax in
-  let%bind budget =
-    sum_fees commands ~f:(fun t -> User_command.fee (to_user_command t))
-    |> to_staged_ledger_or_error
-  in
-  let%bind work_fee =
-    sum_fees completed_works ~f:(fun { Transaction_snark_work.fee; _ } -> fee)
-    |> to_staged_ledger_or_error
-  in
-  let total_work_fee =
-    Option.value ~default:Currency.Fee.zero
-      (Currency.Fee.sub work_fee coinbase_fee)
-  in
-  Option.value_map
-    ~default:(Error (Error.Insufficient_fee (budget, total_work_fee)))
-    ~f:(fun x -> Ok x)
-    (Currency.Fee.sub budget total_work_fee)
-
-let create_fee_transfers completed_works delta public_key coinbase_fts =
-  let open Result.Let_syntax in
-  let singles =
-    (if Currency.Fee.(equal zero delta) then [] else [ (public_key, delta) ])
-    @ List.filter_map completed_works
-        ~f:(fun { Transaction_snark_work.fee; prover; _ } ->
-          if Currency.Fee.equal fee Currency.Fee.zero then None
-          else Some (prover, fee) )
-  in
-  let%bind singles_map =
-    Or_error.try_with (fun () ->
-        Public_key.Compressed.Map.of_alist_reduce singles ~f:(fun f1 f2 ->
-            Option.value_exn (Currency.Fee.add f1 f2) ) )
-    |> to_staged_ledger_or_error
-  in
-  (* deduct the coinbase work fee from the singles_map. It is already part of the coinbase *)
-  Or_error.try_with (fun () ->
-      List.fold coinbase_fts ~init:singles_map
-        ~f:(fun accum { Coinbase.Fee_transfer.receiver_pk; fee = cb_fee } ->
-          match Public_key.Compressed.Map.find accum receiver_pk with
-          | None ->
-              accum
-          | Some fee ->
-              let new_fee = Option.value_exn (Currency.Fee.sub fee cb_fee) in
-              if Currency.Fee.(new_fee > Currency.Fee.zero) then
-                Public_key.Compressed.Map.update accum receiver_pk ~f:(fun _ ->
-                    new_fee )
-              else Public_key.Compressed.Map.remove accum receiver_pk )
-      (* TODO: This creates a weird incentive to have a small public_key *)
-      |> Map.to_alist ~key_order:`Increasing
-      |> List.map ~f:(fun (receiver_pk, fee) ->
-             Fee_transfer.Single.create ~receiver_pk ~fee
-               ~fee_token:Token_id.default )
-      |> One_or_two.group_list
-      |> List.map ~f:Fee_transfer.of_singles
-      |> Or_error.all )
-  |> Or_error.join |> to_staged_ledger_or_error
-
 module Transaction_data = struct
   type 'a t =
     { commands : 'a list
@@ -242,33 +184,98 @@ module Transaction_data = struct
     }
 end
 
-let get_transaction_data (type c) ~constraint_constants coinbase_parts ~receiver
-    ~coinbase_amount ~(to_user_command : c -> User_command.t)
-    (commands : c list) completed_works :
-    (c Transaction_data.t, Error.t) Result.t =
-  let open Result.Let_syntax in
-  let%bind coinbases =
-    O1trace.sync_thread "create_coinbase" (fun () ->
-        create_coinbase ~constraint_constants coinbase_parts ~receiver
-          ~coinbase_amount )
-  in
-  let coinbase_fts =
-    List.concat_map coinbases ~f:(fun cb -> Option.to_list cb.fee_transfer)
-  in
-  let coinbase_work_fees =
-    sum_fees ~f:Coinbase.Fee_transfer.fee coinbase_fts |> Or_error.ok_exn
-  in
-  let txn_works_others =
-    List.filter completed_works ~f:(fun { Transaction_snark_work.prover; _ } ->
-        not (Public_key.Compressed.equal receiver prover) )
-  in
-  let%bind delta =
-    fee_remainder commands txn_works_others coinbase_work_fees ~to_user_command
-  in
-  let%map fee_transfers =
-    create_fee_transfers txn_works_others delta receiver coinbase_fts
-  in
-  { Transaction_data.commands; coinbases; fee_transfers }
+module Transaction_data_getter (T : Transaction_snark_work.S) = struct
+  let create_fee_transfers completed_works delta public_key coinbase_fts =
+    let open Result.Let_syntax in
+    let singles =
+      (if Currency.Fee.(equal zero delta) then [] else [ (public_key, delta) ])
+      @ List.filter_map completed_works ~f:(fun { T.fee; prover; _ } ->
+            if Currency.Fee.equal fee Currency.Fee.zero then None
+            else Some (prover, fee) )
+    in
+    let%bind singles_map =
+      Or_error.try_with (fun () ->
+          Public_key.Compressed.Map.of_alist_reduce singles ~f:(fun f1 f2 ->
+              Option.value_exn (Currency.Fee.add f1 f2) ) )
+      |> to_staged_ledger_or_error
+    in
+    (* deduct the coinbase work fee from the singles_map. It is already part of the coinbase *)
+    Or_error.try_with (fun () ->
+        List.fold coinbase_fts ~init:singles_map
+          ~f:(fun accum { Coinbase.Fee_transfer.receiver_pk; fee = cb_fee } ->
+            match Public_key.Compressed.Map.find accum receiver_pk with
+            | None ->
+                accum
+            | Some fee ->
+                let new_fee = Option.value_exn (Currency.Fee.sub fee cb_fee) in
+                if Currency.Fee.(new_fee > Currency.Fee.zero) then
+                  Public_key.Compressed.Map.update accum receiver_pk
+                    ~f:(fun _ -> new_fee)
+                else Public_key.Compressed.Map.remove accum receiver_pk )
+        (* TODO: This creates a weird incentive to have a small public_key *)
+        |> Map.to_alist ~key_order:`Increasing
+        |> List.map ~f:(fun (receiver_pk, fee) ->
+               Fee_transfer.Single.create ~receiver_pk ~fee
+                 ~fee_token:Token_id.default )
+        |> One_or_two.group_list
+        |> List.map ~f:Fee_transfer.of_singles
+        |> Or_error.all )
+    |> Or_error.join |> to_staged_ledger_or_error
+
+  let fee_remainder (type c) ~(to_user_command : c -> User_command.t)
+      (commands : c list) completed_works coinbase_fee =
+    let open Result.Let_syntax in
+    let%bind budget =
+      sum_fees commands ~f:(fun t -> User_command.fee (to_user_command t))
+      |> to_staged_ledger_or_error
+    in
+    let%bind work_fee =
+      sum_fees completed_works ~f:(fun { T.fee; _ } -> fee)
+      |> to_staged_ledger_or_error
+    in
+    let total_work_fee =
+      Option.value ~default:Currency.Fee.zero
+        (Currency.Fee.sub work_fee coinbase_fee)
+    in
+    Option.value_map
+      ~default:(Error (Error.Insufficient_fee (budget, total_work_fee)))
+      ~f:(fun x -> Ok x)
+      (Currency.Fee.sub budget total_work_fee)
+
+  let get (type c) ~constraint_constants coinbase_parts ~receiver
+      ~coinbase_amount ~(to_user_command : c -> User_command.t)
+      (commands : c list) (completed_works : T.t list) :
+      (c Transaction_data.t, Error.t) Result.t =
+    let open Result.Let_syntax in
+    let%bind coinbases =
+      O1trace.sync_thread "create_coinbase" (fun () ->
+          create_coinbase ~constraint_constants coinbase_parts ~receiver
+            ~coinbase_amount )
+    in
+    let coinbase_fts =
+      List.concat_map coinbases ~f:(fun cb -> Option.to_list cb.fee_transfer)
+    in
+    let coinbase_work_fees =
+      sum_fees ~f:Coinbase.Fee_transfer.fee coinbase_fts |> Or_error.ok_exn
+    in
+    let txn_works_others =
+      List.filter completed_works ~f:(fun { T.prover; _ } ->
+          not (Public_key.Compressed.equal receiver prover) )
+    in
+    let%bind delta =
+      fee_remainder commands txn_works_others coinbase_work_fees
+        ~to_user_command
+    in
+    let%map fee_transfers =
+      create_fee_transfers txn_works_others delta receiver coinbase_fts
+    in
+    { Transaction_data.commands; coinbases; fee_transfers }
+end
+
+module Transaction_data_getter_unchecked =
+  Transaction_data_getter (Transaction_snark_work)
+module Transaction_data_getter_checked =
+  Transaction_data_getter (Transaction_snark_work.Checked)
 
 let get_individual_info (type c) ~constraint_constants coinbase_parts ~receiver
     ~coinbase_amount (commands : c With_status.t list) completed_works
@@ -278,8 +285,8 @@ let get_individual_info (type c) ~constraint_constants coinbase_parts ~receiver
            ; coinbases = coinbase_parts
            ; fee_transfers
            } =
-    get_transaction_data ~constraint_constants coinbase_parts ~receiver
-      ~coinbase_amount commands completed_works ~to_user_command
+    Transaction_data_getter_unchecked.get ~constraint_constants coinbase_parts
+      ~receiver ~coinbase_amount commands completed_works ~to_user_command
   in
   let internal_commands =
     List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
@@ -329,13 +336,15 @@ let check_coinbase (diff : _ Pre_diff_two.t * _ Pre_diff_one.t option) =
 
 let compute_statuses
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~diff
-    ~coinbase_receiver ~coinbase_amount ~global_slot ~txn_state_view ~ledger =
+    ~coinbase_receiver ~coinbase_amount ~global_slot ~txn_state_view ~ledger :
+    (With_valid_signatures_and_proofs.diff, _) result =
   let open Result.Let_syntax in
   (* project transactions into a sequence of transactions *)
   let project_transactions ~coinbase_parts ~commands ~completed_works =
     let%map { Transaction_data.commands; coinbases; fee_transfers } =
-      get_transaction_data ~constraint_constants coinbase_parts
-        ~receiver:coinbase_receiver ~coinbase_amount commands completed_works
+      Transaction_data_getter_checked.get ~constraint_constants coinbase_parts
+        ~receiver:coinbase_receiver ~coinbase_amount commands
+        (completed_works : Transaction_snark_work.Checked.t list)
         ~to_user_command:User_command.forget_check
     in
     List.map commands ~f:(fun t ->
@@ -343,14 +352,16 @@ let compute_statuses
     @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
     @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
   in
-  let project_transactions_pre_diff_two (p : _ Pre_diff_two.t) =
+  let project_transactions_pre_diff_two
+      (p : (Transaction_snark_work.Checked.t, _) Pre_diff_two.t) =
     let coinbase_parts =
       match p.coinbase with Zero -> `Zero | One x -> `One x | Two x -> `Two x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
       ~completed_works:p.completed_works
   in
-  let project_transactions_pre_diff_one (p : _ Pre_diff_one.t) =
+  let project_transactions_pre_diff_one
+      (p : (Transaction_snark_work.Checked.t, _) Pre_diff_one.t) =
     let coinbase_parts =
       match p.coinbase with Zero -> `Zero | One x -> `One x
     in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1349,7 +1349,7 @@ module T = struct
       }
     [@@deriving sexp_of]
 
-    let coinbase_ft (cw : Transaction_snark_work.t) =
+    let coinbase_ft (cw : Transaction_snark_work.Checked.t) =
       (* Here we could not add the fee transfer if the prover=receiver_pk but
          retaining it to preserve that information in the
          staged_ledger_diff. It will be checked in apply_diff before adding*)
@@ -1380,7 +1380,7 @@ module T = struct
       let diff ws ws' =
         Sequence.filter ws ~f:(fun w ->
             Sequence.mem ws'
-              (Transaction_snark_work.statement w)
+              (Transaction_snark_work.Checked.statement w)
               ~equal:Transaction_snark_work.Statement.equal
             |> not )
       in
@@ -1395,7 +1395,7 @@ module T = struct
               (of_fee constraint_constants.account_creation_fee))
         else Some coinbase_amount
       in
-      let stmt = Transaction_snark_work.statement in
+      let stmt = Transaction_snark_work.Checked.statement in
       if is_two then
         match (min1, min2) with
         | None, _ ->
@@ -2202,7 +2202,19 @@ module T = struct
             in
             [%log internal] "Generate_staged_ledger_diff" ;
             let diff, log =
-              O1trace.sync_thread "generate_staged_ledger_diff" (fun () ->
+              O1trace.sync_thread "generate_staged_ledger_diff"
+                (fun
+                  ()
+                  :
+                  (( ( Transaction_snark_work.Checked.t
+                     , User_command.Valid.t )
+                     Staged_ledger_diff.Pre_diff_two.t
+                   * ( Transaction_snark_work.Checked.t
+                     , User_command.Valid.t )
+                     Staged_ledger_diff.Pre_diff_one.t
+                     option )
+                  * _)
+                ->
                   generate ~constraint_constants logger completed_works_seq
                     valid_on_this_ledger ~receiver:coinbase_receiver
                     ~is_coinbase_receiver_new ~supercharge_coinbase partitions )
@@ -3733,27 +3745,20 @@ let%test_module "staged ledger tests" =
                   Option.value_map ft_opt ~default:() ~f:(fun single ->
                       let work =
                         List.hd_exn (sorted_work_from_diff1 first_pre_diff)
-                        |> Transaction_snark_work.forget
                       in
                       assert_same_fee single work.fee )
               | Zero, One ft_opt ->
                   Option.value_map ft_opt ~default:() ~f:(fun single ->
                       let work =
                         List.hd_exn (sorted_work_from_diff2 second_pre_diff_opt)
-                        |> Transaction_snark_work.forget
                       in
                       assert_same_fee single work.fee )
               | Two (Some (ft, ft_opt)), Zero ->
                   let work_done = sorted_work_from_diff1 first_pre_diff in
-                  let work =
-                    List.hd_exn work_done |> Transaction_snark_work.forget
-                  in
+                  let work = List.hd_exn work_done in
                   assert_same_fee ft work.fee ;
                   Option.value_map ft_opt ~default:() ~f:(fun single ->
-                      let work =
-                        List.hd_exn (List.drop work_done 1)
-                        |> Transaction_snark_work.forget
-                      in
+                      let work = List.hd_exn (List.drop work_done 1) in
                       assert_same_fee single work.fee )
               | _ ->
                   failwith

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -74,6 +74,15 @@ module Info = struct
   [@@deriving to_yojson, sexp, compare]
 end
 
+module type S = sig
+  type t =
+    { fee : Fee.t
+    ; proofs : Ledger_proof.t One_or_two.t
+    ; prover : Public_key.Compressed.t
+    }
+  [@@deriving compare, fields, yojson, sexp]
+end
+
 module T = struct
   [%%versioned
   module Stable = struct
@@ -96,7 +105,7 @@ module T = struct
     ; proofs : Ledger_proof.t One_or_two.t
     ; prover : Public_key.Compressed.t
     }
-  [@@deriving compare, yojson, sexp]
+  [@@deriving compare, fields, yojson, sexp]
 
   let statement t = One_or_two.map t.proofs ~f:Ledger_proof.statement
 
@@ -120,7 +129,3 @@ module Checked = struct
 end
 
 let forget = Fn.id
-
-let fee { fee; _ } = fee
-
-let prover { prover; _ } = prover

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -51,16 +51,16 @@ end
        H(all_statements_in_bundle || fee || public_key)
 *)
 
-type t = Mina_wire_types.Transaction_snark_work.V2.t =
-  { fee : Fee.t
-  ; proofs : Ledger_proof.t One_or_two.t
-  ; prover : Public_key.Compressed.t
-  }
-[@@deriving compare, sexp, yojson]
+module type S = sig
+  type t =
+    { fee : Fee.t
+    ; proofs : Ledger_proof.t One_or_two.t
+    ; prover : Public_key.Compressed.t
+    }
+  [@@deriving compare, fields, sexp, yojson]
+end
 
-val fee : t -> Fee.t
-
-val prover : t -> Public_key.Compressed.t
+include S with type t = Mina_wire_types.Transaction_snark_work.V2.t
 
 val info : t -> Info.t
 
@@ -76,12 +76,7 @@ with type V2.t = t
 type unchecked = t
 
 module Checked : sig
-  type nonrec t = t =
-    { fee : Fee.t
-    ; proofs : Ledger_proof.t One_or_two.t
-    ; prover : Public_key.Compressed.t
-    }
-  [@@deriving sexp, compare, to_yojson]
+  include S
 
   module Stable : module type of Stable
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -357,15 +357,14 @@ module For_tests = struct
         let { Keypair.public_key; _ } = Keypair.create () in
         let prover = Public_key.compress public_key in
         Some
-          Transaction_snark_work.Checked.
-            { fee = Fee.of_nanomina_int_exn 1
-            ; proofs =
-                One_or_two.map stmts ~f:(fun statement ->
-                    Ledger_proof.create ~statement
-                      ~sok_digest:Sok_message.Digest.default
-                      ~proof:(Lazy.force Proof.transaction_dummy) )
-            ; prover
-            }
+          { Transaction_snark_work.Checked.fee = Fee.of_nanomina_int_exn 1
+          ; proofs =
+              One_or_two.map stmts ~f:(fun statement ->
+                  Ledger_proof.create ~statement
+                    ~sok_digest:Sok_message.Digest.default
+                    ~proof:(Lazy.force Proof.transaction_dummy) )
+          ; prover
+          }
       in
       let current_state_view, state_and_body_hash =
         let prev_state =

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -17,11 +17,15 @@ module Test_inputs = struct
   end
 
   module Transaction_snark_work = struct
-    type t = Fee.t
+    module Checked = struct
+      type t = Fee.t
 
-    let fee = Fn.id
+      let fee = Fn.id
 
-    let prover _ = Key_gen.Sample_keypairs.genesis_winner |> fst
+      let prover _ = Key_gen.Sample_keypairs.genesis_winner |> fst
+    end
+
+    include Checked
 
     module Statement = struct
       type t = Transaction_snark.Statement.t One_or_two.t

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -1,6 +1,14 @@
 open Core
 open Currency
 
+module type Transaction_snark_work_intf = sig
+  type t
+
+  val fee : t -> Fee.t
+
+  val prover : t -> Signature_lib.Public_key.Compressed.t
+end
+
 module type Inputs_intf = sig
   module Ledger_hash : sig
     type t
@@ -23,15 +31,13 @@ module type Inputs_intf = sig
   end
 
   module Transaction_snark_work : sig
-    type t
-
-    val fee : t -> Fee.t
-
-    val prover : t -> Signature_lib.Public_key.Compressed.t
+    include Transaction_snark_work_intf
 
     module Statement : sig
       type t = Transaction_snark.Statement.t One_or_two.t
     end
+
+    module Checked : Transaction_snark_work_intf
   end
 
   module Snark_pool : sig
@@ -40,7 +46,7 @@ module type Inputs_intf = sig
     val get_completed_work :
          t
       -> Transaction_snark.Statement.t One_or_two.t
-      -> Transaction_snark_work.t option
+      -> Transaction_snark_work.Checked.t option
   end
 
   module Transaction_protocol_state : sig

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -128,7 +128,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
     Option.value_map ~default:true
       (Inputs.Snark_pool.get_completed_work snark_pool statements)
       ~f:(fun priced_proof ->
-        let competing_fee = Inputs.Transaction_snark_work.fee priced_proof in
+        let competing_fee =
+          Inputs.Transaction_snark_work.Checked.fee priced_proof
+        in
         Fee.compare fee competing_fee < 0 )
 
   module For_tests = struct
@@ -154,9 +156,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
             let fee_prover_opt =
               Option.map
                 (Inputs.Snark_pool.get_completed_work snark_pool statement)
-                ~f:(fun (p : Inputs.Transaction_snark_work.t) ->
-                  ( Inputs.Transaction_snark_work.fee p
-                  , Inputs.Transaction_snark_work.prover p ) )
+                ~f:(fun (p : Inputs.Transaction_snark_work.Checked.t) ->
+                  ( Inputs.Transaction_snark_work.Checked.fee p
+                  , Inputs.Transaction_snark_work.Checked.prover p ) )
             in
             (job, fee_prover_opt) ) )
 

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -41,4 +41,4 @@ val all_work :
      list
 
 val completed_work_statements :
-  snark_pool:snark_pool -> State.t -> Transaction_snark_work.unchecked list
+  snark_pool:snark_pool -> State.t -> Transaction_snark_work.Checked.t list


### PR DESCRIPTION
Make `Transaction_snark_work.{Checked.t != t}`. Having the two types equal defeats the purpose of type separation.
It also confuses future refactoring of use of the two types.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
