### PR TITLE
Alphabetize dependencies in direction dune file

### DIFF
--- a/src/lib/direction/dune
+++ b/src/lib/direction/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (libraries core_kernel)
  (preprocess
-  (pps ppx_version ppx_jane ppx_compare))
+  (pps ppx_compare ppx_jane ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Representation of direction in a binary tree"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/direction/dune file for better readability and maintenance.