### PR TITLE
[CI] use mounted cache folder instead of gcloud

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -23,10 +23,13 @@ make -C src/app/libp2p_helper
 MAINNET_TARGETS=""
 [[ ${MINA_BUILD_MAINNET} ]] && MAINNET_TARGETS="src/app/cli/src/mina_mainnet_signatures.exe src/app/rosetta/rosetta_mainnet_signatures.exe src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe"
 
+. ./buildkite/scripts/storage/env.sh
+mkdir -p "${STORAGE_FOLDER}"
+
 echo "--- Build all major targets required for packaging"
 echo "Building from Commit SHA: ${MINA_COMMIT_SHA1}"
 echo "Rust Version: $(rustc --version)"
-dune build "--profile=${DUNE_PROFILE}" $INSTRUMENTED_PARAM \
+dune build "--build-dir=${STORAGE_FOLDER}" "--profile=${DUNE_PROFILE}" $INSTRUMENTED_PARAM \
   ${MAINNET_TARGETS} \
   src/app/logproc/logproc.exe \
   src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -21,10 +21,12 @@ else
    SUDO=""
 fi
 
-
-LOCAL_DEB_FOLDER=debs
-mkdir -p $LOCAL_DEB_FOLDER
 source ./buildkite/scripts/export-git-env-vars.sh
+source ./buildkite/scripts/storage/env.sh
+
+
+mkdir -p $STORAGE_FOLDER
+LOCAL_DEB_FOLDER=$STORAGE_FOLDER/debians
 
 # Download required debians from bucket locally
 if [ -z "$DEBS" ]; then 

--- a/buildkite/scripts/storage/env.sh
+++ b/buildkite/scripts/storage/env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function check_buildkite_vars() {
+    if [ ! -v "BUILDKITE_JOB_ID" ]; then
+        echo -e "Script is executed outside buildkite context.. BUILDKITE_JOB_ID env var not find \n";
+        exit 1
+    fi
+}
+
+function check_cache_exists() {
+    if ! test -d "$STORAGE_MOUNTPOINT"; then
+        echo -e "Cache directory does not exists (or permission denied) : '$STORAGE_MOUNTPOINT'\n";
+        exit 1
+    fi
+}
+
+check_buildkite_vars
+
+export STORAGE_MOUNTPOINT="/var/storagebox"
+export STORAGE_ROOT_FOLDER="buildkite/${BUILDKITE_JOB_ID}"
+export STORAGE_FOLDER="${STORAGE_MOUNTPOINT}/${STORAGE_ROOT_FOLDER}"
+
+
+check_cache_exists
+
+mkdir -p $STORAGE_FOLDER

--- a/buildkite/scripts/storage/manager.sh
+++ b/buildkite/scripts/storage/manager.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+# Script for reading and writing files to/from local agent persistent storage.
+# By default it uses /var/storagebox as a mount point.
+# It requires to be executed in buildkite context. e.g (BUILDKITE_JOB_ID env var to be defined)
+
+# bash strict mode
+set -T # inherit DEBUG and RETURN trap for functions
+set -C # prevent file overwrite by > &> <>
+set -E # inherit -e
+set -e # exit immediately on errors
+set -u # exit on not assigned variables
+set -o pipefail # exit on pipe failure
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+
+################################################################################
+# pre-setup
+################################################################################
+
+./buildkite/scripts/storage/env.sh
+
+################################################################################
+# global variable
+################################################################################
+CLI_VERSION='1.0.0';
+CLI_NAME="$0";
+PS4='debug($LINENO) ${FUNCNAME[0]:+${FUNCNAME[0]}}(): ';
+
+################################################################################
+# functions
+################################################################################
+
+function main_help(){
+    echo Read/Write file or files from/to CI cache which is supposed to be mounted to buildkite-agent 
+    echo "at '$CACHE_MOUNTPOINT'. Script requires to be executed in buildkite context. e.g (BUILDKITE_JOB_ID env var to be defined)".
+    echo ""
+    echo "     $CLI_NAME [operation]"
+    echo ""
+    echo "Sub-commands:"
+    echo ""
+    echo " read - read file/files from cache";
+    echo " write - write file/files to cache";
+    echo ""
+    exit "${1:-0}";
+}
+
+function version(){
+    echo $CLI_NAME $CLI_VERSION;
+    exit 0
+}
+
+#========
+# Read
+#========
+
+function read_help(){
+    echo Read file or files from CI cache which is supposed to be mounted to buildkite-agent 
+    echo "at '$CACHE_MOUNTPOINT'. Script requires to be executed in buildkite context. e.g (BUILDKITE_JOB_ID env var to be defined)".
+    echo ""
+    echo "     $CLI_NAME read [-options] INPUT_CACHE_LOCATION OUTPUT_LOCAL_LOCATION"
+    echo ""
+    echo "Parameters:"
+    echo ""
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-o  | --override" "[bool] override existing cached files";
+    printf "  %-25s %s\n" "-r  | --root" "[path] override cache root folder. WARNING it does not override cache mount point. Do not add leading slash at the beginning or end"; 
+    echo ""
+    echo "Values:"
+    echo ""
+    echo " INPUT_CACHE_LOCATION - path from which we will read (copy) cached artifact(s) (supports wildcard)"
+    echo " OUTPUT_LOCAL_LOCATION - local destination"
+    echo ""
+    echo "Example:"
+    echo ""
+    echo "  " $CLI_NAME read  /workdir  debians/mina-devnet*.deb
+    echo ""
+    echo " Above command will copy 'debians/mina-devnet*.deb' files from CACHE_MOUNTPOINT/BUILDKITE_JOB_ID/debians to /workdir"
+    echo ""
+    echo ""
+    exit 0
+}
+
+function read(){
+    if [[ ${#} == 0 ]]; then
+        read_help;
+    fi
+
+    local __override='-n'
+    local __root="$CACHE_ROOT_FOLDER"
+    local __skip_dirs_creation=0
+      
+    while [ ${#} -gt 0 ]; do
+        error_message="Error: a value is needed for '$1'";
+        case $1 in
+            -h | --help ) 
+                read_help;
+            ;;
+            -o | --override )
+               __override=''
+                shift 1;
+            ;;
+            -r | --root )
+                __root=${2:?$error_message}
+                shift 2;
+            ;;
+            -s | --skip-dirs-create )
+                __skip_dirs_creation=1
+                shift 1;
+            ;;
+            * )
+                if [ ! -v __from ]; then
+                   __from="$CACHE_MOUNTPOINT/$__root/$1"
+                   shift 1;
+                   continue
+                fi
+                
+                if [ ! -v __to ]; then
+                   __to="$1"
+                   shift 1;
+                   continue
+                fi
+                echo -e "${RED} !! Unknown option: $1${CLEAR}\n";
+                echo "";
+                read_help;
+            ;;
+        esac
+    done
+    
+
+    if [[ $__skip_dirs_creation == 1 ]]; then
+        echo "..Skipping dirs creation"
+    else 
+        mkdir -p "$__to"
+    fi
+
+    if ! test -d "$__to"; then
+        echo -e "${RED} !! local location does not exist (or permission denied) : '$__to' ${CLEAR}\n";
+        echo -e "${RED} HINT: allow to create local dirs disabling '--skip-dirs-create' ${CLEAR}\n";
+        exit 1
+    fi
+
+    echo "..Copying $__from -> $__to"
+
+    if ! cp -r $__override $__from $__to ; then
+        echo -e "${RED} !! There are some error while copying file to cache. Exiting... ${CLEAR}\n";
+        exit 2
+    fi
+}
+
+
+#==============
+# write
+#==============
+
+function write_help(){
+    echo Writes file to CI cache which is supposed to be mounted to buildkite-agent 
+    echo "at '$CACHE_MOUNTPOINT'. Script requires to be executed in buildkite context. e.g (BUILDKITE_JOB_ID env var to be defined)".  
+    echo ""
+    echo "     $CLI_NAME write [-options] INPUT_LOCAL_LOCATION OUTPUT_CACHE_LOCATION"
+    echo ""
+    echo ""
+    echo "Parameters:"
+    echo ""
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-g  | --override" "[bool] override existing files";
+    printf "  %-25s %s\n" "-g  | --root" "[path] override cache root folder. WARNING it does not override cache mount point. Do not add leading slash at the beginning or end.";
+    echo ""
+    echo "Values:"
+    echo ""
+    echo " INPUT_LOCAL_LOCATION - single or multiple files to write (supports wildcard)"
+    echo " OUTPUT_CACHE_LOCATION - destination at cache mount"
+    echo ""
+    echo "Example:"
+    echo ""
+    echo "  " $CLI_NAME write  mina-devnet*.deb debians/
+    echo ""
+    echo " Above command will write mina-devnet*.deb files to CACHE_MOUNTPOINT/BUILDKITE_JOB_ID/debians"
+    echo ""
+    echo ""
+    exit 0
+}
+
+
+function write(){
+    check_cache_exists
+
+    if [[ ${#} == 0 ]]; then
+        write_help;
+    fi
+
+    
+    local __override='-n'
+    local __root="$CACHE_ROOT_FOLDER"
+      
+    while [ ${#} -gt 0 ]; do
+        error_message="Error: a value is needed for '$1'";
+        case $1 in
+            -h | --help ) 
+                read_help;
+            ;;
+            -o | --override )
+               __override=''
+                shift 1;
+            ;;
+            -r | --root )
+                __root=${2:?$error_message}
+                shift 2;
+            ;;
+            * )
+                if [ ! -v __from ]; then
+                   __from="$1"
+                   shift 1;
+                   continue
+                fi
+
+                if [ ! -v __to ]; then
+                   __to=$CACHE_MOUNTPOINT/$__root/"$1"
+                   shift 1;
+                   continue
+                fi
+                echo -e "${RED} !! Unknown option: $1${CLEAR}\n";
+                echo "";
+                read_help;
+            ;;
+        esac
+    done
+    
+    if ! test -d "$__to"; then
+        echo ".. Cache folder does not exist : '$__to'. Creating ";
+        mkdir -p "$__to"
+    fi
+
+    echo "..Copying $__from -> $__to"
+    
+    if ! cp -r $__override $__from $__to ; then
+        echo -e "${RED} !! There are some error while copying file to cache. Exiting... ${CLEAR}\n";
+        exit 2
+    fi
+}
+
+function main(){
+    if (( ${#} == 0 )); then
+        main_help 0;
+    fi
+
+    case ${1} in
+        help )
+            main_help 0;
+        ;;
+        read | write )
+            $1 "${@:2}";
+        ;;
+        * )
+            echo -e "${RED} !! Unknown command: $1${CLEAR}\n";
+            main_help 1;
+        ;;
+    esac
+}
+
+main "$@";

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -140,7 +140,7 @@ let generateStep =
                 , commands = commands
                 , label = "Docker: ${spec.step_key}"
                 , key = spec.step_key
-                , target = Size.XLarge
+                , target = Size.QA
                 , docker_login = Some DockerLogin::{=}
                 , depends_on = spec.deps
                 , if = spec.if

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -98,7 +98,7 @@ let build_artifacts
                                                          spec.profile} ${BuildFlags.toSuffixUppercase
                                                                            spec.buildFlags}"
             , key = "build-deb-pkg"
-            , target = Size.XLarge
+            , target = Size.QA
             , retries =
               [ Command.Retry::{
                 , exit_status = Command.ExitStatus.Code +2

--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -71,11 +71,11 @@ let module =
                         = if docker.useBash then "/bin/bash" else "/bin/sh"
 
                     in  { line =
-                            "docker run -it --rm --entrypoint ${entrypoint} --init --volume /var/secrets:/var/secrets --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${      if docker.privileged
+                            "docker run -it --rm --entrypoint ${entrypoint} --init --volume /var/storagebox:/var/storagebox --volume /var/secrets:/var/secrets --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${      if docker.privileged
 
-                                                                                                                                                                                                                then  " --privileged"
+                                                                                                                                                                                                                                                         then  " --privileged"
 
-                                                                                                                                                                                                                else  ""} ${docker.image} -c '${inner.line}'"
+                                                                                                                                                                                                                                                         else  ""} ${docker.image} -c '${inner.line}'"
                         , readable =
                             Optional/map
                               Text
@@ -142,7 +142,7 @@ let tests =
       let dockerExample =
               assert
             :     { line =
-                      "docker run -it --rm --entrypoint /bin/bash --init --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello'"
+                      "docker run -it --rm --entrypoint /bin/bash --init --volume /var/storagebox:/var/storagebox --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello'"
                   , readable = Some "Docker@foo/bar:tag ( echo hello )"
                   }
               ===  M.inDocker
@@ -154,7 +154,7 @@ let tests =
 
       let cacheExample =
               assert
-            :     "./buildkite/scripts/cache-through.sh data.tar \"docker run -it --rm --entrypoint /bin/bash --init --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'\""
+            :     "./buildkite/scripts/cache-through.sh data.tar \"docker run -it --rm --entrypoint /bin/bash --init --volume /var/storagebox:/var/storagebox --volume /var/secrets:/var/secrets --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'\""
               ===  M.format
                      ( M.cacheThrough
                          M.Docker::{


### PR DESCRIPTION
Yojson's pretty printing creates a huge call stack using the built-in
OCaml list iterators. Since we're only printing an array of objects, we
can easily implement a tail-recursive version### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
