### PR TITLE
Polymorphize Ledger_proof.t, add Cached.t

### DIFF
--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -1,9 +1,11 @@
 module type S = Ledger_proof_intf.S
 
-module Prod : S with type t = Transaction_snark.t
+module Prod : S with type 'a Poly.t = 'a Transaction_snark.Poly.t
 
-include S with type t = Prod.t
+include S with type 'a Poly.t = 'a Transaction_snark.Poly.t
 
 module For_tests : sig
   val mk_dummy_proof : Mina_state.Snarked_ledger_state.t -> t
+
+  val mk_dummy_proof_cached : Mina_state.Snarked_ledger_state.t -> Cached.t
 end


### PR DESCRIPTION
Polymorphize `Ledger_proof.t`, add `Cached.t`. These will be used to transform all Mina types containing ledger proofs to use the disk cache.

A step towards _Use Proof_cache_tag.t in Ledger_proof.t #16469._

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
