### PR TITLE
Nix Build Test: don't install git lfs

### DIFF
--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -44,8 +44,6 @@ fi
 # run chown to the current user to fix it
 chown -R "${USER}" /workdir
 
-nix-env -i git-lfs
-
 git config --global --add safe.directory /workdir
 
 # We are in buildkite context so all buildkite related envs are available


### PR DESCRIPTION
Since Git Lfs is completely unused, we should remove it.

Status: don't run CI on this yet. we need to wait for fixes, so we don't wait CI runs. 