### PR TITLE
Fix refresh code on non mainline branch pr

### DIFF
--- a/buildkite/scripts/refresh_code.sh
+++ b/buildkite/scripts/refresh_code.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 git branch -D $BUILDKITE_BRANCH 2>/dev/null || true
+git fetch
 git checkout -b $BUILDKITE_BRANCH
 git reset --hard $BUILDKITE_COMMIT

--- a/buildkite/scripts/refresh_code.sh
+++ b/buildkite/scripts/refresh_code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 git branch -D $BUILDKITE_BRANCH 2>/dev/null || true
-git fetch
+git fetch origin "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
 git checkout -b $BUILDKITE_BRANCH
 git reset --hard $BUILDKITE_COMMIT

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -2012,6 +2012,7 @@ let print_version_help coda_exe version =
   in
   List.iter lines ~f:(Core.printf "%s\n%!")
 
+  
 let print_version_info () = Core.printf "Commit %s\n" Mina_version.commit_id
 
 let () =

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -2012,7 +2012,6 @@ let print_version_help coda_exe version =
   in
   List.iter lines ~f:(Core.printf "%s\n%!")
 
-  
 let print_version_info () = Core.printf "Commit %s\n" Mina_version.commit_id
 
 let () =


### PR DESCRIPTION
Some guys are experiencing issue when running CI with non mainline branches as base. For example:

https://github.com/MinaProtocol/mina/pull/17040

This PR is fixing above issue by fetching before refering to base branch. 

I've tested my solution here: https://github.com/MinaProtocol/mina/pull/17042