### PR TITLE
Clean up unused library dependencies in data_hash_lib

### DIFF
--- a/src/lib/data_hash_lib/dune
+++ b/src/lib/data_hash_lib/dune
@@ -6,14 +6,9 @@
  (library_flags -linkall)
  (libraries
   ;; opam libraries
-  result
-  base.base_internalhash_types
   core_kernel
-  bin_prot.shape
   ppx_inline_test.config
   base
-  sexplib0
-  base.caml
   ;; local libraries
   fields_derivers.graphql
   fields_derivers


### PR DESCRIPTION
Remove the following unused dependencies:
- result
- base.base_internalhash_types
- bin_prot.shape
- sexplib0
- base.caml

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.