### PR TITLE
Clean up unused library dependencies in itn_crypto

### DIFF
--- a/src/lib/itn_crypto/dune
+++ b/src/lib/itn_crypto/dune
@@ -11,7 +11,6 @@
   mirage-crypto-ec
   mirage-crypto-rng
   mirage-crypto-rng-async
-  ppx_inline_test.config
   ;; local libraries
   codable)
  (instrumentation


### PR DESCRIPTION
Remove the following unused dependencies:
- ppx_inline_test.config

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.