### PR TITLE
add liblmdb-dev to focal and bullseye dependency

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -31,7 +31,7 @@ case "${MINA_DEB_CODENAME}" in
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
+    DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, liblmdb-dev, mina-logproc"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;
   stretch|bionic)


### PR DESCRIPTION
Fix for focal debian package. 

Error at runtime when running mina from installed package

```
  mina: error while loading shared libraries: liblmdb.so.0: cannot open shared object file: No such file or directory
```

This error is only observed at runtime. Reason is that we didn't add liblmdb-dev dependency to mina-daemon package. Unfortunately we didn't catch this earlier as focal debian is not used in tests (PR,Nightly). Also docker are not affected since we are installing 'dnsutils' which loads liblmdb-dev. 


Still this is a bit of mystery for me why bullseye debian is not affected

Reproduction path and test:

`docker run -it ubuntu:focal bash`

and then 

```
export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
apt-get update
apt-get install -y lsb-release ca-certificates
echo "deb [trusted=yes] https://packages.o1test.net/ focal alpha" > /etc/apt/sources.list.d/mina.list
apt-get update
apt-get install -y --allow-downgrades mina-mainnet=3.1.2-alpha1-e6571a4

mina version // or similar
```

Above should fail showing an error
then you should install corrected version:

```
echo "deb [trusted=yes] https://packages.o1test.net/ focal experimented" > /etc/apt/sources.list.d/mina.list
apt-get update
apt-get install -y --allow-downgrades mina-mainnet=3.1.2-alpha1-81b54bd
```

now any mina command should be fine