### PR TITLE
[Caching] use zkapp_vk_cache_tag project for caching zkapp verification keys

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1671,6 +1671,11 @@ let initialize_proof_cache_db (config : Config.t) =
     (config.conf_dir ^/ "proof_cache")
   >>| function Error e -> raise_on_initialization_error e | Ok db -> db
 
+let initialize_zkapp_vk_cache_db (config : Config.t) =
+  Zkapp_vk_cache_tag.create_db ~logger:config.logger
+    (config.conf_dir ^/ "zkapp_vk_cache")
+  >>| function Error e -> raise_on_initialization_error e | Ok db -> db
+
 let create ~commit_id ?wallets (config : Config.t) =
   let commit_id_short = String.sub ~pos:0 ~len:8 commit_id in
   let catchup_mode = if config.super_catchup then `Super else `Normal in
@@ -1705,6 +1710,7 @@ let create ~commit_id ?wallets (config : Config.t) =
                  in_memory_reverse_structured_log_messages_for_integration_test
                  config.start_filtered_logs ;
           let%bind proof_cache_db = initialize_proof_cache_db config in
+          let%bind zkapp_vk_cache_db = initialize_zkapp_vk_cache_db config in
           let module Context =
           (val context ~proof_cache_db ~commit_id config)
           in
@@ -2001,7 +2007,7 @@ let create ~commit_id ?wallets (config : Config.t) =
               ~pool_max_size:
                 config.precomputed_values.genesis_constants.txpool_max_size
               ~genesis_constants:config.precomputed_values.genesis_constants
-              ~slot_tx_end
+              ~slot_tx_end ~vk_cache_db:zkapp_vk_cache_db
           in
           let first_received_message_signal = Ivar.create () in
           let online_status, notify_online_impl =

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -211,6 +211,7 @@ let%test_module "Epoch ledger sync tests" =
             ~pool_max_size:precomputed_values.genesis_constants.txpool_max_size
             ~genesis_constants:precomputed_values.genesis_constants
             ~slot_tx_end:None
+            ~vk_cache_db:(Zkapp_vk_cache_tag.For_tests.create_db ())
         in
         Network_pool.Transaction_pool.create ~config ~constraint_constants
           ~consensus_constants ~time_controller ~logger

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -77,6 +77,7 @@
    coda_genesis_ledger
    staged_ledger_diff
    mina_wire_types
+   zkapp_vk_cache_tag
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_base ppx_mina ppx_version ppx_register_event ppx_let ppx_assert ppx_pipebang ppx_deriving.std ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_snarky ppx_deriving_yojson ppx_fields_conv))

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -387,6 +387,7 @@ module type Transaction_resource_pool_intf = sig
     -> verifier:Verifier.t
     -> genesis_constants:Genesis_constants.t
     -> slot_tx_end:Mina_numbers.Global_slot_since_hard_fork.t option
+    -> vk_cache_db:Zkapp_vk_cache_tag.cache_db
     -> Config.t
 
   val member : t -> Transaction_hash.User_command_with_valid_signature.t -> bool

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -428,11 +428,11 @@ struct
       ; mutable current_batch : int
       ; mutable remaining_in_batch : int
       ; config : Config.t
-      ; logger : (Logger.t[@sexp.opaque])
+      ; logger : Logger.t
       ; batcher : Batcher.t
-      ; mutable best_tip_diff_relay : (unit Deferred.t[@sexp.opaque]) Option.t
-      ; mutable best_tip_ledger : (Base_ledger.t[@sexp.opaque]) Option.t
-      ; verification_key_table : (Vk_refcount_table.t[@sexp.opaque])
+      ; mutable best_tip_diff_relay : unit Deferred.t Option.t
+      ; mutable best_tip_ledger : Base_ledger.t Option.t
+      ; verification_key_table : Vk_refcount_table.t
       }
 
     let member t x =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -287,18 +287,19 @@ struct
         ; verifier : (Verifier.t[@sexp.opaque])
         ; genesis_constants : Genesis_constants.t
         ; slot_tx_end : Mina_numbers.Global_slot_since_hard_fork.t option
+        ; vk_cache_db : Zkapp_vk_cache_tag.cache_db
         }
-      [@@deriving sexp_of]
 
       (* remove next line if there's a way to force [@@deriving make] write a
          named parameter instead of an optional parameter *)
       let make ~trust_system ~pool_max_size ~verifier ~genesis_constants
-          ~slot_tx_end =
+          ~slot_tx_end ~vk_cache_db =
         { trust_system
         ; pool_max_size
         ; verifier
         ; genesis_constants
         ; slot_tx_end
+        ; vk_cache_db
         }
     end
 
@@ -331,15 +332,17 @@ struct
     module Vk_refcount_table = struct
       type t =
         { verification_keys :
-            (int * Verification_key_wire.t) Zkapp_basic.F_map.Table.t
+            (int * Zkapp_vk_cache_tag.t) Zkapp_basic.F_map.Table.t
         ; account_id_to_vks : int Zkapp_basic.F_map.Map.t Account_id.Table.t
         ; vk_to_account_ids : int Account_id.Map.t Zkapp_basic.F_map.Table.t
+        ; vk_cache_db : Zkapp_vk_cache_tag.cache_db
         }
 
-      let create () =
+      let create vk_cache_db () =
         { verification_keys = Zkapp_basic.F_map.Table.create ()
         ; account_id_to_vks = Account_id.Table.create ()
         ; vk_to_account_ids = Zkapp_basic.F_map.Table.create ()
+        ; vk_cache_db
         }
 
       let find_vk (t : t) = Hashtbl.find t.verification_keys
@@ -365,7 +368,7 @@ struct
         in
         Hashtbl.update t.verification_keys vk.hash ~f:(function
           | None ->
-              (1, vk)
+              (1, Zkapp_vk_cache_tag.write_key_to_disk t.vk_cache_db vk)
           | Some (count, vk) ->
               (count + 1, vk) ) ;
         Hashtbl.update t.account_id_to_vks account_id
@@ -431,7 +434,6 @@ struct
       ; mutable best_tip_ledger : (Base_ledger.t[@sexp.opaque]) Option.t
       ; verification_key_table : (Vk_refcount_table.t[@sexp.opaque])
       }
-    [@@deriving sexp_of]
 
     let member t x =
       Indexed_pool.member t.pool (Transaction_hash.User_command.of_checked x)
@@ -837,7 +839,8 @@ struct
         ; batcher = Batcher.create ~logger config.verifier
         ; best_tip_diff_relay = None
         ; best_tip_ledger = None
-        ; verification_key_table = Vk_refcount_table.create ()
+        ; verification_key_table =
+            Vk_refcount_table.create config.vk_cache_db ()
         }
       in
       don't_wait_for
@@ -1169,7 +1172,12 @@ struct
                             in
                             let vks =
                               vks
-                              |> List.map ~f:(fun vk -> (vk.hash, vk))
+                              |> List.map ~f:(fun vk_cached ->
+                                     let vk =
+                                       Zkapp_vk_cache_tag.read_key_from_disk
+                                         vk_cached
+                                     in
+                                     (vk.hash, vk) )
                               |> Zkapp_basic.F_map.Map.of_alist_exn
                             in
                             (account_id, vks) )
@@ -1930,6 +1938,7 @@ let%test_module _ =
       let config =
         Test.Resource_pool.make_config ~trust_system ~pool_max_size ~verifier
           ~genesis_constants ~slot_tx_end
+          ~vk_cache_db:(Zkapp_vk_cache_tag.For_tests.create_db ())
       in
       let pool_, _, _ =
         Test.create ~config ~logger ~constraint_constants ~consensus_constants

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -130,7 +130,8 @@ let%test_module "transaction_status" =
       let config =
         Transaction_pool.Resource_pool.make_config ~trust_system ~pool_max_size
           ~verifier ~genesis_constants:precomputed_values.genesis_constants
-          ~slot_tx_end:None ~vk_cache_db:(Zkapp_vk_cache_tag.For_tests.create_db ())
+          ~slot_tx_end:None
+          ~vk_cache_db:(Zkapp_vk_cache_tag.For_tests.create_db ())
       in
       let transaction_pool, _, local_sink =
         Transaction_pool.create ~config

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -130,7 +130,7 @@ let%test_module "transaction_status" =
       let config =
         Transaction_pool.Resource_pool.make_config ~trust_system ~pool_max_size
           ~verifier ~genesis_constants:precomputed_values.genesis_constants
-          ~slot_tx_end:None
+          ~slot_tx_end:None ~vk_cache_db:(Zkapp_vk_cache_tag.For_tests.create_db ())
       in
       let transaction_pool, _, local_sink =
         Transaction_pool.create ~config


### PR DESCRIPTION
PR on top of https://github.com/MinaProtocol/mina/pull/16671. It uses newly create module zkapp_vk_cache_tag. Then using similar approach as proof_cache_tag module it is used in place of Verification_key_wire. 