### PR TITLE
Kimchi-bindings: use UnsafeCell

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -72,7 +72,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
             .collect()
     };
 
-    let witness: Vec<Vec<_>> = witness.iter().map(|x| (*x.0).clone()).collect();
+    let witness: Vec<Vec<_>> = witness.iter().map(|x| (**x).clone()).collect();
     let witness: [Vec<_>; COLUMNS] = witness
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
@@ -140,7 +140,7 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
             .collect()
     };
 
-    let witness: Vec<Vec<_>> = witness.iter().map(|x| (*x.0).clone()).collect();
+    let witness: Vec<Vec<_>> = witness.iter().map(|x| (**x).clone()).collect();
     let witness: [Vec<_>; COLUMNS] = witness
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -66,7 +66,7 @@ pub fn caml_pasta_fq_plonk_proof_create(
             .collect()
     };
 
-    let witness: Vec<Vec<_>> = witness.iter().map(|x| (*x.0).clone()).collect();
+    let witness: Vec<Vec<_>> = witness.iter().map(|x| (**x).clone()).collect();
     let witness: [Vec<_>; COLUMNS] = witness
         .try_into()
         .expect("the witness should be a column of 15 vectors");


### PR DESCRIPTION
Coming from 2ec9256db104760f3538c086a56cc385f1347f7c

If we don't have this update, Rust complains when updating to 1.74.
To convince yourself, update rust-toolchain.toml in kimchi_bindings/stubs to 1.74, and see the error when building.

This is a first step to update Rust in Mina to newer versions.
Doing it gradually.