### PR TITLE
Some changes required for hash removal from Zkapp_command.Stable

### DIFF
--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -102,9 +102,7 @@ module Inputs = struct
               | Work.Single.Spec.Transition
                   (input, (w : Transaction_witness.Stable.Latest.t)) ->
                   process (fun () ->
-                      match
-                        Transaction.read_all_proofs_from_disk w.transaction
-                      with
+                      match w.transaction with
                       | Command (Zkapp_command zkapp_command) -> (
                           let%bind witnesses_specs_stmts =
                             Or_error.try_with (fun () ->
@@ -245,10 +243,7 @@ module Inputs = struct
                             Deferred.return
                             @@
                             (* Validate the received transaction *)
-                            match
-                              Transaction.read_all_proofs_from_disk
-                                w.transaction
-                            with
+                            match w.transaction with
                             | Command (Signed_command cmd) -> (
                                 match Signed_command.check cmd with
                                 | Some cmd ->

--- a/src/lib/staged_ledger/check_commands.ml
+++ b/src/lib/staged_ledger/check_commands.ml
@@ -24,7 +24,8 @@ let verify_command_with_transaction_pool_proxy
   let cmd_hash =
     (* PERF: `hash_command` is slow, so we may need to investigate if we could
        reuse hashes from transition verification. *)
-    User_command.of_verifiable verifiable_cmd |> Transaction_hash.hash_command
+    User_command.of_verifiable verifiable_cmd
+    |> User_command.read_all_proofs_from_disk |> Transaction_hash.hash_command
   in
   match transaction_pool_proxy.find_by_hash cmd_hash with
   | None ->

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -181,11 +181,11 @@ module Make_str (A : Wire_types.Concrete) = struct
     let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
       Pre_diff_two.map
         ~f1:(Transaction_snark_work.write_all_proofs_to_disk ~proof_cache_db)
-        ~f2:Fn.id
+        ~f2:(With_status.map ~f:User_command.write_all_proofs_to_disk)
 
     let read_all_proofs_from_disk : t -> Stable.Latest.t =
       Pre_diff_two.map ~f1:Transaction_snark_work.read_all_proofs_from_disk
-        ~f2:Fn.id
+        ~f2:(With_status.map ~f:User_command.read_all_proofs_from_disk)
   end
 
   module Pre_diff_with_at_most_one_coinbase = struct
@@ -210,11 +210,11 @@ module Make_str (A : Wire_types.Concrete) = struct
     let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
       Pre_diff_one.map
         ~f1:(Transaction_snark_work.write_all_proofs_to_disk ~proof_cache_db)
-        ~f2:Fn.id
+        ~f2:(With_status.map ~f:User_command.write_all_proofs_to_disk)
 
     let read_all_proofs_from_disk : t -> Stable.Latest.t =
       Pre_diff_one.map ~f1:Transaction_snark_work.read_all_proofs_from_disk
-        ~f2:Fn.id
+        ~f2:(With_status.map ~f:User_command.read_all_proofs_from_disk)
   end
 
   module Diff = struct


### PR DESCRIPTION
PR introduces three changes which are very minor, and are needed to enable removal of intermediate hashes from definition of `Zkapp_command.Stable` types.

Explain your changes:

- Fully prepare for type decoupling in `Staged_ledger_diff`
  - Change was introduced as a by-product of managing work in parallel branches, which are now merged to `compatible`
- Add missing `read_all_proofs_from_disk` in `Check_commands`
- Revert an unnecessary change from #16788
  - Change was introduced as a by-product of managing work in parallel branches, which are now merged to `compatible`

Explain how you tested your changes:
* A small refactoring, no changes to behavior.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
