### PR TITLE
Alphabetize dependencies in block_producer dune file

### DIFF
--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -6,73 +6,73 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  sexplib0
-  async_kernel
-  core_kernel
-  core
   async
+  async_kernel
+  core
+  core_kernel
   integers
+  sexplib0
   ;; local libraries
-  mina_wire_types
-  mina_metrics
-  mina_net2
-  debug_assert
-  blockchain_snark
-  with_hash
-  truth
-  mina_numbers
-  transaction_snark
-  ledger_proof
-  error_json
-  currency
-  logger
-  signature_lib
-  transition_frontier
-  transaction_snark_scan_state
-  prover
-  mina_state
-  mina_intf
-  mina_ledger
-  mina_base
-  mina_transaction
-  mina_transaction_logic
-  mina_block
-  protocol_version
-  consensus
-  interruptible
-  o1trace
-  pipe_lib
-  network_pool
-  unix_timestamp
-  otp_lib
-  transition_chain_prover
-  vrf_evaluator
-  transition_frontier_base
   block_time
-  staged_ledger
-  staged_ledger_diff
-  mina_compile_config
-  precomputed_values
+  blockchain_snark
   coda_genesis_proof
-  transition_frontier_extensions
-  unsigned_extended
-  genesis_constants
+  consensus
+  currency
   data_hash_lib
-  sgn
-  sgn_type
-  node_error_service
-  pickles.backend
-  pasta_bindings
-  pickles
-  snark_params
+  debug_assert
+  error_json
+  genesis_constants
+  internal_tracing
+  interruptible
   kimchi_backend
   kimchi_pasta
   kimchi_pasta.basic
-  internal_tracing
+  ledger_proof
+  logger
+  mina_base
+  mina_block
+  mina_compile_config
+  mina_intf
+  mina_ledger
+  mina_metrics
+  mina_net2
   mina_networking
-  mina_runtime_config)
+  mina_numbers
+  mina_runtime_config
+  mina_state
+  mina_transaction
+  mina_transaction_logic
+  mina_wire_types
+  network_pool
+  node_error_service
+  o1trace
+  otp_lib
+  pasta_bindings
+  pickles
+  pickles.backend
+  pipe_lib
+  precomputed_values
+  protocol_version
+  prover
+  sgn
+  sgn_type
+  signature_lib
+  snark_params
+  staged_ledger
+  staged_ledger_diff
+  transaction_snark
+  transaction_snark_scan_state
+  transition_chain_prover
+  transition_frontier
+  transition_frontier_base
+  transition_frontier_extensions
+  truth
+  unix_timestamp
+  unsigned_extended
+  vrf_evaluator
+  with_hash)
  (preprocess
-  (pps ppx_mina ppx_version ppx_jane ppx_register_event))
+  (pps ppx_jane ppx_mina ppx_register_event ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Coda block producer"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/block_producer/dune file for better readability and maintenance.