### PR TITLE
Dune: remove unused dependencies in transaction_snark

### DIFF
--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -6,23 +6,14 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  ppx_inline_test.config
-  async_kernel
-  base.base_internalhash_types
-  bin_prot.shape
   async
-  sexplib0
   bignum
   core
-  core_kernel
-  base.md5
-  base.caml
   async_unix
   splittable_random
   ;; local libraries
   bounded_types
   mina_wire_types
-  mina_base.import
   mina_transaction
   mina_transaction_logic
   hash_prefix_states


### PR DESCRIPTION
Removed unnecessary dependencies from transaction_snark dune file:
- ppx_inline_test.config
- async_kernel
- base.base_internalhash_types
- bin_prot.shape
- sexplib0
- core_kernel
- base.md5
- base.caml
- mina_base.import

These dependencies are either included by other dependencies (like core) or aren't needed.