### PR TITLE
Version linter missing ref files check

### DIFF
--- a/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
+++ b/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
@@ -34,13 +34,13 @@ function checkout_and_dump() {
     source buildkite/scripts/gsutil-upload.sh /tmp/${TYPE_SHAPE_FILE} gs://mina-type-shapes
 }
 
-if ! $(gsutil ls gs://mina-type-shapes/$RELEASE_BRANCH_COMMIT 2>/dev/null); then
+if ! $(gsutil ls gs://mina-type-shapes/${RELEASE_BRANCH_COMMIT}* 2>/dev/null); then
     checkout_and_dump $RELEASE_BRANCH_COMMIT
 fi
 
 if [[ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]]; then 
     BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT=$(git log -n 1 --format="%h" --abbrev=7 ${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH} )
-    if ! $(gsutil ls gs://mina-type-shapes/$BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT 2>/dev/null); then
+    if ! $(gsutil ls gs://mina-type-shapes/${BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT}* 2>/dev/null); then
         checkout_and_dump $BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT
     fi
 fi

--- a/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
+++ b/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
@@ -34,13 +34,13 @@ function checkout_and_dump() {
     source buildkite/scripts/gsutil-upload.sh /tmp/${TYPE_SHAPE_FILE} gs://mina-type-shapes
 }
 
-if ! $(gsutil ls gs://mina-type-shapes/${RELEASE_BRANCH_COMMIT}* 2>/dev/null); then
+if ! gsutil ls "gs://mina-type-shapes/${RELEASE_BRANCH_COMMIT}*" >/dev/null; then
     checkout_and_dump $RELEASE_BRANCH_COMMIT
 fi
 
 if [[ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]]; then 
     BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT=$(git log -n 1 --format="%h" --abbrev=7 ${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH} )
-    if ! $(gsutil ls gs://mina-type-shapes/${BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT}* 2>/dev/null); then
+    if ! gsutil ls "gs://mina-type-shapes/${BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT}*"; then
         checkout_and_dump $BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT
     fi
 fi

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -106,6 +106,9 @@ let minimalDirtyWhen =
       , S.exactly "buildkite/scripts/check-compatibility" "sh"
       , S.exactly "buildkite/scripts/version-linter" "sh"
       , S.exactly "scripts/version-linter" "py"
+      , S.exactly
+          "buildkite/scripts/version-linter-patch-missing-type-shapes"
+          "sh"
       ]
 
 let bullseyeDirtyWhen =

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -54,6 +54,9 @@ in  Pipeline.build
                 [ S.strictlyStart (S.contains "src")
                 , S.exactly "buildkite/src/Jobs/Test/VersionLint" "dhall"
                 , S.exactly "buildkite/scripts/version-linter" "sh"
+                , S.exactly
+                    "buildkite/scripts/version-linter-patch-missing-type-shapes"
+                    "sh"
                 ]
 
           in  JobSpec::{


### PR DESCRIPTION
There is a subtle error in check for missing ref files in version-linter script. There was missing * at the end which made that we always try to regenerate ref files. I noticed that when we merged caqti update which broke compatibilitiy with old toolchain so checking out old code from e.g master always errored out since it tried to build old code with new caqti version. Fixing asterix should partially solve issue. I also regenerated locally ref files and uploaded to mina-type-shapes bucket which solves the issue