### PR TITLE
Verification of zkapp proofs prior to block creation

### DIFF
--- a/changes/16753.md
+++ b/changes/16753.md
@@ -1,0 +1,15 @@
+# PR 16753: [Verification of zkapp proofs prior to block creation](https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a)
+
+## Summary
+
+This PR allow `Staged_ledger.check_commands` to have access to the transaction pool, so it can check transaction commands that all are already in the pool, which are verified, and skip verification for them(which is costly).
+
+## Changes
+- Introduce a `transaction_pool_proxy` that can pass access to `find_by_hash` in a `transaction_pool` down to `Staged_ledger.check_commands`;
+- Replace `User_command_with_valid_signature.t` from `(User_command.Valid.t, hash) With_hash.t` to `(User_command_with_verification_keys.t, hash) With_hash.t` where `User_command_with_verification_keys.t` is just `User_command.Valid.t * Side_loaded_verification_key.t list`;
+- Modify the verifier so it returns verification keys for a valid command that we can cache;
+- Store `User_command_with_verification_keys.t` instead of `User_command.Valid.t` inside a transaction pool;
+- PERF: Check commands already present in the pool so we don't calculate the verification keys twice during `Staged_ledger.check_commands`.
+
+
+

--- a/changes/16753.md
+++ b/changes/16753.md
@@ -11,5 +11,5 @@ This PR allow `Staged_ledger.check_commands` to have access to the transaction p
 - Store `User_command_with_verification_keys.t` instead of `User_command.Valid.t` inside a transaction pool;
 - PERF: Check commands already present in the pool so we don't calculate the verification keys twice during `Staged_ledger.check_commands`.
 
-
-
+## Invariant Assumption:
+- Assumes `Common.check` doesn't depends on the state of the staged ledger, and only depends on the command itself.

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -767,6 +767,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
           transaction_resource_pool
         |> Sequence.map
              ~f:Transaction_hash.User_command_with_valid_signature.data
+        |> Sequence.map ~f:fst
       in
       let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read ivar) in
       [%log internal] "Generate_next_state" ;

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -909,7 +909,13 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                       ~trust_system ~parent:crumb ~transition
                       ~sender:None (* Consider skipping `All here *)
                       ~skip_staged_ledger_verification:`Proofs
-                      ~transition_receipt_time () )
+                      ~transition_receipt_time
+                      ~transaction_pool_proxy:
+                        { find_by_hash =
+                            Network_pool.Transaction_pool.Resource_pool
+                            .find_by_hash transaction_resource_pool
+                        }
+                      () )
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->
                          `Invalid_staged_ledger_diff (e, staged_ledger_diff)

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -783,6 +783,7 @@ let setup_state_machine_runner ~context:(module Context : CONTEXT) ~t ~verifier
     ~catchup_breadcrumbs_writer
     ~(build_func :
           ?skip_staged_ledger_verification:[ `All | `Proofs ]
+       -> ?transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
        -> logger:Logger.t
        -> precomputed_values:Precomputed_values.t
        -> verifier:Verifier.t

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -472,7 +472,8 @@ let reset_frontier_dependencies_validation (transition_with_hash, validation) =
 
 let validate_staged_ledger_diff ?skip_staged_ledger_verification ~proof_cache_db
     ~logger ~get_completed_work ~precomputed_values ~verifier
-    ~parent_staged_ledger ~parent_protocol_state (t, validation) =
+    ~parent_staged_ledger ~parent_protocol_state ~transaction_pool_proxy
+    (t, validation) =
   [%log internal] "Validate_staged_ledger_diff" ;
   let block = With_hash.data t in
   let header = Block.header block in
@@ -518,6 +519,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~proof_cache_db
       ~zkapp_cmd_limit_hardcap:
         precomputed_values.Precomputed_values.genesis_constants
           .zkapp_cmd_limit_hardcap
+      ~transaction_pool_proxy
     |> Deferred.Result.map_error ~f:(fun e ->
            `Staged_ledger_application_failed e )
   in

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -273,6 +273,7 @@ val validate_staged_ledger_diff :
   -> verifier:Verifier.t
   -> parent_staged_ledger:Staged_ledger.t
   -> parent_protocol_state:Protocol_state.Value.t
+  -> transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
   -> ( 'a
      , 'b
      , 'c

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -261,7 +261,8 @@ module Transaction_pool = struct
      verify.
   *)
   type partial_item =
-    [ `Valid of User_command.Valid.t
+    [ `Valid of
+      Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
     | `Valid_assuming of
       User_command.Verifiable.t
       * ( Pickles.Side_loaded.Verification_key.t
@@ -272,7 +273,13 @@ module Transaction_pool = struct
 
   type partial = partial_item list [@@deriving sexp]
 
-  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp]
+  type t =
+    ( diff
+    , partial
+    , Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
+      list )
+    batcher
+  [@@deriving sexp]
 
   type input = [ `Init of diff | `Partially_validated of partial ]
 

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -47,6 +47,9 @@ module Transaction_pool : sig
   val verify :
        t
     -> User_command.Verifiable.t list Envelope.Incoming.t
-    -> (User_command.Valid.t list, Verifier.invalid) Result.t
+    -> ( Mina_transaction.Transaction_hash.User_command_with_verification_keys.t
+         list
+       , Verifier.invalid )
+       Result.t
        Deferred.Or_error.t
 end

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -418,7 +418,9 @@ module Update = struct
           Transaction_hash.User_command_with_valid_signature.transaction_hash
             cmd
         in
-        ( match Transaction_hash.User_command_with_valid_signature.data cmd with
+        ( match
+            Transaction_hash.User_command_with_valid_signature.data cmd |> fst
+          with
         | Zkapp_command p ->
             let p = Zkapp_command.Valid.forget p in
             let updates, proof_updates =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3421,7 +3421,7 @@ let%test_module _ =
               ~receiver_idx ~amount ()
     end
 
-    (** appends a and b to the end of c, taking an element of a or b at random, 
+    (** appends a and b to the end of c, taking an element of a or b at random,
        continuing until both a and b run out of elements
     *)
     let rec gen_merge (a : 'a list) (b : 'a list) (c : 'a list) =
@@ -3794,7 +3794,7 @@ let%test_module _ =
                        let data =
                          Transaction_hash.User_command_with_valid_signature.data
                            tx
-                         |> User_command.forget_check
+                         |> fst |> User_command.forget_check
                        in
                        let nonce =
                          data |> User_command.applicable_at_nonce

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1225,10 +1225,13 @@ struct
                 return
                   { diff with
                     data =
-                      List.map commands
-                        ~f:
+                      List.map commands ~f:(fun ((cmd, _) as cmd_with_keys) ->
+                          let hash =
+                            Transaction_hash.hash_command
+                              (User_command.forget_check cmd)
+                          in
                           Transaction_hash.User_command_with_valid_signature
-                          .create
+                          .make cmd_with_keys hash )
                   } )
 
       let register_locally_generated t txn =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1265,13 +1265,13 @@ module T = struct
        According to project https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a
        we consider a command in pool verified if either of the following holds:
          - It's failed
-         - It's a signed command
+         - It's a signed command, since `Common.check` on a signed command
+           doesn't depend on the state of the ledger
          - It's a zkapp command, passing more checks, demonstrate as below
     *)
     match cmd_with_status with
     | { status = Failed _; data = verifiable_cmd }
     | { data = Signed_command _ as verifiable_cmd; _ } ->
-        (* BUG: this case might not be what we want, need check *)
         `Valid (coerce_cmd_as_verified verifiable_cmd, [])
     | { data = Zkapp_command verifiable_zkapp_cmd as verifiable_cmd; _ } -> (
         let cmd_hash =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1215,7 +1215,19 @@ module T = struct
       =
     (List.map ~f:(With_status.map ~f:Transaction.forget) a, b, c, d)
 
-  let check_commands ledger ~verifier (cs : User_command.t With_status.t list) =
+  type transaction_pool_proxy =
+    { find_by_hash :
+           Mina_transaction.Transaction_hash.t
+        -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+           option
+    }
+
+  let dummy_transaction_pool_proxy : transaction_pool_proxy =
+    { find_by_hash = const None }
+
+  let check_commands ledger ~verifier
+      ~(transaction_pool_proxy : transaction_pool_proxy)
+      (cs : User_command.t With_status.t list) =
     let open Deferred.Or_error.Let_syntax in
     let%bind cs =
       User_command.Applied_sequence.to_all_verifiable cs
@@ -1247,9 +1259,11 @@ module T = struct
                  (Error.of_string "batch verification failed") ) ) )
 
   let apply ?skip_verification ~proof_cache_db ~constraint_constants
-      ~global_slot t ~get_completed_work (witness : Staged_ledger_diff.t)
-      ~logger ~verifier ~current_state_view ~state_and_body_hash
-      ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap =
+      ~global_slot ~get_completed_work ~logger ~verifier ~current_state_view
+      ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase
+      ~zkapp_cmd_limit_hardcap
+      ?(transaction_pool_proxy = dummy_transaction_pool_proxy) t
+      (witness : Staged_ledger_diff.t) =
     let open Deferred.Result.Let_syntax in
     let work = Staged_ledger_diff.completed_works witness in
     let%bind () =
@@ -1267,7 +1281,7 @@ module T = struct
     let%bind prediff =
       Pre_diff_info.get witness ~constraint_constants ~coinbase_receiver
         ~supercharge_coinbase
-        ~check:(check_commands t.ledger ~verifier)
+        ~check:(check_commands t.ledger ~verifier ~transaction_pool_proxy)
       |> Deferred.map
            ~f:
              (Result.map_error ~f:(fun error ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1225,6 +1225,87 @@ module T = struct
   let dummy_transaction_pool_proxy : transaction_pool_proxy =
     { find_by_hash = const None }
 
+  let extract_zkapp_veirfication_keys
+      ({ account_updates; _ } : Zkapp_command.Verifiable.t) : _ Result.t =
+    account_updates |> Zkapp_statement.zkapp_statements_of_forest'
+    |> Zkapp_command.Call_forest.With_hashes_and_data
+       .to_zkapp_command_with_hashes_list
+    |> List.fold_result ~init:[]
+         ~f:(fun
+              acc
+              (((p, (vk_opt, _stmt)), _at_account_update) :
+                (Mina_base.Account_update.t * (_ With_hash.t option * _)) * _ )
+            ->
+           match (vk_opt, p.authorization) with
+           | None, Proof _ ->
+               Error `Missing_verification_key
+           | Some vk, Proof _ ->
+               Ok (vk.data :: acc)
+           | _ ->
+               Ok acc )
+    (* NOTE:
+       we're pushing keys in the front, so we need to revert it on finializing
+    *)
+    |> Result.map ~f:List.rev
+
+  (* NOTE:
+     If txns are already in the txn pool, we may check if the cmds are already valid
+  *)
+  let precheck_verify_commands (transaction_pool_proxy : transaction_pool_proxy)
+      (cmd_with_status : User_command.Verifiable.t With_status.t) =
+    let coerce_cmd_as_verified cmd =
+      (* NOTE: See below notes for explanation*)
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd_coerced)
+          =
+        cmd |> User_command.of_verifiable |> User_command.to_valid_unsafe
+      in
+      cmd_coerced
+    in
+    (* NOTE:
+       According to project https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a
+       we consider a command in pool verified if either of the following holds:
+         - It's failed
+         - It's a signed command
+         - It's a zkapp command, passing more checks, demonstrate as below
+    *)
+    match cmd_with_status with
+    | { status = Failed _; data = verifiable_cmd }
+    | { data = Signed_command _ as verifiable_cmd; _ } ->
+        (* BUG: this case might not be what we want, need check *)
+        `Valid (coerce_cmd_as_verified verifiable_cmd, [])
+    | { data = Zkapp_command verifiable_zkapp_cmd as verifiable_cmd; _ } -> (
+        let cmd_hash =
+          verifiable_cmd |> User_command.of_verifiable
+          |> Transaction_hash.hash_command
+        in
+        match
+          ( extract_zkapp_veirfication_keys verifiable_zkapp_cmd
+          , transaction_pool_proxy.find_by_hash cmd_hash )
+        with
+        | Ok keys_assumed, Some cmd_with_sig ->
+            let _, keys_in_pool =
+              cmd_with_sig
+              |> Transaction_hash.User_command_with_valid_signature.data
+            in
+            if
+              List.equal Side_loaded_verification_key.equal keys_assumed
+                keys_in_pool
+            then `Valid (coerce_cmd_as_verified verifiable_cmd, keys_assumed)
+            else
+              (* WARN: we need to figure out what keys should be returned for this case *)
+              `Unexpected_verification_key []
+        | Error `Missing_verification_key, Some cmd_with_sig ->
+            let _, _keys_in_pool =
+              cmd_with_sig
+              |> Transaction_hash.User_command_with_valid_signature.data
+            in
+            (* WARN: we need to figure out what keys should be returned for this case *)
+            `Missing_verification_key []
+        | Error `Missing_verification_key, None ->
+            `Missing_verification_key []
+        | _ ->
+            `No_fast_forward )
+
   let check_commands ledger ~verifier
       ~(transaction_pool_proxy : transaction_pool_proxy)
       (cs : User_command.t With_status.t list) =
@@ -1238,11 +1319,47 @@ module T = struct
             ~get_batch:(Ledger.get_batch ledger) )
       |> Deferred.return
     in
-    let%map xs = Verifier.verify_commands verifier cs in
+    (* PERF:
+         We filter on the txns to verifier and clear out already verified cases,
+         hence we waste less time interacting with proof layers.
+         More info check https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a *)
+    let last_index = List.length cs - 1 in
+    let _, already_verified_result_with_indices, to_verify_with_indices =
+      cs
+      |> List.fold_right ~init:(last_index, [], [])
+           ~f:(fun cmd_with_status (index, already_verified_result, to_verify)
+              ->
+             match
+               precheck_verify_commands transaction_pool_proxy cmd_with_status
+             with
+             | `No_fast_forward ->
+                 ( index - 1
+                 , already_verified_result
+                 , (index, cmd_with_status) :: to_verify )
+             | ( `Valid _
+               | `Unexpected_verification_key _
+               | `Missing_verification_key _ ) as result ->
+                 ( index - 1
+                 , (index, result) :: already_verified_result
+                 , to_verify ) )
+    in
+    let to_verify_indices, to_verify = List.unzip to_verify_with_indices in
+    let%map verified_results = Verifier.verify_commands verifier to_verify in
+    let verified_result_with_indices =
+      (* NOTE: the 2 lists are unziped in the beginning so should be fine if we rezip them *)
+      List.zip_exn to_verify_indices verified_results
+    in
+    let results_merged =
+      List.merge already_verified_result_with_indices
+        verified_result_with_indices
+        ~compare:(fun (index_left, _) (index_right, _) ->
+          compare index_left index_right )
+      |> List.map ~f:snd
+    in
     Result.all
-      (List.map xs ~f:(function
-        | `Valid x ->
-            Ok x
+      (List.map results_merged ~f:(function
+        | `Valid (cmd, _) ->
+            Ok cmd
         | ( `Invalid_keys _
           | `Invalid_signature _
           | `Invalid_proof _

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -193,16 +193,21 @@ val copy : t -> t
 
 val hash : t -> Staged_ledger_hash.t
 
+type transaction_pool_proxy =
+  { find_by_hash :
+         Mina_transaction.Transaction_hash.t
+      -> Mina_transaction.Transaction_hash.User_command_with_valid_signature.t
+         option
+  }
+
 val apply :
      ?skip_verification:[ `Proofs | `All ]
   -> proof_cache_db:Proof_cache_tag.cache_db
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> global_slot:Mina_numbers.Global_slot_since_genesis.t
-  -> t
   -> get_completed_work:
        (   Transaction_snark_work.Statement.t
         -> Transaction_snark_work.Checked.t option )
-  -> Staged_ledger_diff.t
   -> logger:Logger.t
   -> verifier:Verifier.t
   -> current_state_view:Zkapp_precondition.Protocol_state.View.t
@@ -210,6 +215,9 @@ val apply :
   -> coinbase_receiver:Public_key.Compressed.t
   -> supercharge_coinbase:bool
   -> zkapp_cmd_limit_hardcap:int
+  -> ?transaction_pool_proxy:transaction_pool_proxy
+  -> t
+  -> Staged_ledger_diff.t
   -> ( [ `Hash_after_applying of Staged_ledger_hash.t ]
        * [ `Ledger_proof of
            ( Ledger_proof.Cached.t
@@ -344,9 +352,12 @@ val all_work_pairs :
 (** Statements of all the pending work in t*)
 val all_work_statements_exn : t -> Transaction_snark_work.Statement.t list
 
+val dummy_transaction_pool_proxy : transaction_pool_proxy
+
 val check_commands :
      Ledger.t
   -> verifier:Verifier.t
+  -> transaction_pool_proxy:transaction_pool_proxy
   -> User_command.t With_status.t list
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -48,25 +48,31 @@ val hash_of_transaction_id : string -> t Or_error.t
 
 include Comparable.S with type t := t
 
+module User_command_with_verification_keys : sig
+  type t = User_command.Valid.t * Side_loaded_verification_key.t list
+  [@@deriving hash, sexp, compare, to_yojson]
+end
+
 module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
-  type t = private (User_command.Valid.t, hash) With_hash.t
+  type t = private (User_command_with_verification_keys.t, hash) With_hash.t
   [@@deriving hash, sexp, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 
-  val data : t -> User_command.Valid.t
+  val data : t -> User_command_with_verification_keys.t
 
   val command : t -> User_command.t
 
+  (* NOTE: this function has its name conflicted so we have to rename it *)
   val transaction_hash : t -> hash
 
   val forget_check : t -> (User_command.t, hash) With_hash.t
 
   include Comparable.S with type t := t
 
-  val make : User_command.Valid.t -> hash -> t
+  val make : User_command_with_verification_keys.t -> hash -> t
 end
 
 module User_command : sig

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -103,8 +103,9 @@ let compute_block_trace_metadata transition_with_validation =
     ; ("coinbase_receiver", Account.key_to_yojson @@ coinbase_receiver cs)
     ]
 
-let build ?skip_staged_ledger_verification ~proof_cache_db ~logger
-    ~precomputed_values ~verifier ~trust_system ~parent
+let build ?skip_staged_ledger_verification
+    ?(transaction_pool_proxy = Staged_ledger.dummy_transaction_pool_proxy)
+    ~proof_cache_db ~logger ~precomputed_values ~verifier ~trust_system ~parent
     ~transition:(transition_with_validation : Mina_block.almost_valid_block)
     ~get_completed_work ~sender ~transition_receipt_time () =
   let state_hash =
@@ -126,7 +127,7 @@ let build ?skip_staged_ledger_verification ~proof_cache_db ~logger
           ~parent_protocol_state:
             ( parent.validated_transition |> Mina_block.Validated.header
             |> Mina_block.Header.protocol_state )
-          transition_with_validation
+          ~transaction_pool_proxy transition_with_validation
       with
       | Ok
           ( `Just_emitted_a_proof just_emitted_a_proof

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -29,6 +29,7 @@ val create :
 
 val build :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
+  -> ?transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
   -> proof_cache_db:Proof_cache_tag.cache_db
   -> logger:Logger.t
   -> precomputed_values:Precomputed_values.t

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -34,6 +34,11 @@ let invalid_to_error (invalid : invalid) : Error.t =
   | `Invalid_proof err ->
       Error.tag ~tag:"Invalid_proof" err
 
+(* WARN:
+   If you consider modifying this function, please provide accompanying
+   modification of `Staged_ledger.precheck_verify_commands` as that
+   implementation depends on some assumption of this.
+*)
 let check :
        User_command.Verifiable.t With_status.t
     -> [ `Valid of User_command.Valid.t

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -73,6 +73,11 @@ module Worker_state = struct
 
   type t = (module S)
 
+  (* WARN:
+     If you consider modifying this function, please provide accompanying
+     modification of `Staged_ledger.precheck_verify_commands` as that
+     implementation depends on some assumption of this.
+  *)
   let create
       { logger
       ; proof_level

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -39,7 +39,7 @@ module Worker_state = struct
 
     val verify_commands :
          Mina_base.User_command.Verifiable.t With_status.t With_id_tag.t list
-      -> [ `Valid
+      -> [ `Valid of Pickles.Side_loaded.Verification_key.t list
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Zkapp_statement.t
@@ -118,9 +118,11 @@ module Worker_state = struct
                          (* The command is dropped here to avoid decoding it later in the caller
                             which would create a duplicate. Results are paired back to their inputs
                             using the input [id]*)
-                         `Valid
+                         `Valid []
                      | `Valid_assuming (_, xs) ->
-                         if Or_error.is_ok all_verified then `Valid
+                         if Or_error.is_ok all_verified then
+                           let keys = List.map xs ~f:Tuple3.get1 in
+                           `Valid keys
                          else `Valid_assuming xs
                      | `Invalid_keys keys ->
                          `Invalid_keys keys
@@ -202,9 +204,10 @@ module Worker_state = struct
                    let result =
                      match Common.check c with
                      | `Valid _ ->
-                         `Valid
-                     | `Valid_assuming (_, _) ->
-                         `Valid
+                         `Valid []
+                     | `Valid_assuming (_, xs) ->
+                         let keys = List.map xs ~f:Tuple3.get1 in
+                         `Valid keys
                      | `Invalid_keys keys ->
                          `Invalid_keys keys
                      | `Invalid_signature keys ->
@@ -244,7 +247,7 @@ module Worker = struct
       ; verify_commands :
           ( 'w
           , User_command.Verifiable.t With_status.t With_id_tag.t list
-          , [ `Valid
+          , [ `Valid of Pickles.Side_loaded.Verification_key.t list
             | `Valid_assuming of
               ( Pickles.Side_loaded.Verification_key.t
               * Mina_base.Zkapp_statement.t
@@ -323,7 +326,8 @@ module Worker = struct
                   With_id_tag.t
                   list]
               , [%bin_type_class:
-                  [ `Valid
+                  [ `Valid of
+                    Pickles.Side_loaded.Verification_key.Stable.Latest.t list
                   | `Valid_assuming of
                     ( Pickles.Side_loaded.Verification_key.Stable.Latest.t
                     * Mina_base.Zkapp_statement.Stable.Latest.t
@@ -675,9 +679,9 @@ let reinject_valid_user_command_into_valid_result (command, result) =
   match result with
   | #invalid as invalid ->
       invalid
-  | `Valid_assuming x ->
-      `Valid_assuming x
-  | `Valid ->
+  | `Valid_assuming conditions ->
+      `Valid_assuming conditions
+  | `Valid keys ->
       (* Since we have stripped the transaction from the result, we reconstruct it here.
          The use of [to_valid_unsafe] is justified because a [`Valid] result for this
          command means that it has indeed been validated. *)
@@ -686,7 +690,7 @@ let reinject_valid_user_command_into_valid_result (command, result) =
         User_command.to_valid_unsafe
           (User_command.of_verifiable (With_status.data command))
       in
-      `Valid command_valid
+      `Valid (command_valid, keys)
 
 let finalize_verification_results tagged_commands tagged_results =
   With_id_tag.reassociate_tagged_results tagged_commands tagged_results

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -25,7 +25,9 @@ module Base = struct
       -> Mina_base.User_command.Verifiable.t Mina_base.With_status.t list
          (* The first level of error represents failure to verify, the second a failure in
             communicating with the verifier. *)
-      -> [ `Valid of Mina_base.User_command.Valid.t
+      -> [ `Valid of
+           Mina_transaction.Transaction_hash.User_command_with_verification_keys
+           .t
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Zkapp_statement.t


### PR DESCRIPTION
This is a continuation of #16735
Explain your changes:
* This PR make transaction pool tracks the verify_key so that verifier wouldn't repeat the verification process of a same zkapp command

Explain how you tested your changes:
* Not tested

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Purpose: for all the commands need to be verified in staged_ledger.apply, and skip the verification for those that satisfy specific conditions, so no computation tasks are redone. 
  - Mention expected invariants, implicit constraints
     No invariants expected
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them
	* Closes no issue…hash in a transaction_pool down to Staged_ledger.check_commands