### PR TITLE
Snark Worker: Move Functor.perform to Prod.perform

### DIFF
--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -40,32 +40,6 @@ module Make (Inputs : Intf.Inputs_intf) :
     end
   end
 
-  let perform (s : Worker_state.t) public_key
-      ({ instances; fee } as spec : Work.Spec.t) =
-    One_or_two.Deferred_result.map instances ~f:(fun w ->
-        let open Deferred.Or_error.Let_syntax in
-        let%map proof, time =
-          perform_single s
-            ~message:(Mina_base.Sok_message.create ~fee ~prover:public_key)
-            w
-        in
-        ( proof
-        , (time, match w with Transition _ -> `Transition | Merge _ -> `Merge)
-        ) )
-    |> Deferred.Or_error.map ~f:(function
-         | `One (proof1, metrics1) ->
-             { Snark_work_lib.Work.Result.proofs = `One proof1
-             ; metrics = `One metrics1
-             ; spec
-             ; prover = public_key
-             }
-         | `Two ((proof1, metrics1), (proof2, metrics2)) ->
-             { Snark_work_lib.Work.Result.proofs = `Two (proof1, proof2)
-             ; metrics = `Two (metrics1, metrics2)
-             ; spec
-             ; prover = public_key
-             } )
-
   let dispatch rpc shutdown_on_disconnect query address =
     let%map res =
       Rpc.Connection.with_client

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -25,6 +25,16 @@ module type Inputs_intf = sig
     -> message:Mina_base.Sok_message.t
     -> (Transaction_witness.Stable.Latest.t, Ledger_proof.t) Work.Single.Spec.t
     -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t
+
+  val perform :
+       Worker_state.t
+    -> Signature_lib.Public_key.Compressed.t
+    -> Snark_work_lib.Selector.Spec.Stable.V1.t
+    -> ( Snark_work_lib.Selector.Single.Spec.Stable.V1.t
+         Snark_work_lib.Work.Spec.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Result.t
+       Deferred.Or_error.t
 end
 
 module type Rpc_master = sig

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -304,4 +304,31 @@ module Inputs = struct
         @@ ( Transaction_snark.create ~statement:{ stmt with sok_digest }
                ~proof:(Lazy.force Proof.transaction_dummy)
            , Time.Span.zero )
+
+  let perform (s : Worker_state.t) public_key
+      ({ instances; fee } as spec : Snark_work_lib.Selector.Spec.Stable.Latest.t)
+      =
+    One_or_two.Deferred_result.map instances ~f:(fun w ->
+        let open Deferred.Or_error.Let_syntax in
+        let%map proof, time =
+          perform_single s
+            ~message:(Mina_base.Sok_message.create ~fee ~prover:public_key)
+            w
+        in
+        ( proof
+        , (time, match w with Transition _ -> `Transition | Merge _ -> `Merge)
+        ) )
+    |> Deferred.Or_error.map ~f:(function
+         | `One (proof1, metrics1) ->
+             { Snark_work_lib.Work.Result.proofs = `One proof1
+             ; metrics = `One metrics1
+             ; spec
+             ; prover = public_key
+             }
+         | `Two ((proof1, metrics1), (proof2, metrics2)) ->
+             { Snark_work_lib.Work.Result.proofs = `Two (proof1, proof2)
+             ; metrics = `Two (metrics1, metrics2)
+             ; spec
+             ; prover = public_key
+             } )
 end

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -60,13 +60,6 @@ module Inputs = struct
     let worker_wait_time = 5.
   end
 
-  (* bin_io is for uptime service SNARK worker *)
-  type single_spec =
-    ( Transaction_witness.Stable.Latest.t
-    , Transaction_snark.Stable.Latest.t )
-    Snark_work_lib.Work.Single.Spec.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp]
-
   let zkapp_command_inputs_to_yojson =
     let convert =
       List.map
@@ -91,7 +84,7 @@ module Inputs = struct
 
   let perform_single
       ({ cache; proof_level_snark; proof_cache_db; logger } : Worker_state.t)
-      ~message (single : single_spec) =
+      ~message (single : Snark_work_lib.Selector.Single.Spec.Stable.Latest.t) =
     let open Deferred.Or_error.Let_syntax in
     let open Snark_work_lib in
     let sok_digest = Mina_base.Sok_message.digest message in
@@ -111,7 +104,10 @@ module Inputs = struct
                       (* the [@sexp.opaque] in Work.Single.Spec.t means we can't derive yojson,
                          so we use the less-desirable sexp here
                       *)
-                    , `String (Sexp.to_string (sexp_of_single_spec single)) )
+                    , `String
+                        (Sexp.to_string
+                           (Selector.Single.Spec.Stable.Latest.sexp_of_t single) )
+                    )
                   ] ;
               Error e
           | Ok res ->

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -4,11 +4,12 @@ open Core_kernel
 open Async
 open Mina_base
 module Prod = Snark_worker__Prod.Inputs
+module Work = Snark_work_lib
 
 module Worker_state = struct
   module type S = sig
     val perform_single :
-         Sok_message.t * Prod.single_spec
+         Sok_message.t * Work.Selector.Single.Spec.Stable.Latest.t
       -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t
   end
 
@@ -39,7 +40,7 @@ module Worker = struct
     type 'w functions =
       { perform_single :
           ( 'w
-          , Sok_message.t * Prod.single_spec
+          , Sok_message.t * Work.Selector.Single.Spec.Stable.Latest.t
           , (Ledger_proof.t * Time.Span.t) Or_error.t )
           F.t
       }
@@ -70,7 +71,9 @@ module Worker = struct
         in
         { perform_single =
             f
-              ( [%bin_type_class: Sok_message.Stable.Latest.t * Prod.single_spec]
+              ( [%bin_type_class:
+                  Sok_message.Stable.Latest.t
+                  * Work.Selector.Single.Spec.Stable.Latest.t]
               , [%bin_type_class:
                   (Ledger_proof.Stable.Latest.t * Time.Span.t) Or_error.t]
               , perform_single )


### PR DESCRIPTION
This PR moves Functor.perform to Prod.perform.

The reason for doing so, is in later PRs, a spec may be more than one/two single specs. And if they're subzkapp level, perform would depend on other functions internal to `Prod`

One note: there's no plan getting rid of `perform_single` in this train, as in some other parts of the code, such as uptime snark worker, we're still relying on this old interface.