### PR TITLE
[CI][FORK]  Revert REMOTE env var

### DIFF
--- a/buildkite/scripts/changelog.sh
+++ b/buildkite/scripts/changelog.sh
@@ -93,7 +93,7 @@ else
     exit 1
 fi
 
-REMOTE_BRANCH="${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+REMOTE_BRANCH="origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
 
 BASE_COMMIT=$(git log "${REMOTE_BRANCH}" -1 --pretty=format:%H)
 echo "Diffing current commit: ${BUILDKITE_COMMIT} against branch: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} (${BASE_COMMIT})" >&2

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -13,7 +13,7 @@ elif [ -n "${TAG}" ]; then
   git ls-files
 else
   COMMIT=$(git log -1 --pretty=format:%H)
-  BASE_COMMIT=$(git log "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
+  BASE_COMMIT=$(git log "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" -1 --pretty=format:%H)
   echo "Diffing current commit: ${COMMIT} against branch: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} (${BASE_COMMIT})" >&2 
-  git diff "${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
+  git diff "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" --name-only
 fi

--- a/buildkite/scripts/handle-fork.sh
+++ b/buildkite/scripts/handle-fork.sh
@@ -5,30 +5,15 @@ set -xeo pipefail
 export MINA_REPO="https://github.com/MinaProtocol/mina.git"
 
 if [ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]; then
-    echo "This is not a Forked repo, skipping..."
-    export REMOTE="origin"
+    echo "Unable to detect fork without BUILDKITE_PULL_REQUEST_REPO"
+    echo "Looks like CI was ran without ci-build-me! skipping..."
     export FORK=0
     exit 0
 fi
 
 if [[ "${BUILDKITE_PULL_REQUEST_REPO}" ==  "${MINA_REPO}" ]]; then
     echo "This is not a Forked repo, skipping..."
-    export REMOTE="origin"
     export FORK=0
 else
-    export REMOTE="fork"
     export FORK=1
-    if ! git remote -v | grep "${BUILDKITE_PULL_REQUEST_REPO}"; then
-        git remote add fork ${BUILDKITE_PULL_REQUEST_REPO}
-        git fetch fork --recurse-submodules --tags
-        # This is a workaround for missing git-lfs
-        rm -f .git/hooks/post-checkout || true
-        git switch -c ${BUILDKITE_BRANCH}
-    else
-        git remote set-url fork ${BUILDKITE_PULL_REQUEST_REPO}
-        git fetch fork --recurse-submodules --tags
-        # This is a workaround for missing git-lfs
-        rm -f .git/hooks/post-checkout || true
-        git switch ${BUILDKITE_BRANCH}
-    fi
 fi

--- a/buildkite/scripts/handle-fork.sh
+++ b/buildkite/scripts/handle-fork.sh
@@ -6,7 +6,7 @@ export MINA_REPO="https://github.com/MinaProtocol/mina.git"
 
 if [ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]; then
     echo "Unable to detect fork without BUILDKITE_PULL_REQUEST_REPO"
-    echo "Looks like CI was ran without ci-build-me! skipping..."
+    echo "Looks like CI was ran without !ci-build-me skipping..."
     export FORK=0
     exit 0
 fi

--- a/buildkite/scripts/merges-cleanly.sh
+++ b/buildkite/scripts/merges-cleanly.sh
@@ -26,7 +26,7 @@ git config --global user.name "It's me, CI"
 # * `--no-commit` stops us from updating the index with a merge commit,
 # * `--no-ff` stops us from updating the index to the HEAD, if the merge is a
 #   straightforward fast-forward
-git merge --no-commit --no-ff ${REMOTE}/$BRANCH
+git merge --no-commit --no-ff origin/$BRANCH
 
 RET=$?
 

--- a/buildkite/scripts/refresh_code.sh
+++ b/buildkite/scripts/refresh_code.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-source ./buildkite/scripts/handle-fork.sh
-git fetch ${REMOTE} --recurse-submodules
-git fetch ${REMOTE} --tags
-git fetch ${REMOTE} --prune-tags
+git branch -D $BUILDKITE_BRANCH 2>/dev/null || true
+git checkout -b $BUILDKITE_BRANCH
+git reset --hard $BUILDKITE_COMMIT

--- a/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
+++ b/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
@@ -35,8 +35,10 @@ function checkout_and_dump() {
 }
 
 
+source ./buildkite/scripts/handle-fork.sh
+
 if [[ $FORK == 1 ]]; then 
-    echo "⏩  Skipping type shape patching on for forked repository" 
+    echo "⏩  Skipping type shape patching on a forked repository" 
     exit 0
 fi
 
@@ -45,7 +47,7 @@ if ! $(source buildkite/scripts/cache/manager.sh read mina-type-shapes/"$RELEASE
 fi
 
 if [[ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]]; then 
-    BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT=$(git log -n 1 --format="%h" --abbrev=7 ${REMOTE}/${BUILDKITE_PULL_REQUEST_BASE_BRANCH} )
+    BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT=$(git log -n 1 --format="%h" --abbrev=7 ${BUILDKITE_PULL_REQUEST_BASE_BRANCH} )
     if ! gsutil ls "gs://mina-type-shapes/${BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT}*"; then
         checkout_and_dump $BUILDKITE_PULL_REQUEST_BASE_BRANCH_COMMIT
     fi

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -23,8 +23,10 @@ source buildkite/scripts/export-git-env-vars.sh
 
 pip3 install sexpdata==1.0.0
 
+source ./buildkite/scripts/refresh_code.sh
+
 base_branch=origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-compatible}
-pr_branch=${REMOTE}/${BUILDKITE_BRANCH}
+pr_branch=${BUILDKITE_BRANCH}
 release_branch=origin/$1
 
 echo "--- Run Python version linter with branches: ${pr_branch} ${base_branch} ${release_branch}"


### PR DESCRIPTION
## Fix for forked repo CI

### Issue 

Some external contributors are suffering from failing CI on their correct PRs, for example: https://github.com/MinaProtocol/mina/pull/16925

Origin of issue was my assumption when writing the code that forked repositories always have all mainline branches synced with ours. As a result we can rely on diffing base branch with head on forked repo alone not touching our repo in such comparision. In above case this assumption was proven wrong. Forked repositories does not have base branch (in this case compatible) , so git cannot find them and is erroring out. In buildkite we have 4 env vars which can help us identify PR from forked repository:
```
BUILDKITE_PULL_REQUEST_REPO="https://github.com/mrmr1993/mina.git"
BUILDKITE_REPO="https://github.com/MinaProtocol/mina.git"

BUILDKITE_PULL_REQUEST_BASE_BRANCH="compatible"
BUILDKITE_BRANCH="feature/fix-fork-handling"
```

However, we don't have a information if our base branch is from origin or forked repo. We can back it up from this logic and always use origin.  This will cause another issue that, if you want to run a PR on forked repo without merging to origin, let's say zeko-labs:fix-aarch64 -> zeko-labs:compatible , then it will use mina:compatible anyhow in CI as a base branch for checks. I thought back then that it's a bigger problem than keeping fork up to date,  (but I didn't document it either).

### Solution

Solution is to abandon current logic which sets REMOTE env var which is a product of fork repository detection. We will always use origin (mina) repository as reference branch. In case of merges check we don't need to know what is the current branch etc. BUILDKITE_COMMIT is enough for this kind of checks. Only two problematic checks remains: nix check and version linter. Solution is to just create local branch on BUILDKITE_COMMIT as this is just a name. Nix check requires to work on a branch due to issue, well described in test_nix.sh file. In version linter we need branch for reporting purposes, our locally created branch on BUILDKITE_COMMIT is also enough. 

