### PR TITLE
Regularize signature kind terminology, move deprecated value out of hash prefix modules

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -346,7 +346,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           }
         in
         Transaction_snark.For_tests.single_account_update
-          ~chain:Mina_signature_kind.(Other_network "Invalid")
+          ~signature_kind:Mina_signature_kind.(Other_network "Invalid")
           ~constraint_constants spec
       in
       ( snapp_update

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -104,8 +104,8 @@ let zkapp_account = salt zkapp_account
 
 let zkapp_payload = salt zkapp_payload
 
-let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
-  salt @@ zkapp_body ~chain
+let zkapp_body ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+  salt @@ zkapp_body ~signature_kind
 
 let zkapp_precondition = salt zkapp_precondition
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -63,7 +63,7 @@ let signature_for_testnet = salt signature_testnet
 
 let signature_for_other chain_name = salt @@ signature_other chain_name
 
-let signature ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let signature ~(signature_kind : Mina_signature_kind.t) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet
@@ -79,7 +79,7 @@ let signature_for_testnet_legacy = salt_legacy signature_testnet
 let signature_for_other_legacy chain_name =
   salt_legacy @@ signature_other chain_name
 
-let signature_legacy ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let signature_legacy ~(signature_kind : Mina_signature_kind.t) =
   match signature_kind with
   | Mainnet ->
       signature_for_mainnet_legacy
@@ -104,7 +104,7 @@ let zkapp_account = salt zkapp_account
 
 let zkapp_payload = salt zkapp_payload
 
-let zkapp_body ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let zkapp_body ~(signature_kind : Mina_signature_kind.t) =
   salt @@ zkapp_body ~signature_kind
 
 let zkapp_precondition = salt zkapp_precondition

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -50,7 +50,7 @@ val zkapp_account : Field.t State.t
 
 val zkapp_payload : Field.t State.t
 
-val zkapp_body : ?chain:Mina_signature_kind.t -> Field.t State.t
+val zkapp_body : ?signature_kind:Mina_signature_kind.t -> Field.t State.t
 
 val zkapp_precondition : Field.t State.t
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -2,7 +2,7 @@ open Snark_params
 open Tick
 open Random_oracle
 
-val signature : ?signature_kind:Mina_signature_kind.t -> Field.t State.t
+val signature : signature_kind:Mina_signature_kind.t -> Field.t State.t
 
 val signature_for_mainnet : Field.t State.t
 
@@ -11,7 +11,7 @@ val signature_for_testnet : Field.t State.t
 val signature_for_other : string -> Field.t State.t
 
 val signature_legacy :
-  ?signature_kind:Mina_signature_kind.t -> Field.t Legacy.State.t
+  signature_kind:Mina_signature_kind.t -> Field.t Legacy.State.t
 
 val signature_for_mainnet_legacy : Field.t Legacy.State.t
 
@@ -50,7 +50,7 @@ val zkapp_account : Field.t State.t
 
 val zkapp_payload : Field.t State.t
 
-val zkapp_body : ?signature_kind:Mina_signature_kind.t -> Field.t State.t
+val zkapp_body : signature_kind:Mina_signature_kind.t -> Field.t State.t
 
 val zkapp_precondition : Field.t State.t
 

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -39,7 +39,7 @@ let zkapp_body_mainnet = create "MainnetZkappBody"
 
 let zkapp_body_testnet = create "TestnetZkappBody"
 
-let zkapp_body ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+let zkapp_body ~(signature_kind : Mina_signature_kind.t) =
   match signature_kind with
   | Mainnet ->
       zkapp_body_mainnet

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -39,8 +39,8 @@ let zkapp_body_mainnet = create "MainnetZkappBody"
 
 let zkapp_body_testnet = create "TestnetZkappBody"
 
-let zkapp_body ?(chain = Mina_signature_kind.t_DEPRECATED) =
-  match chain with
+let zkapp_body ?(signature_kind = Mina_signature_kind.t_DEPRECATED) =
+  match signature_kind with
   | Mainnet ->
       zkapp_body_mainnet
   | Testnet ->

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1489,9 +1489,11 @@ module Body = struct
         ; Authorization_kind.Checked.to_input authorization_kind
         ]
 
-    let digest ?chain (t : t) =
+    let digest ?signature_kind (t : t) =
       Random_oracle.Checked.(
-        hash ~init:(Hash_prefix.zkapp_body ?chain) (pack_input (to_input t)))
+        hash
+          ~init:(Hash_prefix.zkapp_body ?signature_kind)
+          (pack_input (to_input t)))
   end
 
   let typ () : (Checked.t, t) Typ.t =
@@ -1562,9 +1564,11 @@ module Body = struct
       ; Authorization_kind.to_input authorization_kind
       ]
 
-  let digest ?chain (t : t) =
+  let digest ?signature_kind (t : t) =
     Random_oracle.(
-      hash ~init:(Hash_prefix.zkapp_body ?chain) (pack_input (to_input t)))
+      hash
+        ~init:(Hash_prefix.zkapp_body ?signature_kind)
+        (pack_input (to_input t)))
 
   module Digested = struct
     type t = Random_oracle.Digest.t
@@ -1730,12 +1734,12 @@ module T = struct
   let of_simple (p : Simple.t) : Stable.Latest.t =
     { body = Body.of_simple p.body; authorization = p.authorization }
 
-  let digest ?chain t = Body.digest ?chain t.Poly.body
+  let digest ?signature_kind t = Body.digest ?signature_kind t.Poly.body
 
   module Checked = struct
     type t = Body.Checked.t
 
-    let digest ?chain (t : t) = Body.Checked.digest ?chain t
+    let digest ?signature_kind (t : t) = Body.Checked.digest ?signature_kind t
   end
 end
 

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1490,9 +1490,12 @@ module Body = struct
         ]
 
     let digest ?signature_kind (t : t) =
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
       Random_oracle.Checked.(
         hash
-          ~init:(Hash_prefix.zkapp_body ?signature_kind)
+          ~init:(Hash_prefix.zkapp_body ~signature_kind)
           (pack_input (to_input t)))
   end
 
@@ -1565,9 +1568,12 @@ module Body = struct
       ]
 
   let digest ?signature_kind (t : t) =
+    let signature_kind =
+      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+    in
     Random_oracle.(
       hash
-        ~init:(Hash_prefix.zkapp_body ?signature_kind)
+        ~init:(Hash_prefix.zkapp_body ~signature_kind)
         (pack_input (to_input t)))
 
   module Digested = struct

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -134,20 +134,24 @@ module type Digest_intf = sig
     module Checked : sig
       include Digest_intf.S_checked
 
-      val create : ?chain:Mina_signature_kind.t -> Account_update.Checked.t -> t
+      val create :
+        ?signature_kind:Mina_signature_kind.t -> Account_update.Checked.t -> t
 
       val create_body :
-        ?chain:Mina_signature_kind.t -> Account_update.Body.Checked.t -> t
+           ?signature_kind:Mina_signature_kind.t
+        -> Account_update.Body.Checked.t
+        -> t
     end
 
     include Digest_intf.S_aux with type t := t and type checked := Checked.t
 
     val create :
-         ?chain:Mina_signature_kind.t
+         ?signature_kind:Mina_signature_kind.t
       -> (Account_update.Body.t, _) Account_update.Poly.t
       -> t
 
-    val create_body : ?chain:Mina_signature_kind.t -> Account_update.Body.t -> t
+    val create_body :
+      ?signature_kind:Mina_signature_kind.t -> Account_update.Body.t -> t
   end
 
   module rec Forest : sig
@@ -258,13 +262,13 @@ module Make_digest_str
     end
 
     let create :
-           ?chain:Mina_signature_kind.t
+           ?signature_kind:Mina_signature_kind.t
         -> (Account_update.Body.t, _) Account_update.Poly.t
         -> t =
       Account_update.digest
 
-    let create_body : ?chain:Mina_signature_kind.t -> Account_update.Body.t -> t
-        =
+    let create_body :
+        ?signature_kind:Mina_signature_kind.t -> Account_update.Body.t -> t =
       Account_update.Body.digest
   end
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1990,8 +1990,8 @@ let%test_module _ =
                 ; amount = Currency.Amount.of_nanomina_int_exn amount
                 } ) )
 
-    let mk_single_account_update ~chain ~fee_payer_idx ~zkapp_account_idx ~fee
-        ~nonce ~ledger =
+    let mk_single_account_update ~signature_kind ~fee_payer_idx
+        ~zkapp_account_idx ~fee ~nonce ~ledger =
       let fee = Currency.Fee.of_nanomina_int_exn fee in
       let fee_payer_kp = test_keys.(fee_payer_idx) in
       let nonce = Account.Nonce.of_int nonce in
@@ -2008,7 +2008,7 @@ let%test_module _ =
           }
       in
       let%map zkapp_command =
-        Transaction_snark.For_tests.single_account_update ~chain
+        Transaction_snark.For_tests.single_account_update ~signature_kind
           ~constraint_constants spec
       in
       Or_error.ok_exn
@@ -3121,7 +3121,7 @@ let%test_module _ =
           in
           let%bind zkapp_command =
             mk_single_account_update
-              ~chain:Mina_signature_kind.(Other_network "invalid")
+              ~signature_kind:Mina_signature_kind.(Other_network "invalid")
               ~fee_payer_idx:0 ~fee:minimum_fee ~nonce:0 ~zkapp_account_idx:1
               ~ledger:(Option.value_exn test.txn_pool.best_tip_ledger)
           in

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -362,7 +362,10 @@ module Message = struct
       |> Inner_curve.Scalar.of_bits
 
     let hash ?signature_kind =
-      make_hash ~init:(Hash_prefix_states.signature_legacy ?signature_kind)
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      make_hash ~init:(Hash_prefix_states.signature_legacy ~signature_kind)
 
     let hash_for_mainnet =
       make_hash ~init:Hash_prefix_states.signature_for_mainnet_legacy
@@ -380,8 +383,9 @@ module Message = struct
       in
       make_checked (fun () ->
           let open Random_oracle.Legacy.Checked in
+          let signature_kind = Mina_signature_kind.t_DEPRECATED in
           hash
-            ~init:(Hash_prefix_states.signature_legacy ?signature_kind:None)
+            ~init:(Hash_prefix_states.signature_legacy ~signature_kind)
             (pack_input input)
           |> Digest.to_bits ~length:Field.size_in_bits
           |> Bitstring_lib.Bitstring.Lsb_first.of_list )
@@ -436,7 +440,10 @@ module Message = struct
       |> Inner_curve.Scalar.of_bits
 
     let hash ?signature_kind =
-      make_hash ~init:(Hash_prefix_states.signature ?signature_kind)
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      make_hash ~init:(Hash_prefix_states.signature ~signature_kind)
 
     let hash_for_mainnet =
       make_hash ~init:Hash_prefix_states.signature_for_mainnet
@@ -454,8 +461,9 @@ module Message = struct
       in
       make_checked (fun () ->
           let open Random_oracle.Checked in
+          let signature_kind = Mina_signature_kind.t_DEPRECATED in
           hash
-            ~init:(Hash_prefix_states.signature ?signature_kind:None)
+            ~init:(Hash_prefix_states.signature ~signature_kind)
             (pack_input input)
           |> Digest.to_bits ~length:Field.size_in_bits
           |> Bitstring_lib.Bitstring.Lsb_first.of_list )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -5121,7 +5121,8 @@ let%test_module "staged ledger tests" =
                   in
                   let%bind zkapp_command =
                     single_account_update
-                      ~chain:Mina_signature_kind.(Other_network "invalid")
+                      ~signature_kind:
+                        Mina_signature_kind.(Other_network "invalid")
                       ~zkapp_prover_and_vk ~constraint_constants spec
                   in
                   Mina_transaction_logic.For_tests.Init_ledger.init

--- a/src/lib/transaction_snark/test/account_update_network_id/account_update_network_id.ml
+++ b/src/lib/transaction_snark/test/account_update_network_id/account_update_network_id.ml
@@ -37,7 +37,8 @@ let%test_module "Account update network id tests" =
                   in
                   let%bind zkapp_command =
                     Transaction_snark.For_tests.single_account_update
-                      ~chain:Mina_signature_kind.(Other_network "invalid")
+                      ~signature_kind:
+                        Mina_signature_kind.(Other_network "invalid")
                       ~constraint_constants:U.constraint_constants spec
                   in
                   Transaction_snark.For_tests.create_trivial_zkapp_account

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4734,9 +4734,9 @@ module Make_str (A : Wire_types.Concrete) = struct
         }
     end
 
-    let single_account_update ?zkapp_prover_and_vk ~chain ~constraint_constants
-        (spec : Single_account_update_spec.t) : Zkapp_command.t Async.Deferred.t
-        =
+    let single_account_update ?zkapp_prover_and_vk ~signature_kind
+        ~constraint_constants (spec : Single_account_update_spec.t) :
+        Zkapp_command.t Async.Deferred.t =
       let `VK vk, `Prover prover =
         match zkapp_prover_and_vk with
         | Some (prover, vk) ->
@@ -4779,7 +4779,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           }
       in
       let account_update_digest_with_selected_chain =
-        Zkapp_command.Digest.Account_update.create ~chain
+        Zkapp_command.Digest.Account_update.create ~signature_kind
           account_update_with_dummy_auth
       in
       let account_update_digest_with_current_chain =

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -312,7 +312,7 @@ module type Full = sig
              , Snark_params.Tick.Field.t )
              With_hash.t
              Async.Deferred.t
-      -> chain:Mina_signature_kind.t
+      -> signature_kind:Mina_signature_kind.t
       -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> Single_account_update_spec.t
       -> Zkapp_command.t Async.Deferred.t


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17153 in the refactoring of the network/signature kind, making it a runtime-configurable setting. The terminology in the code base has been regularized, so the signature kind parameter is always called `~signature_kind` - certain instances were `~chain` previously - and the use of the deprecated compiled config signature kind has been pushed out of the `hash_prefixes.ml` and `hash_prefix_states.ml` files.

## Explain how you tested your changes:

No behaviour has been changed.

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)