### PR TITLE
Verification of zkapp proofs prior to block creation

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -765,8 +765,12 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
       let transactions =
         Network_pool.Transaction_pool.Resource_pool.transactions
           transaction_resource_pool
-        |> Sequence.map
-             ~f:Transaction_hash.User_command_with_valid_signature.data
+        |> Sequence.map ~f:(fun cmd_with_valid_sig ->
+               let cmd, _ =
+                 Transaction_hash.User_command_with_valid_signature.data
+                   cmd_with_valid_sig
+               in
+               cmd )
       in
       let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read ivar) in
       [%log internal] "Generate_next_state" ;

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -913,7 +913,13 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                       ~trust_system ~parent:crumb ~transition
                       ~sender:None (* Consider skipping `All here *)
                       ~skip_staged_ledger_verification:`Proofs
-                      ~transition_receipt_time () )
+                      ~transition_receipt_time
+                      ~transaction_pool_proxy:
+                        { find_by_hash =
+                            Network_pool.Transaction_pool.Resource_pool
+                            .find_by_hash transaction_resource_pool
+                        }
+                      () )
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->
                          `Invalid_staged_ledger_diff (e, staged_ledger_diff)

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -791,6 +791,7 @@ let setup_state_machine_runner ~context:(module Context : CONTEXT) ~t ~verifier
        -> transition:Mina_block.almost_valid_block
        -> sender:Envelope.Sender.t option
        -> transition_receipt_time:Time.t option
+       -> ?transaction_pool_proxy:Breadcrumb.transaction_pool_proxy
        -> unit
        -> ( Breadcrumb.t
           , [> `Invalid_staged_ledger_diff of Error.t

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -791,7 +791,6 @@ let setup_state_machine_runner ~context:(module Context : CONTEXT) ~t ~verifier
        -> transition:Mina_block.almost_valid_block
        -> sender:Envelope.Sender.t option
        -> transition_receipt_time:Time.t option
-       -> ?transaction_pool_proxy:Breadcrumb.transaction_pool_proxy
        -> unit
        -> ( Breadcrumb.t
           , [> `Invalid_staged_ledger_diff of Error.t
@@ -1412,7 +1411,8 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
         ~build_func:
           (Transition_frontier.Breadcrumb.build
              ~proof_cache_db:Context.proof_cache_db
-             ~get_completed_work:(Fn.const None) ) )
+             ~get_completed_work:(Fn.const None)
+             ~transaction_pool_proxy:Staged_ledger.dummy_transaction_pool_proxy ) )
 
 (* Unit tests *)
 

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -472,7 +472,8 @@ let reset_frontier_dependencies_validation (transition_with_hash, validation) =
 
 let validate_staged_ledger_diff ?skip_staged_ledger_verification ~proof_cache_db
     ~logger ~get_completed_work ~precomputed_values ~verifier
-    ~parent_staged_ledger ~parent_protocol_state (t, validation) =
+    ~parent_staged_ledger ~parent_protocol_state ~transaction_pool_proxy
+    (t, validation) =
   [%log internal] "Validate_staged_ledger_diff" ;
   let block = With_hash.data t in
   let header = Block.header block in
@@ -518,6 +519,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~proof_cache_db
       ~zkapp_cmd_limit_hardcap:
         precomputed_values.Precomputed_values.genesis_constants
           .zkapp_cmd_limit_hardcap
+      ~transaction_pool_proxy
     |> Deferred.Result.map_error ~f:(fun e ->
            `Staged_ledger_application_failed e )
   in

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -273,6 +273,7 @@ val validate_staged_ledger_diff :
   -> verifier:Verifier.t
   -> parent_staged_ledger:Staged_ledger.t
   -> parent_protocol_state:Protocol_state.Value.t
+  -> transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
   -> ( 'a
      , 'b
      , 'c

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -244,7 +244,9 @@ let verify (type p r partial) (t : (p, partial, r) t) (proof : p) :
   (match t.state with Verifying _ -> () | Waiting -> start_verifier t) ;
   Ivar.read elt.res
 
-type ('a, 'b, 'c) batcher = ('a, 'b, 'c) t [@@deriving sexp]
+type ('init, 'partially_validated, 'result) batcher =
+  ('init, 'partially_validated, 'result) t
+[@@deriving sexp]
 
 let compare_envelope (e1 : _ Envelope.Incoming.t) (e2 : _ Envelope.Incoming.t) =
   Envelope.Sender.compare e1.sender e2.sender
@@ -261,7 +263,8 @@ module Transaction_pool = struct
      verify.
   *)
   type partial_item =
-    [ `Valid of User_command.Valid.t
+    [ `Valid of
+      Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
     | `Valid_assuming of
       User_command.Verifiable.t
       * ( Pickles.Side_loaded.Verification_key.t
@@ -272,7 +275,13 @@ module Transaction_pool = struct
 
   type partial = partial_item list [@@deriving sexp]
 
-  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp]
+  type t =
+    ( diff
+    , partial
+    , Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
+      list )
+    batcher
+  [@@deriving sexp]
 
   type input = [ `Init of diff | `Partially_validated of partial ]
 

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -47,6 +47,9 @@ module Transaction_pool : sig
   val verify :
        t
     -> User_command.Verifiable.t list Envelope.Incoming.t
-    -> (User_command.Valid.t list, Verifier.invalid) Result.t
+    -> ( Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
+         list
+       , Verifier.invalid )
+       Result.t
        Deferred.Or_error.t
 end

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -199,7 +199,8 @@ module For_tests = struct
         Set.iter data ~f:(check_fee key) ) ;
     Transaction_hash.Map.iteri pool.all_by_hash ~f:(fun ~key ~data ->
         [%test_eq: Transaction_hash.t]
-          (Transaction_hash.User_command_with_valid_signature.hash data)
+          (Transaction_hash.User_command_with_valid_signature.get_field_hash
+             data )
           key )
 end
 
@@ -327,7 +328,9 @@ let remove_all_by_fee_and_hash_and_expiration_exn :
     Transaction_hash.User_command_with_valid_signature.command cmd
     |> User_command.fee_per_wu
   in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   { t with
     all_by_fee = Map_set.remove_exn t.all_by_fee fee_per_wu cmd
   ; all_by_hash = Map.remove t.all_by_hash cmd_hash
@@ -412,7 +415,7 @@ module Update = struct
           else acc
         in
         let cmd_hash =
-          Transaction_hash.User_command_with_valid_signature.hash cmd
+          Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
         ( match Transaction_hash.User_command_with_valid_signature.data cmd with
         | Zkapp_command p ->
@@ -515,8 +518,10 @@ let transactions ~logger t =
           in
           if
             Transaction_hash.equal
-              (Transaction_hash.User_command_with_valid_signature.hash txn)
-              (Transaction_hash.User_command_with_valid_signature.hash head_txn)
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 txn )
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 head_txn )
           then
             match F_sequence.uncons sender_queue' with
             | Some (next_txn, _) ->
@@ -1177,7 +1182,9 @@ let add_from_backtrack :
   let%map () = check_expiry t.config unchecked in
   let fee_payer = User_command.fee_payer unchecked in
   let fee_per_wu = User_command.fee_per_wu unchecked in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
+  in
   let consumed = Option.value_exn (currency_consumed cmd) in
   match Map.find t.all_by_sender fee_payer with
   | None ->
@@ -1229,7 +1236,9 @@ let add_from_backtrack :
             t'.all_by_fee fee_per_wu cmd
       ; all_by_hash =
           Map.set t.all_by_hash
-            ~key:(Transaction_hash.User_command_with_valid_signature.hash cmd)
+            ~key:
+              (Transaction_hash.User_command_with_valid_signature.get_field_hash
+                 cmd )
             ~data:cmd
       ; all_by_sender =
           Map.set t'.all_by_sender ~key:fee_payer

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -417,7 +417,10 @@ module Update = struct
         let cmd_hash =
           Transaction_hash.User_command_with_valid_signature.get_field_hash cmd
         in
-        ( match Transaction_hash.User_command_with_valid_signature.data cmd with
+        let data_cmd, _ =
+          Transaction_hash.User_command_with_valid_signature.data cmd
+        in
+        ( match data_cmd with
         | Zkapp_command p ->
             let p = Zkapp_command.Valid.forget p in
             let updates, proof_updates =

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -494,7 +494,8 @@ let commit_to_pool ledger pool cmd expected_drops =
               (Mina_ledger.Ledger.get ledger loc) )
   in
   let lower =
-    List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+    List.map
+      ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
   in
   [%test_eq: Transaction_hash.t list]
     (lower (Sequence.to_list dropped))
@@ -772,7 +773,7 @@ let apply_transactions txns accounts =
             in
             { a with nonce; balance } ) )
 
-let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
+let txn_hash = Transaction_hash.User_command_with_valid_signature.get_field_hash
 
 let application_invalidates_applied_transactions () =
   Quickcheck.test ~trials:1000

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1228,7 +1228,7 @@ struct
                       List.map commands
                         ~f:
                           Transaction_hash.User_command_with_valid_signature
-                          .create
+                          .create_with_keys
                   } )
 
       let register_locally_generated t txn =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3788,9 +3788,11 @@ let%test_module _ =
                 Test.Resource_pool.get_all test.txn_pool
                 |> List.map ~f:(fun tx ->
                        let data =
-                         Transaction_hash.User_command_with_valid_signature.data
-                           tx
-                         |> User_command.forget_check
+                         let valid, _ =
+                           Transaction_hash.User_command_with_valid_signature
+                           .data tx
+                         in
+                         valid |> User_command.forget_check
                        in
                        let nonce =
                          data |> User_command.applicable_at_nonce

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -681,14 +681,16 @@ struct
               let cmd_hash =
                 With_status.data cmd
                 |> Transaction_hash.User_command_with_valid_signature.create
-                |> Transaction_hash.User_command_with_valid_signature.hash
+                |> Transaction_hash.User_command_with_valid_signature
+                   .get_field_hash
               in
               Set.add set cmd_hash )
         in
         Sequence.to_list dropped_commands
         |> List.partition_tf ~f:(fun cmd ->
                Set.mem command_hashes
-                 (Transaction_hash.User_command_with_valid_signature.hash cmd) )
+                 (Transaction_hash.User_command_with_valid_signature
+                  .get_field_hash cmd ) )
       in
       List.iter committed_commands ~f:(fun cmd ->
           vk_table_lift_hashed vk_table_dec cmd ;
@@ -826,12 +828,10 @@ struct
               ~time_controller ~slot_tx_end:config.Config.slot_tx_end
         ; locally_generated_uncommitted =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; locally_generated_committed =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; current_batch = 0
         ; remaining_in_batch = max_per_15_seconds
         ; config
@@ -1376,12 +1376,12 @@ struct
         in
         let dropped_for_add_hashes =
           List.map dropped_for_add
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let dropped_for_size_hashes =
           List.map dropped_for_size
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:Transaction_hash.User_command_with_valid_signature.get_field_hash
           |> Transaction_hash.Set.of_list
         in
         let all_dropped_cmd_hashes =
@@ -1419,8 +1419,8 @@ struct
                 if
                   not
                     (Set.mem all_dropped_cmd_hashes
-                       (Transaction_hash.User_command_with_valid_signature.hash
-                          cmd ) )
+                       (Transaction_hash.User_command_with_valid_signature
+                        .get_field_hash cmd ) )
                 then register_locally_generated t cmd
             | Error _ ->
                 () ) ;
@@ -1443,7 +1443,8 @@ struct
                 *)
                 if
                   Set.mem all_dropped_cmd_hashes
-                    (Transaction_hash.User_command_with_valid_signature.hash cmd)
+                    (Transaction_hash.User_command_with_valid_signature
+                     .get_field_hash cmd )
                 then `Trd cmd
                 else `Fst cmd
             | Error (cmd, error) ->
@@ -1577,7 +1578,8 @@ struct
                       ->
                let cmp = compare batch1 batch2 in
                let get_hash =
-                 Transaction_hash.User_command_with_valid_signature.hash
+                 Transaction_hash.User_command_with_valid_signature
+                 .get_field_hash
                in
                let get_nonce txn =
                  Transaction_hash.User_command_with_valid_signature.command txn
@@ -3415,7 +3417,7 @@ let%test_module _ =
               ~receiver_idx ~amount ()
     end
 
-    (** appends a and b to the end of c, taking an element of a or b at random, 
+    (** appends a and b to the end of c, taking an element of a or b at random,
        continuing until both a and b run out of elements
     *)
     let rec gen_merge (a : 'a list) (b : 'a list) (c : 'a list) =

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -151,7 +151,7 @@ module Poly = struct
         ; wrap_index : 'g Plonk_verification_key_evals.Stable.V2.t
         ; wrap_vk : 'vk option
         }
-      [@@deriving hash, equal]
+      [@@deriving hash]
     end
   end]
 end

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -151,7 +151,7 @@ module Poly = struct
         ; wrap_index : 'g Plonk_verification_key_evals.Stable.V2.t
         ; wrap_vk : 'vk option
         }
-      [@@deriving hash]
+      [@@deriving hash, equal]
     end
   end]
 end

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1251,13 +1251,14 @@ module T = struct
   let precheck_verify_commands (transaction_pool_proxy : transaction_pool_proxy)
       (cmd_with_status : User_command.Verifiable.t With_status.t) =
     let coerce_cmd_as_verified cmd =
+      (* NOTE: See below notes for explanation*)
       let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd_coerced)
           =
         cmd |> User_command.of_verifiable |> User_command.to_valid_unsafe
       in
       cmd_coerced
     in
-    (* TODO:
+    (* NOTE:
        According to project https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a
        we consider a command in pool verified if either of the following holds:
          - It's failed

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1359,10 +1359,11 @@ module T = struct
     { find_by_hash = const None }
 
   let apply ?skip_verification ~proof_cache_db ~constraint_constants
-      ~global_slot t ~get_completed_work (witness : Staged_ledger_diff.t)
-      ~logger ~verifier ~current_state_view ~state_and_body_hash
-      ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
-      ?(transaction_pool_proxy = dummy_transaction_pool_proxy) =
+      ~global_slot ~get_completed_work ~logger ~verifier ~current_state_view
+      ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase
+      ~zkapp_cmd_limit_hardcap
+      ?(transaction_pool_proxy = dummy_transaction_pool_proxy) t
+      (witness : Staged_ledger_diff.t) =
     let open Deferred.Result.Let_syntax in
     let work = Staged_ledger_diff.completed_works witness in
     let%bind () =
@@ -2558,10 +2559,10 @@ let%test_module "staged ledger tests" =
               , `Staged_ledger sl'
               , `Pending_coinbase_update (is_new_stack, pc_update) ) =
         match%map
-          Sl.apply ~proof_cache_db ~constraint_constants ~global_slot !sl diff'
-            ~logger ~verifier ~get_completed_work:(Fn.const None)
-            ~current_state_view ~state_and_body_hash ~coinbase_receiver
-            ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
+          Sl.apply ~proof_cache_db ~constraint_constants ~global_slot ~logger
+            ~verifier ~get_completed_work:(Fn.const None) ~current_state_view
+            ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase
+            ~zkapp_cmd_limit_hardcap !sl diff'
         with
         | Ok x ->
             x

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1287,13 +1287,16 @@ module T = struct
               List.equal Side_loaded_verification_key.equal keys_assumed
                 keys_in_pool
             then `Valid (coerce_cmd_as_verified verifiable_cmd, keys_assumed)
-            else `Unexpected_verification_key keys_assumed
+            else
+              (* WARN: we need to figure out what keys should be returned for this case *)
+              `Unexpected_verification_key []
         | Error `Missing_verification_key, Some cmd_with_sig ->
-            let _, keys_in_pool =
+            let _, _keys_in_pool =
               cmd_with_sig
               |> Transaction_hash.User_command_with_valid_signature.data
             in
-            `Missing_verification_key keys_in_pool
+            (* WARN: we need to figure out what keys should be returned for this case *)
+            `Missing_verification_key []
         | Error `Missing_verification_key, None ->
             `Missing_verification_key []
         | _ ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1229,8 +1229,8 @@ module T = struct
     let%map xs = Verifier.verify_commands verifier cs in
     Result.all
       (List.map xs ~f:(function
-        | `Valid x ->
-            Ok x
+        | `Valid (cmd, _) ->
+            Ok cmd
         | ( `Invalid_keys _
           | `Invalid_signature _
           | `Invalid_proof _

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -193,6 +193,15 @@ val copy : t -> t
 
 val hash : t -> Staged_ledger_hash.t
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
+val dummy_transaction_pool_proxy : transaction_pool_proxy
+
 val apply :
      ?skip_verification:[ `Proofs | `All ]
   -> proof_cache_db:Proof_cache_tag.cache_db
@@ -210,6 +219,7 @@ val apply :
   -> coinbase_receiver:Public_key.Compressed.t
   -> supercharge_coinbase:bool
   -> zkapp_cmd_limit_hardcap:int
+  -> ?transaction_pool_proxy:transaction_pool_proxy
   -> ( [ `Hash_after_applying of Staged_ledger_hash.t ]
        * [ `Ledger_proof of
            ( Ledger_proof.Cached.t

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -207,11 +207,9 @@ val apply :
   -> proof_cache_db:Proof_cache_tag.cache_db
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> global_slot:Mina_numbers.Global_slot_since_genesis.t
-  -> t
   -> get_completed_work:
        (   Transaction_snark_work.Statement.t
         -> Transaction_snark_work.Checked.t option )
-  -> Staged_ledger_diff.t
   -> logger:Logger.t
   -> verifier:Verifier.t
   -> current_state_view:Zkapp_precondition.Protocol_state.View.t
@@ -220,6 +218,8 @@ val apply :
   -> supercharge_coinbase:bool
   -> zkapp_cmd_limit_hardcap:int
   -> ?transaction_pool_proxy:transaction_pool_proxy
+  -> t
+  -> Staged_ledger_diff.t
   -> ( [ `Hash_after_applying of Staged_ledger_hash.t ]
        * [ `Ledger_proof of
            ( Ledger_proof.Cached.t
@@ -358,6 +358,7 @@ val check_commands :
      Ledger.t
   -> verifier:Verifier.t
   -> User_command.t With_status.t list
+  -> transaction_pool_proxy:transaction_pool_proxy
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
 

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -161,6 +161,11 @@ let hash_of_transaction_id (transaction_id : string) : t Or_error.t =
           Or_error.error_string
             "Could not decode transaction id as either Base58Check or Base64" )
 
+module User_command_with_verification_keys = struct
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature = struct
   type hash = T.t [@@deriving sexp, compare, hash]
 
@@ -168,10 +173,7 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t =
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -179,6 +179,10 @@ module User_command_with_valid_signature = struct
   let create (c : User_command.Valid.t) : t =
     { data = (c, []); hash = hash_command (User_command.forget_check c) }
 
+  let create_with_keys ((cmd, _) as data : User_command_with_verification_keys.t)
+      : t =
+    { data; hash = hash_command (User_command.forget_check cmd) }
+
   let data ({ data; _ } : t) = data
 
   let command ({ data = cmd_valid, _; _ } : t) =

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -168,21 +168,25 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  type t = (User_command.Valid.t, hash) With_hash.t
+  type t =
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =
-    { data = c; hash = hash_command (User_command.forget_check c) }
+    { data = (c, []); hash = hash_command (User_command.forget_check c) }
 
   let data ({ data; _ } : t) = data
 
-  let command ({ data; _ } : t) = User_command.forget_check data
+  let command ({ data = cmd_valid, _; _ } : t) =
+    User_command.forget_check cmd_valid
 
   (* NOTE: this function has its name conflicted so we have to rename it *)
   let get_field_hash ({ hash; _ } : t) = hash
 
-  let forget_check ({ data; hash } : t) =
-    { With_hash.data = User_command.forget_check data; hash }
+  let forget_check ({ data = cmd_valid, _; hash } : t) =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (struct
     type nonrec t = t
@@ -194,7 +198,7 @@ module User_command_with_valid_signature = struct
     let compare (x : t) (y : t) = T.compare x.hash y.hash
   end)
 
-  let make data hash : t = { data; hash }
+  let make valid_cmd hash : t = { data = (valid_cmd, []); hash }
 end
 
 module User_command = struct
@@ -230,8 +234,10 @@ module User_command = struct
 
   let hash ({ hash; _ } : t) = hash
 
-  let of_checked ({ data; hash } : User_command_with_valid_signature.t) : t =
-    { With_hash.data = User_command.forget_check data; hash }
+  let of_checked
+      ({ data = cmd_valid, _; hash } : User_command_with_valid_signature.t) : t
+      =
+    { With_hash.data = User_command.forget_check cmd_valid; hash }
 
   include Comparable.Make (Stable.Latest)
 end

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -61,6 +61,8 @@ module User_command_with_valid_signature : sig
 
   val create : User_command.Valid.t -> t
 
+  val create_with_keys : User_command_with_verification_keys.t -> t
+
   val data : t -> User_command.Valid.t * Side_loaded_verification_key.t list
 
   val command : t -> User_command.t

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -48,14 +48,15 @@ val hash_of_transaction_id : string -> t Or_error.t
 
 include Comparable.S with type t := t
 
+module User_command_with_verification_keys : sig
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t =
-    private
-    ( User_command.Valid.t * Side_loaded_verification_key.t list
-    , hash )
-    With_hash.t
+  type t = private (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,19 +51,8 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  [%%versioned:
-  module Stable : sig
-    [@@@no_toplevel_latest_type]
-
-    module V2 : sig
-      type t =
-        private
-        (User_command.Valid.Stable.V2.t, hash) With_hash.Stable.V1.t
-      [@@deriving sexp, compare, hash, to_yojson]
-    end
-  end]
-
-  type t = Stable.Latest.t [@@deriving sexp, compare, to_yojson]
+  type t = private (User_command.Valid.t, hash) With_hash.t
+  [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
@@ -71,7 +60,8 @@ module User_command_with_valid_signature : sig
 
   val command : t -> User_command.t
 
-  val hash : t -> hash
+  (* NOTE: this function has its name conflicted so we have to rename it *)
+  val get_field_hash : t -> hash
 
   val forget_check : t -> (User_command.t, hash) With_hash.t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,12 +51,16 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t = private (User_command.Valid.t, hash) With_hash.t
+  type t =
+    private
+    ( User_command.Valid.t * Side_loaded_verification_key.t list
+    , hash )
+    With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
-  val data : t -> User_command.Valid.t
+  val data : t -> User_command.Valid.t * Side_loaded_verification_key.t list
 
   val command : t -> User_command.t
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -103,10 +103,21 @@ let compute_block_trace_metadata transition_with_validation =
     ; ("coinbase_receiver", Account.key_to_yojson @@ coinbase_receiver cs)
     ]
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
+let dummy_transcation_pool_proxy : transaction_pool_proxy =
+  { find_by_hash = const None }
+
 let build ?skip_staged_ledger_verification ~proof_cache_db ~logger
     ~precomputed_values ~verifier ~trust_system ~parent
     ~transition:(transition_with_validation : Mina_block.almost_valid_block)
-    ~get_completed_work ~sender ~transition_receipt_time () =
+    ~get_completed_work ~sender ~transition_receipt_time
+    ?(transaction_pool_proxy = dummy_transcation_pool_proxy) () =
   let state_hash =
     ( With_hash.hash
     @@ Mina_block.Validation.block_with_hash transition_with_validation )

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -27,13 +27,6 @@ val create :
   -> transition_receipt_time:Time.t option
   -> t
 
-type transaction_pool_proxy =
-  { find_by_hash :
-         Mina_transaction.Transaction_hash.t
-      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
-         option
-  }
-
 val build :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
   -> proof_cache_db:Proof_cache_tag.cache_db
@@ -48,7 +41,7 @@ val build :
         -> Transaction_snark_work.Checked.t option )
   -> sender:Envelope.Sender.t option
   -> transition_receipt_time:Time.t option
-  -> ?transaction_pool_proxy:transaction_pool_proxy
+  -> ?transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -27,6 +27,13 @@ val create :
   -> transition_receipt_time:Time.t option
   -> t
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
 val build :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
   -> proof_cache_db:Proof_cache_tag.cache_db
@@ -41,6 +48,7 @@ val build :
         -> Transaction_snark_work.Checked.t option )
   -> sender:Envelope.Sender.t option
   -> transition_receipt_time:Time.t option
+  -> ?transaction_pool_proxy:transaction_pool_proxy
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -82,7 +82,8 @@ let verify_blockchain_snarks { verify_blockchain_snarks; _ } chains =
 *)
 let verify_commands { proof_level; _ }
     (cs : User_command.Verifiable.t With_status.t list) :
-    [ `Valid of Mina_base.User_command.Valid.t
+    [ `Valid of
+      Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
     | `Valid_assuming of
       ( Pickles.Side_loaded.Verification_key.t
       * Mina_base.Zkapp_statement.t
@@ -96,9 +97,9 @@ let verify_commands { proof_level; _ }
       List.map cs ~f:(fun c ->
           match Common.check c with
           | `Valid c ->
-              `Valid c
+              `Valid (c, [])
           | `Valid_assuming (c, _) ->
-              `Valid c
+              `Valid (c, [])
           | `Invalid_keys keys ->
               `Invalid_keys keys
           | `Invalid_signature keys ->
@@ -134,9 +135,9 @@ let verify_commands { proof_level; _ }
       Ok
         (List.map cs ~f:(function
           | `Valid c ->
-              `Valid c
+              `Valid (c, [])
           | `Valid_assuming (c, xs) ->
-              if Or_error.is_ok all_verified then `Valid c
+              if Or_error.is_ok all_verified then `Valid (c, [])
               else `Valid_assuming xs
           | `Invalid_keys keys ->
               `Invalid_keys keys

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -39,9 +39,7 @@ module Worker_state = struct
 
     val verify_commands :
          Mina_base.User_command.Verifiable.t With_status.t With_id_tag.t list
-      -> [ `Valid of
-           Mina_transaction.Transaction_hash.User_command_with_verification_keys
-           .t
+      -> [ `Valid of Pickles.Side_loaded.Verification_key.t list
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Zkapp_statement.t
@@ -116,20 +114,14 @@ module Worker_state = struct
                List.map results ~f:(fun (id, result) ->
                    let result =
                      match result with
-                     | `Valid cmd ->
+                     | `Valid _ ->
                          (* The command is dropped here to avoid decoding it later in the caller
                             which would create a duplicate. Results are paired back to their inputs
                             using the input [id]*)
-                         (* The above is out of date.
-                            for the project `verification of zkapp proofs prior to blockchian`,
-                            the reslut `Valid is replaced by `Valid cmd or something similar, hence,
-                            we kinda have to take the serialization cost in trade of caching the key
-                            verification
-                         *)
-                         `Valid (cmd, [])
-                     | `Valid_assuming (cmd, xs) ->
+                         `Valid []
+                     | `Valid_assuming (_, xs) ->
                          let keys = List.map xs ~f:(fun (key, _, _) -> key) in
-                         if Or_error.is_ok all_verified then `Valid (cmd, keys)
+                         if Or_error.is_ok all_verified then `Valid keys
                          else `Valid_assuming xs
                      | `Invalid_keys keys ->
                          `Invalid_keys keys
@@ -210,8 +202,8 @@ module Worker_state = struct
                List.map tagged_commands ~f:(fun (id, c) ->
                    let result =
                      match Common.check c with
-                     | `Valid cmd | `Valid_assuming (cmd, _) ->
-                         `Valid (cmd, [])
+                     | `Valid _ | `Valid_assuming _ ->
+                         `Valid []
                      | `Invalid_keys keys ->
                          `Invalid_keys keys
                      | `Invalid_signature keys ->
@@ -251,10 +243,7 @@ module Worker = struct
       ; verify_commands :
           ( 'w
           , User_command.Verifiable.t With_status.t With_id_tag.t list
-          , [ `Valid of
-              Mina_transaction.Transaction_hash
-              .User_command_with_verification_keys
-              .t
+          , [ `Valid of Pickles.Side_loaded.Verification_key.t list
             | `Valid_assuming of
               ( Pickles.Side_loaded.Verification_key.t
               * Mina_base.Zkapp_statement.t
@@ -335,8 +324,7 @@ module Worker = struct
                   list]
               , [%bin_type_class:
                   [ `Valid of
-                    User_command.Valid.Stable.Latest.t
-                    * Pickles.Side_loaded.Verification_key.Stable.Latest.t list
+                    Pickles.Side_loaded.Verification_key.Stable.Latest.t list
                   | `Valid_assuming of
                     ( Pickles.Side_loaded.Verification_key.Stable.Latest.t
                     * Mina_base.Zkapp_statement.Stable.Latest.t
@@ -682,9 +670,28 @@ let verify_transaction_snarks =
   wrap_verify_snarks_with_trace ~checkpoint_before:"Verify_transaction_snarks"
     ~checkpoint_after:"Verify_transaction_snarks_done" verify_transaction_snarks
 
+(* Reinjects the original user commands into the validation results.
+   This avoids duplicating proof data by not sending it back from the subprocess. *)
+let reinject_valid_user_command_into_valid_result (command, result) =
+  match result with
+  | #invalid as invalid ->
+      invalid
+  | `Valid_assuming conditions ->
+      `Valid_assuming conditions
+  | `Valid keys ->
+      (* Since we have stripped the transaction from the result, we reconstruct it here.
+         The use of [to_valid_unsafe] is justified because a [`Valid] result for this
+         command means that it has indeed been validated. *)
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it command_valid)
+          =
+        User_command.to_valid_unsafe
+          (User_command.of_verifiable (With_status.data command))
+      in
+      `Valid (command_valid, keys)
+
 let finalize_verification_results tagged_commands tagged_results =
   With_id_tag.reassociate_tagged_results tagged_commands tagged_results
-  |> List.map ~f:snd
+  |> List.map ~f:reinject_valid_user_command_into_valid_result
 
 let verify_commands { worker; logger } ts =
   O1trace.thread "dispatch_user_command_verification" (fun () ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -202,8 +202,11 @@ module Worker_state = struct
                List.map tagged_commands ~f:(fun (id, c) ->
                    let result =
                      match Common.check c with
-                     | `Valid _ | `Valid_assuming _ ->
+                     | `Valid _ ->
                          `Valid []
+                     | `Valid_assuming (_, xs) ->
+                         let keys = List.map xs ~f:Tuple3.get1 in
+                         `Valid keys
                      | `Invalid_keys keys ->
                          `Invalid_keys keys
                      | `Invalid_signature keys ->

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -25,7 +25,9 @@ module Base = struct
       -> Mina_base.User_command.Verifiable.t Mina_base.With_status.t list
          (* The first level of error represents failure to verify, the second a failure in
             communicating with the verifier. *)
-      -> [ `Valid of Mina_base.User_command.Valid.t
+      -> [ `Valid of
+           Mina_transaction.Transaction_hash.User_command_with_verification_keys
+           .t
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Zkapp_statement.t


### PR DESCRIPTION
Explain your changes:
* This PR make transaction pool tracks the verify_key so that verifier wouldn't repeat the verification process of a same zkapp command

Explain how you tested your changes:
* Not tested

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Purpose: for all the commands need to be verified in staged_ledger.apply, and skip the verification for those that satisfy specific conditions, so no computation tasks are redone. 
  - Mention expected invariants, implicit constraints
    - It assumes the order of txns being verified doesn't matter
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them
	* Closes no issue