### PR TITLE
Polymorphize Zkapp_command in mina_wire_types

### DIFF
--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -237,11 +237,10 @@ let build_zkapp_cmd ?valid_until ~fee transactions :
   let open State.Let_syntax in
   let%bind body = fee_payer_body ?valid_until fee in
   let%map updates = State.concat_map_m ~f:mk_updates transactions in
-  Zkapp_command.
-    { fee_payer = { body; authorization = Signature.dummy }
-    ; account_updates = updates
-    ; memo = Signed_command_memo.dummy
-    }
+  { Zkapp_command.Poly.fee_payer = { body; authorization = Signature.dummy }
+  ; account_updates = updates
+  ; memo = Signed_command_memo.dummy
+  }
 
 let zkapp_cmd ?valid_until ~noncemap ~fee transactions =
   Monad_lib.State.eval_state

--- a/src/lib/mina_wire_types/mina_base/mina_base_zkapp_command.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_zkapp_command.ml
@@ -78,15 +78,20 @@ module Call_forest = struct
 end
 
 module V1 = struct
+  module T = struct
+    type 'a t =
+      { fee_payer : Mina_base_account_update.Fee_payer.V1.t
+      ; account_updates : 'a
+      ; memo : Mina_base_signed_command_memo.V1.t
+      }
+  end
+
   type t =
-    { fee_payer : Mina_base_account_update.Fee_payer.V1.t
-    ; account_updates :
-        ( Mina_base_account_update.V1.t
-        , Call_forest.Digest.Account_update.V1.t
-        , Call_forest.Digest.Forest.V1.t )
-        Call_forest.V1.t
-    ; memo : Mina_base_signed_command_memo.V1.t
-    }
+    ( Mina_base_account_update.V1.t
+    , Call_forest.Digest.Account_update.V1.t
+    , Call_forest.Digest.Forest.V1.t )
+    Call_forest.V1.t
+    T.t
 end
 
 module Valid = struct

--- a/src/lib/mina_wire_types/mina_base/mina_base_zkapp_command.mli
+++ b/src/lib/mina_wire_types/mina_base/mina_base_zkapp_command.mli
@@ -80,15 +80,20 @@ module Call_forest : sig
 end
 
 module V1 : sig
+  module T : sig
+    type 'a t =
+      { fee_payer : Mina_base_account_update.Fee_payer.V1.t
+      ; account_updates : 'a
+      ; memo : Mina_base_signed_command_memo.V1.t
+      }
+  end
+
   type t =
-    { fee_payer : Mina_base_account_update.Fee_payer.V1.t
-    ; account_updates :
-        ( Mina_base_account_update.V1.t
-        , Call_forest.Digest.Account_update.V1.t
-        , Call_forest.Digest.Forest.V1.t )
-        Call_forest.V1.t
-    ; memo : Mina_base_signed_command_memo.V1.t
-    }
+    ( Mina_base_account_update.V1.t
+    , Call_forest.Digest.Account_update.V1.t
+    , Call_forest.Digest.Forest.V1.t )
+    Call_forest.V1.t
+    T.t
 end
 
 module Valid : sig

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -171,7 +171,7 @@ module Make (Inputs : Intf.Inputs_intf) :
                   let init =
                     match
                       (Mina_base.Account_update.of_fee_payer
-                         zkapp_command.Mina_base.Zkapp_command.fee_payer )
+                         zkapp_command.Mina_base.Zkapp_command.Poly.fee_payer )
                         .authorization
                     with
                     | Proof _ ->

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -165,7 +165,7 @@ let yojson_summary_of_command =
   in
   function
   | User_command.Zkapp_command cmd ->
-      mk_record (zkapp_type cmd) (Zkapp_command.memo cmd)
+      mk_record (zkapp_type cmd) cmd.Zkapp_command.Poly.memo
         ( Zkapp_command.fee_payer_account_update cmd
         |> Account_update.Fee_payer.authorization )
   | Signed_command cmd ->

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4607,7 +4607,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                      } )
           }
       in
-      let ( `Zkapp_command { Zkapp_command.fee_payer; account_updates; memo }
+      let ( `Zkapp_command
+              { Zkapp_command.Poly.fee_payer; account_updates; memo }
           , `Sender_account_update sender_account_update
           , `Proof_zkapp_command snapp_zkapp_command
           , `Txn_commitment commitment
@@ -4715,7 +4716,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             create_trivial_snapp ()
       in
       let%bind.Async.Deferred vk = vk in
-      let ( `Zkapp_command { Zkapp_command.fee_payer; memo; _ }
+      let ( `Zkapp_command { Zkapp_command.Poly.fee_payer; memo; _ }
           , `Sender_account_update _
           , `Proof_zkapp_command _
           , `Txn_commitment _
@@ -4867,7 +4868,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             (prover, vk)
       in
       let%bind.Async.Deferred vk = vk in
-      let ( `Zkapp_command ({ Zkapp_command.fee_payer; memo; _ } as p)
+      let ( `Zkapp_command ({ Zkapp_command.Poly.fee_payer; memo; _ } as p)
           , `Sender_account_update sender_account_update
           , `Proof_zkapp_command snapp_zkapp_command
           , `Txn_commitment commitment


### PR DESCRIPTION
Context: zkapp command appears in two flavors in the code. One flavor
is zkapp command with intermediate hashes being computed for the call
forest. This representation is required for the zkapp command
application. Another flavor is zkapp command with call forest hashes
being replaced with dummies (of `unit` type). This is used for
transmission of a transaction over the wire.

Problem: these two flavors are defined as completely separate types
with all of the functions operating on either of them. This isn't handy
for writing code that is agnostic of flavor. Which either neccesitates
unnecessary conversions or code duplication.

Solution: make the zkapp command type definition in `mina_wire_types`
polymorphic in account updates structure. Perform similar changes in
zkapp command definition (in `mina_base` package). This paves the way
for writing polymorphic function for things that do not depend on call
forest hashes.

Explain how you tested your changes:
* This is refactoring, no changes to functionality are made
* Wire types are also only refactored
    * Shapes remain the same, hence binio compatibility test will succeed
    * Yojson conversion will also remain the same

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
