### PR TITLE
Clean up unused library dependencies in file_system

### DIFF
--- a/src/lib/file_system/dune
+++ b/src/lib/file_system/dune
@@ -2,7 +2,7 @@
  (name file_system)
  (public_name file_system)
  (library_flags -linkall)
- (libraries core_kernel async_kernel core async async_unix base.caml)
+ (libraries core async async_unix)
  (preprocess
   (pps ppx_version ppx_jane))
  (instrumentation


### PR DESCRIPTION
Remove the following unused dependencies:
- core_kernel
- async_kernel
- base.caml

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.