### PR TITLE
[DON'T MERGE] Pickles Branching Factor 3 Experiment

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -10,19 +10,19 @@ include struct
 
   type _ t +=
     | Prev_state : Protocol_state.Value.t t
-    | Prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t t
+    | Prev_state_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t t
     | Transition : Snark_transition.Value.t t
     | Txn_snark : Transaction_snark.Statement.With_sok.t t
-    | Txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t t
+    | Txn_snark_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t t
 end
 
 module Witness = struct
   type t =
     { prev_state : Protocol_state.Value.t
-    ; prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; prev_state_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
     ; transition : Snark_transition.Value.t
     ; txn_snark : Transaction_snark.Statement.With_sok.t
-    ; txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; txn_snark_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
     }
 end
 
@@ -395,7 +395,7 @@ end
 type tag =
   ( Protocol_state.Value.t Data_as_hash.t
   , Statement.t
-  , Nat.N2.n
+  , Nat.N3.n
   , Nat.N1.n )
   Pickles.Tag.t
 
@@ -431,7 +431,7 @@ let rule ~proof_level ~constraint_constants transaction_snark self :
 module type S = sig
   module Proof :
     Pickles.Proof_intf
-      with type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+      with type t = (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
        and type statement = Protocol_state.Value.t
 
   val tag : tag
@@ -443,7 +443,7 @@ module type S = sig
   val step :
        Witness.t
     -> ( Protocol_state.Value.t * (Transaction_snark.Statement.With_sok.t * unit)
-       , N2.n * (N2.n * unit)
+       , N3.n * (N3.n * unit)
        , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
        , (unit * unit * Proof.t) Async.Deferred.t )
@@ -452,7 +452,7 @@ module type S = sig
   val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
 end
 
-let verify ts ~key = Pickles.verify (module Nat.N2) (module Statement) key ts
+let verify ts ~key = Pickles.verify (module Nat.N3) (module Statement) key ts
 
 let constraint_system_digests ~proof_level ~constraint_constants () =
   let digest = Tick.R1CS_constraint_system.digest in
@@ -484,7 +484,7 @@ end) : S = struct
       ~public_input:(Input Statement.typ)
       ~override_wrap_domain:Pickles_base.Proofs_verified.N1
       ~auxiliary_typ:Typ.unit
-      ~max_proofs_verified:(module Nat.N2)
+      ~max_proofs_verified:(module Nat.N3)
       ~name:"blockchain-snark"
       ~choices:(fun ~self ->
         [ rule ~proof_level ~constraint_constants T.tag self ] )

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -6,17 +6,17 @@ open Pickles_types
 module Witness : sig
   type t =
     { prev_state : Protocol_state.Value.t
-    ; prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; prev_state_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
     ; transition : Snark_transition.Value.t
     ; txn_snark : Transaction_snark.Statement.With_sok.t
-    ; txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; txn_snark_proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
     }
 end
 
 type tag =
   ( Protocol_state.value Data_as_hash.t
   , Protocol_state.value
-  , Nat.N2.n
+  , Nat.N3.n
   , Nat.N1.n )
   Pickles.Tag.t
 
@@ -38,7 +38,7 @@ val check :
 module type S = sig
   module Proof :
     Pickles.Proof_intf
-      with type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+      with type t = (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
        and type statement = Protocol_state.Value.t
 
   val tag : tag
@@ -50,7 +50,7 @@ module type S = sig
   val step :
        Witness.t
     -> ( Protocol_state.Value.t * (Transaction_snark.Statement.With_sok.t * unit)
-       , N2.n * (N2.n * unit)
+       , N3.n * (N3.n * unit)
        , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
        , (unit * unit * Proof.t) Async.Deferred.t )

--- a/src/lib/crypto/plonkish_prelude/at_most.ml
+++ b/src/lib/crypto/plonkish_prelude/at_most.ml
@@ -138,6 +138,37 @@ module At_most_2 = struct
   type 'a ty = 'a t
   end
 
+module At_most_3 = struct
+  [%%versioned_binable
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type 'a t = ('a, Nat.N3.n) at_most
+
+      include
+        Core_kernel.Binable.Of_binable1_without_uuid
+          (Core_kernel.List.Stable.V1)
+          (struct
+            type nonrec 'a t = 'a t
+
+            let to_binable = to_list
+
+            let of_binable xs = of_list_and_length_exn xs Nat.N3.n
+          end)
+
+      include (
+        With_length
+          (Nat.N3) :
+            module type of With_length (Nat.N3) with type 'a t := 'a t )
+      end
+    end]
+
+  type 'a t = 'a Stable.Latest.t [@@deriving sexp, equal, compare, hash, yojson]
+
+  type 'a ty = 'a t
+  end
+
 module At_most_8 = struct
   [%%versioned_binable
   module Stable = struct

--- a/src/lib/crypto/plonkish_prelude/at_most.mli
+++ b/src/lib/crypto/plonkish_prelude/at_most.mli
@@ -45,6 +45,8 @@ end
 
 module At_most_2 : VERSIONED with type 'a ty = ('a, Nat.N2.n) at_most
 
+module At_most_3 : VERSIONED with type 'a ty = ('a, Nat.N3.n) at_most
+
 module At_most_8 : VERSIONED with type 'a ty = ('a, Nat.N8.n) at_most
 
 module With_length (N : Nat.Intf) : S with type 'a t = ('a, N.n) at_most

--- a/src/lib/crypto/plonkish_prelude/vector.ml
+++ b/src/lib/crypto/plonkish_prelude/vector.ml
@@ -551,6 +551,27 @@ module Vector_2 = struct
   let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
+module Vector_3 = struct
+  module T = With_length (Nat.N3)
+
+  [%%versioned_binable
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type 'a t = ('a, Nat.N3.n) vec
+
+      include Make.Binable (Nat.N3)
+
+      include (T : module type of T with type 'a t := 'a t)
+    end
+  end]
+
+  include T
+
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
+end
+
 module Vector_4 = struct
   module T = With_length (Nat.N4)
 

--- a/src/lib/crypto/plonkish_prelude/vector.mli
+++ b/src/lib/crypto/plonkish_prelude/vector.mli
@@ -105,6 +105,9 @@ module Vector_4 : VECTOR with type 'a t = ('a, Nat.N4.n) vec
 (** Vector of size 2 *)
 module Vector_2 : VECTOR with type 'a t = ('a, Nat.N2.n) vec
 
+(** Vector of size 3 *)
+module Vector_3 : VECTOR with type 'a t = ('a, Nat.N3.n) vec
+
 (** Functor to build any vector of size [N]. The parameters of the functor is a
     natural encoded at the type level. For instance, {!Vector_2} could be seen
     as the output of [With_length (Nat.N2)]

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -5,7 +5,7 @@ open Pickles_types
 
 let proof_string prev_width domain_log2 =
   let dummy = Pickles.Proof.dummy Nat.N2.n Nat.N2.n prev_width ~domain_log2 in
-  Binable.to_string (module Pickles.Proof.Proofs_verified_2.Stable.Latest) dummy
+  Binable.to_string (module Pickles.Proof.Proofs_verified_3.Stable.Latest) dummy
 
 let blockchain_proof_string = proof_string Nat.N2.n 16
 
@@ -19,12 +19,12 @@ let str ~loc =
   [%str
     let blockchain_proof () =
       Core_kernel.Binable.of_string
-        (module Pickles.Proof.Proofs_verified_2.Stable.Latest)
+        (module Pickles.Proof.Proofs_verified_3.Stable.Latest)
         [%e estring blockchain_proof_string]
 
     let transaction_proof () =
       Core_kernel.Binable.of_string
-        (module Pickles.Proof.Proofs_verified_2.Stable.Latest)
+        (module Pickles.Proof.Proofs_verified_3.Stable.Latest)
         [%e estring transaction_proof_string]]
 
 let main () =

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -4,7 +4,7 @@ open Async
 open Pickles_types
 
 let proof_string prev_width domain_log2 =
-  let dummy = Pickles.Proof.dummy Nat.N2.n Nat.N2.n prev_width ~domain_log2 in
+  let dummy = Pickles.Proof.dummy Nat.N3.n Nat.N3.n prev_width ~domain_log2 in
   Binable.to_string (module Pickles.Proof.Proofs_verified_3.Stable.Latest) dummy
 
 let blockchain_proof_string = proof_string Nat.N2.n 16

--- a/src/lib/mina_base/control.ml
+++ b/src/lib/mina_base/control.ml
@@ -20,8 +20,8 @@ let gen_with_dummies : t Quickcheck.Generator.t =
     lazy
       (Quickcheck.Generator.of_list
          (let dummy_proof =
-            let n2 = Pickles_types.Nat.N2.n in
-            let proof = Pickles.Proof.dummy n2 n2 n2 ~domain_log2:15 in
+            let n3 = Pickles_types.Nat.N3.n in
+            let proof = Pickles.Proof.dummy n3 n3 n3 ~domain_log2:15 in
             Proof proof
           in
           let dummy_signature = Signature Signature.dummy in
@@ -64,8 +64,8 @@ let tag : t -> Tag.t = function
 
 let dummy_of_tag : Tag.t -> t = function
   | Proof ->
-      let n2 = Pickles_types.Nat.N2.n in
-      let proof = Pickles.Proof.dummy n2 n2 n2 ~domain_log2:15 in
+      let n3 = Pickles_types.Nat.N3.n in
+      let proof = Pickles.Proof.dummy n3 n3 n3 ~domain_log2:15 in
       Proof proof
   | Signature ->
       Signature Signature.dummy

--- a/src/lib/mina_base/proof.ml
+++ b/src/lib/mina_base/proof.ml
@@ -7,12 +7,12 @@ let transaction_dummy = lazy (Dummy_values.transaction_proof ())
 [%%versioned
 module Stable = struct
   module V2 = struct
-    type t = Pickles.Proof.Proofs_verified_2.Stable.V2.t
+    type t = Pickles.Proof.Proofs_verified_3.Stable.V2.t
     [@@deriving sexp, yojson, compare]
 
     let to_latest = Fn.id
 
-    let to_yojson_full = Pickles.Proof.Proofs_verified_2.to_yojson_full
+    let to_yojson_full = Pickles.Proof.Proofs_verified_3.to_yojson_full
   end
 end]
 

--- a/src/lib/mina_base/proof.mli
+++ b/src/lib/mina_base/proof.mli
@@ -1,6 +1,6 @@
 open Pickles_types
 
-type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t [@@deriving sexp, compare, yojson]
+type t = (Nat.N3.n, Nat.N3.n) Pickles.Proof.t [@@deriving sexp, compare, yojson]
 
 val blockchain_dummy : t lazy_t
 

--- a/src/lib/mina_wire_types/mina_base/mina_base_proof.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_proof.ml
@@ -1,3 +1,3 @@
 module V2 = struct
-  type t = Pickles.Proof.Proofs_verified_2.V2.t
+  type t = Pickles.Proof.Proofs_verified_3.V2.t
 end

--- a/src/lib/mina_wire_types/pickles/pickles.ml
+++ b/src/lib/mina_wire_types/pickles/pickles.ml
@@ -123,9 +123,9 @@ module M = struct
 
     type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
 
-    module Proofs_verified_2 = struct
+    module Proofs_verified_3 = struct
       module V2 = struct
-        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+        type nonrec t = (Pickles_types.Nat.three, Pickles_types.Nat.three) t
       end
     end
   end
@@ -171,9 +171,9 @@ module Types = struct
     module Proof : sig
       type ('a, 'b) t
 
-      module Proofs_verified_2 : sig
+      module Proofs_verified_3 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+          type nonrec t = (Pickles_types.Nat.three, Pickles_types.Nat.three) t
         end
       end
     end

--- a/src/lib/mina_wire_types/pickles/pickles.ml
+++ b/src/lib/mina_wire_types/pickles/pickles.ml
@@ -65,7 +65,7 @@ module M = struct
 
   module Proof = struct
     type challenge_constant =
-      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
+      Pickles_types.Nat.three Pickles_limb_vector.Constant.t
 
     type tock_affine = Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
 
@@ -153,7 +153,7 @@ module M = struct
       end
 
       module Max_width = struct
-        type n = Pickles_types.Nat.two
+        type n = Pickles_types.Nat.three
       end
     end
 
@@ -181,7 +181,7 @@ module Types = struct
     module Side_loaded : sig
       module Verification_key : sig
         module Max_width : sig
-          type n = Pickles_types.Nat.two
+          type n = Pickles_types.Nat.three
         end
 
         module V2 : sig

--- a/src/lib/mina_wire_types/pickles/pickles.mli
+++ b/src/lib/mina_wire_types/pickles/pickles.mli
@@ -5,9 +5,9 @@ module Types : sig
     module Proof : sig
       type ('a, 'b) t
 
-      module Proofs_verified_2 : sig
+      module Proofs_verified_3 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+          type nonrec t = (Pickles_types.Nat.three, Pickles_types.Nat.three) t
         end
       end
     end
@@ -172,9 +172,9 @@ module Concrete_ : sig
 
     type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
 
-    module Proofs_verified_2 : sig
+    module Proofs_verified_3 : sig
       module V2 : sig
-        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+        type nonrec t = (Pickles_types.Nat.three, Pickles_types.Nat.three) t
       end
     end
   end

--- a/src/lib/mina_wire_types/pickles/pickles.mli
+++ b/src/lib/mina_wire_types/pickles/pickles.mli
@@ -15,7 +15,7 @@ module Types : sig
     module Side_loaded : sig
       module Verification_key : sig
         module Max_width : sig
-          type n = Pickles_types.Nat.two
+          type n = Pickles_types.Nat.three
         end
 
         module V2 : sig
@@ -118,7 +118,7 @@ module Concrete_ : sig
   module Proof : sig
     (* We define some type aliases directly *)
     type challenge_constant =
-      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
+      Pickles_types.Nat.three Pickles_limb_vector.Constant.t
 
     type tock_affine = Pasta_bindings.Fp.t * Pasta_bindings.Fp.t
 
@@ -202,7 +202,7 @@ module Concrete_ : sig
       end
 
       module Max_width : sig
-        type n = Pickles_types.Nat.two
+        type n = Pickles_types.Nat.three
       end
     end
 

--- a/src/lib/mina_wire_types/pickles/pickles_reduced_messages_for_next_proof_over_same_field.ml
+++ b/src/lib/mina_wire_types/pickles/pickles_reduced_messages_for_next_proof_over_same_field.ml
@@ -11,7 +11,7 @@ end
 module Wrap = struct
   module Challenges_vector = struct
     type challenge_constant =
-      Pickles_types.Nat.two Pickles_limb_vector.Constant.t
+      Pickles_types.Nat.three Pickles_limb_vector.Constant.t
 
     type 'a wrap_bp_vec = ('a, Pickles_types.Nat.fifteen) Pickles_types.Vector.t
 

--- a/src/lib/mina_wire_types/pickles_base.ml
+++ b/src/lib/mina_wire_types/pickles_base.ml
@@ -1,6 +1,6 @@
 module Proofs_verified = struct
   module V1 = struct
-    type t = N0 | N1 | N2
+    type t = N0 | N1 | N2 | N3
   end
 end
 

--- a/src/lib/mina_wire_types/pickles_types.ml
+++ b/src/lib/mina_wire_types/pickles_types.ml
@@ -7,6 +7,8 @@ module Nat = struct
 
   type two = z s s
 
+  type three = z s s s
+
   type four = z s s s s
 
   type five = z s s s s s

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -143,8 +143,8 @@ module Pickles = struct
   include Assert_equal2 (O.Proof) (W.Proof)
   include
     Assert_equal0V2
-      (O.Proof.Proofs_verified_2.Stable)
-      (W.Proof.Proofs_verified_2)
+      (O.Proof.Proofs_verified_3.Stable)
+      (W.Proof.Proofs_verified_3)
 end
 
 module Mina_base = struct

--- a/src/lib/mina_wire_types/transaction_snark.ml
+++ b/src/lib/mina_wire_types/transaction_snark.ml
@@ -9,7 +9,7 @@ end
 module type Concrete = sig
   module Proof : sig
     module V2 : sig
-      type t = Pickles.Proof.Proofs_verified_2.V2.t
+      type t = Pickles.Proof.Proofs_verified_3.V2.t
     end
   end
 
@@ -24,7 +24,7 @@ end
 module M = struct
   module Proof = struct
     module V2 = struct
-      type t = Pickles.Proof.Proofs_verified_2.V2.t
+      type t = Pickles.Proof.Proofs_verified_3.V2.t
     end
   end
 

--- a/src/lib/mina_wire_types/transaction_snark.mli
+++ b/src/lib/mina_wire_types/transaction_snark.mli
@@ -9,7 +9,7 @@ end
 module type Concrete = sig
   module Proof : sig
     module V2 : sig
-      type t = Pickles.Proof.Proofs_verified_2.V2.t
+      type t = Pickles.Proof.Proofs_verified_3.V2.t
     end
   end
 

--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -24,6 +24,7 @@ let tick_shifts, tock_shifts =
   ( mk Kimchi_bindings.Protocol.VerifierIndex.Fp.shifts
   , mk Kimchi_bindings.Protocol.VerifierIndex.Fq.shifts )
 
+(* TODO: fix wrap domains & actual wrap_domain_size *)
 let wrap_domains ~proofs_verified =
   let h =
     match proofs_verified with 0 -> 13 | 1 -> 14 | 2 -> 15 | _ -> assert false

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -97,7 +97,7 @@ module Side_loaded : sig
 
     val of_compiled : _ Tag.t -> t Deferred.t
 
-    module Max_width = Nat.N2
+    module Max_width = Nat.N3
   end
 
   module Proof : sig

--- a/src/lib/pickles/dummy.mli
+++ b/src/lib/pickles/dummy.mli
@@ -4,7 +4,7 @@
 module Ipa : sig
   module Wrap : sig
     val challenges :
-      ( (int64, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+      ( (int64, Pickles_types.Nat.N3.n) Pickles_types.Vector.t
         Import.Scalar_challenge.t
         Composition_types.Bulletproof_challenge.t
       , Pickles_types.Nat.z Backend.Tock.Rounds.plus_n )
@@ -21,7 +21,7 @@ module Ipa : sig
 
   module Step : sig
     val challenges :
-      ( (int64, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+      ( (int64, Pickles_types.Nat.N3.n) Pickles_types.Vector.t
         Import.Scalar_challenge.t
         Composition_types.Bulletproof_challenge.t
       , Pickles_types.Nat.z Backend.Tick.Rounds.plus_n )

--- a/src/lib/pickles/limb_vector/challenge.ml
+++ b/src/lib/pickles/limb_vector/challenge.ml
@@ -1,5 +1,5 @@
 open Pickles_types
-module Constant = Constant.Make (Nat.N2)
+module Constant = Constant.Make (Nat.N3)
 
 module type S = sig
   module Impl : Snarky_backendless.Snark_intf.Run
@@ -25,4 +25,4 @@ end
 
 module Make (Impl : Snarky_backendless.Snark_intf.Run) :
   S with module Impl := Impl =
-  Make.T (Impl) (Nat.N2)
+  Make.T (Impl) (Nat.N3)

--- a/src/lib/pickles/limb_vector/challenge.mli
+++ b/src/lib/pickles/limb_vector/challenge.mli
@@ -1,4 +1,4 @@
-module Constant : module type of Constant.Make (Pickles_types.Nat.N2)
+module Constant : module type of Constant.Make (Pickles_types.Nat.N3)
 
 module type S = sig
   module Impl : Snarky_backendless.Snark_intf.Run

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -2182,7 +2182,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let side_loaded_tag =
           Side_loaded.create ~name:"foo"
-            ~max_proofs_verified:(Nat.Add.create Nat.N2.n)
+            ~max_proofs_verified:(Nat.Add.create Nat.N3.n)
             ~feature_flags:Plonk_types.Features.none ~typ:Field.typ
 
         let _tag, _, p, Provers.[ step ] =
@@ -2493,7 +2493,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let side_loaded_tag =
           Side_loaded.create ~name:"foo"
-            ~max_proofs_verified:(Nat.Add.create Nat.N2.n)
+            ~max_proofs_verified:(Nat.Add.create Nat.N3.n)
             ~feature_flags:maybe_features ~typ:Field.typ
 
         let _tag, _, p, Provers.[ step ] =

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -91,11 +91,11 @@ module type S = sig
       val of_base64 : string -> (t, string) Result.t
     end
 
-    module Proofs_verified_2 : sig
+    module Proofs_verified_3 : sig
       [%%versioned:
       module Stable : sig
         module V2 : sig
-          type t = Make(Nat.N2)(Nat.N2).t
+          type t = Make(Nat.N3)(Nat.N3).t
           [@@deriving sexp, compare, equal, yojson, hash]
 
           val to_yojson_full : t -> Yojson.Safe.t
@@ -334,7 +334,7 @@ module type S = sig
 
       val of_compiled : _ Tag.t -> t Deferred.t
 
-      module Max_width = Nat.N2
+      module Max_width = Nat.N3
     end
 
     module Proof : sig

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -37,9 +37,9 @@ module Base = struct
         type ('messages_for_next_wrap_proof, 'messages_for_next_step_proof) t =
           { statement :
               ( Limb_vector.Constant.Hex64.Stable.V1.t
-                Vector.Vector_2.Stable.V1.t
+                Vector.Vector_3.Stable.V1.t
               , Limb_vector.Constant.Hex64.Stable.V1.t
-                Vector.Vector_2.Stable.V1.t
+                Vector.Vector_3.Stable.V1.t
                 Scalar_challenge.Stable.V2.t
               , Tick.Field.Stable.V1.t Shifted_value.Type1.Stable.V1.t
               , bool
@@ -47,7 +47,7 @@ module Base = struct
               , Digest.Constant.Stable.V1.t
               , 'messages_for_next_step_proof
               , Limb_vector.Constant.Hex64.Stable.V1.t
-                Vector.Vector_2.Stable.V1.t
+                Vector.Vector_3.Stable.V1.t
                 Scalar_challenge.Stable.V2.t
                 Bulletproof_challenge.Stable.V1.t
                 Step_bp_vec.Stable.V1.t
@@ -361,11 +361,11 @@ module Proofs_verified_2 = struct
               .Stable
               .V2
               .t
-              Vector.Vector_2.Stable.V1.t )
+              Vector.Vector_3.Stable.V1.t )
             Types.Wrap.Proof_state.Messages_for_next_wrap_proof.Stable.V1.t
           , ( unit
             , Tock.Curve.Affine.t At_most.At_most_2.Stable.V1.t
-            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_2.Stable.V1.t
+            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_3.Stable.V1.t
               Scalar_challenge.Stable.V2.t
               Bulletproof_challenge.Stable.V1.t
               Step_bp_vec.Stable.V1.t
@@ -432,7 +432,7 @@ module Proofs_verified_max = struct
           , ( unit
             , Tock.Curve.Affine.t
               Side_loaded_verification_key.Width.Max_at_most.Stable.V1.t
-            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_2.Stable.V1.t
+            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_3.Stable.V1.t
               Scalar_challenge.Stable.V2.t
               Bulletproof_challenge.Stable.V1.t
               Step_bp_vec.Stable.V1.t

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -345,8 +345,8 @@ module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
         Error "Invalid json for proof. Expecting base64 encoded string"
 end
 
-module Proofs_verified_2 = struct
-  module T = Make (Nat.N2) (Nat.N2)
+module Proofs_verified_3 = struct
+  module T = Make (Nat.N3) (Nat.N3)
 
   module Repr = struct
     [%%versioned
@@ -361,15 +361,15 @@ module Proofs_verified_2 = struct
               .Stable
               .V2
               .t
-              Vector.Vector_2.Stable.V1.t )
+              Vector.Vector_3.Stable.V1.t )
             Types.Wrap.Proof_state.Messages_for_next_wrap_proof.Stable.V1.t
           , ( unit
-            , Tock.Curve.Affine.t At_most.At_most_2.Stable.V1.t
-            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_2.Stable.V1.t
+            , Tock.Curve.Affine.t At_most.At_most_3.Stable.V1.t
+            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_3.Stable.V1.t
               Scalar_challenge.Stable.V2.t
               Bulletproof_challenge.Stable.V1.t
               Step_bp_vec.Stable.V1.t
-              At_most.At_most_2.Stable.V1.t )
+              At_most.At_most_3.Stable.V1.t )
             Base.Messages_for_next_proof_over_same_field.Step.Stable.V1.t )
           Base.Wrap.Stable.V2.t
         [@@deriving compare, sexp, yojson, hash, equal]

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -134,7 +134,9 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
                             N1
                         | S (S Z) ->
                             N2
-                        | S _ ->
+                        | S (S (S Z)) ->
+                            N3
+                        | _ ->
                             assert false )
                     ; domain_log2 =
                         Branch_data.Domain_log2.of_int_exn domain_log2

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -361,11 +361,11 @@ module Proofs_verified_2 = struct
               .Stable
               .V2
               .t
-              Vector.Vector_3.Stable.V1.t )
+              Vector.Vector_2.Stable.V1.t )
             Types.Wrap.Proof_state.Messages_for_next_wrap_proof.Stable.V1.t
           , ( unit
             , Tock.Curve.Affine.t At_most.At_most_2.Stable.V1.t
-            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_3.Stable.V1.t
+            , Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_2.Stable.V1.t
               Scalar_challenge.Stable.V2.t
               Bulletproof_challenge.Stable.V1.t
               Step_bp_vec.Stable.V1.t

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -34,9 +34,9 @@ module Base : sig
         type ('messages_for_next_wrap_proof, 'messages_for_next_step_proof) t =
           { statement :
               ( Limb_vector.Constant.Hex64.Stable.V1.t
-                Pickles_types.Vector.Vector_2.Stable.V1.t
+                Pickles_types.Vector.Vector_3.Stable.V1.t
               , Limb_vector.Constant.Hex64.Stable.V1.t
-                Pickles_types.Vector.Vector_2.Stable.V1.t
+                Pickles_types.Vector.Vector_3.Stable.V1.t
                 Import.Scalar_challenge.Stable.V2.t
               , Backend.Tick.Field.Stable.V1.t
                 Pickles_types.Shifted_value.Type1.Stable.V1.t
@@ -45,7 +45,7 @@ module Base : sig
               , Import.Digest.Constant.Stable.V1.t
               , 'messages_for_next_step_proof
               , Limb_vector.Constant.Hex64.Stable.V1.t
-                Pickles_types.Vector.Vector_2.Stable.V1.t
+                Pickles_types.Vector.Vector_3.Stable.V1.t
                 Import.Scalar_challenge.Stable.V2.t
                 Import.Bulletproof_challenge.Stable.V1.t
                 Import.Step_bp_vec.Stable.V1.t

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -155,8 +155,8 @@ module Make (W : Pickles_types.Nat.Intf) (MLMB : Pickles_types.Nat.Intf) : sig
   val of_yojson : [> `String of string ] -> (t, string) result
 end
 
-module Proofs_verified_2 : sig
-  module T : module type of Make (Pickles_types.Nat.N2) (Pickles_types.Nat.N2)
+module Proofs_verified_3 : sig
+  module T : module type of Make (Pickles_types.Nat.N3) (Pickles_types.Nat.N3)
 
   [%%versioned:
   module Stable : sig

--- a/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.ml
+++ b/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.ml
@@ -54,7 +54,7 @@ module Wrap = struct
 
       module V2 = struct
         type t =
-          Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_2.Stable.V1.t
+          Limb_vector.Constant.Hex64.Stable.V1.t Vector.Vector_3.Stable.V1.t
           Scalar_challenge.Stable.V2.t
           Bulletproof_challenge.Stable.V1.t
           Wrap_bp_vec.Stable.V1.t

--- a/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.mli
+++ b/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.mli
@@ -64,7 +64,7 @@ module Wrap : sig
       module V2 : sig
         type t =
           Limb_vector.Constant.Hex64.Stable.V1.t
-          Pickles_types.Vector.Vector_2.Stable.V1.t
+          Pickles_types.Vector.Vector_3.Stable.V1.t
           Import.Scalar_challenge.Stable.V2.t
           Import.Bulletproof_challenge.Stable.V1.t
           Import.Types.Wrap_bp_vec.Stable.V1.t

--- a/src/lib/pickles/ro.mli
+++ b/src/lib/pickles/ro.mli
@@ -20,8 +20,8 @@ val tick : unit -> Backend.Tick.Field.t
 
 val scalar_chal :
      unit
-  -> (Core_kernel.Int64.t, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+  -> (Core_kernel.Int64.t, Pickles_types.Nat.N3.n) Pickles_types.Vector.t
      Import.Scalar_challenge.t
 
 val chal :
-  unit -> (Core_kernel.Int64.t, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+  unit -> (Core_kernel.Int64.t, Pickles_types.Nat.N3.n) Pickles_types.Vector.t

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -45,7 +45,7 @@ module Make : functor
     type t = Challenge.Constant.t Import.Scalar_challenge.t
 
     val to_field :
-         (Core_kernel.Int64.t, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+         (Core_kernel.Int64.t, Pickles_types.Nat.N3.n) Pickles_types.Vector.t
          Import.Scalar_challenge.t
       -> G.Constant.Scalar.t
   end

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -57,7 +57,7 @@ module Width : sig
 
   val typ : (Checked.t, t) Typ.t
 
-  module Max = Nat.N2
+  module Max = Nat.N3
 
   module Max_vector : Vector.With_version(Max).S
 
@@ -294,7 +294,7 @@ let dummy_wrap_vk :
   lazy
     (let d =
        (Common.wrap_domains
-          ~proofs_verified:(Pickles_base.Proofs_verified.to_int N2) )
+          ~proofs_verified:(Pickles_base.Proofs_verified.to_int N3) )
          .h
      in
      let log2_size = Import.Domain.log2_size d in
@@ -346,8 +346,8 @@ let dummy_wrap_vk :
          } ) )
 
 let dummy : t =
-  { max_proofs_verified = N2
-  ; actual_wrap_domain_size = N2
+  { max_proofs_verified = N3
+  ; actual_wrap_domain_size = N3
   ; wrap_index =
       (let g = Backend.Tock.Curve.(to_affine_exn one) in
        { sigma_comm = Vector.init Plonk_types.Permuts.n ~f:(fun _ -> g)

--- a/src/lib/pickles/side_loaded_verification_key.mli
+++ b/src/lib/pickles/side_loaded_verification_key.mli
@@ -26,7 +26,7 @@ module Width : sig
 
   val typ : (Checked.t, t) Impls.Step.Typ.t
 
-  module Max = Pickles_types.Nat.N2
+  module Max = Pickles_types.Nat.N3
 
   module Max_vector : Pickles_types.Vector.With_version(Max).S
 

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -67,7 +67,7 @@ let verify_one ~srs
               (Vector.trim_front branch_data.proofs_verified_mask
                  (Nat.lte_exn
                     (Vector.length prev_challenge_polynomial_commitments)
-                    Nat.N2.n ) )
+                    Nat.N3.n ) )
             (* Use opt sponge for cutting off the bulletproof challenges early *)
             { app_state
             ; dlog_plonk_index = d.wrap_key

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -535,7 +535,7 @@ struct
                     (Vector.map
                        ~f:(fun proofs_verified ->
                          Common.wrap_domains ~proofs_verified )
-                       [ 0; 1; 2 ] )
+                       [ 0; 1; 2; 3 ] )
                     ~public_input )
         in
         let x_hat =
@@ -884,7 +884,7 @@ struct
         Vector.map2
           ~f:(fun keep f -> (keep, f pt))
           (Vector.trim_front actual_width_mask
-             (Nat.lte_exn Proofs_verified.n Nat.N2.n) )
+             (Nat.lte_exn Proofs_verified.n Nat.N3.n) )
           sg_olds
       in
       (sg_evals plonk.zeta, sg_evals zetaw)
@@ -894,7 +894,7 @@ struct
         let opt_sponge = Opt_sponge.create sponge_params in
         Vector.iter2
           (Vector.trim_front actual_width_mask
-             (Nat.lte_exn Proofs_verified.n Nat.N2.n) )
+             (Nat.lte_exn Proofs_verified.n Nat.N3.n) )
           prev_challenges
           ~f:(fun keep chals ->
             Vector.iter chals ~f:(fun chal ->

--- a/src/lib/pickles/test/branching_factor_three/dune
+++ b/src/lib/pickles/test/branching_factor_three/dune
@@ -1,0 +1,64 @@
+(test
+ (name pickles_test_branching_factor_three)
+  
+ (libraries
+  ;; opam libraries
+  alcotest
+  stdio
+  integers
+  result
+  base.caml
+  bignum.bigint
+  core_kernel
+  base64
+  digestif
+  ppx_inline_test.config
+  sexplib0
+  base
+  async_kernel
+  bin_prot.shape
+  async
+  async_unix
+  ;; local libraries
+  mina_wire_types
+  kimchi_bindings
+  kimchi_types
+  pasta_bindings
+  kimchi_pasta
+  kimchi_pasta.basic
+  kimchi_pasta.constraint_system
+  bitstring_lib
+  snarky.intf
+  pickles.backend
+  pickles_types
+  snarky.backendless
+  snarky_group_map
+  sponge
+  pickles
+  pickles.pseudo
+  pickles.limb_vector
+  pickles_base
+  kimchi_backend
+  base58_check
+  codable
+  random_oracle_input
+  pickles.composition_types
+  pickles.plonk_checks
+  pickles_base.one_hot_vector
+  snarky_log
+  group_map
+  snarky_curve
+  key_cache
+  snark_keys_header
+  tuple_lib
+  promise
+  kimchi_backend_common
+  logger
+  logger.context_logger
+  ppx_version.runtime
+  error_json
+  pickles_optional_custom_gates_circuits)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/lib/pickles/test/branching_factor_three/pickles_test_branching_factor_three.ml
+++ b/src/lib/pickles/test/branching_factor_three/pickles_test_branching_factor_three.ml
@@ -1,0 +1,202 @@
+open Core_kernel
+open Pickles_types
+open Pickles.Impls.Step
+
+let () = Pickles.Backend.Tick.Keypair.set_urs_info []
+
+let () = Pickles.Backend.Tock.Keypair.set_urs_info []
+
+(* This testcase implements OEIS A000073: https://oeis.org/A000073 *)
+
+module Trib_return = struct
+  type branch_direction = Left | Middle | Right
+
+  type _ Snarky_backendless.Request.t +=
+    | Input : branch_direction -> Field.Constant.t Snarky_backendless.Request.t
+    | Output : branch_direction -> Field.Constant.t Snarky_backendless.Request.t
+    | Proof :
+        branch_direction
+        -> (Nat.N3.n, Nat.N3.n) Pickles.Proof.t Snarky_backendless.Request.t
+
+  type step_data =
+    { input : Field.Constant.t
+    ; output : Field.Constant.t
+    ; proof : (Nat.N3.n, Nat.N3.n) Pickles.Proof.t
+    }
+
+  let handler (left : step_data) (middle : step_data) (right : step_data)
+      (Snarky_backendless.Request.With { request; respond }) =
+    match request with
+    | Input Left ->
+        respond (Provide left.input)
+    | Output Left ->
+        respond (Provide left.output)
+    | Proof Left ->
+        respond (Provide left.proof)
+    | Input Middle ->
+        respond (Provide middle.input)
+    | Output Middle ->
+        respond (Provide middle.output)
+    | Proof Middle ->
+        respond (Provide middle.proof)
+    | Input Right ->
+        respond (Provide right.input)
+    | Output Right ->
+        respond (Provide right.output)
+    | Proof Right ->
+        respond (Provide right.proof)
+    | _ ->
+        respond Unhandled
+
+  let _tag, _, p, Pickles.Provers.[ step ] =
+    Pickles.Common.time "compile-trib-return" (fun () ->
+        Pickles.compile_promise ()
+          ~public_input:(Input_and_output (Field.typ, Field.typ))
+            (* Need confirm *)
+          ~override_wrap_domain:Pickles_base.Proofs_verified.N2
+          ~auxiliary_typ:Typ.unit
+          ~max_proofs_verified:(module Nat.N3)
+          ~name:"trib-return"
+          ~choices:(fun ~self ->
+            [ { identifier = "main"
+              ; feature_flags = Plonk_types.Features.none_bool
+              ; prevs = [ self; self; self ]
+              ; main =
+                  (fun { public_input = n } ->
+                    let prev_input direction =
+                      exists Field.typ ~request:(const @@ Input direction)
+                    in
+                    let prev_output direction =
+                      exists Field.typ ~request:(const @@ Output direction)
+                    in
+                    let prev_input_output direction =
+                      (prev_input direction, prev_output direction)
+                    in
+                    let prev_proof direction =
+                      exists (Typ.prover_value ())
+                        ~request:(const @@ Proof direction)
+                    in
+                    let is_zero_case =
+                      Boolean.any [ Field.(equal n zero); Field.(equal n one) ]
+                    in
+                    let is_one_case = Field.(equal n (of_int 2)) in
+                    let is_recursive_case =
+                      let n_minus_one = prev_input Left in
+                      let n_minus_two = prev_input Middle in
+                      let n_minus_three = prev_input Right in
+                      Boolean.all
+                        [ Field.(equal n_minus_one (sub n one))
+                        ; Field.(equal n_minus_two (sub n (of_int 2)))
+                        ; Field.(equal n_minus_three (sub n (of_int 3)))
+                        ]
+                    in
+                    (* ensure precondition holds *)
+                    Boolean.Assert.exactly_one
+                      [ is_zero_case; is_one_case; is_recursive_case ] ;
+                    let recursive_value =
+                      [ Left; Middle; Right ] |> List.map ~f:prev_input
+                      |> Field.sum
+                    in
+                    let trib_value =
+                      Field.(
+                        if_ is_zero_case ~then_:zero
+                          ~else_:
+                            (if_ is_one_case ~then_:one ~else_:recursive_value))
+                    in
+                    Promise.return
+                      { Pickles.Inductive_rule.previous_proof_statements =
+                          [ { public_input = prev_input_output Left
+                            ; proof = prev_proof Left
+                            ; proof_must_verify = is_recursive_case
+                            }
+                          ; { public_input = prev_input_output Middle
+                            ; proof = prev_proof Middle
+                            ; proof_must_verify = is_recursive_case
+                            }
+                          ; { public_input = prev_input_output Right
+                            ; proof = prev_proof Right
+                            ; proof_must_verify = is_recursive_case
+                            }
+                          ]
+                      ; public_output = trib_value
+                      ; auxiliary_output = ()
+                      } )
+              }
+            ] ) )
+
+  module Proof = (val p)
+
+  let trib =
+    let memo_ref =
+      ref
+        (Memo.of_comparable
+           (module Int)
+           (fun _ -> failwith "reaching inside empty trib memo") )
+    in
+    let trib = function
+      | 0 | 1 ->
+          0
+      | 2 ->
+          1
+      | n ->
+          !memo_ref (n - 1) + !memo_ref (n - 2)
+    in
+    memo_ref := Memo.of_comparable (module Int) trib ;
+    trib
+
+  let trib_step_data =
+    let dummy_proof =
+      Pickles.Proof.dummy Nat.N3.n Nat.N3.n Nat.N3.n ~domain_log2:16
+    in
+    let memo_ref =
+      ref
+        (Memo.of_comparable
+           (module Int)
+           (fun _ -> failwith "reaching inside empty trib proof memo") )
+    in
+    let trib_step_data = function
+      | (0 | 1 | 2) as n ->
+          let dummy =
+            { input = Field.Constant.zero
+            ; output = Field.Constant.zero
+            ; proof = dummy_proof
+            }
+          in
+          let input = Field.Constant.of_int n in
+          let output, _, proof =
+            Promise.block_on_async_exn (fun () ->
+                step input ~handler:(handler dummy dummy dummy) )
+          in
+          { input; output; proof }
+      | n ->
+          let input = Field.Constant.of_int n in
+          let output, _, proof =
+            Promise.block_on_async_exn (fun () ->
+                let step_left = !memo_ref (n - 1) in
+                let step_middle = !memo_ref (n - 2) in
+                let step_right = !memo_ref (n - 3) in
+                step input ~handler:(handler step_left step_middle step_right) )
+          in
+          { input; output; proof }
+    in
+    memo_ref := Memo.of_comparable (module Int) trib_step_data ;
+    trib_step_data
+
+  let trib5_data =
+    let data = trib_step_data 5 in
+    assert (Field.Constant.(equal data.output (of_int (trib 5)))) ;
+    data
+end
+
+let test_trib5 () =
+  Or_error.ok_exn
+    (Promise.block_on_async_exn (fun () ->
+         Trib_return.Proof.verify_promise
+           [ Trib_return.
+               ((trib5_data.input, trib5_data.output), trib5_data.proof)
+           ] ) )
+
+let () =
+  let open Alcotest in
+  run "Test branching factor three"
+    [ ("trib", [ ("trib5", `Quick, test_trib5) ]) ]

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -128,6 +128,7 @@ let verify_heterogenous (ts : Instance.t list) =
         let () =
           let [ Pow_2_roots_of_unity greatest_wrap_domain
               ; _
+              ; _
               ; Pow_2_roots_of_unity least_wrap_domain
               ] =
             Wrap_verifier.all_possible_domains ()

--- a/src/lib/pickles/wrap_hack.mli
+++ b/src/lib/pickles/wrap_hack.mli
@@ -1,4 +1,4 @@
-module Padded_length = Pickles_types.Nat.N2
+module Padded_length = Pickles_types.Nat.N3
 
 val pad_accumulator :
      (Backend.Tock.Proof.Challenge_polynomial.t, 'a) Pickles_types.Vector.t

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -196,7 +196,7 @@ let wrap_main
                 Branch_data.Checked.Wrap.pack
                   { proofs_verified_mask =
                       Vector.extend_front_exn actual_proofs_verified_mask
-                        Nat.N2.n Boolean.false_
+                        Nat.N3.n Boolean.false_
                   ; domain_log2
                   }
                 |> Field.Assert.equal branch_data )

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -1,37 +1,44 @@
+open Core_kernel
 open Pickles_types
 
 (** Represents how many proofs are verified. Currently only [0], [1] or [2] *)
+
+[@@@warning "-32"]
+
+[%%versioned:
 module Stable : sig
   module V1 : sig
-    type t = Mina_wire_types.Pickles_base.Proofs_verified.V1.t = N0 | N1 | N2
+    type t = Mina_wire_types.Pickles_base.Proofs_verified.V1.t =
+      | N0
+      | N1
+      | N2
+      | N3
     [@@deriving sexp, compare, yojson, hash, equal]
 
-    include Plonkish_prelude.Sigs.Binable.S with type t := t
-
-    include Plonkish_prelude.Sigs.VERSIONED
+    val to_latest : t -> t
   end
-end
+end]
 
-type t = Stable.V1.t = N0 | N1 | N2
+type t = Stable.V1.t = N0 | N1 | N2 | N3
 [@@deriving sexp, compare, yojson, hash, equal]
 
 (** [of_nat_exn t_n] converts the type level natural [t_n] to the data type natural.
-    Raise an exception if [t_n] represents a value above or equal to 3 *)
+    Raise an exception if [t_n] represents a value above or equal to 4 *)
 val of_nat_exn : 'n Nat.t -> t
 
 (** [of_int_exn n] converts the runtime natural [n] to the data type natural. Raise
-    an exception if the value [n] is above or equal to 3 *)
+    an exception if the value [n] is above or equal to 4 *)
 val of_int_exn : int -> t
 
 (** [to_int v] converts the value [v] to the corresponding integer, i.e [N0 ->
-    0], [N1 -> 1] and [N2 -> 2] *)
+  0], [N1 -> 1], [N2 -> 2] and [N3 -> 3] *)
 val to_int : t -> int
 
 module One_hot : sig
   open Kimchi_pasta_snarky_backend
 
   module Checked : sig
-    type t = Pickles_types.Nat.N3.n One_hot_vector.Step.t
+    type t = Pickles_types.Nat.N4.n One_hot_vector.Step.t
 
     val to_input : t -> Step_impl.Field.t Random_oracle_input.Chunked.t
   end
@@ -41,16 +48,16 @@ module One_hot : sig
   val typ : (Checked.t, t) Step_impl.Typ.t
 end
 
-val to_bool_vec : t -> (bool, Nat.N2.n) Vector.t
+val to_bool_vec : t -> (bool, Nat.N3.n) Vector.t
 
-val of_bool_vec : (bool, Nat.N2.n) Vector.t -> t
+val of_bool_vec : (bool, Nat.N3.n) Vector.t -> t
 
 module Prefix_mask : sig
   open Kimchi_pasta_snarky_backend
 
   module Step : sig
     module Checked : sig
-      type t = (Step_impl.Boolean.var, Nat.N2.n) Vector.t
+      type t = (Step_impl.Boolean.var, Nat.N3.n) Vector.t
     end
 
     val typ : (Checked.t, t) Step_impl.Typ.t
@@ -58,7 +65,7 @@ module Prefix_mask : sig
 
   module Wrap : sig
     module Checked : sig
-      type t = (Wrap_impl.Boolean.var, Nat.N2.n) Vector.t
+      type t = (Wrap_impl.Boolean.var, Nat.N3.n) Vector.t
     end
 
     val typ : (Checked.t, t) Wrap_impl.Typ.t

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -62,12 +62,12 @@ end = struct
       [@@@no_toplevel_latest_type]
 
       module V1 = struct
-        type 'a t = 'a Vector.Vector_2.Stable.V1.t
+        type 'a t = 'a Vector.Vector_3.Stable.V1.t
         [@@deriving compare, yojson, sexp, hash, equal]
       end
     end]
 
-    type 'a t = 'a Vector.Vector_2.t
+    type 'a t = 'a Vector.Vector_3.t
     [@@deriving compare, yojson, sexp, hash, equal]
 
     let map = Vector.map
@@ -83,12 +83,12 @@ end = struct
       [@@@no_toplevel_latest_type]
 
       module V1 = struct
-        type 'a t = 'a At_most.At_most_2.Stable.V1.t
+        type 'a t = 'a At_most.At_most_3.Stable.V1.t
         [@@deriving compare, yojson, sexp, hash, equal]
       end
     end]
 
-    type 'a t = 'a At_most.At_most_2.t
+    type 'a t = 'a At_most.At_most_3.t
     [@@deriving compare, yojson, sexp, hash, equal]
   end
 

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -21,7 +21,7 @@ module Width : sig
 
   val zero : t
 
-  module Max = Nat.N2
+  module Max = Nat.N3
 
   module Max_vector : Vector.With_version(Max).S
 
@@ -48,7 +48,7 @@ end = struct
 
   let zero = Char.of_int_exn 0
 
-  module Max = Nat.N2
+  module Max = Nat.N3
 
   (* Think about versioning here! These vector types *will* change
      serialization if the numbers above change, and so will require a new
@@ -72,7 +72,7 @@ end = struct
 
     let map = Vector.map
 
-    let of_list_exn = Vector.Vector_2.of_list_exn
+    let of_list_exn = Vector.Vector_3.of_list_exn
 
     let to_list = Vector.to_list
   end

--- a/src/lib/pickles_base/side_loaded_verification_key.mli
+++ b/src/lib/pickles_base/side_loaded_verification_key.mli
@@ -102,7 +102,7 @@ module Width : sig
 
   val zero : t
 
-  module Max = Pickles_types.Nat.N2
+  module Max = Pickles_types.Nat.N3
 
   module Max_vector : Pickles_types.Vector.With_version(Max).S
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -66,7 +66,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     [%%versioned
     module Stable = struct
       module V2 = struct
-        type t = Pickles.Proof.Proofs_verified_2.Stable.V2.t
+        type t = Pickles.Proof.Proofs_verified_3.Stable.V2.t
         [@@deriving yojson, compare, equal, sexp, hash]
 
         let to_latest = Fn.id

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -36,7 +36,7 @@ module type Full = sig
   type tag =
     ( Statement.With_sok.var
     , Statement.With_sok.t
-    , Nat.N2.n
+    , Nat.N3.n
     , Nat.N5.n )
     Pickles.Tag.t
 
@@ -306,7 +306,7 @@ module type Full = sig
            , unit
            , unit
            , Zkapp_statement.t
-           , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
+           , (unit * unit * (Nat.N3.n, Nat.N3.n) Pickles.Proof.t)
              Async.Deferred.t )
            Pickles.Prover.t
            * ( Pickles.Side_loaded.Verification_key.t
@@ -347,7 +347,7 @@ module type Full = sig
            , unit
            , unit
            , Zkapp_statement.t
-           , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
+           , (unit * unit * (Nat.N3.n, Nat.N3.n) Pickles.Proof.t)
              Async.Deferred.t )
            Pickles.Prover.t
            * ( Pickles.Side_loaded.Verification_key.t
@@ -390,7 +390,7 @@ module type Full = sig
               , unit
               , unit
               , Zkapp_statement.t
-              , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
+              , (unit * unit * (Nat.N3.n, Nat.N3.n) Pickles.Proof.t)
                 Async.Deferred.t )
               Pickles.Prover.t ]
 


### PR DESCRIPTION
This is a WIP destructive experiment to make Pickles support branching factor 3. 

Some discoveries along the way
- `Composition_types.Branch_data` uses a binary string representation to compress `Proofs_verified` and `Domain_log2` together. The former is fixed to 2 bits. This PR make the former to be 3 bits. We should actually use a net-string-like format, so arbitrary branches could be de-serialized from binaries without more information. 