### PR TITLE
Snark Work Lib: define single result

### DIFF
--- a/src/lib/snark_work_lib/single_result.ml
+++ b/src/lib/snark_work_lib/single_result.ml
@@ -1,0 +1,41 @@
+open Core_kernel
+
+module Poly = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type ('single_spec, 'proof) t =
+        { spec : 'single_spec
+        ; proof : 'proof
+        ; elapsed : Mina_stdlib.Time.Span.Stable.V1.t
+        }
+    end
+  end]
+
+  let map ~f_spec ~f_proof { spec; proof; elapsed } =
+    { spec = f_spec spec; proof = f_proof proof; elapsed }
+end
+
+[%%versioned
+module Stable = struct
+  [@@@no_toplevel_latest_type]
+
+  module V1 = struct
+    type t =
+      (Single_spec.Stable.V1.t, Ledger_proof.Stable.V2.t) Poly.Stable.V1.t
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
+
+let read_all_proofs_from_disk : t -> Stable.Latest.t =
+  Poly.map ~f_spec:Single_spec.read_all_proofs_from_disk
+    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+
+let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
+    Stable.Latest.t -> t =
+  Poly.map
+    ~f_spec:(Single_spec.write_all_proofs_to_disk ~proof_cache_db)
+    ~f_proof:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)

--- a/src/lib/snark_work_lib/single_result.mli
+++ b/src/lib/snark_work_lib/single_result.mli
@@ -1,0 +1,35 @@
+open Core_kernel
+
+module Poly : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type ('single_spec, 'proof) t =
+        { spec : 'single_spec
+        ; proof : 'proof
+        ; elapsed : Mina_stdlib.Time.Span.Stable.V1.t
+        }
+    end
+  end]
+
+  val map : f_spec:('a -> 'b) -> f_proof:('c -> 'd) -> ('a, 'c) t -> ('b, 'd) t
+end
+
+[%%versioned:
+module Stable : sig
+  [@@@no_toplevel_latest_type]
+
+  module V1 : sig
+    type t =
+      (Single_spec.Stable.V1.t, Ledger_proof.Stable.V2.t) Poly.Stable.V1.t
+
+    val to_latest : t -> t
+  end
+end]
+
+type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
+
+val read_all_proofs_from_disk : t -> Stable.Latest.t
+
+val write_all_proofs_to_disk :
+  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t


### PR DESCRIPTION
This is the result for a One work distributed by the Work Selector. The reason for redefining this type(and the combined result type in next PR in train) is to eliminate some invalid value, e.g. for previous result we could have One metric with Two proofs, which doesn't make sense. 

Next in train https://github.com/MinaProtocol/mina/pull/17265