### PR TITLE
Nix: remove old Rust version (1.72 and nightly-2023-09-01)

### DIFF
--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -8,9 +8,6 @@ let
       # override stdenv.targetPlatform here, if necessary
     };
   toolchainHashes = {
-    "1.72" = "sha256-dxE7lmCFWlq0nl/wKcmYvpP9zqQbBitAQgZ1zx9Ooik=";
-    "nightly-2023-09-01" =
-      "sha256-zek9JAnRaoX8V0U2Y5ssXVe9tvoQ0ERGXfUCUGYdrMA=";
     "1.79.0" = "sha256-Ngiz76YP4HTY75GGdH2P+APE/DEIx2R/Dn+BwwOyzZU=";
     "nightly-2024-06-13" = "sha256-s5nlYcYG9EuO2HK2BU3PkI928DZBKCTJ4U9bz3RX1t4=";
     # copy the placeholder line with the correct toolchain name when adding a new toolchain


### PR DESCRIPTION
Follow-up on https://github.com/MinaProtocol/mina/pull/16731 and https://github.com/MinaProtocol/mina/pull/16652