### PR TITLE
[Proof cache] lmdb implementation

### DIFF
--- a/src/lib/proof_cache_tag/dune
+++ b/src/lib/proof_cache_tag/dune
@@ -1,7 +1,7 @@
 (library
  (public_name proof_cache_tag)
  (virtual_modules proof_cache_tag)
- (default_implementation proof_cache_tag.lmdb)
+ (default_implementation proof_cache_tag.identity)
  (libraries
    ;; opam libraries
    core_kernel

--- a/src/lib/proof_cache_tag/dune
+++ b/src/lib/proof_cache_tag/dune
@@ -1,12 +1,15 @@
 (library
  (public_name proof_cache_tag)
  (virtual_modules proof_cache_tag)
- (default_implementation proof_cache_tag.identity)
+ (default_implementation proof_cache_tag.lmdb)
  (libraries
    ;; opam libraries
    core_kernel
+   async
    ;; local libraries
-   mina_base)
+   mina_base
+   logger
+   )
  (preprocess
   (pps ppx_mina ppx_version))
  (instrumentation (backend bisect_ppx)))

--- a/src/lib/proof_cache_tag/identity/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/identity/proof_cache_tag.ml
@@ -8,7 +8,9 @@ let unwrap = Fn.id
 
 let generate () = Fn.id
 
-let create_db () = ()
+let create_db path ~logger =
+  [%log trace] "mocking path %s" path ;
+  Async.Deferred.Result.return ()
 
 module For_tests = struct
   let blockchain_dummy = Mina_base.Proof.blockchain_dummy

--- a/src/lib/proof_cache_tag/lmdb/dune
+++ b/src/lib/proof_cache_tag/lmdb/dune
@@ -1,0 +1,17 @@
+(library
+ (public_name proof_cache_tag.lmdb)
+ (name proof_cache_tag_lmdb)
+ (implements proof_cache_tag)
+ (libraries
+   ;; opam libraries
+   core
+   async
+   base.caml
+   ;; local libraries
+   mina_base
+   disk_cache.lmdb
+   file_system
+   )
+ (preprocess
+  (pps ppx_mina ppx_version ppx_jane))
+ (instrumentation (backend bisect_ppx)))

--- a/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
@@ -1,0 +1,44 @@
+open Async
+open Core
+module Cache = Disk_cache.Make (Pickles.Proof.Proofs_verified_2.Stable.Latest)
+
+type cache_db = Cache.t
+
+type t = { cache_id : Cache.id; cache_db : cache_db }
+
+let create_db = Cache.initialize
+
+let unwrap t = Cache.get t.cache_db t.cache_id
+
+let generate cache_db proof =
+  let cache_id = Cache.put cache_db proof in
+  { cache_id; cache_db }
+
+module For_tests = struct
+  let create_db () =
+    let open Deferred.Let_syntax in
+    Thread_safe.block_on_async_exn (fun () ->
+        let%bind db =
+          create_db
+            (Core.Filename.temp_dir "mina" "proof_cache.lmdb")
+            ~logger:(Logger.null ())
+        in
+        match db with
+        | Ok db ->
+            return db
+        | Error err -> (
+            match err with
+            | `Initialization_error err ->
+                failwithf "cannot initialize db for tests %s"
+                  (Error.to_string_hum err) () ) )
+
+  let blockchain_dummy =
+    Lazy.map
+      ~f:(fun dummy -> generate (create_db ()) dummy)
+      Mina_base.Proof.blockchain_dummy
+
+  let transaction_dummy =
+    Lazy.map
+      ~f:(fun dummy -> generate (create_db ()) dummy)
+      Mina_base.Proof.transaction_dummy
+end

--- a/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
@@ -2,35 +2,38 @@ open Async
 open Core
 module Cache = Disk_cache.Make (Pickles.Proof.Proofs_verified_2.Stable.Latest)
 
-type cache_db = Cache.t
+type cache_db = Lmdb_cache of Cache.t | Identity_cache
 
-type t = { cache_id : Cache.id; cache_db : cache_db }
+type t =
+  | Lmdb of { cache_id : Cache.id; cache_db : cache_db }
+  | Identity of Mina_base.Proof.t
 
-let create_db = Cache.initialize
+let unwrap = function
+  | Lmdb t -> (
+      match t.cache_db with
+      | Identity_cache ->
+          failwith
+            "internal error for proof cache tag. Identity_cache shouldn't be \
+             used in production lmdb implementation"
+      | Lmdb_cache cache_db ->
+          Cache.get cache_db t.cache_id )
+  | Identity proof ->
+      proof
 
-let unwrap t = Cache.get t.cache_db t.cache_id
+let generate db proof =
+  match db with
+  | Lmdb_cache cache_db ->
+      Lmdb
+        { cache_id = Cache.put cache_db proof; cache_db = Lmdb_cache cache_db }
+  | Identity_cache ->
+      Identity proof
 
-let generate cache_db proof =
-  let cache_id = Cache.put cache_db proof in
-  { cache_id; cache_db }
+let create_db path ~logger =
+  Cache.initialize ~logger path
+  |> Deferred.Result.map ~f:(fun cache -> Lmdb_cache cache)
 
 module For_tests = struct
-  let create_db () =
-    let open Deferred.Let_syntax in
-    Thread_safe.block_on_async_exn (fun () ->
-        let%bind db =
-          create_db
-            (Core.Filename.temp_dir "mina" "proof_cache.lmdb")
-            ~logger:(Logger.null ())
-        in
-        match db with
-        | Ok db ->
-            return db
-        | Error err -> (
-            match err with
-            | `Initialization_error err ->
-                failwithf "cannot initialize db for tests %s"
-                  (Error.to_string_hum err) () ) )
+  let create_db () = Identity_cache
 
   let blockchain_dummy =
     Lazy.map

--- a/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/lmdb/proof_cache_tag.ml
@@ -1,30 +1,23 @@
 open Async
 open Core
-module Cache = Disk_cache.Make (Pickles.Proof.Proofs_verified_2.Stable.Latest)
+module Cache = Disk_cache.Make (Mina_base.Proof.Stable.Latest)
 
 type cache_db = Lmdb_cache of Cache.t | Identity_cache
 
 type t =
-  | Lmdb of { cache_id : Cache.id; cache_db : cache_db }
+  | Lmdb of { cache_id : Cache.id; cache_db : Cache.t }
   | Identity of Mina_base.Proof.t
 
 let unwrap = function
-  | Lmdb t -> (
-      match t.cache_db with
-      | Identity_cache ->
-          failwith
-            "internal error for proof cache tag. Identity_cache shouldn't be \
-             used in production lmdb implementation"
-      | Lmdb_cache cache_db ->
-          Cache.get cache_db t.cache_id )
+  | Lmdb t ->
+      Cache.get t.cache_db t.cache_id
   | Identity proof ->
       proof
 
 let generate db proof =
   match db with
   | Lmdb_cache cache_db ->
-      Lmdb
-        { cache_id = Cache.put cache_db proof; cache_db = Lmdb_cache cache_db }
+      Lmdb { cache_id = Cache.put cache_db proof; cache_db }
   | Identity_cache ->
       Identity proof
 

--- a/src/lib/proof_cache_tag/proof_cache_tag.mli
+++ b/src/lib/proof_cache_tag/proof_cache_tag.mli
@@ -1,8 +1,14 @@
+open Core
+open Async
+
 type t
 
 type cache_db
 
-val create_db : unit -> cache_db
+val create_db :
+     string
+  -> logger:Logger.t
+  -> (cache_db, [> `Initialization_error of Error.t ]) Deferred.Result.t
 
 val unwrap : t -> Mina_base.Proof.t
 


### PR DESCRIPTION
Added real implementation for proof caching apart from `identity` one. Lmdb implementation uses `disk_cache.lmdb` as proof cache db lib. 

This PR is continuation of proof_cache_tag lib started in: https://github.com/MinaProtocol/mina/pull/16478