### PR TITLE
[nix] Fix RocksDB building on non-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,7 @@
     } // utils.lib.eachDefaultSystem (system:
       let
         rocksdbOverlay = pkgs: prev:
-          if prev.stdenv.isx86_64 then {
+          if prev.stdenv.isx86_64 && prev.stdenv.isLinux then {
             rocksdb-mina = pkgs.rocksdb511;
           } else {
             rocksdb-mina = pkgs.rocksdb;


### PR DESCRIPTION
In recent PR #17192 I accidentally broke rocksdb building on non-linux platforms (under nix).

This PR fixes it by ensuring that we attempt to use rocksdb `5.x.x` only on `linux-x86_64`.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
