### PR TITLE
Alphabetize dependencies in currency dune file

### DIFF
--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -6,50 +6,50 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  base.base_internalhash_types
-  core_kernel
-  bin_prot.shape
-  base.caml
-  sexplib0
   base
+  base.base_internalhash_types
+  base.caml
+  bin_prot.shape
+  core_kernel
   integers
-  result
   ppx_inline_test.config
+  result
+  sexplib0
   zarith
-  mina_wire_types
   ;; local libraries
   bignum_bigint
   bitstring_lib
   codable
-  test_util
-  unsigned_extended
+  kimchi_backend_common
   mina_numbers
-  snark_bits
-  sgn
-  snark_params
+  mina_wire_types
+  pickles
+  ppx_version.runtime
   random_oracle
   random_oracle_input
-  pickles
+  sgn
+  snark_bits
+  snark_params
   snarky.backendless
-  kimchi_backend_common
-  ppx_version.runtime)
+  test_util
+  unsigned_extended)
  (preprocess
   (pps
+   h_list.ppx
    ppx_annot
-   ppx_mina
-   ppx_version
-   ppx_let
    ppx_assert
    ppx_bin_prot
-   ppx_sexp_conv
    ppx_compare
-   ppx_hash
    ppx_custom_printf
    ppx_deriving.std
    ppx_deriving_yojson
    ppx_fields_conv
-   h_list.ppx
-   ppx_inline_test))
+   ppx_hash
+   ppx_inline_test
+   ppx_let
+   ppx_mina
+   ppx_sexp_conv
+   ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Currency types"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/currency/dune file for better readability and maintenance.