### PR TITLE
Stabilize emergency hf test

### DIFF
--- a/scripts/archive/emergency_hf/test/runner.sh
+++ b/scripts/archive/emergency_hf/test/runner.sh
@@ -22,6 +22,12 @@ function cleanup () {
 DOCKET_NETWORK=emergency_hf
 docker network create $DOCKET_NETWORK || true
 
+if docker ps -a | grep -q replayer-postgres; then
+    echo "Container already exists, killing it"
+    docker kill replayer-postgres
+    docker rm replayer-postgres
+fi
+
 # -v mounts dir with Unix socket on host
 echo "Starting docker with Postgresql"
 docker run \


### PR DESCRIPTION
This pull request includes a small change to the `scripts/archive/emergency_hf/test/runner.sh` file. The change ensures that if the `replayer-postgres` container already exists, it will be killed and removed before starting a new one.