### PR TITLE
[Trivial] kimchi-bindings/stubs: enforce 80 characters limit

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/caml/caml_pointer.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/caml/caml_pointer.rs
@@ -12,8 +12,8 @@ macro_rules! impl_caml_pointer {
             }
 
             extern "C" fn caml_pointer_compare(_: ocaml::Raw, _: ocaml::Raw) -> i32 {
-                // Always return equal. We can use this for sanity checks, and anything else using this
-                // would be broken anyway.
+                // Always return equal. We can use this for sanity checks, and
+                // anything else using this would be broken anyway.
                 0
             }
         }
@@ -49,12 +49,14 @@ macro_rules! impl_caml_pointer {
                 unsafe {
                     // Wholely unsafe, Batman!
                     // We would use [`get_mut_unchecked`] here, but it is nightly-only.
-                    // Instead, we get coerce our constant pointer to a mutable pointer, in the knowledge
-                    // that
-                    // * all of our mutations called from OCaml are blocking, so we won't have multiple
-                    // live mutable references live simultaneously, and
-                    // * the underlying pointer is in the correct state to be mutable, since we can call
-                    //   [`get_mut_unchecked`] in nightly, or can call [`get_mut`] and unwrap if this is
+                    // Instead, we get coerce our constant pointer to a mutable
+                    // pointer, in the knowledge that
+                    // * all of our mutations called from OCaml are blocking, so
+                    // we won't have multiple live mutable references live
+                    // simultaneously, and
+                    // * the underlying pointer is in the correct state to be
+                    //   mutable, since we can call [`get_mut_unchecked`] in
+                    //   nightly, or can call [`get_mut`] and unwrap if this is
                     //   the only live reference.
                     &mut *(((&*self.0) as *const Self::Target) as *mut Self::Target)
                 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/lagrange_basis.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/lagrange_basis.rs
@@ -99,10 +99,9 @@ mod cache {
         }
     }
 
-    /*
-    The FileCache implementation uses a directory as a cache for the Lagrange basis hash map --
-    i.e every file corresponds to a Lagrange basis for a given G-basis and domain size.
-    */
+    // The FileCache implementation uses a directory as a cache for the Lagrange
+    // basis hash map -- i.e every file corresponds to a Lagrange basis for a
+    // given G-basis and domain size.
     impl<G: AffineRepr> LagrangeCache<G> for FileCache<G> {
         type CacheKey = PathBuf;
 
@@ -156,8 +155,8 @@ mod cache {
         }
     }
 
-    // The following two caches are all that we need for mina tests. These will not be initialized unless they are
-    // explicitly called.
+    // The following two caches are all that we need for mina tests. These will
+    // not be initialized unless they are explicitly called.
     static VESTA_FILE_CACHE: Lazy<FileCache<Vesta>> = Lazy::new(|| {
         let cache_base_dir: String =
             env::var("LAGRANGE_CACHE_DIR").expect("LAGRANGE_CACHE_DIR missing in env");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -44,8 +44,8 @@ pub fn linearization_strings<F: ark_ff::PrimeField>(
         mut index_terms,
     } = linearization.linearize(evaluated_cols).unwrap();
 
-    // HashMap deliberately uses an unstable order; here we sort to ensure that the output is
-    // consistent when printing.
+    // HashMap deliberately uses an unstable order; here we sort to ensure that
+    // the output is consistent when printing.
     index_terms.sort_by(|(x, _), (y, _)| x.cmp(y));
 
     let constant = constant_term.ocaml_str();

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -662,7 +662,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
         for _ in 0..4 {
             CircuitGate::extend_multi_range_check(&mut gates, &mut curr_row);
         }
-        // Connect the witnesses of the addition to the corresponding range checks
+        // Connect the witnesses of the addition to the corresponding range
+        // checks
         gates.connect_ffadd_range_checks(1, Some(4), Some(8), 12);
         // Connect the bound check range checks
         gates.connect_ffadd_range_checks(2, None, None, 16);
@@ -701,7 +702,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_ffadd(
         witness
     };
 
-    // not sure if theres a smarter way instead of the double unwrap, but should be fine in the test
+    // not sure if theres a smarter way instead of the double unwrap, but should
+    // be fine in the test
     let cs = ConstraintSystem::<Fp>::create(gates)
         .public(num_public_inputs)
         .build()
@@ -762,7 +764,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
                 None,
             ));
         }
-        // 1 XOR of 128 bits. This will create 8 Xor16 gates and a Generic final gate with all zeros.
+        // 1 XOR of 128 bits. This will create 8 Xor16 gates and a Generic final
+        // gate with all zeros.
         CircuitGate::<Fp>::extend_xor_gadget(&mut gates, 128);
         // connect public inputs to the inputs of the XOR
         gates.connect_cell_pair((0, 0), (2, 0));
@@ -789,7 +792,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_xor(
         cols
     };
 
-    // not sure if theres a smarter way instead of the double unwrap, but should be fine in the test
+    // not sure if theres a smarter way instead of the double unwrap, but should
+    // be fine in the test
     let cs = ConstraintSystem::<Fp>::create(gates)
         .public(num_public_inputs)
         .build()
@@ -882,7 +886,8 @@ pub fn caml_pasta_fp_plonk_proof_example_with_rot(
         cols
     };
 
-    // not sure if theres a smarter way instead of the double unwrap, but should be fine in the test
+    // not sure if theres a smarter way instead of the double unwrap, but should
+    // be fine in the test
     let cs = ConstraintSystem::<Fp>::create(gates)
         .public(num_public_inputs)
         .build()

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -78,12 +78,17 @@ pub fn caml_pasta_fq_plonk_proof_create(
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
 
-    // NB: This method is designed only to be used by tests. However, since creating a new reference will cause `drop` to be called on it once we are done with it. Since `drop` calls `caml_shutdown` internally, we *really, really* do not want to do this, but we have no other way to get at the active runtime.
-    // TODO: There's actually a way to get a handle to the runtime as a function argument. Switch
-    // to doing this instead.
+    // NB: This method is designed only to be used by tests. However, since
+    // creating a new reference will cause `drop` to be called on it once we are
+    // done with it. Since `drop` calls `caml_shutdown` internally, we *really,
+    // really* do not want to do this, but we have no other way to get at the
+    // active runtime.
+    // TODO: There's actually a way to get a handle to the runtime as a function
+    // argument. Switch to doing this instead.
     let runtime = unsafe { ocaml::Runtime::recover_handle() };
 
-    // Release the runtime lock so that other threads can run using it while we generate the proof.
+    // Release the runtime lock so that other threads can run using it while we
+    // generate the proof.
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fp>::setup();
         let proof = ProverProof::create_recursive::<

--- a/src/lib/crypto/kimchi_bindings/stubs/src/projective.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/projective.rs
@@ -68,7 +68,8 @@ macro_rules! impl_projective {
             #[ocaml_gen::func]
             #[ocaml::func]
             pub fn [<caml_ $name:snake _rng>](i: ocaml::Int) -> $GroupProjective {
-                // We only care about entropy here, so we force a conversion i32 -> u32.
+                // We only care about entropy here, so we force a conversion i32
+                // -> u32.
                 let i: u64 = (i as u32).into();
                 let mut rng: StdRng = rand::SeedableRng::seed_from_u64(i);
                 let proj: $Projective = UniformRand::rand(&mut rng);


### PR DESCRIPTION
Would be nice to enforce it everywhere in a CI job. It is easier to read on a small screen or when splitting a Vim/Emacs window in different buffers.