### PR TITLE
[Promotion] Split reversion script

### DIFF
--- a/scripts/debian/reversion-helper.sh
+++ b/scripts/debian/reversion-helper.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function reversion() {
+    local __deb
+    local __package
+    local __source_version
+    local __new_version
+    local __suite
+    local __new_suite
+    local __new_name
+    local __new_release
+    local __codename
+
+    while [[ "$#" -gt 0 ]]; do
+        case "${1}" in
+            --deb)
+                __deb=${2}
+                shift
+                ;;
+            --package)
+                __package=${2}
+                shift
+                ;;
+            --source-version)
+                __source_version=${2}
+                shift
+                ;;
+            --new-version)
+                __new_version=${2}
+                shift
+                ;;
+            --suite)
+                __suite=${2}
+                shift
+                ;;
+            --new-suite)
+                __new_suite=${2}
+                shift
+                ;;
+            --new-name)
+                __new_name=${2}
+                shift
+                ;;
+            --new-release)
+                __new_release=${2}
+                shift
+                ;;
+            --codename)
+                __codename=${2}
+                shift
+                ;;
+            *)
+                echo "$0 Unknown parameter in reversion() : ${1}" >&2
+                exit 1
+        esac
+
+        if ! shift; then
+            echo 'Missing parameter argument.' >&2
+            exit 1
+        fi
+    done
+
+    local __new_deb="${__new_name}_${__new_version}"
+    local __parent_dir=$(dirname "${__deb}_${__source_version}.deb")
+
+    rm -rf "${__new_deb}"
+    rm -rf "${__parent_dir}"/"${__new_deb}.deb"
+
+    dpkg-deb -R "${__deb}_${__source_version}.deb" "${__new_deb}"
+    sed -i 's/Version: '"${__source_version}"'/Version: '"${__new_version}"'/g' "${__new_deb}/DEBIAN/control"
+    sed -i 's/Package: '"${__package}"'/Package: '"${__new_name}"'/g' "${__new_deb}/DEBIAN/control"
+    sed -i 's/Suite: '"${__suite}"'/Suite: '"${__new_suite}"'/g' "${__new_deb}/DEBIAN/control"
+    dpkg-deb --build "${__new_name}_${__new_version}" "${__parent_dir}"/"${__new_deb}.deb"
+
+    rm -rf "${__new_deb}"
+}

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -4,9 +4,6 @@ set -eo pipefail
 CLEAR='\033[0m'
 RED='\033[0;31m'
 
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-source $SCRIPTPATH/reversion-helper.sh
-
 function usage() {
   if [[ -n "$1" ]]; then
     echo -e "${RED}☞  $1${CLEAR}\n";
@@ -61,6 +58,7 @@ else
 fi
 
 function rebuild_deb() {
+  source scripts/debian/reversion-helper.sh
 
   wget https://s3.us-west-2.amazonaws.com/${REPO}/pool/${CODENAME}/m/mi/${DEB}_${VERSION}.deb
   reversion --deb ${DEB} \

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -4,6 +4,9 @@ set -eo pipefail
 CLEAR='\033[0m'
 RED='\033[0;31m'
 
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+source $SCRIPTPATH/reversion-helper.sh
+
 function usage() {
   if [[ -n "$1" ]]; then
     echo -e "${RED}☞  $1${CLEAR}\n";

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -51,7 +51,6 @@ if [[ ! -v NEW_VERSION ]]; then NEW_VERSION=$VERSION; fi;
 if [[ ! -v NEW_SUITE ]]; then NEW_SUITE=$SUITE; fi;
 if [[ ! -v NEW_REPO ]]; then NEW_REPO=$REPO; fi;
 if [[ ! -v DEB ]]; then NEW_NAME=$DEB; fi;
-if [[ ! -v DEB ]]; then NEW_NAME=$DEB; fi;
 if [[ ! -v SIGN ]]; then 
   SIGN_ARG=""
 else 
@@ -59,15 +58,17 @@ else
 fi
 
 function rebuild_deb() {
-  rm -f "${DEB}_${VERSION}.deb"
-  rm -rf "${NEW_NAME}_${NEW_VERSION}"
-    
+
   wget https://s3.us-west-2.amazonaws.com/${REPO}/pool/${CODENAME}/m/mi/${DEB}_${VERSION}.deb
-  dpkg-deb -R "${DEB}_${VERSION}.deb" "${NEW_NAME}_${NEW_VERSION}"
-  sed -i 's/Version: '"${VERSION}"'/Version: '"${NEW_VERSION}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
-  sed -i 's/Package: '"${DEB}"'/Package: '"${NEW_NAME}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
-  sed -i 's/Suite: '"${SUITE}"'/Suite: '"${NEW_SUITE}"'/g' "${NEW_NAME}_${NEW_VERSION}/DEBIAN/control"
-  dpkg-deb --build "${NEW_NAME}_${NEW_VERSION}" "${NEW_NAME}_${NEW_VERSION}.deb"
+  reversion --deb ${DEB} \
+            --package ${DEB} \
+            --source-version ${VERSION} \
+            --new-version ${NEW_VERSION} \
+            --suite ${SUITE} \
+            --new-suite ${NEW_SUITE} \
+            --new-name ${NEW_NAME} \
+            --new-release ${NEW_RELEASE} \
+            --codename ${CODENAME}
 }
 
 rebuild_deb


### PR DESCRIPTION
Refactoring needed for https://github.com/MinaProtocol/mina/pull/16661 under https://github.com/MinaProtocol/mina/issues/16640 investment. New code will use reversion-helper.sh without it's scripting interface, which is now in reversion.sh . However we want to make it compatible with previous version. In order to allow reversion-helper.sh usage from different script I introduced --path parameter which can detect caller pwd