### PR TITLE
Move deprecated value out of call forest base

### DIFF
--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -329,6 +329,7 @@ module Values (S : Sample) = struct
     }
 
   let zkapp_command' () : Mina_base.Zkapp_command.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { fee_payer =
         { body =
             { public_key = public_key ()
@@ -341,7 +342,7 @@ module Values (S : Sample) = struct
     ; account_updates =
         List.init Params.max_zkapp_txn_account_updates ~f:(Fn.const ())
         |> List.fold_left ~init:[] ~f:(fun acc () ->
-               Mina_base.Zkapp_command.Call_forest.cons
+               Mina_base.Zkapp_command.Call_forest.cons ~signature_kind
                  (zkapp_account_update ()) acc )
     ; memo = signed_command_memo ()
     }

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -98,6 +98,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let logger = Logger.create ()
 
   let run network t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let open Malleable_error.Let_syntax in
     let%bind () =
       section_hard "Wait for nodes to initialize"
@@ -231,6 +232,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
@@ -277,7 +279,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest1 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update1
-      |> Zkapp_command.Call_forest.cons (update_vk vk1)
+      |> Zkapp_command.Call_forest.cons ~signature_kind (update_vk vk1)
     in
     let zkapp_command_update_vk1 =
       call_forest_to_zkapp ~call_forest:call_forest1
@@ -286,7 +288,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest2 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update1
-      |> Zkapp_command.Call_forest.cons (update_vk vk2)
+      |> Zkapp_command.Call_forest.cons ~signature_kind (update_vk vk2)
     in
     let zkapp_command_update_vk2_refers_vk1 =
       call_forest_to_zkapp ~call_forest:call_forest2
@@ -295,7 +297,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let call_forest_update_vk2 =
       []
       |> Zkapp_command.Call_forest.cons_tree account_update2
-      |> Zkapp_command.Call_forest.cons (update_vk vk2)
+      |> Zkapp_command.Call_forest.cons ~signature_kind (update_vk vk2)
     in
     let zkapp_command_update_vk2 =
       call_forest_to_zkapp ~call_forest:call_forest_update_vk2

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -121,6 +121,7 @@ let%test_module "Actions test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
@@ -188,7 +189,8 @@ let%test_module "Actions test" =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
       in
       assert (Option.is_some account) ;
@@ -205,7 +207,8 @@ let%test_module "Actions test" =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
              ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
       in
@@ -232,7 +235,8 @@ let%test_module "Actions test" =
         |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command ~ledger
              ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
       in
@@ -269,7 +273,8 @@ let%test_module "Actions test" =
         |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command ~global_slot:slot1 ~ledger
       in
       assert (Option.is_some account0) ;

--- a/src/app/zkapps_examples/test/add_events/add_events.ml
+++ b/src/app/zkapps_examples/test/add_events/add_events.ml
@@ -119,6 +119,7 @@ let%test_module "Add events test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
@@ -188,7 +189,8 @@ let%test_module "Add events test" =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;
@@ -205,7 +207,8 @@ let%test_module "Add events test" =
         |> Zkapp_command.Call_forest.cons_tree Add_events.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;
@@ -224,7 +227,8 @@ let%test_module "Add events test" =
         |> Zkapp_command.Call_forest.cons_tree Add_events.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       assert (Option.is_some account) ;

--- a/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
+++ b/src/app/zkapps_examples/test/big_circuit/big_circuit.ml
@@ -65,8 +65,8 @@ let deploy_account_update : Account_update.t =
 
 let account_updates =
   []
-  |> Zkapp_command.Call_forest.cons account_update
-  |> Zkapp_command.Call_forest.cons deploy_account_update
+  |> Zkapp_command.Call_forest.cons ~signature_kind account_update
+  |> Zkapp_command.Call_forest.cons ~signature_kind deploy_account_update
 
 let memo = Signed_command_memo.empty
 
@@ -87,7 +87,7 @@ let full_commitment =
   Zkapp_command.Transaction_commitment.create_complete transaction_commitment
     ~memo_hash:(Signed_command_memo.hash memo)
     ~fee_payer_hash:
-      (Zkapp_command.Digest.Account_update.create
+      (Zkapp_command.Digest.Account_update.create ~signature_kind
          (Account_update.of_fee_payer fee_payer) )
 
 let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :

--- a/src/app/zkapps_examples/test/calls/calls.ml
+++ b/src/app/zkapps_examples/test/calls/calls.ml
@@ -237,6 +237,7 @@ let%test_module "Composability test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
@@ -315,7 +316,8 @@ let%test_module "Composability test" =
              (Update_state_account_update.account_update calls_kind call_kind)
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let (first_state :: zkapp_state) =

--- a/src/app/zkapps_examples/test/empty_update/empty_update.ml
+++ b/src/app/zkapps_examples/test/empty_update/empty_update.ml
@@ -66,7 +66,7 @@ let deploy_account_update : Account_update.t =
 let account_updates =
   []
   |> Zkapp_command.Call_forest.cons_tree account_update
-  |> Zkapp_command.Call_forest.cons deploy_account_update
+  |> Zkapp_command.Call_forest.cons ~signature_kind deploy_account_update
 
 let memo = Signed_command_memo.empty
 
@@ -90,7 +90,7 @@ let full_commitment =
   Zkapp_command.Transaction_commitment.create_complete transaction_commitment
     ~memo_hash:(Signed_command_memo.hash memo)
     ~fee_payer_hash:
-      (Zkapp_command.Digest.Account_update.create
+      (Zkapp_command.Digest.Account_update.create ~signature_kind
          (Account_update.of_fee_payer fee_payer) )
 
 (* TODO: Make this better. *)

--- a/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
+++ b/src/app/zkapps_examples/test/initialize_state/initialize_state.ml
@@ -128,6 +128,7 @@ let%test_module "Initialize state test" =
           transaction_commitment ~memo_hash
           ~fee_payer_hash:
             (Zkapp_command.Call_forest.Digest.Account_update.create
+               ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let sign_all ({ fee_payer; account_updates; memo } : Zkapp_command.t) :
@@ -190,7 +191,8 @@ let%test_module "Initialize state test" =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -207,7 +209,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -226,7 +229,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
       in
       let zkapp_state =
@@ -241,7 +245,8 @@ let%test_module "Initialize state test" =
         []
         |> Zkapp_command.Call_forest.cons_tree
              Update_state_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -255,7 +260,8 @@ let%test_module "Initialize state test" =
              Initialize_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)
@@ -271,7 +277,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons_tree
              Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind
+             Deploy_account_update.account_update
         |> test_zkapp_command
              ~expected_failure:
                (Account_proved_state_precondition_unsatisfied, Pass_2)

--- a/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
+++ b/src/app/zkapps_examples/test/optional_custom_gates/zkapp_optional_custom_gates_tests.ml
@@ -96,7 +96,7 @@ let%test_module "Zkapp with optional custom gates" =
       let account_updates =
         []
         |> Zkapp_command.Call_forest.cons_tree account_update
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Zkapps_examples.Deploy_account_update.full ~access:Either
                 Account_info.public_key Account_info.token_id vk )
       in

--- a/src/app/zkapps_examples/test/tokens/tokens.ml
+++ b/src/app/zkapps_examples/test/tokens/tokens.ml
@@ -99,7 +99,7 @@ let%test_module "Tokens test" =
         []
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -114,7 +114,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id [] )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -124,7 +124,7 @@ let%test_module "Tokens test" =
     let%test_unit "Proof aborts if token balance changes do not sum to 0" =
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -148,7 +148,7 @@ let%test_module "Tokens test" =
     let%test_unit "Initialize, mint, transfer two succeeds" =
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -156,7 +156,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 1)
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -173,7 +173,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 1))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -183,7 +183,7 @@ let%test_module "Tokens test" =
     let%test_unit "Initialize, mint, transfer two succeeds, ignores non-token" =
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -192,7 +192,7 @@ let%test_module "Tokens test" =
                    ~token_id:owned_token_id ~may_use_token:Parents_own_token
              }
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -200,7 +200,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~token_id:Token_id.default ~may_use_token:Parents_own_token
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -215,7 +215,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -229,7 +229,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -240,7 +240,7 @@ let%test_module "Tokens test" =
                    non-token" =
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -251,7 +251,7 @@ let%test_module "Tokens test" =
              ~calls:
                ( []
                (* Delegate call, should be checked. *)
-               |> Zkapp_command.Call_forest.cons
+               |> Zkapp_command.Call_forest.cons ~signature_kind
                     { Account_update.Poly.authorization =
                         Control.Poly.Signature Signature.dummy
                     ; body =
@@ -264,7 +264,7 @@ let%test_module "Tokens test" =
                     ~calls:
                       ( []
                       (* Delegate call, should be checked. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~signature_kind
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -275,7 +275,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:Inherit_from_parent
                            }
                       (* Parents_own_token, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~signature_kind
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -285,7 +285,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:Parents_own_token
                            }
                       (* Blind call, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~signature_kind
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -295,7 +295,7 @@ let%test_module "Tokens test" =
                                  ~may_use_token:No
                            }
                       (* Blind call, should be skipped. *)
-                      |> Zkapp_command.Call_forest.cons
+                      |> Zkapp_command.Call_forest.cons ~signature_kind
                            { Account_update.Poly.authorization =
                                Control.Poly.Signature Signature.dummy
                            ; body =
@@ -325,7 +325,7 @@ let%test_module "Tokens test" =
                     (Account_updates.mint_with_used_token Inherit_from_parent)
                )
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -333,7 +333,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 15)
                    ~may_use_token:Inherit_from_parent
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -348,7 +348,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -361,7 +361,7 @@ let%test_module "Tokens test" =
              @@ Zkapps_tokens.child_forest pk token_id subtree )
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command ~fee_payer_pk:pk ~signers ~initialize_ledger
              ~finalize_ledger
@@ -372,7 +372,7 @@ let%test_module "Tokens test" =
                    fails" =
       let subtree =
         []
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -381,7 +381,7 @@ let%test_module "Tokens test" =
                    ~token_id:owned_token_id ~may_use_token:Inherit_from_parent
              }
         (* This account update should be ignored by the token zkApp. *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -389,7 +389,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true ~balance_change:(int_to_amount 30)
                    ~may_use_token:Inherit_from_parent
              }
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -404,7 +404,7 @@ let%test_module "Tokens test" =
         (* This account update should bring the total balance back to 0,
            counteracting the effect of the ignored update above.
         *)
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              { Account_update.Poly.authorization =
                  Control.Poly.Signature Signature.dummy
              ; body =
@@ -412,7 +412,7 @@ let%test_module "Tokens test" =
                    ~use_full_commitment:true
                    ~balance_change:(int_to_amount (-30)) ~may_use_token:No
              }
-        |> Zkapp_command.Call_forest.cons ~calls:subtree
+        |> Zkapp_command.Call_forest.cons ~signature_kind ~calls:subtree
              { Account_update.Poly.authorization = Control.Poly.None_given
              ; body =
                  Zkapps_examples.mk_update_body pk
@@ -420,7 +420,7 @@ let%test_module "Tokens test" =
              }
         |> Zkapp_command.Call_forest.cons_tree Account_updates.mint
         |> Zkapp_command.Call_forest.cons_tree Account_updates.initialize
-        |> Zkapp_command.Call_forest.cons
+        |> Zkapp_command.Call_forest.cons ~signature_kind
              (Account_updates.deploy ~balance_change:(fee_to_create_signed 2))
         |> test_zkapp_command
              ~expected_failure:(Update_not_permitted_access, Pass_2)

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -85,6 +85,7 @@ module Rules = struct
           respond Unhandled
 
     let main input =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let public_key =
         exists Public_key.Compressed.typ ~request:(fun () -> Public_key)
       in
@@ -125,7 +126,8 @@ module Rules = struct
                  .to_account_update_and_calls
             in
             let digest =
-              Zkapp_command.Digest.Account_update.Checked.create final_update
+              Zkapp_command.Digest.Account_update.Checked.create ~signature_kind
+                final_update
             in
             ( { Zkapp_call_forest.Checked.account_update =
                   { data = final_update; hash = digest }
@@ -157,10 +159,13 @@ module Rules = struct
   (** Rule to transfer tokens. *)
   module Transfer = struct
     let dummy_account_update_body =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       lazy
         (let dummy_body = Account_update.Body.dummy in
          { With_hash.data = dummy_body
-         ; hash = Zkapp_command.Digest.Account_update.create_body dummy_body
+         ; hash =
+             Zkapp_command.Digest.Account_update.create_body ~signature_kind
+               dummy_body
          } )
 
     let dummy_tree_hash =

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -486,6 +486,7 @@ type return_type =
 
 let to_account_update (account_update : account_update) :
     Zkapp_statement.Checked.t * return_type Prover_value.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   dummy_constraints () ;
   let account_update, calls =
     Account_update_under_construction.In_circuit.to_account_update_and_calls
@@ -493,7 +494,7 @@ let to_account_update (account_update : account_update) :
   in
   let account_update_digest =
     Zkapp_command.Call_forest.Digest.Account_update.Checked.create
-      account_update
+      ~signature_kind account_update
   in
   let public_output : Zkapp_statement.Checked.t =
     { account_update = (account_update_digest :> Field.t)
@@ -803,7 +804,7 @@ let insert_signatures pk_compressed sk
     Zkapp_command.Transaction_commitment.create_complete transaction_commitment
       ~memo_hash
       ~fee_payer_hash:
-        (Zkapp_command.Call_forest.Digest.Account_update.create
+        (Zkapp_command.Call_forest.Digest.Account_update.create ~signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let fee_payer =

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -63,12 +63,14 @@ let update_body ?preconditions ?(update = Account_update.Update.noop) ~account
     }
 
 let update ?(calls = []) body =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open With_stack_hash in
   let open Zkapp_command.Call_forest.Tree in
   { elt =
       { account_update = body
       ; account_update_digest =
-          Zkapp_command.Call_forest.Digest.Account_update.create body
+          Zkapp_command.Call_forest.Digest.Account_update.create ~signature_kind
+            body
       ; calls
       }
   ; stack_hash = Zkapp_command.Call_forest.Digest.Forest.empty

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -4,6 +4,7 @@ open Mina_base
 let different_version = Mina_numbers.Txn_version.(succ current)
 
 let update_vk_perm_to_be ~auth : Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let account_update : Account_update.t =
     { body =
         { Account_update.Body.dummy with
@@ -26,7 +27,8 @@ let update_vk_perm_to_be ~auth : Zkapp_command.t =
     }
   in
   { fee_payer
-  ; account_updates = Zkapp_command.Call_forest.cons account_update []
+  ; account_updates =
+      Zkapp_command.Call_forest.cons ~signature_kind account_update []
   ; memo = Signed_command_memo.empty
   }
 

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -44,6 +44,7 @@ module Checked = struct
       , (Account_update.t, Zkapp_command.Digest.Account_update.t) With_hash.t
       )
       Typ.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let (Typ typ) =
       Typ.(
         Account_update.Body.typ () * Prover_value.typ ()
@@ -75,7 +76,7 @@ module Checked = struct
                 Field.Assert.equal
                   (hash :> Field.t)
                   ( Zkapp_command.Call_forest.Digest.Account_update.Checked
-                    .create account_update
+                    .create ~signature_kind account_update
                     :> Field.t ) ) )
       }
 
@@ -102,6 +103,7 @@ module Checked = struct
   let empty () : t = { hash = empty; data = V.create (fun () -> []) }
 
   let pop_exn ({ hash = h; data = r } : t) : (account_update * t) * t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop_exn" (fun () ->
         let hd_r =
           V.create (fun () -> V.get r |> List.hd_exn |> With_stack_hash.elt)
@@ -116,7 +118,9 @@ module Checked = struct
         in
         let account_update =
           With_hash.of_data account_update
-            ~hash_data:Zkapp_command.Digest.Account_update.Checked.create
+            ~hash_data:
+              (Zkapp_command.Digest.Account_update.Checked.create
+                 ~signature_kind )
         in
         let subforest : t =
           let subforest = V.create (fun () -> (V.get hd_r).calls) in
@@ -146,6 +150,7 @@ module Checked = struct
 
   let pop ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
       (account_update * t) * t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop" (fun () ->
         let hd_r =
           V.create (fun () ->
@@ -165,7 +170,9 @@ module Checked = struct
         in
         let account_update =
           With_hash.of_data account_update
-            ~hash_data:Zkapp_command.Digest.Account_update.Checked.create
+            ~hash_data:
+              (Zkapp_command.Digest.Account_update.Checked.create
+                 ~signature_kind )
         in
         let subforest : t =
           let subforest = V.create (fun () -> (V.get hd_r).calls) in
@@ -214,6 +221,7 @@ module Checked = struct
         ; control = auth
         } ~calls:({ hash = calls_hash; data = calls } : t)
       ({ hash = tl_hash; data = tl_data } : t) : t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.push" (fun () ->
         let tree_hash =
           Zkapp_command.Digest.Tree.Checked.create
@@ -232,7 +240,8 @@ module Checked = struct
               let account_update : Account_update.t = { body; authorization } in
               let calls = V.get calls in
               let res =
-                Zkapp_command.Call_forest.cons ~calls account_update tl
+                Zkapp_command.Call_forest.cons ~signature_kind ~calls
+                  account_update tl
               in
               (* Sanity check; we're re-hashing anyway, might as well make sure it's
                  consistent.

--- a/src/lib/mina_base/zkapp_call_forest_base.ml
+++ b/src/lib/mina_base/zkapp_call_forest_base.ml
@@ -135,10 +135,10 @@ module type Digest_intf = sig
       include Digest_intf.S_checked
 
       val create :
-        ?signature_kind:Mina_signature_kind.t -> Account_update.Checked.t -> t
+        signature_kind:Mina_signature_kind.t -> Account_update.Checked.t -> t
 
       val create_body :
-           ?signature_kind:Mina_signature_kind.t
+           signature_kind:Mina_signature_kind.t
         -> Account_update.Body.Checked.t
         -> t
     end
@@ -146,12 +146,12 @@ module type Digest_intf = sig
     include Digest_intf.S_aux with type t := t and type checked := Checked.t
 
     val create :
-         ?signature_kind:Mina_signature_kind.t
+         signature_kind:Mina_signature_kind.t
       -> (Account_update.Body.t, _) Account_update.Poly.t
       -> t
 
     val create_body :
-      ?signature_kind:Mina_signature_kind.t -> Account_update.Body.t -> t
+      signature_kind:Mina_signature_kind.t -> Account_update.Body.t -> t
   end
 
   module rec Forest : sig
@@ -256,30 +256,16 @@ module Make_digest_str
     module Checked = struct
       include Checked
 
-      let create ?signature_kind =
-        let signature_kind =
-          Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-        in
-        Account_update.Checked.digest ~signature_kind
+      let create = Account_update.Checked.digest
 
-      let create_body ?signature_kind =
-        let signature_kind =
-          Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-        in
-        Account_update.Body.Checked.digest ~signature_kind
+      let create_body = Account_update.Body.Checked.digest
     end
 
-    let create ?signature_kind :
+    let create ~signature_kind :
         (Account_update.Body.t, _) Account_update.Poly.t -> t =
-      let signature_kind =
-        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-      in
       Account_update.digest ~signature_kind
 
-    let create_body ?signature_kind : Account_update.Body.t -> t =
-      let signature_kind =
-        Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-      in
+    let create_body ~signature_kind : Account_update.Body.t -> t =
       Account_update.Body.digest ~signature_kind
   end
 
@@ -484,9 +470,10 @@ let cons_aux (type p) ~(digest_account_update : p -> _) ?(calls = [])
   let tree : _ Tree.t = { account_update; account_update_digest; calls } in
   cons_tree tree xs
 
-let cons ?calls (account_update : Account_update.t) xs =
-  cons_aux ~digest_account_update:Digest.Account_update.create ?calls
-    account_update xs
+let cons ~signature_kind ?calls (account_update : Account_update.t) xs =
+  cons_aux
+    ~digest_account_update:(Digest.Account_update.create ~signature_kind)
+    ?calls account_update xs
 
 let rec accumulate_hashes ~hash_account_update (xs : _ t) =
   let go = accumulate_hashes ~hash_account_update in
@@ -508,8 +495,10 @@ let rec accumulate_hashes ~hash_account_update (xs : _ t) =
       let node_hash = Digest.Tree.create node in
       { elt = node; stack_hash = Digest.Forest.cons node_hash (hash xs) } :: xs
 
-let accumulate_hashes_predicated xs =
-  accumulate_hashes ~hash_account_update:Digest.Account_update.create xs
+let accumulate_hashes_predicated ~signature_kind xs =
+  accumulate_hashes
+    ~hash_account_update:(Digest.Account_update.create ~signature_kind)
+    xs
 
 let forget_hashes =
   let rec impl = List.map ~f:forget_digest
@@ -550,36 +539,42 @@ module With_hashes_and_data = struct
 
   let empty = Digest.Forest.empty
 
-  let hash_account_update ((p : Account_update.Stable.Latest.t), _) =
-    Digest.Account_update.create p
+  let hash_account_update ~signature_kind
+      ((p : Account_update.Stable.Latest.t), _) =
+    Digest.Account_update.create ~signature_kind p
 
-  let accumulate_hashes xs : _ t = accumulate_hashes ~hash_account_update xs
+  let accumulate_hashes ~signature_kind xs : _ t =
+    accumulate_hashes
+      ~hash_account_update:(hash_account_update ~signature_kind)
+      xs
 
-  let of_zkapp_command_simple_list (xs : (Account_update.Simple.t * 'a) list) =
+  let of_zkapp_command_simple_list ~signature_kind
+      (xs : (Account_update.Simple.t * 'a) list) =
     of_account_updates xs
       ~account_update_depth:(fun ((p : Account_update.Simple.t), _) ->
         p.body.call_depth )
     |> map ~f:(fun (p, x) -> (Account_update.of_simple p, x))
-    |> accumulate_hashes
+    |> accumulate_hashes ~signature_kind
 
-  let of_account_updates (xs : (Account_update.Graphql_repr.t * 'a) list) : _ t
-      =
+  let of_account_updates ~signature_kind
+      (xs : (Account_update.Graphql_repr.t * 'a) list) : _ t =
     of_account_updates_map
       ~account_update_depth:(fun ((p : Account_update.Graphql_repr.t), _) ->
         p.body.call_depth )
       ~f:(fun (p, x) -> (Account_update.of_graphql_repr p, x))
       xs
-    |> accumulate_hashes
+    |> accumulate_hashes ~signature_kind
 
   let to_account_updates (x : _ t) = to_account_updates x
 
   let to_zkapp_command_with_hashes_list (x : _ t) =
     to_zkapp_command_with_hashes_list x
 
-  let account_updates_hash' xs = of_account_updates xs |> hash
+  let account_updates_hash' ~signature_kind xs =
+    of_account_updates ~signature_kind xs |> hash
 
-  let account_updates_hash xs =
-    List.map ~f:(fun x -> (x, ())) xs |> account_updates_hash'
+  let account_updates_hash ~signature_kind xs =
+    List.map ~f:(fun x -> (x, ())) xs |> account_updates_hash' ~signature_kind
 end
 
 module With_hashes = struct
@@ -611,35 +606,41 @@ module With_hashes = struct
 
   let empty = Digest.Forest.empty
 
-  let hash_account_update p = Digest.Account_update.create p
+  let hash_account_update ~signature_kind p =
+    Digest.Account_update.create ~signature_kind p
 
-  let accumulate_hashes xs = accumulate_hashes ~hash_account_update xs
+  let accumulate_hashes ~signature_kind xs =
+    accumulate_hashes
+      ~hash_account_update:(hash_account_update ~signature_kind)
+      xs
 
-  let of_zkapp_command_simple_list (xs : Account_update.Simple.t list) =
+  let of_zkapp_command_simple_list ~signature_kind
+      (xs : Account_update.Simple.t list) =
     of_account_updates xs
       ~account_update_depth:(fun (p : Account_update.Simple.t) ->
         p.body.call_depth )
     |> map ~f:Account_update.of_simple
-    |> accumulate_hashes
+    |> accumulate_hashes ~signature_kind
 
-  let of_account_updates (xs : Account_update.Graphql_repr.t list) :
-      Stable.Latest.t =
+  let of_account_updates ~signature_kind
+      (xs : Account_update.Graphql_repr.t list) : Stable.Latest.t =
     of_account_updates_map
       ~account_update_depth:(fun (p : Account_update.Graphql_repr.t) ->
         p.body.call_depth )
       ~f:(fun p -> Account_update.of_graphql_repr p)
       xs
-    |> accumulate_hashes
+    |> accumulate_hashes ~signature_kind
 
   let to_account_updates (x : t) = to_account_updates x
 
   let to_zkapp_command_with_hashes_list (x : t) =
     to_zkapp_command_with_hashes_list x
 
-  let account_updates_hash' xs = of_account_updates xs |> hash
+  let account_updates_hash' ~signature_kind xs =
+    of_account_updates ~signature_kind xs |> hash
 
-  let account_updates_hash xs =
-    List.map ~f:(fun x -> x) xs |> account_updates_hash'
+  let account_updates_hash ~signature_kind xs =
+    List.map ~f:(fun x -> x) xs |> account_updates_hash' ~signature_kind
 end
 
 let is_empty : _ t -> bool = List.is_empty

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -27,7 +27,9 @@ module User_command = struct
     module V1 = struct
       type t = User_command.Stable.V2.t [@@deriving sexp]
 
-      let to_yojson : t -> Yojson.Safe.t = function
+      let to_yojson : t -> Yojson.Safe.t =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
+        function
         | User_command.Poly.Signed_command tx ->
             Helper.to_yojson ~proof_to_yojson:Proof.to_yojson (Signed_command tx)
         | User_command.Poly.Zkapp_command { fee_payer; memo; account_updates }
@@ -39,7 +41,8 @@ module User_command = struct
                  ; account_updates =
                      Zkapp_command.(
                        Call_forest.accumulate_hashes
-                         ~hash_account_update:Digest.Account_update.create)
+                         ~hash_account_update:
+                           (Digest.Account_update.create ~signature_kind))
                        account_updates
                  } )
 

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -955,9 +955,11 @@ module Make (L : Ledger_intf.S) :
         Zkapp_command.Transaction_commitment.create ~account_updates_hash
 
       let full_commitment ~account_update ~memo_hash ~commitment =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
         (* when called from Zkapp_command_logic.apply, the account_update is the fee payer *)
         let fee_payer_hash =
-          Zkapp_command.Digest.Account_update.create account_update
+          Zkapp_command.Digest.Account_update.create ~signature_kind
+            account_update
         in
         Zkapp_command.Transaction_commitment.create_complete commitment
           ~memo_hash ~fee_payer_hash
@@ -2517,7 +2519,7 @@ module For_tests = struct
       Zkapp_command.Transaction_commitment.create_complete commitment
         ~memo_hash:(Signed_command_memo.hash zkapp_command.memo)
         ~fee_payer_hash:
-          (Zkapp_command.Digest.Account_update.create
+          (Zkapp_command.Digest.Account_update.create ~signature_kind
              (Account_update.of_fee_payer zkapp_command.fee_payer) )
     in
     let account_updates_signature =

--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -102,8 +102,8 @@ let%test_module "Access permission tests" =
       in
       let account_updates =
         []
-        |> Zkapp_command.Call_forest.cons account_update
-        |> Zkapp_command.Call_forest.cons deploy_account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind account_update
+        |> Zkapp_command.Call_forest.cons ~signature_kind deploy_account_update
       in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)
@@ -128,7 +128,7 @@ let%test_module "Access permission tests" =
           transaction_commitment
           ~memo_hash:(Signed_command_memo.hash memo)
           ~fee_payer_hash:
-            (Zkapp_command.Digest.Account_update.create
+            (Zkapp_command.Digest.Account_update.create ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       (* TODO: Make this better. *)

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -392,6 +392,7 @@ let%test_module "multisig_account" =
                   [ sender_account_update_data; snapp_account_update_data ]
                 |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
                 |> Zkapp_command.Call_forest.accumulate_hashes_predicated
+                     ~signature_kind
               in
               let account_updates_hash = Zkapp_command.Call_forest.hash ps in
               let transaction : Zkapp_command.Transaction_commitment.t =
@@ -442,6 +443,7 @@ let%test_module "multisig_account" =
                     ~memo_hash:(Signed_command_memo.hash memo)
                     ~fee_payer_hash:
                       (Zkapp_command.Digest.Account_update.create
+                         ~signature_kind
                          (Account_update.of_fee_payer fee_payer) )
                 in
                 { fee_payer with

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -242,6 +242,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
           let protocol_state = Zkapp_precondition.Protocol_state.accept in
           let ps =
             Zkapp_command.Call_forest.With_hashes.of_zkapp_command_simple_list
+              ~signature_kind
               [ sender_account_update_data; snapp_account_update_data ]
           in
           let account_updates_hash = Zkapp_command.Call_forest.hash ps in
@@ -280,7 +281,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
               Zkapp_command.Transaction_commitment.create_complete transaction
                 ~memo_hash
                 ~fee_payer_hash:
-                  (Zkapp_command.Digest.Account_update.create
+                  (Zkapp_command.Digest.Account_update.create ~signature_kind
                      (Account_update.of_fee_payer fee_payer) )
             in
             { fee_payer with

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -354,7 +354,7 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let ps =
                     Zkapp_command.Call_forest.With_hashes
-                    .of_zkapp_command_simple_list
+                    .of_zkapp_command_simple_list ~signature_kind
                       [ sender_account_update; snapp_account_update ]
                   in
                   let account_updates_hash =
@@ -366,7 +366,7 @@ let%test_module "Protocol state precondition tests" =
                   in
                   let memo_hash = Signed_command_memo.hash memo in
                   let fee_payer_hash =
-                    Zkapp_command.Digest.Account_update.create
+                    Zkapp_command.Digest.Account_update.create ~signature_kind
                       (Account_update.of_fee_payer fee_payer)
                   in
                   let full_commitment =
@@ -658,6 +658,7 @@ let%test_module "Account precondition tests" =
           else update )
 
     let%test_unit "delegate precondition on new account" =
+      let signature_kind = U.signature_kind in
       let gen = U.gen_snapp_ledger in
       Quickcheck.test ~trials:5 gen ~f:(fun ({ specs; _ }, new_kp) ->
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
@@ -705,7 +706,7 @@ let%test_module "Account precondition tests" =
                           add_account_precondition ~at:1 delegate_precondition
                             zkapp_command0.account_updates
                           |> Zkapp_command.Call_forest
-                             .accumulate_hashes_predicated
+                             .accumulate_hashes_predicated ~signature_kind
                       }
                     in
                     let keymap =
@@ -722,6 +723,7 @@ let%test_module "Account precondition tests" =
     let%test_unit "unsatisfied delegate precondition, custom token" =
       (* when new account has a custom token, it doesn't get a self-delegation *)
       let constraint_constants = U.constraint_constants in
+      let signature_kind = U.signature_kind in
       let account_creation_fee =
         Currency.Fee.to_nanomina_int constraint_constants.account_creation_fee
       in
@@ -784,7 +786,7 @@ let%test_module "Account precondition tests" =
                           add_account_precondition ~at:1 delegate_precondition
                             zkapp0.account_updates
                           |> Zkapp_command.Call_forest
-                             .accumulate_hashes_predicated
+                             .accumulate_hashes_predicated ~signature_kind
                       }
                     in
                     replace_authorizations ~keymap zkapp_dummy_signatures
@@ -954,7 +956,7 @@ let%test_module "Account precondition tests" =
               in
               let ps =
                 Zkapp_command.Call_forest.With_hashes
-                .of_zkapp_command_simple_list
+                .of_zkapp_command_simple_list ~signature_kind
                   [ sender_account_update; snapp_account_update ]
               in
               let account_updates_hash = Zkapp_command.Call_forest.hash ps in
@@ -964,7 +966,7 @@ let%test_module "Account precondition tests" =
               in
               let memo_hash = Signed_command_memo.hash memo in
               let fee_payer_hash =
-                Zkapp_command.Digest.Account_update.create
+                Zkapp_command.Digest.Account_update.create ~signature_kind
                   (Account_update.of_fee_payer fee_payer)
               in
               let full_commitment =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3605,6 +3605,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         * [ `Connecting_ledger_hash of Ledger_hash.t ]
         * Zkapp_command.t )
         list ) =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let sparse_first_pass_ledger zkapp_command = function
       | `Ledger ledger ->
           Sparse_ledger.of_ledger_subset_exn ledger
@@ -3751,7 +3752,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 let next_commitment = Zkapp_command.commitment zkapp_command in
                 let memo_hash = Signed_command_memo.hash zkapp_command.memo in
                 let fee_payer_hash =
-                  Zkapp_command.Digest.Account_update.create
+                  Zkapp_command.Digest.Account_update.create ~signature_kind
                     (Account_update.of_fee_payer zkapp_command.fee_payer)
                 in
                 let next_full_commitment =
@@ -4486,7 +4487,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let ps =
         Zkapp_command.Call_forest.With_hashes.of_zkapp_command_simple_list
-          account_updates_data
+          ~signature_kind account_updates_data
       in
       let account_updates_hash = Zkapp_command.Call_forest.hash ps in
       let commitment : Zkapp_command.Transaction_commitment.t =
@@ -4496,7 +4497,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         Zkapp_command.Transaction_commitment.create_complete commitment
           ~memo_hash:(Signed_command_memo.hash memo)
           ~fee_payer_hash:
-            (Zkapp_command.Digest.Account_update.create
+            (Zkapp_command.Digest.Account_update.create ~signature_kind
                (Account_update.of_fee_payer fee_payer) )
       in
       let fee_payer =
@@ -4777,6 +4778,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let account_update_digest_with_current_chain =
         Zkapp_command.Digest.Account_update.create
+          ~signature_kind:Mina_signature_kind.t_DEPRECATED
           account_update_with_dummy_auth
       in
       let tree_with_dummy_auth =
@@ -4917,7 +4919,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         snapp_zkapp_command
         |> List.map ~f:(fun p -> (p, p))
         |> Zkapp_command.Call_forest.With_hashes_and_data
-           .of_zkapp_command_simple_list
+           .of_zkapp_command_simple_list ~signature_kind
         |> Zkapp_statement.zkapp_statements_of_forest
         |> Zkapp_command.Call_forest.to_account_updates
       in
@@ -5042,6 +5044,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let signature_transfers ?receiver_auth ~constraint_constants
         (spec : Signature_transfers_spec.t) =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let ( `Zkapp_command zkapp_command
           , `Sender_account_update sender_account_update
           , `Proof_zkapp_command snapp_zkapp_command
@@ -5055,7 +5058,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       assert (List.is_empty snapp_zkapp_command) ;
       let account_updates =
         let sender_account_update = Option.value_exn sender_account_update in
-        Zkapp_command.Call_forest.cons
+        Zkapp_command.Call_forest.cons ~signature_kind
           ( Account_update.of_simple sender_account_update
           |> Account_update.write_all_proofs_to_disk ~proof_cache_db )
           zkapp_command.account_updates
@@ -5246,6 +5249,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let memo = Signed_command_memo.empty in
       let ps =
         Zkapp_command.Call_forest.With_hashes.of_zkapp_command_simple_list
+          ~signature_kind
           [ sender_account_update_data; snapp_account_update_data ]
       in
       let account_updates_hash = Zkapp_command.Call_forest.hash ps in
@@ -5256,6 +5260,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let proof_account_update =
         let tree =
           Zkapp_command.Call_forest.With_hashes.of_zkapp_command_simple_list
+            ~signature_kind
             [ snapp_account_update_data ]
           |> List.hd_exn
         in
@@ -5277,7 +5282,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           Zkapp_command.Transaction_commitment.create_complete transaction
             ~memo_hash:(Signed_command_memo.hash memo)
             ~fee_payer_hash:
-              (Zkapp_command.Digest.Account_update.create
+              (Zkapp_command.Digest.Account_update.create ~signature_kind
                  (Account_update.of_fee_payer fee_payer) )
         in
         Signature_lib.Schnorr.Chunked.sign ~signature_kind sender.private_key

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -81,6 +81,7 @@ let collect_vk_assumptions zkapp_command =
 
 let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
     (unit, invalid) Result.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let account_updates_hash =
     Zkapp_command.Call_forest.hash
       zkapp_command.Zkapp_command.Poly.account_updates
@@ -93,7 +94,7 @@ let check_signatures_of_zkapp_command (zkapp_command : _ Zkapp_command.Poly.t) :
     Zkapp_command.Transaction_commitment.create_complete tx_commitment
       ~memo_hash:(Signed_command_memo.hash zkapp_command.memo)
       ~fee_payer_hash:
-        (Zkapp_command.Digest.Account_update.create
+        (Zkapp_command.Digest.Account_update.create ~signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let check_signature s pk msg =


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17191 in the refactoring of the network/signature kind, making it a runtime-configurable setting. This refactoring has been applied to `mina_base/zkapp_call_forest_base.ml`, removing the use of that deprecated compiled-config value from the modules in that file.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)
