### PR TITLE
Separate transaction_witness stable/regular types

### DIFF
--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -56,12 +56,27 @@ module Inputs = struct
     Snark_work_lib.Work.Single.Spec.Stable.Latest.t
   [@@deriving bin_io_unversioned, sexp]
 
-  type zkapp_command_inputs =
-    ( Transaction_witness.Zkapp_command_segment_witness.t
-    * Transaction_snark.Zkapp_command_segment.Basic.t
-    * Transaction_snark.Statement.With_sok.t )
-    list
-  [@@deriving sexp, to_yojson]
+  let zkapp_command_inputs_to_yojson =
+    let convert =
+      List.map
+        ~f:(fun
+             ( (witness : Transaction_witness.Zkapp_command_segment_witness.t)
+             , segment
+             , statement )
+           ->
+          ( Transaction_witness.Zkapp_command_segment_witness
+            .read_all_proofs_from_disk witness
+          , segment
+          , statement ) )
+    in
+    let impl =
+      [%to_yojson:
+        ( Transaction_witness.Zkapp_command_segment_witness.Stable.Latest.t
+        * Transaction_snark.Zkapp_command_segment.Basic.t
+        * Transaction_snark.Statement.With_sok.t )
+        list]
+    in
+    Fn.compose impl convert
 
   let perform_single ({ m; cache; proof_level } : Worker_state.t) ~message =
     let open Deferred.Or_error.Let_syntax in

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -8,6 +8,8 @@ module Zkapp_command_segment_witness = struct
   (* TODO: Don't serialize all the hashes in here. *)
   [%%versioned
   module Stable = struct
+    [@@@no_toplevel_latest_type]
+
     module V1 = struct
       type t =
         { global_first_pass_ledger : Sparse_ledger.Stable.V2.t
@@ -46,6 +48,61 @@ module Zkapp_command_segment_witness = struct
       let to_latest = Fn.id
     end
   end]
+
+  type t =
+    { global_first_pass_ledger : Sparse_ledger.t
+    ; global_second_pass_ledger : Sparse_ledger.t
+    ; local_state_init :
+        ( (Token_id.t, Zkapp_command.Call_forest.With_hashes.t) Stack_frame.t
+        , ( ( (Token_id.t, Zkapp_command.Call_forest.With_hashes.t) Stack_frame.t
+            , Stack_frame.Digest.t )
+            With_hash.t
+          , Call_stack_digest.t )
+          With_stack_hash.t
+          list
+        , (Amount.t, Sgn.t) Signed_poly.t
+        , Sparse_ledger.t
+        , bool
+        , Kimchi_backend.Pasta.Basic.Fp.t
+        , Mina_numbers.Index.t
+        , Transaction_status.Failure.Collection.t )
+        Mina_transaction_logic.Zkapp_command_logic.Local_state.t
+    ; start_zkapp_command :
+        ( Zkapp_command.t
+        , Kimchi_backend.Pasta.Basic.Fp.t
+        , bool )
+        Mina_transaction_logic.Zkapp_command_logic.Start_data.t
+        list
+    ; state_body : Mina_state.Protocol_state.Body.Value.t
+    ; init_stack : Pending_coinbase.Stack_versioned.t
+    ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
+    }
+
+  let read_all_proofs_from_disk
+      { global_first_pass_ledger
+      ; global_second_pass_ledger
+      ; local_state_init
+      ; start_zkapp_command
+      ; state_body
+      ; init_stack
+      ; block_global_slot
+      } =
+    { Stable.Latest.global_first_pass_ledger
+    ; global_second_pass_ledger
+    ; local_state_init
+    ; start_zkapp_command =
+        List.map
+          ~f:(fun sd ->
+            Mina_transaction_logic.Zkapp_command_logic.Start_data.
+              { sd with
+                account_updates =
+                  Zkapp_command.read_all_proofs_from_disk sd.account_updates
+              } )
+          start_zkapp_command
+    ; state_body
+    ; init_stack
+    ; block_global_slot
+    }
 end
 
 [%%versioned

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -7,6 +7,8 @@ module Zkapp_command_segment_witness : sig
 
   [%%versioned:
   module Stable : sig
+    [@@@no_toplevel_latest_type]
+
     module V1 : sig
       type t =
         { global_first_pass_ledger : Sparse_ledger.Stable.V2.t
@@ -43,6 +45,37 @@ module Zkapp_command_segment_witness : sig
       [@@deriving sexp, to_yojson]
     end
   end]
+
+  type t =
+    { global_first_pass_ledger : Sparse_ledger.t
+    ; global_second_pass_ledger : Sparse_ledger.t
+    ; local_state_init :
+        ( (Token_id.t, Zkapp_command.Call_forest.With_hashes.t) Stack_frame.t
+        , ( ( (Token_id.t, Zkapp_command.Call_forest.With_hashes.t) Stack_frame.t
+            , Stack_frame.Digest.t )
+            With_hash.t
+          , Call_stack_digest.t )
+          With_stack_hash.t
+          list
+        , (Amount.t, Sgn.t) Signed_poly.t
+        , Sparse_ledger.t
+        , bool
+        , Kimchi_backend.Pasta.Basic.Fp.t
+        , Mina_numbers.Index.t
+        , Transaction_status.Failure.Collection.t )
+        Mina_transaction_logic.Zkapp_command_logic.Local_state.t
+    ; start_zkapp_command :
+        ( Zkapp_command.t
+        , Kimchi_backend.Pasta.Basic.Fp.t
+        , bool )
+        Mina_transaction_logic.Zkapp_command_logic.Start_data.t
+        list
+    ; state_body : Mina_state.Protocol_state.Body.Value.t
+    ; init_stack : Pending_coinbase.Stack_versioned.t
+    ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
+    }
+
+  val read_all_proofs_from_disk : t -> Stable.Latest.t
 end
 
 [%%versioned:


### PR DESCRIPTION
This is a **mostly no-op** modification that is required for future switch of zkapp_command types.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
