### PR TITLE
Alphabetize dependencies in fake_network dune file

### DIFF
--- a/src/lib/fake_network/dune
+++ b/src/lib/fake_network/dune
@@ -3,48 +3,48 @@
  (public_name fake_network)
  (libraries
   ;; opam libraries
-  core.uuid
-  async_unix
   async
+  async_unix
   core
+  core.uuid
   ;; local libraries
-  snark_params
-  pickles
-  pickles.backend
-  genesis_constants
-  signature_lib
-  verifier
-  bounded_types
-  precomputed_values
   block_time
-  trust_system
-  logger
-  consensus
-  transition_frontier
-  mina_base
-  gadt_lib
-  mina_networking
-  sync_handler
-  network_peer
-  staged_ledger
-  mina_state
-  with_hash
-  proof_carrying_data
-  mina_block
+  bounded_types
   coda_genesis_proof
-  transition_chain_prover
-  mina_ledger
+  consensus
+  data_hash_lib
+  gadt_lib
+  genesis_constants
   kimchi_bindings
-  kimchi_types
-  pasta_bindings
   kimchi_pasta
   kimchi_pasta.basic
-  data_hash_lib
-  transition_handler
-  network_pool
+  kimchi_types
+  logger
+  mina_base
+  mina_block
   mina_intf
-  pipe_lib)
+  mina_ledger
+  mina_networking
+  mina_state
+  network_peer
+  network_pool
+  pasta_bindings
+  pickles
+  pickles.backend
+  pipe_lib
+  precomputed_values
+  proof_carrying_data
+  signature_lib
+  snark_params
+  staged_ledger
+  sync_handler
+  transition_chain_prover
+  transition_frontier
+  transition_handler
+  trust_system
+  verifier
+  with_hash)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_mina ppx_version ppx_jane ppx_deriving.std)))
+  (pps ppx_deriving.std ppx_jane ppx_mina ppx_version)))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/fake_network/dune file for better readability and maintenance.