### PR TITLE
Restoring openvsix link:

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -139,8 +139,9 @@ branches, or otherwise changing the dependency tree of Mina.
 
 ##### Visual Studio Code / vscodium
 
-You have to install the "OCaml Platform" extension from
-[official marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform).
+You have to install the "OCaml Platform" extension, either from
+[official marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
+or [openvsix](https://open-vsx.org/extension/ocamllabs/ocaml-platform).
 
 After installing it, run `code` (or `codium`) from within the `nix develop mina#with-lsp` shell,
 click "Select Sandbox" in the extension menu, and then pick "Global Sandbox". From then on, it should just work.


### PR DESCRIPTION
We do want to keep a reference to the opensource package. As it became available again this reverts "Removed broken link:"

This reverts commit 3a44c8d195f190ce3df3c664456022f8bcb8c6cd.