### PR TITLE
Clean up unused library dependencies in key_value_database

### DIFF
--- a/src/lib/key_value_database/dune
+++ b/src/lib/key_value_database/dune
@@ -2,7 +2,7 @@
  (name key_value_database)
  (public_name key_value_database)
  (library_flags (-linkall))
- (libraries core_kernel sexplib0)
+ (libraries core_kernel)
  (instrumentation
   (backend bisect_ppx))
  (preprocess


### PR DESCRIPTION
Remove the following unused dependencies:
- sexplib0

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.