### PR TITLE
[compatible] fix work vk tracking issue

### DIFF
--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -316,6 +316,8 @@ module type S = sig
 
       val dummy : t
 
+      val dummy_with_wrap_vk : t Lazy.t
+
       open Impls.Step
 
       val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -284,6 +284,67 @@ Stable.Latest.
   , equal
   , compare )]
 
+let dummy_wrap_vk :
+    ( Pasta_bindings.Fq.t
+    , Kimchi_bindings.Protocol.SRS.Fq.t
+    , Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm )
+    Kimchi_types.VerifierIndex.verifier_index
+    option
+    Lazy.t =
+  lazy
+    (let d =
+       (Common.wrap_domains
+          ~proofs_verified:(Pickles_base.Proofs_verified.to_int N2) )
+         .h
+     in
+     let log2_size = Import.Domain.log2_size d in
+     let public =
+       let (T (input, _conv, _conv_inv)) =
+         Impls.Wrap.input ~feature_flags:Plonk_types.Features.Full.maybe ()
+       in
+       let (Typ typ) = input in
+       typ.size_in_field_elements
+     in
+     (* we only compute the wrap_vk if the srs can be loaded *)
+     let srs = try Some (Backend.Tock.Keypair.load_urs ()) with _ -> None in
+     Option.map srs ~f:(fun srs : Impls.Wrap.Verification_key.t ->
+         { domain =
+             { log_size_of_group = log2_size
+             ; group_gen = Backend.Tock.Field.domain_generator ~log2_size
+             }
+         ; max_poly_size = 1 lsl Nat.to_int Backend.Tock.Rounds.n
+         ; public
+         ; prev_challenges = 2 (* Due to Wrap_hack *)
+         ; srs
+         ; evals =
+             (let x, y = Backend.Tock.Curve.(to_affine_exn one) in
+              let g =
+                { Kimchi_types.unshifted = [| Kimchi_types.Finite (x, y) |]
+                ; shifted = None
+                }
+              in
+              { sigma_comm =
+                  Array.init (Nat.to_int Plonk_types.Permuts.n) ~f:(Fn.const g)
+              ; coefficients_comm =
+                  Array.init (Nat.to_int Plonk_types.Columns.n) ~f:(Fn.const g)
+              ; generic_comm = g
+              ; mul_comm = g
+              ; psm_comm = g
+              ; emul_comm = g
+              ; complete_add_comm = g
+              ; endomul_scalar_comm = g
+              ; xor_comm = None
+              ; range_check0_comm = None
+              ; range_check1_comm = None
+              ; foreign_field_add_comm = None
+              ; foreign_field_mul_comm = None
+              ; rot_comm = None
+              } )
+         ; shifts = Common.tock_shifts ~log2_size
+         ; lookup_index = None
+         ; zk_rows = 3
+         } ) )
+
 let dummy : t =
   { max_proofs_verified = N2
   ; actual_wrap_domain_size = N2
@@ -300,6 +361,8 @@ let dummy : t =
        } )
   ; wrap_vk = None
   }
+
+let dummy_with_wrap_vk = lazy { dummy with wrap_vk = Lazy.force dummy_wrap_vk }
 
 module Checked = struct
   open Step_main_inputs

--- a/src/lib/pickles/side_loaded_verification_key.mli
+++ b/src/lib/pickles/side_loaded_verification_key.mli
@@ -86,6 +86,8 @@ type t = Stable.Latest.t [@@deriving hash, sexp, compare, equal]
 
 val dummy : t
 
+val dummy_with_wrap_vk : t Lazy.t
+
 include Codable.Base58_check_intf with type t := t
 
 include Codable.Base64_intf with type t := t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1436,11 +1436,16 @@ module Make_str (A : Wire_types.Concrete) = struct
               | Proof ->
                   let vk =
                     exists Side_loaded_verification_key.typ ~compute:(fun () ->
-                        Option.value_exn
+                        match
                           (As_prover.read (Typ.prover_value ())
                              (Data_as_hash.prover_value
                                 a.zkapp.verification_key.data ) )
-                            .data )
+                            .data
+                        with
+                        | Some vk ->
+                            vk
+                        | None ->
+                            Side_loaded_verification_key.dummy )
                   in
                   let expected_hash =
                     Data_as_hash.hash a.zkapp.verification_key.data
@@ -4016,7 +4021,10 @@ module Make_str (A : Wire_types.Concrete) = struct
               s.verification_key )
         with
         | None ->
-            failwith "No verification key found in the account"
+            { With_hash.data =
+                Lazy.force Side_loaded_verification_key.dummy_with_wrap_vk
+            ; hash = Verification_key_wire.dummy_vk_hash ()
+            }
         | Some s ->
             s
       in


### PR DESCRIPTION
Pass dummy vk when no vk is present in account for proved account update

Twin against `compatible` for PR #16699.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
