### PR TITLE
Move deprecated value out of schnorr modules

### DIFF
--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -57,10 +57,11 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
     |> Result.ok
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   (* TODO: Should we use the signer_input explicitly here to dogfood it? *)
   (* Should we just inline that here? *)
   let signature =
-    Schnorr.Legacy.sign keys.keypair.private_key
+    Schnorr.Legacy.sign ~signature_kind keys.keypair.private_key
       unsigned_transaction.random_oracle_input
   in
   let signature' =
@@ -88,6 +89,7 @@ let verify ~public_key_hex_bytes ~signed_transaction_string =
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
   let message = Signed_command.to_input_legacy user_command_payload in
-  Schnorr.Legacy.verify signed_transaction.signature
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  Schnorr.Legacy.verify ~signature_kind signed_transaction.signature
     (Snark_params.Tick.Inner_curve.of_affine public_key)
     message

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -241,8 +241,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             when Public_key.Compressed.equal public_key account_a_pk ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign account_a_kp.private_key
-                    (Random_oracle.Input.Chunked.field full_commitment)
+                  (let signature_kind = Mina_signature_kind.t_DEPRECATED in
+                   Schnorr.Chunked.sign ~signature_kind account_a_kp.private_key
+                     (Random_oracle.Input.Chunked.field full_commitment) )
               }
           | fee_payer ->
               fee_payer
@@ -260,9 +261,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 in
                 { account_update with
                   authorization =
-                    Control.Poly.Signature
-                      (Schnorr.Chunked.sign account_a_kp.private_key
-                         (Random_oracle.Input.Chunked.field commitment) )
+                    (let signature_kind = Mina_signature_kind.t_DEPRECATED in
+                     Control.Poly.Signature
+                       (Schnorr.Chunked.sign ~signature_kind
+                          account_a_kp.private_key
+                          (Random_oracle.Input.Chunked.field commitment) ) )
                 }
             | account_update ->
                 account_update )

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -131,7 +131,7 @@ let%test_module "Actions test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -151,7 +151,7 @@ let%test_module "Actions test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -129,7 +129,7 @@ let%test_module "Add events test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -149,7 +149,7 @@ let%test_module "Add events test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -98,7 +98,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -118,7 +118,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -247,7 +247,7 @@ let%test_module "Composability test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -267,7 +267,7 @@ let%test_module "Composability test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -102,7 +102,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -122,7 +122,7 @@ let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -138,7 +138,7 @@ let%test_module "Initialize state test" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -158,7 +158,7 @@ let%test_module "Initialize state test" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -792,6 +792,7 @@ end
 
 let insert_signatures pk_compressed sk
     ({ fee_payer; account_updates; memo } : Zkapp_command.t) : Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let transaction_commitment : Zkapp_command.Transaction_commitment.t =
     (* TODO: This is a pain. *)
     let account_updates_hash = Zkapp_command.Call_forest.hash account_updates in
@@ -811,7 +812,7 @@ let insert_signatures pk_compressed sk
       when Public_key.Compressed.equal public_key pk_compressed ->
         { fee_payer with
           authorization =
-            Schnorr.Chunked.sign sk
+            Schnorr.Chunked.sign ~signature_kind sk
               (Random_oracle.Input.Chunked.field full_commitment)
         }
     | fee_payer ->
@@ -831,7 +832,7 @@ let insert_signatures pk_compressed sk
           { account_update with
             authorization =
               Control.Poly.Signature
-                (Schnorr.Chunked.sign sk
+                (Schnorr.Chunked.sign ~signature_kind sk
                    (Random_oracle.Input.Chunked.field commitment) )
           }
       | account_update ->

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -112,8 +112,9 @@ let validate_keypair =
           dummy_payload
       in
       let message = Mina_base.Signed_command.to_input_legacy dummy_payload in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let verified =
-        Schnorr.Legacy.verify signature
+        Schnorr.Legacy.verify ~signature_kind signature
           (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
           message
       in

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -168,7 +168,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   let sign_payload ?signature_kind (private_key : Signature_lib.Private_key.t)
       (payload : Payload.t) : Signature.t =
-    Signature_lib.Schnorr.Legacy.sign ?signature_kind private_key
+    let signature_kind =
+      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+    in
+    Signature_lib.Schnorr.Legacy.sign ~signature_kind private_key
       (to_input_legacy payload)
 
   let sign ?signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t
@@ -411,7 +414,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
   include Codable.Make_base64 (Stable.Latest.With_top_version_tag)
 
   let check_signature ?signature_kind ({ payload; signer; signature } : t) =
-    Signature_lib.Schnorr.Legacy.verify ?signature_kind signature
+    let signature_kind =
+      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+    in
+    Signature_lib.Schnorr.Legacy.verify ~signature_kind signature
       (Snark_params.Tick.Inner_curve.of_affine signer)
       (to_input_legacy payload)
 

--- a/src/lib/signature_lib/test/signature_lib_tests.ml
+++ b/src/lib/signature_lib/test/signature_lib_tests.ml
@@ -2,6 +2,8 @@ open Signature_lib
 
 let%test_module "Signatures are unchanged test" =
   ( module struct
+    let signature_kind = Mina_signature_kind.Testnet
+
     let privkey =
       Private_key.of_base58_check_exn
         "EKE2M5q5afTtdzZTzyKu89Pzc7274BD6fm2fsDLgLt5zy34TAN5N"
@@ -15,7 +17,7 @@ let%test_module "Signatures are unchanged test" =
 
     let%test "signature of empty random oracle input matches" =
       let signature_got =
-        Schnorr.Legacy.sign privkey
+        Schnorr.Legacy.sign ~signature_kind privkey
           (Random_oracle_input.Legacy.field_elements [||])
       in
       Snark_params.Tick.Field.equal (fst signature_expected) (fst signature_got)
@@ -24,7 +26,7 @@ let%test_module "Signatures are unchanged test" =
 
     let%test "signature of signature matches" =
       let signature_got =
-        Schnorr.Legacy.sign privkey
+        Schnorr.Legacy.sign ~signature_kind privkey
           (Random_oracle_input.Legacy.field_elements
              [| fst signature_expected |] )
       in

--- a/src/lib/string_sign/string_sign.ml
+++ b/src/lib/string_sign/string_sign.ml
@@ -56,8 +56,14 @@ let string_to_input s =
 let verify ?signature_kind signature pk s =
   let m = string_to_input s in
   let inner_curve = Inner_curve.of_affine pk in
-  Schnorr.Legacy.verify ?signature_kind signature inner_curve m
+  let signature_kind =
+    Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+  in
+  Schnorr.Legacy.verify ~signature_kind signature inner_curve m
 
 let sign ?signature_kind sk s =
   let m = string_to_input s in
-  Schnorr.Legacy.sign ?signature_kind sk m
+  let signature_kind =
+    Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+  in
+  Schnorr.Legacy.sign ~signature_kind sk m

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2426,6 +2426,7 @@ module For_tests = struct
       ?(double_sender_nonce = true)
       { Transaction_spec.fee; sender = sender, sender_nonce; receiver; amount }
       : Zkapp_command.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let sender_pk = Public_key.compress sender.public_key in
     let actual_nonce =
       (* Here, we double the spec'd nonce, because we bump the nonce a second
@@ -2520,7 +2521,7 @@ module For_tests = struct
     in
     let account_updates_signature =
       let c = if use_full_commitment then full_commitment else commitment in
-      Schnorr.Chunked.sign sender.private_key
+      Schnorr.Chunked.sign ~signature_kind sender.private_key
         (Random_oracle.Input.Chunked.field c)
     in
     let account_updates =
@@ -2537,7 +2538,7 @@ module For_tests = struct
               account_update )
     in
     let signature =
-      Schnorr.Chunked.sign sender.private_key
+      Schnorr.Chunked.sign ~signature_kind sender.private_key
         (Random_oracle.Input.Chunked.field full_commitment)
     in
     { zkapp_command with

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -140,7 +140,7 @@ let%test_module "Access permission tests" =
             when Public_key.Compressed.equal public_key pk_compressed ->
               { fee_payer with
                 authorization =
-                  Schnorr.Chunked.sign sk
+                  Schnorr.Chunked.sign ~signature_kind sk
                     (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
@@ -160,7 +160,7 @@ let%test_module "Access permission tests" =
                 { account_update with
                   authorization =
                     Control.Poly.Signature
-                      (Schnorr.Chunked.sign sk
+                      (Schnorr.Chunked.sign ~signature_kind sk
                          (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -16,6 +16,8 @@ let%test_module "multisig_account" =
 
     let () = Transaction_snark.For_tests.set_proof_cache proof_cache
 
+    let signature_kind = Mina_signature_kind.Testnet
+
     module M_of_n_predicate = struct
       type _witness = (Schnorr.Chunked.Signature.t * Public_key.t) list
 
@@ -47,7 +49,7 @@ let%test_module "multisig_account" =
       (* check a signature on msg against a public key *)
       let check_sig pk msg sigma : Boolean.var Checked.t =
         let%bind (module S) = Inner_curve.Checked.Shifted.create () in
-        Schnorr.Chunked.Checked.verifies (module S) sigma pk msg
+        Schnorr.Chunked.Checked.verifies ~signature_kind (module S) sigma pk msg
 
       (* verify witness signatures against public keys *)
       let%snarkydef_ verify_sigs pubkeys commitment witness =
@@ -86,7 +88,7 @@ let%test_module "multisig_account" =
             (let%bind pk_var =
                exists Inner_curve.typ ~compute:(As_prover.return pk)
              in
-             let sigma = Schnorr.Chunked.sign sk msg in
+             let sigma = Schnorr.Chunked.sign ~signature_kind sk msg in
              let%bind sigma_var =
                exists Schnorr.Chunked.Signature.typ
                  ~compute:(As_prover.return sigma)
@@ -118,8 +120,8 @@ let%test_module "multisig_account" =
              let%bind pk1_var =
                exists Inner_curve.typ ~compute:(As_prover.return pk1)
              in
-             let sigma0 = Schnorr.Chunked.sign sk0 msg in
-             let sigma1 = Schnorr.Chunked.sign sk1 msg in
+             let sigma0 = Schnorr.Chunked.sign ~signature_kind sk0 msg in
+             let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
              let%bind sigma0_var =
                exists Schnorr.Chunked.Signature.typ
                  ~compute:(As_prover.return sigma0)
@@ -408,9 +410,9 @@ let%test_module "multisig_account" =
                 tx_statement |> Zkapp_statement.to_field_elements
                 |> Random_oracle_input.Chunked.field_elements
               in
-              let sigma0 = Schnorr.Chunked.sign sk0 msg in
-              let sigma1 = Schnorr.Chunked.sign sk1 msg in
-              let sigma2 = Schnorr.Chunked.sign sk2 msg in
+              let sigma0 = Schnorr.Chunked.sign ~signature_kind sk0 msg in
+              let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
+              let sigma2 = Schnorr.Chunked.sign ~signature_kind sk2 msg in
               let handler (Snarky_backendless.Request.With { request; respond })
                   =
                 match request with
@@ -444,7 +446,8 @@ let%test_module "multisig_account" =
                 in
                 { fee_payer with
                   authorization =
-                    Signature_lib.Schnorr.Chunked.sign sender.private_key
+                    Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                      sender.private_key
                       (Random_oracle.Input.Chunked.field txn_comm)
                 }
               in
@@ -452,7 +455,8 @@ let%test_module "multisig_account" =
                 { body = sender_account_update_data.body
                 ; authorization =
                     Signature
-                      (Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      (Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                         sender.private_key
                          (Random_oracle.Input.Chunked.field transaction) )
                 }
               in

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -15,7 +15,7 @@ open Snark_params.Tick.Let_syntax
 (* check a signature on msg against a public key *)
 let check_sig pk msg sigma : Boolean.var Checked.t =
   let%bind (module S) = Inner_curve.Checked.Shifted.create () in
-  Schnorr.Chunked.Checked.verifies (module S) sigma pk msg
+  Schnorr.Chunked.Checked.verifies ~signature_kind (module S) sigma pk msg
 
 (* verify witness signature against public keys *)
 let%snarkydef_ verify_sig pubkeys msg sigma =
@@ -67,7 +67,7 @@ let%test_unit "1-of-1" =
   in
   Quickcheck.test ~trials:1 gen ~f:(fun (sk, msg) ->
       let pk = Inner_curve.(scale one sk) in
-      (let sigma = Schnorr.Chunked.sign sk msg in
+      (let sigma = Schnorr.Chunked.sign ~signature_kind sk msg in
        let%bind sigma_var, msg_var =
          exists
            Typ.(Schnorr.Chunked.Signature.typ * Schnorr.chunked_message_typ ())
@@ -88,7 +88,7 @@ let%test_unit "1-of-2" =
   Quickcheck.test ~trials:1 gen ~f:(fun (sk0, sk1, msg) ->
       let pk0 = Inner_curve.(scale one sk0) in
       let pk1 = Inner_curve.(scale one sk1) in
-      (let sigma1 = Schnorr.Chunked.sign sk1 msg in
+      (let sigma1 = Schnorr.Chunked.sign ~signature_kind sk1 msg in
        let%bind sigma1_var =
          exists Schnorr.Chunked.Signature.typ ~compute:(As_prover.return sigma1)
        and msg_var =
@@ -262,7 +262,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             |> Random_oracle_input.Chunked.field_elements
           in
           let signing_sk = List.nth_exn ring_member_sks sign_index in
-          let sigma = Schnorr.Chunked.sign signing_sk msg in
+          let sigma = Schnorr.Chunked.sign ~signature_kind signing_sk msg in
           let handler (Snarky_backendless.Request.With { request; respond }) =
             match request with
             | Sigma ->
@@ -285,13 +285,15 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             in
             { fee_payer with
               authorization =
-                Signature_lib.Schnorr.Chunked.sign sender.private_key
+                Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                  sender.private_key
                   (Random_oracle.Input.Chunked.field txn_comm)
             }
           in
           let sender : Account_update.Simple.t =
             let sender_signature =
-              Signature_lib.Schnorr.Chunked.sign sender.private_key
+              Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                sender.private_key
                 (Random_oracle.Input.Chunked.field transaction)
             in
             { body = sender_account_update_data.body

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -14,6 +14,9 @@ let genesis_constants = Genesis_constants.Compiled.genesis_constants
 (* Always run tests with proof-level Full *)
 let proof_level = Genesis_constants.Proof_level.Full
 
+(* The default signature kind for tests is Testnet *)
+let signature_kind = Mina_signature_kind.Testnet
+
 let consensus_constants =
   Consensus.Constants.create ~constraint_constants
     ~protocol_constants:genesis_constants.protocol

--- a/src/lib/transaction_snark/test/util.mli
+++ b/src/lib/transaction_snark/test/util.mli
@@ -6,6 +6,8 @@ val genesis_constants : Genesis_constants.t
 
 val proof_level : Genesis_constants.Proof_level.t
 
+val signature_kind : Mina_signature_kind.t
+
 val consensus_constants : Consensus.Constants.t
 
 val constraint_constants : Genesis_constants.Constraint_constants.t

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -239,6 +239,7 @@ let%test_module "Protocol state precondition tests" =
             ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
     let%test_unit "invalid protocol state predicate in other zkapp_command" =
+      let signature_kind = U.signature_kind in
       let state_body = U.genesis_state_body in
       let psv = Mina_state.Protocol_state.Body.view state_body in
       let gen =
@@ -374,14 +375,16 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let fee_payer =
                     let fee_payer_signature_auth =
-                      Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        sender.private_key
                         (Random_oracle.Input.Chunked.field full_commitment)
                     in
                     { fee_payer with authorization = fee_payer_signature_auth }
                   in
                   let sender_account_update : Account_update.Simple.t =
                     let signature_auth : Signature.t =
-                      Signature_lib.Schnorr.Chunked.sign sender.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        sender.private_key
                         (Random_oracle.Input.Chunked.field commitment)
                     in
                     { sender_account_update with
@@ -390,7 +393,8 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let snapp_account_update =
                     let signature_auth =
-                      Signature_lib.Schnorr.Chunked.sign new_kp.private_key
+                      Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                        new_kp.private_key
                         (Random_oracle.Input.Chunked.field full_commitment)
                     in
                     { snapp_account_update with
@@ -860,6 +864,7 @@ let%test_module "Account precondition tests" =
                     ~state_body ledger [ zkapp_command ] ) ) )
 
     let%test_unit "invalid account predicate in fee payer" =
+      let signature_kind = U.signature_kind in
       let state_body = U.genesis_state_body in
       let psv = Mina_state.Protocol_state.Body.view state_body in
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
@@ -968,14 +973,16 @@ let%test_module "Account precondition tests" =
               in
               let fee_payer =
                 let fee_payer_signature_auth =
-                  Signature_lib.Schnorr.Chunked.sign sender.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    sender.private_key
                     (Random_oracle.Input.Chunked.field full_commitment)
                 in
                 { fee_payer with authorization = fee_payer_signature_auth }
               in
               let sender_account_update =
                 let signature_auth : Signature.t =
-                  Signature_lib.Schnorr.Chunked.sign sender.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    sender.private_key
                     (Random_oracle.Input.Chunked.field commitment)
                 in
                 { sender_account_update with
@@ -984,7 +991,8 @@ let%test_module "Account precondition tests" =
               in
               let snapp_account_update =
                 let signature_auth =
-                  Signature_lib.Schnorr.Chunked.sign new_kp.private_key
+                  Signature_lib.Schnorr.Chunked.sign ~signature_kind
+                    new_kp.private_key
                     (Random_oracle.Input.Chunked.field full_commitment)
                 in
                 { snapp_account_update with

--- a/src/lib/uptime_service/payload.ml
+++ b/src/lib/uptime_service/payload.ml
@@ -32,7 +32,8 @@ let sign_blake2_hash ~private_key s =
   let input : (Field.t, bool) Random_oracle.Legacy.Input.t =
     { field_elements; bitstrings }
   in
-  Schnorr.Legacy.sign private_key input
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  Schnorr.Legacy.sign ~signature_kind private_key input
 
 let create_request block_data submitter_keypair =
   let block_data_json = block_data_to_yojson block_data in

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -96,13 +96,14 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
            (Account_update.of_fee_payer fee_payer) )
   in
   let check_signature s pk msg =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     match Signature_lib.Public_key.decompress pk with
     | None ->
         Error (`Invalid_keys [ pk ])
     | Some pk ->
         if
           not
-            (Signature_lib.Schnorr.Chunked.verify s
+            (Signature_lib.Schnorr.Chunked.verify ~signature_kind s
                (Backend.Tick.Inner_curve.of_affine pk)
                (Random_oracle_input.Chunked.field msg) )
         then Error (`Invalid_signature [ Signature_lib.Public_key.compress pk ])

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -96,7 +96,8 @@ let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
     let commitment =
       if use_full_commitment then full_txn_commitment else txn_commitment
     in
-    Signature_lib.Schnorr.Chunked.sign sk
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+    Signature_lib.Schnorr.Chunked.sign ~signature_kind sk
       (Random_oracle.Input.Chunked.field commitment)
   in
   let fee_payer_sk =


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17169 in the refactoring of the network/signature kind, making it a runtime-configurable setting. The use of `Mina_signature_kind.t_DEPRECATED` has been eliminated from the `schnorr.ml` modules - it has been replaced with an explicit parameter. At the affected call sites, this parameter has been set to either  `Mina_signature_kind.Testnet` (when the relevant functions are obviously in tests and the signature kind doesn't need to be configurable) or to `Mina_signature_kind.t_DEPRECATED` (otherwise).

Setting the signature kind to `Testnet` in some test contexts does change test behaviour slightly - before, you could theoretically run a unit test with a compiled config that had `Mainnet` as its signature kind. Now, the test signature kind will always be `Testnet` in these places.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour, aside from the slight test signature kind differences noted above.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)