### PR TITLE
[Int tests] remove boilerplate code for fetching node and genesis keypair

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -71,8 +71,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let run network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
-    let receiver = Network.block_producer network "receiver" in
-    let observer = Network.block_producer network "observer" in
+    let receiver = Network.block_producer_exn network "receiver" in
+    let observer = Network.block_producer_exn network "observer" in
     let%bind receiver_pub_key = pub_key_of_node receiver in
     let empty_bps =
       Core.String.Map.remove

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -71,12 +71,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let run network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
-    let receiver =
-      Core.String.Map.find_exn (Network.block_producers network) "receiver"
-    in
-    let observer =
-      Core.String.Map.find_exn (Network.block_producers network) "observer"
-    in
+    let receiver = Network.block_producer network "receiver" in
+    let observer = Network.block_producer network "observer" in
     let%bind receiver_pub_key = pub_key_of_node receiver in
     let empty_bps =
       Core.String.Map.remove

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -35,13 +35,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node =
-      Core.String.Map.find_exn (Network.block_producers network) "node"
-    in
-    let bp_keypair =
-      (Core.String.Map.find_exn (Network.genesis_keypairs network) "node-key")
-        .keypair
-    in
+    let node = Network.block_producer network "node" in
+    let bp_keypair = (Network.genesis_keypair network "node-key").keypair in
     let bp_pk = bp_keypair.public_key |> Signature_lib.Public_key.compress in
     let bp_pk_account_id = Account_id.create bp_pk Token_id.default in
     let bp_original_balance = Currency.Amount.of_mina_string_exn "1000" in

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -35,8 +35,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node = Network.block_producer network "node" in
-    let bp_keypair = (Network.genesis_keypair network "node-key").keypair in
+    let node = Network.block_producer_exn network "node" in
+    let bp_keypair = (Network.genesis_keypair_exn network "node-key").keypair in
     let bp_pk = bp_keypair.public_key |> Signature_lib.Public_key.compress in
     let bp_pk_account_id = Account_id.create bp_pk Token_id.default in
     let bp_original_balance = Currency.Amount.of_mina_string_exn "1000" in

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -42,15 +42,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node_a =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
-    let node_b =
-      Core.String.Map.find_exn (Network.block_producers network) "node-b"
-    in
-    let node_c =
-      Core.String.Map.find_exn (Network.block_producers network) "node-c"
-    in
+    let node_a = Network.block_producer network "node-a" in
+    let node_b = Network.block_producer network "node-b" in
+    let node_c = Network.block_producer network "node-c" in
     let%bind _ =
       section "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 2))

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -42,9 +42,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node_a = Network.block_producer network "node-a" in
-    let node_b = Network.block_producer network "node-b" in
-    let node_c = Network.block_producer network "node-c" in
+    let node_a = Network.block_producer_exn network "node-a" in
+    let node_b = Network.block_producer_exn network "node-b" in
+    let node_c = Network.block_producer_exn network "node-c" in
     let%bind _ =
       section "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 2))

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -40,9 +40,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Core.String.Map.data (Network.all_mina_nodes network)) )
     in
     [%log info] "gossip_consistency test: done waiting for initializations" ;
-    let receiver_bp = Network.block_producer network "node-a" in
+    let receiver_bp = Network.block_producer_exn network "node-a" in
     let%bind receiver_pub_key = pub_key_of_node receiver_bp in
-    let sender_bp = Network.block_producer network "node-b" in
+    let sender_bp = Network.block_producer_exn network "node-b" in
     let%bind sender_pub_key = pub_key_of_node sender_bp in
     let num_payments = 3 in
     let fee = Currency.Fee.of_nanomina_int_exn 10_000_000 in

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -40,13 +40,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Core.String.Map.data (Network.all_mina_nodes network)) )
     in
     [%log info] "gossip_consistency test: done waiting for initializations" ;
-    let receiver_bp =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
+    let receiver_bp = Network.block_producer network "node-a" in
     let%bind receiver_pub_key = pub_key_of_node receiver_bp in
-    let sender_bp =
-      Core.String.Map.find_exn (Network.block_producers network) "node-b"
-    in
+    let sender_bp = Network.block_producer network "node-b" in
     let%bind sender_pub_key = pub_key_of_node sender_bp in
     let num_payments = 3 in
     let fee = Currency.Fee.of_nanomina_int_exn 10_000_000 in

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -219,16 +219,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node_a = Network.block_producer network "node-a" in
-    let node_b = Network.block_producer network "node-b" in
-    let fish1 = Network.genesis_keypair network "fish1" in
-    let fish2 = Network.genesis_keypair network "fish2" in
-    let timed1 = Network.genesis_keypair network "timed1" in
-    let timed2 = Network.genesis_keypair network "timed2" in
-    let timed3 = Network.genesis_keypair network "timed3" in
-    let timed4 = Network.genesis_keypair network "timed4" in
-    let timed5 = Network.genesis_keypair network "timed5" in
-    let vk_proof = Network.genesis_keypair network "vk-proof" in
+    let node_a = Network.block_producer_exn network "node-a" in
+    let node_b = Network.block_producer_exn network "node-b" in
+    let fish1 = Network.genesis_keypair_exn network "fish1" in
+    let fish2 = Network.genesis_keypair_exn network "fish2" in
+    let timed1 = Network.genesis_keypair_exn network "timed1" in
+    let timed2 = Network.genesis_keypair_exn network "timed2" in
+    let timed3 = Network.genesis_keypair_exn network "timed3" in
+    let timed4 = Network.genesis_keypair_exn network "timed4" in
+    let timed5 = Network.genesis_keypair_exn network "timed5" in
+    let vk_proof = Network.genesis_keypair_exn network "vk-proof" in
     let vk_impossible =
       Core.String.Map.find_exn
         (Network.genesis_keypairs network)

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -219,36 +219,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let node_a =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
-    let node_b =
-      Core.String.Map.find_exn (Network.block_producers network) "node-b"
-    in
-    let fish1 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish1"
-    in
-    let fish2 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish2"
-    in
-    let timed1 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "timed1"
-    in
-    let timed2 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "timed2"
-    in
-    let timed3 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "timed3"
-    in
-    let timed4 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "timed4"
-    in
-    let timed5 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "timed5"
-    in
-    let vk_proof =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "vk-proof"
-    in
+    let node_a = Network.block_producer network "node-a" in
+    let node_b = Network.block_producer network "node-b" in
+    let fish1 = Network.genesis_keypair network "fish1" in
+    let fish2 = Network.genesis_keypair network "fish2" in
+    let timed1 = Network.genesis_keypair network "timed1" in
+    let timed2 = Network.genesis_keypair network "timed2" in
+    let timed3 = Network.genesis_keypair network "timed3" in
+    let timed4 = Network.genesis_keypair network "timed4" in
+    let timed5 = Network.genesis_keypair network "timed5" in
+    let vk_proof = Network.genesis_keypair network "vk-proof" in
     let vk_impossible =
       Core.String.Map.find_exn
         (Network.genesis_keypairs network)

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -55,15 +55,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_initialize
               (Core.String.Map.data all_mina_nodes) ) )
     in
-    let node_a =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
-    let node_b =
-      Core.String.Map.find_exn (Network.block_producers network) "node-b"
-    in
-    let node_c =
-      Core.String.Map.find_exn (Network.block_producers network) "node-c"
-    in
+    let node_a = Network.block_producer network "node-a" in
+    let node_b = Network.block_producer network "node-b" in
+    let node_c = Network.block_producer network "node-c" in
     let%bind () =
       section_hard "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 1))

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -55,9 +55,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_initialize
               (Core.String.Map.data all_mina_nodes) ) )
     in
-    let node_a = Network.block_producer network "node-a" in
-    let node_b = Network.block_producer network "node-b" in
-    let node_c = Network.block_producer network "node-c" in
+    let node_a = Network.block_producer_exn network "node-a" in
+    let node_b = Network.block_producer_exn network "node-b" in
+    let node_c = Network.block_producer_exn network "node-c" in
     let%bind () =
       section_hard "blocks are produced"
         (wait_for t (Wait_condition.blocks_to_be_produced 1))

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -69,25 +69,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let untimed_node_a =
-      Core.String.Map.find_exn
-        (Network.block_producers network)
-        "untimed-node-a"
-    in
-    let untimed_node_b =
-      Core.String.Map.find_exn
-        (Network.block_producers network)
-        "untimed-node-b"
-    in
-    let timed_node_c =
-      Core.String.Map.find_exn (Network.block_producers network) "timed-node-c"
-    in
-    let fish1 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish1"
-    in
-    let fish2 =
-      Core.String.Map.find_exn (Network.genesis_keypairs network) "fish2"
-    in
+    let untimed_node_a = Network.block_producer network "untimed-node-a" in
+    let untimed_node_b = Network.block_producer network "untimed-node-b" in
+    let timed_node_c = Network.block_producer network "timed-node-c" in
+    let fish1 = Network.genesis_keypair network "fish1" in
+    let fish2 = Network.genesis_keypair network "fish2" in
     (* hardcoded values of the balances of fish1 (receiver) and fish2 (sender), update here if they change in the config *)
     (* TODO undo the harcoding, don't be lazy and just make the graphql commands to fetch the balances *)
     let receiver_original_balance = Currency.Amount.of_mina_string_exn "100" in
@@ -99,19 +85,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          ~f:(fun { Signature_lib.Keypair.public_key; _ } ->
            public_key |> Signature_lib.Public_key.to_bigstring
            |> Bigstring.to_string ) ) ;
-    let snark_coordinator =
-      Core.String.Map.find_exn (Network.all_nodes network) "snark-node"
-    in
-    let snark_node_key1 =
-      Core.String.Map.find_exn
-        (Network.genesis_keypairs network)
-        "snark-node-key1"
-    in
-    let snark_node_key2 =
-      Core.String.Map.find_exn
-        (Network.genesis_keypairs network)
-        "snark-node-key2"
-    in
+    let snark_coordinator = Network.node network "snark-node" in
+    let snark_node_key1 = Network.genesis_keypair network "snark-node-key1" in
+    let snark_node_key2 = Network.genesis_keypair network "snark-node-key2" in
+
     [%log info] "snark node keypairs: %s"
       (List.to_string [ snark_node_key1.keypair; snark_node_key2.keypair ]
          ~f:(fun { Signature_lib.Keypair.public_key; _ } ->

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -69,11 +69,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (Wait_condition.nodes_to_initialize
            (Core.String.Map.data all_mina_nodes) )
     in
-    let untimed_node_a = Network.block_producer network "untimed-node-a" in
-    let untimed_node_b = Network.block_producer network "untimed-node-b" in
-    let timed_node_c = Network.block_producer network "timed-node-c" in
-    let fish1 = Network.genesis_keypair network "fish1" in
-    let fish2 = Network.genesis_keypair network "fish2" in
+    let untimed_node_a = Network.block_producer_exn network "untimed-node-a" in
+    let untimed_node_b = Network.block_producer_exn network "untimed-node-b" in
+    let timed_node_c = Network.block_producer_exn network "timed-node-c" in
+    let fish1 = Network.genesis_keypair_exn network "fish1" in
+    let fish2 = Network.genesis_keypair_exn network "fish2" in
     (* hardcoded values of the balances of fish1 (receiver) and fish2 (sender), update here if they change in the config *)
     (* TODO undo the harcoding, don't be lazy and just make the graphql commands to fetch the balances *)
     let receiver_original_balance = Currency.Amount.of_mina_string_exn "100" in
@@ -85,9 +85,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          ~f:(fun { Signature_lib.Keypair.public_key; _ } ->
            public_key |> Signature_lib.Public_key.to_bigstring
            |> Bigstring.to_string ) ) ;
-    let snark_coordinator = Network.node network "snark-node" in
-    let snark_node_key1 = Network.genesis_keypair network "snark-node-key1" in
-    let snark_node_key2 = Network.genesis_keypair network "snark-node-key2" in
+    let snark_coordinator = Network.node_exn network "snark-node" in
+    let snark_node_key1 =
+      Network.genesis_keypair_exn network "snark-node-key1"
+    in
+    let snark_node_key2 =
+      Network.genesis_keypair_exn network "snark-node-key2"
+    in
 
     [%log info] "snark node keypairs: %s"
       (List.to_string [ snark_node_key1.keypair; snark_node_key2.keypair ]

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -74,10 +74,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let num_slots = slot_chain_end + 2 in
-    let receiver = Network.block_producer network "receiver" in
+    let receiver = Network.block_producer_exn network "receiver" in
     let%bind receiver_pub_key = pub_key_of_node receiver in
     let bp_senders =
-      String.Map.remove (Network.block_producer network "receiver")
+      String.Map.remove (Network.block_producers network) "receiver"
       |> String.Map.data
     in
     let sender_kps =

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -74,12 +74,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let num_slots = slot_chain_end + 2 in
-    let receiver =
-      String.Map.find_exn (Network.block_producers network) "receiver"
-    in
+    let receiver = Network.block_producer network "receiver" in
     let%bind receiver_pub_key = pub_key_of_node receiver in
     let bp_senders =
-      String.Map.remove (Network.block_producers network) "receiver"
+      String.Map.remove (Network.block_producer network "receiver")
       |> String.Map.data
     in
     let sender_kps =

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -105,7 +105,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_initialize
               (Core.String.Map.data (Network.all_mina_nodes network)) ) )
     in
-    let whale1 = Network.block_producer network "whale1" in
+    let whale1 = Network.block_producer_exn network "whale1" in
     let%bind whale1_pk = pub_key_of_node whale1 in
     let%bind whale1_sk = priv_key_of_node whale1 in
     let constraint_constants = Network.constraint_constants network in

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -105,9 +105,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Wait_condition.nodes_to_initialize
               (Core.String.Map.data (Network.all_mina_nodes network)) ) )
     in
-    let whale1 =
-      Core.String.Map.find_exn (Network.block_producers network) "whale1"
-    in
+    let whale1 = Network.block_producer network "whale1" in
     let%bind whale1_pk = pub_key_of_node whale1 in
     let%bind whale1_sk = priv_key_of_node whale1 in
     let constraint_constants = Network.constraint_constants network in

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -139,18 +139,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ( Wait_condition.nodes_to_initialize
            @@ (Network.all_mina_nodes network |> Core.String.Map.data) ) )
     in
-    let node =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
+    let node = Network.block_producer network "node-a" in
     let constraint_constants = Network.constraint_constants network in
-    let fish1_kp =
-      (Core.String.Map.find_exn (Network.genesis_keypairs network) "fish1")
-        .keypair
-    in
-    let fish2_kp =
-      (Core.String.Map.find_exn (Network.genesis_keypairs network) "fish2")
-        .keypair
-    in
+    let fish1_kp = (Network.genesis_keypair network "fish1").keypair in
+    let fish2_kp = (Network.genesis_keypair network "fish2").keypair in
     let num_zkapp_accounts = 3 in
     let zkapp_keypairs =
       List.init num_zkapp_accounts ~f:(fun _ -> Signature_lib.Keypair.create ())

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -139,10 +139,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ( Wait_condition.nodes_to_initialize
            @@ (Network.all_mina_nodes network |> Core.String.Map.data) ) )
     in
-    let node = Network.block_producer network "node-a" in
+    let node = Network.block_producer_exn network "node-a" in
     let constraint_constants = Network.constraint_constants network in
-    let fish1_kp = (Network.genesis_keypair network "fish1").keypair in
-    let fish2_kp = (Network.genesis_keypair network "fish2").keypair in
+    let fish1_kp = (Network.genesis_keypair_exn network "fish1").keypair in
+    let fish2_kp = (Network.genesis_keypair_exn network "fish2").keypair in
     let num_zkapp_accounts = 3 in
     let zkapp_keypairs =
       List.init num_zkapp_accounts ~f:(fun _ -> Signature_lib.Keypair.create ())

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -99,13 +99,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let block_producer_nodes =
       Network.block_producers network |> Core.String.Map.data
     in
-    let node =
-      Core.String.Map.find_exn (Network.block_producers network) "node-a"
-    in
-    let fish1_kp =
-      (Core.String.Map.find_exn (Network.genesis_keypairs network) "fish1")
-        .keypair
-    in
+    let node = Network.block_producer network "node-a" in
+    let fish1_kp = (Network.genesis_keypair network "fish1").keypair in
     let fish1_pk = Signature_lib.Public_key.compress fish1_kp.public_key in
     let fish1_account_id =
       Mina_base.Account_id.create fish1_pk Mina_base.Token_id.default

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -99,8 +99,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let block_producer_nodes =
       Network.block_producers network |> Core.String.Map.data
     in
-    let node = Network.block_producer network "node-a" in
-    let fish1_kp = (Network.genesis_keypair network "fish1").keypair in
+    let node = Network.block_producer_exn network "node-a" in
+    let fish1_kp = (Network.genesis_keypair_exn network "fish1").keypair in
     let fish1_pk = Signature_lib.Public_key.compress fish1_kp.public_key in
     let fish1_account_id =
       Mina_base.Account_id.create fish1_pk Mina_base.Token_id.default

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -96,6 +96,8 @@ module Engine = struct
 
     val block_producers : t -> Node.t Core.String.Map.t
 
+    val block_producer_exn : t -> String.t -> Node.t
+
     val snark_coordinators : t -> Node.t Core.String.Map.t
 
     val archive_nodes : t -> Node.t Core.String.Map.t
@@ -104,7 +106,11 @@ module Engine = struct
 
     val all_nodes : t -> Node.t Core.String.Map.t
 
+    val node_exn : t -> String.t -> Node.t
+
     val genesis_keypairs : t -> Network_keypair.t Core.String.Map.t
+
+    val genesis_keypair_exn : t -> String.t -> Network_keypair.t
 
     val initialize_infra : logger:Logger.t -> t -> unit Malleable_error.t
   end

--- a/src/lib/integration_test_local_engine/docker_network.ml
+++ b/src/lib/integration_test_local_engine/docker_network.ml
@@ -320,7 +320,16 @@ let all_non_seed_nodes t =
     ]
   |> Core.String.Map.of_alist_exn
 
+let node t key = 
+  Core.String.Map.find_exn (all_nodes t) key
+
+let block_producer t key =
+  Core.String.Map.find_exn (block_producers t) key
+
 let genesis_keypairs { genesis_keypairs; _ } = genesis_keypairs
+
+let genesis_keypair t key = 
+  Core.String.Map.find_exn (Network.genesis_keypairs t) key
 
 let all_ids t =
   let deployments = all_nodes t |> Core.Map.to_alist in

--- a/src/lib/integration_test_local_engine/docker_network.ml
+++ b/src/lib/integration_test_local_engine/docker_network.ml
@@ -320,16 +320,14 @@ let all_non_seed_nodes t =
     ]
   |> Core.String.Map.of_alist_exn
 
-let node t key = 
-  Core.String.Map.find_exn (all_nodes t) key
+let node_exn t key = Core.String.Map.find_exn (all_nodes t) key
 
-let block_producer t key =
-  Core.String.Map.find_exn (block_producers t) key
+let block_producer_exn t key = Core.String.Map.find_exn (block_producers t) key
 
 let genesis_keypairs { genesis_keypairs; _ } = genesis_keypairs
 
-let genesis_keypair t key = 
-  Core.String.Map.find_exn (Network.genesis_keypairs t) key
+let genesis_keypair_exn t key =
+  Core.String.Map.find_exn (genesis_keypairs t) key
 
 let all_ids t =
   let deployments = all_nodes t |> Core.Map.to_alist in


### PR DESCRIPTION
During integration tests debugging i found it handy to squash boilerplate code for fetching node or keypair from 3 lines to a single one. 

No behavior was changed, purely cosmetic PR