### PR TITLE
CI/Buildkite: remove old jobs checking compatibility against old proof-systems branches

### DIFF
--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -76,19 +76,6 @@ in  Pipeline.build
         , Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run "scripts/merged-to-proof-systems.sh berkeley" ]
-            , label =
-                "[proof-systems] Check merges cleanly into proof-systems berkeley branch"
-            , key = "merged-to-proof-systems-berkeley"
-            , soft_fail = Some (B/SoftFail.Boolean True)
-            , target = Size.Multi
-            , docker = Some Docker::{
-              , image = (../../Constants/ContainerImages.dhall).toolchainBase
-              }
-            }
-        , Command.build
-            Command.Config::{
-            , commands =
               [ Cmd.run "scripts/merged-to-proof-systems.sh develop" ]
             , label =
                 "[proof-systems] Check merges cleanly into proof-systems develop branch"

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -62,19 +62,6 @@ in  Pipeline.build
             }
         , Command.build
             Command.Config::{
-            , commands =
-              [ Cmd.run "scripts/merged-to-proof-systems.sh develop" ]
-            , label =
-                "[proof-systems] Check merges cleanly into proof-systems develop branch"
-            , key = "merged-to-proof-systems-develop"
-            , soft_fail = Some (B/SoftFail.Boolean True)
-            , target = Size.Multi
-            , docker = Some Docker::{
-              , image = (../../Constants/ContainerImages.dhall).toolchainBase
-              }
-            }
-        , Command.build
-            Command.Config::{
             , commands = [ Cmd.run "scripts/merged-to-proof-systems.sh master" ]
             , label =
                 "[proof-systems] Check merges cleanly into proof-systems master branch"

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -63,19 +63,6 @@ in  Pipeline.build
         , Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run "scripts/merged-to-proof-systems.sh compatible" ]
-            , label =
-                "[proof-systems] Check merges cleanly into proof-systems compatible branch"
-            , key = "merged-to-proof-systems-compatible"
-            , soft_fail = Some (B/SoftFail.Boolean True)
-            , target = Size.Multi
-            , docker = Some Docker::{
-              , image = (../../Constants/ContainerImages.dhall).toolchainBase
-              }
-            }
-        , Command.build
-            Command.Config::{
-            , commands =
               [ Cmd.run "scripts/merged-to-proof-systems.sh develop" ]
             , label =
                 "[proof-systems] Check merges cleanly into proof-systems develop branch"


### PR DESCRIPTION
See commit description. Only proof-systems/master is now used.