### PR TITLE
Snark Work Lib: define ID to be assigend to partitioned work

### DIFF
--- a/src/lib/snark_work_lib/id.ml
+++ b/src/lib/snark_work_lib/id.ml
@@ -1,0 +1,35 @@
+open Core_kernel
+
+module Single = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = { which_one : [ `First | `Second | `One ]; pairing_id : int64 }
+      [@@deriving compare, hash, sexp, yojson, equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+module Sub_zkapp = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { which_one : [ `First | `Second | `One ]
+        ; pairing_id : int64
+        ; job_id : int64
+        }
+      [@@deriving compare, hash, sexp, yojson, equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_single ~(job_id : int64) Single.{ which_one; pairing_id } =
+    { which_one; pairing_id; job_id }
+
+  let to_single ({ which_one; pairing_id; _ } : t) : Single.t =
+    { which_one; pairing_id }
+end

--- a/src/lib/snark_work_lib/id.mli
+++ b/src/lib/snark_work_lib/id.mli
@@ -1,0 +1,39 @@
+open Core_kernel
+
+(* A Single.t identifies one part of a One_or_two work *)
+module Single : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      (* Case `One` indicate no need to pair. ID is still needed because zkapp command
+         might be left in pool of half completion. *)
+      type t = { which_one : [ `First | `Second | `One ]; pairing_id : int64 }
+      [@@deriving compare, hash, sexp, yojson, equal]
+
+      val to_latest : t -> t
+    end
+  end]
+end
+
+(* A Sub_zkapp.t identifies a sub-zkapp level work *)
+module Sub_zkapp : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      (* Case `One` indicate no need to pair. ID is still needed because zkapp command
+         might be left in pool of half completion. *)
+      type t =
+        { which_one : [ `First | `Second | `One ]
+        ; pairing_id : int64
+        ; job_id : int64
+        }
+      [@@deriving compare, hash, sexp, yojson, equal]
+
+      val to_latest : t -> t
+    end
+  end]
+
+  val of_single : job_id:int64 -> Single.t -> t
+
+  val to_single : t -> Single.t
+end

--- a/src/lib/snark_work_lib/id.mli
+++ b/src/lib/snark_work_lib/id.mli
@@ -1,11 +1,11 @@
 open Core_kernel
 
-(* A Single.t identifies one part of a One_or_two work *)
+(** A Single.t identifies one part of a One_or_two work *)
 module Single : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      (* Case `One` indicate no need to pair. ID is still needed because zkapp command
+      (** Case `One` indicate no need to pair. ID is still needed because zkapp command
          might be left in pool of half completion. *)
       type t = { which_one : [ `First | `Second | `One ]; pairing_id : int64 }
       [@@deriving compare, hash, sexp, yojson, equal]
@@ -15,12 +15,12 @@ module Single : sig
   end]
 end
 
-(* A Sub_zkapp.t identifies a sub-zkapp level work *)
+(** A Sub_zkapp.t identifies a sub-zkapp level work *)
 module Sub_zkapp : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      (* Case `One` indicate no need to pair. ID is still needed because zkapp command
+      (** Case `One` indicate no need to pair. ID is still needed because zkapp command
          might be left in pool of half completion. *)
       type t =
         { which_one : [ `First | `Second | `One ]


### PR DESCRIPTION
This PR is part project of Snark Worker Rework.

This PR defines 2 kinds of ID, `Single` and `Sub_zkapp`; The first identifies a single spec; while the later identifies a subzkapp spec. 

The conversion between them is needed because we need to correspond a single zkapp command and the set of the subzkapp specs generated from that command. 