### PR TITLE
[Benchmarks] Corner case fix for handling different  result from MA

### DIFF
--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -7,6 +7,7 @@ set -eox pipefail
 YELLOW_THRESHOLD="0.1"
 RED_THRESHOLD="0.3"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
+BRANCH="${BRANCH:-BUILDKITE_BRANCH}"
 
 source buildkite/scripts/bench/install.sh
 
@@ -34,4 +35,4 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
-python3 ./scripts/benchmarks test --benchmark ${BENCHMARK}  --branch ${BUILDKITE_BRANCH} --tmpfile ${BENCHMARK}.csv --yellow-threshold $YELLOW_THRESHOLD --red-threshold $RED_THRESHOLD $MAINLINE_BRANCHES $EXTRA_ARGS
+python3 ./scripts/benchmarks test --benchmark ${BENCHMARK}  --branch ${BRANCH} --tmpfile ${BENCHMARK}.csv --yellow-threshold $YELLOW_THRESHOLD --red-threshold $RED_THRESHOLD $MAINLINE_BRANCHES $EXTRA_ARGS

--- a/buildkite/src/Command/Bench/Base.dhall
+++ b/buildkite/src/Command/Bench/Base.dhall
@@ -63,23 +63,32 @@ let Spec =
 let command
     : Spec.Type -> Command.Type
     =     \(spec : Spec.Type)
-      ->  Command.build
-            Command.Config::{
-            , commands =
-                  spec.preCommands
-                # RunInToolchain.runInToolchain
-                    (Benchmarks.toEnvList Benchmarks.Type::{=})
-                    "./buildkite/scripts/bench/run.sh  ${spec.bench} --red-threshold ${Double/show
-                                                                                         spec.redThreshold} --yellow-threshold ${Double/show
-                                                                                                                                   spec.yellowThreshold}"
-            , label =
-                "Perf: ${spec.label} ${PipelineMode.capitalName spec.mode}"
-            , key = spec.key
-            , target = spec.size
-            , soft_fail = Some (B/SoftFail.Boolean True)
-            , docker = None Docker.Type
-            , depends_on = spec.dependsOn
-            }
+      ->  let branch =
+                      if PipelineMode.isStable spec.mode
+
+                then  "\\\${BUILDKITE_BRANCH}"
+
+                else  "\\\${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+
+          in  Command.build
+                Command.Config::{
+                , commands =
+                      spec.preCommands
+                    # RunInToolchain.runInToolchain
+                        (   Benchmarks.toEnvList Benchmarks.Type::{=}
+                          # [ "BRANCH=${branch}" ]
+                        )
+                        "./buildkite/scripts/bench/run.sh  ${spec.bench} --red-threshold ${Double/show
+                                                                                             spec.redThreshold} --yellow-threshold ${Double/show
+                                                                                                                                       spec.yellowThreshold}"
+                , label =
+                    "Perf: ${spec.label} ${PipelineMode.capitalName spec.mode}"
+                , key = spec.key
+                , target = spec.size
+                , soft_fail = Some (B/SoftFail.Boolean True)
+                , docker = None Docker.Type
+                , depends_on = spec.dependsOn
+                }
 
 let pipeline
     : Spec.Type -> Pipeline.Config.Type

--- a/scripts/benchmarks/lib/bench.py
+++ b/scripts/benchmarks/lib/bench.py
@@ -117,9 +117,8 @@ class Benchmark(abc.ABC):
                         name, branch, str(field), self.branch_header())
 
                     print(f"result: {result}")
-                    print(f"last result: {result[-1]}")
-
-                    records = result[-1].records if (result is not None) and (result[-1] is not None) else []
+                    
+                    records = result[-1].records if (result is not None) and (len(result) > 0) else []
 
                     if len(records) < self.influx_client.moving_average_size :
                         logger.warning(

--- a/scripts/benchmarks/lib/bench.py
+++ b/scripts/benchmarks/lib/bench.py
@@ -116,6 +116,9 @@ class Benchmark(abc.ABC):
                     result = self.influx_client.query_moving_average(
                         name, branch, str(field), self.branch_header())
 
+                    print(f"result: {result}")
+                    print(f"last result: {result[-1]}")
+
                     records = result[-1].records if (result is not None) and (result[-1] is not None) else []
 
                     if len(records) < self.influx_client.moving_average_size :

--- a/scripts/benchmarks/lib/bench.py
+++ b/scripts/benchmarks/lib/bench.py
@@ -116,12 +116,14 @@ class Benchmark(abc.ABC):
                     result = self.influx_client.query_moving_average(
                         name, branch, str(field), self.branch_header())
 
-                    if len(result) < self.influx_client.moving_average_size :
+                    records = result[-1].records if (result is not None) and (result[-1] is not None) else []
+
+                    if len(records) < self.influx_client.moving_average_size :
                         logger.warning(
                             f"Skipping comparison for {name} as there are no enough ({self.influx_client.moving_average_size}) historical data available yet"
                         )
                     else:
-                        average = float(result[-1].records[-1]["_value"])
+                        average = float(records[-1]["_value"])
 
                         current_red_threshold = average * red_threshold
                         current_yellow_threshold = average * yellow_threshold

--- a/scripts/tests/ledger_test_apply.sh
+++ b/scripts/tests/ledger_test_apply.sh
@@ -47,7 +47,7 @@ $RUNTIME_LEDGER_APP --config-file $GENESIS_LEDGER --genesis-dir $TEMP_FOLDER/gen
 
 
 # Silently passing MINA_PRIVKEY_PASS & CODA_PRIVKEY
-CODA_PRIVKEY=$(cat $ACCOUNTS_FILE | jq -r .[0].sk) MINA_PRIVKEY_PASS=$MINA_PRIVKEY_PASS mina advanced wrap-key --privkey-path $SENDER
+CODA_PRIVKEY=$(cat $ACCOUNTS_FILE | jq -r .[0].sk) MINA_PRIVKEY_PASS=$MINA_PRIVKEY_PASS $MINA_APP advanced wrap-key --privkey-path $SENDER
 chmod 700 $SENDER
 
 mkdir $TEMP_FOLDER/genesis/ledger


### PR DESCRIPTION
Fixes corner case for benchmarks for which moving average has different than anticipated format. In some cases result is actual table which has correct length but there are few examples which has always 1. Safest is to always count records

As a result some benchmark did not performed requested comparision against reference data.

I also added switch to always use BUILDKITE_BRANCH when running in nightly and BUILDKITE_PULL_REQUEST_BASE_BRANCH on prs. 