### PR TITLE
Do not shorten commit id if too small

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1307,7 +1307,7 @@ let shorten_commit_id commit_id =
   if String.length commit_id < min_commit_id_length then commit_id
   else
     (* Take the first 8 characters of the commit ID *)
-    String.sub ~pos:0 ~len commit_id
+    String.sub ~pos:0 ~len:min_commit_id_length commit_id
 
 let start t =
   let commit_id_short = shorten_commit_id t.commit_id in


### PR DESCRIPTION
During hardfork work I experienced peculiar issue :

```
2025-07-07 07:52:38 UTC [Fatal] Unhandled top-level exception: $exn
Generating crash report
  exn: {
  "sexp": [
    "monitor.ml.Error",
    [ "Invalid_argument", "pos + len past end: 0 + 8 > 7" ],
    [
      "Raised at Stdlib.invalid_arg in file \"stdlib.ml\", line 30, characters 20-45",
      "Called from Base__String.sub in file \"src/string.ml\", line 64, characters 4-84",
      "Called from Mina_lib.create in file \"src/lib/mina_lib/mina_lib.ml\", line 1697, characters 24-58",
      "Called from Mina_cli_entrypoint.setup_daemon.(fun).mina_initialization_deferred.(fun) in file \"src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml\", line 1378, characters 12-1023",
      "Called from Async_kernel__Deferred0.bind.(fun) in file \"src/deferred0.ml\", line 54, characters 64-69",
      "Called from Async_kernel__Job_queue.run_job in file \"src/job_queue.ml\" (inlined), line 128, characters 2-5",
      "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 169, characters 6-47",
      "Caught by monitor coda"
    ]
  ],
  "backtrace": [
    "Raised at Stdlib.invalid_arg in file \"stdlib.ml\", line 30, characters 20-45",
    "Called from Base__String.sub in file \"src/string.ml\", line 64, characters 4-84",
    "Called from Mina_lib.create in file \"src/lib/mina_lib/mina_lib.ml\", line 1697, characters 24-58",
    "Called from Mina_cli_entrypoint.setup_daemon.(fun).mina_initialization_deferred.(fun) in file \"src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml\", line 1378, characters 12-1023",
    "Called from Async_kernel__Deferred0.bind.(fun) in file \"src/deferred0.ml\", line 54, characters 64-69",
    "Called from Async_kernel__Job_queue.run_job in file \"src/job_queue.ml\" (inlined), line 128, characters 2-5",
    "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 169, characters 6-47"
  ]
}
Environment variable MINA_TIME_OFFSET not found, using default of 0
```

This is becuase in some cases for local testing we are using commit_ids like <dirty> which doesn't have required 8 chars. My fix is to introduce logic to skip String.sub when length is less that 8 but use entire commit id instead