### PR TITLE
Dune: remove unused dependencies in staged_ledger

### DIFF
--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -6,25 +6,17 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  ppx_inline_test.config
   ppx_hash.runtime-lib
-  async_kernel
-  base.caml
-  base
-  sexplib0
-  core_kernel
   core
   lens
   async
   async_unix
-  base.base_internalhash_types
   integers
   ;; local libraries
   kimchi_pasta
   kimchi_pasta.basic
   random_oracle_input
   bounded_types
-  mina_base.import
   mina_ledger
   quickcheck_lib
   mina_metrics


### PR DESCRIPTION
Removed unnecessary dependencies from staged_ledger dune file:
- ppx_inline_test.config
- async_kernel
- base.caml
- base
- sexplib0
- core_kernel  
- base.base_internalhash_types
- mina_base.import

These dependencies are either included by other dependencies (like core) or aren't needed.