### PR TITLE
[Draft] Numeric precondition on zkapp state

### DIFF
--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -540,8 +540,8 @@ let get_account_update_body ~pool body_id =
       ( { balance
         ; nonce
         ; receipt_chain_hash
-        ; delegate
-        ; state = { eq_data = state }
+        ; delegate (* TODO: add first_numeric_id *)
+        ; state = { eq_data = state; first_numeric = Ignore }
         ; action_state
         ; proved_state
         ; is_new

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -541,7 +541,7 @@ let get_account_update_body ~pool body_id =
         ; nonce
         ; receipt_chain_hash
         ; delegate
-        ; state
+        ; state = { eq_data = state }
         ; action_state
         ; proved_state
         ; is_new

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -922,6 +922,7 @@ module Zkapp_account_precondition = struct
         (Public_key.add_if_doesn't_exist (module Conn))
         acct.delegate
     in
+    (* TODO: add first_numeric_id *)
     let%bind state_id =
       Vector.map ~f:Zkapp_basic.Or_ignore.to_option acct.state.eq_data
       |> Zkapp_states_nullable.add_if_doesn't_exist (module Conn)

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -923,7 +923,7 @@ module Zkapp_account_precondition = struct
         acct.delegate
     in
     let%bind state_id =
-      Vector.map ~f:Zkapp_basic.Or_ignore.to_option acct.state
+      Vector.map ~f:Zkapp_basic.Or_ignore.to_option acct.state.eq_data
       |> Zkapp_states_nullable.add_if_doesn't_exist (module Conn)
     in
     let%bind action_state_id =

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -939,12 +939,12 @@ module Account_precondition = struct
       type t = Zkapp_precondition.Account.Stable.V2.t
       [@@deriving sexp, yojson, hash]
 
-      let (_ :
-            ( t
-            , Mina_wire_types.Mina_base.Account_update.Account_precondition.V1.t
-            )
-            Type_equal.t ) =
-        Type_equal.T
+      (* let (_ :
+             ( t
+             , Mina_wire_types.Mina_base.Account_update.Account_precondition.V1.t
+             )
+             Type_equal.t ) =
+         Type_equal.T *)
 
       let to_latest = Fn.id
 
@@ -1006,7 +1006,7 @@ module Preconditions = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Mina_wire_types.Mina_base.Account_update.Preconditions.V1.t =
+      type t =
         { network : Zkapp_precondition.Protocol_state.Stable.V1.t
         ; account : Account_precondition.Stable.V1.t
         ; valid_while :
@@ -1189,7 +1189,7 @@ module Body = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Mina_wire_types.Mina_base.Account_update.Body.V1.t =
+      type t =
         { public_key : Public_key.Compressed.Stable.V1.t
         ; token_id : Token_id.Stable.V2.t
         ; update : Update.Stable.V1.t

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -450,16 +450,35 @@ module Leaf_typs = struct
   let token_id = Hash.typ token_id
 end
 
+module State = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { eq_data : F.Stable.V1.t Eq_data.Stable.V1.t Zkapp_state.V.Stable.V1.t
+        }
+      [@@deriving sexp, equal, yojson, hash, compare]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  module Checked = struct
+    type t = { eq_data : Field.Var.t Eq_data.Checked.t Zkapp_state.V.t }
+    [@@deriving hlist]
+  end
+end
+
 module Account = struct
   [%%versioned
   module Stable = struct
     module V2 = struct
-      type t = Mina_wire_types.Mina_base.Zkapp_precondition.Account.V2.t =
+      type t =
         { balance : Balance.Stable.V1.t Numeric.Stable.V1.t
         ; nonce : Account_nonce.Stable.V1.t Numeric.Stable.V1.t
         ; receipt_chain_hash : Receipt.Chain_hash.Stable.V1.t Hash.Stable.V1.t
         ; delegate : Public_key.Compressed.Stable.V1.t Eq_data.Stable.V1.t
-        ; state : F.Stable.V1.t Eq_data.Stable.V1.t Zkapp_state.V.Stable.V1.t
+        ; state : State.Stable.V1.t
         ; action_state : F.Stable.V1.t Eq_data.Stable.V1.t
         ; proved_state : bool Eq_data.Stable.V1.t
         ; is_new : bool Eq_data.Stable.V1.t
@@ -495,7 +514,7 @@ module Account = struct
     ; nonce
     ; receipt_chain_hash
     ; delegate
-    ; state
+    ; state = State.{ eq_data = state }
     ; action_state
     ; proved_state
     ; is_new
@@ -507,7 +526,11 @@ module Account = struct
     ; receipt_chain_hash = Ignore
     ; delegate = Ignore
     ; state =
-        Vector.init Zkapp_state.Max_state_size.n ~f:(fun _ -> Or_ignore.Ignore)
+        State.
+          { eq_data =
+              Vector.init Zkapp_state.Max_state_size.n ~f:(fun _ ->
+                  Or_ignore.Ignore )
+          }
     ; action_state = Ignore
     ; proved_state = Ignore
     ; is_new = Ignore
@@ -538,7 +561,8 @@ module Account = struct
       ~nonce:!.Numeric.Derivers.nonce
       ~receipt_chain_hash:!.(Or_ignore.deriver field)
       ~delegate:!.(Or_ignore.deriver public_key)
-      ~state:!.(Zkapp_state.deriver @@ Or_ignore.deriver field)
+      ~state:!.(failwith "bla")
+        (* @@ Zkapp_state.deriver @@ Or_ignore.deriver field) *)
       ~action_state:!.(Or_ignore.deriver action_state)
       ~proved_state:!.(Or_ignore.deriver bool)
       ~is_new:!.(Or_ignore.deriver bool)
@@ -575,7 +599,7 @@ module Account = struct
       ; Hash.(to_input Tc.receipt_chain_hash receipt_chain_hash)
       ; Eq_data.(to_input (Tc.public_key ()) delegate)
       ; Vector.reduce_exn ~f:append
-          (Vector.map state ~f:Eq_data.(to_input Tc.field))
+          (Vector.map state.eq_data ~f:Eq_data.(to_input Tc.field))
       ; Eq_data.(to_input (Lazy.force Tc.action_state)) action_state
       ; Eq_data.(to_input Tc.boolean) proved_state
       ; Eq_data.(to_input Tc.boolean) is_new
@@ -592,7 +616,7 @@ module Account = struct
       ; nonce : Account_nonce.Checked.t Numeric.Checked.t
       ; receipt_chain_hash : Receipt.Chain_hash.var Hash.Checked.t
       ; delegate : Public_key.Compressed.var Eq_data.Checked.t
-      ; state : Field.Var.t Eq_data.Checked.t Zkapp_state.V.t
+      ; state : State.Checked.t
       ; action_state : Field.Var.t Eq_data.Checked.t
       ; proved_state : Boolean.var Eq_data.Checked.t
       ; is_new : Boolean.var Eq_data.Checked.t
@@ -617,7 +641,7 @@ module Account = struct
         ; Hash.(to_input_checked Tc.receipt_chain_hash receipt_chain_hash)
         ; Eq_data.(to_input_checked (Tc.public_key ()) delegate)
         ; Vector.reduce_exn ~f:append
-            (Vector.map state ~f:Eq_data.(to_input_checked Tc.field))
+            (Vector.map state.eq_data ~f:Eq_data.(to_input_checked Tc.field))
         ; Eq_data.(to_input_checked (Lazy.force Tc.action_state)) action_state
         ; Eq_data.(to_input_checked Tc.boolean) proved_state
         ; Eq_data.(to_input_checked Tc.boolean) is_new
@@ -660,7 +684,8 @@ module Account = struct
         ]
       @ ( Vector.(
             to_list
-              (map2 state a.zkapp.app_state ~f:Eq_data.(check_checked Tc.field)))
+              (map2 state.eq_data a.zkapp.app_state
+                 ~f:Eq_data.(check_checked Tc.field) ))
         |> List.mapi ~f:(fun i check ->
                let failure =
                  Transaction_status.Failure
@@ -689,20 +714,21 @@ module Account = struct
   end
 
   let typ () : (Checked.t, t) Typ.t =
-    let open Leaf_typs in
-    Typ.of_hlistable
-      [ balance
-      ; nonce
-      ; receipt_chain_hash
-      ; public_key ()
-      ; Zkapp_state.typ (Or_ignore.typ Field.typ ~ignore:Field.zero)
-      ; Or_ignore.typ Field.typ
-          ~ignore:Zkapp_account.Actions.empty_state_element
-      ; Or_ignore.typ Boolean.typ ~ignore:false
-      ; Or_ignore.typ Boolean.typ ~ignore:false
-      ]
-      ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
-      ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+    (* let open Leaf_typs in
+       Typ.of_hlistable
+         [ balance
+         ; nonce
+         ; receipt_chain_hash
+         ; public_key ()
+         ; Zkapp_state.typ (Or_ignore.typ Field.typ ~ignore:Field.zero)
+         ; Or_ignore.typ Field.typ
+             ~ignore:Zkapp_account.Actions.empty_state_element
+         ; Or_ignore.typ Boolean.typ ~ignore:false
+         ; Or_ignore.typ Boolean.typ ~ignore:false
+         ]
+         ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
+         ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist *)
+    failwith "not implemented"
 
   let checks ~new_account
       { balance
@@ -744,7 +770,7 @@ module Account = struct
             Ok () )
     ]
     @ List.mapi
-        Vector.(to_list (zip state zkapp.app_state))
+        Vector.(to_list (zip state.eq_data zkapp.app_state))
         ~f:(fun i (c, v) ->
           let failure =
             Transaction_status.Failure


### PR DESCRIPTION
Experimental draft to allow setting a numeric precondition on the first state element.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
