### PR TITLE
scripts/update-opam-switch: add confirmation before nuking _opam

### DIFF
--- a/scripts/update-opam-switch.sh
+++ b/scripts/update-opam-switch.sh
@@ -10,13 +10,27 @@ cd "$SCRIPT_DIR/.."
 
 sum="$(cksum opam.export | grep -oE '^\S*')"
 switch_dir=opam_switches/"$sum"
-rm -Rf _opam
-if [[ ! -d "$switch_dir" ]]; then
-  # We add o1-labs opam repository and make it default (if it's repeated, it's a no-op)
-  opam repository add --yes --all --set-default o1-labs https://github.com/o1-labs/opam-repository.git
-  opam update
-  opam switch import -y --switch . opam.export
-  mkdir -p opam_switches
-  mv _opam "$switch_dir"
+
+if [[ -d _opam ]]; then
+    read -rp "Directory '_opam' exists and will be removed. Continue? [y/N] " \
+         confirm
+    if [[ "${confirm}" =~ ^[Yy]$ ]]; then
+        rm -Rf _opam
+    else
+        echo "Aborted."
+        exit 1
+    fi
 fi
-ln -s "$switch_dir" _opam
+
+if [[ ! -d "${switch_dir}" ]]; then
+    # We add o1-labs opam repository and make it default
+    # (if it's repeated, it's a no-op)
+    opam repository add --yes --all --set-default o1-labs \
+         https://github.com/o1-labs/opam-repository.git
+    opam update
+    opam switch import -y --switch . opam.export
+    mkdir -p opam_switches
+    mv _opam "${switch_dir}"
+fi
+
+ln -s "${switch_dir}" _opam


### PR DESCRIPTION
Ading a confirmation before deleting `_opam`. The script is called after every commnand in the Makefile.
Instead of changing the default behavior in the Makefile, I prefer to ask for confirmation before any removal.
It happened many times on my machine that I run a target and my local setup was removed.