### PR TITLE
Refactor Common module in verifier

### DIFF
--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -300,19 +300,18 @@ module Valid = struct
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end
 
-let check_verifiable (t : Verifiable.t) : Valid.t Or_error.t =
-  match t with
-  | Signed_command x -> (
-      match Signed_command.check x with
-      | Some c ->
-          Ok (Signed_command c)
-      | None ->
-          Or_error.error_string "Invalid signature" )
-  | Zkapp_command p ->
-      Ok (Zkapp_command (Zkapp_command.Valid.of_verifiable p))
-
-let check ~failed ~find_vk (t : t) : Valid.t Or_error.t =
-  to_verifiable ~failed ~find_vk t |> Or_error.bind ~f:check_verifiable
+module For_tests = struct
+  let check_verifiable (t : Verifiable.t) : Valid.t Or_error.t =
+    match t with
+    | Signed_command x -> (
+        match Signed_command.check x with
+        | Some c ->
+            Ok (Signed_command c)
+        | None ->
+            Or_error.error_string "Invalid signature" )
+    | Zkapp_command p ->
+        Ok (Zkapp_command (Zkapp_command.Valid.For_tests.of_verifiable p))
+end
 
 let forget_check (t : Valid.t) : t =
   match t with

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -815,14 +815,16 @@ module type Valid_intf = sig
   val to_valid_unsafe :
     T.t -> [> `If_this_is_used_it_should_have_a_comment_justifying_it of t ]
 
-  val to_valid :
-       T.t
-    -> failed:bool
-    -> find_vk:
-         (   Zkapp_basic.F.t
-          -> Account_id.t
-          -> (Verification_key_wire.t, Error.t) Result.t )
-    -> t Or_error.t
+  module For_tests : sig
+    val to_valid :
+         T.t
+      -> failed:bool
+      -> find_vk:
+           (   Zkapp_basic.F.t
+            -> Account_id.t
+            -> (Verification_key_wire.t, Error.t) Result.t )
+      -> t Or_error.t
+  end
 
   val of_verifiable : Verifiable.t -> t
 
@@ -868,8 +870,10 @@ struct
 
   let forget (t : t) : T.t = t.zkapp_command
 
-  let to_valid (t : T.t) ~failed ~find_vk : t Or_error.t =
-    Verifiable.create t ~failed ~find_vk |> Or_error.map ~f:of_verifiable
+  module For_tests = struct
+    let to_valid (t : T.t) ~failed ~find_vk : t Or_error.t =
+      Verifiable.create t ~failed ~find_vk |> Or_error.map ~f:of_verifiable
+  end
 end
 
 [%%define_locally Stable.Latest.(of_yojson, to_yojson)]

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -824,9 +824,9 @@ module type Valid_intf = sig
             -> Account_id.t
             -> (Verification_key_wire.t, Error.t) Result.t )
       -> t Or_error.t
-  end
 
-  val of_verifiable : Verifiable.t -> t
+    val of_verifiable : Verifiable.t -> t
+  end
 
   val forget : t -> T.t
 end
@@ -862,8 +862,6 @@ struct
 
   let create zkapp_command : t = { zkapp_command }
 
-  let of_verifiable (t : Verifiable.t) : t = { zkapp_command = of_verifiable t }
-
   let to_valid_unsafe (t : T.t) :
       [> `If_this_is_used_it_should_have_a_comment_justifying_it of t ] =
     `If_this_is_used_it_should_have_a_comment_justifying_it (create t)
@@ -871,6 +869,9 @@ struct
   let forget (t : t) : T.t = t.zkapp_command
 
   module For_tests = struct
+    let of_verifiable (t : Verifiable.t) : t =
+      { zkapp_command = of_verifiable t }
+
     let to_valid (t : T.t) ~failed ~find_vk : t Or_error.t =
       Verifiable.create t ~failed ~find_vk |> Or_error.map ~f:of_verifiable
   end

--- a/src/lib/mina_generators/user_command_generators.ml
+++ b/src/lib/mina_generators/user_command_generators.ml
@@ -145,7 +145,7 @@ let zkapp_command_with_ledger ?(ledger_init_state : Ledger.init_state option)
   in
   let zkapp_command =
     Or_error.ok_exn
-      (Zkapp_command.Valid.to_valid ~failed:false
+      (Zkapp_command.Valid.For_tests.to_valid ~failed:false
          ~find_vk:
            (Zkapp_command.Verifiable.load_vk_from_ledger
               ~get:(Ledger.get ledger)
@@ -198,7 +198,7 @@ let sequence_zkapp_command_with_ledger ?ledger_init_state ?max_account_updates
       in
       let valid_zkapp_command =
         Or_error.ok_exn
-          (Zkapp_command.Valid.to_valid ~failed:false
+          (Zkapp_command.Valid.For_tests.to_valid ~failed:false
              ~find_vk:
                (Zkapp_command.Verifiable.load_vk_from_ledger
                   ~get:(Ledger.get ledger)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2079,7 +2079,7 @@ let%test_module _ =
       in
       let zkapp_command =
         Or_error.ok_exn
-          (Zkapp_command.Valid.to_valid ~failed:false
+          (Zkapp_command.Valid.For_tests.to_valid ~failed:false
              ~find_vk:
                (Zkapp_command.Verifiable.load_vk_from_ledger
                   ~get:(fun _ -> failwith "Not expecting proof zkapp_command")
@@ -2157,7 +2157,7 @@ let%test_module _ =
             in
             let valid_zkapp_command =
               Or_error.ok_exn
-                (Zkapp_command.Valid.to_valid ~failed:false
+                (Zkapp_command.Valid.For_tests.to_valid ~failed:false
                    ~find_vk:
                      (Zkapp_command.Verifiable.load_vk_from_ledger
                         ~get:(Mina_ledger.Ledger.get best_tip_ledger)
@@ -2895,7 +2895,7 @@ let%test_module _ =
       in
       let zkapp_command =
         Or_error.ok_exn
-          (Zkapp_command.Valid.to_valid ~failed:false
+          (Zkapp_command.Valid.For_tests.to_valid ~failed:false
              ~find_vk:
                (Zkapp_command.Verifiable.load_vk_from_ledger
                   ~get:(Mina_ledger.Ledger.get best_tip_ledger)
@@ -3408,7 +3408,7 @@ let%test_module _ =
                   }
             in
             Or_error.ok_exn
-              (Zkapp_command.Valid.to_valid ~failed:false
+              (Zkapp_command.Valid.For_tests.to_valid ~failed:false
                  ~find_vk:
                    (Zkapp_command.Verifiable.load_vk_from_ledger
                       ~get:(Mina_ledger.Ledger.get ledger)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1860,7 +1860,7 @@ let%test_module _ =
             |> Map.map ~f:(fun vk ->
                    Zkapp_basic.F_map.Map.singleton vk.hash vk ) )
         |> Or_error.bind ~f:(fun xs ->
-               List.map xs ~f:User_command.check_verifiable
+               List.map xs ~f:User_command.For_tests.check_verifiable
                |> Or_error.combine_errors )
       with
       | Ok cmds ->
@@ -3120,7 +3120,8 @@ let%test_module _ =
                  ~data:
                    [ User_command.forget_check
                      @@ Zkapp_command
-                          (Zkapp_command.Valid.of_verifiable zkapp_command)
+                          (Zkapp_command.Valid.For_tests.of_verifiable
+                             zkapp_command )
                    ]
                  ~sender:Envelope.Sender.Local )
           with

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2965,7 +2965,7 @@ let%test_module "staged ledger tests" =
               in
               let valid_zkapp_command_with_auths : Zkapp_command.Valid.t =
                 match
-                  Zkapp_command.Valid.to_valid ~failed:false
+                  Zkapp_command.Valid.For_tests.to_valid ~failed:false
                     ~find_vk:(find_vk ledger) zkapp_command_with_auths
                 with
                 | Ok ps ->
@@ -4503,7 +4503,7 @@ let%test_module "staged ledger tests" =
                 ~constraint_constants spec
             in
             let valid_zkapp_command =
-              Zkapp_command.Valid.to_valid ~failed:false
+              Zkapp_command.Valid.For_tests.to_valid ~failed:false
                 ~find_vk:(find_vk ledger) zkapp_command
               |> Or_error.ok_exn
             in
@@ -5007,7 +5007,7 @@ let%test_module "staged ledger tests" =
                   in
                   let valid_zkapp_command =
                     Or_error.ok_exn
-                      (Zkapp_command.Valid.to_valid ~failed:false
+                      (Zkapp_command.Valid.For_tests.to_valid ~failed:false
                          ~find_vk:(find_vk valid_against_ledger)
                          zkapp_command )
                   in
@@ -5024,7 +5024,7 @@ let%test_module "staged ledger tests" =
                   in
                   let failed_zkapp_command =
                     Or_error.ok_exn
-                      (Zkapp_command.Valid.to_valid ~failed:true
+                      (Zkapp_command.Valid.For_tests.to_valid ~failed:true
                          ~find_vk:(find_vk ledger) zkapp_command )
                   in
                   let current_state, current_state_view =
@@ -5143,7 +5143,7 @@ let%test_module "staged ledger tests" =
                     ~vk ~ledger zkapp_account_pk ;
                   let invalid_zkapp_command =
                     Or_error.ok_exn
-                      (Zkapp_command.Valid.to_valid ~failed:false
+                      (Zkapp_command.Valid.For_tests.to_valid ~failed:false
                          ~find_vk:(find_vk ledger) zkapp_command )
                   in
                   let sl = ref @@ Sl.create_exn ~constraint_constants ~ledger in

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -80,6 +80,7 @@ let check :
           ({ fee_payer; account_updates; memo } as zkapp_command_with_vk)
     ; status
     } ->
+      let zkapp_command = Zkapp_command.of_verifiable zkapp_command_with_vk in
       with_return (fun { return } ->
           let account_updates_hash =
             Zkapp_command.Call_forest.hash account_updates
@@ -112,7 +113,8 @@ let check :
           check_signature fee_payer.authorization fee_payer.body.public_key
             full_tx_commitment ;
           (* Check signatures *)
-          Zkapp_command.Call_forest.iteri account_updates ~f:(fun _i (p, _) ->
+          Zkapp_command.Call_forest.iteri zkapp_command.account_updates
+            ~f:(fun _i p ->
               let commitment =
                 if p.body.use_full_commitment then full_tx_commitment
                 else tx_commitment
@@ -141,10 +143,11 @@ let check :
           in
           let v : User_command.Valid.t =
             (* Verification keys should be present if it reaches here *)
-            let zkapp_command =
-              Zkapp_command.Valid.of_verifiable zkapp_command_with_vk
+            let (`If_this_is_used_it_should_have_a_comment_justifying_it
+                  valid_zkapp_command ) =
+              Zkapp_command.Valid.to_valid_unsafe zkapp_command
             in
-            User_command.Poly.Zkapp_command zkapp_command
+            User_command.Poly.Zkapp_command valid_zkapp_command
           in
           match valid_assuming with
           | [] ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -32,6 +32,55 @@ let invalid_to_error = Common.invalid_to_error
 
 type ledger_proof = Ledger_proof.Prod.t
 
+module Processor = struct
+  let verify_commands
+      (cs : User_command.Verifiable.t With_status.t With_id_tag.t list) :
+      _ list Deferred.t =
+    let results = List.map cs ~f:(fun (id, c) -> (id, Common.check c)) in
+    let to_verify =
+      results |> List.map ~f:snd
+      |> List.concat_map ~f:(function
+           | `Valid _ ->
+               []
+           | `Valid_assuming (_, xs) ->
+               xs
+           | `Invalid_keys _
+           | `Invalid_signature _
+           | `Invalid_proof _
+           | `Missing_verification_key _
+           | `Unexpected_verification_key _
+           | `Mismatched_authorization_kind _ ->
+               [] )
+    in
+    let%map all_verified =
+      Pickles.Side_loaded.verify ~typ:Zkapp_statement.typ to_verify
+    in
+    List.map results ~f:(fun (id, result) ->
+        let result =
+          match result with
+          | `Valid _ ->
+              (* The command is dropped here to avoid decoding it later in the caller
+                 which would create a duplicate. Results are paired back to their inputs
+                 using the input [id]*)
+              `Valid
+          | `Valid_assuming (_, xs) ->
+              if Or_error.is_ok all_verified then `Valid else `Valid_assuming xs
+          | `Invalid_keys keys ->
+              `Invalid_keys keys
+          | `Invalid_signature keys ->
+              `Invalid_signature keys
+          | `Invalid_proof err ->
+              `Invalid_proof err
+          | `Missing_verification_key keys ->
+              `Missing_verification_key keys
+          | `Unexpected_verification_key keys ->
+              `Unexpected_verification_key keys
+          | `Mismatched_authorization_kind keys ->
+              `Mismatched_authorization_kind keys
+        in
+        (id, result) )
+end
+
 module Worker_state = struct
   module type S = sig
     val verify_blockchain_snarks :
@@ -86,64 +135,13 @@ module Worker_state = struct
         Pickles.Side_loaded.srs_precomputation () ;
         Deferred.return
           (let module M = struct
-             let verify_commands
-                 (cs :
-                   User_command.Verifiable.t With_status.t With_id_tag.t list )
-                 : _ list Deferred.t =
-               let results =
-                 List.map cs ~f:(fun (id, c) -> (id, Common.check c))
-               in
-               let to_verify =
-                 results |> List.map ~f:snd
-                 |> List.concat_map ~f:(function
-                      | `Valid _ ->
-                          []
-                      | `Valid_assuming (_, xs) ->
-                          xs
-                      | `Invalid_keys _
-                      | `Invalid_signature _
-                      | `Invalid_proof _
-                      | `Missing_verification_key _
-                      | `Unexpected_verification_key _
-                      | `Mismatched_authorization_kind _ ->
-                          [] )
-               in
-               let%map all_verified =
-                 Pickles.Side_loaded.verify ~typ:Zkapp_statement.typ to_verify
-               in
-               List.map results ~f:(fun (id, result) ->
-                   let result =
-                     match result with
-                     | `Valid _ ->
-                         (* The command is dropped here to avoid decoding it later in the caller
-                            which would create a duplicate. Results are paired back to their inputs
-                            using the input [id]*)
-                         `Valid
-                     | `Valid_assuming (_, xs) ->
-                         if Or_error.is_ok all_verified then `Valid
-                         else `Valid_assuming xs
-                     | `Invalid_keys keys ->
-                         `Invalid_keys keys
-                     | `Invalid_signature keys ->
-                         `Invalid_signature keys
-                     | `Invalid_proof err ->
-                         `Invalid_proof err
-                     | `Missing_verification_key keys ->
-                         `Missing_verification_key keys
-                     | `Unexpected_verification_key keys ->
-                         `Unexpected_verification_key keys
-                     | `Mismatched_authorization_kind keys ->
-                         `Mismatched_authorization_kind keys
-                   in
-                   (id, result) )
-
              let verify_commands cs =
                Context_logger.with_logger (Some logger)
                @@ fun () ->
                Internal_tracing.Context_call.with_call_id
                @@ fun () ->
                [%log internal] "Verifier_verify_commands" ;
-               let%map result = verify_commands cs in
+               let%map result = Processor.verify_commands cs in
                [%log internal] "Verifier_verify_commands_done" ;
                result
 


### PR DESCRIPTION
PR performs a well-contained refactoring of the verifier package, mainly its `Common` module.

Goal of the refactoring is to make it more obvious which checks are being done, and which checks depend solely on the `User_command.t` which doesn't change from one call to another, and which depend on `Zkapp_command.Verifiable.t` that depends on ledger/mempool state.

After the refactoring it becomes clear that a transaction that was verified with a call to `verify_commands` can be consider valid if either holds:

* It's status is `Failed`
* It's a signed command
* It's a zkapp command and `collect_vk_assumptions` check is repeated
   - To ensure the verification keys match the hashes in transaction

It's advised to review this PR commit by commit. And it's better with `difftastic`.

Explain how you tested your changes:

* A refactoring, no functionality has changed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
