### PR TITLE
Fix: Update outdated Mina node operator links

### DIFF
--- a/automation/services/echo/README.md
+++ b/automation/services/echo/README.md
@@ -4,7 +4,7 @@ This is a simple node service that listens for transactions to a specific addres
 
 ## Usage
 
-First you'll need to have a `mina` daemon running on your machine. See [the docs for instructions](https://docs.minaprotocol.com/en/node-operators/getting-started) on getting a node, then run the following command:
+First you'll need to have a `mina` daemon running on your machine. See [the docs for instructions](https://docs.minaprotocol.com/node-operators) on getting a node, then run the following command:
 
 ```
 $ mina daemon -rest-port 49370 -peer beta.o1test.net:8303

--- a/automation/services/faucet/README.md
+++ b/automation/services/faucet/README.md
@@ -4,7 +4,7 @@ The faucet service is a simple Discord bot that listens for requests for `CODA` 
 
 ## Usage
 
-First you'll need to have a `coda` daemon running on your machine. See the docs [here](https://docs.minaprotocol.com/en/node-operators/getting-started) for instructions on getting a node, then run the following command:
+First you'll need to have a `coda` daemon running on your machine. See the docs [here](https://docs.minaprotocol.com/node-operators) for instructions on getting a node, then run the following command:
 
 ```
 $ mina daemon -rest-port 49370 -peer beta.o1test.net:8303


### PR DESCRIPTION
This pull request updates broken links to the Mina node operators documentation in two README files.
The previous links pointed to a non-existent "getting-started" page. Now they correctly point to the general "Node Operators" section.