### PR TITLE
Clean up unused library dependencies in hex

### DIFF
--- a/src/lib/hex/dune
+++ b/src/lib/hex/dune
@@ -7,4 +7,4 @@
   (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_version ppx_inline_test))
- (libraries core_kernel ppx_inline_test.config))
+ (libraries core_kernel))


### PR DESCRIPTION
Remove the following unused dependencies:
- ppx_inline_test.config

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.