### PR TITLE
CI: use shellcheck 0.10.0

### DIFF
--- a/buildkite/src/Jobs/Lint/Bash.dhall
+++ b/buildkite/src/Jobs/Lint/Bash.dhall
@@ -14,6 +14,8 @@ let Size = ../../Command/Size.dhall
 
 let RunInToolchain = ../../Command/RunInToolchain.dhall
 
+let shellcheckVersion = "v0.10.0"
+
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -37,8 +39,10 @@ in  Pipeline.build
                 RunInToolchain.runInToolchain
                   ([] : List Text)
                   (     "sudo apt-get update"
-                    ++  " && sudo apt-get install shellcheck"
-                    ++  " && make check-bash "
+                    ++  " && wget https://github.com/koalaman/shellcheck/releases/download/${shellcheckVersion}/shellcheck-${shellcheckVersion}.linux.x86_64.tar.xz"
+                    ++  " && tar xvf shellcheck-${shellcheckVersion}.linux.x86_64.tar.xz"
+                    ++  " && sudo cp shellcheck-${shellcheckVersion}/shellcheck /usr/local/bin/"
+                    ++  " && make check-bash"
                   )
             , label = "Bash: shellcheck"
             , key = "check-bash"


### PR DESCRIPTION
It does use an old version (0.7.1 - see [1]) in the CI as the Debian package is old. 0.7.1 is from 2021.
Running `make check-bash` for https://github.com/MinaProtocol/mina/pull/17525) is fine on my machine with `>= 0.8.0` but it seems to fail in the CI (see [this build](https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3801/steps/canvas?sid=019809c8-bda9-451b-a8c3-82b7ba8cb30d))


[1]
```
Preparing to unpack .../shellcheck_0.7.1-1+deb11u1_amd64.deb ...
Unpacking shellcheck (0.7.1-1+deb11u1) ...
Setting up shellcheck (0.7.1-1+deb11u1) ...
```