### PR TITLE
chore: fix typos for failwith msg

### DIFF
--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -635,7 +635,7 @@ let parse_error_log (message : Logger.Message.t) =
   | _ ->
       failwith
         "Log_error.parse should always be a `From_error_log variant, but was \
-         mis-programmed as something else. this is a progammer error"
+         mis-programmed as something else. this is a programmer error"
 
 let parse_daemon_event (message : Logger.Message.t) =
   let open Or_error.Let_syntax in
@@ -654,7 +654,7 @@ let parse_daemon_event (message : Logger.Message.t) =
           failwith
             "the 'parse' field of a daemon event should always be a \
              `From_daemon_log variant, but was mis-programmed as something \
-             else. this is a progammer error" )
+             else. this is a programmer error" )
   | None ->
       (* TODO: check log level to ensure it matches error log level *)
       parse_error_log message
@@ -675,7 +675,7 @@ let parse_puppeteer_event (message : Puppeteer_message.t) =
           failwith
             "the 'parse' field of a puppeteer event should always be a \
              `From_puppeteer_log variant, but was mis-programmed as something \
-             else. this is a progammer error" )
+             else. this is a programmer error" )
   | None ->
       failwith
         (Printf.sprintf


### PR DESCRIPTION

Explain your changes:

Fix typos for failwith msg

The new pr for https://github.com/MinaProtocol/mina/pull/16776

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
