### PR TITLE
Remove phantom type from Pickles.Proof.t

### DIFF
--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -57,7 +57,7 @@ let zkapp_proof ~zkapp_command =
 
 let dummy_proof =
   Pickles.Proof.dummy Pickles_types.Nat.N2.n Pickles_types.Nat.N2.n
-    Pickles_types.Nat.N2.n ~domain_log2:16
+    ~domain_log2:16
 
 let dummy_vk = Mina_base.Side_loaded_verification_key.dummy
 

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -317,7 +317,7 @@ module Rules = struct
     end
 
     let dummy_proof =
-      lazy (Pickles.Proof.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15)
+      lazy (Pickles.Proof.dummy Nat.N2.n Nat.N2.n ~domain_log2:15)
 
     let next_account_update
         ({ forest; pending_forests; check_may_use_token } : State.Circuit.t) :
@@ -461,7 +461,7 @@ module Rules = struct
       type _ Snarky_backendless.Request.t +=
         | Prove :
             bool * Statement.Value.t
-            -> (Nat.N2.n, Nat.N2.n) Pickles.Proof.t Snarky_backendless.Request.t
+            -> Nat.N2.n Pickles.Proof.t Snarky_backendless.Request.t
 
       let main
           { Pickles.Inductive_rule.public_input =
@@ -510,8 +510,7 @@ module Rules = struct
         ; feature_flags = Pickles_types.Plonk_types.Features.none_bool
         }
 
-      let handler
-          (prove : Statement.Value.t -> (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
+      let handler (prove : Statement.Value.t -> Nat.N2.n Pickles.Proof.t)
           (Snarky_backendless.Request.With { request; respond }) =
         match request with
         | Prove (should_prove, statement) ->
@@ -600,8 +599,7 @@ module Rules = struct
     let handler (public_key : Public_key.Compressed.t) (token_id : Token_id.t)
         (call_forest : Zkapp_call_forest.t)
         (may_use_token : Account_update.May_use_token.t)
-        (prove :
-          Recursive.Statement.Value.t -> (Nat.N2.n, Nat.N2.n) Pickles.Proof.t )
+        (prove : Recursive.Statement.Value.t -> Nat.N2.n Pickles.Proof.t)
         (Snarky_backendless.Request.With { request; respond }) =
       match request with
       | Public_key ->
@@ -676,7 +674,7 @@ let p_module = Lazy.map lazy_compiled ~f:(fun (_, _, p_module, _) -> p_module)
 module P = struct
   type statement = Zkapp_statement.t
 
-  type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+  type t = Nat.N2.n Pickles.Proof.t
 
   module type Proof_intf =
     Pickles.Proof_intf with type statement = statement and type t = t

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.mli
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.mli
@@ -17,7 +17,7 @@ val vk : Pickles.Side_loaded.Verification_key.t Async.Deferred.t Lazy.t
 module P :
   Pickles.Proof_intf
     with type statement = Zkapp_statement.t
-     and type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+     and type t = Nat.N2.n Pickles.Proof.t
 
 val initialize :
      ?may_use_token:Account_update.May_use_token.t

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -571,9 +571,7 @@ let compile :
        Pickles.Tag.t
        * _
        * (module Pickles.Proof_intf
-            with type t = ( max_proofs_verified
-                          , max_proofs_verified )
-                          Pickles.Proof.t
+            with type t = max_proofs_verified Pickles.Proof.t
              and type statement = Zkapp_statement.t )
        * ( prev_valuess
          , widthss
@@ -668,7 +666,7 @@ let compile :
            , unit
            , ( Zkapp_statement.t
              * (return_type * auxiliary_value)
-             * (max_proofs_verified, max_proofs_verified) Pickles.Proof.t )
+             * max_proofs_verified Pickles.Proof.t )
              Deferred.t )
            H3_2.T(Pickles.Prover).t
         -> ( prev_valuess

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -10,19 +10,19 @@ include struct
 
   type _ t +=
     | Prev_state : Protocol_state.Value.t t
-    | Prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t t
+    | Prev_state_proof : Nat.N2.n Pickles.Proof.t t
     | Transition : Snark_transition.Value.t t
     | Txn_snark : Transaction_snark.Statement.With_sok.t t
-    | Txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t t
+    | Txn_snark_proof : Nat.N2.n Pickles.Proof.t t
 end
 
 module Witness = struct
   type t =
     { prev_state : Protocol_state.Value.t
-    ; prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; prev_state_proof : Nat.N2.n Pickles.Proof.t
     ; transition : Snark_transition.Value.t
     ; txn_snark : Transaction_snark.Statement.With_sok.t
-    ; txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; txn_snark_proof : Nat.N2.n Pickles.Proof.t
     }
 end
 
@@ -431,7 +431,7 @@ let rule ~proof_level ~constraint_constants transaction_snark self :
 module type S = sig
   module Proof :
     Pickles.Proof_intf
-      with type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+      with type t = Nat.N2.n Pickles.Proof.t
        and type statement = Protocol_state.Value.t
 
   val tag : tag

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -6,10 +6,10 @@ open Pickles_types
 module Witness : sig
   type t =
     { prev_state : Protocol_state.Value.t
-    ; prev_state_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; prev_state_proof : Nat.N2.n Pickles.Proof.t
     ; transition : Snark_transition.Value.t
     ; txn_snark : Transaction_snark.Statement.With_sok.t
-    ; txn_snark_proof : (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+    ; txn_snark_proof : Nat.N2.n Pickles.Proof.t
     }
 end
 
@@ -38,7 +38,7 @@ val check :
 module type S = sig
   module Proof :
     Pickles.Proof_intf
-      with type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
+      with type t = Nat.N2.n Pickles.Proof.t
        and type statement = Protocol_state.Value.t
 
   val tag : tag

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -4,7 +4,7 @@ open Async
 open Pickles_types
 
 let proof_string prev_width domain_log2 =
-  let dummy = Pickles.Proof.dummy Nat.N2.n Nat.N2.n prev_width ~domain_log2 in
+  let dummy = Pickles.Proof.dummy Nat.N2.n prev_width ~domain_log2 in
   Binable.to_string (module Pickles.Proof.Proofs_verified_2.Stable.Latest) dummy
 
 let blockchain_proof_string = proof_string Nat.N2.n 16

--- a/src/lib/graphql_lib/mina_block/graphql_scalars.ml
+++ b/src/lib/graphql_lib/mina_block/graphql_scalars.ml
@@ -38,7 +38,7 @@ let%test_module "Roundtrip tests" =
 
           (* Sample gotten from: lib/prover/prover.ml *)
           let example : t =
-            Pickles.Proof.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:16
+            Pickles.Proof.dummy Nat.N2.n Nat.N2.n ~domain_log2:16
 
           (* TODO: find better ways to generate `Mina_block.Precomputed.Proof.t` values *)
           let gen = Quickcheck.Generator.return example

--- a/src/lib/mina_base/control.ml
+++ b/src/lib/mina_base/control.ml
@@ -37,7 +37,7 @@ let gen_with_dummies : t Quickcheck.Generator.t =
       (Quickcheck.Generator.of_list
          (let dummy_proof =
             let n2 = Pickles_types.Nat.N2.n in
-            let proof = Pickles.Proof.dummy n2 n2 n2 ~domain_log2:15 in
+            let proof = Pickles.Proof.dummy n2 n2 ~domain_log2:15 in
             Poly.Proof proof
           in
           let dummy_signature = Poly.Signature Signature.dummy in
@@ -81,7 +81,7 @@ let tag : t -> Tag.t = function
 let dummy_of_tag : Tag.t -> t = function
   | Proof ->
       let n2 = Pickles_types.Nat.N2.n in
-      let proof = Pickles.Proof.dummy n2 n2 n2 ~domain_log2:15 in
+      let proof = Pickles.Proof.dummy n2 n2 ~domain_log2:15 in
       Proof proof
   | Signature ->
       Signature Signature.dummy

--- a/src/lib/mina_base/proof.mli
+++ b/src/lib/mina_base/proof.mli
@@ -1,6 +1,6 @@
 open Pickles_types
 
-type t = (Nat.N2.n, Nat.N2.n) Pickles.Proof.t [@@deriving sexp, compare, yojson]
+type t = Nat.N2.n Pickles.Proof.t [@@deriving sexp, compare, yojson]
 
 val blockchain_dummy : t lazy_t
 

--- a/src/lib/mina_wire_types/pickles/pickles.ml
+++ b/src/lib/mina_wire_types/pickles/pickles.ml
@@ -106,7 +106,7 @@ module M = struct
       end
     end
 
-    type ('s, 'mlmb, _) with_data =
+    type ('s, 'mlmb) with_data =
       | T :
           ( 'mlmb Pickles_reduced_messages_for_next_proof_over_same_field.Wrap.t
           , ( 's
@@ -119,13 +119,13 @@ module M = struct
             Pickles_reduced_messages_for_next_proof_over_same_field.Step.V1.t
           )
           Base.Wrap.V2.t
-          -> ('s, 'mlmb, _) with_data
+          -> ('s, 'mlmb) with_data
 
-    type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
+    type 'mlmb t = (unit, 'mlmb) with_data
 
     module Proofs_verified_2 = struct
       module V2 = struct
-        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+        type nonrec t = Pickles_types.Nat.two t
       end
     end
   end
@@ -159,8 +159,7 @@ module M = struct
 
     module Proof = struct
       module V2 = struct
-        type t =
-          (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+        type t = Verification_key.Max_width.n Proof.t
       end
     end
   end
@@ -169,11 +168,11 @@ end
 module Types = struct
   module type S = sig
     module Proof : sig
-      type ('a, 'b) t
+      type 'a t
 
       module Proofs_verified_2 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+          type nonrec t = Pickles_types.Nat.two t
         end
       end
     end
@@ -191,8 +190,7 @@ module Types = struct
 
       module Proof : sig
         module V2 : sig
-          type t =
-            (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+          type t = Verification_key.Max_width.n Proof.t
         end
       end
     end
@@ -216,7 +214,7 @@ module type Concrete =
     with type Side_loaded.Verification_key.V2.t =
       M.Side_loaded.Verification_key.V2.t
      and type Backend.Tick.Field.V1.t = Pasta_bindings.Fp.t
-     and type ('a, 'b) Proof.t = ('a, 'b) M.Proof.t
+     and type 'a Proof.t = 'a M.Proof.t
 
 module type Local_sig = Signature(Types).S
 

--- a/src/lib/mina_wire_types/pickles/pickles.mli
+++ b/src/lib/mina_wire_types/pickles/pickles.mli
@@ -3,11 +3,11 @@ open Utils
 module Types : sig
   module type S = sig
     module Proof : sig
-      type ('a, 'b) t
+      type 'a t
 
       module Proofs_verified_2 : sig
         module V2 : sig
-          type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+          type nonrec t = Pickles_types.Nat.two t
         end
       end
     end
@@ -25,8 +25,7 @@ module Types : sig
 
       module Proof : sig
         module V2 : sig
-          type t =
-            (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+          type t = Verification_key.Max_width.n Proof.t
         end
       end
     end
@@ -155,7 +154,7 @@ module Concrete_ : sig
       end
     end
 
-    type ('s, 'mlmb, _) with_data =
+    type ('s, 'mlmb) with_data =
       | T :
           ( 'mlmb Pickles_reduced_messages_for_next_proof_over_same_field.Wrap.t
           , ( 's
@@ -168,13 +167,13 @@ module Concrete_ : sig
             Pickles_reduced_messages_for_next_proof_over_same_field.Step.V1.t
           )
           Base.Wrap.V2.t
-          -> ('s, 'mlmb, _) with_data
+          -> ('s, 'mlmb) with_data
 
-    type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
+    type 'mlmb t = (unit, 'mlmb) with_data
 
     module Proofs_verified_2 : sig
       module V2 : sig
-        type nonrec t = (Pickles_types.Nat.two, Pickles_types.Nat.two) t
+        type nonrec t = Pickles_types.Nat.two t
       end
     end
   end
@@ -208,8 +207,7 @@ module Concrete_ : sig
 
     module Proof : sig
       module V2 : sig
-        type t =
-          (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+        type t = Verification_key.Max_width.n Proof.t
       end
     end
   end
@@ -222,7 +220,7 @@ module type Concrete =
     with type Side_loaded.Verification_key.V2.t =
       Concrete_.Side_loaded.Verification_key.V2.t
      and type Backend.Tick.Field.V1.t = Pasta_bindings.Fp.t
-     and type ('a, 'b) Proof.t = ('a, 'b) Concrete_.Proof.t
+     and type 'a Proof.t = 'a Concrete_.Proof.t
 
 module type Local_sig = Signature(Types).S
 

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -140,7 +140,7 @@ module Pickles = struct
       (O.Side_loaded.Verification_key.Stable)
       (W.Side_loaded.Verification_key)
   include Assert_equal0V1 (O.Backend.Tick.Field.Stable) (W.Backend.Tick.Field)
-  include Assert_equal2 (O.Proof) (W.Proof)
+  include Assert_equal1 (O.Proof) (W.Proof)
   include
     Assert_equal0V2
       (O.Proof.Proofs_verified_2.Stable)

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -367,9 +367,7 @@ struct
          , widthss
          , heightss
          , Arg_value.t
-         , ( Ret_value.t
-           * Auxiliary_value.t
-           * (max_proofs_verified, max_proofs_verified) Proof.t )
+         , (Ret_value.t * Auxiliary_value.t * max_proofs_verified Proof.t)
            Promise.t )
          H3_2.T(Prover).t
          * _
@@ -750,9 +748,7 @@ struct
                (   Snarky_backendless.Request.request
                 -> Snarky_backendless.Request.response )
           -> Arg_value.t
-          -> ( Ret_value.t
-             * Auxiliary_value.t
-             * (Max_proofs_verified.n, Max_proofs_verified.n) Proof.t )
+          -> (Ret_value.t * Auxiliary_value.t * Max_proofs_verified.n Proof.t)
              Promise.t =
        fun (T b as branch_data) (step_pk, step_vk) ->
         let _, prev_vars_length = b.proofs_verified in
@@ -839,9 +835,7 @@ struct
              , xs3
              , xs4
              , Arg_value.t
-             , ( Ret_value.t
-               * Auxiliary_value.t
-               * (max_proofs_verified, max_proofs_verified) Proof.t )
+             , (Ret_value.t * Auxiliary_value.t * max_proofs_verified Proof.t)
                Promise.t )
              H3_2.T(Prover).t =
        fun bs ks ->
@@ -1024,16 +1018,14 @@ let compile_with_wrap_main_override_promise :
     -> (var, value, max_proofs_verified, branches) Tag.t
        * Cache_handle.t
        * (module Proof_intf
-            with type t = (max_proofs_verified, max_proofs_verified) Proof.t
+            with type t = max_proofs_verified Proof.t
              and type statement = value )
        * ( prev_valuess
          , widthss
          , heightss
          , a_value
-         , ( ret_value
-           * auxiliary_value
-           * (max_proofs_verified, max_proofs_verified) Proof.t )
-           Promise.t )
+         , (ret_value * auxiliary_value * max_proofs_verified Proof.t) Promise.t
+         )
          H3_2.T(Prover).t =
  (* This function is an adapter between the user-facing Pickles.compile API
     and the underlying Make(_).compile function which builds the circuits.
@@ -1162,14 +1154,9 @@ let compile_with_wrap_main_override_promise :
 
     module Max_local_max_proofs_verified = Max_proofs_verified
 
-    include
-      Proof.Make
-        (struct
-          include Max_proofs_verified
-        end)
-        (struct
-          include Max_local_max_proofs_verified
-        end)
+    include Proof.Make (struct
+      include Max_local_max_proofs_verified
+    end)
 
     let id_promise = wrap_disk_key
 
@@ -1316,7 +1303,7 @@ struct
         (fun { public_input = () } ->
           let dummy_proof =
             exists (Typ.prover_value ()) ~compute:(fun () ->
-                Proof.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15 )
+                Proof.dummy Nat.N2.n Nat.N2.n ~domain_log2:15 )
           in
           Promise.return
             { Inductive_rule.previous_proof_statements =

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -54,7 +54,7 @@ val verify_promise :
   -> (module Nat.Intf with type n = 'n)
   -> (module Statement_value_intf with type t = 'a)
   -> Verification_key.t
-  -> ('a * ('n, 'n) Proof.t) list
+  -> ('a * 'n Proof.t) list
   -> unit Or_error.t Promise.t
 
 module Prover : sig
@@ -105,8 +105,7 @@ module Side_loaded : sig
     module Stable : sig
       module V2 : sig
         (* TODO: This should really be able to be any width up to the max width... *)
-        type t =
-          (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+        type t = Verification_key.Max_width.n Proof.t
         [@@deriving sexp, equal, yojson, hash, compare]
 
         val to_base64 : t -> string
@@ -327,15 +326,13 @@ val compile_with_wrap_main_override_promise :
   -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
      * Cache_handle.t
      * (module Proof_intf
-          with type t = ('max_proofs_verified, 'max_proofs_verified) Proof.t
+          with type t = 'max_proofs_verified Proof.t
            and type statement = 'value )
      * ( 'prev_valuess
        , 'widthss
        , 'heightss
        , 'a_value
-       , ( 'ret_value
-         * 'auxiliary_value
-         * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
+       , ('ret_value * 'auxiliary_value * 'max_proofs_verified Proof.t)
          Promise.t )
        H3_2.T(Prover).t
 

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -8,14 +8,14 @@ end
 module Previous_proof_statement = struct
   type ('prev_var, 'width) t =
     { public_input : 'prev_var
-    ; proof : ('width, 'width) Proof.t Impls.Step.Typ.prover_value
+    ; proof : 'width Proof.t Impls.Step.Typ.prover_value
     ; proof_must_verify : B.t
     }
 
   module Constant = struct
     type ('prev_value, 'width) t =
       { public_input : 'prev_value
-      ; proof : ('width, 'width) Proof.t
+      ; proof : 'width Proof.t
       ; proof_must_verify : bool
       }
   end

--- a/src/lib/pickles/inductive_rule.mli
+++ b/src/lib/pickles/inductive_rule.mli
@@ -5,14 +5,14 @@ end
 module Previous_proof_statement : sig
   type ('prev_var, 'width) t =
     { public_input : 'prev_var
-    ; proof : ('width, 'width) Proof.t Impls.Step.Typ.prover_value
+    ; proof : 'width Proof.t Impls.Step.Typ.prover_value
     ; proof_must_verify : B.t
     }
 
   module Constant : sig
     type ('prev_value, 'width) t =
       { public_input : 'prev_value
-      ; proof : ('width, 'width) Proof.t
+      ; proof : 'width Proof.t
       ; proof_must_verify : bool
       }
   end

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -8,7 +8,7 @@ module Make_sig (A : Wire_types.Types.S) = struct
     Pickles_intf.S
       with type Side_loaded.Verification_key.Stable.V2.t =
         A.Side_loaded.Verification_key.V2.t
-       and type ('a, 'b) Proof.t = ('a, 'b) A.Proof.t
+       and type 'a Proof.t = 'a A.Proof.t
 end
 
 module Make_str (_ : Wire_types.Concrete) = struct
@@ -159,9 +159,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Proof = P
 
   module Statement_with_proof = struct
-    type ('s, 'max_width, _) t =
+    type ('s, 'max_width) t =
       (* TODO: use Max local max proofs verified instead of max_width *)
-      ('max_width, 'max_width) Proof.t
+      'max_width Proof.t
   end
 
   module Verification_key = struct
@@ -570,7 +570,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
       module Simple_chain = struct
         type _ Snarky_backendless.Request.t +=
           | Prev_input : Field.Constant.t Snarky_backendless.Request.t
-          | Proof : (Nat.N1.n, Nat.N1.n) Proof.t Snarky_backendless.Request.t
+          | Proof : Nat.N1.n Proof.t Snarky_backendless.Request.t
 
         let handler (prev_input : Field.Constant.t) (proof : _ Proof.t)
             (Snarky_backendless.Request.With { request; respond }) =
@@ -622,8 +622,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let example =
           let s_neg_one = Field.Constant.(negate one) in
-          let b_neg_one : (Nat.N1.n, Nat.N1.n) Proof0.t =
-            Proof0.dummy Nat.N1.n Nat.N1.n Nat.N1.n ~domain_log2:14
+          let b_neg_one : Nat.N1.n Proof0.t =
+            Proof0.dummy Nat.N1.n Nat.N1.n ~domain_log2:14
           in
           let (), (), b0 =
             Common.time "b0" (fun () ->
@@ -653,11 +653,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
       module Tree_proof = struct
         type _ Snarky_backendless.Request.t +=
           | No_recursion_input : Field.Constant.t Snarky_backendless.Request.t
-          | No_recursion_proof :
-              (Nat.N0.n, Nat.N0.n) Proof.t Snarky_backendless.Request.t
+          | No_recursion_proof : Nat.N0.n Proof.t Snarky_backendless.Request.t
           | Recursive_input : Field.Constant.t Snarky_backendless.Request.t
-          | Recursive_proof :
-              (Nat.N2.n, Nat.N2.n) Proof.t Snarky_backendless.Request.t
+          | Recursive_proof : Nat.N2.n Proof.t Snarky_backendless.Request.t
 
         let handler
             ((no_recursion_input, no_recursion_proof) :
@@ -730,8 +728,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let example1, example2 =
           let s_neg_one = Field.Constant.(negate one) in
-          let b_neg_one : (Nat.N2.n, Nat.N2.n) Proof0.t =
-            Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15
+          let b_neg_one : Nat.N2.n Proof0.t =
+            Proof0.dummy Nat.N2.n Nat.N2.n ~domain_log2:15
           in
           let (), (), b0 =
             Common.time "tree b0" (fun () ->
@@ -770,11 +768,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
         type _ Snarky_backendless.Request.t +=
           | Is_base_case : bool Snarky_backendless.Request.t
           | No_recursion_input : Field.Constant.t Snarky_backendless.Request.t
-          | No_recursion_proof :
-              (Nat.N0.n, Nat.N0.n) Proof.t Snarky_backendless.Request.t
+          | No_recursion_proof : Nat.N0.n Proof.t Snarky_backendless.Request.t
           | Recursive_input : Field.Constant.t Snarky_backendless.Request.t
-          | Recursive_proof :
-              (Nat.N2.n, Nat.N2.n) Proof.t Snarky_backendless.Request.t
+          | Recursive_proof : Nat.N2.n Proof.t Snarky_backendless.Request.t
 
         let handler (is_base_case : bool)
             ((no_recursion_input, no_recursion_proof) :
@@ -853,8 +849,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
         let example1, example2 =
           let s_neg_one = Field.Constant.(negate one) in
-          let b_neg_one : (Nat.N2.n, Nat.N2.n) Proof0.t =
-            Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15
+          let b_neg_one : Nat.N2.n Proof0.t =
+            Proof0.dummy Nat.N2.n Nat.N2.n ~domain_log2:15
           in
           let s0, (), b0 =
             Common.time "tree b0" (fun () ->
@@ -1036,7 +1032,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
             (fun { public_input = () } ->
               let dummy_proof =
                 exists (Typ.prover_value ()) ~compute:(fun () ->
-                    Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15 )
+                    Proof0.dummy Nat.N2.n Nat.N2.n ~domain_log2:15 )
               in
               Promise.return
                 { Inductive_rule.previous_proof_statements =
@@ -1105,12 +1101,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
           (* TODO Think this is right.. *)
         end
 
-        let compile :
-            (   unit
-             -> (Max_proofs_verified.n, Max_proofs_verified.n) Proof.t Promise.t
-            )
-            * _
-            * _ =
+        let compile : (unit -> Max_proofs_verified.n Proof.t Promise.t) * _ * _
+            =
           let self = tag in
           let snark_keys_header kind constraint_system_hash =
             { Snark_keys_header.header_version =
@@ -1319,8 +1311,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                    Branch_data.t
                 -> Lazy_keys.t
                 -> unit
-                -> (Max_proofs_verified.n, Max_proofs_verified.n) Proof.t
-                   Promise.t =
+                -> Max_proofs_verified.n Proof.t Promise.t =
              fun (T b as branch_data) (step_pk, step_vk) () ->
               let (_ : (Max_proofs_verified.n, Maxes.ns) Requests.Wrap.t) =
                 Requests.Wrap.create ()
@@ -1874,7 +1865,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
       module Proof = struct
         module Max_local_max_proofs_verified = Max_proofs_verified
-        include Proof.Make (Max_proofs_verified) (Max_local_max_proofs_verified)
+        include Proof.Make (Max_local_max_proofs_verified)
 
         let _id = wrap_disk_key
 
@@ -1903,11 +1894,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
       module Recurse_on_bad_proof = struct
         open Impls.Step
 
-        let _dummy_proof =
-          Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15
+        let _dummy_proof = Proof0.dummy Nat.N2.n Nat.N2.n ~domain_log2:15
 
         type _ Snarky_backendless.Request.t +=
-          | Proof : (Nat.N2.n, Nat.N2.n) Proof0.t Snarky_backendless.Request.t
+          | Proof : Nat.N2.n Proof0.t Snarky_backendless.Request.t
 
         let handler (proof : _ Proof0.t)
             (Snarky_backendless.Request.With { request; respond }) =

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -2,4 +2,4 @@ include
   Pickles_intf.S
     with type Side_loaded.Verification_key.Stable.V2.t =
       Mina_wire_types.Pickles.Side_loaded.Verification_key.V2.t
-     and type ('a, 'b) Proof.t = ('a, 'b) Mina_wire_types.Pickles.Proof.t
+     and type 'a Proof.t = 'a Mina_wire_types.Pickles.Proof.t

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -79,12 +79,12 @@ module type S = sig
   end
 
   module Proof : sig
-    type ('max_width, 'mlmb) t
+    type 'mlmb t
 
-    val dummy : 'w Nat.t -> 'm Nat.t -> _ Nat.t -> domain_log2:int -> ('w, 'm) t
+    val dummy : 'm Nat.t -> _ Nat.t -> domain_log2:int -> 'm t
 
-    module Make (W : Nat.Intf) (MLMB : Nat.Intf) : sig
-      type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson, hash]
+    module Make (MLMB : Nat.Intf) : sig
+      type nonrec t = MLMB.n t [@@deriving sexp, compare, yojson, hash]
 
       val to_base64 : t -> string
 
@@ -95,7 +95,7 @@ module type S = sig
       [%%versioned:
       module Stable : sig
         module V2 : sig
-          type t = Make(Nat.N2)(Nat.N2).t
+          type t = Make(Nat.N2).t
           [@@deriving sexp, compare, equal, yojson, hash]
 
           val to_yojson_full : t -> Yojson.Safe.t
@@ -107,7 +107,7 @@ module type S = sig
   end
 
   module Statement_with_proof : sig
-    type ('s, 'max_width, _) t = ('max_width, 'max_width) Proof.t
+    type ('s, 'max_width) t = 'max_width Proof.t
   end
 
   module Inductive_rule : sig
@@ -118,14 +118,14 @@ module type S = sig
     module Previous_proof_statement : sig
       type ('prev_var, 'width) t =
         { public_input : 'prev_var
-        ; proof : ('width, 'width) Proof.t Impls.Step.Typ.prover_value
+        ; proof : 'width Proof.t Impls.Step.Typ.prover_value
         ; proof_must_verify : B.t
         }
 
       module Constant : sig
         type ('prev_value, 'width) t =
           { public_input : 'prev_value
-          ; proof : ('width, 'width) Proof.t
+          ; proof : 'width Proof.t
           ; proof_must_verify : bool
           }
       end
@@ -264,14 +264,14 @@ module type S = sig
     -> (module Nat.Intf with type n = 'n)
     -> (module Statement_value_intf with type t = 'a)
     -> Verification_key.t
-    -> ('a * ('n, 'n) Proof.t) list
+    -> ('a * 'n Proof.t) list
     -> unit Or_error.t Promise.t
 
   val verify :
        (module Nat.Intf with type n = 'n)
     -> (module Statement_value_intf with type t = 'a)
     -> Verification_key.t
-    -> ('a * ('n, 'n) Proof.t) list
+    -> ('a * 'n Proof.t) list
     -> unit Or_error.t Deferred.t
 
   module Prover : sig
@@ -342,8 +342,7 @@ module type S = sig
       module Stable : sig
         module V2 : sig
           (* TODO: This should really be able to be any width up to the max width... *)
-          type t =
-            (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
+          type t = Verification_key.Max_width.n Proof.t
           [@@deriving sexp, equal, yojson, hash, compare]
 
           val to_base64 : t -> string
@@ -440,15 +439,13 @@ module type S = sig
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
        * (module Proof_intf
-            with type t = ('max_proofs_verified, 'max_proofs_verified) Proof.t
+            with type t = 'max_proofs_verified Proof.t
              and type statement = 'value )
        * ( 'prev_valuess
          , 'widthss
          , 'heightss
          , 'a_value
-         , ( 'ret_value
-           * 'auxiliary_value
-           * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
+         , ('ret_value * 'auxiliary_value * 'max_proofs_verified Proof.t)
            Promise.t )
          H3_2.T(Prover).t
 
@@ -495,15 +492,13 @@ module type S = sig
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
        * (module Proof_intf
-            with type t = ('max_proofs_verified, 'max_proofs_verified) Proof.t
+            with type t = 'max_proofs_verified Proof.t
              and type statement = 'value )
        * ( 'prev_valuess
          , 'widthss
          , 'heightss
          , 'a_value
-         , ( 'ret_value
-           * 'auxiliary_value
-           * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
+         , ('ret_value * 'auxiliary_value * 'max_proofs_verified Proof.t)
            Deferred.t )
          H3_2.T(Prover).t
 
@@ -550,15 +545,13 @@ module type S = sig
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
        * (module Proof_intf
-            with type t = ('max_proofs_verified, 'max_proofs_verified) Proof.t
+            with type t = 'max_proofs_verified Proof.t
              and type statement = 'value )
        * ( 'prev_valuess
          , 'widthss
          , 'heightss
          , 'a_value
-         , ( 'ret_value
-           * 'auxiliary_value
-           * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
+         , ('ret_value * 'auxiliary_value * 'max_proofs_verified Proof.t)
            Deferred.t )
          H3_2.T(Prover).t
 end

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -90,8 +90,8 @@ module Base = struct
   end
 end
 
-type ('s, 'mlmb, 'c) with_data =
-      ('s, 'mlmb, 'c) Mina_wire_types.Pickles.Concrete_.Proof.with_data =
+type ('s, 'mlmb) with_data =
+      ('s, 'mlmb) Mina_wire_types.Pickles.Concrete_.Proof.with_data =
   | T :
       ( 'mlmb Base.Messages_for_next_proof_over_same_field.Wrap.t
       , ( 's
@@ -103,16 +103,16 @@ type ('s, 'mlmb, 'c) with_data =
           Vector.t )
         Base.Messages_for_next_proof_over_same_field.Step.t )
       Base.Wrap.t
-      -> ('s, 'mlmb, _) with_data
+      -> ('s, 'mlmb) with_data
 
 module With_data = struct
-  type ('s, 'mlmb, 'w) t = ('s, 'mlmb, 'w) with_data
+  type ('s, 'mlmb) t = ('s, 'mlmb) with_data
 end
 
-type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) With_data.t
+type 'mlmb t = (unit, 'mlmb) With_data.t
 
-let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
-    (most_recent_width : r Nat.t) ~domain_log2 : (w, h) t =
+let dummy (type h r) (h : h Nat.t) (most_recent_width : r Nat.t) ~domain_log2 :
+    h t =
   let open Ro in
   let g0 = Tock.Curve.(to_affine_exn one) in
   let g len = Array.create ~len g0 in
@@ -206,8 +206,8 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
          { ft_eval1 = tick (); evals = ex } )
     }
 
-module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
-  module Max_proofs_verified_at_most = At_most.With_length (W)
+module Make (MLMB : Nat.Intf) = struct
+  module Max_proofs_verified_at_most = At_most.With_length (MLMB)
   module MLMB_vec = Nvector (MLMB)
 
   module Repr = struct
@@ -227,7 +227,7 @@ module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
     [@@deriving compare, sexp, yojson, hash, equal]
   end
 
-  type nonrec t = (W.n, MLMB.n) t
+  type nonrec t = MLMB.n t
 
   let to_repr (T { statement; prev_evals; proof }) : Repr.t =
     let lte =
@@ -235,7 +235,7 @@ module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
         (Vector.length
            statement.messages_for_next_step_proof
              .challenge_polynomial_commitments )
-        W.n
+        MLMB.n
     in
     let statement =
       { statement with
@@ -344,7 +344,7 @@ module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
 end
 
 module Proofs_verified_2 = struct
-  module T = Make (Nat.N2) (Nat.N2)
+  module T = Make (Nat.N2)
 
   module Repr = struct
     [%%versioned
@@ -407,10 +407,7 @@ module Proofs_verified_2 = struct
 end
 
 module Proofs_verified_max = struct
-  module T =
-    Make
-      (Side_loaded_verification_key.Width.Max)
-      (Side_loaded_verification_key.Width.Max)
+  module T = Make (Side_loaded_verification_key.Width.Max)
 
   module Repr = struct
     [%%versioned

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -92,8 +92,8 @@ module Base : sig
   end
 end
 
-type ('s, 'mlmb, 'c) with_data =
-      ('s, 'mlmb, 'c) Mina_wire_types.Pickles.Concrete_.Proof.with_data =
+type ('s, 'mlmb) with_data =
+      ('s, 'mlmb) Mina_wire_types.Pickles.Concrete_.Proof.with_data =
   | T :
       ( 'mlmb Base.Messages_for_next_proof_over_same_field.Wrap.t
       , ( 's
@@ -107,20 +107,16 @@ type ('s, 'mlmb, 'c) with_data =
           Pickles_types.Vector.t )
         Base.Messages_for_next_proof_over_same_field.Step.t )
       Base.Wrap.t
-      -> ('s, 'mlmb, _) with_data
+      -> ('s, 'mlmb) with_data
 
-type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
+type 'mlmb t = (unit, 'mlmb) with_data
 
 val dummy :
-     'w Pickles_types.Nat.t
-  -> 'h Pickles_types.Nat.t
-  -> 'r Pickles_types.Nat.t
-  -> domain_log2:int
-  -> ('w, 'h) t
+  'h Pickles_types.Nat.t -> 'r Pickles_types.Nat.t -> domain_log2:int -> 'h t
 
-module Make (W : Pickles_types.Nat.Intf) (MLMB : Pickles_types.Nat.Intf) : sig
+module Make (MLMB : Pickles_types.Nat.Intf) : sig
   module Max_proofs_verified_at_most :
-      module type of Pickles_types.At_most.With_length (W)
+      module type of Pickles_types.At_most.With_length (MLMB)
 
   module MLMB_vec : module type of Import.Nvector (MLMB)
 
@@ -142,7 +138,7 @@ module Make (W : Pickles_types.Nat.Intf) (MLMB : Pickles_types.Nat.Intf) : sig
     [@@deriving compare, sexp, yojson, hash, equal]
   end
 
-  type nonrec t = (W.n, MLMB.n) t [@@deriving compare, sexp, hash, equal]
+  type nonrec t = MLMB.n t [@@deriving compare, sexp, hash, equal]
 
   val to_base64 : t -> string
 
@@ -156,7 +152,7 @@ module Make (W : Pickles_types.Nat.Intf) (MLMB : Pickles_types.Nat.Intf) : sig
 end
 
 module Proofs_verified_2 : sig
-  module T : module type of Make (Pickles_types.Nat.N2) (Pickles_types.Nat.N2)
+  module T : module type of Make (Pickles_types.Nat.N2)
 
   [%%versioned:
   module Stable : sig
@@ -173,11 +169,7 @@ module Proofs_verified_2 : sig
 end
 
 module Proofs_verified_max : sig
-  module T :
-      module type of
-        Make
-          (Side_loaded_verification_key.Width.Max)
-          (Side_loaded_verification_key.Width.Max)
+  module T : module type of Make (Side_loaded_verification_key.Width.Max)
 
   [%%versioned:
   module Stable : sig

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -123,7 +123,7 @@ struct
            Impls.Wrap.Verification_key.t
         -> _ array Plonk_verification_key_evals.t
         -> value
-        -> (local_max_proofs_verified, local_max_proofs_verified) Proof.t
+        -> local_max_proofs_verified Proof.t
         -> (var, value, local_max_proofs_verified) Types_map.Basic.t
         -> must_verify:bool
         -> [ `Sg of Tock.Curve.Affine.t ]
@@ -582,7 +582,7 @@ struct
                  , ns
                  , ms )
                  H3.T(Per_proof_witness.Constant.No_app_state).t
-               * (ns, ns) H2.T(Proof).t
+               * ns H1.T(Proof).t
                * (int, k) Vector.t =
          fun ts datas prev_proof_stmts l ->
           match (ts, datas, prev_proof_stmts, l) with
@@ -648,7 +648,7 @@ struct
         (module Extract : Extract.S with type res = res) =
       let rec go :
           type vars values ns ms len.
-             (ns, ns) H2.T(Proof).t
+             ns H1.T(Proof).t
           -> (values, vars, ns, ms) H4.T(Tag).t
           -> (vars, len) Length.t
           -> (res, len) Vector.t =
@@ -863,7 +863,7 @@ struct
     let messages_for_next_wrap_proof =
       let rec go :
           type a.
-             (a, a) H2.T(Proof).t
+             a H1.T(Proof).t
           -> a H1.T(Proof.Base.Messages_for_next_proof_over_same_field.Wrap).t =
         function
         | [] ->

--- a/src/lib/pickles/test/chunked_circuits/chunks2.ml
+++ b/src/lib/pickles/test/chunked_circuits/chunks2.ml
@@ -57,8 +57,7 @@ let test () =
   in
   let module Requests = struct
     type _ Snarky_backendless.Request.t +=
-      | Proof :
-          (Nat.N0.n, Nat.N0.n) Pickles.Proof.t Snarky_backendless.Request.t
+      | Proof : Nat.N0.n Pickles.Proof.t Snarky_backendless.Request.t
 
     let handler (proof : _ Pickles.Proof.t)
         (Snarky_backendless.Request.With { request; respond }) =

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -13,7 +13,7 @@ module Instance = struct
         * chunking_data option
         * Verification_key.t
         * 'a
-        * ('n, 'n) Proof.t
+        * 'n Proof.t
         -> t
 end
 
@@ -243,7 +243,7 @@ let verify_heterogenous (ts : Instance.t list) =
 let verify (type a n) ?chunking_data
     (max_proofs_verified : (module Nat.Intf with type n = n))
     (a_value : (module Intf.Statement_value with type t = a))
-    (key : Verification_key.t) (ts : (a * (n, n) Proof.t) list) =
+    (key : Verification_key.t) (ts : (a * n Proof.t) list) =
   verify_heterogenous
     (List.map ts ~f:(fun (x, p) ->
          Instance.T (max_proofs_verified, a_value, chunking_data, key, x, p) )

--- a/src/lib/pickles/verify.mli
+++ b/src/lib/pickles/verify.mli
@@ -10,7 +10,7 @@ module Instance : sig
         * chunking_data option
         * Verification_key.t
         * 'a
-        * ('n, 'n) Proof.t
+        * 'n Proof.t
         -> t
 end
 
@@ -19,7 +19,7 @@ val verify :
   -> (module Pickles_types.Nat.Intf with type n = 'n)
   -> (module Intf.Statement_value with type t = 'a)
   -> Verification_key.t
-  -> ('a * ('n, 'n) Proof.t) list
+  -> ('a * 'n Proof.t) list
   -> unit Or_error.t Promise.t
 
 val verify_heterogenous : Instance.t list -> unit Or_error.t Promise.t

--- a/src/lib/pickles/wrap_hack.ml
+++ b/src/lib/pickles/wrap_hack.ml
@@ -59,8 +59,7 @@ let hash_messages_for_next_wrap_proof (type n)
     )
 
 (* Pad the messages_for_next_wrap_proof of a proof *)
-let pad_proof (type mlmb) (T p : (mlmb, _) Proof.t) :
-    Proof.Proofs_verified_max.t =
+let pad_proof (type mlmb) (T p : mlmb Proof.t) : Proof.Proofs_verified_max.t =
   T
     { p with
       statement =

--- a/src/lib/pickles/wrap_hack.mli
+++ b/src/lib/pickles/wrap_hack.mli
@@ -17,7 +17,7 @@ val hash_messages_for_next_wrap_proof :
      Composition_types.Wrap.Proof_state.Messages_for_next_wrap_proof.t
   -> Import.Types.Digest.Constant.t
 
-val pad_proof : ('mlmb, 'a) Proof.t -> Proof.Proofs_verified_max.t
+val pad_proof : 'mlmb Proof.t -> Proof.Proofs_verified_max.t
 
 val pad_challenges :
      ( ( Backend.Tock.Field.t

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -570,7 +570,7 @@ let create_genesis_block_inputs (genesis_inputs : Genesis_proof.Inputs.t) =
   in
   let open Pickles_types in
   let blockchain_dummy =
-    Pickles.Proof.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:16
+    Pickles.Proof.dummy Nat.N2.n Nat.N2.n ~domain_log2:16
   in
   let snark_transition =
     let open Staged_ledger_diff in

--- a/src/lib/transaction_snark/test/util.mli
+++ b/src/lib/transaction_snark/test/util.mli
@@ -74,10 +74,8 @@ val trivial_zkapp :
        , unit
        , unit
        , Zkapp_statement.t
-       , ( unit
-         * unit
-         * (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) Pickles.Proof.t )
-         Async.Deferred.t )
+       , (unit * unit * Pickles_types.Nat.N2.n Pickles.Proof.t) Async.Deferred.t
+       )
        Pickles.Prover.t ] )
   Lazy.t
 
@@ -97,10 +95,8 @@ val test_snapp_update :
        , unit
        , unit
        , Zkapp_statement.t
-       , ( unit
-         * unit
-         * (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) Pickles.Proof.t )
-         Async.Deferred.t )
+       , (unit * unit * Pickles_types.Nat.N2.n Pickles.Proof.t) Async.Deferred.t
+       )
        Pickles.Prover.t
   -> Transaction_snark.For_tests.Update_states_spec.t
   -> init_ledger:Mina_transaction_logic.For_tests.Init_ledger.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1404,8 +1404,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
 
       type _ Snarky_backendless.Request.t +=
-        | Zkapp_proof :
-            (Nat.N2.n, Nat.N2.n) Pickles.Proof.t Snarky_backendless.Request.t
+        | Zkapp_proof : Nat.N2.n Pickles.Proof.t Snarky_backendless.Request.t
 
       let handle_zkapp_proof (proof : _ Pickles.Proof.t)
           (Snarky_backendless.Request.With { request; respond }) =
@@ -3196,8 +3195,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           (Statement.With_sok.t * Statement.With_sok.t)
           Snarky_backendless.Request.t
       | Proofs_to_merge :
-          ( (Nat.N2.n, Nat.N2.n) Pickles.Proof.t
-          * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t )
+          (Nat.N2.n Pickles.Proof.t * Nat.N2.n Pickles.Proof.t)
           Snarky_backendless.Request.t
 
     let handle

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -306,8 +306,7 @@ module type Full = sig
            , unit
            , unit
            , Zkapp_statement.t
-           , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
-             Async.Deferred.t )
+           , (unit * unit * Nat.N2.n Pickles.Proof.t) Async.Deferred.t )
            Pickles.Prover.t
            * ( Pickles.Side_loaded.Verification_key.t
              , Snark_params.Tick.Field.t )
@@ -347,8 +346,7 @@ module type Full = sig
            , unit
            , unit
            , Zkapp_statement.t
-           , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
-             Async.Deferred.t )
+           , (unit * unit * Nat.N2.n Pickles.Proof.t) Async.Deferred.t )
            Pickles.Prover.t
            * ( Pickles.Side_loaded.Verification_key.t
              , Snark_params.Tick.Field.t )
@@ -390,8 +388,7 @@ module type Full = sig
               , unit
               , unit
               , Zkapp_statement.t
-              , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
-                Async.Deferred.t )
+              , (unit * unit * Nat.N2.n Pickles.Proof.t) Async.Deferred.t )
               Pickles.Prover.t ]
 
     module Multiple_transfers_spec : sig


### PR DESCRIPTION
This  PR removes an unused phantom type argument for the `Pickles.Proof.t` type. In all cases where `Pickles.Proof.t` is made monomorphic, both type arguments are always the same. 

Since the type effectively unused and didn't affect the value, IIUC it's a noop and there is no need to change the versioning