### PR TITLE
Use Profile.Type.Mainnet in mainnet alike jobs

### DIFF
--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -22,6 +22,8 @@ let Artifacts = ../../Constants/Artifacts.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 let Spec =
@@ -32,6 +34,7 @@ let Spec =
           , additionalDirtyWhen : List S.Type
           , softFail : B/SoftFail
           , timeout : Natural
+          , profile : Profiles.Type
           }
       , default =
           { dockerType = Dockers.Type.Bullseye
@@ -40,6 +43,7 @@ let Spec =
           , additionalDirtyWhen = [] : List S.Type
           , softFail = B/SoftFail.Boolean False
           , timeout = 1000
+          , profile = Profiles.Type.Devnet
           }
       }
 
@@ -70,6 +74,7 @@ let command
                   , codename = spec.dockerType
                   , network = spec.network
                   , artifact = Artifacts.Type.Rosetta
+                  , profile = spec.profile
                   }
             }
 

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetLegacyMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetLegacyMainnet.dhall
@@ -1,7 +1,5 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
-let DebianVersions = ../../Constants/DebianVersions.dhall
-
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -10,25 +8,24 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
 
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
 let Network = ../../Constants/Network.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
-      ( ArtifactPipelines.pipeline
+      ( ArtifactPipelines.onlyDebianPipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.Archive
-            , Artifacts.Type.Rosetta
-            , Artifacts.Type.ZkappTestTransaction
-            ]
-          , network = Network.Type.Mainnet
+          , artifacts = [ Artifacts.Type.Daemon ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             ]
-          , debVersion = DebianVersions.DebVersion.Noble
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , network = Network.Type.MainnetLegacy
           , mode = PipelineMode.Type.Stable
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
@@ -6,26 +6,25 @@ let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonHardfork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , debVersion = DebianVersions.DebVersion.Bookworm
           , network = Network.Type.Mainnet
           , tags =
             [ PipelineTag.Type.Long
@@ -33,6 +32,6 @@ in  Pipeline.build
             , PipelineTag.Type.Stable
             ]
           , mode = PipelineMode.Type.Stable
-          , profile = Profiles.Type.Devnet
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetLegacyMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetLegacyMainnet.dhall
@@ -12,6 +12,8 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.onlyDebianPipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -21,8 +23,9 @@ in  Pipeline.build
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             ]
-          , debVersion = DebianVersions.DebVersion.Noble
+          , debVersion = DebianVersions.DebVersion.Bullseye
           , network = Network.Type.MainnetLegacy
           , mode = PipelineMode.Type.Stable
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
@@ -1,7 +1,5 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
-let DebianVersions = ../../Constants/DebianVersions.dhall
-
 let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
@@ -12,17 +10,19 @@ let PipelineMode = ../../Pipeline/Mode.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonHardfork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
             ]
-          , debVersion = DebianVersions.DebVersion.Bookworm
           , network = Network.Type.Mainnet
           , tags =
             [ PipelineTag.Type.Long
@@ -30,5 +30,6 @@ in  Pipeline.build
             , PipelineTag.Type.Stable
             ]
           , mode = PipelineMode.Type.Stable
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetLegacyMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetLegacyMainnet.dhall
@@ -10,6 +10,8 @@ let PipelineMode = ../../Pipeline/Mode.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 let Network = ../../Constants/Network.dhall
 
 in  Pipeline.build
@@ -21,8 +23,9 @@ in  Pipeline.build
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             ]
-          , debVersion = DebianVersions.DebVersion.Bookworm
+          , debVersion = DebianVersions.DebVersion.Focal
           , network = Network.Type.MainnetLegacy
+          , profile = Profiles.Type.Mainnet
           , mode = PipelineMode.Type.Stable
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -1,16 +1,18 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
 let Network = ../../Constants/Network.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
-
-let Profiles = ../../Constants/Profiles.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
 
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
@@ -23,6 +25,7 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
             ]
+          , debVersion = DebianVersions.DebVersion.Focal
           , network = Network.Type.Mainnet
           , tags =
             [ PipelineTag.Type.Long
@@ -30,6 +33,6 @@ in  Pipeline.build
             , PipelineTag.Type.Stable
             ]
           , mode = PipelineMode.Type.Stable
-          , profile = Profiles.Type.Devnet
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetLegacyMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetLegacyMainnet.dhall
@@ -12,6 +12,8 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.onlyDebianPipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -21,8 +23,9 @@ in  Pipeline.build
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             ]
-          , debVersion = DebianVersions.DebVersion.Bullseye
+          , debVersion = DebianVersions.DebVersion.Noble
           , network = Network.Type.MainnetLegacy
           , mode = PipelineMode.Type.Stable
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
@@ -1,5 +1,7 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -8,21 +10,28 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineMode = ../../Pipeline/Mode.dhall
 
-let DebianVersions = ../../Constants/DebianVersions.dhall
-
 let Network = ../../Constants/Network.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
-      ( ArtifactPipelines.onlyDebianPipeline
+      ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts = [ Artifacts.Type.Daemon ]
+          , artifacts =
+            [ Artifacts.Type.Daemon
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.Archive
+            , Artifacts.Type.Rosetta
+            , Artifacts.Type.ZkappTestTransaction
+            ]
+          , network = Network.Type.Mainnet
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
-          , network = Network.Type.MainnetLegacy
+          , debVersion = DebianVersions.DebVersion.Noble
           , mode = PipelineMode.Type.Stable
+          , profile = Profiles.Type.Mainnet
           }
       )

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -18,9 +18,13 @@ let Network = ../../Constants/Network.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
+let Profile = ../../Constants/Profiles.dhall
+
 let network = Network.Type.Mainnet
 
-let dependsOn = Dockers.dependsOn Dockers.DepsSpec::{ network = network }
+let dependsOn =
+      Dockers.dependsOn
+        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
 
 in  Pipeline.build
       Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/RosettaMainnetConnect.dhall
+++ b/buildkite/src/Jobs/Test/RosettaMainnetConnect.dhall
@@ -4,7 +4,13 @@ let Network = ../../Constants/Network.dhall
 
 let Connectivity = ../../Command/Rosetta/Connectivity.dhall
 
+let Profile = ../../Constants/Profiles.dhall
+
 in  Pipeline.build
       ( Connectivity.pipeline
-          Connectivity.Spec::{ network = Network.Type.Mainnet, timeout = 2400 }
+          Connectivity.Spec::{
+          , network = Network.Type.Mainnet
+          , profile = Profile.Type.Mainnet
+          , timeout = 2400
+          }
       )


### PR DESCRIPTION
Last PR for replayer profile fix on mainnet. Here, we are fixing profiles for mina artifacts jobs in a way, that profile matches network.

| Network | Profile |
|--------|--------|
| Mainnet | Mainnet |
| Devnet | Devnet |
| Berkeley | devnet | 

As a result archive docker will receive suffix similar to daemon 
