### PR TITLE
Fix Instance-Instsance typo in log line

### DIFF
--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -294,7 +294,7 @@ let rec load_with_max_length :
       ~snarked_ledger_hash:genesis_ledger_hash
   in
   match
-    time ~label:"Persistent_frontier.Instsance.check_database" ~logger
+    time ~label:"Persistent_frontier.Instance.check_database" ~logger
     @@ fun () ->
     Persistent_frontier.Instance.check_database
       ~genesis_state_hash:


### PR DESCRIPTION
## Explain your changes:

In one mina daemon log line, `Instance` is currently spelled `Instsance`. This PR fixes that typo.

## Explain how you tested your changes:

I started the daemon in demo mode and confirmed that the spelling is now correct in the log.

## Checklist:

- [x] Just a trivial one-line fix
