### PR TITLE
Make mina test executive public

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -8,7 +8,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -214,14 +215,15 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            List.fold ~init:0 ~f:( + )
            @@ List.drop block_production_delay_histogram_buckets_60s_min 1
          in
-         (* First two slots might be delayed because of test's bootstrap, so we have 2 as a threshold *)
+         (* First two slots might be delayed because of test's bootstrap, so we
+            have 2 as a threshold *)
          ok_if_true "block production was delayed" (blocks_delayed_over_60s <= 2)
         )
     in
     let%bind () =
       section "retrieve metrics of tx sender nodes"
-        (* We omit the result because we just want to query senders to see some useful
-            output in test logs *)
+        (* We omit the result because we just want to query senders to see some
+           useful output in test logs *)
         (Malleable_error.List.iter empty_bps
            ~f:
              (Fn.compose Malleable_error.soften_error

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -9,7 +9,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -53,7 +54,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Network.Node.get_ingress_uri node)
            ~account_id:bp_pk_account_id
        in
-       (* TODO, the intg test framework is ignoring test_constants.coinbase_amount for whatever reason, so hardcoding this until that is fixed *)
+       (* TODO, the intg test framework is ignoring
+          test_constants.coinbase_amount for whatever reason, so hardcoding this
+          until that is fixed *)
        let bp_expected =
          Currency.Amount.add bp_original_balance coinbase_reward
          |> Option.value_exn

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -8,7 +8,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -99,7 +100,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          () )
     in
     section "common prefix of all nodes is no farther back than 1 block"
-      (* the common prefix test relies on at least 4 blocks having been produced.  previous sections altogether have already produced 4, so no further block production is needed.  if previous sections change, then this may need to be re-adjusted*)
+      (* the common prefix test relies on at least 4 blocks having been
+         produced. previous sections altogether have already produced 4, so no
+         further block production is needed. if previous sections change, then this
+         may need to be re-adjusted*)
       (let%bind (labeled_chains : (string * string list) list) =
          Malleable_error.List.map (Core.String.Map.data all_mina_nodes)
            ~f:(fun node ->

--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -2,63 +2,63 @@
  (name test_executive)
  (libraries
   ;; opam libraries
-  async_kernel
   async
-  core
-  uri
-  yojson
-  core_kernel
-  cmdliner
+  async_kernel
+  async_unix
   base.base_internalhash_types
   base.caml
-  async_unix
-  unsigned_extended
-  stdio
+  cmdliner
+  core
+  core_kernel
   sexplib0
+  stdio
+  uri
+  unsigned_extended
+  yojson
   ;; local libraries
-  protocol_version
-  mina_wire_types
-  with_hash
+  block_time
+  cache_dir
+  currency
   data_hash_lib
+  file_system
+  genesis_constants
+  integers
+  integration_test_lib
+  integration_test_local_engine
+  key_gen
   kimchi_backend
   kimchi_pasta
   kimchi_pasta.basic
-  pickles
-  pickles_types
-  random_oracle_input
-  genesis_constants
-  integration_test_lib
-  signature_lib
-  mina_signature_kind
+  logger
   mina_base
+  mina_base.import
+  mina_generators
+  mina_numbers
+  mina_runtime_config
+  mina_signature_kind
   mina_stdlib
   mina_transaction
-  file_system
-  currency
-  mina_runtime_config
-  secrets
-  integration_test_local_engine
-  mina_generators
-  logger
-  random_oracle
-  mina_numbers
-  transaction_snark
-  snark_params
-  pickles.backend
-  pipe_lib
-  mina_base.import
-  key_gen
-  integers
-  user_command_input
-  participating_state
-  visualization
-  sgn
-  zkapp_command_builder
+  mina_wire_types
   network_pool
-  zkapps_examples
-  cache_dir
+  participating_state
+  pickles
+  pickles.backend
+  pickles_types
+  pipe_lib
+  protocol_version
+  random_oracle
+  random_oracle_input
+  secrets
+  sgn
+  signature_lib
   snarky.backendless
-  block_time)
+  snark_params
+  transaction_snark
+  user_command_input
+  visualization
+  with_hash
+  zkapp_command_builder
+  zkapps_examples)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -1,5 +1,7 @@
 (executable
  (name test_executive)
+ (public_name mina-test-executive)
+ (package mina_test_executive)
  (libraries
   ;; opam libraries
   async

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -8,7 +8,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -69,8 +70,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            (Core.String.Map.data all_mina_nodes) )
     in
     (* Since I made the balances of block producers in genesis ledger and next
-       epoch ledgers to be 0, then blocks would only be produced, if the consensus
-       selects the staking epoch *)
+       epoch ledgers to be 0, then blocks would only be produced, if the
+       consensus selects the staking epoch *)
     section "wait for 3 block to be produced"
       (wait_for t (Wait_condition.blocks_to_be_produced 3))
 end

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -8,7 +8,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -112,7 +112,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let epoch_ledger = staking_accounts in
       { epoch_ledger; epoch_seed }
     in
-    (* next accounts contains staking accounts, with balances changed, one new account *)
+    (* next accounts contains staking accounts, with balances changed, one new
+       account *)
     let next_accounts : Test_account.t list =
       let open Test_account in
       [ create ~account_name:"node-a-key" ~balance:"200000" ()
@@ -134,7 +135,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; epoch_data = Some { staking; next = Some next }
     ; genesis_ledger =
         (let open Test_account in
-        (* the genesis ledger contains the staking ledger plus some other accounts *)
+        (* the genesis ledger contains the staking ledger plus some other
+           accounts *)
         staking_accounts
         @ [ create ~account_name:"fish1" ~balance:"100" ()
           ; create ~account_name:"fish2" ~balance:"100" ()
@@ -537,8 +539,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                let bad_height =
                  Unsigned.UInt32.to_int height <= fork_config.blockchain_length
                in
-               (* for now, we accept the "link block" with a global slot since genesis equal to the previous global slot
-                  see issue #13897
+               (* for now, we accept the "link block" with a global slot since
+                  genesis equal to the previous global slot - see issue #13897
                *)
                let bad_slot =
                  Mina_numbers.Global_slot_since_genesis.to_int

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -9,7 +9,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -37,9 +38,15 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   (*
      There are 3 cases of bootstrap that we need to test:
 
-     1: short bootstrap-- bootstrap where node has been down for less than 2k+1 blocks
-     2: medium bootstrap-- bootstrap where node has been down for more than 2k+1 blocks, OR equivalently when the blockchain is longer than 2k+1 blocks and a node goes down and resets to a fresh state, thereby resetting at the genesis block, before reconnecting to the network
-     3: long bootstrap-- bootstrap where node has been down for more than 42k slots (2 epochs) where each epoch emitted at least 1 parallel scan state proof
+     1: short bootstrap-- bootstrap where node has been down for less than 2k+1
+        blocks
+     2: medium bootstrap-- bootstrap where node has been down for more than 2k+1
+        blocks, OR equivalently when the blockchain is longer than 2k+1 blocks and
+        a node goes down and resets to a fresh state, thereby resetting at the
+        genesis block, before reconnecting to the network
+     3: long bootstrap-- bootstrap where node has been down for more than 42k
+        slots (2 epochs) where each epoch emitted at least 1 parallel scan state
+        proof
   *)
 
   (* this test is the medium bootstrap test *)

--- a/src/app/test_executive/mina_test_executive.opam
+++ b/src/app/test_executive/mina_test_executive.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -10,7 +10,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -32,7 +33,12 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               (make_timing ~min_balance:10_000_000_000_000 ~cliff_time:8
                  ~cliff_amount:0 ~vesting_period:4
                  ~vesting_increment:5_000_000_000_000 )
-            (* 30_000_000_000_000 mina is the total.  initially, the balance will be 10k mina.  after 8 global slots, the cliff is hit, although the cliff amount is 0.  4 slots after that, 5_000_000_000_000 mina will vest, and 4 slots after that another 5_000_000_000_000 will vest, and then twice again, for a total of 30k mina all fully liquid and unlocked at the end of the schedule*)
+            (* 30_000_000_000_000 mina is the total. initially, the balance will
+               be 10k mina. after 8 global slots, the cliff is hit, although the
+               cliff amount is 0. 4 slots after that, 5_000_000_000_000 mina will
+               vest, and 4 slots after that another 5_000_000_000_000 will vest,
+               and then twice again, for a total of 30k mina all fully liquid and
+               unlocked at the end of the schedule*)
             ()
         ; create ~account_name:"snark-node-key1" ~balance:"0" ()
         ; create ~account_name:"snark-node-key2" ~balance:"0" ()
@@ -74,8 +80,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let timed_node_c = Network.block_producer_exn network "timed-node-c" in
     let fish1 = Network.genesis_keypair_exn network "fish1" in
     let fish2 = Network.genesis_keypair_exn network "fish2" in
-    (* hardcoded values of the balances of fish1 (receiver) and fish2 (sender), update here if they change in the config *)
-    (* TODO undo the harcoding, don't be lazy and just make the graphql commands to fetch the balances *)
+    (* hardcoded values of the balances of fish1 (receiver) and fish2 (sender),
+       update here if they change in the config *)
+    (* TODO undo the harcoding, don't be lazy and just make the graphql commands
+       to fetch the balances *)
     let receiver_original_balance = Currency.Amount.of_mina_string_exn "100" in
     let sender_original_balance = Currency.Amount.of_mina_string_exn "100" in
     let sender = fish2.keypair in
@@ -98,7 +106,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          ~f:(fun { Signature_lib.Keypair.public_key; _ } ->
            public_key |> Signature_lib.Public_key.to_yojson
            |> Yojson.Safe.to_string ) ) ;
-    (* setup code, creating a signed txn which we'll use to make a successful txn, and then use the same txn in a replay attack which should fail *)
+    (* setup code, creating a signed txn which we'll use to make a successful
+       txn, and then use the same txn in a replay attack which should fail *)
     let receiver_pub_key =
       receiver.public_key |> Signature_lib.Public_key.compress
     in
@@ -169,7 +178,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              (Network.Node.get_ingress_uri untimed_node_b)
              ~account_id:sender_account_id
          in
-         (* TODO, the intg test framework is ignoring test_constants.coinbase_amount for whatever reason, so hardcoding this until that is fixed *)
+         (* TODO, the intg test framework is ignoring
+            test_constants.coinbase_amount for whatever reason, so hardcoding this
+            until that is fixed *)
          let receiver_expected =
            Currency.Amount.add receiver_original_balance amount
            |> Option.value_exn
@@ -195,13 +206,21 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          if
            (* node_a is the receiver *)
            (* node_a_balance >= 400_000_000_000_000 + txn_amount *)
-           (* coinbase_amount is much less than txn_amount, so that even if node_a receives a coinbase, the balance (before receiving currency from a txn) should be less than original_amount + txn_amount *)
+           (* coinbase_amount is much less than txn_amount, so that even if
+              node_a receives a coinbase, the balance (before receiving currency
+              from a txn) should be less than original_amount + txn_amount *)
            Currency.Amount.( >= )
              (Currency.Balance.to_amount receiver_balance)
              receiver_expected
            (* node_b is the sender *)
-           (* node_b_balance <= (300_000_000_000_000 + node_b_num_produced_blocks*possible_coinbase_reward*2) - (txn_amount + txn_fee) *)
-           (* if one is unlucky, node_b could theoretically win a bunch of blocks in a row, which is why we have the `node_b_num_produced_blocks*possible_coinbase_reward*2` bit.  the *2 is because untimed accounts get supercharged rewards *)
+           (* node_b_balance <= \
+              (300_000_000_000_000 + \
+               node_b_num_produced_blocks * possible_coinbase_reward * 2) - \
+              (txn_amount + txn_fee) *)
+           (* if one is unlucky, node_b could theoretically win a bunch of
+              blocks in a row, which is why we have the
+              `node_b_num_produced_blocks*possible_coinbase_reward*2` bit. the *2
+              is because untimed accounts get supercharged rewards *)
            (* TODO, the fee is not calculated in at the moment *)
            && Currency.Amount.( <= )
                 (Currency.Balance.to_amount sender_balance)
@@ -384,11 +403,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               `(transaction_capacity_log+1) * (work_delay+1)`
             and for 2^2 transaction capacity and work delay 1 it is
               `(2+1)*(1+1)=6`.
-            Per block there can be 2 transactions included (other two slots would be for a coinbase and fee transfers).
-            In the initial state of the network, the scan state waits till all the trees are filled before emitting a proof from the first tree.
+            Per block there can be 2 transactions included (other two slots
+            would be for a coinbase and fee transfers).
+            In the initial state of the network, the scan state waits till all
+            the trees are filled before emitting a proof from the first tree.
             Hence, 6*2 = 12 transactions untill we get the first snarked ledger.
             2 successful txn are sent in the prior course of this test,
-            so spamming out at least 10 more here will trigger a ledger proof to be emitted *)
+            so spamming out at least 10 more here will trigger a ledger proof to
+            be emitted *)
            send_payments ~logger ~sender_pub_key ~receiver_pub_key
              ~amount:Currency.Amount.one ~fee ~node:sender 10
          in

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -9,7 +9,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t
@@ -86,7 +87,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (assert_peers_cant_be_partitioned ~max_disconnections:2
            initial_connectivity_data )
     in
-    (* a couple of transactions, so the persisted transition frontier is not trivial *)
+    (* a couple of transactions, so the persisted transition frontier is not
+       trivial *)
     let%bind () =
       section_hard "send a payment"
         (let%bind sender_pub_key = pub_key_of_node node_c in

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -8,7 +8,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   open Test_common.Make (Inputs)
 
-  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  (* TODO: find a way to avoid this type alias (first class module signatures
+     restrictions make this tricky) *)
   type network = Network.t
 
   type node = Network.Node.t

--- a/src/app/test_executive/test_common.ml
+++ b/src/app/test_executive/test_common.ml
@@ -152,7 +152,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (node, response) )
 
   let assert_peers_completely_connected nodes_and_responses =
-    (* this check checks if every single peer in the network is connected to every other peer, in graph theory this network would be a complete graph.  this property will only hold true on small networks *)
+    (* this check checks if every single peer in the network is connected to
+       every other peer, in graph theory this network would be a complete graph.
+       this property will only hold true on small networks *)
     let check_peer_connected_to_all_others ~nodes_by_peer_id ~peer_id
         ~connected_peers =
       let get_node_infra_id p =
@@ -187,13 +189,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           ~connected_peers )
 
   let assert_peers_cant_be_partitioned ~max_disconnections nodes_and_responses =
-    (* this check checks that the network does NOT become partitioned into isolated subgraphs, even if n nodes are hypothetically removed from the network.*)
+    (* this check checks that the network does NOT become partitioned into
+       isolated subgraphs, even if n nodes are hypothetically removed from the
+       network.*)
     let _, responses = List.unzip nodes_and_responses in
     let () =
       Out_channel.with_file "/tmp/network-graph.dot" ~f:(fun c ->
           G.output_graph c (graph_of_adjacency_list responses) )
     in
-    (* Check that the network cannot be disconnected by removing up to max_disconnections number of nodes. *)
+    (* Check that the network cannot be disconnected by removing up to
+       max_disconnections number of nodes. *)
     match
       Mina_stdlib.Nat.take
         (Mina_stdlib.Graph_algorithms.connectivity (module String) responses)

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -198,7 +198,8 @@ let report_test_errors ~log_error_set ~internal_error_set =
       let%bind () = Writer.(flushed (Lazy.force stderr)) in
       return exit_code
 
-(* TODO: refactor cleanup system (smells like a monad for composing linear resources would help a lot) *)
+(* TODO: refactor cleanup system (smells like a monad for composing linear
+   resources would help a lot) *)
 
 let dispatch_cleanup ~logger ~pause_cleanup_func ~network_cleanup_func
     ~log_engine_cleanup_func ~lift_accumulated_errors_func ~net_manager_ref
@@ -506,7 +507,8 @@ let default_cmd =
   let info = Term.info "test_executive" ~doc ~exits:Term.default_error_exits in
   (help_term, info)
 
-(* TODO: move required args to positions instead of flags, or provide reasonable defaults to make them optional *)
+(* TODO: move required args to positions instead of flags, or provide reasonable
+   defaults to make them optional *)
 let () =
   let engine_cmds = List.map engines ~f:engine_cmd in
   Term.(exit @@ eval_choice default_cmd (engine_cmds @ [ help_cmd ]))

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -182,7 +182,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            zkapp_command_spec
     in
     let%bind.Deferred zkapp_command_update_permissions, permissions_updated =
-      (* construct a Zkapp_command.t, similar to zkapp_test_transaction update-permissions *)
+      (* construct a Zkapp_command.t, similar to zkapp_test_transaction
+         update-permissions *)
       let nonce = Account.Nonce.zero in
       let memo =
         Signed_command_memo.create_from_string_exn "Zkapp update permissions"

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -145,8 +145,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             ~key:(Signature_lib.Public_key.compress public_key)
             ~data:private_key )
     in
-    (*Transaction that updates fee payer account in account_updates.
-      The account update should fail due to failing nonce condition if the next transaction with the same fee payer is added to the same block
+    (* Transaction that updates fee payer account in account_updates.
+       The account update should fail due to failing nonce condition if the next
+       transaction with the same fee payer is added to the same block
     *)
     let%bind.Deferred invalid_nonce_zkapp_cmd_from_fish1 =
       let open Zkapp_command_builder in
@@ -172,7 +173,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       replace_authorizations ~keymap with_dummy_signatures
     in
-    (*Transaction that updates fee payer account in account_updates but passes
+    (* Transaction that updates fee payer account in account_updates but passes
        because the nonce precondition is true. There should be no other fee
        payer updates in the same block*)
     let%bind.Deferred valid_zkapp_cmd_from_fish1 =
@@ -199,11 +200,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       replace_authorizations ~keymap with_dummy_signatures
     in
-    (*Set fee payer send permission to Proof. New transactions with the same
-      fee payer are accepted into the pool.
-      Only the ones that make it to the same block are applied.
-      The remaining ones in the pool should be evicted because the fee payer will
-      no longer have the permission to send with Signature authorization*)
+    (* Set fee payer send permission to Proof. New transactions with the same
+       fee payer are accepted into the pool.
+       Only the ones that make it to the same block are applied.
+       The remaining ones in the pool should be evicted because the fee payer
+       will no longer have the permission to send with Signature authorization *)
     let%bind.Deferred set_permission_zkapp_cmd_from_fish1 =
       let open Zkapp_command_builder in
       let with_dummy_signatures =
@@ -249,10 +250,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       replace_authorizations ~keymap with_dummy_signatures
     in
-    (*Transaction that doesn't make it into a block and should be evicted from
-      the pool after fee payer's send permission is changed
-      Making it a low fee transaction to prevent from getting into a block, to
-      test transaction pruning*)
+    (* Transaction that doesn't make it into a block and should be evicted from
+       the pool after fee payer's send permission is changed.
+       Making it a low fee transaction to prevent from getting into a block, to
+       test transaction pruning *)
     let%bind.Deferred invalid_fee_invalid_permission_zkapp_cmd_from_fish1 =
       let open Zkapp_command_builder in
       let with_dummy_signatures =
@@ -368,7 +369,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                  block was produced" ) )
     in
     let%bind () =
-      (*wait for blocks required to produce 2 proofs given 0.75 slot fill rate + some buffer*)
+      (* wait for blocks required to produce 2 proofs given 0.75 slot fill rate +
+         some buffer *)
       section_hard "Wait for proof to be emitted"
         ( wait_for t
         @@ Wait_condition.ledger_proofs_emitted_since_genesis

--- a/src/dune-project
+++ b/src/dune-project
@@ -110,6 +110,7 @@
 (package (name mina_signature_kind))
 (package (name mina_state))
 (package (name mina_stdlib))
+(package (name mina_test_executive))
 (package (name mina_transaction_logic))
 (package (name mina_transaction))
 (package (name mina_version))


### PR DESCRIPTION
This allows to have in the PATH the binary mina-test-executive when using `make
install`/`dune install`. The CI copies the binary `_build/default/src/app/test_executive/test_executive.exe` to
`mina-test-executive`, and this patch will help sharing the same configuration, locally and in the CI.