### PR TITLE
Use better param names for variables

### DIFF
--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -544,7 +544,7 @@ let compile :
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = max_proofs_verified)
     -> name:string
-    -> choices:
+    -> rules:
          (   self:
                ( Zkapp_statement.Checked.t
                , Zkapp_statement.t
@@ -587,9 +587,9 @@ let compile :
            Deferred.t )
          H3_2.T(Pickles.Prover).t =
  fun ?self ?cache ?proof_cache ?disk_keys ?override_wrap_domain ~auxiliary_typ
-     ~max_proofs_verified ~name ~choices () ->
+     ~max_proofs_verified ~name ~rules () ->
   let vk_hash = ref None in
-  let choices ~self =
+  let rules ~self =
     let rec go :
         type branches prev_varss prev_valuess widthss heightss.
            ( branches
@@ -618,7 +618,7 @@ let compile :
            H4_6_with_length.T(Pickles.Inductive_rule.Deferred).t = function
       | [] ->
           []
-      | { identifier; prevs; main; feature_flags } :: choices ->
+      | { identifier; prevs; main; feature_flags } :: rules ->
           { identifier
           ; prevs
           ; feature_flags
@@ -642,15 +642,15 @@ let compile :
                 ; auxiliary_output = (account_update_tree, auxiliary_output)
                 } )
           }
-          :: go choices
+          :: go rules
     in
-    go (choices ~self)
+    go (rules ~self)
   in
   let tag, cache_handle, proof, provers =
     Pickles.compile_async () ?self ?cache ?proof_cache ?disk_keys
       ?override_wrap_domain ~public_input:(Output Zkapp_statement.typ)
       ~auxiliary_typ:Typ.(Prover_value.typ () * auxiliary_typ)
-      ~max_proofs_verified ~name ~choices
+      ~max_proofs_verified ~name ~rules
   in
   let () =
     vk_hash :=

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -486,7 +486,7 @@ end) : S = struct
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N2)
       ~name:"blockchain-snark"
-      ~choices:(fun ~self ->
+      ~rules:(fun ~self ->
         [ rule ~proof_level ~constraint_constants T.tag self ] )
 
   let step = with_handler step

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -309,7 +309,7 @@ val compile_with_wrap_main_override_promise :
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
   -> ?constraint_constants:Snark_keys_header.Constraint_constants.t
-  -> choices:
+  -> rules:
        (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
         -> ( 'branches
            , 'prev_varss

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -315,16 +315,16 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~max_proofs_verified ~name ~choices () =
+      ~max_proofs_verified ~name ~rules () =
     compile_with_wrap_main_override_promise ?self ?cache ?storables ?proof_cache
       ?disk_keys ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~max_proofs_verified ~name ~choices ()
+      ~max_proofs_verified ~name ~rules ()
 
   let compile ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~max_proofs_verified ~name ~choices () =
-    let choices ~self =
-      let choices = choices ~self in
+      ~max_proofs_verified ~name ~rules () =
+    let rules ~self =
+      let rules = rules ~self in
       let rec go :
           type length a b c d e f g h i j.
              ( length
@@ -361,12 +361,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
             }
             :: go rest
       in
-      go choices
+      go rules
     in
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-        ~max_proofs_verified ~name ~choices ()
+        ~max_proofs_verified ~name ~rules ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -383,9 +383,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let compile_async ?self ?cache ?storables ?proof_cache ?disk_keys
       ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-      ~max_proofs_verified ~name ~choices () =
-    let choices ~self =
-      let choices = choices ~self in
+      ~max_proofs_verified ~name ~rules () =
+    let rules ~self =
+      let rules = rules ~self in
       let rec go :
           type length a b c d e f g h i j.
              ( length
@@ -427,12 +427,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
             }
             :: go rest
       in
-      go choices
+      go rules
     in
     let self, cache_handle, proof_module, provers =
       compile_promise ?self ?cache ?storables ?proof_cache ?disk_keys
         ?override_wrap_domain ?num_chunks ~public_input ~auxiliary_typ
-        ~max_proofs_verified ~name ~choices ()
+        ~max_proofs_verified ~name ~rules ()
     in
     let rec adjust_provers :
         type a1 a2 a3 s1 s2_inner.
@@ -496,7 +496,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -534,7 +534,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -588,7 +588,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self ->
+                ~rules:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = [ self ]
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -683,7 +683,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self ->
+                ~rules:(fun ~self ->
                   [ { identifier = "main"
                     ; feature_flags = Plonk_types.Features.none_bool
                     ; prevs = [ No_recursion.tag; self ]
@@ -802,7 +802,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self ->
+                ~rules:(fun ~self ->
                   [ { identifier = "main"
                     ; feature_flags = Plonk_types.Features.none_bool
                     ; prevs = [ No_recursion_return.tag; self ]
@@ -901,7 +901,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; feature_flags = Plonk_types.Features.none_bool
                     ; prevs = []
@@ -941,7 +941,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Field.typ
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; feature_flags = Plonk_types.Features.none_bool
                     ; prevs = []
@@ -1061,7 +1061,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let max_local_max_proofs_verifieds ~self (type n)
             (module Max_proofs_verified : Nat.Intf with type n = n) branches
-            choices =
+            rules =
           let module Local_max_proofs_verifieds = struct
             type t = (int, Max_proofs_verified.n) Vector.t
           end in
@@ -1093,7 +1093,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
               end)
           in
           let module V = H4.To_vector (Local_max_proofs_verifieds) in
-          let padded = V.f branches (M.f choices) |> Vector.transpose in
+          let padded = V.f branches (M.f rules) |> Vector.transpose in
           (padded, Maxes.m padded)
 
         module Lazy_keys = struct
@@ -1923,7 +1923,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"recurse-on-bad"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; feature_flags = Plonk_types.Features.none_bool
                     ; prevs = [ tag; tag ]
@@ -2050,7 +2050,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2088,7 +2088,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2127,7 +2127,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2191,7 +2191,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = [ side_loaded_tag ]
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2358,7 +2358,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N0)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2396,7 +2396,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2435,7 +2435,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N2)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = []
                     ; feature_flags = Plonk_types.Features.none_bool
@@ -2502,7 +2502,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~auxiliary_typ:Typ.unit
                 ~max_proofs_verified:(module Nat.N1)
                 ~name:"blockchain-snark"
-                ~choices:(fun ~self:_ ->
+                ~rules:(fun ~self:_ ->
                   [ { identifier = "main"
                     ; prevs = [ side_loaded_tag ]
                     ; feature_flags = Plonk_types.Features.none_bool

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -422,7 +422,7 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> choices:
+    -> rules:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'branches
              , 'prev_varss
@@ -477,7 +477,7 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> choices:
+    -> rules:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'branches
              , 'prev_varss
@@ -532,7 +532,7 @@ module type S = sig
     -> max_proofs_verified:
          (module Nat.Add.Intf with type n = 'max_proofs_verified)
     -> name:string
-    -> choices:
+    -> rules:
          (   self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
           -> ( 'branches
              , 'prev_varss

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -12,7 +12,7 @@ let test () =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:2 ~override_wrap_domain:N1 ~name:"chunked_circuits"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "2^16"
           ; prevs = []
           ; main =
@@ -79,7 +79,7 @@ let test () =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N1)
       ~name:"recursion over chunks"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "recurse over 2^17"
           ; prevs = [ tag ]
           ; main =

--- a/src/lib/pickles/test/chunked_circuits/chunks4.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks4.ml
@@ -13,7 +13,7 @@ let test () =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:4 ~override_wrap_domain:N1 ~name:"chunked_circuits"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "2^17"
           ; prevs = []
           ; main =

--- a/src/lib/pickles/test/chunked_circuits/chunks8.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks8.ml
@@ -13,7 +13,7 @@ let test () =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N0)
       ~num_chunks:8 ~override_wrap_domain:N2 ~name:"chunked_circuits"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "2^18"
           ; prevs = []
           ; main =

--- a/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
+++ b/src/lib/pickles/test/optional_custom_gates/lookup_range_check.ml
@@ -52,7 +52,7 @@ let test_range_check_lookup () =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N0)
       ~name:"lookup range-check"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "main"
           ; prevs = []
           ; main =

--- a/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
+++ b/src/lib/pickles/test/optional_custom_gates/pickles_test_optional_custom_gates.ml
@@ -237,7 +237,7 @@ let register_test name feature_flags1 feature_flags2 =
       ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N0)
       ~name:"optional_custom_gates"
-      ~choices:(fun ~self:_ ->
+      ~rules:(fun ~self:_ ->
         [ { identifier = "main1"
           ; prevs = []
           ; main =

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -14,21 +14,21 @@ module Make
     (Auxiliary_var : T0)
     (Auxiliary_value : T0) =
 struct
-  let f_debug full_signature _num_choices choices_length ~feature_flags
-      ~num_chunks ~max_proofs_verified =
-    let num_choices = Hlist.Length.to_nat choices_length in
+  let f_debug full_signature _num_rules rules_length ~feature_flags ~num_chunks
+      ~max_proofs_verified =
+    let num_rules = Hlist.Length.to_nat rules_length in
     let dummy_step_domains =
       Promise.return
-      @@ Vector.init num_choices ~f:(fun _ -> Fix_domains.rough_domains)
+      @@ Vector.init num_rules ~f:(fun _ -> Fix_domains.rough_domains)
     in
     let dummy_step_widths =
-      Vector.init num_choices ~f:(fun _ ->
+      Vector.init num_rules ~f:(fun _ ->
           Nat.to_int (Nat.Add.n max_proofs_verified) )
     in
     let dummy_step_keys =
       lazy
         (Promise.return
-           (Vector.init num_choices ~f:(fun _ ->
+           (Vector.init num_rules ~f:(fun _ ->
                 let num_chunks =
                   (* TODO *) Plonk_checks.num_chunks_by_default
                 in
@@ -42,7 +42,7 @@ struct
     let srs = Backend.Tick.Keypair.load_urs () in
     let _, main =
       Wrap_main.wrap_main ~feature_flags ~num_chunks ~srs full_signature
-        choices_length dummy_step_keys dummy_step_widths dummy_step_domains
+        rules_length dummy_step_keys dummy_step_widths dummy_step_domains
         max_proofs_verified
     in
     Timer.clock __LOC__ ;
@@ -55,7 +55,7 @@ struct
     in
     Timer.clock __LOC__ ; t
 
-  let f full_signature num_choices choices_length ~feature_flags ~num_chunks
+  let f full_signature num_rules rules_length ~feature_flags ~num_chunks
       ~max_proofs_verified =
     Common.wrap_domains
       ~proofs_verified:(Nat.to_int (Nat.Add.n max_proofs_verified))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3334,7 +3334,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       ~public_input:(Input Statement.With_sok.typ) ~auxiliary_typ:Typ.unit
       ~max_proofs_verified:(module Nat.N2)
       ~name:"transaction-snark"
-      ~choices:(fun ~self ->
+      ~rules:(fun ~self ->
         let zkapp_command x =
           Base.Zkapp_command_snark.rule ~constraint_constants ~proof_level x
         in
@@ -4186,7 +4186,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~public_input:(Input Zkapp_statement.typ) ~auxiliary_typ:Typ.unit
           ~max_proofs_verified:(module Nat.N0)
           ~name:"trivial"
-          ~choices:(fun ~self:_ -> [ trivial_rule ])
+          ~rules:(fun ~self:_ -> [ trivial_rule ])
       in
       let trivial_prover ?handler stmt =
         let open Async.Deferred.Let_syntax in


### PR DESCRIPTION
This aims to revive https://github.com/MinaProtocol/mina/pull/8073

In Pickles interfaces, 
- `choices` becomes `rules`