### PR TITLE
[CI][Patch Archive Test] do not remove border blocks

### DIFF
--- a/src/test/archive/patch_archive_test/patch_archive_test.ml
+++ b/src/test/archive/patch_archive_test/patch_archive_test.ml
@@ -77,10 +77,10 @@ let main ~db_uri ~network_data_folder () =
 
   let n =
     List.init missing_blocks_count ~f:(fun _ ->
-        (* never remove last block as missing-block-guardian can have issues when patching it
-           as it patching only gaps
+        (* never remove last and first block as missing-block-guardian can have issues
+           when patching "border" blocks as it expect to fill gaps in the middle
         *)
-        Random.int (List.length extensional_files - 1) )
+        Random.int (List.length extensional_files - 2) + 1 )
   in
 
   let unpatched_extensional_files =


### PR DESCRIPTION
Fix patch archive test random instabilities by not allowing to remove first or last block. This is necessary as patching blocks is only implementing by adding blocks in the middle