### PR TITLE
Hide fields of `Transaction_snark_work.Checked.t`

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -719,11 +719,21 @@ module T = struct
       let matching_completed_work_in_pool = get_completed_work work_statement in
       match (statements_match, matching_completed_work_in_pool) with
       | true, Some (completed_work : Transaction_snark_work.Checked.t) ->
-          let verified_proofs = completed_work.proofs in
-          let block_work_proofs = work.proofs in
-          if not @@ Fee.equal completed_work.fee work.fee then
-            Second "fee_not_equal"
-          else if not @@ Account.Key.equal completed_work.prover work.prover
+          let verified_proofs =
+            Transaction_snark_work.Checked.proofs completed_work
+          in
+          let block_work_proofs = Transaction_snark_work.proofs work in
+          if
+            not
+            @@ Fee.equal
+                 (Transaction_snark_work.Checked.fee completed_work)
+                 (Transaction_snark_work.fee work)
+          then Second "fee_not_equal"
+          else if
+            not
+            @@ Account.Key.equal
+                 (Transaction_snark_work.Checked.prover completed_work)
+                 (Transaction_snark_work.prover work)
           then Second "prover_account_not_equal"
           else if
             not
@@ -1350,25 +1360,28 @@ module T = struct
     [@@deriving sexp_of]
 
     let coinbase_ft (cw : Transaction_snark_work.Checked.t) =
+      let fee = Transaction_snark_work.Checked.fee cw in
+      let receiver_pk = Transaction_snark_work.Checked.prover cw in
       (* Here we could not add the fee transfer if the prover=receiver_pk but
          retaining it to preserve that information in the
          staged_ledger_diff. It will be checked in apply_diff before adding*)
       Option.some_if
-        Fee.(cw.fee > Fee.zero)
-        (Coinbase.Fee_transfer.create ~receiver_pk:cw.prover ~fee:cw.fee)
+        Fee.(fee > Fee.zero)
+        (Coinbase.Fee_transfer.create ~receiver_pk ~fee)
 
     let cheapest_two_work (works : Transaction_snark_work.Checked.t Sequence.t)
         =
+      let open Transaction_snark_work.Checked in
       Sequence.fold works ~init:(None, None) ~f:(fun (w1, w2) w ->
           match (w1, w2) with
           | None, _ ->
               (Some w, None)
           | Some x, None ->
-              if Currency.Fee.compare w.fee x.fee < 0 then (Some w, w1)
+              if Fee.compare (fee w) (fee x) < 0 then (Some w, w1)
               else (w1, Some w)
           | Some x, Some y ->
-              if Currency.Fee.compare w.fee x.fee < 0 then (Some w, w1)
-              else if Currency.Fee.compare w.fee y.fee < 0 then (w1, Some w)
+              if Fee.compare (fee w) (fee x) < 0 then (Some w, w1)
+              else if Fee.compare (fee w) (fee y) < 0 then (w1, Some w)
               else (w1, w2) )
 
     let coinbase_work
@@ -1401,7 +1414,8 @@ module T = struct
         | None, _ ->
             None
         | Some w, None ->
-            if Amount.(of_fee w.fee <= budget) then
+            if Amount.(of_fee (Transaction_snark_work.Checked.fee w) <= budget)
+            then
               let cb =
                 Staged_ledger_diff.At_most_two.Two
                   (Option.map (coinbase_ft w) ~f:(fun ft -> (ft, None)))
@@ -1411,7 +1425,11 @@ module T = struct
               let cb = Staged_ledger_diff.At_most_two.Two None in
               Some (cb, works)
         | Some w1, Some w2 ->
-            let%map sum = Fee.add w1.fee w2.fee in
+            let%map sum =
+              Fee.add
+                (Transaction_snark_work.Checked.fee w1)
+                (Transaction_snark_work.Checked.fee w2)
+            in
             if Amount.(of_fee sum <= budget) then
               let cb =
                 Staged_ledger_diff.At_most_two.Two
@@ -1426,7 +1444,9 @@ module T = struct
                   reduce the slots occupied by fee transfers*)
               in
               (cb, diff works (Sequence.of_list [ stmt w1; stmt w2 ]))
-            else if Amount.(of_fee w1.fee <= coinbase_amount) then
+            else if
+              Amount.(of_fee (Transaction_snark_work.Checked.fee w1) <= budget)
+            then
               let cb =
                 Staged_ledger_diff.At_most_two.Two
                   (Option.map (coinbase_ft w1) ~f:(fun ft -> (ft, None)))
@@ -1437,7 +1457,8 @@ module T = struct
               (cb, works)
       else
         Option.map min1 ~f:(fun w ->
-            if Amount.(of_fee w.fee <= budget) then
+            if Amount.(of_fee (Transaction_snark_work.Checked.fee w) <= budget)
+            then
               let cb = Staged_ledger_diff.At_most_two.One (coinbase_ft w) in
               (cb, diff works (Sequence.of_list [ stmt w ]))
             else
@@ -2116,6 +2137,10 @@ module T = struct
                 ~f:(fun (seq, count) w ->
                   match get_completed_work w with
                   | Some cw_checked ->
+                      let fee = Transaction_snark_work.Checked.fee cw_checked in
+                      let prover =
+                        Transaction_snark_work.Checked.prover cw_checked
+                      in
                       (*If new provers can't pay the account-creation-fee then discard
                         their work unless their fee is zero in which case their account
                         won't be created. This is to encourage using an existing accounts
@@ -2123,26 +2148,24 @@ module T = struct
                         This also imposes new snarkers to have a min fee until one of
                         their snarks are purchased and their accounts get created*)
                       if
-                        Currency.Fee.(cw_checked.fee = zero)
+                        Currency.Fee.(fee = zero)
                         || Currency.Fee.(
-                             cw_checked.fee
-                             >= constraint_constants.account_creation_fee)
-                        || not (is_new_account cw_checked.prover)
+                             fee >= constraint_constants.account_creation_fee)
+                        || not (is_new_account prover)
                       then
                         Continue
                           ( Sequence.append seq (Sequence.singleton cw_checked)
-                          , One_or_two.length cw_checked.proofs + count )
+                          , One_or_two.length
+                              (Transaction_snark_work.Checked.proofs cw_checked)
+                            + count )
                       else (
                         [%log debug]
                           ~metadata:
-                            [ ( "work"
-                              , Transaction_snark_work.Checked.to_yojson
-                                  cw_checked )
+                            [ ("prover", Public_key.Compressed.to_yojson prover)
                             ; ( "work_ids"
                               , Transaction_snark_work.Statement.compact_json w
                               )
-                            ; ( "snark_fee"
-                              , Currency.Fee.to_yojson cw_checked.fee )
+                            ; ("snark_fee", Currency.Fee.to_yojson fee)
                             ; ( "account_creation_fee"
                               , Currency.Fee.to_yojson
                                   constraint_constants.account_creation_fee )
@@ -2600,19 +2623,15 @@ let%test_module "staged ledger tests" =
         : Transaction_snark_work.Checked.t option =
       let prover = stmt_to_prover stmts in
       Some
-        { Transaction_snark_work.Checked.fee = work_fee
-        ; proofs = proofs stmts
-        ; prover
-        }
+        (Transaction_snark_work.Checked.create_unsafe
+           { fee = work_fee; proofs = proofs stmts; prover } )
 
     let stmt_to_work_zero_fee ~prover
         (stmts : Transaction_snark_work.Statement.t) :
         Transaction_snark_work.Checked.t option =
       Some
-        { Transaction_snark_work.Checked.fee = Currency.Fee.zero
-        ; proofs = proofs stmts
-        ; prover
-        }
+        (Transaction_snark_work.Checked.create_unsafe
+           { fee = Currency.Fee.zero; proofs = proofs stmts; prover } )
 
     (* Fixed public key for when there is only one snark worker. *)
     let snark_worker_pk =
@@ -2621,7 +2640,9 @@ let%test_module "staged ledger tests" =
 
     let stmt_to_work_one_prover (stmts : Transaction_snark_work.Statement.t) :
         Transaction_snark_work.Checked.t option =
-      Some { fee = work_fee; proofs = proofs stmts; prover = snark_worker_pk }
+      Some
+        (Transaction_snark_work.Checked.create_unsafe
+           { fee = work_fee; proofs = proofs stmts; prover = snark_worker_pk } )
 
     let coinbase_first_prediff = function
       | Staged_ledger_diff.At_most_two.Zero ->
@@ -3249,10 +3270,11 @@ let%test_module "staged ledger tests" =
     let%test_unit "Zero proof-fee should not create a fee transfer" =
       let stmt_to_work_zero_fee stmts =
         Some
-          { Transaction_snark_work.Checked.fee = Currency.Fee.zero
-          ; proofs = proofs stmts
-          ; prover = snark_worker_pk
-          }
+          (Transaction_snark_work.Checked.create_unsafe
+             { fee = Currency.Fee.zero
+             ; proofs = proofs stmts
+             ; prover = snark_worker_pk
+             } )
       in
       let expected_proof_count = 3 in
       Quickcheck.test
@@ -3345,10 +3367,11 @@ let%test_module "staged ledger tests" =
                     let work_done =
                       List.map
                         ~f:(fun stmts ->
-                          { Transaction_snark_work.Checked.fee = Fee.zero
-                          ; proofs = proofs stmts
-                          ; prover = snark_worker_pk
-                          } )
+                          Transaction_snark_work.Checked.create_unsafe
+                            { fee = Fee.zero
+                            ; proofs = proofs stmts
+                            ; prover = snark_worker_pk
+                            } )
                         work
                     in
                     let cmds_this_iter = cmds_this_iter |> Sequence.to_list in
@@ -3407,12 +3430,13 @@ let%test_module "staged ledger tests" =
       let stmt_to_work stmts =
         let prover = stmt_to_prover stmts in
         Some
-          { Transaction_snark_work.Checked.fee =
-              Currency.Fee.(sub work_fee (of_nanomina_int_exn 1))
-              |> Option.value_exn
-          ; proofs = proofs stmts
-          ; prover
-          }
+          (Transaction_snark_work.Checked.create_unsafe
+             { fee =
+                 Currency.Fee.(sub work_fee (of_nanomina_int_exn 1))
+                 |> Option.value_exn
+             ; proofs = proofs stmts
+             ; prover
+             } )
       in
       Quickcheck.test
         Quickcheck.Generator.(tuple2 (gen_below_capacity ()) small_positive_int)
@@ -3474,10 +3498,8 @@ let%test_module "staged ledger tests" =
                Transaction_snark_work.Statement.compare s stmts = 0 ) )
       then
         Some
-          { Transaction_snark_work.Checked.fee = work_fee
-          ; proofs = proofs stmts
-          ; prover
-          }
+          (Transaction_snark_work.Checked.create_unsafe
+             { fee = work_fee; proofs = proofs stmts; prover } )
       else None
 
     (** Like test_simple but with a random number of completed jobs available.
@@ -3663,8 +3685,8 @@ let%test_module "staged ledger tests" =
         (List.find work_list ~f:(fun (s, _) ->
              Transaction_snark_work.Statement.compare s stmts = 0 ) )
         ~f:(fun (_, fee) ->
-          { Transaction_snark_work.Checked.fee; proofs = proofs stmts; prover }
-          )
+          Transaction_snark_work.Checked.create_unsafe
+            { fee; proofs = proofs stmts; prover } )
 
     (** Like test_random_number_of_proofs but with random proof fees.
                    *)

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -448,7 +448,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let%bind completed_works_fees =
       List.fold ~init:(Some Fee.zero) (completed_works t) ~f:(fun sum work ->
           let%bind sum = sum in
-          Fee.( + ) sum work.Transaction_snark_work.fee )
+          Fee.(sum + Transaction_snark_work.fee work) )
     in
     Amount.(of_fee total_reward - of_fee completed_works_fees)
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -1341,9 +1341,11 @@ let fill_work_and_enqueue_transactions t ~logger transactions work =
           (total_proofs works))
     in
     map2_or_error next_jobs
-      (List.concat_map works
-         ~f:(fun { Transaction_snark_work.fee; proofs; prover } ->
-           One_or_two.map proofs ~f:(fun proof -> (fee, proof, prover))
+      (List.concat_map works ~f:(fun w ->
+           let fee = Transaction_snark_work.fee w in
+           let prover = Transaction_snark_work.prover w in
+           One_or_two.map (Transaction_snark_work.proofs w) ~f:(fun proof ->
+               (fee, proof, prover) )
            |> One_or_two.to_list ) )
       ~f:completed_work_to_scanable_work
   in

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -75,12 +75,13 @@ module Info = struct
 end
 
 module type S = sig
-  type t =
-    { fee : Fee.t
-    ; proofs : Ledger_proof.t One_or_two.t
-    ; prover : Public_key.Compressed.t
-    }
-  [@@deriving compare, fields, yojson, sexp]
+  type t [@@deriving compare, sexp, yojson]
+
+  val fee : t -> Fee.t
+
+  val prover : t -> Public_key.Compressed.t
+
+  val proofs : t -> Ledger_proof.t One_or_two.t
 end
 
 module T = struct

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -52,15 +52,22 @@ end
 *)
 
 module type S = sig
-  type t =
-    { fee : Fee.t
-    ; proofs : Ledger_proof.t One_or_two.t
-    ; prover : Public_key.Compressed.t
-    }
-  [@@deriving compare, fields, sexp, yojson]
+  type t [@@deriving compare, sexp, yojson]
+
+  val fee : t -> Fee.t
+
+  val prover : t -> Public_key.Compressed.t
+
+  val proofs : t -> Ledger_proof.t One_or_two.t
 end
 
-include S with type t = Mina_wire_types.Transaction_snark_work.V2.t
+type t = Mina_wire_types.Transaction_snark_work.V2.t =
+  { fee : Currency.Fee.t
+  ; proofs : Ledger_proof.t One_or_two.t
+  ; prover : Public_key.Compressed.t
+  }
+
+include S with type t := t
 
 val info : t -> Info.t
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -357,14 +357,15 @@ module For_tests = struct
         let { Keypair.public_key; _ } = Keypair.create () in
         let prover = Public_key.compress public_key in
         Some
-          { Transaction_snark_work.Checked.fee = Fee.of_nanomina_int_exn 1
-          ; proofs =
-              One_or_two.map stmts ~f:(fun statement ->
-                  Ledger_proof.create ~statement
-                    ~sok_digest:Sok_message.Digest.default
-                    ~proof:(Lazy.force Proof.transaction_dummy) )
-          ; prover
-          }
+          (Transaction_snark_work.Checked.create_unsafe
+             { fee = Fee.of_nanomina_int_exn 1
+             ; proofs =
+                 One_or_two.map stmts ~f:(fun statement ->
+                     Ledger_proof.create ~statement
+                       ~sok_digest:Sok_message.Digest.default
+                       ~proof:(Lazy.force Proof.transaction_dummy) )
+             ; prover
+             } )
       in
       let current_state_view, state_and_body_hash =
         let prev_state =


### PR DESCRIPTION
Having them exposed means that `Transaction_snark_work.Checked.t` can be trivially constructed anywhere, without doing any checks.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
