### PR TITLE
Cache account update action hashes in a new aux field in Account_update

### DIFF
--- a/changes/17120.md
+++ b/changes/17120.md
@@ -1,1 +1,1 @@
-Cache the hash of the actions in an account update to improve ledger application performance
+Cache the hash of the actions in an account update to improve ledger application performance. This optimization opens way to increase of actions limit in the coming hardfork to a hundred actions per account update.

--- a/changes/17120.md
+++ b/changes/17120.md
@@ -1,0 +1,1 @@
+Cache the hash of the actions in an account update to improve ledger application performance

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4233,7 +4233,8 @@ module Block = struct
           ~f:(fun acc ({ fee_payer; account_updates; memo; _ } as zkapp_cmd) ->
             (* add authorizations, not stored in the db *)
             let (fee_payer : Account_update.Fee_payer.t) =
-              { body = fee_payer; authorization = Signature.dummy }
+              Account_update.Fee_payer.with_no_aux ~body:fee_payer
+                ~authorization:Signature.dummy
             in
             let (account_updates : Account_update.Simple.t list) =
               List.map account_updates
@@ -4241,7 +4242,9 @@ module Block = struct
                      (body : Account_update.Body.Simple.t)
                      :
                      Account_update.Simple.t
-                   -> { body; authorization = None_given } )
+                   ->
+                  Account_update.with_no_aux ~body
+                    ~authorization:Control.Poly.None_given )
             in
             let%map cmd_id =
               User_command.Zkapp_command.add_if_doesn't_exist

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4233,7 +4233,7 @@ module Block = struct
           ~f:(fun acc ({ fee_payer; account_updates; memo; _ } as zkapp_cmd) ->
             (* add authorizations, not stored in the db *)
             let (fee_payer : Account_update.Fee_payer.t) =
-              Account_update.Fee_payer.with_no_aux ~body:fee_payer
+              Account_update.Fee_payer.make ~body:fee_payer
                 ~authorization:Signature.dummy
             in
             let (account_updates : Account_update.Simple.t list) =

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -297,8 +297,9 @@ module Values (S : Sample) = struct
     Mina_base.User_command.Signed_command (signed_command' ())
 
   let zkapp_account_update () : Mina_base.Account_update.t =
-    { body =
-        { public_key = public_key ()
+    Mina_base.Account_update.with_no_aux
+      ~body:
+        { Mina_base.Account_update.Body.public_key = public_key ()
         ; token_id = token_id ()
         ; update =
             { app_state =
@@ -325,20 +326,19 @@ module Values (S : Sample) = struct
         ; may_use_token = No
         ; authorization_kind = Proof (field ())
         }
-    ; authorization = Proof side_loaded_proof
-    }
+      ~authorization:(Mina_base.Control.Poly.Proof side_loaded_proof)
 
   let zkapp_command' () : Mina_base.Zkapp_command.t =
     let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { fee_payer =
-        { body =
+        Mina_base.Account_update.Fee_payer.with_no_aux
+          ~body:
             { public_key = public_key ()
             ; fee = fee ()
             ; valid_until = Some (global_slot_since_genesis ())
             ; nonce = account_nonce ()
             }
-        ; authorization = (field (), private_key ())
-        }
+          ~authorization:(field (), private_key ())
     ; account_updates =
         List.init Params.max_zkapp_txn_account_updates ~f:(Fn.const ())
         |> List.fold_left ~init:[] ~f:(fun acc () ->

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -297,7 +297,7 @@ module Values (S : Sample) = struct
     Mina_base.User_command.Signed_command (signed_command' ())
 
   let zkapp_account_update () : Mina_base.Account_update.t =
-    Mina_base.Account_update.with_no_aux
+    Mina_base.Account_update.with_aux
       ~body:
         { Mina_base.Account_update.Body.public_key = public_key ()
         ; token_id = token_id ()

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -331,7 +331,7 @@ module Values (S : Sample) = struct
   let zkapp_command' () : Mina_base.Zkapp_command.t =
     let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { fee_payer =
-        Mina_base.Account_update.Fee_payer.with_no_aux
+        Mina_base.Account_update.Fee_payer.make
           ~body:
             { public_key = public_key ()
             ; fee = fee ()

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -522,7 +522,7 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
     let%map (body : Account_update.Body.Fee_payer.t) =
       Load_data.get_fee_payer_body ~pool cmd.zkapp_fee_payer_body_id
     in
-    Account_update.Fee_payer.with_no_aux ~body ~authorization:Signature.dummy
+    Account_update.Fee_payer.make ~body ~authorization:Signature.dummy
   in
   let nonce_str = Mina_numbers.Account_nonce.to_string fee_payer.body.nonce in
   [%log spam]

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -522,7 +522,7 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
     let%map (body : Account_update.Body.Fee_payer.t) =
       Load_data.get_fee_payer_body ~pool cmd.zkapp_fee_payer_body_id
     in
-    ({ body; authorization = Signature.dummy } : Account_update.Fee_payer.t)
+    Account_update.Fee_payer.with_no_aux ~body ~authorization:Signature.dummy
   in
   let nonce_str = Mina_numbers.Account_nonce.to_string fee_payer.body.nonce in
   [%log spam]
@@ -547,7 +547,7 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
           | None_given ->
               None_given
         in
-        ({ body; authorization } : Account_update.Simple.t) )
+        Account_update.with_no_aux ~body ~authorization )
   in
   let memo = Signed_command_memo.of_base58_check_exn cmd.memo in
   let zkapp_command =

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -187,7 +187,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       (* TODO: This is a pain. *)
-      Account_update.with_no_aux ~body:(body vk)
+      Account_update.with_aux ~body:(body vk)
         ~authorization:(Control.Poly.Signature Signature.dummy)
     in
     let%bind zkapp_command_create_accounts =

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -186,9 +186,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; authorization_kind = Signature
         }
       in
-
       (* TODO: This is a pain. *)
-      { body = body vk; authorization = Signature Signature.dummy }
+      Account_update.with_no_aux ~body:(body vk)
+        ~authorization:(Control.Poly.Signature Signature.dummy)
     in
     let%bind zkapp_command_create_accounts =
       let memo =
@@ -217,14 +217,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        { body =
+        Account_update.Fee_payer.with_no_aux
+          ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = account_a_pk
             ; nonce
             ; fee = Currency.Fee.(of_nanomina_int_exn 20_000_000)
             }
-        ; authorization = Signature.dummy
-        }
+          ~authorization:Signature.dummy
       in
       let memo_hash = Signed_command_memo.hash memo in
       let full_commitment =
@@ -254,6 +254,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = _
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key account_a_pk ->

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -217,7 +217,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = account_a_pk

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -364,6 +364,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         fee_payer =
           { body = { p.fee_payer.body with nonce = Account.Nonce.of_int 2 }
           ; authorization = Signature.dummy
+          ; aux = p.fee_payer.aux
           }
       }
     in

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -364,7 +364,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         fee_payer =
           { body = { p.fee_payer.body with nonce = Account.Nonce.of_int 2 }
           ; authorization = Signature.dummy
-          ; aux = p.fee_payer.aux
           }
       }
     in

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -105,7 +105,7 @@ let%test_module "Actions test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -73,9 +73,8 @@ let%test_module "Actions test" =
         }
 
       let account_update : Account_update.t =
-        { body = account_update_body
-        ; authorization = Signature Signature.dummy
-        }
+        Account_update.with_no_aux ~body:account_update_body
+          ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 
     module Initialize_account_update = struct
@@ -106,14 +105,14 @@ let%test_module "Actions test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        { body =
+        Account_update.Fee_payer.with_no_aux
+          ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed
             ; fee = Currency.Fee.(of_nanomina_int_exn 50)
             ; nonce = Account.Nonce.of_int fee_payer_nonce
             }
-        ; authorization = Signature.dummy
-        }
+          ~authorization:Signature.dummy
       in
       let memo_hash = Signed_command_memo.hash memo in
       let full_commitment =
@@ -142,6 +141,7 @@ let%test_module "Actions test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = _
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -73,7 +73,7 @@ let%test_module "Actions test" =
         }
 
       let account_update : Account_update.t =
-        Account_update.with_no_aux ~body:account_update_body
+        Account_update.with_aux ~body:account_update_body
           ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -104,7 +104,7 @@ let%test_module "Add events test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -73,9 +73,8 @@ let%test_module "Add events test" =
         }
 
       let account_update : Account_update.t =
-        { body = account_update_body
-        ; authorization = Signature Signature.dummy
-        }
+        Account_update.with_no_aux ~body:account_update_body
+          ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 
     module Initialize_account_update = struct
@@ -105,13 +104,13 @@ let%test_module "Add events test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        { body =
+        Account_update.Fee_payer.with_no_aux
+          ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
-        ; authorization = Signature.dummy
-        }
+          ~authorization:Signature.dummy
       in
       let memo_hash = Signed_command_memo.hash memo in
       let full_commitment =
@@ -140,6 +139,7 @@ let%test_module "Add events test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = _
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -73,7 +73,7 @@ let%test_module "Add events test" =
         }
 
       let account_update : Account_update.t =
-        Account_update.with_no_aux ~body:account_update_body
+        Account_update.with_aux ~body:account_update_body
           ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -36,7 +36,7 @@ let account_update : Account_update.t =
   let ({ account_update; _ } : _ Zkapp_command.Call_forest.tree), () =
     Async.Thread_safe.block_on_async_exn prover
   in
-  Account_update.with_no_aux
+  Account_update.with_aux
     ~body:{ account_update.body with authorization_kind = Proof vk_hash }
     ~authorization:account_update.authorization
 
@@ -59,7 +59,7 @@ let deploy_account_update_body : Account_update.Body.t =
   }
 
 let deploy_account_update : Account_update.t =
-  Account_update.with_no_aux ~body:deploy_account_update_body
+  Account_update.with_aux ~body:deploy_account_update_body
     ~authorization:(Control.Poly.Signature Signature.dummy)
 
 let account_updates =

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -74,7 +74,7 @@ let transaction_commitment : Zkapp_command.Transaction_commitment.t =
   Zkapp_command.Transaction_commitment.create ~account_updates_hash
 
 let fee_payer =
-  Account_update.Fee_payer.with_no_aux
+  Account_update.Fee_payer.make
     ~body:
       { Account_update.Body.Fee_payer.dummy with
         public_key = pk_compressed

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -128,11 +128,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer =
-        { body = fee_payer.body
-        ; authorization = Signature.dummy
-        ; aux = fee_payer.aux
-        }
+    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -36,9 +36,9 @@ let account_update : Account_update.t =
   let ({ account_update; _ } : _ Zkapp_command.Call_forest.tree), () =
     Async.Thread_safe.block_on_async_exn prover
   in
-  { body = { account_update.body with authorization_kind = Proof vk_hash }
-  ; authorization = account_update.authorization
-  }
+  Account_update.with_no_aux
+    ~body:{ account_update.body with authorization_kind = Proof vk_hash }
+    ~authorization:account_update.authorization
 
 let deploy_account_update_body : Account_update.Body.t =
   { Account_update.Body.dummy with
@@ -59,9 +59,8 @@ let deploy_account_update_body : Account_update.Body.t =
   }
 
 let deploy_account_update : Account_update.t =
-  { body = deploy_account_update_body
-  ; authorization = Signature Signature.dummy
-  }
+  Account_update.with_no_aux ~body:deploy_account_update_body
+    ~authorization:(Control.Poly.Signature Signature.dummy)
 
 let account_updates =
   []
@@ -75,13 +74,13 @@ let transaction_commitment : Zkapp_command.Transaction_commitment.t =
   Zkapp_command.Transaction_commitment.create ~account_updates_hash
 
 let fee_payer =
-  { Account_update.Fee_payer.body =
+  Account_update.Fee_payer.with_no_aux
+    ~body:
       { Account_update.Body.Fee_payer.dummy with
         public_key = pk_compressed
       ; fee = Currency.Fee.(of_nanomina_int_exn 100)
       }
-  ; authorization = Signature.dummy
-  }
+    ~authorization:Signature.dummy
 
 let full_commitment =
   Zkapp_command.Transaction_commitment.create_complete transaction_commitment
@@ -108,6 +107,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = _
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->
@@ -128,7 +128,11 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
+    { fee_payer =
+        { body = fee_payer.body
+        ; authorization = Signature.dummy
+        ; aux = fee_payer.aux
+        }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -136,9 +136,8 @@ let%test_module "Composability test" =
 
       let account_update : Account_update.t =
         (* TODO: This is a pain. *)
-        { body = account_update_body
-        ; authorization = Signature Signature.dummy
-        }
+        Account_update.with_no_aux ~body:account_update_body
+          ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 
     module Initialize_account_update = struct
@@ -222,13 +221,13 @@ let%test_module "Composability test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        { body =
+        Account_update.Fee_payer.with_no_aux
+          ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
-        ; authorization = Signature.dummy
-        }
+          ~authorization:Signature.dummy
       in
       let memo = Signed_command_memo.empty in
       let memo_hash = Signed_command_memo.hash memo in
@@ -258,6 +257,7 @@ let%test_module "Composability test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = _
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -221,7 +221,7 @@ let%test_module "Composability test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -136,7 +136,7 @@ let%test_module "Composability test" =
 
       let account_update : Account_update.t =
         (* TODO: This is a pain. *)
-        Account_update.with_no_aux ~body:account_update_body
+        Account_update.with_aux ~body:account_update_body
           ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -59,9 +59,8 @@ let deploy_account_update_body : Account_update.Body.t =
 
 let deploy_account_update : Account_update.t =
   (* TODO: This is a pain. *)
-  { body = deploy_account_update_body
-  ; authorization = Signature Signature.dummy
-  }
+  Account_update.with_no_aux ~body:deploy_account_update_body
+    ~authorization:(Control.Poly.Signature Signature.dummy)
 
 let account_updates =
   []
@@ -77,13 +76,13 @@ let transaction_commitment : Zkapp_command.Transaction_commitment.t =
 
 let fee_payer =
   (* TODO: This is a pain. *)
-  { Account_update.Fee_payer.body =
+  Account_update.Fee_payer.with_no_aux
+    ~body:
       { Account_update.Body.Fee_payer.dummy with
         public_key = pk_compressed
       ; fee = Currency.Fee.(of_nanomina_int_exn 100)
       }
-  ; authorization = Signature.dummy
-  }
+    ~authorization:Signature.dummy
 
 let full_commitment =
   (* TODO: This is a pain. *)
@@ -112,6 +111,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = _
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->
@@ -132,7 +132,11 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
+    { fee_payer =
+        { body = fee_payer.body
+        ; authorization = Signature.dummy
+        ; aux = fee_payer.aux
+        }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -132,11 +132,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
 
 let zkapp_command : Zkapp_command.t =
   sign_all
-    { fee_payer =
-        { body = fee_payer.body
-        ; authorization = Signature.dummy
-        ; aux = fee_payer.aux
-        }
+    { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
     ; account_updates
     ; memo
     }

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -76,7 +76,7 @@ let transaction_commitment : Zkapp_command.Transaction_commitment.t =
 
 let fee_payer =
   (* TODO: This is a pain. *)
-  Account_update.Fee_payer.with_no_aux
+  Account_update.Fee_payer.make
     ~body:
       { Account_update.Body.Fee_payer.dummy with
         public_key = pk_compressed

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -59,7 +59,7 @@ let deploy_account_update_body : Account_update.Body.t =
 
 let deploy_account_update : Account_update.t =
   (* TODO: This is a pain. *)
-  Account_update.with_no_aux ~body:deploy_account_update_body
+  Account_update.with_aux ~body:deploy_account_update_body
     ~authorization:(Control.Poly.Signature Signature.dummy)
 
 let account_updates =

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -85,7 +85,7 @@ let%test_module "Initialize state test" =
 
       let account_update : Account_update.t =
         (* TODO: This is a pain. *)
-        Account_update.with_no_aux ~body:account_update_body
+        Account_update.with_aux ~body:account_update_body
           ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -113,7 +113,7 @@ let%test_module "Initialize state test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -85,9 +85,8 @@ let%test_module "Initialize state test" =
 
       let account_update : Account_update.t =
         (* TODO: This is a pain. *)
-        { body = account_update_body
-        ; authorization = Signature Signature.dummy
-        }
+        Account_update.with_no_aux ~body:account_update_body
+          ~authorization:(Control.Poly.Signature Signature.dummy)
     end
 
     module Initialize_account_update = struct
@@ -114,13 +113,13 @@ let%test_module "Initialize state test" =
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
       in
       let fee_payer : Account_update.Fee_payer.t =
-        { body =
+        Account_update.Fee_payer.with_no_aux
+          ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed
             ; fee = Currency.Fee.(of_nanomina_int_exn 100)
             }
-        ; authorization = Signature.dummy
-        }
+          ~authorization:Signature.dummy
       in
       let memo_hash = Signed_command_memo.hash memo in
       let full_commitment =
@@ -149,6 +148,7 @@ let%test_module "Initialize state test" =
           Zkapp_command.Call_forest.map account_updates ~f:(function
             | ({ body = { public_key; use_full_commitment; _ }
                ; authorization = Signature _
+               ; aux = _
                } as account_update :
                 Account_update.t )
               when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -125,7 +125,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -148,14 +148,14 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                      ~token_id:owned_token_id ~may_use_token:Parents_own_token )
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -181,7 +181,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -189,7 +189,7 @@ let%test_module "Tokens test" =
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -197,7 +197,7 @@ let%test_module "Tokens test" =
                      ~token_id:Token_id.default ~may_use_token:Parents_own_token )
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -211,7 +211,7 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -235,7 +235,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             (Account_update.with_no_aux
+             (Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true ~balance_change:(int_to_amount 5)
@@ -245,7 +245,7 @@ let%test_module "Tokens test" =
                ( []
                (* Delegate call, should be checked. *)
                |> Zkapp_command.Call_forest.cons ~signature_kind
-                    (Account_update.with_no_aux
+                    (Account_update.with_aux
                        ~body:
                          (Zkapps_examples.mk_update_body (fst mint_to_keys)
                             ~use_full_commitment:true
@@ -257,7 +257,7 @@ let%test_module "Tokens test" =
                       ( []
                       (* Delegate call, should be checked. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                         @@ Account_update.with_no_aux
+                         @@ Account_update.with_aux
                               ~body:
                                 (Zkapps_examples.mk_update_body
                                    (fst mint_to_keys) ~use_full_commitment:true
@@ -268,7 +268,7 @@ let%test_module "Tokens test" =
                                 (Control.Poly.Signature Signature.dummy)
                       (* Parents_own_token, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                         @@ Account_update.with_no_aux
+                         @@ Account_update.with_aux
                               ~body:
                                 (Zkapps_examples.mk_update_body
                                    (fst mint_to_keys) ~use_full_commitment:true
@@ -278,7 +278,7 @@ let%test_module "Tokens test" =
                                 (Control.Poly.Signature Signature.dummy)
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                         @@ Account_update.with_no_aux
+                         @@ Account_update.with_aux
                               ~body:
                                 (Zkapps_examples.mk_update_body
                                    (fst mint_to_keys) ~use_full_commitment:true
@@ -288,7 +288,7 @@ let%test_module "Tokens test" =
                                 (Control.Poly.Signature Signature.dummy)
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                         @@ Account_update.with_no_aux
+                         @@ Account_update.with_aux
                               ~body:
                                 (Zkapps_examples.mk_update_body
                                    (fst mint_to_keys) ~use_full_commitment:true
@@ -318,7 +318,7 @@ let%test_module "Tokens test" =
                )
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -326,7 +326,7 @@ let%test_module "Tokens test" =
                      ~may_use_token:Inherit_from_parent )
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -340,7 +340,7 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -363,7 +363,7 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true ~balance_change:(int_to_amount 1)
@@ -371,7 +371,7 @@ let%test_module "Tokens test" =
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -379,7 +379,7 @@ let%test_module "Tokens test" =
                      ~may_use_token:Inherit_from_parent )
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
@@ -393,14 +393,14 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body (fst mint_to_keys)
                      ~use_full_commitment:true
                      ~balance_change:(int_to_amount (-30)) ~may_use_token:No )
                 ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind ~calls:subtree
-           @@ Account_update.with_no_aux
+           @@ Account_update.with_aux
                 ~body:
                   (Zkapps_examples.mk_update_body pk
                      ~authorization_kind:None_given )

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -125,13 +125,12 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 1)
-                   ~token_id:owned_token_id
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true ~balance_change:(int_to_amount 1)
+                     ~token_id:owned_token_id )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       match
         Or_error.try_with (fun () ->
@@ -149,22 +148,20 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 1)
-                   ~token_id:owned_token_id ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true ~balance_change:(int_to_amount 1)
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
-                   ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-1))
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       let account =
         []
@@ -184,31 +181,29 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 1)
-                   ~token_id:owned_token_id ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true ~balance_change:(int_to_amount 1)
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 30)
-                   ~token_id:Token_id.default ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount 30)
+                     ~token_id:Token_id.default ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
-                   ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-1))
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       let account =
         []
@@ -216,14 +211,13 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-30))
-                   ~token_id:Token_id.default ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-30))
+                     ~token_id:Token_id.default ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons_tree
              ( fst @@ Async.Thread_safe.block_on_async_exn
              @@ Zkapps_tokens.child_forest pk token_id subtree )
@@ -241,69 +235,67 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 5)
-                   ~token_id:owned_token_id ~may_use_token:Parents_own_token
-             }
+             (Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true ~balance_change:(int_to_amount 5)
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy) )
              ~calls:
                ( []
                (* Delegate call, should be checked. *)
                |> Zkapp_command.Call_forest.cons ~signature_kind
-                    { Account_update.Poly.authorization =
-                        Control.Poly.Signature Signature.dummy
-                    ; body =
-                        Zkapps_examples.mk_update_body (fst mint_to_keys)
-                          ~use_full_commitment:true
-                          ~balance_change:(int_to_amount (-2))
-                          ~token_id:owned_token_id
-                          ~may_use_token:Inherit_from_parent
-                    }
+                    (Account_update.with_no_aux
+                       ~body:
+                         (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                            ~use_full_commitment:true
+                            ~balance_change:(int_to_amount (-2))
+                            ~token_id:owned_token_id
+                            ~may_use_token:Inherit_from_parent )
+                       ~authorization:(Control.Poly.Signature Signature.dummy) )
                     ~calls:
                       ( []
                       (* Delegate call, should be checked. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                           { Account_update.Poly.authorization =
-                               Control.Poly.Signature Signature.dummy
-                           ; body =
-                               Zkapps_examples.mk_update_body (fst mint_to_keys)
-                                 ~use_full_commitment:true
-                                 ~balance_change:(int_to_amount (-2))
-                                 ~token_id:owned_token_id
-                                 ~may_use_token:Inherit_from_parent
-                           }
+                         @@ Account_update.with_no_aux
+                              ~body:
+                                (Zkapps_examples.mk_update_body
+                                   (fst mint_to_keys) ~use_full_commitment:true
+                                   ~balance_change:(int_to_amount (-2))
+                                   ~token_id:owned_token_id
+                                   ~may_use_token:Inherit_from_parent )
+                              ~authorization:
+                                (Control.Poly.Signature Signature.dummy)
                       (* Parents_own_token, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                           { Account_update.Poly.authorization =
-                               Control.Poly.Signature Signature.dummy
-                           ; body =
-                               Zkapps_examples.mk_update_body (fst mint_to_keys)
-                                 ~use_full_commitment:true
-                                 ~balance_change:(int_to_amount 15)
-                                 ~may_use_token:Parents_own_token
-                           }
+                         @@ Account_update.with_no_aux
+                              ~body:
+                                (Zkapps_examples.mk_update_body
+                                   (fst mint_to_keys) ~use_full_commitment:true
+                                   ~balance_change:(int_to_amount 15)
+                                   ~may_use_token:Parents_own_token )
+                              ~authorization:
+                                (Control.Poly.Signature Signature.dummy)
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                           { Account_update.Poly.authorization =
-                               Control.Poly.Signature Signature.dummy
-                           ; body =
-                               Zkapps_examples.mk_update_body (fst mint_to_keys)
-                                 ~use_full_commitment:true
-                                 ~balance_change:(int_to_amount (-15))
-                                 ~may_use_token:No
-                           }
+                         @@ Account_update.with_no_aux
+                              ~body:
+                                (Zkapps_examples.mk_update_body
+                                   (fst mint_to_keys) ~use_full_commitment:true
+                                   ~balance_change:(int_to_amount (-15))
+                                   ~may_use_token:No )
+                              ~authorization:
+                                (Control.Poly.Signature Signature.dummy)
                       (* Blind call, should be skipped. *)
                       |> Zkapp_command.Call_forest.cons ~signature_kind
-                           { Account_update.Poly.authorization =
-                               Control.Poly.Signature Signature.dummy
-                           ; body =
-                               Zkapps_examples.mk_update_body (fst mint_to_keys)
-                                 ~use_full_commitment:true
-                                 ~balance_change:(int_to_amount 15)
-                                 ~may_use_token:No
-                           }
+                         @@ Account_update.with_no_aux
+                              ~body:
+                                (Zkapps_examples.mk_update_body
+                                   (fst mint_to_keys) ~use_full_commitment:true
+                                   ~balance_change:(int_to_amount 15)
+                                   ~may_use_token:No )
+                              ~authorization:
+                                (Control.Poly.Signature Signature.dummy)
                       (* Minting by delegate call should be ignored by the sum
                          check.
                       *)
@@ -326,22 +318,21 @@ let%test_module "Tokens test" =
                )
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 15)
-                   ~may_use_token:Inherit_from_parent
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount 15)
+                     ~may_use_token:Inherit_from_parent )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
-                   ~may_use_token:Parents_own_token
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-1))
+                     ~token_id:owned_token_id ~may_use_token:Parents_own_token )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       let account =
         []
@@ -349,13 +340,12 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-30)) ~may_use_token:No
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-30)) ~may_use_token:No )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons_tree
              ( fst @@ Async.Thread_safe.block_on_async_exn
              @@ Zkapps_tokens.child_forest pk token_id subtree )
@@ -373,31 +363,29 @@ let%test_module "Tokens test" =
       let subtree =
         []
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 1)
-                   ~token_id:owned_token_id ~may_use_token:Inherit_from_parent
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true ~balance_change:(int_to_amount 1)
+                     ~token_id:owned_token_id ~may_use_token:Inherit_from_parent )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         (* This account update should be ignored by the token zkApp. *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true ~balance_change:(int_to_amount 30)
-                   ~may_use_token:Inherit_from_parent
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount 30)
+                     ~may_use_token:Inherit_from_parent )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-1)) ~token_id:owned_token_id
-                   ~may_use_token:Inherit_from_parent
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-1))
+                     ~token_id:owned_token_id ~may_use_token:Inherit_from_parent )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       let account =
         []
@@ -405,19 +393,18 @@ let%test_module "Tokens test" =
            counteracting the effect of the ignored update above.
         *)
         |> Zkapp_command.Call_forest.cons ~signature_kind
-             { Account_update.Poly.authorization =
-                 Control.Poly.Signature Signature.dummy
-             ; body =
-                 Zkapps_examples.mk_update_body (fst mint_to_keys)
-                   ~use_full_commitment:true
-                   ~balance_change:(int_to_amount (-30)) ~may_use_token:No
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body (fst mint_to_keys)
+                     ~use_full_commitment:true
+                     ~balance_change:(int_to_amount (-30)) ~may_use_token:No )
+                ~authorization:(Control.Poly.Signature Signature.dummy)
         |> Zkapp_command.Call_forest.cons ~signature_kind ~calls:subtree
-             { Account_update.Poly.authorization = Control.Poly.None_given
-             ; body =
-                 Zkapps_examples.mk_update_body pk
-                   ~authorization_kind:None_given
-             }
+           @@ Account_update.with_no_aux
+                ~body:
+                  (Zkapps_examples.mk_update_body pk
+                     ~authorization_kind:None_given )
+                ~authorization:Control.Poly.None_given
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
         |> Zkapp_command.Call_forest.cons ~signature_kind

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -332,7 +332,7 @@ module Rules = struct
       let dummy_account_update_body = Lazy.force dummy_account_update_body in
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
-            Account_update.with_no_aux ~body:dummy_account_update_body.data
+            Account_update.with_aux ~body:dummy_account_update_body.data
               ~authorization:Control.Poly.None_given
         ; account_update_digest = dummy_account_update_body.hash
         ; calls = []

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -332,9 +332,8 @@ module Rules = struct
       let dummy_account_update_body = Lazy.force dummy_account_update_body in
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
-            { Account_update.Poly.body = dummy_account_update_body.data
-            ; authorization = Control.Poly.None_given
-            }
+            Account_update.with_no_aux ~body:dummy_account_update_body.data
+              ~authorization:Control.Poly.None_given
         ; account_update_digest = dummy_account_update_body.hash
         ; calls = []
         }

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -695,12 +695,11 @@ let compile :
               prover ?handler ()
             in
             let account_update : Account_update.t =
-              { body = account_update
-              ; authorization =
-                  Proof
-                    ( Proof_cache_tag.write_proof_to_disk proof_cache_db
-                    @@ Pickles.Side_loaded.Proof.of_proof proof )
-              }
+              Account_update.with_no_aux ~body:account_update
+                ~authorization:
+                  (Control.Poly.Proof
+                     ( Proof_cache_tag.write_proof_to_disk proof_cache_db
+                     @@ Pickles.Side_loaded.Proof.of_proof proof ) )
             in
             ( { Zkapp_command.Call_forest.Tree.account_update
               ; account_update_digest
@@ -786,9 +785,9 @@ module Deploy_account_update = struct
 
   let full ?balance_change ?access public_key token_id vk : Account_update.t =
     (* TODO: This is a pain. *)
-    { body = body ?balance_change ?access public_key token_id vk
-    ; authorization = Signature Signature.dummy
-    }
+    Account_update.with_no_aux
+      ~body:(body ?balance_change ?access public_key token_id vk)
+      ~authorization:(Control.Poly.Signature Signature.dummy)
 end
 
 let insert_signatures pk_compressed sk
@@ -823,6 +822,7 @@ let insert_signatures pk_compressed sk
     Zkapp_command.Call_forest.map account_updates ~f:(function
       | ({ body = { public_key; use_full_commitment; _ }
          ; authorization = Signature _
+         ; aux = _
          } as account_update :
           Account_update.t )
         when Public_key.Compressed.equal public_key pk_compressed ->

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -695,7 +695,7 @@ let compile :
               prover ?handler ()
             in
             let account_update : Account_update.t =
-              Account_update.with_no_aux ~body:account_update
+              Account_update.with_aux ~body:account_update
                 ~authorization:
                   (Control.Poly.Proof
                      ( Proof_cache_tag.write_proof_to_disk proof_cache_db
@@ -785,7 +785,7 @@ module Deploy_account_update = struct
 
   let full ?balance_change ?access public_key token_id vk : Account_update.t =
     (* TODO: This is a pain. *)
-    Account_update.with_no_aux
+    Account_update.with_aux
       ~body:(body ?balance_change ?access public_key token_id vk)
       ~authorization:(Control.Poly.Signature Signature.dummy)
 end

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1944,13 +1944,13 @@ module Fee_payer = struct
     end
   end]
 
-  let with_no_aux ~body ~authorization : t = { body; authorization }
+  let make ~body ~authorization : t = { body; authorization }
 
   let gen : t Quickcheck.Generator.t =
     let open Quickcheck.Let_syntax in
     let%map body = Body.Fee_payer.gen in
     let authorization = Signature.dummy in
-    with_no_aux ~body ~authorization
+    make ~body ~authorization
 
   let quickcheck_generator : t Quickcheck.Generator.t = gen
 

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1830,16 +1830,16 @@ module T = struct
   module Aux_data = struct
     type t =
       { actions_hash : Field.t
-            (** The cached hash of the actions in an account update body - currently not updated. *)
+            (** The cached hash of the actions in an account update body *)
       }
 
     let to_yojson : _ -> Yojson.Safe.t = Nothing.unreachable_code
 
     let sexp_of_t : _ -> Ppx_sexp_conv_lib.Sexp.t = Nothing.unreachable_code
 
-    (* TODO: actually compute the actions_hash from the body of an account
-       update *)
-    let of_without_aux : t = { actions_hash = Field.zero }
+    let of_body ~body : t =
+      let actions = Zkapp_account.Actions.of_event_list body.Body.actions in
+      { actions_hash = actions.hash }
   end
 
   type t = (Body.t, Control.t, Aux_data.t) Poly.t
@@ -1857,7 +1857,7 @@ module T = struct
     { body; authorization; aux = () }
 
   let with_aux ~body ~authorization : _ Poly.t =
-    { body; authorization; aux = Aux_data.of_without_aux }
+    { body; authorization; aux = Aux_data.of_body ~body }
 
   let gen : Stable.Latest.t Quickcheck.Generator.t =
     let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1700,6 +1700,9 @@ module Poly = struct
     module Stable = struct
       module V1 = struct
         type ('body, 'authorization) t =
+              ( 'body
+              , 'authorization )
+              Mina_wire_types.Mina_base.Account_update.Poly.V1.t =
           { body : 'body; authorization : 'authorization }
         [@@deriving yojson, sexp]
 
@@ -1726,10 +1729,6 @@ module Poly = struct
     module V1 = struct
       (** An account update in a zkApp transaction *)
       type ('body, 'authorization, 'aux) t =
-            ( 'body
-            , 'authorization
-            , 'aux )
-            Mina_wire_types.Mina_base.Account_update.Poly.V1.t =
         { body : 'body; authorization : 'authorization; aux : 'aux }
       [@@deriving annot, equal, hash, compare, fields]
 

--- a/src/lib/mina_base/test/account_update_test.ml
+++ b/src/lib/mina_base/test/account_update_test.ml
@@ -123,7 +123,7 @@ let body_json_roundtrip () =
 let fee_payer_json_roundtrip () =
   let open Fee_payer in
   let dummy : t =
-    Account_update.Fee_payer.with_no_aux ~body:Body.Fee_payer.dummy
+    Account_update.Fee_payer.make ~body:Body.Fee_payer.dummy
       ~authorization:Signature.dummy
   in
   let open Fields_derivers_zkapps.Derivers in

--- a/src/lib/mina_base/test/account_update_test.ml
+++ b/src/lib/mina_base/test/account_update_test.ml
@@ -123,7 +123,8 @@ let body_json_roundtrip () =
 let fee_payer_json_roundtrip () =
   let open Fee_payer in
   let dummy : t =
-    { body = Body.Fee_payer.dummy; authorization = Signature.dummy }
+    Account_update.Fee_payer.with_no_aux ~body:Body.Fee_payer.dummy
+      ~authorization:Signature.dummy
   in
   let open Fields_derivers_zkapps.Derivers in
   let full = o () in
@@ -133,7 +134,8 @@ let fee_payer_json_roundtrip () =
 let json_roundtrip_dummy () =
   let dummy : Graphql_repr.t =
     to_graphql_repr ~call_depth:0
-      { body = Body.dummy; authorization = Control.dummy_of_tag Signature }
+    @@ Account_update.with_no_aux ~body:Body.dummy
+         ~authorization:(Control.dummy_of_tag Signature)
   in
   let module Fd = Fields_derivers_zkapps.Derivers in
   let full = Graphql_repr.deriver @@ Fd.o () in

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -239,7 +239,7 @@ let build_zkapp_cmd ?valid_until ~fee transactions :
   let%bind body = fee_payer_body ?valid_until fee in
   let%map updates = State.concat_map_m ~f:mk_updates transactions in
   { Zkapp_command.Poly.fee_payer =
-      Account_update.Fee_payer.with_no_aux ~body ~authorization:Signature.dummy
+      Account_update.Fee_payer.make ~body ~authorization:Signature.dummy
   ; account_updates = updates
   ; memo = Signed_command_memo.dummy
   }

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -111,13 +111,11 @@ module Simple_txn = struct
             Amount.Signed.(of_unsigned amount)
         in
         [ update
-            { Account_update.Poly.body = sender_decrease_body
-            ; authorization = dummy_auth
-            }
+          @@ Account_update.with_no_aux ~body:sender_decrease_body
+               ~authorization:dummy_auth
         ; update
-            { Account_update.Poly.body = receiver_increase_body
-            ; authorization = dummy_auth
-            }
+          @@ Account_update.with_no_aux ~body:receiver_increase_body
+               ~authorization:dummy_auth
         ]
     end
 
@@ -175,7 +173,7 @@ module Single = struct
       method updates =
         let open Monad_lib.State.Let_syntax in
         let%map body = update_body ?preconditions ~account amount in
-        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
+        [ update @@ Account_update.with_no_aux ~body ~authorization:dummy_auth ]
     end
 end
 
@@ -193,7 +191,7 @@ module Alter_account = struct
         let%map body =
           update_body ?preconditions ~update:state_update ~account amount
         in
-        [ update { Account_update.Poly.body; authorization = dummy_auth } ]
+        [ update @@ Account_update.with_no_aux ~body ~authorization:dummy_auth ]
     end
 end
 
@@ -216,7 +214,8 @@ module Txn_tree = struct
         let%map calls =
           State_ext.concat_map_m children ~f:(fun c -> c#updates)
         in
-        [ update ~calls { Account_update.Poly.body; authorization = dummy_auth }
+        [ update ~calls
+          @@ Account_update.with_no_aux ~body ~authorization:dummy_auth
         ]
     end
 end
@@ -239,7 +238,8 @@ let build_zkapp_cmd ?valid_until ~fee transactions :
   let open State.Let_syntax in
   let%bind body = fee_payer_body ?valid_until fee in
   let%map updates = State.concat_map_m ~f:mk_updates transactions in
-  { Zkapp_command.Poly.fee_payer = { body; authorization = Signature.dummy }
+  { Zkapp_command.Poly.fee_payer =
+      Account_update.Fee_payer.with_no_aux ~body ~authorization:Signature.dummy
   ; account_updates = updates
   ; memo = Signed_command_memo.dummy
   }

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -111,10 +111,10 @@ module Simple_txn = struct
             Amount.Signed.(of_unsigned amount)
         in
         [ update
-          @@ Account_update.with_no_aux ~body:sender_decrease_body
+          @@ Account_update.with_aux ~body:sender_decrease_body
                ~authorization:dummy_auth
         ; update
-          @@ Account_update.with_no_aux ~body:receiver_increase_body
+          @@ Account_update.with_aux ~body:receiver_increase_body
                ~authorization:dummy_auth
         ]
     end
@@ -173,7 +173,7 @@ module Single = struct
       method updates =
         let open Monad_lib.State.Let_syntax in
         let%map body = update_body ?preconditions ~account amount in
-        [ update @@ Account_update.with_no_aux ~body ~authorization:dummy_auth ]
+        [ update @@ Account_update.with_aux ~body ~authorization:dummy_auth ]
     end
 end
 
@@ -191,7 +191,7 @@ module Alter_account = struct
         let%map body =
           update_body ?preconditions ~update:state_update ~account amount
         in
-        [ update @@ Account_update.with_no_aux ~body ~authorization:dummy_auth ]
+        [ update @@ Account_update.with_aux ~body ~authorization:dummy_auth ]
     end
 end
 
@@ -215,7 +215,7 @@ module Txn_tree = struct
           State_ext.concat_map_m children ~f:(fun c -> c#updates)
         in
         [ update ~calls
-          @@ Account_update.with_no_aux ~body ~authorization:dummy_auth
+          @@ Account_update.with_aux ~body ~authorization:dummy_auth
         ]
     end
 end

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -19,7 +19,7 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
       ~authorization:(Control.Poly.Signature Signature.dummy)
   in
   let fee_payer : Account_update.Fee_payer.t =
-    Account_update.Fee_payer.with_no_aux
+    Account_update.Fee_payer.make
       ~body:
         { Account_update.Body.Fee_payer.dummy with
           fee = Currency.Fee.of_mina_int_exn 100

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -6,7 +6,8 @@ let different_version = Mina_numbers.Txn_version.(succ current)
 let update_vk_perm_to_be ~auth : Zkapp_command.t =
   let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let account_update : Account_update.t =
-    { body =
+    Account_update.with_no_aux
+      ~body:
         { Account_update.Body.dummy with
           update =
             { Account_update.Body.dummy.update with
@@ -15,16 +16,15 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
                   { Permissions.user_default with set_verification_key = auth }
             }
         }
-    ; authorization = Control.Poly.Signature Signature.dummy
-    }
+      ~authorization:(Control.Poly.Signature Signature.dummy)
   in
   let fee_payer : Account_update.Fee_payer.t =
-    { body =
+    Account_update.Fee_payer.with_no_aux
+      ~body:
         { Account_update.Body.Fee_payer.dummy with
           fee = Currency.Fee.of_mina_int_exn 100
         }
-    ; authorization = Signature.dummy
-    }
+      ~authorization:Signature.dummy
   in
   { fee_payer
   ; account_updates =

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -6,7 +6,7 @@ let different_version = Mina_numbers.Txn_version.(succ current)
 let update_vk_perm_to_be ~auth : Zkapp_command.t =
   let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let account_update : Account_update.t =
-    Account_update.with_no_aux
+    Account_update.with_aux
       ~body:
         { Account_update.Body.dummy with
           update =

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -103,12 +103,15 @@ let read_all_proofs_from_disk : t -> Stable.Latest.t = function
   | Zkapp_command zc ->
       Zkapp_command (Zkapp_command.read_all_proofs_from_disk zc)
 
-type ('p, 'a, 'b) with_forest =
-  (Signed_command.t, ('p, 'a, 'b) Zkapp_command.with_forest) Poly.t
+type ('u, 'a, 'b) with_forest =
+  (Signed_command.t, ('u, 'a, 'b) Zkapp_command.with_forest) Poly.t
 [@@deriving equal]
 
 let forget_digests_and_proofs (t : (_, _, _) with_forest) :
-    (unit, unit, unit) with_forest =
+    ( (_, (unit, _) Control.Poly.t) Account_update.Poly.t
+    , unit
+    , unit )
+    with_forest =
   match t with
   | Signed_command sc ->
       Signed_command sc
@@ -116,10 +119,10 @@ let forget_digests_and_proofs (t : (_, _, _) with_forest) :
       Zkapp_command (Zkapp_command.forget_digests_and_proofs zc)
 
 let equal_ignoring_proofs_and_hashes
-    (type proof_l account_update_digest_l forest_digest_l proof_r
-    account_update_digest_r forest_digest_r )
-    (t1 : (proof_l, account_update_digest_l, forest_digest_l) with_forest)
-    (t2 : (proof_r, account_update_digest_r, forest_digest_r) with_forest) =
+    (type account_update_digest_l forest_digest_l account_update_digest_r
+    forest_digest_r )
+    (t1 : (_, account_update_digest_l, forest_digest_l) with_forest)
+    (t2 : (_, account_update_digest_r, forest_digest_r) with_forest) =
   let ignore2 _ _ = true in
   let t1' = forget_digests_and_proofs t1 in
   let t2' = forget_digests_and_proofs t2 in
@@ -419,7 +422,9 @@ let is_incompatible_version = function
   | Zkapp_command p ->
       Zkapp_command.is_incompatible_version p
 
-let has_invalid_call_forest : (_, _, _) with_forest -> bool = function
+let has_invalid_call_forest :
+    ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest -> bool
+    = function
   | Signed_command _ ->
       false
   | Zkapp_command cmd ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -331,7 +331,7 @@ let valid_until (t : (_, _, _) with_forest) =
   | Signed_command x ->
       Signed_command.valid_until x
   | Zkapp_command { fee_payer; _ } -> (
-      match fee_payer.Account_update.Fee_payer.body.valid_until with
+      match fee_payer.body.valid_until with
       | Some valid_until ->
           valid_until
       | None ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -107,7 +107,7 @@ type ('u, 'a, 'b) with_forest =
   (Signed_command.t, ('u, 'a, 'b) Zkapp_command.with_forest) Poly.t
 [@@deriving equal]
 
-let forget_digests_and_proofs (t : (_, _, _) with_forest) :
+let forget_digests_and_proofs_and_aux (t : (_, _, _) with_forest) :
     ( (_, (unit, _) Control.Poly.t, _) Account_update.Poly.t
     , unit
     , unit )
@@ -116,16 +116,16 @@ let forget_digests_and_proofs (t : (_, _, _) with_forest) :
   | Signed_command sc ->
       Signed_command sc
   | Zkapp_command zc ->
-      Zkapp_command (Zkapp_command.forget_digests_and_proofs zc)
+      Zkapp_command (Zkapp_command.forget_digests_and_proofs_and_aux zc)
 
-let equal_ignoring_proofs_and_hashes
+let equal_ignoring_proofs_and_hashes_and_aux
     (type account_update_digest_l forest_digest_l account_update_digest_r
     forest_digest_r )
     (t1 : (_, account_update_digest_l, forest_digest_l) with_forest)
     (t2 : (_, account_update_digest_r, forest_digest_r) with_forest) =
   let ignore2 _ _ = true in
-  let t1' = forget_digests_and_proofs t1 in
-  let t2' = forget_digests_and_proofs t2 in
+  let t1' = forget_digests_and_proofs_and_aux t1 in
+  let t2' = forget_digests_and_proofs_and_aux t2 in
   equal_with_forest ignore2 ignore2 ignore2 t1' t2'
 
 let to_base64 : Stable.Latest.t -> string = function
@@ -461,8 +461,9 @@ module Well_formedness_error = struct
         "Transaction type disabled"
 end
 
-let check_well_formedness ~(genesis_constants : Genesis_constants.t)
-    (t : (_, _, _) with_forest) : (unit, Well_formedness_error.t list) result =
+let check_well_formedness (type aux) ~(genesis_constants : Genesis_constants.t)
+    (t : ((_, _, aux) Account_update.Poly.t, _, _) with_forest) :
+    (unit, Well_formedness_error.t list) result =
   let preds =
     let open Well_formedness_error in
     [ ( has_insufficient_fee

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -119,10 +119,25 @@ let forget_digests_and_proofs_and_aux (t : (_, _, _) with_forest) :
       Zkapp_command (Zkapp_command.forget_digests_and_proofs_and_aux zc)
 
 let equal_ignoring_proofs_and_hashes_and_aux
-    (type account_update_digest_l forest_digest_l account_update_digest_r
+    (type update_auth_proof_l update_aux_l update_auth_proof_r update_aux_r
+    account_update_digest_l forest_digest_l account_update_digest_r
     forest_digest_r )
-    (t1 : (_, account_update_digest_l, forest_digest_l) with_forest)
-    (t2 : (_, account_update_digest_r, forest_digest_r) with_forest) =
+    (t1 :
+      ( ( _
+        , (update_auth_proof_l, _) Control.Poly.t
+        , update_aux_l )
+        Account_update.Poly.t
+      , account_update_digest_l
+      , forest_digest_l )
+      with_forest )
+    (t2 :
+      ( ( _
+        , (update_auth_proof_r, _) Control.Poly.t
+        , update_aux_r )
+        Account_update.Poly.t
+      , account_update_digest_r
+      , forest_digest_r )
+      with_forest ) =
   let ignore2 _ _ = true in
   let t1' = forget_digests_and_proofs_and_aux t1 in
   let t2' = forget_digests_and_proofs_and_aux t2 in

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -108,7 +108,7 @@ type ('u, 'a, 'b) with_forest =
 [@@deriving equal]
 
 let forget_digests_and_proofs (t : (_, _, _) with_forest) :
-    ( (_, (unit, _) Control.Poly.t) Account_update.Poly.t
+    ( (_, (unit, _) Control.Poly.t, _) Account_update.Poly.t
     , unit
     , unit )
     with_forest =
@@ -423,8 +423,8 @@ let is_incompatible_version = function
       Zkapp_command.is_incompatible_version p
 
 let has_invalid_call_forest :
-    ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest -> bool
-    = function
+       ((Account_update.Body.t, _, _) Account_update.Poly.t, _, _) with_forest
+    -> bool = function
   | Signed_command _ ->
       false
   | Zkapp_command cmd ->

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -113,9 +113,9 @@ end)
 module Actions = struct
   type var = Actions_impl.var
 
-  type t = Actions_impl.t
+  type t = { actions : Actions_impl.t; hash : Field.t }
 
-  let is_empty (lst : t) = List.is_empty lst
+  let is_empty ({ actions; _ } : t) = List.is_empty actions
 
   let is_empty_var (e : var) =
     Snark_params.Tick.Field.(
@@ -125,14 +125,14 @@ module Actions = struct
     let salt_phrase = "MinaZkappActionStateEmptyElt" in
     Hash_prefix_create.salt salt_phrase |> Random_oracle.digest
 
-  let push_events (acc : Field.t) (events : t) : Field.t =
-    Actions_impl.push_hash acc (Actions_impl.hash events)
+  let push_events (acc : Field.t) ({ hash; _ } : t) : Field.t =
+    Actions_impl.push_hash acc hash
 
   let push_events_checked (x : Field.Var.t) (e : var) : Field.Var.t =
     Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_actions
       [| x; Data_as_hash.hash e |]
 
-  let of_event_list lst = lst
+  let of_event_list lst = { actions = lst; hash = Actions_impl.hash lst }
 
   [%%define_locally
   Actions_impl.

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -51,11 +51,11 @@ module Checked = struct
         * Zkapp_command.Digest.Account_update.typ)
       |> Typ.transport
            ~back:(fun ((body, authorization), hash) ->
-             { With_hash.data = { Account_update.Poly.body; authorization }
+             { With_hash.data = Account_update.with_no_aux ~body ~authorization
              ; hash
              } )
            ~there:(fun { With_hash.data =
-                           { Account_update.Poly.body; authorization }
+                           { Account_update.Poly.body; authorization; aux = _ }
                        ; hash
                        } -> ((body, authorization), hash) )
       |> Typ.transport_var
@@ -237,7 +237,9 @@ module Checked = struct
               in
               let authorization = V.get auth in
               let tl = V.get tl_data in
-              let account_update : Account_update.t = { body; authorization } in
+              let account_update : Account_update.t =
+                Account_update.with_no_aux ~body ~authorization
+              in
               let calls = V.get calls in
               let res =
                 Zkapp_command.Call_forest.cons ~signature_kind ~calls

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -51,7 +51,7 @@ module Checked = struct
         * Zkapp_command.Digest.Account_update.typ)
       |> Typ.transport
            ~back:(fun ((body, authorization), hash) ->
-             { With_hash.data = Account_update.with_no_aux ~body ~authorization
+             { With_hash.data = Account_update.with_aux ~body ~authorization
              ; hash
              } )
            ~there:(fun { With_hash.data =
@@ -238,7 +238,7 @@ module Checked = struct
               let authorization = V.get auth in
               let tl = V.get tl_data in
               let account_update : Account_update.t =
-                Account_update.with_no_aux ~body ~authorization
+                Account_update.with_aux ~body ~authorization
               in
               let calls = V.get calls in
               let res =

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -523,11 +523,8 @@ module With_hashes_and_data = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('proof, 'data) t =
-        ( ( Account_update.Body.Stable.V1.t
-          , ('proof, Signature.Stable.V1.t) Control.Poly.Stable.V1.t )
-          Account_update.Poly.Stable.V1.t
-          * 'data
+      type ('update, 'data) t =
+        ( 'update * 'data
         , Digest.Account_update.Stable.V1.t
         , Digest.Forest.Stable.V1.t )
         Stable.V1.t

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -470,7 +470,8 @@ let cons_aux (type p) ~(digest_account_update : p -> _) ?(calls = [])
   let tree : _ Tree.t = { account_update; account_update_digest; calls } in
   cons_tree tree xs
 
-let cons ~signature_kind ?calls (account_update : Account_update.t) xs =
+let cons (type aux) ~signature_kind ?calls
+    (account_update : (_, _, aux) Account_update.Poly.t) xs =
   cons_aux
     ~digest_account_update:(Digest.Account_update.create ~signature_kind)
     ?calls account_update xs
@@ -516,8 +517,8 @@ let forget_hashes =
   in
   impl
 
-let forget_hashes_and_proofs p =
-  forget_hashes @@ map ~f:Account_update.forget_proofs p
+let forget_hashes_and_proofs_and_aux p =
+  forget_hashes @@ map ~f:Account_update.forget_proofs_and_aux p
 
 module With_hashes_and_data = struct
   [%%versioned

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -147,7 +147,7 @@ module type Digest_intf = sig
 
     val create :
          signature_kind:Mina_signature_kind.t
-      -> (Account_update.Body.t, _) Account_update.Poly.t
+      -> (Account_update.Body.t, _, _) Account_update.Poly.t
       -> t
 
     val create_body :
@@ -262,7 +262,7 @@ module Make_digest_str
     end
 
     let create ~signature_kind :
-        (Account_update.Body.t, _) Account_update.Poly.t -> t =
+        (Account_update.Body.t, _, _) Account_update.Poly.t -> t =
       Account_update.digest ~signature_kind
 
     let create_body ~signature_kind : Account_update.Body.t -> t =

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -945,8 +945,7 @@ let dummy =
          ~authorization:(Control.Poly.Signature Signature.dummy)
      in
      let fee_payer : Account_update.Fee_payer.t =
-       Account_update.Fee_payer.with_no_aux
-         ~body:Account_update.Body.Fee_payer.dummy
+       Account_update.Fee_payer.make ~body:Account_update.Body.Fee_payer.dummy
          ~authorization:Signature.dummy
      in
      { Poly.fee_payer

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -492,9 +492,8 @@ end = struct
       ( ( Account_update.Body.Stable.Latest.t
         , ( Proof.Stable.Latest.t
           , Signature.Stable.Latest.t )
-          Control.Poly.Stable.Latest.t
-        , Account_update.No_aux.Stable.Latest.t )
-        Account_update.Poly.Stable.Latest.t
+          Control.Poly.Stable.Latest.t )
+        Account_update.Without_aux.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -46,19 +46,18 @@ end
 module Call_forest = Zkapp_call_forest_base
 module Digest = Call_forest.Digest
 
-type ('proof, 'account_update_digest, 'forest_digest) with_forest =
-  ( ( Account_update.Body.t
-    , ('proof, Signature.t) Control.Poly.t )
-    Account_update.Poly.t
-  , 'account_update_digest
-  , 'forest_digest )
-  Call_forest.t
-  Poly.t
+type ('account_update, 'account_update_digest, 'forest_digest) with_forest =
+  ('account_update, 'account_update_digest, 'forest_digest) Call_forest.t Poly.t
 [@@deriving sexp, compare, equal, hash, yojson]
 
 module T = struct
   type t =
-    (Proof_cache_tag.t, Digest.Account_update.t, Digest.Forest.t) with_forest
+    ( ( Account_update.Body.t
+      , (Proof_cache_tag.t, Signature.t) Control.Poly.t )
+      Account_update.Poly.t
+    , Digest.Account_update.t
+    , Digest.Forest.t )
+    with_forest
   [@@deriving sexp_of, to_yojson]
 
   [%%versioned
@@ -163,8 +162,12 @@ let read_all_proofs_from_disk (t : t) : Stable.Latest.t =
   }
 
 let forget_digests_and_proofs
-    ({ fee_payer; memo; account_updates } : (_, _, _) with_forest) :
-    (unit, unit, unit) with_forest =
+    ({ fee_payer; memo; account_updates } :
+      ((_, (_, _) Control.Poly.t) Account_update.Poly.t, _, _) with_forest ) :
+    ( (_, (unit, _) Control.Poly.t) Account_update.Poly.t
+    , unit
+    , unit )
+    with_forest =
   { Poly.fee_payer
   ; memo
   ; account_updates = Call_forest.forget_hashes_and_proofs account_updates
@@ -243,7 +246,9 @@ let fee_payer_account_update (t : (_, _, _) with_forest) = t.fee_payer
 let applicable_at_nonce (t : (_, _, _) with_forest) : Account.Nonce.t =
   t.fee_payer.body.nonce
 
-let target_nonce_on_success (t : (_, _, _) with_forest) : Account.Nonce.t =
+let target_nonce_on_success
+    (t : ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest) :
+    Account.Nonce.t =
   let base_nonce = Account.Nonce.succ (applicable_at_nonce t) in
   let fee_payer_pubkey = t.fee_payer.body.public_key in
   let fee_payer_account_update_increments =
@@ -254,7 +259,8 @@ let target_nonce_on_success (t : (_, _, _) with_forest) : Account.Nonce.t =
   Account.Nonce.add base_nonce
     (Account.Nonce.of_int fee_payer_account_update_increments)
 
-let nonce_increments (t : (_, _, _) with_forest) :
+let nonce_increments
+    (t : ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest) :
     int Public_key.Compressed.Map.t =
   let base_increments =
     Public_key.Compressed.Map.of_alist_exn [ (t.fee_payer.body.public_key, 1) ]
@@ -961,7 +967,13 @@ end) : sig
   end
 
   val group_by_zkapp_command_rev :
-       (_, _, _) with_forest list
+       ( ( Account_update.Body.t
+         , (_, Signature.t) Control.Poly.t )
+         Account_update.Poly.t
+       , _
+       , _ )
+       with_forest
+       list
     -> (Input.global_state * Input.local_state * Input.connecting_ledger_hash)
        list
        list
@@ -1002,7 +1014,7 @@ end = struct
       will need to be passed as part of the snark witness while applying that
       pair.
   *)
-  let group_by_zkapp_command_rev (zkapp_commands : (_, _, _) with_forest list)
+  let group_by_zkapp_command_rev zkapp_commands
       (stmtss : (global_state * local_state * connecting_ledger_hash) list list)
       : Zkapp_command_intermediate_state.t list =
     let intermediate_state ~kind ~spec ~before ~after =
@@ -1305,7 +1317,8 @@ let zkapp_cost ~proof_segments ~signed_single_segments ~signed_pair_segments
    - in incoming blocks
 *)
 let valid_size ~(genesis_constants : Genesis_constants.t)
-    (t : (_, _, _) with_forest) : unit Or_error.t =
+    (t : ((Account_update.Body.t, _) Account_update.Poly.t, _, _) with_forest) :
+    unit Or_error.t =
   let events_elements events =
     List.fold events ~init:0 ~f:(fun acc event -> acc + Array.length event)
   in

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -386,10 +386,7 @@ end
 
 module Verifiable : sig
   type t =
-    ( ( Account_update.Body.t
-      , (Proof_cache_tag.t, Signature.t) Control.Poly.t
-      , Account_update.Aux_data.t )
-      Account_update.Poly.t
+    ( Account_update.t
     , (Side_loaded_verification_key.t, Zkapp_basic.F.t) With_hash.t option )
     Call_forest.With_hashes_and_data.t
     Poly.t
@@ -448,10 +445,7 @@ module Verifiable : sig
 
   module Serializable : sig
     type t =
-      ( ( Account_update.Body.Stable.Latest.t
-        , (Proof.t, Signature.Stable.Latest.t) Control.Poly.Stable.Latest.t
-        , Account_update.No_aux.Stable.Latest.t )
-        Account_update.Poly.Stable.Latest.t
+      ( Account_update.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t
@@ -467,12 +461,7 @@ module Verifiable : sig
     proof_cache_db:Proof_cache_tag.cache_db -> Serializable.t -> t
 end = struct
   type t =
-    ( ( Account_update.Body.Stable.Latest.t
-      , ( Proof_cache_tag.t
-        , Signature.Stable.Latest.t )
-        Control.Poly.Stable.Latest.t
-      , Account_update.Aux_data.t )
-      Account_update.Poly.Stable.Latest.t
+    ( Account_update.t
     , ( Side_loaded_verification_key.Stable.Latest.t
       , Zkapp_basic.F.Stable.Latest.t )
       With_hash.Stable.Latest.t

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -389,7 +389,9 @@ end
 
 module Verifiable : sig
   type t =
-    ( Proof_cache_tag.t
+    ( ( Account_update.Body.t
+      , (Proof_cache_tag.t, Signature.t) Control.Poly.t )
+      Account_update.Poly.t
     , (Side_loaded_verification_key.t, Zkapp_basic.F.t) With_hash.t option )
     Call_forest.With_hashes_and_data.t
     Poly.t
@@ -448,7 +450,9 @@ module Verifiable : sig
 
   module Serializable : sig
     type t =
-      ( Proof.t
+      ( ( Account_update.Body.Stable.Latest.t
+        , (Proof.t, Signature.Stable.Latest.t) Control.Poly.Stable.Latest.t )
+        Account_update.Poly.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t
@@ -464,7 +468,11 @@ module Verifiable : sig
     proof_cache_db:Proof_cache_tag.cache_db -> Serializable.t -> t
 end = struct
   type t =
-    ( Proof_cache_tag.t
+    ( ( Account_update.Body.Stable.Latest.t
+      , ( Proof_cache_tag.t
+        , Signature.Stable.Latest.t )
+        Control.Poly.Stable.Latest.t )
+      Account_update.Poly.Stable.Latest.t
     , ( Side_loaded_verification_key.Stable.Latest.t
       , Zkapp_basic.F.Stable.Latest.t )
       With_hash.Stable.Latest.t
@@ -475,7 +483,11 @@ end = struct
 
   module Serializable = struct
     type t =
-      ( Proof.Stable.Latest.t
+      ( ( Account_update.Body.Stable.Latest.t
+        , ( Proof.Stable.Latest.t
+          , Signature.Stable.Latest.t )
+          Control.Poly.Stable.Latest.t )
+        Account_update.Poly.Stable.Latest.t
       , ( Side_loaded_verification_key.Stable.Latest.t
         , Zkapp_basic.F.Stable.Latest.t )
         With_hash.Stable.Latest.t

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -157,13 +157,7 @@ let read_all_proofs_from_disk (t : t) : Stable.Latest.t =
   }
 
 let forget_digests_and_proofs_and_aux
-    ({ fee_payer; memo; account_updates } :
-      ((_, (_, _) Control.Poly.t, _) Account_update.Poly.t, _, _) with_forest )
-    :
-    ( (_, (unit, _) Control.Poly.t, _) Account_update.Poly.t
-    , unit
-    , unit )
-    with_forest =
+    ({ fee_payer; memo; account_updates } : _ with_forest) =
   { Poly.fee_payer
   ; memo
   ; account_updates =

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -43,6 +43,10 @@ module User_command = struct
         let signature_kind = Mina_signature_kind.t_DEPRECATED in
         function
         | User_command.Poly.Signed_command _ as tx ->
+            (* ~proof_to_yojson is unused when Helper.to_yojson is applied to a
+               Signed_command; the unreachable_code function (which takes a
+               value of the uninhabited Nothing.t type) is a compile-time proof
+               of this fact through the type system. *)
             Helper.to_yojson ~proof_to_yojson:Nothing.unreachable_code tx
         | User_command.Poly.Zkapp_command { fee_payer; memo; account_updates }
           ->

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -7,7 +7,6 @@ module Helper = struct
     let update_to_yojson =
       Account_update.Poly.to_yojson Account_update.Body.to_yojson
         (Control.Poly.to_yojson proof_to_yojson Signature.to_yojson)
-        Account_update.No_aux.to_yojson
     in
     User_command.Poly.to_yojson Signed_command.to_yojson
       (Zkapp_command.with_forest_to_yojson update_to_yojson
@@ -20,7 +19,7 @@ module Helper = struct
       Ppx_deriving_yojson_runtime.(
         Account_update.Poly.of_yojson Account_update.Body.of_yojson
           (Control.Poly.of_yojson proof_of_yojson Signature.of_yojson)
-          Account_update.No_aux.of_yojson t
+          t
         >|= reset_aux)
     in
     User_command.Poly.of_yojson Signed_command.of_yojson

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -6,7 +6,8 @@ module Helper = struct
   let to_yojson ~proof_to_yojson tx =
     let update_to_yojson =
       Account_update.Poly.to_yojson Account_update.Body.to_yojson
-      @@ Control.Poly.to_yojson proof_to_yojson Signature.to_yojson
+        (Control.Poly.to_yojson proof_to_yojson Signature.to_yojson)
+        Account_update.No_aux.to_yojson
     in
     User_command.Poly.to_yojson Signed_command.to_yojson
       (Zkapp_command.with_forest_to_yojson update_to_yojson
@@ -17,7 +18,8 @@ module Helper = struct
   let of_yojson ~proof_of_yojson =
     let update_of_yojson =
       Account_update.Poly.of_yojson Account_update.Body.of_yojson
-      @@ Control.Poly.of_yojson proof_of_yojson Signature.of_yojson
+        (Control.Poly.of_yojson proof_of_yojson Signature.of_yojson)
+        Account_update.No_aux.of_yojson
     in
     User_command.Poly.of_yojson Signed_command.of_yojson
     @@ Zkapp_command.with_forest_of_yojson update_of_yojson

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -4,15 +4,23 @@ module Helper = struct
   open Mina_base
 
   let to_yojson ~proof_to_yojson tx =
+    let update_to_yojson =
+      Account_update.Poly.to_yojson Account_update.Body.to_yojson
+      @@ Control.Poly.to_yojson proof_to_yojson Signature.to_yojson
+    in
     User_command.Poly.to_yojson Signed_command.to_yojson
-      (Zkapp_command.with_forest_to_yojson proof_to_yojson
+      (Zkapp_command.with_forest_to_yojson update_to_yojson
          Zkapp_command.Digest.Account_update.to_yojson
          Zkapp_command.Digest.Forest.to_yojson )
       tx
 
   let of_yojson ~proof_of_yojson =
+    let update_of_yojson =
+      Account_update.Poly.of_yojson Account_update.Body.of_yojson
+      @@ Control.Poly.of_yojson proof_of_yojson Signature.of_yojson
+    in
     User_command.Poly.of_yojson Signed_command.of_yojson
-    @@ Zkapp_command.with_forest_of_yojson proof_of_yojson
+    @@ Zkapp_command.with_forest_of_yojson update_of_yojson
          Zkapp_command.Digest.Account_update.of_yojson
          Zkapp_command.Digest.Forest.of_yojson
 end
@@ -30,8 +38,8 @@ module User_command = struct
       let to_yojson : t -> Yojson.Safe.t =
         let signature_kind = Mina_signature_kind.t_DEPRECATED in
         function
-        | User_command.Poly.Signed_command tx ->
-            Helper.to_yojson ~proof_to_yojson:Proof.to_yojson (Signed_command tx)
+        | User_command.Poly.Signed_command _ as tx ->
+            Helper.to_yojson ~proof_to_yojson:Nothing.unreachable_code tx
         | User_command.Poly.Zkapp_command { fee_payer; memo; account_updates }
           ->
             Helper.to_yojson ~proof_to_yojson:Proof.to_yojson

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1108,7 +1108,7 @@ let gen_fee_payer ?global_slot ?fee_range ?failure ?permissions_auth ~account_id
   in
   (* real signature to be added when this data inserted into a Zkapp_command.t *)
   let authorization = Signature.dummy in
-  Account_update.Fee_payer.with_no_aux ~body ~authorization
+  Account_update.Fee_payer.make ~body ~authorization
 
 (* keep max_account_updates small, so zkApp integration tests don't need lots
    of block producers
@@ -1669,7 +1669,7 @@ let mk_account_update ~pk ~vk : Account_update.Simple.t =
     ~authorization:Control.(dummy_of_tag Proof)
 
 let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
-  Account_update.Fee_payer.with_no_aux
+  Account_update.Fee_payer.make
     ~body:{ public_key = pk; fee; valid_until = None; nonce }
     ~authorization:Signature.dummy
 

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1064,7 +1064,7 @@ let gen_account_update_from ?(no_account_precondition = false)
   in
   let account_id = Account_id.create body.public_key body.token_id in
   Hash_set.add account_ids_seen account_id ;
-  return { Account_update.Poly.body; authorization }
+  return @@ Account_update.with_no_aux ~body ~authorization
 
 (* takes an account id, if we want to sign this data *)
 let gen_account_update_body_fee_payer ?global_slot ?fee_range ?failure
@@ -1108,7 +1108,7 @@ let gen_fee_payer ?global_slot ?fee_range ?failure ?permissions_auth ~account_id
   in
   (* real signature to be added when this data inserted into a Zkapp_command.t *)
   let authorization = Signature.dummy in
-  ({ body; authorization } : Account_update.Fee_payer.t)
+  Account_update.Fee_payer.with_no_aux ~body ~authorization
 
 (* keep max_account_updates small, so zkApp integration tests don't need lots
    of block producers
@@ -1664,14 +1664,14 @@ let mk_account_update_body ~pk ~vk : Account_update.Body.Simple.t =
   }
 
 let mk_account_update ~pk ~vk : Account_update.Simple.t =
-  { body = mk_account_update_body ~pk ~vk
-  ; authorization = Control.(dummy_of_tag Proof)
-  }
+  Account_update.with_no_aux
+    ~body:(mk_account_update_body ~pk ~vk)
+    ~authorization:Control.(dummy_of_tag Proof)
 
 let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
-  { body = { public_key = pk; fee; valid_until = None; nonce }
-  ; authorization = Signature.dummy
-  }
+  Account_update.Fee_payer.with_no_aux
+    ~body:{ public_key = pk; fee; valid_until = None; nonce }
+    ~authorization:Signature.dummy
 
 let gen_max_cost_zkapp_command_from ?memo ?fee_range
     ~(fee_payer_keypair : Signature_lib.Keypair.t)

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -104,10 +104,7 @@ end
 module Fee_payer = struct
   module V1 = struct
     type t =
-      { body : Body.Fee_payer.V1.t
-      ; authorization : Mina_base_signature.V1.t
-      ; aux : unit
-      }
+      { body : Body.Fee_payer.V1.t; authorization : Mina_base_signature.V1.t }
   end
 end
 

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -110,11 +110,11 @@ end
 
 module Poly = struct
   module V1 = struct
-    type ('body, 'authorization, 'aux) t =
-      { body : 'body; authorization : 'authorization; aux : 'aux }
+    type ('body, 'authorization) t =
+      { body : 'body; authorization : 'authorization }
   end
 end
 
 module V1 = struct
-  type t = (Body.V1.t, Mina_base_control.V2.t, unit) Poly.V1.t
+  type t = (Body.V1.t, Mina_base_control.V2.t) Poly.V1.t
 end

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -104,17 +104,20 @@ end
 module Fee_payer = struct
   module V1 = struct
     type t =
-      { body : Body.Fee_payer.V1.t; authorization : Mina_base_signature.V1.t }
+      { body : Body.Fee_payer.V1.t
+      ; authorization : Mina_base_signature.V1.t
+      ; aux : unit
+      }
   end
 end
 
 module Poly = struct
   module V1 = struct
-    type ('body, 'authorization) t =
-      { body : 'body; authorization : 'authorization }
+    type ('body, 'authorization, 'aux) t =
+      { body : 'body; authorization : 'authorization; aux : 'aux }
   end
 end
 
 module V1 = struct
-  type t = (Body.V1.t, Mina_base_control.V2.t) Poly.V1.t
+  type t = (Body.V1.t, Mina_base_control.V2.t, unit) Poly.V1.t
 end

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -247,9 +247,6 @@ module Mina_base = struct
       (O.Zkapp_command.Call_forest.Stable)
       (W.Zkapp_command.Call_forest)
   include Assert_equal0V2 (O.Control.Stable) (W.Control)
-  include Assert_equal0V1 (O.Account_update.Stable) (W.Account_update)
-  include Assert_equal0V1 (O.Zkapp_command.Stable) (W.Zkapp_command)
-  include Assert_equal0V2 (O.User_command.Stable) (W.User_command)
   include
     Assert_equal0V1
       (O.Pending_coinbase.State_stack.Stable)
@@ -315,7 +312,6 @@ module Mina_transaction = struct
   module O = Mina_transaction.Transaction
   module W = WT.Mina_transaction
   include Assert_equal1V2 (O.Poly.Stable) (W.Poly)
-  include Assert_equal0V2 (O.Stable) (W)
 end
 
 module Mina_state = struct
@@ -390,10 +386,6 @@ module Network_pool = struct
     Assert_equal0V2
       (O.Snark_pool.Diff_versioned.Stable)
       (W.Snark_pool.Diff_versioned)
-  include
-    Assert_equal0V2
-      (O.Transaction_pool.Diff_versioned.Stable)
-      (W.Transaction_pool.Diff_versioned)
 end
 
 module Consensus = struct

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -510,7 +510,7 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
   let zkapp_command_wire : Zkapp_command.Stable.Latest.t =
     { fee_payer =
         (* Real signature added in below *)
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:{ public_key = sender_pk; fee; nonce; valid_until = None }
           ~authorization:Signature.dummy
     ; account_updates =

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -509,15 +509,15 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
   let receiver_pk = Public_key.compress receiver.public_key in
   let zkapp_command_wire : Zkapp_command.Stable.Latest.t =
     { fee_payer =
-        { Account_update.Fee_payer.body =
-            { public_key = sender_pk; fee; nonce; valid_until = None }
-            (* Real signature added in below *)
-        ; authorization = Signature.dummy
-        }
+        (* Real signature added in below *)
+        Account_update.Fee_payer.with_no_aux
+          ~body:{ public_key = sender_pk; fee; nonce; valid_until = None }
+          ~authorization:Signature.dummy
     ; account_updates =
         Zkapp_command.Call_forest.of_account_updates
           ~account_update_depth:(Fn.const 0)
-          [ { Account_update.Poly.body =
+          [ Account_update.with_no_aux
+              ~body:
                 { Account_update.Body.public_key = sender_pk
                 ; update = Account_update.Update.noop
                 ; token_id = Token_id.default
@@ -540,10 +540,10 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
                 ; authorization_kind =
                     Account_update.Authorization_kind.None_given
                 }
-            ; authorization = Control.Poly.None_given
-            }
-          ; { Account_update.Poly.body =
-                { public_key = receiver_pk
+              ~authorization:Control.Poly.None_given
+          ; Account_update.with_no_aux
+              ~body:
+                { Account_update.Body.public_key = receiver_pk
                 ; update = Account_update.Update.noop
                 ; token_id = Token_id.default
                 ; balance_change = Amount.Signed.of_unsigned amount
@@ -562,8 +562,7 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
                 ; use_full_commitment = not increment_receiver
                 ; authorization_kind = None_given
                 }
-            ; authorization = None_given
-            }
+              ~authorization:Control.Poly.None_given
           ]
     ; memo = Signed_command_memo.empty
     }

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -230,8 +230,8 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
         |> Or_error.all )
     |> Or_error.join |> to_staged_ledger_or_error
 
-  let fee_remainder (type proof a b c)
-      ~(to_user_command : c -> (proof, a, b) User_command.with_forest)
+  let fee_remainder (type update a b c)
+      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
       (commands : c list) completed_works coinbase_fee =
     let open Result.Let_syntax in
     let%bind budget =
@@ -250,9 +250,9 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       ~f:(fun x -> Ok x)
       (Currency.Fee.sub budget total_work_fee)
 
-  let get_transaction_data (type proof a b c) ~constraint_constants
+  let get_transaction_data (type update a b c) ~constraint_constants
       coinbase_parts ~receiver ~coinbase_amount
-      ~(to_user_command : c -> (proof, a, b) User_command.with_forest)
+      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
       (commands : c list) (completed_works : T.t list) :
       (c Transaction_data.t, Error.t) Result.t =
     let open Result.Let_syntax in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2889,7 +2889,8 @@ let%test_module "staged ledger tests" =
                   |> Sequence.to_list
                 in
                 assert (
-                  List.equal User_command.equal_ignoring_proofs_and_hashes
+                  List.equal
+                    User_command.equal_ignoring_proofs_and_hashes_and_aux
                     commands_in_ledger commands_applied )
             | None ->
                 () ) ;
@@ -4593,7 +4594,7 @@ let%test_module "staged ledger tests" =
                        User_command.forget_check data )
               in
               assert (
-                List.equal User_command.equal_ignoring_proofs_and_hashes
+                List.equal User_command.equal_ignoring_proofs_and_hashes_and_aux
                   valid_commands
                   ( [ valid_command_1
                     ; valid_command_2

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -73,7 +73,12 @@ let hash_signed_command (cmd : Signed_command.t) =
 
 let hash_zkapp_command (type p)
     ({ fee_payer; account_updates; memo } :
-      (p, unit, unit) Zkapp_command.with_forest ) =
+      ( ( Account_update.Body.t
+        , (p, Signature.t) Control.Poly.t )
+        Account_update.Poly.t
+      , unit
+      , unit )
+      Zkapp_command.with_forest ) =
   let cmd_dummy_signatures_and_proofs =
     { Zkapp_command.Poly.memo
     ; fee_payer = { fee_payer with authorization = Signature.dummy }

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -71,10 +71,11 @@ let hash_signed_command (cmd : Signed_command.t) =
   let cmd_dummy_signature = { cmd with signature = Signature.dummy } in
   signed_cmd_hasher cmd_dummy_signature
 
-let hash_zkapp_command (type p)
+let hash_zkapp_command (type p aux)
     ({ fee_payer; account_updates; memo } :
       ( ( Account_update.Body.t
-        , (p, Signature.t) Control.Poly.t )
+        , (p, Signature.t) Control.Poly.t
+        , aux )
         Account_update.Poly.t
       , unit
       , unit )
@@ -84,7 +85,7 @@ let hash_zkapp_command (type p)
     ; fee_payer = { fee_payer with authorization = Signature.dummy }
     ; account_updates =
         Zkapp_command.Call_forest.map account_updates
-          ~f:(fun (acct_update : (_, _) Account_update.Poly.t) ->
+          ~f:(fun (acct_update : (_, _, _) Account_update.Poly.t) ->
             let dummy_auth =
               match acct_update.authorization with
               | Control.Poly.Proof _ ->
@@ -94,7 +95,8 @@ let hash_zkapp_command (type p)
               | Control.Poly.None_given ->
                   Control.Poly.None_given
             in
-            { acct_update with authorization = dummy_auth } )
+            Account_update.forget_aux
+              { acct_update with authorization = dummy_auth } )
     }
   in
   zkapp_cmd_hasher cmd_dummy_signatures_and_proofs

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -38,7 +38,7 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
         |> Mina_block.Validated.valid_commands
         |> List.exists ~f:(fun { data = found; _ } ->
                let found' = User_command.forget_check found in
-               User_command.equal_ignoring_proofs_and_hashes cmd found' )
+               User_command.equal_ignoring_proofs_and_hashes_and_aux cmd found' )
       in
       if List.exists ~f:in_breadcrumb best_tip_path then State.Included
       else if

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1422,7 +1422,10 @@ module Make (L : Ledger_intf.S) :
           Zkapp_basic.Set_or_keep.map ~f:Option.some
             account_update.body.update.verification_key
 
-        let actions (account_update : t) = account_update.body.actions
+        let actions (account_update : t) =
+          { Zkapp_account.Actions.actions = account_update.body.actions
+          ; hash = account_update.aux.actions_hash
+          }
 
         let zkapp_uri (account_update : t) =
           account_update.body.update.zkapp_uri

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2453,7 +2453,7 @@ module For_tests = struct
     let zkapp_command : Zkapp_command.Simple.t =
       { fee_payer =
           (* Real signature added in below *)
-          Account_update.Fee_payer.with_no_aux
+          Account_update.Fee_payer.make
             ~body:
               { public_key = sender_pk
               ; fee

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -116,7 +116,7 @@ let%test_module "Access permission tests" =
       in
       let fee_payer =
         (* TODO: This is a pain. *)
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { Account_update.Body.Fee_payer.dummy with
               public_key = pk_compressed

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -174,10 +174,7 @@ let%test_module "Access permission tests" =
       let zkapp_command : Zkapp_command.t =
         sign_all
           { fee_payer =
-              { body = fee_payer.body
-              ; authorization = Signature.dummy
-              ; aux = fee_payer.aux
-              }
+              { body = fee_payer.body; authorization = Signature.dummy }
           ; account_updates
           ; memo
           }

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -99,7 +99,7 @@ let%test_module "Access permission tests" =
       in
       let deploy_account_update : Account_update.t =
         (* TODO: This is a pain. *)
-        Account_update.with_no_aux ~body:deploy_account_update_body
+        Account_update.with_aux ~body:deploy_account_update_body
           ~authorization:(Control.Poly.Signature Signature.dummy)
       in
       let account_updates =

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -319,19 +319,20 @@ let%test_module "multisig_account" =
               in
               let sender_pk = sender.public_key |> Public_key.compress in
               let fee_payer : Account_update.Fee_payer.t =
-                { body =
+                Account_update.Fee_payer.with_no_aux
+                  ~body:
                     { public_key = sender_pk
                     ; fee
                     ; valid_until = None
                     ; nonce = sender_nonce
                     }
                     (* Real signature added in below *)
-                ; authorization = Signature.dummy
-                }
+                  ~authorization:Signature.dummy
               in
               let sender_account_update_data : Account_update.Simple.t =
-                { body =
-                    { public_key = sender_pk
+                Account_update.with_no_aux
+                  ~body:
+                    { Account_update.Body.Simple.public_key = sender_pk
                     ; update = Account_update.Update.noop
                     ; token_id = Token_id.default
                     ; balance_change =
@@ -354,12 +355,13 @@ let%test_module "multisig_account" =
                     ; may_use_token = No
                     ; authorization_kind = Signature
                     }
-                ; authorization = Signature Signature.dummy
-                }
+                  ~authorization:(Control.Poly.Signature Signature.dummy)
               in
               let snapp_account_update_data : Account_update.Simple.t =
-                { body =
-                    { public_key = multisig_account_pk
+                Account_update.with_no_aux
+                  ~body:
+                    { Account_update.Body.Simple.public_key =
+                        multisig_account_pk
                     ; update = update_empty_permissions
                     ; token_id = Token_id.default
                     ; balance_change =
@@ -380,9 +382,9 @@ let%test_module "multisig_account" =
                     ; may_use_token = No
                     ; authorization_kind = Proof (With_hash.hash vk)
                     }
-                ; authorization =
-                    Proof (Lazy.force Mina_base.Proof.transaction_dummy)
-                }
+                  ~authorization:
+                    (Control.Poly.Proof
+                       (Lazy.force Mina_base.Proof.transaction_dummy) )
               in
               let memo = Signed_command_memo.empty in
               let ps =
@@ -460,6 +462,7 @@ let%test_module "multisig_account" =
                       (Signature_lib.Schnorr.Chunked.sign ~signature_kind
                          sender.private_key
                          (Random_oracle.Input.Chunked.field transaction) )
+                ; aux = sender_account_update_data.aux
                 }
               in
               let zkapp_command : Zkapp_command.t =
@@ -469,6 +472,7 @@ let%test_module "multisig_account" =
                       [ sender
                       ; { body = snapp_account_update_data.body
                         ; authorization = Proof pi
+                        ; aux = snapp_account_update_data.aux
                         }
                       ]
                   ; memo

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -319,7 +319,7 @@ let%test_module "multisig_account" =
               in
               let sender_pk = sender.public_key |> Public_key.compress in
               let fee_payer : Account_update.Fee_payer.t =
-                Account_update.Fee_payer.with_no_aux
+                Account_update.Fee_payer.make
                   ~body:
                     { public_key = sender_pk
                     ; fee

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -177,7 +177,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
           let sender_pk = sender.public_key |> Public_key.compress in
           let fee_payer : Account_update.Fee_payer.t =
             (* Real signature added in below *)
-            Account_update.Fee_payer.with_no_aux
+            Account_update.Fee_payer.make
               ~body:
                 { public_key = sender_pk
                 ; fee = Amount.to_fee fee

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -697,7 +697,7 @@ let test_zkapp_command ?expected_failure ?(memo = Signed_command_memo.empty)
     ?(fee = Currency.Fee.(of_nanomina_int_exn 100)) ~fee_payer_pk ~signers
     ~initialize_ledger ~finalize_ledger zkapp_command =
   let fee_payer : Account_update.Fee_payer.t =
-    Account_update.Fee_payer.with_no_aux
+    Account_update.Fee_payer.make
       ~body:
         { Account_update.Body.Fee_payer.dummy with
           public_key = fee_payer_pk

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -697,13 +697,13 @@ let test_zkapp_command ?expected_failure ?(memo = Signed_command_memo.empty)
     ?(fee = Currency.Fee.(of_nanomina_int_exn 100)) ~fee_payer_pk ~signers
     ~initialize_ledger ~finalize_ledger zkapp_command =
   let fee_payer : Account_update.Fee_payer.t =
-    { body =
+    Account_update.Fee_payer.with_no_aux
+      ~body:
         { Account_update.Body.Fee_payer.dummy with
           public_key = fee_payer_pk
         ; fee
         }
-    ; authorization = Signature.dummy
-    }
+      ~authorization:Signature.dummy
   in
   let zkapp_command : Zkapp_command.t =
     Array.fold signers

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -47,7 +47,7 @@ let%test_module "Zkapp payments tests" =
       in
       Zkapp_command.of_simple ~proof_cache_db
         { fee_payer =
-            Account_update.Fee_payer.with_no_aux
+            Account_update.Fee_payer.make
               ~body:
                 { public_key = acct1.account.public_key
                 ; fee = Fee.of_nanomina_int_exn full_amount

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -47,17 +47,19 @@ let%test_module "Zkapp payments tests" =
       in
       Zkapp_command.of_simple ~proof_cache_db
         { fee_payer =
-            { body =
+            Account_update.Fee_payer.with_no_aux
+              ~body:
                 { public_key = acct1.account.public_key
                 ; fee = Fee.of_nanomina_int_exn full_amount
                 ; valid_until = None
                 ; nonce = acct1.account.nonce
                 }
-            ; authorization = Signature.dummy
-            }
+              ~authorization:Signature.dummy
         ; account_updates =
-            [ { body =
-                  { public_key = acct1.account.public_key
+            [ Account_update.with_no_aux
+                ~body:
+                  { Account_update.Body.Simple.public_key =
+                      acct1.account.public_key
                   ; update =
                       { app_state =
                           Pickles_types.Vector.map new_state ~f:(fun x ->
@@ -89,10 +91,11 @@ let%test_module "Zkapp payments tests" =
                   ; may_use_token = No
                   ; authorization_kind = Signature
                   }
-              ; authorization = Signature Signature.dummy
-              }
-            ; { body =
-                  { public_key = acct2.account.public_key
+                ~authorization:(Control.Poly.Signature Signature.dummy)
+            ; Account_update.with_no_aux
+                ~body:
+                  { Account_update.Body.Simple.public_key =
+                      acct2.account.public_key
                   ; update = Account_update.Update.noop
                   ; token_id = Token_id.default
                   ; balance_change = Amount.Signed.(of_unsigned receiver_amount)
@@ -112,8 +115,7 @@ let%test_module "Zkapp payments tests" =
                   ; may_use_token = No
                   ; authorization_kind = None_given
                   }
-              ; authorization = None_given
-              }
+                ~authorization:Control.Poly.None_given
             ]
         ; memo
         }

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -279,19 +279,20 @@ let%test_module "Protocol state precondition tests" =
                     Signature_lib.Public_key.compress new_kp.public_key
                   in
                   let fee_payer =
-                    { Account_update.Fee_payer.body =
+                    Account_update.Fee_payer.with_no_aux
+                      ~body:
                         { public_key = sender_pk
                         ; fee
                         ; valid_until = None
                         ; nonce = sender_nonce
                         }
                         (*To be updated later*)
-                    ; authorization = Signature.dummy
-                    }
+                      ~authorization:Signature.dummy
                   in
                   let sender_account_update : Account_update.Simple.t =
-                    { body =
-                        { public_key = sender_pk
+                    Account_update.with_no_aux
+                      ~body:
+                        { Account_update.Body.Simple.public_key = sender_pk
                         ; update = Account_update.Update.noop
                         ; token_id = Token_id.default
                         ; balance_change =
@@ -315,12 +316,12 @@ let%test_module "Protocol state precondition tests" =
                         ; authorization_kind = Signature
                         }
                         (*To be updated later*)
-                    ; authorization = Control.Poly.Signature Signature.dummy
-                    }
+                      ~authorization:(Control.Poly.Signature Signature.dummy)
                   in
                   let snapp_account_update : Account_update.Simple.t =
-                    { body =
-                        { public_key = snapp_pk
+                    Account_update.with_no_aux
+                      ~body:
+                        { Account_update.Body.Simple.public_key = snapp_pk
                         ; update = snapp_update
                         ; token_id = Token_id.default
                         ; balance_change =
@@ -347,10 +348,8 @@ let%test_module "Protocol state precondition tests" =
                         ; may_use_token = No
                         ; authorization_kind = Signature
                         }
-                    ; authorization =
-                        Control.Poly.Signature Signature.dummy
                         (*To be updated later*)
-                    }
+                      ~authorization:(Control.Poly.Signature Signature.dummy)
                   in
                   let ps =
                     Zkapp_command.Call_forest.With_hashes
@@ -883,19 +882,20 @@ let%test_module "Account precondition tests" =
                 Signature_lib.Public_key.compress new_kp.public_key
               in
               let fee_payer =
-                { Account_update.Fee_payer.body =
+                Account_update.Fee_payer.with_no_aux
+                  ~body:
                     { public_key = sender_pk
                     ; fee
                     ; valid_until = None
                     ; nonce = Account.Nonce.succ sender_nonce (*Invalid nonce*)
                     }
                     (*To be updated later*)
-                ; authorization = Signature.dummy
-                }
+                  ~authorization:Signature.dummy
               in
               let sender_account_update : Account_update.Simple.t =
-                { body =
-                    { public_key = sender_pk
+                Account_update.with_no_aux
+                  ~body:
+                    { Account_update.Body.Simple.public_key = sender_pk
                     ; update = Account_update.Update.noop
                     ; token_id = Token_id.default
                     ; balance_change =
@@ -919,12 +919,12 @@ let%test_module "Account precondition tests" =
                     ; authorization_kind = Signature
                     }
                     (*To be updated later*)
-                ; authorization = Control.Poly.Signature Signature.dummy
-                }
+                  ~authorization:(Control.Poly.Signature Signature.dummy)
               in
               let snapp_account_update : Account_update.Simple.t =
-                { body =
-                    { public_key = snapp_pk
+                Account_update.with_no_aux
+                  ~body:
+                    { Account_update.Body.Simple.public_key = snapp_pk
                     ; update = snapp_update
                     ; token_id = Token_id.default
                     ; balance_change =
@@ -949,10 +949,8 @@ let%test_module "Account precondition tests" =
                     ; may_use_token = No
                     ; authorization_kind = Signature
                     }
-                ; authorization =
-                    Control.Poly.Signature Signature.dummy
                     (*To be updated later*)
-                }
+                  ~authorization:(Control.Poly.Signature Signature.dummy)
               in
               let ps =
                 Zkapp_command.Call_forest.With_hashes

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -279,7 +279,7 @@ let%test_module "Protocol state precondition tests" =
                     Signature_lib.Public_key.compress new_kp.public_key
                   in
                   let fee_payer =
-                    Account_update.Fee_payer.with_no_aux
+                    Account_update.Fee_payer.make
                       ~body:
                         { public_key = sender_pk
                         ; fee
@@ -882,7 +882,7 @@ let%test_module "Account precondition tests" =
                 Signature_lib.Public_key.compress new_kp.public_key
               in
               let fee_payer =
-                Account_update.Fee_payer.with_no_aux
+                Account_update.Fee_payer.make
                   ~body:
                     { public_key = sender_pk
                     ; fee

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4281,7 +4281,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           | Some (fee_payer_kp, fee_payer_nonce) ->
               (fee_payer_kp.public_key |> Public_key.compress, fee_payer_nonce)
         in
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { public_key
             ; fee
@@ -5195,7 +5195,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let sender_pk = sender.public_key |> Public_key.compress in
       let fee_payer : Account_update.Fee_payer.t =
         (* Real signature added in below *)
-        Account_update.Fee_payer.with_no_aux
+        Account_update.Fee_payer.make
           ~body:
             { public_key = sender_pk
             ; fee

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -46,7 +46,7 @@ let check_signed_command c =
         Result.Error (`Invalid_signature (Signed_command.public_keys c))
 
 let collect_vk_assumption
-    ( (p : (Account_update.Body.t, _ Control.Poly.t) Account_update.Poly.t)
+    ( (p : (Account_update.Body.t, _ Control.Poly.t, _) Account_update.Poly.t)
     , ( (vk_opt :
           (Side_loaded_verification_key.t, Pasta_bindings.Fp.t) With_hash.t
           option )

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -46,14 +46,14 @@ let mk_account_update_body ?preconditions ?(increment_nonce = false)
 let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Zkapp_command.t =
   let fee_payer : Account_update.Fee_payer.t =
-    { body =
+    Account_update.Fee_payer.with_no_aux
+      ~body:
         { public_key = fee_payer_pk
         ; fee = Currency.Fee.of_nanomina_int_exn fee
         ; valid_until = None
         ; nonce = fee_payer_nonce
         }
-    ; authorization = Signature.dummy
-    }
+      ~authorization:Signature.dummy
   in
   let memo =
     Option.value_map memo ~default:Signed_command_memo.dummy
@@ -76,9 +76,9 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
               | Signature ->
                   Control.Poly.Signature Signature.dummy
             in
-            { Account_update.Poly.body = Account_update.Body.of_simple body
-            ; authorization
-            } )
+            Account_update.with_no_aux
+              ~body:(Account_update.Body.of_simple body)
+              ~authorization )
     }
 
 let proof_cache_db = Proof_cache_tag.For_tests.create_db ()
@@ -112,7 +112,8 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
   let open Async_kernel.Deferred.Let_syntax in
   let%map account_updates_with_valid_authorizations =
     Zkapp_command.Call_forest.deferred_mapi zkapp_command.account_updates
-      ~f:(fun _ndx ({ body; authorization } : _ Account_update.Poly.t) tree ->
+      ~f:(fun _ndx ({ body; authorization; aux } : _ Account_update.Poly.t) tree
+         ->
         let%map valid_authorization =
           match authorization with
           | Control.Poly.Signature _dummy ->
@@ -150,7 +151,7 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
           | None_given ->
               return authorization
         in
-        { Account_update.Poly.body; authorization = valid_authorization } )
+        { Account_update.Poly.body; authorization = valid_authorization; aux } )
   in
   { zkapp_command with
     fee_payer = fee_payer_with_valid_signature

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -46,7 +46,7 @@ let mk_account_update_body ?preconditions ?(increment_nonce = false)
 let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Zkapp_command.t =
   let fee_payer : Account_update.Fee_payer.t =
-    Account_update.Fee_payer.with_no_aux
+    Account_update.Fee_payer.make
       ~body:
         { public_key = fee_payer_pk
         ; fee = Currency.Fee.of_nanomina_int_exn fee


### PR DESCRIPTION
## Explain your changes:

A new `aux` field has been added to the `Account_update` types. For the stable versions of these types it holds nothing, but for the unstable versions of these types it is used to cache the hash of the actions of the body of the account update. This new field is not intended for serialization, so the `yojson` and `sexp` definitions in `Account_update` were modified to ensure that the serialization format for these types is unchanged.

This PR is prompted by the observation in https://github.com/MinaProtocol/mina/pull/16968 that the `--transfer-parties-get-actions-events` flag in the `mina ledger test apply` benchmark causes the final application time to increase by roughly 7 seconds. (Benchmarking was done on my laptop). This time would also increase by a further 7 seconds for every 100 actions added to the max actions in the genesis constants. By caching the `actions_hash` on `Account_update` creation, this increase is eliminated, and the final application time is now constant with respect to the number of actions in an account update.

## Explain how you tested your changes:

I ran `mina ledger test apply` with and without the `--transfer-parties-get-actions-events` flag, and with various edited values of the max actions in the genesis constants. In all cases the final application time in that benchmark was roughly 3 seconds:

1. With `actions=events=0`:

```
Result of application 580: true (took 3.1157171726226807s): new root jwN9rKMrRduBhpxuSGHMFShc4iY4cTuMnL1i3ghc69ygHuva6Mt
```

2. With `actions=events=1000` and `max_action_elements=max_event_elements=1000`:

```
Result of application 580: true (took 3.2762835025787354s): new root jxKot9cGbGuffuVWRCYXeHKAwNuniDRRSjCiKxSp6GxBpArHRpX
```

Increasing the actions and events still causes the `real` time of the benchmark to increase, but this is independent of the number of actions and events in the other parties in the ledger - it goes from about `1m` with 100 max, to `7m` with 1000 max.

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules