### PR TITLE
[CI] wait for aptly service

### DIFF
--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -53,7 +53,7 @@ for i in "${debs[@]}"; do
 done
 
 # Start aptly
-source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background
+source ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background --wait
 
 # Install debians
 echo "Installing mina packages: $DEBS"

--- a/buildkite/scripts/debian/start_local_repo.sh
+++ b/buildkite/scripts/debian/start_local_repo.sh
@@ -20,4 +20,4 @@ mkdir -p $LOCAL_DEB_FOLDER
 source ./buildkite/scripts/export-git-env-vars.sh
 ./buildkite/scripts/cache/manager.sh read --root debs "$MINA_DEB_CODENAME/*" _build
 ./buildkite/scripts/cache/manager.sh read "debians/$MINA_DEB_CODENAME/*" _build
-./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background
+./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background --wait


### PR DESCRIPTION
Performance tests are failing occasionally due to too early access to aptly in order to fetch packages. As a consequence they cannot find them and error out. This PR solves this race conditions and make all scripts to wait (optional flag to preserve compatibility),