### PR TITLE
Stop sending data on libp2p streams after the first error

### DIFF
--- a/src/lib/mina_net2/libp2p_stream.ml
+++ b/src/lib/mina_net2/libp2p_stream.ml
@@ -172,8 +172,10 @@ let create_from_existing ~logger ~helper ~stream_id ~protocol ~peer
     }
   in
   let send_outgoing_messages_task =
-    Pipe.iter outgoing_r ~f:(fun msg ->
-        if Pipe.is_closed outgoing_w then Deferred.unit
+    Pipe.fold ~init:false outgoing_r ~f:(fun encountered_error msg ->
+        if encountered_error then
+          (* The stream has already failed, no need to process this message. *)
+          Deferred.return encountered_error
         else
           let parts = split_string msg ~every:max_chunk_size in
           match%map
@@ -184,14 +186,15 @@ let create_from_existing ~logger ~helper ~stream_id ~protocol ~peer
                      (Libp2p_ipc.Rpcs.SendStream.create_request ~stream_id ~data) )
           with
           | Ok _ ->
-              ()
+              false
           | Error e ->
               [%log error] "error sending message on stream $idx: $error"
                 ~metadata:
                   [ ("idx", `String (Libp2p_ipc.stream_id_to_string stream_id))
                   ; ("error", Error_json.error_to_yojson e)
                   ] ;
-              Pipe.close outgoing_w )
+              Pipe.close outgoing_w ;
+              true )
     (* TODO implement proper stream closing *)
     (* >>= ( fun () ->
        match%map Libp2p_helper.do_rpc helper
@@ -207,7 +210,7 @@ let create_from_existing ~logger ~helper ~stream_id ~protocol ~peer
                ] ;
              ) *)
   in
-  upon send_outgoing_messages_task (fun () ->
+  upon send_outgoing_messages_task (fun _encountered_error ->
       let (`Stream_should_be_released should_release) =
         stream_closed ~logger ~who_closed:Us t
       in


### PR DESCRIPTION
Without this, we will attempt to send more enqueued messages, but if the stream has already failed then we've already decided to close it. This prevents a cascade of error messages like
```
2025-02-08 15:09:17 UTC [Error] error sending message on stream "20": $error
  error: {
  "string": "only wrote 0 out of 15 bytes error: libp2p error: stream reset"
  }
2025-02-08 15:09:17 UTC [Warn] RPC call error for "get_best_tip"

2025-02-08 15:09:17 UTC [Error] error sending message on stream "20": $error
  error: { "string": "internal RPC error: unknown stream_idx" }
2025-02-08 15:09:17 UTC [Error] error sending message on stream "20": $error
  error: { "string": "internal RPC error: unknown stream_idx" }
2025-02-08 15:09:17 UTC [Error] error sending message on stream "20": $error
  error: { "string": "internal RPC error: unknown stream_idx" }

```
