### PR TITLE
Implement Work Partitioner V2

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -231,6 +231,7 @@
 (package (name webkit_trace_event))
 (package (name with_hash))
 (package (name work_selector))
+(package (name work_partitioner))
 (package (name zkapp_command_builder))
 (package (name zkapps_examples))
 (package (name zkapp_limits))

--- a/src/lib/snark_work_lib/partitioned.ml
+++ b/src/lib/snark_work_lib/partitioned.ml
@@ -12,7 +12,7 @@ module Pairing = struct
     module Stable = struct
       module V1 = struct
         (* this identifies a One_or_two work from Work_selector's perspective *)
-        type t = Pairing_ID of int
+        type t = Pairing_ID of int64
         [@@deriving compare, hash, sexp, yojson, equal]
 
         let to_latest = Fn.id
@@ -82,7 +82,7 @@ module Zkapp_command_job = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type t = Job_ID of int [@@deriving compare, hash, sexp, yojson]
+        type t = Job_ID of int64 [@@deriving compare, hash, sexp, yojson]
 
         let to_latest = Fn.id
       end

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -44,7 +44,8 @@
   transaction_protocol_state
   transaction_snark
   transaction_snark_work
-  transaction_witness)
+  transaction_witness
+  work_partitioner)
  (preprocess
   (pps
    ppx_bin_prot

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -10,7 +10,8 @@
    mina_base
    snark_work_lib
    transaction_snark
-   transaction_witness)
+   transaction_witness
+   work_selector)
    
  (preprocess
   (pps

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -16,7 +16,8 @@
  (preprocess
   (pps
    ppx_custom_printf
-   ppx_let))
+   ppx_let
+   ppx_mina))
    
  (instrumentation
   (backend bisect_ppx))

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -1,0 +1,12 @@
+(library
+ (name work_partitioner)
+ (public_name work_partitioner)
+ (library_flags -linkall)
+ (libraries core_kernel)
+ (preprocess
+  (pps
+   ppx_let))
+   
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Partition work returned by Work_selector and issue them to real Snark Worker"))

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -2,9 +2,18 @@
  (name work_partitioner)
  (public_name work_partitioner)
  (library_flags -linkall)
- (libraries core_kernel)
+ (libraries 
+   ;; OPAM libraries
+   async
+   core_kernel
+   ;; Local libraries
+   mina_base
+   transaction_snark
+   transaction_witness)
+   
  (preprocess
   (pps
+   ppx_custom_printf
    ppx_let))
    
  (instrumentation

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -8,6 +8,7 @@
    core_kernel
    ;; Local libraries
    mina_base
+   snark_work_lib
    transaction_snark
    transaction_witness)
    

--- a/src/lib/work_partitioner/id_generator.ml
+++ b/src/lib/work_partitioner/id_generator.ml
@@ -1,0 +1,15 @@
+open Core_kernel
+
+type t = { reusable_ids : int Queue.t; mutable last_id : int }
+
+let create () = { reusable_ids = Queue.create (); last_id = 0 }
+
+let next_id (t : t) : int =
+  match Queue.dequeue t.reusable_ids with
+  | Some id ->
+      id
+  | None ->
+      t.last_id <- t.last_id + 1 ;
+      t.last_id
+
+let recycle_id (t : t) (id : int) = Queue.enqueue t.reusable_ids id

--- a/src/lib/work_partitioner/id_generator.ml
+++ b/src/lib/work_partitioner/id_generator.ml
@@ -1,15 +1,21 @@
 open Core_kernel
 
-type t = { reusable_ids : int Queue.t; mutable last_id : int }
+(* NOTE: range is both inclusive *)
+type t = { logger : Logger.t; range : int64 * int64; mutable next_id : int64 }
 
-let create () = { reusable_ids = Queue.create (); last_id = 0 }
+let create ~logger =
+  { logger
+  ; range = (Int64.min_value, Int64.max_value)
+  ; next_id = Int64.min_value
+  }
 
-let next_id (t : t) : int =
-  match Queue.dequeue t.reusable_ids with
-  | Some id ->
-      id
-  | None ->
-      t.last_id <- t.last_id + 1 ;
-      t.last_id
-
-let recycle_id (t : t) (id : int) = Queue.enqueue t.reusable_ids id
+let next_id (t : t) : Int64.t =
+  let open Int64 in
+  let result = t.next_id in
+  let lower, upper = t.range in
+  if equal t.next_id upper then (
+    let logger = t.logger in
+    [%log warn] "ID generator reaching int64 boundart, recuring from 0" ;
+    t.next_id <- lower )
+  else t.next_id <- succ t.next_id ;
+  result

--- a/src/lib/work_partitioner/job_pool.ml
+++ b/src/lib/work_partitioner/job_pool.ml
@@ -1,0 +1,86 @@
+open Core_kernel
+
+(* NOTE: Maybe this is reusable with Work Selector as they also have reissue mechanism *)
+module Make (ID : Hashtbl.Key) (Job : T) = struct
+  type job_item = Job.t option ref
+
+  type t =
+    { timeline : (ID.t * job_item) Deque.t (* For iteration  *)
+    ; index : (ID.t, job_item) Hashtbl.t (* For marking job as done *)
+    }
+
+  let create () =
+    { timeline = Deque.create (); index = Hashtbl.create (module ID) }
+
+  let rec peek (t : t) =
+    match Deque.dequeue_front t.timeline with
+    | None ->
+        None
+    | Some (_, { contents = None }) ->
+        peek t
+    | Some ((id, { contents = Some pending }) as item) ->
+        Deque.enqueue_front t.timeline item ;
+        Some (id, pending)
+
+  let rec take_first_ready ~(pred : Job.t -> bool) (t : t) =
+    match Deque.dequeue_front t.timeline with
+    | None ->
+        None
+    | Some (_, { contents = None }) ->
+        (* Job done *)
+        take_first_ready ~pred t
+    | Some ((id, { contents = Some pending }) as item) ->
+        if pred pending then Some (id, pending)
+        else (
+          Deque.enqueue_front t.timeline item ;
+          None )
+
+  let attempt_add ~(key : ID.t) ~(job : Job.t) (t : t) =
+    let data = ref (Some job) in
+    match Hashtbl.add ~key ~data t.index with
+    | `Ok ->
+        Deque.enqueue_back t.timeline (key, data) ;
+        `Ok
+    | `Duplicate ->
+        `Duplicate
+
+  let slash (t : t) (id : ID.t) =
+    match Hashtbl.find_and_remove t.index id with
+    | None ->
+        None
+    | Some job_item ->
+        let result = !job_item in
+        job_item := None ;
+        result
+
+  let change ~(id : ID.t) ~(f : Job.t option -> Job.t option) (t : t) =
+    let process (current : job_item option) =
+      let output =
+        match current with
+        | None ->
+            f None
+        | Some job_already ->
+            let tmp = f !job_already in
+            job_already := None ;
+            tmp
+      in
+      match output with
+      | None ->
+          None
+      | Some data ->
+          let new_item = ref (Some data) in
+          Deque.enqueue_back t.timeline (id, new_item) ;
+          Some new_item
+    in
+
+    Hashtbl.change t.index id ~f:process
+
+  let replace ~(id : ID.t) ~(job : Job.t) = change ~id ~f:(const (Some job))
+
+  let find (t : t) (id : ID.t) =
+    match Hashtbl.find t.index id with
+    | Some { contents = Some job } ->
+        Some job
+    | _ ->
+        None
+end

--- a/src/lib/work_partitioner/mergable_single_work.ml
+++ b/src/lib/work_partitioner/mergable_single_work.ml
@@ -1,0 +1,31 @@
+(* This is half work to be merged into a Two of type _ One_or_two.t *)
+
+open Core_kernel
+module Work = Snark_work_lib
+
+type t =
+  { which_half : [ `First | `Second ]
+  ; proof : Ledger_proof.Cached.t
+  ; metric : Core.Time.Span.t * [ `Merge | `Transition ]
+  ; spec : Work.Selector.Single.Spec.t
+  ; prover : Signature_lib.Public_key.Compressed.t
+  ; common : Work.Partitioned.Spec_common.t
+  }
+
+let merge_to_one_result_exn (left : t) (right : t) : Work.Selector.Result.t =
+  assert (
+    List.for_all ~f:Fn.id
+      [ phys_equal left.which_half `First
+      ; phys_equal right.which_half `Second
+      ; Signature_lib.Public_key.Compressed.equal left.prover right.prover
+      ; Currency.Fee.equal left.common.fee_of_full right.common.fee_of_full
+      ] ) ;
+  let metrics = `Two (left.metric, right.metric) in
+  { proofs = `Two (left.proof, right.proof)
+  ; metrics
+  ; spec =
+      { instances = `Two (left.spec, right.spec)
+      ; fee = left.common.fee_of_full
+      }
+  ; prover = left.prover
+  }

--- a/src/lib/work_partitioner/pending_zkapp_command.ml
+++ b/src/lib/work_partitioner/pending_zkapp_command.ml
@@ -1,0 +1,50 @@
+(* NOTE: this module is where the real optimization happen. One assumption we
+   have is the order of merging is irrelvant to the correctness of the final
+   proof. Hence we're only using a counter `merge_remaining` to track have we
+   reach the final proof
+*)
+
+open Core_kernel
+module Work = Snark_work_lib
+
+type t =
+  { spec : Work.Selector.Single.Spec.t
+        (* the original work being splitted, should be identical to Work_selector.work *)
+  ; fee_of_full : Currency.Fee.t
+  ; unscheduled_segments : Work.Partitioned.Zkapp_command_job.Spec.t Queue.t
+  ; pending_mergable_proofs : Ledger_proof.Cached.t Deque.t
+        (* we may need to insert proofs to merge back to the queue, hence a Deque *)
+  ; mutable elapsed : Time.Stable.Span.V1.t
+  ; mutable merge_remaining : int
+  }
+
+let generate_merge ~(t : t) () =
+  let try_take2 (q : 'a Deque.t) : ('a * 'a) option =
+    match Deque.dequeue_front q with
+    | None ->
+        None
+    | Some fst -> (
+        match Deque.dequeue_front q with
+        | Some snd ->
+            Some (fst, snd)
+        | None ->
+            Deque.enqueue_front q fst ; None )
+  in
+  let open Option.Let_syntax in
+  let%map proof1, proof2 = try_take2 t.pending_mergable_proofs in
+  Work.Partitioned.Zkapp_command_job.Spec.Poly.Merge { proof1; proof2 }
+
+let generate_segment ~(t : t) () =
+  let open Option.Let_syntax in
+  let%map segment = Queue.dequeue t.unscheduled_segments in
+  segment
+
+let generate_job_spec (t : t) : Work.Partitioned.Zkapp_command_job.Spec.t option
+    =
+  List.find_map ~f:(fun f -> f ()) [ generate_merge ~t; generate_segment ~t ]
+
+let submit_proof (t : t) ~(proof : Ledger_proof.Cached.t)
+    ~(elapsed : Time.Stable.Span.V1.t) =
+  Deque.enqueue_back t.pending_mergable_proofs proof ;
+  t.merge_remaining <- t.merge_remaining - 1 ;
+  t.elapsed <- Time.Span.(t.elapsed + elapsed)

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -1,0 +1,46 @@
+(* module contains logic that may be shared across coordinator and worker. This
+   is needed for backward compatibility reason. *)
+
+open Core_kernel
+open Async
+open Mina_base
+open Transaction_snark
+
+(* NOTE:
+   This is used in both Work_partitioner and Snark_worker for compatibility
+   reasons
+*)
+let extract_zkapp_segment_works ~m:(module M : S)
+    ~(input : Mina_state.Snarked_ledger_state.t)
+    ~(witness : Transaction_witness.Stable.Latest.t)
+    ~(zkapp_command : Zkapp_command.t) :
+    ( Zkapp_command_segment.Witness.t
+    * Zkapp_command_segment.Basic.t
+    * Statement.With_sok.t )
+    list
+    Deferred.Or_error.t =
+  Or_error.try_with (fun () ->
+      Transaction_snark.zkapp_command_witnesses_exn
+        ~constraint_constants:M.constraint_constants
+        ~global_slot:witness.block_global_slot
+        ~state_body:witness.protocol_state_body
+        ~fee_excess:Currency.Amount.Signed.zero
+        [ ( `Pending_coinbase_init_stack witness.init_stack
+          , `Pending_coinbase_of_statement
+              { Transaction_snark.Pending_coinbase_stack_state.source =
+                  input.source.pending_coinbase_stack
+              ; target = input.target.pending_coinbase_stack
+              }
+          , `Sparse_ledger witness.first_pass_ledger
+          , `Sparse_ledger witness.second_pass_ledger
+          , `Connecting_ledger_hash input.connecting_ledger_left
+          , zkapp_command )
+        ]
+      |> List.rev )
+  |> Result.map_error ~f:(fun e ->
+         Error.createf
+           !"Failed to generate inputs for zkapp_command : %s: %s"
+           ( Zkapp_command.read_all_proofs_from_disk zkapp_command
+           |> Zkapp_command.Stable.Latest.to_yojson |> Yojson.Safe.to_string )
+           (Error.to_string_hum e) )
+  |> Deferred.return

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -211,8 +211,8 @@ and issue_job_from_partitioner ~(partitioner : t) () :
   List.find_map
     ~f:(fun f -> f ())
     [ reissue_old_task ~partitioner
-    ; issue_from_tmp_slot ~partitioner
     ; issue_from_zkapp_command_work_pool ~partitioner
+    ; issue_from_tmp_slot ~partitioner
     ]
 
 (* WARN: this should only be called if partitioner.first_in_pair is None *)

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -271,44 +271,30 @@ type submit_result =
 (* If the `option` in Processed is present, it indicates we need to submit to the underlying selector *)
 
 let submit_single ~partitioner ~this_single ~id =
-  let Mergable_single_work.{ which_half; common; _ } = this_single in
-  let issued = Time.of_span_since_epoch common.issued_since_unix_epoch in
-  let delta = Time.(diff (now ()) issued) in
-  if Time.Span.( > ) delta partitioner.reassignment_timeout then
-    (* This is how we guarantee there's no ID being repeated. We should remove
-       logic on slashing old work submitted in Work Selector though, as they're
-       now redundant.
-    *)
-    Slashed
-  else
-    let result = ref None in
-    Hashtbl.change partitioner.pairing_pool id ~f:(function
-      | Some other_single ->
-          let work =
-            match which_half with
-            | `First ->
-                Mergable_single_work.merge_to_one_result_exn this_single
-                  other_single
-            | `Second ->
-                Mergable_single_work.merge_to_one_result_exn other_single
-                  this_single
-          in
+  let Mergable_single_work.{ which_half; _ } = this_single in
+  let result = ref None in
+  Hashtbl.change partitioner.pairing_pool id ~f:(function
+    | Some other_single ->
+        let work =
+          match which_half with
+          | `First ->
+              Mergable_single_work.merge_to_one_result_exn this_single
+                other_single
+          | `Second ->
+              Mergable_single_work.merge_to_one_result_exn other_single
+                this_single
+        in
 
-          result := Some work ;
-          None
-      | None ->
-          Some this_single ) ;
-    Processed !result
+        result := Some work ;
+        None
+    | None ->
+        Some this_single ) ;
+  Processed !result
 
 let submit_into_pending_zkapp_command ~partitioner
     ~spec:({ pairing; job_id; _ } : Work.Partitioned.Zkapp_command_job.t)
     ~metric:({ proof; elapsed } : Work.Partitioned.Proof_with_metric.t)
     ~(prover : Signature_lib.Public_key.Compressed.t) =
-  let job_is_old (job : Work.Partitioned.Zkapp_command_job.t) : bool =
-    let issued = Time.of_span_since_epoch job.common.issued_since_unix_epoch in
-    let delta = Time.(diff (now ()) issued) in
-    Time.Span.( > ) delta partitioner.reassignment_timeout
-  in
   let returns = ref SchemeUnmatched in
   let process pending =
     Pending_zkapp_command.submit_proof ~proof ~elapsed pending ;
@@ -359,29 +345,18 @@ let submit_into_pending_zkapp_command ~partitioner
            meaning it's completed, ignoring" ;
         returns := Slashed ;
         None
-    | Some job -> (
-        if job_is_old job then (
-          (* This is how we guarantee there's no ID being repeated. We should remove
-             logic on slashing old work submitted in Work Selector though, as they're
-             now redundant.
-          *)
-          returns := Slashed ;
-          printf
-            "Job submitted is too old, it should be reissued by the work \
-             partitioner, ignoring" ;
-          Some job )
-        else
-          match
-            Zkapp_command_job_pool.find partitioner.zkapp_command_jobs pairing
-          with
-          | None ->
-              printf
-                "Worker submit a work that's already slashed from pending \
-                 zkapp command pool, meaning it's completed, ignoring " ;
-              returns := Slashed ;
-              None
-          | Some pending ->
-              process pending ; None )
+    | Some _ -> (
+        match
+          Zkapp_command_job_pool.find partitioner.zkapp_command_jobs pairing
+        with
+        | None ->
+            printf
+              "Worker submit a work that's already slashed from pending zkapp \
+               command pool, meaning it's completed, ignoring " ;
+            returns := Slashed ;
+            None
+        | Some pending ->
+            process pending ; None )
   in
 
   Sent_job_pool.change ~id:job_id ~f:slash_or_process

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -246,3 +246,11 @@ let request_partitioned_work
     ; request_from_selector_and_consume_by_partitioner ~partitioner
         ~selection_method ~selector ~logger ~fee ~snark_pool
     ]
+
+(* Logics for work submitting *)
+
+type submit_result =
+  | SchemeUnmatched
+  | Slashed
+  | Processed of Work.Selector.Result.t option
+(* If the `option` in Processed is present, it indicates we need to submit to the underlying selector *)

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -53,6 +53,8 @@ let create ~(reassignment_timeout : Time.Span.t) ~(logger : Logger.t) : t =
   ; tmp_slot = None
   }
 
+let epoch_now () = Time.(now () |> to_span_since_epoch)
+
 (* Logics for work requesting *)
 let reissue_old_task ~(partitioner : t) () : Work.Partitioned.Spec.t option =
   let job_is_old (job : Work.Partitioned.Zkapp_command_job.t) : bool =
@@ -66,12 +68,10 @@ let reissue_old_task ~(partitioner : t) () : Work.Partitioned.Spec.t option =
   with
   | None ->
       None
-  | Some (id, job_with_status) ->
-      let issued_since_unix_epoch = Time.(now () |> to_span_since_epoch) in
+  | Some (id, job) ->
+      let issued_since_unix_epoch = epoch_now () in
       let reissued =
-        { job_with_status with
-          common = { job_with_status.common with issued_since_unix_epoch }
-        }
+        { job with common = { job.common with issued_since_unix_epoch } }
       in
       Sent_job_pool.replace ~id ~job:reissued
         partitioner.jobs_sent_by_partitioner ;
@@ -91,7 +91,7 @@ let issue_from_zkapp_command_work_pool ~(partitioner : t) () :
       (Id_generator.next_id partitioner.id_generator)
   in
   let fee_of_full = pending_zkapp_command.fee_of_full in
-  let issued_since_unix_epoch = Time.(now () |> to_span_since_epoch) in
+  let issued_since_unix_epoch = epoch_now () in
   let spec =
     Work.Partitioned.Zkapp_command_job.Poly.
       { spec
@@ -104,3 +104,95 @@ let issue_from_zkapp_command_work_pool ~(partitioner : t) () :
     partitioner.jobs_sent_by_partitioner ;
 
   Work.Partitioned.Spec.Poly.Sub_zkapp_command { spec; metric = () }
+
+let rec issue_from_tmp_slot ~(partitioner : t) () =
+  match partitioner.tmp_slot with
+  | Some spec ->
+      partitioner.tmp_slot <- None ;
+      Some (convert_single_work_from_selector ~partitioner ~spec)
+  | None ->
+      None
+
+(* try to issue a single work received from the underlying Work_selector
+   `one_or_two` tracks which task is it inside a `One_or_two`*)
+and convert_single_work_from_selector ~(partitioner : t)
+    ~spec:(single_spec, pairing, fee_of_full) : Work.Partitioned.Spec.t =
+  match single_spec with
+  | Transition (input, witness) as work -> (
+      (* WARN: a smilar copy of this exists in `Snark_worker.Worker_impl_prod` *)
+      match witness.transaction with
+      | Command (Zkapp_command zkapp_command) -> (
+          match
+            Async.Thread_safe.block_on_async (fun () ->
+                let witness =
+                  Transaction_witness.read_all_proofs_from_disk witness
+                in
+                Snark_worker_shared.extract_zkapp_segment_works
+                  ~m:partitioner.transaction_snark ~input ~witness
+                  ~zkapp_command )
+          with
+          | Ok (Ok (_ :: _ as all)) ->
+              let unscheduled_segments =
+                all
+                |> List.map ~f:(fun (witness, spec, statement) ->
+                       Work.Partitioned.Zkapp_command_job.Spec.Poly.Segment
+                         { statement; witness; spec } )
+                |> Queue.of_list
+              in
+              let pending_mergable_proofs = Deque.create () in
+              let merge_remaining = Queue.length unscheduled_segments - 1 in
+              let pending_zkapp_command =
+                Pending_zkapp_command.
+                  { unscheduled_segments
+                  ; pending_mergable_proofs
+                  ; merge_remaining
+                  ; spec = work
+                  ; elapsed = Time.Span.zero
+                  ; fee_of_full
+                  }
+              in
+              let pairing =
+                Work.Partitioned.Pairing.Sub_zkapp.of_single
+                  (fun () ->
+                    Pairing_ID (Id_generator.next_id partitioner.id_generator)
+                    )
+                  pairing
+              in
+              assert (
+                phys_equal `Ok
+                  (Zkapp_command_job_pool.attempt_add ~key:pairing
+                     ~job:pending_zkapp_command partitioner.zkapp_command_jobs ) ) ;
+              issue_job_from_partitioner ~partitioner ()
+              |> Option.value_exn
+                   ~message:
+                     "FATAL: we already inserted work into partitioner so this \
+                      shouldn't happen"
+          | Ok (Ok []) ->
+              failwith "No witness generated"
+          | Ok (Error e) ->
+              failwith (Error.to_string_hum e)
+          | Error e ->
+              failwith (Exn.to_string e) )
+      | Command (Signed_command _) | Fee_transfer _ | Coinbase _ ->
+          Single
+            { single_spec
+            ; pairing
+            ; metric = ()
+            ; common = { fee_of_full; issued_since_unix_epoch = epoch_now () }
+            } )
+  | Merge _ ->
+      Single
+        { single_spec
+        ; pairing
+        ; metric = ()
+        ; common = { fee_of_full; issued_since_unix_epoch = epoch_now () }
+        }
+
+and issue_job_from_partitioner ~(partitioner : t) () :
+    Work.Partitioned.Spec.t option =
+  List.find_map
+    ~f:(fun f -> f ())
+    [ reissue_old_task ~partitioner
+    ; issue_from_tmp_slot ~partitioner
+    ; issue_from_zkapp_command_work_pool ~partitioner
+    ]

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -377,3 +377,70 @@ let submit_into_pending_zkapp_command ~partitioner
   Sent_job_pool.change ~id:job_id ~f:slash_or_process
     partitioner.jobs_sent_by_partitioner ;
   !returns
+
+let submit_partitioned_work ~(result : Work.Partitioned.Result.t)
+    ~(callback : Work.Selector.Result.t -> unit) ~(partitioner : t) =
+  let submit_result =
+    match result with
+    | { data =
+          Work.Partitioned.Spec.Poly.Old
+            { instances; common = { fee_of_full = fee; _ } }
+      ; prover
+      } ->
+        let to_submit =
+          Work.Partitioned.construct_selector_result ~instances ~fee ~prover
+        in
+        Processed (Some to_submit)
+    | { data =
+          Work.Partitioned.Spec.Poly.Single
+            { single_spec
+            ; pairing = `One
+            ; metric
+            ; common = { fee_of_full = fee; _ }
+            }
+      ; prover
+      } ->
+        let instances = `One (single_spec, metric) in
+        let to_submit =
+          Work.Partitioned.construct_selector_result ~instances ~fee ~prover
+        in
+        Processed (Some to_submit)
+    | { data =
+          Work.Partitioned.Spec.Poly.Single
+            { single_spec
+            ; pairing = (`First id | `Second id) as first_or_second
+            ; metric = { proof; elapsed }
+            ; common
+            }
+      ; prover
+      } ->
+        let which_half =
+          match first_or_second with `First _ -> `First | `Second _ -> `Second
+        in
+
+        let metric =
+          match single_spec with
+          | Work.Work.Single.Spec.Transition (_, _) ->
+              (elapsed, `Transition)
+          | Work.Work.Single.Spec.Merge (_, _, _) ->
+              (elapsed, `Merge)
+        in
+        let this_single =
+          Mergable_single_work.
+            { which_half; proof; metric; spec = single_spec; prover; common }
+        in
+        submit_single ~partitioner ~this_single ~id
+    | { data = Work.Partitioned.Spec.Poly.Sub_zkapp_command { spec; metric }
+      ; prover
+      } ->
+        submit_into_pending_zkapp_command ~partitioner ~spec ~metric ~prover
+  in
+  match submit_result with
+  | SchemeUnmatched ->
+      `SchemeUnmatched
+  | Slashed ->
+      `Slashed
+  | Processed (Some result) ->
+      callback result ; `Ok
+  | Processed None ->
+      `Ok

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -1,0 +1,1 @@
+module Snark_worker_shared = Snark_worker_shared

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 module Snark_worker_shared = Snark_worker_shared
 module Work = Snark_work_lib
 module Zkapp_command_job_pool =
@@ -6,3 +7,48 @@ module Sent_job_pool =
   Job_pool.Make
     (Work.Partitioned.Zkapp_command_job.ID)
     (Work.Partitioned.Zkapp_command_job)
+
+type t =
+  { logger : Logger.t
+  ; transaction_snark : (module Transaction_snark.S)
+        (* WARN: we're mixing ID for `pairing_pool` and `zkapp_command_jobs.
+           Should be fine *)
+  ; id_generator : Id_generator.t (* NOTE: Fields for pooling *)
+  ; pairing_pool :
+      (Work.Partitioned.Pairing.ID.t, Mergable_single_work.t) Hashtbl.t
+        (* if one single work from underlying Work_selector is completed but
+           not the other. throw it here. *)
+  ; zkapp_command_jobs : Zkapp_command_job_pool.t
+        (* NOTE: Fields for reissue pooling*)
+  ; reassignment_timeout : Time.Span.t
+  ; jobs_sent_by_partitioner : Sent_job_pool.t
+        (* we only track tasks created by a Work_partitioner here. For reissue
+           of regular jobs, we still turn to the underlying Work_selector *)
+        (* WARN: we're assuming everything in this queue is sorted in time from old to new.
+           So queue head is the oldest task.
+        *)
+  ; mutable tmp_slot :
+      ( Work.Selector.Single.Spec.t
+      * Work.Partitioned.Pairing.Single.t
+      * Currency.Fee.t )
+      option
+        (* When receving a `Two works from the underlying Work_selector, store one of them here,
+           so we could issue them to another worker.
+        *)
+  }
+
+let create ~(reassignment_timeout : Time.Span.t) ~(logger : Logger.t) : t =
+  let module M = Transaction_snark.Make (struct
+    let constraint_constants = Genesis_constants.Compiled.constraint_constants
+
+    let proof_level = Genesis_constants.Compiled.proof_level
+  end) in
+  { logger
+  ; transaction_snark = (module M)
+  ; id_generator = Id_generator.create ()
+  ; pairing_pool = Hashtbl.create (module Work.Partitioned.Pairing.ID)
+  ; zkapp_command_jobs = Zkapp_command_job_pool.create ()
+  ; reassignment_timeout
+  ; jobs_sent_by_partitioner = Sent_job_pool.create ()
+  ; tmp_slot = None
+  }

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -220,3 +220,29 @@ let consume_job_from_selector ~(partitioner : t) ~(spec : Work.Selector.Spec.t)
       partitioner.tmp_slot <- Some (spec1, pairing1, fee_of_full) ;
       convert_single_work_from_selector ~partitioner ~single_spec:spec2
         ~pairing:pairing2 ~fee_of_full
+
+let request_from_selector_and_consume_by_partitioner ~(partitioner : t)
+    ~(selection_method : (module Work_selector.Selection_method_intf))
+    ~(selector : Work_selector.State.t) ~(logger : Logger.t)
+    ~(fee : Currency.Fee.t) ~snark_pool () =
+  let (module Work_selection_method) = selection_method in
+  let open Core_kernel in
+  let open Option.Let_syntax in
+  let%map instances =
+    Work_selection_method.work ~logger ~fee ~snark_pool selector
+  in
+  let spec : Work.Selector.Spec.t = { instances; fee } in
+
+  consume_job_from_selector ~partitioner ~spec ()
+
+let request_partitioned_work
+    ~(selection_method : (module Work_selector.Selection_method_intf))
+    ~(logger : Logger.t) ~(fee : Currency.Fee.t)
+    ~(snark_pool : Work_selector.snark_pool) ~(selector : Work_selector.State.t)
+    ~(partitioner : t) : Work.Partitioned.Spec.t option =
+  List.find_map
+    ~f:(fun f -> f ())
+    [ issue_job_from_partitioner ~partitioner
+    ; request_from_selector_and_consume_by_partitioner ~partitioner
+        ~selection_method ~selector ~logger ~fee ~snark_pool
+    ]

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -1,1 +1,8 @@
 module Snark_worker_shared = Snark_worker_shared
+module Work = Snark_work_lib
+module Zkapp_command_job_pool =
+  Job_pool.Make (Work.Partitioned.Pairing.Sub_zkapp) (Pending_zkapp_command)
+module Sent_job_pool =
+  Job_pool.Make
+    (Work.Partitioned.Zkapp_command_job.ID)
+    (Work.Partitioned.Zkapp_command_job)

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -45,7 +45,7 @@ let create ~(reassignment_timeout : Time.Span.t) ~(logger : Logger.t) : t =
   end) in
   { logger
   ; transaction_snark = (module M)
-  ; id_generator = Id_generator.create ()
+  ; id_generator = Id_generator.create ~logger
   ; pairing_pool = Hashtbl.create (module Work.Partitioned.Pairing.ID)
   ; zkapp_command_jobs = Zkapp_command_job_pool.create ()
   ; reassignment_timeout
@@ -294,8 +294,6 @@ let submit_single ~partitioner ~this_single ~id =
                   this_single
           in
 
-          let (Pairing_ID id) = id in
-          Id_generator.recycle_id partitioner.id_generator id ;
           result := Some work ;
           None
       | None ->
@@ -314,9 +312,6 @@ let submit_into_pending_zkapp_command ~partitioner
   let returns = ref SchemeUnmatched in
   let process pending =
     Pending_zkapp_command.submit_proof ~proof ~elapsed pending ;
-
-    let (Job_ID id) = job_id in
-    Id_generator.recycle_id partitioner.id_generator id ;
 
     if 0 = pending.merge_remaining then
       let final_proof =


### PR DESCRIPTION
This is part of the project [Rework Snark Worker](https://www.notion.so/o1labs/Rework-architecture-of-snark-worker-coordinator-1c9e79b1f91080e69bb6d77f6286154e), intended to make job issuing from the Snark work coordinator issue finer-grained jobs, so that more parallelism is possible.

This, **although is indeed a noop**, will affect later PR where we switch the RPC logic completely. If this is buggy, **CI will fail on later PR that actually does the switch**. 

## Mechanism
### Basics
The new layer is called a `Work_partitioner`. It's in function between a `Work_selector` and a `Snark_worker`. It's duty is:
- After receiving requests from Snark_worker, try to request the work_selector to get some work to do. 
	- If the work is "too big", it will break it into smaller jobs. (Defined here: https://github.com/MinaProtocol/mina/blob/corvo/implement-work-partitioner/src/lib/snark_work_lib/partitioned.ml), it will store most jobs into its state, and only issue one small job to the snark worker;
	- On top of that, when snark worker is actually requesting a work, it should query its own state, and only query the underlying Work_selector if there's no "small jobs" to issue. 
- After receiving responses from Snark_worker, 
  - Try to combine them together if they're indeed small jobs. And upon completion on the combination. Submit the job. This job should have same shape as it originally requested from an underlying Work_selector.
  - If it's not a small job(some jobs distributed by the work_selector) are already small enough, just return it to the work_selector.

### Small jobs

A "small job" is smaller than the original job provided by a Work_selector, in 2 possibilities:
- The Work_selector provide a "`Two" in a One_or_two, in this case, partitioner should distribute 2 specs separately
- The Work_selector distribute a Zkapp command, in this case, partitioner should distribute all base snark jobs, and merge jobs between them separately
  
## Design Issue

- We don't want to not break other parts of the system, most notably GraphQL APIs. We bolt on a new layer atop the `Work_selector`. Ideally, when there's refactor, we should unite with the `Work_selector`. 

- This layer, doesn't take care of the work reissue of a full job in the Work_selector's perspective, this is because they already have mechanism to do so there. So we only redistribute "small jobs". 

- It's assumed that we don't care the order of zkapp command base snarks / merge snarks being performed.
  
## RPCs

### Use of assertion when merging 2 Single work to a One_or_two
In the function `merge_to_one_result_exn` [here](https://github.com/MinaProtocol/mina/blob/67f565a16b0414906e19356cb190dc0d042d1ca7/src/lib/work_partitioner/mergable_single_work.ml#L15), we are using assertion. The assumptions should be true unless there's bug in code. Still, this worth some attention. 

### Several failwith when unwrapping errors in work partitioner
See [here](https://github.com/MinaProtocol/mina/blob/67f565a16b0414906e19356cb190dc0d042d1ca7/src/lib/work_partitioner/work_partitioner.ml#L173).
