### PR TITLE
[Benchmarks] fix for moving average. Add category for jane benchmarks

### DIFF
--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -10,7 +10,7 @@ EXTRA_ARGS=""
 
 source buildkite/scripts/bench/install.sh
 
-MAINLINE_BRANCHES="-m develop -m compatible -m master -m dkijania/fix_benchmark_upload"
+MAINLINE_BRANCHES="-m develop -m compatible -m master -m dkijania/enhance_benchmarks"
 while [[ "$#" -gt 0 ]]; do case $1 in
   heap-usage) BENCHMARK="heap-usage"; ;;
   mina-base) BENCHMARK="mina-base"; ;;

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -92,6 +92,8 @@ let minimalDirtyWhen =
       , S.exactly "buildkite/src/Command/MinaArtifact" "dhall"
       , S.exactly "buildkite/src/Command/PatchArchiveTest" "dhall"
       , S.exactly "buildkite/src/Command/Bench/Base" "dhall"
+      , S.strictlyStart (S.contains "scripts/benchmarks")
+      , S.strictlyStart (S.contains "buildkite/scripts/bench")
       , S.exactly "buildkite/src/Command/ReplayerTest" "dhall"
       , S.strictlyStart (S.contains "buildkite/src/Jobs/Release/MinaArtifact")
       , S.strictlyStart (S.contains "dockerfiles/stages")


### PR DESCRIPTION
Two small issues fix for benchmarks.

- check if there is enough data for calculating moving average. If not, skip comparison
- add missing category tag for jane street related benchmarks