### PR TITLE
Implement opaque sexp_of, to_yojson for proof_cache_tag

### DIFF
--- a/src/lib/proof_cache_tag/dune
+++ b/src/lib/proof_cache_tag/dune
@@ -10,6 +10,6 @@
   disk_cache
   pickles)
  (preprocess
-  (pps ppx_mina ppx_version))
+  (pps ppx_mina ppx_version ppx_jane))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/lib/proof_cache_tag/proof_cache_tag.ml
+++ b/src/lib/proof_cache_tag/proof_cache_tag.ml
@@ -8,6 +8,12 @@ type t =
   | Lmdb of { cache_id : Cache.id; cache_db : Cache.t }
   | Identity of Pickles.Proof.Proofs_verified_2.Stable.Latest.t
 
+(* Sexp serialization is opaque for proof_cache_tag *)
+let sexp_of_t _ = Sexp.of_string "proof_cache_tag"
+
+(* JSON serialization is opaque for proof_cache_tag *)
+let to_yojson _ = `String "proof_cache_tag"
+
 let read_proof_from_disk = function
   | Lmdb t ->
       Cache.get t.cache_db t.cache_id

--- a/src/lib/proof_cache_tag/proof_cache_tag.mli
+++ b/src/lib/proof_cache_tag/proof_cache_tag.mli
@@ -1,7 +1,7 @@
 open Core_kernel
 open Async_kernel
 
-type t
+type t [@@deriving sexp_of, to_yojson]
 
 type cache_db
 


### PR DESCRIPTION
We need these derivations for debug output and logging for transactions.
For these purposes it would be a lot of changes to perform explicit conversions that replace proofs with `(unit)`.
And there will be little actual benefit.

The main usage of this will be debug printout of entire `Index_pool.t`. Because of layers of derivations, removing it would be a huge amount of work.

This change is introduced after it was established that it'll be used only for logging.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
