### PR TITLE
[CI] do not use deb-s3 for when the version is the same

### DIFF
--- a/buildkite/scripts/debian/promote.sh
+++ b/buildkite/scripts/debian/promote.sh
@@ -68,10 +68,7 @@ echo "Promoting debs: ${PACKAGE}_${VERSION} to Release: ${TO_COMPONENT} and Code
 # Promote the deb .
 # If this fails, attempt to remove the lockfile and retry.
 
-if [[ -z "$NEW_VERSION" ]] || [[ "$NEW_VERSION" == "$VERSION" ]]; then
-  deb-s3 copy --s3-region=us-west-2 --lock --bucket packages.o1test.net --preserve-versions --cache-control=max-age=120  $PACKAGE $CODENAME $TO_COMPONENT --versions $VERSION --arch $ARCH --component ${FROM_COMPONENT} --codename ${CODENAME}
-else
-  source scripts/debian/reversion.sh \
+source scripts/debian/reversion.sh \
     --deb $PACKAGE  \
     --codename $CODENAME \
     --new-release $TO_COMPONENT \
@@ -84,4 +81,3 @@ else
     --repo $REPO \
     --new-repo $NEW_REPO \
     $SIGN_ARG
-fi


### PR DESCRIPTION
Issue spotted while testing https://github.com/MinaProtocol/mina/pull/16633. If the source and target version are the same previously we were using deb-s3 copy. However this introduce small issues as it not updates SUITE attribute which we are trying to kepp in track when manually doing reversion (by downloading packages locally unwrapping it modifying Package file and uploading it again).

The ultimate solution would be to patch our forked version of deb-s3, but till now we will use our working version 