### PR TITLE
Remove Zkapp_command.Valid.Stable

### DIFF
--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -805,13 +805,8 @@ let weight (zkapp_command : t) : int =
     ]
 
 module type Valid_intf = sig
-  [%%versioned:
-  module Stable : sig
-    module V1 : sig
-      type t = private { zkapp_command : T.Stable.V1.t }
-      [@@deriving sexp, compare, equal, hash, yojson]
-    end
-  end]
+  type nonrec t = private { zkapp_command : t }
+  [@@deriving sexp, compare, equal, hash, yojson]
 
   val to_valid_unsafe :
     T.t -> [> `If_this_is_used_it_should_have_a_comment_justifying_it of t ]
@@ -830,34 +825,9 @@ module type Valid_intf = sig
   val forget : t -> T.t
 end
 
-module Valid :
-  Valid_intf
-    with type Stable.V1.t = Mina_wire_types.Mina_base.Zkapp_command.Valid.V1.t =
-struct
-  module S = Stable
-
-  module Verification_key_hash = struct
-    [%%versioned
-    module Stable = struct
-      module V1 = struct
-        type t = Zkapp_basic.F.Stable.V1.t
-        [@@deriving sexp, compare, equal, hash, yojson]
-
-        let to_latest = Fn.id
-      end
-    end]
-  end
-
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t = Mina_wire_types.Mina_base.Zkapp_command.Valid.V1.t =
-        { zkapp_command : S.V1.t }
-      [@@deriving sexp, compare, equal, hash, yojson]
-
-      let to_latest = Fn.id
-    end
-  end]
+module Valid : Valid_intf = struct
+  type t = { zkapp_command : T.t }
+  [@@deriving sexp, compare, equal, hash, yojson]
 
   let create zkapp_command : t = { zkapp_command }
 

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -249,7 +249,6 @@ module Mina_base = struct
   include Assert_equal0V2 (O.Control.Stable) (W.Control)
   include Assert_equal0V1 (O.Account_update.Stable) (W.Account_update)
   include Assert_equal0V1 (O.Zkapp_command.Stable) (W.Zkapp_command)
-  include Assert_equal0V1 (O.Zkapp_command.Valid.Stable) (W.Zkapp_command.Valid)
   include Assert_equal0V2 (O.User_command.Stable) (W.User_command)
   include
     Assert_equal0V1


### PR DESCRIPTION
Explain your changes:
* Remove type that wasn't used in any sensible way

Explain how you tested your changes:
* Simple refactoring, no changes to functionality

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None

