### PR TITLE
Move Result_without_metrics to a separate file

### DIFF
--- a/src/lib/snark_work_lib/dune
+++ b/src/lib/snark_work_lib/dune
@@ -1,7 +1,6 @@
 (library
  (name snark_work_lib)
  (public_name snark_work_lib)
- (library_flags -linkall)
  (inline_tests
   (flags -verbose -show-counts))
  (libraries

--- a/src/lib/snark_work_lib/result_without_metrics.ml
+++ b/src/lib/snark_work_lib/result_without_metrics.ml
@@ -1,0 +1,11 @@
+(*NOTE: This type is used by GraphQL endpoints and standalone snark worker *)
+type 'proof t =
+  { proofs : 'proof One_or_two.t
+  ; statements : Transaction_snark.Statement.t One_or_two.t
+  ; prover : Signature_lib.Public_key.Compressed.t
+  ; fee : Currency.Fee.t
+  }
+[@@deriving yojson, sexp]
+
+let map ~f_proof { proofs; statements; prover; fee } =
+  { proofs = One_or_two.map ~f:f_proof proofs; statements; prover; fee }

--- a/src/lib/snark_work_lib/result_without_metrics.mli
+++ b/src/lib/snark_work_lib/result_without_metrics.mli
@@ -1,0 +1,9 @@
+type 'proof t =
+  { proofs : 'proof One_or_two.t
+  ; statements : Transaction_snark.Statement.t One_or_two.t
+  ; prover : Signature_lib.Public_key.Compressed.t
+  ; fee : Currency.Fee.t
+  }
+[@@deriving yojson, sexp]
+
+val map : f_proof:('a -> 'b) -> 'a t -> 'b t

--- a/src/lib/snark_work_lib/snark_work_lib.ml
+++ b/src/lib/snark_work_lib/snark_work_lib.ml
@@ -1,0 +1,6 @@
+module Work = struct
+  include Work
+  module Result_without_metrics = Result_without_metrics
+end
+
+module Selector = Selector

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -117,16 +117,3 @@ module Result = struct
     ; prover
     }
 end
-
-module Result_without_metrics = struct
-  type 'proof t =
-    { proofs : 'proof One_or_two.t
-    ; statements : Transaction_snark.Statement.t One_or_two.t
-    ; prover : Signature_lib.Public_key.Compressed.t
-    ; fee : Currency.Fee.t
-    }
-  [@@deriving yojson, sexp]
-
-  let map ~f_proof { proofs; statements; prover; fee } =
-    { proofs = One_or_two.map ~f:f_proof proofs; statements; prover; fee }
-end


### PR DESCRIPTION
This is a noop. I'm reorganizing Snark Work Lib, so it's cleaner when I'm introducing new types.