### PR TITLE
Add an implementation of a `Converting_merkle_tree`

### DIFF
--- a/changes/16853.md
+++ b/changes/16853.md
@@ -1,0 +1,14 @@
+# PR 16853: Add an implementation of a Converting_merkle_tree
+
+## Summary
+
+Added an implementation of `Converting_merkle_tree`, a module which muxes
+write requests to a `primary_ledger` to also target a `converting_ledger`.
+The intention is to use this in the leadup to a hardfork, where we can run
+the post-hardfork schema alongside the existing schema.
+
+## Changes
+- Add an implementation of a Converting_merkle_tree
+- Added tests using a temporary `Account.Unstable` type. Subsequent work
+  will change this to a type which is more reflective of the upcoming changes
+  to the `Account` type.

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -1,0 +1,226 @@
+open Core_kernel
+
+module Make (Inputs : sig
+  include Intf.Inputs.Intf
+
+  type converted_account
+
+  val convert : Account.t -> converted_account
+end)
+(Primary_ledger : Intf.Ledger.S
+                    with module Location = Inputs.Location
+                     and module Addr = Inputs.Location.Addr
+                     and type key := Inputs.Key.t
+                     and type token_id := Inputs.Token_id.t
+                     and type token_id_set := Inputs.Token_id.Set.t
+                     and type account := Inputs.Account.t
+                     and type root_hash := Inputs.Hash.t
+                     and type hash := Inputs.Hash.t
+                     and type account_id := Inputs.Account_id.t
+                     and type account_id_set := Inputs.Account_id.Set.t)
+(Converting_ledger : Intf.Ledger.S
+                       with module Location = Inputs.Location
+                        and module Addr = Inputs.Location.Addr
+                        and type key := Inputs.Key.t
+                        and type token_id := Inputs.Token_id.t
+                        and type token_id_set := Inputs.Token_id.Set.t
+                        and type account := Inputs.converted_account
+                        and type root_hash := Inputs.Hash.t
+                        and type hash := Inputs.Hash.t
+                        and type account_id := Inputs.Account_id.t
+                        and type account_id_set := Inputs.Account_id.Set.t) : sig
+  include
+    Intf.Ledger.S
+      with module Location = Inputs.Location
+       and module Addr = Inputs.Location.Addr
+       and type key := Inputs.Key.t
+       and type token_id := Inputs.Token_id.t
+       and type token_id_set := Inputs.Token_id.Set.t
+       and type account := Inputs.Account.t
+       and type root_hash := Inputs.Hash.t
+       and type hash := Inputs.Hash.t
+       and type account_id := Inputs.Account_id.t
+       and type account_id_set := Inputs.Account_id.Set.t
+
+  val create : Primary_ledger.t -> Converting_ledger.t option -> t
+
+  val primary_ledger : t -> Primary_ledger.t
+
+  val converting_ledger : t -> Converting_ledger.t option
+end = struct
+  let convert = Inputs.convert
+
+  module Location = Inputs.Location
+  module Addr = Inputs.Location.Addr
+  module Path = Primary_ledger.Path
+
+  type path = Primary_ledger.path
+
+  type index = int
+
+  type t =
+    { primary_ledger : Primary_ledger.t
+    ; converting_ledger : Converting_ledger.t option
+    }
+
+  let create primary_ledger converting_ledger =
+    { primary_ledger; converting_ledger }
+
+  let primary_ledger { primary_ledger; _ } = primary_ledger
+
+  let converting_ledger { converting_ledger; _ } = converting_ledger
+
+  let depth t = Primary_ledger.depth t.primary_ledger
+
+  let num_accounts t = Primary_ledger.num_accounts t.primary_ledger
+
+  let merkle_path_at_addr_exn t addr =
+    Primary_ledger.merkle_path_at_addr_exn t.primary_ledger addr
+
+  let get_inner_hash_at_addr_exn t addr =
+    Primary_ledger.get_inner_hash_at_addr_exn t.primary_ledger addr
+
+  let set_all_accounts_rooted_at_exn t addr accounts =
+    Primary_ledger.set_all_accounts_rooted_at_exn t.primary_ledger addr accounts ;
+    match t.converting_ledger with
+    | None ->
+        ()
+    | Some converting_ledger ->
+        Converting_ledger.set_all_accounts_rooted_at_exn converting_ledger addr
+          (List.map ~f:convert accounts)
+
+  let set_batch_accounts t addressed_accounts =
+    Primary_ledger.set_batch_accounts t.primary_ledger addressed_accounts ;
+    match t.converting_ledger with
+    | None ->
+        ()
+    | Some converting_ledger ->
+        Converting_ledger.set_batch_accounts converting_ledger
+          (List.map
+             ~f:(fun (addr, account) -> (addr, convert account))
+             addressed_accounts )
+
+  let get_all_accounts_rooted_at_exn t addr =
+    Primary_ledger.get_all_accounts_rooted_at_exn t.primary_ledger addr
+
+  let merkle_root t = Primary_ledger.merkle_root t.primary_ledger
+
+  let to_list t = Primary_ledger.to_list t.primary_ledger
+
+  let to_list_sequential t = Primary_ledger.to_list_sequential t.primary_ledger
+
+  let iteri t ~f = Primary_ledger.iteri t.primary_ledger ~f
+
+  let foldi t ~init ~f = Primary_ledger.foldi t.primary_ledger ~init ~f
+
+  let foldi_with_ignored_accounts t account_ids ~init ~f =
+    Primary_ledger.foldi_with_ignored_accounts t.primary_ledger account_ids
+      ~init ~f
+
+  let fold_until t ~init ~f ~finish =
+    Primary_ledger.fold_until t.primary_ledger ~init ~f ~finish
+
+  let accounts t = Primary_ledger.accounts t.primary_ledger
+
+  let tokens t = Primary_ledger.tokens t.primary_ledger
+
+  let token_owner t token_id =
+    Primary_ledger.token_owner t.primary_ledger token_id
+
+  let token_owners t = Primary_ledger.token_owners t.primary_ledger
+
+  let location_of_account t account_id =
+    Primary_ledger.location_of_account t.primary_ledger account_id
+
+  let location_of_account_batch t account_ids =
+    Primary_ledger.location_of_account_batch t.primary_ledger account_ids
+
+  let get_or_create_account t account_id account =
+    let open Or_error.Let_syntax in
+    let%bind res =
+      Primary_ledger.get_or_create_account t.primary_ledger account_id account
+    in
+    let%map converting_res =
+      match t.converting_ledger with
+      | None ->
+          return res
+      | Some converting_ledger ->
+          Converting_ledger.get_or_create_account converting_ledger account_id
+            (convert account)
+    in
+    let () =
+      match (res, converting_res) with
+      | (`Added, _), (`Existed, _) | (`Existed, _), (`Added, _) ->
+          failwith "Inconsistent account state in converting ledger"
+      | (_, loc_res), (_, loc_conv) ->
+          if not (Location.equal loc_res loc_conv) then
+            failwith "Inconsistent location in converting ledger"
+    in
+    res
+
+  let close t =
+    Primary_ledger.close t.primary_ledger ;
+    Option.iter ~f:Converting_ledger.close t.converting_ledger
+
+  let last_filled t = Primary_ledger.last_filled t.primary_ledger
+
+  let get_uuid t = Primary_ledger.get_uuid t.primary_ledger
+
+  let get_directory t = Primary_ledger.get_directory t.primary_ledger
+
+  let get t location = Primary_ledger.get t.primary_ledger location
+
+  let get_batch t locations =
+    Primary_ledger.get_batch t.primary_ledger locations
+
+  let set t location account =
+    Primary_ledger.set t.primary_ledger location account ;
+    match t.converting_ledger with
+    | None ->
+        ()
+    | Some converting_ledger ->
+        Converting_ledger.set converting_ledger location (convert account)
+
+  let set_batch ?hash_cache t located_accounts =
+    Primary_ledger.set_batch ?hash_cache t.primary_ledger located_accounts ;
+    match t.converting_ledger with
+    | None ->
+        ()
+    | Some converting_ledger ->
+        Converting_ledger.set_batch converting_ledger
+          (List.map
+             ~f:(fun (loc, account) -> (loc, convert account))
+             located_accounts )
+
+  let get_at_index_exn t idx =
+    Primary_ledger.get_at_index_exn t.primary_ledger idx
+
+  let set_at_index_exn t idx account =
+    Primary_ledger.set_at_index_exn t.primary_ledger idx account ;
+    match t.converting_ledger with
+    | None ->
+        ()
+    | Some converting_ledger ->
+        Converting_ledger.set_at_index_exn converting_ledger idx
+          (convert account)
+
+  let index_of_account_exn t account_id =
+    Primary_ledger.index_of_account_exn t.primary_ledger account_id
+
+  let merkle_path t location =
+    Primary_ledger.merkle_path t.primary_ledger location
+
+  let merkle_path_at_index_exn t idx =
+    Primary_ledger.merkle_path_at_index_exn t.primary_ledger idx
+
+  let merkle_path_batch t locations =
+    Primary_ledger.merkle_path_batch t.primary_ledger locations
+
+  let wide_merkle_path_batch t locations =
+    Primary_ledger.wide_merkle_path_batch t.primary_ledger locations
+
+  let get_hash_batch_exn t locations =
+    Primary_ledger.get_hash_batch_exn t.primary_ledger locations
+
+  let detached_signal t = Primary_ledger.detached_signal t.primary_ledger
+end

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -47,6 +47,8 @@ end)
   val primary_ledger : t -> Primary_ledger.t
 
   val converting_ledger : t -> Converting_ledger.t
+
+  val convert : Inputs.Account.t -> Inputs.converted_account
 end = struct
   let convert = Inputs.convert
 

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -54,4 +54,6 @@ end)
   val primary_ledger : t -> Primary_ledger.t
 
   val converting_ledger : t -> Converting_ledger.t
+
+  val convert : Inputs.Account.t -> Inputs.converted_account
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -49,9 +49,9 @@ end)
        and type account_id := Inputs.Account_id.t
        and type account_id_set := Inputs.Account_id.Set.t
 
-  val create : Primary_ledger.t -> Converting_ledger.t option -> t
+  val create : Primary_ledger.t -> Converting_ledger.t -> t
 
   val primary_ledger : t -> Primary_ledger.t
 
-  val converting_ledger : t -> Converting_ledger.t option
+  val converting_ledger : t -> Converting_ledger.t
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -1,0 +1,57 @@
+(** Create a merkle tree implementation that proxies through to
+    [Primary_ledger] for all reads and writes, but also updates the
+    [Converting_ledger] on every mutation.
+
+    The goal of this is to make it easy to upgrade ledgers for breaking changes
+    to the merkle tree. A running daemon can use this to keep track of ledgers
+    as normal, but can also retrieve the [Converting_ledger] so that it may be
+    used for an automated switch-over at upgrade time.
+*)
+module Make (Inputs : sig
+  include Intf.Inputs.Intf
+
+  type converted_account
+
+  val convert : Account.t -> converted_account
+end)
+(Primary_ledger : Intf.Ledger.S
+                    with module Location = Inputs.Location
+                     and module Addr = Inputs.Location.Addr
+                     and type key := Inputs.Key.t
+                     and type token_id := Inputs.Token_id.t
+                     and type token_id_set := Inputs.Token_id.Set.t
+                     and type account := Inputs.Account.t
+                     and type root_hash := Inputs.Hash.t
+                     and type hash := Inputs.Hash.t
+                     and type account_id := Inputs.Account_id.t
+                     and type account_id_set := Inputs.Account_id.Set.t)
+(Converting_ledger : Intf.Ledger.S
+                       with module Location = Inputs.Location
+                        and module Addr = Inputs.Location.Addr
+                        and type key := Inputs.Key.t
+                        and type token_id := Inputs.Token_id.t
+                        and type token_id_set := Inputs.Token_id.Set.t
+                        and type account := Inputs.converted_account
+                        and type root_hash := Inputs.Hash.t
+                        and type hash := Inputs.Hash.t
+                        and type account_id := Inputs.Account_id.t
+                        and type account_id_set := Inputs.Account_id.Set.t) : sig
+  include
+    Intf.Ledger.S
+      with module Location = Inputs.Location
+       and module Addr = Inputs.Location.Addr
+       and type key := Inputs.Key.t
+       and type token_id := Inputs.Token_id.t
+       and type token_id_set := Inputs.Token_id.Set.t
+       and type account := Inputs.Account.t
+       and type root_hash := Inputs.Hash.t
+       and type hash := Inputs.Hash.t
+       and type account_id := Inputs.Account_id.t
+       and type account_id_set := Inputs.Account_id.Set.t
+
+  val create : Primary_ledger.t -> Converting_ledger.t option -> t
+
+  val primary_ledger : t -> Primary_ledger.t
+
+  val converting_ledger : t -> Converting_ledger.t option
+end

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -54,6 +54,7 @@ let test_db () =
   Quickcheck.test ~trials:5 ~sexp_of:[%sexp_of: Balance.t list]
     gen_non_zero_balances ~f:(fun balances ->
       let account_ids = Account_id.gen_accounts num_accounts in
+      let T = Account_id.eq in
       let accounts = List.map2_exn account_ids balances ~f:Account.create in
       DB.with_ledger ~depth:Depth.depth ~f:(fun db ->
           let enumerate_dir_combinations max_depth =

--- a/src/lib/merkle_ledger_tests/test/main.ml
+++ b/src/lib/merkle_ledger_tests/test/main.ml
@@ -7,5 +7,7 @@
 *)
 
 let () =
-  let tests = Test_database.tests @ Test.tests @ Test_mask.tests in
+  let tests =
+    Test_database.tests @ Test.tests @ Test_mask.tests @ Test_converting.tests
+  in
   Alcotest.run "Merkle ledger" tests

--- a/src/lib/merkle_ledger_tests/test_converting.ml
+++ b/src/lib/merkle_ledger_tests/test_converting.ml
@@ -1,0 +1,147 @@
+open Core
+open Test_stubs
+module Database = Merkle_ledger.Database
+
+module Migrated = struct
+  module Account :
+    Merkle_ledger.Intf.Account
+      with type token_id := Token_id.t
+       and type account_id := Account_id.t
+       and type balance := Balance.t
+       and type t = Mina_base.Account.Unstable.t = struct
+    include Mina_base.Account.Unstable
+
+    let token Mina_base.Account.Unstable.{ token_id; _ } = token_id
+
+    let identifier ({ public_key; token_id; _ } : t) =
+      Account_id.create public_key token_id
+  end
+
+  module Hash = struct
+    module T = struct
+      type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
+    end
+
+    include T
+
+    let (eq : (t, Test_stubs.Hash_arg.t) Type_equal.t) = Type_equal.T
+
+    include Codable.Make_base58_check (struct
+      type t = T.t [@@deriving bin_io_unversioned]
+
+      let description = "Ledger test hash"
+
+      let version_byte = Base58_check.Version_bytes.ledger_test_hash
+    end)
+
+    include Hashable.Make_binable (Test_stubs.Hash_arg)
+
+    (* to prevent pre-image attack,
+     * important impossible to create an account such that (merge a b = hash_account account) *)
+
+    let hash_account account =
+      Md5.digest_string (Format.sprintf !"0%{sexp: Account.t}" account)
+
+    let merge ~height a b =
+      let res =
+        Md5.digest_string
+          (sprintf "test_ledger_%d:%s%s" height (Md5.to_hex a) (Md5.to_hex b))
+      in
+      res
+
+    let empty_account = hash_account Account.empty
+  end
+end
+
+module Inputs_migrated =
+  Test_database.Make_inputs (Migrated.Account) (Migrated.Hash)
+
+module type DB_migrated =
+  Test_database.Account_Db with type account := Migrated.Account.t
+
+module Db = Database.Make (Test_database.Inputs)
+module Db_migrated = Database.Make (Inputs_migrated)
+
+module Db_converting =
+  Merkle_ledger.Converting_merkle_tree.Make
+    (struct
+      type converted_account = Mina_base.Account.Unstable.t
+
+      let convert (account : Mina_base.Account.Stable.Latest.t) =
+        { Mina_base.Account.Unstable.public_key = account.public_key
+        ; token_id = account.token_id
+        ; token_symbol = account.token_symbol
+        ; balance = account.balance
+        ; nonce = account.nonce
+        ; receipt_chain_hash = account.receipt_chain_hash
+        ; delegate = account.delegate
+        ; voting_for = account.voting_for
+        ; timing = account.timing
+        ; permissions = account.permissions
+        ; zkapp = account.zkapp
+        ; unstable_field = account.nonce
+        }
+
+      include Test_database.Inputs
+    end)
+    (Db)
+    (Db_migrated)
+
+module Make (Cfg : sig
+  val depth : int
+end) =
+struct
+  let with_instance ~f =
+    let db1 = Db.create ~depth:Cfg.depth () in
+    let db2 = Db_migrated.create ~depth:Cfg.depth () in
+    let ledger = Db_converting.create db1 db2 in
+    try
+      let result = f ledger in
+      Db_converting.close ledger ; result
+    with exn -> Db_converting.close ledger ; raise exn
+
+  let create_new_account_exn mdb account =
+    let public_key = Account.identifier account in
+    let action, location =
+      Db_converting.get_or_create_account mdb public_key account
+      |> Or_error.ok_exn
+    in
+    match action with
+    | `Existed ->
+        failwith "Expected to allocate a new account"
+    | `Added ->
+        location
+
+  let test_section_name =
+    Printf.sprintf "In-memory converting db (depth %d)" Cfg.depth
+
+  let test_stack = Stack.create ()
+
+  let add_test ?(speed = `Quick) name f =
+    Alcotest.test_case name speed f |> Stack.push test_stack
+
+  let () =
+    add_test "add and retrieve an account" (fun () ->
+        with_instance ~f:(fun db ->
+            let account = Quickcheck.random_value Account.gen in
+            let location = create_new_account_exn db account in
+            let stored_migrated_account =
+              let migrated_db = Db_converting.converting_ledger db in
+              Option.value_exn (Db_migrated.get migrated_db location)
+            in
+            [%test_eq: Account.t]
+              (Option.value_exn (Db_converting.get db location))
+              account ;
+            [%test_eq: Migrated.Account.t] stored_migrated_account
+              (Db_converting.convert account) ) )
+
+  let tests =
+    let actual_tests = Stack.fold test_stack ~f:(fun l t -> t :: l) ~init:[] in
+    (test_section_name, actual_tests)
+end
+
+let tests =
+  let module Tests = Make (struct
+    let depth = 30
+  end) in
+  [ Tests.tests ]

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -35,8 +35,8 @@ module type Account_Db =
   Merkle_ledger.Intf.Ledger.DATABASE
     with module Location = Location
     with module Addr = Location.Addr
-    with type root_hash := Hash.t
-     and type hash := Hash.t
+    with type root_hash := Md5.t
+     and type hash := Md5.t
      and type key := Key.t
      and type token_id := Token_id.t
      and type token_id_set := Token_id.Set.t
@@ -247,7 +247,7 @@ module Make (Test : Test_intf) = struct
                 in
                 MT.set_batch_accounts mdb addresses_and_accounts ;
                 let new_merkle_root = MT.merkle_root mdb in
-                assert (Hash.equal old_merkle_root new_merkle_root) ) ) )
+                assert (Md5.equal old_merkle_root new_merkle_root) ) ) )
 
   let () =
     add_test "set_batch_accounts would change the merkle root" (fun () ->
@@ -296,7 +296,7 @@ module Make (Test : Test_intf) = struct
                     let old_merkle_root = MT.merkle_root mdb in
                     MT.set_batch_accounts mdb new_addresses_and_accounts ;
                     let new_merkle_root = MT.merkle_root mdb in
-                    assert (not @@ Hash.equal old_merkle_root new_merkle_root) ) ) ) )
+                    assert (not @@ Md5.equal old_merkle_root new_merkle_root) ) ) ) )
 
   let () =
     add_test "key by key account retrieval after set_batch_accounts works"
@@ -385,7 +385,7 @@ module Make (Test : Test_intf) = struct
                 failwith
                   "create_empty with empty ledger somehow already has that key?"
             | `Added, _ ->
-                [%test_eq: Hash.t] start_hash (merkle_root ledger) ) )
+                [%test_eq: Md5.t] start_hash (merkle_root ledger) ) )
 
   let () =
     add_test "get_at_index_exn t (index_of_account_exn t public_key) = account"
@@ -555,13 +555,14 @@ module Make (Test : Test_intf) = struct
     (test_section_name, actual_tests)
 end
 
+module Inputs = Make_inputs (Account) (Hash)
+
 module Make_db (Depth : sig
   val depth : int
 end) =
 Make (struct
   let depth = Depth.depth
 
-  module Inputs = Make_inputs (Account) (Hash)
   module MT = Database.Make (Inputs)
 
   (* TODO: maybe this function should work with dynamic modules *)

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -320,6 +320,7 @@ module Make (Test : Test_intf) = struct
               in
               let account_ids = Account_id.gen_accounts num_accounts in
               let balances = gen_values Balance.gen in
+              let T = Account_id.eq in
               let accounts =
                 List.map2_exn account_ids balances ~f:(fun public_key balance ->
                     Account.create public_key balance )
@@ -350,6 +351,7 @@ module Make (Test : Test_intf) = struct
               in
               let account_ids = Account_id.gen_accounts num_accounts in
               let balances = gen_values Balance.gen num_accounts in
+              let T = Account_id.eq in
               let base_accounts =
                 List.map2_exn account_ids balances ~f:Account.create
               in
@@ -409,6 +411,7 @@ module Make (Test : Test_intf) = struct
               Quickcheck.random_value
                 (Quickcheck.Generator.list_with_length num_accounts Balance.gen)
             in
+            let T = Account_id.eq in
             let accounts =
               List.map2_exn account_ids balances ~f:Account.create
             in
@@ -444,6 +447,7 @@ module Make (Test : Test_intf) = struct
               List.init num_accounts ~f:(fun n ->
                   Balance.of_nanomina_int_exn (n + 1) )
             in
+            let T = Account_id.eq in
             let parent_accounts =
               List.map2_exn account_ids balances ~f:Account.create
             in
@@ -486,6 +490,7 @@ module Make (Test : Test_intf) = struct
               List.init num_accounts ~f:(fun n ->
                   Balance.of_nanomina_int_exn (n + 1) )
             in
+            let T = Account_id.eq in
             let parent_accounts =
               List.map2_exn account_ids balances ~f:Account.create
             in
@@ -539,6 +544,7 @@ module Make (Test : Test_intf) = struct
               Quickcheck.random_value
                 (Quickcheck.Generator.list_with_length num_accounts Balance.gen)
             in
+            let T = Account_id.eq in
             let accounts =
               List.map2_exn account_ids balances ~f:Account.create
             in
@@ -571,6 +577,7 @@ module Make (Test : Test_intf) = struct
               Quickcheck.random_value
                 (Quickcheck.Generator.list_with_length num_accounts Balance.gen)
             in
+            let T = Account_id.eq in
             let accounts =
               List.map2_exn account_ids balances ~f:Account.create
             in
@@ -612,6 +619,7 @@ module Make (Test : Test_intf) = struct
         Test.with_instances (fun maskable mask ->
             let attached_mask = Maskable.register_mask maskable mask in
             let k = Account_id.gen_accounts 1 |> List.hd_exn in
+            let T = Account_id.eq in
             let acct1 = Account.create k (Balance.of_nanomina_int_exn 10) in
             let loc =
               Mask.Attached.get_or_create_account attached_mask k acct1

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -204,12 +204,18 @@ end = struct
     Account_id.create public_key token_id
 end
 
-module Hash : Merkle_ledger.Intf.Hash with type account := Account.t = struct
+module Hash_arg = struct
+  type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
+end
+
+module Hash = struct
   module T = struct
     type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
   end
 
   include T
+
+  let (_ : (t, Hash_arg.t) Type_equal.t) = Type_equal.T
 
   include Codable.Make_base58_check (struct
     type t = T.t [@@deriving bin_io_unversioned]
@@ -219,7 +225,7 @@ module Hash : Merkle_ledger.Intf.Hash with type account := Account.t = struct
     let version_byte = Base58_check.Version_bytes.ledger_test_hash
   end)
 
-  include Hashable.Make_binable (T)
+  include Hashable.Make_binable (Hash_arg)
 
   (* to prevent pre-image attack,
    * important impossible to create an account such that (merge a b = hash_account account) *)

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -128,6 +128,8 @@ module Account_id : sig
 
   val eq :
     (Mina_wire_types.Mina_base_account_id.M.V2.t, t) Core_kernel.Type_equal.t
+
+  val eq2 : (Mina_base.Account_id.t, t) Core_kernel.Type_equal.t
 end = struct
   [%%versioned
   module Stable = struct
@@ -138,8 +140,6 @@ end = struct
       let to_latest = Fn.id
     end
   end]
-
-  type t = Mina_base.Account_id.t
 
   include Hashable.Make_binable (Stable.Latest)
   include Comparable.Make (Stable.Latest)
@@ -163,6 +163,8 @@ end = struct
       (Quickcheck.Generator.list_with_length num_accounts gen)
 
   let eq = Core_kernel.Type_equal.T
+
+  let eq2 = Core_kernel.Type_equal.T
 end
 
 module Account : sig
@@ -180,6 +182,10 @@ module Account : sig
   val update_balance : t -> Balance.t -> t
 
   val public_key : t -> Mina_base.Account.Key.t
+
+  val of_yojson : Yojson.Safe.t -> (t, string) Result.t
+
+  val to_yojson : t -> Yojson.Safe.t
 end = struct
   (* want bin_io, not available with Account.t *)
   type t = Mina_base.Account.Stable.Latest.t

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -1036,3 +1036,66 @@ let deriver obj =
        ~permissions:!.Permissions.deriver
        ~zkapp:!.(option ~js_type:Or_undefined (Zkapp_account.deriver @@ o ()))
        obj
+
+module Unstable = struct
+  type t =
+    { public_key : Public_key.Compressed.Stable.V1.t
+    ; token_id : Token_id.Stable.V2.t
+    ; token_symbol : Token_symbol.Stable.V1.t
+    ; balance : Balance.Stable.V1.t
+    ; nonce : Nonce.Stable.V1.t
+    ; receipt_chain_hash : Receipt.Chain_hash.Stable.V1.t
+    ; delegate : Public_key.Compressed.Stable.V1.t option
+    ; voting_for : State_hash.Stable.V1.t
+    ; timing : Timing.Stable.V2.t
+    ; permissions : Permissions.Stable.V2.t
+    ; zkapp : Zkapp_account.Stable.V2.t option
+    ; unstable_field : Nonce.Stable.V1.t
+    }
+  [@@deriving
+    sexp, equal, hash, compare, yojson, hlist, fields, bin_io_unversioned]
+
+  let balance { balance; _ } = balance
+
+  let empty =
+    { public_key = Public_key.Compressed.empty
+    ; token_id = Token_id.default
+    ; token_symbol = Token_symbol.default
+    ; balance = Balance.zero
+    ; nonce = Nonce.zero
+    ; receipt_chain_hash = Receipt.Chain_hash.empty
+    ; delegate = None
+    ; voting_for = State_hash.dummy
+    ; timing = Timing.Untimed
+    ; permissions =
+        Permissions.user_default
+        (* TODO: This should maybe be Permissions.empty *)
+    ; zkapp = None
+    ; unstable_field = Nonce.zero
+    }
+
+  let identifier ({ public_key; token_id; _ } : t) =
+    Account_id.create public_key token_id
+
+  let token_id ({ token_id; _ } : t) = token_id
+
+  let to_input (t : t) =
+    let open Random_oracle.Input.Chunked in
+    let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
+    Fields.fold ~init:[]
+      ~public_key:(f Public_key.Compressed.to_input)
+      ~token_id:(f Token_id.to_input) ~balance:(f Balance.to_input)
+      ~token_symbol:(f Token_symbol.to_input) ~nonce:(f Nonce.to_input)
+      ~receipt_chain_hash:(f Receipt.Chain_hash.to_input)
+      ~delegate:(f (Fn.compose Public_key.Compressed.to_input delegate_opt))
+      ~voting_for:(f State_hash.to_input) ~timing:(f Timing.to_input)
+      ~zkapp:(f (Fn.compose field hash_zkapp_account_opt))
+      ~permissions:(f Permissions.to_input) ~unstable_field:(f Nonce.to_input)
+    |> List.reduce_exn ~f:append
+
+  let digest t =
+    Random_oracle.hash ~init:crypto_hash_prefix
+      (Random_oracle.pack_input (to_input t))
+
+  let empty_digest = lazy (digest empty)
+end

--- a/src/lib/syncable_ledger/test/test.ml
+++ b/src/lib/syncable_ledger/test/test.ml
@@ -368,6 +368,7 @@ module Db = struct
         let account_ids = Account_id.gen_accounts num_accounts in
         let currency_balance = Currency.Balance.of_nanomina_int_exn balance in
         List.iter account_ids ~f:(fun aid ->
+            let T = Account_id.eq2 in
             let account = Account.create aid currency_balance in
             ignore
               ( get_or_create_account ledger aid account |> Or_error.ok_exn
@@ -541,6 +542,7 @@ module Mask = struct
           Int.pow 2 Input.mask_layers * balance
         in
         List.iter account_ids ~f:(fun account_id ->
+            let T = Account_id.eq2 in
             let account =
               Account.create account_id
                 (Currency.Balance.of_nanomina_int_exn
@@ -565,6 +567,7 @@ module Mask = struct
             let child_mask = Mask.create ~depth:Input.depth () in
             let attached_mask = Maskable.register_mask parent_base child_mask in
             List.iter account_ids ~f:(fun account_id ->
+                let T = Account_id.eq2 in
                 let account =
                   Account.create account_id
                     (Currency.Balance.of_nanomina_int_exn child_balance)


### PR DESCRIPTION
This PR introduces a converting merkle tree implementation. From the doc-comment:
```
(** Create a merkle tree implementation that proxies through to
    [Primary_ledger] for all reads and writes, but also updates the
    [Converting_ledger] on every mutation.
    The goal of this is to make it easy to upgrade ledgers for breaking changes
    to the merkle tree. A running daemon can use this to keep track of ledgers
    as normal, but can also retrieve the [Converting_ledger] so that it may be
    used for an automated switch-over at upgrade time.
*)
```

This mechanism forms the core of our automated ledger upgrades for hard-forks. I have tested this manually with
* the same `Converting_ledger` implementation as the `Primary_ledger` implementation, and confirming that the resulting hashes are identical
* a `Converting_ledger` that upgrades the app-state size for zkApps to 32 field elements, and confirming that the ledger contents are as expected.

This PR is separated from the rest of the implementation because it needs its own careful review: if we are not correctly propagating all of the side-effects, then the ledgers will fall out of sync and our ledger upgrade will not be successful. The follow-up PRs will make use of this mechanism to provide the option of an upgrade mechanism.

Design note: the `Converting_ledger` is treated as optional. In my initial experiments, I attempted to multiplex between a non-optional `Converting_ledger` and the normal masks / db implementations, but this resulted in large abstraction leaks into the ledger interface. Instead, the code is least affected by replacing uses of `Ledger.Db` with `Ledger.Converting_db` and similarly replacing the default ledger masks with a converting mask. In sum, this implementation achieves:
* the ability to turn it on or off
  - I believe that we don't want to turn this on until we are approaching the hard fork, because this has some performance implications
* a clear logical separation between upgraded ledger management and primary ledger management
  - in particular, this is important around the database ledgers, and especially so for the epoch ledgers (where we use database snapshots extensively)
* mostly unchanged code wherever we aren't directly reasoning about database ledgers or conversions.