### PR TITLE
Clean up Transition Router dependencies

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -217,7 +217,6 @@
 (package (name transition_frontier_persistent_frontier))
 (package (name transition_frontier_persistent_root))
 (package (name transition_handler))
-(package (name transition_router))
 (package (name trust_system))
 (package (name unsigned_extended))
 (package (name uptime_service))

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -40,9 +40,13 @@
   network_peer
   o1trace
   precomputed_values
+  proof_cache_tag
   proof_carrying_data
   pipe_lib
   signature_lib
+  staged_ledger
+  staged_ledger_diff
+  syncable_ledger
   transition_handler
   transition_frontier
   transition_frontier_base

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -4,51 +4,51 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_mina ppx_version ppx_jane ppx_compare))
+  (pps ppx_compare ppx_jane ppx_mina ppx_version))
  (libraries
   ;; opam libraries
-  integers
-  base.caml
-  async_kernel
-  core_kernel
-  core
   async
+  async_kernel
+  base.caml
+  core
+  core_kernel
+  integers
   sexplib0
   ;; local libraries
   best_tip_prover
-  transition_handler
-  o1trace
-  bounded_types
-  mina_stdlib
-  mina_net2
-  consensus
-  logger
-  error_json
-  trust_system
-  mina_block
-  mina_state
-  transition_frontier_persistent_frontier
-  mina_networking
-  transition_frontier_controller
-  pipe_lib
-  transition_frontier
-  bootstrap_controller
-  mina_intf
-  transition_frontier_persistent_root
-  transition_frontier_base
-  mina_base
-  signature_lib
-  network_peer
-  with_hash
   block_time
-  mina_metrics
-  precomputed_values
-  mina_numbers
-  interruptible
-  genesis_constants
-  unsigned_extended
-  proof_carrying_data
-  ledger_catchup
+  bootstrap_controller
+  bounded_types
+  consensus
   data_hash_lib
+  error_json
+  genesis_constants
+  internal_tracing
+  interruptible
+  ledger_catchup
+  logger
+  mina_base
+  mina_block
+  mina_intf
+  mina_metrics
+  mina_networking
+  mina_numbers
+  mina_net2
+  mina_state
+  mina_stdlib
   mina_wire_types
-  internal_tracing))
+  network_peer
+  o1trace
+  precomputed_values
+  proof_carrying_data
+  pipe_lib
+  signature_lib
+  transition_handler
+  transition_frontier
+  transition_frontier_base
+  transition_frontier_controller
+  transition_frontier_persistent_frontier
+  transition_frontier_persistent_root
+  trust_system
+  unsigned_extended
+  with_hash))

--- a/src/lib/transition_router/dune-project
+++ b/src/lib/transition_router/dune-project
@@ -1,0 +1,4 @@
+(lang dune 3.3)
+(implicit_transitive_deps false)
+
+(package (name transition_router))

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -449,9 +449,9 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ?transition_writer_ref:None ~consensus_local_state
-        ~frontier_w ~persistent_root ~persistent_frontier ~cache_exceptions
-        ~initial_root_transition ~catchup_mode
+        ~clear_reader ~consensus_local_state ~frontier_w ~persistent_root
+        ~persistent_frontier ~cache_exceptions ~initial_root_transition
+        ~catchup_mode
         ~best_seen_transition:
           (Option.map ~f:(fun x -> `Block x) best_seen_transition)
         ()
@@ -479,9 +479,9 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ?transition_writer_ref:None ~consensus_local_state
-        ~frontier_w ~initial_root_transition ~persistent_root
-        ~persistent_frontier ~cache_exceptions ~catchup_mode
+        ~clear_reader ~consensus_local_state ~frontier_w
+        ~initial_root_transition ~persistent_root ~persistent_frontier
+        ~cache_exceptions ~catchup_mode
         ~best_seen_transition:(Some (`Block best_tip))
         ()
   | best_tip_opt, Some frontier ->
@@ -540,8 +540,8 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ~collected_transitions ~cache_exceptions
-        ?transition_writer_ref:None ~frontier_w frontier ()
+        ~clear_reader ~collected_transitions ~cache_exceptions ~frontier_w
+        frontier ()
 
 let wait_till_genesis ~logger ~time_controller
     ~(precomputed_values : Precomputed_values.t) =

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -100,11 +100,11 @@ let is_transition_for_bootstrap
           ~context:(module Context)
           ~existing:root_consensus_state ~candidate:new_consensus_state
 
-let start_transition_frontier_controller ~context:(module Context : CONTEXT)
-    ~trust_system ~verifier ~network ~time_controller ~get_completed_work
-    ~producer_transition_writer_ref ~verified_transition_writer ~clear_reader
-    ~collected_transitions ~cache_exceptions ?transition_writer_ref ~frontier_w
-    frontier =
+let start_transition_frontier_controller ?transition_writer_ref
+    ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
+    ~time_controller ~get_completed_work ~producer_transition_writer_ref
+    ~verified_transition_writer ~clear_reader ~collected_transitions
+    ~cache_exceptions ~frontier_w frontier () =
   let open Context in
   [%str_log info] Starting_transition_frontier_controller ;
   let ( transition_frontier_controller_reader
@@ -159,12 +159,12 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
   |> don't_wait_for ;
   transition_writer_ref
 
-let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
-    ~verifier ~network ~time_controller ~get_completed_work
-    ~producer_transition_writer_ref ~verified_transition_writer ~clear_reader
-    ?transition_writer_ref ~consensus_local_state ~frontier_w
+let start_bootstrap_controller ?transition_writer_ref
+    ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
+    ~time_controller ~get_completed_work ~producer_transition_writer_ref
+    ~verified_transition_writer ~clear_reader ~consensus_local_state ~frontier_w
     ~initial_root_transition ~persistent_root ~persistent_frontier
-    ~cache_exceptions ~best_seen_transition ~catchup_mode =
+    ~cache_exceptions ~best_seen_transition ~catchup_mode () =
   let open Context in
   [%str_log info] Starting_bootstrap_controller ;
   [%log info] "Starting Bootstrap Controller phase" ;
@@ -216,7 +216,7 @@ let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
         ~clear_reader ~collected_transitions ~cache_exceptions
-        ~transition_writer_ref ~frontier_w new_frontier
+        ~transition_writer_ref ~frontier_w new_frontier ()
       |> Fn.const () ) ;
   transition_writer_ref
 
@@ -454,6 +454,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~initial_root_transition ~catchup_mode
         ~best_seen_transition:
           (Option.map ~f:(fun x -> `Block x) best_seen_transition)
+        ()
   | Some best_tip, Some frontier
     when is_transition_for_bootstrap
            ~context:(module Context)
@@ -482,6 +483,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~frontier_w ~initial_root_transition ~persistent_root
         ~persistent_frontier ~cache_exceptions ~catchup_mode
         ~best_seen_transition:(Some (`Block best_tip))
+        ()
   | best_tip_opt, Some frontier ->
       let collected_transitions =
         match best_tip_opt with
@@ -539,7 +541,7 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
         ~clear_reader ~collected_transitions ~cache_exceptions
-        ?transition_writer_ref:None ~frontier_w frontier
+        ?transition_writer_ref:None ~frontier_w frontier ()
 
 let wait_till_genesis ~logger ~time_controller
     ~(precomputed_values : Precomputed_values.t) =
@@ -731,7 +733,8 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
                              ~clear_reader ~transition_writer_ref
                              ~consensus_local_state ~frontier_w ~persistent_root
                              ~persistent_frontier ~initial_root_transition
-                             ~best_seen_transition:(Some b_or_h) ~catchup_mode )
+                             ~best_seen_transition:(Some b_or_h) ~catchup_mode
+                             () )
                       else Deferred.unit
                   | None ->
                       Deferred.unit


### PR DESCRIPTION
NOTE: the correctness of this PR is backed by [this CI nightly run](https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3658#0196e8bb-e344-4aa1-b8ae-3af50bce1bf7)

As title, this is a noop cleaning up transition router's dependency. 

We now add temporary `dune-project` to transition router. We'll finally get rid of all of them once we ensure all modules satisfy `(implicit_transitive_deps false)`, and erase the `(implicit_transitive_deps true)` in the root `dune-project`