### PR TITLE
Remove unnecessary derivations from valid command types

### DIFF
--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -295,7 +295,7 @@ module Valid = struct
   type t_ = t
 
   type t = (Signed_command.With_valid_signature.t, Zkapp_command.Valid.t) Poly.t
-  [@@deriving sexp, yojson]
+  [@@deriving sexp_of, to_yojson]
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -295,7 +295,7 @@ module Valid = struct
   type t_ = t
 
   type t = (Signed_command.With_valid_signature.t, Zkapp_command.Valid.t) Poly.t
-  [@@deriving sexp, compare, equal, yojson]
+  [@@deriving sexp, equal, yojson]
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -295,7 +295,7 @@ module Valid = struct
   type t_ = t
 
   type t = (Signed_command.With_valid_signature.t, Zkapp_command.Valid.t) Poly.t
-  [@@deriving sexp, equal, yojson]
+  [@@deriving sexp, yojson]
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -295,7 +295,7 @@ module Valid = struct
   type t_ = t
 
   type t = (Signed_command.With_valid_signature.t, Zkapp_command.Valid.t) Poly.t
-  [@@deriving sexp, compare, equal, hash, yojson]
+  [@@deriving sexp, compare, equal, yojson]
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -747,8 +747,7 @@ let weight (zkapp_command : (_, _) with_forest) : int =
     ]
 
 module type Valid_intf = sig
-  type nonrec t = private { zkapp_command : t }
-  [@@deriving sexp, compare, equal, hash, yojson]
+  type nonrec t = private { zkapp_command : t } [@@deriving sexp_of, to_yojson]
 
   val to_valid_unsafe :
     T.t -> [> `If_this_is_used_it_should_have_a_comment_justifying_it of t ]
@@ -770,8 +769,7 @@ module type Valid_intf = sig
 end
 
 module Valid : Valid_intf = struct
-  type t = { zkapp_command : T.t }
-  [@@deriving sexp, compare, equal, hash, yojson]
+  type t = { zkapp_command : T.t } [@@deriving sexp_of, to_yojson]
 
   let create zkapp_command : t = { zkapp_command }
 

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -272,7 +272,8 @@ module Transaction_pool = struct
 
   type partial = partial_item list [@@deriving sexp_of]
 
-  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp_of]
+  type t = (diff, partial, User_command.Valid.t list) batcher
+  [@@deriving sexp_of]
 
   type input = [ `Init of diff | `Partially_validated of partial ]
 

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -253,7 +253,7 @@ module Transaction_pool = struct
   open Mina_base
 
   type diff = User_command.Verifiable.t list Envelope.Incoming.t
-  [@@deriving sexp]
+  [@@deriving sexp_of]
 
   (* A partially verified transaction is either valid, or valid assuming that some list of
      (verification key, statement, proof) triples will verify. That is, the transaction has
@@ -268,11 +268,11 @@ module Transaction_pool = struct
         * Zkapp_statement.t
         * Pickles.Side_loaded.Proof.t )
         list ]
-  [@@deriving sexp]
+  [@@deriving sexp_of]
 
-  type partial = partial_item list [@@deriving sexp]
+  type partial = partial_item list [@@deriving sexp_of]
 
-  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp]
+  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp_of]
 
   type input = [ `Init of diff | `Partially_validated of partial ]
 

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -40,7 +40,7 @@ val compare_envelope : _ Envelope.Incoming.t -> _ Envelope.Incoming.t -> int
 module Transaction_pool : sig
   open Mina_base
 
-  type t [@@deriving sexp]
+  type t [@@deriving sexp_of]
 
   val create : logger:Logger.t -> Verifier.t -> t
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -405,9 +405,8 @@ module Update = struct
         { fee_per_wu : Currency.Fee_rate.t
         ; command : Transaction_hash.User_command_with_valid_signature.t
         }
-  [@@deriving sexp]
 
-  type t = single Writer_result.Tree.t (* [@sexp.opaque] *) [@@deriving sexp]
+  type t = single Writer_result.Tree.t
 
   let to_yojson _ = `String "<update>"
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1059,10 +1059,11 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
             |> M.lift
           in
           (* check remove_exn dropped the right things *)
-          [%test_eq:
-            Transaction_hash.User_command_with_valid_signature.t Sequence.t]
-            dropped
-            (F_sequence.to_seq drop_queue) ;
+          assert (
+            [%equal:
+              Transaction_hash.User_command_with_valid_signature.t Sequence.t]
+              dropped
+              (F_sequence.to_seq drop_queue) ) ;
           (* Add the new transaction *)
           let%bind cmd, _ =
             let%map v, dropped' =

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -35,7 +35,7 @@ val set_sender_local_state : t -> Sender_local_state.t -> t
 module rec Update : sig
   val apply : Update.t -> t -> t
 
-  type t [@@deriving to_yojson, sexp]
+  type t [@@deriving to_yojson]
 
   val merge : t -> t -> t
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -178,7 +178,7 @@ module Diff_versioned = struct
   type rejected = Rejected.t [@@deriving sexp, yojson, compare]
 
   type verified = Transaction_hash.User_command_with_valid_signature.t list
-  [@@deriving sexp, to_yojson]
+  [@@deriving to_yojson]
 
   let summary t =
     Printf.sprintf
@@ -1002,7 +1002,7 @@ struct
 
       type rejected = Rejected.t
 
-      type verified = Diff_versioned.verified [@@deriving sexp, to_yojson]
+      type verified = Diff_versioned.verified [@@deriving to_yojson]
 
       let reject_overloaded_diff (diff : verified) : rejected =
         List.map diff ~f:(fun cmd ->

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -28,11 +28,10 @@ end
 module Valid = struct
   module T = struct
     type t = User_command.Valid.t Poly.t
-    [@@deriving sexp, compare, equal, hash, yojson]
+    [@@deriving sexp, compare, equal, yojson]
   end
 
   include T
-  include Hashable.Make (T)
   include Comparable.Make (T)
 end
 

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -26,13 +26,7 @@ module Poly = struct
 end
 
 module Valid = struct
-  module T = struct
-    type t = User_command.Valid.t Poly.t
-    [@@deriving sexp, compare, equal, yojson]
-  end
-
-  include T
-  include Comparable.Make (T)
+  type t = User_command.Valid.t Poly.t [@@deriving sexp, equal, yojson]
 end
 
 [%%versioned

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -26,7 +26,7 @@ module Poly = struct
 end
 
 module Valid = struct
-  type t = User_command.Valid.t Poly.t [@@deriving sexp, yojson]
+  type t = User_command.Valid.t Poly.t [@@deriving sexp_of, to_yojson]
 end
 
 [%%versioned

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -26,7 +26,7 @@ module Poly = struct
 end
 
 module Valid = struct
-  type t = User_command.Valid.t Poly.t [@@deriving sexp, equal, yojson]
+  type t = User_command.Valid.t Poly.t [@@deriving sexp, yojson]
 end
 
 [%%versioned

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -175,7 +175,7 @@ module User_command_with_valid_signature = struct
   let hash_of_yojson = of_yojson
 
   type t = (User_command.Valid.t, hash) With_hash.t
-  [@@deriving hash, sexp, compare, to_yojson]
+  [@@deriving hash, sexp_of, compare, to_yojson]
 
   let equal ({ hash = h1; _ } : t) ({ hash = h2; _ } : t) = T.equal h1 h2
 

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -175,7 +175,7 @@ module User_command_with_valid_signature = struct
   let hash_of_yojson = of_yojson
 
   type t = (User_command.Valid.t, hash) With_hash.t
-  [@@deriving hash, sexp_of, to_yojson]
+  [@@deriving sexp_of, to_yojson]
 
   let equal ({ hash = h1; _ } : t) ({ hash = h2; _ } : t) = T.equal h1 h2
 

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -175,7 +175,7 @@ module User_command_with_valid_signature = struct
   let hash_of_yojson = of_yojson
 
   type t = (User_command.Valid.t, hash) With_hash.t
-  [@@deriving hash, sexp_of, compare, to_yojson]
+  [@@deriving hash, sexp_of, to_yojson]
 
   let equal ({ hash = h1; _ } : t) ({ hash = h2; _ } : t) = T.equal h1 h2
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -56,7 +56,7 @@ module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
   type t = private (User_command.Valid.t, hash) With_hash.t
-  [@@deriving equal, hash, sexp, compare, to_yojson]
+  [@@deriving equal, hash, sexp_of, compare, to_yojson]
 
   val create : User_command.Valid.t -> t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -56,7 +56,7 @@ module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
   type t = private (User_command.Valid.t, hash) With_hash.t
-  [@@deriving equal, hash, sexp_of, to_yojson]
+  [@@deriving equal, sexp_of, to_yojson]
 
   val create : User_command.Valid.t -> t
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -56,7 +56,7 @@ module User_command_with_valid_signature : sig
   type hash = t [@@deriving sexp, compare, hash, yojson]
 
   type t = private (User_command.Valid.t, hash) With_hash.t
-  [@@deriving equal, hash, sexp_of, compare, to_yojson]
+  [@@deriving equal, hash, sexp_of, to_yojson]
 
   val create : User_command.Valid.t -> t
 


### PR DESCRIPTION
This PR is a series of the following changes:

- **Remove User_command_with_valid_signature.t_of_sexp**
- **Remove Transaction_hash.User_command_with_valid_signature.compare**
- **Remove Transaction_hash.User_command_with_valid_signature.hash**
- **Remove User_command.Valid.hash**
- **Remove User_command.Valid.compare**
- **Remove User_command.Valid.equal**
- **Remove t_of_sexp, of_yojson from User_command.Valid**
- **Remove unnecessary derivations from Zkapp_command.Valid**

All of the derivations are no longer necessary. The only usages that remained were in test and were not crucial to test implementation.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
