### PR TITLE
Add User_command.Verifiable.Seriliazable

### DIFF
--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1734,6 +1734,17 @@ module T = struct
   end
 end
 
+let map_proofs ~f p =
+  let map_auth = function
+    | Control.Poly.Proof p ->
+        Control.Poly.Proof (f p)
+    | Signature s ->
+        Signature s
+    | None_given ->
+        None_given
+  in
+  { Poly.authorization = map_auth p.Poly.authorization; body = p.Poly.body }
+
 module Fee_payer = struct
   [%%versioned
   module Stable = struct

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -142,7 +142,7 @@ module Verifiable = struct
     ( Signed_command.Stable.Latest.t
     , Zkapp_command.Verifiable.t )
     Poly.Stable.Latest.t
-  [@@deriving sexp, bin_io_unversioned]
+  [@@deriving sexp_of]
 
   let fee_payer (t : t) =
     match t with
@@ -150,6 +150,28 @@ module Verifiable = struct
         Signed_command.fee_payer x
     | Zkapp_command p ->
         Account_update.Fee_payer.account_id p.fee_payer
+
+  module Serializable = struct
+    type t =
+      ( Signed_command.Stable.Latest.t
+      , Zkapp_command.Verifiable.Serializable.t )
+      Poly.Stable.Latest.t
+    [@@deriving bin_io_unversioned]
+  end
+
+  let to_serializable (t : t) : Serializable.t =
+    match t with
+    | Signed_command c ->
+        Signed_command c
+    | Zkapp_command cmd ->
+        Zkapp_command (Zkapp_command.Verifiable.to_serializable cmd)
+
+  let of_serializable (t : Serializable.t) : t =
+    match t with
+    | Signed_command c ->
+        Signed_command c
+    | Zkapp_command cmd ->
+        Zkapp_command (Zkapp_command.Verifiable.of_serializable cmd)
 end
 
 let to_verifiable (t : t) ~failed ~find_vk : Verifiable.t Or_error.t =

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -141,6 +141,15 @@ end
 
 include T
 
+let map_proofs ~(f : 'p -> 'q)
+    ({ Poly.fee_payer; memo; account_updates } : ('p, 'b, 'c) with_forest) :
+    ('q, 'b, 'c) with_forest =
+  { Poly.fee_payer
+  ; memo
+  ; account_updates =
+      Call_forest.map ~f:(Account_update.map_proofs ~f) account_updates
+  }
+
 let write_all_proofs_to_disk (w : Stable.Latest.t) : t =
   { fee_payer = w.fee_payer
   ; memo = w.memo

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -253,7 +253,7 @@ module Transaction_pool = struct
   open Mina_base
 
   type diff = User_command.Verifiable.t list Envelope.Incoming.t
-  [@@deriving sexp]
+  [@@deriving sexp_of]
 
   (* A partially verified transaction is either valid, or valid assuming that some list of
      (verification key, statement, proof) triples will verify. That is, the transaction has
@@ -268,11 +268,12 @@ module Transaction_pool = struct
         * Zkapp_statement.t
         * Pickles.Side_loaded.Proof.t )
         list ]
-  [@@deriving sexp]
+  [@@deriving sexp_of]
 
-  type partial = partial_item list [@@deriving sexp]
+  type partial = partial_item list [@@deriving sexp_of]
 
-  type t = (diff, partial, User_command.Valid.t list) batcher [@@deriving sexp]
+  type t = (diff, partial, User_command.Valid.t list) batcher
+  [@@deriving sexp_of]
 
   type input = [ `Init of diff | `Partially_validated of partial ]
 

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -40,7 +40,7 @@ val compare_envelope : _ Envelope.Incoming.t -> _ Envelope.Incoming.t -> int
 module Transaction_pool : sig
   open Mina_base
 
-  type t [@@deriving sexp]
+  type t [@@deriving sexp_of]
 
   val create : logger:Logger.t -> Verifier.t -> t
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -256,7 +256,9 @@ module Worker = struct
         ; verify_commands =
             f
               ( [%bin_type_class:
-                  User_command.Verifiable.t With_status.Stable.Latest.t list]
+                  User_command.Verifiable.Serializable.t
+                  With_status.Stable.Latest.t
+                  list]
               , [%bin_type_class:
                   [ `Valid
                   | `Valid_assuming of


### PR DESCRIPTION
After switch to using proof cache tags in zkapp commands, it's useful to have two verifiable types: one without tags (which is serializable) and another that has proof tags, one that is easily convertable to `Zkapp_command.Valid.t`.

This commit introduces `User_command.Verifiable.Serializable.t` which contains proofs, and has `bin_io` derivation. At the same time `bin_io` is removed from the `User_command.Verifiable.t`, which later will start containing proof cache tags.

Full PR contents:

- **Introduce Account_update.map_proofs**
- **Remove of_sexp from Batcher.Transaction_pool**
- **Introduce User_command.Verifiable.Serializable.t**

Explain how you tested your changes:
* This is a refactoring, no behavior is changed.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
