### PR TITLE
Remove Stable from Transaction_snark_work.Checked

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2221,19 +2221,7 @@ module T = struct
             in
             [%log internal] "Generate_staged_ledger_diff" ;
             let diff, log =
-              O1trace.sync_thread "generate_staged_ledger_diff"
-                (fun
-                  ()
-                  :
-                  (( ( Transaction_snark_work.Checked.t
-                     , User_command.Valid.t )
-                     Staged_ledger_diff.Pre_diff_two.t
-                   * ( Transaction_snark_work.Checked.t
-                     , User_command.Valid.t )
-                     Staged_ledger_diff.Pre_diff_one.t
-                     option )
-                  * _)
-                ->
+              O1trace.sync_thread "generate_staged_ledger_diff" (fun () ->
                   generate ~constraint_constants logger completed_works_seq
                     valid_on_this_ledger ~receiver:coinbase_receiver
                     ~is_coinbase_receiver_new ~supercharge_coinbase partitions )

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -85,8 +85,6 @@ type unchecked = t
 module Checked : sig
   include S
 
-  module Stable : module type of Stable
-
   val create_unsafe : unchecked -> t
 
   val statement : t -> Statement.t


### PR DESCRIPTION
The `Transaction_snark_work.Checked.Stable` module is not used (for a good reason), and shouldn't be exposed.

Plus removing an unnecessary type annotation in `staged_ledger.ml`.

Based on review comments from PR:

- #16485

Explain how you tested your changes:
* It's a refactoring that doesn't change any behavior
* It compiles :)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None