### PR TITLE
[CI][Refactoring] Use variant in place of plain string 

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -24,7 +24,7 @@ let ReleaseSpec =
       { Type =
           { deps : List Command.TaggedKey.Type
           , network : Text
-          , service : Text
+          , service : Artifacts.Type
           , version : Text
           , branch : Text
           , repo : Text
@@ -42,7 +42,7 @@ let ReleaseSpec =
           { deps = [] : List Command.TaggedKey.Type
           , network = "devnet"
           , version = "\\\${MINA_DOCKER_TAG}"
-          , service = Artifacts.dockerName Artifacts.Type.Daemon
+          , service = Artifacts.Type.Daemon
           , branch = "\\\${BUILDKITE_BRANCH}"
           , repo = "\\\${BUILDKITE_REPO}"
           , deb_codename = "bullseye"
@@ -65,7 +65,7 @@ let generateStep =
 
           let buildDockerCmd =
                     "./scripts/docker/build.sh"
-                ++  " --service ${spec.service}"
+                ++  " --service ${Artifacts.dockerName spec.service}"
                 ++  " --network ${spec.network}"
                 ++  " --version ${spec.version}"
                 ++  " --branch ${spec.branch}"
@@ -81,7 +81,7 @@ let generateStep =
 
           let releaseDockerCmd =
                     "./scripts/docker/release.sh"
-                ++  " --service ${spec.service}"
+                ++  " --service ${Artifacts.dockerName spec.service}"
                 ++  " --version ${spec.version}"
                 ++  " --network ${spec.network}"
                 ++  " --deb-codename ${spec.deb_codename}"

--- a/buildkite/src/Command/HardforkPackageGeneration.dhall
+++ b/buildkite/src/Command/HardforkPackageGeneration.dhall
@@ -159,7 +159,7 @@ let pipeline
                     DockerImage.ReleaseSpec::{
                     , deps =
                       [ { name = pipelineName, key = generateLedgersJobKey } ]
-                    , service = Artifacts.dockerName Artifacts.Type.Daemon
+                    , service = Artifacts.Type.Daemon
                     , network = network_name
                     , deb_codename = "${DebianVersions.lowerName debVersion}"
                     , deb_profile = profile
@@ -214,7 +214,7 @@ let pipeline
                     DockerImage.ReleaseSpec::{
                     , deps =
                       [ { name = pipelineName, key = generateLedgersJobKey } ]
-                    , service = Artifacts.dockerName Artifacts.Type.Archive
+                    , service = Artifacts.Type.Archive
                     , network = network_name
                     , deb_codename = "${DebianVersions.lowerName debVersion}"
                     , deb_profile = profile
@@ -228,7 +228,7 @@ let pipeline
                     DockerImage.ReleaseSpec::{
                     , deps =
                       [ { name = pipelineName, key = generateLedgersJobKey } ]
-                    , service = Artifacts.dockerName Artifacts.Type.Rosetta
+                    , service = Artifacts.Type.Rosetta
                     , network = network_name
                     , deb_repo = DebianRepo.Type.Local
                     , deb_codename = "${DebianVersions.lowerName debVersion}"

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -157,8 +157,7 @@ let docker_step
                       (     \(n : Network.Type)
                         ->  DockerImage.ReleaseSpec::{
                             , deps = deps
-                            , service =
-                                Artifacts.dockerName Artifacts.Type.Daemon
+                            , service = Artifacts.Type.Daemon
                             , network = Network.lowerName n
                             , deb_codename =
                                 "${DebianVersions.lowerName spec.debVersion}"
@@ -179,7 +178,7 @@ let docker_step
                 , BatchTxn =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps
-                    , service = "mina-batch-txn"
+                    , service = Artifacts.Type.BatchTxn
                     , network = "berkeley"
                     , deb_codename =
                         "${DebianVersions.lowerName spec.debVersion}"
@@ -195,7 +194,7 @@ let docker_step
                 , Archive =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps
-                    , service = "mina-archive"
+                    , service = Artifacts.Type.Archive
                     , deb_codename =
                         "${DebianVersions.lowerName spec.debVersion}"
                     , deb_profile = spec.profile
@@ -215,8 +214,7 @@ let docker_step
                       (     \(n : Network.Type)
                         ->  DockerImage.ReleaseSpec::{
                             , deps = deps
-                            , service =
-                                Artifacts.dockerName Artifacts.Type.Rosetta
+                            , service = Artifacts.Type.Rosetta
                             , network = Network.lowerName n
                             , deb_codename =
                                 "${DebianVersions.lowerName spec.debVersion}"
@@ -234,7 +232,7 @@ let docker_step
                 , ZkappTestTransaction =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps
-                    , service = "mina-zkapp-test-transaction"
+                    , service = Artifacts.Type.ZkappTestTransaction
                     , build_flags = spec.buildFlags
                     , deb_repo = DebianRepo.Type.Local
                     , deb_profile = spec.profile
@@ -250,7 +248,7 @@ let docker_step
                 , FunctionalTestSuite =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps
-                    , service = "mina-test-suite"
+                    , service = Artifacts.Type.FunctionalTestSuite
                     , deb_codename =
                         "${DebianVersions.lowerName spec.debVersion}"
                     , build_flags = spec.buildFlags
@@ -264,6 +262,8 @@ let docker_step
                     , network = "berkeley"
                     }
                   ]
+                , Toolchain = [] : List DockerImage.ReleaseSpec.Type
+                , ItnOrchestrator = [] : List DockerImage.ReleaseSpec.Type
                 }
                 artifact
 

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -18,6 +18,8 @@ let Artifact
       | Rosetta
       | ZkappTestTransaction
       | FunctionalTestSuite
+      | Toolchain
+      | ItnOrchestrator
       >
 
 let AllButTests =
@@ -28,12 +30,14 @@ let AllButTests =
       , Artifact.TestExecutive
       , Artifact.Rosetta
       , Artifact.ZkappTestTransaction
+      , Artifact.Toolchain
+      , Artifact.ItnOrchestrator
       ]
 
 let Main =
       [ Artifact.Daemon, Artifact.LogProc, Artifact.Archive, Artifact.Rosetta ]
 
-let All = AllButTests # [ Artifact.FunctionalTestSuite ]
+let All = AllButTests # [ Artifact.FunctionalTestSuite, Artifact.Toolchain ]
 
 let capitalName =
           \(artifact : Artifact)
@@ -46,6 +50,8 @@ let capitalName =
             , Rosetta = "Rosetta"
             , ZkappTestTransaction = "ZkappTestTransaction"
             , FunctionalTestSuite = "FunctionalTestSuite"
+            , Toolchain = "Toolchain"
+            , ItnOrchestrator = "ItnOrchestrator"
             }
             artifact
 
@@ -60,6 +66,8 @@ let lowerName =
             , Rosetta = "rosetta"
             , ZkappTestTransaction = "zkapp_test_transaction"
             , FunctionalTestSuite = "functional_test_suite"
+            , Toolchain = "toolchain"
+            , ItnOrchestrator = "itn_orchestrator"
             }
             artifact
 
@@ -74,6 +82,8 @@ let dockerName =
             , Rosetta = "mina-rosetta"
             , ZkappTestTransaction = "mina-zkapp-test-transaction"
             , FunctionalTestSuite = "mina-test-suite"
+            , Toolchain = "mina-toolchain"
+            , ItnOrchestrator = "itn-orchestrator"
             }
             artifact
 
@@ -89,6 +99,8 @@ let toDebianName =
             , Rosetta = "rosetta_${Network.lowerName network}"
             , ZkappTestTransaction = "zkapp_test_transaction"
             , FunctionalTestSuite = "functional_test_suite"
+            , Toolchain = ""
+            , ItnOrchestrator = ""
             }
             artifact
 
@@ -121,6 +133,8 @@ let toDebianNames =
                                 networks
                           , ZkappTestTransaction = [ "zkapp_test_transaction" ]
                           , FunctionalTestSuite = [ "functional_test_suite" ]
+                          , Toolchain = [] : List Text
+                          , ItnOrchestrator = [] : List Text
                           }
                           a
                   )
@@ -165,6 +179,8 @@ let dockerTag =
                     "${version_and_codename}-${Network.lowerName network}"
                 , ZkappTestTransaction = "${version_and_codename}"
                 , FunctionalTestSuite = "${version_and_codename}"
+                , Toolchain = "${version_and_codename}"
+                , ItnOrchestrator = "${version_and_codename}"
                 }
                 artifact
 

--- a/buildkite/src/Jobs/Release/ItnOrchestratorArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ItnOrchestratorArtifact.dhall
@@ -14,9 +14,11 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let DebianRepo = ../../Constants/DebianRepo.dhall
 
+let Artifacts = ../../Constants/Artifacts.dhall
+
 let spec =
       DockerImage.ReleaseSpec::{
-      , service = "itn-orchestrator"
+      , service = Artifacts.Type.ItnOrchestrator
       , step_key = "itn-orchestrator-docker-image"
       , network = "berkeley"
       , deb_repo = DebianRepo.Type.Local

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
@@ -8,6 +8,8 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
+let Artifacts = ../../Constants/Artifacts.dhall
+
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -27,7 +29,7 @@ in  Pipeline.build
       , steps =
         [ let toolchainBullseyeSpec =
                 DockerImage.ReleaseSpec::{
-                , service = "mina-toolchain"
+                , service = Artifacts.Type.Toolchain
                 , deb_codename = "bullseye"
                 , no_cache = True
                 , step_key = "toolchain-bullseye-docker-image"

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
@@ -8,6 +8,8 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
+let Artifacts = ../../Constants/Artifacts.dhall
+
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -27,7 +29,7 @@ in  Pipeline.build
       , steps =
         [ let toolchainSpec =
                 DockerImage.ReleaseSpec::{
-                , service = "mina-toolchain"
+                , service = Artifacts.Type.Toolchain
                 , deb_codename = "focal"
                 , no_cache = True
                 , step_key = "toolchain-focal-docker-image"


### PR DESCRIPTION
Refactoring which will open door for logic in https://github.com/MinaProtocol/mina/pull/16392 and more. Basically I moved all docker build commands to MinaArtifacts and convert service attribute from Text to Artifact.Type. This should help adding any logic on top of Artifacts.Type