### PR TITLE
Makefile: add targets to setup, clean and login to PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ GITLONGHASH := $(shell git rev-parse HEAD)
 # Unique signature of libp2p code tree
 LIBP2P_HELPER_SIG := $(shell cd src/app/libp2p_helper ; find . -type f -print0  | xargs -0 sha1sum | sort | sha1sum | cut -f 1 -d ' ')
 
+# Database for archive
+PG_USER ?= mina
+PG_PW 	?= minaminamina
+PG_DB 	?= archive
+PG_HOST	?= localhost
+PG_PORT	?= 5432
+
 ########################################
 .PHONY: help
 help: ## Display this help information
@@ -441,3 +448,27 @@ docker-build-toolchain: ## Build the toolchain to be used in CI
 .PHONY: ml-docs
 ml-docs: ocaml_checks ## Generate OCaml documentation
 	dune build --profile=$(DUNE_PROFILE) @doc
+
+
+########################################
+# PostgreSQL, used for the archive node
+
+.PHONY: postgres-setup
+postgres-setup: ## Set up PostgreSQL database for archive node
+	@echo "Setting up PostgreSQL database: ${PG_DB} with user: ${PG_USER}"
+	@sudo -u postgres createuser -d -r -s $(PG_USER) 2>/dev/null || true
+	@sudo -u postgres psql -c "ALTER USER $(PG_USER) PASSWORD '$(PG_PW)'" 2>/dev/null || true
+	@sudo -u postgres createdb -O $(PG_USER) $(PG_DB) 2>/dev/null || true
+	@echo "PostgreSQL setup complete"
+
+.PHONY: postgres-login
+postgres-login: ## Login to PostgreSQL database
+	@echo "Connecting to PostgreSQL database: ${PG_DB} as user: ${PG_USER}"
+	@PGPASSWORD=$(PG_PW) psql -h $(PG_HOST) -p $(PG_PORT) -U $(PG_USER) -d $(PG_DB)
+
+.PHONY: postgres-clean
+postgres-clean:
+	@echo "Dropping DB: ${PG_DB} and user: ${PG_USER}"
+	@sudo -u postgres psql -c "DROP DATABASE IF EXISTS ${PG_DB}"
+	@sudo -u postgres psql -c "DROP ROLE IF EXISTS ${PG_USER}"
+	@echo "Cleanup complete."


### PR DESCRIPTION
You can test locally using:
```
make postgres-setup
make postgres-clean

make postgres-setup
make postgres-login
```

And change the variable PG_USER, PG_DB, PG_PW, etc as you wish.
It also helps to connect to a remote database.

It will be used later with other targets to execute some archive specific scripts.