### PR TITLE
Snark Work Lib: define combined result

### DIFF
--- a/src/lib/snark_work_lib/combined_result.ml
+++ b/src/lib/snark_work_lib/combined_result.ml
@@ -1,0 +1,47 @@
+open Core_kernel
+
+module Poly = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type ('single_spec, 'proof) t =
+        { data :
+            ('single_spec, 'proof) Single_result.Poly.Stable.V1.t
+            One_or_two.Stable.V1.t
+        ; fee : Currency.Fee.Stable.V1.t
+        ; prover : Signature_lib.Public_key.Compressed.Stable.V1.t
+        }
+    end
+  end]
+
+  let map ~f_single_spec ~f_proof { data; fee; prover } =
+    let f_single_result Single_result.Poly.{ spec; proof; elapsed } =
+      Single_result.Poly.
+        { spec = f_single_spec spec; proof = f_proof proof; elapsed }
+    in
+    { data = One_or_two.map ~f:f_single_result data; fee; prover }
+end
+
+[%%versioned
+module Stable = struct
+  [@@@no_toplevel_latest_type]
+
+  module V1 = struct
+    type t =
+      (Single_spec.Stable.V1.t, Ledger_proof.Stable.V2.t) Poly.Stable.V1.t
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
+
+let read_all_proofs_from_disk : t -> Stable.Latest.t =
+  Poly.map ~f_single_spec:Single_spec.read_all_proofs_from_disk
+    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+
+let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
+    Stable.Latest.t -> t =
+  Poly.map
+    ~f_single_spec:(Single_spec.write_all_proofs_to_disk ~proof_cache_db)
+    ~f_proof:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)

--- a/src/lib/snark_work_lib/combined_result.mli
+++ b/src/lib/snark_work_lib/combined_result.mli
@@ -1,0 +1,38 @@
+open Core_kernel
+
+module Poly : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type ('single_spec, 'proof) t =
+        { data :
+            ('single_spec, 'proof) Single_result.Poly.Stable.V1.t
+            One_or_two.Stable.V1.t
+        ; fee : Currency.Fee.Stable.V1.t
+        ; prover : Signature_lib.Public_key.Compressed.Stable.V1.t
+        }
+    end
+  end]
+
+  val map :
+    f_single_spec:('a -> 'b) -> f_proof:('c -> 'd) -> ('a, 'c) t -> ('b, 'd) t
+end
+
+[%%versioned:
+module Stable : sig
+  [@@@no_toplevel_latest_type]
+
+  module V1 : sig
+    type t =
+      (Single_spec.Stable.V1.t, Ledger_proof.Stable.V2.t) Poly.Stable.V1.t
+
+    val to_latest : t -> t
+  end
+end]
+
+type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
+
+val read_all_proofs_from_disk : t -> Stable.Latest.t
+
+val write_all_proofs_to_disk :
+  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t


### PR DESCRIPTION
EDIT: it seems we should just use `Mina_wire_types.Network_pool.Snark_pool.Diff_versioned.V2.t`, closing
This is the type to be sent back to a work selector and collected back to the snark pool. 

Previous in train: https://github.com/MinaProtocol/mina/pull/17264