### PR TITLE
Clean up unused library dependencies in exit_handlers

### DIFF
--- a/src/lib/exit_handlers/dune
+++ b/src/lib/exit_handlers/dune
@@ -2,7 +2,7 @@
  (name exit_handlers)
  (public_name exit_handlers)
  (library_flags -linkall)
- (libraries core_kernel async_kernel async_unix logger core base base.caml)
+ (libraries core_kernel async_kernel async_unix logger)
  (instrumentation
   (backend bisect_ppx))
  (preprocess


### PR DESCRIPTION
Remove the following unused dependencies:
- core
- base
- base.caml

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.