### PR TITLE
Clean up unused preprocessor dependencies in bash_colors

### DIFF
--- a/src/lib/bash_colors/dune
+++ b/src/lib/bash_colors/dune
@@ -2,6 +2,4 @@
  (name bash_colors)
  (public_name bash_colors)
  (instrumentation
-  (backend bisect_ppx))
- (preprocess
-  (pps ppx_version)))
+  (backend bisect_ppx)))


### PR DESCRIPTION
Remove ppx_version from bash_colors dune file as it is not used in the code.

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.