### PR TITLE
mina automation test runners

### DIFF
--- a/src/test/archive/patch_archive_test/patch_archive_test.ml
+++ b/src/test/archive/patch_archive_test/patch_archive_test.ml
@@ -9,24 +9,6 @@
     - compare original and copy
 *)
 
-module Network_Data = struct
-  type t =
-    { init_script : String.t
-    ; precomputed_blocks_zip : String.t
-    ; genesis_ledger_file : String.t
-    ; replayer_input_file : String.t
-    ; folder : String.t
-    }
-
-  let create folder =
-    { init_script = "archive_db.sql"
-    ; genesis_ledger_file = "input.json"
-    ; precomputed_blocks_zip = "precomputed_blocks.zip"
-    ; replayer_input_file = "replayer_input_file.json"
-    ; folder
-    }
-end
-
 open Core_kernel
 open Async
 open Mina_automation
@@ -36,7 +18,7 @@ let main ~db_uri ~network_data_folder () =
   let missing_blocks_count = 3 in
   let network_name = "dummy" in
 
-  let network_data = Network_Data.create network_data_folder in
+  let network_data = Network_data.create network_data_folder in
 
   let output_folder = Filename.temp_dir_name ^ "/output" in
 
@@ -49,7 +31,7 @@ let main ~db_uri ~network_data_folder () =
   let%bind _ = Psql.create_empty_db ~connection ~db:source_db_name in
   let%bind _ =
     Psql.run_script ~connection ~db:source_db_name
-      (network_data.folder ^ "/" ^ network_data.init_script)
+      (Network_data.init_script_path network_data)
   in
   let%bind () = Psql.create_mina_db ~connection ~db:target_db_name in
 
@@ -80,24 +62,13 @@ let main ~db_uri ~network_data_folder () =
         (* never remove last block as missing-block-guardian can have issues when patching it
            as it patching only gaps
         *)
-        Random.int (List.length extensional_files - 1) )
+        Random.int (List.length extensional_files - 2) + 1 )
   in
 
   let unpatched_extensional_files =
     List.filteri extensional_files ~f:(fun i _ ->
         not (List.mem n i ~equal:Int.equal) )
-    |> List.dedup_and_sort ~compare:(fun left right ->
-           let scan_height item =
-             let item =
-               Filename.basename item |> Str.global_replace (Str.regexp "-") " "
-             in
-             Scanf.sscanf item "%s %d %s" (fun _ height _ -> height)
-           in
-
-           let left_height = scan_height left in
-           let right_height = scan_height right in
-
-           Int.compare left_height right_height )
+    |> Utils.sort_archive_files
   in
 
   let%bind _ =
@@ -105,8 +76,7 @@ let main ~db_uri ~network_data_folder () =
       ~archive_uri:target_db ~format:Extensional
   in
 
-  let%bind missing_blocks_auditor_path = Missing_blocks_auditor.path
-  in
+  let%bind missing_blocks_auditor_path = Missing_blocks_auditor.path in
 
   let%bind archive_blocks_path = Archive_blocks.path in
 
@@ -121,9 +91,7 @@ let main ~db_uri ~network_data_folder () =
     }
   in
 
-  let missing_blocks_guardian =
-    Missing_blocks_guardian.default
-  in
+  let missing_blocks_guardian = Missing_blocks_guardian.default in
 
   let%bind _ = Missing_blocks_guardian.run missing_blocks_guardian ~config in
 
@@ -131,8 +99,7 @@ let main ~db_uri ~network_data_folder () =
 
   let%bind _ =
     Replayer.run replayer ~archive_uri:target_db
-      ~input_config:
-        (network_data.folder ^ "/" ^ network_data.replayer_input_file)
+      ~input_config:(Network_data.replayer_input_file_path network_data)
       ~interval_checkpoint:10 ~output_ledger:"./output_ledger" ()
   in
 

--- a/src/test/mina_automation/fixture/archive.ml
+++ b/src/test/mina_automation/fixture/archive.ml
@@ -1,0 +1,74 @@
+open Async
+open Mina_automation
+open Intf
+
+let logger = Logger.create ()
+
+type after_bootstrap =
+  { archive : Archive.Process.t; network_data : Network_data.t }
+
+type before_bootstrap =
+  { config : Archive.Config.t; network_data : Network_data.t }
+
+let setup_connection ~network_data =
+  let open Deferred.Let_syntax in
+  let postgres_uri = Sys.getenv_exn "POSTGRES_URI" in
+  let connection = Psql.Conn_str postgres_uri in
+  let db_name = "random_db" in
+  let%bind () = Psql.create_mina_db ~connection ~db:db_name in
+  return
+    (Archive.Config.create
+       ~config_file:(Network_data.genesis_ledger_path network_data)
+       ~postgres_uri:(postgres_uri ^ "/" ^ db_name)
+       ~server_port:3030 )
+
+module type TestCaseWithBootstrap = TestCase with type t = after_bootstrap
+
+module type TestCaseWithoutBootstrap = TestCase with type t = before_bootstrap
+
+module Make_FixtureWithBootstrap (M : TestCaseWithBootstrap) :
+  Fixture with type t = after_bootstrap = struct
+  type t = after_bootstrap
+
+  let test_case = M.test_case
+
+  let setup () =
+    let open Deferred.Or_error.Let_syntax in
+    let network_data_folder = Sys.getenv_exn "NETWORK_DATA_FOLDER" in
+    let network_data = Network_data.create network_data_folder in
+    let%bind.Deferred config = setup_connection ~network_data in
+    let executor = Archive.of_config config in
+    let%bind.Deferred archive = Archive.start executor in
+    [%log info] "Archive started successfully with " ;
+    return { archive; network_data }
+
+  let teardown t =
+    let open Deferred.Or_error.Let_syntax in
+    [%log info] "Tearing down archive" ;
+    let%bind _ = Archive.Process.force_kill t.archive in
+    Deferred.Or_error.ok_unit
+
+  let on_test_fail (t : t) =
+    let open Deferred.Let_syntax in
+    let%bind contents = Process.stdout t.archive.process |> Reader.contents in
+    [%log debug] "Archive process output: %s" contents ;
+    return ()
+end
+
+module Make_FixtureWithoutBootstrap (M : TestCaseWithoutBootstrap) :
+  Fixture with type t = before_bootstrap = struct
+  type t = before_bootstrap
+
+  let test_case = M.test_case
+
+  let setup () =
+    let open Deferred.Or_error.Let_syntax in
+    let network_data_folder = Sys.getenv_exn "NETWORK_DATA_FOLDER" in
+    let network_data = Network_data.create network_data_folder in
+    let%bind.Deferred config = setup_connection ~network_data in
+    return { config; network_data }
+
+  let teardown _t = Deferred.Or_error.ok_unit
+
+  let on_test_fail _t = Deferred.unit
+end

--- a/src/test/mina_automation/fixture/archive.mli
+++ b/src/test/mina_automation/fixture/archive.mli
@@ -1,0 +1,18 @@
+open Mina_automation
+open Intf
+
+type after_bootstrap =
+  { archive : Archive.Process.t; network_data : Network_data.t }
+
+type before_bootstrap =
+  { config : Archive.Config.t; network_data : Network_data.t }
+
+module type TestCaseWithBootstrap = TestCase with type t = after_bootstrap
+
+module type TestCaseWithoutBootstrap = TestCase with type t = before_bootstrap
+
+module Make_FixtureWithBootstrap (M : TestCaseWithBootstrap) :
+  Fixture with type t = after_bootstrap
+
+module Make_FixtureWithoutBootstrap (M : TestCaseWithoutBootstrap) :
+  Fixture with type t = before_bootstrap

--- a/src/test/mina_automation/fixture/dune
+++ b/src/test/mina_automation/fixture/dune
@@ -1,0 +1,11 @@
+(library
+ (name mina_automation_fixture)
+ (public_name mina_automation.fixture)
+ (libraries
+   ;; opam libraries
+   async
+   core
+  ;; local libraries
+  mina_automation
+ )
+ (preprocess (pps ppx_deriving_yojson ppx_jane ppx_mina)))

--- a/src/test/mina_automation/fixture/intf.ml
+++ b/src/test/mina_automation/fixture/intf.ml
@@ -1,0 +1,21 @@
+open Async
+
+type test_result = Passed | Failed of string | Warning of string
+
+module type TestCase = sig
+  type t
+
+  val test_case : t -> test_result Deferred.Or_error.t
+end
+
+module type Fixture = sig
+  type t
+
+  val setup : unit -> t Deferred.Or_error.t
+
+  val test_case : t -> test_result Deferred.Or_error.t
+
+  val teardown : t -> unit Deferred.Or_error.t
+
+  val on_test_fail : t -> unit Deferred.t
+end

--- a/src/test/mina_automation/network_data.ml
+++ b/src/test/mina_automation/network_data.ml
@@ -1,0 +1,54 @@
+open Async
+
+(** 
+  This module defines a type [t] representing test network data and provides functions to manipulate and access this data.
+
+  {1 Type Definitions}
+
+  - [t]: A record type containing the following fields:
+    - [init_script]: The initialization script file name.
+    - [precomputed_blocks_zip]: The precomputed blocks archive file name.
+    - [genesis_ledger_file]: The genesis ledger file name.
+    - [replayer_input_file]: The replayer input file name.
+    - [folder]: The folder containing the files.
+
+  {1 Functions}
+
+  - [create folder]: Creates a new [t] record with default file names and the specified folder.
+  - [init_script_path t]: Returns the full path to the initialization script file.
+  - [replayer_input_file_path t]: Returns the full path to the replayer input file.
+  - [precomputed_blocks_zip t]: Returns the full path to the precomputed blocks archive file.
+  - [genesis_ledger_path t]: Returns the full path to the genesis ledger file.
+  - [untar_precomputed_blocks t output]: Extracts the precomputed blocks archive to the specified output directory and returns a sorted list of the extracted files.
+*)
+type t =
+  { init_script : String.t
+  ; precomputed_blocks_zip : String.t
+  ; genesis_ledger_file : String.t
+  ; replayer_input_file : String.t
+  ; folder : String.t
+  }
+
+let create folder =
+  { init_script = "archive_db.sql"
+  ; genesis_ledger_file = "genesis.json"
+  ; precomputed_blocks_zip = "precomputed_blocks.tar.xz"
+  ; replayer_input_file = "replayer_input_file.json"
+  ; folder
+  }
+
+let init_script_path t = t.folder ^ "/" ^ t.init_script
+
+let replayer_input_file_path t = t.folder ^ "/" ^ t.replayer_input_file
+
+let precomputed_blocks_zip t = t.folder ^ "/" ^ t.precomputed_blocks_zip
+
+let genesis_ledger_path t = t.folder ^ "/" ^ t.genesis_ledger_file
+
+let untar_precomputed_blocks t output =
+  let open Deferred.Let_syntax in
+  let%bind () = Unix.mkdir ~p:() output in
+  let precomputed_blocks_zip = precomputed_blocks_zip t in
+  let%bind _ = Utils.untar ~archive:precomputed_blocks_zip ~output in
+  let%bind array = Sys.readdir output in
+  Deferred.return (Array.to_list array |> Utils.sort_archive_files)

--- a/src/test/mina_automation/runner/dune
+++ b/src/test/mina_automation/runner/dune
@@ -1,0 +1,11 @@
+(library
+ (name mina_automation_runner)
+ (public_name mina_automation.runner)
+ (libraries
+   ;; opam libraries
+   async
+   core
+  ;; local libraries
+  mina_automation.fixture
+ )
+ (preprocess (pps ppx_deriving_yojson ppx_jane ppx_mina)))

--- a/src/test/mina_automation/runner/runner.ml
+++ b/src/test/mina_automation/runner/runner.ml
@@ -1,0 +1,34 @@
+open Async
+open Core
+open Mina_automation_fixture
+
+let run (module F : Intf.Fixture) =
+  let open Deferred.Let_syntax in
+  let%bind test_case_after_setup =
+    match%bind.Deferred F.setup () with
+    | Ok t ->
+        return t
+    | Error err ->
+        failwithf "Setup failed with error: %s" (Error.to_string_hum err) ()
+  in
+  Monitor.protect
+    ~finally:(fun () ->
+      match%bind F.teardown test_case_after_setup with
+      | Ok () ->
+          Deferred.unit
+      | Error err ->
+          eprintf "Teardown failed with error: %s\n" (Error.to_string_hum err) ;
+          Deferred.unit )
+    (fun () ->
+      match%bind.Deferred F.test_case test_case_after_setup with
+      | Ok result ->
+          return result
+      | Error err ->
+          let%bind _ = F.on_test_fail test_case_after_setup in
+          return (Intf.Failed (Error.to_string_hum err)) )
+
+let run_blocking test_case () =
+  let (_ : Intf.test_result) =
+    Async.Thread_safe.block_on_async_exn (fun () -> run test_case)
+  in
+  ()


### PR DESCRIPTION
Helpers for new kind of tests which have a common setup in tear down. For example in single archive node tests we will have a very same setup (bootstrapping archive on db) and teardown (killing process). Thanks to that addition we can focus only on test logic in test library leaving rest for Fixture module in mina automation library