### PR TITLE
Remove User_command.Valid.Stable

### DIFF
--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -294,18 +294,8 @@ let valid_until (t : t) =
 module Valid = struct
   type t_ = t
 
-  [%%versioned
-  module Stable = struct
-    module V2 = struct
-      type t =
-        ( Signed_command.With_valid_signature.Stable.V2.t
-        , Zkapp_command.Valid.Stable.V1.t )
-        Poly.Stable.V2.t
-      [@@deriving sexp, compare, equal, hash, yojson]
-
-      let to_latest = Fn.id
-    end
-  end]
+  type t = (Signed_command.With_valid_signature.t, Zkapp_command.Valid.t) Poly.t
+  [@@deriving sexp, compare, equal, hash, yojson]
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -251,7 +251,6 @@ module Mina_base = struct
   include Assert_equal0V1 (O.Zkapp_command.Stable) (W.Zkapp_command)
   include Assert_equal0V1 (O.Zkapp_command.Valid.Stable) (W.Zkapp_command.Valid)
   include Assert_equal0V2 (O.User_command.Stable) (W.User_command)
-  include Assert_equal0V2 (O.User_command.Valid.Stable) (W.User_command.Valid)
   include
     Assert_equal0V1
       (O.Pending_coinbase.State_stack.Stable)


### PR DESCRIPTION
Explain your changes:
* Remove type that wasn't used in any sensible way

Explain how you tested your changes:
* Simple refactoring, no changes to functionality

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None