### PR TITLE
Fix src/lib/mina_lmdb_storage

### DIFF
--- a/src/lib/mina_lmdb_storage/block.ml
+++ b/src/lib/mina_lmdb_storage/block.ml
@@ -1,5 +1,3 @@
-(* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
 open Core_kernel
 open Lmdb_storage
 

--- a/src/lib/mina_lmdb_storage/dune
+++ b/src/lib/mina_lmdb_storage/dune
@@ -45,8 +45,6 @@
    transition_frontier_full_frontier
    mina_numbers
    data_hash_lib
-   ;; test deps
-   inline_test_quiet_logs
    )
  (inline_tests (flags -verbose -show-counts))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
Before merging PR #16361 into `compatible`, latest `compatible` wasn't merged into the feature branch. Because of that CI run didn't catch a compilation error.

This PR fixes compilation by removing usage of `Inline_test_quiet_logs`.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None