### PR TITLE
Mina StdLib: implement Heterogenous Hashtable

### DIFF
--- a/src/lib/mina_stdlib/hashtblh.ml
+++ b/src/lib/mina_stdlib/hashtblh.ml
@@ -1,0 +1,35 @@
+module Make (Key : sig
+  type _ t
+
+  val compare : _ t -> _ t -> int
+
+  val hash : _ t -> int
+
+  val sexp_of_t : _ t -> Sexp.t
+end) =
+struct
+  type e = E : 'a -> e
+
+  let unsafe_cast (E x : e) : 'a = Obj.magic x
+
+  module KeyE = struct
+    type t = EK : 'a Key.t -> t
+
+    let compare (EK lhs : t) (EK rhs : t) = Key.compare lhs rhs
+
+    let hash (EK key) = Key.hash key
+
+    let sexp_of_t (EK key) = Key.sexp_of_t key
+  end
+
+  type table = (KeyE.t, e) Hashtbl.t
+
+  let create () = Hashtbl.create (module KeyE)
+
+  let find (type a) (tbl : table) (key : a Key.t) : a option =
+    let%map.Option v = Hashtbl.find tbl (KeyE.EK key) in
+    unsafe_cast v
+
+  let set (type a) (tbl : table) ~(key : a Key.t) ~(data : a) =
+    Hashtbl.set tbl ~key:(KeyE.EK key) ~data:(E data)
+end

--- a/src/lib/mina_stdlib/hashtblh.mli
+++ b/src/lib/mina_stdlib/hashtblh.mli
@@ -1,0 +1,23 @@
+(* NOTE:
+   This module implemented type safe heterogeneous hash table.
+   One unsafe `Obj.magic` is used, GADT is here to guarantee type safety, as long
+   as the underlying yojsonable implementation is injective.
+*)
+
+module Make (Key : sig
+  type _ t
+
+  val compare : _ t -> _ t -> int
+
+  val hash : _ t -> int
+
+  val sexp_of_t : _ t -> Sexp.t
+end) : sig
+  type table
+
+  val create : unit -> table
+
+  val find : table -> 'a Key.t -> 'a option
+
+  val set : table -> key:'a Key.t -> data:'a -> unit
+end


### PR DESCRIPTION
This PR added a Heterogeneous Hash-table, This would be useful when we defining some pattern like

```ocaml
module Key
  type _ t =
    | Int: int -> double t
    | String: string -> bool t
end
```

Now your hash table could contain both mappings from int to double and string to bool. 

I'll add test shortly. 