### PR TITLE
Pickles: stop tracking unused value `proof_verifieds`

### DIFF
--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -518,8 +518,7 @@ struct
                       ~actual_feature_flags:rule.feature_flags
                       ~max_proofs_verified:Max_proofs_verified.n ~branches ~self
                       ~public_input ~auxiliary_typ Arg_var.to_field_elements
-                      Arg_value.to_field_elements rule ~wrap_domains
-                      ~proofs_verifieds ~chain_to )
+                      Arg_value.to_field_elements rule ~wrap_domains ~chain_to )
               in
               Timer.clock __LOC__ ; incr i ; res
             in
@@ -856,8 +855,7 @@ struct
     in
     Timer.clock __LOC__ ;
     let data : _ Types_map.Compiled.t =
-      { proofs_verifieds
-      ; max_proofs_verified
+      { max_proofs_verified
       ; public_input = typ
       ; wrap_key =
           Lazy.map wrap_vk

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1162,13 +1162,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
               , 'm )
               Step_branch_data.t
           end in
-          let proofs_verifieds = Vector.singleton 2 in
           let (T inner_step_data as step_data) =
             Step_branch_data.create ~index:0 ~feature_flags ~num_chunks:1
               ~actual_feature_flags ~max_proofs_verified:Max_proofs_verified.n
               ~branches:Branches.n ~self ~public_input:(Input typ)
               ~auxiliary_typ:typ A.to_field_elements A_value.to_field_elements
-              rule ~wrap_domains ~proofs_verifieds ~chain_to:(Promise.return ())
+              rule ~wrap_domains ~chain_to:(Promise.return ())
             (* TODO? *)
           in
           let step_domains = Vector.singleton inner_step_data.domains in
@@ -1849,7 +1848,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
           in
           let data : _ Types_map.Compiled.t =
             { feature_flags
-            ; proofs_verifieds
             ; max_proofs_verified = (module Max_proofs_verified)
             ; public_input = typ
             ; wrap_key =

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -77,7 +77,7 @@ let create
     ~wrap_domains ~(feature_flags : Opt.Flag.t Plonk_types.Features.Full.t)
     ~num_chunks ~(actual_feature_flags : bool Plonk_types.Features.t)
     ~(max_proofs_verified : max_proofs_verified Nat.t)
-    ~(proofs_verifieds : (int, branches) Vector.t) ~(branches : branches Nat.t)
+    ~(branches : branches Nat.t)
     ~(public_input :
        ( var
        , value
@@ -186,7 +186,6 @@ let create
       rule
       ~basic:
         { public_input = typ
-        ; proofs_verifieds
         ; wrap_domains
         ; step_domains
         ; feature_flags

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -91,7 +91,6 @@ val create :
   -> num_chunks:int
   -> actual_feature_flags:bool Plonk_types.Features.t
   -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
-  -> proofs_verifieds:(int, 'branches) Pickles_types.Vector.t
   -> branches:'branches Pickles_types.Nat.t
   -> public_input:
        ( 'var

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -480,10 +480,7 @@ let step_main :
                       , max_proofs_verified
                       , self_branches )
                       Types_map.For_step.t =
-                    { proofs_verifieds =
-                        `Known
-                          (Vector.map basic.proofs_verifieds ~f:Field.of_int)
-                    ; max_proofs_verified
+                    { max_proofs_verified
                     ; public_input = basic.public_input
                     ; wrap_domain = `Known basic.wrap_domains.h
                     ; step_domains = `Known basic.step_domains

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -62,8 +62,7 @@ let verify_one ~srs
   let statement =
     let prev_messages_for_next_step_proof =
       with_label __LOC__ (fun () ->
-          hash_messages_for_next_step_proof ~widths:d.proofs_verifieds
-            ~max_width:(Nat.Add.n d.max_proofs_verified)
+          hash_messages_for_next_step_proof
             ~proofs_verified_mask:
               (Vector.trim_front branch_data.proofs_verified_mask
                  (Nat.lte_exn

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -1121,7 +1121,7 @@ struct
     let after_index = sponge_after_index index in
     ( after_index
     , (* TODO: Just get rid of the proofs verified mask and always absorb in full *)
-      stage (fun t ~widths:_ ~max_width:_ ~proofs_verified_mask ->
+      stage (fun t ~proofs_verified_mask ->
           let sponge = Sponge.copy after_index in
           let t =
             { t with

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -85,8 +85,6 @@ val hash_messages_for_next_step_proof_opt :
              , 'b )
              Pickles_types.Vector.t )
            Import.Types.Step.Proof_state.Messages_for_next_step_proof.t
-        -> widths:'d
-        -> max_width:'e
         -> proofs_verified_mask:
              ( Impl.Field.t Snarky_backendless.Boolean.t
              , 'b )

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -148,8 +148,6 @@ module For_step = struct
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
     { max_proofs_verified :
         (module Nat.Add.Intf with type n = 'max_proofs_verified)
-    ; proofs_verifieds :
-        [ `Known of (Impls.Step.Field.t, 'branches) Vector.t | `Side_loaded ]
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
     ; wrap_key : inner_curve_var array Plonk_verification_key_evals.t
     ; wrap_domain :
@@ -184,7 +182,6 @@ module For_step = struct
     in
     { max_proofs_verified
     ; public_input
-    ; proofs_verifieds = `Side_loaded
     ; wrap_key
     ; wrap_domain = `Side_loaded index.actual_wrap_domain_size
     ; step_domains = `Side_loaded
@@ -206,7 +203,7 @@ module For_step = struct
   let of_compiled_with_known_wrap_key
       ({ wrap_key; step_domains } : _ Optional_wrap_key.known)
       ({ max_proofs_verified
-       ; proofs_verifieds
+       ; proofs_verifieds = _
        ; public_input
        ; wrap_key = _
        ; wrap_domains
@@ -218,8 +215,6 @@ module For_step = struct
        } :
         _ Compiled.t ) =
     { max_proofs_verified
-    ; proofs_verifieds =
-        `Known (Vector.map proofs_verifieds ~f:Impls.Step.Field.of_int)
     ; public_input
     ; wrap_key =
         Plonk_verification_key_evals.map wrap_key

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -87,8 +87,6 @@ end
 module Compiled = struct
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) basic =
     { public_input : ('a_var, 'a_value) Impls.Step.Typ.t
-    ; proofs_verifieds : (int, 'branches) Vector.t
-          (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
     ; feature_flags : Opt.Flag.t Plonk_types.Features.Full.t
@@ -102,8 +100,6 @@ module Compiled = struct
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
     { max_proofs_verified :
         (module Nat.Add.Intf with type n = 'max_proofs_verified)
-    ; proofs_verifieds : (int, 'branches) Vector.t
-          (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
     ; wrap_key :
         Tick.Inner_curve.Affine.t array Plonk_verification_key_evals.t Promise.t
@@ -121,7 +117,6 @@ module Compiled = struct
 
   let to_basic
       { max_proofs_verified
-      ; proofs_verifieds = _
       ; public_input
       ; wrap_vk
       ; wrap_domains
@@ -203,7 +198,6 @@ module For_step = struct
   let of_compiled_with_known_wrap_key
       ({ wrap_key; step_domains } : _ Optional_wrap_key.known)
       ({ max_proofs_verified
-       ; proofs_verifieds = _
        ; public_input
        ; wrap_key = _
        ; wrap_domains

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -54,8 +54,6 @@ end
 module Compiled : sig
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) basic =
     { public_input : ('a_var, 'a_value) Impls.Step.Typ.t
-    ; proofs_verifieds : (int, 'branches) Pickles_types.Vector.t
-          (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
     ; feature_flags : Opt.Flag.t Plonk_types.Features.Full.t
@@ -66,8 +64,6 @@ module Compiled : sig
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
     { max_proofs_verified :
         (module Pickles_types.Nat.Add.Intf with type n = 'max_proofs_verified)
-    ; proofs_verifieds : (int, 'branches) Pickles_types.Vector.t
-          (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
     ; wrap_key :
         Backend.Tick.Inner_curve.Affine.t array

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -88,9 +88,6 @@ module For_step : sig
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
     { max_proofs_verified :
         (module Pickles_types.Nat.Add.Intf with type n = 'max_proofs_verified)
-    ; proofs_verifieds :
-        [ `Known of (Impls.Step.Field.t, 'branches) Pickles_types.Vector.t
-        | `Side_loaded ]
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
     ; wrap_key :
         inner_curve_var array Pickles_types.Plonk_verification_key_evals.t


### PR DESCRIPTION
This PR builds upon #16849. This removes `proof_verifieds` as a function argument where it was unused, and then removes the corresponding tracking that is no longer used.

This PR is a no-op, but simplifies some of the internals of pickles to make it easier to understand. As long as this compiles, this PR is safe, given the lack of functional changes.