### PR TITLE
Decouple Mina_block.Validated.{Stable.Latest.t, t}

### DIFF
--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -1032,11 +1032,17 @@ let%test_module "Ledger_catchup tests" =
       let catchup_breadcrumbs_are_best_tip_path =
         Rose_tree.equal (Rose_tree.of_list_exn target_best_tip_path)
           catchup_breadcrumbs ~f:(fun breadcrumb_tree1 breadcrumb_tree2 ->
-            Mina_block.Validated.equal
-              (Transition_frontier.Breadcrumb.validated_transition
-                 breadcrumb_tree1 )
-              (Transition_frontier.Breadcrumb.validated_transition
-                 breadcrumb_tree2 ) )
+            let b1 =
+              Mina_block.Validated.unwrap
+                (Transition_frontier.Breadcrumb.validated_transition
+                   breadcrumb_tree1 )
+            in
+            let b2 =
+              Mina_block.Validated.unwrap
+                (Transition_frontier.Breadcrumb.validated_transition
+                   breadcrumb_tree2 )
+            in
+            Mina_block.Validated.Stable.Latest.equal b1 b2 )
       in
       if not catchup_breadcrumbs_are_best_tip_path then
         failwith

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1637,7 +1637,7 @@ let%test_module "Ledger_catchup tests" =
             (* We force evaluation of state body hash for both blocks for further equality check *)
             let _hash1 = Mina_block.Validated.state_body_hash b1 in
             let _hash2 = Mina_block.Validated.state_body_hash b2 in
-            Mina_block.Validated.equal b1 b2 )
+            Mina_block.Validated.(Stable.Latest.equal (unwrap b1) (unwrap b2)) )
       in
       if not catchup_breadcrumbs_are_best_tip_path then
         failwith

--- a/src/lib/mina_block/validated_block.ml
+++ b/src/lib/mina_block/validated_block.ml
@@ -3,6 +3,8 @@ open Mina_base
 
 [%%versioned
 module Stable = struct
+  [@@@no_toplevel_latest_type]
+
   module V2 = struct
     type t =
       Block.Stable.V2.t State_hash.With_state_hashes.Stable.V1.t
@@ -10,15 +12,17 @@ module Stable = struct
     [@@deriving equal]
 
     let to_latest = ident
+
+    let hashes (t, _) = With_hash.hash t
   end
 end]
 
-type t = Stable.Latest.t
+type t =
+  Block.t State_hash.With_state_hashes.t
+  * State_hash.t Mina_stdlib.Nonempty_list.t
 
 let to_yojson (block_with_hashes, _) =
   State_hash.With_state_hashes.to_yojson Block.to_yojson block_with_hashes
-
-[%%define_locally Stable.Latest.(equal)]
 
 let lift (b, v) =
   match v with
@@ -70,3 +74,5 @@ let body t = t |> forget |> With_hash.data |> Block.body
 let is_genesis t =
   header t |> Header.protocol_state |> Mina_state.Protocol_state.consensus_state
   |> Consensus.Data.Consensus_state.is_genesis_state
+
+let unwrap = Fn.id

--- a/src/lib/mina_block/validated_block.mli
+++ b/src/lib/mina_block/validated_block.mli
@@ -2,12 +2,16 @@ open Mina_base
 
 [%%versioned:
 module Stable : sig
+  [@@@no_toplevel_latest_type]
+
   module V2 : sig
     type t [@@deriving equal]
+
+    val hashes : t -> State_hash.State_hashes.t
   end
 end]
 
-type t = Stable.Latest.t [@@deriving to_yojson, equal]
+type t [@@deriving to_yojson]
 
 val lift : Validation.fully_valid_with_block -> t
 
@@ -33,3 +37,5 @@ val header : t -> Header.t
 val body : t -> Staged_ledger_diff.Body.t
 
 val is_genesis : t -> bool
+
+val unwrap : t -> Stable.Latest.t

--- a/src/lib/transition_frontier/catchup_hash_tree.ml
+++ b/src/lib/transition_frontier/catchup_hash_tree.ml
@@ -213,7 +213,7 @@ let apply_diffs t (ds : Diff.Full.E.t list) =
         breadcrumb_added t b
     | E (Root_transitioned { new_root; garbage = Full hs; _ }) ->
         List.iter (Diff.Node_list.to_lite hs) ~f:(remove_node t) ;
-        let h = (Root_data.Limited.hashes new_root).state_hash in
+        let h = (Root_data.Limited.Stable.Latest.hashes new_root).state_hash in
         Hashtbl.change t.nodes h ~f:(function
           | None ->
               [%log' debug t.logger]

--- a/src/lib/transition_frontier/extensions/root_history.ml
+++ b/src/lib/transition_frontier/extensions/root_history.ml
@@ -68,7 +68,7 @@ module T = struct
         (* TODO: send full diffs to extensions to avoid extra lookups in frontier *)
         | E (Root_transitioned { new_root; _ }, _) ->
             Full_frontier.find_exn frontier
-              (Root_data.Limited.hashes new_root).state_hash
+              (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
             |> Root_data.Historical.of_breadcrumb |> enqueue root_history ;
             true
         | E _ ->

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -8,7 +8,7 @@ type lite = Lite
 module Node = struct
   type 'a t =
     | Full : Breadcrumb.t -> full t
-    | Lite : Mina_block.Validated.Stable.V2.t -> lite t
+    | Lite : Mina_block.Validated.t -> lite t
 end
 
 module Node_list = struct
@@ -70,7 +70,7 @@ module Root_transition = struct
     | Full : Staged_ledger.Scan_state.t -> full root_transition_scan_state
 
   type 'repr t =
-    { new_root : Root_data.Limited.t
+    { new_root : Root_data.Limited.Stable.Latest.t
     ; garbage : 'repr Node_list.t
     ; old_root_scan_state : 'repr root_transition_scan_state
     ; just_emitted_a_proof : bool
@@ -178,7 +178,7 @@ let to_yojson (type repr mutant) (key : (repr, mutant) t) =
         `Assoc
           [ ( "new_root"
             , State_hash.to_yojson
-                (Root_data.Limited.hashes new_root).state_hash )
+                (Root_data.Limited.Stable.Latest.hashes new_root).state_hash )
           ; ("garbage", `List (List.map ~f:State_hash.to_yojson garbage_hashes))
           ; ("just_emitted_a_proof", `Bool just_emitted_a_proof)
           ]

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -62,7 +62,7 @@ module Root_transition : sig
     | Full : Staged_ledger.Scan_state.t -> full root_transition_scan_state
 
   type 'repr t =
-    { new_root : Root_data.Limited.t
+    { new_root : Root_data.Limited.Stable.Latest.t
     ; garbage : 'repr Node_list.t
     ; old_root_scan_state : 'repr root_transition_scan_state
     ; just_emitted_a_proof : bool

--- a/src/lib/transition_frontier/frontier_base/root_data.ml
+++ b/src/lib/transition_frontier/frontier_base/root_data.ml
@@ -4,6 +4,8 @@ open Mina_base
 module Common = struct
   [%%versioned
   module Stable = struct
+    [@@@no_toplevel_latest_type]
+
     module V2 = struct
       type t =
         { scan_state : Staged_ledger.Scan_state.Stable.V2.t
@@ -11,15 +13,20 @@ module Common = struct
         }
 
       let to_latest = Fn.id
-
-      let to_yojson { scan_state = _; pending_coinbase } =
-        `Assoc
-          [ ("scan_state", `String "<opaque>")
-          ; ( "pending_coinbase"
-            , Pending_coinbase.Stable.V2.to_yojson pending_coinbase )
-          ]
     end
   end]
+
+  type t = Stable.Latest.t =
+    { scan_state : Staged_ledger.Scan_state.t
+    ; pending_coinbase : Pending_coinbase.t
+    }
+
+  let to_yojson { scan_state = _; pending_coinbase } =
+    `Assoc
+      [ ("scan_state", `String "<opaque>")
+      ; ( "pending_coinbase"
+        , Pending_coinbase.Stable.V2.to_yojson pending_coinbase )
+      ]
 
   let create ~scan_state ~pending_coinbase = { scan_state; pending_coinbase }
 
@@ -60,6 +67,8 @@ end
 module Limited = struct
   [%%versioned
   module Stable = struct
+    [@@@no_toplevel_latest_type]
+
     module V3 = struct
       type t =
         { transition : Mina_block.Validated.Stable.V2.t
@@ -69,27 +78,40 @@ module Limited = struct
             list
         ; common : Common.Stable.V2.t
         }
+      [@@deriving fields]
 
       let to_latest = Fn.id
+
+      let hashes t = Mina_block.Validated.Stable.Latest.hashes t.transition
+
+      let create ~transition ~scan_state ~pending_coinbase ~protocol_states =
+        let common = { Common.Stable.V2.scan_state; pending_coinbase } in
+        { transition; common; protocol_states }
     end
   end]
+
+  type t =
+    { transition : Mina_block.Validated.t
+    ; protocol_states :
+        Mina_state.Protocol_state.Value.t
+        Mina_base.State_hash.With_state_hashes.t
+        list
+    ; common : Common.t
+    }
+  [@@deriving fields]
 
   let to_yojson { transition; protocol_states = _; common } =
     `Assoc
       [ ("transition", Mina_block.Validated.to_yojson transition)
       ; ("protocol_states", `String "<opaque>")
-      ; ("common", Common.Stable.V2.to_yojson common)
+      ; ("common", Common.to_yojson common)
       ]
 
   let create ~transition ~scan_state ~pending_coinbase ~protocol_states =
     let common = { Common.scan_state; pending_coinbase } in
     { transition; common; protocol_states }
 
-  let transition t = t.transition
-
   let hashes t = With_hash.hash @@ Mina_block.Validated.forget t.transition
-
-  let protocol_states t = t.protocol_states
 
   let scan_state t = Common.scan_state t.common
 
@@ -103,20 +125,18 @@ module Minimal = struct
 
     module V2 = struct
       type t = { hash : State_hash.Stable.V1.t; common : Common.Stable.V2.t }
-      [@@driving to_yojson]
+      [@@deriving fields]
+
+      let of_limited ~common hash = { hash; common }
 
       let to_latest = Fn.id
     end
   end]
 
   type t = Stable.Latest.t = { hash : State_hash.t; common : Common.t }
-  [@@driving to_yojson]
+  [@@deriving fields]
 
-  let hash t = t.hash
-
-  let of_limited (l : Limited.t) =
-    let hash = Mina_block.Validated.state_hash l.transition in
-    { hash; common = l.common }
+  let of_limited ~common hash = { hash; common }
 
   let upgrade t ~transition ~protocol_states =
     let hash = hash t in
@@ -144,6 +164,10 @@ module Minimal = struct
   let scan_state t = Common.scan_state t.common
 
   let pending_coinbase t = Common.pending_coinbase t.common
+
+  let generate = Fn.id
+
+  let unwrap = Fn.id
 end
 
 type t =

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -1,5 +1,18 @@
 open Mina_base
 
+module Common : sig
+  [%%versioned:
+  module Stable : sig
+    [@@@no_toplevel_latest_type]
+
+    module V2 : sig
+      type t
+    end
+  end]
+
+  type t
+end
+
 (* Historical root data is similar to Limited root data, except that it also
  * contains a recording of some extra computed staged ledger properties that
  * were available on a breadcrumb in the transition frontier when this was
@@ -27,10 +40,30 @@ module Limited : sig
 
     module V3 : sig
       type t
+
+      val hashes : t -> State_hash.State_hashes.Stable.V1.t
+
+      val common : t -> Common.Stable.V2.t
+
+      val protocol_states :
+           t
+        -> Mina_state.Protocol_state.Value.Stable.V2.t
+           Mina_base.State_hash.With_state_hashes.Stable.V1.t
+           list
+
+      val create :
+           transition:Mina_block.Validated.Stable.V2.t
+        -> scan_state:Staged_ledger.Scan_state.Stable.V2.t
+        -> pending_coinbase:Pending_coinbase.Stable.V2.t
+        -> protocol_states:
+             Mina_state.Protocol_state.value
+             State_hash.With_state_hashes.Stable.V1.t
+             list
+        -> t
     end
   end]
 
-  type t = Stable.Latest.t [@@deriving to_yojson]
+  type t [@@deriving to_yojson]
 
   val transition : t -> Mina_block.Validated.t
 
@@ -50,6 +83,8 @@ module Limited : sig
     -> protocol_states:
          Mina_state.Protocol_state.value State_hash.With_state_hashes.t list
     -> t
+
+  val common : t -> Common.t
 end
 
 (* Minimal root data contains the smallest amount of information about a root.
@@ -60,10 +95,18 @@ end
 module Minimal : sig
   [%%versioned:
   module Stable : sig
+    [@@@no_toplevel_latest_type]
+
     module V2 : sig
       type t
+
+      val hash : t -> State_hash.t
+
+      val of_limited : common:Common.Stable.V2.t -> State_hash.Stable.V1.t -> t
     end
   end]
+
+  type t
 
   val hash : t -> State_hash.t
 
@@ -71,7 +114,7 @@ module Minimal : sig
 
   val pending_coinbase : t -> Pending_coinbase.t
 
-  val of_limited : Limited.t -> t
+  val of_limited : common:Common.t -> State_hash.t -> t
 
   val upgrade :
        t
@@ -85,6 +128,10 @@ module Minimal : sig
     -> scan_state:Staged_ledger.Scan_state.t
     -> pending_coinbase:Pending_coinbase.t
     -> t
+
+  val generate : Stable.Latest.t -> t
+
+  val unwrap : t -> Stable.Latest.t
 end
 
 type t =

--- a/src/lib/transition_frontier/full_catchup_tree.ml
+++ b/src/lib/transition_frontier/full_catchup_tree.ml
@@ -368,7 +368,7 @@ let apply_diffs (t : t) (ds : Diff.Full.E.t list) =
         breadcrumb_added t b
     | E (Root_transitioned { new_root; garbage = Full hs; _ }) ->
         List.iter (Diff.Node_list.to_lite hs) ~f:(remove_node t) ;
-        let h = (Root_data.Limited.hashes new_root).state_hash in
+        let h = (Root_data.Limited.Stable.Latest.hashes new_root).state_hash in
         if Hashtbl.mem t.nodes h then prune t ~root_hash:h
         else (
           [%log' debug t.logger]

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -306,7 +306,6 @@ let visualize_to_string t =
 let calculate_root_transition_diff t heir =
   let root = root t in
   let heir_hash = Breadcrumb.state_hash heir in
-  let heir_transition = Breadcrumb.validated_transition heir in
   let heir_staged_ledger = Breadcrumb.staged_ledger heir in
   let heir_siblings =
     List.filter (successors t root) ~f:(fun breadcrumb ->
@@ -326,15 +325,18 @@ let calculate_root_transition_diff t heir =
         in
         { transition; scan_state } )
   in
+  let new_scan_state = Staged_ledger.scan_state heir_staged_ledger in
   let protocol_states =
     Protocol_states_for_root_scan_state.protocol_states_for_next_root_scan_state
-      t.protocol_states_for_root_scan_state
-      ~new_scan_state:(Staged_ledger.scan_state heir_staged_ledger)
+      t.protocol_states_for_root_scan_state ~new_scan_state
       ~old_root_state:(Breadcrumb.protocol_state_with_hashes root)
   in
+  let heir_transition =
+    Breadcrumb.validated_transition heir |> Mina_block.Validated.unwrap
+  in
   let new_root_data =
-    Root_data.Limited.create ~transition:heir_transition
-      ~scan_state:(Staged_ledger.scan_state heir_staged_ledger)
+    Root_data.Limited.Stable.Latest.create ~transition:heir_transition
+      ~scan_state:new_scan_state
       ~pending_coinbase:
         (Staged_ledger.pending_coinbase_collection heir_staged_ledger)
       ~protocol_states
@@ -633,10 +635,12 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
       t.best_tip <- new_best_tip ;
       (old_best_tip, None)
   | Root_transitioned { new_root; garbage = Full garbage; _ } ->
-      let new_root_hash = (Root_data.Limited.hashes new_root).state_hash in
+      let new_root_hash =
+        (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
+      in
       let old_root_hash = t.root in
       let new_root_protocol_states =
-        Root_data.Limited.protocol_states new_root
+        Root_data.Limited.Stable.Latest.protocol_states new_root
       in
       [%log' internal t.logger] "Move_frontier_root" ;
       move_root t ~new_root_hash ~new_root_protocol_states ~garbage

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -249,7 +249,7 @@ let check t ~genesis_state_hash =
         let%bind root =
           get t.db ~key:Root ~error:(`Corrupt (`Not_found `Root))
         in
-        let root_hash = Root_data.Minimal.hash root in
+        let root_hash = Root_data.Minimal.Stable.Latest.hash root in
         let%bind best_tip =
           get t.db ~key:Best_tip ~error:(`Corrupt (`Not_found `Best_tip))
         in
@@ -301,9 +301,10 @@ let check t ~genesis_state_hash =
   |> Result.join
 
 let initialize t ~root_data =
-  let open Root_data.Limited in
   let root_state_hash, root_transition =
-    let t = Mina_block.Validated.forget (transition root_data) in
+    let t =
+      Mina_block.Validated.forget (Root_data.Limited.transition root_data)
+    in
     ( State_hash.With_state_hashes.state_hash t
     , State_hash.With_state_hashes.data t )
   in
@@ -314,10 +315,17 @@ let initialize t ~root_data =
       Batch.set batch ~key:Db_version ~data:version ;
       Batch.set batch ~key:(Transition root_state_hash) ~data:root_transition ;
       Batch.set batch ~key:(Arcs root_state_hash) ~data:[] ;
-      Batch.set batch ~key:Root ~data:(Root_data.Minimal.of_limited root_data) ;
+      Batch.set batch ~key:Root
+        ~data:
+          ( Root_data.Minimal.of_limited
+              ~common:(Root_data.Limited.common root_data)
+              root_state_hash
+          |> Root_data.Minimal.unwrap ) ;
       Batch.set batch ~key:Best_tip ~data:root_state_hash ;
       Batch.set batch ~key:Protocol_states_for_root_scan_state
-        ~data:(protocol_states root_data |> List.map ~f:With_hash.data) )
+        ~data:
+          ( Root_data.Limited.protocol_states root_data
+          |> List.map ~f:With_hash.data ) )
 
 let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
     ~parent_hashes =
@@ -340,7 +348,7 @@ let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
       let%map.Result () =
         List.fold2_exn ~init:(Result.return ()) ~f:populate parent_hashes arcs
       in
-      Root_data.Minimal.hash old_root
+      Root_data.Minimal.Stable.Latest.hash old_root
   | _ ->
       Error (`Not_found `Old_root_transition)
 
@@ -360,11 +368,19 @@ let add ~arcs_cache ~transition =
     Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs)
 
 let move_root ~old_root_hash ~new_root ~garbage =
-  let open Root_data.Limited in
+  let new_root_hash =
+    (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
+  in
   fun batch ->
-    Batch.set batch ~key:Root ~data:(Root_data.Minimal.of_limited new_root) ;
+    Batch.set batch ~key:Root
+      ~data:
+        (Root_data.Minimal.Stable.Latest.of_limited
+           ~common:(Root_data.Limited.Stable.Latest.common new_root)
+           new_root_hash ) ;
     Batch.set batch ~key:Protocol_states_for_root_scan_state
-      ~data:(List.map ~f:With_hash.data (protocol_states new_root)) ;
+      ~data:
+        (List.map ~f:With_hash.data
+           (Root_data.Limited.Stable.Latest.protocol_states new_root) ) ;
     List.iter (old_root_hash :: garbage) ~f:(fun node_hash ->
         (* because we are removing entire forks of the tree, there is
          * no need to have extra logic to any remove arcs to the node
@@ -396,15 +412,17 @@ let get_transition t hash =
 
 let get_arcs t hash = get t.db ~key:(Arcs hash) ~error:(`Not_found (`Arcs hash))
 
-let get_root t = get t.db ~key:Root ~error:(`Not_found `Root)
+let get_root_impl t = get t.db ~key:Root ~error:(`Not_found `Root)
+
+let get_root t = get_root_impl t |> Result.map ~f:Root_data.Minimal.generate
 
 let get_protocol_states_for_root_scan_state t =
   get t.db ~key:Protocol_states_for_root_scan_state
     ~error:(`Not_found `Protocol_states_for_root_scan_state)
 
 let get_root_hash t =
-  let%map root = get_root t in
-  Root_data.Minimal.hash root
+  let%map root = get_root_impl t in
+  Root_data.Minimal.Stable.Latest.hash root
 
 let get_best_tip t = get t.db ~key:Best_tip ~error:(`Not_found `Best_tip)
 

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -85,7 +85,7 @@ val add :
 
 val move_root :
      old_root_hash:State_hash.t
-  -> new_root:Root_data.Limited.t
+  -> new_root:Root_data.Limited.Stable.Latest.t
   -> garbage:State_hash.t list
   -> batch_t
   -> unit

--- a/src/lib/transition_frontier/persistent_frontier/worker.ml
+++ b/src/lib/transition_frontier/persistent_frontier/worker.ml
@@ -70,7 +70,8 @@ module Worker = struct
           List.drop_last root_transition_diffs
           |> Option.value ~default:[]
           |> List.bind ~f:(fun { new_root; garbage = Lite garbage; _ } ->
-                 (Root_data.Limited.hashes new_root).state_hash :: garbage )
+                 (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
+                 :: garbage )
         in
         let total_root_transition_diff =
           Option.map final_root_transition_diff


### PR DESCRIPTION
Remove `Stable.Latest.t = t` from interfaces. This is a preparation step for removing the equality in the implementation as well.

A step towards _Use Proof_cache_tag.t in scan state #16571._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
