### PR TITLE
Update proof-systems: reintroduce perm_aggreg parallelization + bugfix

### DIFF
--- a/changes/16812.md
+++ b/changes/16812.md
@@ -1,0 +1,1 @@
+Reintroduce a perm_aggreg optimisation in proof-systems that was previously reverted due to an off-by-one bug, which is fixed now.


### PR DESCRIPTION
This reintroduces the feature reverted here https://github.com/MinaProtocol/mina/pull/16782, with a bugfix.

`proof-systems` PR:
- https://github.com/o1-labs/proof-systems/pull/3121