### PR TITLE
Fix promotion job : introduce from/to repo with accompanying key

### DIFF
--- a/buildkite/scripts/debian/promote.sh
+++ b/buildkite/scripts/debian/promote.sh
@@ -48,7 +48,13 @@ if [[ -z "$FROM_COMPONENT" ]]; then usage "Source component is not set!"; fi;
 if [[ -z "$TO_COMPONENT" ]]; then usage "Target component is not set!"; fi;
 if [[ -z "$REPO" ]]; then usage "Repository is not set!"; fi;
 if [[ -z "$NEW_REPO" ]]; then NEW_REPO=$REPO; fi;
-if [[ -z "$REPO_KEY" ]]; then usage "Target repository key is not set!"; fi;
+if [ -z "${REPO_KEY:-}" ]; then
+  SIGN_ARG=""
+else
+  sudo chown -R opam ~/.gnupg/
+  gpg --batch --yes --import /var/secrets/debian/key.gpg
+  SIGN_ARG="--sign $REPO_KEY"
+fi
 
 # check for AWS Creds
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
@@ -76,6 +82,6 @@ else
     --new-suite $TO_COMPONENT \
     --new-name $NEW_NAME \
     --repo $REPO \
-    --new-repo $NEW_REPO
-    --sign $REPO_KEY
+    --new-repo $NEW_REPO \
+    $SIGN_ARG
 fi

--- a/buildkite/scripts/run_promote_build_job.sh
+++ b/buildkite/scripts/run_promote_build_job.sh
@@ -33,7 +33,7 @@ PROMOTE_PACKAGE_DHALL_DEF="(./buildkite/src/Entrypoints/PromotePackage.dhall)"
 PROFILES_DHALL_DEF="(./buildkite/src/Constants/Profiles.dhall)"
 NETWORK_DHALL_DEF="(./buildkite/src/Constants/Network.dhall)"
 DEBIAN_CHANNEL_DHALL_DEF="(./buildkite/src/Constants/DebianChannel.dhall)"
-
+DEBIAN_REPO_DHALL_DEF="(./buildkite/src/Constants/DebianRepo.dhall)"
 
 function usage() {
   if [[ -n "$1" ]]; then
@@ -49,6 +49,8 @@ function usage() {
   echo "  NETWORK                     The Docker and Debian network (Devnet, Mainnet)"
   echo "  FROM_CHANNEL                Source debian channel"
   echo "  TO_CHANNEL                  Target debian channel"
+  echo "  FROM_REPO                   Source debian repository"
+  echo "  TO_REPO                     Target debian repository"
   echo "  PUBLISH                     The Publish to docker.io flag. If defined, script will publish docker do docker.io. Otherwise it will still resides in gcr.io"
   echo ""
   exit 1
@@ -66,6 +68,8 @@ if [[ -n "$DEBIANS" ]]; then
     if [[ -z "$PUBLISH" ]]; then PUBLISH=0; fi;
     if [[ -z "$FROM_CHANNEL" ]]; then FROM_CHANNEL="Unstable"; fi;
     if [[ -z "$TO_CHANNEL" ]]; then TO_CHANNEL="Unstable"; fi;
+    if [[ -z "$FROM_REPO" ]]; then FROM_REPO="PackagesO1Test"; fi;
+    if [[ -z "$TO_REPO" ]]; then TO_REPO="PackagesO1Test"; fi;
     if [[ -z "$FROM_VERSION" ]]; then usage "Version is not set!"; exit 1; fi;
     if [[ -z "$NEW_VERSION" ]]; then NEW_VERSION=$FROM_VERSION; fi;
     
@@ -112,4 +116,4 @@ if [[ "${REMOVE_PROFILE_FROM_NAME}" -eq 0 ]]; then
 else 
   REMOVE_PROFILE_FROM_NAME="True"
 fi 
-echo $PROMOTE_PACKAGE_DHALL_DEF'.promote_artifacts '"$DHALL_DEBIANS"' '"$DHALL_DOCKERS"' "'"${FROM_VERSION}"'" "'"${NEW_VERSION}"'" "amd64" '$PROFILES_DHALL_DEF'.Type.'"${PROFILE}"' '$NETWORK_DHALL_DEF'.Type.'"${NETWORK}"' '"${DHALL_CODENAMES}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${FROM_CHANNEL}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${TO_CHANNEL}"' "'"${NEW_VERSION}"'" '${REMOVE_PROFILE_FROM_NAME}' '${DHALL_PUBLISH}' ' | dhall-to-yaml --quoted 
+echo $PROMOTE_PACKAGE_DHALL_DEF'.promote_artifacts '"$DHALL_DEBIANS"' '"$DHALL_DOCKERS"' "'"${FROM_VERSION}"'" "'"${NEW_VERSION}"'" "amd64" '$PROFILES_DHALL_DEF'.Type.'"${PROFILE}"' '$NETWORK_DHALL_DEF'.Type.'"${NETWORK}"' '"${DHALL_CODENAMES}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${FROM_CHANNEL}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${TO_CHANNEL}"' '$DEBIAN_REPO_DHALL_DEF'.Type.'"${FROM_REPO}"' '$DEBIAN_REPO_DHALL_DEF'.Type.'"${TO_REPO}"' "'"${NEW_VERSION}"'" '${REMOVE_PROFILE_FROM_NAME}' '${DHALL_PUBLISH}' ' | dhall-to-yaml --quoted 

--- a/buildkite/scripts/run_verify_promoted_build_job.sh
+++ b/buildkite/scripts/run_verify_promoted_build_job.sh
@@ -33,6 +33,7 @@ PROMOTE_PACKAGE_DHALL_DEF="(./buildkite/src/Entrypoints/PromotePackage.dhall)"
 PROFILES_DHALL_DEF="(./buildkite/src/Constants/Profiles.dhall)"
 NETWORK_DHALL_DEF="(./buildkite/src/Constants/Network.dhall)"
 DEBIAN_CHANNEL_DHALL_DEF="(./buildkite/src/Constants/DebianChannel.dhall)"
+DEBIAN_REPO_DHALL_DEF="(./buildkite/src/Constants/DebianRepo.dhall)"
 
 
 function usage() {
@@ -47,6 +48,7 @@ function usage() {
   echo "  PROFILE                     The Docker and Debian profile (Standard, Lightnet)"
   echo "  NETWORK                     The Docker and Debian network (Devnet, Mainnet)"
   echo "  TO_CHANNEL                  Target debian channel"
+  echo "  TO_REPO                     Target debian repo"
   echo "  PUBLISH                     The Publish to docker.io flag. If defined, script will publish docker do docker.io. Otherwise it will still resides in gcr.io"
   echo ""
   exit 1
@@ -63,6 +65,7 @@ if [[ -n "$DEBIANS" ]]; then
     if [[ -z "$REMOVE_PROFILE_FROM_NAME" ]]; then REMOVE_PROFILE_FROM_NAME=0; fi;
     if [[ -z "$PUBLISH" ]]; then PUBLISH=0; fi;
     if [[ -z "$TO_CHANNEL" ]]; then TO_CHANNEL="Unstable"; fi;
+    if [[ -z "$TO_REPO" ]]; then TO_REPO="PackagesO1Test"; fi;
     if [[ -z "$NEW_VERSION" ]]; then NEW_VERSION=$FROM_VERSION; fi;
     
 
@@ -107,4 +110,4 @@ if [[ "${REMOVE_PROFILE_FROM_NAME}" -eq 0 ]]; then
 else 
   REMOVE_PROFILE_FROM_NAME="True"
 fi 
-echo $PROMOTE_PACKAGE_DHALL_DEF'.verify_artifacts '"$DHALL_DEBIANS"' '"$DHALL_DOCKERS"' "'"${NEW_VERSION}"'" '$PROFILES_DHALL_DEF'.Type.'"${PROFILE}"' '$NETWORK_DHALL_DEF'.Type.'"${NETWORK}"' '"${DHALL_CODENAMES}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${TO_CHANNEL}"' "'"${NEW_VERSION}"'" '${REMOVE_PROFILE_FROM_NAME}' '${DHALL_PUBLISH}' ' | dhall-to-yaml --quoted 
+echo $PROMOTE_PACKAGE_DHALL_DEF'.verify_artifacts '"$DHALL_DEBIANS"' '"$DHALL_DOCKERS"' "'"${NEW_VERSION}"'" '$PROFILES_DHALL_DEF'.Type.'"${PROFILE}"' '$NETWORK_DHALL_DEF'.Type.'"${NETWORK}"' '"${DHALL_CODENAMES}"' '$DEBIAN_CHANNEL_DHALL_DEF'.Type.'"${TO_CHANNEL}"' '$DEBIAN_REPO_DHALL_DEF'.Type.'"${TO_REPO}"' "'"${NEW_VERSION}"'" '${REMOVE_PROFILE_FROM_NAME}' '${DHALL_PUBLISH}' ' | dhall-to-yaml --quoted 

--- a/buildkite/src/Command/Promotion/PromotePackages.dhall
+++ b/buildkite/src/Command/Promotion/PromotePackages.dhall
@@ -22,6 +22,8 @@ let Artifact = ../../Constants/Artifacts.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
+let DebianRepo = ../../Constants/DebianRepo.dhall
+
 let PromoteDebian = ./PromoteDebian.dhall
 
 let PromoteDocker = ./PromoteDocker.dhall
@@ -44,6 +46,8 @@ let PromotePackagesSpec =
           , codenames : List DebianVersions.DebVersion
           , from_channel : DebianChannel.Type
           , to_channel : DebianChannel.Type
+          , source_debian_repo : DebianRepo.Type
+          , target_debian_repo : DebianRepo.Type
           , new_tags : List Text
           , remove_profile_from_name : Bool
           , publish : Bool
@@ -53,6 +57,8 @@ let PromotePackagesSpec =
           , dockers = [] : List Artifact.Type
           , version = ""
           , new_debian_version = ""
+          , source_debian_repo = DebianRepo.Type.Unstable
+          , target_debian_repo = DebianRepo.Type.Nightly
           , architecture = "amd64"
           , profile = Profiles.Type.Standard
           , network = Network.Type.Mainnet
@@ -88,6 +94,10 @@ let promotePackagesToDebianSpecs
                                 , codename = codename
                                 , from_channel = promote_packages.from_channel
                                 , to_channel = promote_packages.to_channel
+                                , source_repo =
+                                    promote_packages.source_debian_repo
+                                , target_repo =
+                                    promote_packages.target_debian_repo
                                 , remove_profile_from_name =
                                     promote_packages.remove_profile_from_name
                                 , step_key =

--- a/buildkite/src/Command/Promotion/VerifyDebian.dhall
+++ b/buildkite/src/Command/Promotion/VerifyDebian.dhall
@@ -33,9 +33,9 @@ let promoteDebianVerificationStep =
                 , commands =
                   [ Cmd.run
                       "source buildkite/scripts/export-git-env-vars.sh && ./scripts/debian/verify.sh --repo ${DebianRepo.bucket_or_default
-                                                                                                                spec.target_repo}--package ${name} --version ${spec.new_version} --codename ${DebianVersions.lowerName
-                                                                                                                                                                                                spec.codename}  --channel ${DebianChannel.lowerName
-                                                                                                                                                                                                                              spec.to_channel}"
+                                                                                                                spec.target_repo} --package ${name} --version ${spec.new_version} --codename ${DebianVersions.lowerName
+                                                                                                                                                                                                 spec.codename}  --channel ${DebianChannel.lowerName
+                                                                                                                                                                                                                               spec.to_channel}"
                   ]
                 , label = "Debian: ${spec.step_key}"
                 , key = spec.step_key

--- a/buildkite/src/Command/Promotion/VerifyDebian.dhall
+++ b/buildkite/src/Command/Promotion/VerifyDebian.dhall
@@ -32,10 +32,10 @@ let promoteDebianVerificationStep =
                 Command.Config::{
                 , commands =
                   [ Cmd.run
-                      "source buildkite/scripts/export-git-env-vars.sh && ./scripts/debian/verify.sh --bucket ${DebianRepo.bucket_or_default
-                                                                                                                  spec.target_repo}--package ${name} --version ${spec.new_version} --codename ${DebianVersions.lowerName
-                                                                                                                                                                                                  spec.codename}  --channel ${DebianChannel.lowerName
-                                                                                                                                                                                                                                spec.to_channel}"
+                      "source buildkite/scripts/export-git-env-vars.sh && ./scripts/debian/verify.sh --repo ${DebianRepo.bucket_or_default
+                                                                                                                spec.target_repo}--package ${name} --version ${spec.new_version} --codename ${DebianVersions.lowerName
+                                                                                                                                                                                                spec.codename}  --channel ${DebianChannel.lowerName
+                                                                                                                                                                                                                              spec.to_channel}"
                   ]
                 , label = "Debian: ${spec.step_key}"
                 , key = spec.step_key

--- a/buildkite/src/Command/Promotion/VerifyPackages.dhall
+++ b/buildkite/src/Command/Promotion/VerifyPackages.dhall
@@ -8,6 +8,8 @@ let List/map = Prelude.List.map
 
 let Package = ../../Constants/DebianPackage.dhall
 
+let DebianRepo = ../../Constants/DebianRepo.dhall
+
 let Network = ../../Constants/Network.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
@@ -42,6 +44,7 @@ let VerifyPackagesSpec =
           , debians : List Package.Type
           , dockers : List Artifact.Type
           , new_debian_version : Text
+          , debian_repo : DebianRepo.Type
           , profile : Profiles.Type
           , network : Network.Type
           , codenames : List DebianVersions.DebVersion
@@ -55,6 +58,7 @@ let VerifyPackagesSpec =
           , debians = [] : List Package.Type
           , dockers = [] : List Artifact.Type
           , new_debian_version = "\\\\\$MINA_DEB_VERSION"
+          , debian_repo = DebianRepo.Type.PackagesO1Test
           , profile = Profiles.Type.Standard
           , network = Network.Type.Mainnet
           , codenames = [] : List DebianVersions.DebVersion
@@ -139,6 +143,7 @@ let verifyPackagesToDebianSpecs
                                 , package = debian
                                 , new_version =
                                     verify_packages.new_debian_version
+                                , target_repo = verify_packages.debian_repo
                                 , network = verify_packages.network
                                 , codename = codename
                                 , to_channel = verify_packages.channel

--- a/buildkite/src/Entrypoints/PromotePackage.dhall
+++ b/buildkite/src/Entrypoints/PromotePackage.dhall
@@ -14,6 +14,8 @@ let Network = ../Constants/Network.dhall
 
 let DebianVersions = ../Constants/DebianVersions.dhall
 
+let DebianRepo = ../Constants/DebianRepo.dhall
+
 let Pipeline = ../Pipeline/Dsl.dhall
 
 let PipelineMode = ../Pipeline/Mode.dhall
@@ -29,6 +31,8 @@ let promote_artifacts =
       ->  \(codenames : List DebianVersions.DebVersion)
       ->  \(from_channel : DebianChannel.Type)
       ->  \(to_channel : DebianChannel.Type)
+      ->  \(from_repo : DebianRepo.Type)
+      ->  \(to_repo : DebianRepo.Type)
       ->  \(tag : Text)
       ->  \(remove_profile_from_name : Bool)
       ->  \(publish : Bool)
@@ -39,6 +43,8 @@ let promote_artifacts =
                 , version = version
                 , architecture = architecture
                 , new_debian_version = new_version
+                , source_debian_repo = from_repo
+                , target_debian_repo = to_repo
                 , profile = profile
                 , network = network
                 , codenames = codenames

--- a/buildkite/src/Entrypoints/PromotePackage.dhall
+++ b/buildkite/src/Entrypoints/PromotePackage.dhall
@@ -80,6 +80,7 @@ let verify_artifacts =
       ->  \(network : Network.Type)
       ->  \(codenames : List DebianVersions.DebVersion)
       ->  \(to_channel : DebianChannel.Type)
+      ->  \(repo : DebianRepo.Type)
       ->  \(tag : Text)
       ->  \(remove_profile_from_name : Bool)
       ->  \(publish : Bool)
@@ -89,6 +90,7 @@ let verify_artifacts =
                 , debians = debians
                 , dockers = dockers
                 , new_debian_version = new_version
+                , debian_repo = repo
                 , profile = profile
                 , network = network
                 , codenames = codenames

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -3,7 +3,6 @@ set -eox pipefail
 
 CLEAR='\033[0m'
 RED='\033[0;31m'
-BUCKET=packages.o1test.net
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -d|--deb) DEB="$2"; shift;;
@@ -52,7 +51,7 @@ if [[ -z "$RELEASE" ]]; then NEW_RELEASE=$RELEASE; fi;
 if [[ -z "$VERSION" ]]; then NEW_VERSION=$VERSION; fi;
 if [[ -z "$SUITE" ]]; then NEW_SUITE=$SUITE; fi;
 if [[ -z "$REPO" ]]; then echo "No repository specified"; echo ""; usage "$0" "$1" ; fi
-if [[ -z "$SIGN" ]]; then 
+if [ -z "${SIGN:-}" ]; then 
   SIGN_ARG=""
 else 
   SIGN_ARG="--sign $SIGN"
@@ -62,7 +61,7 @@ function rebuild_deb() {
   rm -f "${DEB}_${VERSION}.deb"
   rm -rf "${NEW_NAME}_${NEW_VERSION}"
     
-  wget https://s3.us-west-2.amazonaws.com/${BUCKET}/pool/${CODENAME}/m/mi/${DEB}_${VERSION}.deb
+  wget https://s3.us-west-2.amazonaws.com/${REPO}/pool/${CODENAME}/m/mi/${DEB}_${VERSION}.deb
   dpkg-deb -R "${DEB}_${VERSION}.deb" "${NEW_NAME}_${NEW_VERSION}"
   sed -i 's/Version: '"${VERSION}"'/Version: '"${NEW_VERSION}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
   sed -i 's/Package: '"${DEB}"'/Package: '"${NEW_NAME}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -8,6 +8,7 @@ BUCKET=packages.o1test.net
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -c|--channel) CHANNEL="$2"; shift;;
+  -r|--repo) BUCKET="$2"; shift;;
   -v|--version) VERSION="$2"; shift;;
   -p|--package) PACKAGE="$2"; shift;;
   -m|--codename) CODENAME="$2"; shift;;

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -4,15 +4,14 @@ set -eox pipefail
 CHANNEL=umt-mainnet
 VERSION=3.0.0-f872d85
 CODENAME=bullseye
-BUCKET=packages.o1test.net
+REPO=packages.o1test.net
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -c|--channel) CHANNEL="$2"; shift;;
-  -r|--repo) BUCKET="$2"; shift;;
+  -r|--repo) REPO="$2"; shift;;
   -v|--version) VERSION="$2"; shift;;
   -p|--package) PACKAGE="$2"; shift;;
   -m|--codename) CODENAME="$2"; shift;;
-  -b|--bucket) BUCKET="$2"; shift;;
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
@@ -32,7 +31,7 @@ SCRIPT=' set -x \
     && echo installing mina \
     && apt-get update > /dev/null \
     && apt-get install -y lsb-release ca-certificates > /dev/null \
-    && echo "deb [trusted=yes] https://'$BUCKET' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
+    && echo "deb [trusted=yes] https://'$REPO' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
     && apt-get update > /dev/null \
     && apt list -a '$PACKAGE' \
     && apt-get install -y --allow-downgrades '$PACKAGE'='$VERSION' \


### PR DESCRIPTION
Fixing promotion job after introducing multiple debian repo.  

Promotion job which is used rarely was lacking adjustment after code change for supporting signing debian packages. Main goal was not to change UX of promotion pipeline, so still PackagesO1Test is default debian repository for both source and target. 

Issue was caused by lack of repo-key propagation to promote.sh script. `Packages.o1test.net` debian repository is not signed therefore such key does not exist for it. 

There were two fixes possible:

- either completely remove repo-key and derived settings like sign etc, since currently used packages.o1test.net repository is not signed
- support signed repositories, which requires import correctly debian key locally (+ some gpg options) and expose setting for allowing cross debian repo promotion (currently code was kind of prepared for that, but disabled)

I decided to use second method as i was working couple last days on autompromotion for nightly, so was up to date with the code and wanted to use this opportunity to publish also packages to (un)stable.packages.apt.minaprotocol.com  .

Fix was to make repository key optional  depending on target repository where we want to place debian package. Consequence of this change was necessity to propagate target debian repository id from cli entrypoint through dhall files where we have also defined repo key (or its lack) to promote.sh and verify.sh scripts. This decision is based also on current plans to use signed and isolated debian repositories  (which holds only stable packages for example). I cherry picked code from autopromote branch mostly (https://github.com/MinaProtocol/mina/pull/16562). Unfortunately this change also introduced side changes which are not necessary but will help to solve merges in the future:
- rename bucket to repo
- allow to use FROM_REPO, TO_REPO env vars in promote pipeline to defined source, target repo, with defaults set to PackagesO1Test
