### PR TITLE
Verification of zkapp proofs prior to block creation 

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -765,8 +765,12 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
       let transactions =
         Network_pool.Transaction_pool.Resource_pool.transactions
           transaction_resource_pool
-        |> Sequence.map
-             ~f:Transaction_hash.User_command_with_valid_signature.data
+        |> Sequence.map ~f:(fun cmd_with_valid_sig ->
+               let cmd, _ =
+                 Transaction_hash.User_command_with_valid_signature.data
+                   cmd_with_valid_sig
+               in
+               cmd )
       in
       let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read ivar) in
       [%log internal] "Generate_next_state" ;

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -913,7 +913,13 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                       ~trust_system ~parent:crumb ~transition
                       ~sender:None (* Consider skipping `All here *)
                       ~skip_staged_ledger_verification:`Proofs
-                      ~transition_receipt_time () )
+                      ~transition_receipt_time
+                      ~transaction_pool_proxy:
+                        { find_by_hash =
+                            Network_pool.Transaction_pool.Resource_pool
+                            .find_by_hash transaction_resource_pool
+                        }
+                      () )
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->
                          `Invalid_staged_ledger_diff (e, staged_ledger_diff)

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -791,6 +791,7 @@ let setup_state_machine_runner ~context:(module Context : CONTEXT) ~t ~verifier
        -> transition:Mina_block.almost_valid_block
        -> sender:Envelope.Sender.t option
        -> transition_receipt_time:Time.t option
+       -> ?transaction_pool_proxy:Breadcrumb.transaction_pool_proxy
        -> unit
        -> ( Breadcrumb.t
           , [> `Invalid_staged_ledger_diff of Error.t

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -199,7 +199,8 @@ module For_tests = struct
         Set.iter data ~f:(check_fee key) ) ;
     Transaction_hash.Map.iteri pool.all_by_hash ~f:(fun ~key ~data ->
         [%test_eq: Transaction_hash.t]
-          (Transaction_hash.User_command_with_valid_signature.hash data)
+          (Transaction_hash.User_command_with_valid_signature.get_field_hash
+             data )
           key )
 end
 
@@ -327,7 +328,9 @@ let remove_all_by_fee_and_hash_and_expiration_exn :
     Transaction_hash.User_command_with_valid_signature.command cmd
     |> User_command.fee_per_wu
   in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   { t with
     all_by_fee = Map_set.remove_exn t.all_by_fee fee_per_wu cmd
   ; all_by_hash = Map.remove t.all_by_hash cmd_hash
@@ -412,7 +415,7 @@ module Update = struct
           else acc
         in
         let cmd_hash =
-          Transaction_hash.User_command_with_valid_signature.hash cmd
+          Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
         ( match Transaction_hash.User_command_with_valid_signature.data cmd with
         | Zkapp_command p ->
@@ -515,8 +518,10 @@ let transactions ~logger t =
           in
           if
             Transaction_hash.equal
-              (Transaction_hash.User_command_with_valid_signature.hash txn)
-              (Transaction_hash.User_command_with_valid_signature.hash head_txn)
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 txn )
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 head_txn )
           then
             match F_sequence.uncons sender_queue' with
             | Some (next_txn, _) ->
@@ -1177,7 +1182,9 @@ let add_from_backtrack :
   let%map () = check_expiry t.config unchecked in
   let fee_payer = User_command.fee_payer unchecked in
   let fee_per_wu = User_command.fee_per_wu unchecked in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   let consumed = Option.value_exn (currency_consumed cmd) in
   match Map.find t.all_by_sender fee_payer with
   | None ->
@@ -1229,7 +1236,9 @@ let add_from_backtrack :
             t'.all_by_fee fee_per_wu cmd
       ; all_by_hash =
           Map.set t.all_by_hash
-            ~key:(Transaction_hash.User_command_with_valid_signature.hash cmd)
+            ~key:
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 cmd )
             ~data:cmd
       ; all_by_sender =
           Map.set t'.all_by_sender ~key:fee_payer

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -417,7 +417,10 @@ module Update = struct
         let cmd_hash =
           Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
-        ( match Transaction_hash.User_command_with_valid_signature.data cmd with
+        let data_cmd, _ =
+          Transaction_hash.User_command_with_valid_signature.data cmd
+        in
+        ( match data_cmd with
         | Zkapp_command p ->
             let p = Zkapp_command.Valid.forget p in
             let updates, proof_updates =

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -494,7 +494,8 @@ let commit_to_pool ledger pool cmd expected_drops =
               (Mina_ledger.Ledger.get ledger loc) )
   in
   let lower =
-    List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+    List.map
+      ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
   in
   [%test_eq: Transaction_hash.t list]
     (lower (Sequence.to_list dropped))
@@ -772,7 +773,7 @@ let apply_transactions txns accounts =
             in
             { a with nonce; balance } ) )
 
-let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
+let txn_hash = Transaction_hash.User_command_with_valid_signature.get_field_hash
 
 let application_invalidates_applied_transactions () =
   Quickcheck.test ~trials:1000

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3788,9 +3788,11 @@ let%test_module _ =
                 Test.Resource_pool.get_all test.txn_pool
                 |> List.map ~f:(fun tx ->
                        let data =
-                         Transaction_hash.User_command_with_valid_signature.data
-                           tx
-                         |> User_command.forget_check
+                         let valid, _ =
+                           Transaction_hash.User_command_with_valid_signature
+                           .data tx
+                         in
+                         valid |> User_command.forget_check
                        in
                        let nonce =
                          data |> User_command.applicable_at_nonce

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -681,14 +681,16 @@ struct
               let cmd_hash =
                 With_status.data cmd
                 |> Transaction_hash.User_command_with_valid_signature.create
-                |> Transaction_hash.User_command_with_valid_signature.hash
+                |> Transaction_hash.User_command_with_valid_signature
+                   .get_field_hash
               in
               Set.add set cmd_hash )
         in
         Sequence.to_list dropped_commands
         |> List.partition_tf ~f:(fun cmd ->
                Set.mem command_hashes
-                 (Transaction_hash.User_command_with_valid_signature.hash cmd) )
+                 (Transaction_hash.User_command_with_valid_signature
+                  .get_field_hash cmd ) )
       in
       List.iter committed_commands ~f:(fun cmd ->
           vk_table_lift_hashed vk_table_dec cmd ;
@@ -826,12 +828,10 @@ struct
               ~time_controller ~slot_tx_end:config.Config.slot_tx_end
         ; locally_generated_uncommitted =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; locally_generated_committed =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; current_batch = 0
         ; remaining_in_batch = max_per_15_seconds
         ; config
@@ -1376,12 +1376,12 @@ struct
         in
         let dropped_for_add_hashes =
           List.map dropped_for_add
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let dropped_for_size_hashes =
           List.map dropped_for_size
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let all_dropped_cmd_hashes =
@@ -1419,8 +1419,8 @@ struct
                 if
                   not
                     (Set.mem all_dropped_cmd_hashes
-                       (Transaction_hash.User_command_with_valid_signature.hash
-                          cmd ) )
+                       (Transaction_hash.User_command_with_valid_signature
+                        .get_field_hash cmd ) )
                 then register_locally_generated t cmd
             | Error _ ->
                 () ) ;
@@ -1443,7 +1443,8 @@ struct
                 *)
                 if
                   Set.mem all_dropped_cmd_hashes
-                    (Transaction_hash.User_command_with_valid_signature.hash cmd)
+                    (Transaction_hash.User_command_with_valid_signature
+                     .get_field_hash cmd )
                 then `Trd cmd
                 else `Fst cmd
             | Error (cmd, error) ->
@@ -1577,7 +1578,8 @@ struct
                       ->
                let cmp = compare batch1 batch2 in
                let get_hash =
-                 Transaction_hash.User_command_with_valid_signature.hash
+                 Transaction_hash.User_command_with_valid_signature
+                 .get_field_hash
                in
                let get_nonce txn =
                  Transaction_hash.User_command_with_valid_signature.command txn
@@ -3415,7 +3417,7 @@ let%test_module _ =
               ~receiver_idx ~amount ()
     end
 
-    (** appends a and b to the end of c, taking an element of a or b at random, 
+    (** appends a and b to the end of c, taking an element of a or b at random,
        continuing until both a and b run out of elements
     *)
     let rec gen_merge (a : 'a list) (b : 'a list) (c : 'a list) =

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -161,6 +161,11 @@ let hash_of_transaction_id (transaction_id : string) : t Or_error.t =
           Or_error.error_string
             "Could not decode transaction id as either Base58Check or Base64" )
 
+module User_command_with_verification_keys = struct
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature = struct
   type hash = T.t [@@deriving sexp, compare, hash]
 
@@ -168,10 +173,7 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t =
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -168,21 +168,25 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t = (User_command.Valid.t, hash) With_hash.t
+  type t =
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =
-    { data = c; hash = hash_command (User_command.forget_check c) }
+    { data = (c, []); hash = hash_command (User_command.forget_check c) }
 
   let data ({ data; _ } : t) = data
 
-  let command ({ data; _ } : t) = User_command.forget_check data
+  let command ({ data = cmd_valid, _; _ } : t) =
+    User_command.forget_check cmd_valid
 
   (* NOTE: this function has its name conflicted so we have to rename it *)
   let get_field_hash ({ hash; _ } : t) = hash
 
-  let forget_check ({ data; hash } : t) =
-    { With_hash.data = User_command.forget_check data; hash }
+  let forget_check ({ data = cmd_valid, _; hash } : t) =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (struct
     type nonrec t = t
@@ -194,7 +198,7 @@ module User_command_with_valid_signature = struct
     let compare (x : t) (y : t) = T.compare x.hash y.hash
   end)
 
-  let make data hash : t = { data; hash }
+  let make valid_cmd hash : t = { data = (valid_cmd, []); hash }
 end
 
 module User_command = struct
@@ -230,8 +234,10 @@ module User_command = struct
 
   let hash ({ hash; _ } : t) = hash
 
-  let of_checked ({ data; hash } : User_command_with_valid_signature.t) : t =
-    { With_hash.data = User_command.forget_check data; hash }
+  let of_checked
+      ({ data = cmd_valid, _; hash } : User_command_with_valid_signature.t) : t
+      =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (Stable.Latest)
 end

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -48,14 +48,15 @@ val hash_of_transaction_id : string -> t Or_error.t
 
 include Comparable.S with type t := t
 
+module User_command_with_verification_keys : sig
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t =
-    private
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = private (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,19 +51,8 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  [%%versioned:
-  module Stable : sig
-    [@@@no_toplevel_latest_type]
-
-    module V2 : sig
-      type t =
-        private
-        (User_command.Valid.Stable.V2.t, hash) With_hash.Stable.V1.t
-      [@@deriving sexp, compare, hash, to_yojson]
-    end
-  end]
-
-  type t = Stable.Latest.t [@@deriving sexp, compare, to_yojson]
+  type t = private (User_command.Valid.t, hash) With_hash.t
+  [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
@@ -71,7 +60,8 @@ module User_command_with_valid_signature : sig
 
   val command : t -> User_command.t
 
-  val hash : t -> hash
+  (* NOTE: this function has its name conflicted so we have to rename it *)
+  val get_field_hash : t -> hash
 
   val forget_check : t -> (User_command.t, hash) With_hash.t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,12 +51,16 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t = private (User_command.Valid.t, hash) With_hash.t
+  type t =
+    private
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
-  val data : t -> User_command.Valid.t
+  val data : t -> User_command.Valid.t * Side_loaded_verification_key.t list
 
   val command : t -> User_command.t
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -103,10 +103,21 @@ let compute_block_trace_metadata transition_with_validation =
     ; ("coinbase_receiver", Account.key_to_yojson @@ coinbase_receiver cs)
     ]
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
+let dummy_transcation_pool_proxy : transaction_pool_proxy =
+  { find_by_hash = const None }
+
 let build ?skip_staged_ledger_verification ~proof_cache_db ~logger
     ~precomputed_values ~verifier ~trust_system ~parent
     ~transition:(transition_with_validation : Mina_block.almost_valid_block)
-    ~get_completed_work ~sender ~transition_receipt_time () =
+    ~get_completed_work ~sender ~transition_receipt_time
+    ?(transaction_pool_proxy = dummy_transcation_pool_proxy) () =
   let state_hash =
     ( With_hash.hash
     @@ Mina_block.Validation.block_with_hash transition_with_validation )

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -27,6 +27,13 @@ val create :
   -> transition_receipt_time:Time.t option
   -> t
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
 val build :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
   -> proof_cache_db:Proof_cache_tag.cache_db
@@ -41,6 +48,7 @@ val build :
         -> Transaction_snark_work.Checked.t option )
   -> sender:Envelope.Sender.t option
   -> transition_receipt_time:Time.t option
+  -> ?transaction_pool_proxy:transaction_pool_proxy
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t


### PR DESCRIPTION

Explain your changes:
* This PR make transaction pool tracks the verify_key so that verifier wouldn't repeat the verification process of a same zkapp command

Explain how you tested your changes:
* Not tested

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them
	* Closes no issue