### PR TITLE
scripts/debian: use compatible version

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -239,6 +239,10 @@ build_batch_txn_deb() {
 build_functional_test_suite_deb() {
   create_control_file mina-test-suite "${SHARED_DEPS}" 'Test suite apps for mina.'
 
+  mkdir -p "${BUILDDIR}/etc/mina/test/archive"
+
+  cp -r ../src/test/archive/* "${BUILDDIR}"/etc/mina/test/archive/
+
   # Binaries
   cp ./default/src/test/command_line_tests/command_line_tests.exe "${BUILDDIR}/usr/local/bin/mina-command-line-tests"
   cp ./default/src/app/benchmarks/benchmarks.exe "${BUILDDIR}/usr/local/bin/mina-benchmarks"
@@ -347,7 +351,7 @@ build_daemon_berkeley_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building Mina Berkeley testnet signatures deb without keys:"
 
-  create_control_file "${MINA_DEB_NAME}" "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon'
+  create_control_file "${MINA_DEB_NAME}" "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Berkeley Network' "${SUGGESTED_DEPS}"
 
   copy_common_daemon_configs berkeley testnet 'seed-lists/berkeley_seeds.txt'
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -161,6 +161,7 @@ copy_common_daemon_configs() {
   # Include all useful genesis ledgers
   cp ../genesis_ledgers/mainnet.json "${BUILDDIR}/var/lib/coda/mainnet.json"
   cp ../genesis_ledgers/devnet.json "${BUILDDIR}/var/lib/coda/devnet.json"
+  cp ../genesis_ledgers/berkeley.json "${BUILDDIR}/var/lib/coda/berkeley.json"
   # Set the default configuration based on Network name ($1)
   cp ../genesis_ledgers/"${1}".json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
   cp ../scripts/hardfork/create_runtime_config.sh "${BUILDDIR}/usr/local/bin/mina-hf-create-runtime-config"
@@ -237,10 +238,6 @@ build_batch_txn_deb() {
 ##################################### GENERATE TEST SUITE PACKAGE #######################################
 build_functional_test_suite_deb() {
   create_control_file mina-test-suite "${SHARED_DEPS}" 'Test suite apps for mina.'
-
-  mkdir -p "${BUILDDIR}/etc/mina/test/archive"
-
-  cp -r ../src/test/archive/* "${BUILDDIR}"/etc/mina/test/archive/
 
   # Binaries
   cp ./default/src/test/command_line_tests/command_line_tests.exe "${BUILDDIR}/usr/local/bin/mina-command-line-tests"
@@ -336,7 +333,7 @@ build_daemon_devnet_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building testnet signatures deb without keys:"
 
-  create_control_file mina-devnet "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Devnet Network'
+  create_control_file mina-devnet "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Devnet Network' "${SUGGESTED_DEPS}"
 
   copy_common_daemon_configs devnet testnet 'seed-lists/devnet_seeds.txt'
 
@@ -348,13 +345,14 @@ build_daemon_devnet_deb() {
 build_daemon_berkeley_deb() {
 
   echo "------------------------------------------------------------"
-  echo "--- Building testnet signatures deb without keys:"
+  echo "--- Building Mina Berkeley testnet signatures deb without keys:"
 
-  create_control_file ${MINA_DEB_NAME} "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon for the Berkeley Network'
+  create_control_file "${MINA_DEB_NAME}" "${SHARED_DEPS}${DAEMON_DEPS}" 'Mina Protocol Client and Daemon'
 
-  copy_common_daemon_configs berkeley testnet 'seed-lists/devnet_seeds.txt'
+  copy_common_daemon_configs berkeley testnet 'seed-lists/berkeley_seeds.txt'
 
-  build_deb ${MINA_DEB_NAME}
+  build_deb "${MINA_DEB_NAME}"
+
 }
 ##################################### END BERKELEY PACKAGE ######################################
 

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -73,4 +73,4 @@ function rebuild_deb() {
 }
 
 rebuild_deb
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}" --bucket "${NEW_REPO}"
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}" --bucket "${NEW_REPO}" ${SIGN_ARG}

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -73,4 +73,4 @@ function rebuild_deb() {
 }
 
 rebuild_deb
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}" --bucket "${REPO}" ${SIGN_ARG}
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}" --bucket "${NEW_REPO}"


### PR DESCRIPTION
This is simply copy/pasting the version from compatible, to not have any conflict anymore.