### PR TITLE
Small refactoring of `mina_block.ml` and `block_sink.ml`

### DIFF
--- a/src/lib/gossip_net/message.ml
+++ b/src/lib/gossip_net/message.ml
@@ -11,7 +11,6 @@ module Master = struct
           Snark_pool.Resource_pool.Diff.t Network_pool.With_nonce.t
       | Transaction_pool_diff of
           Transaction_pool.Resource_pool.Diff.t Network_pool.With_nonce.t
-    [@@deriving to_yojson]
 
     type snark_pool_diff_msg = Snark_pool.Resource_pool.Diff.t
 

--- a/src/lib/mina_block/block.ml
+++ b/src/lib/mina_block/block.ml
@@ -47,21 +47,21 @@ type t = Stable.Latest.t =
 
 type with_hash = t State_hash.With_state_hashes.t
 
-let to_yojson t =
+let to_logging_yojson header : Yojson.Safe.t =
   `Assoc
     [ ( "protocol_state"
-      , Protocol_state.value_to_yojson (Header.protocol_state t.header) )
+      , Protocol_state.value_to_yojson (Header.protocol_state header) )
     ; ("protocol_state_proof", `String "<opaque>")
     ; ("staged_ledger_diff", `String "<opaque>")
     ; ("delta_transition_chain_proof", `String "<opaque>")
     ; ( "current_protocol_version"
       , `String
-          (Protocol_version.to_string
-             (Header.current_protocol_version t.header) ) )
+          (Protocol_version.to_string (Header.current_protocol_version header))
+      )
     ; ( "proposed_protocol_version"
       , `String
           (Option.value_map
-             (Header.proposed_protocol_version_opt t.header)
+             (Header.proposed_protocol_version_opt header)
              ~default:"<None>" ~f:Protocol_version.to_string ) )
     ]
 

--- a/src/lib/mina_block/block.mli
+++ b/src/lib/mina_block/block.mli
@@ -10,7 +10,9 @@ module Stable : sig
   end
 end]
 
-type t = Stable.Latest.t [@@deriving to_yojson]
+type t = Stable.Latest.t
+
+val to_logging_yojson : Header.t -> Yojson.Safe.t
 
 type with_hash = t State_hash.With_state_hashes.t
 

--- a/src/lib/mina_block/validated_block.ml
+++ b/src/lib/mina_block/validated_block.ml
@@ -22,7 +22,9 @@ type t =
   * State_hash.t Mina_stdlib.Nonempty_list.t
 
 let to_yojson (block_with_hashes, _) =
-  State_hash.With_state_hashes.to_yojson Block.to_yojson block_with_hashes
+  State_hash.With_state_hashes.to_yojson
+    (Fn.compose Block.to_logging_yojson Block.header)
+    block_with_hashes
 
 let lift (b, v) =
   match v with

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -129,7 +129,9 @@ let push sink (b_or_h, `Time_received tm, `Valid_cb cb) =
         let metadata =
           match b_or_h with
           | `Block b_env ->
-              [ ("block", Mina_block.to_yojson @@ Envelope.Incoming.data b_env)
+              [ ( "block"
+                , Mina_block.to_logging_yojson @@ Mina_block.header
+                  @@ Envelope.Incoming.data b_env )
               ]
           | `Header h_env ->
               [ ( "header"

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -219,7 +219,8 @@ let make_timeout t transition_with_hash duration =
           ; ( "duration"
             , `Int (Block_time.Span.to_ms duration |> Int64.to_int_trunc) )
           ; ( "cached_transition"
-            , With_hash.data transition_with_hash |> Mina_block.to_yojson )
+            , With_hash.data transition_with_hash
+              |> Mina_block.header |> Mina_block.to_logging_yojson )
           ]
         "Timed out waiting for the parent of $cached_transition after \
          $duration ms, signalling a catchup job" ;


### PR DESCRIPTION
_Step toward #16582_

Explain your changes:
* Replace `Mina_block.to_yojson` with `Mina_block.to_logging_yojson`
   * the new functions operates on headers, but pretends to dump the block-like json
* Small refactoring of `block_sink.ml` (just syntax)

Explain how you tested your changes:
* [x] it compiles
* [x] no functionality is changed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
