### PR TITLE
[Rosetta fix] Install git & revert rosetta -> mesh change

### DIFF
--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -46,6 +46,7 @@ RUN apt-get update --quiet --yes \
     libssl1.1 \
     tzdata \
     jq \
+    git \
     sudo \
     procps \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -71,7 +71,7 @@ RUN export GOBIN="$(pwd)/bin" \
     && curl -L "https://github.com/coinbase/mesh-cli/archive/refs/tags/v0.10.1.tar.gz" -o "/tmp/v0.10.1.tar.gz" \
     && tar xzf "/tmp/v0.10.1.tar.gz" -C "/tmp" \
     && cd "/tmp/mesh-cli-0.10.1" \
-    && /usr/lib/go/bin/go mod edit -replace github.com/coinbase/mesh-sdk-go@v0.8.1=github.com/MinaProtocol/rosetta-sdk-go@stake-delegation-v1 \
+    && /usr/lib/go/bin/go mod edit -replace github.com/coinbase/rosetta-sdk-go@v0.8.1=github.com/MinaProtocol/rosetta-sdk-go@stake-delegation-v1 \
     && /usr/lib/go/bin/go mod tidy \
     && /usr/lib/go/bin/go install
 


### PR DESCRIPTION
Original issue was: 

```
github.com/coinbase/rosetta-sdk-go/types@v1.0.0: git init --bare in /root/go/pkg/mod/cache/vcs/b533490f0e0edb9a52f10692f73836419bd8db7ac5bda88f3c45fc77ca71fdd7: exec: "git": executable file not found in $PATH
```

Which was fixed by changing lib name from rosetta-sdk-go -> mesh-sdk-go. This unblocked rosetta docker build but caused another problem which is visible on 3 mainline branches at integration tests:

```
Command Failed: unable to create transaction: unable to sign payloads: unable to to sign payload: failed to parse signing payload: payment not found in signingPayload
🚨 Error: The command exited with status 1
```
(https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/183#0196d740-fd12-40d1-9090-75205e843a5f)


Above fix is unfortunately partial since we are using our fork (minaprotocol/rosetta-sdk-go) instead of original mesh library, which was replacing orginal rosetta sdk while building docker. See https://github.com/coinbase/mesh-sdk-go/pull/464. 

After we renamed rosetta-sdk -> mesh-sdk we broke replacement operation since mesh-cli still depends on rosetta-sdk-go not mesh-sdk-go. :

entry after running go mod graph:
```
...
github.com/coinbase/rosetta-cli github.com/coinbase/rosetta-sdk-go@v0.8.1
....
```
This command did not error out but it failed to replace module. As a result we have issue with signingPayload since it uses orginal mesh version which is not compatible with our rosetta impl.

Looks like the correct fix is just to install git, to allow go download and initialize rosetta-sdk-go lib