### PR TITLE
Decoupling Daemon External Port from healthcheck script

### DIFF
--- a/dockerfiles/scripts/healthcheck-utilities.sh
+++ b/dockerfiles/scripts/healthcheck-utilities.sh
@@ -1,10 +1,14 @@
 #
 # Determine whether a local daemon is SYNCed with its network
 #
+"${DAEMON_EXTERNAL_PORT:=3085}"
 
 function updateSyncStatusLabel() {
     status=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { syncStatus } " }' localhost:3085/graphql | \
+        curl --silent --show-error \
+            --header "Content-Type:application/json" \
+            -d'{ "query": "query { syncStatus } " }' \
+            "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.syncStatus'
     )
     str=$(echo ${status} | sed 's/"//g' )
@@ -13,7 +17,10 @@ function updateSyncStatusLabel() {
 
 function isDaemonSynced() {
     status=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { syncStatus } " }' localhost:3085/graphql | \
+        curl --silent --show-error \
+            --header "Content-Type:application/json" \
+            -d'{ "query": "query { syncStatus } " }' \
+            "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.syncStatus'
     )
     case ${status} in
@@ -27,14 +34,6 @@ function isDaemonSynced() {
         return 0
         ;;
       *)
-        DAEMON_CONFIG="/root/daemon.json"
-        if [ -f "$DAEMON_CONFIG" ]; then
-            now=$(date +%s)
-            timestamp=$(grep 'timestamp' ${DAEMON_CONFIG} | awk '{print $2}' | sed -e s/\"//g)
-            timestamp_second=$(date -d ${timestamp} +%s)
-
-            [[ $now -le $timestamp_seconds ]] && return 0 # special case to claim synced before the genesis timestamp
-        fi
         echo "Daemon is out of sync with status: ${status}"
 
         return 1
@@ -46,12 +45,12 @@ function isDaemonSynced() {
 #
 function isChainlengthHighestReceived() {
     chainLength=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { blockchainLength } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { blockchainLength } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.blockchainLength'
     )
 
     highestReceived=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.highestBlockLengthReceived'
     )
     
@@ -65,7 +64,7 @@ function isChainlengthHighestReceived() {
 function peerCountGreaterThan() {
     peerCountMinThreshold=${1:-2}
     peerCount=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { peers } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { peers } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.peers | length'
     )
     
@@ -78,11 +77,11 @@ function peerCountGreaterThan() {
 #
 function ownsFunds() {
     ownedWalletCount=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.ownedWallets | length'
     )
     balanceTotal=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets { balance { total } } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets { balance { total } } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.ownedWallets[0].balance.total'
     )
     # remove leading and trailing quotes for integer interpretation
@@ -98,7 +97,7 @@ function ownsFunds() {
 function hasSentUserCommandsGreaterThan() {
     userCmdMinThreshold=${1:-1}
     userCmdSent=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { userCommandsSent } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { userCommandsSent } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.userCommandsSent'
     )
     
@@ -111,7 +110,7 @@ function hasSentUserCommandsGreaterThan() {
 #
 function hasSnarkWorker() {
     snarkWorker=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { snarkWorker } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { snarkWorker } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.snarkWorker'
     )
     rc=$?
@@ -139,7 +138,7 @@ function isArchiveSynced() {
             -w -c "SELECT height FROM blocks ORDER BY height DESC LIMIT 1"
     )
     highestReceived=$(
-        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' "localhost:${DAEMON_EXTERNAL_PORT}/graphql" | \
             jq '.data.daemonStatus.highestBlockLengthReceived'
     )
     


### PR DESCRIPTION
**Explain your changes:**
This PR avoids using a static port for reaching the daemon's graphql endpoint. It defines an global variable for all the Functions that inherits the value from the environment, or sets it to the previously used password otherwise (i.e., 3085).

**Explain how you tested your changes:**
I expect to produce an artifact and check the corresponding `readinessProbe` in a Kubernetes deployment completes successfully.

Checklist:

- [*] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [*] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] All tests pass (CI will check this if you didn't)
