### PR TITLE
Alphabetize dependencies in gadt_lib dune file

### DIFF
--- a/src/lib/gadt_lib/dune
+++ b/src/lib/gadt_lib/dune
@@ -5,4 +5,4 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_jane)))
+  (pps ppx_jane ppx_version)))


### PR DESCRIPTION
Alphabetize library dependencies in src/lib/gadt_lib/dune file for better readability and maintenance.