### PR TITLE
Alphabetize dependencies in fields_derivers_json dune file

### DIFF
--- a/src/lib/fields_derivers_json/dune
+++ b/src/lib/fields_derivers_json/dune
@@ -3,11 +3,11 @@
  (public_name fields_derivers.json)
  (libraries
   ;; opam libraries
-  yojson
+  core_kernel
   fieldslib
   ppx_inline_test.config
-  core_kernel
   result
+  yojson
   ;; local libraries
   fields_derivers)
  (instrumentation
@@ -17,10 +17,10 @@
  (preprocess
   (pps
    ppx_annot
-   ppx_deriving_yojson
-   ppx_jane
-   ppx_fields_conv
-   ppx_let
-   ppx_inline_test
    ppx_custom_printf
+   ppx_deriving_yojson
+   ppx_fields_conv
+   ppx_inline_test
+   ppx_jane
+   ppx_let
    ppx_version)))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/fields_derivers_json/dune file for better readability and maintenance.