### PR TITLE
Use public package names in compile config's dune

### DIFF
--- a/src/lib/mina_compile_config/dune
+++ b/src/lib/mina_compile_config/dune
@@ -1,7 +1,7 @@
 (library
  (name mina_compile_config)
  (public_name mina_compile_config)
- (libraries mina_node_config node_config_for_unit_tests core_kernel currency)
+ (libraries mina_node_config mina_node_config.for_unit_tests core_kernel currency)
  (instrumentation
   (backend bisect_ppx))
  (preprocess


### PR DESCRIPTION
Dune file of mina_compile_config package was referring to a library from another package by its internal name.

Explain how you tested your changes:
* `nix build '.?submodules=1#pkgs.mina_compile_config'` succeeds

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None