### PR TITLE
hotfix / follow-up  to Move kimchi-stubs into proof-systems

### DIFF
--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -64,10 +64,11 @@ git branch -D $BUILDKITE_BRANCH 2>/dev/null || true
 git checkout -b $BUILDKITE_BRANCH
 git reset --hard $BUILDKITE_COMMIT
 
-nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --no-link
-
 # Test developer terminal with lsp server
-nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "dune build src"
+nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "echo tested"
+nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "dune build src" &
+  nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --no-link
+wait
 
 if [[ "$NIX_CACHE_GCP_ID" != "" ]] && [[ "$NIX_CACHE_GCP_SECRET" != "" ]]; then
   mkdir -p $HOME/.aws

--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -67,7 +67,7 @@ git reset --hard $BUILDKITE_COMMIT
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --no-link
 
 # Test developer terminal with lsp server
-nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "echo tested"
+nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "dune build src"
 
 if [[ "$NIX_CACHE_GCP_ID" != "" ]] && [[ "$NIX_CACHE_GCP_SECRET" != "" ]]; then
   mkdir -p $HOME/.aws

--- a/changes/16857.md
+++ b/changes/16857.md
@@ -1,4 +1,4 @@
-# PR 16831: Move plonk_wasm into proof-systems
+# PR 16857: Hotfix / Followup for [16820](./16820.md) (Move plonk_wasm into proof-systems)
 
 ## Summary
 

--- a/changes/16857.md
+++ b/changes/16857.md
@@ -1,0 +1,14 @@
+# PR 16831: Move plonk_wasm into proof-systems
+
+## Summary
+
+hotfix / followup to #16820
+
+## Changes
+
+- fix `o1js_stubs` build
+- enforce `dune build src` in nix ci
+- rename `MARLIN_PLONK_*` env vars to `KIMCHI_*`
+
+## Impact
+Fixes the nix build and ensures it with CI test

--- a/flake.nix
+++ b/flake.nix
@@ -305,6 +305,7 @@
           zip
           libiconv 
           cargo           
+          curl
           (pkgs.python3.withPackages (python-pkgs: [
               python-pkgs.click
               python-pkgs.requests

--- a/nix/README.md
+++ b/nix/README.md
@@ -464,14 +464,14 @@ If you get an error like this:
 File "src/lib/crypto/kimchi_bindings/stubs/dune", line 77, characters 0-237:
 77 | (rule
 78 |  (enabled_if
-79 |   (<> %{env:MARLIN_PLONK_STUBS=n} n))
+79 |   (<> %{env:KIMCHI_STUBS=n} n))
 80 |  (targets libwires_15_stubs.a)
 81 |  (deps
-82 |   (env_var MARLIN_PLONK_STUBS))
+82 |   (env_var KIMCHI_STUBS))
 83 |  (action
 84 |   (progn
 85 |    (copy
-86 |     %{env:MARLIN_PLONK_STUBS=n}/lib/libwires_15_stubs.a
+86 |     %{env:KIMCHI_STUBS=n}/lib/libwires_15_stubs.a
 87 |     libwires_15_stubs.a))))
 Error: File unavailable:
 /nix/store/2i0iqm48p20mrn69nbgr0pf76vdzjxj6-marlin_plonk_bindings_stubs-0.1.0/lib/lib/libwires_15_stubs.a

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -170,8 +170,8 @@ let
         let src = info.pseudoPackages."${pkg}";
         in dune-nix.makefileTest ./.. pkg src;
       marlinPlonkStubs = {
-        MARLIN_PLONK_STUBS = "${pkgs.kimchi_bindings_stubs}";
-        MARLIN_PLONK_STUBS_STATIC_LIB = "${pkgs.kimchi_stubs_static_lib}";
+        KIMCHI_STUBS = "${pkgs.kimchi_bindings_stubs}";
+        KIMCHI_STUBS_STATIC_LIB = "${pkgs.kimchi_stubs_static_lib}";
       };
       childProcessesTester = pkgs.writeShellScriptBin "mina-tester.sh"
         (builtins.readFile ../src/lib/child_processes/tester.sh);
@@ -337,8 +337,8 @@ let
         # this is used to retrieve the path of the built static library
         # and copy it from within a dune rule
         # (see src/lib/crypto/kimchi_bindings/stubs/dune)
-        MARLIN_PLONK_STUBS = "${pkgs.kimchi_bindings_stubs}";
-        MARLIN_PLONK_STUBS_STATIC_LIB = "${pkgs.kimchi_stubs_static_lib}";
+        KIMCHI_STUBS = "${pkgs.kimchi_bindings_stubs}";
+        KIMCHI_STUBS_STATIC_LIB = "${pkgs.kimchi_stubs_static_lib}";
         DISABLE_CHECK_OPAM_SWITCH = "true";
 
         MINA_VERSION_IMPLEMENTATION = "mina_version.runtime";

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -107,11 +107,12 @@ in {
         fixupLockFile ../src/lib/crypto/proof-systems/Cargo.lock;
     };
     buildPhase = ''
-      cargo build -p kimchi-stubs --release --lib --all-features
+      cargo build -p kimchi-stubs --release --lib
     '';
     installPhase = ''
         mkdir -p $out/lib
         cp target/release/libkimchi_stubs.a $out/lib/
+        cp target/release/libkimchi_stubs.so $out/lib/dllkimchi_stubs.so
     '';
     doCheck = false;
   };

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -38,11 +38,11 @@
 ;; rules to build the static library for kimchi
 ;;
 
-;; note: to build Mina, nix will set `MARLIN_PLONK_STUBS` and ignore this rule
+;; note: to build Mina, nix will set `KIMCHI_STUBS` and ignore this rule
 
 (rule
  (enabled_if
-  (= %{env:MARLIN_PLONK_STUBS=n} n))
+  (= %{env:KIMCHI_STUBS=n} n))
  (targets dllkimchi_stubs.so libkimchi_stubs.a)
  (deps
   Cargo.toml
@@ -51,7 +51,7 @@
   (source_tree kimchi-stubs-vendors)
   (source_tree .cargo)
   (source_tree ../../proof-systems)
-  (env_var MARLIN_PLONK_STUBS))
+  (env_var KIMCHI_STUBS))
  (locks /cargo-lock) ;; lock for rustup
  (action
   (progn
@@ -92,13 +92,15 @@
 
 (rule
  (enabled_if
-  (<> %{env:MARLIN_PLONK_STUBS_STATIC_LIB=n} n))
+  (<> %{env:KIMCHI_STUBS_STATIC_LIB=n} n))
  (targets libkimchi_stubs.a)
  (deps
-  (env_var MARLIN_PLONK_STUBS_STATIC_LIB))
+  (env_var KIMCHI_STUBS_STATIC_LIB))
  (action
   (progn
-   (copy %{env:MARLIN_PLONK_STUBS_STATIC_LIB=n}/lib/libkimchi_stubs.a libkimchi_stubs.a))))
+   (copy %{env:KIMCHI_STUBS_STATIC_LIB=n}/lib/libkimchi_stubs.a libkimchi_stubs.a)
+   (copy %{env:KIMCHI_STUBS_STATIC_LIB=n}/lib/dllkimchi_stubs.so dllkimchi_stubs.so)
+   )))
 
 ;;
 ;; declare the libraries we're going to generate to match the bindings
@@ -162,12 +164,12 @@
 ;; generate the OCaml bindings
 ;;
 
-;; note: to build Mina, nix will set `MARLIN_PLONK_STUBS` and ignore this rule
+;; note: to build Mina, nix will set `KIMCHI_STUBS` and ignore this rule
 
 (rule
  (targets kimchi_types.ml pasta_bindings.ml kimchi_bindings.ml)
  (enabled_if
-  (= %{env:MARLIN_PLONK_STUBS=n} n))
+  (= %{env:KIMCHI_STUBS=n} n))
  (mode promote)
  (deps
   ../../../../.ocamlformat
@@ -177,7 +179,7 @@
   (source_tree kimchi-stubs-vendors)
   (source_tree .cargo)
   (source_tree ../../proof-systems)
-  (env_var MARLIN_PLONK_STUBS))
+  (env_var KIMCHI_STUBS))
  (locks /cargo-lock) ;; lock for rustup
  (action
   (progn
@@ -194,12 +196,12 @@
 (rule
  (targets kimchi_types.ml pasta_bindings.ml kimchi_bindings.ml)
  (enabled_if
-  (<> %{env:MARLIN_PLONK_STUBS=n} n))
+  (<> %{env:KIMCHI_STUBS=n} n))
  (mode promote)
  (deps
   ../../../../.ocamlformat
-  (env_var MARLIN_PLONK_STUBS))
+  (env_var KIMCHI_STUBS))
  (action
   (progn
-   (run %{env:MARLIN_PLONK_STUBS=n}/bin/wires_15_stubs %{targets})
+   (run %{env:KIMCHI_STUBS=n}/bin/wires_15_stubs %{targets})
    (run ocamlformat -i %{targets}))))


### PR DESCRIPTION
hotfix / followup to #16820

- fix `o1js_stubs` build
- enforce `dune build src` in nix ci
- rename `MARLIN_PLONK_*` env vars to `KIMCHI_*`