### PR TITLE
Refactor Transition Router May 20th

### DIFF
--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -327,6 +327,8 @@ module Pipe : sig
 
     val transition_frontier_primary_transitions : Counter.t
 
+    val router_writer_guard_void : Counter.t
+
     val router_transition_frontier_controller : Counter.t
 
     val router_bootstrap_controller : Counter.t

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -341,6 +341,8 @@ module Pipe = struct
 
     let router_transition_frontier_controller : Counter.t = ()
 
+    let router_writer_guard_void : Counter.t = ()
+
     let router_bootstrap_controller : Counter.t = ()
 
     let router_verified_transitions : Counter.t = ()

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1035,6 +1035,10 @@ module Pipe = struct
       Counter.v "transition_frontier_primary_transitions" ~help ~namespace
         ~subsystem
 
+    let router_writer_guard_void : Counter.t =
+      let help = "Overflow in writer guard in Transition_router" in
+      Counter.v "router_writer_guard_void" ~help ~namespace ~subsystem
+
     let router_transition_frontier_controller : Counter.t =
       let help =
         "Overflow in transition frontier controller pipe in Transition_router"

--- a/src/lib/pipe_lib/dune
+++ b/src/lib/pipe_lib/dune
@@ -5,12 +5,14 @@
  (public_name pipe_lib)
  (libraries
   ;; opam libraries
+  async
   sexplib
   core_kernel
   async_kernel
   core
   ppx_inline_test.config
   ;; local libraries
+  actor
   run_in_thread
   logger)
  (instrumentation

--- a/src/lib/pipe_lib/writer_guard.ml
+++ b/src/lib/pipe_lib/writer_guard.ml
@@ -1,0 +1,91 @@
+open Core
+open Async
+
+module Make (Inputs : sig
+  module Data : sig
+    type t
+
+    val to_yojson : t -> Yojson.Safe.t
+  end
+
+  val capacity : int
+
+  type aux
+
+  val callback : aux option -> Data.t -> unit
+end) =
+struct
+  include Inputs
+
+  (* Buffering behaviors should go directly into channel type *)
+  type writer =
+    (Data.t, Strict_pipe.synchronous, unit Deferred.t) Strict_pipe.Writer.t
+
+  type writer_with_aux = { writer : writer; aux : aux }
+
+  type state = { writer_with_aux : writer_with_aux option; id : int }
+
+  let drop_and_call_callback (state : state) (data : Data.t) =
+    let aux_opt = Option.map ~f:(fun w -> w.aux) state.writer_with_aux in
+    callback aux_opt data
+
+  let channel_type =
+    Actor.With_capacity
+      (`Capacity capacity, `Overflow (Drop_and_call_head drop_and_call_callback))
+
+  module Request = struct
+    type _ t =
+      | ClosePipe : { id : int } -> [ `Closed_already_or_replaced | `Ok ] t
+      | ReplacePipe : writer_with_aux -> int t
+  end
+
+  module Guard = Actor.WithRequest (Data) (Request)
+
+  let data_handler ~(state : state) ~(message : Data.t) =
+    match state.writer_with_aux with
+    | None ->
+        Deferred.return Actor.MUnprocessed
+    | Some { writer; _ } ->
+        let%map () = Strict_pipe.Writer.write writer message in
+        Actor.MNext state
+
+  let request_handler :
+      type response.
+         state:state
+      -> request:response Request.t
+      -> (state, response) Actor.req_processed Deferred.t =
+   fun ~state ~request ->
+    let open Request in
+    match request with
+    | ClosePipe { id = request_id } -> (
+        match state with
+        | { id = held_id; writer_with_aux = Some { writer; _ } }
+          when held_id = request_id ->
+            Strict_pipe.Writer.kill writer ;
+            Deferred.return
+              (Actor.RNext ({ state with writer_with_aux = None }, `Ok))
+        | _ ->
+            Deferred.return (Actor.RNext (state, `Closed_already_or_replaced)) )
+    | ReplacePipe writer_with_aux ->
+        Option.iter state.writer_with_aux ~f:(fun { writer; _ } ->
+            Strict_pipe.Writer.kill writer ) ;
+        (* WARN:
+           We know that the new writer provided is always valid because pipe
+           guard would only receive ClosePipe after ReplacePipe. If that's not
+           true we need to fix here.
+        *)
+        let new_id = state.id + 1 in
+        Deferred.return
+          (Actor.RNext
+             ({ writer_with_aux = Some writer_with_aux; id = new_id }, new_id)
+          )
+
+  [%%define_locally Guard.(spawn, send_data, send_control, send_request)]
+
+  let create ~logger () =
+    Guard.create ~name:(`String "Valid Transition Pipe Guard")
+      ~request_handler:{ f = request_handler }
+      ~control_handler:Actor.DummyMessage.handler
+      ~data_channel_type:channel_type ~data_handler ~logger
+      ~state:{ writer_with_aux = None; id = 0 }
+end

--- a/src/lib/pipe_lib/writer_guard.ml
+++ b/src/lib/pipe_lib/writer_guard.ml
@@ -80,7 +80,7 @@ struct
              ({ writer_with_aux = Some writer_with_aux; id = new_id }, new_id)
           )
 
-  [%%define_locally Guard.(spawn, send_data, send_control, send_request)]
+  [%%define_locally Guard.(spawn, send_data, send_request)]
 
   let create ~logger () =
     Guard.create ~name:(`String "Valid Transition Pipe Guard")

--- a/src/lib/transition_router/valid_transition.ml
+++ b/src/lib/transition_router/valid_transition.ml
@@ -1,0 +1,25 @@
+open Network_peer
+open Core_kernel
+
+type t =
+  [ `Block of Mina_block.initial_valid_block Envelope.Incoming.t
+  | `Header of Mina_block.initial_valid_header Envelope.Incoming.t ]
+  * [ `Valid_cb of Mina_net2.Validation_callback.t option ]
+
+let to_yojson : t -> Yojson.Safe.t = function
+  | `Block { sender; received_at; _ }, _ ->
+      `Assoc
+        [ ("sender", Envelope.Sender.to_yojson sender)
+        ; ( "received_at"
+          , Mina_stdlib.Time.Span.to_yojson
+              (Time.to_span_since_epoch received_at) )
+        ; ("kind", `String "block")
+        ]
+  | `Header { sender; received_at; _ }, _ ->
+      `Assoc
+        [ ("sender", Envelope.Sender.to_yojson sender)
+        ; ( "received_at"
+          , Mina_stdlib.Time.Span.to_yojson
+              (Time.to_span_since_epoch received_at) )
+        ; ("kind", `String "header")
+        ]


### PR DESCRIPTION
Next in train: https://github.com/MinaProtocol/mina/pull/17225

In this PR, we factor out a pipe-guard, it runs sequentially, taking care of all requests from any functions inside transition-router, so to avoid any race condition.

This refactor is only partial: I've only abstracted about the Writer and create a actor that guards on it. This could be done in a more elegant behavior if we allow propagating the changes to other modules to prevent usage of pipe readers on their end. Then we could have a full guard on the (reader, writer) pair. This doesn't provide more security, though, as on reader's end there can't be anything going wrong.

Ideally, I would like to have any `don't_wait_for`s being redesigned as an Actor. But I think for now it's enough for us to just fix bugs as we run into them and replace them with actors.

CI Nightly is passing in next PR in this train: https://github.com/MinaProtocol/mina/pull/17225