### PR TITLE
Job Pool: redesign with hashmap & queue

### DIFF
--- a/src/lib/work_partitioner/job_pool.mli
+++ b/src/lib/work_partitioner/job_pool.mli
@@ -1,44 +1,42 @@
 open Core_kernel
 
-type ('accum, 'final) fold_action =
-  | Continue of 'accum
-  | Continue_remove of 'accum
-  | Stop of 'final
-  | Stop_remove of 'final
-
-module Make (Id : Map.Key) (Spec : T) : sig
+module Make (Id : Hashtbl.Key) (Spec : T) : sig
   type job = (Spec.t, Id.t) Snark_work_lib.With_job_meta.t
 
   (** [t] is a immutable job pool, it differs from a normal Map in that jobs
       could be canceled with [fold_until]. *)
   type t
 
-  (** [first_job t] gives the job with smalled ID in the pool. *)
-  val first_job : t -> job option
-
-  (** [fold_until ~init ~f ~finish t] will fold all jobs in the pool in
-      monotonically increasing order with repsect to ID. In addition, user may
-      instruct this function to delete the items along the process. *)
-  val fold_until :
-       init:'acc
-    -> f:('acc -> job -> ('acc, 'final) fold_action)
-    -> finish:('acc -> 'final)
-    -> t
-    -> 'final * t
+  (** [create ()] creates an empty job pool *)
+  val create : unit -> t
 
   (** [add ~id ~job t] attempts to add a job [job] with id [id] to [t]. It
-      returns [`Ok t'] on successful with the new data structure, and
-      [`Duplicate] if the key [id] is already occupied in the pool. *)
-  val add : id:Id.t -> job:job -> t -> t Map_intf.Or_duplicate.t
+      returns [`Ok] on successful, and [`Duplicate] if the key [id] is already
+      occupied in the pool. *)
+  val add : id:Id.t -> job:job -> t -> [> `Duplicate | `Ok ]
 
-  (** [change ~id ~f t] attempts to find an item with id [id] in the pool, and apply
-      [f] on it. *)
-  val change : id:Id.t -> f:(job option -> job option) -> t -> t
-
-  (** [set ~id ~job t] sets the index [id] to [job] in [t] no matter if [id] is
-      occupied or not. *)
-  val set : id:Id.t -> job:job -> t -> t
+  (** [remove ~id t] removes job corresponding to [id] in [t] and returns it if
+      it does exist *)
+  val remove : id:Id.t -> t -> job option
 
   (** [find ~id t] finds the job corresponding to id [id] in [t]. *)
   val find : id:Id.t -> t -> job option
+
+  (** [change_inplace ~id ~f t] attempts to find an item with id [id] in the
+      pool, and apply [f] on it. The order of this item in the timeline is
+      unchanged. *)
+  val change_inplace : id:Id.t -> f:(job option -> job option) -> t -> unit
+
+  (** [set ~id ~job t] sets the index [id] to [job] in [t] no matter if [id] is
+      occupied or not. The order of this item in the timeline is unchanged. *)
+  val set_inplace : id:Id.t -> job:job -> t -> unit
+
+  (** [remove_until_first_change ~pred t] iterates through the timeline, remove
+      all jobs unsatisfying [pred], and returns first job satisfying [pred] if
+      it does exit. *)
+  val remove_until_first : pred:(job -> bool) -> t -> job option
+
+  (** [first ~pred t] iterates through the timeline, and returns first job
+      satisfying [pred] if it does exist. *)
+  val first : pred:(job -> bool) -> t -> job option
 end


### PR DESCRIPTION
This is a redesign of Job Pool. 
Changes compared to the very 1st iteration:
- Removed references
- Removed `fold_until` and replaced with `first` and `remove_until_first`