### PR TITLE
Makefile: removing genesis_ledger target as old and out-dated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,17 +90,6 @@ ifeq (, $(MINA_LIBP2P_HELPER_PATH))
 	make -C src/app/libp2p_helper
 endif
 
-.PHONY: genesis_ledger
-genesis_ledger: ocaml_checks ## Build runtime genesis ledger
-	$(info Building runtime_genesis_ledger)
-	(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
-	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
-	dune exec \
-		--profile=$(DUNE_PROFILE) \
-		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe -- \
-		--genesis-dir $(GENESIS_DIR)
-	$(info Genesis ledger and genesis proof generated)
-
 .PHONY: check
 check: ocaml_checks libp2p_helper ## Check that all OCaml packages build without issues
 	dune build @src/check


### PR DESCRIPTION
When trying to run it, we get a missing `--config-dir` error. Therefore it means it is unused.
