### PR TITLE
Add an aux field to Account_update

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4233,7 +4233,7 @@ module Block = struct
           ~f:(fun acc ({ fee_payer; account_updates; memo; _ } as zkapp_cmd) ->
             (* add authorizations, not stored in the db *)
             let (fee_payer : Account_update.Fee_payer.t) =
-              { body = fee_payer; authorization = Signature.dummy }
+              { body = fee_payer; authorization = Signature.dummy; aux = () }
             in
             let (account_updates : Account_update.Simple.t list) =
               List.map account_updates
@@ -4241,7 +4241,7 @@ module Block = struct
                      (body : Account_update.Body.Simple.t)
                      :
                      Account_update.Simple.t
-                   -> { body; authorization = None_given } )
+                   -> { body; authorization = None_given; aux = () } )
             in
             let%map cmd_id =
               User_command.Zkapp_command.add_if_doesn't_exist

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -326,6 +326,7 @@ module Values (S : Sample) = struct
         ; authorization_kind = Proof (field ())
         }
     ; authorization = Proof side_loaded_proof
+    ; aux = ()
     }
 
   let zkapp_command' () : Mina_base.Zkapp_command.t =
@@ -337,6 +338,7 @@ module Values (S : Sample) = struct
             ; nonce = account_nonce ()
             }
         ; authorization = (field (), private_key ())
+        ; aux = ()
         }
     ; account_updates =
         List.init Params.max_zkapp_txn_account_updates ~f:(Fn.const ())

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -522,7 +522,8 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
     let%map (body : Account_update.Body.Fee_payer.t) =
       Load_data.get_fee_payer_body ~pool cmd.zkapp_fee_payer_body_id
     in
-    ({ body; authorization = Signature.dummy } : Account_update.Fee_payer.t)
+    ( { body; authorization = Signature.dummy; aux = () }
+      : Account_update.Fee_payer.t )
   in
   let nonce_str = Mina_numbers.Account_nonce.to_string fee_payer.body.nonce in
   [%log spam]
@@ -547,7 +548,8 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
           | None_given ->
               None_given
         in
-        ({ body; authorization } : Account_update.Simple.t) )
+        let aux = () in
+        ({ body; authorization; aux } : Account_update.Simple.t) )
   in
   let memo = Signed_command_memo.of_base58_check_exn cmd.memo in
   let zkapp_command =

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -187,7 +187,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
 
       (* TODO: This is a pain. *)
-      { body = body vk; authorization = Signature Signature.dummy }
+      { body = body vk; authorization = Signature Signature.dummy; aux = () }
     in
     let%bind zkapp_command_create_accounts =
       let memo =
@@ -223,6 +223,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             ; fee = Currency.Fee.(of_nanomina_int_exn 20_000_000)
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let memo_hash = Signed_command_memo.hash memo in
@@ -251,6 +252,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key account_a_pk ->

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -363,6 +363,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         fee_payer =
           { body = { p.fee_payer.body with nonce = Account.Nonce.of_int 2 }
           ; authorization = Signature.dummy
+          ; aux = ()
           }
       }
     in

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -75,6 +75,7 @@ let%test_module "Actions test" =
       let account_update : Account_update.t =
         { body = account_update_body
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
     end
 
@@ -113,6 +114,7 @@ let%test_module "Actions test" =
             ; nonce = Account.Nonce.of_int fee_payer_nonce
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let memo_hash = Signed_command_memo.hash memo in
@@ -141,6 +143,7 @@ let%test_module "Actions test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -75,6 +75,7 @@ let%test_module "Add events test" =
       let account_update : Account_update.t =
         { body = account_update_body
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
     end
 
@@ -111,6 +112,7 @@ let%test_module "Add events test" =
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let memo_hash = Signed_command_memo.hash memo in
@@ -139,6 +141,7 @@ let%test_module "Add events test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -38,6 +38,7 @@ let account_update : Account_update.t =
   in
   { body = { account_update.body with authorization_kind = Proof vk_hash }
   ; authorization = account_update.authorization
+  ; aux = ()
   }
 
 let deploy_account_update_body : Account_update.Body.t =
@@ -61,6 +62,7 @@ let deploy_account_update_body : Account_update.Body.t =
 let deploy_account_update : Account_update.t =
   { body = deploy_account_update_body
   ; authorization = Signature Signature.dummy
+  ; aux = ()
   }
 
 let account_updates =
@@ -81,6 +83,7 @@ let fee_payer =
       ; fee = Currency.Fee.(of_nanomina_int_exn 100)
       }
   ; authorization = Signature.dummy
+  ; aux = ()
   }
 
 let full_commitment =
@@ -108,6 +111,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = ()
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->
@@ -128,7 +132,8 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
+    { fee_payer =
+        { body = fee_payer.body; authorization = Signature.dummy; aux = () }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -138,6 +138,7 @@ let%test_module "Composability test" =
         (* TODO: This is a pain. *)
         { body = account_update_body
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
     end
 
@@ -228,6 +229,7 @@ let%test_module "Composability test" =
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let memo = Signed_command_memo.empty in
@@ -257,6 +259,7 @@ let%test_module "Composability test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -61,6 +61,7 @@ let deploy_account_update : Account_update.t =
   (* TODO: This is a pain. *)
   { body = deploy_account_update_body
   ; authorization = Signature Signature.dummy
+  ; aux = ()
   }
 
 let account_updates =
@@ -83,6 +84,7 @@ let fee_payer =
       ; fee = Currency.Fee.(of_nanomina_int_exn 100)
       }
   ; authorization = Signature.dummy
+  ; aux = ()
   }
 
 let full_commitment =
@@ -112,6 +114,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = ()
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->
@@ -132,7 +135,8 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
+    { fee_payer =
+        { body = fee_payer.body; authorization = Signature.dummy; aux = () }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -87,6 +87,7 @@ let%test_module "Initialize state test" =
         (* TODO: This is a pain. *)
         { body = account_update_body
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
     end
 
@@ -120,6 +121,7 @@ let%test_module "Initialize state test" =
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let memo_hash = Signed_command_memo.hash memo in
@@ -148,6 +150,7 @@ let%test_module "Initialize state test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -131,6 +131,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id
+             ; aux = ()
              }
       in
       match
@@ -155,6 +156,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons
              { Account_update.Poly.authorization =
@@ -164,6 +166,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
                    ~may_use_token:Parents_own_token
+             ; aux = ()
              }
       in
       let account =
@@ -190,6 +193,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
+             ; aux = ()
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
@@ -199,6 +203,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons
              { Account_update.Poly.authorization =
@@ -208,6 +213,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
                    ~may_use_token:Parents_own_token
+             ; aux = ()
              }
       in
       let account =
@@ -223,6 +229,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30))
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons_tree
              ( fst @@ Async.Thread_safe.block_on_async_exn
@@ -247,6 +254,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 5)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
+             ; aux = ()
              }
              ~calls:
                ( []
@@ -260,6 +268,7 @@ let%test_module "Tokens test" =
                           ~balance_change:(int_to_amount (-2))
                           ~token_id:owned_token_id
                           ~may_use_token:Inherit_from_parent
+                    ; aux = ()
                     }
                     ~calls:
                       ( []
@@ -273,6 +282,7 @@ let%test_module "Tokens test" =
                                  ~balance_change:(int_to_amount (-2))
                                  ~token_id:owned_token_id
                                  ~may_use_token:Inherit_from_parent
+                           ; aux = ()
                            }
                       (* Parents_own_token, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
@@ -283,6 +293,7 @@ let%test_module "Tokens test" =
                                  ~use_full_commitment:true
                                  ~balance_change:(int_to_amount 15)
                                  ~may_use_token:Parents_own_token
+                           ; aux = ()
                            }
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
@@ -293,6 +304,7 @@ let%test_module "Tokens test" =
                                  ~use_full_commitment:true
                                  ~balance_change:(int_to_amount (-15))
                                  ~may_use_token:No
+                           ; aux = ()
                            }
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons
@@ -303,6 +315,7 @@ let%test_module "Tokens test" =
                                  ~use_full_commitment:true
                                  ~balance_change:(int_to_amount 15)
                                  ~may_use_token:No
+                           ; aux = ()
                            }
                       (* Minting by delegate call should be ignored by the sum
                          check.
@@ -332,6 +345,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 15)
                    ~may_use_token:Inherit_from_parent
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons
              { Account_update.Poly.authorization =
@@ -341,6 +355,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
                    ~may_use_token:Parents_own_token
+             ; aux = ()
              }
       in
       let account =
@@ -355,6 +370,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons_tree
              ( fst @@ Async.Thread_safe.block_on_async_exn
@@ -379,6 +395,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Inherit_from_parent
+             ; aux = ()
              }
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons
@@ -388,6 +405,7 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~may_use_token:Inherit_from_parent
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons
              { Account_update.Poly.authorization =
@@ -397,6 +415,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
                    ~may_use_token:Inherit_from_parent
+             ; aux = ()
              }
       in
       let account =
@@ -411,12 +430,14 @@ let%test_module "Tokens test" =
                  Zkapps_examples.mk_update_body (fst mint_to_keys)
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons ~calls:subtree
              { Account_update.Poly.authorization = Control.Poly.None_given
              ; body =
                  Zkapps_examples.mk_update_body pk
                    ~authorization_kind:None_given
+             ; aux = ()
              }
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -329,6 +329,7 @@ module Rules = struct
         { account_update =
             { Account_update.Poly.body = dummy_account_update_body.data
             ; authorization = Control.Poly.None_given
+            ; aux = ()
             }
         ; account_update_digest = dummy_account_update_body.hash
         ; calls = []

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -699,6 +699,7 @@ let compile :
                   Proof
                     ( Proof_cache_tag.write_proof_to_disk proof_cache_db
                     @@ Pickles.Side_loaded.Proof.of_proof proof )
+              ; aux = ()
               }
             in
             ( { Zkapp_command.Call_forest.Tree.account_update
@@ -787,6 +788,7 @@ module Deploy_account_update = struct
     (* TODO: This is a pain. *)
     { body = body ?balance_change ?access public_key token_id vk
     ; authorization = Signature Signature.dummy
+    ; aux = ()
     }
 end
 
@@ -821,6 +823,7 @@ let insert_signatures pk_compressed sk
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = ()
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/lib/mina_base/test/account_update_test.ml
+++ b/src/lib/mina_base/test/account_update_test.ml
@@ -123,7 +123,7 @@ let body_json_roundtrip () =
 let fee_payer_json_roundtrip () =
   let open Fee_payer in
   let dummy : t =
-    { body = Body.Fee_payer.dummy; authorization = Signature.dummy }
+    { body = Body.Fee_payer.dummy; authorization = Signature.dummy; aux = () }
   in
   let open Fields_derivers_zkapps.Derivers in
   let full = o () in
@@ -133,7 +133,10 @@ let fee_payer_json_roundtrip () =
 let json_roundtrip_dummy () =
   let dummy : Graphql_repr.t =
     to_graphql_repr ~call_depth:0
-      { body = Body.dummy; authorization = Control.dummy_of_tag Signature }
+      { body = Body.dummy
+      ; authorization = Control.dummy_of_tag Signature
+      ; aux = ()
+      }
   in
   let module Fd = Fields_derivers_zkapps.Derivers in
   let full = Graphql_repr.deriver @@ Fd.o () in

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -111,10 +111,12 @@ module Simple_txn = struct
         [ update
             { Account_update.Poly.body = sender_decrease_body
             ; authorization = dummy_auth
+            ; aux = ()
             }
         ; update
             { Account_update.Poly.body = receiver_increase_body
             ; authorization = dummy_auth
+            ; aux = ()
             }
         ]
     end
@@ -173,7 +175,9 @@ module Single = struct
       method updates =
         let open Monad_lib.State.Let_syntax in
         let%map body = update_body ?preconditions ~account amount in
-        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
+        [ update
+            { Account_update.Poly.body; authorization = dummy_auth; aux = () }
+        ]
     end
 end
 
@@ -191,7 +195,9 @@ module Alter_account = struct
         let%map body =
           update_body ?preconditions ~update:state_update ~account amount
         in
-        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
+        [ update
+            { Account_update.Poly.body; authorization = dummy_auth; aux = () }
+        ]
     end
 end
 
@@ -214,7 +220,8 @@ module Txn_tree = struct
         let%map calls =
           State_ext.concat_map_m children ~f:(fun c -> c#updates)
         in
-        [ update ~calls { Account_update.Poly.body; authorization = dummy_auth }
+        [ update ~calls
+            { Account_update.Poly.body; authorization = dummy_auth; aux = () }
         ]
     end
 end
@@ -237,7 +244,8 @@ let build_zkapp_cmd ?valid_until ~fee transactions :
   let open State.Let_syntax in
   let%bind body = fee_payer_body ?valid_until fee in
   let%map updates = State.concat_map_m ~f:mk_updates transactions in
-  { Zkapp_command.Poly.fee_payer = { body; authorization = Signature.dummy }
+  { Zkapp_command.Poly.fee_payer =
+      { body; authorization = Signature.dummy; aux = () }
   ; account_updates = updates
   ; memo = Signed_command_memo.dummy
   }

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -15,6 +15,7 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
             }
         }
     ; authorization = Control.Poly.Signature Signature.dummy
+    ; aux = ()
     }
   in
   let fee_payer : Account_update.Fee_payer.t =
@@ -23,6 +24,7 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
           fee = Currency.Fee.of_mina_int_exn 100
         }
     ; authorization = Signature.dummy
+    ; aux = ()
     }
   in
   { fee_payer

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -107,7 +107,7 @@ type ('u, 'a, 'b) with_forest =
 [@@deriving equal]
 
 let forget_digests_and_proofs (t : (_, _, _) with_forest) :
-    ( (_, (unit, _) Control.Poly.t) Account_update.Poly.t
+    ( (_, (unit, _) Control.Poly.t, _) Account_update.Poly.t
     , unit
     , unit )
     with_forest =
@@ -421,8 +421,8 @@ let is_incompatible_version = function
       Zkapp_command.is_incompatible_version p
 
 let has_invalid_call_forest :
-    ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest -> bool
-    = function
+       ((Account_update.Body.t, _, _) Account_update.Poly.t, _, _) with_forest
+    -> bool = function
   | Signed_command _ ->
       false
   | Zkapp_command cmd ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -102,12 +102,15 @@ let read_all_proofs_from_disk : t -> Stable.Latest.t = function
   | Zkapp_command zc ->
       Zkapp_command (Zkapp_command.read_all_proofs_from_disk zc)
 
-type ('p, 'a, 'b) with_forest =
-  (Signed_command.t, ('p, 'a, 'b) Zkapp_command.with_forest) Poly.t
+type ('u, 'a, 'b) with_forest =
+  (Signed_command.t, ('u, 'a, 'b) Zkapp_command.with_forest) Poly.t
 [@@deriving equal]
 
 let forget_digests_and_proofs (t : (_, _, _) with_forest) :
-    (unit, unit, unit) with_forest =
+    ( (_, (unit, _) Control.Poly.t) Account_update.Poly.t
+    , unit
+    , unit )
+    with_forest =
   match t with
   | Signed_command sc ->
       Signed_command sc
@@ -115,10 +118,10 @@ let forget_digests_and_proofs (t : (_, _, _) with_forest) :
       Zkapp_command (Zkapp_command.forget_digests_and_proofs zc)
 
 let equal_ignoring_proofs_and_hashes
-    (type proof_l account_update_digest_l forest_digest_l proof_r
-    account_update_digest_r forest_digest_r )
-    (t1 : (proof_l, account_update_digest_l, forest_digest_l) with_forest)
-    (t2 : (proof_r, account_update_digest_r, forest_digest_r) with_forest) =
+    (type account_update_digest_l forest_digest_l account_update_digest_r
+    forest_digest_r )
+    (t1 : (_, account_update_digest_l, forest_digest_l) with_forest)
+    (t2 : (_, account_update_digest_r, forest_digest_r) with_forest) =
   let ignore2 _ _ = true in
   let t1' = forget_digests_and_proofs t1 in
   let t2' = forget_digests_and_proofs t2 in
@@ -417,7 +420,9 @@ let is_incompatible_version = function
   | Zkapp_command p ->
       Zkapp_command.is_incompatible_version p
 
-let has_invalid_call_forest : (_, _, _) with_forest -> bool = function
+let has_invalid_call_forest :
+    ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest -> bool
+    = function
   | Signed_command _ ->
       false
   | Zkapp_command cmd ->

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -50,11 +50,12 @@ module Checked = struct
         * Zkapp_command.Digest.Account_update.typ)
       |> Typ.transport
            ~back:(fun ((body, authorization), hash) ->
-             { With_hash.data = { Account_update.Poly.body; authorization }
+             { With_hash.data =
+                 { Account_update.Poly.body; authorization; aux = () }
              ; hash
              } )
            ~there:(fun { With_hash.data =
-                           { Account_update.Poly.body; authorization }
+                           { Account_update.Poly.body; authorization; aux = () }
                        ; hash
                        } -> ((body, authorization), hash) )
       |> Typ.transport_var
@@ -229,7 +230,10 @@ module Checked = struct
               in
               let authorization = V.get auth in
               let tl = V.get tl_data in
-              let account_update : Account_update.t = { body; authorization } in
+              let aux = () in
+              let account_update : Account_update.t =
+                { body; authorization; aux }
+              in
               let calls = V.get calls in
               let res =
                 Zkapp_command.Call_forest.cons ~calls account_update tl

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -519,11 +519,8 @@ module With_hashes_and_data = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('proof, 'data) t =
-        ( ( Account_update.Body.Stable.V1.t
-          , ('proof, Signature.Stable.V1.t) Control.Poly.Stable.V1.t )
-          Account_update.Poly.Stable.V1.t
-          * 'data
+      type ('update, 'data) t =
+        ( 'update * 'data
         , Digest.Account_update.Stable.V1.t
         , Digest.Forest.Stable.V1.t )
         Stable.V1.t

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -144,7 +144,7 @@ module type Digest_intf = sig
 
     val create :
          ?chain:Mina_signature_kind.t
-      -> (Account_update.Body.t, _) Account_update.Poly.t
+      -> (Account_update.Body.t, _, _) Account_update.Poly.t
       -> t
 
     val create_body : ?chain:Mina_signature_kind.t -> Account_update.Body.t -> t
@@ -259,7 +259,7 @@ module Make_digest_str
 
     let create :
            ?chain:Mina_signature_kind.t
-        -> (Account_update.Body.t, _) Account_update.Poly.t
+        -> (Account_update.Body.t, _, _) Account_update.Poly.t
         -> t =
       Account_update.digest
 

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -385,7 +385,9 @@ end
 
 module Verifiable : sig
   type t =
-    ( Proof_cache_tag.t
+    ( ( Account_update.Body.t
+      , (Proof_cache_tag.t, Signature.t) Control.Poly.t )
+      Account_update.Poly.t
     , (Side_loaded_verification_key.t, Zkapp_basic.F.t) With_hash.t option )
     Call_forest.With_hashes_and_data.t
     Poly.t
@@ -444,7 +446,9 @@ module Verifiable : sig
 
   module Serializable : sig
     type t =
-      ( Proof.t
+      ( ( Account_update.Body.Stable.Latest.t
+        , (Proof.t, Signature.Stable.Latest.t) Control.Poly.Stable.Latest.t )
+        Account_update.Poly.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t
@@ -460,7 +464,11 @@ module Verifiable : sig
     proof_cache_db:Proof_cache_tag.cache_db -> Serializable.t -> t
 end = struct
   type t =
-    ( Proof_cache_tag.t
+    ( ( Account_update.Body.Stable.Latest.t
+      , ( Proof_cache_tag.t
+        , Signature.Stable.Latest.t )
+        Control.Poly.Stable.Latest.t )
+      Account_update.Poly.Stable.Latest.t
     , ( Side_loaded_verification_key.Stable.Latest.t
       , Zkapp_basic.F.Stable.Latest.t )
       With_hash.Stable.Latest.t
@@ -471,7 +479,11 @@ end = struct
 
   module Serializable = struct
     type t =
-      ( Proof.Stable.Latest.t
+      ( ( Account_update.Body.Stable.Latest.t
+        , ( Proof.Stable.Latest.t
+          , Signature.Stable.Latest.t )
+          Control.Poly.Stable.Latest.t )
+        Account_update.Poly.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -4,15 +4,23 @@ module Helper = struct
   open Mina_base
 
   let to_yojson ~proof_to_yojson tx =
+    let update_to_yojson =
+      Account_update.Poly.to_yojson Account_update.Body.to_yojson
+      @@ Control.Poly.to_yojson proof_to_yojson Signature.to_yojson
+    in
     User_command.Poly.to_yojson Signed_command.to_yojson
-      (Zkapp_command.with_forest_to_yojson proof_to_yojson
+      (Zkapp_command.with_forest_to_yojson update_to_yojson
          Zkapp_command.Digest.Account_update.to_yojson
          Zkapp_command.Digest.Forest.to_yojson )
       tx
 
   let of_yojson ~proof_of_yojson =
+    let update_of_yojson =
+      Account_update.Poly.of_yojson Account_update.Body.of_yojson
+      @@ Control.Poly.of_yojson proof_of_yojson Signature.of_yojson
+    in
     User_command.Poly.of_yojson Signed_command.of_yojson
-    @@ Zkapp_command.with_forest_of_yojson proof_of_yojson
+    @@ Zkapp_command.with_forest_of_yojson update_of_yojson
          Zkapp_command.Digest.Account_update.of_yojson
          Zkapp_command.Digest.Forest.of_yojson
 end
@@ -28,8 +36,8 @@ module User_command = struct
       type t = User_command.Stable.V2.t [@@deriving sexp]
 
       let to_yojson : t -> Yojson.Safe.t = function
-        | User_command.Poly.Signed_command tx ->
-            Helper.to_yojson ~proof_to_yojson:Proof.to_yojson (Signed_command tx)
+        | User_command.Poly.Signed_command _ as tx ->
+            Helper.to_yojson ~proof_to_yojson:Nothing.unreachable_code tx
         | User_command.Poly.Zkapp_command { fee_payer; memo; account_updates }
           ->
             Helper.to_yojson ~proof_to_yojson:Proof.to_yojson

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1064,7 +1064,7 @@ let gen_account_update_from ?(no_account_precondition = false)
   in
   let account_id = Account_id.create body.public_key body.token_id in
   Hash_set.add account_ids_seen account_id ;
-  return { Account_update.Poly.body; authorization }
+  return { Account_update.Poly.body; authorization; aux = () }
 
 (* takes an account id, if we want to sign this data *)
 let gen_account_update_body_fee_payer ?global_slot ?fee_range ?failure
@@ -1108,7 +1108,8 @@ let gen_fee_payer ?global_slot ?fee_range ?failure ?permissions_auth ~account_id
   in
   (* real signature to be added when this data inserted into a Zkapp_command.t *)
   let authorization = Signature.dummy in
-  ({ body; authorization } : Account_update.Fee_payer.t)
+  let aux = () in
+  ({ body; authorization; aux } : Account_update.Fee_payer.t)
 
 (* keep max_account_updates small, so zkApp integration tests don't need lots
    of block producers
@@ -1666,11 +1667,13 @@ let mk_account_update_body ~pk ~vk : Account_update.Body.Simple.t =
 let mk_account_update ~pk ~vk : Account_update.Simple.t =
   { body = mk_account_update_body ~pk ~vk
   ; authorization = Control.(dummy_of_tag Proof)
+  ; aux = ()
   }
 
 let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
   { body = { public_key = pk; fee; valid_until = None; nonce }
   ; authorization = Signature.dummy
+  ; aux = ()
   }
 
 let gen_max_cost_zkapp_command_from ?memo ?fee_range

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -104,17 +104,20 @@ end
 module Fee_payer = struct
   module V1 = struct
     type t =
-      { body : Body.Fee_payer.V1.t; authorization : Mina_base_signature.V1.t }
+      { body : Body.Fee_payer.V1.t
+      ; authorization : Mina_base_signature.V1.t
+      ; aux : unit
+      }
   end
 end
 
 module Poly = struct
   module V1 = struct
-    type ('body, 'authorization) t =
-      { body : 'body; authorization : 'authorization }
+    type ('body, 'authorization, 'aux) t =
+      { body : 'body; authorization : 'authorization; aux : 'aux }
   end
 end
 
 module V1 = struct
-  type t = (Body.V1.t, Mina_base_control.V2.t) Poly.V1.t
+  type t = (Body.V1.t, Mina_base_control.V2.t, unit) Poly.V1.t
 end

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -513,6 +513,7 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
             { public_key = sender_pk; fee; nonce; valid_until = None }
             (* Real signature added in below *)
         ; authorization = Signature.dummy
+        ; aux = ()
         }
     ; account_updates =
         Zkapp_command.Call_forest.of_account_updates
@@ -541,6 +542,7 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
                     Account_update.Authorization_kind.None_given
                 }
             ; authorization = Control.Poly.None_given
+            ; aux = ()
             }
           ; { Account_update.Poly.body =
                 { public_key = receiver_pk
@@ -563,6 +565,7 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
                 ; authorization_kind = None_given
                 }
             ; authorization = None_given
+            ; aux = ()
             }
           ]
     ; memo = Signed_command_memo.empty

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -230,8 +230,8 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
         |> Or_error.all )
     |> Or_error.join |> to_staged_ledger_or_error
 
-  let fee_remainder (type proof a b c)
-      ~(to_user_command : c -> (proof, a, b) User_command.with_forest)
+  let fee_remainder (type update a b c)
+      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
       (commands : c list) completed_works coinbase_fee =
     let open Result.Let_syntax in
     let%bind budget =
@@ -250,9 +250,9 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       ~f:(fun x -> Ok x)
       (Currency.Fee.sub budget total_work_fee)
 
-  let get_transaction_data (type proof a b c) ~constraint_constants
+  let get_transaction_data (type update a b c) ~constraint_constants
       coinbase_parts ~receiver ~coinbase_amount
-      ~(to_user_command : c -> (proof, a, b) User_command.with_forest)
+      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
       (commands : c list) (completed_works : T.t list) :
       (c Transaction_data.t, Error.t) Result.t =
     let open Result.Let_syntax in

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -73,7 +73,12 @@ let hash_signed_command (cmd : Signed_command.t) =
 
 let hash_zkapp_command (type p)
     ({ fee_payer; account_updates; memo } :
-      (p, unit, unit) Zkapp_command.with_forest ) =
+      ( ( Account_update.Body.t
+        , (p, Signature.t) Control.Poly.t )
+        Account_update.Poly.t
+      , unit
+      , unit )
+      Zkapp_command.with_forest ) =
   let cmd_dummy_signatures_and_proofs =
     { Zkapp_command.Poly.memo
     ; fee_payer = { fee_payer with authorization = Signature.dummy }

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -74,7 +74,8 @@ let hash_signed_command (cmd : Signed_command.t) =
 let hash_zkapp_command (type p)
     ({ fee_payer; account_updates; memo } :
       ( ( Account_update.Body.t
-        , (p, Signature.t) Control.Poly.t )
+        , (p, Signature.t) Control.Poly.t
+        , _ )
         Account_update.Poly.t
       , unit
       , unit )
@@ -84,7 +85,7 @@ let hash_zkapp_command (type p)
     ; fee_payer = { fee_payer with authorization = Signature.dummy }
     ; account_updates =
         Zkapp_command.Call_forest.map account_updates
-          ~f:(fun (acct_update : (_, _) Account_update.Poly.t) ->
+          ~f:(fun (acct_update : (_, _, _) Account_update.Poly.t) ->
             let dummy_auth =
               match acct_update.authorization with
               | Control.Poly.Proof _ ->

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2456,6 +2456,7 @@ module For_tests = struct
               }
               (* Real signature added in below *)
           ; authorization = Signature.dummy
+          ; aux = ()
           }
       ; account_updates =
           [ { body =
@@ -2484,6 +2485,7 @@ module For_tests = struct
             ; authorization =
                 ( if use_full_commitment then Signature Signature.dummy
                 else Proof (Lazy.force Mina_base.Proof.transaction_dummy) )
+            ; aux = ()
             }
           ; { body =
                 { public_key = receiver
@@ -2507,6 +2509,7 @@ module For_tests = struct
                 ; authorization_kind = None_given
                 }
             ; authorization = None_given
+            ; aux = ()
             }
           ]
       ; memo = Signed_command_memo.empty
@@ -2529,7 +2532,8 @@ module For_tests = struct
     let account_updates =
       Zkapp_command.Call_forest.map zkapp_command.account_updates
         ~f:(fun
-             (account_update : (Account_update.Body.t, _) Account_update.Poly.t)
+             (account_update :
+               (Account_update.Body.t, _, _) Account_update.Poly.t )
            ->
           match account_update.body.authorization_kind with
           | Signature ->

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -52,6 +52,7 @@ let%test_module "Access permission tests" =
         | Account_update.Authorization_kind.Proof _ ->
             { body = { account_update.body with authorization_kind = auth_kind }
             ; authorization = account_update.authorization
+            ; aux = ()
             }
         | Account_update.Authorization_kind.Signature ->
             { body =
@@ -67,10 +68,12 @@ let%test_module "Access permission tests" =
                     }
                 }
             ; authorization = Signature Signature.dummy
+            ; aux = ()
             }
         | Account_update.Authorization_kind.None_given ->
             { body = { account_update.body with authorization_kind = auth_kind }
             ; authorization = None_given
+            ; aux = ()
             }
       in
       let deploy_account_update_body : Account_update.Body.t =
@@ -98,6 +101,7 @@ let%test_module "Access permission tests" =
         (* TODO: This is a pain. *)
         { body = deploy_account_update_body
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
       in
       let account_updates =
@@ -120,6 +124,7 @@ let%test_module "Access permission tests" =
             ; fee = Currency.Fee.of_nanomina_int_exn 100
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let full_commitment =
@@ -150,6 +155,7 @@ let%test_module "Access permission tests" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = ()
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->
@@ -171,7 +177,10 @@ let%test_module "Access permission tests" =
       let zkapp_command : Zkapp_command.t =
         sign_all
           { fee_payer =
-              { body = fee_payer.body; authorization = Signature.dummy }
+              { body = fee_payer.body
+              ; authorization = Signature.dummy
+              ; aux = ()
+              }
           ; account_updates
           ; memo
           }

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -325,6 +325,7 @@ let%test_module "multisig_account" =
                     }
                     (* Real signature added in below *)
                 ; authorization = Signature.dummy
+                ; aux = ()
                 }
               in
               let sender_account_update_data : Account_update.Simple.t =
@@ -353,6 +354,7 @@ let%test_module "multisig_account" =
                     ; authorization_kind = Signature
                     }
                 ; authorization = Signature Signature.dummy
+                ; aux = ()
                 }
               in
               let snapp_account_update_data : Account_update.Simple.t =
@@ -380,6 +382,7 @@ let%test_module "multisig_account" =
                     }
                 ; authorization =
                     Proof (Lazy.force Mina_base.Proof.transaction_dummy)
+                ; aux = ()
                 }
               in
               let memo = Signed_command_memo.empty in
@@ -454,6 +457,7 @@ let%test_module "multisig_account" =
                     Signature
                       (Signature_lib.Schnorr.Chunked.sign sender.private_key
                          (Random_oracle.Input.Chunked.field transaction) )
+                ; aux = ()
                 }
               in
               let zkapp_command : Zkapp_command.t =
@@ -463,6 +467,7 @@ let%test_module "multisig_account" =
                       [ sender
                       ; { body = snapp_account_update_data.body
                         ; authorization = Proof pi
+                        ; aux = ()
                         }
                       ]
                   ; memo

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -184,6 +184,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
                 }
                 (* Real signature added in below *)
             ; authorization = Signature.dummy
+            ; aux = ()
             }
           in
           let sender_account_update_data : Account_update.Simple.t =
@@ -211,6 +212,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
                 ; authorization_kind = Signature
                 }
             ; authorization = Signature Signature.dummy
+            ; aux = ()
             }
           in
           let snapp_account_update_data : Account_update.Simple.t =
@@ -237,6 +239,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
                 }
             ; authorization =
                 Proof (Lazy.force Mina_base.Proof.transaction_dummy)
+            ; aux = ()
             }
           in
           let protocol_state = Zkapp_precondition.Protocol_state.accept in
@@ -296,6 +299,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             in
             { body = sender_account_update_data.body
             ; authorization = Signature sender_signature
+            ; aux = ()
             }
           in
           let zkapp_command : Zkapp_command.t =
@@ -305,6 +309,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
                   [ sender
                   ; { body = snapp_account_update_data.body
                     ; authorization = Proof pi
+                    ; aux = ()
                     }
                   ]
               ; memo

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -696,6 +696,7 @@ let test_zkapp_command ?expected_failure ?(memo = Signed_command_memo.empty)
         ; fee
         }
     ; authorization = Signature.dummy
+    ; aux = ()
     }
   in
   let zkapp_command : Zkapp_command.t =

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -54,6 +54,7 @@ let%test_module "Zkapp payments tests" =
                 ; nonce = acct1.account.nonce
                 }
             ; authorization = Signature.dummy
+            ; aux = ()
             }
         ; account_updates =
             [ { body =
@@ -90,6 +91,7 @@ let%test_module "Zkapp payments tests" =
                   ; authorization_kind = Signature
                   }
               ; authorization = Signature Signature.dummy
+              ; aux = ()
               }
             ; { body =
                   { public_key = acct2.account.public_key
@@ -113,6 +115,7 @@ let%test_module "Zkapp payments tests" =
                   ; authorization_kind = None_given
                   }
               ; authorization = None_given
+              ; aux = ()
               }
             ]
         ; memo

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -286,6 +286,7 @@ let%test_module "Protocol state precondition tests" =
                         }
                         (*To be updated later*)
                     ; authorization = Signature.dummy
+                    ; aux = ()
                     }
                   in
                   let sender_account_update : Account_update.Simple.t =
@@ -315,6 +316,7 @@ let%test_module "Protocol state precondition tests" =
                         }
                         (*To be updated later*)
                     ; authorization = Control.Poly.Signature Signature.dummy
+                    ; aux = ()
                     }
                   in
                   let snapp_account_update : Account_update.Simple.t =
@@ -349,6 +351,7 @@ let%test_module "Protocol state precondition tests" =
                     ; authorization =
                         Control.Poly.Signature Signature.dummy
                         (*To be updated later*)
+                    ; aux = ()
                     }
                   in
                   let ps =
@@ -884,6 +887,7 @@ let%test_module "Account precondition tests" =
                     }
                     (*To be updated later*)
                 ; authorization = Signature.dummy
+                ; aux = ()
                 }
               in
               let sender_account_update : Account_update.Simple.t =
@@ -913,6 +917,7 @@ let%test_module "Account precondition tests" =
                     }
                     (*To be updated later*)
                 ; authorization = Control.Poly.Signature Signature.dummy
+                ; aux = ()
                 }
               in
               let snapp_account_update : Account_update.Simple.t =
@@ -945,6 +950,7 @@ let%test_module "Account precondition tests" =
                 ; authorization =
                     Control.Poly.Signature Signature.dummy
                     (*To be updated later*)
+                ; aux = ()
                 }
               in
               let ps =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4284,6 +4284,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; nonce
             }
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let sender_is_the_same_as_fee_payer =
@@ -4344,6 +4345,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ( { body = sender_account_update_body
             ; authorization =
                 Control.Poly.Signature Signature.dummy (*To be updated later*)
+            ; aux = ()
             }
             : Account_update.Simple.t )
       in
@@ -4408,6 +4410,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   }
               ; authorization =
                   Control.Poly.Signature Signature.dummy (*To be updated later*)
+              ; aux = ()
               }
               : Account_update.Simple.t ) )
       in
@@ -4455,6 +4458,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 ; authorization_kind
                 }
             ; authorization = receiver_auth
+            ; aux = ()
             } )
       in
       let account_updates_data =
@@ -4497,7 +4501,10 @@ module Make_str (A : Wire_types.Concrete) = struct
               Signature_lib.Schnorr.Chunked.sign sender.private_key
                 (Random_oracle.Input.Chunked.field commitment)
             in
-            { body = s.body; authorization = Signature sender_signature_auth } )
+            { body = s.body
+            ; authorization = Signature sender_signature_auth
+            ; aux = ()
+            } )
       in
       let other_receivers =
         List.map2_exn other_receivers receivers ~f:(fun s (receiver, _amt) ->
@@ -4522,6 +4529,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 in
                 { Account_update.Poly.body = s.body
                 ; authorization = Control.Poly.Signature receiver_signature_auth
+                ; aux = ()
                 }
             | Control.Poly.Proof _ ->
                 failwith ""
@@ -4630,6 +4638,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             if no_auth then
               ( { body = snapp_account_update.body
                 ; authorization = Control.Poly.None_given
+                ; aux = ()
                 }
                 : Account_update.Simple.t )
             else
@@ -4644,6 +4653,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               in
               ( { body = snapp_account_update.body
                 ; authorization = Signature signature
+                ; aux = ()
                 }
                 : Account_update.Simple.t ) )
       in
@@ -4738,6 +4748,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               }
           ; authorization =
               Control.Poly.Proof (Lazy.force Mina_base.Proof.blockchain_dummy)
+          ; aux = ()
           }
       in
       let account_update_digest_with_selected_chain =
@@ -4910,6 +4921,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 in
                 ( { body = simple_snapp_account_update.body
                   ; authorization = Proof pi
+                  ; aux = ()
                   }
                   : Account_update.Simple.t )
             | Signature ->
@@ -4925,12 +4937,14 @@ module Make_str (A : Wire_types.Concrete) = struct
                 Async.Deferred.return
                   ( { body = simple_snapp_account_update.body
                     ; authorization = Signature signature
+                    ; aux = ()
                     }
                     : Account_update.Simple.t )
             | None ->
                 Async.Deferred.return
                   ( { body = simple_snapp_account_update.body
                     ; authorization = Control.Poly.None_given
+                    ; aux = ()
                     }
                     : Account_update.Simple.t )
             | _ ->
@@ -5091,6 +5105,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             }
             (* Real signature added in below *)
         ; authorization = Signature.dummy
+        ; aux = ()
         }
       in
       let sender_account_update_data : Account_update.Simple.t =
@@ -5117,6 +5132,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; authorization_kind = Signature
             }
         ; authorization = Signature Signature.dummy
+        ; aux = ()
         }
       in
       let snapp_account_update_data : Account_update.Simple.t =
@@ -5141,6 +5157,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; authorization_kind = Proof (With_hash.hash vk)
             }
         ; authorization = Proof (Lazy.force Mina_base.Proof.transaction_dummy)
+        ; aux = ()
         }
       in
       let memo = Signed_command_memo.empty in
@@ -5197,7 +5214,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let account_updates =
         [ sender
-        ; { body = snapp_account_update_data.body; authorization = Proof pi }
+        ; { body = snapp_account_update_data.body
+          ; authorization = Proof pi
+          ; aux = ()
+          }
         ]
       in
       Zkapp_command.of_simple ~proof_cache_db

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -45,7 +45,7 @@ let check_signed_command c =
         Result.Error (`Invalid_signature (Signed_command.public_keys c))
 
 let collect_vk_assumption
-    ( (p : (Account_update.Body.t, _ Control.Poly.t) Account_update.Poly.t)
+    ( (p : (Account_update.Body.t, _ Control.Poly.t, _) Account_update.Poly.t)
     , ( (vk_opt :
           (Side_loaded_verification_key.t, Pasta_bindings.Fp.t) With_hash.t
           option )


### PR DESCRIPTION
This is a draft for @georgeee, which starts to resolve a TODO in this branch related to caching the hash of the `actions` in an account update.