### PR TITLE
Consensus_vrf/test: aesthetic changes

### DIFF
--- a/src/lib/consensus/vrf/tests/test_consensus_vrf.ml
+++ b/src/lib/consensus/vrf/tests/test_consensus_vrf.ml
@@ -9,24 +9,22 @@
 open Core_kernel
 
 let test_hash_checked_and_unchecked () =
-  let open Snark_params.Tick in
+  let open Quickcheck.Generator.Let_syntax in
   let constraint_constants =
     Genesis_constants.For_unit_tests.Constraint_constants.t
   in
   let gen_inner_curve_point =
-    let open Quickcheck.Generator.Let_syntax in
     let%map compressed = Non_zero_curve_point.gen in
     Non_zero_curve_point.to_inner_curve compressed
   in
   let gen_message_and_curve_point =
-    let open Quickcheck.Generator.Let_syntax in
     let%map msg = Consensus_vrf.Message.gen ~constraint_constants
     and g = gen_inner_curve_point in
     (msg, g)
   in
   Quickcheck.test ~trials:10 gen_message_and_curve_point
     ~f:
-      (Test_util.test_equal ~equal:Field.equal
+      (Test_util.test_equal ~equal:Snark_params.Tick.Field.equal
          Snark_params.Tick.Typ.(
            Consensus_vrf.Message.typ ~constraint_constants
            * Snark_params.Tick.Inner_curve.typ)
@@ -35,30 +33,29 @@ let test_hash_checked_and_unchecked () =
          (fun (msg, g) -> Consensus_vrf.Output.hash ~constraint_constants msg g) )
 
 let standalone_and_integrates_vrf_are_consistent () =
-  let open Consensus_vrf in
+  let open Quickcheck.Generator.Let_syntax in
   let constraint_constants =
     Genesis_constants.For_unit_tests.Constraint_constants.t
   in
-  let module Standalone = Standalone (struct
+  let module Standalone = Consensus_vrf.Standalone (struct
     let constraint_constants = constraint_constants
   end) in
   let inputs =
-    let open Quickcheck.Generator.Let_syntax in
     let%bind private_key = Signature_lib.Private_key.gen in
-    let%map message = Message.gen ~constraint_constants in
+    let%map message = Consensus_vrf.Message.gen ~constraint_constants in
     (private_key, message)
   in
   Quickcheck.test ~seed:(`Deterministic "") inputs
     ~f:(fun (private_key, message) ->
       let integrated_vrf =
-        Integrated.eval ~constraint_constants ~private_key message
+        Consensus_vrf.Integrated.eval ~constraint_constants ~private_key message
       in
       let standalone_eval = Standalone.Evaluation.create private_key message in
       let context : Standalone.Context.t =
         { message
         ; public_key =
             Signature_lib.Public_key.of_private_key_exn private_key
-            |> Group.of_affine
+            |> Consensus_vrf.Group.of_affine
         }
       in
       let standalone_vrf =
@@ -70,8 +67,8 @@ let standalone_and_integrates_vrf_are_consistent () =
             Alcotest.fail "Standalone VRF evaluation failed"
         | Some standalone_vrf ->
             (* Check that the standalone VRF output matches the integrated VRF output *)
-            let open Snark_params.Tick.Field in
-            if equal standalone_vrf integrated_vrf then true
+            if Snark_params.Tick.Field.equal standalone_vrf integrated_vrf then
+              true
             else
               let str_standalone_vrf =
                 Snark_params.Tick.Field.to_string standalone_vrf


### PR DESCRIPTION
- Move at the top of the method declaration multiple local open statements
- Remove local open of Snark_params.Tick to be more explicit, and be consistent
  in using full path or local open (full path used).
- Remove local open of Consensus_vrf and use full path
