### PR TITLE
Fix for publishing debian packages in nightly

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -391,7 +391,6 @@ function publish_debian() {
                 --suite "unstable" \
                 --new-suite ${__channel} \
                 --new-name ${__artifact_full_name} \
-                --new-release ${__channel} \
                 --codename ${__codename}
     fi
 

--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -390,8 +390,7 @@ function publish_debian() {
                 --new-version ${__target_version} \
                 --suite "unstable" \
                 --new-suite ${__channel} \
-                --new-name ${__artifact_full_name} \
-                --codename ${__codename}
+                --new-name ${__artifact_full_name}
     fi
 
     echo " 🍥  Publishing $__artifact debian to $__channel channel with $__target_version version"

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -24,17 +24,17 @@ TEST_EXECUTIVE_DEPS=", mina-logproc, python3, docker"
 
 case "${MINA_DEB_CODENAME}" in
   noble|jammy)
-    SHARED_DEPS="libssl3t64, libgmp10, libgomp1, tzdata, rocksdb-tools"
+    SHARED_DEPS="libssl3t64, libgmp10, libgomp1, tzdata, rocksdb-tools, liblmdb0"
     DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libproc2-0 , mina-logproc"
     ARCHIVE_DEPS="libssl3t64, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bookworm)
-    SHARED_DEPS="libssl3, libgmp10, libgomp1, tzdata, rocksdb-tools"
+    SHARED_DEPS="libssl3, libgmp10, libgomp1, tzdata, rocksdb-tools, liblmdb0"
     DAEMON_DEPS=", libffi8, libjemalloc2, libpq-dev, libproc2-0 , mina-logproc"
     ARCHIVE_DEPS="libssl3, libgomp1, libpq-dev, libjemalloc2"
     ;;
   bullseye|focal)
-    SHARED_DEPS="libssl1.1, libgmp10, libgomp1, tzdata, rocksdb-tools"
+    SHARED_DEPS="libssl1.1, libgmp10, libgomp1, tzdata, rocksdb-tools, liblmdb0"
     DAEMON_DEPS=", libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc"
     ARCHIVE_DEPS="libssl1.1, libgomp1, libpq-dev, libjemalloc2"
     ;;

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -58,8 +58,7 @@ function rebuild_deb() {
             --new-version ${NEW_VERSION} \
             --suite ${SUITE} \
             --new-suite ${NEW_SUITE} \
-            --new-name ${NEW_NAME} \
-            --codename ${CODENAME}
+            --new-name ${NEW_NAME}
 }
 
 rebuild_deb

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -34,7 +34,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   *) echo "❌ Unknown parameter passed: $1"; usage exit 1;;
 esac; shift; done
 
-if [[ ! -v SUITE ]]; then echo "❌ No release nor suite specified"; echo ""; usage "$0" "$1" ; exit 1; fi
+if [[ ! -v SUITE ]]; then echo "❌ No suite specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v VERSION ]]; then echo "❌ No version specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v REPO ]]; then echo "❌ No repo specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v NEW_NAME ]]; then NEW_NAME=$DEB; fi;

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -34,13 +34,10 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   *) echo "❌ Unknown parameter passed: $1"; usage exit 1;;
 esac; shift; done
 
-if [[ ! -v RELEASE && ! -v SUITE ]]; then echo "❌ No release nor suite specified"; echo ""; usage "$0" "$1" ; exit 1; fi
+if [[ ! -v SUITE ]]; then echo "❌ No release nor suite specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v VERSION ]]; then echo "❌ No version specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v REPO ]]; then echo "❌ No repo specified"; echo ""; usage "$0" "$1" ; exit 1; fi
-if [[ ! -v SUITE ]]; then SUITE=$RELEASE; fi;
-if [[ ! -v RELEASE ]]; then RELEASE=$SUITE; fi;
 if [[ ! -v NEW_NAME ]]; then NEW_NAME=$DEB; fi;
-if [[ ! -v NEW_RELEASE ]]; then NEW_RELEASE=$RELEASE; fi;
 if [[ ! -v NEW_VERSION ]]; then NEW_VERSION=$VERSION; fi;
 if [[ ! -v NEW_SUITE ]]; then NEW_SUITE=$SUITE; fi;
 if [[ ! -v NEW_REPO ]]; then NEW_REPO=$REPO; fi;
@@ -62,9 +59,8 @@ function rebuild_deb() {
             --suite ${SUITE} \
             --new-suite ${NEW_SUITE} \
             --new-name ${NEW_NAME} \
-            --new-release ${NEW_RELEASE} \
             --codename ${CODENAME}
 }
 
 rebuild_deb
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_RELEASE}" --bucket "${NEW_REPO}" ${SIGN_ARG}
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_SUITE}" --bucket "${NEW_REPO}" ${SIGN_ARG}


### PR DESCRIPTION
Fixing publishing debian package in mainline nightly. Two errors were found:

### Invalid parameter passing to reversion script:

After we merged https://github.com/MinaProtocol/mina/pull/17513 it modifyes reversion.sh script, This change was not updated in my PR which was introducing  publishing post-job. This PR is fixing this situation. 

#### Lack of liblmdb0

More sever issue, and this is a sweet information that we found this issue here. Publishing is generally disabled on nightly so we would find out this problem when releasing probably. 

Fix is to add lliblmdb0 to every debian