### PR TITLE
Dune: remove unused dependencies in mina_state

### DIFF
--- a/src/lib/mina_state/dune
+++ b/src/lib/mina_state/dune
@@ -24,13 +24,6 @@
    h_list.ppx))
  (libraries
   ;; opam libraries
-  ppx_inline_test.config
-  base.base_internalhash_types
-  base.caml
-  bin_prot.shape
-  base
-  sexplib0
-  core_kernel
   core
   ;; local libraries
   signature_lib


### PR DESCRIPTION
Removed unnecessary dependencies from mina_state dune file:
- ppx_inline_test.config
- base.base_internalhash_types
- base.caml
- bin_prot.shape
- base
- sexplib0
- core_kernel

These dependencies are either included by other dependencies (like core) or aren't needed.