### PR TITLE
Add tests reproducing a deadlock related to lmdb observed in devnet

### DIFF
--- a/src/lib/disk_cache/test/README.md
+++ b/src/lib/disk_cache/test/README.md
@@ -1,0 +1,81 @@
+# Disk Cache Deadlock Tests
+
+This directory contains tests to reproduce and verify the LMDB deadlock issue that occurs when finalizers run during write operations.
+
+## Test Overview
+
+The tests demonstrate that:
+- **LMDB cache**: Deadlocks when GC runs finalizers during write operations
+- **Filesystem cache**: Does NOT deadlock under the same conditions
+
+## Running the Tests
+
+### Run all disk cache tests
+```bash
+dune runtest src/lib/disk_cache/
+```
+
+### Run just the deadlock tests
+```bash
+# Run both deadlock tests
+dune runtest src/lib/disk_cache/test/
+
+# LMDB deadlock test only
+dune exec src/lib/disk_cache/test/test_lmdb_deadlock.exe
+
+# Filesystem control test only
+dune exec src/lib/disk_cache/test/test_filesystem_deadlock.exe
+```
+
+### Configuration via Environment Variables
+
+- `CACHE_DEADLOCK_TEST_TIMEOUT`: Timeout in seconds (e.g., "5.0"). Default is 10 seconds if not set. Set to empty string ("") to disable timeout.
+- `CACHE_DEADLOCK_TEST_DIR`: Custom directory for cache database. If not set, uses temporary directory.
+
+Example:
+```bash
+# Run with 5 second timeout
+CACHE_DEADLOCK_TEST_TIMEOUT=5.0 dune exec src/lib/disk_cache/test/test_lmdb_deadlock.exe
+
+# Run without timeout (will hang if deadlock occurs)
+CACHE_DEADLOCK_TEST_TIMEOUT="" dune exec src/lib/disk_cache/test/test_lmdb_deadlock.exe
+
+# Run with custom directory
+CACHE_DEADLOCK_TEST_DIR=/tmp/my-test dune runtest src/lib/disk_cache/test/
+```
+
+## Expected Behavior
+
+### LMDB Test
+When a deadlock is detected (with timeout set):
+```
+DEADLOCK DETECTED: Cache.put timed out after 5.0 seconds!
+This indicates a deadlock in the cache implementation.
+The finalizer likely tried to acquire a lock during GC.
+```
+
+### Filesystem Test
+Should always pass:
+```
+Evil put completed successfully (no deadlock)
+
+SUCCESS: Cache does NOT deadlock with finalizers.
+```
+
+## How It Works
+
+The test creates a "evil" data structure that triggers garbage collection during serialization. This causes finalizers to run while a cache write operation is in progress:
+
+1. Create a cache entry and hold a reference to it
+2. Start a new cache write operation
+3. During serialization, clear the reference and trigger GC
+4. The finalizer attempts to remove the old entry from the cache
+5. **LMDB**: Deadlocks trying to acquire write lock it already holds
+6. **Filesystem**: Completes successfully (uses simple file deletion)
+
+## File Structure
+
+- `test_cache_deadlock.ml`: Shared test logic (library)
+- `test_lmdb_deadlock.ml`: LMDB deadlock test
+- `test_filesystem_deadlock.ml`: Filesystem control test
+- `dune`: Test configuration

--- a/src/lib/disk_cache/test/dune
+++ b/src/lib/disk_cache/test/dune
@@ -1,0 +1,48 @@
+(library
+ (name test_cache_deadlock_lib)
+ (modules test_cache_deadlock)
+ (libraries
+  ;; opam libraries
+  async
+  core
+  core_kernel
+  ;; local libraries
+  disk_cache_intf
+  file_system
+  logger)
+ (preprocess
+  (pps ppx_jane ppx_version))
+ (flags
+  (:standard -w -22)))
+
+(test
+ (name test_lmdb_deadlock)
+ (modules test_lmdb_deadlock)
+ (libraries
+  ;; opam libraries
+  async
+  core
+  core_kernel
+  ;; local libraries
+  disk_cache.lmdb
+  test_cache_deadlock_lib)
+ (preprocess
+  (pps ppx_jane ppx_version))
+ (flags
+  (:standard -w -22)))
+
+(test
+ (name test_filesystem_deadlock)
+ (modules test_filesystem_deadlock)
+ (libraries
+  ;; opam libraries
+  async
+  core
+  core_kernel
+  ;; local libraries
+  disk_cache.filesystem
+  test_cache_deadlock_lib)
+ (preprocess
+  (pps ppx_jane ppx_version))
+ (flags
+  (:standard -w -22)))

--- a/src/lib/disk_cache/test/dune
+++ b/src/lib/disk_cache/test/dune
@@ -22,8 +22,6 @@
  (libraries
   ;; opam libraries
   async
-  core
-  core_kernel
   ;; local libraries
   disk_cache.lmdb
   test_cache_deadlock_lib)
@@ -38,8 +36,6 @@
  (libraries
   ;; opam libraries
   async
-  core
-  core_kernel
   ;; local libraries
   disk_cache.filesystem
   test_cache_deadlock_lib)

--- a/src/lib/disk_cache/test/dune
+++ b/src/lib/disk_cache/test/dune
@@ -12,8 +12,9 @@
   logger)
  (preprocess
   (pps ppx_jane ppx_version))
+ ;; Ignoring -22 because we use Binable.of_binable_without_uuid
  (flags
-  (:standard -w -22)))
+  (:standard -w +a -w -22)))
 
 (test
  (name test_lmdb_deadlock)
@@ -29,7 +30,7 @@
  (preprocess
   (pps ppx_jane ppx_version))
  (flags
-  (:standard -w -22)))
+  (:standard -w +a)))
 
 (test
  (name test_filesystem_deadlock)
@@ -45,4 +46,4 @@
  (preprocess
   (pps ppx_jane ppx_version))
  (flags
-  (:standard -w -22)))
+  (:standard -w +a)))

--- a/src/lib/disk_cache/test/dune
+++ b/src/lib/disk_cache/test/dune
@@ -10,6 +10,8 @@
   disk_cache_intf
   file_system
   logger)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_version))
  ;; Ignoring -22 because we use Binable.of_binable_without_uuid
@@ -25,6 +27,8 @@
   ;; local libraries
   disk_cache.lmdb
   test_cache_deadlock_lib)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_version))
  (flags
@@ -39,6 +43,8 @@
   ;; local libraries
   disk_cache.filesystem
   test_cache_deadlock_lib)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_version))
  (flags

--- a/src/lib/disk_cache/test/test_cache_deadlock.ml
+++ b/src/lib/disk_cache/test/test_cache_deadlock.ml
@@ -1,0 +1,137 @@
+(* Test for cache deadlock with finalizers - works with any disk_cache implementation *)
+
+open Core
+open Async
+
+(* Create a custom binable module that triggers GC during serialization *)
+module Evil_data = struct
+  module T = struct
+    type t = { value : string; trigger_gc : (unit -> unit) option }
+    [@@deriving sexp]
+  end
+
+  include T
+
+  (* We convert to/from string for bin_io, injecting our GC trigger during conversion *)
+  include
+    Binable.Of_binable_without_uuid
+      (String)
+      (struct
+        type nonrec t = t
+
+        let to_binable t =
+          (* Trigger GC during serialization if requested *)
+          Option.iter t.trigger_gc ~f:(fun f -> f ()) ;
+          t.value
+
+        let of_binable value = { value; trigger_gc = None }
+      end)
+end
+
+module type Cache_intf = sig
+  module Make : Disk_cache_intf.F
+end
+
+let run_test_with_cache (module Cache_impl : Cache_intf) ~timeout_seconds
+    ~tmpdir =
+  let module Cache = Cache_impl.Make (Evil_data) in
+  let%bind cache_result = Cache.initialize tmpdir ~logger:(Logger.null ()) in
+  let cache =
+    match cache_result with
+    | Ok cache ->
+        cache
+    | Error (`Initialization_error err) ->
+        failwithf "Failed to initialize cache: %s" (Error.to_string_hum err) ()
+  in
+
+  (* Create a cache entry that will be garbage collected when serializing "evil"
+     data *)
+  let entry_ref = ref None in
+  let entry_data = { Evil_data.value = "entry"; trigger_gc = None } in
+  entry_ref := Some (Cache.put cache entry_data) ;
+
+  (* Create evil data that triggers GC during serialization *)
+  let evil_data =
+    { Evil_data.value = "evil"
+    ; trigger_gc =
+        Some
+          (fun () ->
+            (* Clear reference and trigger GC to run finalizers *)
+            entry_ref := None ;
+            Core.printf "References cleared, triggering GC...\n%!" ;
+            Gc.compact () ;
+            Core.printf
+              "GC triggered during serialization - finalizers should run now\n\
+               %!" )
+    }
+  in
+
+  (* This put may deadlock if a finalizer runs during serialization *)
+  Core.printf "Attempting evil put...\n%!" ;
+
+  (* Run the potentially deadlocking operation with a timeout *)
+  let put_with_timeout () =
+    let put_deferred =
+      In_thread.run (fun () ->
+          ignore (Cache.put cache evil_data : Cache.id) ;
+          `Success )
+    in
+    match timeout_seconds with
+    | Some timeout ->
+        let timeout_span = Core.Time.Span.of_sec timeout in
+        Clock.with_timeout timeout_span put_deferred
+    | None ->
+        let%map result = put_deferred in
+        `Result result
+  in
+
+  match%bind put_with_timeout () with
+  | `Timeout ->
+      Core.printf
+        "\nDEADLOCK DETECTED: Cache.put timed out after %.1f seconds!\n%!"
+        (Option.value_exn timeout_seconds) ;
+      Core.printf "This indicates a deadlock in the cache implementation.\n%!" ;
+      Core.printf "The finalizer likely tried to acquire a lock during GC.\n%!" ;
+      return ()
+  | `Result `Success ->
+      Core.printf "Evil put completed successfully (no deadlock)\n%!" ;
+      Core.printf "\nSUCCESS: Cache does NOT deadlock with finalizers.\n%!" ;
+      return ()
+
+let test_cache_deadlock (module Cache_impl : Cache_intf) =
+  let open Async in
+  let open Deferred.Let_syntax in
+  
+  (* Read configuration from environment variables *)
+  let timeout_seconds = 
+    match Sys.getenv "CACHE_DEADLOCK_TEST_TIMEOUT" with
+    | Some "" -> None  (* Empty string means no timeout *)
+    | Some t -> Some (Float.of_string t)
+    | None -> Some 10.0  (* Default 10 second timeout for CI *)
+  in
+  let database_dir = Sys.getenv "CACHE_DEADLOCK_TEST_DIR" in
+  
+  Core.printf "\nCache deadlock test\n%!" ;
+  Core.printf "===================\n%!" ;
+  ( match timeout_seconds with
+  | Some t ->
+      Core.printf "Timeout: %.1f seconds\n%!" t
+  | None ->
+      Core.printf "Timeout: disabled (test will hang if deadlock occurs)\n%!" ) ;
+  Core.printf "\n%!" ;
+
+  let run_in_dir dir =
+    Core.printf "Using database directory: %s\n%!" dir ;
+    let%bind () =
+      run_test_with_cache
+        (module Cache_impl)
+        ~timeout_seconds ~tmpdir:dir
+    in
+    Core.printf "\nTest completed successfully.\n%!" ;
+    return ()
+  in
+
+  match database_dir with
+  | Some dir -> run_in_dir dir
+  | None ->
+      File_system.with_temp_dir "/tmp/cache_deadlock_test" ~f:run_in_dir

--- a/src/lib/disk_cache/test/test_cache_deadlock.ml
+++ b/src/lib/disk_cache/test/test_cache_deadlock.ml
@@ -5,12 +5,8 @@ open! Async_kernel
 
 (* Create a custom binable module that triggers GC during serialization *)
 module Evil_data = struct
-  module T = struct
-    type t = { value : string; trigger_gc : (unit -> unit) option }
-    [@@deriving sexp]
-  end
-
-  include T
+  type t = { value : string; trigger_gc : (unit -> unit) option }
+  [@@deriving sexp]
 
   (* We convert to/from string for bin_io, injecting our GC trigger during conversion *)
   include

--- a/src/lib/disk_cache/test/test_cache_deadlock.ml
+++ b/src/lib/disk_cache/test/test_cache_deadlock.ml
@@ -88,15 +88,15 @@ let run_test_with_cache (module Cache_impl : Cache_intf) ~timeout_seconds
   match%bind put_with_timeout () with
   | `Timeout ->
       Core.printf
-        "\nDEADLOCK DETECTED: Cache.put timed out after %.1f seconds!\n%!"
+        "\nDEADLOCK DETECTED: Cache.put timed out after %.1f seconds!\n"
         (Option.value_exn timeout_seconds) ;
-      Core.printf "This indicates a deadlock in the cache implementation.\n%!" ;
-      Core.printf "The finalizer likely tried to acquire a lock during GC.\n%!" ;
-      return ()
+      Core.printf "This indicates a deadlock in the cache implementation.\n" ;
+      Core.printf "The finalizer likely tried to acquire a lock during GC.\n" ;
+      return `Timeout
   | `Result `Success ->
-      Core.printf "Evil put completed successfully (no deadlock)\n%!" ;
-      Core.printf "\nSUCCESS: Cache does NOT deadlock with finalizers.\n%!" ;
-      return ()
+      Core.printf "Evil put completed successfully (no deadlock)" ;
+      Core.printf "\nCache does NOT deadlock with finalizers." ;
+      return `Success
 
 let test_cache_deadlock (module Cache_impl : Cache_intf) =
   (* Read configuration from environment variables *)
@@ -112,22 +112,18 @@ let test_cache_deadlock (module Cache_impl : Cache_intf) =
   in
   let database_dir = Sys.getenv_opt "CACHE_DEADLOCK_TEST_DIR" in
 
-  Core.printf "\nCache deadlock test\n%!" ;
-  Core.printf "===================\n%!" ;
+  Core.printf "\nCache deadlock test\n" ;
+  Core.printf "===================\n" ;
   ( match timeout_seconds with
   | Some t ->
-      Core.printf "Timeout: %.1f seconds\n%!" t
+      Core.printf "Timeout: %.1f seconds\n" t
   | None ->
-      Core.printf "Timeout: disabled (test will hang if deadlock occurs)\n%!" ) ;
-  Core.printf "\n%!" ;
+      Core.printf "Timeout: disabled (test will hang if deadlock occurs)\n" ) ;
+  Core.printf "\n" ;
 
   let run_in_dir dir =
-    Core.printf "Using database directory: %s\n%!" dir ;
-    let%bind () =
-      run_test_with_cache (module Cache_impl) ~timeout_seconds ~tmpdir:dir
-    in
-    Core.printf "\nTest completed successfully.\n%!" ;
-    return ()
+    Core.printf "Using database directory: %s\n" dir ;
+    run_test_with_cache (module Cache_impl) ~timeout_seconds ~tmpdir:dir
   in
 
   match database_dir with

--- a/src/lib/disk_cache/test/test_cache_deadlock.ml
+++ b/src/lib/disk_cache/test/test_cache_deadlock.ml
@@ -123,15 +123,14 @@ let test_cache_deadlock (module Cache_impl : Cache_intf) =
   let run_in_dir dir =
     Core.printf "Using database directory: %s\n%!" dir ;
     let%bind () =
-      run_test_with_cache
-        (module Cache_impl)
-        ~timeout_seconds ~tmpdir:dir
+      run_test_with_cache (module Cache_impl) ~timeout_seconds ~tmpdir:dir
     in
     Core.printf "\nTest completed successfully.\n%!" ;
     return ()
   in
 
   match database_dir with
-  | Some dir -> run_in_dir dir
+  | Some dir ->
+      run_in_dir dir
   | None ->
       File_system.with_temp_dir "/tmp/cache_deadlock_test" ~f:run_in_dir

--- a/src/lib/disk_cache/test/test_cache_deadlock.mli
+++ b/src/lib/disk_cache/test/test_cache_deadlock.mli
@@ -1,0 +1,7 @@
+open Async
+
+module type Cache_intf = sig
+  module Make : Disk_cache_intf.F
+end
+
+val test_cache_deadlock : (module Cache_intf) -> unit Deferred.t

--- a/src/lib/disk_cache/test/test_cache_deadlock.mli
+++ b/src/lib/disk_cache/test/test_cache_deadlock.mli
@@ -4,4 +4,5 @@ module type Cache_intf = sig
   module Make : Disk_cache_intf.F
 end
 
-val test_cache_deadlock : (module Cache_intf) -> unit Deferred.t
+val test_cache_deadlock :
+  (module Cache_intf) -> [ `Success | `Timeout ] Deferred.t

--- a/src/lib/disk_cache/test/test_filesystem_deadlock.ml
+++ b/src/lib/disk_cache/test/test_filesystem_deadlock.ml
@@ -1,0 +1,9 @@
+(* Filesystem cache control test - should not deadlock *)
+open! Core
+open Async
+
+let () =
+  printf "Running Filesystem cache control test...\n%!" ;
+  Thread_safe.block_on_async_exn (fun () ->
+    Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock (module Disk_cache)
+  )

--- a/src/lib/disk_cache/test/test_filesystem_deadlock.ml
+++ b/src/lib/disk_cache/test/test_filesystem_deadlock.ml
@@ -1,5 +1,4 @@
 (* Filesystem cache control test - should not deadlock *)
-open! Core
 open Async
 
 let () =

--- a/src/lib/disk_cache/test/test_filesystem_deadlock.ml
+++ b/src/lib/disk_cache/test/test_filesystem_deadlock.ml
@@ -4,5 +4,12 @@ open Async
 let () =
   printf "Running Filesystem cache control test...\n%!" ;
   Thread_safe.block_on_async_exn (fun () ->
-      Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
-        (module Disk_cache) )
+      let%bind res =
+        Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
+          (module Disk_cache)
+      in
+      match res with
+      | `Success ->
+          printf "Success" ; Deferred.unit
+      | `Timeout ->
+          failwith "The process should not time out" )

--- a/src/lib/disk_cache/test/test_filesystem_deadlock.ml
+++ b/src/lib/disk_cache/test/test_filesystem_deadlock.ml
@@ -4,5 +4,5 @@ open Async
 let () =
   printf "Running Filesystem cache control test...\n%!" ;
   Thread_safe.block_on_async_exn (fun () ->
-    Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock (module Disk_cache)
-  )
+      Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
+        (module Disk_cache) )

--- a/src/lib/disk_cache/test/test_lmdb_deadlock.ml
+++ b/src/lib/disk_cache/test/test_lmdb_deadlock.ml
@@ -1,0 +1,9 @@
+(* LMDB-specific deadlock test *)
+open! Core
+open Async
+
+let () =
+  printf "Running LMDB cache deadlock test...\n%!" ;
+  Thread_safe.block_on_async_exn (fun () ->
+    Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock (module Disk_cache)
+  )

--- a/src/lib/disk_cache/test/test_lmdb_deadlock.ml
+++ b/src/lib/disk_cache/test/test_lmdb_deadlock.ml
@@ -4,5 +4,5 @@ open Async
 let () =
   printf "Running LMDB cache deadlock test...\n%!" ;
   Thread_safe.block_on_async_exn (fun () ->
-    Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock (module Disk_cache)
-  )
+      Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
+        (module Disk_cache) )

--- a/src/lib/disk_cache/test/test_lmdb_deadlock.ml
+++ b/src/lib/disk_cache/test/test_lmdb_deadlock.ml
@@ -1,5 +1,4 @@
 (* LMDB-specific deadlock test *)
-open! Core
 open Async
 
 let () =

--- a/src/lib/disk_cache/test/test_lmdb_deadlock.ml
+++ b/src/lib/disk_cache/test/test_lmdb_deadlock.ml
@@ -2,7 +2,17 @@
 open Async
 
 let () =
-  printf "Running LMDB cache deadlock test...\n%!" ;
+  printf "Running LMDB cache deadlock test...\n" ;
   Thread_safe.block_on_async_exn (fun () ->
-      Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
-        (module Disk_cache) )
+      let%bind res =
+        Test_cache_deadlock_lib.Test_cache_deadlock.test_cache_deadlock
+          (module Disk_cache)
+      in
+      match res with
+      | `Timeout ->
+          printf
+            "It is expected that LMDB cache times out for now. This should be \
+             fixed." ;
+          Deferred.unit
+      | `Success ->
+          failwith "The process should time out" )


### PR DESCRIPTION
(This reproduction is complete, but I'm not sure this is the exact form a permanent test of this deadlock should take. I'm putting it up for people to take a look at it.)

## Some context

We have been observing a problem in devnet where mina nodes occasionally become completely unresponsive, no longer emitting logs or responding to rpc calls like `mina client status`. We have gotten a couple of reproductions by connecting to devnet locally, which allowed us to collect this backtrace with gdb at the point the freeze occurred:

```
#0  0x00007ffff6e9bad0 in __pthread_mutex_lock_full () from /nix/store/p9kdj55g5l39nbrxpjyz5wc1m0s7rzsx-glibc-2.40-66/lib/libc.so.6
#1  0x00007ffff7f1f492 in mdb_txn_renew0 () from /nix/store/096qj8qh7f03lwlw2ha9d3p73dirdzi2-lmdb-0.9.33/lib/liblmdb.so
#2  0x00007ffff7f205bb in mdb_txn_begin () from /nix/store/096qj8qh7f03lwlw2ha9d3p73dirdzi2-lmdb-0.9.33/lib/liblmdb.so
#3  0x000000000363ceaa in mdbs_txn_begin ()
#4  0x00000000025170e9 in camlLmdb__go_1194 ()
#5  0x00000000025171fc in camlLmdb__trivial_1205 ()
#6  0x0000000002513fb0 in camlLmdb_storage__Generic__f_5007 () at src/lib/lmdb_storage/generic.ml:112
#7  0x00000000031ffd04 in camlBase__Exn__handle_uncaught_aux_2205 ()
#8  0x0000000003ea4b95 in caml_start_program ()
#9  0x0000000003e9a5f3 in caml_callback_exn ()
#10 0x0000000003e9d261 in caml_final_do_calls_exn ()
#11 0x0000000003e84ef4 in caml_do_pending_actions_exn ()
#12 0x0000000003e88d72 in caml_alloc_small_dispatch ()
#13 0x0000000003ea4a5e in caml_call_gc ()
#14 0x000000000110fac1 in caml_curry6_1 ()
#15 0x00000000011121a9 in caml_apply3 ()
#16 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#17 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#18 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#19 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#20 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#21 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#22 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#23 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#24 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#25 0x0000000002b8a791 in camlPlonkish_prelude__Vector__f_4233 () at src/lib/crypto/plonkish_prelude/vector.ml:235
#26 0x0000000002afe480 in camlKimchi_backend_common__Plonk_types__bin_write_t_9951 () at src/lib/crypto/plonkish_prelude/vector.ml:336
#27 0x0000000002b1780d in camlKimchi_backend_common__Plonk_types__bin_write_t_15291 () at src/lib/crypto/kimchi_backend/common/plonk_types.ml:1311
#28 0x0000000002619b77 in camlPickles__Proof__bin_write_t_6497 () at src/lib/pickles/proof.ml:37
#29 0x00000000025159e2 in camlLmdb_storage__Conv__fun_4202 () at src/lib/lmdb_storage/conv.ml:36
#30 0x00000000025180be in camlLmdb__fun_2876 ()
#31 0x000000000251710d in camlLmdb__go_1194 ()
#32 0x00000000025171fc in camlLmdb__trivial_1205 ()
#33 0x0000000002513fb0 in camlLmdb_storage__Generic__f_5007 () at src/lib/lmdb_storage/generic.ml:112
#34 0x0000000002511345 in camlDisk_cache__put_5675 () at src/lib/disk_cache/lmdb/disk_cache.ml:38
```

The issue appears to be related to how lmdb interacts with garbage collection. There was one potential bug in the ocaml lmdb bindings package, but we also saw this line in our own code:

https://github.com/MinaProtocol/mina/blob/3505b6c000c7d0fb04b2043ee9fdce7616f2d1e0/src/lib/disk_cache/lmdb/disk_cache.ml#L37

that looked suspicious. Specifically, if GC coincidentally activated *during a cache write transaction*, and it happened to run the finalizer for the `id` of something stored in the cache, then that finalizer would attempt to write to the cache during the in-progress write. This would cause a deadlock - the thread would end up waiting for the write mutex that it already acquired.

## Explain your changes:

To test the hypothesis above, two new standalone test executables have been added to `src/lib/disk_cache/test`. They share a common implementation, and only differ in the cache backend used - one uses `lmdb` and the other uses `filesystem`. The test:

1. Defines a type with a `bin_io` instance that allows us to optionally trigger GC (among other things) during serialization.
2. Creates a cache for this type
3. Writes an initial value to the cache and keeps a reference around to it
4. Tries to write a second value to the cache, but with one difference - while serializing the value we drop the reference to the `id` of the first value and then manually trigger garbage collection.

The test executables have a `--timeout` parameter to provide a version of the test that doesn't hang indefinitely. If you omit that parameter, then the `lmdb` version does indeed hang, and the `filesystem` version does not. The backtrace I get from the `lmdb` version is this:

```
#0  0x00007ff1cfbb4ad0 in __pthread_mutex_lock_full () from /nix/store/p9kdj55g5l39nbrxpjyz5wc1m0s7rzsx-glibc-2.40-66/lib/libc.so.6
#1  0x00007ff1d012d492 in mdb_txn_renew0 () from /nix/store/096qj8qh7f03lwlw2ha9d3p73dirdzi2-lmdb-0.9.33/lib/liblmdb.so
#2  0x00007ff1d012e5bb in mdb_txn_begin () from /nix/store/096qj8qh7f03lwlw2ha9d3p73dirdzi2-lmdb-0.9.33/lib/liblmdb.so
#3  0x0000000000bea9ba in mdbs_txn_begin ()
#4  0x00000000006ecf39 in camlLmdb__go_1194 ()
#5  0x00000000006ed04c in camlLmdb__trivial_1205 ()
#6  0x00000000006db330 in camlLmdb_storage__Generic__f_5007 () at src/lib/lmdb_storage/generic.ml:112
#7  0x0000000000af4144 in camlBase__Exn__handle_uncaught_aux_2205 ()
#8  0x0000000000c21725 in caml_start_program ()
#9  0x0000000000c17a93 in caml_callback_exn ()
#10 0x0000000000c1a701 in caml_final_do_calls_exn ()
#11 0x0000000000c02394 in caml_do_pending_actions_exn ()
#12 0x0000000000c025cf in caml_process_pending_actions_exn ()
#13 0x0000000000c15469 in caml_gc_compaction ()
#14 0x00000000006d76ad in camlTest_cache_deadlock__fun_9440 () at src/lib/disk_cache/test/test_cache_deadlock.ml:61
#15 0x00000000006d71cf in camlTest_cache_deadlock__to_binable_3286 () at src/option.ml:94
#16 0x0000000000ad47b2 in camlBin_prot__Utils__bin_size_t_1197 ()
#17 0x00000000006dcd35 in camlLmdb_storage__Conv__fun_4202 () at src/lib/lmdb_storage/conv.ml:34
#18 0x00000000006edf0e in camlLmdb__fun_2876 ()
#19 0x00000000006ecf5d in camlLmdb__go_1194 ()
#20 0x00000000006ed04c in camlLmdb__trivial_1205 ()
#21 0x00000000006db330 in camlLmdb_storage__Generic__f_5007 () at src/lib/lmdb_storage/generic.ml:112
#22 0x00000000006d84c5 in camlDisk_cache__put_5675 () at src/lib/disk_cache/lmdb/disk_cache.ml:38
#23 0x00000000006d76ec in camlTest_cache_deadlock__fun_9443 () at src/lib/disk_cache/test/test_cache_deadlock.ml:74
```

It seems to me like this is the same issue. I should note, though, that this doesn't reproduce the issue in the precise circumstances that it occurs in devnet, but it definitely reproduces *a* bug.