### PR TITLE
[Zkapp VK Caching] Cache Tag Project

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -232,3 +232,4 @@
 (package (name zkapp_command_builder))
 (package (name zkapps_examples))
 (package (name zkapp_limits))
+(package (name zkapp_vk_cache_tag))

--- a/src/lib/zkapp_vk_cache_tag/dune
+++ b/src/lib/zkapp_vk_cache_tag/dune
@@ -1,0 +1,14 @@
+(library
+ (public_name zkapp_vk_cache_tag)
+ (libraries
+   ;; opam libraries
+   core_kernel
+   async
+   ;; local libraries
+   logger
+   disk_cache
+   mina_base
+   )
+ (preprocess
+  (pps ppx_mina ppx_version))
+ (instrumentation (backend bisect_ppx)))

--- a/src/lib/zkapp_vk_cache_tag/zkapp_vk_cache_tag.ml
+++ b/src/lib/zkapp_vk_cache_tag/zkapp_vk_cache_tag.ml
@@ -1,0 +1,28 @@
+module Cache = Disk_cache.Make (Mina_base.Verification_key_wire.Stable.Latest)
+
+type cache_db = Lmdb_cache of Cache.t | Identity_cache
+
+type t =
+  | Lmdb of { cache_id : Cache.id; cache_db : Cache.t }
+  | Identity of Mina_base.Verification_key_wire.t
+
+let read_key_from_disk = function
+  | Lmdb t ->
+      Cache.get t.cache_db t.cache_id
+  | Identity key ->
+      key
+
+let write_key_to_disk db key =
+  match db with
+  | Lmdb_cache cache_db ->
+      Lmdb { cache_id = Cache.put cache_db key; cache_db }
+  | Identity_cache ->
+      Identity key
+
+let create_db path ~logger =
+  Cache.initialize ~logger path
+  |> Async.Deferred.Result.map ~f:(fun cache -> Lmdb_cache cache)
+
+module For_tests = struct
+  let create_db () = Identity_cache
+end

--- a/src/lib/zkapp_vk_cache_tag/zkapp_vk_cache_tag.mli
+++ b/src/lib/zkapp_vk_cache_tag/zkapp_vk_cache_tag.mli
@@ -1,0 +1,19 @@
+open Core
+open Async
+
+type t
+
+type cache_db
+
+val create_db :
+     string
+  -> logger:Logger.t
+  -> (cache_db, [> `Initialization_error of Error.t ]) Deferred.Result.t
+
+val read_key_from_disk : t -> Mina_base.Verification_key_wire.t
+
+val write_key_to_disk : cache_db -> Mina_base.Verification_key_wire.t -> t
+
+module For_tests : sig
+  val create_db : unit -> cache_db
+end


### PR DESCRIPTION
Introducing zkapp_vk_cache_tag dune module for cache implementation for Zkapp Verification key. In further PRs this project will be use in places we want to cache verification keys, for example transaction pool. I created yet another database exclusively for zkapp vk (we won't mix it with proofs in cache db)

Caching is not enabled yet, so there should not be any change of behaviour

This Pr enables merging further work under `dkijania/experiment_with_wires branch` which goal is to implement caching in tranasaction_pool module for `Vk_refcount_table` struct 


Basically module mimic how proof_cache_tag looks like. As a result we will have two cache db one for proofs and one for verification keys

Enables https://github.com/MinaProtocol/mina/pull/16674