### PR TITLE
Verification of zkapp proofs prior to block creation

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -765,8 +765,12 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
       let transactions =
         Network_pool.Transaction_pool.Resource_pool.transactions
           transaction_resource_pool
-        |> Sequence.map
-             ~f:Transaction_hash.User_command_with_valid_signature.data
+        |> Sequence.map ~f:(fun cmd_with_valid_sig ->
+               let cmd, _ =
+                 Transaction_hash.User_command_with_valid_signature.data
+                   cmd_with_valid_sig
+               in
+               cmd )
       in
       let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read ivar) in
       [%log internal] "Generate_next_state" ;

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -325,7 +325,7 @@ module Transaction_pool = struct
                               (* TODO: This rechecks the signatures on zkApp transactions... oh well for now *)
                               Some ((i, j), v) ) )
             in
-            let%map res =
+            let%map res, _ =
               (* Verify the unknowns *)
               Verifier.verify_commands verifier
                 (List.map unknowns ~f:(fun (_, txn) ->

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -199,7 +199,8 @@ module For_tests = struct
         Set.iter data ~f:(check_fee key) ) ;
     Transaction_hash.Map.iteri pool.all_by_hash ~f:(fun ~key ~data ->
         [%test_eq: Transaction_hash.t]
-          (Transaction_hash.User_command_with_valid_signature.hash data)
+          (Transaction_hash.User_command_with_valid_signature.get_field_hash
+             data )
           key )
 end
 
@@ -327,7 +328,9 @@ let remove_all_by_fee_and_hash_and_expiration_exn :
     Transaction_hash.User_command_with_valid_signature.command cmd
     |> User_command.fee_per_wu
   in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   { t with
     all_by_fee = Map_set.remove_exn t.all_by_fee fee_per_wu cmd
   ; all_by_hash = Map.remove t.all_by_hash cmd_hash
@@ -412,7 +415,7 @@ module Update = struct
           else acc
         in
         let cmd_hash =
-          Transaction_hash.User_command_with_valid_signature.hash cmd
+          Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
         ( match Transaction_hash.User_command_with_valid_signature.data cmd with
         | Zkapp_command p ->
@@ -515,8 +518,10 @@ let transactions ~logger t =
           in
           if
             Transaction_hash.equal
-              (Transaction_hash.User_command_with_valid_signature.hash txn)
-              (Transaction_hash.User_command_with_valid_signature.hash head_txn)
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 txn )
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 head_txn )
           then
             match F_sequence.uncons sender_queue' with
             | Some (next_txn, _) ->
@@ -1177,7 +1182,9 @@ let add_from_backtrack :
   let%map () = check_expiry t.config unchecked in
   let fee_payer = User_command.fee_payer unchecked in
   let fee_per_wu = User_command.fee_per_wu unchecked in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   let consumed = Option.value_exn (currency_consumed cmd) in
   match Map.find t.all_by_sender fee_payer with
   | None ->
@@ -1229,7 +1236,9 @@ let add_from_backtrack :
             t'.all_by_fee fee_per_wu cmd
       ; all_by_hash =
           Map.set t.all_by_hash
-            ~key:(Transaction_hash.User_command_with_valid_signature.hash cmd)
+            ~key:
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 cmd )
             ~data:cmd
       ; all_by_sender =
           Map.set t'.all_by_sender ~key:fee_payer

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -417,7 +417,10 @@ module Update = struct
         let cmd_hash =
           Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
-        ( match Transaction_hash.User_command_with_valid_signature.data cmd with
+        let data_cmd, _ =
+          Transaction_hash.User_command_with_valid_signature.data cmd
+        in
+        ( match data_cmd with
         | Zkapp_command p ->
             let p = Zkapp_command.Valid.forget p in
             let updates, proof_updates =

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -494,7 +494,8 @@ let commit_to_pool ledger pool cmd expected_drops =
               (Mina_ledger.Ledger.get ledger loc) )
   in
   let lower =
-    List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+    List.map
+      ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
   in
   [%test_eq: Transaction_hash.t list]
     (lower (Sequence.to_list dropped))
@@ -772,7 +773,7 @@ let apply_transactions txns accounts =
             in
             { a with nonce; balance } ) )
 
-let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
+let txn_hash = Transaction_hash.User_command_with_valid_signature.get_field_hash
 
 let application_invalidates_applied_transactions () =
   Quickcheck.test ~trials:1000

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3788,9 +3788,11 @@ let%test_module _ =
                 Test.Resource_pool.get_all test.txn_pool
                 |> List.map ~f:(fun tx ->
                        let data =
-                         Transaction_hash.User_command_with_valid_signature.data
-                           tx
-                         |> User_command.forget_check
+                         let valid, _ =
+                           Transaction_hash.User_command_with_valid_signature
+                           .data tx
+                         in
+                         valid |> User_command.forget_check
                        in
                        let nonce =
                          data |> User_command.applicable_at_nonce

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -681,14 +681,16 @@ struct
               let cmd_hash =
                 With_status.data cmd
                 |> Transaction_hash.User_command_with_valid_signature.create
-                |> Transaction_hash.User_command_with_valid_signature.hash
+                |> Transaction_hash.User_command_with_valid_signature
+                   .get_field_hash
               in
               Set.add set cmd_hash )
         in
         Sequence.to_list dropped_commands
         |> List.partition_tf ~f:(fun cmd ->
                Set.mem command_hashes
-                 (Transaction_hash.User_command_with_valid_signature.hash cmd) )
+                 (Transaction_hash.User_command_with_valid_signature
+                  .get_field_hash cmd ) )
       in
       List.iter committed_commands ~f:(fun cmd ->
           vk_table_lift_hashed vk_table_dec cmd ;
@@ -826,12 +828,10 @@ struct
               ~time_controller ~slot_tx_end:config.Config.slot_tx_end
         ; locally_generated_uncommitted =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; locally_generated_committed =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; current_batch = 0
         ; remaining_in_batch = max_per_15_seconds
         ; config
@@ -1376,12 +1376,12 @@ struct
         in
         let dropped_for_add_hashes =
           List.map dropped_for_add
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let dropped_for_size_hashes =
           List.map dropped_for_size
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let all_dropped_cmd_hashes =
@@ -1419,8 +1419,8 @@ struct
                 if
                   not
                     (Set.mem all_dropped_cmd_hashes
-                       (Transaction_hash.User_command_with_valid_signature.hash
-                          cmd ) )
+                       (Transaction_hash.User_command_with_valid_signature
+                        .get_field_hash cmd ) )
                 then register_locally_generated t cmd
             | Error _ ->
                 () ) ;
@@ -1443,7 +1443,8 @@ struct
                 *)
                 if
                   Set.mem all_dropped_cmd_hashes
-                    (Transaction_hash.User_command_with_valid_signature.hash cmd)
+                    (Transaction_hash.User_command_with_valid_signature
+                     .get_field_hash cmd )
                 then `Trd cmd
                 else `Fst cmd
             | Error (cmd, error) ->
@@ -1577,7 +1578,8 @@ struct
                       ->
                let cmp = compare batch1 batch2 in
                let get_hash =
-                 Transaction_hash.User_command_with_valid_signature.hash
+                 Transaction_hash.User_command_with_valid_signature
+                 .get_field_hash
                in
                let get_nonce txn =
                  Transaction_hash.User_command_with_valid_signature.command txn
@@ -3415,7 +3417,7 @@ let%test_module _ =
               ~receiver_idx ~amount ()
     end
 
-    (** appends a and b to the end of c, taking an element of a or b at random, 
+    (** appends a and b to the end of c, taking an element of a or b at random,
        continuing until both a and b run out of elements
     *)
     let rec gen_merge (a : 'a list) (b : 'a list) (c : 'a list) =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1226,7 +1226,7 @@ module T = struct
             ~get_batch:(Ledger.get_batch ledger) )
       |> Deferred.return
     in
-    let%map xs = Verifier.verify_commands verifier cs in
+    let%map xs, _ = Verifier.verify_commands verifier cs in
     Result.all
       (List.map xs ~f:(function
         | `Valid x ->

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -161,6 +161,11 @@ let hash_of_transaction_id (transaction_id : string) : t Or_error.t =
           Or_error.error_string
             "Could not decode transaction id as either Base58Check or Base64" )
 
+module User_command_with_verification_keys = struct
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature = struct
   type hash = T.t [@@deriving sexp, compare, hash]
 
@@ -168,10 +173,7 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t =
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -168,21 +168,25 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t = (User_command.Valid.t, hash) With_hash.t
+  type t =
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =
-    { data = c; hash = hash_command (User_command.forget_check c) }
+    { data = (c, []); hash = hash_command (User_command.forget_check c) }
 
   let data ({ data; _ } : t) = data
 
-  let command ({ data; _ } : t) = User_command.forget_check data
+  let command ({ data = cmd_valid, _; _ } : t) =
+    User_command.forget_check cmd_valid
 
   (* NOTE: this function has its name conflicted so we have to rename it *)
   let get_field_hash ({ hash; _ } : t) = hash
 
-  let forget_check ({ data; hash } : t) =
-    { With_hash.data = User_command.forget_check data; hash }
+  let forget_check ({ data = cmd_valid, _; hash } : t) =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (struct
     type nonrec t = t
@@ -194,7 +198,7 @@ module User_command_with_valid_signature = struct
     let compare (x : t) (y : t) = T.compare x.hash y.hash
   end)
 
-  let make data hash : t = { data; hash }
+  let make valid_cmd hash : t = { data = (valid_cmd, []); hash }
 end
 
 module User_command = struct
@@ -230,8 +234,10 @@ module User_command = struct
 
   let hash ({ hash; _ } : t) = hash
 
-  let of_checked ({ data; hash } : User_command_with_valid_signature.t) : t =
-    { With_hash.data = User_command.forget_check data; hash }
+  let of_checked
+      ({ data = cmd_valid, _; hash } : User_command_with_valid_signature.t) : t
+      =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (Stable.Latest)
 end

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -48,14 +48,15 @@ val hash_of_transaction_id : string -> t Or_error.t
 
 include Comparable.S with type t := t
 
+module User_command_with_verification_keys : sig
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t =
-    private
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = private (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,19 +51,8 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  [%%versioned:
-  module Stable : sig
-    [@@@no_toplevel_latest_type]
-
-    module V2 : sig
-      type t =
-        private
-        (User_command.Valid.Stable.V2.t, hash) With_hash.Stable.V1.t
-      [@@deriving sexp, compare, hash, to_yojson]
-    end
-  end]
-
-  type t = Stable.Latest.t [@@deriving sexp, compare, to_yojson]
+  type t = private (User_command.Valid.t, hash) With_hash.t
+  [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
@@ -71,7 +60,8 @@ module User_command_with_valid_signature : sig
 
   val command : t -> User_command.t
 
-  val hash : t -> hash
+  (* NOTE: this function has its name conflicted so we have to rename it *)
+  val get_field_hash : t -> hash
 
   val forget_check : t -> (User_command.t, hash) With_hash.t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,12 +51,16 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t = private (User_command.Valid.t, hash) With_hash.t
+  type t =
+    private
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
-  val data : t -> User_command.Valid.t
+  val data : t -> User_command.Valid.t * Side_loaded_verification_key.t list
 
   val command : t -> User_command.t
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -714,11 +714,11 @@ let verify_commands { worker; logger } ts =
           let tagged_commands = With_id_tag.tag_list ts in
           Worker.Connection.run connection ~f:Worker.functions.verify_commands
             ~arg:tagged_commands
-          |> Deferred.Or_error.map ~f:(fun (tagged_results, _) ->
+          |> Deferred.Or_error.map ~f:(fun (tagged_results, hashes) ->
                  let results =
                    finalize_verification_results tagged_commands tagged_results
                  in
-                 `Continue results ) ) )
+                 `Continue (results, hashes) ) ) )
 
 let verify_commands t ts =
   let logger = t.logger in

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -25,14 +25,15 @@ module Base = struct
       -> Mina_base.User_command.Verifiable.t Mina_base.With_status.t list
          (* The first level of error represents failure to verify, the second a failure in
             communicating with the verifier. *)
-      -> [ `Valid of Mina_base.User_command.Valid.t
-         | `Valid_assuming of
-           ( Pickles.Side_loaded.Verification_key.t
-           * Mina_base.Zkapp_statement.t
-           * Pickles.Side_loaded.Proof.t )
+      -> ( [ `Valid of Mina_base.User_command.Valid.t
+           | `Valid_assuming of
+             ( Pickles.Side_loaded.Verification_key.t
+             * Mina_base.Zkapp_statement.t
+             * Pickles.Side_loaded.Proof.t )
+             list
+           | invalid ]
            list
-         | invalid ]
-         list
+         * Pickles.Side_loaded.Verification_key.t list )
          Deferred.Or_error.t
 
     val verify_blockchain_snarks :


### PR DESCRIPTION
This PR aims to reduce commands verification time inside staged ledger diff validation 
- `Transaction_hash` has it's definiton replaced with non-versioned type
- The above induced a name conflicting side effect, hence `hash` is renamed to `get_field_hash`