### PR TITLE
Add actor concurrency model(similar to Elixir)

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.3)
 (implicit_transitive_deps true)
 
+(package (name actor))
 (package (name allocation_functor))
 (package (name archive))
 (package (name archive_blocks))

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -1,5 +1,5 @@
 open Async
-open Core
+open Core_kernel
 
 type 'state msg_processed = MNext of 'state | MExit | MUnprocessed
 
@@ -129,7 +129,7 @@ struct
         let open Deferred.Let_syntax in
         let rec wait_then_enqueue () =
           if Deque.length actor.data_inbox >= capacity then
-            let%bind () = Async.Scheduler.yield () in
+            let%bind () = Scheduler.yield () in
             wait_then_enqueue ()
           else (
             Deque.enqueue_back actor.data_inbox message ;
@@ -239,7 +239,7 @@ struct
               actor.is_running <- false ;
               Deferred.unit
           | MUnprocessed ->
-              let%bind () = Async.Scheduler.yield () in
+              let%bind () = Scheduler.yield () in
               loop ()
       in
 

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -13,9 +13,9 @@ type (_, _, _) overflow_behavior =
   | Drop_head :
       [ `Warns | `No_warns ]
       -> ('data, unit, [ `Drop_head ]) overflow_behavior
-  | Call_head :
+  | Drop_and_call_head :
       ('data -> 'returns)
-      -> ('data, 'returns option, [ `Call_head ]) overflow_behavior
+      -> ('data, 'returns option, [ `Drop_and_call_head ]) overflow_behavior
   | Push_back : ('data, unit Deferred.t, [ `Push_back ]) overflow_behavior
 
 type (_, _, _) channel_type =
@@ -157,7 +157,7 @@ struct
                   ]
           | `No_warns ->
               () )
-    | With_capacity (`Capacity cap, `Overflow (Call_head callback)) ->
+    | With_capacity (`Capacity cap, `Overflow (Drop_and_call_head callback)) ->
         (* NOTE: always enqueue first to deal with capacity 0/negative *)
         Deque.enqueue_back actor.data_inbox message ;
 

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -171,8 +171,6 @@ struct
           Some (callback actor.state head)
         else None
 
-  type process_status = Status_processed | Status_fallthrough | Status_exit
-
   let spawn (actor : _ t) : unit Deferred.Or_error.t =
     let process_msg ~state ~deque ~handler () =
       match Deque.dequeue_front deque with

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -1,0 +1,155 @@
+open Async
+open Core
+
+module Make (DataMessage : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) =
+struct
+  exception
+    ActorDataInboxOverflow of
+      { name : string; capacity : int; attempt_enqueing : DataMessage.t }
+
+  exception RunningActorSpawned of { name : string }
+
+  type (_, _) overflow_behavior =
+    | Throw : (unit Or_error.t, [ `Throw ]) overflow_behavior
+    | Drop_head :
+        [ `Warns | `No_warns ]
+        -> (unit, [ `Drop_head ]) overflow_behavior
+    | Call_head :
+        (DataMessage.t -> 'returns)
+        -> ('returns option, [ `Call_head ]) overflow_behavior
+    | Push_back : (unit Deferred.t, [ `Push_back ]) overflow_behavior
+
+  type (_, _) channel_type =
+    | Infinity : (unit, [ `Infinity ]) channel_type
+    | With_capacity :
+        [ `Capacity of int ]
+        * [ `Overflow of ('returns, 'behavior) overflow_behavior ]
+        -> ('returns, 'behavior) channel_type
+
+  type 'state or_exit = Next of 'state | Exit
+
+  type ('data_returns, 'data_overflew, 'control_msg, 'state) t =
+    { name : string
+    ; control_inbox : 'control_msg Queue.t
+    ; data_inbox : DataMessage.t Queue.t
+    ; data_channel_type : ('data_returns, 'data_overflew) channel_type
+    ; data_handler :
+        state:'state -> message:DataMessage.t -> 'state or_exit Deferred.t
+    ; control_handler :
+        state:'state -> message:'control_msg -> 'state or_exit Deferred.t
+    ; logger : Logger.t
+    ; mutable is_running : bool
+    ; mutable state : 'state
+    }
+
+  let create ~name ~data_channel_type ~data_handler ~control_handler ~logger
+      ~state =
+    { name
+    ; control_inbox = Queue.create ()
+    ; data_inbox = Queue.create ()
+    ; data_channel_type
+    ; data_handler
+    ; control_handler
+    ; logger
+    ; is_running = false
+    ; state
+    }
+
+  let terminate ~(actor : _ t) = actor.is_running <- false
+
+  let send_control ~(actor : _ t) ~message =
+    Queue.enqueue actor.control_inbox message
+
+  let send_data :
+      type data_returns data_overflew.
+         actor:(data_returns, data_overflew, _, _) t
+      -> message:DataMessage.t
+      -> data_returns =
+   fun ~actor ~message ->
+    match actor.data_channel_type with
+    | Infinity ->
+        Queue.enqueue actor.data_inbox message
+    | With_capacity (`Capacity capacity, `Overflow Push_back) ->
+        let open Deferred.Let_syntax in
+        let rec wait_then_enqueue () =
+          if Queue.length actor.data_inbox >= capacity then
+            let%bind () = Async.Scheduler.yield () in
+            wait_then_enqueue ()
+          else (
+            Queue.enqueue actor.data_inbox message ;
+            Deferred.return () )
+        in
+        wait_then_enqueue ()
+    | With_capacity (`Capacity capacity, `Overflow Throw) ->
+        if Queue.length actor.data_inbox >= capacity then
+          Or_error.of_exn
+            (ActorDataInboxOverflow
+               { name = actor.name; capacity; attempt_enqueing = message } )
+        else Ok ()
+    | With_capacity (`Capacity capacity, `Overflow (Drop_head warns_or_not))
+      -> (
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Queue.enqueue actor.data_inbox message ;
+        if Queue.length actor.data_inbox > capacity then
+          let dropped = Queue.dequeue_exn actor.data_inbox in
+          match warns_or_not with
+          | `Warns ->
+              let logger = actor.logger in
+              [%log info]
+                "Actor %s has data inbox capacity %d, dropping head message \
+                 $message"
+                actor.name capacity
+                ~metadata:[ ("message", DataMessage.to_yojson dropped) ]
+          | `No_warns ->
+              () )
+    | With_capacity (`Capacity cap, `Overflow (Call_head callback)) ->
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Queue.enqueue actor.data_inbox message ;
+
+        if Queue.length actor.data_inbox > cap then
+          let head = Queue.dequeue_exn actor.data_inbox in
+          Some (callback head)
+        else None
+
+  let spawn (actor : _ t) : unit Deferred.Or_error.t =
+    if actor.is_running then
+      Deferred.Or_error.of_exn (RunningActorSpawned { name = actor.name })
+    else (
+      actor.is_running <- true ;
+      let rec loop () =
+        if not actor.is_running then Deferred.unit
+        else
+          match Queue.dequeue actor.control_inbox with
+          | Some control_msg -> (
+              let%bind new_state =
+                actor.control_handler ~state:actor.state ~message:control_msg
+              in
+              match new_state with
+              | Next new_state ->
+                  actor.state <- new_state ;
+                  loop ()
+              | Exit ->
+                  Deferred.unit )
+          | None -> (
+              match Queue.dequeue actor.data_inbox with
+              | Some data_msg -> (
+                  let%bind new_state =
+                    actor.data_handler ~state:actor.state ~message:data_msg
+                  in
+                  match new_state with
+                  | Next new_state ->
+                      actor.state <- new_state ;
+                      loop ()
+                  | Exit ->
+                      Deferred.unit )
+              | None ->
+                  let%bind () = Async.Scheduler.yield () in
+                  loop () )
+      in
+      let%bind.Deferred () = loop () in
+      Deferred.Or_error.return () )
+end

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -253,8 +253,7 @@ module Regular (DataMessage : sig
   val to_yojson : t -> Yojson.Safe.t
 end) =
 struct
-  module Inner = WithRequest (DataMessage) (DummyRequest)
-  include Inner
+  include WithRequest (DataMessage) (DummyRequest)
 
   let create = create ~request_handler:{ f = DummyRequest.handler }
 end

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -236,6 +236,7 @@ struct
               actor.state <- state ;
               loop ()
           | MExit ->
+              actor.is_running <- false ;
               Deferred.unit
           | MUnprocessed ->
               let%bind () = Async.Scheduler.yield () in

--- a/src/lib/actor/actor.mli
+++ b/src/lib/actor/actor.mli
@@ -1,0 +1,219 @@
+open Async
+open Core_kernel
+
+(** ['state msg_processed] is the type of result that either a data handler, or
+    a control handler should return.
+    [MNext s] indicates we sucessfully processed the message, and the state of
+    the actor is updated to [s];
+    [MExit] indicates we should stop the actor;
+    [MUnprocessed] indicates we can't process this message now, and hence the
+    message would be put back into the coressponding message queue. *)
+type 'state msg_processed = MNext of 'state | MExit | MUnprocessed
+
+(** [('state, 'response) req_processed] is the type of result returned by a
+    request handler. *)
+type ('state, 'response) req_processed =
+  | RNext of ('state * 'response)
+      (** [RNext (s, r)] indicates we sucessfully processed the message, and the
+          state of the actor is updated to [s], and the response of the request
+          is [r]; *)
+  | RExit of 'response
+      (** [RExit r] indicates we should stop the actor with response of this
+          request being [r]; *)
+  | RUnprocessed
+      (** [RUnprocessed] indicates we can't process this request now, and hence
+          the request would be put back into the request queue. *)
+
+(** [('state, 'data, 'return_type, 'kind) overflow_behavior] defines the
+    behavior the data inbox should have when there's to many data being sent to
+    it. *)
+type (_, _, _, _) overflow_behavior =
+  | Throw : ('state, 'data, unit Or_error.t, [ `Throw ]) overflow_behavior
+      (** We should throw an error *)
+  | Drop_head :
+      [ `Warns | `No_warns ]
+      -> ('state, 'data, unit, [ `Drop_head ]) overflow_behavior
+      (** We should drop the head of queue message. Could log what's being
+          dropped in additional on demand *)
+  | Drop_and_call_head :
+      ('state -> 'data -> 'returns)
+      -> ( 'state
+         , 'data
+         , 'returns option
+         , [ `Drop_and_call_head ] )
+         overflow_behavior
+      (** We should drop the head of queue message. and call it with the
+          callback provided *)
+  | Push_back
+      : ('state, 'data, unit Deferred.t, [ `Push_back ]) overflow_behavior
+      (** We block and provide a signal and return a `Deferred.t` *)
+
+(** [('state, 'data, 'return_type, 'kind) channel_type] defines the kind of
+    channel we're using. *)
+type (_, _, _, _) channel_type =
+  | Infinity : ('state, 'data, unit, [ `Infinity ]) channel_type
+      (** The channel has infinity buffering size so it never overflows *)
+  | With_capacity :
+      [ `Capacity of int ]
+      * [ `Overflow of ('state, 'data, 'returns, 'behavior) overflow_behavior ]
+      -> ('state, 'data, 'returns, 'behavior) channel_type
+      (** [With_capacity (`Capacity c, `Overflow b)] indicates the channel has limited
+      capacitiy [c]. When overflowing it would have behavior [b] *)
+
+(** When either control inbox or data inbox is unused in an actor, we could use
+    [DummyMessage] as a placeholder *)
+module DummyMessage : sig
+  type t = unit [@@deriving to_yojson]
+
+  val handler : state:'a -> message:t -> 'a msg_processed Deferred.t
+end
+
+(** When request inbox is unused in an actor, we could use [DummyRequest] as a
+    placeholder. *)
+module DummyRequest : sig
+  type _ t = Nothing : unit t
+
+  val handler :
+       state:'state
+    -> request:'response t
+    -> ('state, 'response) req_processed Deferred.t
+end
+
+(** The feature complete functor for constructing an actor. *)
+module WithRequest (DataMessage : sig
+  (** type of data being passed to data inbox of an actor *)
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) (Request : sig
+  (** type of request sent to request inbox of an actor *)
+  type _ t
+end) : sig
+  (** The actor data inbox has too many data, this is only trigger when using
+      Throw as overflow_behavior. *)
+  exception
+    ActorDataInboxOverflow of
+      { name : Yojson.Safe.t; capacity : int; attempt_enqueing : DataMessage.t }
+
+  (** An already running actor is being spawned. *)
+  exception RunningActorSpawned of { name : Yojson.Safe.t }
+
+  (** Type of request handler for an actor, this has to be a record due to
+      OCaml's restriction on params passing to a function.  *)
+  type 'state request_handler =
+    { f :
+        'response.
+           state:'state
+        -> request:'response Request.t
+        -> ('state, 'response) req_processed Deferred.t
+    }
+
+  (** Type of a actor *)
+  type ('data_returns, 'data_overflew, 'control_msg, 'state) t
+
+  (** Create an actor with specified fields, it's not running after creation *)
+  val create :
+       name:Yojson.Safe.t
+    -> data_channel_type:
+         ('state, DataMessage.t, 'data_returns, 'data_overflew) channel_type
+    -> request_handler:'state request_handler
+    -> control_handler:
+         (   state:'state
+          -> message:'control_msg
+          -> 'state msg_processed Deferred.t )
+    -> data_handler:
+         (   state:'state
+          -> message:DataMessage.t
+          -> 'state msg_processed Deferred.t )
+    -> logger:Logger.t
+    -> state:'state
+    -> ('data_returns, 'data_overflew, 'control_msg, 'state) t
+
+  (** [terminate ~actor] terminates the actor after the current running cycle. *)
+  val terminate :
+    actor:('data_returns, 'data_overflew, 'control_msg, 'state) t -> unit
+
+  (** [send_request ~actor ~request] sends a request to an actor, it returns a
+      [Deferred.t] that's resolved when the actor processed the request. *)
+  val send_request :
+    'response 'data_returns 'data_overflew 'control_msg 'state.
+       actor:('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> request:'response Request.t
+    -> 'response Deferred.t
+
+  (** [send_request ~actor ~request] sends a control message to an actor. *)
+  val send_control :
+       actor:('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> message:'control_msg
+    -> unit
+
+  (** [send_request ~actor ~request] sends a data message to an actor. *)
+  val send_data :
+    'data_returns 'data_overflew 'control_msg 'state.
+       actor:('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> message:DataMessage.t
+    -> 'data_returns
+
+  (** [spwan actor] run's an actor, it returns a unit when the actor exits, and
+      may throw some errors *)
+  val spawn :
+       ('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> unit Deferred.Or_error.t
+end
+
+module Regular (DataMessage : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) : sig
+  (** The actor data inbox has too many data, this is only trigger when using
+      Throw as overflow_behavior. *)
+  exception
+    ActorDataInboxOverflow of
+      { name : Yojson.Safe.t; capacity : int; attempt_enqueing : DataMessage.t }
+
+  (** An already running actor is being spawned. *)
+  exception RunningActorSpawned of { name : Yojson.Safe.t }
+
+  (** Type of a actor *)
+  type ('data_returns, 'data_overflew, 'control_msg, 'state) t
+
+  (** Create an actor with specified fields, it's not running after creation *)
+  val create :
+       name:Yojson.Safe.t
+    -> data_channel_type:
+         ('state, DataMessage.t, 'data_returns, 'data_overflew) channel_type
+    -> control_handler:
+         (   state:'state
+          -> message:'control_msg
+          -> 'state msg_processed Deferred.t )
+    -> data_handler:
+         (   state:'state
+          -> message:DataMessage.t
+          -> 'state msg_processed Deferred.t )
+    -> logger:Logger.t
+    -> state:'state
+    -> ('data_returns, 'data_overflew, 'control_msg, 'state) t
+
+  val terminate :
+    actor:('data_returns, 'data_overflew, 'control_msg, 'state) t -> unit
+
+  (** [send_control ~actor ~message] sends a control message to an actor. *)
+  val send_control :
+       actor:('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> message:'control_msg
+    -> unit
+
+  (** [send_data ~actor ~message] sends a data message to an actor. *)
+  val send_data :
+    'data_returns 'data_overflew 'control_msg 'state.
+       actor:('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> message:DataMessage.t
+    -> 'data_returns
+
+  (** [spwan actor] run's an actor, it returns a unit when the actor exits, and
+      may throw some errors *)
+  val spawn :
+       ('data_returns, 'data_overflew, 'control_msg, 'state) t
+    -> unit Deferred.Or_error.t
+end

--- a/src/lib/actor/dune
+++ b/src/lib/actor/dune
@@ -1,0 +1,18 @@
+(library
+ (name actor)
+ (public_name actor)
+ (libraries
+  ;; OPAM libraries
+  async
+  core
+  ;; MINA libraries
+  logger)
+  
+ (preprocess
+  (pps
+   ppx_let
+   ppx_mina
+   ppx_version))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Actor pattern for mass concurrency"))

--- a/src/lib/actor/dune
+++ b/src/lib/actor/dune
@@ -4,10 +4,9 @@
  (libraries
   ;; OPAM libraries
   async
-  core
+  core_kernel
   ;; MINA libraries
   logger)
-  
  (preprocess
   (pps
    ppx_let

--- a/src/lib/actor/tests/dune
+++ b/src/lib/actor/tests/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_actor)
+ (libraries
+  ;; OPAM libraries
+  alcotest
+  async
+  core
+  ;; MINA libraries
+  actor
+  logger)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_let)))

--- a/src/lib/actor/tests/ping_pong.ml
+++ b/src/lib/actor/tests/ping_pong.ml
@@ -1,0 +1,64 @@
+open Async
+open Core
+
+module PingMessage = struct
+  type t = Ping [@@deriving yojson]
+end
+
+module PongMessage = struct
+  type t = Pong [@@deriving yojson]
+end
+
+module Ponger = Actor.Make (PingMessage)
+module Pinger = Actor.Make (PongMessage)
+
+let test_case () =
+  let emitted_numbers = Queue.create () in
+  let logger = Logger.create () in
+  let data_handler =
+    ref (fun ~state:_ ~message:_ -> failwith "unimplemented")
+  in
+  let pinger =
+    Pinger.create ~name:"pinger"
+      ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
+      ~data_handler:(fun ~state ~message:Pong ->
+        !data_handler ~state ~message:PongMessage.Pong )
+      ~control_handler:(fun ~state ~message:() ->
+        Deferred.return (Pinger.Next state) )
+      ~logger ~state:10
+  in
+  let ponger =
+    Ponger.create ~name:"ponger"
+      ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
+      ~data_handler:(fun ~state ~message:Ping ->
+        Queue.enqueue emitted_numbers state ;
+        let%bind.Deferred () = Pinger.send_data ~actor:pinger ~message:Pong in
+        Deferred.return (Ponger.Next (state - 1)) )
+      ~control_handler:(fun ~state ~message:() ->
+        Deferred.return (Ponger.Next state) )
+      ~logger ~state:99
+  in
+  (data_handler :=
+     fun ~state ~message:Pong ->
+       Queue.enqueue emitted_numbers state ;
+       if 0 = state - 1 then (
+         Ponger.terminate ~actor:ponger ;
+         Deferred.return Pinger.Exit )
+       else
+         let%bind.Deferred () = Ponger.send_data ~actor:ponger ~message:Ping in
+         Deferred.return (Pinger.Next (state - 1)) ) ;
+  let all_deferred () =
+    Deferred.all
+      [ Ponger.spawn ponger
+      ; Pinger.spawn pinger
+      ; (let%bind () = Pinger.send_data ~actor:pinger ~message:Pong in
+         Deferred.Or_error.return () )
+      ]
+  in
+
+  let _ = Async.Thread_safe.block_on_async all_deferred in
+
+  Alcotest.(check (list int))
+    "ping pong emitted number is expected"
+    (Queue.to_list emitted_numbers)
+    [ 10; 99; 9; 98; 8; 97; 7; 96; 6; 95; 5; 94; 4; 93; 3; 92; 2; 91; 1 ]

--- a/src/lib/actor/tests/ping_pong.ml
+++ b/src/lib/actor/tests/ping_pong.ml
@@ -19,7 +19,7 @@ let test_case () =
     ref (fun ~state:_ ~message:_ -> failwith "unimplemented")
   in
   let pinger =
-    Pinger.create ~name:"pinger"
+    Pinger.create ~name:(`String "pinger")
       ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
       ~data_handler:(fun ~state ~message:Pong ->
         !data_handler ~state ~message:PongMessage.Pong )
@@ -28,7 +28,7 @@ let test_case () =
       ~logger ~state:10
   in
   let ponger =
-    Ponger.create ~name:"ponger"
+    Ponger.create ~name:(`String "ponger")
       ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
       ~data_handler:(fun ~state ~message:Ping ->
         Queue.enqueue emitted_numbers state ;

--- a/src/lib/actor/tests/test_actor.ml
+++ b/src/lib/actor/tests/test_actor.ml
@@ -1,0 +1,5 @@
+let () =
+  let open Alcotest in
+  run "Actor"
+    [ ("ping pong", [ test_case "Simple ping pong" `Quick Ping_pong.test_case ])
+    ]


### PR DESCRIPTION
Next in train: https://github.com/MinaProtocol/mina/pull/17224

NOTE: CI Nightly is passing in the last PR in this train: https://github.com/MinaProtocol/mina/pull/17225

NOTE2: This indeed needs careful review, I've spotted several bugs already.

## Purpose
This is [Actor model](https://en.wikipedia.org/wiki/Actor_model), going to be used to refactor transition router. Well, not strictly because it also supports a server model where an actor could process requests and return responses.


## Potential Improvements
For now we only have 3 inboxes for an Actor: `request`, `control` and `data`, in that priority order. `request` support handling dependently typed requests defined by GADTs. `control` is just a normal queue that never drops any messages.  `data` is supposed to partially simulate `strict_pipe`'s behavior.

This model could be generalized to any number of channels. Utilizing Heterogeneous Lists. This could further be refactored using a heterogeneous priority queue so messages can have customized priority. But it seems for now we don't have a good use case of such actor.

## Benefits

### Hooking into an actor
If everything is modeled as actor, we could design a supervisor system by hooking into Actor implementation, and then we can have a good flamegraph implementation knowing at which time, which actor is running.

### Inspecting an actor
You could just look into the struct to inspect what messages in queue an actor has, and its state. Previously all such abstraction is inside lambda functions -- You just can't identify an lambda without some quirks I guess.

### Mitigate concurrency issues
The very reason I'm trying to introduce this is `Transition_router` has some nasty synchronization bugs, I haven't been able to figure out the fix even knowing the issue. One of the blockers is that there's virtually no good way to debug `Async` code due to everything being lambda, and abusing `don't_wait_for` made the code worse. 