### PR TITLE
Fix typos with codespell in pickles and transition_frontier

### DIFF
--- a/src/lib/pickles/README.md
+++ b/src/lib/pickles/README.md
@@ -92,7 +92,7 @@ library. Refer to the file header for a content description:
 
 For a general explain for recursive-SNARKs, please check [ZKP MOOC Lec 10: Recursive SNARKs](https://www.youtube.com/watch?v=0LW-qeVe6QI&list=PLS01nW3Rtgor_yJmQsGBZAg5XM4TSGpPs&index=10)
 
-Some public videos you can find on YouTube describing the intial idea behind
+Some public videos you can find on YouTube describing the initial idea behind
 Pickles. It might be outdated if the IOP is changed.
 - [zkStudyClub: Izaak Meckler o1Labs - Pickles ](https://www.youtube.com/watch?v=kmCXdjv5oP0)
 - [ZK-GLOBAL 0x05 - Izaak Meckler - Meet Pickles SNARK ](https://www.youtube.com/watch?v=nOnGOxyh7jY)

--- a/src/lib/pickles/snarky_tests/snarky_tests.ml
+++ b/src/lib/pickles/snarky_tests/snarky_tests.ml
@@ -382,7 +382,7 @@ module As_prover_circuits = struct
     (* test that accessing non existent vars fails*)
     let generate_witness_fails () =
       Alcotest.(
-        check_raises "should fail accesing non existent var"
+        check_raises "should fail accessing non existent var"
           (Failure "vector_get") generate_witness_fails)
 
     (* test that as_prover doesn't affect constraints *)

--- a/src/lib/pickles/test/test_wrap.ml
+++ b/src/lib/pickles/test/test_wrap.ml
@@ -100,7 +100,7 @@ let run_recursive_proof_test (actual_feature_flags : Plonk_types.Features.flags)
            - The next step proof also computes the deferred values inside the circuit and verifies
              that they match those used by the previous wrap proof.
 
-      The code below generates the deferred values so that we can verifiy that we can actually
+      The code below generates the deferred values so that we can verify that we can actually
       compute those values correctly inside the circuit.  Special thanks to Matthew Ryan for
       explaining this in detail. *)
   let { Wrap.For_tests_only.deferred_values

--- a/src/lib/transition_frontier/README.md
+++ b/src/lib/transition_frontier/README.md
@@ -100,7 +100,7 @@ The database supports the following schema:
 | `Db_version`                          | `()`           | `int`                       | The current schema version stored in the database. |
 | `Root`                                | `()`           | `Root_data.Minimal.t`       | The auxiliary root data. |
 | `Best_tip`                            | `()`           | `State_hash.t`              | Pointer to the current best tip. |
-| `Protocol_states_for_root_scan_state` | `()`           | `Protocol_state.value list` | Auxilliary block headers required for constructing the scan state at the root |
+| `Protocol_states_for_root_scan_state` | `()`           | `Protocol_state.value list` | Auxiliary block headers required for constructing the scan state at the root |
 | `Transition`                          | `State_hash.t` | `External_transition.t`     | Block storage by state hash. |
 | `Arcs`                                | `State_hash.t` | `State_hash.t list`         | Successor hash storage by predecessor hash. |
 
@@ -110,7 +110,7 @@ TODO
 
 ### Root History
 
-TOOD
+TODO
 
 TODO: note about the fact it is currently an extension
 

--- a/src/lib/transition_frontier/extensions/extensions.mli
+++ b/src/lib/transition_frontier/extensions/extensions.mli
@@ -1,9 +1,9 @@
 (** Transition frontier extensions defines the set of extensions which are
  *  attached to an instance of a transition frontier. A transition frontier
  *  extension is an incrementally computed view on the transition frontier's
- *  contents. Extensions synchronously recieve diffs applied to the transition
+ *  contents. Extensions synchronously receive diffs applied to the transition
  *  frontier. Every extension is associated with a broadcast pipe, which allows
- *  outside consumers of extensions to recieve updates a extension's view.
+ *  outside consumers of extensions to receive updates a extension's view.
  *  Calling [notify] from this module will update all extensions with the new
  *  transition frontier diffs, waiting for all consumers of each extensions'
  *  broadcast pipes to finish handling any view updates that may occur.

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -90,7 +90,7 @@ module Limited : sig
 end
 
 (* Minimal root data contains the smallest amount of information about a root.
- * It contains a hash pointing to the root transition, and the auxilliary data
+ * It contains a hash pointing to the root transition, and the auxiliary data
  * needed to reconstruct the staged ledger at that point (scan_state,
  * pending_coinbase).
  *)

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -386,7 +386,7 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
    * the following operations on masks in order:
    *
    *     0) notify consensus that root transitioned
-   *     1) unattach and destroy all the garbage (to avoid unecessary trickling of
+   *     1) unattach and destroy all the garbage (to avoid unnecessary trickling of
    *        invalidations from `m0` during the next step)
    *     2) commit `m1` into `m0`, making `m0` into `m1'` (same merkle root as `m1`), and
    *        making `m1` into an identity mask (an empty mask on top of `m1'`).

--- a/src/lib/transition_frontier/persistent_frontier/sync.mli
+++ b/src/lib/transition_frontier/persistent_frontier/sync.mli
@@ -1,6 +1,6 @@
 (** This module provides the implementation for actively "syncing" the
  *  persistent frontier database. A [Sync] job can be created, and can
- *  then be sent diffs to accumulate and apply to the databse in chunks
+ *  then be sent diffs to accumulate and apply to the database in chunks
  *  (using the [Diff_buffer]).
  *)
 

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -294,7 +294,7 @@ let rec load_with_max_length :
       ~snarked_ledger_hash:genesis_ledger_hash
   in
   match
-    time ~label:"Persistent_frontier.Instsance.check_database" ~logger
+    time ~label:"Persistent_frontier.Instance.check_database" ~logger
     @@ fun () ->
     Persistent_frontier.Instance.check_database
       ~genesis_state_hash:

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -524,7 +524,7 @@ include struct
 
   let common_ancestor = proxy1 common_ancestor
 
-  (* reduce sucessors functions (probably remove hashes special case *)
+  (* reduce successors functions (probably remove hashes special case *)
   let successors = proxy1 successors
 
   let successors_rec = proxy1 successors_rec
@@ -598,7 +598,7 @@ module For_tests = struct
         >>| Result.map_error ~f:(Fn.compose fail (function
           | `Bootstrap_required -> "bootstrap required"
           | `Persistent_frontier_malformed -> "persistent frontier malformed"
-          | `Faliure msg -> msg))
+          | `Failure msg -> msg))
         >>| Result.ok_or_failwith
       in
       let%bind () = Deferred.List.iter trees ~f:(deferred_rose_tree_iter ~f:(add_breadcrumb_exn frontier)) in


### PR DESCRIPTION
Tired of seeing bots.

Close https://github.com/MinaProtocol/mina/pull/16975