### PR TITLE
Clean up unused library dependencies in fake_network

### DIFF
--- a/src/lib/fake_network/dune
+++ b/src/lib/fake_network/dune
@@ -4,14 +4,9 @@
  (libraries
   ;; opam libraries
   core.uuid
-  core_kernel.uuid
   async_unix
   async
   core
-  core_kernel
-  base.caml
-  async_kernel
-  sexplib0
   ;; local libraries
   snark_params
   pickles


### PR DESCRIPTION
Remove the following unused dependencies:
- core_kernel.uuid
- core_kernel
- base.caml
- async_kernel
- sexplib0

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.