### PR TITLE
Lift `Ledger Proof Prod` to to level to avoid module alias

### DIFF
--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -3,69 +3,63 @@ open Mina_base
 
 module type S = Ledger_proof_intf.S
 
-module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
-  [%%versioned
-  module Stable = struct
-    module V2 = struct
-      type t = Transaction_snark.Stable.V2.t
-      [@@deriving compare, equal, sexp, yojson, hash]
+[%%versioned
+module Stable = struct
+  module V2 = struct
+    type t = Transaction_snark.Stable.V2.t
+    [@@deriving compare, equal, sexp, yojson, hash]
 
-      let to_latest = Fn.id
-    end
-  end]
-
-  let statement (t : t) = Transaction_snark.statement t
-
-  let statement_with_sok (t : t) = Transaction_snark.statement_with_sok t
-
-  let sok_digest = Transaction_snark.sok_digest
-
-  let statement_target (t : Mina_state.Snarked_ledger_state.t) = t.target
-
-  let statement_with_sok_target (t : Mina_state.Snarked_ledger_state.With_sok.t)
-      =
-    t.target
-
-  let underlying_proof = Transaction_snark.proof
-
-  let snarked_ledger_hash =
-    Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash statement
-
-  let create ~statement ~sok_digest ~proof =
-    Transaction_snark.create ~statement:{ statement with sok_digest } ~proof
-
-  module Cached = struct
-    type t =
-      ( Mina_state.Snarked_ledger_state.With_sok.t
-      , Proof_cache_tag.t )
-      Proof_carrying_data.t
-
-    let write_proof_to_disk ~proof_cache_db (t : Stable.Latest.t) : t =
-      { Proof_carrying_data.proof =
-          Proof_cache_tag.write_proof_to_disk proof_cache_db
-            (Transaction_snark.proof t)
-      ; data = Transaction_snark.statement_with_sok t
-      }
-
-    let read_proof_from_disk
-        ({ Proof_carrying_data.data = statement; proof } : t) : Stable.Latest.t
-        =
-      Transaction_snark.create ~statement
-        ~proof:(Proof_cache_tag.read_proof_from_disk proof)
-
-    let statement (t : t) = { t.data with sok_digest = () }
-
-    let sok_digest (t : t) = t.data.sok_digest
-
-    let underlying_proof (t : t) = t.proof
-
-    let create ~(statement : Mina_state.Snarked_ledger_state.t) ~sok_digest
-        ~proof : t =
-      { Proof_carrying_data.proof; data = { statement with sok_digest } }
+    let to_latest = Fn.id
   end
-end
+end]
 
-include Prod
+let statement (t : t) = Transaction_snark.statement t
+
+let statement_with_sok (t : t) = Transaction_snark.statement_with_sok t
+
+let sok_digest = Transaction_snark.sok_digest
+
+let statement_target (t : Mina_state.Snarked_ledger_state.t) = t.target
+
+let statement_with_sok_target (t : Mina_state.Snarked_ledger_state.With_sok.t) =
+  t.target
+
+let underlying_proof = Transaction_snark.proof
+
+let snarked_ledger_hash =
+  Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash statement
+
+let create ~statement ~sok_digest ~proof =
+  Transaction_snark.create ~statement:{ statement with sok_digest } ~proof
+
+module Cached = struct
+  type t =
+    ( Mina_state.Snarked_ledger_state.With_sok.t
+    , Proof_cache_tag.t )
+    Proof_carrying_data.t
+
+  let write_proof_to_disk ~proof_cache_db (t : Stable.Latest.t) : t =
+    { Proof_carrying_data.proof =
+        Proof_cache_tag.write_proof_to_disk proof_cache_db
+          (Transaction_snark.proof t)
+    ; data = Transaction_snark.statement_with_sok t
+    }
+
+  let read_proof_from_disk ({ Proof_carrying_data.data = statement; proof } : t)
+      : Stable.Latest.t =
+    Transaction_snark.create ~statement
+      ~proof:(Proof_cache_tag.read_proof_from_disk proof)
+
+  let statement (t : t) = { t.data with sok_digest = () }
+
+  let sok_digest (t : t) = t.data.sok_digest
+
+  let underlying_proof (t : t) = t.proof
+
+  let create ~(statement : Mina_state.Snarked_ledger_state.t) ~sok_digest ~proof
+      : t =
+    { Proof_carrying_data.proof; data = { statement with sok_digest } }
+end
 
 module For_tests = struct
   let mk_dummy_proof statement =

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -1,8 +1,6 @@
 module type S = Ledger_proof_intf.S
 
-module Prod : S with type t = Transaction_snark.t
-
-include S with type t = Prod.t
+include S with type t = Transaction_snark.t
 
 module For_tests : sig
   val mk_dummy_proof : Mina_state.Snarked_ledger_state.t -> t

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -20,7 +20,7 @@ module Cache = struct
 end
 
 module Inputs = struct
-  module Ledger_proof = Ledger_proof.Prod
+  module Ledger_proof = Ledger_proof
 
   module Worker_state = struct
     module type S = Transaction_snark.S

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -10,7 +10,7 @@ type t =
   ; blockchain_verification_key : Pickles.Verification_key.t
   ; transaction_verification_key : Pickles.Verification_key.t
   ; verify_transaction_snarks :
-         (Ledger_proof.Prod.t * Mina_base.Sok_message.t) list
+         (Ledger_proof.t * Mina_base.Sok_message.t) list
       -> unit Or_error.t Or_error.t Deferred.t
   }
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -10,7 +10,7 @@ type invalid = Common.invalid [@@deriving bin_io_unversioned, to_yojson]
 
 let invalid_to_error = Common.invalid_to_error
 
-type ledger_proof = Ledger_proof.Prod.t
+type ledger_proof = Ledger_proof.t
 
 module Processor = struct
   let verify_commands

--- a/src/lib/verifier/prod.mli
+++ b/src/lib/verifier/prod.mli
@@ -1,1 +1,1 @@
-include Verifier_intf.S with type ledger_proof = Ledger_proof.Prod.t
+include Verifier_intf.S with type ledger_proof = Ledger_proof.t


### PR DESCRIPTION


This PR removed `Ledger_proof.Prod` and lift it to top level. `Ledger_proof.t` and `Ledger_proof.Prod.t` are the exact same thing and there's no reason leaving them as 2 types.
