### PR TITLE
Nix: remove rocksdb definitions

### DIFF
--- a/nix/impure-shell.nix
+++ b/nix/impure-shell.nix
@@ -21,10 +21,8 @@ pkgs.mkShell {
     wasm-pack
     lmdb
     rosetta-cli
-    rocksdb.tools
   ];
   OPAMSWITCH = "mina";
-  MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
   shellHook = ''
     eval $(opam env)
     if ! opam switch list --short 2>&1 | grep -w mina 2>&1 > /dev/null; then

--- a/nix/misc.nix
+++ b/nix/misc.nix
@@ -2,41 +2,4 @@
 final: prev: {
   sodium-static =
     final.libsodium.overrideAttrs (o: { dontDisableStatic = true; });
-
-  rocksdb = (prev.rocksdb.override {
-    snappy = null;
-    lz4 = null;
-    zstd = null;
-    bzip2 = null;
-  }).overrideAttrs (_: {
-    cmakeFlags = [
-      "-DPORTABLE=1"
-      "-DWITH_JEMALLOC=0"
-      "-DWITH_JNI=0"
-      "-DWITH_BENCHMARK_TOOLS=0"
-      "-DWITH_TESTS=1"
-      "-DWITH_TOOLS=0"
-      "-DWITH_BZ2=0"
-      "-DWITH_LZ4=0"
-      "-DWITH_SNAPPY=0"
-      "-DWITH_ZLIB=0"
-      "-DWITH_ZSTD=0"
-      "-DWITH_GFLAGS=0"
-      "-DUSE_RTTI=1"
-    ];
-  });
-
-  rocksdb511 = let
-    impl = (import (fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/nixos-19.03-small.tar.gz";
-      sha256 = "11z6ajj108fy2q5g8y4higlcaqncrbjm3dnv17pvif6avagw4mcb";
-    }) { system = "x86_64-linux"; }).rocksdb.override {
-      snappy = null;
-      lz4 = null;
-      bzip2 = null;
-    };
-  in if impl.version == "5.11.3" then
-    impl
-  else
-    throw "Expected rocksdb version 5.11.3, but got ${impl.version}";
 }

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -62,21 +62,6 @@ let
           '';
         };
 
-        rocksdb_stubs = super.rocksdb_stubs.overrideAttrs (oa: {
-          MINA_ROCKSDB = let
-            mainPath = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
-            staticPath = "${
-                pkgs.rocksdb-mina.static or pkgs.rocksdb-mina
-              }/lib/librocksdb.a";
-          in if builtins.pathExists mainPath then
-            mainPath
-          else if builtins.pathExists staticPath then
-            staticPath
-          else
-            throw
-            "Could not find librocksdb.a in either ${mainPath} or ${staticPath}";
-        });
-
         # This is needed because
         # - lld package is not wrapped to pick up the correct linker flags
         # - bintools package also includes as which is incompatible with gcc
@@ -341,8 +326,6 @@ let
           pkgs.fd
         ] ++ ocaml-libs;
 
-        # todo: slimmed rocksdb
-        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
         GO_CAPNP_STD = "${pkgs.go-capnproto2.src}/std";
 
         # this is used to retrieve the path of the built static library
@@ -453,8 +436,6 @@ let
       mainnet-pkg = self.mina-dev.overrideAttrs (s: {
         version = "mainnet";
         DUNE_PROFILE = "mainnet";
-        # For compatibility with Docker build
-        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
       });
 
       mainnet = wrapMina self.mainnet-pkg { };
@@ -462,8 +443,6 @@ let
       devnet-pkg = self.mina-dev.overrideAttrs (s: {
         version = "devnet";
         DUNE_PROFILE = "devnet";
-        # For compatibility with Docker build
-        MINA_ROCKSDB = "${pkgs.rocksdb-mina}/lib/librocksdb.a";
       });
 
       devnet = wrapMina self.devnet-pkg { };


### PR DESCRIPTION
rocksdb is defined in o1-labs/opam-repository, pinned to 5.17.2.

While investigating an issue with @dkijania to get Noble working, we realised that multiple versions of rocksdb where used across the codebase. In particular, there is a version of rocksdb in o1-labs/opam-repository, [5.17.2](https://github.com/o1-labs/opam-repository/tree/master/packages/rocksdb_stubs/rocksdb_stubs.5.17.2), used by [rocks](https://github.com/o1-labs/opam-repository/blob/master/packages/rocks/rocks.0.1.1/opam#L17).

The toolchain does install its own version, nix too, and opam-repository references its own too.
`rocks` will be linked by using the first one it finds in a path given by `CAML_LD_LIBRARY_PATH`, see [here](https://github.com/o1-labs/orocksdb/blob/0.1.1/src/rocks_linker_flags_gen.ml#L28), which is the path defined in the OCaml switch.

Removing versions installed globally should be a no-op, as it is supposed to use the version given by o1-labs/opam-repository.

The reviewer is encouraged to run the (nix) build on its machine to verify the above claim.

The removal from the toolchain will be done by @dkijania in a separate patch.