### PR TITLE
Update graphql code to use stable zkapp_command

### DIFF
--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -5,7 +5,7 @@ module Ledger = Mina_ledger.Ledger
 
 let underToCamel s = String.lowercase s |> Mina_graphql.Reflection.underToCamel
 
-let graphql_zkapp_command (zkapp_command : Zkapp_command.t) =
+let graphql_zkapp_command (zkapp_command : Zkapp_command.Stable.Latest.t) =
   sprintf
     {|
 mutation MyMutation {
@@ -184,7 +184,8 @@ let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
   printf "ZkApp transaction yojson: %s\n\n%!"
     (Zkapp_command.to_yojson zkapp_command |> Yojson.Safe.to_string) ;
   printf "(ZkApp transaction graphQL input %s\n\n%!"
-    (graphql_zkapp_command zkapp_command) ;
+    ( graphql_zkapp_command
+    @@ Zkapp_command.read_all_proofs_from_disk zkapp_command ) ;
   printf "Updated accounts\n" ;
   let%bind accounts = Ledger.to_list ledger in
   List.iter accounts ~f:(fun acc ->
@@ -286,8 +287,12 @@ module Util = struct
       printf "Zkapp transaction yojson:\n %s\n\n%!"
         (Zkapp_command.to_yojson zkapp_command |> Yojson.Safe.to_string) ;
       printf "Zkapp transaction graphQL input %s\n\n%!"
-        (graphql_zkapp_command zkapp_command) )
-    else printf "%s\n%!" (graphql_zkapp_command zkapp_command)
+        ( graphql_zkapp_command
+        @@ Zkapp_command.read_all_proofs_from_disk zkapp_command ) )
+    else
+      printf "%s\n%!"
+        ( graphql_zkapp_command
+        @@ Zkapp_command.read_all_proofs_from_disk zkapp_command )
 
   let memo =
     Option.value_map ~default:Signed_command_memo.empty ~f:(fun m ->
@@ -761,7 +766,7 @@ let%test_module "ZkApps test transaction" =
           io_field "sendZkapp" ~typ:(non_null string)
             ~args:Arg.[ arg "input" ~typ:(non_null typ) ]
             ~doc:"sample query"
-            ~resolve:(fun _ () (zkapp_command' : Zkapp_command.t) ->
+            ~resolve:(fun _ () (zkapp_command' : Zkapp_command.Stable.Latest.t) ->
               let ok_fee_payer =
                 print_diff_yojson ~path:[ "fee_payer" ]
                   (Account_update.Fee_payer.to_yojson zkapp_command.fee_payer)
@@ -808,7 +813,10 @@ let%test_module "ZkApps test transaction" =
           match user_cmd with
           | Zkapp_command p ->
               let p = Zkapp_command.Valid.forget p in
-              let q = graphql_zkapp_command p in
+              let q =
+                graphql_zkapp_command
+                  (Zkapp_command.read_all_proofs_from_disk p)
+              in
               Async.Thread_safe.block_on_async_exn (fun () ->
                   match%map hit_server p q with
                   | Ok _res ->

--- a/src/lib/graphql_lib/transaction/graphql_scalars.ml
+++ b/src/lib/graphql_lib/transaction/graphql_scalars.ml
@@ -49,7 +49,9 @@ let%test_module "Roundtrip tests" =
     let%test_module "TransactionId" =
       ( module struct
         module TransactionId_gen = struct
-          include Mina_transaction.Transaction_id.User_command
+          include Mina_base.User_command.Stable.Latest
+
+          let gen = Mina_base.User_command.gen
         end
 
         include Make_test (TransactionId) (TransactionId_gen)

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -72,7 +72,11 @@ let deploy_zkapps ~scheduler_tbl ~mina ~ledger ~deployment_fee ~max_cost
         @@ fun () ->
         if finished () then Deferred.return (`Finished ())
         else
-          match%bind Zkapps.send_zkapp_command mina zkapp_command with
+          (* TODO create without hash accumulation and remove read_all_proofs_from_disk call *)
+          match%bind
+            Zkapps.send_zkapp_command mina
+              (Zkapp_command.read_all_proofs_from_disk zkapp_command)
+          with
           | Ok _ ->
               fee_payer_nonces.(ndx) :=
                 Account.Nonce.succ !(fee_payer_nonces.(ndx)) ;
@@ -283,7 +287,11 @@ let send_zkapps ~(genesis_constants : Genesis_constants.t)
         let%bind () =
           O1trace.thread "itn_send_zkapp"
           @@ fun () ->
-          match%map Zkapps.send_zkapp_command mina zkapp_command with
+          (* TODO create without hash accumulation and remove read_all_proofs_from_disk call *)
+          match%map
+            Zkapps.send_zkapp_command mina
+              (Zkapp_command.read_all_proofs_from_disk zkapp_command)
+          with
           | Ok _ ->
               [%log info] "Sent out zkApp with fee payer's summary $summary"
                 ~metadata:

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -391,8 +391,8 @@ module Mutations = struct
     | `Bootstrapping ->
         return (Error "Daemon is bootstrapping")
 
-  let mock_zkapp_command mina zkapp_command :
-      ( (Zkapp_command.t, Transaction_hash.t) With_hash.t
+  let mock_zkapp_command mina (zkapp_command : Zkapp_command.Stable.Latest.t) :
+      ( (Zkapp_command.Stable.Latest.t, Transaction_hash.t) With_hash.t
         Types.Zkapp_command.With_status.t
       , string )
       result
@@ -465,16 +465,14 @@ module Mutations = struct
                       ( Transition_frontier.Breadcrumb.consensus_state breadcrumb
                       |> Consensus.Data.Consensus_state
                          .global_slot_since_genesis )
-                    ~state_view ledger zkapp_command
+                    ~state_view ledger
+                    (Zkapp_command.write_all_proofs_to_disk zkapp_command)
                 in
                 (* rearrange data to match result type of `send_zkapp_command` *)
                 let applied_ok =
                   Result.map applied
                     ~f:(fun (zkapp_command_applied, _local_state_and_amount) ->
-                      let ({ data = zkapp_command; status }
-                            : Zkapp_command.t With_status.t ) =
-                        zkapp_command_applied.command
-                      in
+                      let status = zkapp_command_applied.command.status in
                       let hash =
                         Transaction_hash.hash_zkapp_command zkapp_command
                       in
@@ -1703,7 +1701,9 @@ module Queries = struct
                       match Zkapp_command.of_base64 serialized_txn with
                       | Ok zkapp_command ->
                           let user_cmd =
-                            User_command.Zkapp_command zkapp_command
+                            User_command.Zkapp_command
+                              (Zkapp_command.write_all_proofs_to_disk
+                                 zkapp_command )
                           in
                           (* The command gets piped through [forget_check]
                              below; this is just to make the types work
@@ -1796,6 +1796,7 @@ module Queries = struct
             let cmd_with_hash =
               Transaction_hash.User_command_with_valid_signature.forget_check
                 txn
+              |> With_hash.map ~f:User_command.read_all_proofs_from_disk
             in
             match cmd_with_hash.data with
             | Signed_command _ ->
@@ -2049,8 +2050,10 @@ module Queries = struct
         in
         let frontier_broadcast_pipe = Mina_lib.transition_frontier mina in
         let transaction_pool = Mina_lib.transaction_pool mina in
+        (* TODO: do not compute hashes to just get the status *)
         Transaction_inclusion_status.get_status ~frontier_broadcast_pipe
-          ~transaction_pool txn.data )
+          ~transaction_pool
+        @@ User_command.write_all_proofs_to_disk txn.data )
 
   let current_snark_worker =
     field "currentSnarkWorker" ~typ:Types.snark_worker

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -2011,25 +2011,27 @@ module Zkapp_command = struct
 
   let zkapp_command =
     let conv
-        (x : (Mina_lib.t, Zkapp_command.t) Fields_derivers_graphql.Schema.typ) :
-        (Mina_lib.t, Zkapp_command.t) typ =
+        (x :
+          ( Mina_lib.t
+          , Zkapp_command.Stable.Latest.t )
+          Fields_derivers_graphql.Schema.typ ) :
+        (Mina_lib.t, Zkapp_command.Stable.Latest.t) typ =
       Obj.magic x
     in
     obj "ZkappCommandResult" ~fields:(fun _ ->
         [ field_no_status "id"
             ~doc:"A Base64 string representing the zkApp command"
             ~typ:(non_null transaction_id) ~args:[]
-            ~resolve:(fun _ zkapp_command ->
-              Zkapp_command zkapp_command.With_hash.data )
+            ~resolve:(fun _ { With_hash.data; _ } -> Zkapp_command data)
         ; field_no_status "hash"
             ~doc:"A cryptographic hash of the zkApp command"
             ~typ:(non_null transaction_hash) ~args:[]
-            ~resolve:(fun _ zkapp_command -> zkapp_command.With_hash.hash)
+            ~resolve:(fun _ { With_hash.hash; _ } -> hash)
         ; field_no_status "zkappCommand"
             ~typ:(Zkapp_command.typ () |> conv)
             ~args:Arg.[]
             ~doc:"zkApp command representing the transaction"
-            ~resolve:(fun _ zkapp_command -> zkapp_command.With_hash.data)
+            ~resolve:(fun _ { With_hash.data; _ } -> data)
         ; field "failureReason" ~typ:(list @@ Command_status.failure_reasons)
             ~args:[]
             ~doc:
@@ -2657,7 +2659,7 @@ module Input = struct
   end
 
   module SendTestZkappInput = struct
-    type input = Mina_base.Zkapp_command.t
+    type input = Mina_base.Zkapp_command.Stable.Latest.t
 
     let arg_typ =
       scalar "SendTestZkappInput" ~doc:"zkApp command for a test zkApp"
@@ -3019,8 +3021,10 @@ module Input = struct
     let arg_typ =
       let conv
           (x :
-            Mina_base.Zkapp_command.t Fields_derivers_graphql.Schema.Arg.arg_typ
-            ) : Mina_base.Zkapp_command.t Graphql_async.Schema.Arg.arg_typ =
+            Mina_base.Zkapp_command.Stable.Latest.t
+            Fields_derivers_graphql.Schema.Arg.arg_typ ) :
+          Mina_base.Zkapp_command.Stable.Latest.t
+          Graphql_async.Schema.Arg.arg_typ =
         Obj.magic x
       in
       let arg_typ =

--- a/src/lib/transaction/transaction_id.ml
+++ b/src/lib/transaction/transaction_id.ml
@@ -1,7 +1,7 @@
 (* transaction_id.ml : type and Base64 conversions for GraphQL *)
 
-module User_command = Mina_base.User_command
+open Mina_base
 
-type t = User_command.t
+type t = User_command.Stable.Latest.t
 
 [%%define_locally User_command.(to_base64, of_base64)]


### PR DESCRIPTION
This is a no-op change which prepares codebase for future switch of zkapp_command types.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
