### PR TITLE
Move deprecated value out of mina base

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4004,6 +4004,7 @@ module Block = struct
 
   let add_from_extensional (module Conn : CONNECTION) ~proof_cache_db
       ?(v1_transaction_hash = false) (block : Extensional.Block.t) =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let open Deferred.Result.Let_syntax in
     let%bind block_id =
       match%bind find_opt (module Conn) ~state_hash:block.state_hash with
@@ -4186,7 +4187,7 @@ module Block = struct
             let%map cmd_id =
               User_command.Zkapp_command.add_if_doesn't_exist
                 (module Conn)
-                (Zkapp_command.of_simple ~proof_cache_db
+                (Zkapp_command.of_simple ~signature_kind ~proof_cache_db
                    { fee_payer; account_updates; memo } )
             in
             (zkapp_cmd, cmd_id) :: acc )

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2141,6 +2141,7 @@ let receipt_chain_hash =
            "NN For a zkApp, 0 for fee payer or 1-based index of account update"
          (optional string)
      in
+     let signature_kind = Mina_signature_kind.t_DEPRECATED in
      fun () ->
        let previous_hash =
          Receipt.Chain_hash.of_base58_check_exn previous_hash
@@ -2159,9 +2160,9 @@ let receipt_chain_hash =
              in
              let receipt_elt =
                let _txn_commitment, full_txn_commitment =
-                 Zkapp_command.get_transaction_commitments
-                   (Zkapp_command.write_all_proofs_to_disk ~proof_cache_db
-                      zkapp_cmd )
+                 Zkapp_command.get_transaction_commitments ~signature_kind
+                   (Zkapp_command.write_all_proofs_to_disk ~signature_kind
+                      ~proof_cache_db zkapp_cmd )
                in
                Receipt.Zkapp_command_elt.Zkapp_command_commitment
                  full_txn_commitment

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -516,6 +516,7 @@ let get_parent_state_view ~pool block_id =
 
 let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
     (cmd : Sql.Zkapp_command.t) : Mina_transaction.Transaction.t Deferred.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let query_db = Mina_caqti.query pool in
   (* use dummy authorizations *)
   let%bind (fee_payer : Account_update.Fee_payer.t) =
@@ -551,7 +552,8 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
   in
   let memo = Signed_command_memo.of_base58_check_exn cmd.memo in
   let zkapp_command =
-    Zkapp_command.of_simple ~proof_cache_db { fee_payer; account_updates; memo }
+    Zkapp_command.of_simple ~signature_kind ~proof_cache_db
+      { fee_payer; account_updates; memo }
   in
   return
   @@ Mina_transaction.Transaction.Command

--- a/src/app/zkapps_examples/calls/zkapps_calls.ml
+++ b/src/app/zkapps_examples/calls/zkapps_calls.ml
@@ -132,11 +132,12 @@ type _ Snarky_backendless.Request.t +=
     for the [Execute_call] request.
 *)
 let execute_call ~may_use_token account_update old_state =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let call_inputs = { Call_data.Input.Circuit.old_state } in
   let call_outputs, called_account_update, sub_calls =
     exists
       (Typ.tuple3 Call_data.Output.typ
-         (Zkapp_call_forest.Checked.account_update_typ ())
+         (Zkapp_call_forest.Checked.account_update_typ ~signature_kind ())
          Zkapp_call_forest.typ )
       ~request:(fun () ->
         let may_use_token =

--- a/src/app/zkapps_examples/tokens/zkapps_tokens.ml
+++ b/src/app/zkapps_examples/tokens/zkapps_tokens.ml
@@ -330,6 +330,7 @@ module Rules = struct
         State.Circuit.t
         * Zkapp_call_forest.Checked.account_update
         * Account_update.May_use_token.Checked.t =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       let dummy_account_update_body = Lazy.force dummy_account_update_body in
       let dummy : _ Zkapp_command.Call_forest.Tree.t =
         { account_update =
@@ -343,7 +344,8 @@ module Rules = struct
         Zkapp_command.Digest.Tree.constant (Lazy.force dummy_tree_hash)
       in
       let (account_update, forest), rest_of_forest =
-        Zkapp_call_forest.Checked.pop ~dummy ~dummy_tree_hash forest
+        Zkapp_call_forest.Checked.pop ~signature_kind ~dummy ~dummy_tree_hash
+          forest
       in
       let rest_of_forest_is_empty =
         Zkapp_call_forest.Checked.is_empty rest_of_forest

--- a/src/app/zkapps_examples/zkapps_examples.ml
+++ b/src/app/zkapps_examples/zkapps_examples.ml
@@ -208,6 +208,7 @@ module Account_update_under_construction = struct
 
     let to_account_update_and_calls (t : t) :
         Account_update.Body.Checked.t * Zkapp_call_forest.Checked.t =
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       (* TODO: Don't do this. *)
       let var_of_t (type var value) (typ : (var, value) Typ.t) (x : value) : var
           =
@@ -283,7 +284,8 @@ module Account_update_under_construction = struct
         | Rev_calls rev_calls ->
             List.fold_left ~init:(Zkapp_call_forest.Checked.empty ()) rev_calls
               ~f:(fun acc (account_update, calls) ->
-                Zkapp_call_forest.Checked.push ~account_update ~calls acc )
+                Zkapp_call_forest.Checked.push ~signature_kind ~account_update
+                  ~calls acc )
         | Calls calls ->
             calls
       in

--- a/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
+++ b/src/lib/mina_base/test/helpers/zkapp_cmd_builder.ml
@@ -16,6 +16,8 @@ type transaction = < updates : (account_update list, nonces) Monad_lib.State.t >
 
 let dummy_auth = Control.Poly.Signature Signature.dummy
 
+let signature_kind = Mina_signature_kind.Testnet
+
 let get_nonce_exn (pk : Public_key.Compressed.t) :
     ( Account_nonce.t
     , Account_nonce.t Public_key.Compressed.Map.t )
@@ -63,7 +65,6 @@ let update_body ?preconditions ?(update = Account_update.Update.noop) ~account
     }
 
 let update ?(calls = []) body =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open With_stack_hash in
   let open Zkapp_command.Call_forest.Tree in
   { elt =

--- a/src/lib/mina_base/test/verification_key_permission_test.ml
+++ b/src/lib/mina_base/test/verification_key_permission_test.ml
@@ -4,7 +4,7 @@ open Mina_base
 let different_version = Mina_numbers.Txn_version.(succ current)
 
 let update_vk_perm_to_be ~auth : Zkapp_command.t =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  let signature_kind = Mina_signature_kind.Testnet in
   let account_update : Account_update.t =
     Account_update.with_aux
       ~body:

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -91,11 +91,15 @@ end]
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
 [@@deriving sexp_of, to_yojson]
 
-let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t = function
+let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  function
   | Signed_command sc ->
       Signed_command sc
   | Zkapp_command zc ->
-      Zkapp_command (Zkapp_command.write_all_proofs_to_disk ~proof_cache_db zc)
+      Zkapp_command
+        (Zkapp_command.write_all_proofs_to_disk ~signature_kind ~proof_cache_db
+           zc )
 
 let read_all_proofs_from_disk : t -> Stable.Latest.t = function
   | Signed_command sc ->

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -62,18 +62,19 @@ end
 
 module Gen = Gen_make (Signed_command)
 
-let gen_signed =
+let gen_signed ~signature_kind =
   let module G = Signed_command.Gen in
   let open Quickcheck.Let_syntax in
   let%bind keys =
     Quickcheck.Generator.list_with_length 2
       Mina_base_import.Signature_keypair.gen
   in
-  let sign_type = `Real Mina_signature_kind.t_DEPRECATED in
+  let sign_type = `Real signature_kind in
   G.payment_with_random_participants ~sign_type ~keys:(Array.of_list keys)
     ~max_amount:10000 ~fee_range:1000 ()
 
-let gen = Gen.to_signed_command gen_signed
+let gen =
+  Gen.to_signed_command (gen_signed ~signature_kind:Mina_signature_kind.Testnet)
 
 [%%versioned
 module Stable = struct
@@ -91,9 +92,8 @@ end]
 type t = (Signed_command.t, Zkapp_command.t) Poly.t
 [@@deriving sexp_of, to_yojson]
 
-let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
-  function
+let write_all_proofs_to_disk ~signature_kind ~proof_cache_db :
+    Stable.Latest.t -> t = function
   | Signed_command sc ->
       Signed_command sc
   | Zkapp_command zc ->
@@ -366,8 +366,7 @@ module Valid = struct
 end
 
 module For_tests = struct
-  let check_verifiable (t : Verifiable.t) : Valid.t Or_error.t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  let check_verifiable ~signature_kind (t : Verifiable.t) : Valid.t Or_error.t =
     match t with
     | Signed_command x -> (
         match Signed_command.check ~signature_kind x with

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -16,7 +16,8 @@ let if_ = Zkapp_command.value_if
 
 let is_empty = List.is_empty
 
-let pop_exn : t -> (Account_update.t * t) * t = function
+let pop_exn ~signature_kind:(_ : Mina_signature_kind.t) :
+    t -> (Account_update.t * t) * t = function
   | { stack_hash = _
     ; elt = { account_update; calls; account_update_digest = _ }
     }
@@ -39,12 +40,11 @@ module Checked = struct
     ; control : Control.t Prover_value.t
     }
 
-  let account_update_typ () :
+  let account_update_typ ~signature_kind () :
       ( account_update
       , (Account_update.t, Zkapp_command.Digest.Account_update.t) With_hash.t
       )
       Typ.t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let (Typ typ) =
       Typ.(
         Account_update.Body.typ () * Prover_value.typ ()
@@ -102,8 +102,8 @@ module Checked = struct
 
   let empty () : t = { hash = empty; data = V.create (fun () -> []) }
 
-  let pop_exn ({ hash = h; data = r } : t) : (account_update * t) * t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  let pop_exn ~signature_kind ({ hash = h; data = r } : t) :
+      (account_update * t) * t =
     with_label "Zkapp_call_forest.pop_exn" (fun () ->
         let hd_r =
           V.create (fun () -> V.get r |> List.hd_exn |> With_stack_hash.elt)
@@ -148,9 +148,8 @@ module Checked = struct
             } )
           : (account_update * t) * t ) )
 
-  let pop ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
+  let pop ~signature_kind ~dummy ~dummy_tree_hash ({ hash = h; data = r } : t) :
       (account_update * t) * t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.pop" (fun () ->
         let hd_r =
           V.create (fun () ->
@@ -215,13 +214,12 @@ module Checked = struct
           : (account_update * t) * t ) )
 
   (* TODO Consider moving out of mina_base *)
-  let push
+  let push ~signature_kind
       ~account_update:
         { account_update = { hash = account_update_hash; data = account_update }
         ; control = auth
         } ~calls:({ hash = calls_hash; data = calls } : t)
       ({ hash = tl_hash; data = tl_data } : t) : t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     with_label "Zkapp_call_forest.push" (fun () ->
         let tree_hash =
           Zkapp_command.Digest.Tree.Checked.create

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -136,8 +136,8 @@ end
 
 include T
 
-let write_all_proofs_to_disk ~proof_cache_db (w : Stable.Latest.t) : t =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let write_all_proofs_to_disk ~signature_kind ~proof_cache_db
+    (w : Stable.Latest.t) : t =
   { fee_payer = w.fee_payer
   ; memo = w.memo
   ; account_updates =
@@ -166,8 +166,7 @@ let forget_digests_and_proofs_and_aux
 
 [%%define_locally Stable.Latest.(gen)]
 
-let of_simple ~proof_cache_db (w : Simple.t) : t =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let of_simple ~signature_kind ~proof_cache_db (w : Simple.t) : t =
   { fee_payer = w.fee_payer
   ; memo = w.memo
   ; account_updates =
@@ -215,8 +214,7 @@ let to_simple (t : t) : Simple.t =
              } )
   }
 
-let all_account_updates t : _ Call_forest.t =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let all_account_updates ~signature_kind t : _ Call_forest.t =
   let p = t.Poly.fee_payer in
   let body = Account_update.Body.of_fee_payer p.body in
   let account_update =
@@ -926,8 +924,7 @@ let zkapp_command_to_json x =
 let arg_query_string x =
   Fields_derivers_zkapps.Test.Loop.json_to_string_gql @@ to_json x
 
-let dummy =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let dummy ~signature_kind =
   lazy
     (let account_update =
        Account_update.with_aux ~body:Account_update.Body.dummy
@@ -1433,8 +1430,7 @@ let is_incompatible_version
       | Set { set_verification_key = _auth, txn_version; _ } ->
           not Mina_numbers.Txn_version.(equal_to_current txn_version) )
 
-let get_transaction_commitments (zkapp_command : _ Poly.t) =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let get_transaction_commitments ~signature_kind (zkapp_command : _ Poly.t) =
   let memo_hash = Signed_command_memo.hash zkapp_command.memo in
   let fee_payer_hash =
     Account_update.of_fee_payer zkapp_command.fee_payer

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -397,6 +397,7 @@ module Mutations = struct
       , string )
       result
       Io.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     (* instead of adding the zkapp_command to the transaction pool, as we would for an actual zkapp,
        apply the zkapp using an ephemeral ledger
     *)
@@ -466,7 +467,7 @@ module Mutations = struct
                       |> Consensus.Data.Consensus_state
                          .global_slot_since_genesis )
                     ~state_view ledger
-                    (Zkapp_command.write_all_proofs_to_disk
+                    (Zkapp_command.write_all_proofs_to_disk ~signature_kind
                        ~proof_cache_db:(Mina_lib.proof_cache_db mina)
                        zkapp_command )
                 in
@@ -1656,6 +1657,7 @@ module Queries = struct
   (* helper for pooledUserCommands, pooledZkappCommands *)
   let get_commands ~proof_cache_db ~resource_pool ~pk_opt ~hashes_opt ~txns_opt
       =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     match (pk_opt, hashes_opt, txns_opt) with
     | None, None, None ->
         Network_pool.Transaction_pool.Resource_pool.get_all resource_pool
@@ -1709,7 +1711,7 @@ module Queries = struct
                           let user_cmd =
                             User_command.Zkapp_command
                               (Zkapp_command.write_all_proofs_to_disk
-                                 ~proof_cache_db zkapp_command )
+                                 ~signature_kind ~proof_cache_db zkapp_command )
                           in
                           (* The command gets piped through [forget_check]
                              below; this is just to make the types work

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -502,6 +502,8 @@ let commit_to_pool ledger pool cmd expected_drops =
 
 let proof_cache_db = Proof_cache_tag.For_tests.create_db ()
 
+let signature_kind = Mina_signature_kind.Testnet
+
 let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
     ~double_increment_sender ~increment_receiver ~amount ~fee nonce_int =
   let nonce = Account.Nonce.of_int nonce_int in
@@ -568,7 +570,8 @@ let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
     }
   in
   let zkapp_command =
-    Zkapp_command.write_all_proofs_to_disk ~proof_cache_db zkapp_command_wire
+    Zkapp_command.write_all_proofs_to_disk ~signature_kind ~proof_cache_db
+      zkapp_command_wire
   in
   (* We skip signing the commitment and updating the authorization as it is not necessary to have a valid transaction for these tests. *)
   let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd) =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1126,6 +1126,7 @@ struct
           ( verified Envelope.Incoming.t
           , Intf.Verification_error.t )
           Deferred.Result.t =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
         let open Deferred.Result.Let_syntax in
         let open Intf.Verification_error in
         let%bind () =
@@ -1185,7 +1186,7 @@ struct
           O1trace.sync_thread "convert_transactions_to_verifiable" (fun () ->
               List.map
                 ~f:
-                  (User_command.write_all_proofs_to_disk
+                  (User_command.write_all_proofs_to_disk ~signature_kind
                      ~proof_cache_db:t.config.proof_cache_db )
                 diff
               |> User_command.Unapplied_sequence.to_all_verifiable
@@ -1674,6 +1675,8 @@ let%test_module _ =
 
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
+    let signature_kind = Mina_signature_kind.Testnet
+
     let constraint_constants = precomputed_values.constraint_constants
 
     let consensus_constants = precomputed_values.consensus_constants
@@ -1868,7 +1871,8 @@ let%test_module _ =
             |> Map.map ~f:(fun vk ->
                    Zkapp_basic.F_map.Map.singleton vk.hash vk ) )
         |> Or_error.bind ~f:(fun xs ->
-               List.map xs ~f:User_command.For_tests.check_verifiable
+               List.map xs
+                 ~f:(User_command.For_tests.check_verifiable ~signature_kind)
                |> Or_error.combine_errors )
       with
       | Ok cmds ->

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -191,6 +191,7 @@ let create_ledger_and_zkapps ?(min_num_updates = 1) ?(num_proof_updates = 0)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~max_num_updates () :
     (Mina_ledger.Ledger.t * Zkapp_command.t list) Async.Deferred.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let `VK verification_key, `Prover prover =
     Transaction_snark.For_tests.create_trivial_snapp ()
   in
@@ -394,7 +395,7 @@ let create_ledger_and_zkapps ?(min_num_updates = 1) ?(num_proof_updates = 0)
         |> Async.Deferred.List.filter_mapi ~how:`Sequential
              ~f:(fun i (account_updates : Account_update.Simple.t list) ->
                let p =
-                 Zkapp_command.of_simple ~proof_cache_db
+                 Zkapp_command.of_simple ~signature_kind ~proof_cache_db
                    { simple_parties with account_updates }
                in
                let combination =

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -62,6 +62,7 @@ module Impl = struct
   let perform_single
       ({ cache; proof_level_snark; proof_cache_db; logger } : Worker_state.t)
       ~message (single : Snark_work_lib.Selector.Single.Spec.Stable.Latest.t) =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let open Deferred.Or_error.Let_syntax in
     let open Snark_work_lib in
     let sok_digest = Mina_base.Sok_message.digest message in
@@ -101,7 +102,7 @@ module Impl = struct
                           extract_zkapp_segment_works ~m ~input ~witness:w
                             ~zkapp_command:
                               (Zkapp_command.write_all_proofs_to_disk
-                                 ~proof_cache_db zkapp_command )
+                                 ~signature_kind ~proof_cache_db zkapp_command )
                           |> Deferred.return
                         in
                         let log_base_snark f ~statement ~spec ~all_inputs =

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -158,11 +158,14 @@ module Pre_diff_with_at_most_two_coinbase = struct
     (Transaction_snark_work.t, User_command.t With_status.t) Pre_diff_two.t
 
   let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     Pre_diff_two.map
       ~f1:(Transaction_snark_work.write_all_proofs_to_disk ~proof_cache_db)
       ~f2:
         (With_status.map
-           ~f:(User_command.write_all_proofs_to_disk ~proof_cache_db) )
+           ~f:
+             (User_command.write_all_proofs_to_disk ~signature_kind
+                ~proof_cache_db ) )
 
   let read_all_proofs_from_disk : t -> Stable.Latest.t =
     Pre_diff_two.map ~f1:Transaction_snark_work.read_all_proofs_from_disk
@@ -189,11 +192,14 @@ module Pre_diff_with_at_most_one_coinbase = struct
     (Transaction_snark_work.t, User_command.t With_status.t) Pre_diff_one.t
 
   let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     Pre_diff_one.map
       ~f1:(Transaction_snark_work.write_all_proofs_to_disk ~proof_cache_db)
       ~f2:
         (With_status.map
-           ~f:(User_command.write_all_proofs_to_disk ~proof_cache_db) )
+           ~f:
+             (User_command.write_all_proofs_to_disk ~signature_kind
+                ~proof_cache_db ) )
 
   let read_all_proofs_from_disk : t -> Stable.Latest.t =
     Pre_diff_one.map ~f1:Transaction_snark_work.read_all_proofs_from_disk

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -49,8 +49,9 @@ let read_all_proofs_from_disk : t -> Stable.Latest.t =
   Poly.Stable.Latest.map ~f:User_command.read_all_proofs_from_disk
 
 let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   Poly.Stable.Latest.map
-    ~f:(User_command.write_all_proofs_to_disk ~proof_cache_db)
+    ~f:(User_command.write_all_proofs_to_disk ~signature_kind ~proof_cache_db)
 
 type 'command t_ = 'command Poly.t =
   | Command of 'command

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1622,6 +1622,7 @@ module Make (L : Ledger_intf.S) :
       ( Transaction_partially_applied.Zkapp_command_partially_applied.t
       * user_acc )
       Or_error.t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let open Or_error.Let_syntax in
     let previous_hash = merkle_root ledger in
     let original_first_pass_account_states =
@@ -1665,7 +1666,9 @@ module Make (L : Ledger_intf.S) :
         } )
     in
     let user_acc = f init initial_state in
-    let account_updates = Zkapp_command.all_account_updates command in
+    let account_updates =
+      Zkapp_command.all_account_updates ~signature_kind command
+    in
     let%map global_state, local_state =
       Or_error.try_with (fun () ->
           M.start ~constraint_constants
@@ -2517,7 +2520,9 @@ module For_tests = struct
       ; memo = Signed_command_memo.empty
       }
     in
-    let zkapp_command = Zkapp_command.of_simple ~proof_cache_db zkapp_command in
+    let zkapp_command =
+      Zkapp_command.of_simple ~signature_kind ~proof_cache_db zkapp_command
+    in
     let commitment = Zkapp_command.commitment zkapp_command in
     let full_commitment =
       Zkapp_command.Transaction_commitment.create_complete commitment

--- a/src/lib/transaction_logic/transaction_applied.ml
+++ b/src/lib/transaction_logic/transaction_applied.ml
@@ -77,10 +77,13 @@ module Zkapp_command_applied = struct
 
   let write_all_proofs_to_disk ~proof_cache_db
       { Stable.Latest.accounts; command; new_accounts } : t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { accounts
     ; command =
         With_status.map
-          ~f:(Zkapp_command.write_all_proofs_to_disk ~proof_cache_db)
+          ~f:
+            (Zkapp_command.write_all_proofs_to_disk ~signature_kind
+               ~proof_cache_db )
           command
     ; new_accounts
     }

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -492,7 +492,8 @@ module type Call_forest_intf = sig
 
   val is_empty : t -> bool
 
-  val pop_exn : t -> (account_update * t) * t
+  val pop_exn :
+    signature_kind:Mina_signature_kind.t -> t -> (account_update * t) * t
 end
 
 module type Stack_frame_intf = sig
@@ -1012,6 +1013,7 @@ module Make (Inputs : Inputs_intf) = struct
       (* The stack for the most recent zkApp *)
         (call_stack : Call_stack.t) (* The partially-completed parent stacks *)
       : get_next_account_update_result =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     (* If the current stack is complete, 'return' to the previous
        partially-completed one.
     *)
@@ -1030,7 +1032,7 @@ module Make (Inputs : Inputs_intf) = struct
       )
     in
     let (account_update, account_update_forest), remainder_of_current_forest =
-      Call_forest.pop_exn (Stack_frame.calls current_forest)
+      Call_forest.pop_exn ~signature_kind (Stack_frame.calls current_forest)
     in
     let may_use_parents_own_token =
       Account_update.may_use_parents_own_token account_update

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -466,7 +466,7 @@ let%test_module "multisig_account" =
                 }
               in
               let zkapp_command : Zkapp_command.t =
-                Zkapp_command.of_simple ~proof_cache_db
+                Zkapp_command.of_simple ~signature_kind ~proof_cache_db
                   { fee_payer
                   ; account_updates =
                       [ sender

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -304,7 +304,7 @@ let%test_unit "ring-signature zkapp tx with 3 zkapp_command" =
             }
           in
           let zkapp_command : Zkapp_command.t =
-            Zkapp_command.of_simple ~proof_cache_db
+            Zkapp_command.of_simple ~signature_kind ~proof_cache_db
               { fee_payer
               ; account_updates =
                   [ sender

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -45,7 +45,7 @@ let%test_module "Zkapp payments tests" =
       let new_state : _ Zkapp_state.V.t =
         Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:Field.of_int
       in
-      Zkapp_command.of_simple ~proof_cache_db
+      Zkapp_command.of_simple ~signature_kind:U.signature_kind ~proof_cache_db
         { fee_payer =
             Account_update.Fee_payer.make
               ~body:

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -406,7 +406,7 @@ let%test_module "Protocol state precondition tests" =
                     ; account_updates =
                         [ sender_account_update; snapp_account_update ]
                     }
-                    |> Zkapp_command.of_simple ~proof_cache_db
+                    |> Zkapp_command.of_simple ~signature_kind ~proof_cache_db
                   in
                   Mina_transaction_logic.For_tests.Init_ledger.init
                     (module Mina_ledger.Ledger.Ledger_inner)
@@ -1000,7 +1000,7 @@ let%test_module "Account precondition tests" =
                 }
               in
               let zkapp_command_with_invalid_fee_payer =
-                Zkapp_command.of_simple ~proof_cache_db
+                Zkapp_command.of_simple ~signature_kind ~proof_cache_db
                   { fee_payer
                   ; memo
                   ; account_updates =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1867,6 +1867,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
       let main ?(witness : Witness.t option) (spec : Spec.t)
           ~constraint_constants (statement : Statement.With_sok.var) =
+        let signature_kind = Mina_signature_kind.t_DEPRECATED in
         let open Impl in
         run_checked (dummy_constraints ()) ;
         let ( ! ) x = Option.value_exn x in
@@ -1960,7 +1961,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                     | `Skip ->
                         []
                     | `Start p ->
-                        Zkapp_command.all_account_updates p.account_updates )
+                        Zkapp_command.all_account_updates ~signature_kind
+                          p.account_updates )
                 in
                 let h =
                   exists Zkapp_command.Digest.Forest.typ ~compute:(fun () ->
@@ -4561,7 +4563,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 s )
       in
       ( `Zkapp_command
-          (Zkapp_command.of_simple ~proof_cache_db
+          (Zkapp_command.of_simple ~signature_kind ~proof_cache_db
              { fee_payer; account_updates = other_receivers; memo } )
       , `Sender_account_update sender_account_update
       , `Proof_zkapp_command snapp_zkapp_command
@@ -4687,7 +4689,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let account_updates =
         Option.to_list sender_account_update @ snapp_zkapp_command
       in
-      Zkapp_command.of_simple ~proof_cache_db
+      Zkapp_command.of_simple ~signature_kind ~proof_cache_db
         { fee_payer; memo; account_updates }
 
     (* This spec is intended to build a zkapp command with only one account update
@@ -4986,7 +4988,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         @ snapp_zkapp_command @ receivers
       in
       let zkapp_command : Zkapp_command.t =
-        Zkapp_command.of_simple ~proof_cache_db
+        Zkapp_command.of_simple ~signature_kind ~proof_cache_db
           { fee_payer; account_updates; memo }
       in
       zkapp_command
@@ -5317,7 +5319,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           }
         ]
       in
-      Zkapp_command.of_simple ~proof_cache_db
+      Zkapp_command.of_simple ~signature_kind ~proof_cache_db
         { fee_payer; account_updates; memo }
   end
 end

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -117,6 +117,7 @@ module Zkapp_command_segment_witness = struct
        ; block_global_slot
        } :
         Stable.V1.t ) : t =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { global_first_pass_ledger
     ; global_second_pass_ledger
     ; local_state_init =
@@ -131,8 +132,8 @@ module Zkapp_command_segment_witness = struct
             Mina_transaction_logic.Zkapp_command_logic.Start_data.
               { sd with
                 account_updates =
-                  Zkapp_command.write_all_proofs_to_disk ~proof_cache_db
-                    sd.account_updates
+                  Zkapp_command.write_all_proofs_to_disk ~signature_kind
+                    ~proof_cache_db sd.account_updates
               } )
           start_zkapp_command
     ; state_body

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -45,6 +45,7 @@ let mk_account_update_body ?preconditions ?(increment_nonce = false)
 
 let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Zkapp_command.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let fee_payer : Account_update.Fee_payer.t =
     Account_update.Fee_payer.make
       ~body:
@@ -59,7 +60,7 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
     Option.value_map memo ~default:Signed_command_memo.dummy
       ~f:Signed_command_memo.create_from_string_exn
   in
-  Zkapp_command.write_all_proofs_to_disk
+  Zkapp_command.write_all_proofs_to_disk ~signature_kind
     ~proof_cache_db:(Proof_cache_tag.For_tests.create_db ())
     { Zkapp_command.Poly.fee_payer
     ; memo
@@ -88,8 +89,9 @@ let proof_cache_db = Proof_cache_tag.For_tests.create_db ()
 *)
 let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
     Zkapp_command.t Async_kernel.Deferred.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let txn_commitment, full_txn_commitment =
-    Zkapp_command.get_transaction_commitments zkapp_command
+    Zkapp_command.get_transaction_commitments ~signature_kind zkapp_command
   in
   let sign_for_account_update ~use_full_commitment sk =
     let commitment =


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17299 in the refactoring of the network/signature kind, making it a runtime-configurable setting. This refactoring has been applied to the final few files in `mina_base` still referencing the deprecated compiled-config value for the signature kind.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour, other than the slight difference that certain tests now always use the `Mina_signature_kind.Testnet` signature kind.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)
