### PR TITLE
[CI] Prune dockers before build

### DIFF
--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -163,8 +163,10 @@ export_docker_tag
 
 BUILD_NETWORK="--network=host"
 
-# Prune old docker images (24 hours)
-docker system prune --all  --filter until=24h
+# Prune old docker images (24 hours) from the cache
+# This is a temporary solution to keep the cache from growing too large.
+# We will also need to evaluate the impact of this on the build process and adjust as necessary.
+docker system prune --all --force --filter until=24h
 
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT}" ]]; then

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -163,6 +163,9 @@ export_docker_tag
 
 BUILD_NETWORK="--network=host"
 
+# Prune old docker images (24 hours)
+docker system prune --all  --filter until=24h
+
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT}" ]]; then
   cat $DOCKERFILE_PATH | docker build $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO -t "$TAG" -


### PR DESCRIPTION
After Luis introduced persistent storage for docker images, out situation improved a bit (agents are not crashing due to OOM). However, on our target is a new issue: docker storage growth in alarming time. This simple fix will prune old images (older than 24 hours) before building any. Since docker build is a major contributor to a space issue it will bring a bit of space relief when prunning before building