### PR TITLE
Wire transaction pool proxy in txn handler

### DIFF
--- a/changes/17091.md
+++ b/changes/17091.md
@@ -1,0 +1,1 @@
+Expose transaction pool to transition handler, so when a node received blocks gossiped by peers, it's able to skip some verification of commands if it knows they're already verified.

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -336,6 +336,7 @@ module type Transition_router_intf = sig
           -> Transaction_snark_work.Checked.t option )
     -> catchup_mode:[ `Normal | `Super ]
     -> notify_online:(unit -> unit Deferred.t)
+    -> ?transaction_pool_proxy:Staged_ledger.transaction_pool_proxy
     -> unit
     -> ( [ `Transition of Mina_block.Validated.t ]
        * [ `Source of [ `Gossip | `Catchup | `Internal ] ]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2152,6 +2152,17 @@ let create ~commit_id ?wallets (config : Config.t) =
           let get_most_recent_valid_block () =
             Broadcast_pipe.Reader.peek most_recent_valid_block_reader
           in
+
+          let transaction_resource_pool =
+            Network_pool.Transaction_pool.resource_pool transaction_pool
+          in
+          let transaction_pool_proxy : Staged_ledger.transaction_pool_proxy =
+            { find_by_hash =
+                Network_pool.Transaction_pool.Resource_pool.find_by_hash
+                  transaction_resource_pool
+            }
+          in
+
           let valid_transitions, initialization_finish_signal =
             Transition_router.run
               ~context:(module Context)
@@ -2168,7 +2179,7 @@ let create ~commit_id ?wallets (config : Config.t) =
               ~most_recent_valid_block_writer
               ~get_completed_work:
                 (Network_pool.Snark_pool.get_completed_work snark_pool)
-              ~notify_online ()
+              ~notify_online ~transaction_pool_proxy ()
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -359,7 +359,7 @@ let%test_module "Epoch ledger sync tests" =
           ~get_completed_work:(Fn.const None) ~catchup_mode:`Normal
           ~network_transition_reader:block_reader ~producer_transition_reader
           ~get_most_recent_valid_block ~most_recent_valid_block_writer
-          ~notify_online ()
+          ~notify_online ?transaction_pool_proxy:None ()
       in
       let%bind () = Ivar.read initialization_finish_signal in
       let tr_tm1 = Unix.gettimeofday () in

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -30,4 +30,5 @@
   with_hash
   genesis_constants
   consensus
-  bootstrap_controller))
+  bootstrap_controller
+  staged_ledger))

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -18,7 +18,7 @@ end
 let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     ~time_controller ~collected_transitions ~frontier ~get_completed_work
     ~network_transition_reader ~producer_transition_reader ~clear_reader
-    ~cache_exceptions =
+    ~cache_exceptions ?transaction_pool_proxy =
   let open Context in
   let valid_transition_pipe_capacity = 50 in
   let start_time = Time.now () in
@@ -136,7 +136,8 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
     ~time_controller ~trust_system ~verifier ~frontier ~get_completed_work
     ~primary_transition_reader ~producer_transition_reader
     ~clean_up_catchup_scheduler ~catchup_job_writer ~catchup_breadcrumbs_reader
-    ~catchup_breadcrumbs_writer ~processed_transition_writer ;
+    ~catchup_breadcrumbs_writer ~processed_transition_writer
+    ?transaction_pool_proxy ;
   Ledger_catchup.run
     ~context:(module Context)
     ~trust_system ~verifier ~network ~frontier ~catchup_job_reader

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -54,6 +54,7 @@
   internal_tracing
   transition_frontier_extensions
   staged_ledger_diff
+  staged_ledger
   mina_runtime_config)
  (instrumentation
   (backend bisect_ppx))

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -105,7 +105,8 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 
 let process_transition ~context:(module Context : CONTEXT) ~trust_system
     ~verifier ~get_completed_work ~frontier ~catchup_scheduler
-    ~processed_transition_writer ~time_controller ~block_or_header ~valid_cb =
+    ~processed_transition_writer ~time_controller ~block_or_header ~valid_cb
+    ?transaction_pool_proxy =
   let is_block_in_frontier =
     Fn.compose Option.is_some @@ Transition_frontier.find frontier
   in
@@ -249,7 +250,7 @@ let process_transition ~context:(module Context : CONTEXT) ~trust_system
               ~verifier ~get_completed_work ~trust_system
               ~transition_receipt_time ~sender:(Some sender)
               ~parent:parent_breadcrumb ~transition:mostly_validated_transition
-              (* TODO: Can we skip here? *) () )
+              ?transaction_pool_proxy (* TODO: Can we skip here? *) () )
           ~transform_result:(function
             | Error (`Invalid_staged_ledger_hash error)
             | Error (`Invalid_staged_ledger_diff error) ->
@@ -315,7 +316,7 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
          * [ `Ledger_catchup of unit Ivar.t | `Catchup_scheduler ]
        , crash buffered
        , unit )
-       Writer.t ) ~processed_transition_writer =
+       Writer.t ) ~processed_transition_writer ?transaction_pool_proxy =
   let open Context in
   let catchup_scheduler =
     Catchup_scheduler.create ~logger ~precomputed_values ~verifier ~trust_system
@@ -458,7 +459,8 @@ let run ~context:(module Context : CONTEXT) ~verifier ~trust_system
                       Transition_frontier_controller.transitions_being_processed)
               | `Partially_valid_transition (block_or_header, `Valid_cb valid_cb)
                 ->
-                  process_transition ~block_or_header ~valid_cb ) ) )
+                  process_transition ~block_or_header ~valid_cb
+                    ?transaction_pool_proxy ) ) )
 
 let%test_module "Transition_handler.Processor tests" =
   ( module struct
@@ -563,7 +565,7 @@ let%test_module "Transition_handler.Processor tests" =
                   ~primary_transition_reader:valid_transition_reader
                   ~producer_transition_reader ~catchup_job_writer
                   ~catchup_breadcrumbs_reader ~catchup_breadcrumbs_writer
-                  ~processed_transition_writer ;
+                  ~processed_transition_writer ?transaction_pool_proxy:None ;
                 List.iter branch ~f:(fun breadcrumb ->
                     let b =
                       downcast_breadcrumb breadcrumb

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -51,4 +51,5 @@
   ledger_catchup
   data_hash_lib
   mina_wire_types
-  internal_tracing))
+  internal_tracing
+  staged_ledger))

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -104,7 +104,7 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
     ~trust_system ~verifier ~network ~time_controller ~get_completed_work
     ~producer_transition_writer_ref ~verified_transition_writer ~clear_reader
     ~collected_transitions ~cache_exceptions ?transition_writer_ref ~frontier_w
-    frontier =
+    frontier ?transaction_pool_proxy =
   let open Context in
   [%str_log info] Starting_transition_frontier_controller ;
   let ( transition_frontier_controller_reader
@@ -151,6 +151,7 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
       ~frontier ~get_completed_work
       ~network_transition_reader:transition_frontier_controller_reader
       ~producer_transition_reader ~clear_reader ~cache_exceptions
+      ?transaction_pool_proxy
   in
   Strict_pipe.Reader.iter new_verified_transition_reader
     ~f:
@@ -416,7 +417,8 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
     ~get_completed_work ~frontier_w ~producer_transition_writer_ref
     ~clear_reader ~verified_transition_writer ~cache_exceptions
     ~most_recent_valid_block_writer ~persistent_root ~persistent_frontier
-    ~consensus_local_state ~catchup_mode ~notify_online =
+    ~consensus_local_state ~catchup_mode ~notify_online ?transaction_pool_proxy
+    =
   let open Context in
   [%log info] "Initializing transition router" ;
   let%bind () =
@@ -539,7 +541,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
         ~clear_reader ~collected_transitions ~cache_exceptions
-        ?transition_writer_ref:None ~frontier_w frontier
+        ?transition_writer_ref:None ~frontier_w frontier ?transaction_pool_proxy
 
 let wait_till_genesis ~logger ~time_controller
     ~(precomputed_values : Precomputed_values.t) =
@@ -590,7 +592,8 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
     ~get_current_frontier ~frontier_broadcast_writer:frontier_w
     ~network_transition_reader ~producer_transition_reader
     ~get_most_recent_valid_block ~most_recent_valid_block_writer
-    ~get_completed_work ~catchup_mode ~notify_online () =
+    ~get_completed_work ~catchup_mode ~notify_online ?transaction_pool_proxy ()
+    =
   let open Context in
   [%log info] "Starting transition router" ;
   let initialization_finish_signal = Ivar.create () in
@@ -670,7 +673,7 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
           ~get_completed_work ~frontier_w ~catchup_mode
           ~producer_transition_writer_ref ~clear_reader
           ~verified_transition_writer ~most_recent_valid_block_writer
-          ~consensus_local_state ~notify_online
+          ~consensus_local_state ~notify_online ?transaction_pool_proxy
       in
       Ivar.fill_if_empty initialization_finish_signal () ;
 


### PR DESCRIPTION
This PR expose the transaction pool to `Transition_handler.processor`, so when it's building a breadcrumb, it would be able to query the pool for already verified proofs, so to save time on actually verifying the commands.

One refactor that make this possible is we lift `Transaction_pool_proxy` to to level as it's own module, so we could handle the dependency issue rather than wiring everything together. 