### PR TITLE
Alphabetize dependencies in exit_handlers dune file

### DIFF
--- a/src/lib/exit_handlers/dune
+++ b/src/lib/exit_handlers/dune
@@ -2,9 +2,9 @@
  (name exit_handlers)
  (public_name exit_handlers)
  (library_flags -linkall)
- (libraries core_kernel async_kernel async_unix logger)
+ (libraries async_kernel async_unix core_kernel logger)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_mina ppx_version ppx_here ppx_let))
+  (pps ppx_here ppx_let ppx_mina ppx_version))
  (synopsis "Exit handlers"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/exit_handlers/dune file for better readability and maintenance.