### PR TITLE
Improve transition router logging

### DIFF
--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -46,6 +46,8 @@ module Reader : sig
 
   val pipe_name : _ t -> string option
 
+  val to_yojson : _ t -> Yojson.Safe.t
+
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
   val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
@@ -118,6 +120,8 @@ module Writer : sig
   type ('t, 'behavior, 'return) t
 
   val pipe_name : (_, _, _) t -> string option
+
+  val to_yojson : (_, _, _) t -> Yojson.Safe.t
 
   val to_linear_pipe : ('t, 'behavior, 'return) t -> 't Linear_pipe.Writer.t
 

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -167,7 +167,6 @@ let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
     ~cache_exceptions ~best_seen_transition ~catchup_mode =
   let open Context in
   [%str_log info] Starting_bootstrap_controller ;
-  [%log info] "Starting Bootstrap Controller phase" ;
   let bootstrap_controller_reader, bootstrap_controller_writer =
     let name = "bootstrap controller pipe" in
     create_buffered_pipe ~name


### PR DESCRIPTION
Transition Router feels impossible for me to debug. Here's some improve making it generate more data to read on logging.

NOTE: Major refactor on Transition Router is happening. So this PR may be no longer irrelevant, we'll see.