### PR TITLE
LMDB Cache: partially reuse GCed IDs so to save cycles on cleaning LMDB V2

### DIFF
--- a/src/lib/disk_cache/lmdb/disk_cache.ml
+++ b/src/lib/disk_cache/lmdb/disk_cache.ml
@@ -42,8 +42,11 @@ module Make (Data : Binable.S) = struct
     let idx =
       match Queue.dequeue reusable_keys with
       | None ->
+          (* We don't have reusable keys, assign a new one nobody ever used *)
           incr counter ; !counter - 1
       | Some reused_key ->
+          (* Any key inside [reusable_keys] is marked as garbage by GC, so we're
+             free to use them *)
           reused_key
     in
     let res = { idx } in

--- a/src/lib/disk_cache/lmdb/disk_cache.ml
+++ b/src/lib/disk_cache/lmdb/disk_cache.ml
@@ -21,7 +21,8 @@ module Make (Data : Binable.S) = struct
     ; db : Rw.holder
     ; counter : int ref
     ; reusable_keys : int Queue.t
-          (** A list of ids that are no longer reachable from OCaml's side *)
+          (** A list of ids that are no longer reachable from OCaml runtime, but
+              haven't been cleared inside the LMDB disk cache *)
     }
 
   (** How big can the queue [reusable_keys] be before we do a cleanup *)


### PR DESCRIPTION
This is a revamp of https://github.com/MinaProtocol/mina/pull/17469. 

With some rounds of review & misunderstanding. I realized the choose of DS and the name of that DS is not optimal. 

Hence a redesign, aiming at clarify the intention. 

------------

In our previous implementation, to avoid deadlock, all keys that are supposed to be removed from underlying LMDB cache is put in a hashset instead. On invoke of a `put`, if there's too many such keys, we'll call a round of clean up of all of those keys. 

For the keys returned by `put`, it was just a monotonically increasing integer.

----------

In this PR, we try to retrive keys from the hashset(replaced by a queue), so we can skip the cycle wasted to clean up any specific keys reused this way when we try to invoke a clean up. 

----------

Follow-up: I'm looking at the underlying implementation of our LMDB wrapper. `put` should be further improved as a batching operation to avoid repetitive DB operation overhead. 