### PR TITLE
Add a link to explainer for recursive-SNARKs

### DIFF
--- a/src/lib/pickles/README.md
+++ b/src/lib/pickles/README.md
@@ -90,6 +90,8 @@ library. Refer to the file header for a content description:
 
 ## Resources
 
+For a general explain for recursive-SNARKs, please check [ZKP MOOC Lec 10: Recursive SNARKs](https://www.youtube.com/watch?v=0LW-qeVe6QI&list=PLS01nW3Rtgor_yJmQsGBZAg5XM4TSGpPs&index=10)
+
 Some public videos you can find on YouTube describing the intial idea behind
 Pickles. It might be outdated if the IOP is changed.
 - [zkStudyClub: Izaak Meckler o1Labs - Pickles ](https://www.youtube.com/watch?v=kmCXdjv5oP0)


### PR DESCRIPTION
This PR added a link to zkpmooc on recusive-SNARKs, no changelog should be added. 