### PR TITLE
Prepare for switch of zkapp_command types

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2135,7 +2135,8 @@ let receipt_chain_hash =
              in
              let receipt_elt =
                let _txn_commitment, full_txn_commitment =
-                 Zkapp_command.get_transaction_commitments zkapp_cmd
+                 Zkapp_command.get_transaction_commitments
+                   (Zkapp_command.write_all_proofs_to_disk zkapp_cmd)
                in
                Receipt.Zkapp_command_elt.Zkapp_command_commitment
                  full_txn_commitment

--- a/src/app/cli/src/init/itn.ml
+++ b/src/app/cli/src/init/itn.ml
@@ -180,6 +180,7 @@ let create_accounts ~(genesis_constants : Genesis_constants.t)
         Transaction_snark.For_tests.multiple_transfers ~constraint_constants
           multispec )
   in
+  (* TODO do not compute hashes and remove Zkapp_command.read_all_proofs_from_disk *)
   let zkapps_batches = List.chunks_of zkapps ~length:zkapps_per_block in
   Deferred.List.iter zkapps_batches ~f:(fun zkapps_batch ->
       Format.printf "Processing batch of %d zkApps@." (List.length zkapps_batch) ;
@@ -219,7 +220,8 @@ let create_accounts ~(genesis_constants : Genesis_constants.t)
                 balance_change_str ) ) ;
       let%bind res =
         Daemon_rpcs.Client.dispatch Daemon_rpcs.Send_zkapp_commands.rpc
-          zkapps_batch port
+          (List.map ~f:Zkapp_command.read_all_proofs_from_disk zkapps_batch)
+          port
       in
       ( match res with
       | Ok res_inner -> (

--- a/src/lib/filtered_external_transition/filtered_external_transition.ml
+++ b/src/lib/filtered_external_transition/filtered_external_transition.ml
@@ -163,7 +163,7 @@ let of_transition block tracked_participants
         ; coinbase_receiver = None
         } ~f:(fun acc_transactions -> function
       | { data = Command command; status } -> (
-          let command = (command :> User_command.t) in
+          let command = User_command.read_all_proofs_from_disk command in
           let should_include_transaction command participants =
             List.exists (User_command.accounts_referenced command)
               ~f:(fun account_id ->

--- a/src/lib/integration_test_lib/graphql_requests.ml
+++ b/src/lib/integration_test_lib/graphql_requests.ml
@@ -748,7 +748,8 @@ let send_zkapp_batch ~logger node_uri
   let open Deferred.Or_error.Let_syntax in
   let zkapp_commands_json =
     List.map zkapp_commands ~f:(fun zkapp_command ->
-        Mina_base.Zkapp_command.to_json zkapp_command |> Yojson.Safe.to_basic )
+        Zkapp_command.read_all_proofs_from_disk zkapp_command
+        |> Mina_base.Zkapp_command.to_json |> Yojson.Safe.to_basic )
     |> Array.of_list
   in
   let send_zkapp_graphql () =

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -280,6 +280,8 @@ struct
     }
 
   let zkapp_to_be_included_in_frontier ~has_failures ~zkapp_command =
+    (* TODO: don't use read_all_proofs_from_disk, instead avoid computing hashes on the level above *)
+    let zkapp_command = Zkapp_command.read_all_proofs_from_disk zkapp_command in
     let txn_hash =
       Mina_transaction.Transaction_hash.hash_zkapp_command zkapp_command
     in
@@ -297,12 +299,15 @@ struct
         ~metadata:
           [ ("state_hash", State_hash.to_yojson breadcrumb_added.state_hash)
           ; ("txn_hash", Mina_transaction.Transaction_hash.to_yojson txn_hash)
-          ; ("txn", Zkapp_command.to_yojson zkapp_command)
+          ; ("txn", Zkapp_command.Stable.Latest.to_yojson zkapp_command)
           ] ;
       [%log' debug (Logger.create ())]
         "wait_condition check, zkapp_to_be_included_in_frontier, \
          zkapp_command: $zkapp_command "
-        ~metadata:[ ("zkapp_command", Zkapp_command.to_yojson zkapp_command) ] ;
+        ~metadata:
+          [ ( "zkapp_command"
+            , Zkapp_command.Stable.Latest.to_yojson zkapp_command )
+          ] ;
       [%log' debug (Logger.create ())]
         "wait_condition check, zkapp_to_be_included_in_frontier, user_commands \
          from breadcrumb: $tx_hashes state_hash: $state_hash"

--- a/src/lib/mina_base/test/zkapp_command_test.ml
+++ b/src/lib/mina_base/test/zkapp_command_test.ml
@@ -119,10 +119,13 @@ end = struct
   let full = deriver @@ Fd.o ()
 
   let json_roundtrip_dummy () =
-    let dummy = Lazy.force dummy in
-    [%test_eq: t] dummy (dummy |> Fd.to_json full |> Fd.of_json full)
+    let dummy = Lazy.force dummy |> Zkapp_command.read_all_proofs_from_disk in
+    [%test_eq: Stable.Latest.t] dummy
+      (dummy |> Fd.to_json full |> Fd.of_json full)
 
   let full_circuit () =
     Run_in_thread.block_on_async_exn
-    @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full (Lazy.force dummy)
+    @@ fun () ->
+    Fields_derivers_zkapps.Test.Loop.run full
+      (Zkapp_command.read_all_proofs_from_disk @@ Lazy.force dummy)
 end

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -97,7 +97,9 @@ let setup_and_submit_user_command t (user_command_input : User_command_input.t)
                 | `Not_broadcasted ->
                     "not_broadcasted" ) )
           ; ( "valid_commands"
-            , `List (List.map ~f:User_command.to_yojson valid_commands) )
+            , `List
+                (List.map ~f:User_command.Stable.Latest.to_yojson valid_commands)
+            )
           ; ( "invalid_commands"
             , `List
                 (List.map invalid_commands ~f:(fun (_cmd, diff_err) ->
@@ -118,7 +120,8 @@ let setup_and_submit_user_commands t user_command_list =
       [ ("mina_command", `String "scheduling a batch of user transactions") ] ;
   Mina_lib.add_transactions t user_command_list
 
-let setup_and_submit_zkapp_commands t (zkapp_commands : Zkapp_command.t list) =
+let setup_and_submit_zkapp_commands t
+    (zkapp_commands : Zkapp_command.Stable.Latest.t list) =
   let open Participating_state.Let_syntax in
   (* hack to get types to work out *)
   let%map () = return () in
@@ -167,7 +170,8 @@ let setup_and_submit_zkapp_commands t (zkapp_commands : Zkapp_command.t list) =
   | Error e ->
       Error e
 
-let setup_and_submit_zkapp_command t (zkapp_command : Zkapp_command.t) =
+let setup_and_submit_zkapp_command t
+    (zkapp_command : Zkapp_command.Stable.Latest.t) =
   let res = setup_and_submit_zkapp_commands t [ zkapp_command ] in
   let%map.Participating_state res' = res in
   match%map.Deferred res' with

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -126,14 +126,16 @@ module Inputs = struct
                                     , `Sparse_ledger w.second_pass_ledger
                                     , `Connecting_ledger_hash
                                         input.connecting_ledger_left
-                                    , zkapp_command )
+                                    , Zkapp_command.write_all_proofs_to_disk
+                                        zkapp_command )
                                   ]
                                 |> List.rev )
                             |> Result.map_error ~f:(fun e ->
                                    Error.createf
                                      !"Failed to generate inputs for \
                                        zkapp_command : %s: %s"
-                                     ( Zkapp_command.to_yojson zkapp_command
+                                     ( Zkapp_command.Stable.Latest.to_yojson
+                                         zkapp_command
                                      |> Yojson.Safe.to_string )
                                      (Error.to_string_hum e) )
                             |> Deferred.return


### PR DESCRIPTION
A batch of unrelated changes in preparation of removing hashes from Zkapp_command.Stable.Latest.t.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
