### PR TITLE
Don't use with_return in get_status

### DIFF
--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -30,36 +30,35 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
   | None ->
       State.Unknown
   | Some transition_frontier ->
-      with_return (fun { return } ->
-          let best_tip_path =
-            Transition_frontier.best_tip_path transition_frontier
-          in
-          let in_breadcrumb breadcrumb =
-            breadcrumb |> Transition_frontier.Breadcrumb.validated_transition
-            |> Mina_block.Validated.valid_commands
-            |> List.exists ~f:(fun { data = cmd'; _ } ->
-                   User_command.equal cmd (User_command.forget_check cmd') )
-          in
-          if List.exists ~f:in_breadcrumb best_tip_path then
-            return State.Included ;
-          if
-            List.exists ~f:in_breadcrumb
-              (Transition_frontier.all_breadcrumbs transition_frontier)
-          then return State.Pending ;
-          (*This is to look for commands in the pool which are valid.
-             Membership check requires only the user command and no other
-             aspect of User_command.Valid.t and so no need to check signatures
-             or extract zkApp verification keys.*)
-          let (`If_this_is_used_it_should_have_a_comment_justifying_it
-                checked_cmd ) =
-            User_command.to_valid_unsafe cmd
-          in
-          if
-            Transaction_pool.Resource_pool.member resource_pool
-              (Transaction_hash.User_command_with_valid_signature.create
-                 checked_cmd )
-          then return State.Pending ;
-          State.Unknown )
+      let best_tip_path =
+        Transition_frontier.best_tip_path transition_frontier
+      in
+      let in_breadcrumb breadcrumb =
+        breadcrumb |> Transition_frontier.Breadcrumb.validated_transition
+        |> Mina_block.Validated.valid_commands
+        |> List.exists ~f:(fun { data = cmd'; _ } ->
+               User_command.equal cmd (User_command.forget_check cmd') )
+      in
+      if List.exists ~f:in_breadcrumb best_tip_path then State.Included
+      else if
+        List.exists ~f:in_breadcrumb
+          (Transition_frontier.all_breadcrumbs transition_frontier)
+      then State.Pending
+      else
+        (*This is to look for commands in the pool which are valid.
+           Membership check requires only the user command and no other
+           aspect of User_command.Valid.t and so no need to check signatures
+           or extract zkApp verification keys.*)
+        let (`If_this_is_used_it_should_have_a_comment_justifying_it checked_cmd)
+            =
+          User_command.to_valid_unsafe cmd
+        in
+        if
+          Transaction_pool.Resource_pool.member resource_pool
+            (Transaction_hash.User_command_with_valid_signature.create
+               checked_cmd )
+        then State.Pending
+        else State.Unknown
 
 let%test_module "transaction_status" =
   ( module struct


### PR DESCRIPTION
A small refactoring. Use of `with_return` is not justified, and a classical functional matching fits better.

Explain how you tested your changes:
* A trivial refactoring.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
