### PR TITLE
Buildkite: fix shellcheck on setup-db-archive-node

### DIFF
--- a/buildkite/scripts/setup-database-for-archive-node.sh
+++ b/buildkite/scripts/setup-database-for-archive-node.sh
@@ -12,5 +12,5 @@ sudo service postgresql start
 sudo -u postgres psql -c "CREATE USER ${user} WITH LOGIN SUPERUSER PASSWORD '${password}';"
 sudo pg_isready
 service postgresql status
-sudo -u postgres createdb -O $user $db
-PGPASSWORD=$password psql -h localhost -p $port -U $user -d $db -a -f src/app/archive/create_schema.sql
+sudo -u postgres createdb -O "${user}" "${db}"
+PGPASSWORD="${password}" psql -h localhost -p "${port}" -U "${user}" -d "${db}" -a -f src/app/archive/create_schema.sql


### PR DESCRIPTION
Make `shellcheck` happy on `buildkite/scripts/setup-database-for-archive-node.sh`.
Previous output was:
```
In buildkite/scripts/setup-database-for-archive-node.sh line 15:
sudo -u postgres createdb -O $user $db
                             ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^-^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
sudo -u postgres createdb -O "$user" "$db"


In buildkite/scripts/setup-database-for-archive-node.sh line 16:
PGPASSWORD=$password psql -h localhost -p $port -U $user -d $db -a -f src/app/archive/create_schema.sql
                                          ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                            ^-^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
PGPASSWORD=$password psql -h localhost -p "$port" -U "$user" -d "$db" -a -f src/app/archive/create_schema.sql
```