### PR TITLE
Ensure daemon acquires the daemon lockfile after cleaning up a stale lockfile

### DIFF
--- a/changes/16974.md
+++ b/changes/16974.md
@@ -1,0 +1,6 @@
+This PR fixes a bug where the mina daemon would not acquire the daemon lockfile
+(the `.mina-lock` file in the daemon config directory) after it had deleted a
+stale lockfile left over from a crashed or killed daemon. Daemons must always
+acquire this lockfile before continuing startup, since it is used, for instance,
+to prevent multiple daemons from starting up in the same config directory and
+potentially interfering with each other.

--- a/src/lib/mina_lib/conf_dir.ml
+++ b/src/lib/mina_lib/conf_dir.ml
@@ -6,7 +6,19 @@ let compute_conf_dir conf_dir_opt =
   let home = Sys.home_directory () in
   Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir_opt
 
-let check_and_set_lockfile ~logger conf_dir =
+(** Attempt to create the daemon lockfile in the [conf_dir], and otherwise throw
+    an error (to signal shutdown) if this fails. The lockfile is acquired by a
+    daemon during startup, before anything in the [conf_dir] is modified. It is
+    used to prevent subsequent daemons from starting up in the [conf_dir] if a
+    daemon already holds the lockfile.
+
+    The lockfile is held by a process if the file exists, contains a PID, and
+    that process has that PID. Since daemons can crash or be killed -
+    interfering with daemon cleanup - it is possible for a lockfile to exist and
+    yet not be held by any existing process. If such a lockfile exists, it must
+    be removed by the daemon, and then the daemon must attempt to re-acquire the
+    lockfile. *)
+let rec check_and_set_lockfile ~logger conf_dir =
   let lockfile = conf_dir ^/ ".mina-lock" in
   match Sys.file_exists lockfile with
   | `No -> (
@@ -72,7 +84,9 @@ let check_and_set_lockfile ~logger conf_dir =
                       [ ("lockfile", `String lockfile)
                       ; ("pid", `Int (Pid.to_int pid))
                       ] ;
-                  Unix.unlink lockfile ) ) )
+                  let%bind () = Unix.unlink lockfile in
+                  [%log info] "Re-attempting to acquire the lockfile" ;
+                  check_and_set_lockfile ~logger conf_dir ) ) )
       with
       | Ok () ->
           ()


### PR DESCRIPTION
## Explain your changes:

The daemon lockfile `.mina-lock` is created in the config directory used by a running daemon. It contains the PID of the running daemon, and a daemon with the same PID as in the lockfile is said to own (have acquired) that lockfile. This file is used to exclude other daemons from starting up in the same config directory; if the lockfile exists and is owned by another process then new daemons will refuse to continue startup once they see it. This file is normally deleted during daemon shutdown. However, if a daemon crashes or is killed, then it may not have a chance to delete this file before it exits.

If a new daemon starts up and finds that a daemon lockfile exists but is not owned by any process (meaning there is no running process with the same PID as is recorded in the lockfile) then it must delete that lockfile. Before these changes, the daemon would delete the stale lockfile, but then would continue startup without bothering to acquire the daemon lockfile. This is obviously bad. With these changes, the daemon will re-attempt to acquire the lockfile after it deletes the existing one.

## Explain how you tested your changes:

I started up a mina daemon in demo mode on my laptop and waited for it to create the lockfile. I then SIGKILL'd it so it exited without deleting its lockfile. I started up a new daemon and saw that the new log message was displayed, and that a new lockfile had been created with the PID of the new daemon.

## Checklist:

- [x] Dependency versions are unchanged.
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules. Not applicable.
- [x] Does this close issues? The bug is not described in any open issue.
