### PR TITLE
Refactor Snark Worker

### DIFF
--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -57,10 +57,8 @@ type Structured_log_events.t +=
            $proof_zkapp_command_count proof zkapp_command"
       }]
 
-module Make (Inputs : Intf.Inputs_intf) :
-  Intf.S0 with type ledger_proof := Inputs.Ledger_proof.t = struct
+module Make (Inputs : Intf.Inputs_intf) = struct
   open Inputs
-  module Rpcs = Rpcs.Make (Inputs)
 
   module Work = struct
     open Snark_work_lib

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -134,27 +134,6 @@ module type S0 = sig
 
   module Work : Work_S with type ledger_proof := ledger_proof
 
-  module Rpcs : sig
-    module Get_work :
-      Rpc_master
-        with type Master.T.query = unit
-         and type Master.T.response =
-          (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
-
-    module Submit_work :
-      Rpc_master
-        with type Master.T.query = Work.Result.t
-         and type Master.T.response = unit
-
-    module Failed_to_generate_snark :
-      Rpc_master
-        with type Master.T.query =
-          Bounded_types.Wrapped_error.t
-          * Work.Spec.t
-          * Signature_lib.Public_key.Compressed.t
-         and type Master.T.response = unit
-  end
-
   val command_from_rpcs :
        commit_id:string
     -> proof_level:Genesis_constants.Proof_level.t

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -1,6 +1,7 @@
-open Core_kernel
 open Async
+open Core_kernel
 open Signature_lib
+open Snark_work_lib
 
 (* for versioning of the types here, see
 
@@ -13,79 +14,74 @@ open Signature_lib
    return types with bin_io; the versioned modules are defined in snark_worker.ml
 *)
 
-module Make (Inputs : Intf.Inputs_intf) = struct
-  open Inputs
-  open Snark_work_lib
+module Get_work = struct
+  module Master = struct
+    let name = "get_work"
 
-  module Get_work = struct
-    module Master = struct
-      let name = "get_work"
+    module T = struct
+      type query = unit
 
-      module T = struct
-        type query = unit
-
-        type response =
-          ( ( Transaction_witness.Stable.Latest.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
-          * Public_key.Compressed.t )
-          option
-      end
-
-      module Caller = T
-      module Callee = T
-    end
-
-    include Master.T
-    include Versioned_rpc.Both_convert.Plain.Make (Master)
-  end
-
-  module Submit_work = struct
-    module Master = struct
-      let name = "submit_work"
-
-      module T = struct
-        type query =
-          ( ( Transaction_witness.Stable.Latest.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
+      type response =
+        ( ( Transaction_witness.Stable.Latest.t
           , Ledger_proof.t )
-          Work.Result.t
-
-        type response = unit
-      end
-
-      module Caller = T
-      module Callee = T
+          Work.Single.Spec.t
+          Work.Spec.t
+        * Public_key.Compressed.t )
+        option
     end
 
-    include Master.T
-    include Versioned_rpc.Both_convert.Plain.Make (Master)
+    module Caller = T
+    module Callee = T
   end
 
-  module Failed_to_generate_snark = struct
-    module Master = struct
-      let name = "failed_to_generate_snark"
+  include Master.T
+  include Versioned_rpc.Both_convert.Plain.Make (Master)
+end
 
-      module T = struct
-        type query =
-          Error.t
-          * ( Transaction_witness.Stable.Latest.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
-          * Public_key.Compressed.t
+module Submit_work = struct
+  module Master = struct
+    let name = "submit_work"
 
-        type response = unit
-      end
+    module T = struct
+      type query =
+        ( ( Transaction_witness.Stable.Latest.t
+          , Ledger_proof.t )
+          Work.Single.Spec.t
+          Work.Spec.t
+        , Ledger_proof.t )
+        Work.Result.t
 
-      module Caller = T
-      module Callee = T
+      type response = unit
     end
 
-    include Master.T
-    include Versioned_rpc.Both_convert.Plain.Make (Master)
+    module Caller = T
+    module Callee = T
   end
+
+  include Master.T
+  include Versioned_rpc.Both_convert.Plain.Make (Master)
+end
+
+module Failed_to_generate_snark = struct
+  module Master = struct
+    let name = "failed_to_generate_snark"
+
+    module T = struct
+      type query =
+        Error.t
+        * ( Transaction_witness.Stable.Latest.t
+          , Ledger_proof.t )
+          Work.Single.Spec.t
+          Work.Spec.t
+        * Public_key.Compressed.t
+
+      type response = unit
+    end
+
+    module Caller = T
+    module Callee = T
+  end
+
+  include Master.T
+  include Versioned_rpc.Both_convert.Plain.Make (Master)
 end


### PR DESCRIPTION
Explain your changes:
* Refactor Snark Worker, so it's easier to do modification. Previously ~4 places need to be touched when you modify a single RPC definition. Now only 2, one for Master interface and another for Versioned RPC. 

Explain how you tested your changes:
* This is a no-op

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
	- No change log should be needed
- [x] Document code purpose, how to use it
  - We assume we don't need Functors for Snark Workers
- [x] Tests were added for the new behavior
  - No new behavior
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them
	* None
