### PR TITLE
Pickles: Remove unused function argument

### DIFF
--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1402,8 +1402,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                        (Vector.length
                                           m.old_bulletproof_challenges )
                                    in
-                                   Wrap_hack.hash_messages_for_next_wrap_proof
-                                     max_proofs_verified m
+                                   Wrap_hack.hash_messages_for_next_wrap_proof m
                                end)
                            in
                           let module V = H1.To_vector (Digest.Constant) in
@@ -1756,7 +1755,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                 { next_statement.proof_state with
                                   messages_for_next_wrap_proof =
                                     Wrap_hack.hash_messages_for_next_wrap_proof
-                                      max_proofs_verified
                                       messages_for_next_wrap_proof_prepared
                                 ; deferred_values =
                                     { next_statement.proof_state.deferred_values with

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -286,7 +286,6 @@ struct
                 statement.proof_state.sponge_digest_before_evaluations
             ; messages_for_next_wrap_proof =
                 Wrap_hack.hash_messages_for_next_wrap_proof
-                  Local_max_proofs_verified.n
                   { old_bulletproof_challenges = prev_challenges
                   ; challenge_polynomial_commitment =
                       statement.proof_state.messages_for_next_wrap_proof
@@ -725,8 +724,7 @@ struct
                       Lazy.force Dummy.Ipa.Wrap.challenges_computed )
               }
             in
-            Wrap_hack.hash_messages_for_next_wrap_proof Max_proofs_verified.n t
-            :: pad [] ms n
+            Wrap_hack.hash_messages_for_next_wrap_proof t :: pad [] ms n
       in
       lazy
         (Vector.rev

--- a/src/lib/pickles/test/test_wrap_hack.ml
+++ b/src/lib/pickles/test/test_wrap_hack.ml
@@ -38,7 +38,7 @@ let test_hash_messages_for_next_wrap_proof (type n) (n : n Nat.t) () =
       make_checked (fun () ->
           Wrap_hack.Checked.hash_messages_for_next_wrap_proof n t ) )
     (fun t ->
-      Wrap_hack.Checked.hash_constant_messages_for_next_wrap_proof n t
+      Wrap_hack.Checked.hash_constant_messages_for_next_wrap_proof t
       |> Digest.Constant.to_bits |> Impls.Wrap.Field.Constant.project )
     messages_for_next_wrap_proof
 

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -201,7 +201,6 @@ let verify_heterogenous (ts : Instance.t list) =
                   t.statement.proof_state.sponge_digest_before_evaluations
               ; messages_for_next_wrap_proof =
                   Wrap_hack.hash_messages_for_next_wrap_proof
-                    Max_proofs_verified.n
                     (Reduced_messages_for_next_proof_over_same_field.Wrap
                      .prepare
                        t.statement.proof_state.messages_for_next_wrap_proof )

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -353,9 +353,7 @@ let wrap
                      P.Base.Messages_for_next_proof_over_same_field.Wrap
                      .Prepared
                      .t ) =
-                 Wrap_hack.hash_messages_for_next_wrap_proof
-                   (Vector.length m.old_bulletproof_challenges)
-                   m
+                 Wrap_hack.hash_messages_for_next_wrap_proof m
              end)
          in
         let module V = H1.To_vector (Digest.Constant) in
@@ -565,7 +563,7 @@ let wrap
               { next_statement.proof_state with
                 messages_for_next_wrap_proof =
                   Wrap_hack.hash_messages_for_next_wrap_proof
-                    max_proofs_verified messages_for_next_wrap_proof_prepared
+                    messages_for_next_wrap_proof_prepared
               ; deferred_values =
                   { next_statement.proof_state.deferred_values with
                     plonk =

--- a/src/lib/pickles/wrap_hack.ml
+++ b/src/lib/pickles/wrap_hack.ml
@@ -43,7 +43,7 @@ let pad_accumulator (xs : (Tock.Proof.Challenge_polynomial.t, _) Vector.t) =
   |> Vector.to_list
 
 (* Hash the me only, padding first. *)
-let hash_messages_for_next_wrap_proof (type n) (_max_proofs_verified : n Nat.t)
+let hash_messages_for_next_wrap_proof (type n)
     (t :
       ( Tick.Curve.Affine.t
       , (_, n) Vector.t )

--- a/src/lib/pickles/wrap_hack.mli
+++ b/src/lib/pickles/wrap_hack.mli
@@ -8,8 +8,7 @@ val pad_accumulator :
      list
 
 val hash_messages_for_next_wrap_proof :
-     'n Pickles_types.Nat.t
-  -> ( Backend.Tick.Curve.Affine.t
+     ( Backend.Tick.Curve.Affine.t
      , ( ( Backend.Tock.Field.t
          , Pickles_types.Nat.z Backend.Tock.Rounds.plus_n )
          Pickles_types.Vector.t
@@ -58,8 +57,7 @@ module Checked : sig
     lazy_t
 
   val hash_constant_messages_for_next_wrap_proof :
-       'a Pickles_types.Nat.t
-    -> ( Backend.Tick.Curve.Affine.t
+       ( Backend.Tick.Curve.Affine.t
        , ( ( Backend.Tock.Field.t
            , Pickles_types.Nat.z Backend.Tock.Rounds.plus_n )
            Pickles_types.Vector.t


### PR DESCRIPTION
This PR removes an unused argument from `hash_messages_for_next_wrap_proof`. This is a no-op, and the only validation needed is that this compiles.