### PR TITLE
Fix internal logs for itn 

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -2015,7 +2015,8 @@ let print_version_info () = Core.printf "Commit %s\n" Mina_version.commit_id
 
 let () =
   Random.self_init () ;
-  let logger = Logger.create () in
+  let compile_config = Mina_compile_config.Compiled.t in
+  let logger = Logger.create ~itn_features:compile_config.itn_features () in
   don't_wait_for (ensure_testnet_id_still_good logger) ;
   (* Turn on snark debugging in prod for now *)
   Snarky_backendless.Snark.set_eval_constraints true ;
@@ -2029,7 +2030,6 @@ let () =
    | [| _mina_exe; version |] when is_version_cmd version ->
        Mina_version.print_version ()
    | _ ->
-       let compile_config = Mina_compile_config.Compiled.t in
        Command.run
          (Command.group ~summary:"Mina" ~preserve_subcommand_order:()
             (mina_commands logger ~itn_features:compile_config.itn_features) )


### PR DESCRIPTION
Fixing native logger setup which was another victim for revert after introducing runtime config.

This commit changed logger behavior in regards to itn_features flag:

https://github.com/MinaProtocol/mina/commit/2c858d7309499da50e23ac480b5af3bff6e777a6#diff-e8bcb44f0f9c363945c8e5adcea9ea47904f79f44e362eef7ec6c484e61aa1a1L413

However it was reverted incompletely. As a result Mina_compile_config usage was removed but not reinstated on mina setup code. 

I tested above fix with internal log fetcher app and by manually validating that all the logger with internal level are derived from the one setup with ~itn_features 

