### PR TITLE
Move to_yojson outside of Stable in Mina_block.t

### DIFF
--- a/src/lib/mina_block/block.ml
+++ b/src/lib/mina_block/block.ml
@@ -11,24 +11,6 @@ module Stable = struct
       }
     [@@deriving fields, sexp]
 
-    let to_yojson t =
-      `Assoc
-        [ ( "protocol_state"
-          , Protocol_state.value_to_yojson (Header.protocol_state t.header) )
-        ; ("protocol_state_proof", `String "<opaque>")
-        ; ("staged_ledger_diff", `String "<opaque>")
-        ; ("delta_transition_chain_proof", `String "<opaque>")
-        ; ( "current_protocol_version"
-          , `String
-              (Protocol_version.to_string
-                 (Header.current_protocol_version t.header) ) )
-        ; ( "proposed_protocol_version"
-          , `String
-              (Option.value_map
-                 (Header.proposed_protocol_version_opt t.header)
-                 ~default:"<None>" ~f:Protocol_version.to_string ) )
-        ]
-
     let to_latest = Fn.id
 
     module Creatable = struct
@@ -71,8 +53,26 @@ end]
 
 type with_hash = t State_hash.With_state_hashes.t [@@deriving sexp]
 
+let to_yojson t =
+  `Assoc
+    [ ( "protocol_state"
+      , Protocol_state.value_to_yojson (Header.protocol_state t.header) )
+    ; ("protocol_state_proof", `String "<opaque>")
+    ; ("staged_ledger_diff", `String "<opaque>")
+    ; ("delta_transition_chain_proof", `String "<opaque>")
+    ; ( "current_protocol_version"
+      , `String
+          (Protocol_version.to_string
+             (Header.current_protocol_version t.header) ) )
+    ; ( "proposed_protocol_version"
+      , `String
+          (Option.value_map
+             (Header.proposed_protocol_version_opt t.header)
+             ~default:"<None>" ~f:Protocol_version.to_string ) )
+    ]
+
 [%%define_locally
-Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t, to_yojson, equal)]
+Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t, equal)]
 
 let wrap_with_hash block =
   With_hash.of_data block

--- a/src/lib/mina_block/block.mli
+++ b/src/lib/mina_block/block.mli
@@ -6,7 +6,7 @@ module Stable : sig
   [@@@no_toplevel_latest_type]
 
   module V2 : sig
-    type t [@@deriving sexp, to_yojson, equal]
+    type t [@@deriving sexp, equal]
   end
 end]
 

--- a/src/lib/mina_block/validated_block.ml
+++ b/src/lib/mina_block/validated_block.ml
@@ -9,17 +9,16 @@ module Stable = struct
       * State_hash.Stable.V1.t Mina_stdlib.Nonempty_list.Stable.V1.t
     [@@deriving sexp, equal]
 
-    let to_yojson (block_with_hashes, _) =
-      State_hash.With_state_hashes.Stable.V1.to_yojson Block.Stable.V2.to_yojson
-        block_with_hashes
-
     let to_latest = ident
   end
 end]
 
 type t = Stable.Latest.t
 
-[%%define_locally Stable.Latest.(t_of_sexp, sexp_of_t, equal, to_yojson)]
+let to_yojson (block_with_hashes, _) =
+  State_hash.With_state_hashes.to_yojson Block.to_yojson block_with_hashes
+
+[%%define_locally Stable.Latest.(t_of_sexp, sexp_of_t, equal)]
 
 let lift (b, v) =
   match v with

--- a/src/lib/mina_block/validated_block.mli
+++ b/src/lib/mina_block/validated_block.mli
@@ -4,8 +4,6 @@ open Mina_base
 module Stable : sig
   module V2 : sig
     type t [@@deriving sexp, equal]
-
-    val to_yojson : t -> Yojson.Safe.t
   end
 end]
 

--- a/src/lib/transition_frontier/frontier_base/root_data.ml
+++ b/src/lib/transition_frontier/frontier_base/root_data.ml
@@ -70,18 +70,16 @@ module Limited = struct
         ; common : Common.Stable.V2.t
         }
 
-      let to_yojson { transition; protocol_states = _; common } =
-        `Assoc
-          [ ("transition", Mina_block.Validated.Stable.V2.to_yojson transition)
-          ; ("protocol_states", `String "<opaque>")
-          ; ("common", Common.Stable.V2.to_yojson common)
-          ]
-
       let to_latest = Fn.id
     end
   end]
 
-  [%%define_locally Stable.Latest.(to_yojson)]
+  let to_yojson { transition; protocol_states = _; common } =
+    `Assoc
+      [ ("transition", Mina_block.Validated.to_yojson transition)
+      ; ("protocol_states", `String "<opaque>")
+      ; ("common", Common.Stable.V2.to_yojson common)
+      ]
 
   let create ~transition ~scan_state ~pending_coinbase ~protocol_states =
     let common = { Common.scan_state; pending_coinbase } in

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -23,10 +23,14 @@ end
 module Limited : sig
   [%%versioned:
   module Stable : sig
+    [@@@no_toplevel_latest_type]
+
     module V3 : sig
-      type t [@@deriving to_yojson]
+      type t
     end
   end]
+
+  type t = Stable.Latest.t [@@deriving to_yojson]
 
   val transition : t -> Mina_block.Validated.t
 


### PR DESCRIPTION
Move `to_yojson` outside of `Stable` in `Mina_block.t`.
Implementation is not really stable and is only used for logging.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
