### PR TITLE
Relax zkapp types in Transaction and Pre_diff_info

### DIFF
--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -50,6 +50,8 @@ end]
 
 type t = User_command.t Poly.t [@@deriving sexp, yojson]
 
+type ('a, 'b) with_forest = ('a, 'b) User_command.with_forest Poly.t
+
 let read_all_proofs_from_disk : t -> Stable.Latest.t =
   Poly.Stable.Latest.map ~f:User_command.read_all_proofs_from_disk
 
@@ -98,7 +100,7 @@ let expected_supply_increase = function
   | Coinbase t ->
       Coinbase.expected_supply_increase t
 
-let public_keys (t : t) =
+let public_keys (t : (_, _) with_forest) =
   let account_ids =
     match t with
     | Command (Signed_command cmd) ->
@@ -112,7 +114,8 @@ let public_keys (t : t) =
   in
   List.map account_ids ~f:Account_id.public_key
 
-let account_access_statuses (t : t) (status : Transaction_status.t) =
+let account_access_statuses (t : (_, _) with_forest)
+    (status : Transaction_status.t) =
   match t with
   | Command (Signed_command cmd) ->
       Signed_command.account_access_statuses cmd status
@@ -125,11 +128,11 @@ let account_access_statuses (t : t) (status : Transaction_status.t) =
   | Coinbase cb ->
       Coinbase.account_access_statuses cb status
 
-let accounts_referenced (t : t) =
+let accounts_referenced (t : (_, _) with_forest) =
   List.map (account_access_statuses t Applied) ~f:(fun (acct_id, _status) ->
       acct_id )
 
-let fee_payer_pk (t : t) =
+let fee_payer_pk (t : (_, _) with_forest) =
   match t with
   | Command (Signed_command cmd) ->
       Signed_command.fee_payer_pk cmd
@@ -140,14 +143,14 @@ let fee_payer_pk (t : t) =
   | Coinbase cb ->
       Coinbase.fee_payer_pk cb
 
-let valid_size ~genesis_constants (t : t) =
+let valid_size ~genesis_constants (t : (_, _) with_forest) =
   match t with
   | Command cmd ->
       User_command.valid_size ~genesis_constants cmd
   | Fee_transfer _ | Coinbase _ ->
       Ok ()
 
-let check_well_formedness ~genesis_constants (t : t) =
+let check_well_formedness ~genesis_constants (t : (_, _) with_forest) =
   match t with
   | Command cmd ->
       User_command.check_well_formedness ~genesis_constants cmd


### PR DESCRIPTION
Relax types in two modules to make existing functions more polymorphic.

Explain your changes:
- Relax user command types in `Pre_diff_info`
- Relax types in `Transaction`

Explain how you tested your changes:
* Simple refactoring, no change to behavior or code structure

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
