### PR TITLE
Add With_hash.Set module

### DIFF
--- a/src/lib/mina_stdlib/dune
+++ b/src/lib/mina_stdlib/dune
@@ -3,7 +3,7 @@
  (public_name mina_stdlib)
  (inline_tests
   (flags -verbose -show-counts))
- (modules_without_implementation sigs)
+ (modules_without_implementation generic_set sigs)
  (flags
   (:standard -w a -warn-error +a)
   -open

--- a/src/lib/mina_stdlib/generic_set.mli
+++ b/src/lib/mina_stdlib/generic_set.mli
@@ -1,0 +1,61 @@
+(** General interface of a Set *)
+module type S0 = sig
+  type el
+
+  type t
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val add : t -> el -> t
+
+  val union : t -> t -> t
+
+  val iter : t -> f:(el -> unit) -> unit
+
+  val equal : t -> t -> bool
+
+  val of_list : el list -> t
+
+  val length : t -> int
+
+  val singleton : el -> t
+
+  val remove : t -> el -> t
+
+  val min_elt_exn : t -> el
+
+  val to_sequence : t -> el Sequence.t
+end
+
+(** General interface of a Set with one type parameter *)
+module type S1 = sig
+  type 'a el
+
+  type 'a t
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val add : 'a t -> 'a el -> 'a t
+
+  val union : 'a t -> 'a t -> 'a t
+
+  val iter : 'a t -> f:('a el -> unit) -> unit
+
+  val equal : 'a t -> 'a t -> bool
+
+  val of_list : 'a el list -> 'a t
+
+  val length : 'a t -> int
+
+  val singleton : 'a el -> 'a t
+
+  val remove : 'a t -> 'a el -> 'a t
+
+  val min_elt_exn : 'a t -> 'a el
+
+  val to_sequence : 'a t -> 'a el Sequence.t
+end

--- a/src/lib/with_hash/dune
+++ b/src/lib/with_hash/dune
@@ -9,7 +9,8 @@
   core_kernel
   ;; local libraries
   mina_wire_types
-  ppx_version.runtime)
+  ppx_version.runtime
+  mina_stdlib)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/lib/with_hash/with_hash.ml
+++ b/src/lib/with_hash/with_hash.ml
@@ -26,7 +26,7 @@ let of_data data ~hash_data = { data; hash = hash_data data }
 (** Set for [('a, 'h) t] that assumes the hash ['h] is cryptographically sound, and data is ignored
 *)
 module Set (Hash : Comparable.S) = struct
-  type 'a t = 'a Hash.Map.t
+  type 'a t = 'a Hash.Map.t [@@deriving sexp_of]
 
   let empty = Hash.Map.empty
 

--- a/src/lib/with_hash/with_hash.ml
+++ b/src/lib/with_hash/with_hash.ml
@@ -15,14 +15,48 @@ module Stable = struct
 end]
 
 type ('a, 'h) t = ('a, 'h) Stable.Latest.t = { data : 'a; hash : 'h }
-[@@deriving annot, sexp, equal, compare, hash, yojson]
-
-let data { data; _ } = data
-
-let hash { hash; _ } = hash
+[@@deriving annot, compare, equal, fields, hash, sexp, yojson]
 
 let map t ~f = { t with data = f t.data }
 
 let map_hash t ~f = { t with hash = f t.hash }
 
 let of_data data ~hash_data = { data; hash = hash_data data }
+
+(** Set for [('a, 'h) t] that assumes the hash ['h] is cryptographically sound, and data is ignored
+*)
+module Set (Hash : Comparable.S) = struct
+  type 'a t = 'a Hash.Map.t
+
+  let empty = Hash.Map.empty
+
+  let is_empty = Hash.Map.is_empty
+
+  let add t { data; hash } =
+    match Hash.Map.add t ~key:hash ~data with `Ok t' -> t' | `Duplicate -> t
+
+  let union =
+    Hash.Map.merge ~f:(fun ~key:_ -> function
+      | `Both (_, b) -> Some b | `Left a -> Some a | `Right b -> Some b )
+
+  let iter t ~f = Hash.Map.iteri t ~f:(fun ~key ~data -> f { data; hash = key })
+
+  (* Ignoring values, comparing just on keys *)
+  let equal a b = Hash.Map.equal (fun _ _ -> true) a b
+
+  let of_list = List.fold ~init:empty ~f:add
+
+  let length = Hash.Map.length
+
+  let singleton { data; hash } = Hash.Map.singleton hash data
+
+  let remove t { hash; _ } = Hash.Map.remove t hash
+
+  let min_elt_exn t =
+    let hash, data = Hash.Map.min_elt_exn t in
+    { data; hash }
+
+  let to_sequence t =
+    Hash.Map.to_sequence t
+    |> Sequence.map ~f:(fun (hash, data) -> { data; hash })
+end

--- a/src/lib/with_hash/with_hash.mli
+++ b/src/lib/with_hash/with_hash.mli
@@ -24,5 +24,8 @@ val of_data : 'a -> hash_data:('a -> 'b) -> ('a, 'b) t
 
 (** Set for [('a, 'h) t] that assumes the hash ['h] is cryptographically sound, and data is ignored
 *)
-module Set (Hash : Comparable.S) :
-  Mina_stdlib.Generic_set.S1 with type 'a el := ('a, Hash.t) t
+module Set (Hash : Comparable.S) : sig
+  include Mina_stdlib.Generic_set.S1 with type 'a el := ('a, Hash.t) t
+
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
+end

--- a/src/lib/with_hash/with_hash.mli
+++ b/src/lib/with_hash/with_hash.mli
@@ -1,0 +1,28 @@
+open Core_kernel
+
+[%%versioned:
+module Stable : sig
+  [@@@no_toplevel_latest_type]
+
+  module V1 : sig
+    type ('a, 'h) t = ('a, 'h) Mina_wire_types.With_hash.V1.t =
+      { data : 'a; hash : 'h }
+    [@@deriving annot, sexp, equal, compare, hash, yojson, fields]
+
+    val to_latest : ('a -> 'b) -> ('c -> 'd) -> ('a, 'c) t -> ('b, 'd) t
+  end
+end]
+
+type ('a, 'h) t = ('a, 'h) Stable.Latest.t = { data : 'a; hash : 'h }
+[@@deriving annot, compare, equal, fields, hash, sexp, yojson]
+
+val map : ('a, 'b) t -> f:('a -> 'c) -> ('c, 'b) t
+
+val map_hash : ('a, 'b) t -> f:('b -> 'c) -> ('a, 'c) t
+
+val of_data : 'a -> hash_data:('a -> 'b) -> ('a, 'b) t
+
+(** Set for [('a, 'h) t] that assumes the hash ['h] is cryptographically sound, and data is ignored
+*)
+module Set (Hash : Comparable.S) :
+  Mina_stdlib.Generic_set.S1 with type 'a el := ('a, Hash.t) t


### PR DESCRIPTION
A new module With_hash.Set provides a set that uses `(_, _) With_hash.t`
as elements, using hash for operating the set (and ignoring the value).

A new module is added to Mina_stdlib.
The module provides an interface for general-purpose set (which may
not necessary be implemented via Comparable's Make).

Explain how you tested your changes:

* Only some new code is added in this PR, it'll be used in follow-up PRs
* The new code is a trivial re-package of Map interface, so tests are not necessary, provided a review is performed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
