### PR TITLE
Clean up unused library dependencies in ledger_catchup

### DIFF
--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -9,16 +9,8 @@
   (pps ppx_mina ppx_version ppx_jane))
  (libraries
   ;; opam libraries
-  integers
-  base.base_internalhash_types
   async
   core
-  core_kernel
-  ocamlgraph
-  async_kernel
-  sexplib0
-  ppx_inline_test.config
-  async_unix
   ;; local libraries
   bounded_types
   mina_wire_types


### PR DESCRIPTION
Remove the following unused dependencies:
- integers
- base.base_internalhash_types
- core_kernel
- ocamlgraph
- async_kernel
- sexplib0
- ppx_inline_test.config
- async_unix

This is part of an ongoing effort to clean up unnecessary dependencies in dune files.