### PR TITLE
fixed broken link

### DIFF
--- a/scripts/mina-local-network/README.md
+++ b/scripts/mina-local-network/README.md
@@ -37,7 +37,7 @@
            src/app/logproc/logproc.exe
        ```
 
-     - If you’d like to work with [zkApps](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-zkapps.md) using [SnarkyJS](https://github.com/o1-labs/snarkyjs) locally.
+     - If you’d like to work with [zkApps](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-0004-zkapps.md) using [SnarkyJS](https://github.com/o1-labs/snarkyjs) locally.
 
        - Build the `SnarkyJS`:
 


### PR DESCRIPTION
#16971 
Explain your changes:
Hi! I fixed a broken link in scripts/mina-local-network/README.md — old link was pointing to mip-zkapps.md, but the file has since been renamed to mip-0004-zkapps.md.

Explain how you tested your changes:
...

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
