### PR TITLE
Remove obsolete snark_work_debugger dune project entry

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -179,7 +179,6 @@
 (package (name snark_keys_header))
 (package (name snark_params))
 (package (name snark_profiler_lib))
-(package (name snark_work_debugger))
 (package (name snark_worker))
 (package (name snark_work_lib))
 (package (name snarky_blake2))


### PR DESCRIPTION
## Explain your changes:

After https://github.com/MinaProtocol/mina/pull/17114, the `dune-project` entry for `snark_work_debugger` stopped referring to any local package. Removing entry resolves this error that would be emitted during `dune build`:

```
Error: The package snark_work_debugger does not have any user defined stanzas
attached to it. If this is intentional, add (allow_empty) to the package
definition in the dune-project file
-> required by _build/default/src/snark_work_debugger.install
-> required by alias src/all
-> required by alias default
```

## Explain how you tested your changes:

I ran `dune build` locally and observed that the error disappeared.