### PR TITLE
Don't pass around unnecessary vectors

### DIFF
--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
@@ -19,13 +19,15 @@ pub struct WasmPastaFp(pub Fp);
 
 impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFp {
     const FLATTENED_SIZE: usize = core::mem::size_of::<Fp>();
+
     fn flatten(self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
         self.0.serialize_compressed(&mut bytes).unwrap();
         bytes
     }
-    fn unflatten(flat: Vec<u8>) -> Self {
-        WasmPastaFp(Fp::deserialize_compressed(flat.as_slice()).unwrap())
+
+    fn unflatten(flat: &[u8]) -> Self {
+        WasmPastaFp(Fp::deserialize_compressed(flat).unwrap())
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
@@ -19,13 +19,15 @@ pub struct WasmPastaFq(pub Fq);
 
 impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFq {
     const FLATTENED_SIZE: usize = core::mem::size_of::<Fq>();
+
     fn flatten(self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
         self.0.serialize_compressed(&mut bytes).unwrap();
         bytes
     }
-    fn unflatten(flat: Vec<u8>) -> Self {
-        WasmPastaFq(Fq::deserialize_compressed(flat.as_slice()).unwrap())
+
+    fn unflatten(flat: &[u8]) -> Self {
+        WasmPastaFq(Fq::deserialize_compressed(flat).unwrap())
     }
 }
 


### PR DESCRIPTION
Explain your changes:
* Manually allocating can potentially side-step a compiler optimization of re-using previous allocations where possible. Also, it's not a good practive to pass in a `Vec` to a function where all you do with the `Vec` is call `as_slice`. A `Vec` consists of a pointer, a length, and a capacity whereas a slice is only a pointer and a length. Slices should always be prefered when elements aren't being added or removed.

Explain how you tested your changes:
* I'm hoping for CI to do this for me, but we should really add tests to this crate

TODO: Will update after passing CI

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
