### PR TITLE
[Rosetta] run load test after sanity 

### DIFF
--- a/buildkite/scripts/tests/archive-node-unit-tests.sh
+++ b/buildkite/scripts/tests/archive-node-unit-tests.sh
@@ -1,5 +1,40 @@
 #!/bin/bash
 
+# Archive Node Unit Tests Script
+#
+# This script runs unit tests for the Mina archive node component with database setup.
+# It must be executed from the repository root directory where 'dune-project' exists.
+#
+# USAGE:
+#   ./archive-node-unit-tests.sh <user> <password> <db> <command_key>
+#
+# PARAMETERS:
+#   user         - Database username for test database connection
+#   password     - Database password for test database connection  
+#   db           - Database name for archive node tests
+#   command_key  - Unique identifier for coverage data upload
+#
+# PREREQUISITES:
+#   - Must be run from repository root (where dune-project file exists)
+#   - OPAM environment must be available
+#   - Database setup script must exist at ./buildkite/scripts/setup-database-for-archive-node.sh
+#   - Coverage upload script must exist at ./buildkite/scripts/upload-partial-coverage-data.sh
+#
+# WORKFLOW:
+#   1. Validates script is run from correct directory
+#   2. Validates all required parameters are provided
+#   3. Sets up OPAM environment
+#   4. Configures test database using provided credentials
+#   5. Runs archive node unit tests via dune
+#   6. Uploads partial coverage data for CI/CD pipeline
+#
+# EXIT CODES:
+#   0 - Success
+#   1 - Error (wrong directory, missing parameters, or test failure)
+#
+# ENVIRONMENT VARIABLES SET:
+#   MINA_TEST_POSTGRES - Database connection string set by setup script
+
 set -euo pipefail
 
 if [[ ! -f dune-project ]]; then

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -59,7 +59,7 @@ let command
                   , "source ./buildkite/scripts/export-git-env-vars.sh"
                   , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
                                                                          spec.network} --tag \\\${MINA_DOCKER_TAG} --timeout ${Natural/show
-                                                                                                                                 spec.timeout}"
+                                                                                                                                 spec.timeout} --run-load-test"
                   ]
               ]
             , label =

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -46,6 +46,7 @@ RUN apt-get update --quiet --yes \
     && apt-get install --quiet --yes --no-install-recommends \
     apt-utils \
     apt-transport-https \
+    bc \
     curl \
     build-essential \
     dnsutils \

--- a/scripts/tests/ROSETTA_TESTS.md
+++ b/scripts/tests/ROSETTA_TESTS.md
@@ -1,0 +1,370 @@
+# Rosetta Test Scripts Documentation
+
+This document provides comprehensive documentation for all Rosetta API testing scripts located in `./scripts/tests/`. These scripts are designed to test the Mina Protocol Rosetta API implementation for functionality, performance, and reliability.
+
+## Overview
+
+The Rosetta API test suite consists of four main scripts that work together to provide comprehensive testing capabilities:
+
+- **rosetta-helper.sh**: Core helper functions and utilities
+- **rosetta-sanity.sh**: Basic functionality and sanity testing
+- **rosetta-load.sh**: Performance and load testing
+- **rosetta-connectivity.sh**: End-to-end connectivity testing
+
+## Scripts Documentation
+
+### 1. rosetta-helper.sh
+
+**Purpose**: Core helper functions and utilities shared across all Rosetta test scripts.
+
+**Location**: `scripts/tests/rosetta-helper.sh`
+
+**Key Features**:
+- Common HTTP request handling with standardized headers
+- Test assertion framework for validating API responses
+- Network synchronization utilities
+- Individual test functions for each Rosetta API endpoint
+
+**Main Functions**:
+
+#### `assert(response, query, success_message, error_message)`
+- **Purpose**: Validates API responses using jq queries
+- **Parameters**: 
+  - `response`: Raw API response 
+  - `query`: jq query to validate response
+  - `success_message`: Message shown on success
+  - `error_message`: Message shown on failure
+- **Usage**: Core validation function used by all test endpoints
+
+#### `wait_for_sync(test_data, timeout)`
+- **Purpose**: Waits for Rosetta API to sync with the blockchain
+- **Parameters**:
+  - `test_data`: Reference to test configuration array
+  - `timeout`: Maximum wait time in seconds
+- **Behavior**: Polls `/network/status` endpoint until sync status is "Synced"
+- **Exit**: Exits with code 1 if timeout is reached
+
+#### `test_network_status(test_data)`
+- **Purpose**: Tests `/network/status` endpoint
+- **Validation**: Ensures sync status is "Synced"
+- **Location**: `scripts/tests/rosetta-helper.sh:57-63`
+
+#### `test_network_options(test_data)`
+- **Purpose**: Tests `/network/options` endpoint  
+- **Validation**: Verifies Rosetta version is 1.4.9
+- **Location**: `scripts/tests/rosetta-helper.sh:65-71`
+
+#### `test_block(test_data)`
+- **Purpose**: Tests `/block` endpoint for specific block retrieval
+- **Validation**: Confirms returned block hash matches requested hash
+- **Location**: `scripts/tests/rosetta-helper.sh:73-79`
+
+#### `test_account_balance(test_data)`
+- **Purpose**: Tests `/account/balance` endpoint
+- **Validation**: Ensures balance structure contains MINA currency symbol
+- **Location**: `scripts/tests/rosetta-helper.sh:81-87`
+
+#### `test_payment_transaction(test_data)`
+- **Purpose**: Tests `/search/transactions` endpoint for payment transactions
+- **Validation**: Confirms transaction hash matches requested payment transaction
+- **Location**: `scripts/tests/rosetta-helper.sh:89-103`
+
+#### `test_zkapp_transaction(test_data)`
+- **Purpose**: Tests `/search/transactions` endpoint for zkApp transactions
+- **Validation**: Confirms transaction hash matches requested zkApp transaction
+- **Location**: `scripts/tests/rosetta-helper.sh:105-119`
+
+### 2. rosetta-sanity.sh
+
+**Purpose**: Basic functionality testing of Rosetta API endpoints with predefined test data.
+
+**Location**: `scripts/tests/rosetta-sanity.sh`
+
+**Usage**:
+```bash
+./rosetta-sanity.sh [--network mainnet|devnet] [--address <address>] [--wait-for-sync] [--timeout <seconds>]
+```
+
+**Command-line Options**:
+- `--network`: Target network (mainnet or devnet, default: mainnet)
+- `--address`: Override Rosetta API endpoint address
+- `--wait-for-sync`: Wait for Rosetta to sync before running tests
+- `--timeout`: Sync timeout in seconds (default: 900)
+
+**Test Data Configuration**:
+
+#### Mainnet Test Data:
+- **Network ID**: mainnet
+- **Default Address**: http://rosetta-mainnet.gcp.o1test.net
+- **Test Block**: 3NLaE5ygWrgssHjchYR7auQTZHveVV5au5cv5VhbWWYPdbdSm4FA
+- **Test Account**: B62qrQKS9ghd91shs73TCmBJRW9GzvTJK443DPx2YbqcyoLc56g1ny9
+- **Payment TX**: 5JvGLZ22Pt5co9ikFhHVcewsrGNx9xwPx16oKvJ42oujZRU7Ymfh
+- **zkApp TX**: 5Ju42hSKHMPFFuH2iar8V1scHdWET2TV8ocaazRbEea5yFWDe7RH
+
+#### Devnet Test Data:
+- **Network ID**: devnet  
+- **Default Address**: http://rosetta-devnet.gcp.o1test.net
+- **Test Block**: 3NLX177ZPMRfgYX6sX6tEnhb97gvjWKiivk9Fk2q8M6vHHjAQPYk
+- **Test Account**: B62qizKV19RgCtdosaEnoJRF72YjTSDyfJ5Nrdu8ygKD3q2eZcqUp7B
+- **Payment TX**: 5Jumdze53X3k8rVaNQpJKdt8voGXRgVcFBZugg21FE1K7QkJBhLb
+- **zkApp TX**: 5JuJuyKtrMvxGroWyNE3sxwpuVsupvj7SA8CDX4mqWms4ZZT4Arz
+
+**Test Sequence**:
+1. Network status endpoint validation
+2. Network options endpoint validation  
+3. Block retrieval testing
+4. Account balance querying
+5. Payment transaction search
+6. zkApp transaction search
+
+**Example Usage**:
+```bash
+# Basic mainnet testing
+./rosetta-sanity.sh --network mainnet
+
+# Devnet testing with custom endpoint
+./rosetta-sanity.sh --network devnet --address http://localhost:3087
+
+# Wait for sync before testing
+./rosetta-sanity.sh --network mainnet --wait-for-sync --timeout 1200
+```
+
+### 3. rosetta-load.sh
+
+**Purpose**: Comprehensive performance and load testing of Rosetta API with configurable test intervals and database-driven test data.
+
+**Location**: `scripts/tests/rosetta-load.sh`
+
+**Key Features**:
+- **Database Integration**: Loads real test data from PostgreSQL archive database
+- **Configurable Intervals**: Independent timing control for each test type
+- **Performance Monitoring**: Real-time TPS tracking and memory usage reporting
+- **Multiple Stop Conditions**: Duration-based or request-count-based termination
+- **Precise Timing**: High-precision scheduling prevents timing drift
+
+**Usage**:
+```bash
+./rosetta-load.sh [options]
+```
+
+**Command-line Options**:
+
+#### Network Configuration:
+- `--network <network>`: Target network (mainnet or devnet, default: mainnet)
+- `--address <address>`: Rosetta API endpoint (default: http://rosetta-mainnet.gcp.o1test.net)
+- `--db-conn-str <conn_str>`: PostgreSQL connection string
+
+#### Test Intervals (seconds):
+- `--status-interval N`: Network status API call interval (default: 10)
+- `--options-interval N`: Network options API call interval (default: 10)  
+- `--block-interval N`: Block retrieval API call interval (default: 2)
+- `--account-balance-interval N`: Account balance API call interval (default: 1)
+- `--payment-tx-interval N`: Payment transaction API call interval (default: 2)
+- `--zkapp-tx-interval N`: zkApp transaction API call interval (default: 1)
+
+#### Stop Conditions:
+- `--duration <seconds>`: Run for specified duration
+- `--max-requests N`: Stop after N total requests
+
+**Database Integration**:
+
+The script loads realistic test data from the archive database:
+
+#### `load_blocks_from_db(conn_str)`
+- **Query**: `SELECT state_hash FROM blocks LIMIT 100`
+- **Purpose**: Loads block hashes for block retrieval testing
+- **Storage**: `load[blocks]` array
+
+#### `load_accounts_from_db(conn_str)`  
+- **Query**: `SELECT value FROM public_keys LIMIT 100`
+- **Purpose**: Loads account public keys for balance testing
+- **Storage**: `load[accounts]` array
+
+#### `load_payment_transactions_from_db(conn_str)`
+- **Query**: `SELECT hash FROM user_commands LIMIT 100` 
+- **Purpose**: Loads payment transaction hashes for transaction testing
+- **Storage**: `load[payment_transactions]` array
+
+#### `load_zkapp_transactions_from_db(conn_str)`
+- **Query**: `SELECT hash FROM zkapp_commands LIMIT 100`
+- **Purpose**: Loads zkApp transaction hashes for zkApp testing  
+- **Storage**: `load[zkapp_transactions]` array
+
+**Performance Monitoring**:
+
+#### `print_memory_usage()`
+- **Monitors**: PostgreSQL, mina-archive, mina-rosetta processes
+- **Metrics**: RSS memory usage in MB
+- **Frequency**: Every 10 seconds during load test
+
+#### `print_load_test_statistics()`
+- **Current TPS**: Requests per second since last report
+- **Average TPS**: Overall test average transactions per second
+- **Total Requests**: Cumulative request count
+- **Memory Usage**: Process memory consumption
+
+**Main Load Test Function**:
+
+#### `run_all_tests_custom_intervals()`
+- **Precision Timing**: Uses floating-point timestamps to prevent drift
+- **Random Selection**: Randomly picks test data for each request
+- **Concurrent Testing**: All test types run simultaneously at their configured intervals
+- **Stop Conditions**: Monitors duration and request limits continuously
+
+**Example Usage**:
+```bash
+# Basic load test for 5 minutes
+./rosetta-load.sh --network mainnet --duration 300
+
+# High-frequency testing with custom intervals
+./rosetta-load.sh --network devnet --block-interval 1 --account-balance-interval 0.5
+
+# Database load test with request limit
+./rosetta-load.sh --db-conn-str "postgresql://user:pass@localhost/archive" --max-requests 10000
+
+# Custom endpoint load testing
+./rosetta-load.sh --address http://localhost:3087 --duration 600 --network devnet
+```
+
+### 4. rosetta-connectivity.sh
+
+**Purpose**: End-to-end connectivity testing using Docker containers, combining sanity and load testing in a controlled environment.
+
+**Location**: `scripts/tests/rosetta-connectivity.sh`
+
+**Key Features**:
+- **Docker Integration**: Automatically spins up Rosetta containers
+- **Network Support**: Both mainnet and devnet configurations  
+- **Optional Load Testing**: Can include performance testing
+- **Automatic Cleanup**: Handles container lifecycle management
+- **Volume Mounting**: Mounts repository for script access
+
+**Usage**:
+```bash
+./rosetta-connectivity.sh -t <docker-tag> [-n network] [--run-load-test]
+```
+
+**Command-line Options**:
+- `-t, --tag <tag>`: Docker image tag (required)
+- `-n, --network <network>`: Network configuration (devnet or mainnet, default: devnet)
+- `--run-load-test`: Enable load testing (default: false)  
+- `--timeout <seconds>`: Sync timeout duration (default: 900)
+- `-h, --help`: Show help information
+
+**Docker Configuration**:
+- **Image**: gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK
+- **Port Mapping**: 3087:3087 (Rosetta API port)
+- **Volume Mount**: `.:/workdir` (repository access)
+- **Environment**: MINA_NETWORK set to specified network
+
+**Test Execution Flow**:
+1. **Container Startup**: Launches Docker container with specified tag and network
+2. **Initialization Wait**: 5-second delay for container startup  
+3. **Sanity Testing**: Runs rosetta-sanity.sh with sync wait
+4. **Load Testing** (optional): Executes 600-second load test
+5. **Cleanup**: Stops and removes container (even on failure)
+
+**Trap Handling**:
+- **Error Handling**: `trap stop_docker ERR` ensures cleanup on script failure
+- **Container Management**: Stops and removes container automatically
+
+**Load Test Configuration** (when enabled):
+- **Duration**: 600 seconds (10 minutes)
+- **Database**: postgres://pguser:pguser@localhost:5432/archive  
+- **Endpoint**: http://localhost:3087
+- **Execution Context**: Inside Docker container via `docker exec`
+
+**Example Usage**:
+```bash
+# Basic connectivity test for devnet
+./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --network devnet
+
+# Mainnet connectivity with load testing  
+./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --network mainnet --run-load-test
+
+# Custom timeout for slow environments
+./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --timeout 1800
+```
+
+## Integration and Dependencies
+
+### Script Relationships:
+```
+rosetta-connectivity.sh
+├── Launches Docker container
+├── Calls rosetta-sanity.sh
+│   └── Sources rosetta-helper.sh
+└── Optionally calls rosetta-load.sh  
+    └── Sources rosetta-helper.sh
+```
+
+### External Dependencies:
+- **curl**: HTTP request execution
+- **jq**: JSON response parsing and validation
+- **psql**: PostgreSQL database connectivity (load testing)
+- **docker**: Container management (connectivity testing)
+- **bc**: Floating-point arithmetic (load testing)
+
+### Database Schema Dependencies (Load Testing):
+- **blocks table**: `state_hash` column
+- **public_keys table**: `value` column  
+- **user_commands table**: `hash` column
+- **zkapp_commands table**: `hash` column
+
+## Testing Scenarios
+
+### 1. Quick Sanity Check:
+```bash
+./rosetta-sanity.sh --network devnet --address http://localhost:3087
+```
+
+### 2. Full Load Testing:
+```bash  
+./rosetta-load.sh --network mainnet --duration 1800 --db-conn-str "postgresql://user:pass@host/db"
+```
+
+### 3. Complete E2E Testing:
+```bash
+./rosetta-connectivity.sh --tag latest-tag --network mainnet --run-load-test
+```
+
+### 4. Custom Performance Testing:
+```bash
+./rosetta-load.sh --block-interval 0.5 --account-balance-interval 0.2 --max-requests 50000
+```
+
+## Configuration Files Location
+
+The scripts reference these test data configurations:
+- **Mainnet endpoints**: Hard-coded in rosetta-sanity.sh:10-13
+- **Devnet endpoints**: Hard-coded in rosetta-sanity.sh:15-21
+- **Default intervals**: Defined in rosetta-load.sh:34-59
+- **Database queries**: Defined in rosetta-load.sh:250-308
+
+## Error Handling and Exit Codes
+
+### Common Exit Codes:
+- **0**: Success
+- **1**: General failure (assertion failed, timeout reached, invalid parameters)
+
+### Error Sources:
+- **API Assertion Failures**: Wrong response format or values
+- **Network Connectivity**: Cannot reach Rosetta endpoint
+- **Database Connectivity**: Cannot connect to PostgreSQL (load testing)
+- **Docker Issues**: Container startup or management problems (connectivity testing)
+- **Timeout Conditions**: Sync timeout or test duration limits
+
+## Performance Considerations
+
+### Load Testing Recommendations:
+- **Start Conservative**: Begin with default intervals and increase frequency gradually
+- **Monitor Resources**: Watch memory usage of database and Rosetta processes  
+- **Database Connection**: Ensure PostgreSQL can handle concurrent query load
+- **Network Bandwidth**: Consider network capacity for high-frequency testing
+
+### Typical Performance Metrics:
+- **Low Load**: 1-10 TPS sustainable indefinitely
+- **Medium Load**: 10-50 TPS for extended periods
+- **High Load**: 50+ TPS for stress testing scenarios
+
+This documentation provides comprehensive coverage of all Rosetta testing scripts and their capabilities for validating Mina Protocol's Rosetta API implementation.

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -56,7 +56,7 @@ sleep 5
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
     echo "Running load test for $LOAD_TEST_DURATION seconds..."
-    docker exec $container_id bash -c /workdir/scripts/tests/rosetta-load.sh --address "http://localhost:3087" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION
+    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION"
 else
     echo "Skipping load test."
 fi

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -1,6 +1,42 @@
 #!/usr/bin/env bash
 
-# end to end test for rosetta connectivity with given network 
+# Rosetta Connectivity Test Script
+#
+# This script tests the connectivity and functionality of the Mina Rosetta API
+# by running a Docker container with the Rosetta service and executing various tests.
+#
+# DESCRIPTION:
+#   - Starts a Mina Rosetta Docker container with specified network configuration
+#   - Runs sanity tests to verify basic connectivity and synchronization
+#   - Optionally runs load tests to stress-test the Rosetta API
+#   - Automatically cleans up Docker resources on completion or error
+#
+# REQUIREMENTS:
+#   - Docker must be installed and running
+#   - Script must be executed from the root of the mina repository
+#   - rosetta-sanity.sh and rosetta-load.sh scripts must be available
+#
+# PARAMETERS:
+#   -t, --tag           Docker image tag version (required)
+#   -n, --network       Network configuration: devnet or mainnet (default: devnet)
+#   --timeout           Timeout duration in seconds for tests (default: 900)
+#   --run-load-test     Enable load testing (default: false)
+#   -h, --help          Display usage information
+#
+# EXAMPLES:
+#   ./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --network devnet
+#   ./rosetta-connectivity.sh --tag 3.0.3 --network mainnet --run-load-test --timeout 1200
+#
+# EXIT CODES:
+#   0 - Success
+#   1 - Invalid parameters or missing required arguments
+#
+# NOTES:
+#   - The script sets up error trapping to ensure Docker cleanup
+#   - Container runs on port 3087 and mounts current directory as /workdir
+#   - Load test duration is fixed at 600 seconds when enabled
+
+
 set -x
 CLEAR='\033[0m'
 RED='\033[0;31m'

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -9,6 +9,7 @@ NETWORK=devnet
 TIMEOUT=900
 
 LOAD_TEST_DURATION=600
+RUN_LOAD_TEST=false
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--network) NETWORK="$2"; shift;;

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -56,7 +56,7 @@ sleep 5
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
     echo "Running load test for $LOAD_TEST_DURATION seconds..."
-    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION"
+    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION --network $NETWORK "
 else
     echo "Skipping load test."
 fi

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -56,7 +56,7 @@ sleep 5
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
     echo "Running load test for $LOAD_TEST_DURATION seconds..."
-    docker exec -v .:/workdir   $container_id /workdir/scripts/tests/rosetta-load.sh --address "http://localhost:3087" -db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION
+    docker exec $container_id bash -c /workdir/scripts/tests/rosetta-load.sh --address "http://localhost:3087" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION
 else
     echo "Skipping load test."
 fi

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -40,7 +40,7 @@ function usage() {
 
 if [[ -z "$TAG" ]]; then usage "Docker tag is not set!"; usage; exit 1; fi;
 
-container_id=$(docker run -p 3087:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
+container_id=$(docker run -v .:/workdir -p 3087:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
 
 stop_docker() {
     { docker stop "$container_id" ; docker rm "$container_id" ; } || true

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -8,8 +8,11 @@ RED='\033[0;31m'
 NETWORK=devnet
 TIMEOUT=900
 
+LOAD_TEST_DURATION=600
+
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--network) NETWORK="$2"; shift;;
+  --run-load-test) RUN_LOAD_TEST=true ;;
   -t|--tag) TAG="$2"; shift;;
   --timeout) TIMEOUT="$2"; shift;;
   -h|--help) usage; exit 0;;
@@ -48,5 +51,13 @@ trap stop_docker ERR
 sleep 5
 #run sanity test
 ./scripts/tests/rosetta-sanity.sh --address "http://localhost:3087" --network $NETWORK --wait-for-sync --timeout $TIMEOUT
+
+# Run load test
+if [[ "$RUN_LOAD_TEST" == true ]]; then
+    echo "Running load test for $LOAD_TEST_DURATION seconds..."
+    docker exec -v .:/workdir   $container_id /workdir/scripts/tests/rosetta-load.sh --address "http://localhost:3087" -db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION
+else
+    echo "Skipping load test."
+fi
 
 stop_docker

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -24,7 +24,7 @@ function assert() {
 
 function wait_for_sync() {
     declare -n __test_data=$1
-    declare -n __timeout=$2
+    local __timeout=$2
 
     echo "⏳  Waiting for rosetta to sync..."
     local start_time

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -80,7 +80,7 @@ function test_account_balance() {
     declare -n __test_data=$1
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
         '.balances[0].currency.symbol == "MINA"' \
-        "   ✅  Account: Balance for ok" \
+        "   ✅  Account: Balance ok" \
         "   ❌  Account: Invalid balance structure or balance not found"
 }
 

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -24,10 +24,12 @@ function assert() {
 
 function wait_for_sync() {
     declare -n __test_data=$1
+    declare -n __timeout=$2
 
     echo "⏳  Waiting for rosetta to sync..."
-    local start_time=$(date +%s)
-    local end_time=$((start_time + TIMEOUT))
+    local start_time
+    start_time=$(date +%s)
+    local end_time=$((start_time + __timeout))
     local sync_status=""
 
     while true; do

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Helper functions for Rosetta API sanity and load tests
+
+readonly BLOCKCHAIN="mina"
+
+readonly DEFAULT_HEADERS=(--header "Accept: application/json" --header "Content-Type: application/json")
+
+function assert() {
+    local __response=$1
+    local __query=$2
+    local __success_message=$3
+    local __error_message=$4
+
+    if echo $__response | jq "if ($__query) then true else false end" | grep -q true; then
+        echo "$__success_message"
+    else
+        echo "$__error_message"
+        echo "   Response:"
+        echo "      $( echo $__response | jq)"
+        exit 1
+    fi
+}
+
+function wait_for_sync() {
+    declare -n __test_data=$1
+
+    echo "⏳  Waiting for rosetta to sync..."
+    local start_time=$(date +%s)
+    local end_time=$((start_time + TIMEOUT))
+    local sync_status=""
+
+    while true; do
+        sync_status=$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" 2> /dev/null | jq '.sync_status.stage')
+        if [[ "$sync_status" == "\"Synced\"" ]]; then
+            echo "✅  Rosetta is synced"
+            break
+        elif [[ "$sync_status" == "" ]]; then
+            echo "ℹ️  Rosetta is in bootstrap stage"
+        else 
+            echo "ℹ️  Rosetta is $sync_status stage"
+        fi
+
+        if [[ $(date +%s) -gt $end_time ]]; then
+            echo "❌  Timeout reached. Rosetta did not sync within $TIMEOUT seconds"
+            exit 1
+        fi
+
+        echo "⏳  Rosetta is not synced yet. Waiting till $(printf '%(%FT%T)T\n' $end_time). Retrying in 30 seconds..."
+
+        sleep 30
+    done
+}
+
+function test_network_status() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+        '.sync_status.stage == "Synced"' \
+        "   ✅  Rosetta is synced" \
+        "   ❌  Rosetta is not synced"
+}
+
+function test_network_options() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+        '.version.rosetta_version == "1.4.9"' \
+        "   ✅  Rosetta Version is correct" \
+        "   ❌  Invalid Rosetta Version (expected 1.4.9)"
+}
+
+function test_block() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/block" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"block_identifier\":{\"hash\":\"${__test_data[block]}\"}}" | jq)" \
+        ".block.block_identifier.hash == \"${__test_data[block]}\" " \
+        "   ✅  Block hash correct" \
+        "   ❌  Block hash incorrect or not found (expected ${__test_data[block]})"
+}
+
+function test_account_balance() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
+        '.balances[0].currency.symbol == "MINA"' \
+        "   ✅  Account: Balance for ok" \
+        "   ❌  Account: Invalid balance structure or balance not found"
+}
+
+function test_payment_transaction() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
+        \"network_identifier\": {
+            \"blockchain\": \"$BLOCKCHAIN\",
+            \"network\": \"${__test_data[id]}\"
+        },
+        \"transaction_identifier\": {
+            \"hash\": \"${__test_data[payment_transaction]}\"
+        }
+    }" | jq)" \
+        ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[payment_transaction]}\" " \
+        "   ✅  Payment transaction found" \
+        "   ❌  Payment transaction not found (expected ${__test_data[payment_transaction]})"
+}
+
+function test_zkapp_transaction() {
+    declare -n __test_data=$1
+    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
+        \"network_identifier\": {
+            \"blockchain\": \"$BLOCKCHAIN\",
+            \"network\": \"${__test_data[id]}\"
+        },
+        \"transaction_identifier\": {
+            \"hash\": \"${__test_data[zkapp_transaction]}\"
+        }
+    }" | jq)" \
+        ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[zkapp_transaction]}\" " \
+        "   ✅  Zkapp transaction found" \
+        "   ❌  Zkapp transaction not found (expected ${__test_data[zkapp_transaction]})"
+}

--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -550,14 +550,14 @@ function run_all_tests_custom_intervals() {
 
         # Execute network status test if scheduled
         if (( $(echo "$now >= $status_next" | bc -l) )); then
-            test_network_status "$1"
+            test_network_status "$1" || exit $?
             status_next=$(echo "$now + $status_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi
         
         # Execute network options test if scheduled
         if (( $(echo "$now >= $options_next" | bc -l) )); then
-            test_network_options "$1"
+            test_network_options "$1" || exit $?
             options_next=$(echo "$now + $options_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi
@@ -570,7 +570,7 @@ function run_all_tests_custom_intervals() {
             tmp_data[block]="$block_hash"
             tmp_data[id]="${__test_data[id]}"
             tmp_data[address]="${__test_data[address]}"
-            test_block tmp_data
+            test_block tmp_data || exit $?
             block_next=$(echo "$now + $block_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi
@@ -581,7 +581,7 @@ function run_all_tests_custom_intervals() {
             account=$(pick_random "${__test_data[accounts]}")
             declare -A tmp_data
             tmp_data[account]="$account"
-            test_account_balance tmp_data
+            test_account_balance tmp_data || exit $?
             account_balance_next=$(echo "$now + $account_balance_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi
@@ -592,7 +592,7 @@ function run_all_tests_custom_intervals() {
             payment_tx=$(pick_random "${__test_data[payment_transactions]}")
             declare -A tmp_data
             tmp_data[payment_transaction]="$payment_tx"
-            test_payment_transaction tmp_data
+            test_payment_transaction tmp_data || exit $?
             payment_tx_next=$(echo "$now + $payment_tx_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi
@@ -604,7 +604,7 @@ function run_all_tests_custom_intervals() {
             declare -A tmp_data
             #shellcheck disable=SC2034
             tmp_data[zkapp_transaction]="$zkapp_tx"
-            test_zkapp_transaction tmp_data
+            test_zkapp_transaction tmp_data || exit $?
             zkapp_tx_next=$(echo "$now + $zkapp_tx_interval" | bc)
             requests_this_iteration=$((requests_this_iteration + 1))
         fi

--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+
+# Load test runner for Rosetta API
+
+source "$(dirname "$0")/rosetta-helper.sh"
+
+# Example usage:
+# ./rosetta-load.sh mainnet 2 5 10 15 20 25
+# (network, status_interval, options_interval, block_interval, account_balance_interval, payment_tx_interval, zkapp_tx_interval)
+
+NETWORK="${1:-mainnet}"
+ADDRESS="${2:-http://rosetta-mainnet.gcp.o1test.net}"
+STATUS_INTERVAL="${2:-2}"
+OPTIONS_INTERVAL="${3:-5}"
+BLOCK_INTERVAL="${4:-10}"
+ACCOUNT_BALANCE_INTERVAL="${5:-15}"
+PAYMENT_TX_INTERVAL="${6:-20}"
+ZKAPP_TX_INTERVAL="${7:-25}"
+
+# Argument parsing
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --network)
+            NETWORK="$2"
+            shift 2
+            ;;
+        --address)
+            ADDRESS="$2"
+            shift 2
+            ;;
+        --db-conn-str)
+            DB_CONN_STR="$2"
+            shift 2
+            ;;
+        --status-interval)
+            STATUS_INTERVAL="$2"
+            shift 2
+            ;;
+        --options-interval)
+            OPTIONS_INTERVAL="$2"
+            shift 2
+            ;;
+        --block-interval)
+            BLOCK_INTERVAL="$2"
+            shift 2
+            ;;
+        --account-balance-interval)
+            ACCOUNT_BALANCE_INTERVAL="$2"
+            shift 2
+            ;;
+        --payment-tx-interval)
+            PAYMENT_TX_INTERVAL="$2"
+            shift 2
+            ;;
+        --zkapp-tx-interval)
+            ZKAPP_TX_INTERVAL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--network mainnet|devnet] [--address <address>] [--db-conn-str <conn_str>] [--status-interval N] [--options-interval N] [--block-interval N] [--account-balance-interval N] [--payment-tx-interval N] [--zkapp-tx-interval N]"
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+declare -A load
+export load
+load[id]=${NETWORK}
+load[address]=${ADDRESS}
+
+function load_from_db() {
+    local conn_str="$1"
+    local query="$2"
+    local key="$3"
+    local result
+    result=$(psql "$conn_str" -Atc "$query")
+    load["$key"]=$(echo "$result" | tr '\n' ' ')
+}
+
+function load_blocks_from_db() {
+    load_from_db "$1" "SELECT state_hash FROM blocks LIMIT 100;" "blocks"
+}
+
+function load_accounts_from_db() {
+    load_from_db "$1" "SELECT value FROM public_keys LIMIT 100;" "accounts"
+}
+
+function load_payment_transactions_from_db() {
+    load_from_db "$1" "SELECT hash FROM user_commands LIMIT 100;" "payment_transactions"
+}
+
+function load_zkapp_transactions_from_db() {
+    load_from_db "$1" "SELECT hash FROM zkapp_commands LIMIT 100;" "zkapp_transactions"
+}
+
+
+
+# Example connection string, adjust as needed
+DB_CONN_STR="postgresql://user:password@localhost/mina"
+
+load_blocks_from_db "$DB_CONN_STR" "blocks"
+load_accounts_from_db "$DB_CONN_STR" "accounts"
+load_payment_transactions_from_db "$DB_CONN_STR" "payment_transactions"
+load_zkapp_transactions_from_db "$DB_CONN_STR" "zkapp_transactions"
+
+function run_all_tests_custom_intervals() {
+    declare -n __test_data=$1
+    local status_interval=$2
+    local options_interval=$3
+    local block_interval=$4
+    local account_balance_interval=$5
+    local payment_tx_interval=$6
+    local zkapp_tx_interval=$7
+
+    local status_next=0
+    local options_next=0
+    local block_next=0
+    local account_balance_next=0
+    local payment_tx_next=0
+    local zkapp_tx_next=0
+
+    # Helper to pick a random element from a space-separated string
+    pick_random() {
+        local arr=($1)
+        echo "${arr[RANDOM % ${#arr[@]}]}"
+    }
+
+    while true; do
+        local now=$(date +%s.%N)
+
+        if (( $(echo "$now >= $status_next" | bc -l) )); then
+            test_network_status "$1"
+            status_next=$(echo "$now + $status_interval" | bc)
+        fi
+        if (( $(echo "$now >= $options_next" | bc -l) )); then
+            test_network_options "$1"
+            options_next=$(echo "$now + $options_interval" | bc)
+        fi
+        if (( $(echo "$now >= $block_next" | bc -l) )); then
+            # Pick a random block
+            local block_hash=$(pick_random "${__test_data[blocks]}")
+            declare -A tmp_data
+            tmp_data[block]="$block_hash"
+            test_block tmp_data
+            block_next=$(echo "$now + $block_interval" | bc)
+        fi
+        if (( $(echo "$now >= $account_balance_next" | bc -l) )); then
+            # Pick a random account
+            local account=$(pick_random "${__test_data[accounts]}")
+            declare -A tmp_data
+            tmp_data[account]="$account"
+            test_account_balance tmp_data
+            account_balance_next=$(echo "$now + $account_balance_interval" | bc)
+        fi
+        if (( $(echo "$now >= $payment_tx_next" | bc -l) )); then
+            # Pick a random payment transaction
+            local payment_tx=$(pick_random "${__test_data[payment_transactions]}")
+            declare -A tmp_data
+            tmp_data[payment_transaction]="$payment_tx"
+            test_payment_transaction tmp_data
+            payment_tx_next=$(echo "$now + $payment_tx_interval" | bc)
+        fi
+        if (( $(echo "$now >= $zkapp_tx_next" | bc -l) )); then
+            # Pick a random zkapp transaction
+            local zkapp_tx=$(pick_random "${__test_data[zkapp_transactions]}")
+            declare -A tmp_data
+            tmp_data[zkapp_transaction]="$zkapp_tx"
+            test_zkapp_transaction tmp_data
+            zkapp_tx_next=$(echo "$now + $zkapp_tx_interval" | bc)
+        fi
+
+        sleep 0.1
+    done
+}
+
+run_all_tests_custom_intervals load "$STATUS_INTERVAL" "$OPTIONS_INTERVAL" "$BLOCK_INTERVAL" "$ACCOUNT_BALANCE_INTERVAL" "$PAYMENT_TX_INTERVAL" "$ZKAPP_TX_INTERVAL"

--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -94,18 +94,26 @@ function load_from_db() {
 }
 
 function load_blocks_from_db() {
+    # Load the first 100 blocks from the database
+    echo "Loading blocks from database..."
     load_from_db "$1" "SELECT state_hash FROM blocks LIMIT 100;" "blocks"
 }
 
 function load_accounts_from_db() {
+    # Load the first 100 public keys from the database
+    echo "Loading accounts from database..."
     load_from_db "$1" "SELECT value FROM public_keys LIMIT 100;" "accounts"
 }
 
 function load_payment_transactions_from_db() {
+    # Load the first 100 payment transaction hashes from the database
+    echo "Loading payment transactions from database..."
     load_from_db "$1" "SELECT hash FROM user_commands LIMIT 100;" "payment_transactions"
 }
 
 function load_zkapp_transactions_from_db() {
+    # Load the first 100 zkapp transaction hashes from the database
+    echo "Loading zkapp transactions from database..."
     load_from_db "$1" "SELECT hash FROM zkapp_commands LIMIT 100;" "zkapp_transactions"
 }
 

--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -1,26 +1,130 @@
 #!/usr/bin/env bash
 
+# Rosetta API Load Test Runner
+#
+# This script performs comprehensive load testing of the Rosetta API implementation
+# for the Mina Protocol. It simulates various API calls at configurable intervals
+# to test performance, stability, and correctness under sustained load.
+#
+# The script supports multiple test scenarios:
+# - Network status and options queries
+# - Block retrieval operations  
+# - Account balance lookups
+# - Payment transaction queries
+# - zkApp transaction queries
+#
+# Test data is loaded from a PostgreSQL database containing blocks, accounts,
+# and transactions to ensure realistic load patterns.
+#
+# Usage:
+#   ./rosetta-load.sh [options]
+#
+# Example:
+#   ./rosetta-load.sh --network mainnet --duration 300 --max-requests 1000
+#   ./rosetta-load.sh --network devnet --address http://localhost:3087 --block-interval 5
 
-# Load test runner for Rosetta API
+set -euo pipefail
 
 source "$(dirname "$0")/rosetta-helper.sh"
 
-# Example usage:
-# ./rosetta-load.sh mainnet 2 5 10 15 20 25
-# (network, status_interval, options_interval, block_interval, account_balance_interval, payment_tx_interval, zkapp_tx_interval)
+################################################################################
+# Configuration Constants
+################################################################################
 
-NETWORK="mainnet"
-ADDRESS="http://rosetta-mainnet.gcp.o1test.net"
-DB_CONN_STR="postgresql://user:password@localhost/mina"
-STATUS_INTERVAL="2"
-OPTIONS_INTERVAL="5"
-BLOCK_INTERVAL="10"
-ACCOUNT_BALANCE_INTERVAL="15"
-PAYMENT_TX_INTERVAL="20"
-ZKAPP_TX_INTERVAL="25"
+# Default network to test against (mainnet or devnet)
+readonly DEFAULT_NETWORK="mainnet"
 
+# Default Rosetta API endpoint for mainnet
+readonly DEFAULT_ADDRESS="http://rosetta-mainnet.gcp.o1test.net"
+
+# Default PostgreSQL connection string for loading test data
+readonly DEFAULT_DB_CONN_STR="postgresql://user:password@localhost/mina"
+
+# Default interval (in seconds) for network status API calls
+readonly DEFAULT_STATUS_INTERVAL="10"
+
+# Default interval (in seconds) for network options API calls  
+readonly DEFAULT_OPTIONS_INTERVAL="10"
+
+# Default interval (in seconds) for block retrieval API calls
+readonly DEFAULT_BLOCK_INTERVAL="2"
+
+# Default interval (in seconds) for account balance API calls
+readonly DEFAULT_ACCOUNT_BALANCE_INTERVAL="1"
+
+# Default interval (in seconds) for payment transaction API calls
+readonly DEFAULT_PAYMENT_TX_INTERVAL="2"
+
+# Default interval (in seconds) for zkApp transaction API calls
+readonly DEFAULT_ZKAPP_TX_INTERVAL="1"
+
+# Statistics reporting interval (in seconds)
+readonly STATS_REPORTING_INTERVAL="10"
+
+# Maximum number of test data items to load from database
+readonly MAX_TEST_DATA_ITEMS="100"
+
+################################################################################
+# Runtime Configuration Variables
+################################################################################
+
+NETWORK="$DEFAULT_NETWORK"
+ADDRESS="$DEFAULT_ADDRESS"
+DB_CONN_STR="$DEFAULT_DB_CONN_STR"
+STATUS_INTERVAL="$DEFAULT_STATUS_INTERVAL"
+OPTIONS_INTERVAL="$DEFAULT_OPTIONS_INTERVAL"
+BLOCK_INTERVAL="$DEFAULT_BLOCK_INTERVAL"
+ACCOUNT_BALANCE_INTERVAL="$DEFAULT_ACCOUNT_BALANCE_INTERVAL"
+PAYMENT_TX_INTERVAL="$DEFAULT_PAYMENT_TX_INTERVAL"
+ZKAPP_TX_INTERVAL="$DEFAULT_ZKAPP_TX_INTERVAL"
+
+# Optional duration limit for test run (in seconds)
+DURATION=""
+
+# Optional maximum number of total requests before stopping
+MAX_REQUESTS=""
+
+################################################################################
+# Help and Usage Functions
+################################################################################
+
+# Print usage information and command-line options
+#
+# This function displays comprehensive help text explaining all available
+# command-line options, their default values, and usage examples.
+#
+# Globals:
+#   None
+#
+# Arguments:
+#   None
+#
+# Returns:
+#   None (exits with code 0)
 function usage() {
-    echo "Usage: $0 [--network mainnet|devnet] [--address <address>] [--db-conn-str <conn_str>] [--status-interval N] [--options-interval N] [--block-interval N] [--account-balance-interval N] [--payment-tx-interval N] [--zkapp-tx-interval N]"
+    echo "Usage: $0 [--network mainnet|devnet] [--address <address>] [--db-conn-str <conn_str>] [--status-interval N] [--options-interval N] [--block-interval N] [--account-balance-interval N] [--payment-tx-interval N] [--zkapp-tx-interval N] [--duration <seconds>] [--max-requests N]"
+    echo ""
+    echo "Load test parameters:"
+    echo "  --network <network>              Target network (mainnet or devnet, default: $DEFAULT_NETWORK)"
+    echo "  --address <address>              Rosetta API endpoint (default: $DEFAULT_ADDRESS)"
+    echo "  --db-conn-str <conn_str>         PostgreSQL connection string (default: $DEFAULT_DB_CONN_STR)"
+    echo ""
+    echo "Test intervals (in seconds):"
+    echo "  --status-interval N              Network status API call interval (default: $DEFAULT_STATUS_INTERVAL)"
+    echo "  --options-interval N             Network options API call interval (default: $DEFAULT_OPTIONS_INTERVAL)"
+    echo "  --block-interval N               Block retrieval API call interval (default: $DEFAULT_BLOCK_INTERVAL)"
+    echo "  --account-balance-interval N     Account balance API call interval (default: $DEFAULT_ACCOUNT_BALANCE_INTERVAL)"
+    echo "  --payment-tx-interval N          Payment transaction API call interval (default: $DEFAULT_PAYMENT_TX_INTERVAL)"
+    echo "  --zkapp-tx-interval N            zkApp transaction API call interval (default: $DEFAULT_ZKAPP_TX_INTERVAL)"
+    echo ""
+    echo "Stop conditions:"
+    echo "  --duration <seconds>             Run for specified duration in seconds"
+    echo "  --max-requests N                 Stop after N total requests"
+    echo "  If neither is specified, runs indefinitely"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --network mainnet --duration 300 --max-requests 1000"
+    echo "  $0 --network devnet --address http://localhost:3087 --block-interval 5"
 }
 
 # Argument parsing
@@ -62,6 +166,14 @@ while [[ $# -gt 0 ]]; do
             ZKAPP_TX_INTERVAL="$2"
             shift 2
             ;;
+        --duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        --max-requests)
+            MAX_REQUESTS="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -77,13 +189,39 @@ done
 echo "Running Rosetta load tests with the following parameters:"
 echo "  Network: $NETWORK"
 echo "  Address: $ADDRESS"
-echo "  DB Connection String: $DB_CONN_STR" 
+echo "  DB Connection String: $DB_CONN_STR"
+if [[ -n "$DURATION" ]]; then
+    echo "  Duration: ${DURATION}s"
+fi
+if [[ -n "$MAX_REQUESTS" ]]; then
+    echo "  Max Requests: $MAX_REQUESTS"
+fi
 
 declare -A load
 export load
 load[id]=${NETWORK}
 load[address]=${ADDRESS}
 
+################################################################################
+# Database Loading Functions
+################################################################################
+
+# Execute a SQL query and load results into the test data structure
+#
+# This is a helper function that executes a PostgreSQL query and stores
+# the results in the global load associative array under the specified key.
+# Results are stored as a space-separated string for easy iteration.
+#
+# Globals:
+#   load (associative array) - Modified to store query results
+#
+# Arguments:
+#   $1 - PostgreSQL connection string
+#   $2 - SQL query to execute
+#   $3 - Key name to store results under in load array
+#
+# Returns:
+#   None (modifies global load array)
 function load_from_db() {
     local conn_str="$1"
     local query="$2"
@@ -93,36 +231,243 @@ function load_from_db() {
     load["$key"]=$(echo "$result" | tr '\n' ' ')
 }
 
+# Load block state hashes from the database for testing
+#
+# Retrieves the first 100 block state hashes from the blocks table
+# to use in block retrieval API tests. These hashes are used to
+# make realistic block query requests during load testing.
+#
+# Globals:
+#   load (associative array) - Modified to store block hashes
+#
+# Arguments:
+#   $1 - PostgreSQL connection string
+#
+# Returns:
+#   None (modifies global load array with 'blocks' key)
 function load_blocks_from_db() {
-    # Load the first 100 blocks from the database
     echo "Loading blocks from database..."
-    load_from_db "$1" "SELECT state_hash FROM blocks LIMIT 100;" "blocks"
+    load_from_db "$1" "SELECT state_hash FROM blocks LIMIT $MAX_TEST_DATA_ITEMS;" "blocks"
 }
 
+# Load account public keys from the database for testing
+#
+# Retrieves the first 100 public keys from the public_keys table
+# to use in account balance API tests. These keys represent real
+# accounts that can be queried during load testing.
+#
+# Globals:
+#   load (associative array) - Modified to store account public keys
+#
+# Arguments:
+#   $1 - PostgreSQL connection string
+#
+# Returns:
+#   None (modifies global load array with 'accounts' key)
 function load_accounts_from_db() {
-    # Load the first 100 public keys from the database
     echo "Loading accounts from database..."
-    load_from_db "$1" "SELECT value FROM public_keys LIMIT 100;" "accounts"
+    load_from_db "$1" "SELECT value FROM public_keys LIMIT $MAX_TEST_DATA_ITEMS;" "accounts"
 }
 
+# Load payment transaction hashes from the database for testing
+#
+# Retrieves the first 100 payment transaction hashes from the user_commands
+# table to use in payment transaction API tests. These represent real
+# payment transactions that can be queried during load testing.
+#
+# Globals:
+#   load (associative array) - Modified to store payment transaction hashes
+#
+# Arguments:
+#   $1 - PostgreSQL connection string
+#
+# Returns:
+#   None (modifies global load array with 'payment_transactions' key)
 function load_payment_transactions_from_db() {
-    # Load the first 100 payment transaction hashes from the database
     echo "Loading payment transactions from database..."
-    load_from_db "$1" "SELECT hash FROM user_commands LIMIT 100;" "payment_transactions"
+    load_from_db "$1" "SELECT hash FROM user_commands LIMIT $MAX_TEST_DATA_ITEMS;" "payment_transactions"
 }
 
+# Load zkApp transaction hashes from the database for testing
+#
+# Retrieves the first 100 zkApp transaction hashes from the zkapp_commands
+# table to use in zkApp transaction API tests. These represent real
+# zkApp transactions that can be queried during load testing.
+#
+# Globals:
+#   load (associative array) - Modified to store zkApp transaction hashes
+#
+# Arguments:
+#   $1 - PostgreSQL connection string
+#
+# Returns:
+#   None (modifies global load array with 'zkapp_transactions' key)
 function load_zkapp_transactions_from_db() {
-    # Load the first 100 zkapp transaction hashes from the database
     echo "Loading zkapp transactions from database..."
-    load_from_db "$1" "SELECT hash FROM zkapp_commands LIMIT 100;" "zkapp_transactions"
+    load_from_db "$1" "SELECT hash FROM zkapp_commands LIMIT $MAX_TEST_DATA_ITEMS;" "zkapp_transactions"
 }
 
 
+################################################################################
+# Test Data Initialization
+################################################################################
+
+# Initialize global test data by loading from database
+# This section creates the global associative array and populates it
+# with test data from the PostgreSQL database.
+declare -A load
+export load
+load[id]=${NETWORK}
+load[address]=${ADDRESS}
+
+# Load test data from database
 load_blocks_from_db "$DB_CONN_STR" "blocks"
 load_accounts_from_db "$DB_CONN_STR" "accounts"
 load_payment_transactions_from_db "$DB_CONN_STR" "payment_transactions"
 load_zkapp_transactions_from_db "$DB_CONN_STR" "zkapp_transactions"
 
+################################################################################
+# System Monitoring Functions
+################################################################################
+
+# Print current memory usage for relevant system processes
+#
+# This function monitors memory consumption of key processes involved
+# in the Rosetta API infrastructure:
+# - PostgreSQL database processes
+# - Mina archive processes  
+# - Mina Rosetta API processes
+#
+# Memory usage is calculated by summing RSS (Resident Set Size) values
+# for all matching processes and converting from KB to MB.
+#
+# Globals:
+#   None
+#
+# Arguments:
+#   None
+#
+# Returns:
+#   None (prints memory usage to stdout)
+function print_memory_usage() {
+    echo "  📊 Memory Usage:"
+    
+    # PostgreSQL memory usage (sum of all postgres processes)
+    local postgres_memory
+    postgres_memory=$(ps -p $(pgrep -d, -f postgres) -o rss= 2>/dev/null | awk '{sum+=$1} END {print sum/1024}' 2>/dev/null)
+    if [[ -n "$postgres_memory" ]]; then
+        echo "   - 🐘 PostgreSQL: ${postgres_memory} MB"
+    else
+        echo "   - 🐘 PostgreSQL: N/A (not running)"
+    fi
+    
+    # Mina-archive memory usage
+    local archive_memory
+    archive_memory=$(ps -p $(pgrep -f mina-archive) -o rss= 2>/dev/null | awk '{print $1/1024}' 2>/dev/null)
+    if [[ -n "$archive_memory" ]]; then
+        echo "   - 📦 Mina-archive: ${archive_memory} MB"
+    else
+        echo "   - 📦 Mina-archive: N/A (not running)"
+    fi
+    
+    # Mina-rosetta memory usage (sum of all mina-rosetta processes)
+    local rosetta_memory
+    rosetta_memory=$(ps -p $(pgrep -d, -f mina-rosetta) -o rss= 2>/dev/null | awk '{sum+=$1} END {print sum/1024}' 2>/dev/null)
+    if [[ -n "$rosetta_memory" ]]; then
+        echo "   - 🌹 Mina-rosetta: ${rosetta_memory} MB"
+    else
+        echo "   - 🌹 Mina-rosetta: N/A (not running)"
+    fi
+}
+
+# Print comprehensive load test performance statistics
+#
+# This function calculates and displays current and cumulative performance
+# metrics for the load test, including:
+# - Current TPS (transactions per second) since last report
+# - Average TPS over the entire test duration
+# - Total requests processed
+# - Memory usage of system processes
+#
+# Globals:
+#   None
+#
+# Arguments:
+#   $1 - Current timestamp (float seconds since epoch)
+#   $2 - Test start timestamp (float seconds since epoch)
+#   $3 - Total number of requests processed
+#   $4 - Number of requests since last metric report
+#   $5 - Timestamp of last metric report
+#   $6 - Optional: "true" to indicate final statistics report
+#
+# Returns:
+#   None (prints statistics to stdout)
+function print_load_test_statistics() {
+    local now="$1"
+    local start_time="$2"
+    local total_requests="$3"
+    local requests_since_last_metric="$4"
+    local last_metric_time="$5"
+    local is_final="${6:-false}"
+    
+    local elapsed_since_last
+    elapsed_since_last=$(echo "$now - $last_metric_time" | bc)
+    local current_tps
+    current_tps=$(echo "scale=2; $requests_since_last_metric / $elapsed_since_last" | bc)
+    local total_elapsed
+    total_elapsed=$(echo "$now - $start_time" | bc)
+    local average_tps
+    average_tps=$(echo "scale=2; $total_requests / $total_elapsed" | bc)
+    
+    if [[ "$is_final" == "true" ]]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - 🏁 FINAL STATISTICS:"
+        echo "  ⏱️  Total Duration: ${total_elapsed}s"
+        echo "  📊 Total Requests: $total_requests"
+        echo "  📈 Average TPS: $average_tps"
+    else
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - 🔄 Current TPS: $current_tps, 📈 Average TPS: $average_tps, 📊 Total Requests: $total_requests"
+    fi
+    print_memory_usage
+}
+
+################################################################################
+# Load Test Execution Functions
+################################################################################
+
+# Execute comprehensive load testing with configurable intervals
+#
+# This is the main load testing function that orchestrates all API test calls
+# at their specified intervals. It implements a precise timing system that
+# ensures each test type runs at its configured frequency without drift.
+#
+# The function supports two stop conditions:
+# - Duration-based: stops after specified number of seconds
+# - Request-based: stops after specified number of total requests
+#
+# Test types and their functions:
+# - Network status: test_network_status() - checks API health
+# - Network options: test_network_options() - validates API capabilities  
+# - Block retrieval: test_block() - queries random blocks
+# - Account balance: test_account_balance() - checks random account balances
+# - Payment transactions: test_payment_transaction() - queries random payments
+# - zkApp transactions: test_zkapp_transaction() - queries random zkApp txs
+#
+# Globals:
+#   DURATION - Optional duration limit in seconds
+#   MAX_REQUESTS - Optional maximum request count
+#
+# Arguments:
+#   $1 - Reference to associative array containing test data
+#   $2 - Network status API call interval (seconds)
+#   $3 - Network options API call interval (seconds)
+#   $4 - Block retrieval API call interval (seconds)
+#   $5 - Account balance API call interval (seconds)
+#   $6 - Payment transaction API call interval (seconds)
+#   $7 - zkApp transaction API call interval (seconds)
+#
+# Returns:
+#   0 on successful completion
+#   Exits with code 0 when stop conditions are met
 function run_all_tests_custom_intervals() {
     declare -n __test_data=$1
     local status_interval=$2
@@ -132,65 +477,159 @@ function run_all_tests_custom_intervals() {
     local payment_tx_interval=$6
     local zkapp_tx_interval=$7
 
+    # Next execution timestamps for each test type
     local status_next=0
     local options_next=0
     local block_next=0
     local account_balance_next=0
     local payment_tx_next=0
     local zkapp_tx_next=0
+    local sleep_time=0.0
 
-    # Helper to pick a random element from a space-separated string
+    # Select a random element from a space-separated string
+    # This helper function is used to randomly select test data items
+    # from the loaded database content.
+    #
+    # Arguments:
+    #   $1 - Space-separated string of items
+    #
+    # Returns:
+    #   Single randomly selected item from the input string
     pick_random() {
-        local arr=($1)
+        local -a arr
+        read -ra arr <<< "$1"
         echo "${arr[RANDOM % ${#arr[@]}]}"
     }
 
-    while true; do
-        local now=$(date +%s.%N)
+    # Initialize timing and metrics
+    local start_time
+    start_time=$(date +%s.%N)
+    local total_requests=0
+    local last_metric_time=$start_time
+    local requests_since_last_metric=0
 
+    echo "Starting load test with the following parameters:"
+    echo "  Network: ${__test_data[id]}"
+    echo "  Address: ${__test_data[address]}"
+    echo "  Status Interval: ${status_interval}s"
+    echo "  Options Interval: ${options_interval}s"
+    echo "  Block Interval: ${block_interval}s"
+    echo "  Account Balance Interval: ${account_balance_interval}s"
+    echo "  Payment Transaction Interval: ${payment_tx_interval}s"
+    echo "  zkApp Transaction Interval: ${zkapp_tx_interval}s"
+    echo "  Duration: ${DURATION:-none}"
+    echo "  Max Requests: ${MAX_REQUESTS:-none}"
+    echo "  Statistics Reporting Interval: ${STATS_REPORTING_INTERVAL}s"
+    echo "  Initial Memory Usage:"
+    # Print initial memory usage before starting the load test
+    print_memory_usage
+
+    # Main load testing loop
+    while true; do
+        local now
+        now=$(date +%s.%N)
+        local requests_this_iteration=0
+
+        # Check duration-based stop condition
+        if [[ -n "$DURATION" ]]; then
+            local elapsed
+            elapsed=$(echo "$now - $start_time" | bc)
+            if (( $(echo "$elapsed >= $DURATION" | bc -l) )); then
+                echo "Duration limit reached (${DURATION}s). Stopping load test."
+                print_load_test_statistics "$now" "$start_time" "$total_requests" "$requests_since_last_metric" "$last_metric_time" "true"
+                exit 0
+            fi
+        fi
+
+        # Check request-based stop condition
+        if [[ -n "$MAX_REQUESTS" && $total_requests -ge $MAX_REQUESTS ]]; then
+            echo "Request limit reached ($MAX_REQUESTS). Stopping load test."
+            print_load_test_statistics "$now" "$start_time" "$total_requests" "$requests_since_last_metric" "$last_metric_time" "true"
+            exit 0
+        fi
+
+        # Execute network status test if scheduled
         if (( $(echo "$now >= $status_next" | bc -l) )); then
             test_network_status "$1"
             status_next=$(echo "$now + $status_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
+        
+        # Execute network options test if scheduled
         if (( $(echo "$now >= $options_next" | bc -l) )); then
             test_network_options "$1"
             options_next=$(echo "$now + $options_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
+        
+        # Execute block retrieval test if scheduled
         if (( $(echo "$now >= $block_next" | bc -l) )); then
-            # Pick a random block
-            local block_hash=$(pick_random "${__test_data[blocks]}")
+            local block_hash
+            block_hash=$(pick_random "${__test_data[blocks]}")
             declare -A tmp_data
             tmp_data[block]="$block_hash"
+            tmp_data[id]="${__test_data[id]}"
+            tmp_data[address]="${__test_data[address]}"
             test_block tmp_data
             block_next=$(echo "$now + $block_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
+        
+        # Execute account balance test if scheduled
         if (( $(echo "$now >= $account_balance_next" | bc -l) )); then
-            # Pick a random account
-            local account=$(pick_random "${__test_data[accounts]}")
+            local account
+            account=$(pick_random "${__test_data[accounts]}")
             declare -A tmp_data
             tmp_data[account]="$account"
             test_account_balance tmp_data
             account_balance_next=$(echo "$now + $account_balance_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
+        
+        # Execute payment transaction test if scheduled
         if (( $(echo "$now >= $payment_tx_next" | bc -l) )); then
-            # Pick a random payment transaction
-            local payment_tx=$(pick_random "${__test_data[payment_transactions]}")
+            local payment_tx
+            payment_tx=$(pick_random "${__test_data[payment_transactions]}")
             declare -A tmp_data
             tmp_data[payment_transaction]="$payment_tx"
             test_payment_transaction tmp_data
             payment_tx_next=$(echo "$now + $payment_tx_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
+        
+        # Execute zkApp transaction test if scheduled
         if (( $(echo "$now >= $zkapp_tx_next" | bc -l) )); then
-            # Pick a random zkapp transaction
-            local zkapp_tx=$(pick_random "${__test_data[zkapp_transactions]}")
+            local zkapp_tx
+            zkapp_tx=$(pick_random "${__test_data[zkapp_transactions]}")
             declare -A tmp_data
+            #shellcheck disable=SC2034
             tmp_data[zkapp_transaction]="$zkapp_tx"
             test_zkapp_transaction tmp_data
             zkapp_tx_next=$(echo "$now + $zkapp_tx_interval" | bc)
+            requests_this_iteration=$((requests_this_iteration + 1))
         fi
 
-        sleep 0.1
+        # Update request counters
+        total_requests=$((total_requests + requests_this_iteration))
+        requests_since_last_metric=$((requests_since_last_metric + requests_this_iteration))
+
+        # Print performance statistics every X seconds
+        if (( $(echo "$now - $last_metric_time >= $STATS_REPORTING_INTERVAL" | bc -l) )); then
+            print_load_test_statistics "$now" "$start_time" "$total_requests" "$requests_since_last_metric" "$last_metric_time"
+            last_metric_time=$now
+            requests_since_last_metric=0
+        fi
+
+        # Brief pause to prevent excessive CPU usage
+        sleep $sleep_time
     done
 }
 
+################################################################################
+# Main Execution
+################################################################################
+
+# Execute the load test with configured parameters
+# This starts the main load testing loop using all configured intervals
+# and test data loaded from the database.
 run_all_tests_custom_intervals load "$STATUS_INTERVAL" "$OPTIONS_INTERVAL" "$BLOCK_INTERVAL" "$ACCOUNT_BALANCE_INTERVAL" "$PAYMENT_TX_INTERVAL" "$ZKAPP_TX_INTERVAL"

--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -9,14 +9,19 @@ source "$(dirname "$0")/rosetta-helper.sh"
 # ./rosetta-load.sh mainnet 2 5 10 15 20 25
 # (network, status_interval, options_interval, block_interval, account_balance_interval, payment_tx_interval, zkapp_tx_interval)
 
-NETWORK="${1:-mainnet}"
-ADDRESS="${2:-http://rosetta-mainnet.gcp.o1test.net}"
-STATUS_INTERVAL="${2:-2}"
-OPTIONS_INTERVAL="${3:-5}"
-BLOCK_INTERVAL="${4:-10}"
-ACCOUNT_BALANCE_INTERVAL="${5:-15}"
-PAYMENT_TX_INTERVAL="${6:-20}"
-ZKAPP_TX_INTERVAL="${7:-25}"
+NETWORK="mainnet"
+ADDRESS="http://rosetta-mainnet.gcp.o1test.net"
+DB_CONN_STR="postgresql://user:password@localhost/mina"
+STATUS_INTERVAL="2"
+OPTIONS_INTERVAL="5"
+BLOCK_INTERVAL="10"
+ACCOUNT_BALANCE_INTERVAL="15"
+PAYMENT_TX_INTERVAL="20"
+ZKAPP_TX_INTERVAL="25"
+
+function usage() {
+    echo "Usage: $0 [--network mainnet|devnet] [--address <address>] [--db-conn-str <conn_str>] [--status-interval N] [--options-interval N] [--block-interval N] [--account-balance-interval N] [--payment-tx-interval N] [--zkapp-tx-interval N]"
+}
 
 # Argument parsing
 while [[ $# -gt 0 ]]; do
@@ -58,14 +63,21 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--network mainnet|devnet] [--address <address>] [--db-conn-str <conn_str>] [--status-interval N] [--options-interval N] [--block-interval N] [--account-balance-interval N] [--payment-tx-interval N] [--zkapp-tx-interval N]"
+            usage
             exit 0
             ;;
         *)
-            break
+            echo "Unknown option: $1"
+            usage
+            exit 1
             ;;
     esac
 done
+
+echo "Running Rosetta load tests with the following parameters:"
+echo "  Network: $NETWORK"
+echo "  Address: $ADDRESS"
+echo "  DB Connection String: $DB_CONN_STR" 
 
 declare -A load
 export load
@@ -97,10 +109,6 @@ function load_zkapp_transactions_from_db() {
     load_from_db "$1" "SELECT hash FROM zkapp_commands LIMIT 100;" "zkapp_transactions"
 }
 
-
-
-# Example connection string, adjust as needed
-DB_CONN_STR="postgresql://user:password@localhost/mina"
 
 load_blocks_from_db "$DB_CONN_STR" "blocks"
 load_accounts_from_db "$DB_CONN_STR" "accounts"

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -70,17 +70,6 @@ function run_tests_with_test_data() {
     echo "🎉  All tests passed successfully!"
 }
 
-if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
-    if [[ "$NETWORK" == "mainnet" ]]; then
-        wait_for_sync "mainnet"
-    elif [[ "$NETWORK" == "devnet" ]]; then
-        wait_for_sync "devnet"
-    else
-        echo "Unknown network: $NETWORK. available networks: mainnet, devnet. Exiting..."
-        exit 1
-    fi
-fi
-
 if [[ "$NETWORK" == "mainnet" ]]; then
     if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
         echo "⏳  Waiting for Rosetta to sync on mainnet..."

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -1,5 +1,46 @@
 #!/bin/bash
 
+# Rosetta Sanity Test Script
+#
+# This script performs comprehensive sanity tests on Mina Protocol's Rosetta API endpoints
+# for both mainnet and devnet networks. It validates core functionality including network
+# status, block retrieval, account balances, and transaction searches.
+#
+# USAGE:
+#   ./rosetta-sanity.sh [OPTIONS]
+#
+# OPTIONS:
+#   --network <mainnet|devnet>    Specify the network to test (default: mainnet)
+#   --wait-for-sync               Wait for Rosetta node to sync before running tests
+#   --timeout <seconds>           Timeout for sync wait in seconds (default: 900)
+#   --address <url>               Override the default Rosetta endpoint address
+#   -h, --help                    Display this help message
+#
+# EXAMPLES:
+#   ./rosetta-sanity.sh --network mainnet
+#   ./rosetta-sanity.sh --network devnet --wait-for-sync --timeout 1200
+#   ./rosetta-sanity.sh --address http://localhost:3087 --network mainnet
+#
+# TEST COVERAGE:
+#   1. Network status endpoint validation
+#   2. Network options endpoint validation  
+#   3. Block retrieval functionality
+#   4. Account balance queries
+#   5. Payment transaction searches
+#   6. zkApp transaction searches
+#
+# DEPENDENCIES:
+#   - rosetta-helper.sh (must be in the same directory)
+#   - curl (for API requests)
+#   - jq (for JSON processing)
+#
+# EXIT CODES:
+#   0 - All tests passed successfully
+#   1 - Test failure or invalid parameters
+#
+# AUTHOR: Mina Protocol Team
+# VERSION: 1.0
+
 NETWORK="mainnet"
 WAIT_FOR_SYNC=false
 TIMEOUT=900

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -82,8 +82,16 @@ if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
 fi
 
 if [[ "$NETWORK" == "mainnet" ]]; then
+    if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
+        echo "⏳  Waiting for Rosetta to sync on mainnet..."
+        wait_for_sync "mainnet" "$TIMEOUT"
+    fi
     run_tests_with_test_data "mainnet"
 elif [[ "$NETWORK" == "devnet" ]]; then
+    if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
+        echo "⏳  Waiting for Rosetta to sync on mainnet..."
+        wait_for_sync "mainnet" "$TIMEOUT"
+    fi
     run_tests_with_test_data "devnet"
 else
     echo "Unknown network: $NETWORK. available networks: mainnet, devnet. Exiting..."

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -73,13 +73,19 @@ function run_tests_with_test_data() {
 if [[ "$NETWORK" == "mainnet" ]]; then
     if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
         echo "⏳  Waiting for Rosetta to sync on mainnet..."
-        wait_for_sync "mainnet" "$TIMEOUT"
+        if ! wait_for_sync "mainnet" "$TIMEOUT"; then
+            echo "❌  Failed to sync with mainnet within timeout period"
+            exit 1
+        fi
     fi
     run_tests_with_test_data "mainnet"
 elif [[ "$NETWORK" == "devnet" ]]; then
     if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
-        echo "⏳  Waiting for Rosetta to sync on mainnet..."
-        wait_for_sync "mainnet" "$TIMEOUT"
+        echo "⏳  Waiting for Rosetta to sync on devnet..."
+        if ! wait_for_sync "devnet" "$TIMEOUT"; then
+            echo "❌  Failed to sync with devnet within timeout period"
+            exit 1
+        fi
     fi
     run_tests_with_test_data "devnet"
 else

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -50,22 +50,22 @@ function run_tests_with_test_data() {
     echo ""
     
     echo "🧪  1/6 Testing network/status endpoint"
-    test_network_status "$1"
+    test_network_status "$1" || exit $?
 
     echo "🧪  2/6 Testing network/options endpoint"
-    test_network_options "$1"
+    test_network_options "$1" || exit $?
 
     echo "🧪  3/6 Testing block endpoint"
-    test_block "$1"
+    test_block "$1" || exit $?
 
     echo "🧪  4/6 Testing account/balance endpoint for account"
-    test_account_balance "$1"
+    test_account_balance "$1" || exit $?
 
     echo "🧪  5/6 Testing search/transactions endpoint for payment transaction"
-    test_payment_transaction "$1"
+    test_payment_transaction "$1" || exit $?
 
     echo "🧪  6/6 Testing search/transactions endpoint for zkapp transaction"
-    test_zkapp_transaction "$1"
+    test_zkapp_transaction "$1" || exit $?
 
     echo "🎉  All tests passed successfully!"
 }


### PR DESCRIPTION
Extended rosetta sanity tests by adding optional load test for rosetta which takes 10 minutes (but its duration can be configured).

Load tests in order to gain sufficient randomness need quite many blocks/zkapps etc. So my idea was to use already synced rosetta with filled archive database. If we would like to run load test as a separate test we would need to sync it again, loosing CI time. At this moment we don't have assertion yet on memory consumption etc. We might want to add assertion on memory consumption on postgres database


Currently there is no assertion on memory consumption as we have still have memory leak. We can either wait for fix and add assertion, or let test failing. Alternatively we an set a very big threshold (~4 gb) 
