### PR TITLE
Clean up unused library dependencies in itn_logger

### DIFF
--- a/src/lib/itn_logger/dune
+++ b/src/lib/itn_logger/dune
@@ -3,16 +3,9 @@
  (public_name itn_logger)
  (libraries
   ;; opam libraries
-  base
-  base.caml
-  bin_prot.shape
   async
   async.async_rpc
-  async_kernel
-  async_rpc_kernel
-  async_unix
   core
-  core_kernel
   yojson
   ;; local libraries
   mina_node_config.unconfigurable_constants)


### PR DESCRIPTION
Remove the following unused dependencies:
- base
- base.caml
- bin_prot.shape
- async_kernel
- async_rpc_kernel
- async_unix
- core_kernel

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.