### PR TITLE
Simplify types of Database.{move_root, find_arcs}

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -340,7 +340,7 @@ let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
       let%map.Result () =
         List.fold2_exn ~init:(Result.return ()) ~f:populate parent_hashes arcs
       in
-      old_root
+      Root_data.Minimal.hash old_root
   | _ ->
       Error (`Not_found `Old_root_transition)
 
@@ -359,9 +359,8 @@ let add ~arcs_cache ~transition =
     Batch.set batch ~key:(Arcs hash) ~data:[] ;
     Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs)
 
-let move_root ~old_root ~new_root ~garbage =
+let move_root ~old_root_hash ~new_root ~garbage =
   let open Root_data.Limited in
-  let old_root_hash = Root_data.Minimal.hash old_root in
   fun batch ->
     Batch.set batch ~key:Root ~data:(Root_data.Minimal.of_limited new_root) ;
     Batch.set batch ~key:Protocol_states_for_root_scan_state

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -73,7 +73,7 @@ val find_arcs_and_root :
      t
   -> arcs_cache:State_hash.t list State_hash.Table.t
   -> parent_hashes:State_hash.t list
-  -> ( Root_data.Minimal.t
+  -> ( State_hash.t
      , [> `Not_found of [> `Arcs of State_hash.t | `Old_root_transition ] ] )
      result
 
@@ -84,7 +84,7 @@ val add :
   -> unit
 
 val move_root :
-     old_root:Root_data.Minimal.t
+     old_root_hash:State_hash.t
   -> new_root:Root_data.Limited.t
   -> garbage:State_hash.t list
   -> batch_t

--- a/src/lib/transition_frontier/persistent_frontier/worker.ml
+++ b/src/lib/transition_frontier/persistent_frontier/worker.ml
@@ -37,13 +37,13 @@ module Worker = struct
   (* nothing to close *)
   let close _ = Deferred.unit
 
-  let apply_diff (type mutant) ~old_root ~arcs_cache (diff : mutant Diff.Lite.t)
-      : Database.batch_t -> unit =
+  let apply_diff (type mutant) ~old_root_hash ~arcs_cache
+      (diff : mutant Diff.Lite.t) : Database.batch_t -> unit =
     match diff with
     | New_node (Lite transition) ->
         Database.add ~arcs_cache ~transition
     | Root_transitioned { new_root; garbage = Lite garbage; _ } ->
-        Database.move_root ~old_root ~new_root ~garbage
+        Database.move_root ~old_root_hash ~new_root ~garbage
     | Best_tip_changed best_tip_hash ->
         Database.set_best_tip best_tip_hash
 
@@ -109,11 +109,11 @@ module Worker = struct
               | _ ->
                   None )
           in
-          let%map.Result old_root =
+          let%map.Result old_root_hash =
             Database.find_arcs_and_root t.db ~arcs_cache ~parent_hashes
           in
           List.map diffs_to_apply ~f:(fun (Diff.Lite.E.E diff) ->
-              apply_diff ~old_root ~arcs_cache diff )
+              apply_diff ~old_root_hash ~arcs_cache diff )
         in
         let handle_emitted_proof = function
           | { Diff.Root_transition.just_emitted_a_proof = true; _ } ->


### PR DESCRIPTION
Accept/return state hash instead of `Root_data.Mimimal.t` in `Database.{move_root, find_arcs}`.

This eases integration with `Proof_cache_tag.t`.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
