### PR TITLE
Granular nix: support dune files with only `public_name`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724407960,
-        "narHash": "sha256-pUKTVMYEtsD1AGlHFTdPourowt+tJ3htKhRu7VALFzc=",
+        "lastModified": 1742933373,
+        "narHash": "sha256-sW6ZheQeXe+GULDKLcgRJN4eucP3IXWHz0bHL9KKU1w=",
         "owner": "o1-labs",
         "repo": "describe-dune",
-        "rev": "be828239c05671209e979f9d5c2e3094e3be7a46",
+        "rev": "ba71baa26329399ca2f1d158f15e7c32bba1d072",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724418497,
-        "narHash": "sha256-HjTh7o02QhGXmbxmpE5HRWei3H/pyh/NKCMCnucDaYs=",
+        "lastModified": 1742933757,
+        "narHash": "sha256-FI8sVvIJuKscrnOUj/cqbZRVOxTzgBwYMyZSNcXq+58=",
         "owner": "o1-labs",
         "repo": "dune-nix",
-        "rev": "26dc164a4c3976888e13eabd73a210b78505820f",
+        "rev": "5eedc211a4cfc3bae1833c5a85542be49b4a9f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Support dune files without `name` stanza.

PR bumps versions of `dune-nix` and `describe-dune` to support libraries and executables with only `public_name` defined.
Previous version assumed `name` stannza to be always present.

This fixes granular nix building.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
