### PR TITLE
Fix broken RFC link in disk_caching_stats README

### DIFF
--- a/src/app/disk_caching_stats/README.md
+++ b/src/app/disk_caching_stats/README.md
@@ -1,6 +1,6 @@
 # Disk Caching Stats
 
-This program computes the expected worst-case memory usage of the daemon before and after applying the disk caching changes proposed in [RFC 56: Reducing Daemon Memory Usage](rfcs/0056-reducing-daemon-memory-usage.md).
+This program computes the expected worst-case memory usage of the daemon before and after applying the disk caching changes proposed in [RFC 63: Reducing Daemon Memory Usage](../../../rfcs/0063-reducing-daemon-memory-usage.md).
 
 This program counts the size of GC allocations on various data structures used by the daemon, and does so by carefully ensuring every value is a unique allocation and that there are no shared references within data structures. We do this by transporting values back and forth via bin_prot, simulating the same behavior the daemon will have when it reads and deserializes data from the network. We then use these measurements to estimate the expected worst-case memory footprint of larger data structures in the system, such as the mempools and the frontier. Expectations around shared references across these larger data structures are directly subtracted from the estimates.
 


### PR DESCRIPTION
Updated the outdated reference to RFC 56 in src/app/disk_caching_stats/README.md to point to the correct RFC 63 (rfcs/0063-reducing-daemon-memory-usage.md). This resolves the broken link and ensures documentation accurately reflects the current RFC structure.