### PR TITLE
remove root key on split of the root -> root_(hash, common)

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -283,6 +283,7 @@ let get_root t =
           Batch.with_batch t.db ~f:(fun batch ->
               let hash = Root_data.Minimal.Stable.Latest.hash root in
               let common = Root_data.Minimal.Stable.V2.common root in
+              Batch.remove batch ~key:Root ;
               Batch.set batch ~key:Root_hash ~data:hash ;
               Batch.set batch ~key:Root_common ~data:common ) ;
 

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -435,6 +435,7 @@ let move_root ~old_root_hash ~new_root ~garbage =
     (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
   in
   fun batch ->
+    Batch.remove batch ~key:Root ;
     Batch.set batch ~key:Root_hash ~data:new_root_hash ;
     Batch.set batch ~key:Root_common
       ~data:(Root_data.Limited.Stable.Latest.common new_root) ;


### PR DESCRIPTION
Explain your changes:
* As requested by @georgeee , we now delete the key `Root` when we try to query root, and when we try to move the root

Explain how you tested your changes:
* https://github.com/MinaProtocol/mina/pull/16655

Checklist:
- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* None
