### PR TITLE
Clean up unused library dependencies in mina_generators

### DIFF
--- a/src/lib/mina_generators/dune
+++ b/src/lib/mina_generators/dune
@@ -15,13 +15,11 @@
  (libraries
   ;; opam libraries
   yojson
-  core_kernel
   base_quickcheck
   core
   async
   async_unix
   base
-  sexplib0
   ppx_inline_test.config
   ppx_deriving_yojson.runtime
   ;; local libraries


### PR DESCRIPTION
Remove the following unused dependencies:
- core_kernel
- sexplib0

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.