### PR TITLE
Introduce more elastic way of defining debian/docker depends on step

### DIFF
--- a/buildkite/src/Command/Bench/Base.dhall
+++ b/buildkite/src/Command/Bench/Base.dhall
@@ -12,10 +12,6 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let RunInToolchain = ../../Command/RunInToolchain.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profiles = ../../Constants/Profiles.dhall
-
 let Command = ../../Command/Base.dhall
 
 let Cmd = ../../Lib/Cmds.dhall
@@ -48,11 +44,7 @@ let Spec =
       , default =
           { mode = PipelineMode.Type.PullRequest
           , size = Size.Perf
-          , dependsOn =
-              DebianVersions.dependsOn
-                DebianVersions.DebVersion.Bullseye
-                Network.Type.Berkeley
-                Profiles.Type.Standard
+          , dependsOn = DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
           , additionalDirtyWhen = [] : List SelectFiles.Type
           , yellowThreshold = 0.1
           , redThreshold = 0.2

--- a/buildkite/src/Command/Bench/LedgerApply.dhall
+++ b/buildkite/src/Command/Bench/LedgerApply.dhall
@@ -8,13 +8,9 @@ let RunInToolchain = ../../Command/RunInToolchain.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let BuildFlags = ../../Constants/BuildFlags.dhall
 
 let SelectFiles = ../../Lib/SelectFiles.dhall
-
-let Network = ../../Constants/Network.dhall
 
 let Spec =
       { Type =
@@ -23,13 +19,8 @@ let Spec =
       }
 
 let dependsOn =
-      DebianVersions.dependsOnStep
-        (None Text)
-        DebianVersions.DebVersion.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
-        BuildFlags.Type.Instrumented
-        "build"
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 let pipeline
     : Spec.Type -> Pipeline.Config.Type

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -172,13 +172,15 @@ let docker_step
       ->  let step_dep_name = "build"
 
           let deps =
-                DebianVersions.dependsOnStep
-                  (Some spec.prefix)
-                  spec.debVersion
-                  spec.network
-                  spec.profile
-                  spec.buildFlags
-                  step_dep_name
+                DebianVersions.dependsOn
+                  DebianVersions.DepsSpec::{
+                  , deb_version = spec.debVersion
+                  , network = spec.network
+                  , profile = spec.profile
+                  , build_flag = spec.buildFlags
+                  , step = step_dep_name
+                  , prefix = spec.prefix
+                  }
 
           let docker_publish = DockerPublish.Type.Essential
 

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -18,8 +18,6 @@ let Size = ../../Command/Size.dhall
 
 let Network = ../../Constants/Network.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
@@ -68,10 +66,11 @@ let command
             , soft_fail = Some spec.softFail
             , depends_on =
                 Dockers.dependsOn
-                  spec.dockerType
-                  spec.network
-                  Profiles.Type.Standard
-                  Artifacts.Type.Rosetta
+                  Dockers.DepsSpec::{
+                  , codename = spec.dockerType
+                  , network = spec.network
+                  , artifact = Artifacts.Type.Rosetta
+                  }
             }
 
 let pipeline

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -1,7 +1,3 @@
-let Prelude = ../External/Prelude.dhall
-
-let Optional/default = Prelude.Optional.default
-
 let Profiles = ./Profiles.dhall
 
 let Network = ./Network.dhall
@@ -34,43 +30,36 @@ let lowerName =
             }
             debVersion
 
-let dependsOnStep =
-          \(prefix : Optional Text)
-      ->  \(debVersion : DebVersion)
-      ->  \(network : Network.Type)
-      ->  \(profile : Profiles.Type)
-      ->  \(buildFlag : BuildFlags.Type)
-      ->  \(step : Text)
-      ->  let profileSuffix = Profiles.toSuffixUppercase profile
-
-          let prefix = Optional/default Text "MinaArtifact" prefix
-
-          let name =
-                "${prefix}${capitalName
-                              debVersion}${Network.capitalName
-                                             network}${profileSuffix}${BuildFlags.toSuffixUppercase
-                                                                         buildFlag}"
-
-          in  merge
-                { Bookworm = [ { name = name, key = "${step}-deb-pkg" } ]
-                , Bullseye = [ { name = name, key = "${step}-deb-pkg" } ]
-                , Jammy = [ { name = name, key = "${step}-deb-pkg" } ]
-                , Focal = [ { name = name, key = "${step}-deb-pkg" } ]
-                , Noble = [ { name = name, key = "${step}-deb-pkg" } ]
-                }
-                debVersion
+let DepsSpec =
+      { Type =
+          { deb_version : DebVersion
+          , network : Network.Type
+          , profile : Profiles.Type
+          , build_flag : BuildFlags.Type
+          , step : Text
+          , prefix : Text
+          }
+      , default =
+          { deb_version = DebVersion.Bullseye
+          , network = Network.Type.Berkeley
+          , profile = Profiles.Type.Standard
+          , build_flag = BuildFlags.Type.None
+          , step = "build"
+          , prefix = "MinaArtifact"
+          }
+      }
 
 let dependsOn =
-          \(debVersion : DebVersion)
-      ->  \(network : Network.Type)
-      ->  \(profile : Profiles.Type)
-      ->  dependsOnStep
-            (None Text)
-            debVersion
-            network
-            profile
-            BuildFlags.Type.None
-            "build"
+          \(spec : DepsSpec.Type)
+      ->  let profileSuffix = Profiles.toSuffixUppercase spec.profile
+
+          let name =
+                "${spec.prefix}${capitalName
+                                   spec.deb_version}${Network.capitalName
+                                                        spec.network}${profileSuffix}${BuildFlags.toSuffixUppercase
+                                                                                         spec.build_flag}"
+
+          in  [ { name = name, key = "${spec.step}-deb-pkg" } ]
 
 let minimalDirtyWhen =
       [ S.exactly "buildkite/src/Constants/DebianVersions" "dhall"
@@ -122,6 +111,6 @@ in  { DebVersion = DebVersion
     , capitalName = capitalName
     , lowerName = lowerName
     , dependsOn = dependsOn
-    , dependsOnStep = dependsOnStep
     , dirtyWhen = dirtyWhen
+    , DepsSpec = DepsSpec
     }

--- a/buildkite/src/Constants/DockerVersions.dhall
+++ b/buildkite/src/Constants/DockerVersions.dhall
@@ -30,36 +30,43 @@ let lowerName =
             }
             docker
 
-let dependsOnStep =
-          \(docker : Docker)
-      ->  \(prefix : Text)
-      ->  \(network : Network.Type)
-      ->  \(profile : Profiles.Type)
-      ->  \(binary : Artifacts.Type)
-      ->  let network = "${Network.capitalName network}"
+let DepsSpec =
+      { Type =
+          { codename : Docker
+          , prefix : Text
+          , network : Network.Type
+          , profile : Profiles.Type
+          , artifact : Artifacts.Type
+          , suffix : Text
+          }
+      , default =
+          { codename = Docker.Bullseye
+          , prefix = "MinaArtifact"
+          , network = Network.Type.Berkeley
+          , profile = Profiles.Type.Standard
+          , artifact = Artifacts.Type.Daemon
+          , suffix = "docker-image"
+          }
+      }
 
-          let profileSuffix = "${Profiles.toSuffixUppercase profile}"
+let dependsOn =
+          \(spec : DepsSpec.Type)
+      ->  let network = "${Network.capitalName spec.network}"
 
-          let suffix = "docker-image"
+          let profileSuffix = "${Profiles.toSuffixUppercase spec.profile}"
 
-          let key = "${Artifacts.lowerName binary}-${suffix}"
+          let key = "${Artifacts.lowerName spec.artifact}-${spec.suffix}"
 
           in  [ { name =
-                    "${prefix}${capitalName docker}${network}${profileSuffix}"
+                    "${spec.prefix}${capitalName
+                                       spec.codename}${network}${profileSuffix}"
                 , key = key
                 }
               ]
-
-let dependsOn =
-          \(docker : Docker)
-      ->  \(network : Network.Type)
-      ->  \(profile : Profiles.Type)
-      ->  \(binary : Artifacts.Type)
-      ->  dependsOnStep docker "MinaArtifact" network profile binary
 
 in  { Type = Docker
     , capitalName = capitalName
     , lowerName = lowerName
     , dependsOn = dependsOn
-    , dependsOnStep = dependsOnStep
+    , DepsSpec = DepsSpec
     }

--- a/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
+++ b/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
@@ -10,15 +10,7 @@ let CheckGraphQLSchema = ../../Command/CheckGraphQLSchema.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
-let Network = ../../Constants/Network.dhall
-
-let dependsOn =
-      DebianVersions.dependsOn
-        DebianVersions.DebVersion.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
+let dependsOn = DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
@@ -14,22 +14,13 @@ let PipelineMode = ../../Pipeline/Mode.dhall
 
 let ConnectToNetwork = ../../Command/ConnectToNetwork.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Network = ../../Constants/Network.dhall
-
-let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let network = Network.Type.Devnet
 
-let dependsOn =
-      Dockers.dependsOn
-        Dockers.Type.Bullseye
-        network
-        Profiles.Type.Standard
-        Artifacts.Type.Daemon
+let dependsOn = Dockers.dependsOn Dockers.DepsSpec::{ network = network }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -14,22 +14,13 @@ let PipelineMode = ../../Pipeline/Mode.dhall
 
 let ConnectToNetwork = ../../Command/ConnectToNetwork.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
-let Artifacts = ../../Constants/Artifacts.dhall
-
 let Network = ../../Constants/Network.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let network = Network.Type.Mainnet
 
-let dependsOn =
-      Dockers.dependsOn
-        Dockers.Type.Bullseye
-        network
-        Profiles.Type.Standard
-        Artifacts.Type.Daemon
+let dependsOn = Dockers.dependsOn Dockers.DepsSpec::{ network = network }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
+++ b/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
@@ -8,20 +8,13 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let PatchArchiveTest = ../../Command/PatchArchiveTest.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
-let Network = ../../Constants/Network.dhall
-
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let dependsOn =
       Dockers.dependsOn
-        Dockers.Type.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
-        Artifacts.Type.FunctionalTestSuite
+        Dockers.DepsSpec::{ artifact = Artifacts.Type.FunctionalTestSuite }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/ReplayerTest.dhall
+++ b/buildkite/src/Jobs/Test/ReplayerTest.dhall
@@ -8,20 +8,13 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let ReplayerTest = ../../Command/ReplayerTest.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Dockers = ../../Constants/DockerVersions.dhall
-
-let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let dependsOn =
       Dockers.dependsOn
-        Dockers.Type.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
-        Artifacts.Type.FunctionalTestSuite
+        Dockers.DepsSpec::{ artifact = Artifacts.Type.FunctionalTestSuite }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -12,8 +12,6 @@ let Command = ../../Command/Base.dhall
 
 let Size = ../../Command/Size.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Dockers = ../../Constants/DockerVersions.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
@@ -67,10 +65,11 @@ in  Pipeline.build
             , target = Size.Small
             , depends_on =
                 Dockers.dependsOn
-                  Dockers.Type.Bullseye
-                  network
-                  Profiles.Type.Standard
-                  Artifacts.Type.Rosetta
+                  Dockers.DepsSpec::{
+                  , codename = Dockers.Type.Bullseye
+                  , artifact = Artifacts.Type.Rosetta
+                  , network = network
+                  }
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTestsLong.dhall
@@ -72,10 +72,12 @@ in  Pipeline.build
             , target = Size.Small
             , depends_on =
                 Dockers.dependsOn
-                  Dockers.Type.Bullseye
-                  network
-                  Profiles.Type.Standard
-                  Artifacts.Type.Rosetta
+                  Dockers.DepsSpec::{
+                  , codename = Dockers.Type.Bullseye
+                  , network = network
+                  , profile = Profiles.Type.Standard
+                  , artifact = Artifacts.Type.Rosetta
+                  }
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -14,21 +14,14 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Profiles = ../../Constants/Profiles.dhall
 
-let Network = ../../Constants/Network.dhall
-
 let Docker = ../../Command/Docker/Type.dhall
 
 let Size = ../../Command/Size.dhall
 
 let dependsOn =
         DebianVersions.dependsOn
-          DebianVersions.DebVersion.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Lightnet
-      # DebianVersions.dependsOn
-          DebianVersions.DebVersion.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Standard
+          DebianVersions.DepsSpec::{ profile = Profiles.Type.Lightnet }
+      # DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
 
 let buildTestCmd
     : Size -> Command.Type

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -10,25 +10,14 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let TestExecutive = ../../Command/TestExecutive.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Dockers = ../../Constants/DockerVersions.dhall
-
-let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let dependsOn =
-        Dockers.dependsOn
-          Dockers.Type.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Standard
-          Artifacts.Type.Daemon
+        Dockers.dependsOn Dockers.DepsSpec::{ artifact = Artifacts.Type.Daemon }
       # Dockers.dependsOn
-          Dockers.Type.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Standard
-          Artifacts.Type.Archive
+          Dockers.DepsSpec::{ artifact = Artifacts.Type.Archive }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
@@ -10,25 +10,14 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let TestExecutive = ../../Command/TestExecutive.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Dockers = ../../Constants/DockerVersions.dhall
-
-let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let dependsOn =
-        Dockers.dependsOn
-          Dockers.Type.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Standard
-          Artifacts.Type.Daemon
+        Dockers.dependsOn Dockers.DepsSpec::{ artifact = Artifacts.Type.Daemon }
       # Dockers.dependsOn
-          Dockers.Type.Bullseye
-          Network.Type.Berkeley
-          Profiles.Type.Standard
-          Artifacts.Type.Archive
+          Dockers.DepsSpec::{ artifact = Artifacts.Type.Archive }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -20,15 +20,7 @@ let Size = ../../Command/Size.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profiles = ../../Constants/Profiles.dhall
-
-let dependsOn =
-      DebianVersions.dependsOn
-        DebianVersions.DebVersion.Bullseye
-        Network.Type.Berkeley
-        Profiles.Type.Standard
+let dependsOn = DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
 
 let buildTestCmd
     : Text -> Size -> List Command.TaggedKey.Type -> B/SoftFail -> Command.Type


### PR DESCRIPTION
DockerVersions.dhall and DebianVersions.dhall contains constants related to docker and debian build steps in CI. A lot of tests are referencing those steps as step dependency. Those build steps are highly customizable but in order to depends on them we need to specify a lot of arguments like : network,profile,codename etc. This is not very optimal and this PR cleans up dependsOn function which should improve DEX when using depends on  functionality