### PR TITLE
Remove unused sexp derivations from masking ledger

### DIFF
--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -43,8 +43,6 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
 
   let cast (m : (module Base_intf with type t = 'a)) (t : 'a) = T (m, t)
 
-  let sexp_of_witness (T ((module B), t)) = B.sexp_of_t t
-
   (** M can be used wherever a base ledger is demanded, construct instances
    * by using the witness constructor directly
    *
@@ -53,9 +51,7 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
    * In the future, this should be a `ppx`.
    *)
   module M : Base_intf with type t = witness = struct
-    type t = witness [@@deriving sexp_of]
-
-    let t_of_sexp _ = failwith "t_of_sexp unimplemented"
+    type t = witness
 
     type index = int
 

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -216,7 +216,7 @@ module type SYNCABLE = sig
 
   type addr
 
-  type t [@@deriving sexp]
+  type t
 
   type path
 
@@ -450,7 +450,7 @@ module Ledger = struct
 
     (** The type of the witness for a base ledger exposed here so that it can
    * be easily accessed from outside this module *)
-    type witness [@@deriving sexp_of]
+    type witness
 
     module type Base_intf =
       S

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -16,8 +16,6 @@ end = struct
 
   type t = { uuid : Uuid.t; depth : int } [@@deriving sexp_of]
 
-  let t_of_sexp _ = failwith "t_of_sexp unimplemented"
-
   type index = int
 
   module Location = Location

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -16,15 +16,10 @@ module Make (Inputs : Inputs_intf.S) = struct
       issues with bin_io to do so *)
   module Parent = struct
     type t = (Base.t, string (* Location where null was set *)) Result.t
-    [@@deriving sexp]
   end
 
   module Detached_parent_signal = struct
     type t = unit Async.Ivar.t
-
-    let sexp_of_t (_ : t) = Sexp.List []
-
-    let t_of_sexp (_ : Sexp.t) : t = Async.Ivar.create ()
   end
 
   type maps_t =
@@ -34,7 +29,6 @@ module Make (Inputs : Inputs_intf.S) = struct
     ; locations : Location.t Account_id.Map.t
     ; non_existent_accounts : Account_id.Set.t
     }
-  [@@deriving sexp]
 
   (** Merges second maps object into the first one,
       potentially overwriting some keys *)
@@ -91,12 +85,11 @@ module Make (Inputs : Inputs_intf.S) = struct
           (* If present, contains maps containing changes both for this mask
              and for a few ancestors.
              This is used as a lookup cache. *)
-    ; mutable accumulated : (accumulated_t[@sexp.opaque]) option
+    ; mutable accumulated : accumulated_t option
     ; mutable is_committing : bool
     }
-  [@@deriving sexp]
 
-  type unattached = t [@@deriving sexp]
+  type unattached = t
 
   let empty_maps =
     { accounts = Location_binable.Map.empty
@@ -120,9 +113,7 @@ module Make (Inputs : Inputs_intf.S) = struct
   let get_uuid { uuid; _ } = uuid
 
   module Attached = struct
-    type parent = Base.t [@@deriving sexp]
-
-    type t = unattached [@@deriving sexp]
+    type t = unattached
 
     module Path = Base.Path
     module Addr = Location.Addr

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -8,7 +8,7 @@ module Transaction_snark_work = Transaction_snark_work
 module Base_ledger = Mina_ledger.Ledger
 
 module Staged_ledger = struct
-  type t = Base_ledger.t [@@deriving sexp]
+  type t = Base_ledger.t
 
   let ledger = Fn.id
 end
@@ -33,7 +33,6 @@ module Transition_frontier = struct
     ; diff_writer : (diff Broadcast_pipe.Writer.t[@sexp.opaque])
     ; diff_reader : (diff Broadcast_pipe.Reader.t[@sexp.opaque])
     }
-  [@@deriving sexp]
 
   let add_statements table stmts =
     List.iter stmts ~f:(fun s ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -3178,10 +3178,6 @@ let%test_module "staged ledger tests" =
           tuple2
             (gen_zkapps_at_capacity_fixed_blocks expected_proof_count)
             small_positive_int)
-        ~sexp_of:
-          [%sexp_of:
-            (Ledger.t * Mina_base.User_command.Valid.t list * int option list)
-            * int]
         ~trials:1
         ~f:(fun ((ledger, zkapps, iters), global_slot) ->
           async_with_given_ledger ledger (fun ~snarked_ledger sl test_mask ->


### PR DESCRIPTION
Sexp derivation where not used in any meaningful way, and cluttered the
code a lot.

Explain how you tested your changes:
* Code still compiles after sexp derivation removal
* No functionality was changed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
