### PR TITLE
Fix granular nix compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -323,8 +323,8 @@
           granular = ocamlPackages.default;
           default = ocamlPackages.mina;
           inherit (pkgs)
-            libp2p_helper kimchi_bindings_stubs snarky_js validation
-            trace-tool zkapp-cli;
+            libp2p_helper kimchi_bindings_stubs snarky_js validation trace-tool
+            zkapp-cli;
           inherit (dockerImages)
             mina-image-slim mina-image-full mina-archive-image-full
             mina-image-instr-full;

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -208,8 +208,8 @@ let
         makefileTest "__src-lib-ppx_version-test__" super;
       tested.child_processes = super.tested.child_processes.overrideAttrs
         (s: { buildInputs = s.buildInputs ++ [ childProcessesTester ]; });
-      tested.block_storage =
-        super.tested.block_storage.overrideAttrs withLibp2pHelper;
+      tested.mina_lmdb_storage =
+        super.tested.mina_lmdb_storage.overrideAttrs withLibp2pHelper;
       tested.mina_lib = super.tested.mina_lib.overrideAttrs withLibp2pHelper;
       tested.mina_lib_tests =
         super.tested.mina_lib_tests.overrideAttrs withLibp2pHelper;

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -144,6 +144,7 @@ let
       mv _build/default/src/test/command_line_tests/command_line_tests.exe tests.exe
       chmod +x tests.exe
       export TMPDIR=tmp # to align with janestreet core library
+      export HOME=tmp # some commands rely on home directory
       mkdir -p $TMPDIR
       export MINA_LIBP2P_PASS="naughty blue worm"
       export MINA_PRIVKEY_PASS="naughty blue worm"

--- a/src/lib/disk_cache/dune
+++ b/src/lib/disk_cache/dune
@@ -1,4 +1,5 @@
 (library
+ (name disk_cache)
  (public_name disk_cache)
  (virtual_modules disk_cache)
  (default_implementation disk_cache.identity)

--- a/src/lib/proof_cache_tag/dune
+++ b/src/lib/proof_cache_tag/dune
@@ -1,4 +1,5 @@
 (library
+ (name proof_cache_tag)
  (public_name proof_cache_tag)
  (libraries
    ;; opam libraries


### PR DESCRIPTION
There were a number of changes to codebase that required an update to nix code related to _Granular nix_:

* `command_line_tests` relied on home directory to exist, which wasn't the case for the environment provided by nix testing
* `block_storage` was removed and `mina_lmdb_storage` was created as a replacement

Furthermore, two dune libraries were introduced that were not specifying `(name)` stanza in dune file. Dune's specification mentions it as an obligatory, however in presence of `public_name` dune handles this case well. While we could extend nix code to support that case in a similar way, this time it seemed easier to simply make the two new libraries to conform to what other dune libraries are doing.

Explain how you tested your changes:
* [x] `nix build --max-jobs 20 --cores 20 '.?submodules=1#granular'`
* [x] Successful [run](https://buildkite.com/o-1-labs-2/mina-nix-experimental/builds/51#0194f998-1bf8-40e4-a6cd-ea1103732b28) of experimental nix pipeline

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None