### PR TITLE
Simplify interface of persistent frontier worker

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -126,11 +126,14 @@ module Instance = struct
   let start_sync ~constraint_constants t ~persistent_root_instance =
     let open Result.Let_syntax in
     let%map () = assert_no_sync t in
+    let dequeue_snarked_ledger () =
+      Persistent_root.Instance.dequeue_snarked_ledger persistent_root_instance
+    in
     t.sync <-
       Some
         (Sync.create ~constraint_constants ~logger:t.factory.logger
            ~time_controller:t.factory.time_controller ~db:t.db
-           ~persistent_root_instance )
+           ~dequeue_snarked_ledger )
 
   let stop_sync t =
     let open Deferred.Let_syntax in

--- a/src/lib/transition_frontier/persistent_frontier/sync.ml
+++ b/src/lib/transition_frontier/persistent_frontier/sync.ml
@@ -8,8 +8,8 @@ let buffer t = Diff_buffer.Rev_dyn_array.to_list t.buffer.diff_array
 (* NB: the persistent frontier must remain open as
  * long as the synchronization is using it *)
 let create ~constraint_constants ~logger ~time_controller ~db
-    ~persistent_root_instance =
-  let worker = Worker.create { db; logger; persistent_root_instance } in
+    ~dequeue_snarked_ledger =
+  let worker = Worker.create { db; logger; dequeue_snarked_ledger } in
   let buffer =
     Diff_buffer.create ~constraint_constants ~time_controller ~worker
   in

--- a/src/lib/transition_frontier/persistent_frontier/sync.mli
+++ b/src/lib/transition_frontier/persistent_frontier/sync.mli
@@ -14,7 +14,7 @@ val create :
   -> logger:Logger.t
   -> time_controller:Block_time.Controller.t
   -> db:Database.t
-  -> persistent_root_instance:Persistent_root.Instance.t
+  -> dequeue_snarked_ledger:(unit -> unit)
   -> t
 
 val notify : t -> diffs:Diff.Lite.E.t list -> unit

--- a/src/lib/transition_frontier/persistent_frontier/worker.mli
+++ b/src/lib/transition_frontier/persistent_frontier/worker.mli
@@ -1,10 +1,7 @@
 open Frontier_base
 
 type create_args =
-  { db : Database.t
-  ; logger : Logger.t
-  ; persistent_root_instance : Persistent_root.Instance.t
-  }
+  { db : Database.t; logger : Logger.t; dequeue_snarked_ledger : unit -> unit }
 
 type input = Diff.Lite.E.t list
 


### PR DESCRIPTION
Use `dequeue_snarked_ledger` instead of persistent root instance when creating the worker.

This simplifies the future unit testing effort.

Explain how you tested your changes:
* [x] This is a tiny refactoring, tests passing on CI is a good enough measure of success

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None