### PR TITLE
pin ocamlfind.1.9.3 to alt path until connectivity solved

### DIFF
--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -118,7 +118,6 @@ RUN curl --proto '=https' \
     --component rust-src \
     --target wasm32-unknown-unknown \
     --no-self-update \
-  && cargo install cargo-xtask \
   && $HOME/.cargo/bin/cargo install cargo-xtask \
   && rm /tmp/rustup-init
 USER root

--- a/dockerfiles/stages/2-opam-deps
+++ b/dockerfiles/stages/2-opam-deps
@@ -41,7 +41,8 @@ WORKDIR $HOME/$MINA_DIR
 # Set environment variables *before* running OPAM commands
 ENV OPAMYES=1
 
-RUN opam pin add ocamlfind.1.9.3 http://157.180.13.160:8080/archives/ocamlfind.1.9.3+opam.tar.gz
+# --- Use alternative ocamlfind location since download.camlcity.org is not available
+RUN opam pin add ocamlfind.1.9.3 http://download2.camlcity.org/download/findlib-1.9.3.tar.gz
 
 # Update repo and install the switch (sources must be available locally!)
 RUN opam update && \

--- a/dockerfiles/stages/2-opam-deps
+++ b/dockerfiles/stages/2-opam-deps
@@ -38,11 +38,14 @@ RUN git clone \
 
 WORKDIR $HOME/$MINA_DIR
 
-ENV OPAMYES 1
+# Set environment variables *before* running OPAM commands
+ENV OPAMYES=1
 
-# --- Import Opam Switch
-# TODO: handle this opam work without cloning the full repository (directly pull opam.export)
-RUN opam switch import opam.export --quiet
+RUN opam pin add ocamlfind.1.9.3 http://157.180.13.160:8080/archives/ocamlfind.1.9.3+opam.tar.gz
+
+# Update repo and install the switch (sources must be available locally!)
+RUN opam update && \
+    opam switch import opam.export --yes
 
 # --- Pin external packages / submodules
 # TODO: Would be really nice to pull this script, the git submodules, and opam.export exclusively in this stage


### PR DESCRIPTION
We are experiencing issues with unvailable location for ocamlfind1.9.3 sources:

https://buildkite.com/o-1-labs-2/mina-toolchains-build/builds/168#019734d1-e310-4849-86b4-08555fb281e1

Quickest solution is to pin ocamlfind1.9.3 to alternative location advised on similar issue: 

https://github.com/ocaml/ocamlfind/issues/98#issuecomment-2678150397