### PR TITLE
Alphabetize dependencies in bowe_gabizon_hash dune file

### DIFF
--- a/src/lib/bowe_gabizon_hash/dune
+++ b/src/lib/bowe_gabizon_hash/dune
@@ -4,7 +4,7 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_jane ppx_compare))
+  (pps ppx_compare ppx_jane ppx_version))
  (inline_tests
   (flags -verbose -show-counts))
  (libraries core_kernel))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/bowe_gabizon_hash/dune file for better readability and maintenance.