### PR TITLE
Work Partitioner: define Job Pool

### DIFF
--- a/src/lib/snark_work_lib/snark_work_lib.ml
+++ b/src/lib/snark_work_lib/snark_work_lib.ml
@@ -7,3 +7,4 @@ module Work = struct
 end
 
 module Selector = Selector
+module With_job_meta = With_job_meta

--- a/src/lib/work_partitioner/job_pool.ml
+++ b/src/lib/work_partitioner/job_pool.ml
@@ -1,0 +1,125 @@
+open Core_kernel
+
+type ('accum, 'final) fold_action =
+  { action : [ `Continue of 'accum | `Stop of 'final ]; slashed : bool }
+
+let epoch_now () = Time.(now () |> to_span_since_epoch)
+
+module Make (ID : Hashtbl.Key) (Spec : T) = struct
+  type job = (Spec.t, ID.t) Snark_work_lib.With_job_meta.t
+
+  type job_item = job option ref
+
+  type t =
+    { timeline : job_item Deque.t (* For iteration  *)
+    ; index : (ID.t, job_item) Hashtbl.t (* For marking job as done *)
+    }
+
+  let create () =
+    { timeline = Deque.create (); index = Hashtbl.create (module ID) }
+
+  let rec peek (t : t) =
+    match Deque.dequeue_front t.timeline with
+    | None ->
+        None
+    | Some { contents = None } ->
+        peek t
+    | Some ({ contents = Some pending } as item) ->
+        Deque.enqueue_front t.timeline item ;
+        Some pending
+
+  let fold_until ~(init : 'accum)
+      ~(f : 'accum -> job -> ('accum, 'final) fold_action)
+      ~(finish : 'accum -> 'final) t : 'final =
+    let stack = ref [] in
+    let acc = ref init in
+    let result = ref None in
+    while Option.is_none !result do
+      match Deque.dequeue_front t.timeline with
+      | None ->
+          result := finish !acc
+      | Some { contents = None } ->
+          (* Job done *)
+          ()
+      | Some ({ contents = Some job } as item) -> (
+          let { action; slashed } = f init job in
+          if not slashed then stack := item :: !stack ;
+          match action with
+          | `Continue new_acc ->
+              acc := new_acc
+          | `Stop final ->
+              result := final )
+    done ;
+    List.iter ~f:(fun item -> Deque.enqueue_front t.timeline item) !stack ;
+    !result
+
+  let attempt_add ~(key : ID.t) ~(job : job) (t : t) =
+    let data = ref (Some job) in
+    match Hashtbl.add ~key ~data t.index with
+    | `Ok ->
+        Deque.enqueue_back t.timeline data ;
+        `Ok
+    | `Duplicate ->
+        `Duplicate
+
+  let slash (t : t) (id : ID.t) =
+    match Hashtbl.find_and_remove t.index id with
+    | None ->
+        None
+    | Some job_item ->
+        let result = !job_item in
+        job_item := None ;
+        result
+
+  let change ~(id : ID.t) ~(f : job option -> job option) (t : t) =
+    let process (current : job_item option) =
+      let output =
+        match current with
+        | None ->
+            f None
+        | Some job_already ->
+            let tmp = f !job_already in
+            job_already := None ;
+            tmp
+      in
+      match output with
+      | None ->
+          None
+      | Some data ->
+          let new_item = ref (Some data) in
+          Deque.enqueue_back t.timeline new_item ;
+          Some new_item
+    in
+
+    Hashtbl.change t.index id ~f:process
+
+  let replace ~(id : ID.t) ~(job : job) = change ~id ~f:(const (Some job))
+
+  let find (t : t) (id : ID.t) =
+    match Hashtbl.find t.index id with
+    | Some { contents = Some job } ->
+        Some job
+    | _ ->
+        None
+
+  let reissue_if_old (t : t) ~(reassignment_timeout : Time.Span.t) =
+    let job_is_old (job : job) : bool =
+      let issued = Time.of_span_since_epoch job.issued_since_unix_epoch in
+      let delta = Time.(diff (now ()) issued) in
+      Time.Span.( > ) delta reassignment_timeout
+    in
+    match
+      fold_until ~init:None
+        ~f:(fun _ (job as item) ->
+          if job_is_old job then { slashed = true; action = `Stop (Some item) }
+          else { slashed = false; action = `Continue None } )
+        ~finish:Fn.id t
+    with
+    | None ->
+        None
+    | Some job ->
+        let issued_since_unix_epoch = epoch_now () in
+        let reissued = { job with issued_since_unix_epoch } in
+        replace ~id:job.job_id ~job:reissued t ;
+        Some job
+end

--- a/src/lib/work_partitioner/job_pool.mli
+++ b/src/lib/work_partitioner/job_pool.mli
@@ -1,0 +1,36 @@
+open Core_kernel
+
+type ('accum, 'final) fold_action =
+  { action : [ `Continue of 'accum | `Stop of 'final ]; slashed : bool }
+
+module Make (ID : Hashtbl.Key) (Spec : T) : sig
+  type job = (Spec.t, ID.t) Snark_work_lib.With_job_meta.t
+
+  type job_item = job option ref
+
+  type t
+
+  val create : unit -> t
+
+  val peek : t -> job option
+
+  val fold_until :
+       init:'accum
+    -> f:('accum -> job -> ('accum, 'a option) fold_action)
+    -> finish:('accum -> 'a option)
+    -> t
+    -> 'a option
+
+  val attempt_add : key:ID.t -> job:job -> t -> [> `Duplicate | `Ok ]
+
+  val slash : t -> ID.t -> job option
+
+  val change : id:ID.t -> f:(job option -> job option) -> t -> unit
+
+  val replace : id:ID.t -> job:job -> t -> unit
+
+  val find : t -> ID.t -> job option
+
+  val reissue_if_old :
+    t -> reassignment_timeout:Core_kernel_private.Span_float.t -> job option
+end


### PR DESCRIPTION
Here's a graph of internal of a work partitioner by @georgeee 
![image](https://github.com/user-attachments/assets/49f3e647-35ee-4252-8f4c-b7bae864cb88)

`Pairing Pool`, `Jobs sent by Partitioner` and `zkApp Command Jobs` would all be instance of this functor.