### PR TITLE
Work Selector: fix potential memleak

### DIFF
--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -83,6 +83,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
                                 ( Time.diff end_time start_time
                                 |> Time.Span.to_ms ) )
                           ] ;
+                      t.jobs_seen <- Seen_key.Map.empty ;
                       t.available_jobs <- new_available_jobs ) ;
                   Deferred.unit )
               |> Deferred.don't_wait_for ) ;


### PR DESCRIPTION
The job_seen Map is never fully cleared when a new batch of works arrived, this would cause potential memleak.