### PR TITLE
Fix for rosetta on small archive 

### DIFF
--- a/src/app/rosetta/indexer_test/indexer_test.ml
+++ b/src/app/rosetta/indexer_test/indexer_test.ml
@@ -707,9 +707,9 @@ module Max_block =
 module Offset_limit = struct
   type t = { offset : int; limit : int }
 
-  let offset_generator = Int.gen_incl 1 100
+  let offset_generator = Int.gen_incl 1 50
 
-  let limit_generator = Int.gen_incl 1 50
+  let limit_generator = Int.gen_incl 1 25
 
   let transaction_testable =
     Alcotest.testable

--- a/src/app/rosetta/indexer_test/indexer_test.ml
+++ b/src/app/rosetta/indexer_test/indexer_test.ml
@@ -707,9 +707,12 @@ module Max_block =
 module Offset_limit = struct
   type t = { offset : int; limit : int }
 
-  let offset_generator = Int.gen_incl 1 50
+  (* Max value + Max limit value should not exceed valid user_commands count in database
+     otherwise quickcheck will become flaky.
+  *)
+  let offset_generator = Int.gen_incl 2 30
 
-  let limit_generator = Int.gen_incl 1 25
+  let limit_generator = Int.gen_incl 1 20
 
   let transaction_testable =
     Alcotest.testable

--- a/src/app/rosetta/lib/search.ml
+++ b/src/app/rosetta/lib/search.ml
@@ -991,25 +991,38 @@ module Sql = struct
       User_commands.run ~logger ~offset ~limit (module Conn) query
       |> Errors.Lift.sql ~context:"Finding user commands with transaction query"
     in
+
+    (* user_command_count is a total number of user commands disregard limit & offset paramaters
+       therefore we need to calculate the real length of user commands.
+       The same for internal commands and zkapp commands
+    *)
+    let real_user_command_length =
+      List.length raw_user_commands |> Int64.of_int_exn
+    in
+
     let offset =
       Option.map offset ~f:(fun offset ->
-          Int64.(max 0L (offset - user_commands_count)) )
+          Int64.(max 0L (offset - real_user_command_length)) )
     in
     let limit =
       Option.map limit ~f:(fun limit ->
-          Int64.(max 0L (limit - user_commands_count)) )
+          Int64.(max 0L (limit - real_user_command_length)) )
     in
     let%bind internal_commands_count, raw_internal_commands =
       Internal_commands.run (module Conn) ~logger ~offset ~limit query
       |> Errors.Lift.sql ~context:"Finding internal commands within block"
     in
+    let real_internal_command_length =
+      List.length raw_internal_commands |> Int64.of_int_exn
+    in
+
     let offset =
       Option.map offset ~f:(fun offset ->
-          Int64.(max 0L (offset - user_commands_count)) )
+          Int64.(max 0L (offset - real_internal_command_length)) )
     in
     let limit =
       Option.map limit ~f:(fun limit ->
-          Int64.(max 0L (limit - user_commands_count)) )
+          Int64.(max 0L (limit - real_internal_command_length)) )
     in
     let%bind zkapp_commands_count, raw_zkapp_commands =
       Zkapp_commands.run (module Conn) ~logger ~offset ~limit query


### PR DESCRIPTION
While syncing develop with compatible branch i noticed that, we regenerated new sample db archive data with much smaller transaction count (~54) than usual and this is causing  indexer test to fail on offset & limit  test. 

The root of the issue is imperfect deduct of offset/limit during fetch of user_command, internal_commands and zkapp command separately from db. Offset and limit is used separately for each type of commands mapping postgres OFFSET and LIMIT commands not for overall txs. 

Let's assume that we want to fetch 52 transactions with 10 offset (OFFSET 10 LIMIT 52) while having 
-  50 user commands
-  20 internal commands
-  5 zkapp commands

as a result we should receive:

- 40 user commands (because we skipped 10 txs due to offset)
- 12 internal commands
- 0 zkapp commands

While due to error in using offset & limit parameters we are getting: 

- 40 user commands (because we skipped 10 txs due to offset)
- 2 internal commands (because we deduct limit without taking into consideration offset, thus we deduct 50 while we should 50 - offset (40)  )
- 0 zkapp commands


The solution is to deduct offset from total user command while limit only by returned user commands . 


I also decreased ranges in generators as there are not enough transactions to fulfill max case 60 + 20 txs. 
