### PR TITLE
[CI] convert standard to devnet handler

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -115,8 +115,8 @@ let generateStep =
                 Extensions.joinOptionals
                   "-"
                   [ merge
-                      { Standard = None Text
-                      , Mainnet = None Text
+                      { Mainnet = None Text
+                      , Devnet = None Text
                       , Dev = None Text
                       , Lightnet = Some
                           "${Profiles.toSuffixLowercase spec.deb_profile}"


### PR DESCRIPTION
Fixing CI issue in DockerImage.dhall. Old Standard variant was used instead of Devnet one