### PR TITLE
Work Selector: remove reschedule mechanism as superceded by partitioner

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -903,20 +903,10 @@ let add_work t (work : Snark_work_lib.Result.Partitioned.Stable.Latest.t) =
   | Processed None ->
       `Ok
   | Processed (Some (stmts, priced_proof)) ->
-      let cb _ =
-        (* NOTE: remove it from seen jobs after attempting to adding it to the
-           pool to avoid this work being reassigned.
-           - If the diff is accepted, then remove it from the seen jobs;
-           - If not then the work should have already been in the pool with a
-           lower fee or the statement isn't referenced anymore or any other
-           error. In any case remove it from the seen jobs so that it can be
-           picked up if needed. *)
-        Work_selector.remove t.work_selector stmts
-      in
       ignore (Or_error.try_with (fun () -> update_metrics ()) : unit Or_error.t) ;
       Network_pool.Snark_pool.(
         Local_sink.push t.pipes.snark_local_sink
-          (Add_solved_work (stmts, priced_proof), cb))
+          (Add_solved_work (stmts, priced_proof), Fn.const ()))
       |> Deferred.don't_wait_for ;
       `Ok
 

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -116,10 +116,8 @@ module type Lib_intf = sig
     include
       State_intf with type transition_frontier := Inputs.Transition_frontier.t
 
-    val remove_old_assignments : t -> logger:Logger.t -> unit
-
-    (**Jobs that have not been assigned yet*)
-    val all_unseen_works :
+    (**Jobs that have not been scheduled yet*)
+    val all_unscheduled_works :
          t
       -> ( Transaction_witness.t
          , Ledger_proof.Cached.t )
@@ -127,9 +125,7 @@ module type Lib_intf = sig
          One_or_two.t
          list
 
-    val remove : t -> Transaction_snark.Statement.t One_or_two.t -> unit
-
-    val set :
+    val set_as_scheduled :
          t
       -> ( Transaction_witness.t
          , Ledger_proof.Cached.t )

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -1,16 +1,16 @@
 open Core_kernel
 
 module Make (Lib : Intf.Lib_intf) = struct
-  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
-    Lib.State.remove_old_assignments state ~logger ;
-    let unseen_jobs = Lib.State.all_unseen_works state in
+  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+    let unseen_jobs = Lib.State.all_unscheduled_works state in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
         None
     | expensive_work ->
         let i = Random.int (List.length expensive_work) in
         let x = List.nth_exn expensive_work i in
-        Lib.State.set state x ; Some x
+        Lib.State.set_as_scheduled state x ;
+        Some x
 end
 
 let%test_module "test" =

--- a/src/lib/work_selector/random_offset.ml
+++ b/src/lib/work_selector/random_offset.ml
@@ -42,16 +42,16 @@ module Make (Lib : Intf.Lib_intf) = struct
         List.nth_exn expensive_work !offset
   end
 
-  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
-    Lib.State.remove_old_assignments state ~logger ;
-    let unseen_jobs = Lib.State.all_unseen_works state in
+  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+    let unseen_jobs = Lib.State.all_unscheduled_works state in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
         None
     | expensive_work ->
         Offset.update ~new_length:(List.length expensive_work) ;
         let x = Offset.get_nth expensive_work in
-        Lib.State.set state x ; Some x
+        Lib.State.set_as_scheduled state x ;
+        Some x
 end
 
 let%test_module "test" =

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -1,12 +1,12 @@
 module Make (Lib : Intf.Lib_intf) = struct
-  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
-    Lib.State.remove_old_assignments state ~logger ;
-    let unseen_jobs = Lib.State.all_unseen_works state in
+  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+    let unseen_jobs = Lib.State.all_unscheduled_works state in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
         None
     | x :: _ ->
-        Lib.State.set state x ; Some x
+        Lib.State.set_as_scheduled state x ;
+        Some x
 end
 
 let%test_module "test" =

--- a/src/lib/work_selector/work_selector.ml
+++ b/src/lib/work_selector/work_selector.ml
@@ -21,8 +21,6 @@ module Selection_methods = struct
   module Random_offset = Random_offset.Make (Lib)
 end
 
-let remove = Lib.State.remove
-
 let pending_work_statements = Lib.pending_work_statements
 
 let all_work = Lib.all_work

--- a/src/lib/work_selector/work_selector.mli
+++ b/src/lib/work_selector/work_selector.mli
@@ -23,9 +23,6 @@ module Selection_methods : sig
   module Random_offset : Selection_method_intf
 end
 
-(** remove the specified work from seen jobs *)
-val remove : State.t -> Transaction_snark.Statement.t One_or_two.t -> unit
-
 (** Seen/Unseen jobs that are not in the snark pool yet *)
 val pending_work_statements :
      snark_pool:snark_pool


### PR DESCRIPTION
Since we have rescheduling mechanism in partitioner, the original reschedule mechanism is no longer relevant. 