### PR TITLE
Persistent_frontier: use get_root_hash instead of get_root

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -171,10 +171,9 @@ module Instance = struct
     let open Result.Let_syntax in
     let%bind () = assert_no_sync t in
     let lift_error r msg = Result.map_error r ~f:(Fn.const (`Failure msg)) in
-    let%bind root =
-      lift_error (Database.get_root t.db) "failed to get root hash"
+    let%bind root_hash =
+      lift_error (Database.get_root_hash t.db) "failed to get root hash"
     in
-    let root_hash = Root_data.Minimal.hash root in
     if State_hash.equal root_hash target_root.state_hash then
       (* If the target hash is already the root hash, no fast forward required, but we should check the frontier hash. *)
       Ok ()


### PR DESCRIPTION
Persistent_frontier: use `get_root_hash` instead of `get_root`.
A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
