### PR TITLE
Remove unused ledger function `set_inner_hash_at_addr_exn`

### DIFF
--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -140,9 +140,6 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
 
     let set_batch_accounts (T ((module Base), t)) = Base.set_batch_accounts t
 
-    let set_inner_hash_at_addr_exn (T ((module Base), t)) =
-      Base.set_inner_hash_at_addr_exn t
-
     let get_inner_hash_at_addr_exn (T ((module Base), t)) =
       Base.get_inner_hash_at_addr_exn t
 

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -171,10 +171,6 @@ module Make (Inputs : Intf.Inputs.DATABASE) = struct
     assert (Addr.depth address <= mdb.depth) ;
     get_hash mdb (Location.Hash address)
 
-  let set_inner_hash_at_addr_exn mdb address hash =
-    assert (Addr.depth address <= mdb.depth) ;
-    set_bin mdb (Location.Hash address) Hash.bin_size_t Hash.bin_write_t hash
-
   let get_generic mdb location =
     assert (Location.is_generic location) ;
     get_raw mdb location

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -228,8 +228,6 @@ module type SYNCABLE = sig
 
   val get_inner_hash_at_addr_exn : t -> addr -> hash
 
-  val set_inner_hash_at_addr_exn : t -> addr -> hash -> unit
-
   val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
 
   val set_batch_accounts : t -> (addr * account) list -> unit

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -157,9 +157,6 @@ end = struct
   let set_batch_accounts _t =
     failwith "set_batch_accounts: null ledgers cannot be mutated"
 
-  let set_inner_hash_at_addr_exn _t =
-    failwith "set_inner_hash_at_addr_exn: null ledgers cannot be mutated"
-
   let get_inner_hash_at_addr_exn t addr =
     empty_hash_at_height (Addr.height ~ledger_depth:t.depth addr)
 

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -172,23 +172,6 @@ module Make (Test : Test_intf) = struct
                    in
                    assert ([%equal: Test.Location.t] location location') ) ) )
 
-  let () =
-    add_test
-      "set_inner_hash_at_addr_exn(address,hash); \
-       get_inner_hash_at_addr_exn(address) = hash" (fun () ->
-        let random_hash =
-          Hash.hash_account @@ Quickcheck.random_value Account.gen
-        in
-        Test.with_instance (fun mdb ->
-            Quickcheck.test
-              (Direction.gen_var_length_list ~start:1 (MT.depth mdb))
-              ~sexp_of:[%sexp_of: Direction.t List.t]
-              ~f:(fun direction ->
-                let address = MT.Addr.of_directions direction in
-                MT.set_inner_hash_at_addr_exn mdb address random_hash ;
-                let result = MT.get_inner_hash_at_addr_exn mdb address in
-                assert (Hash.equal result random_hash) ) ) )
-
   let random_accounts max_height =
     let num_accounts = 1 lsl max_height in
     Quickcheck.random_value

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -205,11 +205,6 @@ module Make (Inputs : Inputs_intf.S) = struct
       update_maps t ~f:(fun maps ->
           { maps with hashes = Map.set maps.hashes ~key:address ~data:hash } )
 
-    let set_inner_hash_at_addr_exn t address hash =
-      assert_is_attached t ;
-      assert (Addr.depth address <= t.depth) ;
-      self_set_hash t address hash
-
     let self_set_location t account_id location =
       update_maps t ~f:(fun maps ->
           { maps with


### PR DESCRIPTION
This PR is a no-op, removing an unused ledger function. The tests corresponding to this function have been deleted.

This function is problematic -- or actually unimplementable -- for automated ledger upgrades where the calculated hash is different. Since it's unused, it makes more sense to delete it entirely.