### PR TITLE
fix: function name

### DIFF
--- a/buildkite/scripts/check-compatibility.sh
+++ b/buildkite/scripts/check-compatibility.sh
@@ -15,7 +15,7 @@ function image_tag {
     IMAGE_TAG="$SHA-bullseye-berkeley"
 }
 
-function download-docker {
+function download_docker {
    SHA=$1
    image_tag $SHA
    docker pull gcr.io/o1labs-192920/mina-daemon:$IMAGE_TAG


### PR DESCRIPTION
updated the function naming convention to avoid using dashes in Bash function names.

p.s. in Bash, dashes are interpreted as subtraction operators, which was causing issues. the function names now use underscores instead of dashes to ensure proper functionality.