### PR TITLE
Enable integers_stubs_js test

### DIFF
--- a/src/lib/integers_stubs_js/test/dune
+++ b/src/lib/integers_stubs_js/test/dune
@@ -1,4 +1,4 @@
-(executable
+(test
  (name test)
  (modes js)
  (js_of_ocaml


### PR DESCRIPTION
This test is somehow not enabled. renaming dune rule `executable -> test` will fix that. 