### PR TITLE
Alphabetize dependencies in cache_lib dune file

### DIFF
--- a/src/lib/cache_lib/dune
+++ b/src/lib/cache_lib/dune
@@ -6,10 +6,10 @@
  (libraries
   ;; opam libraries
   async_kernel
-  core_kernel
   base
   base.base_internalhash_types
   core
+  core_kernel
   ppx_inline_test.config
   ;; local libraries
   logger)
@@ -17,9 +17,9 @@
   (backend bisect_ppx))
  (preprocess
   (pps
-   ppx_mina
-   ppx_version
    ppx_base
-   ppx_let
    ppx_custom_printf
-   ppx_inline_test)))
+   ppx_inline_test
+   ppx_let
+   ppx_mina
+   ppx_version)))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/cache_lib/dune file for better readability and maintenance.