### PR TITLE
Remove static mut from rayon module

### DIFF
--- a/changes/16758.md
+++ b/changes/16758.md
@@ -1,0 +1,1 @@
+Remove static mut from rayon module


### PR DESCRIPTION
Explain your changes:
* I've swapped the unsafe use of `static mut` for the safe usage of `LocalKey<RefCell<T>>` such that we are guaranteed not to have any UB. This comes at a slight runtime overhead, but this should not be a problem as it will only happen on starting or stopping the thread-pool. `static mut` is dangerous, and safety has only really been upheld by the runtime environment outside of this crate. If that runtime environment were to change, the old code could cause UB.

Explain how you tested your changes:
* I'm hoping for CI to do this for me to be honest

TODO - I will update the list below once I see that CI is passing

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
