### PR TITLE
Don't read proofs when computing transaction hash

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -2079,7 +2079,7 @@ module User_command = struct
       in
       let memo = ps.memo |> Signed_command_memo.to_base58_check in
       let hash =
-        Transaction_hash.hash_wrapped_zkapp_command ps
+        Transaction_hash.hash_zkapp_command_with_hashes ps
         |> Transaction_hash.to_base58_check
       in
       Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -137,7 +137,7 @@ let%test_module "Archive node unit tests" =
       Async.Quickcheck.async_test ~sexp_of:[%sexp_of: User_command.t]
         user_command_signed_gen ~f:(fun user_command ->
           let transaction_hash =
-            Transaction_hash.hash_wrapped_command user_command
+            Transaction_hash.hash_command_with_hashes user_command
           in
           match%map
             let open Deferred.Result.Let_syntax in
@@ -169,7 +169,7 @@ let%test_module "Archive node unit tests" =
       Async.Quickcheck.async_test ~trials:20 ~sexp_of:[%sexp_of: User_command.t]
         user_command_zkapp_gen ~f:(fun user_command ->
           let transaction_hash =
-            Transaction_hash.hash_wrapped_command user_command
+            Transaction_hash.hash_command_with_hashes user_command
           in
           match user_command with
           | Signed_command _ ->

--- a/src/app/cli/src/init/itn.ml
+++ b/src/app/cli/src/init/itn.ml
@@ -186,7 +186,7 @@ let create_accounts ~(genesis_constants : Genesis_constants.t)
       Format.printf "Processing batch of %d zkApps@." (List.length zkapps_batch) ;
       List.iteri zkapps_batch ~f:(fun i zkapp ->
           let txn_hash =
-            Transaction_hash.hash_wrapped_zkapp_command zkapp
+            Transaction_hash.hash_zkapp_command_with_hashes zkapp
             |> Transaction_hash.to_base58_check
           in
           Format.printf " zkApp %d, transaction hash: %s@." i txn_hash ;

--- a/src/lib/staged_ledger/check_commands.ml
+++ b/src/lib/staged_ledger/check_commands.ml
@@ -25,7 +25,7 @@ let verify_command_with_transaction_pool_proxy
     (* PERF: `hash_command` is slow, so we may need to investigate if we could
        reuse hashes from transition verification. *)
     User_command.of_verifiable verifiable_cmd
-    |> User_command.read_all_proofs_from_disk |> Transaction_hash.hash_command
+    |> Transaction_hash.hash_command_with_hashes
   in
   match transaction_pool_proxy.find_by_hash cmd_hash with
   | None ->

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -31,13 +31,13 @@ val hash_signed_command : Signed_command.t -> t
 
 val hash_signed_command_v1 : Signed_command.Stable.V1.t -> t
 
-val hash_zkapp_command : Zkapp_command.Stable.Latest.t -> t
+val hash_zkapp_command : (_, unit, unit) Zkapp_command.with_forest -> t
 
-val hash_command : User_command.Stable.Latest.t -> t
+val hash_command : (_, unit, unit) User_command.with_forest -> t
 
-val hash_wrapped_zkapp_command : Zkapp_command.t -> t
+val hash_zkapp_command_with_hashes : (_, _, _) Zkapp_command.with_forest -> t
 
-val hash_wrapped_command : User_command.t -> t
+val hash_command_with_hashes : (_, _, _) User_command.with_forest -> t
 
 val hash_fee_transfer : Fee_transfer.Single.t -> t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -31,13 +31,13 @@ val hash_signed_command : Signed_command.t -> t
 
 val hash_signed_command_v1 : Signed_command.Stable.V1.t -> t
 
-val hash_zkapp_command : (_, unit, unit) Zkapp_command.with_forest -> t
+val hash_zkapp_command : Zkapp_command.Stable.Latest.t -> t
 
-val hash_command : (_, unit, unit) User_command.with_forest -> t
+val hash_command : User_command.Stable.Latest.t -> t
 
-val hash_zkapp_command_with_hashes : (_, _, _) Zkapp_command.with_forest -> t
+val hash_zkapp_command_with_hashes : Zkapp_command.t -> t
 
-val hash_command_with_hashes : (_, _, _) User_command.with_forest -> t
+val hash_command_with_hashes : User_command.t -> t
 
 val hash_fee_transfer : Fee_transfer.Single.t -> t
 

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -470,7 +470,7 @@ let add_breadcrumb_exn t breadcrumb =
   in
   let tx_hash_json command =
     User_command.forget_check command
-    |> Mina_transaction.Transaction_hash.hash_wrapped_command
+    |> Mina_transaction.Transaction_hash.hash_command_with_hashes
     |> Mina_transaction.Transaction_hash.to_yojson
   in
   [%str_log' trace t.logger] Added_breadcrumb_user_commands


### PR DESCRIPTION
Don't read proofs to compute transaction hashes.

It is achieved by relaxing signatures in implementation of `Transaction_hash`.
Also some functions names are updated to follow the latest naming convention.

Explain your changes:
- **Make hash_command and its variants polymorphic in proof**
- **Restrict types for hash_command and variants**

Explain how you tested your changes:
* Simple and straightforward refactoring of types

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
