### PR TITLE
Isolate step hash computation in batch verifier input calculation

### DIFF
--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -52,9 +52,7 @@ let hash_message_inputs_for_next_step_proof ~app_state
       Array.concat_map x ~f:(fun x -> Array.of_list (g x)) )
     ~app_state
 
-let hash_messages_for_next_step_proof ~app_state
-    (t : _ Types.Step.Proof_state.Messages_for_next_step_proof.t) =
-  let hash_input = hash_message_inputs_for_next_step_proof ~app_state t in
+let hash_messages_for_next_step_proof hash_input =
   Tick_field_sponge.digest Tick_field_sponge.params hash_input
 
 let dlog_pcs_batch (type nat proofs_verified total)

--- a/src/lib/pickles/common.mli
+++ b/src/lib/pickles/common.mli
@@ -161,25 +161,7 @@ val hash_message_inputs_for_next_step_proof :
   -> Pasta_bindings.Fp.t array
 
 val hash_messages_for_next_step_proof :
-     app_state:('a -> Kimchi_pasta.Basic.Fp.Stable.Latest.t Core_kernel.Array.t)
-  -> ( Backend.Tock.Curve.Affine.t array
-     (* the type for the verification key *)
-     , 'a
-     (* the state of the application *)
-     , ( Kimchi_pasta.Basic.Fp.Stable.Latest.t
-         * Kimchi_pasta.Basic.Fp.Stable.Latest.t
-       , 'n )
-       Pickles_types.Vector.t
-     (* challenge polynomial commitments. We use the full parameter type to
-        restrict the size of the vector to be the same than the one for the next
-        parameter which are the bulletproof challenges *)
-     , ( (Kimchi_pasta.Basic.Fp.Stable.Latest.t, 'm) Pickles_types.Vector.t
-       , 'n
-       (* size of the vector *) )
-       Pickles_types.Vector.t
-     (* bulletproof challenges *) )
-     Import.Types.Step.Proof_state.Messages_for_next_step_proof.t
-  -> Import.Types.Digest.Constant.t
+  Pasta_bindings.Fp.t array -> Import.Types.Digest.Constant.t
 
 val tick_public_input_of_statement :
      max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1407,12 +1407,14 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                  old_buletproof_challenges inside the messages_for_next_wrap_proof
                                  might not be correct *)
                               Common.hash_messages_for_next_step_proof
-                                ~app_state:to_field_elements
-                                (P.Base.Messages_for_next_proof_over_same_field
-                                 .Step
-                                 .prepare ~dlog_plonk_index
-                                   prev_statement.proof_state
-                                     .messages_for_next_step_proof )
+                                (Common.hash_message_inputs_for_next_step_proof
+                                   ~app_state:to_field_elements
+                                   (P.Base
+                                    .Messages_for_next_proof_over_same_field
+                                    .Step
+                                    .prepare ~dlog_plonk_index
+                                      prev_statement.proof_state
+                                        .messages_for_next_step_proof ) )
                           }
                       ; messages_for_next_wrap_proof =
                           (let module M =
@@ -1435,7 +1437,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                        (Vector.length
                                           m.old_bulletproof_challenges )
                                    in
-                                   Wrap_hack.hash_messages_for_next_wrap_proof m
+                                   Wrap_hack.hash_messages_for_next_wrap_proof
+                                   @@ Wrap_hack
+                                      .hash_message_inputs_for_next_wrap_proof m
                                end)
                            in
                           let module V = H1.To_vector (Digest.Constant) in
@@ -1788,7 +1792,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                 { next_statement.proof_state with
                                   messages_for_next_wrap_proof =
                                     Wrap_hack.hash_messages_for_next_wrap_proof
-                                      messages_for_next_wrap_proof_prepared
+                                    @@ Wrap_hack
+                                       .hash_message_inputs_for_next_wrap_proof
+                                         messages_for_next_wrap_proof_prepared
                                 ; deferred_values =
                                     { next_statement.proof_state.deferred_values with
                                       plonk =

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -258,10 +258,11 @@ struct
              in
              (* TODO: Only do this hashing when necessary *)
              Common.hash_messages_for_next_step_proof
-               (Reduced_messages_for_next_proof_over_same_field.Step.prepare
-                  ~dlog_plonk_index:dlog_index
-                  statement.messages_for_next_step_proof )
-               ~app_state:to_field_elements )
+             @@ Common.hash_message_inputs_for_next_step_proof
+                  (Reduced_messages_for_next_proof_over_same_field.Step.prepare
+                     ~dlog_plonk_index:dlog_index
+                     statement.messages_for_next_step_proof )
+                  ~app_state:to_field_elements )
         ; proof_state =
             { deferred_values =
                 (let deferred_values = deferred_values_computed in
@@ -286,11 +287,12 @@ struct
                 statement.proof_state.sponge_digest_before_evaluations
             ; messages_for_next_wrap_proof =
                 Wrap_hack.hash_messages_for_next_wrap_proof
-                  { old_bulletproof_challenges = prev_challenges
-                  ; challenge_polynomial_commitment =
-                      statement.proof_state.messages_for_next_wrap_proof
-                        .challenge_polynomial_commitment
-                  }
+                @@ Wrap_hack.hash_message_inputs_for_next_wrap_proof
+                     { old_bulletproof_challenges = prev_challenges
+                     ; challenge_polynomial_commitment =
+                         statement.proof_state.messages_for_next_wrap_proof
+                           .challenge_polynomial_commitment
+                     }
             }
         }
       in
@@ -723,7 +725,9 @@ struct
                       Lazy.force Dummy.Ipa.Wrap.challenges_computed )
               }
             in
-            Wrap_hack.hash_messages_for_next_wrap_proof t :: pad [] ms n
+            Wrap_hack.hash_messages_for_next_wrap_proof
+              (Wrap_hack.hash_message_inputs_for_next_wrap_proof t)
+            :: pad [] ms n
       in
       lazy
         (Vector.rev

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -336,10 +336,12 @@ let wrap
                 old_buletproof_challenges inside the messages_for_next_step_proof
                 might not be correct *)
              Common.hash_messages_for_next_step_proof
-               ~app_state:to_field_elements
-               (P.Base.Messages_for_next_proof_over_same_field.Step.prepare
-                  ~dlog_plonk_index
-                  prev_statement.proof_state.messages_for_next_step_proof ) )
+             @@ Common.hash_message_inputs_for_next_step_proof
+                  ~app_state:to_field_elements
+                  (P.Base.Messages_for_next_proof_over_same_field.Step.prepare
+                     ~dlog_plonk_index
+                     prev_statement.proof_state.messages_for_next_step_proof )
+            )
         }
     ; messages_for_next_wrap_proof =
         (let module M =
@@ -353,7 +355,8 @@ let wrap
                      P.Base.Messages_for_next_proof_over_same_field.Wrap
                      .Prepared
                      .t ) =
-                 Wrap_hack.hash_messages_for_next_wrap_proof m
+                 Wrap_hack.hash_messages_for_next_wrap_proof
+                 @@ Wrap_hack.hash_message_inputs_for_next_wrap_proof m
              end)
          in
         let module V = H1.To_vector (Digest.Constant) in
@@ -563,7 +566,8 @@ let wrap
               { next_statement.proof_state with
                 messages_for_next_wrap_proof =
                   Wrap_hack.hash_messages_for_next_wrap_proof
-                    messages_for_next_wrap_proof_prepared
+                  @@ Wrap_hack.hash_message_inputs_for_next_wrap_proof
+                       messages_for_next_wrap_proof_prepared
               ; deferred_values =
                   { next_statement.proof_state.deferred_values with
                     plonk =

--- a/src/lib/pickles/wrap_hack.ml
+++ b/src/lib/pickles/wrap_hack.ml
@@ -56,13 +56,8 @@ let hash_message_inputs_for_next_wrap_proof (type n)
   .to_field_elements t ~g1:(fun ((x, y) : Tick.Curve.Affine.t) -> [ x; y ])
 
 (* Hash the me only, padding first. *)
-let hash_messages_for_next_wrap_proof (type n)
-    (t :
-      ( Tick.Curve.Affine.t
-      , (_, n) Vector.t )
-      Composition_types.Wrap.Proof_state.Messages_for_next_wrap_proof.t ) =
-  let input = hash_message_inputs_for_next_wrap_proof t in
-  Tock_field_sponge.digest Tock_field_sponge.params input
+let hash_messages_for_next_wrap_proof (type n) hash_input =
+  Tock_field_sponge.digest Tock_field_sponge.params hash_input
 
 (* Pad the messages_for_next_wrap_proof of a proof *)
 let pad_proof (type mlmb) (T p : (mlmb, _) Proof.t) :
@@ -116,8 +111,9 @@ module Checked = struct
       let s2 = full_state sponge in
       [| s0; s1; s2 |] )
 
-  let hash_constant_messages_for_next_wrap_proof =
+  let hash_constant_messages_for_next_wrap_proof t =
     hash_messages_for_next_wrap_proof
+    @@ hash_message_inputs_for_next_wrap_proof t
 
   (* TODO: No need to hash the entire bulletproof challenges. Could
      just hash the segment of the public input LDE corresponding to them

--- a/src/lib/pickles/wrap_hack.mli
+++ b/src/lib/pickles/wrap_hack.mli
@@ -18,14 +18,7 @@ val hash_message_inputs_for_next_wrap_proof :
   -> Backend.Tock.Field.t array
 
 val hash_messages_for_next_wrap_proof :
-     ( Backend.Tick.Curve.Affine.t
-     , ( ( Backend.Tock.Field.t
-         , Pickles_types.Nat.z Backend.Tock.Rounds.plus_n )
-         Pickles_types.Vector.t
-       , 'n )
-       Pickles_types.Vector.t )
-     Composition_types.Wrap.Proof_state.Messages_for_next_wrap_proof.t
-  -> Import.Types.Digest.Constant.t
+  Backend.Tock.Field.t array -> Import.Types.Digest.Constant.t
 
 val pad_proof : ('mlmb, 'a) Proof.t -> Proof.Proofs_verified_max.t
 


### PR DESCRIPTION
## Explain your changes:

This PR relates to the project described in https://github.com/MinaProtocol/mina/pull/16832. It implements the second initial refactoring described in that PR - this one isolates the calculation of the `messages_for_next_step_proof` and `messages_for_next_wrap_proof` from the preparation of the batch verifier inputs in `verifiy_heterogenous`. These messages (which are hashes) are instead calculated fully, before the batch verifier inputs are constructed. This PR is otherwise independent from that one, and either can be merged before the other.

To support this change, the functions `hash_messages_for_next_step_proof` and `hash_messages_for_next_wrap_proof` were  modified so that the hashes inputs are calculated outside of those functions. This required adapting a few unrelated call sites; I haven't yet checked to see if the hashing that goes on there is parallelizable like the code in `verify_heterogenous` is.

## Explain how you tested your changes:

As in https://github.com/MinaProtocol/mina/pull/16832, I cherry-picked the test command in https://github.com/MinaProtocol/mina/pull/16793 to collect internal logs from the verifier on a test precomputed block. From those logs, I calculated that the hashing step I isolated is responsible for 79% of the time taken in `Compute_batch_verify_inputs`. Nearly all of the remainder of the time was spent in computing the hash inputs. Performance seemed unchanged. I should mention again that this testing was only done locally on one machine (my laptop).

Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules