### PR TITLE
Pickles: remove `~branching` argument

### DIFF
--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -118,7 +118,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let tag1, _, _, Pickles.Provers.[ trivial_prover1 ] =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Pickles_types.Nat.N1)
         ~max_proofs_verified:(module Pickles_types.Nat.N0)
         ~name:"trivial1"
         ~choices:(fun ~self:_ -> [ Trivial_rule1.rule ])
@@ -129,7 +128,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let tag2, _, _, Pickles.Provers.[ trivial_prover2 ] =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Pickles_types.Nat.N1)
         ~max_proofs_verified:(module Pickles_types.Nat.N0)
         ~name:"trivial2"
         ~choices:(fun ~self:_ -> [ Trivial_rule2.rule ])

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -23,7 +23,6 @@ let%test_module "Actions test" =
         , Pickles.Provers.[ initialize_prover; add_actions_prover ] ) =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"no actions"
         ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -23,7 +23,6 @@ let%test_module "Add events test" =
         , Pickles.Provers.[ initialize_prover; add_events_prover ] ) =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"no events"
         ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -21,7 +21,6 @@ let num_constraints = 1 lsl 15
 
 let tag, _cache, _p_module, Pickles.Provers.[ prover ] =
   Zkapps_examples.compile () ~cache:Cache_dir.cache ~auxiliary_typ:Impl.Typ.unit
-    ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"big_circuit"
     ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -68,7 +68,6 @@ let%test_module "Composability test" =
             ] ) =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:(option_typ Zkapps_calls.Call_data.Output.typ)
-        ~branches:(module Nat.N4)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
         ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -18,7 +18,6 @@ let account_id = Account_id.create pk_compressed Token_id.default
 
 let tag, _, p_module, Pickles.Provers.[ prover ] =
   Zkapps_examples.compile () ~cache:Cache_dir.cache ~auxiliary_typ:Impl.Typ.unit
-    ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"empty_update"
     ~choices:(fun ~self:_ -> [ Zkapps_empty_update.rule pk_compressed ])

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -27,7 +27,6 @@ let%test_module "Initialize state test" =
         , Pickles.Provers.[ initialize_prover; update_state_prover ] ) =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
         ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
+++ b/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
@@ -31,7 +31,6 @@ struct
 
   let tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
     Zkapps_examples.compile ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~name:"custom gates"
       ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -629,7 +629,6 @@ module Transfer_recursive = struct
          ~override_wrap_domain:Pickles_base.Proofs_verified.N1
          ~public_input:(Input Rules.Transfer.Recursive.Statement.typ)
          ~auxiliary_typ:Impl.Typ.unit
-         ~branches:(module Nat.N1)
          ~max_proofs_verified:(module Nat.N2)
          ~name:"transfer recurse"
          ~choices:(fun ~self -> [ Rules.Transfer.Recursive.rule self ]) )
@@ -658,7 +657,6 @@ let lazy_compiled =
     (Zkapps_examples.compile () ~cache:Cache_dir.cache
        ~override_wrap_domain:Pickles_base.Proofs_verified.N1
        ~auxiliary_typ:Impl.Typ.unit
-       ~branches:(module Nat.N3)
        ~max_proofs_verified:(module Nat.N2)
        ~name:"tokens"
        ~choices:(fun ~self:_ ->

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -552,7 +552,8 @@ let compile :
                , max_proofs_verified
                , branches )
                Pickles.Tag.t
-          -> ( prev_varss
+          -> ( branches
+             , prev_varss
              , prev_valuess
              , widthss
              , heightss
@@ -562,7 +563,7 @@ let compile :
              , unit (* TODO: Remove? *)
              , auxiliary_var
              , auxiliary_value )
-             H4_6.T(Pickles.Inductive_rule).t )
+             H4_6_with_length.T(Pickles.Inductive_rule).t )
     -> unit
     -> ( Zkapp_statement.Checked.t
        , Zkapp_statement.t
@@ -591,8 +592,9 @@ let compile :
   let vk_hash = ref None in
   let choices ~self =
     let rec go :
-        type prev_varss prev_valuess widthss heightss.
-           ( prev_varss
+        type branches prev_varss prev_valuess widthss heightss.
+           ( branches
+           , prev_varss
            , prev_valuess
            , widthss
            , heightss
@@ -602,8 +604,9 @@ let compile :
            , unit
            , auxiliary_var
            , auxiliary_value )
-           H4_6.T(Pickles.Inductive_rule).t
-        -> ( prev_varss
+           H4_6_with_length.T(Pickles.Inductive_rule).t
+        -> ( branches
+           , prev_varss
            , prev_valuess
            , widthss
            , heightss
@@ -613,7 +616,7 @@ let compile :
            , Zkapp_statement.t
            , return_type Prover_value.t * auxiliary_var
            , return_type * auxiliary_value )
-           H4_6.T(Pickles.Inductive_rule.Deferred).t = function
+           H4_6_with_length.T(Pickles.Inductive_rule.Deferred).t = function
       | [] ->
           []
       | { identifier; prevs; main; feature_flags } :: choices ->

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -541,7 +541,6 @@ let compile :
     -> ?disk_keys:(_, branches) Vector.t * _
     -> ?override_wrap_domain:_
     -> auxiliary_typ:(auxiliary_var, auxiliary_value) Typ.t
-    -> branches:(module Nat.Intf with type n = branches)
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
@@ -588,7 +587,7 @@ let compile :
            Deferred.t )
          H3_2.T(Pickles.Prover).t =
  fun ?self ?cache ?proof_cache ?disk_keys ?override_wrap_domain ~auxiliary_typ
-     ~branches ~max_proofs_verified ~name ~choices () ->
+     ~max_proofs_verified ~name ~choices () ->
   let vk_hash = ref None in
   let choices ~self =
     let rec go :
@@ -651,7 +650,7 @@ let compile :
     Pickles.compile_async () ?self ?cache ?proof_cache ?disk_keys
       ?override_wrap_domain ~public_input:(Output Zkapp_statement.typ)
       ~auxiliary_typ:Typ.(Prover_value.typ () * auxiliary_typ)
-      ~branches ~max_proofs_verified ~name ~choices
+      ~max_proofs_verified ~name ~choices
   in
   let () =
     vk_hash :=

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -484,7 +484,6 @@ end) : S = struct
       ~public_input:(Input Statement.typ)
       ~override_wrap_domain:Pickles_base.Proofs_verified.N1
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N2)
       ~name:"blockchain-snark"
       ~choices:(fun ~self ->

--- a/src/lib/crypto/plonkish_prelude/hlist.ml
+++ b/src/lib/crypto/plonkish_prelude/hlist.ml
@@ -834,17 +834,18 @@ module H4_4 = struct
   end
 end
 
-module H4_6 = struct
+module H4_6_with_length = struct
   module T (F : sig
     type (_, _, _, _, _, _, _, _, _, _) t
   end) =
   struct
-    type (_, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
-      | [] : (unit, unit, unit, unit, _, _, _, _, _, _) t
+    type ('length, _, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
+      | [] : (Nat.z, unit, unit, unit, unit, _, _, _, _, _, _) t
       | ( :: ) :
           ('a1, 'a2, 'a3, 'a4, 's1, 's2, 's3, 's4, 's5, 's6) F.t
-          * ('b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
-          -> ( 'a1 * 'b1
+          * ('length, 'b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
+          -> ( 'length Nat.s
+             , 'a1 * 'b1
              , 'a2 * 'b2
              , 'a3 * 'b3
              , 'a4 * 'b4
@@ -857,13 +858,14 @@ module H4_6 = struct
              t
 
     let rec length :
-        type t1 t2 t3 t4 e1 e2 e3 e4 e5 e6.
-        (t1, t2, t3, t4, e1, e2, e3, e4, e5, e6) t -> t1 Length.n = function
+        type length t1 t2 t3 t4 e1 e2 e3 e4 e5 e6.
+        (length, t1, t2, t3, t4, e1, e2, e3, e4, e5, e6) t -> length Nat.t =
+      function
       | [] ->
-          T (Z, Z)
+          Z
       | _ :: xs ->
-          let (T (n, p)) = length xs in
-          T (S n, S p)
+          let n = length xs in
+          S n
   end
 end
 

--- a/src/lib/crypto/plonkish_prelude/hlist.ml
+++ b/src/lib/crypto/plonkish_prelude/hlist.ml
@@ -859,13 +859,13 @@ module H4_6_with_length = struct
 
     let rec length :
         type length t1 t2 t3 t4 e1 e2 e3 e4 e5 e6.
-        (length, t1, t2, t3, t4, e1, e2, e3, e4, e5, e6) t -> length Nat.t =
-      function
+           (length, t1, t2, t3, t4, e1, e2, e3, e4, e5, e6) t
+        -> length Nat.t * (t1, length) Length.t = function
       | [] ->
-          Z
+          (Z, Z)
       | _ :: xs ->
-          let n = length xs in
-          S n
+          let n, p = length xs in
+          (S n, S p)
   end
 end
 

--- a/src/lib/crypto/plonkish_prelude/hlist.mli
+++ b/src/lib/crypto/plonkish_prelude/hlist.mli
@@ -958,7 +958,7 @@ module H4_6_with_length : sig
 
     val length :
          ('length, 't1, 't2, 't3, 't4, 'e1, 'e2, 'e3, 'e4, 'e5, 'e6) t
-      -> 'length Nat.t
+      -> 'length Nat.t * ('t1, 'length) Length.t
   end
 end
 

--- a/src/lib/crypto/plonkish_prelude/hlist.mli
+++ b/src/lib/crypto/plonkish_prelude/hlist.mli
@@ -932,18 +932,19 @@ end
     parameters, but also varies homogeneously over six other type parameters.
     It supports no operations. See {!Hlist0.H1_1}.
 *)
-module H4_6 : sig
+module H4_6_with_length : sig
   module T : functor
     (A : sig
        type (_, _, _, _, _, _, _, _, _, _) t
      end)
     -> sig
-    type (_, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
-      | [] : (unit, unit, unit, unit, 's1, 's2, 's3, 's4, 's5, 's6) t
+    type ('length, _, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
+      | [] : (Nat.z, unit, unit, unit, unit, 's1, 's2, 's3, 's4, 's5, 's6) t
       | ( :: ) :
           ('a1, 'a2, 'a3, 'a4, 's1, 's2, 's3, 's4, 's5, 's6) A.t
-          * ('b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
-          -> ( 'a1 * 'b1
+          * ('length, 'b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
+          -> ( 'length Nat.s
+             , 'a1 * 'b1
              , 'a2 * 'b2
              , 'a3 * 'b3
              , 'a4 * 'b4
@@ -956,7 +957,8 @@ module H4_6 : sig
              t
 
     val length :
-      ('t1, 't2, 't3, 't4, 'e1, 'e2, 'e3, 'e4, 'e5, 'e6) t -> 't1 Length.n
+         ('length, 't1, 't2, 't3, 't4, 'e1, 'e2, 'e3, 'e4, 'e5, 'e6) t
+      -> 'length Nat.t
   end
 end
 

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -1015,7 +1015,8 @@ let compile_with_wrap_main_override_promise :
     -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
     -> choices:
          (   self:(var, value, max_proofs_verified, branches) Tag.t
-          -> ( prev_varss
+          -> ( branches
+             , prev_varss
              , prev_valuess
              , widthss
              , heightss
@@ -1025,7 +1026,7 @@ let compile_with_wrap_main_override_promise :
              , ret_value
              , auxiliary_var
              , auxiliary_value )
-             H4_6.T(Inductive_rule.Promise).t )
+             H4_6_with_length.T(Inductive_rule.Promise).t )
     -> unit
     -> (var, value, max_proofs_verified, branches) Tag.t
        * Cache_handle.t
@@ -1094,8 +1095,9 @@ let compile_with_wrap_main_override_promise :
       (Auxiliary_value)
   in
   let rec conv_irs :
-      type v1ss v2ss wss hss.
-         ( v1ss
+      type branches v1ss v2ss wss hss.
+         ( branches
+         , v1ss
          , v2ss
          , wss
          , hss
@@ -1105,7 +1107,7 @@ let compile_with_wrap_main_override_promise :
          , ret_value
          , auxiliary_var
          , auxiliary_value )
-         H4_6.T(Inductive_rule.Promise).t
+         H4_6_with_length.T(Inductive_rule.Promise).t
       -> (v1ss, v2ss, wss, hss) H4.T(M.IR).t = function
     | [] ->
         []

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -346,7 +346,8 @@ struct
       -> ?override_wrap_main:
            (max_proofs_verified, branches, prev_varss) wrap_main_generic
       -> ?num_chunks:int
-      -> branches:(module Nat.Intf with type n = branches)
+      -> branches:branches Nat.t
+      -> prev_varss_length:(prev_varss, branches) Length.t
       -> max_proofs_verified:
            (module Nat.Add.Intf with type n = max_proofs_verified)
       -> name:string
@@ -360,9 +361,7 @@ struct
            , Ret_value.t )
            Inductive_rule.public_input
       -> auxiliary_typ:(Auxiliary_var.t, Auxiliary_value.t) Impls.Step.Typ.t
-      -> choices:
-           (   self:(var, value, max_proofs_verified, branches) Tag.t
-            -> (prev_varss, prev_valuess, widthss, heightss) H4.T(IR).t )
+      -> choices:(prev_varss, prev_valuess, widthss, heightss) H4.T(IR).t
       -> unit
       -> ( prev_valuess
          , widthss
@@ -380,9 +379,9 @@ struct
        ~storables:
          { step_storable; step_vk_storable; wrap_storable; wrap_vk_storable }
        ~proof_cache ?disk_keys ?override_wrap_domain ?override_wrap_main
-       ?(num_chunks = Plonk_checks.num_chunks_by_default)
-       ~branches:(module Branches) ~max_proofs_verified ~name
-       ?constraint_constants ~public_input ~auxiliary_typ ~choices () ->
+       ?(num_chunks = Plonk_checks.num_chunks_by_default) ~branches
+       ~prev_varss_length ~max_proofs_verified ~name ?constraint_constants
+       ~public_input ~auxiliary_typ ~choices () ->
     let snark_keys_header kind constraint_system_hash =
       let constraint_constants : Snark_keys_header.Constraint_constants.t =
         match constraint_constants with
@@ -416,9 +415,6 @@ struct
                                          with type n = max_proofs_verified )
     in
     let T = Max_proofs_verified.eq in
-    let choices = choices ~self in
-    let (T (prev_varss_n, prev_varss_length)) = HIR.length choices in
-    let T = Nat.eq_exn prev_varss_n Branches.n in
     let padded, (module Maxes) =
       max_local_max_proofs_verifieds
         ( module struct
@@ -466,7 +462,7 @@ struct
               (Auxiliary_var)
               (Auxiliary_value)
           in
-          M.f full_signature prev_varss_n prev_varss_length ~max_proofs_verified
+          M.f full_signature branches prev_varss_length ~max_proofs_verified
             ~feature_flags ~num_chunks
       | Some override ->
           Common.wrap_domains
@@ -482,7 +478,7 @@ struct
         , Auxiliary_var.t
         , Auxiliary_value.t
         , Max_proofs_verified.n
-        , Branches.n
+        , branches
         , 'vars
         , 'vals
         , 'n
@@ -520,10 +516,10 @@ struct
                 Common.time "make step data" (fun () ->
                     Step_branch_data.create ~index:!i ~feature_flags ~num_chunks
                       ~actual_feature_flags:rule.feature_flags
-                      ~max_proofs_verified:Max_proofs_verified.n
-                      ~branches:Branches.n ~self ~public_input ~auxiliary_typ
-                      Arg_var.to_field_elements Arg_value.to_field_elements rule
-                      ~wrap_domains ~proofs_verifieds ~chain_to )
+                      ~max_proofs_verified:Max_proofs_verified.n ~branches ~self
+                      ~public_input ~auxiliary_typ Arg_var.to_field_elements
+                      Arg_value.to_field_elements rule ~wrap_domains
+                      ~proofs_verifieds ~chain_to )
               in
               Timer.clock __LOC__ ; incr i ; res
             in
@@ -1008,7 +1004,6 @@ let compile_with_wrap_main_override_promise :
          , ret_value )
          Inductive_rule.public_input
     -> auxiliary_typ:(auxiliary_var, auxiliary_value) Impls.Step.Typ.t
-    -> branches:(module Nat.Intf with type n = branches)
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
@@ -1047,7 +1042,7 @@ let compile_with_wrap_main_override_promise :
  *)
  fun ?self ?(cache = []) ?(storables = Storables.default) ?proof_cache
      ?disk_keys ?override_wrap_domain ?override_wrap_main ?num_chunks
-     ~public_input ~auxiliary_typ ~branches ~max_proofs_verified ~name
+     ~public_input ~auxiliary_typ ~max_proofs_verified ~name
      ?constraint_constants ~choices () ->
   let self =
     match self with
@@ -1114,13 +1109,16 @@ let compile_with_wrap_main_override_promise :
     | r :: rs ->
         r :: conv_irs rs
   in
+  let choices = choices ~self in
+  let branches, prev_varss_length =
+    let module IR_hlist = H4_6_with_length.T (Inductive_rule.Promise) in
+    IR_hlist.length choices
+  in
   let provers, wrap_vk, wrap_disk_key, cache_handle =
     M.compile ~self ~proof_cache ~cache ~storables ?disk_keys
       ?override_wrap_domain ?override_wrap_main ?num_chunks ~branches
-      ~max_proofs_verified ~name ~public_input ~auxiliary_typ
-      ?constraint_constants
-      ~choices:(fun ~self -> conv_irs (choices ~self))
-      ()
+      ~prev_varss_length ~max_proofs_verified ~name ~public_input ~auxiliary_typ
+      ?constraint_constants ~choices:(conv_irs choices) ()
   in
   let (module Max_proofs_verified) = max_proofs_verified in
   let T = Max_proofs_verified.eq in
@@ -1347,7 +1345,6 @@ struct
   let tag, _, p, ([ step ] : _ H3_2.T(Prover).t) =
     compile_with_wrap_main_override_promise () ~override_wrap_main
       ~public_input:(Input Typ.unit) ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N2)
       ~name:"blockchain-snark"
       ~choices:(fun ~self -> [ rule self ])
@@ -1386,7 +1383,6 @@ struct
       Common.time "compile" (fun () ->
           compile_with_wrap_main_override_promise ()
             ~public_input:(Input Typ.unit) ~auxiliary_typ:Typ.unit
-            ~branches:(module Nat.N1)
             ~max_proofs_verified:(module Nat.N2)
             ~name:"recurse-on-bad"
             ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -312,7 +312,8 @@ val compile_with_wrap_main_override_promise :
   -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
   -> choices:
        (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
-        -> ( 'prev_varss
+        -> ( 'branches
+           , 'prev_varss
            , 'prev_valuess
            , 'widthss
            , 'heightss
@@ -322,7 +323,7 @@ val compile_with_wrap_main_override_promise :
            , 'ret_value
            , 'auxiliary_var
            , 'auxiliary_value )
-           H4_6.T(Inductive_rule.Promise).t )
+           H4_6_with_length.T(Inductive_rule.Promise).t )
   -> unit
   -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
      * Cache_handle.t

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -306,7 +306,6 @@ val compile_with_wrap_main_override_promise :
        , 'ret_value )
        Inductive_rule.public_input
   -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
-  -> branches:(module Nat.Intf with type n = 'branches)
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
   -> ?constraint_constants:Snark_keys_header.Constraint_constants.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -314,14 +314,14 @@ module Make_str (_ : Wire_types.Concrete) = struct
     Compile.compile_with_wrap_main_override_promise
 
   let compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
-      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
       ~max_proofs_verified ~name ~choices () =
     compile_with_wrap_main_override_promise ?self ?cache ?storables ?proof_cache
       ?disk_keys ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~branches ~max_proofs_verified ~name ~choices ()
+      ~max_proofs_verified ~name ~choices ()
 
   let compile ?self ?cache ?storables ?proof_cache ?disk_keys
-      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
       ~max_proofs_verified ~name ~choices () =
     let choices ~self =
       let choices = choices ~self in
@@ -365,7 +365,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     in
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
-        ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+        ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
         ~max_proofs_verified ~name ~choices ()
     in
     let rec adjust_provers :
@@ -382,7 +382,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     (self, cache_handle, proof_module, adjust_provers provers)
 
   let compile_async ?self ?cache ?storables ?proof_cache ?disk_keys
-      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+      ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
       ~max_proofs_verified ~name ~choices () =
     let choices ~self =
       let choices = choices ~self in
@@ -431,7 +431,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     in
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
-        ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ ~branches
+        ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
         ~max_proofs_verified ~name ~choices ()
     in
     let rec adjust_provers :
@@ -494,7 +494,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -533,7 +532,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Output Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -588,7 +586,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self ->
@@ -684,7 +681,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise () ~public_input:(Input Field.typ)
                 ~override_wrap_domain:Pickles_base.Proofs_verified.N1
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self ->
@@ -804,7 +800,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise () ~public_input:(Output Field.typ)
                 ~override_wrap_domain:Pickles_base.Proofs_verified.N1
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self ->
@@ -904,7 +899,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise ()
                 ~public_input:(Input_and_output (Field.typ, Field.typ))
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -945,7 +939,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise ()
                 ~public_input:(Input_and_output (Field.typ, Field.typ))
                 ~auxiliary_typ:Field.typ
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -1930,7 +1923,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Typ.unit)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"recurse-on-bad"
                 ~choices:(fun ~self:_ ->
@@ -2058,7 +2050,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2097,7 +2088,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2137,7 +2127,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise () ~public_input:(Input Field.typ)
                 ~override_wrap_domain:Pickles_base.Proofs_verified.N1
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2202,7 +2191,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2370,7 +2358,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2409,7 +2396,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2449,7 +2435,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
               compile_promise () ~public_input:(Input Field.typ)
                 ~override_wrap_domain:Pickles_base.Proofs_verified.N1
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->
@@ -2517,7 +2502,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Common.time "compile" (fun () ->
               compile_promise () ~public_input:(Input Field.typ)
                 ~auxiliary_typ:Typ.unit
-                ~branches:(module Nat.N1)
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
                 ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -326,10 +326,31 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let choices ~self =
       let choices = choices ~self in
       let rec go :
-          type a b c d e f g h i j.
-             (a, b, c, d, e, f, g, h, i, j) H4_6.T(Inductive_rule).t
-          -> (a, b, c, d, e, f, g, h, i, j) H4_6.T(Inductive_rule.Promise).t =
-        function
+          type length a b c d e f g h i j.
+             ( length
+             , a
+             , b
+             , c
+             , d
+             , e
+             , f
+             , g
+             , h
+             , i
+             , j )
+             H4_6_with_length.T(Inductive_rule).t
+          -> ( length
+             , a
+             , b
+             , c
+             , d
+             , e
+             , f
+             , g
+             , h
+             , i
+             , j )
+             H4_6_with_length.T(Inductive_rule.Promise).t = function
         | [] ->
             []
         | { identifier; prevs; main; feature_flags } :: rest ->
@@ -366,10 +387,31 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let choices ~self =
       let choices = choices ~self in
       let rec go :
-          type a b c d e f g h i j.
-             (a, b, c, d, e, f, g, h, i, j) H4_6.T(Inductive_rule.Deferred).t
-          -> (a, b, c, d, e, f, g, h, i, j) H4_6.T(Inductive_rule.Promise).t =
-        function
+          type length a b c d e f g h i j.
+             ( length
+             , a
+             , b
+             , c
+             , d
+             , e
+             , f
+             , g
+             , h
+             , i
+             , j )
+             H4_6_with_length.T(Inductive_rule.Deferred).t
+          -> ( length
+             , a
+             , b
+             , c
+             , d
+             , e
+             , f
+             , g
+             , h
+             , i
+             , j )
+             H4_6_with_length.T(Inductive_rule.Promise).t = function
         | [] ->
             []
         | { identifier; prevs; main; feature_flags } :: rest ->

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -398,7 +398,6 @@ module type S = sig
       @param disk_keys Caches for the individial keys
       @param override_wrap_domain This let you tell pickles that the wrap circuit will be smaller/bigger than it's expecting's. At the moment, we map 0 proofs verified to 2^14, 1 proofs verified to 2^15, and 2 to 2^16. However, you'll usually see this used with 2 proofs, which actually only requires 2^15 (so we set this as N1). This was also part of the inspiration for your project: its existence tells us that we can recurse over more proofs.
       @param num_chunks Configurable parameter enabling circuits larger than maximum
-      @param branches Number of different circuits that Tock(i.e. Wrap) accepts as inputs
       @param max_proofs_verified Number of different circuits that Tick(i.e. Step) accepts as inputs
   *)
   val compile_promise :
@@ -420,7 +419,6 @@ module type S = sig
          , 'ret_value )
          Inductive_rule.public_input
     -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
-    -> branches:(module Nat.Intf with type n = 'branches)
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
@@ -476,7 +474,6 @@ module type S = sig
          , 'ret_value )
          Inductive_rule.public_input
     -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
-    -> branches:(module Nat.Intf with type n = 'branches)
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
@@ -532,7 +529,6 @@ module type S = sig
          , 'ret_value )
          Inductive_rule.public_input
     -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
-    -> branches:(module Nat.Intf with type n = 'branches)
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -426,7 +426,8 @@ module type S = sig
     -> name:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
-          -> ( 'prev_varss
+          -> ( 'branches
+             , 'prev_varss
              , 'prev_valuess
              , 'widthss
              , 'heightss
@@ -436,7 +437,7 @@ module type S = sig
              , 'ret_value
              , 'auxiliary_var
              , 'auxiliary_value )
-             H4_6.T(Inductive_rule.Promise).t )
+             H4_6_with_length.T(Inductive_rule.Promise).t )
     -> unit
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
@@ -481,7 +482,8 @@ module type S = sig
     -> name:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
-          -> ( 'prev_varss
+          -> ( 'branches
+             , 'prev_varss
              , 'prev_valuess
              , 'widthss
              , 'heightss
@@ -491,7 +493,7 @@ module type S = sig
              , 'ret_value
              , 'auxiliary_var
              , 'auxiliary_value )
-             H4_6.T(Inductive_rule).t )
+             H4_6_with_length.T(Inductive_rule).t )
     -> unit
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
@@ -536,7 +538,8 @@ module type S = sig
     -> name:string
     -> choices:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
-          -> ( 'prev_varss
+          -> ( 'branches
+             , 'prev_varss
              , 'prev_valuess
              , 'widthss
              , 'heightss
@@ -546,7 +549,7 @@ module type S = sig
              , 'ret_value
              , 'auxiliary_var
              , 'auxiliary_value )
-             H4_6.T(Inductive_rule.Deferred).t )
+             H4_6_with_length.T(Inductive_rule.Deferred).t )
     -> unit
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -10,7 +10,6 @@ let test () =
   let tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:2 ~override_wrap_domain:N1 ~name:"chunked_circuits"
       ~choices:(fun ~self:_ ->
@@ -78,7 +77,6 @@ let test () =
       =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N1)
       ~name:"recursion over chunks"
       ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/test/chunked_circuits/chunks4.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks4.ml
@@ -11,7 +11,6 @@ let test () =
   let _tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:4 ~override_wrap_domain:N1 ~name:"chunked_circuits"
       ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/test/chunked_circuits/chunks8.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks8.ml
@@ -11,7 +11,6 @@ let test () =
   let _tag, _cache_handle, proof, Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:8 ~override_wrap_domain:N2 ~name:"chunked_circuits"
       ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
+++ b/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
@@ -50,7 +50,6 @@ let test_range_check_lookup () =
   let _tag, _cache_handle, (module Proof), Pickles.Provers.[ prove ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N0)
       ~name:"lookup range-check"
       ~choices:(fun ~self:_ ->

--- a/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
+++ b/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
@@ -235,7 +235,6 @@ let register_test name feature_flags1 feature_flags2 =
   let tag, _cache_handle, proof, Pickles.Provers.[ prove1; prove2 ] =
     Pickles.compile ~public_input:(Pickles.Inductive_rule.Input Typ.unit)
       ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N2)
       ~max_proofs_verified:(module Nat.N0)
       ~name:"optional_custom_gates"
       ~choices:(fun ~self:_ ->

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -29,7 +29,6 @@ let%test_module "Access permission tests" =
     let tag, _, p_module, Pickles.Provers.[ prover ] =
       Zkapps_examples.compile () ~cache:Cache_dir.cache ~proof_cache
         ~auxiliary_typ:Impl.Typ.unit
-        ~branches:(module Nat.N1)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
         ~choices:(fun ~self:_ -> [ Zkapps_empty_update.rule pk_compressed ])

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -221,7 +221,6 @@ let%test_module "multisig_account" =
                   ~override_wrap_domain:Pickles_base.Proofs_verified.N1
                   ~public_input:(Input Zkapp_statement.typ)
                   ~auxiliary_typ:Typ.unit
-                  ~branches:(module Nat.N2)
                   ~max_proofs_verified:(module Nat.N2)
                     (* You have to put 2 here... *)
                   ~name:"multisig"

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -129,7 +129,6 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
           let tag, _, (module P), Pickles.Provers.[ ringsig_prover ] =
             Pickles.compile () ~cache:Cache_dir.cache ~proof_cache
               ~public_input:(Input Zkapp_statement.typ) ~auxiliary_typ:Typ.unit
-              ~branches:(module Nat.N1)
               ~max_proofs_verified:(module Nat.N0)
               ~name:"ringsig"
               ~choices:(fun ~self:_ -> [ ring_sig_rule ring_member_pks ])

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3332,7 +3332,6 @@ module Make_str (A : Wire_types.Concrete) = struct
     Pickles.compile () ~cache:Cache_dir.cache ?proof_cache:!proof_cache
       ~override_wrap_domain:Pickles_base.Proofs_verified.N1
       ~public_input:(Input Statement.With_sok.typ) ~auxiliary_typ:Typ.unit
-      ~branches:(module Nat.N5)
       ~max_proofs_verified:(module Nat.N2)
       ~name:"transaction-snark"
       ~choices:(fun ~self ->
@@ -4185,7 +4184,6 @@ module Make_str (A : Wire_types.Concrete) = struct
         in
         Pickles.compile () ~cache:Cache_dir.cache ?proof_cache:!proof_cache
           ~public_input:(Input Zkapp_statement.typ) ~auxiliary_typ:Typ.unit
-          ~branches:(module Nat.N1)
           ~max_proofs_verified:(module Nat.N0)
           ~name:"trivial"
           ~choices:(fun ~self:_ -> [ trivial_rule ])


### PR DESCRIPTION
This PR is a no-op, but simplifies the pickles interface.

Pickles previously required the user to manually provide the number of inductive rule branches in its `~choices` argument separately as the `~branches` argument, and then asserted that it equals the true number at runtime. This is both annoying and unnecessary.

This PR modifies the hlist type used for the `choices` to encode its length as a type-level nat by construction. Since this type can now always be inferred from the hlist itself, there is no longer any need to pass a separate type witness for the number of branches.