### PR TITLE
Runtime genesis ledger: remove `dune-project`

### DIFF
--- a/src/app/runtime_genesis_ledger/dune-project
+++ b/src/app/runtime_genesis_ledger/dune-project
@@ -1,3 +1,0 @@
-(lang dune 2.8)
-(name runtime_genesis_ledger)
-(implicit_transitive_deps true)

--- a/src/dune-project
+++ b/src/dune-project
@@ -168,6 +168,7 @@
 (package (name rosetta_lib))
 (package (name rosetta_models))
 (package (name run_in_thread))
+(package (name runtime_genesis_ledger))
 (package (name secrets))
 (package (name sgn))
 (package (name sgn_type))


### PR DESCRIPTION
It seems useless.