### PR TITLE
Deprecate the use of compiled signature kind

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2288,7 +2288,7 @@ let signature_kind =
     (let%map.Command () = Command.Param.return () in
      fun () ->
        let signature_kind_string =
-         match Mina_signature_kind.t with
+         match Mina_signature_kind.t_DEPRECATED with
          | Mainnet ->
              "mainnet"
          | Testnet ->

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -63,7 +63,7 @@ let signature_for_testnet = salt signature_testnet
 
 let signature_for_other chain_name = salt @@ signature_other chain_name
 
-let signature ?(signature_kind = Mina_signature_kind.t) =
+let signature ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet
@@ -79,7 +79,7 @@ let signature_for_testnet_legacy = salt_legacy signature_testnet
 let signature_for_other_legacy chain_name =
   salt_legacy @@ signature_other chain_name
 
-let signature_legacy ?(signature_kind = Mina_signature_kind.t) =
+let signature_legacy ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet_legacy
@@ -104,7 +104,8 @@ let zkapp_account = salt zkapp_account
 
 let zkapp_payload = salt zkapp_payload
 
-let zkapp_body ?(chain = Mina_signature_kind.t) = salt @@ zkapp_body ~chain
+let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
+  salt @@ zkapp_body ~chain
 
 let zkapp_precondition = salt zkapp_precondition
 

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -39,7 +39,7 @@ let zkapp_body_mainnet = create "MainnetZkappBody"
 
 let zkapp_body_testnet = create "TestnetZkappBody"
 
-let zkapp_body ?(chain = Mina_signature_kind.t) =
+let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
   match chain with
   | Mainnet ->
       zkapp_body_mainnet

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2884,7 +2884,7 @@ module Queries = struct
       ~typ:(non_null string)
       ~args:Arg.[]
       ~resolve:(fun _ () ->
-        match Mina_signature_kind.t with
+        match Mina_signature_kind.t_DEPRECATED with
         | Mainnet ->
             "mainnet"
         | Testnet ->

--- a/src/lib/signature_kind/compile_config/mina_signature_kind.ml
+++ b/src/lib/signature_kind/compile_config/mina_signature_kind.ml
@@ -1,6 +1,6 @@
 include Mina_signature_kind_type
 
-let t =
+let t_DEPRECATED =
   match Node_config.network with
   | "testnet" ->
       Testnet

--- a/src/lib/signature_kind/mainnet/mina_signature_kind.ml
+++ b/src/lib/signature_kind/mainnet/mina_signature_kind.ml
@@ -1,3 +1,3 @@
 include Mina_signature_kind_type
 
-let t = Mainnet
+let t_DEPRECATED = Mainnet

--- a/src/lib/signature_kind/mina_signature_kind.mli
+++ b/src/lib/signature_kind/mina_signature_kind.mli
@@ -3,4 +3,6 @@ type t = Mina_signature_kind_type.t =
   | Mainnet
   | Other_network of string
 
-val t : t
+(** The Mina_signature_kind_type in the compiled config. Deprecated - will be
+    replaced by a runtime-derived value. *)
+val t_DEPRECATED : t

--- a/src/lib/signature_kind/testnet/mina_signature_kind.ml
+++ b/src/lib/signature_kind/testnet/mina_signature_kind.ml
@@ -1,3 +1,3 @@
 include Mina_signature_kind_type
 
-let t = Testnet
+let t_DEPRECATED = Testnet

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -305,7 +305,7 @@ module Message = struct
   let network_id_other chain_name = chain_name
 
   let network_id =
-    match Mina_signature_kind.t with
+    match Mina_signature_kind.t_DEPRECATED with
     | Mainnet ->
         network_id_mainnet
     | Testnet ->
@@ -335,7 +335,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t) =
+    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
       make_derive
         ~network_id:
           ( match signature_kind with
@@ -409,7 +409,7 @@ module Message = struct
       |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
       |> Tock.Field.project
 
-    let derive ?(signature_kind = Mina_signature_kind.t) =
+    let derive ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
       make_derive
         ~network_id:
           ( match signature_kind with


### PR DESCRIPTION
## Explain your changes:

This is the start of a series of PRs that will eventually remove the default compiled config `Mina_signature_kind.t` value from the code base completely, turning it into a completely runtime-configurable value.

This first PR only renames the value `Mina_signature_kind.t` to `Mina_signature_kind.t_DEPRECATED`, to make it clear during this ongoing refactoring that the value should not be used in new code, and to make my life a little easier during this refactor. Subsequent PRs will gradually replace the use of the value in functions with a `~signature_kind` parameter that can be set by the caller. This will push the deprecated value upward in the code base until we reach a point at which the signature kind can be determined by other means (with a runtime config value, or a hard-wired `Testnet` value for tests). Once all of its uses are gone, the compiled config value can be removed completely.

## Explain how you tested your changes:

This PR merely renames a top-level binding in the code base to prepare for subsequent PRs in this series. It does not change any behaviour.

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them