### PR TITLE
Use nixos-24.11-small

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,16 +325,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713180868,
-        "narHash": "sha256-5CSnPSCEWeUmrFiLuYIQIPQzPrpCB8x3VhE+oXLRO3k=",
+        "lastModified": 1747187171,
+        "narHash": "sha256-heMv6zpxnLYhdcMtUxSn8PWaDLKlJCvQwhbarTNrXYI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "140546acf30a8212a03a88ded8506413fa3b5d21",
+        "rev": "97bd66213bef339d11520ee2e84e3907394b16c7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11-small",
+        "ref": "nixos-24.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -307,6 +307,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1713180868,
@@ -434,6 +450,7 @@
         "nix-utils": "nix-utils",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-mozilla": "nixpkgs-mozilla",
+        "nixpkgs-old": "nixpkgs-old",
         "o1-opam-repository": "o1-opam-repository",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository",

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
 
   inputs.utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11-small";
+  inputs.nixpkgs-old.url = "github:nixos/nixpkgs/nixos-23.05-small";
 
   inputs.mix-to-nix.url = "github:serokell/mix-to-nix";
   inputs.nix-npm-buildPackage.url = "github:serokell/nix-npm-buildpackage";
@@ -54,7 +55,7 @@
 
   outputs = inputs@{ self, nixpkgs, utils, mix-to-nix, nix-npm-buildPackage
     , opam-nix, opam-repository, nixpkgs-mozilla, flake-buildkite-pipeline
-    , nix-utils, flockenzeit, ... }:
+    , nix-utils, flockenzeit, nixpkgs-old, ... }:
     let
       inherit (nixpkgs) lib;
 
@@ -95,7 +96,6 @@
             requireSubmodules (import ./nix/ocaml.nix { inherit inputs pkgs; });
         };
       };
-
       nixosModules.mina = import ./nix/modules/mina.nix inputs;
       # Mina Demo container
       # Use `nixos-container create --flake mina`
@@ -267,6 +267,10 @@
           } else {
             rocksdb-mina = pkgs.rocksdb;
           };
+        go119Overlay = (_: _: {
+          inherit (nixpkgs-old.legacyPackages.${system})
+            go_1_19 buildGo119Module;
+        });
 
         # nixpkgs with all relevant overlays applied
         pkgs = nixpkgs.legacyPackages.${system}.extend
@@ -281,7 +285,8 @@
                   nodejs = pkgs.nodejs-16_x;
                 };
             })
-          ] ++ builtins.attrValues self.overlays ++ [ rocksdbOverlay ]));
+          ] ++ builtins.attrValues self.overlays
+            ++ [ rocksdbOverlay go119Overlay ]));
 
         checks = import ./nix/checks.nix inputs pkgs;
 
@@ -312,17 +317,18 @@
           rocksdb.tools
         ];
       in {
+
         inherit ocamlPackages;
 
         # Main user-facing binaries.
-        packages = rec {
+        packages = (rec {
           inherit (ocamlPackages)
             mina devnet mainnet mina_tests mina-ocaml-format mina_client_sdk
             test_executive with-instrumentation;
           # Granular nix
           inherit (ocamlPackages)
-            src exes all all-tested pkgs all-exes files tested info
-            dune-description base-libs external-libs;
+            src exes all all-tested all-exes files tested info dune-description
+            base-libs external-libs;
           # ^ TODO move elsewhere, external-libs isn't a package
           # TODO consider the following: inherit (ocamlPackages) default;
           granular = ocamlPackages.default;
@@ -334,6 +340,9 @@
             mina-image-slim mina-image-full mina-archive-image-full
             mina-image-instr-full;
           mina-deb = debianPackages.mina;
+          impure-shell = (import ./nix/impure-shell.nix pkgs).inputDerivation;
+        }) // {
+          inherit (ocamlPackages) pkgs;
         };
 
         # Pure dev shell, from which you can build Mina yourself manually, or hack on it.
@@ -372,8 +381,6 @@
           '';
           buildInputs = [ self.packages.${system}.test_executive ];
         };
-        packages.impure-shell =
-          (import ./nix/impure-shell.nix pkgs).inputDerivation;
 
         # An "impure" shell, giving you the system deps of Mina, opam, cargo and go.
         devShells.impure = import ./nix/impure-shell.nix pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -262,10 +262,10 @@
     } // utils.lib.eachDefaultSystem (system:
       let
         rocksdbOverlay = pkgs: prev:
-          if prev.stdenv.isAarch64 || prev.stdenv.isDarwin then {
-            rocksdb-mina = pkgs.rocksdb;
-          } else {
+          if prev.stdenv.isx86_64 then {
             rocksdb-mina = pkgs.rocksdb511;
+          } else {
+            rocksdb-mina = pkgs.rocksdb;
           };
 
         # nixpkgs with all relevant overlays applied
@@ -306,10 +306,8 @@
           libiconv
           cargo
           curl
-          (pkgs.python3.withPackages (python-pkgs: [
-              python-pkgs.click
-              python-pkgs.requests
-            ]))
+          (pkgs.python3.withPackages
+            (python-pkgs: [ python-pkgs.click python-pkgs.requests ]))
           jq
           rocksdb.tools
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   };
 
   inputs.utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11-small";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11-small";
   inputs.nixpkgs-old.url = "github:nixos/nixpkgs/nixos-23.05-small";
 
   inputs.mix-to-nix.url = "github:serokell/mix-to-nix";
@@ -413,6 +413,6 @@
 
         inherit checks;
 
-        formatter = pkgs.nixfmt;
+        formatter = pkgs.nixfmt-classic;
       });
 }

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,4 +1,10 @@
-# An overlay defining Go parts&dependencies of Mina
+# An overlay with an additional parameter buildGo119Module
+# defining Go parts&dependencies of Mina
+
+# We are using legacy Go 1.19 because it's hardcoded
+# in libp2p libraries, and we'd need to update these libraries in
+# order to use a higher version
+
 final: prev: {
   vend = final.callPackage ./vend { };
 

--- a/nix/misc.nix
+++ b/nix/misc.nix
@@ -26,55 +26,17 @@ final: prev: {
     ];
   });
 
-  rocksdb511 = final.stdenv.mkDerivation (_:
-    let
-      buildAndInstallFlags =
-        [ "USE_RTTI=1" "DEBUG_LEVEL=0" "DISABLE_WARNING_AS_ERROR=1" ];
-    in {
-      pname = "rocksdb";
-      version = "5.11.3";
-
-      src = final.fetchFromGitHub {
-        owner = "facebook";
-        repo = "rocksdb";
-        rev = "v5.11.3";
-        hash = "sha256:15x2r7aib1xinwcchl32wghs8g96k4q5xgv6z97mxgp35475x01p";
-      };
-
-      outputs = [ "out" ];
-
-      nativeBuildInputs = with final; [ which perl ];
-      buildInputs = with final; [ gflags ];
-
-      postPatch = ''
-        # Hack to fix typos
-        sed -i 's,#inlcude,#include,g' build_tools/build_detect_platform
-      '';
-
-      # Environment vars used for building certain configurations
-      PORTABLE = "1";
-      USE_SSE = "1";
-      CMAKE_CXX_FLAGS = "-std=gnu++11";
-      JEMALLOC_LIB = "";
-
-      # ${if enableLite then "LIBNAME" else null} = "librocksdb_lite";
-      # ${if enableLite then "CXXFLAGS" else null} = "-DROCKSDB_LITE=1";
-
-      buildFlags = buildAndInstallFlags ++ [ "static_lib" ];
-
-      installFlags = buildAndInstallFlags
-        ++ [ "INSTALL_PATH=\${out}" "install-static" ];
-
-      enableParallelBuilding = true;
-
-      meta = with final.lib; {
-        homepage = "http://rocksdb.org";
-        description =
-          "A library that provides an embeddable, persistent key-value store for fast storage";
-        license = licenses.bsd3;
-        platforms = platforms.all;
-        maintainers = with maintainers; [ adev wkennington ];
-      };
-    });
-    
+  rocksdb511 = let
+    impl = (import (fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/nixos-19.03-small.tar.gz";
+      sha256 = "11z6ajj108fy2q5g8y4higlcaqncrbjm3dnv17pvif6avagw4mcb";
+    }) { system = "x86_64-linux"; }).rocksdb.override {
+      snappy = null;
+      lz4 = null;
+      bzip2 = null;
+    };
+  in if impl.version == "5.11.3" then
+    impl
+  else
+    throw "Expected rocksdb version 5.11.3, but got ${impl.version}";
 }

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -62,9 +62,20 @@ let
           '';
         };
 
-        rocksdb_stubs = super.rocksdb_stubs.overrideAttrs {
-          MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
-        };
+        rocksdb_stubs = super.rocksdb_stubs.overrideAttrs (oa: {
+          MINA_ROCKSDB = let
+            mainPath = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
+            staticPath = "${
+                pkgs.rocksdb-mina.static or pkgs.rocksdb-mina
+              }/lib/librocksdb.a";
+          in if builtins.pathExists mainPath then
+            mainPath
+          else if builtins.pathExists staticPath then
+            staticPath
+          else
+            throw
+            "Could not find librocksdb.a in either ${mainPath} or ${staticPath}";
+        });
 
         # This is needed because
         # - lld package is not wrapped to pick up the correct linker flags

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -496,5 +496,5 @@ let
 
       inherit dune-description base-libs external-libs;
     };
-in scope.overrideScope'
+in scope.overrideScope
 (pkgs.lib.composeManyExtensions ([ overlay granularOverlay ]))

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -2,10 +2,15 @@
 final: prev:
 let
   rustPlatformFor = rust:
-    prev.makeRustPlatform {
-      cargo = rust;
-      rustc = rust;
-      # override stdenv.targetPlatform here, if necessary
+    let
+      rustWithTargetPlatforms = rust // {
+        # Ensure compatibility with nixpkgs >= 24.11
+        targetPlatforms = final.lib.platforms.all;
+        badTargetPlatforms = [ ];
+      };
+    in prev.makeRustPlatform {
+      cargo = rustWithTargetPlatforms;
+      rustc = rustWithTargetPlatforms;
     };
   toolchainHashes = {
     "1.81.0" = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -9,7 +9,8 @@ let
     };
   toolchainHashes = {
     "1.81.0" = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
-    "nightly-2024-09-05" = "sha256-s5nlYcYG9EuO2HK2BU3PkI928DZBKCTJ4U9bz3RX1t4=";
+    "nightly-2024-09-05" =
+      "sha256-s5nlYcYG9EuO2HK2BU3PkI928DZBKCTJ4U9bz3RX1t4=";
     # copy the placeholder line with the correct toolchain name when adding a new toolchain
     # That is,
     # 1. Put the correct version name;
@@ -95,9 +96,8 @@ in {
   in rust_platform.buildRustPackage {
     pname = "kimchi_stubs_static_lib";
     version = "0.1.0";
-    src = final.lib.sourceByRegex ../src [
-      "^lib(/crypto(/proof-systems(/.*)?)?)?$"
-    ];
+    src = final.lib.sourceByRegex ../src
+      [ "^lib(/crypto(/proof-systems(/.*)?)?)?$" ];
     sourceRoot = "source/lib/crypto/proof-systems";
     nativeBuildInputs = [ final.ocamlPackages_mina.ocaml ];
     buildInputs = with final; lib.optional stdenv.isDarwin libiconv;
@@ -110,8 +110,8 @@ in {
       cargo build -p kimchi-stubs --release --lib
     '';
     installPhase = ''
-        mkdir -p $out/lib
-        cp target/release/libkimchi_stubs.a $out/lib/
+      mkdir -p $out/lib
+      cp target/release/libkimchi_stubs.a $out/lib/
     '';
     doCheck = false;
   };

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -161,7 +161,7 @@ in {
         sha256 = "sha256-IPxP68xtNSpwJjV2yNMeepAS0anzGl02hYlSTvPocz8=";
       };
 
-      cargoSha256 = "sha256-pBeQaG6i65uJrJptZQLuIaCb/WCQMhba1Z1OhYqA8Zc=";
+      cargoHash = "sha256-pBeQaG6i65uJrJptZQLuIaCb/WCQMhba1Z1OhYqA8Zc=";
       nativeBuildInputs = [ final.pkg-config ];
 
       buildInputs = with final;


### PR DESCRIPTION
Use 24.11 channel instead of 23.11.

o1js is already on a newer channel, so it makes sense to update both.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
