### PR TITLE
Alphabetize dependencies in fields_derivers_zkapps dune file

### DIFF
--- a/src/lib/fields_derivers_zkapps/dune
+++ b/src/lib/fields_derivers_zkapps/dune
@@ -3,26 +3,26 @@
  (public_name fields_derivers.zkapps)
  (libraries
   ;; opam libraries
-  result
-  ppx_inline_test.config
-  integers
-  graphql
-  fieldslib
-  core_kernel
-  base.caml
   base
-  sexplib0
+  base.caml
+  core_kernel
+  fieldslib
+  graphql
   graphql_parser
+  integers
+  ppx_inline_test.config
+  result
+  sexplib0
   ;; local libraries
-  signature_lib
+  currency
+  fields_derivers
   fields_derivers.graphql
   fields_derivers.json
-  currency
   mina_numbers
-  snark_params
   pickles
-  fields_derivers
   sgn
+  signature_lib
+  snark_params
   unsigned_extended
   with_hash)
  (inline_tests
@@ -32,11 +32,11 @@
  (preprocess
   (pps
    ppx_annot
-   ppx_deriving_yojson
-   ppx_base
-   ppx_fields_conv
-   ppx_let
-   ppx_inline_test
    ppx_assert
-   ppx_version
-   ppx_custom_printf)))
+   ppx_base
+   ppx_custom_printf
+   ppx_deriving_yojson
+   ppx_fields_conv
+   ppx_inline_test
+   ppx_let
+   ppx_version)))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/fields_derivers_zkapps/dune file for better readability and maintenance.