### PR TITLE
[Rosetta][3.0.3.1] use mina missing block guardian script instead of download missing blocks

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -364,7 +364,7 @@ build_archive_deb () {
   cp ./default/src/app/extract_blocks/extract_blocks.exe "${BUILDDIR}/usr/local/bin/mina-extract-blocks"
   
   mkdir -p "${BUILDDIR}/etc/mina/archive"
-  cp ../scripts/archive/missing-blocks-guardian.sh "${BUILDDIR}/etc/mina/archive"
+  cp ../scripts/archive/missing-blocks-guardian.sh "${BUILDDIR}/usr/local/bin/mina-missing-blocks-guardian"
   
   cp ./default/src/app/missing_blocks_auditor/missing_blocks_auditor.exe "${BUILDDIR}/usr/local/bin/mina-missing-blocks-auditor"
   cp ./default/src/app/replayer/replayer.exe "${BUILDDIR}/usr/local/bin/mina-replayer"

--- a/src/app/rosetta/scripts/docker-start.sh
+++ b/src/app/rosetta/scripts/docker-start.sh
@@ -52,6 +52,13 @@ POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:=/data/postgresql}
 PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:5432/${POSTGRES_DBNAME}
 DUMP_TIME=${DUMP_TIME:=0000}
 ARCHIVE_GENESIS_INIT=${ARCHIVE_GENESIS_INIT:=0}
+# Missing block guardian env vars
+export DB_USERNAME="$POSTGRES_USERNAME"
+export DB_HOST=127.0.0.1
+export DB_PORT=5432
+export DB_NAME="$POSTGRES_DBNAME"
+export PGPASSWORD="$POSTGRES_USERNAME"
+export PRECOMPUTED_BLOCKS_URL="https://storage.googleapis.com/mina_network_block_data"
 
 # Genesis Ledger
 if [ -n "$MINA_GENESIS_LEDGER_URL" ]; then
@@ -109,7 +116,7 @@ MINA_DAEMON_PID=$!
 sleep 30
 
 echo "========================= POPULATING MISSING BLOCKS ==========================="
-./download-missing-blocks.sh --network ${MINA_NETWORK} --archive-uri ${PG_CONN} &
+/etc/mina/archive/missing-blocks-guardian.sh single-run
 
 if ! kill -0 "${MINA_DAEMON_PID}"; then
   echo "[FATAL] Mina daemon failed to start, exiting docker-start.sh"

--- a/src/app/rosetta/scripts/docker-start.sh
+++ b/src/app/rosetta/scripts/docker-start.sh
@@ -116,7 +116,7 @@ MINA_DAEMON_PID=$!
 sleep 30
 
 echo "========================= POPULATING MISSING BLOCKS ==========================="
-TIMEOUT=3600 /etc/mina/archive/missing-blocks-guardian.sh daemon &
+TIMEOUT=3600 mina-missing-blocks-guardian daemon &
 
 if ! kill -0 "${MINA_DAEMON_PID}"; then
   echo "[FATAL] Mina daemon failed to start, exiting docker-start.sh"

--- a/src/app/rosetta/scripts/docker-start.sh
+++ b/src/app/rosetta/scripts/docker-start.sh
@@ -116,7 +116,7 @@ MINA_DAEMON_PID=$!
 sleep 30
 
 echo "========================= POPULATING MISSING BLOCKS ==========================="
-/etc/mina/archive/missing-blocks-guardian.sh single-run
+/etc/mina/archive/missing-blocks-guardian.sh single-run &
 
 if ! kill -0 "${MINA_DAEMON_PID}"; then
   echo "[FATAL] Mina daemon failed to start, exiting docker-start.sh"

--- a/src/app/rosetta/scripts/docker-start.sh
+++ b/src/app/rosetta/scripts/docker-start.sh
@@ -116,7 +116,7 @@ MINA_DAEMON_PID=$!
 sleep 30
 
 echo "========================= POPULATING MISSING BLOCKS ==========================="
-/etc/mina/archive/missing-blocks-guardian.sh single-run &
+TIMEOUT=3600 /etc/mina/archive/missing-blocks-guardian.sh daemon &
 
 if ! kill -0 "${MINA_DAEMON_PID}"; then
   echo "[FATAL] Mina daemon failed to start, exiting docker-start.sh"


### PR DESCRIPTION
fix missing-blocks-guardian location in rosetta docker

cherry-picked from: https://github.com/MinaProtocol/mina/pull/16375

resolves: https://github.com/MinaProtocol/mina/issues/16503