### PR TITLE
Fix the compatibility-with-develop test

### DIFF
--- a/buildkite/scripts/check-compatibility.sh
+++ b/buildkite/scripts/check-compatibility.sh
@@ -4,6 +4,8 @@
 
 set -eox pipefail
 
+CURR_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+
 function get_shas {
   SHAS=$(git log -n 10 --format="%h" --abbrev=7 --first-parent)
 }
@@ -147,8 +149,6 @@ else
 fi
 
 MAIN_BRANCH_IMAGE_TAG=$IMAGE_TAG
-
-CURR_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 
 echo "Checking out PR branch"
 git checkout $CURR_BRANCH


### PR DESCRIPTION
This PR ensures that this test is actually checking what it purports to be checking: that `CURR_BRANCH` is compatible with `MAINLINE_BRANCH`. Since https://github.com/MinaProtocol/mina/pull/14181 first landed, the order of operations in https://github.com/MinaProtocol/mina/blob/914218e94d5880cacf45b9bbf31aebb381792f46/buildkite/scripts/check-compatibility.sh#L143-L162 ensures that `CURR_BRANCH` is always incorrectly set to `MAINLINE_BRANCH`, and so the test will never have given us useful information.

It is likely that we don't want this test for now anyway. However, it feels pragmatic to fix the test so that we can use it for subsequent hard forks.