### PR TITLE
docs(nix): simplify obsolete 'untrusted substituter' advice in  nix/README.md

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -594,9 +594,10 @@ values with possibly already existing):
 ```
 trusted-substituters = https://storage.googleapis.com/mina-nix-cache https://cache.nixos.org
 trusted-public-keys = nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c= nix-cache.minaprotocol.org:fdcuDzmnM0Kbf7yU4yywBuUEJWClySc1WIF6t6Mm8h4= nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+trusted-users = root your-username
 ```
 
-And then reload your `nix-daemon` service.
+Replace `your-username` with your actual username. If the `trusted-users` line already exists, add your username to the space-separated list (e.g., `trusted-users = root existing-user your-username`) and then reload your `nix-daemon` service.
 
 ### `gcc: Argument list too long`
 


### PR DESCRIPTION
Explain your changes:
* updated `nix/README.md` to simplify and modernize guidance for the `Warning: ignoring untrusted substituter,` recommending trusted-users in `/etc/nix/nix.conf`.

In #17276 as @glyh thought to enable `accept-flake-config = true` in `nix.conf` but through this 
* Nix will blindly accept any configuration a flake wants to impose, including potentially malicious ones like running arbitrary commands as root or using untrusted builders . it's a significant security trade-off.
* doesn't directly fix "Broken Public Key": If a public key for a cache is genuinely malformed or incorrect in the flake.nix or elsewhere, accept-flake-config won't fix the key itself. It would just force Nix to try and use whatever (potentially broken) cache configuration the flake provides. The underlying issue of a bad key would persist

* safer solution: adding user to `trusted-user` allows Nix to use flake-specified substituters (and others) without globally accepting all flake configurations. This is a common and safer approach.

Explain how you tested your changes:
* this is a documentation-only change. the Nix configuration advice provided is a standard and widely tested solution for the described warning.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #17276 
