### PR TITLE
Snarked Ledger State: implement Full.Poly.drop_sok

### DIFF
--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -183,6 +183,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ]
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
         ~value_of_hlist:of_hlist
+
+    let drop_sok (t : _ t) = { t with sok_digest = () }
   end
 
   [%%versioned

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -110,6 +110,22 @@ module type Full = sig
          , 'sok_digest
          , Mina_transaction_logic.Zkapp_command_logic.Local_state.Value.t )
          t
+
+    val drop_sok :
+         ( 'ledger_hash
+         , 'amount
+         , 'pending_coinbase
+         , 'fee_excess
+         , 'sok_digest
+         , 'local_state )
+         t
+      -> ( 'ledger_hash
+         , 'amount
+         , 'pending_coinbase
+         , 'fee_excess
+         , unit
+         , 'local_state )
+         t
   end
 
   module Statement_ledgers : sig


### PR DESCRIPTION
This function is needed for Subzkapp level snark works to be cachable. As in a snark worker the caching uses Statement rather than Statement with an Sok for keys.