### PR TITLE
Snark Worker: move `perform` from {Functor -> Prod}

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -368,11 +368,12 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           return @@ Itn_logger.log ~process ~timestamp ~message ~metadata () )
     ]
   in
-  let log_snark_work_metrics (work : Snark_worker.Work.Result.t) =
+  let log_snark_work_metrics
+      (work : Snark_work_lib.Selector.Result.Stable.Latest.t) =
     Mina_metrics.(Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;
     One_or_two.iter
       (One_or_two.zip_exn work.metrics
-         (Snark_worker.Work.Result.transactions work) )
+         (Snark_work_lib.Selector.Result.Stable.Latest.transactions work) )
       ~f:(fun ((total, tag), transaction_opt) ->
         ( match tag with
         | `Merge ->
@@ -445,15 +446,21 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                      ~f_witness:Transaction_witness.read_all_proofs_from_disk )
             in
             [%log trace]
-              ~metadata:[ ("work_spec", Snark_worker.Work.Spec.to_yojson work) ]
+              ~metadata:
+                [ ( "work_spec"
+                  , Snark_work_lib.Selector.Spec.Stable.Latest.to_yojson work )
+                ]
               "responding to a Get_work request with some new work" ;
             Mina_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
             (work, key)) )
     ; implement Snark_worker.Rpcs_versioned.Submit_work.Latest.rpc
-        (fun () (work : Snark_worker.Work.Result.t) ->
+        (fun () (work : Snark_work_lib.Selector.Result.Stable.Latest.t) ->
           [%log trace] "received completed work from a snark worker"
             ~metadata:
-              [ ("work_spec", Snark_worker.Work.Spec.to_yojson work.spec) ] ;
+              [ ( "work_spec"
+                , Snark_work_lib.Selector.Spec.Stable.Latest.to_yojson work.spec
+                )
+              ] ;
           log_snark_work_metrics work ;
           Deferred.return @@ Mina_lib.add_work mina work )
     ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
@@ -461,7 +468,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           ()
           ((error, _work_spec, _prover_public_key) :
             Error.t
-            * Snark_worker.Work.Spec.t
+            * Snark_work_lib.Selector.Spec.Stable.Latest.t
             * Signature_lib.Public_key.Compressed.t )
         ->
           [%str_log error]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -873,7 +873,7 @@ let request_work t =
 
 let work_selection_method t = t.config.work_selection_method
 
-let add_work t (work : Snark_worker_lib.Work.Result.t) =
+let add_work t (work : Snark_work_lib.Selector.Result.Stable.Latest.t) =
   let update_metrics () =
     let snark_pool = snark_pool t in
     let fee_opt =

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -111,7 +111,7 @@ val request_work : t -> Work_selector.work Snark_work_lib.Work.Spec.t option
 
 val work_selection_method : t -> (module Work_selector.Selection_method_intf)
 
-val add_work : t -> Snark_worker.Work.Result.t -> unit
+val add_work : t -> Snark_work_lib.Selector.Result.Stable.Latest.t -> unit
 
 val add_work_graphql :
      t

--- a/src/lib/snark_work_lib/selector.ml
+++ b/src/lib/snark_work_lib/selector.ml
@@ -51,6 +51,10 @@ module Result = struct
         (Spec.Stable.V1.t, Ledger_proof.Stable.V2.t) Work.Result.Stable.V1.t
 
       let to_latest = Fn.id
+
+      let transactions (t : t) =
+        One_or_two.map t.spec.instances ~f:(fun i ->
+            Single_spec.Stable.Latest.transaction i )
     end
   end]
 

--- a/src/lib/snark_work_lib/single_spec.ml
+++ b/src/lib/snark_work_lib/single_spec.ml
@@ -58,6 +58,10 @@ module Stable = struct
     [@@deriving sexp, yojson]
 
     let to_latest = Fn.id
+
+    let transaction t =
+      Option.map (Poly.witness t) ~f:(fun w ->
+          w.Transaction_witness.Stable.Latest.transaction )
   end
 end]
 

--- a/src/lib/snark_work_lib/single_spec.mli
+++ b/src/lib/snark_work_lib/single_spec.mli
@@ -39,6 +39,8 @@ module Stable : sig
     [@@deriving sexp, yojson]
 
     val to_latest : t -> t
+
+    val transaction : t -> Mina_transaction.Transaction.Stable.V2.t option
   end
 end]
 

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -1,10 +1,10 @@
 open Core
 open Async
 open Events
+open Snark_work_lib
 
 module Make = struct
   module Rpcs = Rpcs.Make
-  module Work = Snark_work_lib
   include Prod.Inputs
 
   let dispatch rpc shutdown_on_disconnect query address =
@@ -181,9 +181,8 @@ module Make = struct
               [ ("address", `String (Host_and_port.to_string daemon_address))
               ; ( "work_ids"
                 , Transaction_snark_work.Statement.compact_json
-                    (One_or_two.map
-                       (Work.Work.Spec.instances work)
-                       ~f:Work.Work.Single.Spec.statement ) )
+                    (One_or_two.map (Work.Spec.instances work)
+                       ~f:Work.Single.Spec.statement ) )
               ] ;
           let%bind () = wait () in
           (* Pause to wait for stdout to flush *)
@@ -204,16 +203,15 @@ module Make = struct
               log_and_retry "performing work" e (retry_pause 10.) go
           | Ok result ->
               emit_proof_metrics result.metrics
-                (Work.Selector.Result.Stable.Latest.transactions result)
+                (Selector.Result.Stable.Latest.transactions result)
                 logger ;
               [%log info] "Submitted completed SNARK work $work_ids to $address"
                 ~metadata:
                   [ ("address", `String (Host_and_port.to_string daemon_address))
                   ; ( "work_ids"
                     , Transaction_snark_work.Statement.compact_json
-                        (One_or_two.map
-                           (Work.Work.Spec.instances work)
-                           ~f:Work.Work.Single.Spec.statement ) )
+                        (One_or_two.map (Work.Spec.instances work)
+                           ~f:Work.Single.Spec.statement ) )
                   ] ;
               let rec submit_work () =
                 match%bind

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -61,15 +61,17 @@ module type Work_S = sig
   end
 end
 
-module type Rpcs_versioned_S = sig
-  module Work : Work_S
+module Work = Snark_work_lib
 
+module type Rpcs_versioned_S = sig
   module Get_work : sig
     module V2 : sig
       type query = unit [@@deriving bin_io]
 
       type response =
-        (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
+        ( Work.Selector.Spec.Stable.Latest.t
+        * Signature_lib.Public_key.Compressed.t )
+        option
       [@@deriving bin_io]
 
       val rpc : (query, response) Rpc.Rpc.t
@@ -80,7 +82,7 @@ module type Rpcs_versioned_S = sig
 
   module Submit_work : sig
     module V2 : sig
-      type query = Work.Result.t [@@deriving bin_io]
+      type query = Work.Selector.Result.Stable.Latest.t [@@deriving bin_io]
 
       type response = unit [@@deriving bin_io]
 
@@ -92,7 +94,10 @@ module type Rpcs_versioned_S = sig
 
   module Failed_to_generate_snark : sig
     module V2 : sig
-      type query = Error.t * Work.Spec.t * Signature_lib.Public_key.Compressed.t
+      type query =
+        Error.t
+        * Work.Selector.Spec.Stable.Latest.t
+        * Signature_lib.Public_key.Compressed.t
       [@@deriving bin_io]
 
       type response = unit [@@deriving bin_io]

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -1,5 +1,6 @@
 open Core
 open Async
+open Snark_work_lib
 
 let command_name = "snark-worker"
 
@@ -35,8 +36,6 @@ module type Rpc_master = sig
 end
 
 module type Work_S = sig
-  open Snark_work_lib
-
   type ledger_proof
 
   module Single : sig
@@ -61,16 +60,13 @@ module type Work_S = sig
   end
 end
 
-module Work = Snark_work_lib
-
 module type Rpcs_versioned_S = sig
   module Get_work : sig
     module V2 : sig
       type query = unit [@@deriving bin_io]
 
       type response =
-        ( Work.Selector.Spec.Stable.Latest.t
-        * Signature_lib.Public_key.Compressed.t )
+        (Selector.Spec.Stable.Latest.t * Signature_lib.Public_key.Compressed.t)
         option
       [@@deriving bin_io]
 
@@ -82,7 +78,7 @@ module type Rpcs_versioned_S = sig
 
   module Submit_work : sig
     module V2 : sig
-      type query = Work.Selector.Result.Stable.Latest.t [@@deriving bin_io]
+      type query = Selector.Result.Stable.Latest.t [@@deriving bin_io]
 
       type response = unit [@@deriving bin_io]
 
@@ -96,7 +92,7 @@ module type Rpcs_versioned_S = sig
     module V2 : sig
       type query =
         Error.t
-        * Work.Selector.Spec.Stable.Latest.t
+        * Selector.Spec.Stable.Latest.t
         * Signature_lib.Public_key.Compressed.t
       [@@deriving bin_io]
 

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -10,12 +10,6 @@ module Worker = struct
     open Core_kernel
     open Signature_lib
 
-    module Work = struct
-      type ledger_proof = Inputs.Ledger_proof.t
-
-      include Work
-    end
-
     [%%versioned_rpc
     module Get_work = struct
       module V2 = struct


### PR DESCRIPTION
After the snark worker rework, this function will likely to depend on more functions defined in Prod, specifically parts related to zkapp segments and merges.

Hence it make sense to put `perform` in `Prod` where there's related functions available. 