### PR TITLE
Refactor `User_command.Make_to_all_verifiable.to_all_verifiable` with `process_separately`

### DIFF
--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Mina_stdlib
 
 module Poly = struct
   [%%versioned
@@ -165,42 +166,42 @@ module Make_to_all_verifiable
 struct
   let to_all_verifiable (ts : t Strategy.Command_wrapper.t list) ~load_vk_cache
       : Verifiable.t Strategy.Command_wrapper.t list Or_error.t =
+    (* TODO: it seems we're just doing noop with the Strategy.Command_wrapper,
+       need double-check.
+    *)
     let open Or_error.Let_syntax in
-    (* First we tag everything with its index *)
-    let its = List.mapi ts ~f:(fun i x -> (i, x)) in
-    (* then we partition out the zkapp commands *)
-    let izk_cmds, is_cmds =
-      List.partition_map its ~f:(fun (i, cmd) ->
-          match Strategy.Command_wrapper.unwrap cmd with
-          | Zkapp_command c ->
-              First (i, Strategy.Command_wrapper.map cmd ~f:(Fn.const c))
-          | Signed_command c ->
-              Second (i, Strategy.Command_wrapper.map cmd ~f:(Fn.const c)) )
+    let partitioner (cmd : t Strategy.Command_wrapper.t) =
+      match Strategy.Command_wrapper.unwrap cmd with
+      | Zkapp_command c ->
+          First (Strategy.Command_wrapper.map cmd ~f:(Fn.const c))
+      | Signed_command c ->
+          Second (Strategy.Command_wrapper.map cmd ~f:(Fn.const c))
     in
-    (* then unzip the indices *)
-    let ixs, zk_cmds = List.unzip izk_cmds in
-    (* then we verify the zkapp commands *)
-    (* TODO: we could optimize this by skipping the fee payer and non-proof authorizations *)
-    let accounts_referenced =
-      List.fold_left zk_cmds ~init:Account_id.Set.empty ~f:(fun set zk_cmd ->
-          Strategy.Command_wrapper.unwrap zk_cmd
-          |> Zkapp_command.accounts_referenced |> Account_id.Set.of_list
-          |> Set.union set )
+    let process_left zk_cmds =
+      (* TODO: we could optimize this by skipping the fee payer and non-proof authorizations *)
+      let accounts_referenced =
+        List.fold_left zk_cmds ~init:Account_id.Set.empty ~f:(fun set zk_cmd ->
+            Strategy.Command_wrapper.unwrap zk_cmd
+            |> Zkapp_command.accounts_referenced |> Account_id.Set.of_list
+            |> Set.union set )
+      in
+      let vk_cache = load_vk_cache accounts_referenced in
+      Strategy.create_all zk_cmds vk_cache
     in
-    let vk_cache = load_vk_cache accounts_referenced in
-    let%map vzk_cmds = Strategy.create_all zk_cmds vk_cache in
-    (* rezip indices *)
-    let ivzk_cmds = List.zip_exn ixs vzk_cmds in
-    (* Put them back in with a sort by index (un-partition) *)
-    let ivs =
-      List.map is_cmds ~f:(fun (i, cmd) ->
-          (i, Strategy.Command_wrapper.map cmd ~f:(fun c -> Signed_command c)) )
-      @ List.map ivzk_cmds ~f:(fun (i, cmd) ->
-            (i, Strategy.Command_wrapper.map cmd ~f:(fun c -> Zkapp_command c)) )
-      |> List.sort ~compare:(fun (i, _) (j, _) -> i - j)
+    let process_right =
+      List.map ~f:(fun cmd ->
+          Strategy.Command_wrapper.map cmd ~f:(fun c -> Signed_command c) )
     in
-    (* Drop the indices *)
-    List.unzip ivs |> snd
+    let finalizer vzk_cmds_m is_cmds_mapped ~f =
+      let%map vzk_cmds = vzk_cmds_m in
+      let vzk_cmds_mapped =
+        List.map vzk_cmds ~f:(fun cmd ->
+            Strategy.Command_wrapper.map cmd ~f:(fun c -> Zkapp_command c) )
+      in
+      f vzk_cmds_mapped is_cmds_mapped
+    in
+    List.process_separately ts ~partitioner ~process_left ~process_right
+      ~finalizer
 end
 
 module Unapplied_sequence =

--- a/src/lib/mina_stdlib/dune
+++ b/src/lib/mina_stdlib/dune
@@ -1,6 +1,8 @@
 (library
  (name mina_stdlib)
  (public_name mina_stdlib)
+ (inline_tests
+  (flags -verbose -show-counts))
  (modules_without_implementation sigs)
  (flags
   (:standard -w a -warn-error +a)

--- a/src/lib/mina_stdlib/list.ml
+++ b/src/lib/mina_stdlib/list.ml
@@ -30,3 +30,46 @@ module Length = struct
     let ( < ) = lt
   end
 end
+
+(** [process_separately] splits the list in two, and applies transformations
+  * to both parts, then it merges the list back in the same order it was originally.
+  * [process_left] and [process_right] are expected to return the same number
+  * of elements processed in the same order.
+  *)
+let process_separately
+    (type input left right left_output right_output output_item final_output)
+    ~(partitioner : input -> (left, right) Either.t)
+    ~(process_left : left list -> left_output)
+    ~(process_right : right list -> right_output)
+    ~(finalizer :
+          left_output
+       -> right_output
+       -> f:(output_item list -> output_item list -> output_item list)
+       -> final_output ) (input : input list) : final_output =
+  let input_with_indices = List.mapi input ~f:(fun idx el -> (idx, el)) in
+  let lefts, rights =
+    List.partition_map input_with_indices ~f:(fun (idx, el) ->
+        match partitioner el with
+        | First x ->
+            First (idx, x)
+        | Second y ->
+            Second (idx, y) )
+  in
+  let batch_process_snd ~f = Fn.compose (Tuple2.map_snd ~f) List.unzip in
+  let lefts_idx, lefts_processed = batch_process_snd ~f:process_left lefts in
+  let rights_idx, rights_processed =
+    batch_process_snd ~f:process_right rights
+  in
+
+  finalizer lefts_processed rights_processed
+    ~f:(fun left_materialized right_materialized ->
+      let left_materialized_indexed =
+        List.zip_exn lefts_idx left_materialized
+      in
+      let right_materialized_indexed =
+        List.zip_exn rights_idx right_materialized
+      in
+      List.merge left_materialized_indexed right_materialized_indexed
+        ~compare:(fun (left_idx, _) (right_idx, _) ->
+          Int.compare left_idx right_idx )
+      |> List.map ~f:snd )

--- a/src/lib/mina_stdlib/list.mli
+++ b/src/lib/mina_stdlib/list.mli
@@ -58,3 +58,15 @@ module Length : sig
     val ( < ) : 'a t
   end
 end
+
+val process_separately :
+     partitioner:('input -> ('left, 'right) Base.Either.t)
+  -> process_left:('left list -> 'left_output)
+  -> process_right:('right list -> 'right_output)
+  -> finalizer:
+       (   'left_output
+        -> 'right_output
+        -> f:('output_item list -> 'output_item list -> 'output_item list)
+        -> 'final_output )
+  -> 'input list
+  -> 'final_output


### PR DESCRIPTION
A simple noop refactor, should be no behavioral change. No change log should be needed.