### PR TITLE
Alphabetize dependencies in filtered_external_transition dune

### DIFF
--- a/src/lib/filtered_external_transition/dune
+++ b/src/lib/filtered_external_transition/dune
@@ -4,46 +4,46 @@
  (library_flags -linkall)
  (libraries
   ;; opam libraries
-  core_kernel
-  bin_prot.shape
-  base.caml
   base
+  base.caml
+  bin_prot.shape
   core
+  core_kernel
   sexplib0
   ;; local libraries
-  staged_ledger_diff
-  staged_ledger
-  transaction_snark_work
-  consensus
-  data_hash_lib
-  currency
-  with_hash
-  mina_base
-  mina_state
-  mina_transaction
-  mina_block
-  signature_lib
-  mina_base.import
-  mina_numbers
-  ppx_version.runtime
-  pickles.backend
-  pickles
-  snark_params
-  kimchi_backend
-  sgn_type
-  sgn
-  mina_transaction_logic
   block_time
+  consensus
+  currency
+  data_hash_lib
+  kimchi_backend
   kimchi_pasta
   kimchi_pasta.basic
-  mina_wire_types)
+  mina_base
+  mina_base.import
+  mina_block
+  mina_numbers
+  mina_state
+  mina_transaction
+  mina_transaction_logic
+  mina_wire_types
+  pickles
+  pickles.backend
+  ppx_version.runtime
+  sgn
+  sgn_type
+  signature_lib
+  snark_params
+  staged_ledger
+  staged_ledger_diff
+  transaction_snark_work
+  with_hash)
  (preprocess
   (pps
    base_quickcheck.ppx_quickcheck
+   ppx_deriving_yojson
    ppx_jane
    ppx_mina
-   ppx_version
-   ppx_deriving_yojson))
+   ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Filtering operations for external transitions"))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/filtered_external_transition/dune file for better readability and maintenance.