### PR TITLE
Move deprecated value out of transaction logic

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -641,6 +641,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
         ~transport:(Logger_file_system.evergrowing ~log_filename)
         () ) ;
   let proof_cache_db = Proof_cache_tag.create_identity_db () in
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let logger = Logger.create () in
   let json = Yojson.Safe.from_file input_file in
   let input =
@@ -1284,7 +1285,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                   let%bind phase_1s =
                     Deferred.List.mapi txns ~f:(fun n txn ->
                         match
-                          Ledger.apply_transaction_first_pass
+                          Ledger.apply_transaction_first_pass ~signature_kind
                             ~constraint_constants
                             ~global_slot:
                               (Mina_numbers.Global_slot_since_genesis.of_uint32

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -32,9 +32,10 @@ let get_second_pass_ledger_mask ~ledger ~constraint_constants ~global_slot
     in
     Mina_ledger.Ledger.register_mask ledger new_mask
   in
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let _partial_stmt =
-    Mina_ledger.Ledger.apply_transaction_first_pass ~constraint_constants
-      ~global_slot
+    Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+      ~constraint_constants ~global_slot
       ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
       second_pass_ledger
       (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -461,7 +461,8 @@ module Mutations = struct
                   |> Mina_state.Protocol_state.Body.view
                 in
                 let applied =
-                  Ledger.apply_zkapp_command_unchecked ~constraint_constants
+                  Ledger.apply_zkapp_command_unchecked ~signature_kind
+                    ~constraint_constants
                     ~global_slot:
                       ( Transition_frontier.Breadcrumb.consensus_state breadcrumb
                       |> Consensus.Data.Consensus_state

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -118,16 +118,19 @@ let apply_user_command ~constraint_constants ~txn_global_slot =
 
 let apply_transaction_first_pass ~constraint_constants ~global_slot
     ~txn_state_view =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   apply_transaction_logic
-    (T.apply_transaction_first_pass ~constraint_constants ~global_slot
-       ~txn_state_view )
+    (T.apply_transaction_first_pass ~signature_kind ~constraint_constants
+       ~global_slot ~txn_state_view )
 
 let apply_transaction_second_pass =
   apply_transaction_logic T.apply_transaction_second_pass
 
 let apply_transactions ~constraint_constants ~global_slot ~txn_state_view =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   apply_transaction_logic
-    (T.apply_transactions ~constraint_constants ~global_slot ~txn_state_view)
+    (T.apply_transactions ~signature_kind ~constraint_constants ~global_slot
+       ~txn_state_view )
 
 let apply_zkapp_first_pass_unchecked_with_states ~constraint_constants
     ~global_slot ~state_view ~fee_excess ~supply_increase ~first_pass_ledger

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -666,6 +666,7 @@ let get_ledger t state_hash_opt =
 
 let get_snarked_ledger_full t state_hash_opt =
   let open Deferred.Or_error.Let_syntax in
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let%bind state_hash =
     Option.value_map state_hash_opt ~f:Deferred.Or_error.return
       ~default:
@@ -702,7 +703,7 @@ let get_snarked_ledger_full t state_hash_opt =
                       (State_hash.to_base58_check state_hash)
               in
               let apply_first_pass =
-                Ledger.apply_transaction_first_pass
+                Ledger.apply_transaction_first_pass ~signature_kind
                   ~constraint_constants:
                     t.config.precomputed_values.constraint_constants
               in

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -444,6 +444,7 @@ let init_permissionless_ledger ledger account_info =
         { account with balance; permissions = Permissions.empty } )
 
 let apply_to_ledger ledger cmd =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   match Transaction_hash.User_command_with_valid_signature.command cmd with
   | User_command.Signed_command c ->
       let (`If_this_is_used_it_should_have_a_comment_justifying_it v) =
@@ -458,7 +459,8 @@ let apply_to_ledger ledger cmd =
           )
   | User_command.Zkapp_command p -> (
       let applied, _ =
-        Mina_ledger.Ledger.apply_zkapp_command_unchecked ~constraint_constants
+        Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
+          ~constraint_constants
           ~global_slot:dummy_state_view.global_slot_since_genesis
           ~state_view:dummy_state_view ledger p
         |> Or_error.ok_exn

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2295,7 +2295,7 @@ let%test_module _ =
               let applied, _ =
                 Or_error.ok_exn
                 @@ Mina_ledger.Ledger.apply_zkapp_command_unchecked
-                     ~constraint_constants
+                     ~signature_kind ~constraint_constants
                      ~global_slot:dummy_state_view.global_slot_since_genesis
                      ~state_view:dummy_state_view ledger p
               in

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -126,8 +126,10 @@ module Transaction_key = struct
       in
       Mina_ledger.Ledger.register_mask ledger new_mask
     in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let _partial_stmt =
-      Mina_ledger.Ledger.apply_transaction_first_pass ~constraint_constants
+      Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+        ~constraint_constants
         ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
         ~txn_state_view:Transaction_snark_tests.Util.genesis_state_view
         second_pass_ledger

--- a/src/lib/transaction_logic/test/protocol_config_examples.ml
+++ b/src/lib/transaction_logic/test/protocol_config_examples.ml
@@ -32,3 +32,5 @@ let constraint_constants =
   { Genesis_constants.For_unit_tests.Constraint_constants.t with
     account_creation_fee = Fee.of_mina_int_exn 1
   }
+
+let signature_kind = Mina_signature_kind.Testnet

--- a/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
+++ b/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
@@ -95,8 +95,8 @@ let simple_payment () =
       [%test_pred: Transaction_applied.Stable.Latest.t list Or_error.t]
         Or_error.is_ok
         Or_error.(
-          Transaction_logic.apply_transactions ~constraint_constants
-            ~global_slot ~txn_state_view ledger [ txn ]
+          Transaction_logic.apply_transactions ~signature_kind
+            ~constraint_constants ~global_slot ~txn_state_view ledger [ txn ]
           >>| List.map ~f:Transaction_applied.read_all_proofs_from_disk) )
 
 let simple_payment_signer_different_from_fee_payer () =
@@ -115,8 +115,8 @@ let simple_payment_signer_different_from_fee_payer () =
       expect_failure
         ~error:
           "Cannot pay fees from a public key that did not sign the transaction"
-        (Transaction_logic.apply_transactions ~constraint_constants ~global_slot
-           ~txn_state_view ledger [ txn ] ) )
+        (Transaction_logic.apply_transactions ~signature_kind
+           ~constraint_constants ~global_slot ~txn_state_view ledger [ txn ] ) )
 
 let coinbase_order_of_created_accounts_is_correct ~with_fee_transfer () =
   let amount = Amount.of_mina_int_exn 720 in

--- a/src/lib/transaction_logic/test/zkapp_logic.ml
+++ b/src/lib/transaction_logic/test/zkapp_logic.ml
@@ -38,7 +38,8 @@ let%test_module "Test transaction logic." =
       in
       let%bind ledger = Ledger_helpers.ledger_of_accounts accounts in
       let%map txn, _ =
-        Transaction_logic.apply_zkapp_command_unchecked ~constraint_constants
+        Transaction_logic.apply_zkapp_command_unchecked ~signature_kind
+          ~constraint_constants
           ~global_slot:Global_slot_since_genesis.(of_int 120)
           ~state_view:protocol_state ledger cmd
       in

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -908,7 +908,11 @@ module type Inputs_intf = sig
     val commitment : account_updates:Call_forest.t -> t
 
     val full_commitment :
-      account_update:Account_update.t -> memo_hash:Field.t -> commitment:t -> t
+         signature_kind:Mina_signature_kind.t
+      -> account_update:Account_update.t
+      -> memo_hash:Field.t
+      -> commitment:t
+      -> t
   end
 
   and Index : sig
@@ -1009,11 +1013,10 @@ module Make (Inputs : Inputs_intf) = struct
     ; new_frame : Stack_frame.t
     }
 
-  let get_next_account_update (current_forest : Stack_frame.t)
+  let get_next_account_update ~signature_kind (current_forest : Stack_frame.t)
       (* The stack for the most recent zkApp *)
         (call_stack : Call_stack.t) (* The partially-completed parent stacks *)
       : get_next_account_update_result =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     (* If the current stack is complete, 'return' to the previous
        partially-completed one.
     *)
@@ -1127,7 +1130,8 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (([ s1; s2; s3; s4; s5 ] : _ Pickles_types.Vector.t), last_action_slot)
 
-  let apply ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+  let apply ~signature_kind
+      ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~(is_start : [ `Yes of _ Start_data.t | `No | `Compute of _ Start_data.t ])
       (h :
         (< global_state : Global_state.t
@@ -1209,7 +1213,7 @@ module Make (Inputs : Inputs_intf) = struct
           } =
         with_label ~label:"get next account update" (fun () ->
             (* TODO: Make the stack frame hashed inside of the local state *)
-            get_next_account_update to_pop call_stack )
+            get_next_account_update ~signature_kind to_pop call_stack )
       in
       let local_state =
         with_label ~label:"token owner not caller" (fun () ->
@@ -1242,8 +1246,8 @@ module Make (Inputs : Inputs_intf) = struct
                 ~account_updates:(Stack_frame.calls remaining)
             in
             let full_tx_commitment_on_start =
-              Transaction_commitment.full_commitment ~account_update
-                ~memo_hash:start_data.memo_hash
+              Transaction_commitment.full_commitment ~signature_kind
+                ~account_update ~memo_hash:start_data.memo_hash
                 ~commitment:tx_commitment_on_start
             in
             let tx_commitment =

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -1515,7 +1515,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               let result =
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(succ zero)
@@ -1597,7 +1597,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               match
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(succ zero)
@@ -1699,7 +1699,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               let result =
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(succ zero)
@@ -1814,7 +1814,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               match
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(of_int 9999)
@@ -2056,7 +2056,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               let result =
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(of_int 10_100)
@@ -2213,7 +2213,7 @@ let%test_module "account timing check" =
               Mina_ledger.Ledger.apply_initial_ledger_state ledger
                 ledger_init_state ;
               let result =
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:
                     Mina_numbers.Global_slot_since_genesis.(of_int 110_000)

--- a/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
+++ b/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
@@ -178,8 +178,8 @@ let%test_module "Fee payer tests" =
               ( match
                   let mask = Ledger.Mask.create ~depth:U.ledger_depth () in
                   let ledger0 = Ledger.register_mask ledger mask in
-                  Ledger.apply_transactions ledger0 ~constraint_constants
-                    ~global_slot ~txn_state_view
+                  Ledger.apply_transactions ~signature_kind ledger0
+                    ~constraint_constants ~global_slot ~txn_state_view
                     [ Transaction.Command (Zkapp_command zkapp_command) ]
                 with
               | Error _ ->

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -106,8 +106,9 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
             in
             let partial_stmt =
               match
-                Ledger.apply_transaction_first_pass ~constraint_constants
-                  ~global_slot ~txn_state_view:state_view ledger
+                Ledger.apply_transaction_first_pass ~signature_kind
+                  ~constraint_constants ~global_slot ~txn_state_view:state_view
+                  ledger
                   (Mina_transaction.Transaction.Command
                      (Zkapp_command zkapp_command) )
               with
@@ -535,6 +536,7 @@ let check_balance pk balance ledger =
 
 (** Test legacy transactions*)
 let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let open Mina_transaction in
   let to_preunion (t : Transaction.t) =
     match t with
@@ -619,8 +621,8 @@ let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
   let expect_snark_failure, applied_transaction =
     match
       Result.( >>= )
-        (Ledger.apply_transaction_first_pass ledger ~constraint_constants
-           ~global_slot ~txn_state_view txn_unchecked )
+        (Ledger.apply_transaction_first_pass ~signature_kind ledger
+           ~constraint_constants ~global_slot ~txn_state_view txn_unchecked )
         (Ledger.apply_transaction_second_pass ledger)
     with
     | Ok res ->

--- a/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/zkapp_preconditions.ml
@@ -1011,7 +1011,7 @@ let%test_module "Account precondition tests" =
                 (module Mina_ledger.Ledger.Ledger_inner)
                 init_ledger ledger ;
               match
-                Mina_ledger.Ledger.apply_zkapp_command_unchecked
+                Mina_ledger.Ledger.apply_zkapp_command_unchecked ~signature_kind
                   ~constraint_constants
                   ~global_slot:psv.global_slot_since_genesis ~state_view:psv
                   ledger zkapp_command_with_invalid_fee_payer

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -704,8 +704,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             Zkapp_command.Transaction_commitment.Checked.create
               ~account_updates_hash
 
-          let full_commitment ~account_update:{ account_update; _ } ~memo_hash
-              ~commitment =
+          let full_commitment ~signature_kind:_
+              ~account_update:{ account_update; _ } ~memo_hash ~commitment =
             Zkapp_command.Transaction_commitment.Checked.create_complete
               commitment ~memo_hash ~fee_payer_hash:account_update.hash
         end
@@ -1989,7 +1989,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 in
                 let global_state, local_state =
                   with_label "apply" (fun () ->
-                      S.apply ~constraint_constants
+                      S.apply ~signature_kind ~constraint_constants
                         ~is_start:
                           ( match account_update_spec.is_start with
                           | `No ->
@@ -2007,7 +2007,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                 match account_update_spec.is_start with
                 | `No ->
                     let global_state, local_state =
-                      S.apply ~constraint_constants ~is_start:`No
+                      S.apply ~signature_kind ~constraint_constants
+                        ~is_start:`No
                         S.{ perform }
                         acc
                     in
@@ -3645,9 +3646,9 @@ module Make_str (A : Wire_types.Concrete) = struct
           let txn_applied, states =
             let partial_txn, states =
               Sparse_ledger.apply_zkapp_first_pass_unchecked_with_states
-                ~first_pass_ledger ~second_pass_ledger ~constraint_constants
-                ~global_slot ~state_view ~fee_excess ~supply_increase
-                zkapp_command
+                ~signature_kind ~first_pass_ledger ~second_pass_ledger
+                ~constraint_constants ~global_slot ~state_view ~fee_excess
+                ~supply_increase zkapp_command
               |> Or_error.ok_exn
             in
             Sparse_ledger.apply_zkapp_second_pass_unchecked_with_states

--- a/src/lib/transaction_snark/transaction_validator.ml
+++ b/src/lib/transaction_snark/transaction_validator.ml
@@ -24,10 +24,11 @@ let apply_user_command ~constraint_constants ~txn_global_slot l uc =
         (Ledger.apply_user_command l' ~constraint_constants ~txn_global_slot uc) )
 
 let apply_transactions' ~constraint_constants ~global_slot ~txn_state_view l t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   O1trace.sync_thread "apply_transaction" (fun () ->
       within_mask l ~f:(fun l' ->
-          Ledger.apply_transactions ~constraint_constants ~global_slot
-            ~txn_state_view l' t ) )
+          Ledger.apply_transactions ~signature_kind ~constraint_constants
+            ~global_slot ~txn_state_view l' t ) )
 
 let apply_transactions ~constraint_constants ~global_slot ~txn_state_view l txn
     =
@@ -35,10 +36,11 @@ let apply_transactions ~constraint_constants ~global_slot ~txn_state_view l txn
 
 let apply_transaction_first_pass ~constraint_constants ~global_slot
     ~txn_state_view l txn : Ledger.Transaction_partially_applied.t Or_error.t =
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   O1trace.sync_thread "apply_transaction_first_pass" (fun () ->
       within_mask l ~f:(fun l' ->
-          Ledger.apply_transaction_first_pass l' ~constraint_constants
-            ~global_slot ~txn_state_view txn ) )
+          Ledger.apply_transaction_first_pass ~signature_kind l'
+            ~constraint_constants ~global_slot ~txn_state_view txn ) )
 
 let%test_unit "invalid transactions do not dirty the ledger" =
   let open Core in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -66,9 +66,10 @@ module Transaction_with_witness = struct
       ; second_pass_ledger_witness
       ; block_global_slot
       } =
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { transaction_with_info =
         Mina_transaction_logic.Transaction_applied.write_all_proofs_to_disk
-          ~proof_cache_db transaction_with_info
+          ~signature_kind ~proof_cache_db transaction_with_info
     ; state_hash
     ; statement
     ; init_stack
@@ -1015,6 +1016,7 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
             { command = t.command
             ; previous_hash = t.previous_hash
             ; original_first_pass_account_states
+            ; signature_kind = Mina_signature_kind.t_DEPRECATED
             ; constraint_constants = t.constraint_constants
             ; state_view = t.state_view
             ; global_state

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -481,10 +481,11 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
         Ledger.Maskable.register_mask s
           (Ledger.Mask.create ~depth:(Ledger.Any_ledger.M.depth s) ())
       in
+      let signature_kind = Mina_signature_kind.t_DEPRECATED in
       (* STEP 5 *)
       (*Validate transactions against the protocol state associated with the transaction*)
       let apply_first_pass =
-        Ledger.apply_transaction_first_pass
+        Ledger.apply_transaction_first_pass ~signature_kind
           ~constraint_constants:Context.constraint_constants
       in
       let apply_second_pass = Ledger.apply_transaction_second_pass in


### PR DESCRIPTION
## Explain your changes:

This PR follows https://github.com/MinaProtocol/mina/pull/17316 in the refactoring of the network/signature kind, making it a runtime-configurable setting. This refactoring has been applied to the `transaction_logic` package, removing the use of that deprecated compiled-config value from the modules in that package.

## Explain how you tested your changes:

This PR only changes the interface of certain modules and does not change runtime behaviour, other than the slight difference that certain tests now always use the `Mina_signature_kind.Testnet` signature kind.

## Checklist

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project (N/A)
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior (N/A)
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (N/A)
- [x] Does this close issues? (N/A)
