### PR TITLE
Modify mina ledger test apply to allow for filled actions and events in updates

### DIFF
--- a/scripts/tests/ledger_test_apply.sh
+++ b/scripts/tests/ledger_test_apply.sh
@@ -21,12 +21,15 @@ TEMP_ACCOUNTS_FILE=$TEMP_FOLDER/accounts_tmp.json
 GENESIS_LEDGER=$TEMP_FOLDER/genesis_ledger.config
 SENDER=$TEMP_FOLDER/sender
 
-while [[ "$#" -gt 0 ]]; do case $1 in
-  -m|--mina-app) MINA_APP="$2"; shift;;
-  -r|--runtime-ledger-app) RUNTIME_LEDGER_APP="$2"; shift;;
-  *) echo "Unknown parameter passed: $1"; exit 1;;
-esac; shift; done
+ACTIONS_EVENTS_OPT="--transfer-parties-get-actions-events"
+FULL_ACTIONS_EVENTS=""
 
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -m|--mina-app) MINA_APP="$2"; shift; shift;;
+  -r|--runtime-ledger-app) RUNTIME_LEDGER_APP="$2"; shift; shift;;
+  $ACTIONS_EVENTS_OPT) FULL_ACTIONS_EVENTS="$ACTIONS_EVENTS_OPT"; shift;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; done
 
 echo "Exporting ledger to $TEMP_FOLDER"
 echo "20k accounts is way less than the size of a mainnet ledger (200k), but good enough for testing"
@@ -55,5 +58,4 @@ mkdir $TEMP_FOLDER/genesis/ledger
 tar -zxf  $TEMP_FOLDER/genesis/genesis_ledger_*.tar.gz -C $TEMP_FOLDER/genesis/ledger
 
 echo "running test:"
-time $MINA_APP ledger test apply --ledger-path $TEMP_FOLDER/genesis/ledger  --privkey-path $SENDER --num-txs 200 --dump-benchmark $BENCHMARK_FILE
-
+time $MINA_APP ledger test apply --ledger-path $TEMP_FOLDER/genesis/ledger  --privkey-path $SENDER --num-txs 200 --dump-benchmark $BENCHMARK_FILE $ACTIONS_EVENTS_OPT

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1248,8 +1248,7 @@ let import_key =
        Set MINA_PRIVKEY_PASS environment variable to use non-interactively \
        (key will be imported using the same password)."
     (let%map_open.Command access_method =
-       choose_one
-         ~if_nothing_chosen:(Default_to `None)
+       choose_one ~if_nothing_chosen:(Default_to `None)
          [ Cli_lib.Flag.Uri.Client.rest_graphql_opt
            |> map ~f:(Option.map ~f:(fun port -> `GraphQL port))
          ; Cli_lib.Flag.conf_dir
@@ -1459,8 +1458,7 @@ let export_key =
 let list_accounts =
   Command.async ~summary:"List all owned accounts"
     (let%map_open.Command access_method =
-       choose_one
-         ~if_nothing_chosen:(Default_to `None)
+       choose_one ~if_nothing_chosen:(Default_to `None)
          [ Cli_lib.Flag.Uri.Client.rest_graphql_opt
            |> map ~f:(Option.map ~f:(fun port -> `GraphQL port))
          ; Cli_lib.Flag.conf_dir
@@ -2346,6 +2344,13 @@ let test_ledger_application =
      and benchmark =
        flag "--dump-benchmark" ~doc:"Dump json file with benchmark data"
          (optional string)
+     and transfer_parties_get_actions_events =
+       flag "--transfer-parties-get-actions-events"
+         ~doc:
+           "If true, all updates in the ledger commands will have full actions \
+            and events. If false, they will have empty actions and events. \
+            Default: false."
+         no_arg
      in
      Cli_lib.Exceptions.handle_nicely
      @@ fun () ->
@@ -2361,8 +2366,9 @@ let test_ledger_application =
      let genesis_constants = Genesis_constants.Compiled.genesis_constants in
      Test_ledger_application.test ~privkey_path ~ledger_path ?prev_block_path
        ~first_partition_slots ~no_new_stack ~has_second_partition
-       ~num_txs_per_round ~rounds ~no_masks ~max_depth ~tracing num_txs
-       ~constraint_constants ~genesis_constants ~benchmark )
+       ~num_txs_per_round ~rounds ~no_masks ~max_depth ~tracing
+       ~transfer_parties_get_actions_events num_txs ~constraint_constants
+       ~genesis_constants ~benchmark )
 
 let itn_create_accounts =
   let compile_config = Mina_compile_config.Compiled.t in

--- a/src/app/cli/src/init/test_ledger_application.ml
+++ b/src/app/cli/src/init/test_ledger_application.ml
@@ -23,19 +23,18 @@ let read_privkey privkey_path =
 let generate_event =
   Snark_params.Tick.Field.gen |> Quickcheck.Generator.map ~f:(fun x -> [| x |])
 
-let mk_tx ~event_elements ~action_elements
+let mk_tx ~transfer_parties_get_actions_events ~event_elements ~action_elements
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) keypair
     nonce =
   let num_acc_updates = 8 in
-  let multispec : Transaction_snark.For_tests.Multiple_transfers_spec.t =
+  let signaturespec : Transaction_snark.For_tests.Signature_transfers_spec.t =
     let fee_payer = None in
     let generated_values =
       let open Base_quickcheck.Generator.Let_syntax in
       let%bind receivers =
         Base_quickcheck.Generator.list_with_length ~length:num_acc_updates
         @@ let%map kp = Signature_lib.Keypair.gen in
-           ( Signature_lib.Public_key.compress kp.public_key
-           , Currency.Amount.zero )
+           (First kp, Currency.Amount.zero)
       in
       let%bind events =
         Quickcheck.Generator.list_with_length event_elements generate_event
@@ -71,11 +70,17 @@ let mk_tx ~event_elements ~action_elements
     ; snapp_update
     ; actions
     ; events
+    ; transfer_parties_get_actions_events
     ; call_data
     ; preconditions
     }
   in
-  Transaction_snark.For_tests.multiple_transfers ~constraint_constants multispec
+  let receiver_auth =
+    if transfer_parties_get_actions_events then Some Control.Tag.Signature
+    else None
+  in
+  Transaction_snark.For_tests.signature_transfers ?receiver_auth
+    ~constraint_constants signaturespec
 
 let generate_protocol_state_stub ~consensus_constants ~constraint_constants
     ledger =
@@ -85,9 +90,10 @@ let generate_protocol_state_stub ~consensus_constants ~constraint_constants
     ~genesis_epoch_data:None ~constraint_constants ~consensus_constants
     ~genesis_body_reference
 
-let apply_txs ~action_elements ~event_elements ~constraint_constants
-    ~first_partition_slots ~no_new_stack ~has_second_partition ~num_txs
-    ~prev_protocol_state ~(keypair : Signature_lib.Keypair.t) ~i ledger =
+let apply_txs ~transfer_parties_get_actions_events ~action_elements
+    ~event_elements ~constraint_constants ~first_partition_slots ~no_new_stack
+    ~has_second_partition ~num_txs ~prev_protocol_state
+    ~(keypair : Signature_lib.Keypair.t) ~i ledger =
   let init_nonce =
     let account_id = Account_id.of_public_key keypair.public_key in
     let loc =
@@ -101,7 +107,8 @@ let apply_txs ~action_elements ~event_elements ~constraint_constants
     Fn.compose (Unsigned.UInt32.add init_nonce) Unsigned.UInt32.of_int
   in
   let mk_tx' =
-    mk_tx ~action_elements ~event_elements ~constraint_constants keypair
+    mk_tx ~transfer_parties_get_actions_events ~action_elements ~event_elements
+      ~constraint_constants keypair
   in
   let fork_slot =
     Option.value_map ~default:Mina_numbers.Global_slot_since_genesis.zero
@@ -173,8 +180,8 @@ let apply_txs ~action_elements ~event_elements ~constraint_constants
 
 let test ~privkey_path ~ledger_path ?prev_block_path ~first_partition_slots
     ~no_new_stack ~has_second_partition ~num_txs_per_round ~rounds ~no_masks
-    ~max_depth ~tracing num_txs_final ~benchmark
-    ~(genesis_constants : Genesis_constants.t)
+    ~max_depth ~tracing ~transfer_parties_get_actions_events num_txs_final
+    ~benchmark ~(genesis_constants : Genesis_constants.t)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
   O1trace.thread "mina"
   @@ fun () ->
@@ -259,12 +266,12 @@ let test ~privkey_path ~ledger_path ?prev_block_path ~first_partition_slots
       in
       List.hd (List.drop ledgers (max_depth - 1))
       |> Option.iter ~f:drop_old_ledger ;
-      apply ~action_elements:0 ~event_elements:0 ~num_txs:num_txs_per_round ~i
-        ledger
+      apply ~transfer_parties_get_actions_events:false ~action_elements:0
+        ~event_elements:0 ~num_txs:num_txs_per_round ~i ledger
       >>| save_preparation_times >>| mask_handler ledger
       >>| Fn.flip Tuple2.create (ledger :: ledgers) )
   >>| fst
-  >>= apply ~num_txs:num_txs_final
+  >>= apply ~transfer_parties_get_actions_events ~num_txs:num_txs_final
         ~action_elements:genesis_constants.max_action_elements
         ~event_elements:genesis_constants.max_event_elements ~i:rounds
   >>| stop_tracing >>| save_and_dump_benchmarks

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -391,6 +391,39 @@ module type Full = sig
               , (unit * unit * Nat.N2.n Pickles.Proof.t) Async.Deferred.t )
               Pickles.Prover.t ]
 
+    module Signature_transfers_spec : sig
+      type t =
+        { fee : Currency.Fee.t
+        ; sender : Signature_lib.Keypair.t * Mina_base.Account.Nonce.t
+        ; fee_payer :
+            (Signature_lib.Keypair.t * Mina_base.Account.Nonce.t) option
+        ; receivers :
+            ( ( Signature_lib.Keypair.t
+              , Signature_lib.Public_key.Compressed.t )
+              Either.t
+            * Currency.Amount.t )
+            list
+        ; amount : Currency.Amount.t
+        ; zkapp_account_keypairs : Signature_lib.Keypair.t list
+        ; memo : Signed_command_memo.t
+        ; new_zkapp_account : bool
+        ; snapp_update : Account_update.Update.t
+              (* Authorization for the update being performed *)
+        ; actions : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; events : Tick.Field.t Bounded_types.ArrayN4000.Stable.V1.t list
+        ; transfer_parties_get_actions_events : bool
+        ; call_data : Tick.Field.t
+        ; preconditions : Account_update.Preconditions.t option
+        }
+      [@@deriving sexp]
+    end
+
+    val signature_transfers :
+         ?receiver_auth:Control.Tag.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
+      -> Signature_transfers_spec.t
+      -> Zkapp_command.t
+
     module Multiple_transfers_spec : sig
       type t =
         { fee : Currency.Fee.t


### PR DESCRIPTION
## Explain your changes:

The `mina ledger test apply` command and the `scripts/tests/ledger_test_apply.sh` script now recognize the flag `--transfer-parties-get-actions-events`. When set, the commands used in the test are generated so that every account update in those commands has their actions and events filled completely. This is 100 actions and 100 events in each update with the current genesis constants. Otherwise, these fields are left empty. By default, the flag is off (matching the current behaviour).

To support this change, a new `signature_transfers` command generator and associated spec have been added to `Transaction_snarks.For_tests`. These generalize the existing `multiple_transfers` command generator by allowing receivers and the sender to have their actions and events filled with the spec actions and events. The `multiple_transfers` function is now implemented using `signature_transfers`.

## Explain how you tested your changes:

I ran the `scripts/tests/ledger_test_apply.sh` script locally, with and without this new flag. The results aren't expected to be completely stable over time, but I did get roughly the same results running the test a few times in a row. I've included the tail ends of one run for each condition:

- Without flag (0 actions, 0 events per update)

```
Result of application 578: true (took 41.265487670898438ms): new root jw6z2P6t7FANE3dZqauoaLetnhxK139Lxcp88pMiZCyJVthtUFd
Result of application 579: true (took 41.391849517822266ms): new root jwCsDTTQKTfJ3b22TEo7cbnPYBKaPWhNS5mMBvsVF8DruRriezx
Result of application 580: true (took 2.7522416114807129s): new root jxhkc949Kj58jMRcgzdbYNQhbJ4EYaH15VRQRPEAf9CgZfdXeUC

real	0m55.356s
user	0m54.868s
sys	0m0.182s
```

- With flag (100 actions, 100 events per update)

```
Result of application 578: true (took 42.382955551147461ms): new root jwPengZFgoSN3z2N7xjbux5MRDPpnnFhbpJXHkWfZ7EtjYszedZ
Result of application 579: true (took 42.351245880126953ms): new root jxzRheZDN5CuSkZmoewYeAarUJ1XZLBZFBCfvXUM17MWYmnDhzT
Result of application 580: true (took 10.166671276092529s): new root jxYu6tVvd3BRBubdQaqTBN9VSbSh1PordSrgGGnQxWMJWsWQfRB

real	1m32.554s
user	1m31.894s
sys	0m0.187s
```

On average, all applications except 580 took the same time in both cases (around 40ms). That's expected, since those applications are just setup, and all have 0 events, 0 actions in them.

Out of curiosity, I modified the max events and actions genesis constants so the test would run with different numbers of actions and events. The final application time seems to be unaffected by the max number of events, and it increases by ~7s for every additional 100 actions (from 3s for 0 actions to 73s for 1000 actions). This is all still on my laptop.

## Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules. Not applicable.
- [x] Does this close issues? No open issues.