### PR TITLE
Mina Stdlib: Add Time.Span

### DIFF
--- a/src/lib/mina_stdlib/tests/dune
+++ b/src/lib/mina_stdlib/tests/dune
@@ -1,0 +1,18 @@
+(test
+ (name main)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async_kernel
+  async_unix
+  base
+  sexplib0
+  yojson
+  alcotest
+  ;; local libraries
+  mina_stdlib
+  ppx_version.runtime)
+ (preprocess
+  (pps ppx_jane ppx_version ppx_deriving.std ppx_base ppx_let ppx_assert))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/lib/mina_stdlib/tests/main.ml
+++ b/src/lib/mina_stdlib/tests/main.ml
@@ -1,0 +1,34 @@
+(** Testing
+    -------
+    Component:  Mina stdlib
+    Invocation: dune exec src/lib/mina_stdlib/tests/main.exe
+    Subject:    Main test runner for mina_stdlib tests
+ *)
+
+(* Run all tests *)
+let () =
+  let open Alcotest in
+  run "Time.Span.Stable.V1 JSON roundtrip"
+    [ ( "basic roundtrip tests"
+      , [ test_case "basic json roundtrip" `Quick
+            Time_test.test_basic_json_roundtrip
+        ; test_case "zero span roundtrip" `Quick
+            Time_test.test_zero_span_roundtrip
+        ; test_case "positive span roundtrip" `Quick
+            Time_test.test_positive_span_roundtrip
+        ; test_case "negative span roundtrip" `Quick
+            Time_test.test_negative_span_roundtrip
+        ; test_case "fraction span roundtrip" `Quick
+            Time_test.test_fraction_span_roundtrip
+        ; test_case "very small span roundtrip" `Quick
+            Time_test.test_very_small_span_roundtrip
+        ; test_case "large span roundtrip" `Quick
+            Time_test.test_large_span_roundtrip
+        ] )
+    ; ( "error cases"
+      , [ test_case "invalid json input" `Quick
+            Time_test.test_invalid_json_input
+        ; test_case "non-float json type" `Quick
+            Time_test.test_non_float_json_type
+        ] )
+    ]

--- a/src/lib/mina_stdlib/tests/time_test.ml
+++ b/src/lib/mina_stdlib/tests/time_test.ml
@@ -1,0 +1,117 @@
+open Core_kernel
+
+(** Testing
+    -------
+    Component:  Mina stdlib
+    Invocation: dune exec src/lib/mina_stdlib/tests/main.exe
+    Subject:    Test JSON roundtrip for Time.Span.Stable.V1
+ *)
+
+module SpanV1 = Mina_stdlib.Time.Span.Stable.V1
+
+(* Test that basic JSON serialization roundtrip works *)
+let test_basic_json_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 42.0 in
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Roundtrip equality" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test zero span roundtrip *)
+let test_zero_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 0.0 in
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Zero span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test positive span roundtrip *)
+let test_positive_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 86400.0 in
+  (* One day *)
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Positive span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test negative span roundtrip *)
+let test_negative_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec (-3600.0) in
+  (* Negative one hour *)
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Negative span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test fraction span roundtrip *)
+let test_fraction_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 0.001 in
+  (* 1 millisecond *)
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Fraction span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test very small span roundtrip *)
+let test_very_small_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 1e-6 in
+  (* 1 microsecond *)
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Very small span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test large span roundtrip *)
+let test_large_span_roundtrip () =
+  let span = Core_kernel.Time.Span.of_sec 31536000.0 in
+  (* 1 year *)
+  let json = SpanV1.to_yojson span in
+  match SpanV1.of_yojson json with
+  | Ok decoded ->
+      Alcotest.(check bool)
+        "Large span roundtrip" true
+        (Core_kernel.Time.Span.equal span decoded)
+  | Error msg ->
+      Alcotest.fail ("JSON parsing failed: " ^ msg)
+
+(* Test invalid JSON input *)
+let test_invalid_json_input () =
+  match SpanV1.of_yojson (`String "not a valid float") with
+  | Ok _ ->
+      Alcotest.fail "Expected error for invalid input"
+  | Error _ ->
+      (* Expected error, test passes *)
+      ()
+
+(* Test non-float JSON type *)
+let test_non_float_json_type () =
+  match SpanV1.of_yojson (`Bool true) with
+  | Ok _ ->
+      Alcotest.fail "Expected error for non-float JSON type"
+  | Error _ ->
+      (* Expected error, test passes *)
+      ()

--- a/src/lib/mina_stdlib/time.ml
+++ b/src/lib/mina_stdlib/time.ml
@@ -1,0 +1,28 @@
+open Core_kernel
+
+module Span = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* NOTE:
+         `Core_kernel.Time.Stable.Span.V3.t` tracks time in seconds in an IEEE754
+         64bit float. Hence conversion to/from float poses no precision lost.
+      *)
+      type t = Core_kernel.Time.Stable.Span.V3.t [@@deriving sexp]
+
+      let to_yojson span = `Float (Time.Span.to_sec span)
+
+      let of_yojson = function
+        | `Float span ->
+            Ok (Time.Span.of_sec span)
+        | _ ->
+            Error "Mina_stdlib.Time.Span: Could not parse"
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  [%%define_locally Stable.Latest.(to_yojson, of_yojson)]
+
+  include Core_kernel.Time.Span
+end


### PR DESCRIPTION
This generic time span type is needed, as new snark worker would include a `span_since_unix_epoch` in the work spec. It represents the instant a snark work is issued. 

`Core_kernel.Time.Span` doesn't have a yojson implementation and `Core_kernel.Time` is not serializable(also we need to deal with timezone hassle if we use it). Hence I think this solution is simpler & better.

For tests, I think we're fine without test for this PR, but tell me if we should add tests. I think if we want any, it would be specifically on lossless round-tripping.
