### PR TITLE
Clean up unused library dependencies in internal_tracing

### DIFF
--- a/src/lib/hex/dune
+++ b/src/lib/hex/dune
@@ -7,4 +7,4 @@
   (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_version ppx_inline_test))
- (libraries core_kernel ppx_inline_test.config))
+ (libraries core_kernel))

--- a/src/lib/internal_tracing/dune
+++ b/src/lib/internal_tracing/dune
@@ -6,10 +6,7 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  base.base_internalhash_types
   core
-  core_kernel
-  sexplib0
   yojson
   async_kernel
   ;; local libraries


### PR DESCRIPTION
Remove the following unused dependencies:
- base.base_internalhash_types
- core_kernel
- sexplib0

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.