### PR TITLE
[single node tests] use float comparision instead of flaky string comparision

### DIFF
--- a/src/test/command_line_tests/command_line_tests.ml
+++ b/src/test/command_line_tests/command_line_tests.ml
@@ -89,7 +89,7 @@ module CliTests = struct
       let actual = Scanf.sscanf output "MINA : %f" (fun actual -> actual) in
       let total_currency_float = float_of_int total_currency /. 1000000000.0 in
       assert_don't_contain_log_output output ;
-      if not (Float.equal total_currency_float actual) then
+      if not Float.(abs (total_currency_float - actual) < 0.001) then
         failwithf "invalid mina total count %f vs %f" total_currency_float
           actual () ;
       return ()

--- a/src/test/command_line_tests/command_line_tests.ml
+++ b/src/test/command_line_tests/command_line_tests.ml
@@ -86,14 +86,12 @@ module CliTests = struct
         |> List.sum (module Int) ~f:Fn.id
       in
       let%bind output = MinaCli.ledger_currency mina_cli ~ledger_file in
+      let actual = Scanf.sscanf output "MINA : %f" (fun actual -> actual) in
       let total_currency_float = float_of_int total_currency /. 1000000000.0 in
-      let total_currency_string =
-        Printf.sprintf "MINA: %.9f" total_currency_float
-      in
       assert_don't_contain_log_output output ;
-      if not (String.equal total_currency_string (String.strip output)) then
-        failwithf "invalid mina total count %s vs %s" total_currency_string
-          output () ;
+      if not (Float.equal total_currency_float actual) then
+        failwithf "invalid mina total count %f vs %f" total_currency_float
+          actual () ;
       return ()
     in
     run test_case mina_path


### PR DESCRIPTION
Single node test was flaky due to relying on string comparision on ledger currency test like here: 

https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/36424#019493cb-40be-4294-bb92-d0826c56786f

Now comparision is relying on float representation.