### PR TITLE
Alphabetize dependencies in daemon_rpcs dune file

### DIFF
--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -6,50 +6,50 @@
   (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  base.caml
-  sexplib0
-  bin_prot.shape
-  yojson
-  core
   async
-  ppx_deriving_yojson.runtime
-  core_kernel
-  async_unix
   async.async_rpc
-  async_rpc_kernel
   async_kernel
+  async_rpc_kernel
+  async_unix
+  base.caml
+  bin_prot.shape
+  core
+  core_kernel
+  ppx_deriving_yojson.runtime
+  sexplib0
+  yojson
   ;; local libraries
-  network_peer
-  genesis_constants
-  bounded_types
-  currency
-  mina_net2
-  transition_frontier
   block_time
-  mina_numbers
-  itn_logger
+  bounded_types
   cli_lib
-  transaction_inclusion_status
   consensus
-  mina_networking
-  mina_base
-  user_command_input
-  perf_histograms
-  sync_status
-  node_addrs_and_ports
-  mina_node_config.unconfigurable_constants
-  logger
-  network_pool
+  currency
   data_hash_lib
+  genesis_constants
+  itn_logger
+  logger
+  mina_base
+  mina_net2
+  mina_networking
+  mina_node_config.unconfigurable_constants
+  mina_numbers
+  network_peer
+  network_pool
+  node_addrs_and_ports
+  perf_histograms
+  ppx_version.runtime
+  sync_status
+  transaction_inclusion_status
+  transition_frontier
   trust_system
-  ppx_version.runtime)
+  user_command_input)
  (preprocess
   (pps
-   ppx_version
-   ppx_jane
-   ppx_deriving_yojson
    ppx_compare
-   ppx_deriving.make))
+   ppx_deriving.make
+   ppx_deriving_yojson
+   ppx_jane
+   ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Lib powering the client interactions with the daemon"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/daemon_rpcs/dune file for better readability and maintenance.