### PR TITLE
Clean up unused preprocessor dependencies in graphql_wrapper

### DIFF
--- a/src/lib/graphql_wrapper/dune
+++ b/src/lib/graphql_wrapper/dune
@@ -3,6 +3,4 @@
  (public_name graphql_wrapper)
  (libraries graphql graphql-async graphql_parser)
  (instrumentation
-  (backend bisect_ppx))
- (preprocess
-  (pps ppx_deriving.show ppx_deriving_yojson ppx_version)))
+  (backend bisect_ppx)))


### PR DESCRIPTION
Remove ppx_deriving.show, ppx_deriving_yojson, and ppx_version from 
graphql_wrapper dune file as they are not used in the code.

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.