### PR TITLE
Add block command verifier test subcommand

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2279,6 +2279,22 @@ let test_genesis_creation =
      Cli_lib.Exceptions.handle_nicely
        Test_genesis_creation.time_genesis_creation )
 
+let test_block_command_verification =
+  Command.async ~summary:"Test block comand verification"
+    (let%map_open.Command large_precomputed_json_file =
+       flag "--block-file" ~doc:"FILE file with serialized block"
+         (optional_with_default
+            "_build/default/src/lib/mina_block/tests/hetzner-itn-1-1795.json"
+            string )
+     and log_directory =
+       flag "--log-dir" ~doc:"FILE directory for log output"
+         (optional_with_default "." string)
+     in
+     Cli_lib.Exceptions.handle_nicely
+     @@ fun () ->
+     Test_block_command_verification.time_block_command_verification
+       ~large_precomputed_json_file ~log_directory )
+
 let test_ledger_application =
   Command.async ~summary:"Test ledger application"
     (let%map_open.Command privkey_path = Cli_lib.Flag.privkey_read_path
@@ -2489,7 +2505,9 @@ let advanced ~itn_features =
     ; ("print-signature-kind", signature_kind)
     ; ( "test"
       , Command.group ~summary:"Testing-only commands"
-          [ ("create-genesis", test_genesis_creation) ] )
+          [ ("create-genesis", test_genesis_creation)
+          ; ("verify-block-commands", test_block_command_verification)
+          ] )
     ]
   in
   let cmds =

--- a/src/app/cli/src/init/test_block_command_verification.ml
+++ b/src/app/cli/src/init/test_block_command_verification.ml
@@ -1,0 +1,96 @@
+open Core_kernel
+open Async_kernel
+
+let time_block_command_verification ~(large_precomputed_json_file : string)
+    ~(log_directory : string) =
+  printf "Reading block from %s\n" large_precomputed_json_file ;
+  let json =
+    Yojson.Safe.from_string (In_channel.read_all large_precomputed_json_file)
+  in
+  let precomputed =
+    match Mina_block.Precomputed.of_yojson json with
+    | Ok json ->
+        json
+    | Error err ->
+        failwith err
+  in
+  let logger = Logger.create () in
+  let commit_id = "<commit>" in
+  Logger.Consumer_registry.register ~id:Logger.Logger_id.mina
+    ~processor:Internal_tracing.For_logger.processor ~commit_id
+    ~transport:
+      (Logger_file_system.dumb_logrotate ~directory:log_directory
+         ~log_filename:"internal-tracing.log"
+         ~max_size:(1024 * 1024 * 10)
+         ~num_rotate:50 )
+    () ;
+  let%bind () =
+    Internal_tracing.toggle ~commit_id ~force:true ~logger `Enabled
+  in
+  let commands =
+    precomputed.staged_ledger_diff |> Staged_ledger_diff.commands
+  in
+  let find_vk _frozen_ledger_hash account_id =
+    (let open Option.Let_syntax in
+    let%bind account =
+      List.find_map precomputed.accounts_accessed ~f:(fun (_idx, acnt) ->
+          let acnt_id = Mina_base.Account.identifier acnt in
+          if Mina_base.Account_id.equal acnt_id account_id then Some acnt
+          else None )
+    in
+    let%bind zkapp = account.zkapp in
+    zkapp.verification_key)
+    |> Option.value_map
+         ~default:(Or_error.error_string "Zkapp verification key not found")
+         ~f:Or_error.return
+  in
+  let verifiable_commands =
+    List.map commands ~f:(fun command ->
+        let verifiable_command =
+          Mina_base.User_command.to_verifiable ~failed:false ~find_vk
+            command.data
+          |> Or_error.ok_exn
+        in
+        ( 0 (* this id is irrelevant to verify_commands *)
+        , { Mina_base.With_status.data = verifiable_command
+          ; status = command.status
+          } ) )
+  in
+  let proof_level = Genesis_constants.Proof_level.Full in
+  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
+  let module T = Transaction_snark.Make (struct
+    let constraint_constants = constraint_constants
+
+    let proof_level = proof_level
+  end) in
+  let module B = Blockchain_snark.Blockchain_snark_state.Make (struct
+    let tag = T.tag
+
+    let constraint_constants = constraint_constants
+
+    let proof_level = proof_level
+  end) in
+  let%bind blockchain_verification_key = Lazy.force B.Proof.verification_key in
+  let%bind transaction_verification_key = Lazy.force T.verification_key in
+  let%bind verifier =
+    Verifier.Prod.Worker_state.create
+      { conf_dir = None
+      ; enable_internal_tracing = false
+      ; internal_trace_filename = None
+      ; logger
+      ; commit_id
+      ; blockchain_verification_key
+      ; transaction_verification_key
+      ; proof_level
+      }
+  in
+  let start = Time_ns.now () in
+  let%bind result =
+    Verifier.Prod.Worker_state.verify_commands verifier verifiable_commands
+  in
+  let num_valid =
+    List.count result ~f:(function _, `Valid -> true | _ -> false)
+  in
+  printf "Valid commands: %d/%d\n" num_valid (List.length verifiable_commands) ;
+  printf "Time: %s\n" Time_ns.(Span.to_string_hum (diff (Time_ns.now ()) start)) ;
+  return ()

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -230,6 +230,10 @@ module Worker_state = struct
              let set_itn_logger_data ~daemon_port:_ = ()
            end : S )
 
+  let verify_commands (t : t) =
+    let module Worker_state = (val t) in
+    Worker_state.verify_commands
+
   let get = Fn.id
 end
 

--- a/src/lib/verifier/prod.mli
+++ b/src/lib/verifier/prod.mli
@@ -1,1 +1,39 @@
 include Verifier_intf.S with type ledger_proof = Ledger_proof.Prod.t
+
+open Async_kernel
+open Mina_base
+
+module With_id_tag : sig
+  type 'a t = int * 'a
+end
+
+module Worker_state : sig
+  type t
+
+  type init_arg =
+    { conf_dir : string option
+    ; enable_internal_tracing : bool
+    ; internal_trace_filename : string option
+    ; logger : Logger.t
+    ; proof_level : Genesis_constants.Proof_level.t
+    ; commit_id : string
+    ; blockchain_verification_key : Pickles.Verification_key.Stable.Latest.t
+    ; transaction_verification_key : Pickles.Verification_key.Stable.Latest.t
+    }
+
+  val verify_commands :
+       t
+    -> Mina_base.User_command.Verifiable.t With_status.t With_id_tag.t list
+    -> [ `Valid
+       | `Valid_assuming of
+         ( Pickles.Side_loaded.Verification_key.t
+         * Mina_base.Zkapp_statement.t
+         * Pickles.Side_loaded.Proof.t )
+         list
+       | invalid ]
+       With_id_tag.t
+       list
+       Deferred.t
+
+  val create : init_arg -> t Deferred.t
+end


### PR DESCRIPTION
## Explain your changes:

A new advanced test subcommand has been added, that can be invoked with:

```
mina advanced test verify-block-commands --block-file <FILE> --log-dir <DIR>
```

It will verify the commands in a precomputed block json file. By default it will verify the file contained in `_build/default/src/lib/mina_block/tests/hetzner-itn-1-1795.json` (the file downloaded and cached when building the `mina_block` tests) and will use the current working directory for log output. Both flags are optional.

To ease the implementation of the command above, the `Worker_state` of the `Prod` verifier is now exposed. This is useful for testing the verifier when the worker spawning aspect of it is irrelevant, as it can be tricky to get a full verifier going. Instead, an individual verifier worker can be created for this purpose.

## Explain how you tested your changes:

I ran the command on my development laptop with a few combinations of different options. I also ran it with the environment variable `PICKLES_PROFILING=true` exported, to confirm that the internal pickles timing logs in the verifier were also output (to stdout) when running the command.

## Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules