### PR TITLE
Refactor Transition Router V2

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.3)
 (implicit_transitive_deps true)
 
+(package (name actor))
 (package (name allocation_functor))
 (package (name archive))
 (package (name archive_blocks))

--- a/src/dune-project
+++ b/src/dune-project
@@ -218,7 +218,6 @@
 (package (name transition_frontier_persistent_frontier))
 (package (name transition_frontier_persistent_root))
 (package (name transition_handler))
-(package (name transition_router))
 (package (name trust_system))
 (package (name unsigned_extended))
 (package (name uptime_service))

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -1,0 +1,155 @@
+open Async
+open Core
+
+module Make (DataMessage : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) =
+struct
+  exception
+    ActorDataInboxOverflow of
+      { name : string; capacity : int; attempt_enqueing : DataMessage.t }
+
+  exception RunningActorSpawned of { name : string }
+
+  type (_, _) overflow_behavior =
+    | Throw : (unit Or_error.t, [ `Throw ]) overflow_behavior
+    | Drop_head :
+        [ `Warns | `No_warns ]
+        -> (unit, [ `Drop_head ]) overflow_behavior
+    | Call_head :
+        (DataMessage.t -> 'returns)
+        -> ('returns option, [ `Call_head ]) overflow_behavior
+    | Push_back : (unit Deferred.t, [ `Push_back ]) overflow_behavior
+
+  type (_, _) channel_type =
+    | Infinity : (unit, [ `Infinity ]) channel_type
+    | With_capacity :
+        [ `Capacity of int ]
+        * [ `Overflow of ('returns, 'behavior) overflow_behavior ]
+        -> ('returns, 'behavior) channel_type
+
+  type 'state or_exit = Next of 'state | Exit
+
+  type ('data_returns, 'data_overflew, 'control_msg, 'state) t =
+    { name : string
+    ; control_inbox : 'control_msg Queue.t
+    ; data_inbox : DataMessage.t Queue.t
+    ; data_channel_type : ('data_returns, 'data_overflew) channel_type
+    ; data_handler :
+        state:'state -> message:DataMessage.t -> 'state or_exit Deferred.t
+    ; control_handler :
+        state:'state -> message:'control_msg -> 'state or_exit Deferred.t
+    ; logger : Logger.t
+    ; mutable is_running : bool
+    ; mutable state : 'state
+    }
+
+  let create ~name ~data_channel_type ~data_handler ~control_handler ~logger
+      ~state =
+    { name
+    ; control_inbox = Queue.create ()
+    ; data_inbox = Queue.create ()
+    ; data_channel_type
+    ; data_handler
+    ; control_handler
+    ; logger
+    ; is_running = false
+    ; state
+    }
+
+  let terminate ~(actor : _ t) = actor.is_running <- false
+
+  let send_control ~(actor : _ t) ~message =
+    Queue.enqueue actor.control_inbox message
+
+  let send_data :
+      type data_returns data_overflew.
+         actor:(data_returns, data_overflew, _, _) t
+      -> message:DataMessage.t
+      -> data_returns =
+   fun ~actor ~message ->
+    match actor.data_channel_type with
+    | Infinity ->
+        Queue.enqueue actor.data_inbox message
+    | With_capacity (`Capacity capacity, `Overflow Push_back) ->
+        let open Deferred.Let_syntax in
+        let rec wait_then_enqueue () =
+          if Queue.length actor.data_inbox >= capacity then
+            let%bind () = Async.Scheduler.yield () in
+            wait_then_enqueue ()
+          else (
+            Queue.enqueue actor.data_inbox message ;
+            Deferred.return () )
+        in
+        wait_then_enqueue ()
+    | With_capacity (`Capacity capacity, `Overflow Throw) ->
+        if Queue.length actor.data_inbox >= capacity then
+          Or_error.of_exn
+            (ActorDataInboxOverflow
+               { name = actor.name; capacity; attempt_enqueing = message } )
+        else Ok ()
+    | With_capacity (`Capacity capacity, `Overflow (Drop_head warns_or_not))
+      -> (
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Queue.enqueue actor.data_inbox message ;
+        if Queue.length actor.data_inbox > capacity then
+          let dropped = Queue.dequeue_exn actor.data_inbox in
+          match warns_or_not with
+          | `Warns ->
+              let logger = actor.logger in
+              [%log info]
+                "Actor %s has data inbox capacity %d, dropping head message \
+                 $message"
+                actor.name capacity
+                ~metadata:[ ("message", DataMessage.to_yojson dropped) ]
+          | `No_warns ->
+              () )
+    | With_capacity (`Capacity cap, `Overflow (Call_head callback)) ->
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Queue.enqueue actor.data_inbox message ;
+
+        if Queue.length actor.data_inbox > cap then
+          let head = Queue.dequeue_exn actor.data_inbox in
+          Some (callback head)
+        else None
+
+  let spawn (actor : _ t) : unit Deferred.Or_error.t =
+    if actor.is_running then
+      Deferred.Or_error.of_exn (RunningActorSpawned { name = actor.name })
+    else (
+      actor.is_running <- true ;
+      let rec loop () =
+        if not actor.is_running then Deferred.unit
+        else
+          match Queue.dequeue actor.control_inbox with
+          | Some control_msg -> (
+              let%bind new_state =
+                actor.control_handler ~state:actor.state ~message:control_msg
+              in
+              match new_state with
+              | Next new_state ->
+                  actor.state <- new_state ;
+                  loop ()
+              | Exit ->
+                  Deferred.unit )
+          | None -> (
+              match Queue.dequeue actor.data_inbox with
+              | Some data_msg -> (
+                  let%bind new_state =
+                    actor.data_handler ~state:actor.state ~message:data_msg
+                  in
+                  match new_state with
+                  | Next new_state ->
+                      actor.state <- new_state ;
+                      loop ()
+                  | Exit ->
+                      Deferred.unit )
+              | None ->
+                  let%bind () = Async.Scheduler.yield () in
+                  loop () )
+      in
+      let%bind.Deferred () = loop () in
+      Deferred.Or_error.return () )
+end

--- a/src/lib/actor/dune
+++ b/src/lib/actor/dune
@@ -1,0 +1,18 @@
+(library
+ (name actor)
+ (public_name actor)
+ (libraries
+  ;; OPAM libraries
+  async
+  core
+  ;; MINA libraries
+  logger)
+  
+ (preprocess
+  (pps
+   ppx_let
+   ppx_mina
+   ppx_version))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Actor pattern for mass concurrency"))

--- a/src/lib/actor/tests/dune
+++ b/src/lib/actor/tests/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_actor)
+ (libraries
+  ;; OPAM libraries
+  alcotest
+  async
+  core
+  ;; MINA libraries
+  actor
+  logger)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_let)))

--- a/src/lib/actor/tests/ping_pong.ml
+++ b/src/lib/actor/tests/ping_pong.ml
@@ -1,0 +1,64 @@
+open Async
+open Core
+
+module PingMessage = struct
+  type t = Ping [@@deriving yojson]
+end
+
+module PongMessage = struct
+  type t = Pong [@@deriving yojson]
+end
+
+module Ponger = Actor.Make (PingMessage)
+module Pinger = Actor.Make (PongMessage)
+
+let test_case () =
+  let emitted_numbers = Queue.create () in
+  let logger = Logger.create () in
+  let data_handler =
+    ref (fun ~state:_ ~message:_ -> failwith "unimplemented")
+  in
+  let pinger =
+    Pinger.create ~name:"pinger"
+      ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
+      ~data_handler:(fun ~state ~message:Pong ->
+        !data_handler ~state ~message:PongMessage.Pong )
+      ~control_handler:(fun ~state ~message:() ->
+        Deferred.return (Pinger.Next state) )
+      ~logger ~state:10
+  in
+  let ponger =
+    Ponger.create ~name:"ponger"
+      ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
+      ~data_handler:(fun ~state ~message:Ping ->
+        Queue.enqueue emitted_numbers state ;
+        let%bind.Deferred () = Pinger.send_data ~actor:pinger ~message:Pong in
+        Deferred.return (Ponger.Next (state - 1)) )
+      ~control_handler:(fun ~state ~message:() ->
+        Deferred.return (Ponger.Next state) )
+      ~logger ~state:99
+  in
+  (data_handler :=
+     fun ~state ~message:Pong ->
+       Queue.enqueue emitted_numbers state ;
+       if 0 = state - 1 then (
+         Ponger.terminate ~actor:ponger ;
+         Deferred.return Pinger.Exit )
+       else
+         let%bind.Deferred () = Ponger.send_data ~actor:ponger ~message:Ping in
+         Deferred.return (Pinger.Next (state - 1)) ) ;
+  let all_deferred () =
+    Deferred.all
+      [ Ponger.spawn ponger
+      ; Pinger.spawn pinger
+      ; (let%bind () = Pinger.send_data ~actor:pinger ~message:Pong in
+         Deferred.Or_error.return () )
+      ]
+  in
+
+  let _ = Async.Thread_safe.block_on_async all_deferred in
+
+  Alcotest.(check (list int))
+    "ping pong emitted number is expected"
+    (Queue.to_list emitted_numbers)
+    [ 10; 99; 9; 98; 8; 97; 7; 96; 6; 95; 5; 94; 4; 93; 3; 92; 2; 91; 1 ]

--- a/src/lib/actor/tests/ping_pong.ml
+++ b/src/lib/actor/tests/ping_pong.ml
@@ -19,7 +19,7 @@ let test_case () =
     ref (fun ~state:_ ~message:_ -> failwith "unimplemented")
   in
   let pinger =
-    Pinger.create ~name:"pinger"
+    Pinger.create ~name:(`String "pinger")
       ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
       ~data_handler:(fun ~state ~message:Pong ->
         !data_handler ~state ~message:PongMessage.Pong )
@@ -28,7 +28,7 @@ let test_case () =
       ~logger ~state:10
   in
   let ponger =
-    Ponger.create ~name:"ponger"
+    Ponger.create ~name:(`String "ponger")
       ~data_channel_type:(With_capacity (`Capacity 1, `Overflow Push_back))
       ~data_handler:(fun ~state ~message:Ping ->
         Queue.enqueue emitted_numbers state ;

--- a/src/lib/actor/tests/test_actor.ml
+++ b/src/lib/actor/tests/test_actor.ml
@@ -1,0 +1,5 @@
+let () =
+  let open Alcotest in
+  run "Actor"
+    [ ("ping pong", [ test_case "Simple ping pong" `Quick Ping_pong.test_case ])
+    ]

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -4,51 +4,55 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_mina ppx_version ppx_jane ppx_compare))
+  (pps ppx_compare ppx_jane ppx_mina ppx_version))
  (libraries
   ;; opam libraries
-  integers
-  base.caml
-  async_kernel
-  core_kernel
-  core
   async
+  async_kernel
+  base.caml
+  core
+  core_kernel
+  integers
   sexplib0
   ;; local libraries
   best_tip_prover
-  transition_handler
-  o1trace
-  bounded_types
-  mina_stdlib
-  mina_net2
-  consensus
-  logger
-  error_json
-  trust_system
-  mina_block
-  mina_state
-  transition_frontier_persistent_frontier
-  mina_networking
-  transition_frontier_controller
-  pipe_lib
-  transition_frontier
-  bootstrap_controller
-  mina_intf
-  transition_frontier_persistent_root
-  transition_frontier_base
-  mina_base
-  signature_lib
-  network_peer
-  with_hash
   block_time
-  mina_metrics
-  precomputed_values
-  mina_numbers
-  interruptible
-  genesis_constants
-  unsigned_extended
-  proof_carrying_data
-  ledger_catchup
+  bootstrap_controller
+  bounded_types
+  consensus
   data_hash_lib
+  error_json
+  genesis_constants
+  internal_tracing
+  interruptible
+  ledger_catchup
+  logger
+  mina_base
+  mina_block
+  mina_intf
+  mina_metrics
+  mina_networking
+  mina_numbers
+  mina_net2
+  mina_state
+  mina_stdlib
   mina_wire_types
-  internal_tracing))
+  network_peer
+  o1trace
+  precomputed_values
+  proof_cache_tag
+  proof_carrying_data
+  pipe_lib
+  signature_lib
+  staged_ledger
+  staged_ledger_diff
+  syncable_ledger
+  transition_handler
+  transition_frontier
+  transition_frontier_base
+  transition_frontier_controller
+  transition_frontier_persistent_frontier
+  transition_frontier_persistent_root
+  trust_system
+  unsigned_extended
+  with_hash))

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -7,6 +7,7 @@
   (pps ppx_compare ppx_jane ppx_mina ppx_version))
  (libraries
   ;; opam libraries
+  actor
   async
   async_kernel
   base.caml

--- a/src/lib/transition_router/dune-project
+++ b/src/lib/transition_router/dune-project
@@ -1,0 +1,4 @@
+(lang dune 3.3)
+(implicit_transitive_deps false)
+
+(package (name transition_router))

--- a/src/lib/transition_router/pipe_guard.ml
+++ b/src/lib/transition_router/pipe_guard.ml
@@ -1,0 +1,70 @@
+open Core
+open Async
+open Pipe_lib
+
+module Make (Data : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) =
+struct
+  type writer =
+    ( Data.t
+    , Strict_pipe.drop_head Strict_pipe.buffered
+    , unit )
+    Strict_pipe.Writer.t
+
+  module Request = struct
+    type _ t =
+      | ClosePipe : { id : int } -> [ `Closed_already_or_replaced | `Ok ] t
+      | ReplacePipe : writer -> int t
+  end
+
+  type state = { writer : writer option; id : int }
+
+  module Guard = Actor.WithRequest (Data) (Request)
+
+  let data_handler ~(state : state) ~(message : Data.t) =
+    Deferred.return
+      ( match state.writer with
+      | None ->
+          Actor.MUnprocessed
+      | Some writer ->
+          Strict_pipe.Writer.write writer message ;
+          Actor.MNext state )
+
+  let request_handler :
+      type response.
+         state:state
+      -> request:response Request.t
+      -> (state, response) Actor.req_processed Deferred.t =
+   fun ~state ~request ->
+    let open Request in
+    match request with
+    | ClosePipe { id = request_id } -> (
+        match state with
+        | { id = held_id; writer = Some writer } when held_id = request_id ->
+            Strict_pipe.Writer.kill writer ;
+            Deferred.return (Actor.RNext ({ state with writer = None }, `Ok))
+        | _ ->
+            Deferred.return (Actor.RNext (state, `Closed_already_or_replaced)) )
+    | ReplacePipe writer ->
+        Option.iter state.writer ~f:(fun writer ->
+            Strict_pipe.Writer.kill writer ) ;
+        (* WARN:
+           We know that the new writer provided is always valid because pipe
+           guard would only receive ClosePipe after ReplacePipe. If that's not
+           true we need to fix here.
+        *)
+        let new_id = state.id + 1 in
+        Deferred.return
+          (Actor.RNext ({ writer = Some writer; id = new_id }, new_id))
+
+  [%%define_locally Guard.(spawn, send_data, send_control, send_request)]
+
+  let create ~logger () =
+    Guard.create ~name:(`String "Valid Transition Pipe Guard")
+      ~request_handler:{ f = request_handler }
+      ~control_handler:Actor.DummyMessage.handler ~data_channel_type:Infinity
+      ~data_handler ~logger ~state:{ writer = None; id = 0 }
+end

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -100,11 +100,11 @@ let is_transition_for_bootstrap
           ~context:(module Context)
           ~existing:root_consensus_state ~candidate:new_consensus_state
 
-let start_transition_frontier_controller ~context:(module Context : CONTEXT)
-    ~trust_system ~verifier ~network ~time_controller ~get_completed_work
-    ~producer_transition_writer_ref ~verified_transition_writer ~clear_reader
-    ~collected_transitions ~cache_exceptions ?transition_writer_ref ~frontier_w
-    frontier =
+let start_transition_frontier_controller ?transition_writer_ref
+    ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
+    ~time_controller ~get_completed_work ~producer_transition_writer_ref
+    ~verified_transition_writer ~clear_reader ~collected_transitions
+    ~cache_exceptions ~frontier_w frontier () =
   let open Context in
   [%str_log info] Starting_transition_frontier_controller ;
   let ( transition_frontier_controller_reader
@@ -159,12 +159,12 @@ let start_transition_frontier_controller ~context:(module Context : CONTEXT)
   |> don't_wait_for ;
   transition_writer_ref
 
-let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
-    ~verifier ~network ~time_controller ~get_completed_work
-    ~producer_transition_writer_ref ~verified_transition_writer ~clear_reader
-    ?transition_writer_ref ~consensus_local_state ~frontier_w
+let start_bootstrap_controller ?transition_writer_ref
+    ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
+    ~time_controller ~get_completed_work ~producer_transition_writer_ref
+    ~verified_transition_writer ~clear_reader ~consensus_local_state ~frontier_w
     ~initial_root_transition ~persistent_root ~persistent_frontier
-    ~cache_exceptions ~best_seen_transition ~catchup_mode =
+    ~cache_exceptions ~best_seen_transition ~catchup_mode () =
   let open Context in
   [%str_log info] Starting_bootstrap_controller ;
   [%log info] "Starting Bootstrap Controller phase" ;
@@ -216,7 +216,7 @@ let start_bootstrap_controller ~context:(module Context : CONTEXT) ~trust_system
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
         ~clear_reader ~collected_transitions ~cache_exceptions
-        ~transition_writer_ref ~frontier_w new_frontier
+        ~transition_writer_ref ~frontier_w new_frontier ()
       |> Fn.const () ) ;
   transition_writer_ref
 
@@ -449,11 +449,12 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ?transition_writer_ref:None ~consensus_local_state
-        ~frontier_w ~persistent_root ~persistent_frontier ~cache_exceptions
-        ~initial_root_transition ~catchup_mode
+        ~clear_reader ~consensus_local_state ~frontier_w ~persistent_root
+        ~persistent_frontier ~cache_exceptions ~initial_root_transition
+        ~catchup_mode
         ~best_seen_transition:
           (Option.map ~f:(fun x -> `Block x) best_seen_transition)
+        ()
   | Some best_tip, Some frontier
     when is_transition_for_bootstrap
            ~context:(module Context)
@@ -478,10 +479,11 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ?transition_writer_ref:None ~consensus_local_state
-        ~frontier_w ~initial_root_transition ~persistent_root
-        ~persistent_frontier ~cache_exceptions ~catchup_mode
+        ~clear_reader ~consensus_local_state ~frontier_w
+        ~initial_root_transition ~persistent_root ~persistent_frontier
+        ~cache_exceptions ~catchup_mode
         ~best_seen_transition:(Some (`Block best_tip))
+        ()
   | best_tip_opt, Some frontier ->
       let collected_transitions =
         match best_tip_opt with
@@ -538,8 +540,8 @@ let initialize ~context:(module Context : CONTEXT) ~sync_local_state ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~time_controller ~get_completed_work
         ~producer_transition_writer_ref ~verified_transition_writer
-        ~clear_reader ~collected_transitions ~cache_exceptions
-        ?transition_writer_ref:None ~frontier_w frontier
+        ~clear_reader ~collected_transitions ~cache_exceptions ~frontier_w
+        frontier ()
 
 let wait_till_genesis ~logger ~time_controller
     ~(precomputed_values : Precomputed_values.t) =
@@ -731,7 +733,8 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
                              ~clear_reader ~transition_writer_ref
                              ~consensus_local_state ~frontier_w ~persistent_root
                              ~persistent_frontier ~initial_root_transition
-                             ~best_seen_transition:(Some b_or_h) ~catchup_mode )
+                             ~best_seen_transition:(Some b_or_h) ~catchup_mode
+                             () )
                       else Deferred.unit
                   | None ->
                       Deferred.unit

--- a/src/lib/transition_router/valid_transition.ml
+++ b/src/lib/transition_router/valid_transition.ml
@@ -1,0 +1,25 @@
+open Network_peer
+open Core_kernel
+
+type t =
+  [ `Block of Mina_block.initial_valid_block Envelope.Incoming.t
+  | `Header of Mina_block.initial_valid_header Envelope.Incoming.t ]
+  * [ `Valid_cb of Mina_net2.Validation_callback.t option ]
+
+let to_yojson : t -> Yojson.Safe.t = function
+  | `Block { sender; received_at; _ }, _ ->
+      `Assoc
+        [ ("sender", Envelope.Sender.to_yojson sender)
+        ; ( "received_at"
+          , Mina_stdlib.Time.Span.to_yojson
+              (Time.to_span_since_epoch received_at) )
+        ; ("kind", `String "block")
+        ]
+  | `Header { sender; received_at; _ }, _ ->
+      `Assoc
+        [ ("sender", Envelope.Sender.to_yojson sender)
+        ; ( "received_at"
+          , Mina_stdlib.Time.Span.to_yojson
+              (Time.to_span_since_epoch received_at) )
+        ; ("kind", `String "header")
+        ]


### PR DESCRIPTION
NOTE: the correctness of this PR is backed by [this CI nightly run](https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3658#0196e8bb-e344-4aa1-b8ae-3af50bce1bf7)

This PR is based on https://github.com/MinaProtocol/mina/pull/17214 and https://github.com/MinaProtocol/mina/pull/17216.

In this PR, we factor out a `pipe-guard`, it runs sequentially,  taking care of all requests from any functions inside `transition-router`, so to avoid any race condition.