### PR TITLE
Dune: remove unused dependencies in mina_block

### DIFF
--- a/src/lib/mina_block/dune
+++ b/src/lib/mina_block/dune
@@ -4,14 +4,7 @@
  (libraries
   ;; opam libraries
   integers
-  core_kernel
-  async_kernel
-  bin_prot.shape
-  base.caml
-  sexplib0
   base64
-  result
-  base
   core
   ;; local libraries
   mina_ledger


### PR DESCRIPTION
Removed unnecessary dependencies from mina_block dune file:
- core_kernel
- async_kernel
- bin_prot.shape  
- base.caml
- sexplib0
- result
- base

These dependencies are either included by other dependencies (like core) or aren't needed.