### PR TITLE
Bump up proof systems and wasm bindgen to 0.2.100

### DIFF
--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -36,8 +36,10 @@ serde = "1.0.171"
 serde_json = "1.0.103"
 serde_with = ">=2.1.0"
 serde-wasm-bindgen = ">=0.4"
-# Strictly enforcing 0.2.87
-wasm-bindgen = { version = "=0.2.87" }
+# Strictly enforcing 0.2.100
+# The version must be the same as in Cargo.toml in the repository
+# o1-labs/proof-systems.
+wasm-bindgen = { version = "=0.2.100" }
 web-sys = { version = "0.3.35", features = [
   "Window",
   "Document",

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -39,8 +39,12 @@ serde-wasm-bindgen = ">=0.4"
 # Strictly enforcing 0.2.100
 # The version must be the same as in Cargo.toml in the repository
 # o1-labs/proof-systems.
+# wasm-bindgen must be updated when web-sys is udpated as they live in the same
+# repository.
 wasm-bindgen = { version = "=0.2.100" }
-web-sys = { version = "0.3.35", features = [
+# web-sys must be updated when wasm-bindgen is udpated as they live in the same
+# repository.
+web-sys = { version = "0.3.77", features = [
   "Window",
   "Document",
   "HtmlElement",

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -54,10 +54,10 @@ web-sys = { version = "0.3.77", features = [
 ] }
 
 # arkworks
-ark-ec = { version = "0.4.2", features = ["parallel"] }
-ark-ff = { version = "0.4.2", features = ["parallel", "asm"] }
-ark-poly = { version = "0.4.2", features = ["parallel"] }
-ark-serialize = "0.4.2"
+ark-ec = { version = "=0.4.2", features = ["parallel"] }
+ark-ff = { version = "=0.4.2", features = ["parallel", "asm"] }
+ark-poly = { version = "=0.4.2", features = ["parallel"] }
+ark-serialize = "=0.4.2"
 
 # proof-systems
 groupmap = { path = "../../proof-systems/groupmap" }


### PR DESCRIPTION
Leaving in draft. When doing cargo vendor, wasm-bindgen still points to 0.2.93. Investigating the dependency graph.

Do not review and don't merge. Depends on https://github.com/o1-labs/proof-systems/pull/3103