### PR TITLE
Apply patch from scripts/hardfork/localnet_patches

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1377,9 +1377,9 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
           let%map mina =
             Mina_lib.create ~commit_id:Mina_version.commit_id ~wallets
               (Mina_lib.Config.make ~logger ~pids ~trust_system ~conf_dir
-                 ~chain_id ~is_seed ~disable_node_status ~demo_mode
-                 ~coinbase_receiver ~net_config ~gossip_net_params
-                 ~proposed_protocol_version_opt
+                 ~file_log_level ~log_level ~log_json ~chain_id ~is_seed
+                 ~disable_node_status ~demo_mode ~coinbase_receiver ~net_config
+                 ~gossip_net_params ~proposed_protocol_version_opt
                  ~work_selection_method:
                    (Cli_lib.Arg_type.work_selection_method_to_module
                       work_selection_method )

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -60,6 +60,9 @@ type t =
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; uptime_send_node_commit : bool [@default false]
   ; stop_time : int
+  ; file_log_level : Logger.Level.t [@default Logger.Level.Info]
+  ; log_level : Logger.Level.t [@default Logger.Level.Info]
+  ; log_json : bool [@default false]
   ; graphql_control_port : int option [@default None]
   ; zkapp_cmd_limit : int option ref
   ; compile_config : Mina_compile_config.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -182,7 +182,8 @@ let log_snark_coordinator_warning (config : Config.t) snark_worker =
         ()
 
 module Snark_worker = struct
-  let run_process ~logger ~proof_level pids client_port kill_ivar num_threads =
+  let run_process ~logger ~proof_level pids client_port kill_ivar num_threads
+      ~conf_dir ~file_log_level ~log_json ~log_level =
     let env =
       Option.map
         ~f:(fun num -> `Extend [ ("RAYON_NUM_THREADS", string_of_int num) ])
@@ -196,7 +197,8 @@ module Snark_worker = struct
           :: Snark_worker.arguments ~proof_level
                ~daemon_address:
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
-               ~shutdown_on_disconnect:false )
+               ~shutdown_on_disconnect:false ~conf_dir ~file_log_level ~log_json
+               ~log_level )
     in
     Child_processes.Termination.register_process pids snark_worker_process
       Snark_worker ;
@@ -266,7 +268,10 @@ module Snark_worker = struct
         log_snark_worker_warning t ;
         let%map snark_worker_process =
           run_process ~logger:t.config.logger
-            ~proof_level:t.config.precomputed_values.proof_level t.config.pids
+            ~proof_level:t.config.precomputed_values.proof_level
+            ~log_json:t.config.log_json ~file_log_level:t.config.file_log_level
+            ~log_level:t.config.log_level t.config.pids
+            ~conf_dir:t.config.conf_dir
             t.config.gossip_net_params.addrs_and_ports.client_port kill_ivar
             t.config.snark_worker_config.num_threads
         in

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -241,18 +241,22 @@ let command_from_rpcs ~commit_id ~proof_level:default_proof_level
         ~aliases:[ "shutdown-on-disconnect" ]
         (optional bool)
         ~doc:"true|false Shutdown when disconnected from daemon (default:true)"
+    and log_json = Cli_lib.Flag.Log.json
+    and log_level = Cli_lib.Flag.Log.level
+    and file_log_level = Cli_lib.Flag.Log.file_log_level
     and conf_dir = Cli_lib.Flag.conf_dir in
     fun () ->
       let logger =
         Logger.create () ~metadata:[ ("process", `String "Snark Worker") ]
       in
       let proof_level = Option.value ~default:default_proof_level proof_level in
+      Cli_lib.Stdout_log.setup log_json log_level ;
       Option.value_map ~default:() conf_dir ~f:(fun conf_dir ->
           let logrotate_max_size = 1024 * 10 in
           let logrotate_num_rotate = 1 in
           Logger.Consumer_registry.register ~commit_id
             ~id:Logger.Logger_id.snark_worker
-            ~processor:(Logger.Processor.raw ())
+            ~processor:(Logger.Processor.raw ~log_level:file_log_level ())
             ~transport:
               (Logger_file_system.dumb_logrotate ~directory:conf_dir
                  ~log_filename:"mina-snark-worker.log"
@@ -267,11 +271,19 @@ let command_from_rpcs ~commit_id ~proof_level:default_proof_level
         ~logger ~proof_level ~constraint_constants daemon_port
         (Option.value ~default:true shutdown_on_disconnect))
 
-let arguments ~proof_level ~daemon_address ~shutdown_on_disconnect =
-  [ "-daemon-address"
+let arguments ~proof_level ~daemon_address ~shutdown_on_disconnect ~conf_dir
+    ~log_json ~log_level ~file_log_level =
+  [ "--daemon-address"
   ; Host_and_port.to_string daemon_address
-  ; "-proof-level"
+  ; "--proof-level"
   ; Genesis_constants.Proof_level.to_string proof_level
-  ; "-shutdown-on-disconnect"
+  ; "--shutdown-on-disconnect"
   ; Bool.to_string shutdown_on_disconnect
+  ; "--config-directory"
+  ; conf_dir
+  ; "--file-log-level"
+  ; Logger.Level.show file_log_level
+  ; "--log-level"
+  ; Logger.Level.show log_level
   ]
+  @ if log_json then [ "--log_json" ] else []


### PR DESCRIPTION
Applying patch from sctipts/hardfork/localnet_patch/compatible.patch. + my rebasing. 

After this is merged I will merge compatible to develop so both patches can be removed from repo. 

Original explanation from George why it was'nt done before:

> They haven't been merged back then because we developed this test after a feature freeze. We were aggressively limiting what code can land and happen to be in the release. And for the test I was fine with just keeping these changes as patches that were applied just for the sake of running this test.