### PR TITLE
Alphabetize dependencies in codable dune file

### DIFF
--- a/src/lib/codable/dune
+++ b/src/lib/codable/dune
@@ -6,15 +6,15 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  core_kernel
   base64
+  core_kernel
   ppx_deriving_yojson.runtime
-  yojson
   result
+  yojson
   ;; local libraries
   base58_check)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_jane ppx_deriving_yojson))
+  (pps ppx_deriving_yojson ppx_jane ppx_version))
  (synopsis "Extension of Yojson to make it easy for a type to derive yojson"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/codable/dune file for better readability and maintenance.