### PR TITLE
Remove sexp derivation from Snark_pool

### DIFF
--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -10,7 +10,7 @@ open Network_peer
  *  can only be initialized, and any interaction with it must go through
  *  its [Resource_pool_diff_intf] *)
 module type Resource_pool_base_intf = sig
-  type t [@@deriving sexp_of]
+  type t
 
   val label : string
 
@@ -19,7 +19,7 @@ module type Resource_pool_base_intf = sig
   type transition_frontier
 
   module Config : sig
-    type t [@@deriving sexp_of]
+    type t
   end
 
   (** Diff from a transition frontier extension that would update the resource pool*)
@@ -74,12 +74,12 @@ module type Resource_pool_diff_intf = sig
 
   val label : string
 
-  type t [@@deriving sexp, to_yojson]
+  type t [@@deriving to_yojson]
 
-  type verified [@@deriving sexp, to_yojson]
+  type verified [@@deriving to_yojson]
 
   (** Part of the diff that was not added to the resource pool*)
-  type rejected [@@deriving sexp, to_yojson]
+  type rejected [@@deriving to_yojson]
 
   val empty : t
 
@@ -302,9 +302,9 @@ module type Snark_pool_diff_intf = sig
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp]
+  [@@deriving compare]
 
-  type verified = t [@@deriving compare, sexp]
+  type verified = t [@@deriving compare]
 
   type compact =
     { work_ids : int One_or_two.t
@@ -337,7 +337,7 @@ end
 module type Transaction_pool_diff_intf = sig
   type resource_pool
 
-  type t = User_command.t list [@@deriving sexp, of_yojson]
+  type t = User_command.t list [@@deriving of_yojson]
 
   module Diff_error : sig
     type t =
@@ -353,13 +353,13 @@ module type Transaction_pool_diff_intf = sig
       | Fee_payer_account_not_found
       | Fee_payer_not_permitted_to_send
       | After_slot_tx_end
-    [@@deriving sexp, yojson]
+    [@@deriving yojson]
 
     val to_string_hum : t -> string
   end
 
   module Rejected : sig
-    type t = (User_command.t * Diff_error.t) list [@@deriving sexp, yojson]
+    type t = (User_command.t * Diff_error.t) list [@@deriving yojson]
   end
 
   type Structured_log_events.t +=

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -98,7 +98,7 @@ struct
           ; verifier : (Verifier.t[@sexp.opaque])
           ; disk_location : string
           }
-        [@@deriving sexp, make]
+        [@@deriving make]
       end
 
       type transition_frontier_diff =
@@ -113,7 +113,6 @@ struct
         ; account_creation_fee : Currency.Fee.t
         ; batcher : Batcher.Snark_pool.t
         }
-      [@@deriving sexp]
 
       let make_config = Config.make
 
@@ -546,7 +545,7 @@ module Diff_versioned = struct
             * Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp, to_yojson, hash]
+      [@@deriving compare, to_yojson, hash]
 
       let to_latest = Fn.id
     end
@@ -557,7 +556,7 @@ module Diff_versioned = struct
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson, hash]
+  [@@deriving compare, to_yojson, hash]
 end
 
 let%test_module "random set test" =
@@ -688,15 +687,6 @@ let%test_module "random set test" =
                 @@ Signature_lib.Public_key.Compressed.equal mal_pk fee.prover ) )
       in
       Quickcheck.test ~trials:5
-        ~sexp_of:
-          [%sexp_of:
-            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
-            Deferred.t
-            * ( Transaction_snark_work.Statement.t
-              * Ledger_proof.t One_or_two.t
-              * Fee_with_prover.t
-              * Signature_lib.Public_key.Compressed.t )
-              list]
         (Quickcheck.Generator.tuple2 (gen ()) invalid_work_gen)
         ~f:(fun (t, invalid_work_lst) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
@@ -731,13 +721,6 @@ let%test_module "random set test" =
                    the snark pool, the fee of the work is at most the minimum \
                    of those fees" =
       Quickcheck.test ~trials:5
-        ~sexp_of:
-          [%sexp_of:
-            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
-            Deferred.t
-            * Mocks.Transaction_snark_work.Statement.t
-            * Fee_with_prover.t
-            * Fee_with_prover.t]
         (Async.Quickcheck.Generator.tuple4 (gen ())
            Mocks.Transaction_snark_work.Statement.gen Fee_with_prover.gen
            Fee_with_prover.gen )
@@ -761,13 +744,6 @@ let%test_module "random set test" =
                    proof of the same work only if it's fee is smaller than the \
                    existing priced proof" =
       Quickcheck.test ~trials:5
-        ~sexp_of:
-          [%sexp_of:
-            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
-            Deferred.t
-            * Mocks.Transaction_snark_work.Statement.t
-            * Fee_with_prover.t
-            * Fee_with_prover.t]
         (Quickcheck.Generator.tuple4 (gen ())
            Mocks.Transaction_snark_work.Statement.gen Fee_with_prover.gen
            Fee_with_prover.gen )
@@ -955,8 +931,11 @@ let%test_module "random set test" =
       in
       let check_work ~expected ~got =
         let sort = List.sort ~compare:compare_work in
-        [%test_eq: Mock_snark_pool.Resource_pool.Diff.t list] (sort got)
-          (sort expected)
+        if
+          [%compare: Mock_snark_pool.Resource_pool.Diff.t list] (sort got)
+            (sort expected)
+          <> 0
+        then failwith "diffs don't match"
       in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let open Deferred.Let_syntax in

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -87,7 +87,7 @@ module Diff_versioned : sig
             * Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp, hash]
+      [@@deriving compare, hash]
     end
   end]
 end

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -11,13 +11,13 @@ module Rejected = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = unit [@@deriving sexp, yojson]
+      type t = unit [@@deriving to_yojson]
 
       let to_latest = Fn.id
     end
   end]
 
-  type t = Stable.Latest.t [@@deriving sexp, yojson]
+  type t = Stable.Latest.t [@@deriving to_yojson]
 end
 
 module Make
@@ -28,13 +28,13 @@ module Make
   type t = Mina_wire_types.Network_pool.Snark_pool.Diff_versioned.V2.t =
     | Add_solved_work of Work.t * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson, hash]
+  [@@deriving compare, to_yojson, hash]
 
-  type verified = t [@@deriving compare, sexp, to_yojson]
+  type verified = t [@@deriving compare, to_yojson, hash]
 
   let t_of_verified = ident
 
-  type rejected = Rejected.t [@@deriving sexp, yojson]
+  type rejected = Rejected.t [@@deriving to_yojson]
 
   let label = Pool.label
 


### PR DESCRIPTION
Remove derivations from snark pool types.

This eases integration with `Proof_cache_tag.t`, as we don't need to implement `sexp`, `yojson` for it.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
