### PR TITLE
Do not load config twice in mina_cli_entrypoint.ml

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -228,9 +228,8 @@ let setup_daemon logger ~itn_features =
   and snark_work_fee =
     flag "--snark-worker-fee" ~aliases:[ "snark-worker-fee" ]
       ~doc:
-        (sprintf
-           "FEE Amount a worker wants to get compensated for generating a \
-            snark proof" )
+        "FEE Amount a worker wants to get compensated for generating a snark \
+         proof"
       (optional txn_fee)
   and work_reassignment_wait =
     flag "--work-reassignment-wait"

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -567,7 +567,6 @@ let send_payment_graphql =
             graphql_endpoint
             ({ Cli_lib.Flag.sender; fee; nonce; memo }, receiver, amount)
           ->
-         let open Deferred.Let_syntax in
          let fee = Option.value ~default:default_transaction_fee fee in
          let%map response =
            let input =
@@ -596,7 +595,6 @@ let delegate_stake_graphql =
             graphql_endpoint
             ({ Cli_lib.Flag.sender; fee; nonce; memo }, receiver)
           ->
-         let open Deferred.Let_syntax in
          let fee = Option.value ~default:default_transaction_fee fee in
          let%map response =
            Graphql_client.query_exn

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -847,13 +847,13 @@ module Config_loader : Config_loader_intf = struct
       let%map.Option conf_dir = conf_dir in
       Option.value ~default:(conf_dir ^/ "genesis") genesis_dir
     in
-    let%bind.Deferred constants =
-      Runtime_config.Constants.load_constants_with_logging ?conf_dir
-        ?cli_proof_level ~logger ~itn_features config_files
-    in
     let%bind config =
       Runtime_config.Json_loader.load_config_files ?conf_dir ~logger
         config_files
+    in
+    let constants =
+      Runtime_config.Constants.load_constants' ?cli_proof_level ~itn_features
+        config
     in
     match%bind.Deferred
       init_from_config_file ?overwrite_version ?genesis_dir ~logger ~constants

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -2038,15 +2038,11 @@ module Constants : Constants_intf = struct
   (* Use this function if you don't need/want the ledger configuration *)
   let load_constants_with_logging ?conf_dir ?commit_id_short ?itn_features
       ?cli_proof_level ~logger config_files =
-    (* do not log reading compile time constants as this impacs cli command output *)
-    Deferred.Or_error.ok_exn
-    @@
-    let open Deferred.Or_error.Let_syntax in
-    let%map runtime_config =
-      Json_loader.load_config_files ?conf_dir ?commit_id_short ~logger
-        config_files
-    in
-    load_constants' ?itn_features ?cli_proof_level runtime_config
+    Deferred.Or_error.(
+      ok_exn
+        ( Json_loader.load_config_files ?conf_dir ?commit_id_short ~logger
+            config_files
+        >>| load_constants' ?itn_features ?cli_proof_level ))
 
   let load_constants = load_constants_with_logging ~logger:(Logger.null ())
 


### PR DESCRIPTION
Previous implementation was leading to logs about loading config files appearing twice.

Also contains some cosmetic changes based on re-review of #16186.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
