### PR TITLE
Reorganize Actions in zkapp command

### DIFF
--- a/src/lib/mina_base/test/zkapp_account_test.ml
+++ b/src/lib/mina_base/test/zkapp_account_test.ml
@@ -12,11 +12,11 @@ open Mina_base
 open Zkapp_account
 
 module type Events_list_intf = sig
-  type t = Event.t list [@@deriving compare, sexp]
+  type t
 
-  type var = t Data_as_hash.t
+  type var
 
-  val typ : (var, t) Typ.t
+  val typ : (var, Event.t list) Typ.t
 
   val push_to_data_as_hash : var -> Event.var -> var
 
@@ -65,7 +65,7 @@ let checked_pop_reverses_push (module E : Events_list_intf) () =
               in
               go [] pushed
             in
-            [%test_eq: E.t] events popped )
+            [%test_eq: Event.t list] events popped )
       in
       match Snark_params.Tick.Run.run_and_check f with
       | Ok () ->

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -113,22 +113,26 @@ end)
 module Actions = struct
   type var = Actions_impl.var
 
-  type t = Actions_impl.t [@@deriving sexp, compare]
+  type t = Actions_impl.t * unit
+
+  let is_empty ((lst, _) : t) = List.is_empty lst
 
   let is_empty_var (e : var) =
     Snark_params.Tick.Field.(
       Checked.equal (Data_as_hash.hash e) (Var.constant Actions_impl.empty_hash))
 
-  let empty_state_element =
+  let empty_state_element : Field.t =
     let salt_phrase = "MinaZkappActionStateEmptyElt" in
     Hash_prefix_create.salt salt_phrase |> Random_oracle.digest
 
-  let push_events (acc : Field.t) (events : t) : Field.t =
+  let push_events (acc : Field.t) ((events, _) : t) : Field.t =
     Actions_impl.push_hash acc (Actions_impl.hash events)
 
   let push_events_checked (x : Field.Var.t) (e : var) : Field.Var.t =
     Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_actions
       [| x; Data_as_hash.hash e |]
+
+  let of_event_list lst = (lst, ())
 
   [%%define_locally
   Actions_impl.

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -113,9 +113,9 @@ end)
 module Actions = struct
   type var = Actions_impl.var
 
-  type t = Actions_impl.t * unit
+  type t = Actions_impl.t
 
-  let is_empty ((lst, _) : t) = List.is_empty lst
+  let is_empty (lst : t) = List.is_empty lst
 
   let is_empty_var (e : var) =
     Snark_params.Tick.Field.(
@@ -125,14 +125,14 @@ module Actions = struct
     let salt_phrase = "MinaZkappActionStateEmptyElt" in
     Hash_prefix_create.salt salt_phrase |> Random_oracle.digest
 
-  let push_events (acc : Field.t) ((events, _) : t) : Field.t =
+  let push_events (acc : Field.t) (events : t) : Field.t =
     Actions_impl.push_hash acc (Actions_impl.hash events)
 
   let push_events_checked (x : Field.Var.t) (e : var) : Field.Var.t =
     Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_actions
       [| x; Data_as_hash.hash e |]
 
-  let of_event_list lst = (lst, ())
+  let of_event_list lst = lst
 
   [%%define_locally
   Actions_impl.

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -868,8 +868,6 @@ end
 (* so transaction ids have a version tag *)
 include Codable.Make_base64 (Stable.Latest.With_top_version_tag)
 
-type account_updates = (Account_update.t, unit, unit) Call_forest.t
-
 let account_updates_deriver obj =
   let of_zkapp_command_with_depth (ps : Account_update.Graphql_repr.t list) =
     Call_forest.of_account_updates ps

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -587,6 +587,7 @@ module Account_update_body_components = struct
        , 'token_id
        , 'amount
        , 'events
+       , 'actions
        , 'call_data
        , 'int
        , 'bool
@@ -602,7 +603,7 @@ module Account_update_body_components = struct
     ; balance_change : 'amount
     ; increment_nonce : 'bool
     ; events : 'events
-    ; actions : 'events
+    ; actions : 'actions
     ; call_data : 'call_data
     ; call_depth : 'int
     ; protocol_state_precondition : 'protocol_state_precondition
@@ -676,7 +677,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
        first_use_of_account:bool -> Account.t -> d Quickcheck.Generator.t )
     ~(f_account_update_account_precondition :
        d -> Account_update.Account_precondition.t ) ~authorization_tag () :
-    (_, _, _, a, _, _, _, b, _, d, _, _, _) Account_update_body_components.t
+    (_, _, _, a, _, _, _, _, b, _, d, _, _, _) Account_update_body_components.t
     Quickcheck.Generator.t =
   let open Quickcheck.Let_syntax in
   (* fee payers have to be in the ledger *)

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -948,7 +948,8 @@ let gen_account_update_body_components (type a b c d) ?global_slot
                       .global_slot_since_genesis )
              in
              let action_state, _last_action_slot =
-               Mina_ledger.Ledger.update_action_state zk.action_state actions
+               Mina_ledger.Ledger.update_action_state zk.action_state
+                 (Zkapp_account.Actions.of_event_list actions)
                  ~txn_global_slot ~last_action_slot
              in
              action_state

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1085,7 +1085,7 @@ module Make (L : Ledger_intf.S) :
     module Actions = struct
       type t = Zkapp_account.Actions.t
 
-      let is_empty = List.is_empty
+      let is_empty = Zkapp_account.Actions.is_empty
 
       let push_events = Account_update.Actions.push_events
     end
@@ -1420,7 +1420,7 @@ module Make (L : Ledger_intf.S) :
           Zkapp_basic.Set_or_keep.map ~f:Option.some
             account_update.body.update.verification_key
 
-        let actions (account_update : t) = account_update.body.actions
+        let actions (account_update : t) = (account_update.body.actions, ())
 
         let zkapp_uri (account_update : t) =
           account_update.body.update.zkapp_uri

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1420,7 +1420,7 @@ module Make (L : Ledger_intf.S) :
           Zkapp_basic.Set_or_keep.map ~f:Option.some
             account_update.body.update.verification_key
 
-        let actions (account_update : t) = (account_update.body.actions, ())
+        let actions (account_update : t) = account_update.body.actions
 
         let zkapp_uri (account_update : t) =
           account_update.body.update.zkapp_uri


### PR DESCRIPTION
This PR refactors definitions of Actions in a way that allows alternative definition of Actions.t type.

This is useul to store some auziliary hash information.

- **Make definition of Zkapp_account.Actions more explicit**
- **Add actions type variable to Account_update_body_components**
- **Change type of Zkapp_account.Actions**
- **Rollback addition of unit to Actions.t**

Explain how you tested your changes:
* Simple refactoring, no behavior changes

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
