### PR TITLE
Snark Work Lib: Implement Subzkapp Spec

### DIFF
--- a/src/lib/snark_work_lib/sub_zkapp_spec.ml
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.ml
@@ -1,0 +1,79 @@
+open Core_kernel
+
+[%%versioned
+module Stable = struct
+  [@@@no_toplevel_latest_type]
+
+  module V1 = struct
+    type t =
+      | Segment of
+          { statement : Transaction_snark.Statement.With_sok.Stable.V2.t
+          ; witness :
+              Transaction_snark.Zkapp_command_segment.Witness.Stable.V1.t
+          ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          }
+      | Merge of
+          { proof1 : Ledger_proof.Stable.V2.t
+          ; proof2 : Ledger_proof.Stable.V2.t
+          }
+    [@@deriving sexp, yojson]
+
+    let statement : t -> Transaction_snark.Statement.t = function
+      | Segment { statement; _ } ->
+          Mina_state.Snarked_ledger_state.Poly.drop_sok statement
+      | Merge { proof1; proof2; _ } -> (
+          let stmt1 = Ledger_proof.statement proof1 in
+          let stmt2 = Ledger_proof.statement proof2 in
+          let stmt = Mina_state.Snarked_ledger_state.merge stmt1 stmt2 in
+          match stmt with
+          | Ok stmt ->
+              stmt
+          | Error e ->
+              failwithf
+                "Failed to construct a statement from zkapp merge command %s"
+                (Error.to_string_hum e) () )
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t =
+  | Segment of
+      { statement : Transaction_snark.Statement.With_sok.t
+      ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
+      ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
+      }
+  | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
+
+let read_all_proofs_from_disk : t -> Stable.Latest.t = function
+  | Segment { statement; witness; spec } ->
+      Segment
+        { statement
+        ; witness =
+            Transaction_snark.Zkapp_command_segment.Witness
+            .read_all_proofs_from_disk witness
+        ; spec
+        }
+  | Merge { proof1; proof2 } ->
+      Merge
+        { proof1 = Ledger_proof.Cached.read_proof_from_disk proof1
+        ; proof2 = Ledger_proof.Cached.read_proof_from_disk proof2
+        }
+
+let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
+    Stable.Latest.t -> t = function
+  | Segment { statement; witness; spec } ->
+      Segment
+        { statement
+        ; witness =
+            Transaction_snark.Zkapp_command_segment.Witness
+            .write_all_proofs_to_disk ~proof_cache_db witness
+        ; spec
+        }
+  | Merge { proof1; proof2 } ->
+      Merge
+        { proof1 =
+            Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof1
+        ; proof2 =
+            Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof2
+        }

--- a/src/lib/snark_work_lib/sub_zkapp_spec.mli
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.mli
@@ -1,0 +1,38 @@
+open Core_kernel
+
+[%%versioned:
+module Stable : sig
+  [@@@no_toplevel_latest_type]
+
+  module V1 : sig
+    type t =
+      | Segment of
+          { statement : Transaction_snark.Statement.With_sok.Stable.V2.t
+          ; witness :
+              Transaction_snark.Zkapp_command_segment.Witness.Stable.V1.t
+          ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          }
+      | Merge of
+          { proof1 : Ledger_proof.Stable.V2.t
+          ; proof2 : Ledger_proof.Stable.V2.t
+          }
+    [@@deriving sexp, yojson]
+
+    val statement : t -> Transaction_snark.Statement.t
+
+    val to_latest : t -> t
+  end
+end]
+
+type t =
+  | Segment of
+      { statement : Transaction_snark.Statement.With_sok.t
+      ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
+      ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
+      }
+  | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
+
+val read_all_proofs_from_disk : t -> Stable.Latest.t
+
+val write_all_proofs_to_disk :
+  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -106,6 +106,39 @@ module Zkapp_command_segment_witness = struct
     ; init_stack
     ; block_global_slot
     }
+
+  let write_all_proofs_to_disk ~proof_cache_db
+      ({ global_first_pass_ledger
+       ; global_second_pass_ledger
+       ; local_state_init
+       ; start_zkapp_command
+       ; state_body
+       ; init_stack
+       ; block_global_slot
+       } :
+        Stable.V1.t ) : t =
+    { global_first_pass_ledger
+    ; global_second_pass_ledger
+    ; local_state_init =
+        Mina_transaction_logic.Zkapp_command_logic.Local_state.map_with_hashes
+          ~f:
+            (Zkapp_command.Call_forest.With_hashes.write_all_proofs_to_disk
+               ~proof_cache_db )
+          local_state_init
+    ; start_zkapp_command =
+        List.map
+          ~f:(fun sd ->
+            Mina_transaction_logic.Zkapp_command_logic.Start_data.
+              { sd with
+                account_updates =
+                  Zkapp_command.write_all_proofs_to_disk ~proof_cache_db
+                    sd.account_updates
+              } )
+          start_zkapp_command
+    ; state_body
+    ; init_stack
+    ; block_global_slot
+    }
 end
 
 [%%versioned

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -76,6 +76,9 @@ module Zkapp_command_segment_witness : sig
     }
 
   val read_all_proofs_from_disk : t -> Stable.Latest.t
+
+  val write_all_proofs_to_disk :
+    proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t
 end
 
 [%%versioned:

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -42,7 +42,7 @@ module Zkapp_command_segment_witness : sig
         ; init_stack : Pending_coinbase.Stack_versioned.Stable.V1.t
         ; block_global_slot : Mina_numbers.Global_slot_since_genesis.Stable.V1.t
         }
-      [@@deriving sexp, to_yojson]
+      [@@deriving sexp, yojson]
     end
   end]
 


### PR DESCRIPTION
This PR is part of the project Snark Worker Rework.

This PR implements subzkapp spec, which is either a Merge or a Segment. Later Snark Coordinator could distribute such spec as an option. 