### PR TITLE
Alphabetize dependencies in error_json dune file

### DIFF
--- a/src/lib/error_json/dune
+++ b/src/lib/error_json/dune
@@ -3,10 +3,10 @@
  (public_name error_json)
  (libraries
   ;; opam libraries
-  sexplib0
-  yojson
   base
-  sexplib)
+  sexplib
+  sexplib0
+  yojson)
  (instrumentation
   (backend bisect_ppx))
  (preprocess


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/error_json/dune file for better readability and maintenance.