### PR TITLE
Stop inappropriately using `$REMOTE` in monorepo triage

### DIFF
--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -13,7 +13,7 @@ elif [ -n "${TAG}" ]; then
   git ls-files
 else
   COMMIT=$(git log -1 --pretty=format:%H)
-  BASE_COMMIT=$(git log "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
+  BASE_COMMIT=$(git log "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
   echo "Diffing current commit: ${COMMIT} against branch: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} (${BASE_COMMIT})" >&2 
-  git diff "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
+  git diff "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
 fi


### PR DESCRIPTION
PR #16665 previously changed the semantics of `$REMOTE` in our CI fork checks, without adequately updating all of the places it was used. This PR fixes the oversight in monorepo triage, which broke CI for all external contributors (see e.g. PR #16925).