### PR TITLE
Dockerfiles/scripts: adding jammy toolchain

### DIFF
--- a/dockerfiles/stages/1-build-deps-jammy
+++ b/dockerfiles/stages/1-build-deps-jammy
@@ -1,0 +1,15 @@
+FROM build-deps AS build-deps-jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sudo apt-get update --quiet \
+  && sudo apt-get upgrade --quiet --yes \
+  && sudo apt-get install --no-install-recommends --quiet --yes \
+    libssl3t64 \
+    libproc2-0 \
+  && sudo rm -rf /var/lib/apt/lists/*
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+  && unzip awscliv2.zip \
+  && sudo ./aws/install \
+  && rm -rf awscliv2.zip aws

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -153,6 +153,9 @@ case "${SERVICE}" in
           focal)
             DOCKERFILE_PATH="$DOCKERFILE_PATH_SCRIPT_1 dockerfiles/stages/1-build-deps-focal $DOCKERFILE_PATH_SCRIPT_2_AND_MORE"
             ;;
+          jammy)
+              DOCKERFILE_PATH="$DOCKERFILE_PATH_SCRIPT_1 dockerfiles/stages/1-build-deps-jammy $DOCKERFILE_PATH_SCRIPT_2_AND_MORE"
+              ;;
           noble)
             DOCKERFILE_PATH="$DOCKERFILE_PATH_SCRIPT_1 dockerfiles/stages/1-build-deps-noble $DOCKERFILE_PATH_SCRIPT_2_AND_MORE"
             ;;


### PR DESCRIPTION
Can be tested using `make CODENAME=jammy docker-build-toolchain`.