### PR TITLE
Remove unnecessary derivations from User_command.t

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -437,23 +437,11 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                 ~f:Fn.const
             in
             let%map work = Mina_lib.request_work mina in
-            let work_wire =
-              { work with
-                instances =
-                  One_or_two.map work.instances
-                    ~f:
-                      (Snark_work_lib.Work.Single.Spec.map
-                         ~f_witness:
-                           Transaction_witness.read_all_proofs_from_disk
-                         ~f_proof:ident )
-              }
-            in
             [%log trace]
-              ~metadata:
-                [ ("work_spec", Snark_worker.Work.Spec.to_yojson work_wire) ]
+              ~metadata:[ ("work_spec", Snark_worker.Work.Spec.to_yojson work) ]
               "responding to a Get_work request with some new work" ;
             Mina_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
-            (work_wire, key)) )
+            (work, key)) )
     ; implement Snark_worker.Rpcs_versioned.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->
           [%log trace] "received completed work from a snark worker"

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -40,7 +40,7 @@ module String_list_formatter = struct
 end
 
 module Prove_receipt = struct
-  type t = Receipt.Chain_hash.t * User_command.t list [@@deriving yojson]
+  type t = Receipt.Chain_hash.t * User_command.t list [@@deriving to_yojson]
 
   let to_text proof =
     sprintf "Merkle List of transactions:\n%s"

--- a/src/lib/mina_base/test/zero_vesting_period.ml
+++ b/src/lib/mina_base/test/zero_vesting_period.ml
@@ -150,10 +150,10 @@ let mk_zkapp_with_vesting_period n =
             "7mXAxX8GG74Dvgf8t4bdFDuiv9LnXeQmPcev9aSyZKxgsJNsSsJBz92Vqi7uzarkj5nwj9ngVbcya5cizm9af1G4RU6JA7q4"
           ]
         },
-        "account_update_digest": "0x324D57B61E07061A094A9E064984738480D8D3BF336A4CD33993A9FE6B37A823",
+        "account_update_digest": null,
         "calls": []
       },
-      "stack_hash": "0x3C28388F95EAF826FCC6CF06DBDD4A2E694FA7C5A281E0A623560F3A5BAF94AB"
+      "stack_hash": null
     },
     {
       "elt": {
@@ -257,10 +257,10 @@ let mk_zkapp_with_vesting_period n =
           },
           "authorization": [ "None_given" ]
         },
-        "account_update_digest": "0x1581BF4B656B5D89E65A7B9322F460D9AEAF08ABDD62CD6DD6D6FE1EE266035E",
+        "account_update_digest": null,
         "calls": []
       },
-      "stack_hash": "0x1C66CA0E7429D1D71E51BF1A5240D5A5C712DB9C4B7C31034A7A0115B612E83A"
+      "stack_hash": null
     }
   ],
   "memo": "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH"
@@ -268,7 +268,7 @@ let mk_zkapp_with_vesting_period n =
 
       |json}
       n
-    |> Yojson.Safe.from_string |> Zkapp_command.of_yojson
+    |> Yojson.Safe.from_string |> Zkapp_command.Stable.Latest.of_yojson
   in
   match res with
   | Ppx_deriving_yojson_runtime.Result.Ok zkapp ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -88,7 +88,7 @@ module Stable = struct
 end]
 
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
-[@@deriving sexp_of, compare, equal, hash, to_yojson]
+[@@deriving sexp_of, compare, equal, to_yojson]
 
 let write_all_proofs_to_disk : Stable.Latest.t -> t = function
   | Signed_command sc ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -88,7 +88,7 @@ module Stable = struct
 end]
 
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
-[@@deriving sexp_of, compare, equal, to_yojson]
+[@@deriving sexp_of, equal, to_yojson]
 
 let write_all_proofs_to_disk : Stable.Latest.t -> t = function
   | Signed_command sc ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -114,8 +114,11 @@ let forget_digests_and_proofs (t : (_, _, _) with_forest) :
   | Zkapp_command zc ->
       Zkapp_command (Zkapp_command.forget_digests_and_proofs zc)
 
-let equal_ignoring_proofs_and_hashes (type a b c a' b' c')
-    (t1 : (a, b, c) with_forest) (t2 : (a', b', c') with_forest) =
+let equal_ignoring_proofs_and_hashes
+    (type proof_l account_update_digest_l forest_digest_l proof_r
+    account_update_digest_r forest_digest_r )
+    (t1 : (proof_l, account_update_digest_l, forest_digest_l) with_forest)
+    (t2 : (proof_r, account_update_digest_r, forest_digest_r) with_forest) =
   let ignore2 _ _ = true in
   let t1' = forget_digests_and_proofs t1 in
   let t2' = forget_digests_and_proofs t2 in

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -88,7 +88,7 @@ module Stable = struct
 end]
 
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
-[@@deriving sexp_of, equal, to_yojson]
+[@@deriving sexp_of, to_yojson]
 
 let write_all_proofs_to_disk : Stable.Latest.t -> t = function
   | Signed_command sc ->
@@ -104,6 +104,22 @@ let read_all_proofs_from_disk : t -> Stable.Latest.t = function
 
 type ('p, 'a, 'b) with_forest =
   (Signed_command.t, ('p, 'a, 'b) Zkapp_command.with_forest) Poly.t
+[@@deriving equal]
+
+let forget_digests_and_proofs (t : (_, _, _) with_forest) :
+    (unit, unit, unit) with_forest =
+  match t with
+  | Signed_command sc ->
+      Signed_command sc
+  | Zkapp_command zc ->
+      Zkapp_command (Zkapp_command.forget_digests_and_proofs zc)
+
+let equal_ignoring_proofs_and_hashes (type a b c a' b' c')
+    (t1 : (a, b, c) with_forest) (t2 : (a', b', c') with_forest) =
+  let ignore2 _ _ = true in
+  let t1' = forget_digests_and_proofs t1 in
+  let t2' = forget_digests_and_proofs t2 in
+  equal_with_forest ignore2 ignore2 ignore2 t1' t2'
 
 let to_base64 : Stable.Latest.t -> string = function
   | Signed_command sc ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -88,7 +88,7 @@ module Stable = struct
 end]
 
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
-[@@deriving sexp, compare, equal, hash, yojson]
+[@@deriving sexp_of, compare, equal, hash, to_yojson]
 
 let write_all_proofs_to_disk : Stable.Latest.t -> t = function
   | Signed_command sc ->

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -58,7 +58,7 @@ type ('proof, 'account_update_digest, 'forest_digest) with_forest =
 
 module T = struct
   type t = (Proof.t, Digest.Account_update.t, Digest.Forest.t) with_forest
-  [@@deriving sexp_of, compare, equal, to_yojson]
+  [@@deriving sexp_of, equal, to_yojson]
 
   [%%versioned
   module Stable = struct

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -58,7 +58,7 @@ type ('proof, 'account_update_digest, 'forest_digest) with_forest =
 
 module T = struct
   type t = (Proof.t, Digest.Account_update.t, Digest.Forest.t) with_forest
-  [@@deriving sexp, compare, equal, hash, yojson]
+  [@@deriving sexp_of, compare, equal, hash, to_yojson]
 
   [%%versioned
   module Stable = struct

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -160,28 +160,6 @@ let write_all_proofs_to_disk (w : Stable.Latest.t) : t =
              Digest.Account_update.create p )
   }
 
-let map_proofs ~(f : 'p -> 'q)
-    ({ Poly.fee_payer; memo; account_updates } : ('p, 'b, 'c) with_forest) :
-    ('q, 'b, 'c) with_forest =
-  let map_auth = function
-    | Control.Poly.Proof p ->
-        Control.Poly.Proof (f p)
-    | Signature s ->
-        Signature s
-    | None_given ->
-        None_given
-  in
-  let map_account_update p =
-    { Account_update.Poly.authorization =
-        map_auth p.Account_update.Poly.authorization
-    ; body = p.Account_update.Poly.body
-    }
-  in
-  { Poly.fee_payer
-  ; memo
-  ; account_updates = Call_forest.map ~f:map_account_update account_updates
-  }
-
 let read_all_proofs_from_disk (t : t) : Stable.Latest.t =
   { fee_payer = t.fee_payer
   ; memo = t.memo

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -58,7 +58,7 @@ type ('proof, 'account_update_digest, 'forest_digest) with_forest =
 
 module T = struct
   type t = (Proof.t, Digest.Account_update.t, Digest.Forest.t) with_forest
-  [@@deriving sexp_of, equal, to_yojson]
+  [@@deriving sexp_of, to_yojson]
 
   [%%versioned
   module Stable = struct
@@ -160,11 +160,42 @@ let write_all_proofs_to_disk (w : Stable.Latest.t) : t =
              Digest.Account_update.create p )
   }
 
+let map_proofs ~(f : 'p -> 'q)
+    ({ Poly.fee_payer; memo; account_updates } : ('p, 'b, 'c) with_forest) :
+    ('q, 'b, 'c) with_forest =
+  let map_auth = function
+    | Control.Poly.Proof p ->
+        Control.Poly.Proof (f p)
+    | Signature s ->
+        Signature s
+    | None_given ->
+        None_given
+  in
+  let map_account_update p =
+    { Account_update.Poly.authorization =
+        map_auth p.Account_update.Poly.authorization
+    ; body = p.Account_update.Poly.body
+    }
+  in
+  { Poly.fee_payer
+  ; memo
+  ; account_updates = Call_forest.map ~f:map_account_update account_updates
+  }
+
 let read_all_proofs_from_disk (t : t) : Stable.Latest.t =
   { fee_payer = t.fee_payer
   ; memo = t.memo
   ; account_updates = Call_forest.forget_hashes t.account_updates
   }
+
+let forget_digests_and_proofs
+    ({ fee_payer; memo; account_updates } : (_, _, _) with_forest) :
+    (unit, unit, unit) with_forest =
+  map_proofs ~f:(const ())
+    { Poly.fee_payer
+    ; memo
+    ; account_updates = Call_forest.forget_hashes account_updates
+    }
 
 [%%define_locally Stable.Latest.(gen)]
 

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -58,7 +58,7 @@ type ('proof, 'account_update_digest, 'forest_digest) with_forest =
 
 module T = struct
   type t = (Proof.t, Digest.Account_update.t, Digest.Forest.t) with_forest
-  [@@deriving sexp_of, compare, equal, hash, to_yojson]
+  [@@deriving sexp_of, compare, equal, to_yojson]
 
   [%%versioned
   module Stable = struct

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2052,8 +2052,7 @@ module Queries = struct
         let transaction_pool = Mina_lib.transaction_pool mina in
         (* TODO: do not compute hashes to just get the status *)
         Transaction_inclusion_status.get_status ~frontier_broadcast_pipe
-          ~transaction_pool
-        @@ User_command.write_all_proofs_to_disk txn.data )
+          ~transaction_pool txn.data )
 
   let current_snark_worker =
     field "currentSnarkWorker" ~typ:Types.snark_worker

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -104,7 +104,7 @@ val add_from_backtrack :
   -> (t, Command_error.t) Result.t
 
 (** Check whether a command is in the pool *)
-val member : t -> Transaction_hash.User_command.t -> bool
+val member : t -> Transaction_hash.t -> bool
 
 (** Check whether the pool has any commands for a given fee payer *)
 val has_commands_for_fee_payer : t -> Account_id.t -> bool

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -408,7 +408,7 @@ module type Transaction_resource_pool_intf = sig
     -> vk_cache_db:Zkapp_vk_cache_tag.cache_db
     -> Config.t
 
-  val member : t -> Transaction_hash.User_command_with_valid_signature.t -> bool
+  val member : t -> Transaction_hash.t -> bool
 
   val transactions :
     t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -429,8 +429,7 @@ struct
       ; verification_key_table : Vk_refcount_table.t
       }
 
-    let member t x =
-      Indexed_pool.member t.pool (Transaction_hash.User_command.of_checked x)
+    let member t x = Indexed_pool.member t.pool x
 
     let transactions t = Indexed_pool.transactions ~logger:t.logger t.pool
 
@@ -1281,7 +1280,8 @@ struct
         let check_command pool cmd =
           let already_in_pool =
             Indexed_pool.member pool
-              (Transaction_hash.User_command.of_checked cmd)
+              (Transaction_hash.User_command_with_valid_signature
+               .transaction_hash cmd )
           in
           let%map.Result () =
             if already_in_pool then
@@ -1886,7 +1886,8 @@ let%test_module _ =
         ~f:(fun ~key ~data:_ ->
           assert (
             Indexed_pool.member pool.pool
-              (Transaction_hash.User_command.of_checked key) ) )
+              (Transaction_hash.User_command_with_valid_signature
+               .transaction_hash key ) ) )
 
     let assert_fee_wu_ordering (pool : Test.Resource_pool.t) =
       let txns = Test.Resource_pool.transactions pool |> Sequence.to_list in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -192,7 +192,7 @@ end
 
 type Structured_log_events.t +=
   | Rejecting_command_for_reason of
-      { command : User_command.t
+      { transaction_hash : Transaction_hash.t
       ; reason : Diff_versioned.Diff_error.t
       ; error_extra : (string * Yojson.Safe.t) list
       }
@@ -1052,28 +1052,32 @@ struct
       let of_indexed_pool_error e =
         (diff_error_of_indexed_pool_error e, indexed_pool_error_metadata e)
 
-      let report_command_error ~logger ~is_sender_local tx (e : Command_error.t)
-          =
+      let report_command_error ~logger ~is_sender_local transaction_hash
+          (e : Command_error.t) =
         let diff_err, error_extra = of_indexed_pool_error e in
         if is_sender_local then
           [%str_log error]
             (Rejecting_command_for_reason
-               { command = tx; reason = diff_err; error_extra } ) ;
+               { transaction_hash; reason = diff_err; error_extra } ) ;
         let log = if is_sender_local then [%log error] else [%log debug] in
         match e with
         | Insufficient_replace_fee (`Replace_fee rfee, fee) ->
             log
-              "rejecting $cmd because of insufficient replace fee ($rfee > \
-               $fee)"
+              "rejecting command with hash $transaction_hash because of \
+               insufficient replace fee ($rfee > $fee)"
               ~metadata:
-                [ ("cmd", User_command.to_yojson tx)
+                [ ( "transaction_hash"
+                  , Transaction_hash.to_yojson transaction_hash )
                 ; ("rfee", Currency.Fee.to_yojson rfee)
                 ; ("fee", Currency.Fee.to_yojson fee)
                 ]
         | Unwanted_fee_token fee_token ->
-            log "rejecting $cmd because we don't accept fees in $token"
+            log
+              "rejecting command with hash $transaction_hash because we don't \
+               accept fees in $token"
               ~metadata:
-                [ ("cmd", User_command.to_yojson tx)
+                [ ( "transaction_hash"
+                  , Transaction_hash.to_yojson transaction_hash )
                 ; ("token", Token_id.to_yojson fee_token)
                 ]
         | _ ->
@@ -1323,7 +1327,7 @@ struct
                   | Error err ->
                       report_command_error ~logger:t.logger ~is_sender_local
                         (Transaction_hash.User_command_with_valid_signature
-                         .command cmd )
+                         .transaction_hash cmd )
                         err ;
                       Error (diff_error_of_indexed_pool_error err)
               in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2871,12 +2871,18 @@ let%test_module "staged ledger tests" =
                 (* There is an edge case where cmds_applied_this_iter = 0, when
                    there is only enough space for coinbase transactions. *)
                 assert (cmds_applied_this_iter <= Sequence.length cmds_this_iter) ;
-                [%test_eq: User_command.t list]
-                  (List.map (Staged_ledger_diff.commands diff)
-                     ~f:(fun { With_status.data; _ } -> data) )
-                  ( Sequence.take cmds_this_iter cmds_applied_this_iter
+                let commands_in_ledger =
+                  List.map (Staged_ledger_diff.commands diff)
+                    ~f:(fun { With_status.data; _ } -> data)
+                in
+                let commands_applied =
+                  Sequence.take cmds_this_iter cmds_applied_this_iter
                   |> Sequence.map ~f:User_command.forget_check
-                  |> Sequence.to_list )
+                  |> Sequence.to_list
+                in
+                assert (
+                  [%equal: User_command.t list] commands_in_ledger
+                    commands_applied )
             | None ->
                 () ) ;
             let coinbase_cost = coinbase_cost diff in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -57,7 +57,7 @@ module T = struct
       | Invalid_public_key of Public_key.Compressed.t
       | ZkApps_exceed_limit of int * int
       | Unexpected of Error.t
-    [@@deriving sexp]
+    [@@deriving sexp_of]
 
     let to_string = function
       | Couldn't_reach_verifier e ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2881,8 +2881,8 @@ let%test_module "staged ledger tests" =
                   |> Sequence.to_list
                 in
                 assert (
-                  [%equal: User_command.t list] commands_in_ledger
-                    commands_applied )
+                  List.equal User_command.equal_ignoring_proofs_and_hashes
+                    commands_in_ledger commands_applied )
             | None ->
                 () ) ;
             let coinbase_cost = coinbase_cost diff in
@@ -4576,7 +4576,8 @@ let%test_module "staged ledger tests" =
                        User_command.forget_check data )
               in
               assert (
-                List.equal User_command.equal valid_commands
+                List.equal User_command.equal_ignoring_proofs_and_hashes
+                  valid_commands
                   ( [ valid_command_1
                     ; valid_command_2
                     ; valid_command_5

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -158,7 +158,7 @@ module Staged_ledger_error : sig
     | Invalid_public_key of Public_key.Compressed.t
     | ZkApps_exceed_limit of int * int
     | Unexpected of Error.t
-  [@@deriving sexp]
+  [@@deriving sexp_of]
 
   val to_string : t -> string
 
@@ -334,7 +334,7 @@ val of_scan_state_pending_coinbases_and_snarked_ledger_unchecked :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> ( Transaction_witness.t
+  -> ( Transaction_witness.Stable.Latest.t
      , Ledger_proof.Cached.t )
      Snark_work_lib.Work.Single.Spec.t
      One_or_two.t

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -41,7 +41,7 @@ module Stable = struct
   end
 end]
 
-type t = User_command.t Poly.t [@@deriving sexp, yojson]
+type t = User_command.t Poly.t [@@deriving sexp_of, to_yojson]
 
 type ('a, 'b, 'c) with_forest = ('a, 'b, 'c) User_command.with_forest Poly.t
 

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -38,8 +38,6 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
         |> Mina_block.Validated.valid_commands
         |> List.exists ~f:(fun { data = found; _ } ->
                let found' = User_command.forget_check found in
-               (* We do equality check w/o proofs and hashes first to ensure
-                  we don't read proofs from disk without necessity. *)
                User_command.equal_ignoring_proofs_and_hashes cmd found'
                && User_command.Stable.Latest.equal cmd
                     (User_command.read_all_proofs_from_disk found') )

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -36,29 +36,24 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
       let in_breadcrumb breadcrumb =
         breadcrumb |> Transition_frontier.Breadcrumb.validated_transition
         |> Mina_block.Validated.valid_commands
-        |> List.exists ~f:(fun { data = cmd'; _ } ->
-               User_command.equal cmd (User_command.forget_check cmd') )
+        |> List.exists ~f:(fun { data = found; _ } ->
+               let found' = User_command.forget_check found in
+               (* We do equality check w/o proofs and hashes first to ensure
+                  we don't read proofs from disk without necessity. *)
+               User_command.equal_ignoring_proofs_and_hashes cmd found'
+               && User_command.Stable.Latest.equal cmd
+                    (User_command.read_all_proofs_from_disk found') )
       in
       if List.exists ~f:in_breadcrumb best_tip_path then State.Included
       else if
         List.exists ~f:in_breadcrumb
           (Transition_frontier.all_breadcrumbs transition_frontier)
       then State.Pending
-      else
-        (*This is to look for commands in the pool which are valid.
-           Membership check requires only the user command and no other
-           aspect of User_command.Valid.t and so no need to check signatures
-           or extract zkApp verification keys.*)
-        let (`If_this_is_used_it_should_have_a_comment_justifying_it checked_cmd)
-            =
-          User_command.to_valid_unsafe cmd
-        in
-        if
-          Transaction_pool.Resource_pool.member resource_pool
-            (Transaction_hash.User_command_with_valid_signature.create
-               checked_cmd )
-        then State.Pending
-        else State.Unknown
+      else if
+        Transaction_pool.Resource_pool.member resource_pool
+          (Transaction_hash.hash_command cmd)
+      then State.Pending
+      else State.Unknown
 
 let%test_module "transaction_status" =
   ( module struct

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
@@ -22,5 +22,5 @@ val get_status :
      frontier_broadcast_pipe:
        Transition_frontier.t Option.t Broadcast_pipe.Reader.t
   -> transaction_pool:Network_pool.Transaction_pool.t
-  -> User_command.t
+  -> User_command.Stable.Latest.t
   -> State.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -1298,7 +1298,7 @@ let work_statements_for_new_diff t : Transaction_snark_work.Statement.t list =
 
 let all_work_pairs t
     ~(get_state : State_hash.t -> Mina_state.Protocol_state.value Or_error.t) :
-    ( Transaction_witness.t
+    ( Transaction_witness.Stable.Latest.t
     , Ledger_proof.Cached.t )
     Snark_work_lib.Work.Single.Spec.t
     One_or_two.t
@@ -1333,9 +1333,10 @@ let all_work_pairs t
             | Merge ->
                 Or_error.error_string "init_stack was Merge"
           in
-          { Transaction_witness.first_pass_ledger = first_pass_ledger_witness
+          { Transaction_witness.Stable.Latest.first_pass_ledger =
+              first_pass_ledger_witness
           ; second_pass_ledger = second_pass_ledger_witness
-          ; transaction
+          ; transaction = Transaction.read_all_proofs_from_disk transaction
           ; protocol_state_body
           ; init_stack
           ; status

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -257,7 +257,7 @@ val check_required_protocol_states :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> ( Transaction_witness.t
+  -> ( Transaction_witness.Stable.Latest.t
      , Ledger_proof.Cached.t )
      Snark_work_lib.Work.Single.Spec.t
      One_or_two.t

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -134,7 +134,7 @@ type t =
   ; status : Mina_base.Transaction_status.t
   ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
   }
-[@@deriving sexp, yojson]
+[@@deriving sexp_of, to_yojson]
 
 let read_all_proofs_from_disk
     { transaction

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -105,7 +105,7 @@ type t =
   ; status : Mina_base.Transaction_status.t
   ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
   }
-[@@deriving sexp, yojson]
+[@@deriving sexp_of, to_yojson]
 
 val read_all_proofs_from_disk : t -> Stable.Latest.t
 

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -197,8 +197,7 @@ let send_produced_block_at ~logger ~interruptor ~url ~peer_id
 
 let read_all_proofs_for_work_single_spec =
   Snark_work_lib.Work.Single.Spec.map
-    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
-    ~f_witness:Transaction_witness.read_all_proofs_from_disk
+    ~f_proof:Ledger_proof.Cached.read_proof_from_disk ~f_witness:ident
 
 let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
     ~url ~snark_worker ~transition_frontier ~peer_id

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -2,7 +2,12 @@ open Core_kernel
 open Currency
 
 module Test_inputs = struct
-  module Transaction_witness = Int
+  module Transaction_witness = struct
+    module Stable = struct
+      module Latest = Int
+    end
+  end
+
   module Ledger_hash = Int
   module Sparse_ledger = Int
   module Transaction = Int

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -23,7 +23,11 @@ module type Inputs_intf = sig
   end
 
   module Transaction_witness : sig
-    type t
+    module Stable : sig
+      module Latest : sig
+        type t
+      end
+    end
   end
 
   module Ledger_proof : sig
@@ -72,7 +76,7 @@ module type Inputs_intf = sig
          t
       -> get_state:
            (Mina_base.State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-      -> ( Transaction_witness.t
+      -> ( Transaction_witness.Stable.Latest.t
          , Ledger_proof.Cached.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
@@ -121,7 +125,7 @@ module type Lib_intf = sig
     (**Jobs that have not been assigned yet*)
     val all_unseen_works :
          t
-      -> ( Transaction_witness.t
+      -> ( Transaction_witness.Stable.Latest.t
          , Ledger_proof.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
@@ -131,7 +135,7 @@ module type Lib_intf = sig
 
     val set :
          t
-      -> ( Transaction_witness.t
+      -> ( Transaction_witness.Stable.Latest.t
          , Ledger_proof.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
@@ -141,10 +145,14 @@ module type Lib_intf = sig
   val get_expensive_work :
        snark_pool:Snark_pool.t
     -> fee:Fee.t
-    -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+    -> ( Transaction_witness.Stable.Latest.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
-    -> (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+    -> ( Transaction_witness.Stable.Latest.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
 
@@ -187,7 +195,7 @@ module type Make_selection_method_intf = functor (Lib : Lib_intf) ->
   Selection_method_intf
     with type staged_ledger := Lib.Inputs.Staged_ledger.t
      and type work :=
-      ( Lib.Inputs.Transaction_witness.t
+      ( Lib.Inputs.Transaction_witness.Stable.Latest.t
       , Lib.Inputs.Ledger_proof.t )
       Snark_work_lib.Work.Single.Spec.t
      and type snark_pool := Lib.Inputs.Snark_pool.t

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -28,7 +28,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
     type t =
       { mutable available_jobs :
-          (Inputs.Transaction_witness.t, Inputs.Ledger_proof.t) Work_spec.t
+          ( Inputs.Transaction_witness.Stable.Latest.t
+          , Inputs.Ledger_proof.t )
+          Work_spec.t
           One_or_two.t
           list
       ; mutable jobs_seen : Job_status.t Seen_key.Map.t
@@ -82,7 +84,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
                                 |> Time.Span.to_ms ) )
                           ] ;
                       let new_available_jobs_unwrapped :
-                          ( Inputs.Transaction_witness.t
+                          ( Inputs.Transaction_witness.Stable.Latest.t
                           , Inputs.Ledger_proof.t )
                           Work_spec.t
                           One_or_two.t

--- a/src/lib/work_selector/work_selector.ml
+++ b/src/lib/work_selector/work_selector.ml
@@ -2,7 +2,9 @@ module Lib = Work_lib.Make (Inputs.Implementation_inputs)
 module State = Lib.State
 
 type work =
-  (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+  ( Transaction_witness.Stable.Latest.t
+  , Ledger_proof.t )
+  Snark_work_lib.Work.Single.Spec.t
 [@@deriving yojson]
 
 type snark_pool = Network_pool.Snark_pool.t

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -2,7 +2,9 @@ module State :
   Intf.State_intf with type transition_frontier := Transition_frontier.t
 
 type work =
-  (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+  ( Transaction_witness.Stable.Latest.t
+  , Ledger_proof.t )
+  Snark_work_lib.Work.Single.Spec.t
 [@@deriving yojson]
 
 type snark_pool = Network_pool.Snark_pool.t


### PR DESCRIPTION
This PR removes a bunch of derivations that are not used in any way that matters.

Removing them eases path towards using proof cache tags in the `Zkapp_command.t`.

- **Remove of_sexp, of_yojson from User_command.t**
- **Remove Zkapp_command.hash derivation**
- **Remove Zkapp_command.compare derivation**
- **Remove Zkapp_command.equal derivation**

Explain how you tested your changes:
* Simple refactoring, no change of behavior.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
