### PR TITLE
Snark Worker: Remove Prod.single_spec

### DIFF
--- a/src/lib/snark_work_lib/snark_work_lib.ml
+++ b/src/lib/snark_work_lib/snark_work_lib.ml
@@ -7,3 +7,7 @@ module Work = struct
 end
 
 module Selector = Selector
+
+module Spec = struct
+  module Single = Single_spec
+end

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -60,13 +60,6 @@ module Inputs = struct
     let worker_wait_time = 5.
   end
 
-  (* bin_io is for uptime service SNARK worker *)
-  type single_spec =
-    ( Transaction_witness.Stable.Latest.t
-    , Transaction_snark.Stable.Latest.t )
-    Snark_work_lib.Work.Single.Spec.Stable.Latest.t
-  [@@deriving bin_io_unversioned, sexp]
-
   let zkapp_command_inputs_to_yojson =
     let convert =
       List.map
@@ -91,7 +84,7 @@ module Inputs = struct
 
   let perform_single
       ({ cache; proof_level_snark; proof_cache_db; logger } : Worker_state.t)
-      ~message (single : single_spec) =
+      ~message (single : Snark_work_lib.Selector.Single.Spec.Stable.Latest.t) =
     let open Deferred.Or_error.Let_syntax in
     let open Snark_work_lib in
     let sok_digest = Mina_base.Sok_message.digest message in
@@ -111,7 +104,10 @@ module Inputs = struct
                       (* the [@sexp.opaque] in Work.Single.Spec.t means we can't derive yojson,
                          so we use the less-desirable sexp here
                       *)
-                    , `String (Sexp.to_string (sexp_of_single_spec single)) )
+                    , `String
+                        (Sexp.to_string
+                           (Snark_work_lib.Selector.Single.Spec.Stable.Latest
+                            .sexp_of_t single ) ) )
                   ] ;
               Error e
           | Ok res ->

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -101,13 +101,8 @@ module Inputs = struct
                 ~metadata:
                   [ ("error", Error_json.error_to_yojson e)
                   ; ( "spec"
-                      (* the [@sexp.opaque] in Work.Single.Spec.t means we can't derive yojson,
-                         so we use the less-desirable sexp here
-                      *)
-                    , `String
-                        (Sexp.to_string
-                           (Snark_work_lib.Selector.Single.Spec.Stable.Latest
-                            .sexp_of_t single ) ) )
+                    , Snark_work_lib.Selector.Single.Spec.Stable.Latest
+                      .to_yojson single )
                   ] ;
               Error e
           | Ok res ->

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -8,7 +8,7 @@ module Prod = Snark_worker__Prod.Inputs
 module Worker_state = struct
   module type S = sig
     val perform_single :
-         Sok_message.t * Prod.single_spec
+         Sok_message.t * Snark_work_lib.Spec.Single.Stable.Latest.t
       -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t
   end
 
@@ -39,7 +39,7 @@ module Worker = struct
     type 'w functions =
       { perform_single :
           ( 'w
-          , Sok_message.t * Prod.single_spec
+          , Sok_message.t * Snark_work_lib.Spec.Single.Stable.Latest.t
           , (Ledger_proof.t * Time.Span.t) Or_error.t )
           F.t
       }
@@ -70,7 +70,9 @@ module Worker = struct
         in
         { perform_single =
             f
-              ( [%bin_type_class: Sok_message.Stable.Latest.t * Prod.single_spec]
+              ( [%bin_type_class:
+                  Sok_message.Stable.Latest.t
+                  * Snark_work_lib.Spec.Single.Stable.Latest.t]
               , [%bin_type_class:
                   (Ledger_proof.Stable.Latest.t * Time.Span.t) Or_error.t]
               , perform_single )


### PR DESCRIPTION
This would conflict with https://github.com/MinaProtocol/mina/pull/17275, but conflicts are not terribly hard to resolve.

This type is just `Snark_work_lib.Spec.Single`(or `Snark_work_lib.Selector.Single.Spec`). Redundant.

A general question: Is there any point supporting both yojson & sexp as debugging dump format? Could we get rid of sexp? 