### PR TITLE
Move deprecated value out of account update

### DIFF
--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1489,10 +1489,7 @@ module Body = struct
         ; Authorization_kind.Checked.to_input authorization_kind
         ]
 
-    let digest ?signature_kind (t : t) =
-      let signature_kind =
-        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-      in
+    let digest ~signature_kind (t : t) =
       Random_oracle.Checked.(
         hash
           ~init:(Hash_prefix.zkapp_body ~signature_kind)
@@ -1567,10 +1564,7 @@ module Body = struct
       ; Authorization_kind.to_input authorization_kind
       ]
 
-  let digest ?signature_kind (t : t) =
-    let signature_kind =
-      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-    in
+  let digest ~signature_kind (t : t) =
     Random_oracle.(
       hash
         ~init:(Hash_prefix.zkapp_body ~signature_kind)
@@ -1740,12 +1734,12 @@ module T = struct
   let of_simple (p : Simple.t) : Stable.Latest.t =
     { body = Body.of_simple p.body; authorization = p.authorization }
 
-  let digest ?signature_kind t = Body.digest ?signature_kind t.Poly.body
+  let digest ~signature_kind t = Body.digest ~signature_kind t.Poly.body
 
   module Checked = struct
     type t = Body.Checked.t
 
-    let digest ?signature_kind (t : t) = Body.Checked.digest ?signature_kind t
+    let digest ~signature_kind (t : t) = Body.Checked.digest ~signature_kind t
   end
 end
 

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -256,20 +256,31 @@ module Make_digest_str
     module Checked = struct
       include Checked
 
-      let create = Account_update.Checked.digest
+      let create ?signature_kind =
+        let signature_kind =
+          Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+        in
+        Account_update.Checked.digest ~signature_kind
 
-      let create_body = Account_update.Body.Checked.digest
+      let create_body ?signature_kind =
+        let signature_kind =
+          Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+        in
+        Account_update.Body.Checked.digest ~signature_kind
     end
 
-    let create :
-           ?signature_kind:Mina_signature_kind.t
-        -> (Account_update.Body.t, _) Account_update.Poly.t
-        -> t =
-      Account_update.digest
+    let create ?signature_kind :
+        (Account_update.Body.t, _) Account_update.Poly.t -> t =
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      Account_update.digest ~signature_kind
 
-    let create_body :
-        ?signature_kind:Mina_signature_kind.t -> Account_update.Body.t -> t =
-      Account_update.Body.digest
+    let create_body ?signature_kind : Account_update.Body.t -> t =
+      let signature_kind =
+        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
+      in
+      Account_update.Body.digest ~signature_kind
   end
 
   module Forest = struct

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -401,7 +401,7 @@ let%test_module "multisig_account" =
               in
               let tx_statement : Zkapp_statement.t =
                 { account_update =
-                    Account_update.Body.digest
+                    Account_update.Body.digest ~signature_kind
                       (Account_update.of_simple snapp_account_update_data).body
                 ; calls = (Zkapp_command.Digest.Forest.empty :> field)
                 }

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -252,7 +252,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
           in
           let tx_statement : Zkapp_statement.t =
             { account_update =
-                Account_update.Body.digest
+                Account_update.Body.digest ~signature_kind
                   (Account_update.of_simple snapp_account_update_data).body
             ; calls = (Zkapp_command.Digest.Forest.empty :> field)
             }


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17171 in the refactoring of the network/signature kind, making it a runtime-configurable setting. This refactoring has been applied to `mina_base/account_update.ml`, removing the use of that deprecated compiled-config value from the modules in that file.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)
