### PR TITLE
Clean up unused library dependencies in downloader

### DIFF
--- a/src/lib/downloader/dune
+++ b/src/lib/downloader/dune
@@ -3,14 +3,10 @@
  (public_name downloader)
  (libraries
   ;; opam libraries
-  async_kernel
   async
   core
-  core_kernel
-  sexplib0
   core_kernel.pairing_heap
   async_unix
-  base.caml
   ;; local libraries
   network_peer
   pipe_lib


### PR DESCRIPTION
Remove the following unused dependencies:
- async_kernel
- core_kernel
- sexplib0
- base.caml

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.