### PR TITLE
[Trivial] lib/crypto: run dune fmt --auto-promote

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_backend_common)
  (public_name kimchi_backend_common)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_backend/dune
+++ b/src/lib/crypto/kimchi_backend/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_backend)
  (public_name kimchi_backend)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_backend/gadgets/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/dune
@@ -1,9 +1,12 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_gadgets)
  (public_name kimchi_backend.gadgets)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_jane))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_jane))
  (libraries
   ;; opam libraries
   bignum.bigint

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/dune
@@ -1,47 +1,48 @@
 (library
  (name kimchi_gadgets_test_runner)
  (public_name kimchi_backend.gadgets_test_runner)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
  (libraries
-   ;; opam libraries
-   stdio
-   integers
-   result
-   base.caml
-   bignum.bigint
-   core_kernel
-   base64
-   digestif
-   ppx_inline_test.config
-   sexplib0
-   base
-   async_kernel
-   bin_prot.shape
-   ;; local libraries
-   mina_wire_types
-   kimchi_bindings
-   kimchi_types
-   pasta_bindings
-   kimchi_pasta
-   kimchi_pasta.basic
-   kimchi_pasta.constraint_system
-   bitstring_lib
-   snarky.intf
-   snarky.backendless
-   snarky_group_map
-   sponge
-   kimchi_backend
-   base58_check
-   codable
-   random_oracle_input
-   snarky_log
-   group_map
-   snarky_curve
-   key_cache
-   snark_keys_header
-   tuple_lib
-   promise
-   kimchi_backend_common
-   ppx_version.runtime
-))
+  ;; opam libraries
+  stdio
+  integers
+  result
+  base.caml
+  bignum.bigint
+  core_kernel
+  base64
+  digestif
+  ppx_inline_test.config
+  sexplib0
+  base
+  async_kernel
+  bin_prot.shape
+  ;; local libraries
+  mina_wire_types
+  kimchi_bindings
+  kimchi_types
+  pasta_bindings
+  kimchi_pasta
+  kimchi_pasta.basic
+  kimchi_pasta.constraint_system
+  bitstring_lib
+  snarky.intf
+  snarky.backendless
+  snarky_group_map
+  sponge
+  kimchi_backend
+  base58_check
+  codable
+  random_oracle_input
+  snarky_log
+  group_map
+  snarky_curve
+  key_cache
+  snark_keys_header
+  tuple_lib
+  promise
+  kimchi_backend_common
+  ppx_version.runtime))

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
@@ -1,47 +1,48 @@
 (executable
  (name example)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
  (libraries
-   ;; opam libraries
-   stdio
-   integers
-   result
-   base.caml
-   bignum.bigint
-   core_kernel
-   base64
-   digestif
-   ppx_inline_test.config
-   sexplib0
-   base
-   async_kernel
-   bin_prot.shape
-   ;; local libraries
-   mina_wire_types
-   kimchi_bindings
-   kimchi_types
-   pasta_bindings
-   kimchi_pasta
-   kimchi_pasta.basic
-   kimchi_pasta.constraint_system
-   bitstring_lib
-   snarky.intf
-   snarky.backendless
-   snarky_group_map
-   sponge
-   kimchi_backend
-   base58_check
-   codable
-   random_oracle_input
-   snarky_log
-   group_map
-   snarky_curve
-   key_cache
-   snark_keys_header
-   tuple_lib
-   promise
-   kimchi_backend_common
-   ppx_version.runtime
-   kimchi_backend.gadgets_test_runner
-))
+  ;; opam libraries
+  stdio
+  integers
+  result
+  base.caml
+  bignum.bigint
+  core_kernel
+  base64
+  digestif
+  ppx_inline_test.config
+  sexplib0
+  base
+  async_kernel
+  bin_prot.shape
+  ;; local libraries
+  mina_wire_types
+  kimchi_bindings
+  kimchi_types
+  pasta_bindings
+  kimchi_pasta
+  kimchi_pasta.basic
+  kimchi_pasta.constraint_system
+  bitstring_lib
+  snarky.intf
+  snarky.backendless
+  snarky_group_map
+  sponge
+  kimchi_backend
+  base58_check
+  codable
+  random_oracle_input
+  snarky_log
+  group_map
+  snarky_curve
+  key_cache
+  snark_keys_header
+  tuple_lib
+  promise
+  kimchi_backend_common
+  ppx_version.runtime
+  kimchi_backend.gadgets_test_runner))

--- a/src/lib/crypto/kimchi_backend/pasta/basic/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/basic/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_pasta_basic)
  (public_name kimchi_pasta.basic)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/caml/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/caml/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_pasta_constraint_system_caml)
  (public_name kimchi_pasta.constraint_system.caml)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_backend/pasta/constraint_system/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/constraint_system/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_pasta_constraint_system)
  (public_name kimchi_pasta.constraint_system)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_backend/pasta/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/dune
@@ -1,5 +1,6 @@
 (library
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (name kimchi_pasta)
  (public_name kimchi_pasta)
  (flags -warn-error -27)

--- a/src/lib/crypto/kimchi_bindings/js/test/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/dune
@@ -1,25 +1,28 @@
 (library
  (name bindings_js_test)
- (js_of_ocaml (flags +toplevel.js +dynlink.js))
+ (js_of_ocaml
+  (flags +toplevel.js +dynlink.js))
  (libraries
-   base
-   bindings_js
-   core_kernel
-   digestif.ocaml
-   digestif
-   integers_stubs_js
-   js_of_ocaml
-   kimchi_bindings
-   kimchi_types
-   pasta_bindings
-   kimchi_backend
-   kimchi_backend_common
-   kimchi_pasta
-   kimchi_pasta.basic
-   kimchi_pasta.constraint_system
-   mina_metrics.none
-   run_in_thread.fake
-   snarky.backendless
-   snarky.intf)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version js_of_ocaml-ppx)))
+  base
+  bindings_js
+  core_kernel
+  digestif.ocaml
+  digestif
+  integers_stubs_js
+  js_of_ocaml
+  kimchi_bindings
+  kimchi_types
+  pasta_bindings
+  kimchi_backend
+  kimchi_backend_common
+  kimchi_pasta
+  kimchi_pasta.basic
+  kimchi_pasta.constraint_system
+  mina_metrics.none
+  run_in_thread.fake
+  snarky.backendless
+  snarky.intf)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version js_of_ocaml-ppx)))

--- a/src/lib/crypto/kimchi_bindings/pasta_fp_poseidon/dune
+++ b/src/lib/crypto/kimchi_bindings/pasta_fp_poseidon/dune
@@ -2,6 +2,9 @@
  (public_name kimchi_bindings.pasta_fp_poseidon)
  (name kimchi_pasta_fp_poseidon)
  (libraries kimchi_bindings)
- (instrumentation (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
- (preprocess (pps ppx_version ppx_inline_test)))
+ (instrumentation
+  (backend bisect_ppx))
+ (inline_tests
+  (flags -verbose -show-counts))
+ (preprocess
+  (pps ppx_version ppx_inline_test)))

--- a/src/lib/crypto/kimchi_bindings/pasta_fq_poseidon/dune
+++ b/src/lib/crypto/kimchi_bindings/pasta_fq_poseidon/dune
@@ -2,6 +2,9 @@
  (public_name kimchi_bindings.pasta_fq_poseidon)
  (name kimchi_pasta_fq_poseidon)
  (libraries kimchi_bindings)
- (instrumentation (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
- (preprocess (pps ppx_version ppx_inline_test)))
+ (instrumentation
+  (backend bisect_ppx))
+ (inline_tests
+  (flags -verbose -show-counts))
+ (preprocess
+  (pps ppx_version ppx_inline_test)))

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -21,7 +21,8 @@
   (<> %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
  (targets rustflags.sexp)
  (action
-  (with-stdout-to rustflags.sexp
+  (with-stdout-to
+   rustflags.sexp
    (echo "-C target-feature=+bmi2,+adx"))))
 
 (rule
@@ -29,7 +30,8 @@
   (= %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
  (targets rustflags.sexp)
  (action
-  (with-stdout-to rustflags.sexp
+  (with-stdout-to
+   rustflags.sexp
    (echo "-C target-feature=-bmi2,-adx"))))
 
 ;;
@@ -90,7 +92,8 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries bounded_types)
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test)))
 
@@ -101,7 +104,8 @@
  (libraries kimchi_types pasta_bindings.backend bounded_types)
  (instrumentation
   (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test)))
 
@@ -112,7 +116,8 @@
  (libraries pasta_bindings kimchi_types bounded_types)
  (instrumentation
   (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test)))
 
@@ -128,7 +133,8 @@
  (libraries bounded_types)
  (instrumentation
   (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test))
  (implements pasta_bindings.backend))

--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings_backend/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings_backend/dune
@@ -4,7 +4,8 @@
  (modules pasta_bindings_backend)
  (instrumentation
   (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test))
  (virtual_modules pasta_bindings_backend)

--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings_backend/none/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings_backend/none/dune
@@ -3,7 +3,8 @@
  (name pasta_bindings_backend_none)
  (instrumentation
   (backend bisect_ppx))
- (inline_tests (flags -verbose -show-counts))
+ (inline_tests
+  (flags -verbose -show-counts))
  (preprocess
   (pps ppx_version ppx_inline_test))
  (implements pasta_bindings.backend))

--- a/src/lib/crypto/plonkish_prelude/dune
+++ b/src/lib/crypto/plonkish_prelude/dune
@@ -25,7 +25,7 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries
-   ;; opam libraries
+  ;; opam libraries
   sexplib0
   result
   core_kernel
@@ -37,5 +37,4 @@
   tuple_lib
   ppx_version.runtime
   bounded_types
-  mina_wire_types
-  ))
+  mina_wire_types))

--- a/src/lib/crypto/plonkish_prelude/test/dune
+++ b/src/lib/crypto/plonkish_prelude/test/dune
@@ -2,13 +2,15 @@
  (names main)
  (flags
   (:standard -warn-error +a)
-  -open Core_kernel)
- (preprocess (pps ppx_jane))
+  -open
+  Core_kernel)
+ (preprocess
+  (pps ppx_jane))
  (libraries
   ; Opam
   core_kernel
   alcotest
   ; Mina
-  plonkish_prelude
-  )
- (action (run %{test})))
+  plonkish_prelude)
+ (action
+  (run %{test})))


### PR DESCRIPTION
Cherry-picked from https://github.com/MinaProtocol/mina/pull/16464/

Following an old work trying to replace the reformat script. In some next PRs, the dune files in stubs and wasm will be changed.

Can be replicated using:
```
cd src/lib/crypto && dune fmt --auto-promote
```

It is because I modify later in [16464](https://github.com/MinaProtocol/mina/pull/16464/) the dune files, and I pretty-print it. It is to have minimal (and separated) changes in the [16464](https://github.com/MinaProtocol/mina/pull/16464/)