### PR TITLE
Clean up unused library dependencies in fields_derivers

### DIFF
--- a/src/lib/fields_derivers/dune
+++ b/src/lib/fields_derivers/dune
@@ -1,7 +1,7 @@
 (library
  (name fields_derivers)
  (public_name fields_derivers)
- (libraries core_kernel ppx_inline_test.config fieldslib sexplib0 base.caml)
+ (libraries core_kernel ppx_inline_test.config fieldslib)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests


### PR DESCRIPTION
Remove the following unused dependencies:
- sexplib0
- base.caml

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.