### PR TITLE
Focal https

### DIFF
--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -23,6 +23,14 @@ RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 COPY scripts/archive-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
+
 # Dependencies
 RUN apt-get update --quiet --yes \
     && apt-get upgrade --quiet --yes \
@@ -36,7 +44,6 @@ RUN apt-get update --quiet --yes \
         libpq-dev \
         gnupg2 \
         apt-transport-https \
-        ca-certificates \
         dnsutils \
         tzdata \
         postgresql \

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -27,6 +27,9 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libprocps8
 #    libjemalloc2
 
+# Use https for apt sources
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
+
 # Dependencies
 RUN apt-get update --quiet --yes \
   && apt-get upgrade --quiet --yes \

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -40,7 +40,6 @@ RUN apt-get update --quiet --yes \
   && apt-get upgrade --quiet --yes \
   && apt-get install --quiet --yes --no-install-recommends \
     apt-transport-https \
-    ca-certificates \
     curl \
     dnsutils \
     dumb-init \

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -27,7 +27,12 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libprocps8
 #    libjemalloc2
 
-# Use https for apt sources
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
 RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
 
 # Dependencies

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -27,6 +27,13 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libprocps8
 #    libjemalloc2
 
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
 
 # --- Dependencies across many platforms
 RUN apt-get update --quiet --yes \
@@ -35,7 +42,6 @@ RUN apt-get update --quiet --yes \
     apt-utils \
     apt-transport-https \
     curl \
-    ca-certificates \
     build-essential \
     dnsutils \
     dumb-init \

--- a/dockerfiles/Dockerfile-mina-test-suite
+++ b/dockerfiles/Dockerfile-mina-test-suite
@@ -18,6 +18,14 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libprocps8
 #    libjemalloc2
 
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
+
 # --- Dependencies across many platforms
 RUN apt-get update --quiet --yes \
   && apt-get upgrade --quiet --yes \
@@ -25,7 +33,6 @@ RUN apt-get update --quiet --yes \
     apt-utils \
     apt-transport-https \
     curl \
-    ca-certificates \
     build-essential \
     dnsutils \
     dumb-init \

--- a/dockerfiles/Dockerfile-txn-burst
+++ b/dockerfiles/Dockerfile-txn-burst
@@ -16,6 +16,14 @@ ARG deb_repo="http://packages.o1test.net"
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
+
 # Dependencies
 RUN apt-get -y update \
     && apt-get -y upgrade \
@@ -26,7 +34,6 @@ RUN apt-get -y update \
         dumb-init \
         libssl1.1 \
         apt-transport-https \
-        ca-certificates \
         dnsutils \
 	apt-utils \
         man \

--- a/dockerfiles/Dockerfile-zkapp-test-transaction
+++ b/dockerfiles/Dockerfile-zkapp-test-transaction
@@ -10,6 +10,14 @@ ARG deb_repo="http://packages.o1test.net"
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
+# Install ca-certificates using HTTP
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch to HTTPS
+RUN sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
+
 # Dependencies
 RUN apt-get -y update \
     && apt-get -y upgrade \
@@ -20,7 +28,6 @@ RUN apt-get -y update \
         dumb-init \
         libssl1.1 \
         apt-transport-https \
-        ca-certificates \
         dnsutils \
 	apt-utils \
         man \


### PR DESCRIPTION
This PR works around an issue where Ubuntu Focal repositories do not respond to HTTP requests. It does it by switching to `https` all apt sources used to fetch dependencies.