### PR TITLE
Fix `override_wrap_domain` document

### DIFF
--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -395,7 +395,7 @@ module type S = sig
       @param storables A swappable underlying implementation of the cache.
       @param proof_cache Cache that allows us to pass in precomputed proofs. Useful for CI.
       @param disk_keys Caches for the individial keys
-      @param override_wrap_domain This let you tell pickles that the wrap circuit will be smaller/bigger than it's expecting's. At the moment, we map 0 proofs verified to 2^14, 1 proofs verified to 2^15, and 2 to 2^16. However, you'll usually see this used with 2 proofs, which actually only requires 2^15 (so we set this as N1). This was also part of the inspiration for your project: its existence tells us that we can recurse over more proofs.
+      @param override_wrap_domain This let you tell pickles that the wrap circuit will be smaller/bigger than it's expecting's. At the moment, we map 0 proofs verified to 2^13, 1 proofs verified to 2^14, and 2 to 2^15. However, you'll usually see this used with 2 proofs, which actually only requires 2^14 (so we set this as N1).
       @param num_chunks Configurable parameter enabling circuits larger than maximum
       @param max_proofs_verified Number of different circuits that Tick(i.e. Step) accepts as inputs
   *)


### PR DESCRIPTION
This is a noop change, aims to fix the inccorectly documented arg `override_wrap_domain`