### PR TITLE
Defunctorize Graphql client

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -4,11 +4,7 @@ open Signature_lib
 open Mina_base
 open Mina_transaction
 
-module Client = Graphql_lib.Client.Make (struct
-  let preprocess_variables_string = Fn.id
-
-  let headers = String.Map.empty
-end)
+module Client = Graphql_lib.Client
 
 module Args = struct
   open Command.Param
@@ -1341,7 +1337,7 @@ let import_key =
                !"\n😄 Imported account!\nPublic key: %s\n"
                (Public_key.Compressed.to_base58_check public_key)
          | `Graphql_error _ as e ->
-             don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn e)
+             don't_wait_for (Client.Connection_error.ok_exn e)
        in
        match access_method with
        | `GraphQL graphql_endpoint -> (
@@ -1349,7 +1345,7 @@ let import_key =
            | Ok res ->
                print_result res
            | Error err ->
-               don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn err) )
+               don't_wait_for (Client.Connection_error.ok_exn err) )
        | `Conf_dir conf_dir ->
            let%map res = do_local conf_dir in
            print_result res
@@ -1496,7 +1492,7 @@ let list_accounts =
          | Error (`Failed_request _ as err) ->
              Error err
          | Error (`Graphql_error _ as err) ->
-             don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn err) ;
+             don't_wait_for (Client.Connection_error.ok_exn err) ;
              Ok ()
        in
        let do_local conf_dir =
@@ -1521,7 +1517,7 @@ let list_accounts =
            | Ok () ->
                ()
            | Error err ->
-               don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn err) )
+               don't_wait_for (Client.Connection_error.ok_exn err) )
        | `Conf_dir conf_dir ->
            do_local conf_dir
        | `None -> (

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -1,11 +1,7 @@
 open Core
 open Async
 
-module Client = Graphql_lib.Client.Make (struct
-  let preprocess_variables_string = Fn.id
-
-  let headers = String.Map.empty
-end)
+module Client = Graphql_lib.Client
 
 let run_exn ~f query_obj (uri : Uri.t Cli_lib.Flag.Types.with_name) =
   let log_location_detail =

--- a/src/lib/integration_test_lib/graphql_requests.ml
+++ b/src/lib/integration_test_lib/graphql_requests.ml
@@ -9,11 +9,7 @@ open Mina_transaction
 let node_password = "naughty blue worm"
 
 module Graphql = struct
-  module Client = Graphql_lib.Client.Make (struct
-    let preprocess_variables_string = Fn.id
-
-    let headers = String.Map.empty
-  end)
+  module Client = Graphql_lib.Client
 
   (* graphql_ppx uses Stdlib symbols instead of Base *)
   open Stdlib

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -2,11 +2,7 @@ open Core_kernel
 open Async
 module Prod = Snark_worker__Prod.Inputs
 
-module Graphql_client = Graphql_lib.Client.Make (struct
-  let preprocess_variables_string = Fn.id
-
-  let headers = String.Map.empty
-end)
+module Graphql_client = Graphql_lib.Client
 
 module Encoders = Mina_graphql.Types.Input
 module Scalars = Graphql_lib.Scalars


### PR DESCRIPTION
This PR removes the `Make` functor from Graphql_lib/Client that was always called with the same argument (aka `Fn.id` and `Map.empty`).
