### PR TITLE
move itn_feature from compile config to env var

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1368,7 +1368,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                   "Cannot provide both uptime submitter public key and uptime \
                    submitter keyfile"
           in
-          if compile_config.itn_features then
+          if itn_features then
             (* set queue bound directly in Itn_logger
                adding bound to Mina_lib config introduces cycle
             *)
@@ -1405,7 +1405,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~uptime_send_node_commit ~stop_time ~node_status_url
                  ~graphql_control_port:itn_graphql_port ~simplified_node_stats
                  ~zkapp_cmd_limit:(ref compile_config.zkapp_cmd_limit)
-                 ~compile_config () )
+                 ~itn_features ~compile_config () )
           in
           { mina
           ; client_trustlist
@@ -1464,11 +1464,11 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
         let () = Mina_plugins.init_plugins ~logger mina plugins in
         return mina )
 
-let daemon logger =
+let daemon logger ~itn_features =
   let compile_config = Mina_compile_config.Compiled.t in
   Command.async ~summary:"Mina daemon"
     (Command.Param.map
-       (setup_daemon logger ~itn_features:compile_config.itn_features
+       (setup_daemon logger ~itn_features
           ~default_snark_worker_fee:compile_config.default_snark_worker_fee )
        ~f:(fun setup_daemon () ->
          (* Immediately disable updating the time offset. *)
@@ -1478,7 +1478,7 @@ let daemon logger =
          [%log info] "Daemon ready. Clients can now connect" ;
          Async.never () ) )
 
-let replay_blocks logger =
+let replay_blocks logger ~itn_features =
   let replay_flag =
     let open Command.Param in
     flag "--blocks-filename" ~aliases:[ "-blocks-filename" ] (required string)
@@ -1492,7 +1492,7 @@ let replay_blocks logger =
   let compile_config = Mina_compile_config.Compiled.t in
   Command.async ~summary:"Start mina daemon with blocks replayed from a file"
     (Command.Param.map3 replay_flag read_kind
-       (setup_daemon logger ~itn_features:compile_config.itn_features
+       (setup_daemon logger ~itn_features
           ~default_snark_worker_fee:compile_config.default_snark_worker_fee )
        ~f:(fun blocks_filename read_kind setup_daemon () ->
          (* Enable updating the time offset. *)
@@ -1685,7 +1685,7 @@ let snark_hashes =
       let json = Cli_lib.Flag.json in
       fun () -> if json then Core.printf "[]\n%!"]
 
-let internal_commands logger =
+let internal_commands logger ~itn_features =
   [ ( Snark_worker.Intf.command_name
     , Snark_worker.command ~proof_level:Genesis_constants.Compiled.proof_level
         ~constraint_constants:Genesis_constants.Compiled.constraint_constants
@@ -1918,7 +1918,7 @@ let internal_commands logger =
               () ) ;
           Deferred.return ()) )
   ; ("dump-type-shapes", dump_type_shapes)
-  ; ("replay-blocks", replay_blocks logger)
+  ; ("replay-blocks", replay_blocks logger ~itn_features)
   ; ("audit-type-shapes", audit_type_shapes)
   ; ( "test-genesis-block-generation"
     , Command.async ~summary:"Generate a genesis proof"
@@ -1985,13 +1985,14 @@ let internal_commands logger =
 
 let mina_commands logger ~itn_features =
   [ ("accounts", Client.accounts)
-  ; ("daemon", daemon logger)
+  ; ("daemon", daemon logger ~itn_features)
   ; ("client", Client.client)
   ; ("advanced", Client.advanced ~itn_features)
   ; ("ledger", Client.ledger)
   ; ("libp2p", Client.libp2p)
   ; ( "internal"
-    , Command.group ~summary:"Internal commands" (internal_commands logger) )
+    , Command.group ~summary:"Internal commands"
+        (internal_commands logger ~itn_features) )
   ; (Parallel.worker_command_name, Parallel.worker_command)
   ; ("transaction-snark-profiler", Transaction_snark_profiler.command)
   ]
@@ -2015,8 +2016,8 @@ let print_version_info () = Core.printf "Commit %s\n" Mina_version.commit_id
 
 let () =
   Random.self_init () ;
-  let compile_config = Mina_compile_config.Compiled.t in
-  let logger = Logger.create ~itn_features:compile_config.itn_features () in
+  let itn_features = Sys.getenv "ITN_FEATURES" |> Option.is_some in
+  let logger = Logger.create ~itn_features () in
   don't_wait_for (ensure_testnet_id_still_good logger) ;
   (* Turn on snark debugging in prod for now *)
   Snarky_backendless.Snark.set_eval_constraints true ;
@@ -2032,8 +2033,7 @@ let () =
    | _ ->
        Command.run
          (Command.group ~summary:"Mina" ~preserve_subcommand_order:()
-            (mina_commands logger ~itn_features:compile_config.itn_features) )
-  ) ;
+            (mina_commands logger ~itn_features) ) ) ;
   Core.exit 0
 
 let linkme = ()

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -213,6 +213,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ?limited_graphql_port ?itn_graphql_port ?auth_keys
     ?(open_limited_graphql_port = false) ?(insecure_rest_server = false) mina =
   let compile_config = (Mina_lib.config mina).compile_config in
+  let itn_features = (Mina_lib.config mina).itn_features in
   let client_trustlist =
     ref
       (Unix.Cidr.Set.of_list
@@ -552,7 +553,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
             ~schema:Mina_graphql.schema_limited
             ~server_description:"GraphQL server with limited queries"
             ~require_auth:false rest_server_port ) ) ;
-  if compile_config.itn_features then
+  if itn_features then
     (* Third graphql server with ITN-particular queries exposed *)
     Option.iter itn_graphql_port ~f:(fun rest_server_port ->
         O1trace.background_thread "serve_itn_graphql" (fun () ->

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -58,7 +58,6 @@
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2021-09-24T00:00:00Z"]
 [%%define block_window_duration 180000]
-[%%define itn_features false]
 [%%define print_versioned_types false]
 [%%define test_full_epoch false]
 

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -58,7 +58,6 @@
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2020-09-16 03:15:00-07:00"]
 [%%define block_window_duration 180000]
-[%%define itn_features false]
 [%%define print_versioned_types false]
 [%%define test_full_epoch false]
 

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -12,7 +12,6 @@ module Inputs = struct
     ; default_transaction_fee_string : string
     ; default_snark_worker_fee_string : string
     ; minimum_user_command_fee_string : string
-    ; itn_features : bool
     ; compaction_interval_ms : int option
     ; block_window_duration_ms : int
     ; vrf_poll_interval_ms : int
@@ -40,7 +39,6 @@ type t =
   ; default_transaction_fee : Currency.Fee.Stable.Latest.t
   ; default_snark_worker_fee : Currency.Fee.Stable.Latest.t
   ; minimum_user_command_fee : Currency.Fee.Stable.Latest.t
-  ; itn_features : bool
   ; compaction_interval : Time.Span.t option
   ; block_window_duration : Time.Span.t
   ; vrf_poll_interval : Time.Span.t
@@ -70,7 +68,6 @@ let make (inputs : Inputs.t) =
       Currency.Fee.of_mina_string_exn inputs.default_snark_worker_fee_string
   ; minimum_user_command_fee =
       Currency.Fee.of_mina_string_exn inputs.minimum_user_command_fee_string
-  ; itn_features = inputs.itn_features
   ; compaction_interval =
       Option.map
         ~f:(fun x -> Float.of_int x |> Time.Span.of_ms)
@@ -106,7 +103,6 @@ let to_yojson t =
       , Currency.Fee.to_yojson t.default_snark_worker_fee )
     ; ( "minimum_user_command_fee"
       , Currency.Fee.to_yojson t.minimum_user_command_fee )
-    ; ("itn_features", `Bool t.itn_features)
     ; ( "compaction_interval"
       , Option.value_map ~default:`Null
           ~f:(fun x -> `Float (Time.Span.to_ms x))
@@ -145,7 +141,6 @@ module Compiled = struct
       ; default_transaction_fee_string = Node_config.default_transaction_fee
       ; default_snark_worker_fee_string = Node_config.default_snark_worker_fee
       ; minimum_user_command_fee_string = Node_config.minimum_user_command_fee
-      ; itn_features = Node_config.itn_features
       ; compaction_interval_ms = Node_config.compaction_interval
       ; block_window_duration_ms = Node_config.block_window_duration
       ; vrf_poll_interval_ms = Node_config.vrf_poll_interval
@@ -183,7 +178,6 @@ module For_unit_tests = struct
           Node_config_for_unit_tests.default_snark_worker_fee
       ; minimum_user_command_fee_string =
           Node_config_for_unit_tests.minimum_user_command_fee
-      ; itn_features = Node_config_for_unit_tests.itn_features
       ; compaction_interval_ms = Node_config_for_unit_tests.compaction_interval
       ; block_window_duration_ms =
           Node_config_for_unit_tests.block_window_duration

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -64,5 +64,6 @@ type t =
   ; graphql_control_port : int option [@default None]
   ; zkapp_cmd_limit : int option ref
   ; compile_config : Mina_compile_config.t
+  ; itn_features : bool
   }
 [@@deriving make]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1686,7 +1686,7 @@ let create ~commit_id ?wallets (config : Config.t) =
   Async.Scheduler.within' ~monitor (fun () ->
       let set_itn_data (type t) (module M : Itn_settable with type t = t) (t : t)
           =
-        if config.compile_config.itn_features then
+        if config.itn_features then
           let ({ client_port; _ } : Node_addrs_and_ports.t) =
             config.gossip_net_params.addrs_and_ports
           in

--- a/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
+++ b/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
@@ -53,8 +53,6 @@ let (genesis_state_timestamp : string) = ("2019-01-30 12:00:00-08:00" : string)
 
 let (block_window_duration : int) = (2000 : int)
 
-let (itn_features : bool) = (true : bool)
-
 let compaction_interval = None
 
 let (network : string) = ("testnet" : string)

--- a/src/lib/node_config/intf/node_config_intf.mli
+++ b/src/lib/node_config/intf/node_config_intf.mli
@@ -80,8 +80,6 @@ module type S = sig
 
   val block_window_duration : int
 
-  val itn_features : bool
-
   val compaction_interval : int option
 
   val vrf_poll_interval : int

--- a/src/lib/node_config/node_config.ml
+++ b/src/lib/node_config/node_config.ml
@@ -70,8 +70,6 @@ let scan_state_transaction_capacity_log_2 =
 
 [%%inject "block_window_duration", block_window_duration]
 
-[%%inject "itn_features", itn_features]
-
 [%%ifndef compaction_interval]
 
 let compaction_interval = None


### PR DESCRIPTION
This PR is successor of https://github.com/MinaProtocol/mina/pull/16754 where we fixed itn features setup for logger. 

Here we want to remove itn_features flag from compile config completely and  read it from env var. I used this approach as i wanted to preserve conditional appearance of itn_* related cli argument. If there is a better way to control when those argument are available, then I'm happy to change it. 

Usage: 

```
ITN_FEATURES=1 DUNE_PROFILE=devnet dune exec src/app/cli/src/mina.exe -- daemon  -insecure-rest-server --itn-graphql-port 8080 --itn-keys ....  
```