### PR TITLE
Fix Spelling Errors in Comments and Error Messages for Clarity

### DIFF
--- a/automation/bake/Dockerfile
+++ b/automation/bake/Dockerfile
@@ -10,7 +10,7 @@ COPY ../../genesis_ledgers/${TESTNET_NAME}.json "${CONFIG_FILE}"
 
 RUN head ${CONFIG_FILE}
 
-# Create the defautl config dir and an empty config
+# Create the default config dir and an empty config
 RUN mkdir -p /root/.mina-config
 # && echo "{}" > /root/.mina-config/daemon.json
 

--- a/automation/scripts/github_branch_autosync/github_autosync/__main__.py
+++ b/automation/scripts/github_branch_autosync/github_autosync/__main__.py
@@ -29,4 +29,4 @@ elif "handle_payload" in args.operation:
         json_payload = json.dumps(data)
         handle_incoming_commit_push_json(data,config=config)
 else:
-    print("operation no supported", file=sys.stderr)
+    print("operation not supported", file=sys.stderr)


### PR DESCRIPTION
 Old: # Create the defautl config dir and an empty config
New: # Create the default config dir and an empty config
Reason: The word "defautl" was a typo; it should be "default" to correctly describe the configuration directory.

Old: print("operation no supported", file=sys.stderr)
New: print("operation not supported", file=sys.stderr)
Reason: The phrase "operation no supported" is grammatically incorrect. It should be "operation not supported" for proper English syntax.