### PR TITLE
[Master] correct path to rosetta-cli archive

### DIFF
--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -65,9 +65,9 @@ RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar 
 # The following commands install rosetta-cli with an updated rosetta-sdk-go dependency, which supports delegation transactions.
 # Upstream PR to rosetta-sdk-go: https://github.com/coinbase/rosetta-sdk-go/pull/457
 # They can be replaced once there is a new release of rosetta-cli containing the above change by:
-#RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/${ROSETTA_CLI_VERSION}/scripts/install.sh | sh -s
+#RUN curl -sSfL https://raw.githubusercontent.com/coinbase/mesh-cli/${ROSETTA_CLI_VERSION}/scripts/install.sh | sh -s
 RUN export GOBIN="$(pwd)/bin" \
-    && curl -L "https://github.com/coinbase/rosetta-cli/archive/refs/tags/v0.10.1.tar.gz" -o "/tmp/v0.10.1.tar.gz" \
+    && curl -L "https://github.com/coinbase/mesh-cli/archive/refs/tags/v0.10.1.tar.gz" -o "/tmp/v0.10.1.tar.gz" \
     && tar xzf "/tmp/v0.10.1.tar.gz" -C "/tmp" \
     && cd "/tmp/mesh-cli-0.10.1" \
     && /usr/lib/go/bin/go mod edit -replace github.com/coinbase/rosetta-sdk-go@v0.8.1=github.com/MinaProtocol/rosetta-sdk-go@stake-delegation-v1 \


### PR DESCRIPTION
Change to the `dockerfiles/Dockerfile-mina-rosetta` to update the installation process for the Rosetta CLI with a new dependency.

Updates to Rosetta CLI installation:

* [`dockerfiles/Dockerfile-mina-rosetta`](diffhunk://#diff-54b335cf3a3b99ca2072224ae14abfecab9f753647cf3daaaf18086559edc271L68-R70): Changed the URL and references from `rosetta-cli` to `mesh-cli` to reflect the new dependency and ensure compatibility with the updated rosetta-sdk-go.