### PR TITLE
Alphabetize dependencies in kimchi_backend dune file

### DIFF
--- a/src/lib/crypto/kimchi_backend/dune
+++ b/src/lib/crypto/kimchi_backend/dune
@@ -7,25 +7,25 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.std))
+  (pps ppx_deriving.std ppx_deriving_yojson ppx_jane ppx_version))
  (libraries
   ;; opam libraries
-  integers
+  base.base_internalhash_types
+  bin_prot.shape
   core_kernel
+  integers
   ppx_inline_test.config
   sexplib0
-  bin_prot.shape
-  base.base_internalhash_types
   ;; local libraries
-  kimchi_bindings
-  kimchi_types
-  pasta_bindings
-  snarkette
-  key_cache
   hex
+  key_cache
   kimchi_backend_common
+  kimchi_bindings
   kimchi_pasta
   kimchi_pasta.basic
   kimchi_pasta.constraint_system
-  sponge
-  snarky.intf))
+  kimchi_types
+  pasta_bindings
+  snarky.intf
+  snarkette
+  sponge))

--- a/src/lib/crypto/plonkish_prelude/dune
+++ b/src/lib/crypto/plonkish_prelude/dune
@@ -15,26 +15,26 @@
   (:standard -w +a-40..42-44 -warn-error +a))
  (preprocess
   (pps
-   ppx_mina
-   ppx_version
+   h_list.ppx
+   ppx_deriving.std
    ppx_deriving_yojson
    ppx_jane
-   ppx_deriving.std
-   h_list.ppx))
+   ppx_mina
+   ppx_version))
  (modules_without_implementation sigs poly_types)
  (instrumentation
   (backend bisect_ppx))
  (libraries
   ;; opam libraries
-  sexplib0
-  result
-  core_kernel
   base.caml
   bin_prot.shape
+  core_kernel
+  result
+  sexplib0
   ;; local libraries
-  kimchi_pasta_snarky_backend
-  snarky.backendless
-  tuple_lib
-  ppx_version.runtime
   bounded_types
-  mina_wire_types))
+  kimchi_pasta_snarky_backend
+  mina_wire_types
+  ppx_version.runtime
+  snarky.backendless
+  tuple_lib))


### PR DESCRIPTION
Alphabetize library dependencies in the following dune files for better readability and maintenance:
- src/lib/crypto/kimchi_backend/dune
- src/lib/crypto/plonkish_prelude/dune