### PR TITLE
Work Partitioner: implement ID generator

### DIFF
--- a/src/lib/work_partitioner/id_generator.ml
+++ b/src/lib/work_partitioner/id_generator.ml
@@ -1,24 +1,23 @@
 open Core_kernel
 
-(* NOTE: range is both inclusive *)
-type t = { logger : Logger.t; range : int64 * int64; mutable next_id : int64 }
+(* NOTE: This range is both inclusive *)
+let id_lower_bound = Int64.min_value
 
-let create ~logger =
-  { logger
-  ; range = (Int64.min_value, Int64.max_value)
-  ; next_id = Int64.min_value
-  }
+let id_upper_bound = Int64.max_value
+
+type t = { logger : Logger.t; mutable next_id : int64 }
+
+let create ~logger = { logger; next_id = Int64.min_value }
 
 let next_id (t : t) () : Int64.t =
   let open Int64 in
   let result = t.next_id in
-  let lower, upper = t.range in
-  if equal t.next_id upper then (
+  if equal t.next_id id_upper_bound then (
     let logger = t.logger in
     [%log warn]
       "ID generator exceeded upper boundary %Ld, recuring from lower boundry \
        %Ld"
-      upper lower ;
-    t.next_id <- lower )
+      id_upper_bound id_lower_bound ;
+    t.next_id <- id_lower_bound )
   else t.next_id <- succ t.next_id ;
   result

--- a/src/lib/work_partitioner/id_generator.ml
+++ b/src/lib/work_partitioner/id_generator.ml
@@ -1,0 +1,24 @@
+open Core_kernel
+
+(* NOTE: range is both inclusive *)
+type t = { logger : Logger.t; range : int64 * int64; mutable next_id : int64 }
+
+let create ~logger =
+  { logger
+  ; range = (Int64.min_value, Int64.max_value)
+  ; next_id = Int64.min_value
+  }
+
+let next_id (t : t) () : Int64.t =
+  let open Int64 in
+  let result = t.next_id in
+  let lower, upper = t.range in
+  if equal t.next_id upper then (
+    let logger = t.logger in
+    [%log warn]
+      "ID generator exceeded upper boundary %Ld, recuring from lower boundry \
+       %Ld"
+      upper lower ;
+    t.next_id <- lower )
+  else t.next_id <- succ t.next_id ;
+  result

--- a/src/lib/work_partitioner/id_generator.mli
+++ b/src/lib/work_partitioner/id_generator.mli
@@ -1,0 +1,5 @@
+type t
+
+val create : logger:Logger.t -> t
+
+val next_id : t -> unit -> int64


### PR DESCRIPTION
This PR is part of the project Snark Worker Rework.

ID generator is used so Work Partitioner could identify a spec, so it could know which job in the pool SNARK worker is submitting a result for. 

No interface is here because this is considered an internal detail of a work Partitioner.