### PR TITLE
Add converting ledger with test

### DIFF
--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -1098,4 +1098,19 @@ module Unstable = struct
       (Random_oracle.pack_input (to_input t))
 
   let empty_digest = lazy (digest empty)
+
+  let of_stable (account : Stable.Latest.t) : t =
+    { public_key = account.public_key
+    ; token_id = account.token_id
+    ; token_symbol = account.token_symbol
+    ; balance = account.balance
+    ; nonce = account.nonce
+    ; receipt_chain_hash = account.receipt_chain_hash
+    ; delegate = account.delegate
+    ; voting_for = account.voting_for
+    ; timing = account.timing
+    ; permissions = account.permissions
+    ; zkapp = account.zkapp
+    ; unstable_field = account.nonce
+    }
 end


### PR DESCRIPTION
This PR is an adaptation of https://github.com/MinaProtocol/mina/pull/17155 - some of the changes in that PR were ported to https://github.com/MinaProtocol/mina/pull/16853, and the converting ledger interface changed slightly in https://github.com/MinaProtocol/mina/pull/16853 as well.

## Explain your changes:

The new Converting_ledger ledger type in mina_ledger is backed by a converting_merkle_tree - the result is a ledger with an interface involving the stable account type, backed by a primary database containing stable accounts, that also keeps a secondary database containing unstable accounts synced with that primary database.

## Explain how you tested your changes:

A basic unit test has been added to confirm that the `Converting_ledger` keeps its two databases in sync after one user "send" transaction has been applied. More can (and probably should) be added, either in this PR or in a subsequent one, testing more complex ledger usage.

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? No.