### PR TITLE
Abstract snarked ledger type and add checkpoint operations

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -308,8 +308,8 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
               | Genesis_epoch_ledger l ->
                   let%map accts = Mina_ledger.Ledger.to_list l in
                   Ok accts
-              | Ledger_db db ->
-                  let%map accts = Mina_ledger.Ledger.Db.to_list db in
+              | Any_ledger db ->
+                  let%map accts = Mina_ledger.Ledger.Any_ledger.M.to_list db in
                   Ok accts )
           | Error err ->
               return (Error err) )

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -95,7 +95,7 @@ let received_bad_proof ({ context = (module Context); _ } as t) host e =
             , [ ("error", Error_json.error_to_yojson e) ] ) ))
 
 let done_syncing_root root_sync_ledger =
-  Option.is_some (Sync_ledger.Db.peek_valid_tree root_sync_ledger)
+  Option.is_some (Sync_ledger.Any_ledger.peek_valid_tree root_sync_ledger)
 
 let should_sync ~root_sync_ledger t candidate_state =
   (not @@ done_syncing_root root_sync_ledger)
@@ -127,7 +127,7 @@ let start_sync_job_with_peer ~sender ~root_sync_ledger
   return
   @@
   match
-    Sync_ledger.Db.new_goal root_sync_ledger
+    Sync_ledger.Any_ledger.new_goal root_sync_ledger
       (Frozen_ledger_hash.to_ledger_hash snarked_ledger_hash)
       ~data:
         ( State_hash.With_state_hashes.state_hash
@@ -204,8 +204,8 @@ let on_transition ({ context = (module Context); _ } as t) ~sender
 let sync_ledger ({ context = (module Context); _ } as t) ~preferred
     ~root_sync_ledger ~transition_graph ~sync_ledger_reader =
   let open Context in
-  let query_reader = Sync_ledger.Db.query_reader root_sync_ledger in
-  let response_writer = Sync_ledger.Db.answer_writer root_sync_ledger in
+  let query_reader = Sync_ledger.Any_ledger.query_reader root_sync_ledger in
+  let response_writer = Sync_ledger.Any_ledger.answer_writer root_sync_ledger in
   Mina_networking.glue_sync_ledger ~preferred t.network query_reader
     response_writer ;
   Pipe_lib.Choosable_synchronous_pipe.iter sync_ledger_reader
@@ -272,7 +272,7 @@ let download_snarked_ledger ~trust_system ~preferred_peers ~transition_graph
     ~sync_ledger_reader ~context t temp_snarked_ledger =
   time_deferred
     (let root_sync_ledger =
-       Sync_ledger.Db.create temp_snarked_ledger ~context ~trust_system
+       Sync_ledger.Any_ledger.create temp_snarked_ledger ~context ~trust_system
      in
      don't_wait_for
        (sync_ledger t ~preferred:preferred_peers ~root_sync_ledger
@@ -280,8 +280,8 @@ let download_snarked_ledger ~trust_system ~preferred_peers ~transition_graph
      (* We ignore the resulting ledger returned here since it will always
         * be the same as the ledger we started with because we are syncing
         * a db ledger. *)
-     let%map _, data = Sync_ledger.Db.valid_tree root_sync_ledger in
-     Sync_ledger.Db.destroy root_sync_ledger ;
+     let%map _, data = Sync_ledger.Any_ledger.valid_tree root_sync_ledger in
+     Sync_ledger.Any_ledger.destroy root_sync_ledger ;
      data )
 
 (** Run one bootstrap cycle *)
@@ -434,7 +434,7 @@ let run_cycle ~context:(module Context : CONTEXT) ~trust_system ~verifier
               let%map staged_ledger_construction_time, construction_result =
                 time_deferred
                   (let open Deferred.Let_syntax in
-                  let temp_mask = Ledger.of_database temp_snarked_ledger in
+                  let temp_mask = Ledger.of_any_ledger temp_snarked_ledger in
                   let%map result =
                     Staged_ledger
                     .of_scan_state_pending_coinbases_and_snarked_ledger ~logger
@@ -833,7 +833,7 @@ let%test_module "Bootstrap_controller tests" =
             make_non_running_bootstrap ~genesis_root ~network:me.network
           in
           let root_sync_ledger =
-            Sync_ledger.Db.create
+            Sync_ledger.Any_ledger.create
               (Transition_frontier.root_snarked_ledger me.state.frontier)
               ~context:(module Context)
               ~trust_system
@@ -971,10 +971,10 @@ let%test_module "Bootstrap_controller tests" =
             ~root:(Transition_frontier.root new_frontier)
             sorted_external_transitions ;
           [%test_result: Ledger_hash.t]
-            ( Ledger.Db.merkle_root
+            ( Ledger.Any_ledger.M.merkle_root
             @@ Transition_frontier.root_snarked_ledger new_frontier )
             ~expect:
-              ( Ledger.Db.merkle_root
+              ( Ledger.Any_ledger.M.merkle_root
               @@ Transition_frontier.root_snarked_ledger peer_net.state.frontier
               ) )
 
@@ -996,7 +996,7 @@ let%test_module "Bootstrap_controller tests" =
               in
               let snarked_ledger =
                 Transition_frontier.root_snarked_ledger frontier
-                |> Ledger.of_database
+                |> Ledger.of_any_ledger
               in
               let snarked_local_state =
                 Transition_frontier.root frontier
@@ -1083,10 +1083,10 @@ let%test_module "Bootstrap_controller tests" =
             ~root:(Transition_frontier.root new_frontier)
             sorted_external_transitions ;
           [%test_result: Ledger_hash.t]
-            ( Ledger.Db.merkle_root
+            ( Ledger.Any_ledger.M.merkle_root
             @@ Transition_frontier.root_snarked_ledger new_frontier )
             ~expect:
-              ( Ledger.Db.merkle_root
+              ( Ledger.Any_ledger.M.merkle_root
               @@ Transition_frontier.root_snarked_ledger
                    stronger_chain.state.frontier ) )
 *)

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -317,7 +317,7 @@ module type S = sig
         module Ledger_snapshot : sig
           type t =
             | Genesis_epoch_ledger of Mina_ledger.Ledger.t
-            | Ledger_db of Mina_ledger.Ledger.Db.t
+            | Any_ledger of Mina_ledger.Ledger.Any_ledger.M.t
 
           val close : t -> unit
 
@@ -718,7 +718,7 @@ module type S = sig
          Consensus_state.Value.t
       -> Consensus_state.Value.t
       -> local_state:Local_state.t
-      -> snarked_ledger:Mina_ledger.Ledger.Db.t
+      -> snarked_ledger:Mina_ledger.Ledger.Any_ledger.M.t
       -> genesis_ledger_hash:Mina_base.Frozen_ledger_hash.t
       -> unit
 

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -96,6 +96,13 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
 
     let get_directory (T ((module Base), t)) = Base.get_directory t
 
+    let make_checkpoint (T ((module Base), t)) ~directory_name =
+      Base.make_checkpoint t ~directory_name
+
+    let create_checkpoint (T ((module Base), t)) ~directory_name () =
+      let new_t = Base.create_checkpoint t ~directory_name () in
+      T ((module Base), new_t)
+
     let last_filled (T ((module Base), t)) = Base.last_filled t
 
     let close (T ((module Base), t)) = Base.close t

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -169,6 +169,23 @@ end = struct
 
   let get_directory t = Primary_ledger.get_directory t.primary_ledger
 
+  let make_checkpoint t ~directory_name =
+    let converting_dir = directory_name ^ "_converting" in
+    Primary_ledger.make_checkpoint t.primary_ledger ~directory_name ;
+    Converting_ledger.make_checkpoint t.converting_ledger
+      ~directory_name:converting_dir
+
+  let create_checkpoint t ~directory_name () =
+    let converting_dir = directory_name ^ "_converting" in
+    let new_primary =
+      Primary_ledger.create_checkpoint t.primary_ledger ~directory_name ()
+    in
+    let new_converting =
+      Converting_ledger.create_checkpoint t.converting_ledger
+        ~directory_name:converting_dir ()
+    in
+    { primary_ledger = new_primary; converting_ledger = new_converting }
+
   let get t location = Primary_ledger.get t.primary_ledger location
 
   let get_batch t locations =

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -386,6 +386,12 @@ module Ledger = struct
     (** return Some [directory] for ledgers that use a file system, else None *)
     val get_directory : t -> string option
 
+    (** create a checkpoint of the ledger at the given directory *)
+    val make_checkpoint : t -> directory_name:string -> unit
+
+    (** create a checkpoint and return a new ledger instance pointing to it *)
+    val create_checkpoint : t -> directory_name:string -> unit -> t
+
     val get : t -> Location.t -> account option
 
     val get_batch : t -> Location.t list -> (Location.t * account option) list

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -110,6 +110,10 @@ end = struct
 
   let get_directory _ = None
 
+  let make_checkpoint _t ~directory_name:_ = ()
+
+  let create_checkpoint t ~directory_name:_ () = t
+
   let last_filled _t = None
 
   let close _t = ()

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2602,8 +2602,8 @@ module Queries = struct
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           l ->
           Ledger.Any_ledger.cast (module Ledger) l
-      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_db l ->
-          Ledger.Any_ledger.cast (module Ledger.Db) l
+      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Any_ledger l ->
+          l
     in
     let root_consensus_state =
       let frontier =

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -1509,14 +1509,15 @@ module AccountObj = struct
                             genesis ledger. The account was not present in the \
                             ledger." ;
                          None )
-                 | Ledger_db staking_ledger -> (
+                 | Any_ledger staking_ledger -> (
                      try
                        let index =
-                         Ledger.Db.index_of_account_exn staking_ledger
+                         Ledger.Any_ledger.M.index_of_account_exn staking_ledger
                            account_id
                        in
                        let account =
-                         Ledger.Db.get_at_index_exn staking_ledger index
+                         Ledger.Any_ledger.M.get_at_index_exn staking_ledger
+                           index
                        in
                        let%bind delegate_key = account.delegate in
                        Some (get_best_ledger_account_pk mina delegate_key)

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -185,6 +185,10 @@ module Ledger_inner = struct
     let mask = Mask.create ~depth:(Db.depth db) () in
     Maskable.register_mask casted mask
 
+  let of_any_ledger any_ledger =
+    let mask = Mask.create ~depth:(Any_ledger.M.depth any_ledger) () in
+    Maskable.register_mask any_ledger mask
+
   (* Mask.Attached.create () fails, can't create an attached mask directly
      shadow create in order to create an attached mask
   *)
@@ -200,6 +204,10 @@ module Ledger_inner = struct
   let create_ephemeral ~depth () =
     let _base, mask = create_ephemeral_with_base ~depth () in
     mask
+
+  let create_unmasked_ledger ?directory_name ~depth () =
+    let db = Db.create ?directory_name ~depth () in
+    Any_ledger.cast (module Db) db
 
   (** Create a new empty ledger.
 

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -97,7 +97,18 @@ val create : ?directory_name:string -> depth:int -> unit -> t
 
 val create_ephemeral : depth:int -> unit -> t
 
+(** Create an unmasked database ledger wrapped as Any_ledger.M.t.
+    
+    Unlike [create], this returns a raw database ledger without registering
+    a mask on top. This is useful for persistent ledgers like the snarked
+    ledger that don't need mask functionality.
+*)
+val create_unmasked_ledger :
+  ?directory_name:string -> depth:int -> unit -> Any_ledger.M.t
+
 val of_database : Db.t -> t
+
+val of_any_ledger : Any_ledger.M.t -> t
 
 (** This is not _really_ copy, merely a stop-gap until we remove usages of copy in our codebase. What this actually does is creates a new empty mask on top of the current ledger *)
 val copy : t -> t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -691,7 +691,7 @@ let get_snarked_ledger_full t state_hash_opt =
       let root_snarked_ledger =
         Transition_frontier.root_snarked_ledger frontier
       in
-      let ledger = Ledger.of_database root_snarked_ledger in
+      let ledger = Ledger.of_any_ledger root_snarked_ledger in
       let path = Transition_frontier.path_map frontier b ~f:Fn.id in
       let%bind () =
         Mina_stdlib.Deferred.Result.List.iter path ~f:(fun b ->

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -168,8 +168,8 @@ let%test_module "Epoch ledger sync tests" =
       Mina_ledger.Ledger.create
         ~depth:Context.precomputed_values.constraint_constants.ledger_depth ()
 
-    let make_empty_db_ledger (module Context : CONTEXT) =
-      Mina_ledger.Ledger.Db.create
+    let make_empty_unmasked_ledger (module Context : CONTEXT) =
+      Mina_ledger.Ledger.create_unmasked_ledger
         ~depth:Context.precomputed_values.constraint_constants.ledger_depth ()
 
     (* [instance] and [test_number] are used to make ports distinct
@@ -438,26 +438,26 @@ let%test_module "Epoch ledger sync tests" =
         (module Context : CONTEXT) (test : test_state) =
       let open Context in
       let make_sync_ledger () =
-        let db_ledger = make_empty_db_ledger (module Context) in
+        let any_ledger = make_empty_unmasked_ledger (module Context) in
         List.iter starting_accounts ~f:(fun (acct : Account.t) ->
             let acct_id = Account_id.create acct.public_key Token_id.default in
             match
-              Mina_ledger.Ledger.Db.get_or_create_account db_ledger acct_id acct
+              Mina_ledger.Ledger.Any_ledger.M.get_or_create_account any_ledger acct_id acct
             with
             | Ok _ ->
                 ()
             | Error _ ->
                 failwith "Could not add starting account" ) ;
         let sync_ledger =
-          Mina_ledger.Sync_ledger.Db.create
+          Mina_ledger.Sync_ledger.Any_ledger.create
             ~context:(module Context)
-            ~trust_system:Context.trust_system db_ledger
+            ~trust_system:Context.trust_system any_ledger
         in
         let query_reader =
-          Mina_ledger.Sync_ledger.Db.query_reader sync_ledger
+          Mina_ledger.Sync_ledger.Any_ledger.query_reader sync_ledger
         in
         let answer_writer =
-          Mina_ledger.Sync_ledger.Db.answer_writer sync_ledger
+          Mina_ledger.Sync_ledger.Any_ledger.answer_writer sync_ledger
         in
         (*
         (* setup a proxy response pipe so we can inspect the messages from our test *)
@@ -490,14 +490,16 @@ let%test_module "Epoch ledger sync tests" =
       let sync_ledger1 = make_sync_ledger () in
       let%bind () =
         match%map
-          Mina_ledger.Sync_ledger.Db.fetch sync_ledger1 staking_ledger_root
-            ~data:() ~equal:(fun () () -> true)
+          Mina_ledger.Sync_ledger.Any_ledger.fetch sync_ledger1
+            staking_ledger_root ~data:() ~equal:(fun () () -> true)
         with
         | `Ok ledger ->
             let sync_ledger1_tm1 = Unix.gettimeofday () in
             [%log debug] "(%s) Time to sync ledger 1: %0.02f" test.name
               (sync_ledger1_tm1 -. sync_ledger1_tm0) ;
-            let ledger_root = Mina_ledger.Ledger.Db.merkle_root ledger in
+            let ledger_root =
+              Mina_ledger.Ledger.Any_ledger.M.merkle_root ledger
+            in
             assert (Ledger_hash.equal ledger_root staking_ledger_root) ;
             [%log debug] "Synced current epoch ledger successfully"
         | `Target_changed _ ->
@@ -507,15 +509,17 @@ let%test_module "Epoch ledger sync tests" =
       let sync_ledger2_tm0 = Unix.gettimeofday () in
       let sync_ledger2 = make_sync_ledger () in
       match%bind
-        Mina_ledger.Sync_ledger.Db.fetch sync_ledger2 next_epoch_ledger_root
-          ~data:() ~equal:(fun () () -> true)
+        Mina_ledger.Sync_ledger.Any_ledger.fetch sync_ledger2
+          next_epoch_ledger_root ~data:() ~equal:(fun () () -> true)
       with
       | `Ok ledger ->
           let sync_ledger2_tm1 = Unix.gettimeofday () in
           [%log debug] "(%s) Time to sync ledger 2: %0.02f" test.name
             (sync_ledger2_tm1 -. sync_ledger2_tm0) ;
           test.cleanup () ;
-          let ledger_root = Mina_ledger.Ledger.Db.merkle_root ledger in
+          let ledger_root =
+            Mina_ledger.Ledger.Any_ledger.M.merkle_root ledger
+          in
           assert (Ledger_hash.equal ledger_root next_epoch_ledger_root) ;
           [%log debug] "Synced next epoch ledger, sync test succeeded" ;
           Deferred.unit
@@ -567,17 +571,17 @@ let%test_module "Epoch ledger sync tests" =
         ledger
 
     let make_db_ledger (module Context : CONTEXT) (accounts : Account.t list) =
-      let db_ledger = make_empty_db_ledger (module Context) in
+      let any_ledger = make_empty_unmasked_ledger (module Context) in
       List.iter accounts ~f:(fun acct ->
           let acct_id = Account_id.create acct.public_key Token_id.default in
           match
-            Mina_ledger.Ledger.Db.get_or_create_account db_ledger acct_id acct
+            Mina_ledger.Ledger.Any_ledger.M.get_or_create_account any_ledger acct_id acct
           with
           | Ok _ ->
               ()
           | Error _ ->
               failwith "Could not add account" ) ;
-      Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_db db_ledger
+      Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Any_ledger any_ledger
 
     let test_accounts =
       Quickcheck.(random_value @@ Generator.list_with_length 20 Account.gen)

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -49,8 +49,7 @@ module Make (Inputs : Inputs_intf) :
 
   let get_ledger_by_hash ~frontier ledger_hash =
     let root_ledger =
-      Ledger.Any_ledger.cast (module Ledger.Db)
-      @@ Transition_frontier.root_snarked_ledger frontier
+      Transition_frontier.root_snarked_ledger frontier
     in
     let staking_epoch_ledger =
       Transition_frontier.consensus_local_state frontier
@@ -73,8 +72,8 @@ module Make (Inputs : Inputs_intf) :
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           _ ->
           None
-      | Ledger_db ledger ->
-          Some (Ledger.Any_ledger.cast (module Ledger.Db) ledger)
+      | Any_ledger ledger ->
+          Some ledger
     else if
       Ledger_hash.equal ledger_hash
         (Consensus.Data.Local_state.Snapshot.Ledger_snapshot.merkle_root
@@ -84,8 +83,8 @@ module Make (Inputs : Inputs_intf) :
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           _ ->
           None
-      | Ledger_db ledger ->
-          Some (Ledger.Any_ledger.cast (module Ledger.Db) ledger)
+      | Any_ledger ledger ->
+          Some ledger
     else None
 
   let answer_query :
@@ -306,7 +305,7 @@ let%test_module "Sync_handler" =
               in
               let source_ledger =
                 Transition_frontier.For_tests.root_snarked_ledger frontier
-                |> Ledger.of_database
+                |> Ledger.of_any_ledger
               in
               let desired_root = Ledger.merkle_root source_ledger in
               let sync_ledger =

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -462,15 +462,15 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
           t.persistent_root_instance.factory.directory
       in
       let () =
-        Ledger.Db.make_checkpoint t.persistent_root_instance.snarked_ledger
+        Ledger.Any_ledger.M.make_checkpoint t.persistent_root_instance.snarked_ledger
           ~directory_name:location
       in
       [%log' info t.logger]
         ~metadata:
           [ ( "potential_snarked_ledger_hash"
             , Frozen_ledger_hash.to_yojson @@ Frozen_ledger_hash.of_ledger_hash
-              @@ Ledger.Db.merkle_root t.persistent_root_instance.snarked_ledger
-            )
+              @@ Ledger.Any_ledger.M.merkle_root
+                   t.persistent_root_instance.snarked_ledger )
           ]
         "Enqueued a snarked ledger" ;
       Persistent_root.Instance.enqueue_snarked_ledger ~location

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -59,7 +59,7 @@ val protocol_states_for_root_scan_state :
 val apply_diffs :
      t
   -> Diff.Full.E.t list
-  -> enable_epoch_ledger_sync:[ `Enabled of Mina_ledger.Ledger.Db.t | `Disabled ]
+  -> enable_epoch_ledger_sync:[ `Enabled of Mina_ledger.Ledger.Any_ledger.M.t | `Disabled ]
   -> has_long_catchup_job:bool
   -> [ `New_root_and_diffs_with_mutants of
        Root_identifier.t option * Diff.Full.With_mutant.t list ]

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -53,7 +53,7 @@ let construct_staged_ledger_at_root ~proof_cache_db
     | Some protocol_state ->
         Ok protocol_state
   in
-  let mask = Mina_ledger.Ledger.of_database root_ledger in
+  let mask = Mina_ledger.Ledger.of_any_ledger root_ledger in
   let local_state = Blockchain_state.snarked_local_state blockchain_state in
   let staged_ledger_hash =
     Blockchain_state.staged_ledger_hash blockchain_state
@@ -263,10 +263,7 @@ module Instance = struct
               List.map protocol_states
                 ~f:(With_hash.of_data ~hash_data:Protocol_state.hashes)
           }
-        ~root_ledger:
-          (Mina_ledger.Ledger.Any_ledger.cast
-             (module Mina_ledger.Ledger.Db)
-             root_ledger )
+        ~root_ledger:root_ledger
         ~consensus_local_state ~max_length ~persistent_root_instance
     in
     let%bind extensions =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -569,6 +569,10 @@ module For_tests = struct
     Mina_ledger.Ledger_transfer.Make
       (Mina_ledger.Ledger)
       (Mina_ledger.Ledger.Db)
+  module Ledger_transfer_to_any =
+    Mina_ledger.Ledger_transfer.Make
+      (Mina_ledger.Ledger)
+      (Mina_ledger.Ledger.Any_ledger.M)
   open Full_frontier.For_tests
 
   let proxy2 f { full_frontier = x; _ } { full_frontier = y; _ } = f x y
@@ -666,7 +670,7 @@ module For_tests = struct
               ~f:(fun instance ->
                 Persistent_frontier.Database.close instance.db ) ;
             Option.iter persistent_root.Persistent_root.Factory_type.instance
-              ~f:(fun instance -> Ledger.Db.close instance.snarked_ledger) ;
+              ~f:(fun instance -> Ledger.Any_ledger.M.close instance.snarked_ledger) ;
             clean_temp_dirs x ) ;
         (persistent_root, persistent_frontier) )
 
@@ -758,7 +762,7 @@ module For_tests = struct
         Persistent_root.Instance.set_root_state_hash instance
           (Mina_block.Validated.state_hash transition) ;
         ignore
-        @@ Ledger_transfer.transfer_accounts ~src:root_snarked_ledger
+        @@ Ledger_transfer_to_any.transfer_accounts ~src:root_snarked_ledger
              ~dest:(Persistent_root.Instance.snarked_ledger instance) ) ;
     let frontier_result =
       Async.Thread_safe.block_on_async_exn (fun () ->

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -87,7 +87,7 @@ val persistent_root : t -> Persistent_root.t
 
 val persistent_frontier : t -> Persistent_frontier.t
 
-val root_snarked_ledger : t -> Mina_ledger.Ledger.Db.t
+val root_snarked_ledger : t -> Mina_ledger.Ledger.Any_ledger.M.t
 
 val extensions : t -> Extensions.t
 


### PR DESCRIPTION
The upcoming hardfork ledger migration implementation will use the newly-introduced converting merkle tree implementation to maintain a secondary migrated version of a ledger database alongside a primary unmigrated database. The most important ledger (probably the only ledger) that we will need to keep in sync in this way is the snarked root ledger. Ideally we would be able to simply create a converting merkle tree and use it in place of the snarked root, but this is not currently possible - the `snarked_ledger` is referenced and handled throughout the code as a bare `Ledger.Db.t`.

This PR changes the `snarked_ledger` in `Instance.t` in `persistent_root.ml` to be an `Any_ledger.M.t`, so that we can create a converting merkle tree and use it here (when that creation PR is merged, and we've enabled it in runtime config that also needs to be added). Various bits of code needed to change as a result. Notable API additions that should probably be checked carefully:

- An unmasked `Any_ledger.M.t` based on a raw `Ledger.DB.t` can now be created with `create_unmasked_ledger` - the `snarked_ledger` is now created this way.
- Methods `make_checkpoint` and `create_checkpoint` have been added to the `Ledger` interface - these will ultimately checkpoint the underlying database(s) (in practice this will be just one database right now, but will be two if the ledger sync feature is enabled). You still have to `commit` the changes you want properly.
- An `of_any_ledger` will create a new empty mask on top of an existing `Any_ledger.M.t` - this is used where `of_database` was previously used in the affected code.