### PR TITLE
Add create with migration for converting ledger

### DIFF
--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -44,6 +44,8 @@ end)
 
   val create : Primary_ledger.t -> Converting_ledger.t -> t
 
+  val create_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
+
   val primary_ledger : t -> Primary_ledger.t
 
   val converting_ledger : t -> Converting_ledger.t
@@ -66,6 +68,15 @@ end = struct
     }
 
   let create primary_ledger converting_ledger =
+    { primary_ledger; converting_ledger }
+
+  let create_with_migration primary_ledger converting_ledger =
+    assert (Converting_ledger.num_accounts converting_ledger = 0) ;
+    let accounts =
+      Primary_ledger.foldi primary_ledger ~init:[] ~f:(fun addr acc account ->
+          (addr, convert account) :: acc )
+    in
+    Converting_ledger.set_batch_accounts converting_ledger accounts ;
     { primary_ledger; converting_ledger }
 
   let primary_ledger { primary_ledger; _ } = primary_ledger

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -51,6 +51,11 @@ end)
 
   val create : Primary_ledger.t -> Converting_ledger.t -> t
 
+  (** Create a converting ledger with an already-existing [Primary_ledger.t] and
+      an empty [Converting_ledger.t] that will be initialized with the migrated
+      account data. *)
+  val create_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
+
   val primary_ledger : t -> Primary_ledger.t
 
   val converting_ledger : t -> Converting_ledger.t

--- a/src/lib/merkle_ledger_tests/test_converting.ml
+++ b/src/lib/merkle_ledger_tests/test_converting.ml
@@ -91,6 +91,10 @@ module Make (Cfg : sig
   val depth : int
 end) =
 struct
+  let with_primary ~f = Db.with_ledger ~f ~depth:Cfg.depth
+
+  let with_migrated ~f = Db_migrated.with_ledger ~f ~depth:Cfg.depth
+
   let with_instance ~f =
     let db1 = Db.create ~depth:Cfg.depth () in
     let db2 = Db_migrated.create ~depth:Cfg.depth () in
@@ -100,17 +104,22 @@ struct
       Db_converting.close ledger ; result
     with exn -> Db_converting.close ledger ; raise exn
 
-  let create_new_account_exn mdb account =
-    let public_key = Account.identifier account in
-    let action, location =
-      Db_converting.get_or_create_account mdb public_key account
-      |> Or_error.ok_exn
-    in
+  let existing_account_exn account =
+    let action, location = Or_error.ok_exn account in
     match action with
     | `Existed ->
         failwith "Expected to allocate a new account"
     | `Added ->
         location
+
+  let create_new_converting_account_exn mdb account =
+    let public_key = Account.identifier account in
+    Db_converting.get_or_create_account mdb public_key account
+    |> existing_account_exn
+
+  let create_new_primary_account_exn db account =
+    let public_key = Account.identifier account in
+    Db.get_or_create_account db public_key account |> existing_account_exn
 
   let test_section_name =
     Printf.sprintf "In-memory converting db (depth %d)" Cfg.depth
@@ -124,7 +133,7 @@ struct
     add_test "add and retrieve an account" (fun () ->
         with_instance ~f:(fun db ->
             let account = Quickcheck.random_value Account.gen in
-            let location = create_new_account_exn db account in
+            let location = create_new_converting_account_exn db account in
             let stored_migrated_account =
               let migrated_db = Db_converting.converting_ledger db in
               Option.value_exn (Db_migrated.get migrated_db location)
@@ -134,6 +143,23 @@ struct
               account ;
             [%test_eq: Migrated.Account.t] stored_migrated_account
               (Db_converting.convert account) ) )
+
+  let () =
+    add_test "add an account, migrate, retrieve" (fun () ->
+        with_primary ~f:(fun primary ->
+            let account = Quickcheck.random_value Account.gen in
+            let location = create_new_primary_account_exn primary account in
+            with_migrated ~f:(fun migrated ->
+                (* We don't need the actual converting ledger for this test,
+                   only the side effect of migration *)
+                let _converting =
+                  Db_converting.create_with_migration primary migrated
+                in
+                let stored_migrated_account =
+                  Option.value_exn (Db_migrated.get migrated location)
+                in
+                [%test_eq: Migrated.Account.t] stored_migrated_account
+                  (Db_converting.convert account) ) ) )
 
   let tests =
     let actual_tests = Stack.fold test_stack ~f:(fun l t -> t :: l) ~init:[] in


### PR DESCRIPTION
## Explain your changes:

The new `create_with_migration` method for a `Converting_ledger` takes an empty secondary ledger and migrates the primary ledger's data to it before constructing the full `Converting_ledger`. This migration is necessary if an already-synced secondary ledger does not already exist for the primary ledger.

I've made it the caller's responsibility to provide an empty secondary ledger because we will want to use this to migrate a few different ledgers; I think it would be better to handle at the call site the task of detecting if a migrated already exists and/or providing database config.

## Explain how you tested your changes:

I've added another very simple test in `merkle_ledger_tests/test_converting.ml`.

## Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?