### PR TITLE
Clean up `Snark_work_lib.Work`

### DIFF
--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -1,5 +1,3 @@
-(* TODO: remove type generalizations #2594 *)
-
 open Core_kernel
 
 module Single = struct

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -6,8 +6,6 @@ module Single = struct
   module Spec = struct
     [%%versioned
     module Stable = struct
-      [@@@no_toplevel_latest_type]
-
       module V2 = struct
         type ('witness, 'ledger_proof) t =
           | Transition of Transaction_snark.Statement.Stable.V2.t * 'witness
@@ -61,8 +59,6 @@ end
 module Spec = struct
   [%%versioned
   module Stable = struct
-    [@@@no_toplevel_latest_type]
-
     module V1 = struct
       type 'single t =
         { instances : 'single One_or_two.Stable.V1.t


### PR DESCRIPTION
This is needed so project [rework snark worker](https://github.com/MinaProtocol/mina/pull/16923) could be merged. 

Here we basically removed 2 `no_toplevel_latest_type` directives.