### PR TITLE
Alphabetize dependencies in base58_check dune file

### DIFF
--- a/src/lib/base58_check/dune
+++ b/src/lib/base58_check/dune
@@ -5,10 +5,10 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  digestif
-  core_kernel
-  base58
   base
+  base58
+  core_kernel
+  digestif
   ppx_inline_test.config)
  (library_flags (-linkall))
  (preprocess


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/base58_check/dune file for better readability and maintenance.