### PR TITLE
Remove Stable from Transaction_hash.User_command_with_valid_signature

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -199,7 +199,8 @@ module For_tests = struct
         Set.iter data ~f:(check_fee key) ) ;
     Transaction_hash.Map.iteri pool.all_by_hash ~f:(fun ~key ~data ->
         [%test_eq: Transaction_hash.t]
-          (Transaction_hash.User_command_with_valid_signature.hash data)
+          (Transaction_hash.User_command_with_valid_signature.transaction_hash
+             data )
           key )
 end
 
@@ -327,7 +328,9 @@ let remove_all_by_fee_and_hash_and_expiration_exn :
     Transaction_hash.User_command_with_valid_signature.command cmd
     |> User_command.fee_per_wu
   in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.transaction_hash cmd
+  in
   { t with
     all_by_fee = Map_set.remove_exn t.all_by_fee fee_per_wu cmd
   ; all_by_hash = Map.remove t.all_by_hash cmd_hash
@@ -412,7 +415,8 @@ module Update = struct
           else acc
         in
         let cmd_hash =
-          Transaction_hash.User_command_with_valid_signature.hash cmd
+          Transaction_hash.User_command_with_valid_signature.transaction_hash
+            cmd
         in
         ( match Transaction_hash.User_command_with_valid_signature.data cmd with
         | Zkapp_command p ->
@@ -515,8 +519,10 @@ let transactions ~logger t =
           in
           if
             Transaction_hash.equal
-              (Transaction_hash.User_command_with_valid_signature.hash txn)
-              (Transaction_hash.User_command_with_valid_signature.hash head_txn)
+              (Transaction_hash.User_command_with_valid_signature
+               .transaction_hash txn )
+              (Transaction_hash.User_command_with_valid_signature
+               .transaction_hash head_txn )
           then
             match F_sequence.uncons sender_queue' with
             | Some (next_txn, _) ->
@@ -1177,7 +1183,9 @@ let add_from_backtrack :
   let%map () = check_expiry t.config unchecked in
   let fee_payer = User_command.fee_payer unchecked in
   let fee_per_wu = User_command.fee_per_wu unchecked in
-  let cmd_hash = Transaction_hash.User_command_with_valid_signature.hash cmd in
+  let cmd_hash =
+    Transaction_hash.User_command_with_valid_signature.transaction_hash cmd
+  in
   let consumed = Option.value_exn (currency_consumed cmd) in
   match Map.find t.all_by_sender fee_payer with
   | None ->
@@ -1229,7 +1237,9 @@ let add_from_backtrack :
             t'.all_by_fee fee_per_wu cmd
       ; all_by_hash =
           Map.set t.all_by_hash
-            ~key:(Transaction_hash.User_command_with_valid_signature.hash cmd)
+            ~key:
+              (Transaction_hash.User_command_with_valid_signature
+               .transaction_hash cmd )
             ~data:cmd
       ; all_by_sender =
           Map.set t'.all_by_sender ~key:fee_payer

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -494,7 +494,8 @@ let commit_to_pool ledger pool cmd expected_drops =
               (Mina_ledger.Ledger.get ledger loc) )
   in
   let lower =
-    List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+    List.map
+      ~f:Transaction_hash.User_command_with_valid_signature.transaction_hash
   in
   [%test_eq: Transaction_hash.t list]
     (lower (Sequence.to_list dropped))
@@ -772,7 +773,8 @@ let apply_transactions txns accounts =
             in
             { a with nonce; balance } ) )
 
-let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
+let txn_hash =
+  Transaction_hash.User_command_with_valid_signature.transaction_hash
 
 let application_invalidates_applied_transactions () =
   Quickcheck.test ~trials:1000

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -681,14 +681,16 @@ struct
               let cmd_hash =
                 With_status.data cmd
                 |> Transaction_hash.User_command_with_valid_signature.create
-                |> Transaction_hash.User_command_with_valid_signature.hash
+                |> Transaction_hash.User_command_with_valid_signature
+                   .transaction_hash
               in
               Set.add set cmd_hash )
         in
         Sequence.to_list dropped_commands
         |> List.partition_tf ~f:(fun cmd ->
                Set.mem command_hashes
-                 (Transaction_hash.User_command_with_valid_signature.hash cmd) )
+                 (Transaction_hash.User_command_with_valid_signature
+                  .transaction_hash cmd ) )
       in
       List.iter committed_commands ~f:(fun cmd ->
           vk_table_lift_hashed vk_table_dec cmd ;
@@ -1376,12 +1378,16 @@ struct
         in
         let dropped_for_add_hashes =
           List.map dropped_for_add
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:
+              Transaction_hash.User_command_with_valid_signature
+              .transaction_hash
           |> Transaction_hash.Set.of_list
         in
         let dropped_for_size_hashes =
           List.map dropped_for_size
-            ~f:Transaction_hash.User_command_with_valid_signature.hash
+            ~f:
+              Transaction_hash.User_command_with_valid_signature
+              .transaction_hash
           |> Transaction_hash.Set.of_list
         in
         let all_dropped_cmd_hashes =
@@ -1419,8 +1425,8 @@ struct
                 if
                   not
                     (Set.mem all_dropped_cmd_hashes
-                       (Transaction_hash.User_command_with_valid_signature.hash
-                          cmd ) )
+                       (Transaction_hash.User_command_with_valid_signature
+                        .transaction_hash cmd ) )
                 then register_locally_generated t cmd
             | Error _ ->
                 () ) ;
@@ -1443,7 +1449,8 @@ struct
                 *)
                 if
                   Set.mem all_dropped_cmd_hashes
-                    (Transaction_hash.User_command_with_valid_signature.hash cmd)
+                    (Transaction_hash.User_command_with_valid_signature
+                     .transaction_hash cmd )
                 then `Trd cmd
                 else `Fst cmd
             | Error (cmd, error) ->
@@ -1577,7 +1584,8 @@ struct
                       ->
                let cmp = compare batch1 batch2 in
                let get_hash =
-                 Transaction_hash.User_command_with_valid_signature.hash
+                 Transaction_hash.User_command_with_valid_signature
+                 .transaction_hash
                in
                let get_nonce txn =
                  Transaction_hash.User_command_with_valid_signature.command txn

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -828,12 +828,10 @@ struct
               ~time_controller ~slot_tx_end:config.Config.slot_tx_end
         ; locally_generated_uncommitted =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; locally_generated_committed =
             Hashtbl.create
-              ( module Transaction_hash.User_command_with_valid_signature.Stable
-                       .Latest )
+              (module Transaction_hash.User_command_with_valid_signature)
         ; current_batch = 0
         ; remaining_in_batch = max_per_15_seconds
         ; config

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -193,7 +193,7 @@ module User_command_with_valid_signature = struct
 
   let command ({ data; _ } : t) = User_command.forget_check data
 
-  let hash ({ hash; _ } : t) = hash
+  let transaction_hash ({ hash; _ } : t) = hash
 
   let forget_check ({ data; hash } : t) =
     { With_hash.data = User_command.forget_check data; hash }

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -168,23 +168,8 @@ module User_command_with_valid_signature = struct
 
   let hash_of_yojson = of_yojson
 
-  [%%versioned
-  module Stable = struct
-    module V2 = struct
-      type t =
-        ( (User_command.Valid.Stable.V2.t[@hash.ignore])
-        , (T.Stable.V1.t[@to_yojson hash_to_yojson]) )
-        With_hash.Stable.V1.t
-      [@@deriving sexp, hash, to_yojson]
-
-      let to_latest = Fn.id
-
-      (* Compare only on hashes, comparing on the data too would be slower and
-         add no value.
-      *)
-      let compare (x : t) (y : t) = T.compare x.hash y.hash
-    end
-  end]
+  type t = (User_command.Valid.t, hash) With_hash.t
+  [@@deriving hash, sexp, compare, to_yojson]
 
   let create (c : User_command.Valid.t) : t =
     { data = c; hash = hash_command (User_command.forget_check c) }
@@ -198,7 +183,18 @@ module User_command_with_valid_signature = struct
   let forget_check ({ data; hash } : t) =
     { With_hash.data = User_command.forget_check data; hash }
 
-  include Comparable.Make (Stable.Latest)
+  include Comparable.Make (struct
+    type nonrec t = t
+
+    let sexp_of_t = sexp_of_t
+
+    let t_of_sexp = t_of_sexp
+
+    (* Compare only on hashes, comparing on the data too would be slower and
+       add no value.
+    *)
+    let compare (x : t) (y : t) = T.compare x.hash y.hash
+  end)
 
   let make data hash : t = { data; hash }
 end

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -51,19 +51,8 @@ include Comparable.S with type t := t
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  [%%versioned:
-  module Stable : sig
-    [@@@no_toplevel_latest_type]
-
-    module V2 : sig
-      type t =
-        private
-        (User_command.Valid.Stable.V2.t, hash) With_hash.Stable.V1.t
-      [@@deriving sexp, compare, hash, to_yojson]
-    end
-  end]
-
-  type t = Stable.Latest.t [@@deriving hash, sexp, compare, to_yojson]
+  type t = private (User_command.Valid.t, hash) With_hash.t
+  [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -63,7 +63,7 @@ module User_command_with_valid_signature : sig
     end
   end]
 
-  type t = Stable.Latest.t [@@deriving sexp, compare, to_yojson]
+  type t = Stable.Latest.t [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
@@ -71,7 +71,7 @@ module User_command_with_valid_signature : sig
 
   val command : t -> User_command.t
 
-  val hash : t -> hash
+  val transaction_hash : t -> hash
 
   val forget_check : t -> (User_command.t, hash) With_hash.t
 


### PR DESCRIPTION
Refactoring is executed in two steps:

- **Rename function hash -> transaction_hash**
  - Simple renaming of a function with changes across codebase
- **Remove unused Stable module in Transaction_hash**
  - Remove unstable module completely
  - Add `hash` function back to `User_command_with_valid_signature` module so that it can be used for hash tables

Explain how you tested your changes:
* This refactoring doesn't change any functionality

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
