### PR TITLE
Deps: bump Ocaml from 4.14.0 to 4.14.2

### DIFF
--- a/opam.export
+++ b/opam.export
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-compiler: ["ocaml.4.14.0"]
+compiler: ["ocaml.4.14.2"]
 roots: [
   "alcotest.1.1.0"
   "alcotest-async.1.1.0"
@@ -22,7 +22,7 @@ roots: [
   "lmdb.1.0"
   "menhir.20210419"
   "merlin.4.5-414"
-  "ocaml-base-compiler.4.14.0"
+  "ocaml-base-compiler.4.14.2"
   "ocamlformat.0.20.1"
   "ocamlgraph.1.8.8"
   "ocp-browser.1.3.3"
@@ -161,8 +161,8 @@ installed: [
   "mirage-crypto-rng-async.0.11.0"
   "mmap.1.1.0"
   "num.1.1"
-  "ocaml.4.14.0"
-  "ocaml-base-compiler.4.14.0"
+  "ocaml.4.14.2"
+  "ocaml-base-compiler.4.14.2"
   "ocaml-compiler-libs.v0.12.3"
   "ocaml-config.2"
   "ocaml-migrate-parsetree.2.3.0"


### PR DESCRIPTION
4.14.0 switches are literally uncreatable on Arch Linux. Hence the bump requested. 