### PR TITLE
Fix rosetta sanity success message

### DIFF
--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -104,7 +104,7 @@ function run_tests_with_test_data() {
     echo "🧪  2/6 Testing network/options endpoint"
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
         '.version.rosetta_version == "1.4.9"' \
-        "   ✅  Rosetta Version is not correct" \
+        "   ✅  Rosetta Version is correct" \
         "   ❌  Invalid Rosetta Version (expected 1.4.9)"
 
     echo "🧪  3/6 Testing network/list endpoint"


### PR DESCRIPTION
FIxed message on successful version check for rosetta:

```
✅  Rosetta is synced
🔗  Testing Rosetta sanity functionality for network: devnet

🧪  1/6 Testing network/status endpoint
   ✅  Rosetta is synced
🧪  2/6 Testing network/options endpoint
   ✅  Rosetta Version is **not** correct <--- removed not
🧪  3/6 Testing network/list endpoint
   ✅  Block hash correct
🧪  4/6 Testing account/balance endpoint for account
   ✅  Account: Balance for ok
🧪  5/6 Testing search/transactions endpoint for payment transaction
   ✅  Payment transaction found
🧪  6/6 Testing search/transactions endpoint for zkapp transaction
   ✅  Zkapp transaction found
🎉  All tests passed successfully!
```