### PR TITLE
Clean up unused library dependencies in direction

### DIFF
--- a/src/lib/direction/dune
+++ b/src/lib/direction/dune
@@ -2,7 +2,7 @@
  (name direction)
  (public_name direction)
  (library_flags -linkall)
- (libraries core_kernel sexplib0)
+ (libraries core_kernel)
  (preprocess
   (pps ppx_version ppx_jane ppx_compare))
  (instrumentation


### PR DESCRIPTION
Remove the following unused dependency:
- sexplib0

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.