### PR TITLE
Simplify usages of Account_update.map_proofs

### DIFF
--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1750,6 +1750,8 @@ let map_proofs ~f p =
   in
   { Poly.authorization = map_auth p.Poly.authorization; body = p.Poly.body }
 
+let forget_proofs p = map_proofs ~f:(const ()) p
+
 module Fee_payer = struct
   [%%versioned
   module Stable = struct
@@ -1795,6 +1797,12 @@ module Fee_payer = struct
 end
 
 include T
+
+let read_all_proofs_from_disk (p : t) : Stable.Latest.t =
+  map_proofs ~f:Proof_cache_tag.read_proof_from_disk p
+
+let write_all_proofs_to_disk ~proof_cache_db (p : Stable.Latest.t) : t =
+  map_proofs ~f:(Proof_cache_tag.write_proof_to_disk proof_cache_db) p
 
 let account_id (t : (Body.t, _) Poly.t) : Account_id.t =
   Account_id.create t.body.public_key t.body.token_id

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -519,6 +519,9 @@ let forget_hashes =
   in
   impl
 
+let forget_hashes_and_proofs p =
+  forget_hashes @@ map ~f:Account_update.forget_proofs p
+
 module With_hashes_and_data = struct
   [%%versioned
   module Stable = struct
@@ -593,13 +596,10 @@ module With_hashes = struct
   end]
 
   let read_all_proofs_from_disk : t -> Stable.Latest.t =
-    map ~f:(Account_update.map_proofs ~f:Proof_cache_tag.read_proof_from_disk)
+    map ~f:Account_update.read_all_proofs_from_disk
 
   let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
-    map
-      ~f:
-        (Account_update.map_proofs
-           ~f:(Proof_cache_tag.write_proof_to_disk proof_cache_db) )
+    map ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
 
   let empty = Digest.Forest.empty
 

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -493,13 +493,6 @@ let rec accumulate_hashes ~hash_account_update (xs : _ t) =
       let node_hash = Digest.Tree.create node in
       { elt = node; stack_hash = Digest.Forest.cons node_hash (hash xs) } :: xs
 
-let accumulate_hashes' (type a b) (xs : (Account_update.t, a, b) t) :
-    (Account_update.t, Digest.Account_update.t, Digest.Forest.t) t =
-  let hash_account_update (p : Account_update.t) =
-    Digest.Account_update.create p
-  in
-  accumulate_hashes ~hash_account_update xs
-
 let accumulate_hashes_predicated xs =
   accumulate_hashes ~hash_account_update:Digest.Account_update.create xs
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4650,25 +4650,8 @@ module Make_str (A : Wire_types.Concrete) = struct
       let account_updates =
         Option.to_list sender_account_update @ snapp_zkapp_command
       in
-      let zkapp_command : Zkapp_command.t =
-        { fee_payer
-        ; memo
-        ; account_updates =
-            Zkapp_command.Call_forest.of_account_updates account_updates
-              ~account_update_depth:(fun (p : Account_update.Simple.t) ->
-                p.body.call_depth )
-            |> Zkapp_command.Call_forest.map
-                 ~f:
-                   (Fn.compose
-                      (Account_update.map_proofs
-                         ~f:(Proof_cache_tag.write_proof_to_disk proof_cache_db) )
-                      Account_update.of_simple )
-            |> Zkapp_command.Call_forest.accumulate_hashes
-                 ~hash_account_update:(fun (p : Account_update.t) ->
-                   Zkapp_command.Digest.Account_update.create p )
-        }
-      in
-      zkapp_command
+      Zkapp_command.of_simple ~proof_cache_db
+        { fee_payer; memo; account_updates }
 
     (* This spec is intended to build a zkapp command with only one account update
        with proof authorization. This is mainly for cross-network replay tests. We

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4786,9 +4786,13 @@ module Make_str (A : Wire_types.Concrete) = struct
             }
         ]
       in
-      Zkapp_command.map_proofs
-        ~f:(Proof_cache_tag.write_proof_to_disk proof_cache_db)
-        { fee_payer; memo; account_updates = forest }
+      { Zkapp_command.Poly.fee_payer
+      ; memo
+      ; account_updates =
+          Zkapp_command.Call_forest.map
+            ~f:(Account_update.write_all_proofs_to_disk ~proof_cache_db)
+            forest
+      }
 
     module Update_states_spec = struct
       type t =
@@ -5012,8 +5016,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         let sender_account_update = Option.value_exn sender_account_update in
         Zkapp_command.Call_forest.cons
           ( Account_update.of_simple sender_account_update
-          |> Account_update.map_proofs
-               ~f:(Proof_cache_tag.write_proof_to_disk proof_cache_db) )
+          |> Account_update.write_all_proofs_to_disk ~proof_cache_db )
           zkapp_command.account_updates
       in
       { zkapp_command with account_updates }

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -59,15 +59,15 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Option.value_map memo ~default:Signed_command_memo.dummy
       ~f:Signed_command_memo.create_from_string_exn
   in
-  Zkapp_command.map_proofs
-    ~f:(const @@ Lazy.force Proof.For_tests.blockchain_dummy_tag)
+  Zkapp_command.write_all_proofs_to_disk
+    ~proof_cache_db:(Proof_cache_tag.For_tests.create_db ())
     { Zkapp_command.Poly.fee_payer
     ; memo
     ; account_updates =
         Zkapp_command.Call_forest.map account_updates
-          ~f:(fun (p : Account_update.Body.Simple.t) ->
+          ~f:(fun (body : Account_update.Body.Simple.t) ->
             let authorization =
-              match p.authorization_kind with
+              match body.authorization_kind with
               | None_given ->
                   Control.Poly.None_given
               | Proof _ ->
@@ -76,10 +76,9 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
               | Signature ->
                   Control.Poly.Signature Signature.dummy
             in
-            { Account_update.Poly.body = Account_update.Body.of_simple p
+            { Account_update.Poly.body = Account_update.Body.of_simple body
             ; authorization
             } )
-        |> Zkapp_command.Call_forest.accumulate_hashes_predicated
     }
 
 let proof_cache_db = Proof_cache_tag.For_tests.create_db ()


### PR DESCRIPTION
This PR reduces complexity of code relying (transitively) on `Account_update.map_proofs`.

It localizes usages of `map_proofs` to `Account_update` module and exposes instead a number of higher-level functions.

Explain how you tested your changes:
* A refactoring, no logic is changed

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
