### PR TITLE
Dune: remove unused dependencies in coda_genesis_ledger

### DIFF
--- a/src/lib/genesis_ledger/dune
+++ b/src/lib/genesis_ledger/dune
@@ -3,8 +3,7 @@
  (name genesis_ledger)
  (libraries
   ;; opam libraries
-  core_kernel
-  base
+  core
   ;; local libraries
   key_gen
   mina_base
@@ -14,7 +13,6 @@
   genesis_constants
   data_hash_lib
   mina_ledger
-  mina_base.import
   bounded_types)
  (instrumentation
   (backend bisect_ppx))


### PR DESCRIPTION
Removed unnecessary dependencies from coda_genesis_ledger (genesis_ledger) dune file:
- core_kernel
- base
- mina_base.import

These dependencies are either included by other dependencies (like core) or aren't needed.