### PR TITLE
Snark Worker: fix incorrect CLI arg after hardfork localnet patch

### DIFF
--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -286,4 +286,4 @@ let arguments ~proof_level ~daemon_address ~shutdown_on_disconnect ~conf_dir
   ; "--log-level"
   ; Logger.Level.show log_level
   ]
-  @ if log_json then [ "--log_json" ] else []
+  @ if log_json then [ "--log-json" ] else []


### PR DESCRIPTION
As title. 

I run into this sometimes when running snark coordinator

```
Error parsing command line:

  unknown flag --log_json

For usage information, run

  mina internal snark-worker -help
```

Here's the output of `mina internal snark-worker --help`

```
Snark worker

  mina.exe internal snark-worker 

=== flags ===

  --daemon-address HOST-AND-PORT         address daemon is listening on
                                         (alias: -daemon-address)
  [--config-directory DIR]               Configuration directory
                                         (alias: -config-directory)
  [--file-log-level LEVEL]               Set log level for the log file
                                         (Internal|Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
                                         default: Trace)
                                         (alias: -file-log-level)
  [--log-json]                           Print log output as JSON (default:
                                         plain text)
                                         (alias: -log-json)
  [--log-level LEVEL]                    Set log level
                                         (Internal|Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
                                         default: Info)
                                         (alias: -log-level)
  [--proof-level _]                      full|check|none
                                         (alias: -proof-level)
  [--shutdown-on-disconnect true|false]  Shutdown when disconnected from daemon
                                         (default:true)
                                         (alias: -shutdown-on-disconnect)
  [-help]                                print this help text and exit
                                         (alias: -?)
```