### PR TITLE
Set Nix Dirty When to include `opam.export`

### DIFF
--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -27,6 +27,7 @@ in  Pipeline.build
           , S.exactly "flake" "nix"
           , S.exactly "flake" "lock"
           , S.exactly "default" "nix"
+          , S.exactly "opam" "export"
           ]
         , path = "Test"
         , name = "NixBuildTest"


### PR DESCRIPTION
Previous bump on OPAM.export skipped nix build test completely. We should include that file so CI is ranned. 

