### PR TITLE
Keep snark work proofs on disk until we actually need them

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -437,6 +437,13 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                 ~f:Fn.const
             in
             let%map work = Mina_lib.request_work mina in
+            let work =
+              Snark_work_lib.Work.Spec.map work
+                ~f:
+                  (Snark_work_lib.Work.Single.Spec.map
+                     ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+                     ~f_witness:Transaction_witness.read_all_proofs_from_disk )
+            in
             [%log trace]
               ~metadata:[ ("work_spec", Snark_worker.Work.Spec.to_yojson work) ]
               "responding to a Get_work request with some new work" ;

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2374,6 +2374,13 @@ module Queries = struct
         let less_than uint1 uint2 = Unsigned.UInt32.compare uint1 uint2 < 0 in
         let to_bundle_specs =
           List.map ~f:(fun (spec, fee_prover) ->
+              let spec =
+                One_or_two.map spec
+                  ~f:
+                    (Snark_work_lib.Work.Single.Spec.map
+                       ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+                       ~f_witness:Transaction_witness.read_all_proofs_from_disk )
+              in
               { Types.Snark_work_bundle.spec; fee_prover } )
         in
         match end_idx with

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -624,7 +624,7 @@ let pending_work =
 
 module Snark_work_bundle = struct
   type t =
-    { spec : Work_selector.work One_or_two.t
+    { spec : Work_selector.in_memory_work One_or_two.t
     ; fee_prover : (Currency.Fee.t * Public_key.Compressed.t) option
     }
 
@@ -638,7 +638,7 @@ module Snark_work_bundle = struct
             ~doc:"Snark work specification in json format"
             ~args:Arg.[]
             ~resolve:(fun _ { spec; _ } ->
-              One_or_two.to_yojson Work_selector.work_to_yojson spec
+              One_or_two.to_yojson Work_selector.in_memory_work_to_yojson spec
               |> Yojson.Safe.to_string )
         ; field "snarkFee" ~typ:fee
             ~doc:"Fee if proof for the spec exists in snark pool"

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2586,3 +2586,5 @@ let best_chain_block_by_state_hash (t : t) hash =
             (State_hash.to_base58_check hash) )
 
 let zkapp_cmd_limit t = t.config.zkapp_cmd_limit
+
+let proof_cache_db t = t.proof_cache_db

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -258,3 +258,5 @@ val best_chain_block_by_state_hash :
   t -> State_hash.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
 
 val zkapp_cmd_limit : t -> int option ref
+
+val proof_cache_db : t -> Proof_cache_tag.cache_db

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -87,6 +87,9 @@ module Spec = struct
   type 'single t = 'single Stable.Latest.t =
     { instances : 'single One_or_two.t; fee : Currency.Fee.t }
   [@@deriving fields, sexp, yojson]
+
+  let map ~f { instances; fee } =
+    { instances = One_or_two.map ~f instances; fee }
 end
 
 module Result = struct

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -334,7 +334,7 @@ val of_scan_state_pending_coinbases_and_snarked_ledger_unchecked :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> ( Transaction_witness.Stable.Latest.t
+  -> ( Transaction_witness.t
      , Ledger_proof.Cached.t )
      Snark_work_lib.Work.Single.Spec.t
      One_or_two.t

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -38,9 +38,7 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
         |> Mina_block.Validated.valid_commands
         |> List.exists ~f:(fun { data = found; _ } ->
                let found' = User_command.forget_check found in
-               User_command.equal_ignoring_proofs_and_hashes cmd found'
-               && User_command.Stable.Latest.equal cmd
-                    (User_command.read_all_proofs_from_disk found') )
+               User_command.equal_ignoring_proofs_and_hashes cmd found' )
       in
       if List.exists ~f:in_breadcrumb best_tip_path then State.Included
       else if

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -1298,7 +1298,7 @@ let work_statements_for_new_diff t : Transaction_snark_work.Statement.t list =
 
 let all_work_pairs t
     ~(get_state : State_hash.t -> Mina_state.Protocol_state.value Or_error.t) :
-    ( Transaction_witness.Stable.Latest.t
+    ( Transaction_witness.t
     , Ledger_proof.Cached.t )
     Snark_work_lib.Work.Single.Spec.t
     One_or_two.t
@@ -1333,10 +1333,9 @@ let all_work_pairs t
             | Merge ->
                 Or_error.error_string "init_stack was Merge"
           in
-          { Transaction_witness.Stable.Latest.first_pass_ledger =
-              first_pass_ledger_witness
+          { Transaction_witness.first_pass_ledger = first_pass_ledger_witness
           ; second_pass_ledger = second_pass_ledger_witness
-          ; transaction = Transaction.read_all_proofs_from_disk transaction
+          ; transaction
           ; protocol_state_body
           ; init_stack
           ; status

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -257,7 +257,7 @@ val check_required_protocol_states :
 val all_work_pairs :
      t
   -> get_state:(State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-  -> ( Transaction_witness.Stable.Latest.t
+  -> ( Transaction_witness.t
      , Ledger_proof.Cached.t )
      Snark_work_lib.Work.Single.Spec.t
      One_or_two.t

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -197,7 +197,8 @@ let send_produced_block_at ~logger ~interruptor ~url ~peer_id
 
 let read_all_proofs_for_work_single_spec =
   Snark_work_lib.Work.Single.Spec.map
-    ~f_proof:Ledger_proof.Cached.read_proof_from_disk ~f_witness:ident
+    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+    ~f_witness:Transaction_witness.read_all_proofs_from_disk
 
 let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
     ~url ~snark_worker ~transition_frontier ~peer_id

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -2,12 +2,7 @@ open Core_kernel
 open Currency
 
 module Test_inputs = struct
-  module Transaction_witness = struct
-    module Stable = struct
-      module Latest = Int
-    end
-  end
-
+  module Transaction_witness = Int
   module Ledger_hash = Int
   module Sparse_ledger = Int
   module Transaction = Int

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -23,11 +23,7 @@ module type Inputs_intf = sig
   end
 
   module Transaction_witness : sig
-    module Stable : sig
-      module Latest : sig
-        type t
-      end
-    end
+    type t
   end
 
   module Ledger_proof : sig
@@ -76,7 +72,7 @@ module type Inputs_intf = sig
          t
       -> get_state:
            (Mina_base.State_hash.t -> Mina_state.Protocol_state.value Or_error.t)
-      -> ( Transaction_witness.Stable.Latest.t
+      -> ( Transaction_witness.t
          , Ledger_proof.Cached.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
@@ -125,8 +121,8 @@ module type Lib_intf = sig
     (**Jobs that have not been assigned yet*)
     val all_unseen_works :
          t
-      -> ( Transaction_witness.Stable.Latest.t
-         , Ledger_proof.t )
+      -> ( Transaction_witness.t
+         , Ledger_proof.Cached.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
          list
@@ -135,8 +131,8 @@ module type Lib_intf = sig
 
     val set :
          t
-      -> ( Transaction_witness.Stable.Latest.t
-         , Ledger_proof.t )
+      -> ( Transaction_witness.t
+         , Ledger_proof.Cached.t )
          Snark_work_lib.Work.Single.Spec.t
          One_or_two.t
       -> unit
@@ -145,13 +141,13 @@ module type Lib_intf = sig
   val get_expensive_work :
        snark_pool:Snark_pool.t
     -> fee:Fee.t
-    -> ( Transaction_witness.Stable.Latest.t
-       , Ledger_proof.t )
+    -> ( Transaction_witness.t
+       , Ledger_proof.Cached.t )
        Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
-    -> ( Transaction_witness.Stable.Latest.t
-       , Ledger_proof.t )
+    -> ( Transaction_witness.t
+       , Ledger_proof.Cached.t )
        Snark_work_lib.Work.Single.Spec.t
        One_or_two.t
        list
@@ -195,8 +191,8 @@ module type Make_selection_method_intf = functor (Lib : Lib_intf) ->
   Selection_method_intf
     with type staged_ledger := Lib.Inputs.Staged_ledger.t
      and type work :=
-      ( Lib.Inputs.Transaction_witness.Stable.Latest.t
-      , Lib.Inputs.Ledger_proof.t )
+      ( Lib.Inputs.Transaction_witness.t
+      , Lib.Inputs.Ledger_proof.Cached.t )
       Snark_work_lib.Work.Single.Spec.t
      and type snark_pool := Lib.Inputs.Snark_pool.t
      and type transition_frontier := Lib.Inputs.Transition_frontier.t

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -28,8 +28,8 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
     type t =
       { mutable available_jobs :
-          ( Inputs.Transaction_witness.Stable.Latest.t
-          , Inputs.Ledger_proof.t )
+          ( Inputs.Transaction_witness.t
+          , Inputs.Ledger_proof.Cached.t )
           Work_spec.t
           One_or_two.t
           list
@@ -83,20 +83,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
                                 ( Time.diff end_time start_time
                                 |> Time.Span.to_ms ) )
                           ] ;
-                      let new_available_jobs_unwrapped :
-                          ( Inputs.Transaction_witness.Stable.Latest.t
-                          , Inputs.Ledger_proof.t )
-                          Work_spec.t
-                          One_or_two.t
-                          list =
-                        let f =
-                          Snark_work_lib.Work.Single.Spec.map ~f_witness:ident
-                            ~f_proof:
-                              Inputs.Ledger_proof.Cached.read_proof_from_disk
-                        in
-                        List.map new_available_jobs ~f:(One_or_two.map ~f)
-                      in
-                      t.available_jobs <- new_available_jobs_unwrapped ) ;
+                      t.available_jobs <- new_available_jobs ) ;
                   Deferred.unit )
               |> Deferred.don't_wait_for ) ;
           Deferred.unit )

--- a/src/lib/work_selector/work_selector.ml
+++ b/src/lib/work_selector/work_selector.ml
@@ -2,6 +2,11 @@ module Lib = Work_lib.Make (Inputs.Implementation_inputs)
 module State = Lib.State
 
 type work =
+  ( Transaction_witness.t
+  , Ledger_proof.Cached.t )
+  Snark_work_lib.Work.Single.Spec.t
+
+type in_memory_work =
   ( Transaction_witness.Stable.Latest.t
   , Ledger_proof.t )
   Snark_work_lib.Work.Single.Spec.t

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -2,6 +2,11 @@ module State :
   Intf.State_intf with type transition_frontier := Transition_frontier.t
 
 type work =
+  ( Transaction_witness.t
+  , Ledger_proof.Cached.t )
+  Snark_work_lib.Work.Single.Spec.t
+
+type in_memory_work =
   ( Transaction_witness.Stable.Latest.t
   , Ledger_proof.t )
   Snark_work_lib.Work.Single.Spec.t


### PR DESCRIPTION
This PR changes the types for snark work while we're passing it around. Most importantly, this means that we aren't reading all of the proofs any time we enumerate the available work.

This PR addresses on [this review comment](https://github.com/MinaProtocol/mina/pull/16964#discussion_r2047380211) on PR #16964.