### PR TITLE
Buildkite/test-executive: remove reference to hashicorp

### DIFF
--- a/buildkite/scripts/run-test-executive-local.sh
+++ b/buildkite/scripts/run-test-executive-local.sh
@@ -37,16 +37,19 @@ fi
 # Don't prompt for answers during apt-get install
 export DEBIAN_FRONTEND=noninteractive
 
-rm -f /etc/apt/sources.list.d/hashicorp.list
-
 apt-get update
-apt-get install -y git apt-transport-https ca-certificates aptly tzdata curl
+apt-get install -y git \
+  apt-transport-https \
+  aptly \
+  ca-certificates \
+  curl \
+  docker \
+  docker-compose-plugin \
+  docker-ce \
+  tzdata
 
 git config --global --add safe.directory /workdir
 
-echo "deb [trusted=yes] https://apt.releases.hashicorp.com $MINA_DEB_CODENAME main" | tee /etc/apt/sources.list.d/hashicorp.list
-apt-get update
-apt-get install -y "docker" "docker-compose-plugin" "docker-ce"
 
 source buildkite/scripts/debian/install.sh "mina-test-executive"
 


### PR DESCRIPTION
And inline and gather `apt-get install` commands