### PR TITLE
[CI] autopromote nightly

### DIFF
--- a/buildkite/scripts/debian/promote.sh
+++ b/buildkite/scripts/debian/promote.sh
@@ -69,7 +69,7 @@ echo "Promoting debs: ${PACKAGE}_${VERSION} to Release: ${TO_COMPONENT} and Code
 # If this fails, attempt to remove the lockfile and retry.
 
 if [[ -z "$NEW_VERSION" ]] || [[ "$NEW_VERSION" == "$VERSION" ]]; then
-  deb-s3 copy --s3-region=us-west-2 --lock --bucket packages.o1test.net --preserve-versions --cache-control=max-age=120  $PACKAGE $CODENAME $TO_COMPONENT --versions $VERSION --arch $ARCH --component ${FROM_COMPONENT} --codename ${CODENAME}
+  deb-s3 copy --s3-region=us-west-2 --lock --bucket $REPO --preserve-versions --cache-control=max-age=120  $PACKAGE $CODENAME $TO_COMPONENT --versions $VERSION --arch $ARCH --component ${FROM_COMPONENT} --codename ${CODENAME}
 else
   source scripts/debian/reversion.sh \
     --deb $PACKAGE  \
@@ -84,4 +84,4 @@ else
     --repo $REPO \
     --new-repo $NEW_REPO \
     $SIGN_ARG
-fi
+fi    

--- a/buildkite/src/Command/Promotion/PromoteDebian.dhall
+++ b/buildkite/src/Command/Promotion/PromoteDebian.dhall
@@ -36,6 +36,7 @@ let PromoteDebianSpec =
           , profile : Profiles.Type
           , remove_profile_from_name : Bool
           , step_key : Text
+          , allow_signing : Bool
           , if : Optional B/If
           }
       , default =
@@ -53,6 +54,7 @@ let PromoteDebianSpec =
           , profile = Profiles.Type.Standard
           , remove_profile_from_name = False
           , step_key = "promote-debian-package"
+          , allow_signing = True
           , if = None B/If
           }
       }
@@ -73,6 +75,13 @@ let promoteDebianStep =
 
                 else  ""
 
+          let sign_arg_opt =
+                      if spec.allow_signing
+
+                then  "${DebianRepo.keyArg spec.target_repo}"
+
+                else  ""
+
           in  Command.build
                 Command.Config::{
                 , commands =
@@ -87,8 +96,8 @@ let promoteDebianStep =
                                                                                                                                                          spec.target_repo} --package ${package_name} --version ${spec.version}  --new-version ${spec.new_version}  --architecture ${spec.architecture}  --codename ${DebianVersions.lowerName
                                                                                                                                                                                                                                                                                                                        spec.codename}  --from-component ${DebianChannel.lowerName
                                                                                                                                                                                                                                                                                                                                                             spec.from_channel}  --to-component ${DebianChannel.lowerName
-                                                                                                                                                                                                                                                                                                                                                                                                   spec.to_channel} ${new_name}"
-                , label = "Debian: ${spec.step_key}"
+                                                                                                                                                                                                                                                                                                                                                                                                   spec.to_channel} ${new_name} ${sign_arg_opt}"
+                , label = "Promote Debian: ${spec.step_key}"
                 , key = spec.step_key
                 , target = Size.Small
                 , depends_on = spec.deps

--- a/buildkite/src/Command/Promotion/PromoteDocker.dhall
+++ b/buildkite/src/Command/Promotion/PromoteDocker.dhall
@@ -85,7 +85,7 @@ let promoteDockerStep =
           in  Command.build
                 Command.Config::{
                 , commands = commands
-                , label = "Docker: ${spec.step_key}"
+                , label = "Promote Docker: ${spec.step_key}"
                 , key = spec.step_key
                 , target = Size.XLarge
                 , depends_on = spec.deps

--- a/buildkite/src/Command/Promotion/VerifyPackages.dhall
+++ b/buildkite/src/Command/Promotion/VerifyPackages.dhall
@@ -8,8 +8,6 @@ let List/map = Prelude.List.map
 
 let Package = ../../Constants/DebianPackage.dhall
 
-let DebianRepo = ../../Constants/DebianRepo.dhall
-
 let Network = ../../Constants/Network.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
@@ -27,6 +25,8 @@ let Profiles = ../../Constants/Profiles.dhall
 let Artifact = ../../Constants/Artifacts.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let DebianRepo = ../../Constants/DebianRepo.dhall
 
 let Command = ../Base.dhall
 
@@ -47,9 +47,14 @@ let VerifyPackagesSpec =
           , debian_repo : DebianRepo.Type
           , profile : Profiles.Type
           , network : Network.Type
+          , repo : DebianRepo.Type
           , codenames : List DebianVersions.DebVersion
           , channel : DebianChannel.Type
-          , new_tags : List Text
+          , tags :
+                  DebianVersions.DebVersion
+              ->  DebianChannel.Type
+              ->  DebianRepo.Type
+              ->  List Text
           , remove_profile_from_name : Bool
           , published : Bool
           }
@@ -57,13 +62,13 @@ let VerifyPackagesSpec =
           { promote_step_name = None
           , debians = [] : List Package.Type
           , dockers = [] : List Artifact.Type
+          , repo = DebianRepo.Type.PackagesO1Test
           , new_debian_version = "\\\\\$MINA_DEB_VERSION"
           , debian_repo = DebianRepo.Type.PackagesO1Test
           , profile = Profiles.Type.Standard
           , network = Network.Type.Mainnet
           , codenames = [] : List DebianVersions.DebVersion
           , channel = DebianChannel.Type.Compatible
-          , new_tags = [] : List Text
           , remove_profile_from_name = False
           , published = False
           }
@@ -85,7 +90,11 @@ let verifyPackagesToDockerSpecs
                                 , profile = verify_packages.profile
                                 , name = docker
                                 , codename = codename
-                                , new_tags = verify_packages.new_tags
+                                , new_tags =
+                                    verify_packages.tags
+                                      codename
+                                      verify_packages.channel
+                                      verify_packages.repo
                                 , network = verify_packages.network
                                 , publish = verify_packages.published
                                 , remove_profile_from_name =

--- a/buildkite/src/Constants/DebianRepo.dhall
+++ b/buildkite/src/Constants/DebianRepo.dhall
@@ -32,6 +32,17 @@ let bucket =
             }
             repo
 
+let shortName =
+          \(repo : DebianRepo)
+      ->  merge
+            { Local = "local"
+            , PackagesO1Test = "packages"
+            , Unstable = "unstable"
+            , Nightly = "nightly"
+            , Stable = "stable"
+            }
+            repo
+
 let bucket_or_default =
           \(repo : DebianRepo)
       ->  let maybeBucket =
@@ -59,9 +70,9 @@ let keyId =
       ->  merge
             { Local = None Text
             , PackagesO1Test = None Text
-            , Unstable = Some "B40D16B1A4773DE415DAF9DBFE236881C07523DC"
-            , Nightly = Some "B40D16B1A4773DE415DAF9DBFE236881C07523DC"
-            , Stable = Some "B40D16B1A4773DE415DAF9DBFE236881C07523DC"
+            , Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
+            , Nightly = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
+            , Stable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             }
             repo
 
@@ -132,4 +143,5 @@ in  { Type = DebianRepo
     , bucketArg = bucketArg
     , keyId = keyId
     , keyArg = keyArg
+    , shortName = shortName
     }

--- a/buildkite/src/Entrypoints/PromotePackage.dhall
+++ b/buildkite/src/Entrypoints/PromotePackage.dhall
@@ -12,6 +12,8 @@ let DebianChannel = ../Constants/DebianChannel.dhall
 
 let Network = ../Constants/Network.dhall
 
+let Command = ../Command/Base.dhall
+
 let DebianVersions = ../Constants/DebianVersions.dhall
 
 let DebianRepo = ../Constants/DebianRepo.dhall
@@ -50,7 +52,11 @@ let promote_artifacts =
                 , codenames = codenames
                 , from_channel = from_channel
                 , to_channel = to_channel
-                , new_tags = [ tag ]
+                , new_tags =
+                        \(codename : DebianVersions.DebVersion)
+                    ->  \(channel : DebianChannel.Type)
+                    ->  \(repo : DebianRepo.Type)
+                    ->  [ tag ]
                 , remove_profile_from_name = remove_profile_from_name
                 , publish = publish
                 }
@@ -68,6 +74,7 @@ let promote_artifacts =
                       dockersSpecs
                       DebianVersions.DebVersion.Bullseye
                       PipelineMode.Type.Stable
+                      ([] : List Command.TaggedKey.Type)
                   )
 
           in  pipelineType.pipeline
@@ -78,6 +85,7 @@ let verify_artifacts =
       ->  \(new_version : Text)
       ->  \(profile : Profile.Type)
       ->  \(network : Network.Type)
+      ->  \(repo : DebianRepo.Type)
       ->  \(codenames : List DebianVersions.DebVersion)
       ->  \(to_channel : DebianChannel.Type)
       ->  \(repo : DebianRepo.Type)
@@ -95,7 +103,12 @@ let verify_artifacts =
                 , network = network
                 , codenames = codenames
                 , channel = to_channel
-                , new_tags = [ tag ]
+                , repo = repo
+                , tags =
+                        \(codename : DebianVersions.DebVersion)
+                    ->  \(channel : DebianChannel.Type)
+                    ->  \(repo : DebianRepo.Type)
+                    ->  [ tag ]
                 , remove_profile_from_name = remove_profile_from_name
                 , published = publish
                 }

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -14,6 +14,8 @@ let DebianPackage = ../../Constants/DebianPackage.dhall
 
 let DebianChannel = ../../Constants/DebianChannel.dhall
 
+let DebianRepo = ../../Constants/DebianRepo.dhall
+
 let Network = ../../Constants/Network.dhall
 
 let Profiles = ../../Constants/Profiles.dhall
@@ -28,53 +30,61 @@ let PromotePackages = ../../Command/Promotion/PromotePackages.dhall
 
 let VerifyPackages = ../../Command/Promotion/VerifyPackages.dhall
 
+let pipelineName = "AutoPromoteNightly"
+
+let currentDate = "\\\$(date \"+%Y%m%d\")"
+
+let new_tags =
+          \(codename : DebianVersions.DebVersion)
+      ->  \(channel : DebianChannel.Type)
+      ->  \(repo : DebianRepo.Type)
+      ->  [ "latest-${DebianChannel.lowerName channel}-${DebianRepo.shortName
+                                                           repo}"
+          ]
+
 let promotePackages =
       PromotePackages.PromotePackagesSpec::{
       , debians =
-        [ DebianPackage.Type.Daemon
-        , DebianPackage.Type.LogProc
+        [ DebianPackage.Type.LogProc
+        , DebianPackage.Type.Daemon
         , DebianPackage.Type.Archive
         ]
       , dockers = [ Artifacts.Type.Daemon, Artifacts.Type.Archive ]
       , version = "\\\${FROM_VERSION_MANUAL:-\\\${MINA_DEB_VERSION}}"
       , architecture = "amd64"
-      , new_debian_version = "\\\$(date \"+%Y%m%d\")"
+      , new_debian_version = currentDate
       , profile = Profiles.Type.Standard
       , network = Network.Type.Devnet
       , codenames =
         [ DebianVersions.DebVersion.Bullseye, DebianVersions.DebVersion.Focal ]
       , from_channel = DebianChannel.Type.Unstable
       , to_channel = DebianChannel.Type.Compatible
-      , new_tags =
-        [ "latest-compatible-nightly"
-        , "compatible-nightly-\\\$(date \"+%Y%m%d\")"
-        ]
+      , source_debian_repo = DebianRepo.Type.PackagesO1Test
+      , new_tags = new_tags
+      , target_debian_repo = DebianRepo.Type.Nightly
       , remove_profile_from_name = False
       , publish = False
+      , depends_on =
+        [ { name = "PublishDebians", key = "publish-focal-deb-pkg" } ]
       }
 
 let verifyPackages =
-      VerifyPackages.VerifyPackagesSpec::{
-      , promote_step_name = Some "AutoPromoteNightly"
-      , debians =
-        [ DebianPackage.Type.Daemon
-        , DebianPackage.Type.LogProc
-        , DebianPackage.Type.Archive
-        ]
-      , dockers = [ Artifacts.Type.Daemon, Artifacts.Type.Archive ]
-      , new_debian_version = "\\\$(date \"+%Y%m%d\")"
-      , profile = Profiles.Type.Standard
-      , network = Network.Type.Devnet
-      , codenames =
-        [ DebianVersions.DebVersion.Bullseye, DebianVersions.DebVersion.Focal ]
-      , channel = DebianChannel.Type.Compatible
-      , new_tags =
-        [ "latest-compatible-nightly"
-        , "compatible-nightly-\\\$(date \"+%Y%m%d\")"
-        ]
-      , remove_profile_from_name = False
-      , published = False
-      }
+          \(pipelineName : Text)
+      ->  \(promote_packages : PromotePackages.PromotePackagesSpec.Type)
+      ->  VerifyPackages.VerifyPackagesSpec::{
+          , promote_step_name = Some pipelineName
+          , debians = promote_packages.debians
+          , dockers = promote_packages.dockers
+          , new_debian_version = promote_packages.new_debian_version
+          , profile = promote_packages.profile
+          , network = promote_packages.network
+          , codenames = promote_packages.codenames
+          , channel = promote_packages.to_channel
+          , repo = promote_packages.target_debian_repo
+          , tags = new_tags
+          , remove_profile_from_name = promote_packages.remove_profile_from_name
+          , published = promote_packages.publish
+          }
 
 let promoteDebiansSpecs =
       PromotePackages.promotePackagesToDebianSpecs promotePackages
@@ -83,10 +93,20 @@ let promoteDockersSpecs =
       PromotePackages.promotePackagesToDockerSpecs promotePackages
 
 let verifyDebiansSpecs =
-      VerifyPackages.verifyPackagesToDebianSpecs verifyPackages
+      VerifyPackages.verifyPackagesToDebianSpecs
+        (verifyPackages pipelineName promotePackages)
 
 let verifyDockersSpecs =
-      VerifyPackages.verifyPackagesToDockerSpecs verifyPackages
+      VerifyPackages.verifyPackagesToDockerSpecs
+        (verifyPackages pipelineName promotePackages)
+
+let steps =
+        PromotePackages.promoteSteps
+          promoteDebiansSpecs
+          promoteDockersSpecs
+          pipelineName
+          promotePackages.depends_on
+      # VerifyPackages.verificationSteps verifyDebiansSpecs verifyDockersSpecs
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -94,11 +114,7 @@ in  Pipeline.build
         , dirtyWhen = [ S.everything ]
         , path = "Promote"
         , tags = [ PipelineTag.Type.Promote ]
-        , name = "AutoPromoteNightly"
+        , name = pipelineName
         }
-      , steps =
-            PromotePackages.promoteSteps promoteDebiansSpecs promoteDockersSpecs
-          # VerifyPackages.verificationSteps
-              verifyDebiansSpecs
-              verifyDockersSpecs
+      , steps = steps
       }

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumented.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumented.dhall
@@ -6,6 +6,8 @@ let BuildFlags = ../../Constants/BuildFlags.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -15,5 +17,10 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             ]
           , buildFlags = BuildFlags.Type.Instrumented
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
@@ -6,6 +6,8 @@ let Artifacts = ../../Constants/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -19,5 +21,10 @@ in  Pipeline.build
             , Artifacts.Type.ZkappTestTransaction
             ]
           , debVersion = DebianVersions.DebVersion.Focal
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            ]
           }
       )

--- a/buildkite/src/Pipeline/Filter.dhall
+++ b/buildkite/src/Pipeline/Filter.dhall
@@ -10,6 +10,7 @@ let Filter
       | Long
       | LongAndVeryLong
       | TearDownOnly
+      | TearDownAndPromote
       | ToolchainsOnly
       | AllTests
       | Release
@@ -27,6 +28,7 @@ let tags
             , LongAndVeryLong = [ Tag.Type.Long, Tag.Type.VeryLong ]
             , Long = [ Tag.Type.Long ]
             , TearDownOnly = [ Tag.Type.TearDown ]
+            , TearDownAndPromote = [ Tag.Type.TearDown, Tag.Type.Promote ]
             , ToolchainsOnly = [ Tag.Type.Toolchain ]
             , DebianBuild = [ Tag.Type.Debian ]
             , DockerBuild = [ Tag.Type.Docker ]
@@ -51,6 +53,7 @@ let show
             , Long = "Long"
             , ToolchainsOnly = "Toolchain"
             , TearDownOnly = "TearDownOnly"
+            , TearDownAndPromote = "TearDownAndPromote"
             , AllTests = "AllTests"
             , Release = "Release"
             , Promote = "Promote"

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -45,7 +45,7 @@ if [[ -z "$NEW_NAME" ]]; then NEW_NAME=$DEB; fi;
 if [[ -z "$NEW_RELEASE" ]]; then NEW_RELEASE=$RELEASE; fi;
 if [[ -z "$NEW_VERSION" ]]; then NEW_VERSION=$VERSION; fi;
 if [[ -z "$NEW_SUITE" ]]; then NEW_SUITE=$SUITE; fi;
-if [[ -z "$NEW_REPO" ]]; then NEW_REPO=$SUITE; fi;
+if [[ -z "$NEW_REPO" ]]; then NEW_REPO=$REPO; fi;
 if [[ -z "$DEB" ]]; then NEW_NAME=$DEB; fi;
 if [[ -z "$RELEASE" ]]; then NEW_RELEASE=$RELEASE; fi;
 if [[ -z "$VERSION" ]]; then NEW_VERSION=$VERSION; fi;
@@ -55,6 +55,8 @@ if [ -z "${SIGN:-}" ]; then
   SIGN_ARG=""
 else 
   SIGN_ARG="--sign $SIGN"
+else 
+  SIGN_ARG=""
 fi
 
 function rebuild_deb() {
@@ -70,4 +72,4 @@ function rebuild_deb() {
 }
 
 rebuild_deb
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version ${NEW_VERSION} --codename ${CODENAME} --release ${NEW_RELEASE} --bucket ${NEW_REPO}
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version ${NEW_VERSION} --codename ${CODENAME} --release ${NEW_RELEASE} --bucket ${NEW_REPO} $SIGN_ARG

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -30,8 +30,9 @@ SCRIPT=' set -x \
     && export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
     && echo installing mina \
     && apt-get update > /dev/null \
-    && apt-get install -y lsb-release ca-certificates > /dev/null \
-    && echo "deb [trusted=yes] https://'$REPO' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
+    && apt-get install -y lsb-release ca-certificates wget gnupg > /dev/null \
+    && (wget -q https://'$BUCKET'/key.pgp -O- | apt-key add) \
+    && echo "deb [trusted=yes] https://'$BUCKET' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
     && apt-get update > /dev/null \
     && apt list -a '$PACKAGE' \
     && apt-get install -y --allow-downgrades '$PACKAGE'='$VERSION' \

--- a/scripts/docker/verify.sh
+++ b/scripts/docker/verify.sh
@@ -16,6 +16,6 @@ esac; shift; done
 docker pull $REPO/$PACKAGE:$VERSION-${CODENAME}${SUFFIX}
 
 if [ ?$ != 0 ]; then
-  echo "Docker verification for $_codename $_package failed"
+  echo "Docker verification for $CODENAME $PACKAGE failed"
   exit 1
 fi


### PR DESCRIPTION
Introducing promotion jobs for debian and docker (mina,archive,logproc,rosetta), which can be used in nightly pipeline. Thanks to that we can have automatic promotion of desired packages into new channel or repo. Currently we are using only one debian packages repo. This is problematic as unstable packages can create conflict which can prevent users from downloading stable packages. This was partially solved by prevent publishing packages in PR. 

However, there are several issues more like:

- name of repo (packages.o1test.net) which is not a nicest debian repo name
- repo is not signed
- it is still problematic to host all packages unstable/stable etc. in single pool as override can happen. 

In order to solve above issues we introduced 3 new **signed** debian repositories:

- unstable.packages.apt.minaprotocol.com
- stable.packages.apt.minaprotocol.com
- nightly.packages.apt.minaprotocol.com

This PR is introducing new job which can promote package from/to any repository/channel. 

Default usage is to promote packages from unstable to nightly on nightly pipeline. It also simplifies naming convention as one need to use --allow-downgrade with precise version name. After this PR is merge we can just use

```
wget -q https://nightly.packages.apt.minaprotocol.com/key.gpg -O- | sudo tee /etc/apt/keyrings/nightly.minprotocol.com > /dev/null
echo "deb [signed-by= /etc/apt/keyrings/nightly.minprotocol.com] https://nightly.packages.apt.minaprotocol.com bullseye compatible" | sudo tee -a /etc/apt/sources.list.d/mina-nightly.list > /dev/null

sudo apt-get upgrade mina-mainnet // or mina-devnet etc.
```

In order to upgrade to newest nightly debian, as default naming convention for nightly is {package}:{date} (e.g. mina_devnet:20250206).

In case of docker we are adding rolling tag "latest-bullseye-develop-nightly" (which is moving to new docker after each nightly)

IMPORTANT:

This pr is not affecting our nightly pipeline. i introduced parallel pipeline called 'Mina Scheduled End-to-End Nightly' which implements promotion (namely it uses different filter and teardow,n which fetches promotion as well).

Once scheduled nightly pipeline is stable we can disable cron job in nightly pipeline and update slack updates. As a result nightly pipeline would be used only for personal branch nightlies
 
