### PR TITLE
Fix a bug in fork_config graphql

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -245,7 +245,7 @@ module Json_layout = struct
             ]
 
         let of_permissions (perm : Mina_base.Permissions.t) =
-          { edit_state = Auth_required.of_account_perm perm.edit_action_state
+          { edit_state = Auth_required.of_account_perm perm.edit_state
           ; send = Auth_required.of_account_perm perm.send
           ; receive = Auth_required.of_account_perm perm.receive
           ; set_delegate = Auth_required.of_account_perm perm.set_delegate


### PR DESCRIPTION
Graphql `fork_config` was buggy: one field's value was replaced with another.

This PR fixes the issue.

Explain how you tested your changes:
* Manually tested using staking ledger export and `fork_config`
* TODO: in future PR implement unit tests for the `fork_config` export and/or simplify the implementation

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
