### PR TITLE
Clean up unused library dependencies in interruptible

### DIFF
--- a/src/lib/interruptible/dune
+++ b/src/lib/interruptible/dune
@@ -8,7 +8,6 @@
   ;; opam libraries
   core_kernel
   async_kernel
-  ppx_inline_test.config
   ;; local libraries
   run_in_thread)
  (preprocess


### PR DESCRIPTION
Remove the following unused dependencies:
- ppx_inline_test.config

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.