### PR TITLE
 Defer Hashing in Staged Ledger Diff Application: Guilty

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -186,10 +186,6 @@ module Make (Inputs : Inputs_intf.S) = struct
           acc.current <- f acc.current ;
           acc.next <- f acc.next )
 
-    let self_set_hash t address hash =
-      update_maps t ~f:(fun maps ->
-          { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
-
     let path_batch_impl ~fixup_path ~self_lookup ~base_lookup t locations =
       assert_is_attached t ;
       let maps, ancestor = maps_and_ancestor t in
@@ -291,6 +287,10 @@ module Make (Inputs : Inputs_intf.S) = struct
           }
       | None, Error loc ->
           raise (Dangling_parent_reference (t.uuid, loc))
+
+    let self_set_hash t address hash =
+      update_maps t ~f:(fun maps ->
+          { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
 
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -186,6 +186,10 @@ module Make (Inputs : Inputs_intf.S) = struct
           acc.current <- f acc.current ;
           acc.next <- f acc.next )
 
+    let self_set_hash_impl t address hash =
+      update_maps t ~f:(fun maps ->
+          { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
+
     let path_batch_impl ~fixup_path ~self_lookup ~base_lookup t locations =
       assert_is_attached t ;
       let maps, ancestor = maps_and_ancestor t in
@@ -288,9 +292,7 @@ module Make (Inputs : Inputs_intf.S) = struct
       | None, Error loc ->
           raise (Dangling_parent_reference (t.uuid, loc))
 
-    let self_set_hash t address hash =
-      update_maps t ~f:(fun maps ->
-          { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
+    let self_set_hash t address hash = self_set_hash_impl t address hash
 
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -190,14 +190,11 @@ module Make (Inputs : Inputs_intf.S) = struct
       update_maps t ~f:(fun maps ->
           { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
 
-    let path_batch_impl ~fixup_path ~self_lookup ~base_lookup t locations =
-      assert_is_attached t ;
-      let maps, ancestor = maps_and_ancestor t in
+    let path_batch_impl ~fixup_path ~self_lookup ~base_lookup locations =
       let self_paths =
         List.map locations ~f:(fun location ->
             let address = Location.to_path_exn location in
-            self_lookup ~hashes:maps.hashes ~current_location:t.current_location
-              ~depth:t.depth address
+            self_lookup address
             |> Option.value_map
                  ~default:(Either.Second (location, address))
                  ~f:Either.first )
@@ -210,15 +207,13 @@ module Make (Inputs : Inputs_intf.S) = struct
             | Either.Second (location, _) ->
                 Some location )
         in
-        if List.is_empty locs then [] else base_lookup ancestor locs
+        if List.is_empty locs then [] else base_lookup locs
       in
       let f parent_paths = function
         | Either.First path ->
             (parent_paths, path)
         | Either.Second (_, address) ->
-            let path =
-              fixup_path ~hashes:maps.hashes ~address (List.hd_exn parent_paths)
-            in
+            let path = fixup_path ~address (List.hd_exn parent_paths) in
             (List.tl_exn parent_paths, path)
       in
       snd @@ List.fold_map ~init:all_parent_paths ~f self_paths
@@ -330,7 +325,7 @@ module Make (Inputs : Inputs_intf.S) = struct
               Map.set maps.token_owners ~key:token_id ~data:account_id
           } )
 
-    let _hashes_and_ancestor t =
+    let hashes_and_ancestor t =
       let { hashes; _ }, ancestor = maps_and_ancestor t in
       (hashes, ancestor)
 
@@ -461,13 +456,25 @@ module Make (Inputs : Inputs_intf.S) = struct
     let merkle_path t location =
       merkle_path_at_addr_exn t (Location.to_path_exn location)
 
-    let merkle_path_batch =
-      path_batch_impl ~base_lookup:Base.merkle_path_batch
-        ~self_lookup:self_merkle_path ~fixup_path:fixup_merkle_path
+    let merkle_path_batch t =
+      assert_is_attached t ;
+      let hashes, ancestor = hashes_and_ancestor t in
+      path_batch_impl
+        ~base_lookup:(Base.merkle_path_batch ancestor)
+        ~self_lookup:
+          (self_merkle_path ~current_location:t.current_location ~depth:t.depth
+             ~hashes )
+        ~fixup_path:(fixup_merkle_path ~hashes)
 
-    let wide_merkle_path_batch =
-      path_batch_impl ~base_lookup:Base.wide_merkle_path_batch
-        ~self_lookup:self_wide_merkle_path ~fixup_path:fixup_wide_merkle_path
+    let wide_merkle_path_batch t =
+      assert_is_attached t ;
+      let hashes, ancestor = hashes_and_ancestor t in
+      path_batch_impl
+        ~base_lookup:(Base.wide_merkle_path_batch ancestor)
+        ~self_lookup:
+          (self_wide_merkle_path ~current_location:t.current_location
+             ~depth:t.depth ~hashes )
+        ~fixup_path:(fixup_wide_merkle_path ~hashes)
 
     (* given a Merkle path corresponding to a starting address, calculate
        addresses and hashes for each node affected by the starting hash; that is,

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -250,6 +250,21 @@ module Make (Inputs : Inputs_intf.S) = struct
     let empty_hash =
       Empty_hashes.extensible_cache (module Hash) ~init_hash:Hash.empty_account
 
+    let self_path_get_hash ~hashes ~current_location height address =
+      match Map.find hashes address with
+      | Some hash ->
+          Some hash
+      | None ->
+          let is_empty =
+            match current_location with
+            | None ->
+                true
+            | Some current_location ->
+                let current_address = Location.to_path_exn current_location in
+                Addr.is_further_right ~than:current_address address
+          in
+          if is_empty then Some (empty_hash height) else None
+
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;
       assert (Addr.depth address <= t.depth) ;
@@ -349,21 +364,6 @@ module Make (Inputs : Inputs_intf.S) = struct
               Some s )
       in
       self_find_or_batch_lookup self_find Base.get_batch t
-
-    let self_path_get_hash ~hashes ~current_location height address =
-      match Map.find hashes address with
-      | Some hash ->
-          Some hash
-      | None ->
-          let is_empty =
-            match current_location with
-            | None ->
-                true
-            | Some current_location ->
-                let current_address = Location.to_path_exn current_location in
-                Addr.is_further_right ~than:current_address address
-          in
-          if is_empty then Some (empty_hash height) else None
 
     let self_merkle_path ~hashes ~current_location =
       let element height address =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -265,6 +265,17 @@ module Make (Inputs : Inputs_intf.S) = struct
           in
           if is_empty then Some (empty_hash height) else None
 
+    let self_merkle_path ~hashes ~current_location =
+      let element height address =
+        let sibling = Addr.sibling address in
+        let dir = Location.last_direction address in
+        let%map.Option sibling_hash =
+          self_path_get_hash ~hashes ~current_location height sibling
+        in
+        Direction.map dir ~left:(`Left sibling_hash) ~right:(`Right sibling_hash)
+      in
+      self_path_impl ~element
+
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;
       assert (Addr.depth address <= t.depth) ;
@@ -364,17 +375,6 @@ module Make (Inputs : Inputs_intf.S) = struct
               Some s )
       in
       self_find_or_batch_lookup self_find Base.get_batch t
-
-    let self_merkle_path ~hashes ~current_location =
-      let element height address =
-        let sibling = Addr.sibling address in
-        let dir = Location.last_direction address in
-        let%map.Option sibling_hash =
-          self_path_get_hash ~hashes ~current_location height sibling
-        in
-        Direction.map dir ~left:(`Left sibling_hash) ~right:(`Right sibling_hash)
-      in
-      self_path_impl ~element
 
     let self_wide_merkle_path ~hashes ~current_location =
       let element height address =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -330,6 +330,10 @@ module Make (Inputs : Inputs_intf.S) = struct
               Map.set maps.token_owners ~key:token_id ~data:account_id
           } )
 
+    let _hashes_and_ancestor t =
+      let { hashes; _ }, ancestor = maps_and_ancestor t in
+      (hashes, ancestor)
+
     (* a read does a lookup in the account_tbl; if that fails, delegate to
        parent *)
     let get t location =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -247,6 +247,9 @@ module Make (Inputs : Inputs_intf.S) = struct
         let%map.Option rest = self_path_impl ~element ~depth parent_address in
         el :: rest
 
+    let empty_hash =
+      Empty_hashes.extensible_cache (module Hash) ~init_hash:Hash.empty_account
+
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;
       assert (Addr.depth address <= t.depth) ;
@@ -346,9 +349,6 @@ module Make (Inputs : Inputs_intf.S) = struct
               Some s )
       in
       self_find_or_batch_lookup self_find Base.get_batch t
-
-    let empty_hash =
-      Empty_hashes.extensible_cache (module Hash) ~init_hash:Hash.empty_account
 
     let self_path_get_hash ~hashes ~current_location height address =
       match Map.find hashes address with

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -437,9 +437,9 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     let merkle_path_at_addr_exn t address =
       assert_is_attached t ;
-      let maps, ancestor = maps_and_ancestor t in
+      let hashes, ancestor = hashes_and_ancestor t in
       match
-        self_merkle_path ~depth:t.depth ~hashes:maps.hashes
+        self_merkle_path ~depth:t.depth ~hashes
           ~current_location:t.current_location address
       with
       | Some path ->
@@ -448,7 +448,7 @@ module Make (Inputs : Inputs_intf.S) = struct
           let parent_merkle_path =
             Base.merkle_path_at_addr_exn ancestor address
           in
-          fixup_merkle_path ~hashes:maps.hashes parent_merkle_path ~address
+          fixup_merkle_path ~hashes parent_merkle_path ~address
 
     let merkle_path_at_index_exn t index =
       merkle_path_at_addr_exn t (Addr.of_int_exn ~ledger_depth:t.depth index)
@@ -500,8 +500,8 @@ module Make (Inputs : Inputs_intf.S) = struct
     (* use mask Merkle root, if it exists, else get from parent *)
     let merkle_root t =
       assert_is_attached t ;
-      let maps, ancestor = maps_and_ancestor t in
-      match Map.find maps.hashes (Addr.root ()) with
+      let hashes, ancestor = hashes_and_ancestor t in
+      match Map.find hashes (Addr.root ()) with
       | Some hash ->
           hash
       | None ->
@@ -590,8 +590,8 @@ module Make (Inputs : Inputs_intf.S) = struct
        parent *)
     let get_hash t addr =
       assert_is_attached t ;
-      let maps, ancestor = maps_and_ancestor t in
-      match Map.find maps.hashes addr with
+      let hashes, ancestor = hashes_and_ancestor t in
+      match Map.find hashes addr with
       | Some hash ->
           Some hash
       | None -> (
@@ -602,10 +602,10 @@ module Make (Inputs : Inputs_intf.S) = struct
 
     let get_hash_batch_exn t locations =
       assert_is_attached t ;
-      let maps, ancestor = maps_and_ancestor t in
+      let hashes, ancestor = hashes_and_ancestor t in
       let self_hashes_rev =
         List.rev_map locations ~f:(fun location ->
-            (location, Map.find maps.hashes (Location.to_path_exn location)) )
+            (location, Map.find hashes (Location.to_path_exn location)) )
       in
       let parent_locations_rev =
         List.filter_map self_hashes_rev ~f:(fun (location, hash) ->

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -172,21 +172,6 @@ module Make (Inputs : Inputs_intf.S) = struct
       | None ->
           (t.maps, get_parent t)
 
-    (** Either copies accumulated or initializes it with the parent being used as the [base]. *)
-    let to_accumulated t =
-      actualize_accumulated t ;
-      match (t.accumulated, t.parent) with
-      | Some { base; detached_next_signal; next; current }, _ ->
-          { base; detached_next_signal; next; current }
-      | None, Ok base ->
-          { base
-          ; next = t.maps
-          ; current = t.maps
-          ; detached_next_signal = t.detached_parent_signal
-          }
-      | None, Error loc ->
-          raise (Dangling_parent_reference (t.uuid, loc))
-
     let get_uuid t = assert_is_attached t ; t.uuid
 
     let get_directory t =
@@ -291,6 +276,21 @@ module Make (Inputs : Inputs_intf.S) = struct
             (parent_addr, `Right (value sibling_mask_hash ~default:h))
       in
       Fn.compose snd @@ List.fold_map ~init ~f
+
+    (** Either copies accumulated or initializes it with the parent being used as the [base]. *)
+    let to_accumulated t =
+      actualize_accumulated t ;
+      match (t.accumulated, t.parent) with
+      | Some { base; detached_next_signal; next; current }, _ ->
+          { base; detached_next_signal; next; current }
+      | None, Ok base ->
+          { base
+          ; next = t.maps
+          ; current = t.maps
+          ; detached_next_signal = t.detached_parent_signal
+          }
+      | None, Error loc ->
+          raise (Dangling_parent_reference (t.uuid, loc))
 
     let set_inner_hash_at_addr_exn t address hash =
       assert_is_attached t ;


### PR DESCRIPTION
This is the guilty counterpart of #16822, should be merged after it. 

This PR aims to delay the hash calculation of the merkle tree in diff application. For more see [notion page](https://www.notion.so/o1labs/Defer-hashing-in-tx-application-1bde79b1f91080569768c42651cef720?pvs=4) 

TODO: add commits from [here](https://github.com/MinaProtocol/mina/compare/compatible...corvo/revive/defer-hashing-in-staged-ledger-diff-application-2) one by one to this PR