### PR TITLE
Ensure PID lock files are synced to disk

### DIFF
--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -249,6 +249,7 @@ let start_custom :
       Deferred.map ~f:Or_error.return
       @@ Async.Writer.save lock_path
            ~contents:(Pid.to_string @@ Process.pid process)
+           ~fsync:true
   in
   let terminated_ivar = Ivar.create () in
   let stdout_pipe = reader_to_strict_pipe (Process.stdout process) stdout in


### PR DESCRIPTION
## Explain your changes:

The Async.Writer.save function uses with_file_atomic to ensure that a given string is always written to a file completely or not at all. However, if the ?fsync parameter for that function is set to false - the default, and what it was before these changes - the temp file that with_file_atomic creates may not be flushed to disk before being moved to the target location. Thus, a well-timed interruption might cause the PID file to be created but be entirely empty. An empty PID file will cause this line to throw an exception:

https://github.com/MinaProtocol/mina/blob/2a9d6219863c13ddea4185aec9aa6378140ef0ca/src/lib/child_processes/child_processes.ml#L117

because the empty string cannot be parsed as an `Int`. This crash was discussed in a [slack thread on the issue](https://o1-labs.slack.com/archives/C02BFPS6BA4/p1749650726329999?thread_ts=1749621387.259289&cid=C02BFPS6BA4).

Now, the buffer will be flushed before the file is moved, which should ensure that the PID file is always in the correct state: filled with a PID, or absent entirely.

## Explain how you tested your changes:

I could reproduce the crash observed internally by manually creating an empty PID file before starting the mina daemon. I've been unable to get `mina` to create an empty PID file in the way I suggested above (that would be fixed by these changes) sadly. The only way I could come up with to do that was adding this line:

```ocaml
  Core.Signal.send_exn Signal.kill `My_group ;
```

right after the `Writer.save` line, which would simulate a crash very soon after we started saving the PID file. However, that did not seem to interrupt the PID file saving when I ran the mina daemon on my laptop. It's possible that my local file system driver and hard drive are too aggressive about flushing to disk, compared to the environment in which the crash was observed. Or, I'm wrong about this being the cause.

## Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? No associated GitHub issue.