### PR TITLE
Prioritize explicitly defined config files over magic config files loading

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1769,7 +1769,7 @@ module Json_loader : Json_loader_intf = struct
     let open Deferred.Or_error.Let_syntax in
     let config_files = List.map ~f:(fun a -> (a, `Must_exist)) config_files in
     let config_files =
-      get_magic_config_files ?conf_dir ?commit_id_short () @ config_files
+      config_files @ get_magic_config_files ?conf_dir ?commit_id_short ()
     in
     let%map config_jsons =
       let config_files_paths =


### PR DESCRIPTION
Reorder the loading of configuration files to ensure that explicitly specified files via command-line arguments or environment variables take precedence over magic config files, otherwise, these will never be picked up when magic config files exist.

For example, running `mina daemon --config-file /mina/sandbox.json ...` will result in this loading order:
```["/var/lib/coda/config_46a78df1.json","/root/.mina-config/daemon.json","/mina/sandbox.json"]```
By applying this fix, the loading order will change to:
```["/mina/sandbox.json","/var/lib/coda/config_46a78df1.json","/root/.mina-config/daemon.json"]```