### PR TITLE
Polymorphize Ledger Proof

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -351,7 +351,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 let ledger_proof_statement =
                   match ledger_proof_opt with
                   | Some (proof, _) ->
-                      Ledger_proof.Cached.statement proof
+                      Ledger_proof.Poly.statement proof
                   | None ->
                       let state =
                         previous_protocol_state
@@ -366,7 +366,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 let supply_increase =
                   Option.value_map ledger_proof_opt
                     ~f:(fun (proof, _) ->
-                      (Ledger_proof.Cached.statement proof).supply_increase )
+                      (Ledger_proof.Poly.statement proof).supply_increase )
                     ~default:Currency.Amount.Signed.zero
                 in
                 let body_reference =

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -41,8 +41,6 @@ end]
 
 let statement_with_sok (t : t) = Transaction_snark.statement_with_sok t
 
-let sok_digest = Transaction_snark.sok_digest
-
 let statement_target (t : Mina_state.Snarked_ledger_state.t) = t.target
 
 let statement_with_sok_target (t : Mina_state.Snarked_ledger_state.With_sok.t) =
@@ -70,8 +68,6 @@ module Cached = struct
       : Stable.Latest.t =
     Transaction_snark.create ~statement
       ~proof:(Proof_cache_tag.read_proof_from_disk proof)
-
-  let sok_digest (t : t) = t.data.sok_digest
 
   let underlying_proof (t : t) = t.proof
 end

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -21,6 +21,10 @@ module Poly = struct
       Mina_state.Snarked_ledger_state.Poly.Stable.V2.t
     , 'proof )
     Proof_carrying_data.t
+
+  let create ~(statement : Mina_state.Snarked_ledger_state.t) ~sok_digest ~proof
+      : _ t =
+    { Proof_carrying_data.proof; data = { statement with sok_digest } }
 end
 
 [%%versioned
@@ -49,9 +53,6 @@ let underlying_proof = Transaction_snark.proof
 let snarked_ledger_hash =
   Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash statement
 
-let create ~statement ~sok_digest ~proof =
-  Transaction_snark.create ~statement:{ statement with sok_digest } ~proof
-
 module Cached = struct
   type t =
     ( Mina_state.Snarked_ledger_state.With_sok.t
@@ -75,20 +76,16 @@ module Cached = struct
   let sok_digest (t : t) = t.data.sok_digest
 
   let underlying_proof (t : t) = t.proof
-
-  let create ~(statement : Mina_state.Snarked_ledger_state.t) ~sok_digest ~proof
-      : t =
-    { Proof_carrying_data.proof; data = { statement with sok_digest } }
 end
 
 module For_tests = struct
   let mk_dummy_proof statement =
-    create ~statement ~sok_digest:Sok_message.Digest.default
+    Poly.create ~statement ~sok_digest:Sok_message.Digest.default
       ~proof:(Lazy.force Proof.transaction_dummy)
 
   module Cached = struct
     let mk_dummy_proof statement =
-      Cached.create ~statement ~sok_digest:Sok_message.Digest.default
+      Poly.create ~statement ~sok_digest:Sok_message.Digest.default
         ~proof:(Lazy.force Proof.For_tests.transaction_dummy_tag)
   end
 end

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -3,6 +3,26 @@ open Mina_base
 
 module type S = Ledger_proof_intf.S
 
+module Poly = struct
+  type ( 'ledger_hash
+       , 'amount
+       , 'pending_coinbase
+       , 'fee_excess
+       , 'sok_digest
+       , 'local_state
+       , 'proof )
+       t =
+    ( ( 'ledger_hash
+      , 'amount
+      , 'pending_coinbase
+      , 'fee_excess
+      , 'sok_digest
+      , 'local_state )
+      Mina_state.Snarked_ledger_state.Poly.Stable.V2.t
+    , 'proof )
+    Proof_carrying_data.t
+end
+
 [%%versioned
 module Stable = struct
   module V2 = struct

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -27,6 +27,8 @@ module Poly = struct
     { Proof_carrying_data.proof; data = { statement with sok_digest } }
 
   let statement (t : _ t) = { t.data with sok_digest = () }
+
+  let underlying_proof (t : _ t) = t.proof
 end
 
 [%%versioned
@@ -45,8 +47,6 @@ let statement_target (t : Mina_state.Snarked_ledger_state.t) = t.target
 
 let statement_with_sok_target (t : Mina_state.Snarked_ledger_state.With_sok.t) =
   t.target
-
-let underlying_proof = Transaction_snark.proof
 
 let snarked_ledger_hash =
   Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash Poly.statement
@@ -68,8 +68,6 @@ module Cached = struct
       : Stable.Latest.t =
     Transaction_snark.create ~statement
       ~proof:(Proof_cache_tag.read_proof_from_disk proof)
-
-  let underlying_proof (t : t) = t.proof
 end
 
 module For_tests = struct

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -25,6 +25,8 @@ module Poly = struct
   let create ~(statement : Mina_state.Snarked_ledger_state.t) ~sok_digest ~proof
       : _ t =
     { Proof_carrying_data.proof; data = { statement with sok_digest } }
+
+  let statement (t : _ t) = { t.data with sok_digest = () }
 end
 
 [%%versioned
@@ -36,8 +38,6 @@ module Stable = struct
     let to_latest = Fn.id
   end
 end]
-
-let statement (t : t) = Transaction_snark.statement t
 
 let statement_with_sok (t : t) = Transaction_snark.statement_with_sok t
 
@@ -51,7 +51,7 @@ let statement_with_sok_target (t : Mina_state.Snarked_ledger_state.With_sok.t) =
 let underlying_proof = Transaction_snark.proof
 
 let snarked_ledger_hash =
-  Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash statement
+  Fn.compose Mina_state.Snarked_ledger_state.snarked_ledger_hash Poly.statement
 
 module Cached = struct
   type t =
@@ -70,8 +70,6 @@ module Cached = struct
       : Stable.Latest.t =
     Transaction_snark.create ~statement
       ~proof:(Proof_cache_tag.read_proof_from_disk proof)
-
-  let statement (t : t) = { t.data with sok_digest = () }
 
   let sok_digest (t : t) = t.data.sok_digest
 

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -81,8 +81,6 @@ module type S = sig
        , Mina_state.Local_state.t )
        Mina_state.Registers.t
 
-  val sok_digest : t -> Sok_message.Digest.t
-
   val underlying_proof : t -> Proof.t
 
   val snarked_ledger_hash : t -> Frozen_ledger_hash.t
@@ -97,8 +95,6 @@ module type S = sig
       proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t
 
     val read_proof_from_disk : t -> Stable.Latest.t
-
-    val sok_digest : t -> Sok_message.Digest.t
 
     val underlying_proof : t -> Proof_cache_tag.t
   end

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -33,6 +33,23 @@ module type S = sig
          , Mina_state.Local_state.t
          , 'proof )
          t
+
+    val statement :
+         ( 'ledger_hash
+         , 'amount
+         , 'pending_coinbase
+         , 'fee_excess
+         , 'sok_digest
+         , 'local_state
+         , 'proof )
+         t
+      -> ( 'ledger_hash
+         , 'amount
+         , 'pending_coinbase
+         , 'fee_excess
+         , unit
+         , 'local_state )
+         Mina_state.Snarked_ledger_state.Poly.t
   end
 
   type t [@@deriving compare, equal, sexp, yojson, hash]
@@ -54,8 +71,6 @@ module type S = sig
        , Pending_coinbase.Stack_versioned.t
        , Mina_state.Local_state.t )
        Mina_state.Registers.t
-
-  val statement : t -> Mina_state.Snarked_ledger_state.t
 
   val statement_with_sok : t -> Mina_state.Snarked_ledger_state.With_sok.t
 
@@ -82,8 +97,6 @@ module type S = sig
       proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t
 
     val read_proof_from_disk : t -> Stable.Latest.t
-
-    val statement : t -> Mina_state.Snarked_ledger_state.t
 
     val sok_digest : t -> Sok_message.Digest.t
 

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -20,6 +20,19 @@ module type S = sig
         Mina_state.Snarked_ledger_state.Poly.Stable.V2.t
       , 'proof )
       Proof_carrying_data.t
+
+    val create :
+         statement:Mina_state.Snarked_ledger_state.t
+      -> sok_digest:'sok_digest
+      -> proof:'proof
+      -> ( Frozen_ledger_hash.t
+         , (Currency.Amount.t, Sgn.t) Currency.Signed_poly.t
+         , Pending_coinbase.Stack_versioned.t
+         , Fee_excess.t
+         , 'sok_digest
+         , Mina_state.Local_state.t
+         , 'proof )
+         t
   end
 
   type t [@@deriving compare, equal, sexp, yojson, hash]
@@ -34,12 +47,6 @@ module type S = sig
       val to_latest : t -> t
     end
   end]
-
-  val create :
-       statement:Mina_state.Snarked_ledger_state.t
-    -> sok_digest:Sok_message.Digest.t
-    -> proof:Proof.t
-    -> t
 
   val statement_target :
        Mina_state.Snarked_ledger_state.t
@@ -81,11 +88,5 @@ module type S = sig
     val sok_digest : t -> Sok_message.Digest.t
 
     val underlying_proof : t -> Proof_cache_tag.t
-
-    val create :
-         statement:Mina_state.Snarked_ledger_state.t
-      -> sok_digest:Sok_message.Digest.t
-      -> proof:Proof_cache_tag.t
-      -> t
   end
 end

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -2,6 +2,26 @@ open Core_kernel
 open Mina_base
 
 module type S = sig
+  module Poly : sig
+    type ( 'ledger_hash
+         , 'amount
+         , 'pending_coinbase
+         , 'fee_excess
+         , 'sok_digest
+         , 'local_state
+         , 'proof )
+         t =
+      ( ( 'ledger_hash
+        , 'amount
+        , 'pending_coinbase
+        , 'fee_excess
+        , 'sok_digest
+        , 'local_state )
+        Mina_state.Snarked_ledger_state.Poly.Stable.V2.t
+      , 'proof )
+      Proof_carrying_data.t
+  end
+
   type t [@@deriving compare, equal, sexp, yojson, hash]
 
   [%%versioned:

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -50,6 +50,8 @@ module type S = sig
          , unit
          , 'local_state )
          Mina_state.Snarked_ledger_state.Poly.t
+
+    val underlying_proof : (_, _, _, _, _, _, 'proof) t -> 'proof
   end
 
   type t [@@deriving compare, equal, sexp, yojson, hash]
@@ -81,8 +83,6 @@ module type S = sig
        , Mina_state.Local_state.t )
        Mina_state.Registers.t
 
-  val underlying_proof : t -> Proof.t
-
   val snarked_ledger_hash : t -> Frozen_ledger_hash.t
 
   module Cached : sig
@@ -95,7 +95,5 @@ module type S = sig
       proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t
 
     val read_proof_from_disk : t -> Stable.Latest.t
-
-    val underlying_proof : t -> Proof_cache_tag.t
   end
 end

--- a/src/lib/mina_block/tests/memory_caching.ml
+++ b/src/lib/mina_block/tests/memory_caching.ml
@@ -46,7 +46,9 @@ let test_do ledger_proofs tmp_dir =
       ledger_proofs
   in
   let n = 10 in
-  let%bind growth = test_mem ~n ~f:Ledger_proof.underlying_proof proofs_file in
+  let%bind growth =
+    test_mem ~n ~f:Ledger_proof.Poly.underlying_proof proofs_file
+  in
   let f p = (Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db p).proof in
   let%map growth_cached = test_mem ~n ~f proofs_file in
   printf "Growth without cache: %d\n" growth ;

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -540,7 +540,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
         Protocol_state.snarked_ledger_hash parent_protocol_state
     | Some (proof, _) ->
         Mina_state.Snarked_ledger_state.snarked_ledger_hash
-        @@ Ledger_proof.Cached.statement proof
+        @@ Ledger_proof.Poly.statement proof
   in
   let hash_errors =
     Result.combine_errors_unit

--- a/src/lib/mina_wire_types/transaction_snark.ml
+++ b/src/lib/mina_wire_types/transaction_snark.ml
@@ -1,8 +1,14 @@
 open Utils
+open Mina_state
 
 module Types = struct
   module type S = sig
-    module V2 : S0
+    module V2 : sig
+      type t =
+        ( Snarked_ledger_state.With_sok.V2.t
+        , Pickles.Proof.Proofs_verified_2.V2.t )
+        Proof_carrying_data.V1.t
+    end
   end
 end
 

--- a/src/lib/mina_wire_types/transaction_snark.mli
+++ b/src/lib/mina_wire_types/transaction_snark.mli
@@ -1,8 +1,14 @@
 open Utils
+open Mina_state
 
 module Types : sig
   module type S = sig
-    module V2 : S0
+    module V2 : sig
+      type t =
+        ( Snarked_ledger_state.With_sok.V2.t
+        , Pickles.Proof.Proofs_verified_2.V2.t )
+        Proof_carrying_data.V1.t
+    end
   end
 end
 

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -530,7 +530,7 @@ module Snark_pool = struct
           in
           let message = Mina_base.Sok_message.create ~fee ~prover in
           ( One_or_two.map statements ~f:(fun statement ->
-                Ledger_proof.create ~statement ~sok_digest
+                Ledger_proof.Poly.create ~statement ~sok_digest
                   ~proof:(Lazy.force Proof.transaction_dummy) )
           , message )
         in

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -467,7 +467,7 @@ module Snark_pool = struct
 
     let of_proof_envelope t =
       Envelope.Incoming.map t ~f:(fun (ps, message) ->
-          (One_or_two.map ~f:Ledger_proof.statement ps, message) )
+          (One_or_two.map ~f:Ledger_proof.Poly.statement ps, message) )
 
     include T
     include Comparable.Make (T)

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -680,7 +680,7 @@ let%test_module "random set test" =
               in
               ( work
               , One_or_two.map work ~f:(fun statement ->
-                    Ledger_proof.create ~statement
+                    Ledger_proof.Poly.create ~statement
                       ~sok_digest:invalid_sok_digest
                       ~proof:(Lazy.force Proof.transaction_dummy) )
               , fee

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -353,7 +353,7 @@ struct
           let open Deferred.Let_syntax in
           let statement_check () =
             One_or_two.Deferred_result.map proofs ~f:(fun (p, s) ->
-                let proof_statement = Ledger_proof.statement p in
+                let proof_statement = Ledger_proof.Poly.statement p in
                 if Transaction_snark.Statement.( = ) proof_statement s then
                   Deferred.Result.return ()
                 else

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -80,7 +80,7 @@ module Worker_state = struct
 
   let ledger_proof_opt next_state = function
     | Some t ->
-        Ledger_proof.(statement_with_sok t, underlying_proof t)
+        Ledger_proof.(statement_with_sok t, Poly.underlying_proof t)
     | None ->
         ( { (Blockchain_state.ledger_proof_statement
                (Protocol_state.blockchain_state next_state) )

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -198,10 +198,10 @@ module Inputs = struct
                                   ~metadata:
                                     [ ( "stmt1"
                                       , Transaction_snark.Statement.to_yojson
-                                          (Ledger_proof.statement prev) )
+                                          (Ledger_proof.Poly.statement prev) )
                                     ; ( "stmt2"
                                       , Transaction_snark.Statement.to_yojson
-                                          (Ledger_proof.statement curr) )
+                                          (Ledger_proof.Poly.statement curr) )
                                     ; ("error", `String (Error.to_string_hum e))
                                     ; ( "inputs"
                                       , zkapp_command_inputs_to_yojson
@@ -238,7 +238,8 @@ module Inputs = struct
                               in
                               if
                                 Transaction_snark.Statement.equal
-                                  (Ledger_proof.statement p) input
+                                  (Ledger_proof.Poly.statement p)
+                                  input
                               then Deferred.return (Ok p)
                               else (
                                 [%log fatal]
@@ -248,7 +249,7 @@ module Inputs = struct
                                   ~metadata:
                                     [ ( "got"
                                       , Transaction_snark.Statement.to_yojson
-                                          (Ledger_proof.statement p) )
+                                          (Ledger_proof.Poly.statement p) )
                                     ; ( "expected"
                                       , Transaction_snark.Statement.to_yojson
                                           input )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2588,7 +2588,7 @@ let%test_module "staged ledger tests" =
     let proofs stmts : Ledger_proof.Cached.t One_or_two.t =
       let sok_digest = Sok_message.Digest.default in
       One_or_two.map stmts ~f:(fun statement ->
-          Ledger_proof.Cached.create ~statement ~sok_digest
+          Ledger_proof.Poly.create ~statement ~sok_digest
             ~proof:(Lazy.force Proof.For_tests.transaction_dummy_tag) )
 
     let stmt_to_work_random_prover (stmts : Transaction_snark_work.Statement.t)

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -140,7 +140,7 @@ module T = struct
       List.exists proofs ~f:(fun (proof, statement, _msg) ->
           not
             (Transaction_snark.Statement.equal
-               (Ledger_proof.statement proof)
+               (Ledger_proof.Poly.statement proof)
                statement ) )
     then
       log_error "Statement and proof do not match"
@@ -149,7 +149,7 @@ module T = struct
             , `List
                 (List.map proofs ~f:(fun (p, _, _) ->
                      Transaction_snark.Statement.to_yojson
-                       (Ledger_proof.statement p) ) ) )
+                       (Ledger_proof.Poly.statement p) ) ) )
           ]
     else
       let start = Time.now () in
@@ -224,7 +224,7 @@ module T = struct
       verify_proofs ~logger ~verifier
         (List.map ts ~f:(fun (p, m) ->
              ( Ledger_proof.Cached.read_proof_from_disk p
-             , Ledger_proof.Cached.statement p
+             , Ledger_proof.Poly.statement p
              , m ) ) )
   end
 
@@ -274,7 +274,7 @@ module T = struct
     let statement_check = `Partial in
     let last_proof_statement =
       Option.map
-        ~f:(fun ((p, _), _) -> Ledger_proof.Cached.statement p)
+        ~f:(fun ((p, _), _) -> Ledger_proof.Poly.statement p)
         (Scan_state.latest_ledger_proof scan_state)
     in
     Statement_scanner.check_invariants ~constraint_constants scan_state
@@ -377,7 +377,7 @@ module T = struct
     in
     let last_proof_statement =
       Scan_state.latest_ledger_proof scan_state
-      |> Option.map ~f:(fun ((p, _), _) -> Ledger_proof.Cached.statement p)
+      |> Option.map ~f:(fun ((p, _), _) -> Ledger_proof.Poly.statement p)
     in
     f ~constraint_constants ~last_proof_statement ~ledger:snarked_ledger
       ~scan_state ~pending_coinbase_collection:pending_coinbases
@@ -946,7 +946,7 @@ module T = struct
             |> to_staged_ledger_or_error
           in
           let ledger_proof_stack =
-            (Ledger_proof.Cached.statement proof).target.pending_coinbase_stack
+            (Ledger_proof.Poly.statement proof).target.pending_coinbase_stack
           in
           let%map () =
             if Pending_coinbase.Stack.equal oldest_stack ledger_proof_stack then
@@ -2682,7 +2682,7 @@ let%test_module "staged ledger tests" =
       let fee_excess =
         Option.value_map ~default:Fee_excess.zero proof_opt
           ~f:(fun (proof, _txns) ->
-            (Ledger_proof.Cached.statement proof).fee_excess )
+            (Ledger_proof.Poly.statement proof).fee_excess )
       in
       assert (Fee_excess.is_zero fee_excess)
 
@@ -2816,7 +2816,7 @@ let%test_module "staged ledger tests" =
                         ~apply_first_pass_sparse_ledger !sl.scan_state
                     in
                     let target_snarked_ledger =
-                      let stmt = Ledger_proof.Cached.statement proof in
+                      let stmt = Ledger_proof.Poly.statement proof in
                       stmt.target.first_pass_ledger
                     in
                     [%test_eq: Ledger_hash.t] target_snarked_ledger

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -667,7 +667,7 @@ struct
 
   let check_invariants (t : t) ~verifier =
     check_invariants_impl t.scan_state
-      ~merge_to_statement:(Fn.compose Ledger_proof.Cached.statement fst)
+      ~merge_to_statement:(Fn.compose Ledger_proof.Poly.statement fst)
       ~verify:(Verifier.verify ~verifier)
 end
 
@@ -676,8 +676,8 @@ let statement_of_job : job -> Transaction_snark.Statement.t option = function
       Some statement
   | Merge ((p1, _), (p2, _)) ->
       Transaction_snark.Statement.merge
-        (Ledger_proof.Cached.statement p1)
-        (Ledger_proof.Cached.statement p2)
+        (Ledger_proof.Poly.statement p1)
+        (Ledger_proof.Poly.statement p2)
       |> Result.ok
 
 let create ~work_delay ~transaction_capacity_log_2 : t =
@@ -1253,7 +1253,7 @@ let extract_from_job (job : job) =
 let snark_job_list_json t =
   let all_jobs : Job_view.t list list =
     let fa (a : Ledger_proof_with_sok_message.t) =
-      Ledger_proof.Cached.statement (fst a)
+      Ledger_proof.Poly.statement (fst a)
     in
     let fd (d : Transaction_with_witness.t) = d.statement in
     Parallel_scan.view_jobs_with_position t.scan_state fa fd
@@ -1346,8 +1346,8 @@ let all_work_pairs t
     | Second (p1, p2) ->
         let%map merged =
           Transaction_snark.Statement.merge
-            (Ledger_proof.Cached.statement p1)
-            (Ledger_proof.Cached.statement p2)
+            (Ledger_proof.Poly.statement p1)
+            (Ledger_proof.Poly.statement p2)
         in
         Snark_work_lib.Work.Single.Spec.Merge (merged, p1, p2)
   in
@@ -1407,14 +1407,14 @@ let fill_work_and_enqueue_transactions t ~logger transactions work =
              } ) )
       proof_opt
       ~f:(fun ((proof, _), _txns_with_witnesses) ->
-        let curr_stmt = Ledger_proof.Cached.statement proof in
+        let curr_stmt = Ledger_proof.Poly.statement proof in
         let prev_stmt, incomplete_zkapp_updates_from_old_proof =
           Option.value_map
             ~default:
               (curr_stmt, ([], `Border_block_continued_in_the_next_tree false))
             old_proof_and_incomplete_zkapp_updates
             ~f:(fun ((p', _), incomplete_zkapp_updates_from_old_proof) ->
-              ( Ledger_proof.Cached.statement p'
+              ( Ledger_proof.Poly.statement p'
               , incomplete_zkapp_updates_from_old_proof ) )
         in
         (*prev_target is connected to curr_source- Order of the arguments is

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -95,7 +95,7 @@ module T = struct
         }
       [@@deriving equal, fields, sexp, yojson]
 
-      let statement t = One_or_two.map t.proofs ~f:Ledger_proof.statement
+      let statement t = One_or_two.map t.proofs ~f:Ledger_proof.Poly.statement
 
       let proofs t = t.proofs
 
@@ -110,10 +110,10 @@ module T = struct
     }
   [@@deriving fields]
 
-  let statement t = One_or_two.map t.proofs ~f:Ledger_proof.Cached.statement
+  let statement t = One_or_two.map t.proofs ~f:Ledger_proof.Poly.statement
 
   let info t =
-    let statements = One_or_two.map t.proofs ~f:Ledger_proof.Cached.statement in
+    let statements = One_or_two.map t.proofs ~f:Ledger_proof.Poly.statement in
     { Info.statements
     ; work_ids = One_or_two.map statements ~f:Transaction_snark.Statement.hash
     ; fee = t.fee

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -441,7 +441,7 @@ module For_tests = struct
       in
       let ledger_proof_statement =
         Option.value_map ledger_proof_opt
-          ~f:(fun (proof, _) -> Ledger_proof.Cached.statement proof)
+          ~f:(fun (proof, _) -> Ledger_proof.Poly.statement proof)
           ~default:previous_ledger_proof_stmt
       in
       let genesis_ledger_hash =

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -376,7 +376,7 @@ module For_tests = struct
              { fee = Fee.of_nanomina_int_exn 1
              ; proofs =
                  One_or_two.map stmts ~f:(fun statement ->
-                     Ledger_proof.Cached.create ~statement
+                     Ledger_proof.Poly.create ~statement
                        ~sok_digest:Sok_message.Digest.default
                        ~proof:(Lazy.force Proof.For_tests.transaction_dummy_tag) )
              ; prover


### PR DESCRIPTION
Spec/Result for Snark worker would be designed in a poly way as many functions are used for both cached/stable types. We need to polymerize underlying Ledger Proof to allow this.  

EDIT: Actually, double checked this is indeed unnecessary