### PR TITLE
Clean up unused library dependencies in key_gen

### DIFF
--- a/src/lib/key_gen/dune
+++ b/src/lib/key_gen/dune
@@ -5,4 +5,4 @@
   (backend bisect_ppx))
  (preprocess
   (pps ppx_version))
- (libraries core_kernel signature_lib base))
+ (libraries core_kernel signature_lib))


### PR DESCRIPTION
Remove the following unused dependencies:
- base

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.