### PR TITLE
Alphabetize dependencies in bounded_types dune file

### DIFF
--- a/src/lib/bounded_types/dune
+++ b/src/lib/bounded_types/dune
@@ -4,16 +4,16 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries
-  ppx_version.runtime
-  stdlib
   base.caml
-  core_kernel
   bin_prot
   bin_prot.shape
+  core_kernel
   ppx_inline_test.config
-  sexplib0)
+  ppx_version.runtime
+  sexplib0
+  stdlib)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_mina ppx_deriving_yojson ppx_inline_test))
+  (pps ppx_deriving_yojson ppx_inline_test ppx_jane ppx_mina))
  (library_flags -linkall)
  (synopsis "Put bounds on bin_prot deserializing"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/bounded_types/dune file for better readability and maintenance.