### PR TITLE
OPAM deps: remove opam-depext

### DIFF
--- a/opam.export
+++ b/opam.export
@@ -187,7 +187,6 @@ installed: [
   "odoc.2.1.0"
   "odoc-parser.1.0.0"
   "opam-core.2.1.2"
-  "opam-depext.1.2.1"
   "opam-file-format.2.1.4"
   "opam-format.2.1.2"
   "ounit2.2.2.6"


### PR DESCRIPTION
From a warning:

```
<><> opam-depext.1.2.1 installed successfully <><><><><><><><><><><><><><><><><>
=> opam-depext is unnecessary when used with opam >= 2.1. Please use opam install directly instead
```