### PR TITLE
Remove equal from Mina_block.t

### DIFF
--- a/src/lib/mina_block/block.ml
+++ b/src/lib/mina_block/block.ml
@@ -72,7 +72,7 @@ end]
 type with_hash = t State_hash.With_state_hashes.t [@@deriving sexp]
 
 [%%define_locally
-Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t, to_yojson, equal)]
+Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t, to_yojson)]
 
 let wrap_with_hash block =
   With_hash.of_data block

--- a/src/lib/mina_block/block.ml
+++ b/src/lib/mina_block/block.ml
@@ -71,8 +71,7 @@ let to_yojson t =
              ~default:"<None>" ~f:Protocol_version.to_string ) )
     ]
 
-[%%define_locally
-Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t)]
+[%%define_locally Stable.Latest.(create, header, body, t_of_sexp, sexp_of_t)]
 
 let wrap_with_hash block =
   With_hash.of_data block

--- a/src/lib/mina_block/block.mli
+++ b/src/lib/mina_block/block.mli
@@ -10,7 +10,7 @@ module Stable : sig
   end
 end]
 
-type t = Stable.Latest.t [@@deriving sexp, to_yojson, equal]
+type t = Stable.Latest.t [@@deriving sexp, to_yojson]
 
 type with_hash = t State_hash.With_state_hashes.t [@@deriving sexp]
 


### PR DESCRIPTION
Remove equal from `Mina_block.t`. This eases integration with `Proof_cache_tag.t`.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None