### PR TITLE
[DO NOT MERGE; TESTING] Fix rosetta integration tests on develop

### DIFF
--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -93,7 +93,7 @@ cat <<EOF >"$MINA_CONFIG_FILE"
 {
   "genesis": { "genesis_state_timestamp": "$CURRENT_TIME" },
   "proof": { "block_window_duration_ms": 20000 },
-  "daemon": { "network_id": "${MINA_NETWORK}" },
+  "daemon": { "network_id": "${MINA_NETWORK}", "fork": {} },
   "ledger": {
     "accounts": [
       { "pk": "${BLOCK_PRODUCER_PUB_KEY}", "balance": "600000000", "delegate": null, "sk": null },

--- a/buildkite/scripts/rosetta-integration-tests.sh
+++ b/buildkite/scripts/rosetta-integration-tests.sh
@@ -252,10 +252,10 @@ fi
 
 mina client status --json
 
-next_block_time=$(mina client status --json | jq '.next_block_production.timing[1]' | tr -d '"') curr_time=$(date +%s%N | cut -b1-13)
-sleep_time=$((($next_block_time - $curr_time) / 10000000))
+next_block_time=$(mina client status --json | jq '.next_block_production.timing[1].time' | tr -d '"') curr_time=$(date +%s%N | cut -b1-13)
+sleep_time=$((($next_block_time - $curr_time) / 1000))
 echo "Sleeping for ${sleep_time}s until next block is created..."
-sleep $sleep_time
+sleep ${sleep_time}
 
 # Mina Rosetta Checks (spec construction data perf)
 echo "============ ROSETTA CLI: VALIDATE CONF FILE ${ROSETTA_CONFIGURATION_FILE} =============="


### PR DESCRIPTION
On compatible we use the `berkeley` ledger as a fallthrough. On develop, we use the `devnet` ledger. The `devnet` ledger has a `fork` entry in its config file :man_facepalming: 