### PR TITLE
Alphabetize dependencies in bootstrap_controller dune file

### DIFF
--- a/src/lib/bootstrap_controller/dune
+++ b/src/lib/bootstrap_controller/dune
@@ -6,63 +6,63 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_mina ppx_version ppx_jane ppx_compare ppx_register_event))
+  (pps ppx_compare ppx_jane ppx_mina ppx_register_event ppx_version))
  (libraries
   ;; opam libraries
-  sexplib0
-  core
-  async_kernel
-  core_kernel
   async
+  async_kernel
   async_unix
+  core
+  core_kernel
   ppx_inline_test.config
+  sexplib0
   ;; local libraries
-  mina_numbers
-  gadt_lib
-  child_processes
-  transition_frontier_base
-  mina_metrics
-  error_json
-  bounded_types
-  with_hash
-  mina_state
-  transition_frontier_persistent_frontier
-  verifier
-  data_hash_lib
-  logger
-  network_peer
-  sync_handler
-  transition_frontier
-  pipe_lib
-  mina_intf
-  mina_block
-  mina_base
-  mina_ledger
-  mina_stdlib
-  mina_transaction_logic
-  syncable_ledger
-  consensus
-  mina_networking
-  fake_network
-  trust_system
-  transition_frontier_persistent_root
-  precomputed_values
-  truth
-  merkle_ledger
-  staged_ledger
-  genesis_constants
-  coda_genesis_ledger
   block_time
-  mina_base.util
-  o1trace
-  mina_net2
-  pickles.backend
-  pickles
-  snark_params
-  kimchi_backend
-  sgn_type
-  sgn
+  bounded_types
+  child_processes
+  coda_genesis_ledger
+  consensus
   currency
+  data_hash_lib
+  error_json
+  fake_network
+  gadt_lib
+  genesis_constants
+  kimchi_backend
   kimchi_pasta
   kimchi_pasta.basic
-  mina_wire_types))
+  logger
+  merkle_ledger
+  mina_base
+  mina_base.util
+  mina_block
+  mina_intf
+  mina_ledger
+  mina_metrics
+  mina_net2
+  mina_networking
+  mina_numbers
+  mina_state
+  mina_stdlib
+  mina_transaction_logic
+  mina_wire_types
+  network_peer
+  o1trace
+  pickles
+  pickles.backend
+  pipe_lib
+  precomputed_values
+  sgn
+  sgn_type
+  snark_params
+  staged_ledger
+  sync_handler
+  syncable_ledger
+  transition_frontier
+  transition_frontier_base
+  transition_frontier_persistent_frontier
+  transition_frontier_persistent_root
+  trust_system
+  truth
+  verifier
+  with_hash))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/bootstrap_controller/dune file for better readability and maintenance.