### PR TITLE
Snark Worker: lift Rpc_get_work

### DIFF
--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -1,6 +1,6 @@
 open Async
 open Core
-module Work = Snark_work_lib
+open Snark_work_lib
 
 (** For versioning of the types here, see:
     - RFC 0013: {:https://github.com/MinaProtocol/mina/blob/develop/rfcs/0013-rpc-versioning.md}
@@ -14,7 +14,7 @@ module Master = struct
     type query = unit
 
     type response =
-      ( Snark_work_lib.Selector.Spec.Stable.Latest.t
+      ( Selector.Spec.Stable.Latest.t
       * Signature_lib.Public_key.Compressed.Stable.Latest.t )
       option
   end
@@ -32,7 +32,7 @@ module Stable = struct
       type query = unit
 
       type response =
-        ( Snark_work_lib.Selector.Spec.Stable.V1.t
+        ( Selector.Spec.Stable.V1.t
         * Signature_lib.Public_key.Compressed.Stable.V1.t )
         option
 

--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -1,0 +1,53 @@
+open Async
+open Core
+module Work = Snark_work_lib
+
+(** For versioning of the types here, see:
+    - RFC 0013: {:https://github.com/MinaProtocol/mina/blob/develop/rfcs/0013-rpc-versioning.md}
+    - {:https://ocaml.org/p/async_rpc_kernel/v0.14.0/doc/Async_rpc_kernel/Versioned_rpc/index.html}
+*)
+
+module Master = struct
+  let name = "get_work"
+
+  module T = struct
+    type query = unit
+
+    type response =
+      ( Snark_work_lib.Selector.Spec.Stable.Latest.t
+      * Signature_lib.Public_key.Compressed.Stable.Latest.t )
+      option
+  end
+
+  module Caller = T
+  module Callee = T
+end
+
+include Versioned_rpc.Both_convert.Plain.Make (Master)
+
+[%%versioned_rpc
+module Stable = struct
+  module V2 = struct
+    module T = struct
+      type query = unit
+
+      type response =
+        ( Snark_work_lib.Selector.Spec.Stable.V1.t
+        * Signature_lib.Public_key.Compressed.Stable.V1.t )
+        option
+
+      let query_of_caller_model = Fn.id
+
+      let callee_model_of_query = Fn.id
+
+      let response_of_callee_model = Fn.id
+
+      let caller_model_of_response = Fn.id
+    end
+
+    include T
+    include Register (T)
+  end
+
+  module Latest = V2
+end]

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -16,19 +16,7 @@ open Signature_lib
 
 module Make = struct
   open Snark_work_lib
-
-  module Get_work = struct
-    module Master = struct
-      let name = Rpc_get_work.name
-
-      module T = Rpc_get_work.Master.T
-      module Caller = T
-      module Callee = T
-    end
-
-    include Master.T
-    include Versioned_rpc.Both_convert.Plain.Make (Master)
-  end
+  module Get_work = Rpc_get_work.Master
 
   module Submit_work = struct
     module Master = struct

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -19,20 +19,9 @@ module Make = struct
 
   module Get_work = struct
     module Master = struct
-      let name = "get_work"
+      let name = Rpc_get_work.name
 
-      module T = struct
-        type query = unit
-
-        type response =
-          ( ( Transaction_witness.Stable.Latest.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
-          * Public_key.Compressed.t )
-          option
-      end
-
+      module T = Rpc_get_work.Master.T
       module Caller = T
       module Callee = T
     end

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -16,37 +16,7 @@ module Worker = struct
       include Work
     end
 
-    [%%versioned_rpc
-    module Get_work = struct
-      module V2 = struct
-        module T = struct
-          type query = unit
-
-          type response =
-            ( ( Transaction_witness.Stable.V2.t
-              , Inputs.Ledger_proof.Stable.V2.t )
-              Snark_work_lib.Work.Single.Spec.Stable.V2.t
-              Snark_work_lib.Work.Spec.Stable.V1.t
-            * Public_key.Compressed.Stable.V1.t )
-            option
-
-          let query_of_caller_model = Fn.id
-
-          let callee_model_of_query = Fn.id
-
-          let response_of_callee_model :
-              Rpcs.Get_work.Master.Callee.response -> response =
-            Fn.id
-
-          let caller_model_of_response = Fn.id
-        end
-
-        include T
-        include Rpcs.Get_work.Register (T)
-      end
-
-      module Latest = V2
-    end]
+    module Get_work = Rpc_get_work.Stable
 
     [%%versioned_rpc
     module Submit_work = struct


### PR DESCRIPTION
This PR lifted Rpc_get_work to its own self contained module, so when we're actually modifying the RPC, it can be all done in one file.