### PR TITLE
Alphabetize dependencies in blake2 dune file

### DIFF
--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -4,19 +4,19 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_jane ppx_mina ppx_version ppx_compare ppx_deriving_yojson))
+  (pps ppx_compare ppx_deriving_yojson ppx_jane ppx_mina ppx_version))
  (inline_tests
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
   base.base_internalhash_types
+  base.caml
   bigarray-compat
   bin_prot.shape
   core_kernel
   digestif
-  sexplib0
-  base.caml
   ppx_inline_test.config
+  sexplib0
   ;; local libraries
   bounded_types
   ppx_version.runtime))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/blake2/dune file for better readability and maintenance.