### PR TITLE
Prepare for Transaction.{Stable.Latest.t != t}

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1746,7 +1746,7 @@ let internal_commands logger =
               in
               let spec =
                 [%of_sexp:
-                  ( Transaction_witness.t
+                  ( Transaction_witness.Stable.Latest.t
                   , Ledger_proof.t )
                   Snark_work_lib.Work.Single.Spec.t] sexp
               in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -890,7 +890,10 @@ let add_work t (work : Snark_worker_lib.Work.Result.t) =
     Mina_metrics.(
       Gauge.set Snark_work.pending_snark_work (Int.to_float pending_work))
   in
-  let spec = work.spec.instances in
+  let spec =
+    One_or_two.map work.spec.instances
+      ~f:Snark_work_lib.Work.Single.Spec.statement
+  in
   let cb _ =
     (* remove it from seen jobs after attempting to adding it to the pool to avoid this work being reassigned
      * If the diff is accepted then remove it from the seen jobs.

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -107,7 +107,7 @@ val snark_work_fee : t -> Currency.Fee.t
 
 val set_snark_work_fee : t -> Currency.Fee.t -> unit
 
-val request_work : t -> Snark_worker.Work.Spec.t option
+val request_work : t -> Work_selector.work Snark_work_lib.Work.Spec.t option
 
 val work_selection_method : t -> (module Work_selector.Selection_method_intf)
 

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -67,12 +67,15 @@ module Make (Inputs : Intf.Inputs_intf) :
 
     module Single = struct
       module Spec = struct
-        type t = (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+        type t =
+          ( Transaction_witness.Stable.Latest.t
+          , Ledger_proof.t )
+          Work.Single.Spec.t
         [@@deriving sexp, yojson]
 
         let transaction t =
           Option.map (Work.Single.Spec.witness t) ~f:(fun w ->
-              w.Transaction_witness.transaction )
+              w.Transaction_witness.Stable.Latest.transaction )
 
         let statement = Work.Single.Spec.statement
       end

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -23,7 +23,7 @@ module type Inputs_intf = sig
   val perform_single :
        Worker_state.t
     -> message:Mina_base.Sok_message.t
-    -> (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+    -> (Transaction_witness.Stable.Latest.t, Ledger_proof.t) Work.Single.Spec.t
     -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t
 end
 
@@ -65,7 +65,8 @@ module type Work_S = sig
 
   module Single : sig
     module Spec : sig
-      type t = (Transaction_witness.t, ledger_proof) Work.Single.Spec.t
+      type t =
+        (Transaction_witness.Stable.Latest.t, ledger_proof) Work.Single.Spec.t
       [@@deriving sexp, yojson]
     end
   end
@@ -78,7 +79,9 @@ module type Work_S = sig
     type t = (Spec.t, ledger_proof) Work.Result.t
 
     val transactions :
-      t -> Mina_transaction.Transaction.t option One_or_two.Stable.V1.t
+         t
+      -> Mina_transaction.Transaction.Stable.Latest.t option
+         One_or_two.Stable.Latest.t
   end
 end
 

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -99,10 +99,12 @@ module Inputs = struct
               Deferred.Or_error.return (proof, Time.Span.zero)
           | None -> (
               match single with
-              | Work.Single.Spec.Transition (input, (w : Transaction_witness.t))
-                ->
+              | Work.Single.Spec.Transition
+                  (input, (w : Transaction_witness.Stable.Latest.t)) ->
                   process (fun () ->
-                      match w.transaction with
+                      match
+                        Transaction.read_all_proofs_from_disk w.transaction
+                      with
                       | Command (Zkapp_command zkapp_command) -> (
                           let%bind witnesses_specs_stmts =
                             Or_error.try_with (fun () ->
@@ -243,7 +245,10 @@ module Inputs = struct
                             Deferred.return
                             @@
                             (* Validate the received transaction *)
-                            match w.transaction with
+                            match
+                              Transaction.read_all_proofs_from_disk
+                                w.transaction
+                            with
                             | Command (Signed_command cmd) -> (
                                 match Signed_command.check cmd with
                                 | Some cmd ->

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -25,7 +25,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
         type query = unit
 
         type response =
-          ( (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+          ( ( Transaction_witness.Stable.Latest.t
+            , Ledger_proof.t )
+            Work.Single.Spec.t
             Work.Spec.t
           * Public_key.Compressed.t )
           option
@@ -45,7 +47,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
       module T = struct
         type query =
-          ( (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+          ( ( Transaction_witness.Stable.Latest.t
+            , Ledger_proof.t )
+            Work.Single.Spec.t
             Work.Spec.t
           , Ledger_proof.t )
           Work.Result.t
@@ -68,7 +72,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       module T = struct
         type query =
           Error.t
-          * (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+          * ( Transaction_witness.Stable.Latest.t
+            , Ledger_proof.t )
+            Work.Single.Spec.t
             Work.Spec.t
           * Public_key.Compressed.t
 

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -35,7 +35,9 @@ let submit_graphql input graphql_endpoint =
 
 let perform (s : Prod.Worker_state.t) ~fee ~public_key
     (spec :
-      (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+      ( Transaction_witness.Stable.Latest.t
+      , Ledger_proof.t )
+      Snark_work_lib.Work.Single.Spec.t
       One_or_two.t ) =
   One_or_two.Deferred_result.map spec ~f:(fun w ->
       let open Deferred.Or_error.Let_syntax in
@@ -116,7 +118,8 @@ let command =
              Yojson.Safe.from_string json
              |> One_or_two.of_yojson
                   (Snark_work_lib.Work.Single.Spec.of_yojson
-                     Transaction_witness.of_yojson Ledger_proof.of_yojson )
+                     Transaction_witness.Stable.Latest.of_yojson
+                     Ledger_proof.of_yojson )
            with
            | Ok spec ->
                spec
@@ -138,7 +141,8 @@ let command =
                  | Some spec ->
                      One_or_two.t_of_sexp
                        (Snark_work_lib.Work.Single.Spec.t_of_sexp
-                          Transaction_witness.t_of_sexp Ledger_proof.t_of_sexp )
+                          Transaction_witness.Stable.Latest.t_of_sexp
+                          Ledger_proof.t_of_sexp )
                        (Sexp.of_string spec)
                  | None ->
                      failwith "Provide a spec either in json or sexp format" ) )

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -38,6 +38,8 @@ end
 
 [%%versioned
 module Stable = struct
+  [@@@no_toplevel_latest_type]
+
   module V2 = struct
     type t = User_command.Stable.V2.t Poly.Stable.V2.t
     [@@deriving sexp, compare, equal, hash, yojson]
@@ -45,6 +47,12 @@ module Stable = struct
     let to_latest = Fn.id
   end
 end]
+
+type t = User_command.t Poly.t [@@deriving sexp, yojson]
+
+let read_all_proofs_from_disk : t -> Stable.Latest.t = Fn.id
+
+let write_all_proofs_to_disk : Stable.Latest.t -> t = Fn.id
 
 include Hashable.Make (Stable.Latest)
 include Comparable.Make (Stable.Latest)

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -50,6 +50,8 @@ end
 
 [%%versioned
 module Stable = struct
+  [@@@no_toplevel_latest_type]
+
   module V2 = struct
     type t =
       { transaction : Mina_transaction.Transaction.Stable.V2.t
@@ -65,3 +67,52 @@ module Stable = struct
     let to_latest = Fn.id
   end
 end]
+
+type t =
+  { transaction : Mina_transaction.Transaction.t
+  ; first_pass_ledger : Mina_ledger.Sparse_ledger.t
+  ; second_pass_ledger : Mina_ledger.Sparse_ledger.t
+  ; protocol_state_body : Mina_state.Protocol_state.Body.Value.t
+  ; init_stack : Mina_base.Pending_coinbase.Stack_versioned.t
+  ; status : Mina_base.Transaction_status.t
+  ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
+  }
+[@@deriving sexp, yojson]
+
+let read_all_proofs_from_disk
+    { transaction
+    ; first_pass_ledger
+    ; second_pass_ledger
+    ; protocol_state_body
+    ; init_stack
+    ; status
+    ; block_global_slot
+    } =
+  { Stable.Latest.transaction =
+      Mina_transaction.Transaction.read_all_proofs_from_disk transaction
+  ; first_pass_ledger
+  ; second_pass_ledger
+  ; protocol_state_body
+  ; init_stack
+  ; status
+  ; block_global_slot
+  }
+
+let write_all_proofs_to_disk
+    { Stable.Latest.transaction
+    ; first_pass_ledger
+    ; second_pass_ledger
+    ; protocol_state_body
+    ; init_stack
+    ; status
+    ; block_global_slot
+    } =
+  { transaction =
+      Mina_transaction.Transaction.write_all_proofs_to_disk transaction
+  ; first_pass_ledger
+  ; second_pass_ledger
+  ; protocol_state_body
+  ; init_stack
+  ; status
+  ; block_global_slot
+  }

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -47,6 +47,8 @@ end
 
 [%%versioned:
 module Stable : sig
+  [@@@no_toplevel_latest_type]
+
   module V2 : sig
     type t =
       { transaction : Mina_transaction.Transaction.Stable.V2.t
@@ -60,3 +62,18 @@ module Stable : sig
     [@@deriving sexp, yojson]
   end
 end]
+
+type t =
+  { transaction : Mina_transaction.Transaction.t
+  ; first_pass_ledger : Mina_ledger.Sparse_ledger.t
+  ; second_pass_ledger : Mina_ledger.Sparse_ledger.t
+  ; protocol_state_body : Mina_state.Protocol_state.Body.Value.t
+  ; init_stack : Mina_base.Pending_coinbase.Stack_versioned.t
+  ; status : Mina_base.Transaction_status.t
+  ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
+  }
+[@@deriving sexp, yojson]
+
+val read_all_proofs_from_disk : t -> Stable.Latest.t
+
+val write_all_proofs_to_disk : Stable.Latest.t -> t

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -194,6 +194,11 @@ let send_produced_block_at ~logger ~interruptor ~url ~peer_id
       send_uptime_data ~logger ~interruptor ~submitter_keypair ~url ~state_hash
         ~produced:true block_data
 
+let read_all_proofs_for_work_single_spec =
+  Snark_work_lib.Work.Single.Spec.map
+    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+    ~f_witness:Transaction_witness.read_all_proofs_from_disk
+
 let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
     ~url ~snark_worker ~transition_frontier ~peer_id
     ~(submitter_keypair : Keypair.t) ~snark_work_fee ~graphql_control_port
@@ -324,9 +329,7 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
                   make_interruptible
                     (Uptime_snark_worker.perform_single snark_worker
                        ( message
-                       , Snark_work_lib.Work.Single.Spec.map ~f_witness:ident
-                           ~f_proof:Ledger_proof.Cached.read_proof_from_disk
-                           single_spec ) )
+                       , read_all_proofs_for_work_single_spec single_spec ) )
                 with
                 | Error e ->
                     (* error in submitting to process *)

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -127,13 +127,7 @@ module type Lib_intf = sig
          One_or_two.t
          list
 
-    val remove :
-         t
-      -> ( Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-         One_or_two.t
-      -> unit
+    val remove : t -> Transaction_snark.Statement.t One_or_two.t -> unit
 
     val set :
          t

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -125,9 +125,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
                   false )
                 else true ) )
 
-    let remove t x =
-      t.jobs_seen <-
-        Map.remove t.jobs_seen (One_or_two.map ~f:Work_spec.statement x)
+    let remove t statement = t.jobs_seen <- Map.remove t.jobs_seen statement
 
     let set t x =
       t.jobs_seen <-

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -24,7 +24,7 @@ module Selection_methods : sig
 end
 
 (** remove the specified work from seen jobs *)
-val remove : State.t -> work One_or_two.t -> unit
+val remove : State.t -> Transaction_snark.Statement.t One_or_two.t -> unit
 
 (** Seen/Unseen jobs that are not in the snark pool yet *)
 val pending_work_statements :


### PR DESCRIPTION
Explain your changes:
* Decouples `Transaction.Stable.Latest.t` and `Transaction.t`
* Decoupling unblocks changing the structure of regular type to use on-disk cache

Explain how you tested your changes:
* This is a simple refactoring, no behavior change

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
