### PR TITLE
generate legacy packages for bookworm

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLegacy.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLegacy.dhall
@@ -1,0 +1,28 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineMode = ../../Pipeline/Mode.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.onlyDebianPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts = [ Artifacts.Type.Daemon ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            ]
+          , network = Network.Type.DevnetLegacy
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , mode = PipelineMode.Type.Stable
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetLegacy.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetLegacy.dhall
@@ -1,0 +1,28 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineMode = ../../Pipeline/Mode.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Network = ../../Constants/Network.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.onlyDebianPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts = [ Artifacts.Type.Daemon ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , network = Network.Type.MainnetLegacy
+          , mode = PipelineMode.Type.Stable
+          }
+      )


### PR DESCRIPTION
Fix for nightly build. Bookworm does not have legacy packages resides in persist location. This PR introduces such jobs.