### PR TITLE
Polymorphize Account_update

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -404,7 +404,8 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                           Mina_base.Control.(
                             Tag.equal Proof
                               (tag
-                                 (Mina_base.Account_update.authorization party) ))
+                                 (Mina_base.Account_update.Poly.authorization
+                                    party ) ))
                         then proof_parties_count + 1
                         else proof_parties_count ) )
                 in

--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -47,8 +47,8 @@ let zkapp_proof ~zkapp_command =
     (Mina_base.Zkapp_command.all_account_updates_list zkapp_command)
     ~init:None
     ~f:(fun _acc a ->
-      match a.Mina_base.Account_update.authorization with
-      | Proof proof ->
+      match a.Mina_base.Account_update.Poly.authorization with
+      | Mina_base.Control.Poly.Proof proof ->
           Stop (Some proof)
       | _ ->
           Continue None )

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -260,7 +260,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 in
                 { account_update with
                   authorization =
-                    Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign account_a_kp.private_key
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -372,8 +372,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         { p with
           account_updates =
             Call_forest.map p.account_updates ~f:(fun other_p ->
-                match other_p.Account_update.authorization with
-                | Proof _ ->
+                match other_p.Account_update.Poly.authorization with
+                | Control.Poly.Proof _ ->
                     { other_p with
                       authorization =
                         Control.Poly.Proof

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -150,7 +150,7 @@ let%test_module "Actions test" =
                 in
                 { account_update with
                   authorization =
-                    Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -148,7 +148,7 @@ let%test_module "Add events test" =
                 in
                 { account_update with
                   authorization =
-                    Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -266,7 +266,7 @@ let%test_module "Composability test" =
                 in
                 { account_update with
                   authorization =
-                    Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -157,7 +157,7 @@ let%test_module "Initialize state test" =
                 in
                 { account_update with
                   authorization =
-                    Signature
+                    Control.Poly.Signature
                       (Schnorr.Chunked.sign sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -125,7 +125,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -149,7 +149,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -157,7 +157,7 @@ let%test_module "Tokens test" =
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -184,7 +184,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -193,7 +193,7 @@ let%test_module "Tokens test" =
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -201,7 +201,7 @@ let%test_module "Tokens test" =
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -216,7 +216,7 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -241,7 +241,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -252,7 +252,7 @@ let%test_module "Tokens test" =
                ( []
                (* Delegate call, should be checked. *)
                |> Zkapp_command.Call_forest.cons
-                    { Account_update.authorization =
+                    { Account_update.Poly.authorization =
                         Control.Poly.Signature Signature.dummy
                     ; body =
                         Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -265,7 +265,7 @@ let%test_module "Tokens test" =
                       ( []
                       (* Delegate call, should be checked. *)
                       |> Zkapp_command.Call_forest.cons
-                           { Account_update.authorization =
+                           { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -276,7 +276,7 @@ let%test_module "Tokens test" =
                            }
                       (* Parents_own_token, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
-                           { Account_update.authorization =
+                           { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -286,7 +286,7 @@ let%test_module "Tokens test" =
                            }
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
-                           { Account_update.authorization =
+                           { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -296,7 +296,7 @@ let%test_module "Tokens test" =
                            }
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
-                           { Account_update.authorization =
+                           { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
                                Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -326,7 +326,7 @@ let%test_module "Tokens test" =
                )
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -334,7 +334,7 @@ let%test_module "Tokens test" =
                    ~may_use_token:Inherit_from_parent
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -349,7 +349,7 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -373,7 +373,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -382,7 +382,7 @@ let%test_module "Tokens test" =
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -390,7 +390,7 @@ let%test_module "Tokens test" =
                    ~may_use_token:Inherit_from_parent
              }
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -405,7 +405,7 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons
-             { Account_update.authorization =
+             { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
@@ -413,7 +413,7 @@ let%test_module "Tokens test" =
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
              }
         |> Zkapp_command.Call_forest.cons ~calls:subtree
-             { Account_update.authorization = Control.Poly.None_given
+             { Account_update.Poly.authorization = Control.Poly.None_given
              ; body =
                  Zkapps_examples.mk_update_body pk
                    ~authorization_kind:None_given

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -327,7 +327,7 @@ module Rules = struct
       let dummy_account_update_body = Lazy.force dummy_account_update_body in
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
-            { Account_update.body = dummy_account_update_body.data
+            { Account_update.Poly.body = dummy_account_update_body.data
             ; authorization = Control.Poly.None_given
             }
         ; account_update_digest = dummy_account_update_body.hash

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -827,7 +827,7 @@ let insert_signatures pk_compressed sk
           in
           { account_update with
             authorization =
-              Signature
+              Control.Poly.Signature
                 (Schnorr.Chunked.sign sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -109,11 +109,13 @@ module Simple_txn = struct
             Amount.Signed.(of_unsigned amount)
         in
         [ update
-            Account_update.
-              { body = sender_decrease_body; authorization = dummy_auth }
+            { Account_update.Poly.body = sender_decrease_body
+            ; authorization = dummy_auth
+            }
         ; update
-            Account_update.
-              { body = receiver_increase_body; authorization = dummy_auth }
+            { Account_update.Poly.body = receiver_increase_body
+            ; authorization = dummy_auth
+            }
         ]
     end
 
@@ -170,9 +172,8 @@ module Single = struct
 
       method updates =
         let open Monad_lib.State.Let_syntax in
-        let open Account_update in
         let%map body = update_body ?preconditions ~account amount in
-        [ update { body; authorization = dummy_auth } ]
+        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
     end
 end
 
@@ -187,11 +188,10 @@ module Alter_account = struct
 
       method updates =
         let open Monad_lib.State.Let_syntax in
-        let open Account_update in
         let%map body =
           update_body ?preconditions ~update:state_update ~account amount
         in
-        [ update { body; authorization = dummy_auth } ]
+        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
     end
 end
 
@@ -209,13 +209,13 @@ module Txn_tree = struct
 
       method updates =
         let open Monad_lib.State.Let_syntax in
-        let open Account_update in
         let module State_ext = Monad_lib.Make_ext2 (Monad_lib.State) in
         let%bind body = update_body ~update:state_update ~account amount in
         let%map calls =
           State_ext.concat_map_m children ~f:(fun c -> c#updates)
         in
-        [ update ~calls { body; authorization = dummy_auth } ]
+        [ update ~calls { Account_update.Poly.body; authorization = dummy_auth }
+        ]
     end
 end
 

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -50,9 +50,11 @@ module Checked = struct
         * Zkapp_command.Digest.Account_update.typ)
       |> Typ.transport
            ~back:(fun ((body, authorization), hash) ->
-             { With_hash.data = { Account_update.body; authorization }; hash }
-             )
-           ~there:(fun { With_hash.data = { Account_update.body; authorization }
+             { With_hash.data = { Account_update.Poly.body; authorization }
+             ; hash
+             } )
+           ~there:(fun { With_hash.data =
+                           { Account_update.Poly.body; authorization }
                        ; hash
                        } -> ((body, authorization), hash) )
       |> Typ.transport_var

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -220,10 +220,11 @@ let to_simple (t : t) : Simple.t =
   ; account_updates =
       t.account_updates
       |> Call_forest.to_account_updates_map
-           ~f:(fun ~depth { Account_update.body = b; authorization } ->
-             { Account_update.Simple.authorization
+           ~f:(fun ~depth { Account_update.Poly.body = b; authorization } ->
+             { Account_update.Poly.authorization
              ; body =
-                 { public_key = b.public_key
+                 { Account_update.Body.Simple.public_key =
+                     b.Account_update.Body.public_key
                  ; token_id = b.token_id
                  ; update = b.update
                  ; balance_change = b.balance_change

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1062,7 +1062,7 @@ let gen_account_update_from ?(no_account_precondition = false)
   in
   let account_id = Account_id.create body.public_key body.token_id in
   Hash_set.add account_ids_seen account_id ;
-  return { Account_update.Simple.body; authorization }
+  return { Account_update.Poly.body; authorization }
 
 (* takes an account id, if we want to sign this data *)
 let gen_account_update_body_fee_payer ?global_slot ?fee_range ?failure
@@ -1567,7 +1567,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
   in
   List.iteri account_updates ~f:(fun ndx account_update ->
       (* update receipt chain hash only for signature, proof authorizations *)
-      match Account_update.authorization account_update with
+      match account_update.Account_update.Poly.authorization with
       | Control.Poly.Proof _ | Control.Poly.Signature _ ->
           let acct_id = Account_update.account_id account_update in
           Account_id.Table.update account_state_tbl acct_id ~f:(function

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -108,6 +108,13 @@ module Fee_payer = struct
   end
 end
 
+module Poly = struct
+  module V1 = struct
+    type ('body, 'authorization) t =
+      { body : 'body; authorization : 'authorization }
+  end
+end
+
 module V1 = struct
-  type t = { body : Body.V1.t; authorization : Mina_base_control.V2.t }
+  type t = (Body.V1.t, Mina_base_control.V2.t) Poly.V1.t
 end

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -437,7 +437,7 @@ module Update = struct
                   , if
                       Control.(
                         Tag.equal Proof
-                          (tag (Account_update.authorization account_update)))
+                          (tag account_update.Account_update.Poly.authorization))
                     then proof_updates_count + 1
                     else proof_updates_count ) )
             in

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -518,8 +518,8 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
     ; account_updates =
         Zkapp_command.Call_forest.of_account_updates
           ~account_update_depth:(Fn.const 0)
-          [ { Account_update.body =
-                { public_key = sender_pk
+          [ { Account_update.Poly.body =
+                { Account_update.Body.public_key = sender_pk
                 ; update = Account_update.Update.noop
                 ; token_id = Token_id.default
                 ; balance_change = Amount.Signed.(negate @@ of_unsigned amount)
@@ -538,11 +538,12 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
                 ; may_use_token = No
                 ; use_full_commitment = not double_increment_sender
                 ; implicit_account_creation_fee = false
-                ; authorization_kind = None_given
+                ; authorization_kind =
+                    Account_update.Authorization_kind.None_given
                 }
-            ; authorization = None_given
+            ; authorization = Control.Poly.None_given
             }
-          ; { Account_update.body =
+          ; { Account_update.Poly.body =
                 { public_key = receiver_pk
                 ; update = Account_update.Update.noop
                 ; token_id = Token_id.default

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -191,8 +191,9 @@ module Make (Inputs : Intf.Inputs_intf) :
                             Mina_base.Control.(
                               Tag.equal Proof
                                 (tag
-                                   (Mina_base.Account_update.authorization
-                                      account_update ) ))
+                                   account_update
+                                     .Mina_base.Account_update.Poly
+                                      .authorization ))
                           then proof_updates_count + 1
                           else proof_updates_count ) )
                   in

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -156,7 +156,11 @@ let check_well_formedness ~genesis_constants (t : t) =
 
 let yojson_summary_of_command =
   let is_proof upd =
-    match Account_update.authorization upd with Proof _ -> true | _ -> false
+    match upd.Account_update.Poly.authorization with
+    | Control.Poly.Proof _ ->
+        true
+    | _ ->
+        false
   in
   let zkapp_type cmd =
     let updates = Zkapp_command.account_updates_list cmd in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4518,8 +4518,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                   Signature_lib.Schnorr.Chunked.sign receiver_kp.private_key
                     (Random_oracle.Input.Chunked.field commitment)
                 in
-                { Account_update.Simple.body = s.body
-                ; authorization = Signature receiver_signature_auth
+                { Account_update.Poly.body = s.body
+                ; authorization = Control.Poly.Signature receiver_signature_auth
                 }
             | Control.Poly.Proof _ ->
                 failwith ""
@@ -4728,8 +4728,8 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let account_update_with_dummy_auth =
         Account_update.
-          { body =
-              { public_key =
+          { Poly.body =
+              { Account_update.Body.public_key =
                   Signature_lib.Public_key.compress
                     spec.zkapp_account_keypair.public_key
               ; update = spec.update
@@ -4743,7 +4743,8 @@ module Make_str (A : Wire_types.Concrete) = struct
               ; use_full_commitment = true
               ; implicit_account_creation_fee = false
               ; may_use_token = No
-              ; authorization_kind = Proof (With_hash.hash vk)
+              ; authorization_kind =
+                  Account_update.Authorization_kind.Proof (With_hash.hash vk)
               }
           ; authorization =
               Control.Poly.Proof (Lazy.force Mina_base.Proof.blockchain_dummy)
@@ -4774,7 +4775,9 @@ module Make_str (A : Wire_types.Concrete) = struct
         in
         { tree_with_dummy_auth with
           account_update =
-            { account_update_with_dummy_auth with authorization = Proof pi }
+            { account_update_with_dummy_auth with
+              authorization = Control.Poly.Proof pi
+            }
         ; account_update_digest = account_update_digest_with_current_chain
         }
       in

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -45,7 +45,7 @@ let check_signed_command c =
         Result.Error (`Invalid_signature (Signed_command.public_keys c))
 
 let collect_vk_assumption
-    ( (p : Account_update.t)
+    ( (p : (Account_update.Body.t, _ Control.Poly.t) Account_update.Poly.t)
     , ( (vk_opt :
           (Side_loaded_verification_key.t, Pasta_bindings.Fp.t) With_hash.t
           option )
@@ -116,7 +116,7 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
   Zkapp_command.Call_forest.to_list zkapp_command.account_updates
   |> List.fold_result ~init:() ~f:(fun () p ->
          let commitment =
-           if p.Account_update.body.use_full_commitment then full_tx_commitment
+           if Account_update.use_full_commitment p then full_tx_commitment
            else tx_commitment
          in
          match (p.authorization, p.body.authorization_kind) with

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -144,7 +144,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
           | None_given ->
               return authorization
         in
-        { Account_update.body; authorization = valid_authorization } )
+        { Account_update.Poly.body; authorization = valid_authorization } )
   in
   { zkapp_command with
     fee_payer = fee_payer_with_valid_signature


### PR DESCRIPTION
Introduce `Mina_base.Account_update.Poly` type.

This will later allow us to have one account update type that stores the proof, and another one that stores disk cache tag refering to the proof.

Explain how you tested your changes:
* A refactoring, no behavior changes.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None

