### PR TITLE
Introduce polymorphic type for Mina_base.Control

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -376,7 +376,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 | Proof _ ->
                     { other_p with
                       authorization =
-                        Control.Proof
+                        Control.Poly.Proof
                           (Lazy.force Mina_base.Proof.blockchain_dummy)
                     }
                 | _ ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -117,7 +117,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           in
           { account_update with
             authorization =
-              Control.Signature
+              Control.Poly.Signature
                 (Schnorr.Chunked.sign sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -121,7 +121,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           in
           { account_update with
             authorization =
-              Control.Signature
+              Control.Poly.Signature
                 (Schnorr.Chunked.sign sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -125,7 +125,8 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -148,14 +149,16 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -181,7 +184,8 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -189,14 +193,16 @@ let%test_module "Tokens test" =
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -210,7 +216,8 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -234,7 +241,8 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 5)
@@ -245,7 +253,7 @@ let%test_module "Tokens test" =
                (* Delegate call, should be checked. *)
                |> Zkapp_command.Call_forest.cons
                     { Account_update.authorization =
-                        Control.Signature Signature.dummy
+                        Control.Poly.Signature Signature.dummy
                     ; body =
                         Zkapps_examples.mk_update_body (fst mint_to_keys)
                           ~use_full_commitment:true
@@ -258,7 +266,7 @@ let%test_module "Tokens test" =
                       (* Delegate call, should be checked. *)
                       |> Zkapp_command.Call_forest.cons
                            { Account_update.authorization =
-                               Control.Signature Signature.dummy
+                               Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
                                  ~use_full_commitment:true
@@ -269,7 +277,7 @@ let%test_module "Tokens test" =
                       (* Parents_own_token, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
                            { Account_update.authorization =
-                               Control.Signature Signature.dummy
+                               Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
                                  ~use_full_commitment:true
@@ -279,7 +287,7 @@ let%test_module "Tokens test" =
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
                            { Account_update.authorization =
-                               Control.Signature Signature.dummy
+                               Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
                                  ~use_full_commitment:true
@@ -289,7 +297,7 @@ let%test_module "Tokens test" =
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
                            { Account_update.authorization =
-                               Control.Signature Signature.dummy
+                               Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
                                  ~use_full_commitment:true
@@ -318,14 +326,16 @@ let%test_module "Tokens test" =
                )
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 15)
                    ~may_use_token:Inherit_from_parent
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -339,7 +349,8 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -362,7 +373,8 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -370,14 +382,16 @@ let%test_module "Tokens test" =
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~may_use_token:Inherit_from_parent
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
@@ -391,14 +405,15 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization = Control.Signature Signature.dummy
+             { Account_update.authorization =
+                 Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
              }
         |> Zkapp_command.Call_forest.cons ~calls:subtree
-             { Account_update.authorization = Control.None_given
+             { Account_update.authorization = Control.Poly.None_given
              ; body =
                  Zkapps_examples.mk_update_body pk
                    ~authorization_kind:None_given

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -135,7 +135,7 @@ module Rules = struct
                      to be able to reconstruct the command outside the circuit
                      when it has finished.
                   *)
-                  Prover_value.create (fun () -> Control.None_given)
+                  Prover_value.create (fun () -> Control.Poly.None_given)
               }
             , calls )
           in
@@ -328,7 +328,7 @@ module Rules = struct
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
             { Account_update.body = dummy_account_update_body.data
-            ; authorization = Control.None_given
+            ; authorization = Control.Poly.None_given
             }
         ; account_update_digest = dummy_account_update_body.hash
         ; calls = []

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1757,7 +1757,7 @@ module Fee_payer = struct
     Account_id.create t.body.public_key Token_id.default
 
   let to_account_update (t : t) : T.t =
-    { authorization = Control.Signature t.authorization
+    { authorization = Control.Poly.Signature t.authorization
     ; body = Body.of_fee_payer t.body
     }
 

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -14,7 +14,7 @@ type account_update =
 
 type transaction = < updates : (account_update list, nonces) Monad_lib.State.t >
 
-let dummy_auth = Control.Signature Signature.dummy
+let dummy_auth = Control.Poly.Signature Signature.dummy
 
 let get_nonce_exn (pk : Public_key.Compressed.t) :
     ( Account_nonce.t

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -247,7 +247,7 @@ let all_account_updates (t : t) : _ Call_forest.t =
   let body = Account_update.Body.of_fee_payer p.body in
   let fee_payer : Account_update.t =
     let p = t.fee_payer in
-    { authorization = Control.Signature p.authorization; body }
+    { authorization = Control.Poly.Signature p.authorization; body }
   in
   Call_forest.cons fee_payer t.account_updates
 
@@ -1265,12 +1265,11 @@ module Update_group = Make_update_group (struct
 
   let zkapp_segment_of_controls controls : spec =
     match controls with
-    | [ Control.Proof _ ] ->
+    | [ Control.Poly.Proof _ ] ->
         Proved
-    | [ (Control.Signature _ | Control.None_given) ] ->
+    | [ (Signature _ | None_given) ] ->
         Signed_single
-    | [ Control.(Signature _ | None_given); Control.(Signature _ | None_given) ]
-      ->
+    | [ (Signature _ | None_given); (Signature _ | None_given) ] ->
         Signed_pair
     | _ ->
         failwith "zkapp_segment_of_controls: Unsupported combination"

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1336,7 +1336,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
         in
         let%bind account_update0 =
           (* Signature authorization to start *)
-          let authorization = Control.Signature Signature.dummy in
+          let authorization = Control.Poly.Signature Signature.dummy in
           gen_account_update_from ~no_account_precondition ?balance_change_range
             ?global_slot ~zkapp_account_ids ~account_ids_seen ~update ?failure
             ~authorization ~new_account ~permissions_auth ~zkapp_account
@@ -1468,7 +1468,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   *)
   let balance_change = Currency.Amount.Signed.negate balance_change_sum in
   let%bind balancing_account_update =
-    let authorization = Control.Signature Signature.dummy in
+    let authorization = Control.Poly.Signature Signature.dummy in
     gen_account_update_from ~no_account_precondition ?balance_change_range
       ?global_slot ?failure ~permissions_auth:Control.Tag.Signature
       ~zkapp_account_ids ~account_ids_seen ~authorization ~new_account:false
@@ -1477,7 +1477,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
       ~ignore_sequence_events_precond ()
   in
   let gen_zkapp_command_with_token_accounts ~num_zkapp_command =
-    let authorization = Control.Signature Signature.dummy in
+    let authorization = Control.Poly.Signature Signature.dummy in
     let permissions_auth = Control.Tag.Signature in
     let rec gen_tree acc n =
       if n <= 0 then return (List.rev acc)
@@ -1568,7 +1568,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   List.iteri account_updates ~f:(fun ndx account_update ->
       (* update receipt chain hash only for signature, proof authorizations *)
       match Account_update.authorization account_update with
-      | Control.Proof _ | Control.Signature _ ->
+      | Control.Poly.Proof _ | Control.Poly.Signature _ ->
           let acct_id = Account_update.account_id account_update in
           Account_id.Table.update account_state_tbl acct_id ~f:(function
             | None ->
@@ -1584,7 +1584,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
                     account.Account.receipt_chain_hash
                 in
                 ({ account with receipt_chain_hash }, role) )
-      | Control.None_given ->
+      | Control.Poly.None_given ->
           () ) ;
   zkapp_command_dummy_authorizations
 

--- a/src/lib/mina_wire_types/mina_base/mina_base_control.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_control.ml
@@ -1,6 +1,12 @@
+module Poly = struct
+  module V1 = struct
+    type ('proof, 'signature) t =
+      | Proof of 'proof
+      | Signature of 'signature
+      | None_given
+  end
+end
+
 module V2 = struct
-  type t =
-    | Proof of Pickles.Side_loaded.Proof.V2.t
-    | Signature of Mina_base_signature.V1.t
-    | None_given
+  type t = (Pickles.Side_loaded.Proof.V2.t, Mina_base_signature.V1.t) Poly.V1.t
 end

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -83,12 +83,12 @@ let ( hash_signed_command_v1
             ~f:(fun (acct_update : Account_update.t) ->
               let dummy_auth =
                 match acct_update.authorization with
-                | Control.Proof _ ->
-                    Control.Proof (Lazy.force Proof.transaction_dummy)
-                | Control.Signature _ ->
-                    Control.Signature Signature.dummy
-                | Control.None_given ->
-                    Control.None_given
+                | Control.Poly.Proof _ ->
+                    Control.Poly.Proof (Lazy.force Proof.transaction_dummy)
+                | Control.Poly.Signature _ ->
+                    Control.Poly.Signature Signature.dummy
+                | Control.Poly.None_given ->
+                    Control.Poly.None_given
               in
               { acct_update with authorization = dummy_auth } )
       }

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2527,7 +2527,7 @@ module For_tests = struct
           match account_update.body.authorization_kind with
           | Signature ->
               { account_update with
-                authorization = Control.Signature account_updates_signature
+                authorization = Control.Poly.Signature account_updates_signature
               }
           | _ ->
               account_update )

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -159,7 +159,7 @@ let%test_module "Access permission tests" =
                 in
                 { account_update with
                   authorization =
-                    Control.Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -312,7 +312,7 @@ let%test_module "Protocol state precondition tests" =
                         ; authorization_kind = Signature
                         }
                         (*To be updated later*)
-                    ; authorization = Control.Signature Signature.dummy
+                    ; authorization = Control.Poly.Signature Signature.dummy
                     }
                   in
                   let snapp_account_update : Account_update.Simple.t =
@@ -345,7 +345,7 @@ let%test_module "Protocol state precondition tests" =
                         ; authorization_kind = Signature
                         }
                     ; authorization =
-                        Control.Signature Signature.dummy
+                        Control.Poly.Signature Signature.dummy
                         (*To be updated later*)
                     }
                   in
@@ -383,7 +383,7 @@ let%test_module "Protocol state precondition tests" =
                         (Random_oracle.Input.Chunked.field commitment)
                     in
                     { sender_account_update with
-                      authorization = Control.Signature signature_auth
+                      authorization = Control.Poly.Signature signature_auth
                     }
                   in
                   let snapp_account_update =
@@ -392,7 +392,7 @@ let%test_module "Protocol state precondition tests" =
                         (Random_oracle.Input.Chunked.field full_commitment)
                     in
                     { snapp_account_update with
-                      authorization = Control.Signature signature_auth
+                      authorization = Control.Poly.Signature signature_auth
                     }
                   in
                   let zkapp_command_with_valid_fee_payer =
@@ -908,7 +908,7 @@ let%test_module "Account precondition tests" =
                     ; authorization_kind = Signature
                     }
                     (*To be updated later*)
-                ; authorization = Control.Signature Signature.dummy
+                ; authorization = Control.Poly.Signature Signature.dummy
                 }
               in
               let snapp_account_update : Account_update.Simple.t =
@@ -939,7 +939,8 @@ let%test_module "Account precondition tests" =
                     ; authorization_kind = Signature
                     }
                 ; authorization =
-                    Control.Signature Signature.dummy (*To be updated later*)
+                    Control.Poly.Signature Signature.dummy
+                    (*To be updated later*)
                 }
               in
               let ps =
@@ -974,7 +975,7 @@ let%test_module "Account precondition tests" =
                     (Random_oracle.Input.Chunked.field commitment)
                 in
                 { sender_account_update with
-                  authorization = Control.Signature signature_auth
+                  authorization = Control.Poly.Signature signature_auth
                 }
               in
               let snapp_account_update =
@@ -983,7 +984,7 @@ let%test_module "Account precondition tests" =
                     (Random_oracle.Input.Chunked.field full_commitment)
                 in
                 { snapp_account_update with
-                  authorization = Control.Signature signature_auth
+                  authorization = Control.Poly.Signature signature_auth
                 }
               in
               let zkapp_command_with_invalid_fee_payer =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -140,7 +140,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             Opt_signed
         | [ Control.Poly.(Signature _ | None_given)
           ; Control.Poly.(Signature _ | None_given)
-          ; Control.Poly.(Signature _ | None_given)
           ] ->
             Opt_signed_opt_signed
         | _ ->

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -134,12 +134,13 @@ module Make_str (A : Wire_types.Concrete) = struct
       end]
 
       let of_controls = function
-        | [ Control.Proof _ ] ->
+        | [ Control.Poly.Proof _ ] ->
             Proved
-        | [ (Control.Signature _ | Control.None_given) ] ->
+        | [ (Control.Poly.Signature _ | Control.Poly.None_given) ] ->
             Opt_signed
-        | [ Control.(Signature _ | None_given)
-          ; Control.(Signature _ | None_given)
+        | [ Control.Poly.(Signature _ | None_given)
+          ; Control.Poly.(Signature _ | None_given)
+          ; Control.Poly.(Signature _ | None_given)
           ] ->
             Opt_signed_opt_signed
         | _ ->
@@ -4340,7 +4341,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ((not (List.is_empty receivers)) || new_zkapp_account || empty_sender)
           ( { body = sender_account_update_body
             ; authorization =
-                Control.Signature Signature.dummy (*To be updated later*)
+                Control.Poly.Signature Signature.dummy (*To be updated later*)
             }
             : Account_update.Simple.t )
       in
@@ -4404,7 +4405,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; authorization_kind
                   }
               ; authorization =
-                  Control.Signature Signature.dummy (*To be updated later*)
+                  Control.Poly.Signature Signature.dummy (*To be updated later*)
               }
               : Account_update.Simple.t ) )
       in
@@ -4420,7 +4421,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             let receiver_auth, authorization_kind, use_full_commitment =
               match receiver_auth with
               | Some Control.Tag.Signature ->
-                  ( Control.Signature Signature.dummy
+                  ( Control.Poly.Signature Signature.dummy
                   , Account_update.Authorization_kind.Signature
                   , true )
               | Some Proof ->
@@ -4428,7 +4429,9 @@ module Make_str (A : Wire_types.Concrete) = struct
                     "Not implemented. Pickles_types.Nat.N2.n \
                      Pickles_types.Nat.N2.n ~domain_log2:15)"
               | Some None_given | None ->
-                  (None_given, None_given, false)
+                  ( Control.Poly.None_given
+                  , Account_update.Authorization_kind.None_given
+                  , false )
             in
             { body =
                 { public_key = receiver
@@ -4497,7 +4500,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let other_receivers =
         List.map2_exn other_receivers receivers ~f:(fun s (receiver, _amt) ->
             match s.authorization with
-            | Control.Signature _ ->
+            | Control.Poly.Signature _ ->
                 let commitment =
                   if s.body.use_full_commitment then full_commitment
                   else commitment
@@ -4518,9 +4521,9 @@ module Make_str (A : Wire_types.Concrete) = struct
                 { Account_update.Simple.body = s.body
                 ; authorization = Signature receiver_signature_auth
                 }
-            | Control.Proof _ ->
+            | Control.Poly.Proof _ ->
                 failwith ""
-            | Control.None_given ->
+            | Control.Poly.None_given ->
                 s )
       in
       ( `Zkapp_command
@@ -4623,7 +4626,9 @@ module Make_str (A : Wire_types.Concrete) = struct
         List.map snapp_zkapp_command_keypairs
           ~f:(fun (snapp_account_update, keypair) ->
             if no_auth then
-              ( { body = snapp_account_update.body; authorization = None_given }
+              ( { body = snapp_account_update.body
+                ; authorization = Control.Poly.None_given
+                }
                 : Account_update.Simple.t )
             else
               let commitment =
@@ -4741,7 +4746,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               ; authorization_kind = Proof (With_hash.hash vk)
               }
           ; authorization =
-              Control.Proof (Lazy.force Mina_base.Proof.blockchain_dummy)
+              Control.Poly.Proof (Lazy.force Mina_base.Proof.blockchain_dummy)
           }
       in
       let account_update_digest_with_selected_chain =
@@ -4842,7 +4847,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; authorization_kind =
             ( match current_auth with
             | None ->
-                None_given
+                Account_update.Authorization_kind.None_given
             | Signature ->
                 Signature
             | Proof ->
@@ -4926,7 +4931,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             | None ->
                 Async.Deferred.return
                   ( { body = simple_snapp_account_update.body
-                    ; authorization = None_given
+                    ; authorization = Control.Poly.None_given
                     }
                     : Account_update.Simple.t )
             | _ ->

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -120,7 +120,7 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
            else tx_commitment
          in
          match (p.authorization, p.body.authorization_kind) with
-         | Control.Signature s, Signature ->
+         | Control.Poly.Signature s, Signature ->
              check_signature s p.body.public_key commitment
          | None_given, None_given | Proof _, Proof _ ->
              Ok ()

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -68,11 +68,12 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
              let authorization =
                match p.authorization_kind with
                | None_given ->
-                   Control.None_given
+                   Control.Poly.None_given
                | Proof _ ->
-                   Control.Proof (Lazy.force Mina_base.Proof.blockchain_dummy)
+                   Control.Poly.Proof
+                     (Lazy.force Mina_base.Proof.blockchain_dummy)
                | Signature ->
-                   Control.Signature Signature.dummy
+                   Control.Poly.Signature Signature.dummy
              in
              { body = Account_update.Body.of_simple p; authorization } )
       |> Zkapp_command.Call_forest.accumulate_hashes_predicated
@@ -109,7 +110,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
       ~f:(fun _ndx ({ body; authorization } : Account_update.t) tree ->
         let%map valid_authorization =
           match authorization with
-          | Control.Signature _dummy ->
+          | Control.Poly.Signature _dummy ->
               let pk = body.public_key in
               let sk =
                 match
@@ -125,7 +126,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
               in
               let use_full_commitment = body.use_full_commitment in
               let signature = sign_for_account_update ~use_full_commitment sk in
-              return (Control.Signature signature)
+              return (Control.Poly.Signature signature)
           | Proof _proof -> (
               match prover with
               | None ->
@@ -139,7 +140,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
                   let%map (), (), proof =
                     prover ?handler:(Some handler) txn_stmt
                   in
-                  Control.Proof proof )
+                  Control.Poly.Proof proof )
           | None_given ->
               return authorization
         in


### PR DESCRIPTION
Introduce `Mina_base.Control.Poly` type.

Thijs will later allow us to have one control type that stores the proof, and another one that stores disk cache tag refering to the proof.

Explain how you tested your changes:
* A refactoring, no behavior changes.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
