### PR TITLE
[Sync] Bump watchdog docker from version

### DIFF
--- a/automation/services/watchdog/Dockerfile
+++ b/automation/services/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16-slim-buster
+FROM python:3.9.16-slim-bullseye
 
 ARG GCLOUDSDK_DOWNLOAD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz"
 ARG WATCHMAN_DEB_URL="http://ftp.us.debian.org/debian/pool/main/w/watchman/watchman_4.9.0-5+b1_amd64.deb"


### PR DESCRIPTION
Buster is EOL let's use bullseye