### PR TITLE
Determine Mina_signature_kind.t at runtime

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1248,8 +1248,7 @@ let import_key =
        Set MINA_PRIVKEY_PASS environment variable to use non-interactively \
        (key will be imported using the same password)."
     (let%map_open.Command access_method =
-       choose_one
-         ~if_nothing_chosen:(Default_to `None)
+       choose_one ~if_nothing_chosen:(Default_to `None)
          [ Cli_lib.Flag.Uri.Client.rest_graphql_opt
            |> map ~f:(Option.map ~f:(fun port -> `GraphQL port))
          ; Cli_lib.Flag.conf_dir
@@ -1459,8 +1458,7 @@ let export_key =
 let list_accounts =
   Command.async ~summary:"List all owned accounts"
     (let%map_open.Command access_method =
-       choose_one
-         ~if_nothing_chosen:(Default_to `None)
+       choose_one ~if_nothing_chosen:(Default_to `None)
          [ Cli_lib.Flag.Uri.Client.rest_graphql_opt
            |> map ~f:(Option.map ~f:(fun port -> `GraphQL port))
          ; Cli_lib.Flag.conf_dir
@@ -2289,7 +2287,7 @@ let signature_kind =
     (let%map.Command () = Command.Param.return () in
      fun () ->
        let signature_kind_string =
-         match Mina_signature_kind.t with
+         match Mina_signature_kind.t_DEPRECATED with
          | Mainnet ->
              "mainnet"
          | Testnet ->

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -334,6 +334,7 @@ module Values (S : Sample) = struct
     }
 
   let zkapp_command' () : Mina_base.Zkapp_command.t =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     { fee_payer =
         { body =
             { public_key = public_key ()
@@ -346,7 +347,7 @@ module Values (S : Sample) = struct
     ; account_updates =
         List.init Params.max_zkapp_txn_account_updates ~f:(Fn.const ())
         |> List.fold_left ~init:[] ~f:(fun acc () ->
-               Mina_base.Zkapp_command.Call_forest.cons
+               Mina_base.Zkapp_command.Call_forest.cons ~chain
                  (zkapp_account_update ()) acc )
     ; memo = signed_command_memo ()
     }

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -40,6 +40,7 @@ end
 
 (* Returns signed_transaction_string *)
 let sign ~(keys : Keys.t) ~unsigned_transaction_string =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open Result.Let_syntax in
   let%bind json =
     try return (Yojson.Safe.from_string unsigned_transaction_string)
@@ -60,7 +61,7 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
   (* TODO: Should we use the signer_input explicitly here to dogfood it? *)
   (* Should we just inline that here? *)
   let signature =
-    Schnorr.Legacy.sign keys.keypair.private_key
+    Schnorr.Legacy.sign ~signature_kind keys.keypair.private_key
       unsigned_transaction.random_oracle_input
   in
   let signature' =
@@ -70,6 +71,7 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
   signature |> Signature.Raw.encode
 
 let verify ~public_key_hex_bytes ~signed_transaction_string =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open Result.Let_syntax in
   let%bind json =
     try return (Yojson.Safe.from_string signed_transaction_string)
@@ -88,6 +90,6 @@ let verify ~public_key_hex_bytes ~signed_transaction_string =
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
   let message = Signed_command.to_input_legacy user_command_payload in
-  Schnorr.Legacy.verify signed_transaction.signature
+  Schnorr.Legacy.verify ~signature_kind signed_transaction.signature
     (Snark_params.Tick.Inner_curve.of_affine public_key)
     message

--- a/src/app/rosetta/ocaml-signer/signer_cli.ml
+++ b/src/app/rosetta/ocaml-signer/signer_cli.ml
@@ -31,6 +31,7 @@ let sign_command =
         exit 1
 
 let verify_message_command =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open Command.Let_syntax in
   let%map_open signature =
     flag "--signature" ~doc:"Rosetta signature" (required string)
@@ -46,7 +47,7 @@ let verify_message_command =
       Option.value_exn (Mina_base.Signature.Raw.decode signature)
     in
     let pk = Rosetta_coding.Coding.to_public_key public_key in
-    match String_sign.verify signature pk message with
+    match String_sign.verify ~signature_kind signature pk message with
     | true ->
         return ()
     | false ->

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -232,6 +232,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -98,6 +98,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let logger = Logger.create ()
 
   let run network t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let open Malleable_error.Let_syntax in
     let%bind () =
       section_hard "Wait for nodes to initialize"
@@ -241,7 +242,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             when Public_key.Compressed.equal public_key account_a_pk ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign account_a_kp.private_key
+                  Schnorr.Chunked.sign ~signature_kind account_a_kp.private_key
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -261,7 +262,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign account_a_kp.private_key
+                      (Schnorr.Chunked.sign ~signature_kind
+                         account_a_kp.private_key
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -277,7 +277,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest1 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update1
-      |> Zkapp_command.Call_forest.cons (update_vk vk1)
+      |> Zkapp_command.Call_forest.cons ~chain:signature_kind (update_vk vk1)
     in
     let zkapp_command_update_vk1 =
       call_forest_to_zkapp ~call_forest:call_forest1
@@ -286,7 +286,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest2 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update1
-      |> Zkapp_command.Call_forest.cons (update_vk vk2)
+      |> Zkapp_command.Call_forest.cons ~chain:signature_kind (update_vk vk2)
     in
     let zkapp_command_update_vk2_refers_vk1 =
       call_forest_to_zkapp ~call_forest:call_forest2
@@ -295,7 +295,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest_update_vk2 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update2
-      |> Zkapp_command.Call_forest.cons (update_vk vk2)
+      |> Zkapp_command.Call_forest.cons ~chain:signature_kind (update_vk vk2)
     in
     let zkapp_command_update_vk2 =
       call_forest_to_zkapp ~call_forest:call_forest_update_vk2

--- a/src/app/zkapps_examples/calls/zkapps_calls.ml
+++ b/src/app/zkapps_examples/calls/zkapps_calls.ml
@@ -132,11 +132,12 @@ type _ Snarky_backendless.Request.t +=
     for the [Execute_call] request.
 *)
 let execute_call ~may_use_token account_update old_state =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let call_inputs = { Call_data.Input.Circuit.old_state } in
   let call_outputs, called_account_update, sub_calls =
     exists
       (Typ.tuple3 Call_data.Output.typ
-         (Zkapp_call_forest.Checked.account_update_typ ())
+         (Zkapp_call_forest.Checked.account_update_typ ~chain ())
          Zkapp_call_forest.typ )
       ~request:(fun () ->
         let may_use_token =

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -186,11 +186,13 @@ let%test_module "Actions test" =
 
     let%test_unit "Initialize" =
       let zkapp_command, account =
+        let chain = Mina_signature_kind.t_DEPRECATED in
         let ledger = create_ledger () in
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
       in
       assert (Option.is_some account) ;
@@ -202,12 +204,14 @@ let%test_module "Actions test" =
           assert (List.is_empty account_update.body.actions) )
 
     let%test_unit "Initialize and add sequence events" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let zkapp_command0, account0 =
         let ledger = create_ledger () in
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
              ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
       in
@@ -234,7 +238,8 @@ let%test_module "Actions test" =
         |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
              ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
       in
@@ -264,6 +269,7 @@ let%test_module "Actions test" =
         Mina_numbers.Global_slot_since_genesis.(equal zero) last_action_slot1 )
 
     let%test_unit "Add sequence events in different slots" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let ledger = create_ledger () in
       let slot1 = Mina_numbers.Global_slot_since_genesis.of_int 1 in
       let _zkapp_command0, account0 =
@@ -271,7 +277,8 @@ let%test_module "Actions test" =
         |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command ~global_slot:slot1 ~ledger
       in
       assert (Option.is_some account0) ;

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -98,6 +98,7 @@ let%test_module "Actions test" =
 
     let test_zkapp_command ?expected_failure ?state_body ?global_slot
         ?(fee_payer_nonce = 0) ~ledger zkapp_command =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         let account_updates_hash =
@@ -131,7 +132,7 @@ let%test_module "Actions test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -151,7 +152,7 @@ let%test_module "Actions test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -122,6 +122,7 @@ let%test_module "Actions test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -186,11 +186,13 @@ let%test_module "Add events test" =
     end)
 
     let%test_unit "Initialize" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let zkapp_command, account =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;
@@ -202,12 +204,14 @@ let%test_module "Add events test" =
           assert (List.is_empty account_update.body.events) )
 
     let%test_unit "Initialize and add events" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let zkapp_command, account =
         []
         |> Zkapp_command.Call_forest.cons_tree Add_events.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;
@@ -219,6 +223,7 @@ let%test_module "Add events test" =
           else assert (List.is_empty account_update.body.events) )
 
     let%test_unit "Initialize and add several events" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let zkapp_command, account =
         []
         |> Zkapp_command.Call_forest.cons_tree Add_events.account_update
@@ -226,7 +231,8 @@ let%test_module "Add events test" =
         |> Zkapp_command.Call_forest.cons_tree Add_events.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -120,6 +120,7 @@ let%test_module "Add events test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -97,6 +97,7 @@ let%test_module "Add events test" =
     end
 
     let test_zkapp_command ?expected_failure zkapp_command =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         let account_updates_hash =
@@ -129,7 +130,7 @@ let%test_module "Add events test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -149,7 +150,7 @@ let%test_module "Add events test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -92,13 +92,14 @@ let full_commitment =
 
 let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let fee_payer =
     match fee_payer with
     | { body = { public_key; _ }; _ }
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -118,7 +119,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -64,9 +64,10 @@ let deploy_account_update : Account_update.t =
   }
 
 let account_updates =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   []
-  |> Zkapp_command.Call_forest.cons account_update
-  |> Zkapp_command.Call_forest.cons deploy_account_update
+  |> Zkapp_command.Call_forest.cons ~chain account_update
+  |> Zkapp_command.Call_forest.cons ~chain deploy_account_update
 
 let memo = Signed_command_memo.empty
 

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -84,10 +84,11 @@ let fee_payer =
   }
 
 let full_commitment =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   Zkapp_command.Transaction_commitment.create_complete transaction_commitment
     ~memo_hash:(Signed_command_memo.hash memo)
     ~fee_payer_hash:
-      (Zkapp_command.Digest.Account_update.create
+      (Zkapp_command.Digest.Account_update.create ~chain
          (Account_update.of_fee_payer fee_payer) )
 
 let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -297,6 +297,7 @@ let%test_module "Composability test" =
           Ledger.get ledger loc )
 
     let test_recursive num_calls call_kind =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let increments =
         Array.init num_calls ~f:(fun _ -> Snark_params.Tick.Field.random ())
       in
@@ -317,7 +318,8 @@ let%test_module "Composability test" =
              (Update_state_account_update.account_update calls_kind call_kind)
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let (first_state :: zkapp_state) =

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -238,6 +238,7 @@ let%test_module "Composability test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -214,6 +214,7 @@ let%test_module "Composability test" =
     end
 
     let test_zkapp_command ?expected_failure zkapp_command =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)
         let account_updates_hash =
@@ -247,7 +248,7 @@ let%test_module "Composability test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -267,7 +268,7 @@ let%test_module "Composability test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -96,13 +96,14 @@ let full_commitment =
 (* TODO: Make this better. *)
 let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let fee_payer =
     match fee_payer with
     | { body = { public_key; _ }; _ }
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -122,7 +123,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -86,11 +86,12 @@ let fee_payer =
   }
 
 let full_commitment =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   (* TODO: This is a pain. *)
   Zkapp_command.Transaction_commitment.create_complete transaction_commitment
     ~memo_hash:(Signed_command_memo.hash memo)
     ~fee_payer_hash:
-      (Zkapp_command.Digest.Account_update.create
+      (Zkapp_command.Digest.Account_update.create ~chain
          (Account_update.of_fee_payer fee_payer) )
 
 (* TODO: Make this better. *)

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -64,9 +64,10 @@ let deploy_account_update : Account_update.t =
   }
 
 let account_updates =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   []
   |> Zkapp_command.Call_forest.cons_tree account_update
-  |> Zkapp_command.Call_forest.cons deploy_account_update
+  |> Zkapp_command.Call_forest.cons ~chain deploy_account_update
 
 let memo = Signed_command_memo.empty
 

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -188,11 +188,13 @@ let%test_module "Initialize state test" =
           Ledger.get ledger loc )
 
     let%test_unit "Initialize" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -203,13 +205,15 @@ let%test_module "Initialize state test" =
         zkapp_state
 
     let%test_unit "Initialize and update" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -220,6 +224,7 @@ let%test_module "Initialize state test" =
         zkapp_state
 
     let%test_unit "Initialize and multiple update" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
@@ -228,7 +233,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -239,11 +245,13 @@ let%test_module "Initialize state test" =
         zkapp_state
 
     let%test_unit "Update without initialize fails" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -251,13 +259,15 @@ let%test_module "Initialize state test" =
       assert (Option.is_none (Option.value_exn account).zkapp)
 
     let%test_unit "Double initialize fails" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -265,6 +275,7 @@ let%test_module "Initialize state test" =
       assert (Option.is_none (Option.value_exn account).zkapp)
 
     let%test_unit "Initialize after update fails" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
@@ -273,7 +284,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~chain
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -129,6 +129,7 @@ let%test_module "Initialize state test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -105,6 +105,7 @@ let%test_module "Initialize state test" =
     end
 
     let test_zkapp_command ?expected_failure zkapp_command =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)
@@ -138,7 +139,7 @@ let%test_module "Initialize state test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -158,7 +159,7 @@ let%test_module "Initialize state test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
+++ b/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
@@ -87,6 +87,7 @@ let%test_module "Zkapp with optional custom gates" =
 
     let%test_unit "Zkapp using a combination of optional custom gates verifies"
         =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       Async.Thread_safe.block_on_async_exn
       @@ fun () ->
       let%map.Async_kernel.Deferred vk =
@@ -96,7 +97,7 @@ let%test_module "Zkapp with optional custom gates" =
       let account_updates =
         []
         |> Zkapp_command.Call_forest.cons_tree account_update
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Zkapps_examples.Deploy_account_update.full ~access:Either
                 Account_info.public_key Account_info.token_id vk )
       in

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -95,11 +95,12 @@ let%test_module "Tokens test" =
     let finalize_ledger loc ledger = Ledger.get ledger loc
 
     let%test_unit "Initialize and mint" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -107,6 +108,7 @@ let%test_module "Tokens test" =
       ignore account
 
     let%test_unit "Initialize, mint, transfer none" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let account =
         []
         |> Zkapp_command.Call_forest.cons_tree
@@ -114,7 +116,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id [] )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -122,9 +124,10 @@ let%test_module "Tokens test" =
       ignore account
 
     let%test_unit "Proof aborts if token balance changes do not sum to 0" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -146,9 +149,10 @@ let%test_module "Tokens test" =
           ()
 
     let%test_unit "Initialize, mint, transfer two succeeds" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -156,7 +160,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -173,7 +177,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -181,9 +185,10 @@ let%test_module "Tokens test" =
       ignore account
 
     let%test_unit "Initialize, mint, transfer two succeeds, ignores non-token" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -192,7 +197,7 @@ let%test_module "Tokens test" =
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -200,7 +205,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -215,7 +220,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -229,7 +234,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -238,9 +243,10 @@ let%test_module "Tokens test" =
 
     let%test_unit "Initialize, mint, transfer recursive succeeds, ignores \
                    non-token" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -251,7 +257,7 @@ let%test_module "Tokens test" =
              ~calls:
                ( []
                (* Delegate call, should be checked. *)
-               |> Zkapp_command.Call_forest.cons
+               |> Zkapp_command.Call_forest.cons ~chain
                     { Account_update.Poly.authorization =
                         Control.Poly.Signature Signature.dummy
                     ; body =
@@ -264,7 +270,7 @@ let%test_module "Tokens test" =
                     ~calls:
                       ( []
                       (* Delegate call, should be checked. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~chain
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -275,7 +281,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:Inherit_from_parent
                            }
                       (* Parents_own_token, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~chain
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -285,7 +291,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:Parents_own_token
                            }
                       (* Blind call, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~chain
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -295,7 +301,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:No
                            }
                       (* Blind call, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~chain
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -325,7 +331,7 @@ let%test_module "Tokens test" =
                     (Account_updates.mint_with_used_token Inherit_from_parent)
                )
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -333,7 +339,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 15)
                    ~may_use_token:Inherit_from_parent
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -348,7 +354,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -361,7 +367,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -370,9 +376,10 @@ let%test_module "Tokens test" =
 
     let%test_unit "Initialize, mint, transfer two and non-token without auth \
                    fails" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -381,7 +388,7 @@ let%test_module "Tokens test" =
                    ~token_id:owned_token_id ~may_use_token:Inherit_from_parent
              }
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -389,7 +396,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~may_use_token:Inherit_from_parent
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -404,7 +411,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -412,7 +419,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
              }
-        |> Zkapp_command.Call_forest.cons ~calls:subtree
+        |> Zkapp_command.Call_forest.cons ~chain ~calls:subtree
              { Account_update.Poly.authorization = Control.Poly.None_given
              ; body =
                  Zkapps_examples.mk_update_body pk
@@ -420,7 +427,7 @@ let%test_module "Tokens test" =
              }
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~chain
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command
              ~expected_failure:(Update_not_permitted_access, Pass_2)

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -328,6 +328,7 @@ module Rules = struct
         State.Circuit.t
         * Zkapp_call_forest.Checked.account_update
         * Account_update.May_use_token.Checked.t =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let dummy_account_update_body = Lazy.force dummy_account_update_body in
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
@@ -342,7 +343,7 @@ module Rules = struct
         Zkapp_command.Digest.Tree.constant (Lazy.force dummy_tree_hash)
       in
       let (account_update, forest), rest_of_forest =
-        Zkapp_call_forest.Checked.pop ~dummy ~dummy_tree_hash forest
+        Zkapp_call_forest.Checked.pop ~chain ~dummy ~dummy_tree_hash forest
       in
       let rest_of_forest_is_empty =
         Zkapp_call_forest.Checked.is_empty rest_of_forest

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -85,6 +85,7 @@ module Rules = struct
           respond Unhandled
 
     let main input =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let public_key =
         exists Public_key.Compressed.typ ~request:(fun () -> Public_key)
       in
@@ -125,7 +126,8 @@ module Rules = struct
                  .to_account_update_and_calls
             in
             let digest =
-              Zkapp_command.Digest.Account_update.Checked.create final_update
+              Zkapp_command.Digest.Account_update.Checked.create ~chain
+                final_update
             in
             ( { Zkapp_call_forest.Checked.account_update =
                   { data = final_update; hash = digest }
@@ -157,10 +159,12 @@ module Rules = struct
   (** Rule to transfer tokens. *)
   module Transfer = struct
     let dummy_account_update_body =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       lazy
         (let dummy_body = Account_update.Body.dummy in
          { With_hash.data = dummy_body
-         ; hash = Zkapp_command.Digest.Account_update.create_body dummy_body
+         ; hash =
+             Zkapp_command.Digest.Account_update.create_body ~chain dummy_body
          } )
 
     let dummy_tree_hash =

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -787,6 +787,7 @@ end
 
 let insert_signatures pk_compressed sk
     ({ fee_payer; account_updates; memo } : Zkapp_command.t) : Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let transaction_commitment : Zkapp_command.Transaction_commitment.t =
     (* TODO: This is a pain. *)
     let account_updates_hash = Zkapp_command.Call_forest.hash account_updates in
@@ -806,7 +807,7 @@ let insert_signatures pk_compressed sk
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -826,7 +827,7 @@ let insert_signatures pk_compressed sk
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -226,6 +226,7 @@ module Account_update_under_construction = struct
 
     let to_account_update_and_calls (t : t) :
         Account_update.Body.Checked.t * Zkapp_call_forest.Checked.t =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       (* TODO: Don't do this. *)
       let var_of_t (type var value) (typ : (var, value) Typ.t) (x : value) : var
           =
@@ -301,7 +302,7 @@ module Account_update_under_construction = struct
         | Rev_calls rev_calls ->
             List.fold_left ~init:(Zkapp_call_forest.Checked.empty ()) rev_calls
               ~f:(fun acc (account_update, calls) ->
-                Zkapp_call_forest.Checked.push ~account_update ~calls acc )
+                Zkapp_call_forest.Checked.push ~chain ~account_update ~calls acc )
         | Calls calls ->
             calls
       in

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -486,13 +486,14 @@ type return_type =
 
 let to_account_update (account_update : account_update) :
     Zkapp_statement.Checked.t * return_type Prover_value.t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   dummy_constraints () ;
   let account_update, calls =
     Account_update_under_construction.In_circuit.to_account_update_and_calls
       account_update#account_update_under_construction
   in
   let account_update_digest =
-    Zkapp_command.Call_forest.Digest.Account_update.Checked.create
+    Zkapp_command.Call_forest.Digest.Account_update.Checked.create ~chain
       account_update
   in
   let public_output : Zkapp_statement.Checked.t =
@@ -799,6 +800,7 @@ let insert_signatures pk_compressed sk
       ~memo_hash
       ~fee_payer_hash:
         (Zkapp_command.Call_forest.Digest.Account_update.create
+           ~chain:signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let fee_payer =

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -68,6 +68,7 @@ let generate_test_ledger =
     exit 0)
 
 let validate_keypair =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   Command.async ~summary:"Validate a public, private keypair"
     (let open Command.Let_syntax in
     let open Core_kernel in
@@ -113,7 +114,7 @@ let validate_keypair =
       in
       let message = Mina_base.Signed_command.to_input_legacy dummy_payload in
       let verified =
-        Schnorr.Legacy.verify signature
+        Schnorr.Legacy.verify ~signature_kind signature
           (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
           message
       in

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -63,7 +63,7 @@ let signature_for_testnet = salt signature_testnet
 
 let signature_for_other chain_name = salt @@ signature_other chain_name
 
-let signature ?(signature_kind = Mina_signature_kind.t) =
+let signature ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet
@@ -79,7 +79,7 @@ let signature_for_testnet_legacy = salt_legacy signature_testnet
 let signature_for_other_legacy chain_name =
   salt_legacy @@ signature_other chain_name
 
-let signature_legacy ?(signature_kind = Mina_signature_kind.t) =
+let signature_legacy ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet_legacy
@@ -104,7 +104,8 @@ let zkapp_account = salt zkapp_account
 
 let zkapp_payload = salt zkapp_payload
 
-let zkapp_body ?(chain = Mina_signature_kind.t) = salt @@ zkapp_body ~chain
+let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
+  salt @@ zkapp_body ~chain
 
 let zkapp_precondition = salt zkapp_precondition
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -63,7 +63,7 @@ let signature_for_testnet = salt signature_testnet
 
 let signature_for_other chain_name = salt @@ signature_other chain_name
 
-let signature ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let signature ~(signature_kind : Mina_signature_kind.t) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet
@@ -79,7 +79,7 @@ let signature_for_testnet_legacy = salt_legacy signature_testnet
 let signature_for_other_legacy chain_name =
   salt_legacy @@ signature_other chain_name
 
-let signature_legacy ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let signature_legacy ~(signature_kind : Mina_signature_kind.t) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet_legacy
@@ -104,8 +104,7 @@ let zkapp_account = salt zkapp_account
 
 let zkapp_payload = salt zkapp_payload
 
-let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
-  salt @@ zkapp_body ~chain
+let zkapp_body ~chain = salt @@ zkapp_body ~chain
 
 let zkapp_precondition = salt zkapp_precondition
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -2,7 +2,7 @@ open Snark_params
 open Tick
 open Random_oracle
 
-val signature : ?signature_kind:Mina_signature_kind.t -> Field.t State.t
+val signature : signature_kind:Mina_signature_kind.t -> Field.t State.t
 
 val signature_for_mainnet : Field.t State.t
 
@@ -11,7 +11,7 @@ val signature_for_testnet : Field.t State.t
 val signature_for_other : string -> Field.t State.t
 
 val signature_legacy :
-  ?signature_kind:Mina_signature_kind.t -> Field.t Legacy.State.t
+  signature_kind:Mina_signature_kind.t -> Field.t Legacy.State.t
 
 val signature_for_mainnet_legacy : Field.t Legacy.State.t
 
@@ -50,7 +50,7 @@ val zkapp_account : Field.t State.t
 
 val zkapp_payload : Field.t State.t
 
-val zkapp_body : ?chain:Mina_signature_kind.t -> Field.t State.t
+val zkapp_body : chain:Mina_signature_kind.t -> Field.t State.t
 
 val zkapp_precondition : Field.t State.t
 

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -39,7 +39,7 @@ let zkapp_body_mainnet = create "MainnetZkappBody"
 
 let zkapp_body_testnet = create "TestnetZkappBody"
 
-let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
+let zkapp_body ~(chain : Mina_signature_kind.t) =
   match chain with
   | Mainnet ->
       zkapp_body_mainnet

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -39,7 +39,7 @@ let zkapp_body_mainnet = create "MainnetZkappBody"
 
 let zkapp_body_testnet = create "TestnetZkappBody"
 
-let zkapp_body ?(chain = Mina_signature_kind.t) =
+let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
   match chain with
   | Mainnet ->
       zkapp_body_mainnet

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1489,10 +1489,7 @@ module Body = struct
         ; Authorization_kind.Checked.to_input authorization_kind
         ]
 
-    let digest ?chain (t : t) =
-      let chain =
-        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
-      in
+    let digest ~chain (t : t) =
       Random_oracle.Checked.(
         hash ~init:(Hash_prefix.zkapp_body ~chain) (pack_input (to_input t)))
   end
@@ -1565,8 +1562,7 @@ module Body = struct
       ; Authorization_kind.to_input authorization_kind
       ]
 
-  let digest ?chain (t : t) =
-    let chain = Option.value chain ~default:Mina_signature_kind.t_DEPRECATED in
+  let digest ~chain (t : t) =
     Random_oracle.(
       hash ~init:(Hash_prefix.zkapp_body ~chain) (pack_input (to_input t)))
 
@@ -1734,12 +1730,12 @@ module T = struct
   let of_simple (p : Simple.t) : Stable.Latest.t =
     { body = Body.of_simple p.body; authorization = p.authorization }
 
-  let digest ?chain t = Body.digest ?chain t.Poly.body
+  let digest ~chain t = Body.digest ~chain t.Poly.body
 
   module Checked = struct
     type t = Body.Checked.t
 
-    let digest ?chain (t : t) = Body.Checked.digest ?chain t
+    let digest ~chain (t : t) = Body.Checked.digest ~chain t
   end
 end
 

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1490,8 +1490,11 @@ module Body = struct
         ]
 
     let digest ?chain (t : t) =
+      let chain =
+        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
+      in
       Random_oracle.Checked.(
-        hash ~init:(Hash_prefix.zkapp_body ?chain) (pack_input (to_input t)))
+        hash ~init:(Hash_prefix.zkapp_body ~chain) (pack_input (to_input t)))
   end
 
   let typ () : (Checked.t, t) Typ.t =
@@ -1563,8 +1566,9 @@ module Body = struct
       ]
 
   let digest ?chain (t : t) =
+    let chain = Option.value chain ~default:Mina_signature_kind.t_DEPRECATED in
     Random_oracle.(
-      hash ~init:(Hash_prefix.zkapp_body ?chain) (pack_input (to_input t)))
+      hash ~init:(Hash_prefix.zkapp_body ~chain) (pack_input (to_input t)))
 
   module Digested = struct
     type t = Random_oracle.Digest.t

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -168,7 +168,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let sign_payload ?signature_kind (private_key : Signature_lib.Private_key.t)
       (payload : Payload.t) : Signature.t =
-    Signature_lib.Schnorr.Legacy.sign ?signature_kind private_key
+    let signature_kind =
+      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+    in
+    Signature_lib.Schnorr.Legacy.sign ~signature_kind private_key
       (to_input_legacy payload)
 
   let sign ?signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t
@@ -411,7 +414,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
   include Codable.Make_base64 (Stable.Latest.With_top_version_tag)
 
   let check_signature ?signature_kind ({ payload; signer; signature } : t) =
-    Signature_lib.Schnorr.Legacy.verify ?signature_kind signature
+    let signature_kind =
+      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+    in
+    Signature_lib.Schnorr.Legacy.verify ~signature_kind signature
       (Snark_params.Tick.Inner_curve.of_affine signer)
       (to_input_legacy payload)
 

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -63,12 +63,13 @@ let update_body ?preconditions ?(update = Account_update.Update.noop) ~account
     }
 
 let update ?(calls = []) body =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let open With_stack_hash in
   let open Zkapp_command.Call_forest.Tree in
   { elt =
       { account_update = body
       ; account_update_digest =
-          Zkapp_command.Call_forest.Digest.Account_update.create body
+          Zkapp_command.Call_forest.Digest.Account_update.create ~chain body
       ; calls
       }
   ; stack_hash = Zkapp_command.Call_forest.Digest.Forest.empty

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -4,6 +4,7 @@ open Mina_base
 let different_version = Mina_numbers.Txn_version.(succ current)
 
 let update_vk_perm_to_be ~auth : Zkapp_command.t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let account_update : Account_update.t =
     { body =
         { Account_update.Body.dummy with
@@ -26,7 +27,7 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
     }
   in
   { fee_payer
-  ; account_updates = Zkapp_command.Call_forest.cons account_update []
+  ; account_updates = Zkapp_command.Call_forest.cons ~chain account_update []
   ; memo = Signed_command_memo.empty
   }
 

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -213,7 +213,7 @@ module Checked = struct
           : (account_update * t) * t ) )
 
   (* TODO Consider moving out of mina_base *)
-  let push
+  let push ~chain
       ~account_update:
         { account_update = { hash = account_update_hash; data = account_update }
         ; control = auth
@@ -237,7 +237,7 @@ module Checked = struct
               let account_update : Account_update.t = { body; authorization } in
               let calls = V.get calls in
               let res =
-                Zkapp_command.Call_forest.cons ~calls account_update tl
+                Zkapp_command.Call_forest.cons ~chain ~calls account_update tl
               in
               (* Sanity check; we're re-hashing anyway, might as well make sure it's
                  consistent.

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -44,6 +44,7 @@ module Checked = struct
       , (Account_update.t, Zkapp_command.Digest.Account_update.t) With_hash.t
       )
       Typ.t =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     let (Typ typ) =
       Typ.(
         Account_update.Body.typ () * Prover_value.typ ()
@@ -75,7 +76,7 @@ module Checked = struct
                 Field.Assert.equal
                   (hash :> Field.t)
                   ( Zkapp_command.Call_forest.Digest.Account_update.Checked
-                    .create account_update
+                    .create ~chain account_update
                     :> Field.t ) ) )
       }
 
@@ -102,6 +103,7 @@ module Checked = struct
   let empty () : t = { hash = empty; data = V.create (fun () -> []) }
 
   let pop_exn ({ hash = h; data = r } : t) : (account_update * t) * t =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop_exn" (fun () ->
         let hd_r =
           V.create (fun () -> V.get r |> List.hd_exn |> With_stack_hash.elt)
@@ -116,7 +118,8 @@ module Checked = struct
         in
         let account_update =
           With_hash.of_data account_update
-            ~hash_data:Zkapp_command.Digest.Account_update.Checked.create
+            ~hash_data:
+              (Zkapp_command.Digest.Account_update.Checked.create ~chain)
         in
         let subforest : t =
           let subforest = V.create (fun () -> (V.get hd_r).calls) in
@@ -146,6 +149,7 @@ module Checked = struct
 
   let pop ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
       (account_update * t) * t =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop" (fun () ->
         let hd_r =
           V.create (fun () ->
@@ -165,7 +169,8 @@ module Checked = struct
         in
         let account_update =
           With_hash.of_data account_update
-            ~hash_data:Zkapp_command.Digest.Account_update.Checked.create
+            ~hash_data:
+              (Zkapp_command.Digest.Account_update.Checked.create ~chain)
         in
         let subforest : t =
           let subforest = V.create (fun () -> (V.get hd_r).calls) in

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -16,7 +16,7 @@ let if_ = Zkapp_command.value_if
 
 let is_empty = List.is_empty
 
-let pop_exn : t -> (Account_update.t * t) * t = function
+let pop_exn ~chain:_ : t -> (Account_update.t * t) * t = function
   | { stack_hash = _
     ; elt = { account_update; calls; account_update_digest = _ }
     }
@@ -39,12 +39,11 @@ module Checked = struct
     ; control : Control.t Prover_value.t
     }
 
-  let account_update_typ () :
+  let account_update_typ ~chain () :
       ( account_update
       , (Account_update.t, Zkapp_command.Digest.Account_update.t) With_hash.t
       )
       Typ.t =
-    let chain = Mina_signature_kind.t_DEPRECATED in
     let (Typ typ) =
       Typ.(
         Account_update.Body.typ () * Prover_value.typ ()
@@ -102,8 +101,7 @@ module Checked = struct
 
   let empty () : t = { hash = empty; data = V.create (fun () -> []) }
 
-  let pop_exn ({ hash = h; data = r } : t) : (account_update * t) * t =
-    let chain = Mina_signature_kind.t_DEPRECATED in
+  let pop_exn ~chain ({ hash = h; data = r } : t) : (account_update * t) * t =
     with_label "Zkapp_call_forest.pop_exn" (fun () ->
         let hd_r =
           V.create (fun () -> V.get r |> List.hd_exn |> With_stack_hash.elt)
@@ -147,9 +145,8 @@ module Checked = struct
             } )
           : (account_update * t) * t ) )
 
-  let pop ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
+  let pop ~chain ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
       (account_update * t) * t =
-    let chain = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop" (fun () ->
         let hd_r =
           V.create (fun () ->

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -252,20 +252,30 @@ module Make_digest_str
     module Checked = struct
       include Checked
 
-      let create = Account_update.Checked.digest
+      let create ?chain =
+        let chain =
+          Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
+        in
+        Account_update.Checked.digest ~chain
 
-      let create_body = Account_update.Body.Checked.digest
+      let create_body ?chain =
+        let chain =
+          Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
+        in
+        Account_update.Body.Checked.digest ~chain
     end
 
-    let create :
-           ?chain:Mina_signature_kind.t
-        -> (Account_update.Body.t, _) Account_update.Poly.t
-        -> t =
-      Account_update.digest
+    let create ?chain : (Account_update.Body.t, _) Account_update.Poly.t -> t =
+      let chain =
+        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      Account_update.digest ~chain
 
-    let create_body : ?chain:Mina_signature_kind.t -> Account_update.Body.t -> t
-        =
-      Account_update.Body.digest
+    let create_body ?chain : Account_update.Body.t -> t =
+      let chain =
+        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      Account_update.Body.digest ~chain
   end
 
   module Forest = struct

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -134,20 +134,20 @@ module type Digest_intf = sig
     module Checked : sig
       include Digest_intf.S_checked
 
-      val create : ?chain:Mina_signature_kind.t -> Account_update.Checked.t -> t
+      val create : chain:Mina_signature_kind.t -> Account_update.Checked.t -> t
 
       val create_body :
-        ?chain:Mina_signature_kind.t -> Account_update.Body.Checked.t -> t
+        chain:Mina_signature_kind.t -> Account_update.Body.Checked.t -> t
     end
 
     include Digest_intf.S_aux with type t := t and type checked := Checked.t
 
     val create :
-         ?chain:Mina_signature_kind.t
+         chain:Mina_signature_kind.t
       -> (Account_update.Body.t, _) Account_update.Poly.t
       -> t
 
-    val create_body : ?chain:Mina_signature_kind.t -> Account_update.Body.t -> t
+    val create_body : chain:Mina_signature_kind.t -> Account_update.Body.t -> t
   end
 
   module rec Forest : sig
@@ -252,30 +252,20 @@ module Make_digest_str
     module Checked = struct
       include Checked
 
-      let create ?chain =
-        let chain =
-          Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
-        in
-        Account_update.Checked.digest ~chain
+      let create = Account_update.Checked.digest
 
-      let create_body ?chain =
-        let chain =
-          Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
-        in
-        Account_update.Body.Checked.digest ~chain
+      let create_body = Account_update.Body.Checked.digest
     end
 
-    let create ?chain : (Account_update.Body.t, _) Account_update.Poly.t -> t =
-      let chain =
-        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
-      in
-      Account_update.digest ~chain
+    let create :
+           chain:Mina_signature_kind.t
+        -> (Account_update.Body.t, _) Account_update.Poly.t
+        -> t =
+      Account_update.digest
 
-    let create_body ?chain : Account_update.Body.t -> t =
-      let chain =
-        Option.value chain ~default:Mina_signature_kind.t_DEPRECATED
-      in
-      Account_update.Body.digest ~chain
+    let create_body : chain:Mina_signature_kind.t -> Account_update.Body.t -> t
+        =
+      Account_update.Body.digest
   end
 
   module Forest = struct
@@ -480,8 +470,10 @@ let cons_aux (type p) ~(digest_account_update : p -> _) ?(calls = [])
   cons_tree tree xs
 
 let cons ?calls (account_update : Account_update.t) xs =
-  cons_aux ~digest_account_update:Digest.Account_update.create ?calls
-    account_update xs
+  let chain = Mina_signature_kind.t_DEPRECATED in
+  cons_aux
+    ~digest_account_update:(Digest.Account_update.create ~chain)
+    ?calls account_update xs
 
 let rec accumulate_hashes ~hash_account_update (xs : _ t) =
   let go = accumulate_hashes ~hash_account_update in
@@ -505,13 +497,17 @@ let rec accumulate_hashes ~hash_account_update (xs : _ t) =
 
 let accumulate_hashes' (type a b) (xs : (Account_update.t, a, b) t) :
     (Account_update.t, Digest.Account_update.t, Digest.Forest.t) t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let hash_account_update (p : Account_update.t) =
-    Digest.Account_update.create p
+    Digest.Account_update.create ~chain p
   in
   accumulate_hashes ~hash_account_update xs
 
 let accumulate_hashes_predicated xs =
-  accumulate_hashes ~hash_account_update:Digest.Account_update.create xs
+  let chain = Mina_signature_kind.t_DEPRECATED in
+  accumulate_hashes
+    ~hash_account_update:(Digest.Account_update.create ~chain)
+    xs
 
 let forget_hashes =
   let rec impl = List.map ~f:forget_digest
@@ -550,7 +546,8 @@ module With_hashes_and_data = struct
   let empty = Digest.Forest.empty
 
   let hash_account_update ((p : Account_update.Stable.Latest.t), _) =
-    Digest.Account_update.create p
+    let chain = Mina_signature_kind.t_DEPRECATED in
+    Digest.Account_update.create ~chain p
 
   let accumulate_hashes xs : _ t = accumulate_hashes ~hash_account_update xs
 
@@ -604,7 +601,9 @@ module With_hashes = struct
 
   let empty = Digest.Forest.empty
 
-  let hash_account_update p = Digest.Account_update.create p
+  let hash_account_update p =
+    let chain = Mina_signature_kind.t_DEPRECATED in
+    Digest.Account_update.create ~chain p
 
   let accumulate_hashes xs = accumulate_hashes ~hash_account_update xs
 

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -469,8 +469,7 @@ let cons_aux (type p) ~(digest_account_update : p -> _) ?(calls = [])
   let tree : _ Tree.t = { account_update; account_update_digest; calls } in
   cons_tree tree xs
 
-let cons ?calls (account_update : Account_update.t) xs =
-  let chain = Mina_signature_kind.t_DEPRECATED in
+let cons ~chain ?calls (account_update : Account_update.t) xs =
   cons_aux
     ~digest_account_update:(Digest.Account_update.create ~chain)
     ?calls account_update xs
@@ -495,16 +494,14 @@ let rec accumulate_hashes ~hash_account_update (xs : _ t) =
       let node_hash = Digest.Tree.create node in
       { elt = node; stack_hash = Digest.Forest.cons node_hash (hash xs) } :: xs
 
-let accumulate_hashes' (type a b) (xs : (Account_update.t, a, b) t) :
+let accumulate_hashes' (type a b) ~chain (xs : (Account_update.t, a, b) t) :
     (Account_update.t, Digest.Account_update.t, Digest.Forest.t) t =
-  let chain = Mina_signature_kind.t_DEPRECATED in
   let hash_account_update (p : Account_update.t) =
     Digest.Account_update.create ~chain p
   in
   accumulate_hashes ~hash_account_update xs
 
-let accumulate_hashes_predicated xs =
-  let chain = Mina_signature_kind.t_DEPRECATED in
+let accumulate_hashes_predicated ~chain xs =
   accumulate_hashes
     ~hash_account_update:(Digest.Account_update.create ~chain)
     xs
@@ -545,11 +542,11 @@ module With_hashes_and_data = struct
 
   let empty = Digest.Forest.empty
 
-  let hash_account_update ((p : Account_update.Stable.Latest.t), _) =
-    let chain = Mina_signature_kind.t_DEPRECATED in
+  let hash_account_update ~chain ((p : Account_update.Stable.Latest.t), _) =
     Digest.Account_update.create ~chain p
 
-  let accumulate_hashes xs : _ t = accumulate_hashes ~hash_account_update xs
+  let accumulate_hashes ~chain xs : _ t =
+    accumulate_hashes ~hash_account_update:(hash_account_update ~chain) xs
 
   let of_zkapp_command_simple_list (xs : (Account_update.Simple.t * 'a) list) =
     of_account_updates xs
@@ -558,21 +555,21 @@ module With_hashes_and_data = struct
     |> map ~f:(fun (p, x) -> (Account_update.of_simple p, x))
     |> accumulate_hashes
 
-  let of_account_updates (xs : (Account_update.Graphql_repr.t * 'a) list) : _ t
-      =
+  let of_account_updates ~chain (xs : (Account_update.Graphql_repr.t * 'a) list)
+      : _ t =
     of_account_updates_map
       ~account_update_depth:(fun ((p : Account_update.Graphql_repr.t), _) ->
         p.body.call_depth )
       ~f:(fun (p, x) -> (Account_update.of_graphql_repr p, x))
       xs
-    |> accumulate_hashes
+    |> accumulate_hashes ~chain
 
   let to_account_updates (x : _ t) = to_account_updates x
 
   let to_zkapp_command_with_hashes_list (x : _ t) =
     to_zkapp_command_with_hashes_list x
 
-  let account_updates_hash' xs = of_account_updates xs |> hash
+  let account_updates_hash' ~chain xs = of_account_updates ~chain xs |> hash
 
   let account_updates_hash xs =
     List.map ~f:(fun x -> (x, ())) xs |> account_updates_hash'

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -151,13 +151,14 @@ let map_proofs ~(f : 'p -> 'q)
   }
 
 let write_all_proofs_to_disk (w : Stable.Latest.t) : t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   { fee_payer = w.fee_payer
   ; memo = w.memo
   ; account_updates =
       w.account_updates
       |> Call_forest.accumulate_hashes
            ~hash_account_update:(fun (p : Account_update.t) ->
-             Digest.Account_update.create p )
+             Digest.Account_update.create ~chain p )
   }
 
 let read_all_proofs_from_disk (t : t) : Stable.Latest.t =
@@ -178,6 +179,7 @@ let forget_digests_and_proofs
 [%%define_locally Stable.Latest.(gen)]
 
 let of_simple (w : Simple.t) : t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   { fee_payer = w.fee_payer
   ; memo = w.memo
   ; account_updates =
@@ -187,7 +189,7 @@ let of_simple (w : Simple.t) : t =
       |> Call_forest.map ~f:Account_update.of_simple
       |> Call_forest.accumulate_hashes
            ~hash_account_update:(fun (p : Account_update.t) ->
-             Digest.Account_update.create p )
+             Digest.Account_update.create ~chain p )
   }
 
 let to_simple (t : t) : Simple.t =
@@ -220,6 +222,7 @@ let to_simple (t : t) : Simple.t =
   }
 
 let all_account_updates t : _ Call_forest.t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let p = t.Poly.fee_payer in
   let body = Account_update.Body.of_fee_payer p.body in
   let account_update =
@@ -228,7 +231,7 @@ let all_account_updates t : _ Call_forest.t =
     }
   in
   let fee_payer_digest : Digest.Account_update.t =
-    Digest.Account_update.create account_update
+    Digest.Account_update.create ~chain account_update
   in
   let tree : _ Call_forest.Tree.t =
     { account_update; account_update_digest = fee_payer_digest; calls = [] }
@@ -1039,7 +1042,7 @@ end = struct
             ~spec:(zkapp_segment_of_controls [ a1 ])
             ~before ~after
           :: acc
-      | ( ({ Account_update.Poly.authorization = Control.Poly.Proof _ as a1; _ }
+      | ( ( { Account_update.Poly.authorization = Control.Poly.Proof _ as a1; _ }
           :: zkapp_command )
           :: zkapp_commands
         , (before :: (after :: _ as stmts)) :: stmtss ) ->
@@ -1053,7 +1056,7 @@ end = struct
             :: acc )
       | ( []
           :: ({ authorization = Proof _ as a1; _ } :: zkapp_command)
-             :: zkapp_commands
+          :: zkapp_commands
         , [ _ ] :: (before :: (after :: _ as stmts)) :: stmtss ) ->
           (* This account_update is part of a new transaction, and contains a proof, don't
              pair it with other account updates.
@@ -1065,7 +1068,7 @@ end = struct
                 ~spec:(zkapp_segment_of_controls [ a1 ])
                 ~before ~after
             :: acc )
-      | ( ({ authorization = a1; _ }
+      | ( ( { authorization = a1; _ }
           :: ({ authorization = Proof _; _ } :: _ as zkapp_command) )
           :: zkapp_commands
         , (before :: (after :: _ as stmts)) :: stmtss ) ->
@@ -1090,9 +1093,9 @@ end = struct
                 ~spec:(zkapp_segment_of_controls [ a1 ])
                 ~before ~after
             :: acc )
-      | ( ({ authorization = (Signature _ | None_given) as a1; _ }
+      | ( ( { authorization = (Signature _ | None_given) as a1; _ }
           :: { authorization = (Signature _ | None_given) as a2; _ }
-             :: zkapp_command )
+          :: zkapp_command )
           :: zkapp_commands
         , (before :: _ :: (after :: _ as stmts)) :: stmtss ) ->
           (* The next two zkapp_command do not contain proofs, and are within the same
@@ -1108,9 +1111,9 @@ end = struct
                 ~before ~after
             :: acc )
       | ( []
-          :: ({ authorization = a1; _ }
+          :: ( { authorization = a1; _ }
              :: ({ authorization = Proof _; _ } :: _ as zkapp_command) )
-             :: zkapp_commands
+          :: zkapp_commands
         , [ _ ] :: (before :: (after :: _ as stmts)) :: stmtss ) ->
           (* This account_update is in the next transaction, and the next account_update contains a
              proof, don't pair it with this account_update.
@@ -1123,10 +1126,10 @@ end = struct
                 ~before ~after
             :: acc )
       | ( []
-          :: ({ authorization = (Signature _ | None_given) as a1; _ }
+          :: ( { authorization = (Signature _ | None_given) as a1; _ }
              :: { authorization = (Signature _ | None_given) as a2; _ }
-                :: zkapp_command )
-             :: zkapp_commands
+             :: zkapp_command )
+          :: zkapp_commands
         , [ _ ] :: (before :: _ :: (after :: _ as stmts)) :: stmtss ) ->
           (* The next two zkapp_command do not contain proofs, and are within the same
              new transaction. Pair them.
@@ -1141,9 +1144,9 @@ end = struct
                 ~before ~after
             :: acc )
       | ( [ { authorization = (Signature _ | None_given) as a1; _ } ]
-          :: ({ authorization = (Signature _ | None_given) as a2; _ }
+          :: ( { authorization = (Signature _ | None_given) as a2; _ }
              :: zkapp_command )
-             :: zkapp_commands
+          :: zkapp_commands
         , (before :: _after1) :: (_before2 :: (after :: _ as stmts)) :: stmtss )
         ->
           (* The next two zkapp_command do not contain proofs, and the second is within
@@ -1160,7 +1163,7 @@ end = struct
             :: acc )
       | ( []
           :: ({ authorization = a1; _ } :: zkapp_command)
-             :: (({ authorization = Proof _; _ } :: _) :: _ as zkapp_commands)
+          :: (({ authorization = Proof _; _ } :: _) :: _ as zkapp_commands)
         , [ _ ] :: (before :: ([ after ] as stmts)) :: (_ :: _ as stmtss) ) ->
           (* The next transaction contains a proof, and this account_update is in a new
              transaction, don't pair it with the next account_update.
@@ -1174,12 +1177,13 @@ end = struct
             :: acc )
       | ( []
           :: [ { authorization = (Signature _ | None_given) as a1; _ } ]
-             :: ({ authorization = (Signature _ | None_given) as a2; _ }
-                :: zkapp_command )
-                :: zkapp_commands
+          :: ( { authorization = (Signature _ | None_given) as a2; _ }
+             :: zkapp_command )
+          :: zkapp_commands
         , [ _ ]
           :: [ before; _after1 ]
-             :: (_before2 :: (after :: _ as stmts)) :: stmtss ) ->
+          :: (_before2 :: (after :: _ as stmts))
+          :: stmtss ) ->
           (* The next two zkapp_command do not contain proofs, the first is within a
              new transaction, and the second is within another new transaction.
              Pair them.
@@ -1400,10 +1404,11 @@ let is_incompatible_version
           not Mina_numbers.Txn_version.(equal_to_current txn_version) )
 
 let get_transaction_commitments (zkapp_command : _ Poly.t) =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let memo_hash = Signed_command_memo.hash zkapp_command.memo in
   let fee_payer_hash =
     Account_update.of_fee_payer zkapp_command.fee_payer
-    |> Digest.Account_update.create
+    |> Digest.Account_update.create ~chain
   in
   let account_updates_hash = account_updates_hash zkapp_command in
   let txn_commitment = Transaction_commitment.create ~account_updates_hash in

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -920,6 +920,7 @@ let arg_query_string x =
   Fields_derivers_zkapps.Test.Loop.json_to_string_gql @@ to_json x
 
 let dummy =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   lazy
     (let account_update =
        { Account_update.Poly.body = Account_update.Body.dummy
@@ -932,7 +933,7 @@ let dummy =
        }
      in
      { Poly.fee_payer
-     ; account_updates = Call_forest.cons account_update []
+     ; account_updates = Call_forest.cons ~chain account_update []
      ; memo = Signed_command_memo.empty
      } )
 

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -27,7 +27,9 @@ module User_command = struct
     module V1 = struct
       type t = User_command.Stable.V2.t [@@deriving sexp]
 
-      let to_yojson : t -> Yojson.Safe.t = function
+      let to_yojson : t -> Yojson.Safe.t =
+        let chain = Mina_signature_kind.t_DEPRECATED in
+        function
         | User_command.Poly.Signed_command tx ->
             Helper.to_yojson ~proof_to_yojson:Proof.to_yojson (Signed_command tx)
         | User_command.Poly.Zkapp_command { fee_payer; memo; account_updates }
@@ -39,7 +41,8 @@ module User_command = struct
                  ; account_updates =
                      Zkapp_command.(
                        Call_forest.accumulate_hashes
-                         ~hash_account_update:Digest.Account_update.create)
+                         ~hash_account_update:
+                           (Digest.Account_update.create ~chain))
                        account_updates
                  } )
 

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1134,6 +1134,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
     ?account_state_tbl ~ledger ?protocol_state_view ?vk ?available_public_keys
     ~genesis_constants
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) () =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let open Quickcheck.Let_syntax in
   let fee_payer_pk =
     Signature_lib.Public_key.compress fee_payer_keypair.public_key
@@ -1538,7 +1539,7 @@ let gen_zkapp_command_from ?global_slot ?memo ?(no_account_precondition = false)
         Zkapp_command.Call_forest.map
           ~f:(Fn.compose map_account_update Account_update.of_simple)
           account_updates
-        |> Zkapp_command.Call_forest.accumulate_hashes_predicated
+        |> Zkapp_command.Call_forest.accumulate_hashes_predicated ~chain
     ; memo
     }
   in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2873,7 +2873,7 @@ module Queries = struct
       ~typ:(non_null string)
       ~args:Arg.[]
       ~resolve:(fun _ () ->
-        match Mina_signature_kind.t with
+        match Mina_signature_kind.t_DEPRECATED with
         | Mainnet ->
             "mainnet"
         | Testnet ->

--- a/src/lib/signature_kind/compile_config/mina_signature_kind.ml
+++ b/src/lib/signature_kind/compile_config/mina_signature_kind.ml
@@ -1,6 +1,6 @@
 include Mina_signature_kind_type
 
-let t =
+let t_DEPRECATED =
   match Node_config.network with
   | "testnet" ->
       Testnet

--- a/src/lib/signature_kind/mainnet/mina_signature_kind.ml
+++ b/src/lib/signature_kind/mainnet/mina_signature_kind.ml
@@ -1,3 +1,3 @@
 include Mina_signature_kind_type
 
-let t = Mainnet
+let t_DEPRECATED = Mainnet

--- a/src/lib/signature_kind/mina_signature_kind.mli
+++ b/src/lib/signature_kind/mina_signature_kind.mli
@@ -3,4 +3,6 @@ type t = Mina_signature_kind_type.t =
   | Mainnet
   | Other_network of string
 
-val t : t
+(** The Mina_signature_kind_type in the compiled config. Deprecated - will be
+    replaced by a runtime-derived value. *)
+val t_DEPRECATED : t

--- a/src/lib/signature_kind/testnet/mina_signature_kind.ml
+++ b/src/lib/signature_kind/testnet/mina_signature_kind.ml
@@ -1,3 +1,3 @@
 include Mina_signature_kind_type
 
-let t = Testnet
+let t_DEPRECATED = Testnet

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -305,7 +305,7 @@ module Message = struct
   let network_id_other chain_name = chain_name
 
   let network_id =
-    match Mina_signature_kind.t with
+    match Mina_signature_kind.t_DEPRECATED with
     | Mainnet ->
         network_id_mainnet
     | Testnet ->
@@ -335,7 +335,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t) =
+    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
       make_derive
         ~network_id:
           ( match signature_kind with
@@ -409,7 +409,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t) =
+    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
       make_derive
         ~network_id:
           ( match signature_kind with

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -362,7 +362,10 @@ module Message = struct
       |> Inner_curve.Scalar.of_bits
 
     let hash ?signature_kind =
-      make_hash ~init:(Hash_prefix_states.signature_legacy ?signature_kind)
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      make_hash ~init:(Hash_prefix_states.signature_legacy ~signature_kind)
 
     let hash_for_mainnet =
       make_hash ~init:Hash_prefix_states.signature_for_mainnet_legacy
@@ -378,10 +381,11 @@ module Message = struct
         Random_oracle.Input.Legacy.append t
           { field_elements = [| px; py; r |]; bitstrings = [||] }
       in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       make_checked (fun () ->
           let open Random_oracle.Legacy.Checked in
           hash
-            ~init:(Hash_prefix_states.signature_legacy ?signature_kind:None)
+            ~init:(Hash_prefix_states.signature_legacy ~signature_kind)
             (pack_input input)
           |> Digest.to_bits ~length:Field.size_in_bits
           |> Bitstring_lib.Bitstring.Lsb_first.of_list )
@@ -436,7 +440,10 @@ module Message = struct
       |> Inner_curve.Scalar.of_bits
 
     let hash ?signature_kind =
-      make_hash ~init:(Hash_prefix_states.signature ?signature_kind)
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      make_hash ~init:(Hash_prefix_states.signature ~signature_kind)
 
     let hash_for_mainnet =
       make_hash ~init:Hash_prefix_states.signature_for_mainnet
@@ -452,10 +459,11 @@ module Message = struct
         Random_oracle.Input.Chunked.append t
           { field_elements = [| px; py; r |]; packeds = [||] }
       in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       make_checked (fun () ->
           let open Random_oracle.Checked in
           hash
-            ~init:(Hash_prefix_states.signature ?signature_kind:None)
+            ~init:(Hash_prefix_states.signature ~signature_kind)
             (pack_input input)
           |> Digest.to_bits ~length:Field.size_in_bits
           |> Bitstring_lib.Bitstring.Lsb_first.of_list )

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -11,7 +11,7 @@ module type Message_intf = sig
   type curve_scalar
 
   val derive :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> t
     -> private_key:curve_scalar
     -> public_key:curve
@@ -24,7 +24,7 @@ module type Message_intf = sig
     t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
 
   val hash :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> t
     -> public_key:curve
     -> r:field
@@ -121,13 +121,13 @@ module type S = sig
   val compress : curve -> bool list
 
   val sign :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> Private_key.t
     -> Message.t
     -> Signature.t
 
   val verify :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> Signature.t
     -> Public_key.t
     -> Message.t
@@ -222,25 +222,25 @@ module Make
 
   let is_even (t : Field.t) = not (Bigint.test_bit (Bigint.of_field t) 0)
 
-  let sign ?signature_kind (d_prime : Private_key.t) (m : Message.t) =
+  let sign ~signature_kind (d_prime : Private_key.t) (m : Message.t) =
     let public_key =
       (* TODO: Don't recompute this. *) Curve.scale Curve.one d_prime
     in
     (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
     let d = d_prime in
-    let derive = Message.derive ?signature_kind in
+    let derive = Message.derive ~signature_kind in
     let k_prime = derive m ~public_key ~private_key:d in
     assert (not Curve.Scalar.(equal k_prime zero)) ;
     let r, ry = Curve.(to_affine_exn (scale Curve.one k_prime)) in
     let k = if is_even ry then k_prime else Curve.Scalar.negate k_prime in
-    let hash = Message.hash ?signature_kind in
+    let hash = Message.hash ~signature_kind in
     let e = hash m ~public_key ~r in
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
-  let verify ?signature_kind ((r, s) : Signature.t) (pk : Public_key.t)
+  let verify ~signature_kind ((r, s) : Signature.t) (pk : Public_key.t)
       (m : Message.t) =
-    let hash = Message.hash ?signature_kind in
+    let hash = Message.hash ~signature_kind in
     let e = hash ~public_key:pk ~r m in
     let r_pt = Curve.(scale one s + negate (scale pk e)) in
     match Curve.to_affine_exn r_pt with
@@ -304,15 +304,6 @@ module Message = struct
 
   let network_id_other chain_name = chain_name
 
-  let network_id =
-    match Mina_signature_kind.t_DEPRECATED with
-    | Mainnet ->
-        network_id_mainnet
-    | Testnet ->
-        network_id_testnet
-    | Other_network chain_name ->
-        network_id_other chain_name
-
   module Legacy = struct
     open Tick
 
@@ -335,7 +326,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+    let derive ~(signature_kind : Mina_signature_kind.t) =
       make_derive
         ~network_id:
           ( match signature_kind with
@@ -361,10 +352,7 @@ module Message = struct
       |> Digest.to_bits ~length:Field.size_in_bits
       |> Inner_curve.Scalar.of_bits
 
-    let hash ?signature_kind =
-      let signature_kind =
-        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-      in
+    let hash ~signature_kind =
       make_hash ~init:(Hash_prefix_states.signature_legacy ~signature_kind)
 
     let hash_for_mainnet =
@@ -413,7 +401,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+    let derive ~(signature_kind : Mina_signature_kind.t) =
       make_derive
         ~network_id:
           ( match signature_kind with
@@ -439,10 +427,7 @@ module Message = struct
       |> Digest.to_bits ~length:Field.size_in_bits
       |> Inner_curve.Scalar.of_bits
 
-    let hash ?signature_kind =
-      let signature_kind =
-        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-      in
+    let hash ~signature_kind =
       make_hash ~init:(Hash_prefix_states.signature ~signature_kind)
 
     let hash_for_mainnet =
@@ -529,10 +514,11 @@ let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
     ~value_of_hlist:of_hlist
 
 let%test_unit "schnorr checked + unchecked" =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   Quickcheck.test ~trials:5 gen_legacy ~f:(fun (pk, msg) ->
-      let s = Legacy.sign pk msg in
+      let s = Legacy.sign ~signature_kind pk msg in
       let pubkey = Tick.Inner_curve.(scale one pk) in
-      assert (Legacy.verify s pubkey msg) ;
+      assert (Legacy.verify ~signature_kind s pubkey msg) ;
       (Tick.Test.test_equal ~sexp_of_t:[%sexp_of: bool] ~equal:Bool.equal
          Tick.Typ.(
            tuple3 Tick.Inner_curve.typ (legacy_message_typ ())
@@ -548,10 +534,11 @@ let%test_unit "schnorr checked + unchecked" =
         (pubkey, msg, s) )
 
 let%test_unit "schnorr checked + unchecked" =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   Quickcheck.test ~trials:5 gen_chunked ~f:(fun (pk, msg) ->
-      let s = Chunked.sign pk msg in
+      let s = Chunked.sign ~signature_kind pk msg in
       let pubkey = Tick.Inner_curve.(scale one pk) in
-      assert (Chunked.verify s pubkey msg) ;
+      assert (Chunked.verify ~signature_kind s pubkey msg) ;
       (Tick.Test.test_equal ~sexp_of_t:[%sexp_of: bool] ~equal:Bool.equal
          Tick.Typ.(
            tuple3 Tick.Inner_curve.typ (chunked_message_typ ())

--- a/src/lib/signature_lib/test/signature_lib_tests.ml
+++ b/src/lib/signature_lib/test/signature_lib_tests.ml
@@ -2,6 +2,8 @@ open Signature_lib
 
 let%test_module "Signatures are unchanged test" =
   ( module struct
+    let signature_kind = Mina_signature_kind.t_DEPRECATED
+
     let privkey =
       Private_key.of_base58_check_exn
         "EKE2M5q5afTtdzZTzyKu89Pzc7274BD6fm2fsDLgLt5zy34TAN5N"
@@ -15,7 +17,7 @@ let%test_module "Signatures are unchanged test" =
 
     let%test "signature of empty random oracle input matches" =
       let signature_got =
-        Schnorr.Legacy.sign privkey
+        Schnorr.Legacy.sign ~signature_kind privkey
           (Random_oracle_input.Legacy.field_elements [||])
       in
       Snark_params.Tick.Field.equal (fst signature_expected) (fst signature_got)
@@ -24,7 +26,7 @@ let%test_module "Signatures are unchanged test" =
 
     let%test "signature of signature matches" =
       let signature_got =
-        Schnorr.Legacy.sign privkey
+        Schnorr.Legacy.sign ~signature_kind privkey
           (Random_oracle_input.Legacy.field_elements
              [| fst signature_expected |] )
       in

--- a/src/lib/string_sign/string_sign.ml
+++ b/src/lib/string_sign/string_sign.ml
@@ -53,14 +53,14 @@ let string_to_input s =
     ; bitstrings = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s)))
     }
 
-let verify ?signature_kind signature pk s =
+let verify ~signature_kind signature pk s =
   let m = string_to_input s in
   let inner_curve = Inner_curve.of_affine pk in
-  Schnorr.Legacy.verify ?signature_kind signature inner_curve m
+  Schnorr.Legacy.verify ~signature_kind signature inner_curve m
 
-let sign ?signature_kind sk s =
+let sign ~signature_kind sk s =
   let m = string_to_input s in
-  Schnorr.Legacy.sign ?signature_kind sk m
+  Schnorr.Legacy.sign ~signature_kind sk m
 
 let%test_module "Sign_string tests" =
   ( module struct
@@ -77,11 +77,12 @@ let%test_module "Sign_string tests" =
       { public_key; private_key }
 
     let%test "Sign, verify with default network" =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let s =
         "Now is the time for all good men to come to the aid of their party"
       in
-      let signature = sign keypair.private_key s in
-      verify signature keypair.public_key s
+      let signature = sign ~signature_kind keypair.private_key s in
+      verify ~signature_kind signature keypair.public_key s
 
     let%test "Sign, verify with mainnet" =
       let s = "Rain and Spain don't rhyme with cheese" in

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2424,6 +2424,7 @@ module For_tests = struct
       ?(double_sender_nonce = true)
       { Transaction_spec.fee; sender = sender, sender_nonce; receiver; amount }
       : Zkapp_command.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let sender_pk = Public_key.compress sender.public_key in
     let actual_nonce =
       (* Here, we double the spec'd nonce, because we bump the nonce a second
@@ -2518,7 +2519,7 @@ module For_tests = struct
     in
     let account_updates_signature =
       let c = if use_full_commitment then full_commitment else commitment in
-      Schnorr.Chunked.sign sender.private_key
+      Schnorr.Chunked.sign ~signature_kind sender.private_key
         (Random_oracle.Input.Chunked.field c)
     in
     let account_updates =
@@ -2533,7 +2534,7 @@ module For_tests = struct
               account_update )
     in
     let signature =
-      Schnorr.Chunked.sign sender.private_key
+      Schnorr.Chunked.sign ~signature_kind sender.private_key
         (Random_oracle.Input.Chunked.field full_commitment)
     in
     { zkapp_command with

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -955,9 +955,10 @@ module Make (L : Ledger_intf.S) :
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
 
       let full_commitment ~account_update ~memo_hash ~commitment =
+        let chain = Mina_signature_kind.t_DEPRECATED in
         (* when called from Zkapp_command_logic.apply, the account_update is the fee payer *)
         let fee_payer_hash =
-          Zkapp_command.Digest.Account_update.create account_update
+          Zkapp_command.Digest.Account_update.create ~chain account_update
         in
         Zkapp_command.Transaction_commitment.create_complete commitment
           ~memo_hash ~fee_payer_hash
@@ -2514,7 +2515,7 @@ module For_tests = struct
       Zkapp_command.Transaction_commitment.create_complete commitment
         ~memo_hash:(Signed_command_memo.hash zkapp_command.memo)
         ~fee_payer_hash:
-          (Zkapp_command.Digest.Account_update.create
+          (Zkapp_command.Digest.Account_update.create ~chain:signature_kind
              (Account_update.of_fee_payer zkapp_command.fee_payer) )
     in
     let account_updates_signature =

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -240,7 +240,7 @@ module type S = sig
 
       val is_empty : t -> bool
 
-      val pop_exn : t -> Elt.t * t
+      val pop_exn : chain:Mina_signature_kind.t -> t -> Elt.t * t
 
       val pop : t -> (Elt.t * t) option
 
@@ -1470,7 +1470,7 @@ module Make (L : Ledger_intf.S) :
 
       let is_empty = List.is_empty
 
-      let pop_exn : t -> Elt.t * t = function
+      let pop_exn ~chain:_ : t -> Elt.t * t = function
         | [] ->
             failwith "pop_exn"
         | x :: xs ->

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -474,7 +474,7 @@ module type Stack_intf = sig
 
   val is_empty : t -> bool
 
-  val pop_exn : t -> elt * t
+  val pop_exn : chain:Mina_signature_kind.t -> t -> elt * t
 
   val pop : t -> (elt * t) Opt.t
 
@@ -492,7 +492,7 @@ module type Call_forest_intf = sig
 
   val is_empty : t -> bool
 
-  val pop_exn : t -> (account_update * t) * t
+  val pop_exn : chain:Mina_signature_kind.t -> t -> (account_update * t) * t
 end
 
 module type Stack_frame_intf = sig
@@ -1012,6 +1012,7 @@ module Make (Inputs : Inputs_intf) = struct
       (* The stack for the most recent zkApp *)
         (call_stack : Call_stack.t) (* The partially-completed parent stacks *)
       : get_next_account_update_result =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     (* If the current stack is complete, 'return' to the previous
        partially-completed one.
     *)
@@ -1030,7 +1031,7 @@ module Make (Inputs : Inputs_intf) = struct
       )
     in
     let (account_update, account_update_forest), remainder_of_current_forest =
-      Call_forest.pop_exn (Stack_frame.calls current_forest)
+      Call_forest.pop_exn ~chain (Stack_frame.calls current_forest)
     in
     let may_use_parents_own_token =
       Account_update.may_use_parents_own_token account_update

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -47,6 +47,7 @@ let%test_module "Access permission tests" =
     let memo = Signed_command_memo.empty
 
     let run_test ?expected_failure auth_kind access_permission =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let account_update : Account_update.t =
         match auth_kind with
         | Account_update.Authorization_kind.Proof _ ->
@@ -140,7 +141,7 @@ let%test_module "Access permission tests" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -160,7 +161,7 @@ let%test_module "Access permission tests" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -103,8 +103,9 @@ let%test_module "Access permission tests" =
       in
       let account_updates =
         []
-        |> Zkapp_command.Call_forest.cons account_update
-        |> Zkapp_command.Call_forest.cons deploy_account_update
+        |> Zkapp_command.Call_forest.cons ~chain:signature_kind account_update
+        |> Zkapp_command.Call_forest.cons ~chain:signature_kind
+             deploy_account_update
       in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -129,7 +129,7 @@ let%test_module "Access permission tests" =
           transaction_commitment
           ~memo_hash:(Signed_command_memo.hash memo)
           ~fee_payer_hash:
-            (Zkapp_command.Digest.Account_update.create
+            (Zkapp_command.Digest.Account_update.create ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       (* TODO: Make this better. *)

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -393,6 +393,7 @@ let%test_module "multisig_account" =
                   [ sender_account_update_data; snapp_account_update_data ]
                 |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
                 |> Zkapp_command.Call_forest.accumulate_hashes_predicated
+                     ~chain:signature_kind
               in
               let account_updates_hash = Zkapp_command.Call_forest.hash ps in
               let transaction : Zkapp_command.Transaction_commitment.t =

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -402,7 +402,7 @@ let%test_module "multisig_account" =
               in
               let tx_statement : Zkapp_statement.t =
                 { account_update =
-                    Account_update.Body.digest
+                    Account_update.Body.digest ~chain:signature_kind
                       (Account_update.of_simple snapp_account_update_data).body
                 ; calls = (Zkapp_command.Digest.Forest.empty :> field)
                 }

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -443,6 +443,7 @@ let%test_module "multisig_account" =
                     ~memo_hash:(Signed_command_memo.hash memo)
                     ~fee_payer_hash:
                       (Zkapp_command.Digest.Account_update.create
+                         ~chain:signature_kind
                          (Account_update.of_fee_payer fee_payer) )
                 in
                 { fee_payer with

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -76,6 +76,7 @@ let%test_module "multisig_account" =
           >>= fun () -> verify_sigs pubkeys commitment witness
 
       let%test_unit "1-of-1" =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
         let gen =
           let open Quickcheck.Generator.Let_syntax in
           let%map sk = Private_key.gen and msg = Field.gen_uniform in
@@ -86,7 +87,7 @@ let%test_module "multisig_account" =
             (let%bind pk_var =
                exists Inner_curve.typ ~compute:(As_prover.return pk)
              in
-             let sigma = Schnorr.Chunked.sign sk msg in
+             let sigma = Schnorr.Chunked.sign ~signature_kind sk msg in
              let%bind sigma_var =
                exists Schnorr.Chunked.Signature.typ
                  ~compute:(As_prover.return sigma)
@@ -102,6 +103,7 @@ let%test_module "multisig_account" =
             |> run_and_check |> Or_error.ok_exn )
 
       let%test_unit "2-of-2" =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
         let gen =
           let open Quickcheck.Generator.Let_syntax in
           let%map sk0 = Private_key.gen
@@ -118,8 +120,8 @@ let%test_module "multisig_account" =
              let%bind pk1_var =
                exists Inner_curve.typ ~compute:(As_prover.return pk1)
              in
-             let sigma0 = Schnorr.Chunked.sign sk0 msg in
-             let sigma1 = Schnorr.Chunked.sign sk1 msg in
+             let sigma0 = Schnorr.Chunked.sign ~signature_kind sk0 msg in
+             let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
              let%bind sigma0_var =
                exists Schnorr.Chunked.Signature.typ
                  ~compute:(As_prover.return sigma0)
@@ -145,6 +147,7 @@ let%test_module "multisig_account" =
 
     (* test with a 2-of-3 multisig *)
     let%test_unit "zkapps-based proved transaction" =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let open Mina_transaction_logic.For_tests in
       let gen =
         let open Quickcheck.Generator.Let_syntax in
@@ -408,9 +411,9 @@ let%test_module "multisig_account" =
                 tx_statement |> Zkapp_statement.to_field_elements
                 |> Random_oracle_input.Chunked.field_elements
               in
-              let sigma0 = Schnorr.Chunked.sign sk0 msg in
-              let sigma1 = Schnorr.Chunked.sign sk1 msg in
-              let sigma2 = Schnorr.Chunked.sign sk2 msg in
+              let sigma0 = Schnorr.Chunked.sign ~signature_kind sk0 msg in
+              let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
+              let sigma2 = Schnorr.Chunked.sign ~signature_kind sk2 msg in
               let handler (Snarky_backendless.Request.With { request; respond })
                   =
                 match request with
@@ -444,7 +447,8 @@ let%test_module "multisig_account" =
                 in
                 { fee_payer with
                   authorization =
-                    Signature_lib.Schnorr.Chunked.sign sender.private_key
+                    Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                      sender.private_key
                       (Random_oracle.Input.Chunked.field txn_comm)
                 }
               in
@@ -452,7 +456,8 @@ let%test_module "multisig_account" =
                 { body = sender_account_update_data.body
                 ; authorization =
                     Signature
-                      (Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      (Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                         sender.private_key
                          (Random_oracle.Input.Chunked.field transaction) )
                 }
               in

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -284,6 +284,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
                 ~memo_hash
                 ~fee_payer_hash:
                   (Zkapp_command.Digest.Account_update.create
+                     ~chain:signature_kind
                      (Account_update.of_fee_payer fee_payer) )
             in
             { fee_payer with

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -255,7 +255,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
           in
           let tx_statement : Zkapp_statement.t =
             { account_update =
-                Account_update.Body.digest
+                Account_update.Body.digest ~chain:signature_kind
                   (Account_update.of_simple snapp_account_update_data).body
             ; calls = (Zkapp_command.Digest.Forest.empty :> field)
             }

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -60,6 +60,7 @@ let ring_sig_rule (ring_member_pks : Schnorr.Chunked.Public_key.t list) :
   }
 
 let%test_unit "1-of-1" =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let gen =
     let open Quickcheck.Generator.Let_syntax in
     let%map sk = Private_key.gen and msg = Field.gen_uniform in
@@ -67,7 +68,7 @@ let%test_unit "1-of-1" =
   in
   Quickcheck.test ~trials:1 gen ~f:(fun (sk, msg) ->
       let pk = Inner_curve.(scale one sk) in
-      (let sigma = Schnorr.Chunked.sign sk msg in
+      (let sigma = Schnorr.Chunked.sign ~signature_kind sk msg in
        let%bind sigma_var, msg_var =
          exists
            Typ.(Schnorr.Chunked.Signature.typ * Schnorr.chunked_message_typ ())
@@ -78,6 +79,7 @@ let%test_unit "1-of-1" =
       |> run_and_check |> Or_error.ok_exn )
 
 let%test_unit "1-of-2" =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let gen =
     let open Quickcheck.Generator.Let_syntax in
     let%map sk0 = Private_key.gen
@@ -88,7 +90,7 @@ let%test_unit "1-of-2" =
   Quickcheck.test ~trials:1 gen ~f:(fun (sk0, sk1, msg) ->
       let pk0 = Inner_curve.(scale one sk0) in
       let pk1 = Inner_curve.(scale one sk1) in
-      (let sigma1 = Schnorr.Chunked.sign sk1 msg in
+      (let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
        let%bind sigma1_var =
          exists Schnorr.Chunked.Signature.typ ~compute:(As_prover.return sigma1)
        and msg_var =
@@ -100,6 +102,7 @@ let%test_unit "1-of-2" =
 
 (* test a snapp tx with a 3-account_update ring *)
 let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let proof_cache =
     Result.ok_or_failwith @@ Pickles.Proof_cache.of_yojson
     @@ Yojson.Safe.from_file "proof_cache.json"
@@ -262,7 +265,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             |> Random_oracle_input.Chunked.field_elements
           in
           let signing_sk = List.nth_exn ring_member_sks sign_index in
-          let sigma = Schnorr.Chunked.sign signing_sk msg in
+          let sigma = Schnorr.Chunked.sign ~signature_kind signing_sk msg in
           let handler (Snarky_backendless.Request.With { request; respond }) =
             match request with
             | Sigma ->
@@ -285,13 +288,15 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             in
             { fee_payer with
               authorization =
-                Signature_lib.Schnorr.Chunked.sign sender.private_key
+                Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                  sender.private_key
                   (Random_oracle.Input.Chunked.field txn_comm)
             }
           in
           let sender : Account_update.Simple.t =
             let sender_signature =
-              Signature_lib.Schnorr.Chunked.sign sender.private_key
+              Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                sender.private_key
                 (Random_oracle.Input.Chunked.field transaction)
             in
             { body = sender_account_update_data.body

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -365,6 +365,7 @@ let%test_module "Protocol state precondition tests" =
                   let memo_hash = Signed_command_memo.hash memo in
                   let fee_payer_hash =
                     Zkapp_command.Digest.Account_update.create
+                      ~chain:signature_kind
                       (Account_update.of_fee_payer fee_payer)
                   in
                   let full_commitment =
@@ -960,7 +961,7 @@ let%test_module "Account precondition tests" =
               in
               let memo_hash = Signed_command_memo.hash memo in
               let fee_payer_hash =
-                Zkapp_command.Digest.Account_update.create
+                Zkapp_command.Digest.Account_update.create ~chain:signature_kind
                   (Account_update.of_fee_payer fee_payer)
               in
               let full_commitment =

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -655,6 +655,7 @@ let%test_module "Account precondition tests" =
           else update )
 
     let%test_unit "delegate precondition on new account" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let gen = U.gen_snapp_ledger in
       Quickcheck.test ~trials:5 gen ~f:(fun ({ specs; _ }, new_kp) ->
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
@@ -702,7 +703,7 @@ let%test_module "Account precondition tests" =
                           add_account_precondition ~at:1 delegate_precondition
                             zkapp_command0.account_updates
                           |> Zkapp_command.Call_forest
-                             .accumulate_hashes_predicated
+                             .accumulate_hashes_predicated ~chain
                       }
                     in
                     let keymap =
@@ -717,6 +718,7 @@ let%test_module "Account precondition tests" =
                     [ zkapp_command ] ) ) )
 
     let%test_unit "unsatisfied delegate precondition, custom token" =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       (* when new account has a custom token, it doesn't get a self-delegation *)
       let constraint_constants = U.constraint_constants in
       let account_creation_fee =
@@ -781,7 +783,7 @@ let%test_module "Account precondition tests" =
                           add_account_precondition ~at:1 delegate_precondition
                             zkapp0.account_updates
                           |> Zkapp_command.Call_forest
-                             .accumulate_hashes_predicated
+                             .accumulate_hashes_predicated ~chain
                       }
                     in
                     replace_authorizations ~keymap zkapp_dummy_signatures

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -237,6 +237,7 @@ let%test_module "Protocol state precondition tests" =
             ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
     let%test_unit "invalid protocol state predicate in other zkapp_command" =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let state_body = U.genesis_state_body in
       let psv = Mina_state.Protocol_state.Body.view state_body in
       let gen =
@@ -372,14 +373,16 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let fee_payer =
                     let fee_payer_signature_auth =
-                      Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        sender.private_key
                         (Random_oracle.Input.Chunked.field full_commitment)
                     in
                     { fee_payer with authorization = fee_payer_signature_auth }
                   in
                   let sender_account_update : Account_update.Simple.t =
                     let signature_auth : Signature.t =
-                      Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        sender.private_key
                         (Random_oracle.Input.Chunked.field commitment)
                     in
                     { sender_account_update with
@@ -388,7 +391,8 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let snapp_account_update =
                     let signature_auth =
-                      Signature_lib.Schnorr.Chunked.sign new_kp.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        new_kp.private_key
                         (Random_oracle.Input.Chunked.field full_commitment)
                     in
                     { snapp_account_update with
@@ -856,6 +860,7 @@ let%test_module "Account precondition tests" =
                     ~state_body ledger [ zkapp_command ] ) ) )
 
     let%test_unit "invalid account predicate in fee payer" =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let state_body = U.genesis_state_body in
       let psv = Mina_state.Protocol_state.Body.view state_body in
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
@@ -964,14 +969,16 @@ let%test_module "Account precondition tests" =
               in
               let fee_payer =
                 let fee_payer_signature_auth =
-                  Signature_lib.Schnorr.Chunked.sign sender.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    sender.private_key
                     (Random_oracle.Input.Chunked.field full_commitment)
                 in
                 { fee_payer with authorization = fee_payer_signature_auth }
               in
               let sender_account_update =
                 let signature_auth : Signature.t =
-                  Signature_lib.Schnorr.Chunked.sign sender.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    sender.private_key
                     (Random_oracle.Input.Chunked.field commitment)
                 in
                 { sender_account_update with
@@ -980,7 +987,8 @@ let%test_module "Account precondition tests" =
               in
               let snapp_account_update =
                 let signature_auth =
-                  Signature_lib.Schnorr.Chunked.sign new_kp.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    new_kp.private_key
                     (Random_oracle.Input.Chunked.field full_commitment)
                 in
                 { snapp_account_update with

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3603,6 +3603,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         * [ `Connecting_ledger_hash of Ledger_hash.t ]
         * Zkapp_command.t )
         list ) =
+    let chain = Mina_signature_kind.t_DEPRECATED in
     let sparse_first_pass_ledger zkapp_command = function
       | `Ledger ledger ->
           Sparse_ledger.of_ledger_subset_exn ledger
@@ -3749,7 +3750,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 let next_commitment = Zkapp_command.commitment zkapp_command in
                 let memo_hash = Signed_command_memo.hash zkapp_command.memo in
                 let fee_payer_hash =
-                  Zkapp_command.Digest.Account_update.create
+                  Zkapp_command.Digest.Account_update.create ~chain
                     (Account_update.of_fee_payer zkapp_command.fee_payer)
                 in
                 let next_full_commitment =
@@ -4469,7 +4470,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         Zkapp_command.Transaction_commitment.create_complete commitment
           ~memo_hash:(Signed_command_memo.hash memo)
           ~fee_payer_hash:
-            (Zkapp_command.Digest.Account_update.create
+            (Zkapp_command.Digest.Account_update.create ~chain:signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let fee_payer =
@@ -4662,7 +4663,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
             |> Zkapp_command.Call_forest.accumulate_hashes
                  ~hash_account_update:(fun (p : Account_update.t) ->
-                   Zkapp_command.Digest.Account_update.create p )
+                   Zkapp_command.Digest.Account_update.create
+                     ~chain:signature_kind p )
         }
       in
       zkapp_command
@@ -4759,7 +4761,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           account_update_with_dummy_auth
       in
       let account_update_digest_with_current_chain =
-        Zkapp_command.Digest.Account_update.create
+        Zkapp_command.Digest.Account_update.create ~chain
           account_update_with_dummy_auth
       in
       let tree_with_dummy_auth =
@@ -5186,7 +5188,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           Zkapp_command.Transaction_commitment.create_complete transaction
             ~memo_hash:(Signed_command_memo.hash memo)
             ~fee_payer_hash:
-              (Zkapp_command.Digest.Account_update.create
+              (Zkapp_command.Digest.Account_update.create ~chain:signature_kind
                  (Account_update.of_fee_payer fee_payer) )
         in
         Signature_lib.Schnorr.Chunked.sign ~signature_kind sender.private_key

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1235,7 +1235,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             in
             Stack_frame.of_frame elt
 
-          let pop_exn ({ hash = h; data = r } : t) : elt * t =
+          let pop_exn ~chain:_ ({ hash = h; data = r } : t) : elt * t =
             let hd_r = V.create (fun () -> (V.get r |> List.hd_exn).elt) in
             let tl_r = V.create (fun () -> V.get r |> List.tl_exn) in
             let elt : Stack_frame.t = exists_elt hd_r in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4895,7 +4895,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         snapp_zkapp_command
         |> List.map ~f:(fun p -> (p, p))
         |> Zkapp_command.Call_forest.With_hashes_and_data
-           .of_zkapp_command_simple_list
+           .of_zkapp_command_simple_list ~chain:signature_kind
         |> Zkapp_statement.zkapp_statements_of_forest
         |> Zkapp_command.Call_forest.to_account_updates
       in
@@ -5012,6 +5012,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let multiple_transfers ~constraint_constants
         (spec : Multiple_transfers_spec.t) =
+      let chain = Mina_signature_kind.t_DEPRECATED in
       let ( `Zkapp_command zkapp_command
           , `Sender_account_update sender_account_update
           , `Proof_zkapp_command snapp_zkapp_command
@@ -5025,7 +5026,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       assert (List.is_empty snapp_zkapp_command) ;
       let account_updates =
         let sender_account_update = Option.value_exn sender_account_update in
-        Zkapp_command.Call_forest.cons
+        Zkapp_command.Call_forest.cons ~chain
           (Account_update.of_simple sender_account_update)
           zkapp_command.account_updates
       in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3799,7 +3799,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                    , `Pending_coinbase_of_statement
                        pending_coinbase_stack_state2
                    , zkapp_command2 )
-                   :: rest ->
+                :: rest ->
                   let commitment', full_commitment' =
                     mk_next_commitments zkapp_command2.account_updates
                   in
@@ -4241,6 +4241,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let create_zkapp_command ?receiver_auth ?empty_sender
         ~(constraint_constants : Genesis_constants.Constraint_constants.t) spec
         ~update ~receiver_update =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let { Spec.fee
           ; sender = sender, sender_nonce
           ; fee_payer = fee_payer_opt
@@ -4475,10 +4476,12 @@ module Make_str (A : Wire_types.Concrete) = struct
         let fee_payer_signature_auth =
           match fee_payer_opt with
           | None ->
-              Signature_lib.Schnorr.Chunked.sign sender.private_key
+              Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                sender.private_key
                 (Random_oracle.Input.Chunked.field full_commitment)
           | Some (fee_payer_kp, _) ->
-              Signature_lib.Schnorr.Chunked.sign fee_payer_kp.private_key
+              Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                fee_payer_kp.private_key
                 (Random_oracle.Input.Chunked.field full_commitment)
         in
         { fee_payer with authorization = fee_payer_signature_auth }
@@ -4489,7 +4492,8 @@ module Make_str (A : Wire_types.Concrete) = struct
               if s.body.use_full_commitment then full_commitment else commitment
             in
             let sender_signature_auth =
-              Signature_lib.Schnorr.Chunked.sign sender.private_key
+              Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                sender.private_key
                 (Random_oracle.Input.Chunked.field commitment)
             in
             { body = s.body; authorization = Signature sender_signature_auth } )
@@ -4512,7 +4516,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                          receiver keypair but got receiver public key"
                 in
                 let receiver_signature_auth =
-                  Signature_lib.Schnorr.Chunked.sign receiver_kp.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    receiver_kp.private_key
                     (Random_oracle.Input.Chunked.field commitment)
                 in
                 { Account_update.Poly.body = s.body
@@ -4578,6 +4583,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let deploy_snapp ?(no_auth = false) ?permissions ~constraint_constants
         (spec : Deploy_snapp_spec.t) =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let `VK vk, `Prover _trivial_prover = create_trivial_snapp () in
       let%map.Async.Deferred vk = vk in
       (* only allow timing on a single new snapp account
@@ -4634,7 +4640,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                 else commitment
               in
               let signature =
-                Signature_lib.Schnorr.Chunked.sign keypair.private_key
+                Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                  keypair.private_key
                   (Random_oracle.Input.Chunked.field commitment)
               in
               ( { body = snapp_account_update.body
@@ -4859,6 +4866,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let update_states ?receiver_auth ?zkapp_prover_and_vk ?empty_sender
         ~constraint_constants (spec : Update_states_spec.t) =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let prover, vk =
         match zkapp_prover_and_vk with
         | Some (prover, vk) ->
@@ -4920,7 +4928,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                   else commitment
                 in
                 let signature =
-                  Signature_lib.Schnorr.Chunked.sign snapp_keypair.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    snapp_keypair.private_key
                     (Random_oracle.Input.Chunked.field commitment)
                 in
                 Async.Deferred.return
@@ -5046,6 +5055,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let create_trivial_predicate_snapp
         ?(protocol_state_predicate = Zkapp_precondition.Protocol_state.accept)
         ~(snapp_kp : Signature_lib.Keypair.t) spec ledger =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let { Mina_transaction_logic.For_tests.Transaction_spec.fee
           ; sender = sender, sender_nonce
           ; receiver = _
@@ -5179,14 +5189,14 @@ module Make_str (A : Wire_types.Concrete) = struct
               (Zkapp_command.Digest.Account_update.create
                  (Account_update.of_fee_payer fee_payer) )
         in
-        Signature_lib.Schnorr.Chunked.sign sender.private_key
+        Signature_lib.Schnorr.Chunked.sign ~signature_kind sender.private_key
           (Random_oracle.Input.Chunked.field txn_comm)
       in
       let fee_payer =
         { fee_payer with authorization = fee_payer_signature_auth }
       in
       let sender_signature_auth =
-        Signature_lib.Schnorr.Chunked.sign sender.private_key
+        Signature_lib.Schnorr.Chunked.sign ~signature_kind sender.private_key
           (Random_oracle.Input.Chunked.field transaction)
       in
       let sender : Account_update.Simple.t =

--- a/src/lib/uptime_service/payload.ml
+++ b/src/lib/uptime_service/payload.ml
@@ -23,6 +23,7 @@ type request =
 [@@deriving to_yojson]
 
 let sign_blake2_hash ~private_key s =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let module Field = Snark_params.Tick.Field in
   let blake2 = Blake2.digest_string s in
   let field_elements = [||] in
@@ -32,7 +33,7 @@ let sign_blake2_hash ~private_key s =
   let input : (Field.t, bool) Random_oracle.Legacy.Input.t =
     { field_elements; bitstrings }
   in
-  Schnorr.Legacy.sign private_key input
+  Schnorr.Legacy.sign ~signature_kind private_key input
 
 let create_request block_data submitter_keypair =
   let block_data_json = block_data_to_yojson block_data in

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -80,6 +80,7 @@ let collect_vk_assumptions zkapp_command =
 
 let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
     (unit, invalid) Result.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let account_updates_hash =
     Zkapp_command.Call_forest.hash
       zkapp_command.Zkapp_command.Poly.account_updates
@@ -102,7 +103,7 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
     | Some pk ->
         if
           not
-            (Signature_lib.Schnorr.Chunked.verify s
+            (Signature_lib.Schnorr.Chunked.verify ~signature_kind s
                (Backend.Tick.Inner_curve.of_affine pk)
                (Random_oracle_input.Chunked.field msg) )
         then Error (`Invalid_signature [ Signature_lib.Public_key.compress pk ])

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -93,7 +93,7 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
     Zkapp_command.Transaction_commitment.create_complete tx_commitment
       ~memo_hash:(Signed_command_memo.hash zkapp_command.memo)
       ~fee_payer_hash:
-        (Zkapp_command.Digest.Account_update.create
+        (Zkapp_command.Digest.Account_update.create ~chain:signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let check_signature s pk msg =

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -84,6 +84,7 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
 *)
 let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
     Zkapp_command.t Async_kernel.Deferred.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let txn_commitment, full_txn_commitment =
     Zkapp_command.get_transaction_commitments zkapp_command
   in
@@ -91,7 +92,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
     let commitment =
       if use_full_commitment then full_txn_commitment else txn_commitment
     in
-    Signature_lib.Schnorr.Chunked.sign sk
+    Signature_lib.Schnorr.Chunked.sign ~signature_kind sk
       (Random_oracle.Input.Chunked.field commitment)
   in
   let fee_payer_sk =

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -45,6 +45,7 @@ let mk_account_update_body ?preconditions ?(increment_nonce = false)
 
 let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Zkapp_command.t =
+  let chain = Mina_signature_kind.t_DEPRECATED in
   let fee_payer : Account_update.Fee_payer.t =
     { body =
         { public_key = fee_payer_pk
@@ -76,7 +77,7 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
                    Control.Poly.Signature Signature.dummy
              in
              { body = Account_update.Body.of_simple p; authorization } )
-      |> Zkapp_command.Call_forest.accumulate_hashes_predicated
+      |> Zkapp_command.Call_forest.accumulate_hashes_predicated ~chain
   }
 
 (* replace dummy signatures, proofs with valid ones for fee payer, other zkapp_command


### PR DESCRIPTION
## Explain your changes:

When finished, this PR will remove the compiled `Mina_signature_kind.t` value completely. The signature kind will instead be determined at runtime and passed to the relevant functions.

## Explain how you tested your changes:

Untested, but this is pure refactoring at the moment.

## Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
