### PR TITLE
Snark Work Lib: Drop spec in partitioned result

### DIFF
--- a/src/lib/snark_work_lib/partitioned_result.ml
+++ b/src/lib/snark_work_lib/partitioned_result.ml
@@ -6,9 +6,8 @@ module Stable = struct
 
   module V1 = struct
     type t =
-      ( Transaction_witness.Stable.V2.t
-      , Ledger_proof.Stable.V2.t
-      , Sub_zkapp_spec.Stable.V1.t
+      ( unit
+      , unit
       , ( Core.Time.Stable.Span.V1.t
         , Ledger_proof.Stable.V2.t )
         Proof_carrying_data.Stable.V1.t )
@@ -19,25 +18,18 @@ module Stable = struct
 end]
 
 type t =
-  ( Transaction_witness.t
-  , Ledger_proof.Cached.t
-  , Sub_zkapp_spec.t
+  ( unit
+  , unit
   , (Core.Time.Span.t, Ledger_proof.Cached.t) Proof_carrying_data.t )
   Partitioned_spec.Poly.Stable.V1.t
 
 let read_all_proofs_from_disk : t -> Stable.Latest.t =
-  Partitioned_spec.Poly.map
-    ~f_witness:Transaction_witness.read_all_proofs_from_disk
-    ~f_subzkapp_spec:Sub_zkapp_spec.read_all_proofs_from_disk
-    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
+  Partitioned_spec.Poly.map ~f_single_spec:Fn.id ~f_subzkapp_spec:Fn.id
     ~f_data:
       (Proof_carrying_data.map_proof ~f:Ledger_proof.Cached.read_proof_from_disk)
 
 let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
-  Partitioned_spec.Poly.map
-    ~f_witness:(Transaction_witness.write_all_proofs_to_disk ~proof_cache_db)
-    ~f_subzkapp_spec:(Sub_zkapp_spec.write_all_proofs_to_disk ~proof_cache_db)
-    ~f_proof:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)
+  Partitioned_spec.Poly.map ~f_single_spec:Fn.id ~f_subzkapp_spec:Fn.id
     ~f_data:
       (Proof_carrying_data.map_proof
          ~f:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db) )

--- a/src/lib/snark_work_lib/partitioned_result.mli
+++ b/src/lib/snark_work_lib/partitioned_result.mli
@@ -6,9 +6,8 @@ module Stable : sig
 
   module V1 : sig
     type t =
-      ( Transaction_witness.Stable.V2.t
-      , Ledger_proof.Stable.V2.t
-      , Sub_zkapp_spec.Stable.V1.t
+      ( unit
+      , unit
       , ( Core.Time.Stable.Span.V1.t
         , Ledger_proof.Stable.V2.t )
         Proof_carrying_data.Stable.V1.t )
@@ -19,9 +18,8 @@ module Stable : sig
 end]
 
 type t =
-  ( Transaction_witness.t
-  , Ledger_proof.Cached.t
-  , Sub_zkapp_spec.t
+  ( unit
+  , unit
   , (Core.Time.Span.t, Ledger_proof.Cached.t) Proof_carrying_data.t )
   Partitioned_spec.Poly.Stable.V1.t
 

--- a/src/lib/snark_work_lib/partitioned_spec.ml
+++ b/src/lib/snark_work_lib/partitioned_spec.ml
@@ -4,12 +4,10 @@ module Poly = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('witness, 'ledger_proof, 'sub_zkapp_spec, 'data) t =
+      type ('single_spec, 'sub_zkapp_spec, 'data) t =
         | Single of
             { job :
-                ( ('witness, 'ledger_proof) Single_spec.Poly.Stable.V2.t
-                , Id.Single.Stable.V1.t )
-                With_job_meta.Stable.V1.t
+                ('single_spec, Id.Single.Stable.V1.t) With_job_meta.Stable.V1.t
             ; data : 'data
             }
         | Sub_zkapp_command of
@@ -29,13 +27,10 @@ module Poly = struct
     | Sub_zkapp_command { job; _ } ->
         Sub_zkapp_command { job; data = () }
 
-  let map ~f_witness ~f_subzkapp_spec ~f_proof ~f_data = function
+  let map ~f_single_spec ~f_subzkapp_spec ~f_data = function
     | Single { job; data } ->
         Single
-          { job =
-              With_job_meta.map
-                ~f_spec:(Single_spec.Poly.map ~f_witness ~f_proof)
-                job
+          { job = With_job_meta.map ~f_spec:f_single_spec job
           ; data = f_data data
           }
     | Sub_zkapp_command { job; data } ->
@@ -57,8 +52,7 @@ module Stable = struct
 
   module V1 = struct
     type t =
-      ( Transaction_witness.Stable.V2.t
-      , Ledger_proof.Stable.V2.t
+      ( Single_spec.Stable.V1.t
       , Sub_zkapp_spec.Stable.V1.t
       , unit )
       Poly.Stable.V1.t
@@ -74,8 +68,7 @@ module Stable = struct
   end
 end]
 
-type t =
-  (Transaction_witness.t, Ledger_proof.Cached.t, Sub_zkapp_spec.t, unit) Poly.t
+type t = (Single_spec.t, Sub_zkapp_spec.t, unit) Poly.t
 
 let read_all_proofs_from_disk : t -> Stable.Latest.t = function
   | Single { job; data } ->

--- a/src/lib/snark_work_lib/partitioned_spec.mli
+++ b/src/lib/snark_work_lib/partitioned_spec.mli
@@ -4,12 +4,10 @@ module Poly : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      type ('witness, 'ledger_proof, 'sub_zkapp_spec, 'data) t =
+      type ('single_spec, 'sub_zkapp_spec, 'data) t =
         | Single of
             { job :
-                ( ('witness, 'ledger_proof) Single_spec.Poly.Stable.V2.t
-                , Id.Single.Stable.V1.t )
-                With_job_meta.Stable.V1.t
+                ('single_spec, Id.Single.Stable.V1.t) With_job_meta.Stable.V1.t
             ; data : 'data
             }
         | Sub_zkapp_command of
@@ -23,17 +21,16 @@ module Poly : sig
     end
   end]
 
-  val drop_data : ('a, 'b, 'c, 'd) t -> ('a, 'b, 'c, unit) t
+  val drop_data : ('a, 'b, 'c) t -> ('a, 'b, unit) t
 
   val map :
-       f_witness:('a -> 'b)
+       f_single_spec:('a -> 'b)
     -> f_subzkapp_spec:('c -> 'd)
-    -> f_proof:('e -> 'f)
-    -> f_data:('g -> 'h)
-    -> ('a, 'e, 'c, 'g) t
-    -> ('b, 'f, 'd, 'h) t
+    -> f_data:('e -> 'f)
+    -> ('a, 'c, 'e) t
+    -> ('b, 'd, 'f) t
 
-  val sok_message : ('a, 'b, 'c, 'd) t -> Mina_base.Sok_message.t
+  val sok_message : ('a, 'b, 'c) t -> Mina_base.Sok_message.t
 end
 
 [%%versioned:
@@ -42,8 +39,7 @@ module Stable : sig
 
   module V1 : sig
     type t =
-      ( Transaction_witness.Stable.V2.t
-      , Ledger_proof.Stable.V2.t
+      ( Single_spec.Stable.V1.t
       , Sub_zkapp_spec.Stable.V1.t
       , unit )
       Poly.Stable.V1.t
@@ -55,8 +51,7 @@ module Stable : sig
   end
 end]
 
-type t =
-  (Transaction_witness.t, Ledger_proof.Cached.t, Sub_zkapp_spec.t, unit) Poly.t
+type t = (Single_spec.t, Sub_zkapp_spec.t, unit) Poly.t
 
 val read_all_proofs_from_disk : t -> Stable.Latest.t
 


### PR DESCRIPTION
This is the only type that would be passed across the network when snark worker returns. So I'll only remove spec in this. for other result it would be needed to still have spec in them so we can send them to network pool to further process.

Indeed stable types in those results need to go, will follow up in next PRs.