### PR TITLE
fix changelog entry 16809 to be more concise

### DIFF
--- a/changes/16809.md
+++ b/changes/16809.md
@@ -1,18 +1,1 @@
-# PR 16809: [Verification of zkapp proofs prior to block creation](https://www.notion.so/o1labs/Verification-of-zkapp-proofs-prior-to-block-creation-196e79b1f910807aa8aef723c135375a)
-
-## Summary
-
-- Allow `Staged_ledger.check_commands` to have access to the transaction pool, so it can check transaction commands that all are already in the pool, which are verified, and skip the costly portion of the verification for them.
-
-## Changes
-- Move `check_commands` related functionalities to a separate `Staged_ledger.Check_commands` module;
-- Introduce a `transaction_pool_proxy` that can pass access to `find_by_hash` in a `transaction_pool` down to `Staged_ledger.Check_commands.check_commands`;
-- PERF: Check commands already present in the pool so we don't calculate the verification keys twice during `Staged_ledger.Check_commands.check_commands`. There's still space for improvement due to the indirect invocation of `Transaction_hash.hash_command` in `Check_commands.ml`.
-
-## Impact
-In worst case creating a block requires verification of 125 transactions. This PR completely removes this necessity. In experiments that we conducted it cuts some 15s out of total of 45s that creation of a block takes.
-
-## Invariant Assumption:
-- Assumes `Common.check` doesn't depends on the state of the staged ledger, and only depends on the command itself.
-- Assumes we don't care about the order of the exceptions thrown by `Staged_ledger.check_commands`
-- Assumes no 2 txns in the pool would have same hash but being non-identical
+Stop re-verification of transaction proofs in blocks, reducing block creation time by ~15s (out of the current 45s).


### PR DESCRIPTION
Title is self-descriptive. We want more concise changelog entry for it to be able to be read by end-user. 

No changelog entry should be added.