### PR TITLE
Functorize Pickles.Inductive_rule with Proof arg

### DIFF
--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -20,6 +20,8 @@ let verify_promise = Verify.verify
 open Kimchi_backend
 module Proof_ = P.Base
 module Proof = P
+module Inductive_rule = Inductive_rule.Kimchi
+module Step_branch_data = Step_branch_data.Make (Inductive_rule)
 
 type chunking_data = Verify.Instance.chunking_data =
   { num_chunks : int; domain_size : int; zk_rows : int }
@@ -725,7 +727,7 @@ struct
     accum_dirty (Lazy.map wrap_vk ~f:(Promise.map ~f:snd)) ;
     let wrap_vk = Lazy.map wrap_vk ~f:(Promise.map ~f:fst) in
     let module S =
-      Step.Make (Arg_var) (Arg_value)
+      Step.Make (Inductive_rule) (Arg_var) (Arg_value)
         (struct
           include Max_proofs_verified
         end)

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -303,7 +303,7 @@ val compile_with_wrap_main_override_promise :
        , 'a_value
        , 'ret_var
        , 'ret_value )
-       Inductive_rule.public_input
+       Inductive_rule.Kimchi.public_input
   -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
@@ -321,7 +321,7 @@ val compile_with_wrap_main_override_promise :
            , 'ret_value
            , 'auxiliary_var
            , 'auxiliary_value )
-           H4_6_with_length.T(Inductive_rule.Promise).t )
+           H4_6_with_length.T(Inductive_rule.Kimchi.Promise).t )
   -> unit
   -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
      * Cache_handle.t

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -120,13 +120,9 @@ module type Proof_intf = sig
   type 'width t
 end
 
-module B = struct
-  type t = Impls.Step.Boolean.var
-end
-
 module Make (P : Proof_intf) : Intf with type 'a proof = 'a P.t = struct
   module B = struct
-    include B
+    type t = Impls.Step.Boolean.var
   end
 
   type 'a proof = 'a P.t

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -1,150 +1,249 @@
 open Pickles_types.Poly_types
 open Pickles_types.Hlist
 
+module type Intf = sig
+  module B : sig
+    type t = Impls.Step.Boolean.var
+  end
+
+  type _ proof
+
+  module Previous_proof_statement : sig
+    type ('prev_var, 'width) t =
+      { public_input : 'prev_var
+      ; proof : 'width proof Impls.Step.Typ.prover_value
+      ; proof_must_verify : B.t
+      }
+
+    module Constant : sig
+      type ('prev_value, 'width) t =
+        { public_input : 'prev_value
+        ; proof : 'width proof
+        ; proof_must_verify : bool
+        }
+    end
+  end
+
+  (** This type relates the types of the input and output types of an inductive
+    rule's [main] function to the type of the public input to the resulting
+    circuit.
+*)
+  type ( 'var
+       , 'value
+       , 'input_var
+       , 'input_value
+       , 'ret_var
+       , 'ret_value )
+       public_input =
+    | Input :
+        ('var, 'value) Impls.Step.Typ.t
+        -> ('var, 'value, 'var, 'value, unit, unit) public_input
+    | Output :
+        ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ('ret_var, 'ret_value, unit, unit, 'ret_var, 'ret_value) public_input
+    | Input_and_output :
+        ('var, 'value) Impls.Step.Typ.t
+        * ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ( 'var * 'ret_var
+           , 'value * 'ret_value
+           , 'var
+           , 'value
+           , 'ret_var
+           , 'ret_value )
+           public_input
+
+  (** The input type of an inductive rule's main function. *)
+  type 'public_input main_input =
+    { public_input : 'public_input
+          (** The publicly-exposed input to the circuit's main function. *)
+    }
+
+  type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
+    { previous_proof_statements :
+        ('prev_vars, 'widths) H2.T(Previous_proof_statement).t
+    ; public_output : 'public_output
+    ; auxiliary_output : 'auxiliary_output
+    }
+
+  module Make (M : sig
+    type _ t
+  end) : sig
+    type ( 'prev_vars
+         , 'prev_values
+         , 'widths
+         , 'heights
+         , 'a_var
+         , 'a_value
+         , 'ret_var
+         , 'ret_value
+         , 'auxiliary_var
+         , 'auxiliary_value )
+         t =
+      { identifier : string
+      ; prevs : ('prev_vars, 'prev_values, 'widths, 'heights) H4.T(Tag).t
+      ; main :
+             'a_var main_input
+          -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return M.t
+      ; feature_flags : bool Pickles_types.Plonk_types.Features.t
+      }
+
+    module T
+        (Statement : T0)
+        (Statement_value : T0)
+        (Return_var : T0)
+        (Return_value : T0)
+        (Auxiliary_var : T0)
+        (Auxiliary_value : T0) : sig
+      type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
+        ( 'prev_vars
+        , 'prev_values
+        , 'widths
+        , 'heights
+        , Statement.t
+        , Statement_value.t
+        , Return_var.t
+        , Return_value.t
+        , Auxiliary_var.t
+        , Auxiliary_value.t )
+        t
+    end
+  end
+
+  module Promise : sig
+    include module type of Make (Promise)
+  end
+
+  module Deferred : sig
+    include module type of Make (Async_kernel.Deferred)
+  end
+
+  include module type of Make (Pickles_types.Hlist.Id)
+end
+
+module type Proof_intf = sig
+  type 'width t
+end
+
 module B = struct
   type t = Impls.Step.Boolean.var
 end
 
-module Previous_proof_statement = struct
-  type ('prev_var, 'width) t =
-    { public_input : 'prev_var
-    ; proof : 'width Proof.t Impls.Step.Typ.prover_value
-    ; proof_must_verify : B.t
-    }
-
-  module Constant = struct
-    type ('prev_value, 'width) t =
-      { public_input : 'prev_value
-      ; proof : 'width Proof.t
-      ; proof_must_verify : bool
-      }
+module Make (P : Proof_intf) : Intf with type 'a proof = 'a P.t = struct
+  module B = struct
+    include B
   end
-end
 
-(** This type relates the types of the input and output types of an inductive
+  type 'a proof = 'a P.t
+
+  module Previous_proof_statement = struct
+    type ('prev_var, 'width) t =
+      { public_input : 'prev_var
+      ; proof : 'width P.t Impls.Step.Typ.prover_value
+      ; proof_must_verify : B.t
+      }
+
+    module Constant = struct
+      type ('prev_value, 'width) t =
+        { public_input : 'prev_value
+        ; proof : 'width P.t
+        ; proof_must_verify : bool
+        }
+    end
+  end
+
+  (** This type relates the types of the input and output types of an inductive
     rule's [main] function to the type of the public input to the resulting
     circuit.
 *)
-type ('var, 'value, 'input_var, 'input_value, 'ret_var, 'ret_value) public_input =
-  | Input :
-      ('var, 'value) Impls.Step.Typ.t
-      -> ('var, 'value, 'var, 'value, unit, unit) public_input
-  | Output :
-      ('ret_var, 'ret_value) Impls.Step.Typ.t
-      -> ('ret_var, 'ret_value, unit, unit, 'ret_var, 'ret_value) public_input
-  | Input_and_output :
-      ('var, 'value) Impls.Step.Typ.t * ('ret_var, 'ret_value) Impls.Step.Typ.t
-      -> ( 'var * 'ret_var
-         , 'value * 'ret_value
-         , 'var
-         , 'value
-         , 'ret_var
-         , 'ret_value )
-         public_input
-
-(** The input type of an inductive rule's main function. *)
-type 'public_input main_input =
-  { public_input : 'public_input
-        (** The publicly-exposed input to the circuit's main function. *)
-  }
-
-(** The return type of an inductive rule's main function. *)
-type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
-  { previous_proof_statements :
-      ('prev_vars, 'widths) H2.T(Previous_proof_statement).t
-        (** A list of booleans, determining whether each previous proof must
-            verify.
-        *)
-  ; public_output : 'public_output
-        (** The publicly-exposed output from the circuit's main function. *)
-  ; auxiliary_output : 'auxiliary_output
-        (** The auxiliary output from the circuit's main function. This value
-            is returned to the prover, but not exposed to or used by verifiers.
-        *)
-  }
-
-module Make (M : sig
-  type _ t
-end) =
-struct
-  (** This type models an "inductive rule". It includes
-    - the list of previous statements which this one assumes
-    - the snarky main function
-
-    The types parameters are:
-    - ['prev_vars] the tuple-list of public input circuit types to the previous
-      proofs.
-      - For example, [Boolean.var * (Boolean.var * unit)] represents 2 previous
-        proofs whose public inputs are booleans
-    - ['prev_values] the tuple-list of public input non-circuit types to the
-      previous proofs.
-      - For example, [bool * (bool * unit)] represents 2 previous proofs whose
-        public inputs are booleans.
-    - ['widths] is a tuple list of the maximum number of previous proofs each
-      previous proof itself had.
-      - For example, [Nat.z Nat.s * (Nat.z * unit)] represents 2 previous
-        proofs where the first has at most 1 previous proof and the second had
-        zero previous proofs.
-    - ['heights] is a tuple list of the number of inductive rules in each of
-      the previous proofs
-      - For example, [Nat.z Nat.s Nat.s * (Nat.z Nat.s * unit)] represents 2
-        previous proofs where the first had 2 inductive rules and the second
-        had 1.
-    - ['a_var] is the in-circuit type of the [main] function's public input.
-    - ['a_value] is the out-of-circuit type of the [main] function's public
-      input.
-    - ['ret_var] is the in-circuit type of the [main] function's public output.
-    - ['ret_value] is the out-of-circuit type of the [main] function's public
-      output.
-    - ['auxiliary_var] is the in-circuit type of the [main] function's
-      auxiliary data, to be returned to the prover but not exposed in the
-      public input.
-    - ['auxiliary_value] is the out-of-circuit type of the [main] function's
-      auxiliary data, to be returned to the prover but not exposed in the
-      public input.
-  *)
-  type ( 'prev_vars
-       , 'prev_values
-       , 'widths
-       , 'heights
-       , 'a_var
-       , 'a_value
+  type ( 'var
+       , 'value
+       , 'input_var
+       , 'input_value
        , 'ret_var
-       , 'ret_value
-       , 'auxiliary_var
-       , 'auxiliary_value )
-       t =
-    { identifier : string
-    ; prevs : ('prev_vars, 'prev_values, 'widths, 'heights) H4.T(Tag).t
-    ; main :
-           'a_var main_input
-        -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return M.t
-    ; feature_flags : bool Pickles_types.Plonk_types.Features.t
+       , 'ret_value )
+       public_input =
+    | Input :
+        ('var, 'value) Impls.Step.Typ.t
+        -> ('var, 'value, 'var, 'value, unit, unit) public_input
+    | Output :
+        ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ('ret_var, 'ret_value, unit, unit, 'ret_var, 'ret_value) public_input
+    | Input_and_output :
+        ('var, 'value) Impls.Step.Typ.t
+        * ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ( 'var * 'ret_var
+           , 'value * 'ret_value
+           , 'var
+           , 'value
+           , 'ret_var
+           , 'ret_value )
+           public_input
+
+  (** The input type of an inductive rule's main function. *)
+  type 'public_input main_input =
+    { public_input : 'public_input
+          (** The publicly-exposed input to the circuit's main function. *)
     }
 
-  module T
-      (Statement : T0)
-      (Statement_value : T0)
-      (Return_var : T0)
-      (Return_value : T0)
-      (Auxiliary_var : T0)
-      (Auxiliary_value : T0) =
+  (** The return type of an inductive rule's main function. *)
+  type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
+    { previous_proof_statements :
+        ('prev_vars, 'widths) H2.T(Previous_proof_statement).t
+    ; public_output : 'public_output
+    ; auxiliary_output : 'auxiliary_output
+    }
+
+  module Make (M : sig
+    type _ t
+  end) =
   struct
-    type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
-      ( 'prev_vars
-      , 'prev_values
-      , 'widths
-      , 'heights
-      , Statement.t
-      , Statement_value.t
-      , Return_var.t
-      , Return_value.t
-      , Auxiliary_var.t
-      , Auxiliary_value.t )
-      t
+    type ( 'prev_vars
+         , 'prev_values
+         , 'widths
+         , 'heights
+         , 'a_var
+         , 'a_value
+         , 'ret_var
+         , 'ret_value
+         , 'auxiliary_var
+         , 'auxiliary_value )
+         t =
+      { identifier : string
+      ; prevs : ('prev_vars, 'prev_values, 'widths, 'heights) H4.T(Tag).t
+      ; main :
+             'a_var main_input
+          -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return M.t
+      ; feature_flags : bool Pickles_types.Plonk_types.Features.t
+      }
+
+    module T
+        (Statement : T0)
+        (Statement_value : T0)
+        (Return_var : T0)
+        (Return_value : T0)
+        (Auxiliary_var : T0)
+        (Auxiliary_value : T0) =
+    struct
+      type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
+        ( 'prev_vars
+        , 'prev_values
+        , 'widths
+        , 'heights
+        , Statement.t
+        , Statement_value.t
+        , Return_var.t
+        , Return_value.t
+        , Auxiliary_var.t
+        , Auxiliary_value.t )
+        t
+    end
   end
+
+  module Promise = Make (Promise)
+  module Deferred = Make (Async_kernel.Deferred)
+
+  (* This is the key fix - we need to include the Id-based module to match the MLI *)
+  include Make (Id)
 end
 
-module Promise = Make (Promise)
-module Deferred = Make (Async_kernel.Deferred)
-include Make (Id)
+module Kimchi = Make (Proof)

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -24,10 +24,6 @@ module type Intf = sig
     end
   end
 
-  (** This type relates the types of the input and output types of an inductive
-    rule's [main] function to the type of the public input to the resulting
-    circuit.
-*)
   type ( 'var
        , 'value
        , 'input_var
@@ -189,14 +185,57 @@ module Make (P : Proof_intf) : Intf with type 'a proof = 'a P.t = struct
   type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
     { previous_proof_statements :
         ('prev_vars, 'widths) H2.T(Previous_proof_statement).t
+          (** A list of booleans, determining whether each previous proof must
+          verify.
+      *)
     ; public_output : 'public_output
+          (** The publicly-exposed output from the circuit's main function. *)
     ; auxiliary_output : 'auxiliary_output
+          (** The auxiliary output from the circuit's main function. This value
+        is returned to the prover, but not exposed to or used by verifiers.
+    *)
     }
 
   module Make (M : sig
     type _ t
   end) =
   struct
+    (** This type models an "inductive rule". It includes
+     - the list of previous statements which this one assumes
+     - the snarky main function
+ 
+     The types parameters are:
+     - ['prev_vars] the tuple-list of public input circuit types to the previous
+       proofs.
+       - For example, [Boolean.var * (Boolean.var * unit)] represents 2 previous
+         proofs whose public inputs are booleans
+     - ['prev_values] the tuple-list of public input non-circuit types to the
+       previous proofs.
+       - For example, [bool * (bool * unit)] represents 2 previous proofs whose
+         public inputs are booleans.
+     - ['widths] is a tuple list of the maximum number of previous proofs each
+       previous proof itself had.
+       - For example, [Nat.z Nat.s * (Nat.z * unit)] represents 2 previous
+         proofs where the first has at most 1 previous proof and the second had
+         zero previous proofs.
+     - ['heights] is a tuple list of the number of inductive rules in each of
+       the previous proofs
+       - For example, [Nat.z Nat.s Nat.s * (Nat.z Nat.s * unit)] represents 2
+         previous proofs where the first had 2 inductive rules and the second
+         had 1.
+     - ['a_var] is the in-circuit type of the [main] function's public input.
+     - ['a_value] is the out-of-circuit type of the [main] function's public
+       input.
+     - ['ret_var] is the in-circuit type of the [main] function's public output.
+     - ['ret_value] is the out-of-circuit type of the [main] function's public
+       output.
+     - ['auxiliary_var] is the in-circuit type of the [main] function's
+       auxiliary data, to be returned to the prover but not exposed in the
+       public input.
+     - ['auxiliary_value] is the out-of-circuit type of the [main] function's
+       auxiliary data, to be returned to the prover but not exposed in the
+       public input.
+   *)
     type ( 'prev_vars
          , 'prev_values
          , 'widths
@@ -241,8 +280,6 @@ module Make (P : Proof_intf) : Intf with type 'a proof = 'a P.t = struct
 
   module Promise = Make (Promise)
   module Deferred = Make (Async_kernel.Deferred)
-
-  (* This is the key fix - we need to include the Id-based module to match the MLI *)
   include Make (Id)
 end
 

--- a/src/lib/pickles/inductive_rule.mli
+++ b/src/lib/pickles/inductive_rule.mli
@@ -1,152 +1,133 @@
+module type Intf = sig
+  module B : sig
+    type t = Impls.Step.Boolean.var
+  end
+
+  type _ proof
+
+  module Previous_proof_statement : sig
+    type ('prev_var, 'width) t =
+      { public_input : 'prev_var
+      ; proof : 'width proof Impls.Step.Typ.prover_value
+      ; proof_must_verify : B.t
+      }
+
+    module Constant : sig
+      type ('prev_value, 'width) t =
+        { public_input : 'prev_value
+        ; proof : 'width proof
+        ; proof_must_verify : bool
+        }
+    end
+  end
+
+  type ( 'var
+       , 'value
+       , 'input_var
+       , 'input_value
+       , 'ret_var
+       , 'ret_value )
+       public_input =
+    | Input :
+        ('var, 'value) Impls.Step.Typ.t
+        -> ('var, 'value, 'var, 'value, unit, unit) public_input
+    | Output :
+        ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ('ret_var, 'ret_value, unit, unit, 'ret_var, 'ret_value) public_input
+    | Input_and_output :
+        ('var, 'value) Impls.Step.Typ.t
+        * ('ret_var, 'ret_value) Impls.Step.Typ.t
+        -> ( 'var * 'ret_var
+           , 'value * 'ret_value
+           , 'var
+           , 'value
+           , 'ret_var
+           , 'ret_value )
+           public_input
+
+  (** The input type of an inductive rule's main function. *)
+  type 'public_input main_input =
+    { public_input : 'public_input
+          (** The publicly-exposed input to the circuit's main function. *)
+    }
+
+  type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
+    { previous_proof_statements :
+        ( 'prev_vars
+        , 'widths )
+        Pickles_types.Hlist.H2.T(Previous_proof_statement).t
+    ; public_output : 'public_output
+    ; auxiliary_output : 'auxiliary_output
+    }
+
+  module Make (M : sig
+    type _ t
+  end) : sig
+    type ( 'prev_vars
+         , 'prev_values
+         , 'widths
+         , 'heights
+         , 'a_var
+         , 'a_value
+         , 'ret_var
+         , 'ret_value
+         , 'auxiliary_var
+         , 'auxiliary_value )
+         t =
+      { identifier : string
+      ; prevs :
+          ( 'prev_vars
+          , 'prev_values
+          , 'widths
+          , 'heights )
+          Pickles_types.Hlist.H4.T(Tag).t
+      ; main :
+             'a_var main_input
+          -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return M.t
+      ; feature_flags : bool Pickles_types.Plonk_types.Features.t
+      }
+
+    module T
+        (Statement : Pickles_types.Poly_types.T0)
+        (Statement_value : Pickles_types.Poly_types.T0)
+        (Return_var : Pickles_types.Poly_types.T0)
+        (Return_value : Pickles_types.Poly_types.T0)
+        (Auxiliary_var : Pickles_types.Poly_types.T0)
+        (Auxiliary_value : Pickles_types.Poly_types.T0) : sig
+      type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
+        ( 'prev_vars
+        , 'prev_values
+        , 'widths
+        , 'heights
+        , Statement.t
+        , Statement_value.t
+        , Return_var.t
+        , Return_value.t
+        , Auxiliary_var.t
+        , Auxiliary_value.t )
+        t
+    end
+  end
+
+  module Promise : sig
+    include module type of Make (Promise)
+  end
+
+  module Deferred : sig
+    include module type of Make (Async_kernel.Deferred)
+  end
+
+  include module type of Make (Pickles_types.Hlist.Id)
+end
+
+module type Proof_intf = sig
+  type 'width t
+end
+
 module B : sig
   type t = Impls.Step.Boolean.var
 end
 
-module Previous_proof_statement : sig
-  type ('prev_var, 'width) t =
-    { public_input : 'prev_var
-    ; proof : 'width Proof.t Impls.Step.Typ.prover_value
-    ; proof_must_verify : B.t
-    }
+module Make (P : Proof_intf) : Intf
 
-  module Constant : sig
-    type ('prev_value, 'width) t =
-      { public_input : 'prev_value
-      ; proof : 'width Proof.t
-      ; proof_must_verify : bool
-      }
-  end
-end
-
-type ('var, 'value, 'input_var, 'input_value, 'ret_var, 'ret_value) public_input =
-  | Input :
-      ('var, 'value) Impls.Step.Typ.t
-      -> ('var, 'value, 'var, 'value, unit, unit) public_input
-  | Output :
-      ('ret_var, 'ret_value) Impls.Step.Typ.t
-      -> ('ret_var, 'ret_value, unit, unit, 'ret_var, 'ret_value) public_input
-  | Input_and_output :
-      ('var, 'value) Impls.Step.Typ.t * ('ret_var, 'ret_value) Impls.Step.Typ.t
-      -> ( 'var * 'ret_var
-         , 'value * 'ret_value
-         , 'var
-         , 'value
-         , 'ret_var
-         , 'ret_value )
-         public_input
-
-(** The input type of an inductive rule's main function. *)
-type 'public_input main_input =
-  { public_input : 'public_input
-        (** The publicly-exposed input to the circuit's main function. *)
-  }
-
-(** The return type of an inductive rule's main function. *)
-type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
-  { previous_proof_statements :
-      ('prev_vars, 'widths) Pickles_types.Hlist.H2.T(Previous_proof_statement).t
-        (** A list of booleans, determining whether each previous proof must
-            verify.
-        *)
-  ; public_output : 'public_output
-        (** The publicly-exposed output from the circuit's main function. *)
-  ; auxiliary_output : 'auxiliary_output
-        (** The auxiliary output from the circuit's main function. This value
-            is returned to the prover, but not exposed to or used by verifiers.
-        *)
-  }
-
-module Make (M : sig
-  type _ t
-end) : sig
-  (** This type models an "inductive rule". It includes
-    - the list of previous statements which this one assumes
-    - the snarky main function
-
-    The types parameters are:
-    - ['prev_vars] the tuple-list of public input circuit types to the previous
-      proofs.
-      - For example, [Boolean.var * (Boolean.var * unit)] represents 2 previous
-        proofs whose public inputs are booleans
-    - ['prev_values] the tuple-list of public input non-circuit types to the
-      previous proofs.
-      - For example, [bool * (bool * unit)] represents 2 previous proofs whose
-        public inputs are booleans.
-    - ['widths] is a tuple list of the maximum number of previous proofs each
-      previous proof itself had.
-      - For example, [Nat.z Nat.s * (Nat.z * unit)] represents 2 previous
-        proofs where the first has at most 1 previous proof and the second had
-        zero previous proofs.
-    - ['heights] is a tuple list of the number of inductive rules in each of
-      the previous proofs
-      - For example, [Nat.z Nat.s Nat.s * (Nat.z Nat.s * unit)] represents 2
-        previous proofs where the first had 2 inductive rules and the second
-        had 1.
-    - ['a_var] is the in-circuit type of the [main] function's public input.
-    - ['a_value] is the out-of-circuit type of the [main] function's public
-      input.
-    - ['ret_var] is the in-circuit type of the [main] function's public output.
-    - ['ret_value] is the out-of-circuit type of the [main] function's public
-      output.
-    - ['auxiliary_var] is the in-circuit type of the [main] function's
-      auxiliary data, to be returned to the prover but not exposed in the
-      public input.
-    - ['auxiliary_value] is the out-of-circuit type of the [main] function's
-      auxiliary data, to be returned to the prover but not exposed in the
-      public input.
-  *)
-  type ( 'prev_vars
-       , 'prev_values
-       , 'widths
-       , 'heights
-       , 'a_var
-       , 'a_value
-       , 'ret_var
-       , 'ret_value
-       , 'auxiliary_var
-       , 'auxiliary_value )
-       t =
-    { identifier : string
-    ; prevs :
-        ( 'prev_vars
-        , 'prev_values
-        , 'widths
-        , 'heights )
-        Pickles_types.Hlist.H4.T(Tag).t
-    ; main :
-           'a_var main_input
-        -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return M.t
-    ; feature_flags : bool Pickles_types.Plonk_types.Features.t
-    }
-
-  module T
-      (Statement : Pickles_types.Poly_types.T0)
-      (Statement_value : Pickles_types.Poly_types.T0)
-      (Return_var : Pickles_types.Poly_types.T0)
-      (Return_value : Pickles_types.Poly_types.T0)
-      (Auxiliary_var : Pickles_types.Poly_types.T0)
-      (Auxiliary_value : Pickles_types.Poly_types.T0) : sig
-    type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
-      ( 'prev_vars
-      , 'prev_values
-      , 'widths
-      , 'heights
-      , Statement.t
-      , Statement_value.t
-      , Return_var.t
-      , Return_value.t
-      , Auxiliary_var.t
-      , Auxiliary_value.t )
-      t
-  end
-end
-
-module Promise : sig
-  include module type of Make (Promise)
-end
-
-module Deferred : sig
-  include module type of Make (Async_kernel.Deferred)
-end
-
-include module type of Make (Pickles_types.Hlist.Id)
+module Kimchi : Intf with type 'width proof = 'width Proof.t

--- a/src/lib/pickles/inductive_rule.mli
+++ b/src/lib/pickles/inductive_rule.mli
@@ -51,18 +51,62 @@ module type Intf = sig
           (** The publicly-exposed input to the circuit's main function. *)
     }
 
+  (** The return type of an inductive rule's main function. *)
   type ('prev_vars, 'widths, 'public_output, 'auxiliary_output) main_return =
     { previous_proof_statements :
         ( 'prev_vars
         , 'widths )
         Pickles_types.Hlist.H2.T(Previous_proof_statement).t
+          (** A list of booleans, determining whether each previous proof must
+          verify.
+      *)
     ; public_output : 'public_output
+          (** The publicly-exposed output from the circuit's main function. *)
     ; auxiliary_output : 'auxiliary_output
+          (** The auxiliary output from the circuit's main function. This value
+          is returned to the prover, but not exposed to or used by verifiers.
+      *)
     }
 
   module Make (M : sig
     type _ t
   end) : sig
+    (** This type models an "inductive rule". It includes
+      - the list of previous statements which this one assumes
+      - the snarky main function
+    
+      The types parameters are:
+      - ['prev_vars] the tuple-list of public input circuit types to the previous
+        proofs.
+        - For example, [Boolean.var * (Boolean.var * unit)] represents 2 previous
+          proofs whose public inputs are booleans
+      - ['prev_values] the tuple-list of public input non-circuit types to the
+        previous proofs.
+        - For example, [bool * (bool * unit)] represents 2 previous proofs whose
+          public inputs are booleans.
+      - ['widths] is a tuple list of the maximum number of previous proofs each
+        previous proof itself had.
+        - For example, [Nat.z Nat.s * (Nat.z * unit)] represents 2 previous
+          proofs where the first has at most 1 previous proof and the second had
+          zero previous proofs.
+      - ['heights] is a tuple list of the number of inductive rules in each of
+        the previous proofs
+        - For example, [Nat.z Nat.s Nat.s * (Nat.z Nat.s * unit)] represents 2
+          previous proofs where the first had 2 inductive rules and the second
+          had 1.
+      - ['a_var] is the in-circuit type of the [main] function's public input.
+      - ['a_value] is the out-of-circuit type of the [main] function's public
+        input.
+      - ['ret_var] is the in-circuit type of the [main] function's public output.
+      - ['ret_value] is the out-of-circuit type of the [main] function's public
+        output.
+      - ['auxiliary_var] is the in-circuit type of the [main] function's
+        auxiliary data, to be returned to the prover but not exposed in the
+        public input.
+      - ['auxiliary_value] is the out-of-circuit type of the [main] function's
+        auxiliary data, to be returned to the prover but not exposed in the
+        public input.
+    *)
     type ( 'prev_vars
          , 'prev_values
          , 'widths

--- a/src/lib/pickles/inductive_rule.mli
+++ b/src/lib/pickles/inductive_rule.mli
@@ -124,10 +124,6 @@ module type Proof_intf = sig
   type 'width t
 end
 
-module B : sig
-  type t = Impls.Step.Boolean.var
-end
-
 module Make (P : Proof_intf) : Intf
 
 module Kimchi : Intf with type 'width proof = 'width Proof.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -36,7 +36,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Util = Util
   module Tick_field_sponge = Tick_field_sponge
   module Impls = Impls
-  module Inductive_rule = Inductive_rule
+  module Inductive_rule = Inductive_rule.Kimchi
   module Tag = Tag
   module Types_map = Types_map
   module Dirty = Dirty
@@ -47,6 +47,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Cache = Cache
   module Storables = Compile.Storables
   module Ro = Ro
+  module Step_branch_data = Step_branch_data.Make (Inductive_rule)
 
   type chunking_data = Verify.Instance.chunking_data =
     { num_chunks : int; domain_size : int; zk_rows : int }
@@ -1301,7 +1302,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
             (r, disk_key_verifier)
           in
           let wrap_vk = Lazy.map wrap_vk ~f:(Promise.map ~f:fst) in
-          let module S = Step.Make (A) (A_value) (Max_proofs_verified) in
+          let module S =
+            Step.Make (Inductive_rule) (A) (A_value) (Max_proofs_verified)
+          in
           let prover =
             let f :
                    ( unit * (unit * unit)

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -98,7 +98,7 @@ module Wrap = struct
     (module R)
 end
 
-module Step = struct
+module Step (Inductive_rule : Inductive_rule.Intf) = struct
   module type S = sig
     type statement
 

--- a/src/lib/pickles/requests.mli
+++ b/src/lib/pickles/requests.mli
@@ -4,7 +4,7 @@
 
 open Pickles_types
 
-module Step : sig
+module Step (Inductive_rule : Inductive_rule.Intf) : sig
   module type S = sig
     type statement
 

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -11,11 +11,14 @@ open Common
 (* This contains the "step" prover *)
 
 module Make
+    (Inductive_rule : Inductive_rule.Intf with type 'a proof = 'a Proof.t)
     (A : T0) (A_value : sig
       type t
     end)
     (Max_proofs_verified : Nat.Add.Intf_transparent) =
 struct
+  module Step_branch_data = Step_branch_data.Make (Inductive_rule)
+
   let _double_zip = Double.map2 ~f:Core_kernel.Tuple2.create
 
   module E = struct

--- a/src/lib/pickles/step.mli
+++ b/src/lib/pickles/step.mli
@@ -1,10 +1,13 @@
 open Pickles_types
 
 module Make
+    (Inductive_rule : Inductive_rule.Intf with type 'a proof = 'a Proof.t)
     (A : Pickles_types.Poly_types.T0) (A_value : sig
       type t
     end)
     (Max_proofs_verified : Pickles_types.Nat.Add.Intf_transparent) : sig
+  module Step_branch_data : module type of Step_branch_data.Make (Inductive_rule)
+
   val f :
        ?handler:
          (   Snarky_backendless.Request.request

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -3,237 +3,243 @@ open Pickles_types
 open Hlist
 open Import
 
-(* The data obtained from "compiling" an inductive rule into a circuit. *)
-type ( 'a_var
-     , 'a_value
-     , 'ret_var
-     , 'ret_value
-     , 'auxiliary_var
-     , 'auxiliary_value
-     , 'max_proofs_verified
-     , 'branches
-     , 'prev_vars
-     , 'prev_values
-     , 'local_widths
-     , 'local_heights )
-     t =
-  | T :
-      { proofs_verified :
-          'proofs_verified Nat.t * ('prev_vars, 'proofs_verified) Hlist.Length.t
-      ; index : int
-      ; lte : ('proofs_verified, 'max_proofs_verified) Nat.Lte.t
-      ; domains : Domains.t Promise.t
-      ; rule :
-          ( 'prev_vars
-          , 'prev_values
-          , 'local_widths
-          , 'local_heights
-          , 'a_var
-          , 'a_value
-          , 'ret_var
-          , 'ret_value
-          , 'auxiliary_var
-          , 'auxiliary_value )
-          Inductive_rule.Promise.t
-      ; main :
-             step_domains:(Domains.t, 'branches) Vector.t Promise.t
-          -> (   unit
-              -> ( (Unfinalized.t, 'max_proofs_verified) Vector.t
-                 , Impls.Step.Field.t
-                 , (Impls.Step.Field.t, 'max_proofs_verified) Vector.t )
-                 Types.Step.Statement.t
-                 Promise.t )
-             Promise.t
-      ; requests :
-          (module Requests.Step.S
-             with type statement = 'a_value
-              and type max_proofs_verified = 'max_proofs_verified
-              and type proofs_verified = 'proofs_verified
-              and type prev_values = 'prev_values
-              and type local_signature = 'local_widths
-              and type local_branches = 'local_heights
-              and type return_value = 'ret_value
-              and type auxiliary_value = 'auxiliary_value )
-      ; feature_flags : bool Plonk_types.Features.t
-      }
-      -> ( 'a_var
-         , 'a_value
-         , 'ret_var
-         , 'ret_value
-         , 'auxiliary_var
-         , 'auxiliary_value
-         , 'max_proofs_verified
-         , 'branches
-         , 'prev_vars
-         , 'prev_values
-         , 'local_widths
-         , 'local_heights )
-         t
-
-(* Compile an inductive rule. *)
-let create
-    (type branches max_proofs_verified var value a_var a_value ret_var ret_value)
-    ~index ~(self : (var, value, max_proofs_verified, branches) Tag.t)
-    ~wrap_domains ~(feature_flags : Opt.Flag.t Plonk_types.Features.Full.t)
-    ~num_chunks ~(actual_feature_flags : bool Plonk_types.Features.t)
-    ~(max_proofs_verified : max_proofs_verified Nat.t)
-    ~(branches : branches Nat.t)
-    ~(public_input :
-       ( var
-       , value
-       , a_var
-       , a_value
-       , ret_var
-       , ret_value )
-       Inductive_rule.public_input ) ~auxiliary_typ _var_to_field_elements
-    _value_to_field_elements ~(chain_to : unit Promise.t)
-    (rule : _ Inductive_rule.Promise.t) =
-  Timer.clock __LOC__ ;
-  let module HT = H4.T (Tag) in
-  let (T (self_width, proofs_verified)) = HT.length rule.prevs in
-  let rec extract_lengths :
-      type a b n m k.
-         (a, b, n, m) HT.t
-      -> (a, k) Length.t
-      -> n H1.T(Nat).t * (n, k) Length.t * (m, k) Length.t =
-   fun ts len ->
-    match (ts, len) with
-    | [], Z ->
-        ([], Z, Z)
-    | t :: ts, S len -> (
-        let ns, len_ns, len_ms = extract_lengths ts len in
-        match Type_equal.Id.same_witness self.id t.id with
-        | Some T ->
-            (max_proofs_verified :: ns, S len_ns, S len_ms)
-        | None ->
-            let (module M) =
-              match t.kind with
-              | Compiled ->
-                  let d = Types_map.lookup_compiled t.id in
-                  d.max_proofs_verified
-              | Side_loaded ->
-                  let d = Types_map.lookup_side_loaded t.id in
-                  d.permanent.max_proofs_verified
-            in
-            let T = M.eq in
-            (M.n :: ns, S len_ns, S len_ms) )
-  in
-  Timer.clock __LOC__ ;
-  let widths, local_signature_length, local_branches_length =
-    extract_lengths rule.prevs proofs_verified
-  in
-  let lte = Nat.lte_exn self_width max_proofs_verified in
-  let requests = Requests.Step.create () in
-  let (typ : (var, value) Impls.Step.Typ.t) =
-    match public_input with
-    | Input typ ->
-        typ
-    | Output typ ->
-        typ
-    | Input_and_output (input_typ, output_typ) ->
-        Impls.Step.Typ.(input_typ * output_typ)
-  in
-  (* Here, we prefetch the known wrap keys for all compiled rules.
-     These keys may resolve asynchronously due to key generation for other
-     pickles rules, but we want to preserve the single-threaded behavior of
-     pickles to maximize our chances of successful debugging.
-     Hence, we preload here, and pass the values in as needed when we create
-     [datas] below.
-  *)
-  let module Optional_wrap_key = Types_map.For_step.Optional_wrap_key in
-  let known_wrap_keys =
-    let rec go :
-        type a1 a2 n m.
-        (a1, a2, n, m) H4.T(Tag).t -> m H1.T(Optional_wrap_key).t Promise.t =
-      function
-      | [] ->
-          Promise.return ([] : _ H1.T(Optional_wrap_key).t)
-      | tag :: tags ->
-          let%bind.Promise opt_wrap_key =
-            match Type_equal.Id.same_witness self.id tag.id with
-            | Some T ->
-                Promise.return None
-            | None -> (
-                match tag.kind with
-                | Compiled ->
-                    let compiled = Types_map.lookup_compiled tag.id in
-                    let%map.Promise wrap_key = Lazy.force compiled.wrap_key
-                    and step_domains =
-                      let%map.Promise () =
-                        (* Wait for promises to resolve. *)
-                        Vector.fold ~init:(Promise.return ())
-                          compiled.step_domains ~f:(fun acc step_domain ->
-                            let%bind.Promise _ = step_domain in
-                            acc )
-                      in
-                      Vector.map
-                        ~f:(fun x -> Option.value_exn @@ Promise.peek x)
-                        compiled.step_domains
-                    in
-                    Some { Optional_wrap_key.wrap_key; step_domains }
-                | Side_loaded ->
-                    Promise.return None )
-          in
-          let%map.Promise rest = go tags in
-          (opt_wrap_key :: rest : _ H1.T(Optional_wrap_key).t)
-    in
-    go rule.prevs
-  in
-  Timer.clock __LOC__ ;
-  let step ~step_domains ~known_wrap_keys =
-    Step_main.step_main requests
-      (Nat.Add.create max_proofs_verified)
-      rule
-      ~basic:
-        { public_input = typ
-        ; wrap_domains
-        ; step_domains
-        ; feature_flags
-        ; num_chunks
-        ; zk_rows =
-            ( match num_chunks with
-            | 1 (* cannot match with Plonk_checks.num_chunks_by_default *) ->
-                Plonk_checks.zk_rows_by_default
-            | num_chunks ->
-                let permuts = 7 in
-                ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts )
+module Make (Inductive_rule : Inductive_rule.Intf) = struct
+  (* The data obtained from "compiling" an inductive rule into a circuit. *)
+  type ( 'a_var
+       , 'a_value
+       , 'ret_var
+       , 'ret_value
+       , 'auxiliary_var
+       , 'auxiliary_value
+       , 'max_proofs_verified
+       , 'branches
+       , 'prev_vars
+       , 'prev_values
+       , 'local_widths
+       , 'local_heights )
+       t =
+    | T :
+        { proofs_verified :
+            'proofs_verified Nat.t
+            * ('prev_vars, 'proofs_verified) Hlist.Length.t
+        ; index : int
+        ; lte : ('proofs_verified, 'max_proofs_verified) Nat.Lte.t
+        ; domains : Domains.t Promise.t
+        ; rule :
+            ( 'prev_vars
+            , 'prev_values
+            , 'local_widths
+            , 'local_heights
+            , 'a_var
+            , 'a_value
+            , 'ret_var
+            , 'ret_value
+            , 'auxiliary_var
+            , 'auxiliary_value )
+            Inductive_rule.Promise.t
+        ; main :
+               step_domains:(Domains.t, 'branches) Vector.t Promise.t
+            -> (   unit
+                -> ( (Unfinalized.t, 'max_proofs_verified) Vector.t
+                   , Impls.Step.Field.t
+                   , (Impls.Step.Field.t, 'max_proofs_verified) Vector.t )
+                   Types.Step.Statement.t
+                   Promise.t )
+               Promise.t
+        ; requests :
+            (module Requests.Step(Inductive_rule).S
+               with type statement = 'a_value
+                and type max_proofs_verified = 'max_proofs_verified
+                and type proofs_verified = 'proofs_verified
+                and type prev_values = 'prev_values
+                and type local_signature = 'local_widths
+                and type local_branches = 'local_heights
+                and type return_value = 'ret_value
+                and type auxiliary_value = 'auxiliary_value )
+        ; feature_flags : bool Plonk_types.Features.t
         }
-      ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
-      ~local_signature:widths ~local_signature_length ~local_branches_length
-      ~lte ~known_wrap_keys ~self
-    |> unstage
-  in
-  Timer.clock __LOC__ ;
-  let own_domains =
-    let%bind.Promise known_wrap_keys = known_wrap_keys in
-    let main =
-      step
-        ~step_domains:
-          (Vector.init branches ~f:(fun _ -> Fix_domains.rough_domains))
-        ~known_wrap_keys
+        -> ( 'a_var
+           , 'a_value
+           , 'ret_var
+           , 'ret_value
+           , 'auxiliary_var
+           , 'auxiliary_value
+           , 'max_proofs_verified
+           , 'branches
+           , 'prev_vars
+           , 'prev_values
+           , 'local_widths
+           , 'local_heights )
+           t
+
+  (* Compile an inductive rule. *)
+  let create
+      (type branches max_proofs_verified var value a_var a_value ret_var
+      ret_value ) ~index
+      ~(self : (var, value, max_proofs_verified, branches) Tag.t) ~wrap_domains
+      ~(feature_flags : Opt.Flag.t Plonk_types.Features.Full.t) ~num_chunks
+      ~(actual_feature_flags : bool Plonk_types.Features.t)
+      ~(max_proofs_verified : max_proofs_verified Nat.t)
+      ~(branches : branches Nat.t)
+      ~(public_input :
+         ( var
+         , value
+         , a_var
+         , a_value
+         , ret_var
+         , ret_value )
+         Inductive_rule.public_input ) ~auxiliary_typ _var_to_field_elements
+      _value_to_field_elements ~(chain_to : unit Promise.t)
+      (rule : _ Inductive_rule.Promise.t) =
+    Timer.clock __LOC__ ;
+    let module HT = H4.T (Tag) in
+    let (T (self_width, proofs_verified)) = HT.length rule.prevs in
+    let rec extract_lengths :
+        type a b n m k.
+           (a, b, n, m) HT.t
+        -> (a, k) Length.t
+        -> n H1.T(Nat).t * (n, k) Length.t * (m, k) Length.t =
+     fun ts len ->
+      match (ts, len) with
+      | [], Z ->
+          ([], Z, Z)
+      | t :: ts, S len -> (
+          let ns, len_ns, len_ms = extract_lengths ts len in
+          match Type_equal.Id.same_witness self.id t.id with
+          | Some T ->
+              (max_proofs_verified :: ns, S len_ns, S len_ms)
+          | None ->
+              let (module M) =
+                match t.kind with
+                | Compiled ->
+                    let d = Types_map.lookup_compiled t.id in
+                    d.max_proofs_verified
+                | Side_loaded ->
+                    let d = Types_map.lookup_side_loaded t.id in
+                    d.permanent.max_proofs_verified
+              in
+              let T = M.eq in
+              (M.n :: ns, S len_ns, S len_ms) )
     in
-    let etyp =
-      Impls.Step.input ~proofs_verified:max_proofs_verified
-      (* TODO *)
+    Timer.clock __LOC__ ;
+    let widths, local_signature_length, local_branches_length =
+      extract_lengths rule.prevs proofs_verified
     in
-    let%bind.Promise () = chain_to in
-    Fix_domains.domains ~feature_flags:actual_feature_flags
-      (T (Impls.Step.Typ.unit, Fn.id, Fn.id))
-      etyp main
-  in
-  let step ~step_domains =
-    let%bind.Promise known_wrap_keys = known_wrap_keys in
-    let%map.Promise step_domains = step_domains in
-    step ~step_domains ~known_wrap_keys
-  in
-  Timer.clock __LOC__ ;
-  T
-    { proofs_verified = (self_width, proofs_verified)
-    ; index
-    ; lte
-    ; rule
-    ; domains = own_domains
-    ; main = step
-    ; requests
-    ; feature_flags = actual_feature_flags
-    }
+    let lte = Nat.lte_exn self_width max_proofs_verified in
+    let module Step_requests = Requests.Step (Inductive_rule) in
+    let requests = Step_requests.create () in
+    let (typ : (var, value) Impls.Step.Typ.t) =
+      match public_input with
+      | Input typ ->
+          typ
+      | Output typ ->
+          typ
+      | Input_and_output (input_typ, output_typ) ->
+          Impls.Step.Typ.(input_typ * output_typ)
+    in
+    (* Here, we prefetch the known wrap keys for all compiled rules.
+       These keys may resolve asynchronously due to key generation for other
+       pickles rules, but we want to preserve the single-threaded behavior of
+       pickles to maximize our chances of successful debugging.
+       Hence, we preload here, and pass the values in as needed when we create
+       [datas] below.
+    *)
+    let module Optional_wrap_key = Types_map.For_step.Optional_wrap_key in
+    let known_wrap_keys =
+      let rec go :
+          type a1 a2 n m.
+          (a1, a2, n, m) H4.T(Tag).t -> m H1.T(Optional_wrap_key).t Promise.t =
+        function
+        | [] ->
+            Promise.return ([] : _ H1.T(Optional_wrap_key).t)
+        | tag :: tags ->
+            let%bind.Promise opt_wrap_key =
+              match Type_equal.Id.same_witness self.id tag.id with
+              | Some T ->
+                  Promise.return None
+              | None -> (
+                  match tag.kind with
+                  | Compiled ->
+                      let compiled = Types_map.lookup_compiled tag.id in
+                      let%map.Promise wrap_key = Lazy.force compiled.wrap_key
+                      and step_domains =
+                        let%map.Promise () =
+                          (* Wait for promises to resolve. *)
+                          Vector.fold ~init:(Promise.return ())
+                            compiled.step_domains ~f:(fun acc step_domain ->
+                              let%bind.Promise _ = step_domain in
+                              acc )
+                        in
+                        Vector.map
+                          ~f:(fun x -> Option.value_exn @@ Promise.peek x)
+                          compiled.step_domains
+                      in
+                      Some { Optional_wrap_key.wrap_key; step_domains }
+                  | Side_loaded ->
+                      Promise.return None )
+            in
+            let%map.Promise rest = go tags in
+            (opt_wrap_key :: rest : _ H1.T(Optional_wrap_key).t)
+      in
+      go rule.prevs
+    in
+    Timer.clock __LOC__ ;
+    let module Step_main = Step_main.Make (Inductive_rule) in
+    let step ~step_domains ~known_wrap_keys =
+      Step_main.step_main requests
+        (Nat.Add.create max_proofs_verified)
+        rule
+        ~basic:
+          { public_input = typ
+          ; wrap_domains
+          ; step_domains
+          ; feature_flags
+          ; num_chunks
+          ; zk_rows =
+              ( match num_chunks with
+              | 1 (* cannot match with Plonk_checks.num_chunks_by_default *) ->
+                  Plonk_checks.zk_rows_by_default
+              | num_chunks ->
+                  let permuts = 7 in
+                  ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts )
+          }
+        ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
+        ~local_signature:widths ~local_signature_length ~local_branches_length
+        ~lte ~known_wrap_keys ~self
+      |> unstage
+    in
+    Timer.clock __LOC__ ;
+    let own_domains =
+      let%bind.Promise known_wrap_keys = known_wrap_keys in
+      let main =
+        step
+          ~step_domains:
+            (Vector.init branches ~f:(fun _ -> Fix_domains.rough_domains))
+          ~known_wrap_keys
+      in
+      let etyp =
+        Impls.Step.input ~proofs_verified:max_proofs_verified
+        (* TODO *)
+      in
+      let%bind.Promise () = chain_to in
+      Fix_domains.domains ~feature_flags:actual_feature_flags
+        (T (Impls.Step.Typ.unit, Fn.id, Fn.id))
+        etyp main
+    in
+    let step ~step_domains =
+      let%bind.Promise known_wrap_keys = known_wrap_keys in
+      let%map.Promise step_domains = step_domains in
+      step ~step_domains ~known_wrap_keys
+    in
+    Timer.clock __LOC__ ;
+    T
+      { proofs_verified = (self_width, proofs_verified)
+      ; index
+      ; lte
+      ; rule
+      ; domains = own_domains
+      ; main = step
+      ; requests
+      ; feature_flags = actual_feature_flags
+      }
+end

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -1,130 +1,132 @@
 open Pickles_types
 
-(** The data obtained from "compiling" an inductive rule into a circuit. *)
-type ( 'a_var
-     , 'a_value
-     , 'ret_var
-     , 'ret_value
-     , 'auxiliary_var
-     , 'auxiliary_value
-     (* type level nat *)
-     , 'max_proofs_verified
-     , 'branches
-     , 'prev_vars
-     , 'prev_values
-     (* type level nat *)
-     , 'local_widths
-     (* type level nat *)
-     , 'local_heights )
-     t =
-  | T :
-      { proofs_verified :
-          'proofs_verified Pickles_types.Nat.t
-          * ('prev_vars, 'proofs_verified) Pickles_types.Hlist.Length.t
-      ; index : int
-      ; lte : ('proofs_verified, 'max_proofs_verified) Pickles_types.Nat.Lte.t
-      ; domains : Import.Domains.t Promise.t
-      ; rule :
-          ( 'prev_vars
-          , 'prev_values
-          , 'local_widths
-          , 'local_heights
-          , 'a_var
-          , 'a_value
-          , 'ret_var
-          , 'ret_value
-          , 'auxiliary_var
-          , 'auxiliary_value )
-          Inductive_rule.Promise.t
-            (* Main functions to compute *)
-      ; main :
-             step_domains:
-               (Import.Domains.t, 'branches) Pickles_types.Vector.t Promise.t
-          -> (   unit
-              -> ( (Unfinalized.t, 'max_proofs_verified) Pickles_types.Vector.t
-                 , Impls.Step.Field.t
-                 , ( Impls.Step.Field.t
-                   , 'max_proofs_verified )
-                   Pickles_types.Vector.t )
-                 Import.Types.Step.Statement.t
-                 Promise.t )
-             Promise.t
-      ; requests :
-          (module Requests.Step.S
-             with type auxiliary_value = 'auxiliary_value
-              and type local_branches = 'local_heights
-              and type local_signature = 'local_widths
-              and type max_proofs_verified = 'max_proofs_verified
-              and type prev_values = 'prev_values
-              and type proofs_verified = 'proofs_verified
-              and type return_value = 'ret_value
-              and type statement = 'a_value )
-      ; feature_flags : bool Plonk_types.Features.t
-      }
-      -> ( 'a_var
-         , 'a_value
-         , 'ret_var
-         , 'ret_value
-         , 'auxiliary_var
-         , 'auxiliary_value
-         (* type level nat *)
-         , 'max_proofs_verified
-         , 'branches
-         , 'prev_vars
-         , 'prev_values
-         (* type level nat *)
-         , 'local_widths
-         (* type level nat *)
-         , 'local_heights )
-         t
+module Make (Inductive_rule : Inductive_rule.Intf) : sig
+  (** The data obtained from "compiling" an inductive rule into a circuit. *)
+  type ( 'a_var
+       , 'a_value
+       , 'ret_var
+       , 'ret_value
+       , 'auxiliary_var
+       , 'auxiliary_value
+       (* type level nat *)
+       , 'max_proofs_verified
+       , 'branches
+       , 'prev_vars
+       , 'prev_values
+       (* type level nat *)
+       , 'local_widths
+       (* type level nat *)
+       , 'local_heights )
+       t =
+    | T :
+        { proofs_verified :
+            'proofs_verified Pickles_types.Nat.t
+            * ('prev_vars, 'proofs_verified) Pickles_types.Hlist.Length.t
+        ; index : int
+        ; lte : ('proofs_verified, 'max_proofs_verified) Pickles_types.Nat.Lte.t
+        ; domains : Import.Domains.t Promise.t
+        ; rule :
+            ( 'prev_vars
+            , 'prev_values
+            , 'local_widths
+            , 'local_heights
+            , 'a_var
+            , 'a_value
+            , 'ret_var
+            , 'ret_value
+            , 'auxiliary_var
+            , 'auxiliary_value )
+            Inductive_rule.Promise.t
+              (* Main functions to compute *)
+        ; main :
+               step_domains:
+                 (Import.Domains.t, 'branches) Pickles_types.Vector.t Promise.t
+            -> (   unit
+                -> ( (Unfinalized.t, 'max_proofs_verified) Pickles_types.Vector.t
+                   , Impls.Step.Field.t
+                   , ( Impls.Step.Field.t
+                     , 'max_proofs_verified )
+                     Pickles_types.Vector.t )
+                   Import.Types.Step.Statement.t
+                   Promise.t )
+               Promise.t
+        ; requests :
+            (module Requests.Step(Inductive_rule).S
+               with type auxiliary_value = 'auxiliary_value
+                and type local_branches = 'local_heights
+                and type local_signature = 'local_widths
+                and type max_proofs_verified = 'max_proofs_verified
+                and type prev_values = 'prev_values
+                and type proofs_verified = 'proofs_verified
+                and type return_value = 'ret_value
+                and type statement = 'a_value )
+        ; feature_flags : bool Plonk_types.Features.t
+        }
+        -> ( 'a_var
+           , 'a_value
+           , 'ret_var
+           , 'ret_value
+           , 'auxiliary_var
+           , 'auxiliary_value
+           (* type level nat *)
+           , 'max_proofs_verified
+           , 'branches
+           , 'prev_vars
+           , 'prev_values
+           (* type level nat *)
+           , 'local_widths
+           (* type level nat *)
+           , 'local_heights )
+           t
 
-(** Compile one rule into a value of type [t]
+  (** Compile one rule into a value of type [t]
     [create idx self wrap_domains feature_flags actual_feature_flags
     max_proofs_verified branches public_input aux_typ var_to_field_elem
     val_to_field_elem rule]
 *)
-val create :
-     index:int
-  -> self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
-  -> wrap_domains:Import.Domains.t
-  -> feature_flags:Opt.Flag.t Plonk_types.Features.Full.t
-  -> num_chunks:int
-  -> actual_feature_flags:bool Plonk_types.Features.t
-  -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
-  -> branches:'branches Pickles_types.Nat.t
-  -> public_input:
-       ( 'var
-       , 'value
+  val create :
+       index:int
+    -> self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
+    -> wrap_domains:Import.Domains.t
+    -> feature_flags:Opt.Flag.t Plonk_types.Features.Full.t
+    -> num_chunks:int
+    -> actual_feature_flags:bool Plonk_types.Features.t
+    -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
+    -> branches:'branches Pickles_types.Nat.t
+    -> public_input:
+         ( 'var
+         , 'value
+         , 'a_var
+         , 'a_value
+         , 'ret_var
+         , 'ret_value )
+         Inductive_rule.public_input
+    -> auxiliary_typ:('a, 'b) Impls.Step.Typ.t
+    -> 'c
+    -> 'd
+    -> chain_to:unit Promise.t
+    -> ( 'e
+       , 'f
+       , 'g
+       , 'h
        , 'a_var
        , 'a_value
        , 'ret_var
-       , 'ret_value )
-       Inductive_rule.public_input
-  -> auxiliary_typ:('a, 'b) Impls.Step.Typ.t
-  -> 'c
-  -> 'd
-  -> chain_to:unit Promise.t
-  -> ( 'e
-     , 'f
-     , 'g
-     , 'h
-     , 'a_var
-     , 'a_value
-     , 'ret_var
-     , 'ret_value
-     , 'a
-     , 'b )
-     Inductive_rule.Promise.t
-  -> ( 'a_var
-     , 'a_value
-     , 'ret_var
-     , 'ret_value
-     , 'a
-     , 'b
-     , 'max_proofs_verified
-     , 'branches
-     , 'e
-     , 'f
-     , 'g
-     , 'h )
-     t
+       , 'ret_value
+       , 'a
+       , 'b )
+       Inductive_rule.Promise.t
+    -> ( 'a_var
+       , 'a_value
+       , 'ret_var
+       , 'ret_value
+       , 'a
+       , 'b
+       , 'max_proofs_verified
+       , 'branches
+       , 'e
+       , 'f
+       , 'g
+       , 'h )
+       t
+end

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -2,22 +2,23 @@ open Pickles_types
 open Hlist
 open Import
 open Impls.Step
-module B = Inductive_rule.B
+
+(* Converts from the one hot vector representation of a number
+   0 <= i < n
+
+     0  1  ... i-1  i  i+1       n-1
+   [ 0; 0; ... 0;   1; 0;   ...; 0 ]
+
+   to the numeric representation i. *)
+
+let _one_hot_vector_to_num (type n) (v : n Per_proof_witness.One_hot_vector.t) :
+    Field.t =
+  let n = Vector.length (v :> (Boolean.var, n) Vector.t) in
+  let open Step_verifier in
+  Pseudo.choose (v, Vector.init n ~f:Field.of_int) ~f:Fn.id
 
 module Make (Inductive_rule : Inductive_rule.Intf) = struct
-  (* Converts from the one hot vector representation of a number
-     0 <= i < n
-
-       0  1  ... i-1  i  i+1       n-1
-     [ 0; 0; ... 0;   1; 0;   ...; 0 ]
-
-     to the numeric representation i. *)
-
-  let _one_hot_vector_to_num (type n) (v : n Per_proof_witness.One_hot_vector.t)
-      : Field.t =
-    let n = Vector.length (v :> (Boolean.var, n) Vector.t) in
-    let open Step_verifier in
-    Pseudo.choose (v, Vector.init n ~f:Field.of_int) ~f:Fn.id
+  module B = Inductive_rule.B
 
   let verify_one ~srs
       ({ app_state

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -4,583 +4,593 @@ open Import
 open Impls.Step
 module B = Inductive_rule.B
 
-(* Converts from the one hot vector representation of a number
-   0 <= i < n
+module Make (Inductive_rule : Inductive_rule.Intf) = struct
+  (* Converts from the one hot vector representation of a number
+     0 <= i < n
 
-     0  1  ... i-1  i  i+1       n-1
-   [ 0; 0; ... 0;   1; 0;   ...; 0 ]
+       0  1  ... i-1  i  i+1       n-1
+     [ 0; 0; ... 0;   1; 0;   ...; 0 ]
 
-   to the numeric representation i. *)
+     to the numeric representation i. *)
 
-let _one_hot_vector_to_num (type n) (v : n Per_proof_witness.One_hot_vector.t) :
-    Field.t =
-  let n = Vector.length (v :> (Boolean.var, n) Vector.t) in
-  let open Step_verifier in
-  Pseudo.choose (v, Vector.init n ~f:Field.of_int) ~f:Fn.id
+  let _one_hot_vector_to_num (type n) (v : n Per_proof_witness.One_hot_vector.t)
+      : Field.t =
+    let n = Vector.length (v :> (Boolean.var, n) Vector.t) in
+    let open Step_verifier in
+    Pseudo.choose (v, Vector.init n ~f:Field.of_int) ~f:Fn.id
 
-let verify_one ~srs
-    ({ app_state
-     ; wrap_proof
-     ; proof_state
-     ; prev_proof_evals
-     ; prev_challenges
-     ; prev_challenge_polynomial_commitments
-     } :
-      _ Per_proof_witness.t ) (d : _ Types_map.For_step.t)
-    (messages_for_next_wrap_proof : Digest.t) (unfinalized : Unfinalized.t)
-    (must_verify : B.t) : _ Vector.t * B.t =
-  Boolean.Assert.( = ) unfinalized.should_finalize must_verify ;
-  let deferred_values = proof_state.deferred_values in
-  let finalized, chals =
-    with_label __LOC__ (fun () ->
-        let sponge_digest = proof_state.sponge_digest_before_evaluations in
-        let sponge =
-          let open Step_main_inputs in
-          let sponge = Sponge.create sponge_params in
-          Sponge.absorb sponge (`Field sponge_digest) ;
-          sponge
-        in
-        (* TODO: Refactor args into an "unfinalized proof" struct *)
-        Step_verifier.finalize_other_proof d.max_proofs_verified
-          ~step_domains:d.step_domains ~zk_rows:d.zk_rows ~sponge
-          ~prev_challenges deferred_values prev_proof_evals )
-  in
-  let branch_data = deferred_values.branch_data in
-  let sponge_after_index, hash_messages_for_next_step_proof =
-    let to_field_elements =
-      let (Typ typ) = d.public_input in
-      fun x -> fst (typ.var_to_fields x)
-    in
-    let sponge_after_index, hash_messages_for_next_step_proof =
-      (* TODO: Don't rehash when it's not necessary *)
-      Step_verifier.hash_messages_for_next_step_proof_opt ~index:d.wrap_key
-        to_field_elements
-    in
-    (sponge_after_index, unstage hash_messages_for_next_step_proof)
-  in
-  (* prepare the statement to be verified below *)
-  let statement =
-    let prev_messages_for_next_step_proof =
+  let verify_one ~srs
+      ({ app_state
+       ; wrap_proof
+       ; proof_state
+       ; prev_proof_evals
+       ; prev_challenges
+       ; prev_challenge_polynomial_commitments
+       } :
+        _ Per_proof_witness.t ) (d : _ Types_map.For_step.t)
+      (messages_for_next_wrap_proof : Digest.t) (unfinalized : Unfinalized.t)
+      (must_verify : B.t) : _ Vector.t * B.t =
+    Boolean.Assert.( = ) unfinalized.should_finalize must_verify ;
+    let deferred_values = proof_state.deferred_values in
+    let finalized, chals =
       with_label __LOC__ (fun () ->
-          hash_messages_for_next_step_proof
-            ~proofs_verified_mask:
-              (Vector.trim_front branch_data.proofs_verified_mask
-                 (Nat.lte_exn
-                    (Vector.length prev_challenge_polynomial_commitments)
-                    Nat.N2.n ) )
-            (* Use opt sponge for cutting off the bulletproof challenges early *)
-            { app_state
-            ; dlog_plonk_index = d.wrap_key
-            ; challenge_polynomial_commitments =
-                prev_challenge_polynomial_commitments
-            ; old_bulletproof_challenges = prev_challenges
-            } )
+          let sponge_digest = proof_state.sponge_digest_before_evaluations in
+          let sponge =
+            let open Step_main_inputs in
+            let sponge = Sponge.create sponge_params in
+            Sponge.absorb sponge (`Field sponge_digest) ;
+            sponge
+          in
+          (* TODO: Refactor args into an "unfinalized proof" struct *)
+          Step_verifier.finalize_other_proof d.max_proofs_verified
+            ~step_domains:d.step_domains ~zk_rows:d.zk_rows ~sponge
+            ~prev_challenges deferred_values prev_proof_evals )
     in
-    (* Returns messages for the next step proof and messages for the next
-       wrap proof *)
-    { Types.Wrap.Statement.messages_for_next_step_proof =
-        prev_messages_for_next_step_proof
-    ; proof_state = { proof_state with messages_for_next_wrap_proof }
-    }
-  in
-  (* and when the statement is prepared, we call the step verifier with this
-     statement *)
-  let verified =
-    with_label __LOC__ (fun () ->
-        Step_verifier.verify ~srs
-          ~feature_flags:(Plonk_types.Features.of_full d.feature_flags)
-          ~lookup_parameters:
-            { use = d.feature_flags.uses_lookups
-            ; zero =
-                { var =
-                    { challenge = Field.zero
-                    ; scalar = Shifted_value Field.zero
-                    }
-                ; value =
-                    { challenge = Limb_vector.Challenge.Constant.zero
-                    ; scalar =
-                        Shifted_value.Type1.Shifted_value Field.Constant.zero
-                    }
-                }
-            }
-          ~proofs_verified:d.max_proofs_verified ~wrap_domain:d.wrap_domain
-          ~is_base_case:(Boolean.not must_verify) ~sponge_after_index
-          ~sg_old:prev_challenge_polynomial_commitments ~proof:wrap_proof
-          ~wrap_verification_key:d.wrap_key statement unfinalized )
-  in
-  if debug then
-    as_prover
-      As_prover.(
-        fun () ->
-          let finalized = read Boolean.typ finalized in
-          let verified = read Boolean.typ verified in
-          let must_verify = read Boolean.typ must_verify in
-          printf "finalized: %b\n%!" finalized ;
-          printf "verified: %b\n%!" verified ;
-          printf "must_verify: %b\n\n%!" must_verify) ;
-  (chals, Boolean.(verified &&& finalized ||| not must_verify))
+    let branch_data = deferred_values.branch_data in
+    let sponge_after_index, hash_messages_for_next_step_proof =
+      let to_field_elements =
+        let (Typ typ) = d.public_input in
+        fun x -> fst (typ.var_to_fields x)
+      in
+      let sponge_after_index, hash_messages_for_next_step_proof =
+        (* TODO: Don't rehash when it's not necessary *)
+        Step_verifier.hash_messages_for_next_step_proof_opt ~index:d.wrap_key
+          to_field_elements
+      in
+      (sponge_after_index, unstage hash_messages_for_next_step_proof)
+    in
+    (* prepare the statement to be verified below *)
+    let statement =
+      let prev_messages_for_next_step_proof =
+        with_label __LOC__ (fun () ->
+            hash_messages_for_next_step_proof
+              ~proofs_verified_mask:
+                (Vector.trim_front branch_data.proofs_verified_mask
+                   (Nat.lte_exn
+                      (Vector.length prev_challenge_polynomial_commitments)
+                      Nat.N2.n ) )
+              (* Use opt sponge for cutting off the bulletproof challenges early *)
+              { app_state
+              ; dlog_plonk_index = d.wrap_key
+              ; challenge_polynomial_commitments =
+                  prev_challenge_polynomial_commitments
+              ; old_bulletproof_challenges = prev_challenges
+              } )
+      in
+      (* Returns messages for the next step proof and messages for the next
+         wrap proof *)
+      { Types.Wrap.Statement.messages_for_next_step_proof =
+          prev_messages_for_next_step_proof
+      ; proof_state = { proof_state with messages_for_next_wrap_proof }
+      }
+    in
+    (* and when the statement is prepared, we call the step verifier with this
+       statement *)
+    let verified =
+      with_label __LOC__ (fun () ->
+          Step_verifier.verify ~srs
+            ~feature_flags:(Plonk_types.Features.of_full d.feature_flags)
+            ~lookup_parameters:
+              { use = d.feature_flags.uses_lookups
+              ; zero =
+                  { var =
+                      { challenge = Field.zero
+                      ; scalar = Shifted_value Field.zero
+                      }
+                  ; value =
+                      { challenge = Limb_vector.Challenge.Constant.zero
+                      ; scalar =
+                          Shifted_value.Type1.Shifted_value Field.Constant.zero
+                      }
+                  }
+              }
+            ~proofs_verified:d.max_proofs_verified ~wrap_domain:d.wrap_domain
+            ~is_base_case:(Boolean.not must_verify) ~sponge_after_index
+            ~sg_old:prev_challenge_polynomial_commitments ~proof:wrap_proof
+            ~wrap_verification_key:d.wrap_key statement unfinalized )
+    in
+    if debug then
+      as_prover
+        As_prover.(
+          fun () ->
+            let finalized = read Boolean.typ finalized in
+            let verified = read Boolean.typ verified in
+            let must_verify = read Boolean.typ must_verify in
+            printf "finalized: %b\n%!" finalized ;
+            printf "verified: %b\n%!" verified ;
+            printf "must_verify: %b\n\n%!" must_verify) ;
+    (chals, Boolean.(verified &&& finalized ||| not must_verify))
 
-(* The SNARK function corresponding to the input inductive rule. *)
-let step_main :
-    type proofs_verified self_branches prev_vars prev_values var value a_var a_value ret_var ret_value auxiliary_var auxiliary_value max_proofs_verified local_branches local_signature.
-       (module Requests.Step.S
-          with type local_signature = local_signature
-           and type local_branches = local_branches
-           and type statement = a_value
-           and type prev_values = prev_values
-           and type max_proofs_verified = max_proofs_verified
-           and type proofs_verified = proofs_verified
-           and type return_value = ret_value
-           and type auxiliary_value = auxiliary_value )
-    -> (module Nat.Add.Intf with type n = max_proofs_verified)
-    -> self_branches:self_branches Nat.t
-         (* How many branches does this proof system have *)
-    -> local_signature:local_signature H1.T(Nat).t
-         (* The specification, for each proof that this step circuit verifies, of the maximum width used
-            by that proof system. *)
-    -> local_signature_length:(local_signature, proofs_verified) Hlist.Length.t
-    -> local_branches_length:(local_branches, proofs_verified) Hlist.Length.t
-    -> proofs_verified:(prev_vars, proofs_verified) Hlist.Length.t
-    -> lte:(proofs_verified, max_proofs_verified) Nat.Lte.t
-    -> public_input:
-         ( var
-         , value
+  (* The SNARK function corresponding to the input inductive rule. *)
+  let step_main :
+      type proofs_verified self_branches prev_vars prev_values var value a_var a_value ret_var ret_value auxiliary_var auxiliary_value max_proofs_verified local_branches local_signature.
+         (module Requests.Step(Inductive_rule).S
+            with type local_signature = local_signature
+             and type local_branches = local_branches
+             and type statement = a_value
+             and type prev_values = prev_values
+             and type max_proofs_verified = max_proofs_verified
+             and type proofs_verified = proofs_verified
+             and type return_value = ret_value
+             and type auxiliary_value = auxiliary_value )
+      -> (module Nat.Add.Intf with type n = max_proofs_verified)
+      -> self_branches:self_branches Nat.t
+           (* How many branches does this proof system have *)
+      -> local_signature:local_signature H1.T(Nat).t
+           (* The specification, for each proof that this step circuit verifies, of the maximum width used
+              by that proof system. *)
+      -> local_signature_length:
+           (local_signature, proofs_verified) Hlist.Length.t
+      -> local_branches_length:(local_branches, proofs_verified) Hlist.Length.t
+      -> proofs_verified:(prev_vars, proofs_verified) Hlist.Length.t
+      -> lte:(proofs_verified, max_proofs_verified) Nat.Lte.t
+      -> public_input:
+           ( var
+           , value
+           , a_var
+           , a_value
+           , ret_var
+           , ret_value )
+           Inductive_rule.public_input
+      -> auxiliary_typ:(auxiliary_var, auxiliary_value) Typ.t
+      -> basic:
+           ( var
+           , value
+           , max_proofs_verified
+           , self_branches )
+           Types_map.Compiled.basic
+      -> known_wrap_keys:
+           local_branches H1.T(Types_map.For_step.Optional_wrap_key).t
+      -> self:(var, value, max_proofs_verified, self_branches) Tag.t
+      -> ( prev_vars
+         , prev_values
+         , local_signature
+         , local_branches
          , a_var
          , a_value
          , ret_var
-         , ret_value )
-         Inductive_rule.public_input
-    -> auxiliary_typ:(auxiliary_var, auxiliary_value) Typ.t
-    -> basic:
-         ( var
-         , value
-         , max_proofs_verified
-         , self_branches )
-         Types_map.Compiled.basic
-    -> known_wrap_keys:
-         local_branches H1.T(Types_map.For_step.Optional_wrap_key).t
-    -> self:(var, value, max_proofs_verified, self_branches) Tag.t
-    -> ( prev_vars
-       , prev_values
-       , local_signature
-       , local_branches
-       , a_var
-       , a_value
-       , ret_var
-       , ret_value
-       , auxiliary_var
-       , auxiliary_value )
-       Inductive_rule.Promise.t
-    -> (   unit
-        -> ( (Unfinalized.t, max_proofs_verified) Vector.t
-           , Field.t
-           , (Field.t, max_proofs_verified) Vector.t )
-           Types.Step.Statement.t
-           Promise.t )
-       Staged.t =
- fun (module Req) max_proofs_verified ~self_branches ~local_signature
-     ~local_signature_length ~local_branches_length ~proofs_verified ~lte
-     ~public_input ~auxiliary_typ ~basic ~known_wrap_keys ~self rule ->
-  let module Typ_with_max_proofs_verified = struct
-    type ('var, 'value, 'local_max_proofs_verified, 'local_branches) t =
-      ( ( 'var
-        , 'local_max_proofs_verified
-        , 'local_branches )
-        Per_proof_witness.No_app_state.t
-      , ( 'value
-        , 'local_max_proofs_verified
-        , 'local_branches )
-        Per_proof_witness.Constant.No_app_state.t )
-      Typ.t
-  end in
-  let feature_flags_and_num_chunks (d : _ Tag.t) =
-    if Type_equal.Id.same self.id d.id then
-      (basic.feature_flags, basic.num_chunks)
-    else (Types_map.feature_flags d, Types_map.num_chunks d)
-  in
-  let feature_flags_and_num_chunks =
-    let rec go :
-        type pvars pvals ns1 ns2 br.
-           (pvars, pvals, ns1, ns2) H4.T(Tag).t
-        -> (pvars, br) Length.t
-        -> (Opt.Flag.t Plonk_types.Features.Full.t * int, br) Vector.t =
-     fun ds ld ->
-      match[@warning "-4"] (ds, ld) with
-      | [], Z ->
-          []
-      | d :: ds, S ld ->
-          feature_flags_and_num_chunks d :: go ds ld
-      | [], _ ->
-          .
-      | _ :: _, _ ->
-          .
+         , ret_value
+         , auxiliary_var
+         , auxiliary_value )
+         Inductive_rule.Promise.t
+      -> (   unit
+          -> ( (Unfinalized.t, max_proofs_verified) Vector.t
+             , Field.t
+             , (Field.t, max_proofs_verified) Vector.t )
+             Types.Step.Statement.t
+             Promise.t )
+         Staged.t =
+   fun (module Req) max_proofs_verified ~self_branches ~local_signature
+       ~local_signature_length ~local_branches_length ~proofs_verified ~lte
+       ~public_input ~auxiliary_typ ~basic ~known_wrap_keys ~self rule ->
+    let module Typ_with_max_proofs_verified = struct
+      type ('var, 'value, 'local_max_proofs_verified, 'local_branches) t =
+        ( ( 'var
+          , 'local_max_proofs_verified
+          , 'local_branches )
+          Per_proof_witness.No_app_state.t
+        , ( 'value
+          , 'local_max_proofs_verified
+          , 'local_branches )
+          Per_proof_witness.Constant.No_app_state.t )
+        Typ.t
+    end in
+    let feature_flags_and_num_chunks (d : _ Tag.t) =
+      if Type_equal.Id.same self.id d.id then
+        (basic.feature_flags, basic.num_chunks)
+      else (Types_map.feature_flags d, Types_map.num_chunks d)
     in
-    go rule.prevs proofs_verified
-  in
-  let prev_proof_typs =
-    let rec join :
-        type pvars pvals ns1 ns2 br.
-           (pvars, pvals, ns1, ns2) H4.T(Tag).t
-        -> ns1 H1.T(Nat).t
-        -> (pvars, br) Length.t
-        -> (ns1, br) Length.t
-        -> (ns2, br) Length.t
-        -> (Opt.Flag.t Plonk_types.Features.Full.t * int, br) Vector.t
-        -> (pvars, pvals, ns1, ns2) H4.T(Typ_with_max_proofs_verified).t =
-     fun ds ns1 ld ln1 ln2 feature_flags_and_num_chunkss ->
-      match[@warning "-4"]
-        (ds, ns1, ld, ln1, ln2, feature_flags_and_num_chunkss)
-      with
-      | [], [], Z, Z, Z, [] ->
-          []
-      | ( _d :: ds
-        , n1 :: ns1
-        , S ld
-        , S ln1
-        , S ln2
-        , (feature_flags, num_chunks) :: feature_flags_and_num_chunkss ) ->
-          let t =
-            Per_proof_witness.typ Typ.unit n1 ~feature_flags ~num_chunks
+    let feature_flags_and_num_chunks =
+      let rec go :
+          type pvars pvals ns1 ns2 br.
+             (pvars, pvals, ns1, ns2) H4.T(Tag).t
+          -> (pvars, br) Length.t
+          -> (Opt.Flag.t Plonk_types.Features.Full.t * int, br) Vector.t =
+       fun ds ld ->
+        match[@warning "-4"] (ds, ld) with
+        | [], Z ->
+            []
+        | d :: ds, S ld ->
+            feature_flags_and_num_chunks d :: go ds ld
+        | [], _ ->
+            .
+        | _ :: _, _ ->
+            .
+      in
+      go rule.prevs proofs_verified
+    in
+    let prev_proof_typs =
+      let rec join :
+          type pvars pvals ns1 ns2 br.
+             (pvars, pvals, ns1, ns2) H4.T(Tag).t
+          -> ns1 H1.T(Nat).t
+          -> (pvars, br) Length.t
+          -> (ns1, br) Length.t
+          -> (ns2, br) Length.t
+          -> (Opt.Flag.t Plonk_types.Features.Full.t * int, br) Vector.t
+          -> (pvars, pvals, ns1, ns2) H4.T(Typ_with_max_proofs_verified).t =
+       fun ds ns1 ld ln1 ln2 feature_flags_and_num_chunkss ->
+        match[@warning "-4"]
+          (ds, ns1, ld, ln1, ln2, feature_flags_and_num_chunkss)
+        with
+        | [], [], Z, Z, Z, [] ->
+            []
+        | ( _d :: ds
+          , n1 :: ns1
+          , S ld
+          , S ln1
+          , S ln2
+          , (feature_flags, num_chunks) :: feature_flags_and_num_chunkss ) ->
+            let t =
+              Per_proof_witness.typ Typ.unit n1 ~feature_flags ~num_chunks
+            in
+            t :: join ds ns1 ld ln1 ln2 feature_flags_and_num_chunkss
+        | [], _, _, _, _, _ ->
+            .
+        | _ :: _, _, _, _, _, _ ->
+            .
+      in
+      join rule.prevs local_signature proofs_verified local_signature_length
+        local_branches_length feature_flags_and_num_chunks
+    in
+    let module Prev_typ =
+      H4.Typ (Typ_with_max_proofs_verified) (Per_proof_witness.No_app_state)
+        (Per_proof_witness.Constant.No_app_state)
+        (struct
+          let f = Fn.id
+        end)
+    in
+    let (input_typ, output_typ)
+          : (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
+      match public_input with
+      | Input typ ->
+          (typ, Typ.unit)
+      | Output typ ->
+          (Typ.unit, typ)
+      | Input_and_output (input_typ, output_typ) ->
+          (input_typ, output_typ)
+    in
+    let main () : _ Types.Step.Statement.t Promise.t =
+      let open Impls.Step in
+      let logger = Context_logger.get () in
+      let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
+                                           with type n = max_proofs_verified )
+      in
+      let T = Max_proofs_verified.eq in
+      let app_state = exists input_typ ~request:(fun () -> Req.App_state) in
+      let%bind.Promise { Inductive_rule.previous_proof_statements
+                       ; public_output = ret_var
+                       ; auxiliary_output = auxiliary_var
+                       } =
+        (* Run the application logic of the rule on the predecessor statements *)
+        with_label "rule_main" (fun () ->
+            rule.main { public_input = app_state } )
+      in
+      with_label "step_main" (fun () ->
+          let () =
+            exists Typ.unit ~request:(fun () ->
+                let ret_value = As_prover.read output_typ ret_var in
+                Req.Return_value ret_value )
           in
-          t :: join ds ns1 ld ln1 ln2 feature_flags_and_num_chunkss
-      | [], _, _, _, _, _ ->
-          .
-      | _ :: _, _, _, _, _, _ ->
-          .
-    in
-    join rule.prevs local_signature proofs_verified local_signature_length
-      local_branches_length feature_flags_and_num_chunks
-  in
-  let module Prev_typ =
-    H4.Typ (Typ_with_max_proofs_verified) (Per_proof_witness.No_app_state)
-      (Per_proof_witness.Constant.No_app_state)
-      (struct
-        let f = Fn.id
-      end)
-  in
-  let (input_typ, output_typ)
-        : (a_var, a_value) Typ.t * (ret_var, ret_value) Typ.t =
-    match public_input with
-    | Input typ ->
-        (typ, Typ.unit)
-    | Output typ ->
-        (Typ.unit, typ)
-    | Input_and_output (input_typ, output_typ) ->
-        (input_typ, output_typ)
-  in
-  let main () : _ Types.Step.Statement.t Promise.t =
-    let open Impls.Step in
-    let logger = Context_logger.get () in
-    let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
-                                         with type n = max_proofs_verified )
-    in
-    let T = Max_proofs_verified.eq in
-    let app_state = exists input_typ ~request:(fun () -> Req.App_state) in
-    let%bind.Promise { Inductive_rule.previous_proof_statements
-                     ; public_output = ret_var
-                     ; auxiliary_output = auxiliary_var
-                     } =
-      (* Run the application logic of the rule on the predecessor statements *)
-      with_label "rule_main" (fun () -> rule.main { public_input = app_state })
-    in
-    with_label "step_main" (fun () ->
-        let () =
-          exists Typ.unit ~request:(fun () ->
-              let ret_value = As_prover.read output_typ ret_var in
-              Req.Return_value ret_value )
-        in
-        let () =
-          exists Typ.unit ~request:(fun () ->
-              let auxiliary_value =
-                As_prover.read auxiliary_typ auxiliary_var
-              in
-              Req.Auxiliary_value auxiliary_value )
-        in
-        (* Compute proof parts outside of the prover before requesting values.
-        *)
-        let%map.Promise () =
-          Async_promise.unit_request (fun () ->
-              let previous_proof_statements =
-                let rec go :
-                    type prev_vars prev_values ns1 ns2.
-                       ( prev_vars
-                       , ns1 )
-                       H2.T(Inductive_rule.Previous_proof_statement).t
-                    -> (prev_vars, prev_values, ns1, ns2) H4.T(Tag).t
-                    -> ( prev_values
-                       , ns1 )
-                       H2.T(Inductive_rule.Previous_proof_statement.Constant).t
-                    =
-                 fun previous_proof_statement tags ->
-                  match (previous_proof_statement, tags) with
-                  | [], [] ->
-                      []
-                  | ( { public_input; proof; proof_must_verify } :: stmts
-                    , tag :: tags ) ->
-                      let public_input =
-                        (fun (type var value n m)
-                             (tag : (var, value, n, m) Tag.t) (var : var) :
-                             value ->
-                          let typ : (var, value) Typ.t =
-                            match Type_equal.Id.same_witness self.id tag.id with
-                            | Some T ->
-                                basic.public_input
-                            | None ->
-                                Types_map.public_input tag
-                          in
-                          As_prover.read typ var )
-                          tag public_input
-                      in
-                      { public_input
-                      ; proof = As_prover.read (Typ.prover_value ()) proof
-                      ; proof_must_verify =
-                          As_prover.read Boolean.typ proof_must_verify
-                      }
-                      :: go stmts tags
+          let () =
+            exists Typ.unit ~request:(fun () ->
+                let auxiliary_value =
+                  As_prover.read auxiliary_typ auxiliary_var
                 in
-                go previous_proof_statements rule.prevs
-              in
-              Req.Compute_prev_proof_parts previous_proof_statements )
-        in
-        let dlog_plonk_index =
-          let num_chunks = (* TODO *) Plonk_checks.num_chunks_by_default in
-          exists
-            ~request:(fun () -> Req.Wrap_index)
-            (Plonk_verification_key_evals.typ
-               (Typ.array ~length:num_chunks Step_verifier.Inner_curve.typ) )
-        and prevs =
-          exists (Prev_typ.f prev_proof_typs) ~request:(fun () ->
-              Req.Proof_with_datas )
-        and unfinalized_proofs_unextended =
-          exists
-            (Vector.typ'
-               (Vector.map
-                  ~f:(fun _feature_flags ->
-                    Unfinalized.typ ~wrap_rounds:Backend.Tock.Rounds.n )
-                  feature_flags_and_num_chunks ) )
-            ~request:(fun () -> Req.Unfinalized_proofs)
-        and messages_for_next_wrap_proof =
-          exists (Vector.typ Digest.typ Max_proofs_verified.n)
-            ~request:(fun () -> Req.Messages_for_next_wrap_proof)
-        and actual_wrap_domains =
-          exists
-            (Vector.typ (Typ.prover_value ()) (Length.to_nat proofs_verified))
-            ~request:(fun () -> Req.Wrap_domain_indices)
-        in
-        let proof_witnesses =
-          (* Inject the app-state values into the per-proof witnesses. *)
-          let rec go :
-              type vars ns1 ns2.
-                 (vars, ns1, ns2) H3.T(Per_proof_witness.No_app_state).t
-              -> (vars, ns1) H2.T(Inductive_rule.Previous_proof_statement).t
-              -> (vars, ns1, ns2) H3.T(Per_proof_witness).t =
-           fun proofs stmts ->
-            match (proofs, stmts) with
-            | [], [] ->
-                []
-            | proof :: proofs, stmt :: stmts ->
-                { proof with app_state = stmt.public_input } :: go proofs stmts
+                Req.Auxiliary_value auxiliary_value )
           in
-          go prevs previous_proof_statements
-        in
-        let srs = Backend.Tock.Keypair.load_urs () in
-        [%log internal] "Step_compute_bulletproof_challenges" ;
-        let bulletproof_challenges =
-          with_label "prevs_verified" (fun () ->
-              let rec go :
-                  type vars vals ns1 ns2 n.
-                     (vars, ns1, ns2) H3.T(Per_proof_witness).t
-                  -> (vars, vals, ns1, ns2) H4.T(Types_map.For_step).t
-                  -> vars H1.T(E01(Digest)).t
-                  -> vars H1.T(E01(Unfinalized)).t
-                  -> (vars, ns1) H2.T(Inductive_rule.Previous_proof_statement).t
-                  -> (vars, n) Length.t
-                  -> actual_wrap_domains:
-                       ( Pickles_base.Proofs_verified.t Typ.prover_value
-                       , n )
-                       Vector.t
-                  -> (_, n) Vector.t * B.t list =
-               fun proof_witnesses datas messages_for_next_wrap_proofs
-                   unfinalizeds stmts pi ~actual_wrap_domains ->
-                match
-                  ( proof_witnesses
-                  , datas
-                  , messages_for_next_wrap_proofs
-                  , unfinalizeds
-                  , stmts
-                  , pi
-                  , actual_wrap_domains )
-                with
-                | [], [], [], [], [], Z, [] ->
-                    ([], [])
-                | ( pw :: proof_witnesses
-                  , d :: datas
-                  , messages_for_next_wrap_proof
-                    :: messages_for_next_wrap_proofs
-                  , unfinalized :: unfinalizeds
-                  , { proof_must_verify = must_verify; _ } :: stmts
-                  , S pi
-                  , actual_wrap_domain :: actual_wrap_domains ) ->
-                    let () =
-                      (* Fail with an error if the proof's domain differs from
-                         the hard-coded one otherwise.
-                      *)
-                      match d.wrap_domain with
-                      | `Known wrap_domain ->
-                          as_prover (fun () ->
-                              let actual_wrap_domain =
-                                As_prover.read (Typ.prover_value ())
-                                  actual_wrap_domain
-                                |> Pickles_base.Proofs_verified.to_int
-                              in
-                              let actual_wrap_domain =
-                                Common.wrap_domains
-                                  ~proofs_verified:actual_wrap_domain
-                              in
-                              match (wrap_domain, actual_wrap_domain.h) with
-                              | ( Pow_2_roots_of_unity expected
-                                , Pow_2_roots_of_unity actual )
-                                when expected <> actual ->
-                                  failwithf
-                                    "This circuit was compiled for proofs \
-                                     using the wrap domain of size %d, but a \
-                                     proof was given with size %d. You should \
-                                     pass the ~override_wrap_domain argument \
-                                     to set the correct domain size."
-                                    expected actual ()
-                              | Pow_2_roots_of_unity _, Pow_2_roots_of_unity _
-                                ->
-                                  () )
-                      | `Side_loaded _ ->
-                          ()
-                    in
-                    let chals, v =
-                      verify_one ~srs pw d messages_for_next_wrap_proof
-                        unfinalized must_verify
-                    in
-                    let chalss, vs =
-                      go proof_witnesses datas messages_for_next_wrap_proofs
-                        unfinalizeds stmts pi ~actual_wrap_domains
-                    in
-                    (chals :: chalss, v :: vs)
-              in
-              let chalss, vs =
-                let messages_for_next_wrap_proofs =
-                  with_label "messages_for_next_wrap_proofs" (fun () ->
-                      let module V = H1.Of_vector (Digest) in
-                      V.f proofs_verified
-                        (Vector.trim_front messages_for_next_wrap_proof lte) )
-                and unfinalized_proofs =
-                  let module H = H1.Of_vector (Unfinalized) in
-                  H.f proofs_verified unfinalized_proofs_unextended
-                and datas =
-                  let self_data :
-                      ( var
-                      , value
-                      , max_proofs_verified
-                      , self_branches )
-                      Types_map.For_step.t =
-                    { max_proofs_verified
-                    ; public_input = basic.public_input
-                    ; wrap_domain = `Known basic.wrap_domains.h
-                    ; step_domains = `Known basic.step_domains
-                    ; wrap_key = dlog_plonk_index
-                    ; feature_flags = basic.feature_flags
-                    ; num_chunks = basic.num_chunks
-                    ; zk_rows = basic.zk_rows
-                    }
-                  in
+          (* Compute proof parts outside of the prover before requesting values.
+        *)
+          let%map.Promise () =
+            Async_promise.unit_request (fun () ->
+                let previous_proof_statements =
                   let rec go :
-                      type a1 a2 n m.
-                         (a1, a2, n, m) H4.T(Tag).t
-                      -> m H1.T(Types_map.For_step.Optional_wrap_key).t
-                      -> (a1, a2, n, m) H4.T(Types_map.For_step).t =
-                   fun tags optional_wrap_keys ->
-                    match (tags, optional_wrap_keys) with
+                      type prev_vars prev_values ns1 ns2.
+                         ( prev_vars
+                         , ns1 )
+                         H2.T(Inductive_rule.Previous_proof_statement).t
+                      -> (prev_vars, prev_values, ns1, ns2) H4.T(Tag).t
+                      -> ( prev_values
+                         , ns1 )
+                         H2.T(Inductive_rule.Previous_proof_statement.Constant)
+                         .t =
+                   fun previous_proof_statement tags ->
+                    match (previous_proof_statement, tags) with
                     | [], [] ->
                         []
-                    | tag :: tags, optional_wrap_key :: optional_wrap_keys ->
-                        let data =
-                          match Type_equal.Id.same_witness self.id tag.id with
-                          | None -> (
-                              match tag.kind with
-                              | Compiled ->
-                                  Types_map.For_step
-                                  .of_compiled_with_known_wrap_key
-                                    (Option.value_exn optional_wrap_key)
-                                    (Types_map.lookup_compiled tag.id)
-                              | Side_loaded ->
-                                  Types_map.For_step.of_side_loaded
-                                    (Types_map.lookup_side_loaded tag.id) )
-                          | Some T ->
-                              self_data
+                    | ( { public_input; proof; proof_must_verify } :: stmts
+                      , tag :: tags ) ->
+                        let public_input =
+                          (fun (type var value n m)
+                               (tag : (var, value, n, m) Tag.t) (var : var) :
+                               value ->
+                            let typ : (var, value) Typ.t =
+                              match
+                                Type_equal.Id.same_witness self.id tag.id
+                              with
+                              | Some T ->
+                                  basic.public_input
+                              | None ->
+                                  Types_map.public_input tag
+                            in
+                            As_prover.read typ var )
+                            tag public_input
                         in
-                        data :: go tags optional_wrap_keys
+                        { public_input
+                        ; proof = As_prover.read (Typ.prover_value ()) proof
+                        ; proof_must_verify =
+                            As_prover.read Boolean.typ proof_must_verify
+                        }
+                        :: go stmts tags
                   in
-                  go rule.prevs known_wrap_keys
+                  go previous_proof_statements rule.prevs
                 in
-                go proof_witnesses datas messages_for_next_wrap_proofs
-                  unfinalized_proofs previous_proof_statements proofs_verified
-                  ~actual_wrap_domains
-              in
-              Boolean.Assert.all vs ; chalss )
-        in
-        [%log internal] "Step_compute_bulletproof_challenges_done" ;
-        let messages_for_next_step_proof =
-          let challenge_polynomial_commitments =
-            let module M =
-              H3.Map (Per_proof_witness) (E03 (Step_verifier.Inner_curve))
-                (struct
-                  let f :
-                      type a b c.
-                         (a, b, c) Per_proof_witness.t
-                      -> Step_verifier.Inner_curve.t =
-                   fun acc ->
-                    acc.wrap_proof.opening.challenge_polynomial_commitment
-                end)
-            in
-            let module V = H3.To_vector (Step_verifier.Inner_curve) in
-            V.f proofs_verified (M.f proof_witnesses)
+                Req.Compute_prev_proof_parts previous_proof_statements )
           in
-          with_label "hash_messages_for_next_step_proof" (fun () ->
-              let hash_messages_for_next_step_proof =
-                let to_field_elements =
-                  let (Typ typ) = basic.public_input in
-                  fun x -> fst (typ.var_to_fields x)
+          let dlog_plonk_index =
+            let num_chunks = (* TODO *) Plonk_checks.num_chunks_by_default in
+            exists
+              ~request:(fun () -> Req.Wrap_index)
+              (Plonk_verification_key_evals.typ
+                 (Typ.array ~length:num_chunks Step_verifier.Inner_curve.typ) )
+          and prevs =
+            exists (Prev_typ.f prev_proof_typs) ~request:(fun () ->
+                Req.Proof_with_datas )
+          and unfinalized_proofs_unextended =
+            exists
+              (Vector.typ'
+                 (Vector.map
+                    ~f:(fun _feature_flags ->
+                      Unfinalized.typ ~wrap_rounds:Backend.Tock.Rounds.n )
+                    feature_flags_and_num_chunks ) )
+              ~request:(fun () -> Req.Unfinalized_proofs)
+          and messages_for_next_wrap_proof =
+            exists (Vector.typ Digest.typ Max_proofs_verified.n)
+              ~request:(fun () -> Req.Messages_for_next_wrap_proof)
+          and actual_wrap_domains =
+            exists
+              (Vector.typ (Typ.prover_value ()) (Length.to_nat proofs_verified))
+              ~request:(fun () -> Req.Wrap_domain_indices)
+          in
+          let proof_witnesses =
+            (* Inject the app-state values into the per-proof witnesses. *)
+            let rec go :
+                type vars ns1 ns2.
+                   (vars, ns1, ns2) H3.T(Per_proof_witness.No_app_state).t
+                -> (vars, ns1) H2.T(Inductive_rule.Previous_proof_statement).t
+                -> (vars, ns1, ns2) H3.T(Per_proof_witness).t =
+             fun proofs stmts ->
+              match (proofs, stmts) with
+              | [], [] ->
+                  []
+              | proof :: proofs, stmt :: stmts ->
+                  { proof with app_state = stmt.public_input }
+                  :: go proofs stmts
+            in
+            go prevs previous_proof_statements
+          in
+          let srs = Backend.Tock.Keypair.load_urs () in
+          [%log internal] "Step_compute_bulletproof_challenges" ;
+          let bulletproof_challenges =
+            with_label "prevs_verified" (fun () ->
+                let rec go :
+                    type vars vals ns1 ns2 n.
+                       (vars, ns1, ns2) H3.T(Per_proof_witness).t
+                    -> (vars, vals, ns1, ns2) H4.T(Types_map.For_step).t
+                    -> vars H1.T(E01(Digest)).t
+                    -> vars H1.T(E01(Unfinalized)).t
+                    -> ( vars
+                       , ns1 )
+                       H2.T(Inductive_rule.Previous_proof_statement).t
+                    -> (vars, n) Length.t
+                    -> actual_wrap_domains:
+                         ( Pickles_base.Proofs_verified.t Typ.prover_value
+                         , n )
+                         Vector.t
+                    -> (_, n) Vector.t * B.t list =
+                 fun proof_witnesses datas messages_for_next_wrap_proofs
+                     unfinalizeds stmts pi ~actual_wrap_domains ->
+                  match
+                    ( proof_witnesses
+                    , datas
+                    , messages_for_next_wrap_proofs
+                    , unfinalizeds
+                    , stmts
+                    , pi
+                    , actual_wrap_domains )
+                  with
+                  | [], [], [], [], [], Z, [] ->
+                      ([], [])
+                  | ( pw :: proof_witnesses
+                    , d :: datas
+                    , messages_for_next_wrap_proof
+                      :: messages_for_next_wrap_proofs
+                    , unfinalized :: unfinalizeds
+                    , { proof_must_verify = must_verify; _ } :: stmts
+                    , S pi
+                    , actual_wrap_domain :: actual_wrap_domains ) ->
+                      let () =
+                        (* Fail with an error if the proof's domain differs from
+                           the hard-coded one otherwise.
+                        *)
+                        match d.wrap_domain with
+                        | `Known wrap_domain ->
+                            as_prover (fun () ->
+                                let actual_wrap_domain =
+                                  As_prover.read (Typ.prover_value ())
+                                    actual_wrap_domain
+                                  |> Pickles_base.Proofs_verified.to_int
+                                in
+                                let actual_wrap_domain =
+                                  Common.wrap_domains
+                                    ~proofs_verified:actual_wrap_domain
+                                in
+                                match (wrap_domain, actual_wrap_domain.h) with
+                                | ( Pow_2_roots_of_unity expected
+                                  , Pow_2_roots_of_unity actual )
+                                  when expected <> actual ->
+                                    failwithf
+                                      "This circuit was compiled for proofs \
+                                       using the wrap domain of size %d, but a \
+                                       proof was given with size %d. You \
+                                       should pass the ~override_wrap_domain \
+                                       argument to set the correct domain \
+                                       size."
+                                      expected actual ()
+                                | Pow_2_roots_of_unity _, Pow_2_roots_of_unity _
+                                  ->
+                                    () )
+                        | `Side_loaded _ ->
+                            ()
+                      in
+                      let chals, v =
+                        verify_one ~srs pw d messages_for_next_wrap_proof
+                          unfinalized must_verify
+                      in
+                      let chalss, vs =
+                        go proof_witnesses datas messages_for_next_wrap_proofs
+                          unfinalizeds stmts pi ~actual_wrap_domains
+                      in
+                      (chals :: chalss, v :: vs)
                 in
-                unstage
-                  (Step_verifier.hash_messages_for_next_step_proof
-                     ~index:dlog_plonk_index to_field_elements )
+                let chalss, vs =
+                  let messages_for_next_wrap_proofs =
+                    with_label "messages_for_next_wrap_proofs" (fun () ->
+                        let module V = H1.Of_vector (Digest) in
+                        V.f proofs_verified
+                          (Vector.trim_front messages_for_next_wrap_proof lte) )
+                  and unfinalized_proofs =
+                    let module H = H1.Of_vector (Unfinalized) in
+                    H.f proofs_verified unfinalized_proofs_unextended
+                  and datas =
+                    let self_data :
+                        ( var
+                        , value
+                        , max_proofs_verified
+                        , self_branches )
+                        Types_map.For_step.t =
+                      { max_proofs_verified
+                      ; public_input = basic.public_input
+                      ; wrap_domain = `Known basic.wrap_domains.h
+                      ; step_domains = `Known basic.step_domains
+                      ; wrap_key = dlog_plonk_index
+                      ; feature_flags = basic.feature_flags
+                      ; num_chunks = basic.num_chunks
+                      ; zk_rows = basic.zk_rows
+                      }
+                    in
+                    let rec go :
+                        type a1 a2 n m.
+                           (a1, a2, n, m) H4.T(Tag).t
+                        -> m H1.T(Types_map.For_step.Optional_wrap_key).t
+                        -> (a1, a2, n, m) H4.T(Types_map.For_step).t =
+                     fun tags optional_wrap_keys ->
+                      match (tags, optional_wrap_keys) with
+                      | [], [] ->
+                          []
+                      | tag :: tags, optional_wrap_key :: optional_wrap_keys ->
+                          let data =
+                            match Type_equal.Id.same_witness self.id tag.id with
+                            | None -> (
+                                match tag.kind with
+                                | Compiled ->
+                                    Types_map.For_step
+                                    .of_compiled_with_known_wrap_key
+                                      (Option.value_exn optional_wrap_key)
+                                      (Types_map.lookup_compiled tag.id)
+                                | Side_loaded ->
+                                    Types_map.For_step.of_side_loaded
+                                      (Types_map.lookup_side_loaded tag.id) )
+                            | Some T ->
+                                self_data
+                          in
+                          data :: go tags optional_wrap_keys
+                    in
+                    go rule.prevs known_wrap_keys
+                  in
+                  go proof_witnesses datas messages_for_next_wrap_proofs
+                    unfinalized_proofs previous_proof_statements proofs_verified
+                    ~actual_wrap_domains
+                in
+                Boolean.Assert.all vs ; chalss )
+          in
+          [%log internal] "Step_compute_bulletproof_challenges_done" ;
+          let messages_for_next_step_proof =
+            let challenge_polynomial_commitments =
+              let module M =
+                H3.Map (Per_proof_witness) (E03 (Step_verifier.Inner_curve))
+                  (struct
+                    let f :
+                        type a b c.
+                           (a, b, c) Per_proof_witness.t
+                        -> Step_verifier.Inner_curve.t =
+                     fun acc ->
+                      acc.wrap_proof.opening.challenge_polynomial_commitment
+                  end)
               in
-              let (app_state : var) =
-                match public_input with
-                | Input _ ->
-                    app_state
-                | Output _ ->
-                    ret_var
-                | Input_and_output _ ->
-                    (app_state, ret_var)
-              in
-              hash_messages_for_next_step_proof
-                { app_state
-                ; dlog_plonk_index
-                ; challenge_polynomial_commitments
-                ; old_bulletproof_challenges =
-                    (* Note: the bulletproof_challenges here are unpadded! *)
-                    bulletproof_challenges
-                } )
-        in
-        let unfinalized_proofs =
-          Vector.extend_front unfinalized_proofs_unextended lte
-            Max_proofs_verified.n (Unfinalized.dummy ())
-        in
-        ( { Types.Step.Statement.proof_state =
-              { unfinalized_proofs; messages_for_next_step_proof }
-          ; messages_for_next_wrap_proof
-          }
-          : ( (Unfinalized.t, max_proofs_verified) Vector.t
-            , Field.t
-            , (Field.t, max_proofs_verified) Vector.t )
-            Types.Step.Statement.t ) )
-  in
-  stage main
+              let module V = H3.To_vector (Step_verifier.Inner_curve) in
+              V.f proofs_verified (M.f proof_witnesses)
+            in
+            with_label "hash_messages_for_next_step_proof" (fun () ->
+                let hash_messages_for_next_step_proof =
+                  let to_field_elements =
+                    let (Typ typ) = basic.public_input in
+                    fun x -> fst (typ.var_to_fields x)
+                  in
+                  unstage
+                    (Step_verifier.hash_messages_for_next_step_proof
+                       ~index:dlog_plonk_index to_field_elements )
+                in
+                let (app_state : var) =
+                  match public_input with
+                  | Input _ ->
+                      app_state
+                  | Output _ ->
+                      ret_var
+                  | Input_and_output _ ->
+                      (app_state, ret_var)
+                in
+                hash_messages_for_next_step_proof
+                  { app_state
+                  ; dlog_plonk_index
+                  ; challenge_polynomial_commitments
+                  ; old_bulletproof_challenges =
+                      (* Note: the bulletproof_challenges here are unpadded! *)
+                      bulletproof_challenges
+                  } )
+          in
+          let unfinalized_proofs =
+            Vector.extend_front unfinalized_proofs_unextended lte
+              Max_proofs_verified.n (Unfinalized.dummy ())
+          in
+          ( { Types.Step.Statement.proof_state =
+                { unfinalized_proofs; messages_for_next_step_proof }
+            ; messages_for_next_wrap_proof
+            }
+            : ( (Unfinalized.t, max_proofs_verified) Vector.t
+              , Field.t
+              , (Field.t, max_proofs_verified) Vector.t )
+              Types.Step.Statement.t ) )
+    in
+    stage main
+end

--- a/src/lib/pickles/step_main.mli
+++ b/src/lib/pickles/step_main.mli
@@ -1,61 +1,65 @@
-(** [step_main] is the SNARK function corresponding to the input inductive rule. **)
-val step_main :
-  'proofs_verified 'self_branches 'prev_vars 'prev_values 'var 'value 'a_var
-  'a_value 'ret_var 'ret_value 'auxiliary_var 'auxiliary_value
-  'max_proofs_verified 'local_branches 'local_signature.
-     (module Requests.Step.S
-        with type auxiliary_value = 'auxiliary_value
-         and type local_branches = 'local_branches
-         and type local_signature = 'local_signature
-         and type max_proofs_verified = 'max_proofs_verified
-         and type prev_values = 'prev_values
-         and type proofs_verified = 'proofs_verified
-         and type return_value = 'ret_value
-         and type statement = 'a_value )
-  -> (module Pickles_types.Nat.Add.Intf with type n = 'max_proofs_verified)
-  -> self_branches:'self_branches Pickles_types.Nat.t
-  -> local_signature:
-       'local_signature Pickles_types.Hlist.H1.T(Pickles_types.Nat).t
-  -> local_signature_length:
-       ('local_signature, 'proofs_verified) Pickles_types.Hlist.Length.t
-  -> local_branches_length:
-       ('local_branches, 'proofs_verified) Pickles_types.Hlist.Length.t
-  -> proofs_verified:('prev_vars, 'proofs_verified) Pickles_types.Hlist.Length.t
-  -> lte:('proofs_verified, 'max_proofs_verified) Pickles_types.Nat.Lte.t
-  -> public_input:
-       ( 'var
-       , 'value
+module Make (Inductive_rule : Inductive_rule.Intf) : sig
+  (** [step_main] is the SNARK function corresponding to the input inductive rule. **)
+  val step_main :
+    'proofs_verified 'self_branches 'prev_vars 'prev_values 'var 'value 'a_var
+    'a_value 'ret_var 'ret_value 'auxiliary_var 'auxiliary_value
+    'max_proofs_verified 'local_branches 'local_signature.
+       (module Requests.Step(Inductive_rule).S
+          with type auxiliary_value = 'auxiliary_value
+           and type local_branches = 'local_branches
+           and type local_signature = 'local_signature
+           and type max_proofs_verified = 'max_proofs_verified
+           and type prev_values = 'prev_values
+           and type proofs_verified = 'proofs_verified
+           and type return_value = 'ret_value
+           and type statement = 'a_value )
+    -> (module Pickles_types.Nat.Add.Intf with type n = 'max_proofs_verified)
+    -> self_branches:'self_branches Pickles_types.Nat.t
+    -> local_signature:
+         'local_signature Pickles_types.Hlist.H1.T(Pickles_types.Nat).t
+    -> local_signature_length:
+         ('local_signature, 'proofs_verified) Pickles_types.Hlist.Length.t
+    -> local_branches_length:
+         ('local_branches, 'proofs_verified) Pickles_types.Hlist.Length.t
+    -> proofs_verified:
+         ('prev_vars, 'proofs_verified) Pickles_types.Hlist.Length.t
+    -> lte:('proofs_verified, 'max_proofs_verified) Pickles_types.Nat.Lte.t
+    -> public_input:
+         ( 'var
+         , 'value
+         , 'a_var
+         , 'a_value
+         , 'ret_var
+         , 'ret_value )
+         Inductive_rule.public_input
+    -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
+    -> basic:
+         ( 'var
+         , 'value
+         , 'max_proofs_verified
+         , 'self_branches )
+         Types_map.Compiled.basic
+    -> known_wrap_keys:
+         'local_branches
+         Pickles_types.Hlist.H1.T(Types_map.For_step.Optional_wrap_key).t
+    -> self:('var, 'value, 'max_proofs_verified, 'self_branches) Tag.t
+    -> ( 'prev_vars
+       , 'prev_values
+       , 'local_signature
+       , 'local_branches
        , 'a_var
        , 'a_value
        , 'ret_var
-       , 'ret_value )
-       Inductive_rule.public_input
-  -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
-  -> basic:
-       ( 'var
-       , 'value
-       , 'max_proofs_verified
-       , 'self_branches )
-       Types_map.Compiled.basic
-  -> known_wrap_keys:
-       'local_branches
-       Pickles_types.Hlist.H1.T(Types_map.For_step.Optional_wrap_key).t
-  -> self:('var, 'value, 'max_proofs_verified, 'self_branches) Tag.t
-  -> ( 'prev_vars
-     , 'prev_values
-     , 'local_signature
-     , 'local_branches
-     , 'a_var
-     , 'a_value
-     , 'ret_var
-     , 'ret_value
-     , 'auxiliary_var
-     , 'auxiliary_value )
-     Inductive_rule.Promise.t
-  -> (   unit
-      -> ( (Unfinalized.t, 'max_proofs_verified) Pickles_types.Vector.t
-         , Impls.Step.Field.t
-         , (Impls.Step.Field.t, 'max_proofs_verified) Pickles_types.Vector.t )
-         Import.Types.Step.Statement.t
-         Promise.t )
-     Core_kernel.Staged.t
+       , 'ret_value
+       , 'auxiliary_var
+       , 'auxiliary_value )
+       Inductive_rule.Promise.t
+    -> (   unit
+        -> ( (Unfinalized.t, 'max_proofs_verified) Pickles_types.Vector.t
+           , Impls.Step.Field.t
+           , (Impls.Step.Field.t, 'max_proofs_verified) Pickles_types.Vector.t
+           )
+           Import.Types.Step.Statement.t
+           Promise.t )
+       Core_kernel.Staged.t
+end


### PR DESCRIPTION
This PR changes `Pickles.Inductive_rule` from a module to the result of functor applied to an argument of signature

```ocaml
module type Proof_intf = sig
  type 'width t
end
```

We can recover the existing implementation 

```ocaml
module Kimchi : Intf with type 'width proof = 'width Proof.t
```

We then functorize in as many places as possible to avoid specifying the proof type unless necessary. The result is that modules like `Step_branch_data` and `Step_main` are generic in the proof type (sort of), while e.g. `Compile` and `Pickles` explicitly rely on the concrete `Kimchi` inductive rule.

## Review Notes

This PR is a no-op, only changes types. The diff is bad because of formatting (functorizing results in indentation). The only real changes are in
-  [35315d3](https://github.com/MinaProtocol/mina/pull/16967/commits/35315d312420f452ce926e9a7280734fae66b5b6)
- [68a4bff](https://github.com/MinaProtocol/mina/pull/16967/commits/68a4bff4dd8837553d4e64652d44fdb34f94628b)

everything else is just "follow the errors". I used this difftastic tool that @glyh pointed out, it does a better job.