### PR TITLE
Change type of Best_tip_lru

### DIFF
--- a/src/lib/ledger_catchup/best_tip_lru.ml
+++ b/src/lib/ledger_catchup/best_tip_lru.ml
@@ -2,8 +2,8 @@ open Core
 open Mina_base
 
 type elt =
-  ( Mina_block.initial_valid_block
-  , State_body_hash.t list * Mina_block.t )
+  ( State_hash.t
+  , State_body_hash.t list * Mina_block.Header.t )
   Proof_carrying_data.t
 
 let max_size = 16
@@ -13,10 +13,7 @@ module Q = Hash_queue.Make (State_hash)
 let t = Q.create ()
 
 let add (x : elt) =
-  let h =
-    Proof_carrying_data.data x |> Mina_block.Validation.block_with_hash
-    |> State_hash.With_state_hashes.state_hash
-  in
+  let h = Proof_carrying_data.data x in
   if not (Q.mem t h) then (
     if Q.length t >= max_size then ignore (Q.dequeue_front t : elt option) ;
     Q.enqueue_back_exn t h x )

--- a/src/lib/ledger_catchup/best_tip_lru.mli
+++ b/src/lib/ledger_catchup/best_tip_lru.mli
@@ -1,8 +1,8 @@
 open Mina_base
 
 type elt =
-  ( Mina_block.initial_valid_block
-  , State_body_hash.t list * Mina_block.t )
+  ( State_hash.t
+  , State_body_hash.t list * Mina_block.Header.t )
   Proof_carrying_data.t
 
 val add : elt -> unit

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1250,14 +1250,13 @@ let run_catchup ~context:(module Context : CONTEXT) ~trust_system ~verifier
                       | Remote peer ->
                           Downloader.add_knowledge downloader peer
                             [ (target_parent_hash, target_length) ] ) ;
-                      let%bind.Option { proof = path, root; _ } =
+                      let%bind.Option { proof = path, root_header; _ } =
                         Best_tip_lru.get h
                       in
                       let%bind.Option p =
                         Transition_chain_verifier.verify ~target_hash:h
                           ~transition_chain_proof:
-                            ( ( Mina_block.header root
-                              |> Mina_block.Header.protocol_state
+                            ( ( Mina_block.Header.protocol_state root_header
                               |> Mina_state.Protocol_state.hashes )
                                 .state_hash
                             , path )

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -321,9 +321,15 @@ let download_best_tip ~context:(module Context : CONTEXT) ~notify_online
       @@ Mina_block.Validation.to_header best_tip ) ;
   Option.map res
     ~f:
-      (Envelope.Incoming.map ~f:(fun (x : _ Proof_carrying_data.t) ->
-           Ledger_catchup.Best_tip_lru.add x ;
-           x.data ) )
+      (Envelope.Incoming.map
+         ~f:(fun { Proof_carrying_data.data; proof = path, root } ->
+           Ledger_catchup.Best_tip_lru.add
+             { Proof_carrying_data.data =
+                 Mina_block.Validation.block_with_hash data
+                 |> Mina_base.State_hash.With_state_hashes.state_hash
+             ; proof = (path, Mina_block.header root)
+             } ;
+           data ) )
 
 let load_frontier ~context:(module Context : CONTEXT) ~verifier
     ~persistent_frontier ~persistent_root ~consensus_local_state ~catchup_mode =


### PR DESCRIPTION
Currently we store too much of data in the LRU cache.

This eases integration with `Proof_cache_tag.t`.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
