### PR TITLE
Make sync ledger pipe synchronous

### DIFF
--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -319,8 +319,6 @@ end
 
 module Pipe : sig
   module Drop_on_overflow : sig
-    val bootstrap_sync_ledger : Counter.t
-
     val verified_network_pool_diffs : Counter.t
 
     val transition_frontier_valid_transitions : Counter.t

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -331,8 +331,6 @@ end
 
 module Pipe = struct
   module Drop_on_overflow = struct
-    let bootstrap_sync_ledger : Counter.t = ()
-
     let verified_network_pool_diffs : Counter.t = ()
 
     let transition_frontier_valid_transitions : Counter.t = ()

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1011,10 +1011,6 @@ module Pipe = struct
   module Drop_on_overflow = struct
     let subsystem = subsystem ^ "_overflow"
 
-    let bootstrap_sync_ledger : Counter.t =
-      let help = "Overflow in sync ledger pipe when bootstrapping" in
-      Counter.v "bootstrap_sync_ledger_pipe" ~help ~namespace ~subsystem
-
     let verified_network_pool_diffs : Counter.t =
       let help =
         "Overflow in verified network pool diffs pipe (transactions or snark \


### PR DESCRIPTION
Problem: buffered pipe for bootstrap had no semantical value. It's built
on top of an already-existing buffered pipe in the router.

Solution: use synchronous pipe.The only behavior change is that some
transitions that would otherwise be dropped when boostrap would've
finished will be transfered instead to the succeeding transition
frontier pipe.

Explain how you tested your changes:
* Relying on existing tests
* Semantics didn't change a lot, so no surprises are expected

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
