### PR TITLE
Move deprecated value out of signed_command

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -675,9 +675,10 @@ module Parse = struct
               Signed_command_payload.create ~fee ~fee_payer_pk ~nonce
                 ~valid_until ~memo ~body
             in
+            let signature_kind = Mina_signature_kind.t_DEPRECATED in
             Option.is_some
-            @@ Signed_command.create_with_signature_checked signature signer
-                 payload )
+            @@ Signed_command.create_with_signature_checked ~signature_kind
+                 signature signer payload )
       ; lift = Deferred.return
       }
   end

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -65,7 +65,8 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
       unsigned_transaction.random_oracle_input
   in
   let signature' =
-    Signed_command.sign_payload keys.keypair.private_key user_command_payload
+    Signed_command.sign_payload ~signature_kind keys.keypair.private_key
+      user_command_payload
   in
   [%test_eq: Signature.t] signature signature' ;
   signature |> Signature.Raw.encode

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -272,8 +272,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       { Signed_command_payload.Poly.common; body }
     in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let raw_signature =
-      Signed_command.sign_payload sender.private_key payload
+      Signed_command.sign_payload ~signature_kind sender.private_key payload
       |> Signature.Raw.encode
     in
     let%bind.Async.Deferred zkapp_command_create_accounts =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -133,8 +133,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       { Signed_command_payload.Poly.common; body }
     in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let raw_signature =
-      Signed_command.sign_payload sender.private_key payload
+      Signed_command.sign_payload ~signature_kind sender.private_key payload
       |> Signature.Raw.encode
     in
     (* setup complete *)

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -104,8 +104,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let body = Signed_command_payload.Body.Payment payment_payload in
       { Signed_command_payload.Poly.common; body }
     in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let raw_signature =
-      Signed_command.sign_payload sender.private_key payload
+      Signed_command.sign_payload ~signature_kind sender.private_key payload
       |> Signature.Raw.encode
     in
     match expected_failure with

--- a/src/lib/integration_test_lib/graphql_requests.ml
+++ b/src/lib/integration_test_lib/graphql_requests.ml
@@ -940,6 +940,7 @@ let must_send_payment_with_raw_sig ~logger node_uri ~sender_pub_key
 let sign_and_send_payment ~logger node_uri
     ~(sender_keypair : Import.Signature_keypair.t) ~receiver_pub_key ~amount
     ~fee ~nonce ~memo ~valid_until =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let sender_pub_key =
     sender_keypair.public_key |> Signature_lib.Public_key.compress
   in
@@ -959,7 +960,8 @@ let sign_and_send_payment ~logger node_uri
     { Signed_command_payload.Poly.common; body }
   in
   let raw_signature =
-    Signed_command.sign_payload sender_keypair.private_key payload
+    Signed_command.sign_payload ~signature_kind sender_keypair.private_key
+      payload
     |> Signature.Raw.encode
   in
   send_payment_with_raw_sig ~logger node_uri ~sender_pub_key ~receiver_pub_key

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -166,25 +166,21 @@ module Make_str (_ : Wire_types.Concrete) = struct
     Transaction_union_payload.(
       to_input_legacy (of_user_command_payload payload))
 
-  let sign_payload ?signature_kind (private_key : Signature_lib.Private_key.t)
+  let sign_payload ~signature_kind (private_key : Signature_lib.Private_key.t)
       (payload : Payload.t) : Signature.t =
-    let signature_kind =
-      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-    in
     Signature_lib.Schnorr.Legacy.sign ~signature_kind private_key
       (to_input_legacy payload)
 
-  let sign ?signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t
+  let sign ~signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t
       =
     { payload
     ; signer = kp.public_key
-    ; signature = sign_payload ?signature_kind kp.private_key payload
+    ; signature = sign_payload ~signature_kind kp.private_key payload
     }
 
   module For_tests = struct
     (* Pretend to sign a command. Much faster than actually signing. *)
-    let fake_sign ?signature_kind:_ (kp : Signature_keypair.t)
-        (payload : Payload.t) : t =
+    let fake_sign (kp : Signature_keypair.t) (payload : Payload.t) : t =
       { payload; signer = kp.public_key; signature = Signature.dummy }
   end
 
@@ -233,8 +229,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
         match sign_type with
         | `Fake ->
             gen_inner For_tests.fake_sign
-        | `Real ->
-            gen_inner sign
+        | `Real signature_kind ->
+            gen_inner (sign ~signature_kind)
 
       let gen_with_random_participants ?sign_type ~keys ?nonce ?min_amount
           ~max_amount ?min_fee ~fee_range =
@@ -267,7 +263,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
     let sequence :
            ?length:int
-        -> ?sign_type:[ `Fake | `Real ]
+        -> ?sign_type:[ `Fake | `Real of Mina_signature_kind.t ]
         -> ( Signature_lib.Keypair.t
            * Currency.Amount.t
            * Mina_numbers.Account_nonce.t
@@ -368,8 +364,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
               match sign_type with
               | `Fake ->
                   For_tests.fake_sign
-              | `Real ->
-                  sign
+              | `Real signature_kind ->
+                  sign ~signature_kind
             in
             return @@ sign' sender_pk payload )
   end
@@ -413,10 +409,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   (* give transaction ids have version tag *)
   include Codable.Make_base64 (Stable.Latest.With_top_version_tag)
 
-  let check_signature ?signature_kind ({ payload; signer; signature } : t) =
-    let signature_kind =
-      Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-    in
+  let check_signature ~signature_kind ({ payload; signer; signature } : t) =
     Signature_lib.Schnorr.Legacy.verify ~signature_kind signature
       (Snark_params.Tick.Inner_curve.of_affine signer)
       (to_input_legacy payload)
@@ -430,32 +423,37 @@ module Make_str (_ : Wire_types.Concrete) = struct
     List.for_all (public_keys t) ~f:(fun pk ->
         Option.is_some (Public_key.decompress pk) )
 
-  let create_with_signature_checked ?signature_kind signature signer payload =
+  let create_with_signature_checked ~signature_kind signature signer payload =
     let open Option.Let_syntax in
     let%bind signer = Public_key.decompress signer in
     let t = Poly.{ payload; signature; signer } in
-    Option.some_if (check_signature ?signature_kind t && check_valid_keys t) t
+    Option.some_if (check_signature ~signature_kind t && check_valid_keys t) t
 
   let gen_test =
     let open Quickcheck.Let_syntax in
     let%bind keys =
       Quickcheck.Generator.list_with_length 2 Signature_keypair.gen
     in
-    Gen.payment_with_random_participants ~sign_type:`Real
-      ~keys:(Array.of_list keys) ~max_amount:10000 ~fee_range:1000 ()
+    let sign_type = `Real Mina_signature_kind.Testnet in
+    Gen.payment_with_random_participants ~sign_type ~keys:(Array.of_list keys)
+      ~max_amount:10000 ~fee_range:1000 ()
 
   let%test_unit "completeness" =
-    Quickcheck.test ~trials:20 gen_test ~f:(fun t -> assert (check_signature t))
+    let signature_kind = Mina_signature_kind.Testnet in
+    Quickcheck.test ~trials:20 gen_test ~f:(fun t ->
+        assert (check_signature ~signature_kind t) )
 
   let%test_unit "json" =
     Quickcheck.test ~trials:20 ~sexp_of:sexp_of_t gen_test ~f:(fun t ->
         assert (Codable.For_tests.check_encoding (module Stable.Latest) ~equal t) )
 
   (* return type is `t option` here, interface coerces that to `With_valid_signature.t option` *)
-  let check t = Option.some_if (check_signature t && check_valid_keys t) t
+  let check ~signature_kind t =
+    Option.some_if (check_signature ~signature_kind t && check_valid_keys t) t
 
   (* return type is `t option` here, interface coerces that to `With_valid_signature.t option` *)
-  let check_only_for_signature t = Option.some_if (check_signature t) t
+  let check_only_for_signature ~signature_kind t =
+    Option.some_if (check_signature ~signature_kind t) t
 
   let forget_check t = t
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -16,7 +16,7 @@ module type Gen_intf = sig
      * and an amount $\in [1,max_amount]$
     *)
     val payment :
-         ?sign_type:[ `Fake | `Real ]
+         ?sign_type:[ `Fake | `Real of Mina_signature_kind.t ]
       -> key_gen:
            (Signature_keypair.t * Signature_keypair.t) Quickcheck.Generator.t
       -> ?nonce:Account_nonce.t
@@ -34,7 +34,7 @@ module type Gen_intf = sig
      * and an amount $\in [1,max_amount]$
     *)
     val payment_with_random_participants :
-         ?sign_type:[ `Fake | `Real ]
+         ?sign_type:[ `Fake | `Real of Mina_signature_kind.t ]
       -> keys:Signature_keypair.t array
       -> ?nonce:Account_nonce.t
       -> ?min_amount:int
@@ -66,7 +66,7 @@ module type Gen_intf = sig
     *)
     val sequence :
          ?length:int
-      -> ?sign_type:[ `Fake | `Real ]
+      -> ?sign_type:[ `Fake | `Real of Mina_signature_kind.t ]
       -> ( Signature_lib.Keypair.t
          * Currency.Amount.t
          * Mina_numbers.Account_nonce.t
@@ -147,21 +147,21 @@ module type S = sig
   end
 
   val sign_payload :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> Signature_lib.Private_key.t
     -> Signed_command_payload.t
     -> Signature.t
 
   val sign :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> Signature_keypair.t
     -> Signed_command_payload.t
     -> With_valid_signature.t
 
-  val check_signature : ?signature_kind:Mina_signature_kind.t -> t -> bool
+  val check_signature : signature_kind:Mina_signature_kind.t -> t -> bool
 
   val create_with_signature_checked :
-       ?signature_kind:Mina_signature_kind.t
+       signature_kind:Mina_signature_kind.t
     -> Signature.t
     -> Public_key.Compressed.t
     -> Signed_command_payload.t
@@ -170,18 +170,16 @@ module type S = sig
   val check_valid_keys : t -> bool
 
   module For_tests : sig
-    (** the signature kind is an argument, to match `sign`, but ignored *)
     val fake_sign :
-         ?signature_kind:Mina_signature_kind.t
-      -> Signature_keypair.t
-      -> Signed_command_payload.t
-      -> With_valid_signature.t
+      Signature_keypair.t -> Signed_command_payload.t -> With_valid_signature.t
   end
 
   (** checks signature and keys *)
-  val check : t -> With_valid_signature.t option
+  val check :
+    signature_kind:Mina_signature_kind.t -> t -> With_valid_signature.t option
 
-  val check_only_for_signature : t -> With_valid_signature.t option
+  val check_only_for_signature :
+    signature_kind:Mina_signature_kind.t -> t -> With_valid_signature.t option
 
   val to_valid_unsafe :
        t

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -69,7 +69,8 @@ let gen_signed =
     Quickcheck.Generator.list_with_length 2
       Mina_base_import.Signature_keypair.gen
   in
-  G.payment_with_random_participants ~sign_type:`Real ~keys:(Array.of_list keys)
+  let sign_type = `Real Mina_signature_kind.t_DEPRECATED in
+  G.payment_with_random_participants ~sign_type ~keys:(Array.of_list keys)
     ~max_amount:10000 ~fee_range:1000 ()
 
 let gen = Gen.to_signed_command gen_signed
@@ -344,9 +345,10 @@ end
 
 module For_tests = struct
   let check_verifiable (t : Verifiable.t) : Valid.t Or_error.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     match t with
     | Signed_command x -> (
-        match Signed_command.check x with
+        match Signed_command.check ~signature_kind x with
         | Some c ->
             Ok (Signed_command c)
         | None ->

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1170,7 +1170,10 @@ module Mutations = struct
                 ~memo:(Signed_command_memo.create_from_string_exn memo)
                 ~body
             in
-            let signature = Ok (Signed_command.sign_payload sender payload) in
+            let signature_kind = Mina_signature_kind.t_DEPRECATED in
+            let signature =
+              Ok (Signed_command.sign_payload ~signature_kind sender payload)
+            in
             [%log info]
               "Payment scheduler with handle %s is sending a payment from \
                sender %s"
@@ -2564,7 +2567,8 @@ module Queries = struct
             user_command_input
           |> Deferred.Result.map_error ~f:Error.to_string_hum
         in
-        Signed_command.check_signature user_command )
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
+        Signed_command.check_signature ~signature_kind user_command )
 
   let runtime_config =
     field "runtimeConfig"

--- a/src/lib/secrets/hardware_wallets.ml
+++ b/src/lib/secrets/hardware_wallets.ml
@@ -121,8 +121,9 @@ let sign ~hd_index ~public_key ~user_command_payload :
       |> Deferred.Result.map_error ~f:report_process_error
     in
     let%bind signature = decode_signature signature_str |> Deferred.return in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     match
-      Signed_command.create_with_signature_checked signature
+      Signed_command.create_with_signature_checked ~signature_kind signature
         (Public_key.compress public_key)
         user_command_payload
     with

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -39,7 +39,8 @@ let create_ledger_and_transactions
         ~memo:Signed_command_memo.dummy ~valid_until:None
         ~body:(Payment { receiver_pk = to_pk; amount })
     in
-    Signed_command.sign from_kp payload
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+    Signed_command.sign ~signature_kind from_kp payload
   in
   let nonces =
     Public_key.Compressed.Table.of_alist_exn

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -266,7 +266,12 @@ module Inputs = struct
                             (* Validate the received transaction *)
                             match w.transaction with
                             | Command (Signed_command cmd) -> (
-                                match Signed_command.check cmd with
+                                let signature_kind =
+                                  Mina_signature_kind.t_DEPRECATED
+                                in
+                                match
+                                  Signed_command.check ~signature_kind cmd
+                                with
                                 | Some cmd ->
                                     ( Ok (Command (Signed_command cmd))
                                       : Transaction.Valid.t Or_error.t )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2931,9 +2931,10 @@ let%test_module "staged ledger tests" =
       let%bind ledger_init_state = Ledger.gen_initial_ledger_state in
       let%bind iters = Int.gen_incl 1 (max_blocks_for_coverage 0) in
       let num_cmds = transaction_capacity * iters in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let%bind cmds =
-        User_command.Valid.Gen.sequence ~length:num_cmds ~sign_type:`Real
-          ledger_init_state
+        User_command.Valid.Gen.sequence ~length:num_cmds
+          ~sign_type:(`Real signature_kind) ledger_init_state
       in
       assert (List.length cmds = num_cmds) ;
       return (ledger_init_state, cmds, List.init iters ~f:(Fn.const None))
@@ -3032,9 +3033,10 @@ let%test_module "staged ledger tests" =
       let%bind ledger_init_state = Ledger.gen_initial_ledger_state in
       let iters = max_blocks_for_coverage extra_block_count in
       let total_cmds = transaction_capacity * iters in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let%bind cmds =
-        User_command.Valid.Gen.sequence ~length:total_cmds ~sign_type:`Real
-          ledger_init_state
+        User_command.Valid.Gen.sequence ~length:total_cmds
+          ~sign_type:(`Real signature_kind) ledger_init_state
       in
       assert (List.length cmds = total_cmds) ;
       return (ledger_init_state, cmds, List.init iters ~f:(Fn.const None))
@@ -3058,9 +3060,10 @@ let%test_module "staged ledger tests" =
           (Int.gen_incl 1 ((transaction_capacity / 2) - 1))
       in
       let total_cmds = List.fold cmds_per_iter ~init:0 ~f:( + ) in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let%bind cmds =
-        User_command.Valid.Gen.sequence ~length:total_cmds ~sign_type:`Real
-          ledger_init_state
+        User_command.Valid.Gen.sequence ~length:total_cmds
+          ~sign_type:(`Real signature_kind) ledger_init_state
       in
       assert (List.length cmds = total_cmds) ;
       return (ledger_init_state, cmds, List.map ~f:Option.some cmds_per_iter)
@@ -4243,8 +4246,10 @@ let%test_module "staged ledger tests" =
         Signed_command.Payload.create ~fee ~fee_payer_pk:source_pk ~nonce
           ~memo:Signed_command_memo.dummy ~valid_until:None ~body
       in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let signed_command =
-        User_command.Signed_command (Signed_command.sign kp payload)
+        User_command.Signed_command
+          (Signed_command.sign ~signature_kind kp payload)
       in
       (ledger_init_state, signed_command, global_slot)
 
@@ -4318,7 +4323,9 @@ let%test_module "staged ledger tests" =
             Signed_command.Payload.create ~fee ~fee_payer_pk ~nonce
               ~memo:Signed_command_memo.dummy ~valid_until:None ~body
           in
-          User_command.Signed_command (Signed_command.sign kp payload)
+          let signature_kind = Mina_signature_kind.t_DEPRECATED in
+          User_command.Signed_command
+            (Signed_command.sign ~signature_kind kp payload)
         in
         let signed_command =
           let kp, balance, nonce, _ = ledger_init_state.(0) in
@@ -4416,6 +4423,7 @@ let%test_module "staged ledger tests" =
       (test_spec, kp, global_slot)
 
     let%test_unit "When creating diff, invalid commands would be skipped" =
+      let signature_kind = Mina_signature_kind.Testnet in
       let gen =
         let open Quickcheck.Generator.Let_syntax in
         let%bind spec_keypair_and_slot = gen_spec_keypair_and_global_slot in
@@ -4465,7 +4473,8 @@ let%test_module "staged ledger tests" =
                 ~fee_payer_pk:Public_key.(compress fee_payer.public_key)
                 ~nonce ~memo:Signed_command_memo.dummy ~valid_until:None ~body
             in
-            User_command.Signed_command (Signed_command.sign fee_payer payload)
+            User_command.Signed_command
+              (Signed_command.sign ~signature_kind fee_payer payload)
           in
           let mk_zkapp_command ~(fee_payer : Keypair.t) ?(fee = default_fee)
               ~(nonce : Account.Nonce.t) () =

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -113,8 +113,10 @@ let%test_module "transaction_status" =
 
     (* TODO: Generate zkApps txns *)
     let gen_user_command =
-      Signed_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~fee_range:10
-        ~key_gen ~nonce:(Account_nonce.of_int 1) ()
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
+      Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
+        ~max_amount:100 ~fee_range:10 ~key_gen ~nonce:(Account_nonce.of_int 1)
+        ()
 
     let create_pool ~frontier_broadcast_pipe =
       let config =

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2410,7 +2410,8 @@ module For_tests = struct
       { Transaction_spec.fee; sender = sender, sender_nonce; receiver; amount }
       : Signed_command.t =
     let sender_pk = Public_key.compress sender.public_key in
-    Signed_command.sign sender
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+    Signed_command.sign ~signature_kind sender
       { common =
           { fee
           ; fee_payer_pk = sender_pk

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -15,6 +15,8 @@ let%test_module "account timing check" =
   ( module struct
     open Mina_ledger.Ledger.For_tests
 
+    let signature_kind = Mina_signature_kind.Testnet
+
     let constraint_constants =
       Genesis_constants.For_unit_tests.Constraint_constants.t
 
@@ -496,7 +498,7 @@ let%test_module "account timing check" =
           Quickcheck.Generator.all
           @@ List.map keypairss ~f:(fun (kp1, kp2) ->
                  let%map payment =
-                   Signed_command.Gen.payment ~sign_type:`Real
+                   Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
                      ~key_gen:(return (kp1, kp2))
                      ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
                  in
@@ -554,7 +556,7 @@ let%test_module "account timing check" =
         let amount = 100_000_000_000 in
         let%map user_command =
           let%map payment =
-            Signed_command.Gen.payment ~sign_type:`Real
+            Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
               ~key_gen:(return @@ List.hd_exn keypairss)
               ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
           in
@@ -612,7 +614,7 @@ let%test_module "account timing check" =
         in
         let amount = 100_000_000_000 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
         in
@@ -664,7 +666,7 @@ let%test_module "account timing check" =
         let amount = 100_000_000_000 in
         let%map user_command =
           let%map payment =
-            Signed_command.Gen.payment ~sign_type:`Real
+            Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
               ~key_gen:(return @@ List.hd_exn keypairss)
               ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
           in
@@ -723,7 +725,7 @@ let%test_module "account timing check" =
         in
         let%map user_command =
           let%map payment =
-            Signed_command.Gen.payment ~sign_type:`Real
+            Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
               ~key_gen:(return @@ List.hd_exn keypairss)
               ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
           in
@@ -772,7 +774,7 @@ let%test_module "account timing check" =
         let amount = 9_000_000_000_000 in
         let%map user_command =
           let%map payment =
-            Signed_command.Gen.payment ~sign_type:`Real
+            Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
               ~key_gen:(return @@ List.hd_exn keypairss)
               ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
           in
@@ -819,7 +821,7 @@ let%test_module "account timing check" =
         in
         let amount = 100_000_000_000_000 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
         in
@@ -863,7 +865,7 @@ let%test_module "account timing check" =
         in
         let amount = 20 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:5 ()
         in
@@ -908,7 +910,7 @@ let%test_module "account timing check" =
         in
         let amount = 10_000_000_000_000 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
         in
@@ -956,7 +958,7 @@ let%test_module "account timing check" =
         in
         let amount = 1_000 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
         in
@@ -1006,7 +1008,7 @@ let%test_module "account timing check" =
         in
         let amount = 1_000 in
         let%map user_command =
-          Signed_command.Gen.payment ~sign_type:`Real
+          Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
             ~key_gen:(return @@ List.hd_exn keypairss)
             ~min_amount:amount ~max_amount:amount ~fee_range:0 ()
         in
@@ -1151,7 +1153,7 @@ let%test_module "account timing check" =
                 (i, i)
           in
           let%bind cmd =
-            Signed_command.Gen.payment ~sign_type:`Real
+            Signed_command.Gen.payment ~sign_type:(`Real signature_kind)
               ~key_gen:(return @@ List.hd_exn keypairss)
               ~min_amount ~max_amount ~fee_range:0 ()
           in

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -664,7 +664,9 @@ let%test_module "Transaction union tests" =
           ~memo ~body
       in
       let signer = Signature_lib.Keypair.of_private_key_exn signer in
-      let user_command = Signed_command.sign signer payload in
+      let user_command =
+        Signed_command.sign ~signature_kind:U.signature_kind signer payload
+      in
       U.test_transaction_union ?expected_failure ledger
         (Command (Signed_command user_command)) ;
       let fee_payer = Signed_command.Payload.fee_payer payload in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -472,8 +472,10 @@ module Wallet = struct
         ~nonce ~memo ~valid_until:None
         ~body:(Payment { receiver_pk; amount = Amount.of_nanomina_int_exn amt })
     in
-    let signature = Signed_command.sign_payload fee_payer.private_key payload in
-    Signed_command.check
+    let signature =
+      Signed_command.sign_payload ~signature_kind fee_payer.private_key payload
+    in
+    Signed_command.check ~signature_kind
       Signed_command.Poly.Stable.Latest.
         { payload
         ; signer = Public_key.of_private_key_exn fee_payer.private_key
@@ -488,8 +490,10 @@ module Wallet = struct
         ~nonce ~memo ~valid_until:None
         ~body:(Stake_delegation (Set_delegate { new_delegate = delegate_pk }))
     in
-    let signature = Signed_command.sign_payload fee_payer.private_key payload in
-    Signed_command.check
+    let signature =
+      Signed_command.sign_payload ~signature_kind fee_payer.private_key payload
+    in
+    Signed_command.check ~signature_kind
       Signed_command.Poly.Stable.Latest.
         { payload
         ; signer = Public_key.of_private_key_exn fee_payer.private_key

--- a/src/lib/transaction_snark/transaction_validator.ml
+++ b/src/lib/transaction_snark/transaction_validator.ml
@@ -87,9 +87,10 @@ let%test_unit "invalid transactions do not dirty the ledger" =
         ~memo:Signed_command_memo.dummy
         ~body:(Signed_command_payload.Body.Payment payment)
     in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     Option.value_exn
-      (Signed_command.create_with_signature_checked
-         (Signed_command.sign_payload sender_sk payload)
+      (Signed_command.create_with_signature_checked ~signature_kind
+         (Signed_command.sign_payload ~signature_kind sender_sk payload)
          sender_pk payload )
   in
   Ledger.create_new_account_exn ledger sender_id sender_account ;

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -338,7 +338,8 @@ module For_tests = struct
             ~nonce ~valid_until:None ~memo:Signed_command_memo.dummy
             ~body:(Payment { receiver_pk; amount = send_amount })
         in
-        Signed_command.sign sender_keypair payload )
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
+        Signed_command.sign ~signature_kind sender_keypair payload )
 
   let gen ?(logger = Logger.null ()) ?(send_to_random_pk = false)
       ~(precomputed_values : Precomputed_values.t) ~verifier

--- a/src/lib/user_command_input/user_command_input.ml
+++ b/src/lib/user_command_input/user_command_input.ml
@@ -133,16 +133,18 @@ let create ?nonce ~fee ~fee_payer_pk ~valid_until ~memo ~body ~signer
   in
   { payload; signer; signature = sign_choice }
 
-let sign ~signer ~(user_command_payload : Signed_command_payload.t) = function
+let sign ~signer ~(user_command_payload : Signed_command_payload.t) =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  function
   | Sign_choice.Signature signature ->
       Option.value_map
         ~default:(Deferred.return (Error "Invalid_signature"))
-        (Signed_command.create_with_signature_checked signature signer
-           user_command_payload )
+        (Signed_command.create_with_signature_checked ~signature_kind signature
+           signer user_command_payload )
         ~f:Deferred.Result.return
   | Keypair signer_kp ->
       Deferred.Result.return
-        (Signed_command.sign signer_kp user_command_payload)
+        (Signed_command.sign ~signature_kind signer_kp user_command_payload)
   | Hd_index hd_index ->
       Secrets.Hardware_wallets.sign ~hd_index
         ~public_key:(Public_key.decompress_exn signer)

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -35,10 +35,11 @@ let invalid_to_error (invalid : invalid) : Error.t =
       Error.tag ~tag:"Invalid_proof" err
 
 let check_signed_command c =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   if not (Signed_command.check_valid_keys c) then
     Result.Error (`Invalid_keys (Signed_command.public_keys c))
   else
-    match Signed_command.check_only_for_signature c with
+    match Signed_command.check_only_for_signature ~signature_kind c with
     | Some _ ->
         Result.Ok (`Assuming [])
     | None ->


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17187 in the refactoring of the network/signature kind, making it a runtime-configurable setting. This refactoring has been applied to `mina_base/signed_command.ml` and its `signed_command_intf.ml`, removing the use of that deprecated compiled-config value from the modules in that file.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour, other than the slight difference that certain tests now always use the `Mina_signature_kind.Testnet` signature kind.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)