### PR TITLE
Update Snark Worker to ultilize Snark Work Partitioner V2

### DIFF
--- a/changes/17082.md
+++ b/changes/17082.md
@@ -1,0 +1,1 @@
+Modify the RPC interaction between snark worker and their coordinator. Now Coordinator distributes work at finer grain(1 job only, and could be sub zkapp command level), which means more parallelism would be abused in SNARKs generation.

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1753,8 +1753,11 @@ let internal_commands logger ~itn_features =
               in
 
               let sok_digest = Mina_base.Sok_message.digest sok_message in
-              let spec : Snark_work_lib.Selector.Spec.Stable.Latest.t =
+              let spec =
                 { instances = `One single_spec; fee = Currency.Fee.zero }
+                |> Snark_work_lib.Partitioned.Spec.Poly.of_selector_spec
+                     ~issued_since_unix_epoch:
+                       Time.(now () |> to_span_since_epoch)
               in
               match%map
                 Snark_worker.Worker.Prod.perform ~state ~sok_digest ~spec

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2355,7 +2355,7 @@ module Queries = struct
             Option.map (snark_worker_key mina) ~f:(fun _ -> snark_work_fee mina))
         in
         Work_selector.pending_work_statements ~snark_pool ~fee_opt
-          snark_job_state )
+          snark_job_state.selector )
 
   let snark_work_range =
     field "snarkWorkRange"
@@ -2380,7 +2380,9 @@ module Queries = struct
       ~resolve:(fun { ctx = mina; _ } () start_idx end_idx ->
         let snark_job_state = Mina_lib.snark_job_state mina in
         let snark_pool = Mina_lib.snark_pool mina in
-        let all_work = Work_selector.all_work ~snark_pool snark_job_state in
+        let all_work =
+          Work_selector.all_work ~snark_pool snark_job_state.selector
+        in
         let work_size = all_work |> List.length |> Unsigned.UInt32.of_int in
         let less_than uint1 uint2 = Unsigned.UInt32.compare uint1 uint2 < 0 in
         let to_bundle_specs =

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -115,7 +115,10 @@ val request_work :
 
 val work_selection_method : t -> (module Work_selector.Selection_method_intf)
 
-val add_work : t -> Snark_work_lib.Selector.Result.t -> unit
+val add_work :
+     result:Snark_work_lib.Partitioned.Result.t
+  -> t
+  -> Snark_worker.Rpcs.Submit_work.Master.Callee.response
 
 val add_work_graphql :
      t

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -110,7 +110,8 @@ val snark_work_fee : t -> Currency.Fee.t
 
 val set_snark_work_fee : t -> Currency.Fee.t -> unit
 
-val request_work : t -> Work_selector.work Snark_work_lib.Work.Spec.t option
+val request_work :
+  capability:[ `V2 | `V3 ] -> t -> Snark_work_lib.Partitioned.Spec.t option
 
 val work_selection_method : t -> (module Work_selector.Selection_method_intf)
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -9,6 +9,9 @@ module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Mina_subscriptions
 
+type snark_job_state =
+  { selector : Work_selector.State.t; partitioner : Work_partitioner.t }
+
 type t
 
 type Structured_log_events.t +=
@@ -121,7 +124,7 @@ val add_work_graphql :
      * Network_pool.Snark_pool.Resource_pool.Diff.rejected )
      Deferred.Or_error.t
 
-val snark_job_state : t -> Work_selector.State.t
+val snark_job_state : t -> snark_job_state
 
 val get_current_nonce :
      t

--- a/src/lib/snark_work_lib/metrics.ml
+++ b/src/lib/snark_work_lib/metrics.ml
@@ -1,0 +1,136 @@
+open Core_kernel
+
+type snark_work_generated =
+  | Merge_generated of Time.Span.t
+  | Base_generated of
+      { transaction_type :
+          [ `Zkapp_command | `Signed_command | `Coinbase | `Fee_transfer ]
+      ; elapsed : Time.Span.t
+      ; zkapp_command_count : int
+      ; proof_zkapp_command_count : int
+      }
+  | Sub_zkapp_command of { kind : [ `Merge | `Segment ]; elapsed : Time.Span.t }
+
+let collect_single ~(single_spec : _ Work.Single.Spec.t)
+    ~metric:({ elapsed; _ } : _ Partitioned.Proof_with_metric.Poly.t) =
+  match single_spec with
+  | Work.Single.Spec.Merge (_, _, _) ->
+      Perf_histograms.add_span ~name:"snark_worker_merge_time" elapsed ;
+
+      (* WARN: This `observe` is just noop, not sure why it's here *)
+      Mina_metrics.(
+        Cryptography.Snark_work_histogram.observe
+          Cryptography.snark_work_merge_time_sec (Time.Span.to_sec elapsed)) ;
+      Merge_generated elapsed
+  | Work.Single.Spec.Transition
+      (_, ({ transaction; _ } : _ Transaction_witness.Poly.t)) ->
+      Perf_histograms.add_span ~name:"snark_worker_transition_time" elapsed ;
+      let transaction_type, zkapp_command_count, proof_zkapp_command_count =
+        match transaction with
+        | Mina_transaction.Transaction.Command
+            (Mina_base.User_command.Zkapp_command zkapp_command) ->
+            (* WARN: now this is dead code, if we're using new protocol between
+               snark coordinator and workers *)
+            let init =
+              match
+                (Mina_base.Account_update.of_fee_payer
+                   zkapp_command.Mina_base.Zkapp_command.Poly.fee_payer )
+                  .authorization
+              with
+              | Proof _ ->
+                  (1, 1)
+              | _ ->
+                  (1, 0)
+            in
+            let parties_count, proof_parties_count =
+              Mina_base.Zkapp_command.Call_forest.fold
+                zkapp_command.account_updates ~init
+                ~f:(fun (count, proof_updates_count) account_update ->
+                  ( count + 1
+                  , if
+                      Mina_base.Control.(
+                        Tag.equal Proof
+                          (tag
+                             account_update
+                               .Mina_base.Account_update.Poly.authorization ))
+                    then proof_updates_count + 1
+                    else proof_updates_count ) )
+            in
+            Mina_metrics.(
+              Cryptography.(
+                Counter.inc snark_work_zkapp_base_time_sec
+                  (Time.Span.to_sec elapsed) ;
+                Counter.inc_one snark_work_zkapp_base_submissions ;
+                Counter.inc zkapp_transaction_length
+                  (Float.of_int parties_count) ;
+                Counter.inc zkapp_proof_updates
+                  (Float.of_int proof_parties_count))) ;
+            (`Zkapp_command, parties_count, proof_parties_count)
+        | Mina_transaction.Transaction.Command
+            (Mina_base.User_command.Signed_command _) ->
+            Mina_metrics.(
+              Counter.inc Cryptography.snark_work_base_time_sec
+                (Time.Span.to_sec elapsed)) ;
+            (`Signed_command, 1, 0)
+        | Mina_transaction.Transaction.Coinbase _ ->
+            Mina_metrics.(
+              Counter.inc Cryptography.snark_work_base_time_sec
+                (Time.Span.to_sec elapsed)) ;
+            (`Coinbase, 1, 0)
+        | Mina_transaction.Transaction.Fee_transfer _ ->
+            Mina_metrics.(
+              Counter.inc Cryptography.snark_work_base_time_sec
+                (Time.Span.to_sec elapsed)) ;
+            (`Fee_transfer, 1, 0)
+      in
+      Base_generated
+        { transaction_type
+        ; elapsed
+        ; zkapp_command_count
+        ; proof_zkapp_command_count
+        }
+
+let emit_proof_metrics ~data =
+  Mina_metrics.(Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;
+  match data with
+  | Partitioned.Spec.Poly.Single { single_spec; metric; _ } ->
+      `One (collect_single ~single_spec ~metric)
+  | Partitioned.Spec.Poly.Sub_zkapp_command
+      { spec = { spec = Partitioned.Zkapp_command_job.Spec.Poly.Segment _; _ }
+      ; metric
+      } ->
+      (* WARN:
+         I don't know if this is the desired behavior, we need CI engineers.
+         We're likely to adapt the below somehow to here.
+         Mina_metrics.(
+           Cryptography.(
+             Counter.inc snark_work_zkapp_base_time_sec (Time.Span.to_sec elapsed) ;
+             Counter.inc_one snark_work_zkapp_base_submissions ;
+             Counter.inc zkapp_transaction_length (Float.of_int c) ;
+             Counter.inc zkapp_proof_updates (Float.of_int p))) ;
+      *)
+      Perf_histograms.add_span ~name:"snark_worker_subzkapp_time" metric.elapsed ;
+      Perf_histograms.add_span
+        ~name:"snark_worker_sub_zkapp_command_segment_time" metric.elapsed ;
+      `One (Sub_zkapp_command { kind = `Segment; elapsed = metric.elapsed })
+  | Partitioned.Spec.Poly.Sub_zkapp_command
+      { spec = { spec = Partitioned.Zkapp_command_job.Spec.Poly.Merge _; _ }
+      ; metric
+      } ->
+      (* WARN:
+         I don't know if this is the desired behavior, we need CI engineers.
+         We're likely to adapt the below somehow to here.
+         Mina_metrics.(
+           Cryptography.(
+             Counter.inc snark_work_zkapp_base_time_sec (Time.Span.to_sec elapsed) ;
+             Counter.inc_one snark_work_zkapp_base_submissions ;
+             Counter.inc zkapp_transaction_length (Float.of_int c) ;
+             Counter.inc zkapp_proof_updates (Float.of_int p))) ;
+      *)
+      Perf_histograms.add_span ~name:"snark_worker_subzkapp_time" metric.elapsed ;
+      Perf_histograms.add_span ~name:"snark_worker_sub_zkapp_command_merge_time"
+        metric.elapsed ;
+      `One (Sub_zkapp_command { kind = `Merge; elapsed = metric.elapsed })
+  | Partitioned.Spec.Poly.Old { instances; _ } ->
+      One_or_two.map instances ~f:(fun (single_spec, metric) ->
+          collect_single ~single_spec ~metric )

--- a/src/lib/snark_work_lib/partitioned.ml
+++ b/src/lib/snark_work_lib/partitioned.ml
@@ -350,7 +350,8 @@ module Spec = struct
       , map_with_statement
       , transaction
       , of_selector_spec
-      , to_selector_spec )]
+      , to_selector_spec
+      , fee_of_full )]
   end
 
   [%%versioned

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -41,83 +41,6 @@ let dispatch rpc shutdown_on_disconnect query address =
   | Ok res ->
       res
 
-let emit_proof_metrics
-    (metrics :
-      ( Ledger_proof.Stable.Latest.t
-      * Time_span_with_json.t
-      * [ `Merge | `Transition ] )
-      One_or_two.t ) txns logger =
-  One_or_two.iter (One_or_two.zip_exn metrics txns)
-    ~f:(fun ((_, time, tag), single) ->
-      match tag with
-      | `Merge ->
-          Mina_metrics.(
-            Cryptography.Snark_work_histogram.observe
-              Cryptography.snark_work_merge_time_sec (Time.Span.to_sec time)) ;
-          [%str_log info] (Merge_snark_generated { time })
-      | `Transition ->
-          let transaction_type, zkapp_command_count, proof_zkapp_command_count =
-            (*should be Some in the case of `Transition*)
-            match Option.value_exn single with
-            | Mina_transaction.Transaction.Command
-                (Mina_base.User_command.Zkapp_command zkapp_command) ->
-                let init =
-                  match
-                    (Mina_base.Account_update.of_fee_payer
-                       zkapp_command.Mina_base.Zkapp_command.Poly.fee_payer )
-                      .authorization
-                  with
-                  | Proof _ ->
-                      (1, 1)
-                  | _ ->
-                      (1, 0)
-                in
-                let c, p =
-                  Mina_base.Zkapp_command.Call_forest.fold
-                    zkapp_command.account_updates ~init
-                    ~f:(fun (count, proof_updates_count) account_update ->
-                      ( count + 1
-                      , if
-                          Mina_base.Control.(
-                            Tag.equal Proof
-                              (tag
-                                 account_update
-                                   .Mina_base.Account_update.Poly.authorization ))
-                        then proof_updates_count + 1
-                        else proof_updates_count ) )
-                in
-                Mina_metrics.(
-                  Cryptography.(
-                    Counter.inc snark_work_zkapp_base_time_sec
-                      (Time.Span.to_sec time) ;
-                    Counter.inc_one snark_work_zkapp_base_submissions ;
-                    Counter.inc zkapp_transaction_length (Float.of_int c) ;
-                    Counter.inc zkapp_proof_updates (Float.of_int p))) ;
-                ("zkapp_command", c, p)
-            | Command (Signed_command _) ->
-                Mina_metrics.(
-                  Counter.inc Cryptography.snark_work_base_time_sec
-                    (Time.Span.to_sec time)) ;
-                ("signed command", 1, 0)
-            | Coinbase _ ->
-                Mina_metrics.(
-                  Counter.inc Cryptography.snark_work_base_time_sec
-                    (Time.Span.to_sec time)) ;
-                ("coinbase", 1, 0)
-            | Fee_transfer _ ->
-                Mina_metrics.(
-                  Counter.inc Cryptography.snark_work_base_time_sec
-                    (Time.Span.to_sec time)) ;
-                ("fee_transfer", 1, 0)
-          in
-          [%str_log info]
-            (Base_snark_generated
-               { time
-               ; transaction_type
-               ; zkapp_command_count
-               ; proof_zkapp_command_count
-               } ) )
-
 let main ~logger ~proof_level ~constraint_constants daemon_address
     shutdown_on_disconnect =
   let%bind state = Worker_state.create ~constraint_constants ~proof_level () in
@@ -208,9 +131,10 @@ let main ~logger ~proof_level ~constraint_constants daemon_address
             in
             log_and_retry "performing work" e (retry_pause 10.) go
         | Ok proofs_with_metrics ->
-            emit_proof_metrics proofs_with_metrics
-              (Work.Selector.Spec.Stable.Latest.transactions spec)
-              logger ;
+            Work.Metrics.emit_proof_metrics ~data:proofs_with_metrics
+            |> One_or_two.iter ~f:(fun generated ->
+                   [%str_log info]
+                     (Events.event_of_snark_work_generated generated) ) ;
             [%log info] "Submitted completed SNARK work $work_ids to $address"
               ~metadata:
                 [ ("address", `String (Host_and_port.to_string daemon_address))

--- a/src/lib/snark_worker/events.ml
+++ b/src/lib/snark_worker/events.ml
@@ -43,19 +43,47 @@ type Structured_log_events.t +=
 
 type Structured_log_events.t +=
   | Base_snark_generated of
-      { time : Time_span_with_json.t
-      ; transaction_type : String_with_json.t
+      { elapsed : Time_span_with_json.t
+      ; transaction_type :
+          [ `Zkapp_command | `Signed_command | `Coinbase | `Fee_transfer ]
       ; zkapp_command_count : Int_with_json.t
       ; proof_zkapp_command_count : Int_with_json.t
       }
   [@@deriving
     register_event
       { msg =
-          "Base SNARK generated in $time for $transaction_type transaction \
+          "Base SNARK generated in $elapsed for $transaction_type transaction \
            with $zkapp_command_count zkapp_command and \
            $proof_zkapp_command_count proof zkapp_command"
       }]
 
 type Structured_log_events.t +=
+  | Sub_zkapp_snark_generated of
+      { elapsed : Time_span_with_json.t; kind : [ `Merge | `Segment ] }
+  [@@deriving
+    register_event
+      { msg = "Subzkapp SNARK generated in $elapsed of kind $kind" }]
+
+type Structured_log_events.t +=
   | Generating_snark_work_failed of { error : Yojson.Safe.t }
   [@@deriving register_event { msg = "Failed to generate SNARK work: $error" }]
+
+let event_of_snark_work_generated :
+    Snark_work_lib.Metrics.snark_work_generated -> Structured_log_events.t =
+  function
+  | Snark_work_lib.Metrics.Merge_generated time ->
+      Merge_snark_generated { time }
+  | Snark_work_lib.Metrics.Base_generated
+      { transaction_type
+      ; elapsed
+      ; zkapp_command_count
+      ; proof_zkapp_command_count
+      } ->
+      Base_snark_generated
+        { transaction_type
+        ; elapsed
+        ; zkapp_command_count
+        ; proof_zkapp_command_count
+        }
+  | Snark_work_lib.Metrics.Sub_zkapp_command { kind; elapsed } ->
+      Sub_zkapp_snark_generated { elapsed; kind }

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -1,6 +1,5 @@
 open Async
-open Core
-open Snark_work_lib.Selector
+open Snark_work_lib.Partitioned
 
 module type Worker = sig
   module Worker_state : sig
@@ -35,9 +34,10 @@ module type Worker = sig
        state:Worker_state.t
     -> spec:Spec.Stable.Latest.t
     -> sok_digest:Mina_base.Sok_message.Digest.Stable.Latest.t
-    -> ( Ledger_proof.Stable.Latest.t
-       * Time.Stable.Span.V1.t
-       * [ `Transition | `Merge ] )
-       One_or_two.Stable.V1.t
+    -> ( Transaction_witness.Stable.Latest.t
+       , Transaction_snark.Zkapp_command_segment.Witness.Stable.Latest.t
+       , Ledger_proof.Stable.Latest.t
+       , Proof_with_metric.Stable.Latest.t )
+       Spec.Poly.Stable.Latest.t
        Deferred.Or_error.t
 end

--- a/src/lib/snark_worker/rpc_failed_to_generate_snark.ml
+++ b/src/lib/snark_worker/rpc_failed_to_generate_snark.ml
@@ -26,6 +26,28 @@ include Versioned_rpc.Both_convert.Plain.Make (Master)
 
 [%%versioned_rpc
 module Stable = struct
+  module V3 = struct
+    module T = struct
+      type query =
+        Bounded_types.Wrapped_error.Stable.V1.t
+        * Work.Partitioned.Spec.Stable.V1.t
+        * Public_key.Compressed.Stable.V1.t
+
+      type response = unit
+
+      let query_of_caller_model = Fn.id
+
+      let callee_model_of_query = Fn.id
+
+      let response_of_callee_model = Fn.id
+
+      let caller_model_of_response = Fn.id
+    end
+
+    include T
+    include Register (T)
+  end
+
   module V2 = struct
     module T = struct
       type query =
@@ -67,5 +89,5 @@ module Stable = struct
     include Register (T)
   end
 
-  module Latest = V2
+  module Latest = V3
 end]

--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -12,10 +12,10 @@ module Master = struct
   let name = "get_work"
 
   module T = struct
-    type query = unit
+    type query = [ `V2 | `V3 ]
 
     type response =
-      (Work.Selector.Spec.Stable.Latest.t * Public_key.Compressed.t) option
+      (Work.Partitioned.Spec.Stable.Latest.t * Public_key.Compressed.t) option
   end
 
   module Caller = T
@@ -34,13 +34,42 @@ module Stable = struct
         (Work.Selector.Spec.Stable.V1.t * Public_key.Compressed.Stable.V1.t)
         option
 
-      let query_of_caller_model = Fn.id
+      let query_of_caller_model = const ()
 
-      let callee_model_of_query = Fn.id
+      let callee_model_of_query = const `V2
 
-      let response_of_callee_model = Fn.id
+      let response_of_callee_model (resp : Master.Callee.response) : response =
+        match resp with
+        | Some (spec, key) -> (
+            match Work.Partitioned.Spec.Poly.to_selector_spec spec with
+            | None ->
+                (* WARN: we'd better report to the coordinator we failed rather *)
+                (*          than ignoring the work*)
+                printf
+                  "WARN: V2 Worker receving work `Zkapp_command_segment`, \
+                   which is out of its capability, work dropped" ;
+                None
+            | Some spec ->
+                Some (spec, key) )
+        | None ->
+            None
 
-      let caller_model_of_response = Fn.id
+      let caller_model_of_response : response -> Master.Caller.response =
+        function
+        | Some (spec, key) ->
+            (* Old worker can't tell when it received the job,
+               so just assume it's taking 0s
+            *)
+            let issued_since_unix_epoch =
+              Time.(now () |> to_span_since_epoch)
+            in
+            let spec =
+              Work.Partitioned.Spec.Poly.of_selector_spec
+                ~issued_since_unix_epoch spec
+            in
+            Some (spec, key)
+        | None ->
+            None
     end
 
     include T

--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -26,6 +26,27 @@ include Versioned_rpc.Both_convert.Plain.Make (Master)
 
 [%%versioned_rpc
 module Stable = struct
+  module V3 = struct
+    module T = struct
+      type query = [ `V2 | `V3 ]
+
+      type response =
+        (Work.Partitioned.Spec.Stable.V1.t * Public_key.Compressed.Stable.V1.t)
+        option
+
+      let query_of_caller_model = Fn.id
+
+      let callee_model_of_query = Fn.id
+
+      let response_of_callee_model = Fn.id
+
+      let caller_model_of_response = Fn.id
+    end
+
+    include T
+    include Register (T)
+  end
+
   module V2 = struct
     module T = struct
       type query = unit
@@ -76,5 +97,5 @@ module Stable = struct
     include Register (T)
   end
 
-  module Latest = V2
+  module Latest = V3
 end]

--- a/src/lib/snark_worker/rpc_submit_work.ml
+++ b/src/lib/snark_worker/rpc_submit_work.ml
@@ -24,6 +24,25 @@ include Versioned_rpc.Both_convert.Plain.Make (Master)
 
 [%%versioned_rpc
 module Stable = struct
+  module V3 = struct
+    module T = struct
+      type query = Work.Partitioned.Result.Stable.V1.t
+
+      type response = [ `Ok | `Slashed | `SchemeUnmatched ]
+
+      let query_of_caller_model = Fn.id
+
+      let callee_model_of_query = Fn.id
+
+      let response_of_callee_model = Fn.id
+
+      let caller_model_of_response = Fn.id
+    end
+
+    include T
+    include Register (T)
+  end
+
   module V2 = struct
     module T = struct
       type query = Work.Selector.Result.Stable.V1.t
@@ -73,5 +92,5 @@ module Stable = struct
     include Register (T)
   end
 
-  module Latest = V2
+  module Latest = V3
 end]

--- a/src/lib/work_partitioner/dune
+++ b/src/lib/work_partitioner/dune
@@ -16,7 +16,10 @@
  (preprocess
   (pps
    ppx_custom_printf
-   ppx_let))
+   ppx_deriving_yojson
+   ppx_let
+   ppx_sexp_conv
+   ppx_version))
    
  (instrumentation
   (backend bisect_ppx))

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -10,15 +10,49 @@ open Transaction_snark
    This is used in both Work_partitioner and Snark_worker for compatibility
    reasons
 *)
-let extract_zkapp_segment_works ~m:(module M : S)
-    ~(input : Mina_state.Snarked_ledger_state.t)
-    ~(witness : Transaction_witness.Stable.Latest.t)
-    ~(zkapp_command : Zkapp_command.t) :
+
+module Zkapp_command_inputs = struct
+  [%%versioned
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type t =
+        ( Zkapp_command_segment.Witness.Stable.V1.t
+        * Zkapp_command_segment.Basic.Stable.V1.t
+        * Statement.With_sok.Stable.V2.t )
+        list
+      [@@deriving sexp, to_yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t =
     ( Zkapp_command_segment.Witness.t
     * Zkapp_command_segment.Basic.t
     * Statement.With_sok.t )
     list
-    Deferred.Or_error.t =
+
+  let write_all_proofs_to_disk ~proof_cache_db : Stable.V1.t -> t =
+    List.map ~f:(fun (witness, segment, stmt) ->
+        ( Zkapp_command_segment.Witness.write_all_proofs_to_disk ~proof_cache_db
+            witness
+        , segment
+        , stmt ) )
+
+  let read_all_proofs_from_disk : t -> Stable.V1.t =
+    List.map ~f:(fun (witness, segment, stmt) ->
+        ( Zkapp_command_segment.Witness.read_all_proofs_from_disk witness
+        , segment
+        , stmt ) )
+end
+
+let extract_zkapp_segment_works ~m:(module M : S)
+    ~(input : Mina_state.Snarked_ledger_state.t)
+    ~(witness : Transaction_witness.Stable.Latest.t)
+    ~(zkapp_command : Zkapp_command.t) :
+    Zkapp_command_inputs.t Deferred.Or_error.t =
   Or_error.try_with (fun () ->
       Transaction_snark.zkapp_command_witnesses_exn
         ~constraint_constants:M.constraint_constants


### PR DESCRIPTION
This PR is bigger than I expect it to be. But there's no complicated logics happening. 3 major things are done:
- Update the RPC
- Wire all occurence of RPC to the new version
- Some repetititive codes are grouped together
	- Most notably, I [put the 2 implementation of metrics emission into same module](https://github.com/MinaProtocol/mina/pull/17134/commits/e27953809663fa77f18b391a806b581e0df950e9), so whenever we track, these are tracked together. 

This is the last PR in the PR train that implemented the feature as a whole. Following PRs are testing/cleaning up. 