### PR TITLE
Archive load genesis test

### DIFF
--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -1,87 +1,5 @@
-open Async
 open Core
-open Mina_automation
 open Mina_automation_runner
-open Mina_automation_fixture.Archive
-
-(**
- * Test the basic functionality of the mina archive with mocked deamon
- *)
-
-(* asserts count of archive blocked (we are skipping genesis block) *)
-let assert_archived_blocks ~archive_uri ~expected =
-  let connection = Psql.Conn_str archive_uri in
-  let%bind actual_blocks_count =
-    Psql.run_command ~connection
-      "SELECT COUNT(*) FROM blocks WHERE global_slot_since_genesis > 1"
-  in
-  let actual_blocks_count =
-    match actual_blocks_count with
-    | Ok count ->
-        count |> Int.of_string
-    | Error err ->
-        failwith ("Failed to query blocks count: " ^ Error.to_string_hum err)
-  in
-  if Int.( <> ) actual_blocks_count expected then
-    failwithf "Invalid number of archive blocks. Actual (%d) vs Expected (%d)"
-      actual_blocks_count expected ()
-  else Deferred.unit
-
-module ArchivePrecomputedBlocksFromDaemon = struct
-  type t = Mina_automation_fixture.Archive.after_bootstrap
-
-  let test_case (test_data : t) =
-    let open Deferred.Let_syntax in
-    let daemon = Daemon.default in
-    let archive_uri = test_data.archive.config.postgres_uri in
-    let output = test_data.temp_dir in
-    let%bind precomputed_blocks =
-      Network_data.untar_precomputed_blocks test_data.network_data output
-    in
-    let precomputed_blocks =
-      List.map precomputed_blocks ~f:(fun file -> output ^ "/" ^ file)
-      |> List.filter ~f:(fun file -> String.is_suffix file ~suffix:".json")
-    in
-    Archive.Process.start_logging test_data.archive ;
-    let%bind () =
-      Daemon.archive_blocks_from_files daemon
-        ~archive_address:test_data.archive.config.server_port
-        ~format:Archive_blocks.Precomputed precomputed_blocks
-    in
-
-    let%bind () =
-      assert_archived_blocks ~archive_uri
-        ~expected:(List.length precomputed_blocks)
-    in
-    let connection = Psql.Conn_str archive_uri in
-    let%bind latest_state_hash =
-      Psql.run_command ~connection
-        "SELECT state_hash FROM blocks ORDER BY id DESC LIMIT 1"
-    in
-    let latest_state_hash =
-      match latest_state_hash with
-      | Ok hash ->
-          hash
-      | Error err ->
-          failwith
-            ("Failed to query latest state hash: " ^ Error.to_string_hum err)
-    in
-    let output_ledger = output ^ "/output_ledger.json" in
-    let replayer = Replayer.default in
-    let%bind replayer_output =
-      Replayer.run replayer ~archive_uri
-        ~input_config:
-          (Network_data.replayer_input_file_path test_data.network_data)
-        ~target_state_hash:latest_state_hash ~interval_checkpoint:10
-        ~output_ledger ()
-    in
-    let () = print_endline replayer_output in
-    let output_ledger = Replayer.Output.of_json_file_exn output_ledger in
-    assert (
-      String.equal output_ledger.target_epoch_ledgers_state_hash
-        latest_state_hash ) ;
-    Deferred.Or_error.return Mina_automation_fixture.Intf.Passed
-end
 
 let () =
   Backtrace.elide := false ;
@@ -94,6 +12,13 @@ let () =
       , [ test_case "The mina daemon works in background mode" `Quick
             (Runner.run_blocking
                ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
-                          (ArchivePrecomputedBlocksFromDaemon) ) )
+                          (Archive_precomputed_blocks_test) ) )
+        ] )
+    ; ( "genesis_load"
+      , [ test_case "Load mainnet genesis ledger without memory leak" `Quick
+            (Runner.run_blocking
+               ( module Mina_automation_fixture.Archive
+                        .Make_FixtureWithoutBootstrap
+                          (Load_genesis_ledger) ) )
         ] )
     ]

--- a/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
+++ b/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
@@ -1,0 +1,80 @@
+open Async
+open Core
+open Mina_automation
+open Mina_automation_fixture.Archive
+
+(**
+ * Test the basic functionality of the mina archive with mocked deamon
+ *)
+
+(* asserts count of archive blocked (we are skipping genesis block) *)
+let assert_archived_blocks ~archive_uri ~expected =
+  let connection = Psql.Conn_str archive_uri in
+  let%bind actual_blocks_count =
+    Psql.run_command ~connection
+      "SELECT COUNT(*) FROM blocks WHERE global_slot_since_genesis > 1"
+  in
+  let actual_blocks_count =
+    match actual_blocks_count with
+    | Ok count ->
+        count |> Int.of_string
+    | Error err ->
+        failwith ("Failed to query blocks count: " ^ Error.to_string_hum err)
+  in
+  if Int.( <> ) actual_blocks_count expected then
+    failwithf "Invalid number of archive blocks. Actual (%d) vs Expected (%d)"
+      actual_blocks_count expected ()
+  else Deferred.unit
+
+type t = Mina_automation_fixture.Archive.after_bootstrap
+
+let test_case (test_data : t) =
+  let open Deferred.Let_syntax in
+  let daemon = Daemon.default in
+  let archive_uri = test_data.archive.config.postgres_uri in
+  let output = test_data.temp_dir in
+  let%bind precomputed_blocks =
+    Network_data.untar_precomputed_blocks test_data.network_data output
+  in
+  let precomputed_blocks =
+    List.map precomputed_blocks ~f:(fun file -> output ^ "/" ^ file)
+    |> List.filter ~f:(fun file -> String.is_suffix file ~suffix:".json")
+  in
+  Archive.Process.start_logging test_data.archive ;
+  let%bind () =
+    Daemon.archive_blocks_from_files daemon
+      ~archive_address:test_data.archive.config.server_port
+      ~format:Archive_blocks.Precomputed precomputed_blocks
+  in
+
+  let%bind () =
+    assert_archived_blocks ~archive_uri
+      ~expected:(List.length precomputed_blocks)
+  in
+  let connection = Psql.Conn_str archive_uri in
+  let%bind latest_state_hash =
+    Psql.run_command ~connection
+      "SELECT state_hash FROM blocks ORDER BY id DESC LIMIT 1"
+  in
+  let latest_state_hash =
+    match latest_state_hash with
+    | Ok hash ->
+        hash
+    | Error err ->
+        failwith
+          ("Failed to query latest state hash: " ^ Error.to_string_hum err)
+  in
+  let output_ledger = output ^ "/output_ledger.json" in
+  let replayer = Replayer.default in
+  let%bind replayer_output =
+    Replayer.run replayer ~archive_uri
+      ~input_config:
+        (Network_data.replayer_input_file_path test_data.network_data)
+      ~target_state_hash:latest_state_hash ~interval_checkpoint:10
+      ~output_ledger ()
+  in
+  let () = print_endline replayer_output in
+  let output_ledger = Replayer.Output.of_json_file_exn output_ledger in
+  assert (
+    String.equal output_ledger.target_epoch_ledgers_state_hash latest_state_hash ) ;
+  Deferred.Or_error.return Mina_automation_fixture.Intf.Passed

--- a/src/test/archive/archive_node_tests/dune
+++ b/src/test/archive/archive_node_tests/dune
@@ -17,5 +17,5 @@
    mina_automation.runner
  )
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_jane ppx_compare))
+ (preprocess (pps ppx_version ppx_jane ppx_mina ppx_compare))
 )

--- a/src/test/archive/archive_node_tests/load_genesis_ledger.ml
+++ b/src/test/archive/archive_node_tests/load_genesis_ledger.ml
@@ -1,0 +1,112 @@
+open Async
+open Core
+open Mina_automation
+open Mina_automation_fixture.Archive
+
+(**
+  Test file for memory leak detection in archive process.
+  
+  This test is designed to identify potential memory leaks that occur during
+  the archive process, specifically focusing on session cleanup issues with
+  PostgreSQL connections. The memory leak manifests as sessions not being
+  properly cleaned up, leading to an abrupt increase in PostgreSQL memory
+  consumption over time.
+  
+  The test validates that:
+  - Archive operations properly release database sessions
+  - PostgreSQL memory usage remains stable during archive cycles
+*)
+
+type t = Mina_automation_fixture.Archive.before_bootstrap
+
+let postgres_process_name = "postgres"
+
+let check_postgres_memory_increase_is_below_threshold logger threshold time_interval
+    previous_postgres_memory =
+  let%bind current_memory =
+    Utils.get_memory_usage_mb_of_process_family postgres_process_name
+  in
+  let increase = Float.( - ) current_memory !previous_postgres_memory in
+  if Float.( > ) increase threshold then
+    failwith
+      (Printf.sprintf
+         "Postgres memory increased by more than %s MB in the last %s seconds"
+         (Float.to_string threshold)
+         (Time.Span.to_string time_interval) )
+  else (
+    previous_postgres_memory := current_memory ;
+    [%log info] "Postgres Memory usage: %s MB" (Float.to_string current_memory) ;
+    Deferred.return () )
+
+let test_case (test_data : t) =
+  let open Deferred.Let_syntax in
+  let config =
+    { test_data.config with config_file = "genesis_ledgers/mainnet.json" }
+  in
+  let logger = Logger.create () in
+  let%bind process = Archive.of_config config |> Archive.start in
+  Archive.Process.start_logging process ;
+
+  let max_postgres_memory = 4000.0 in
+  let sleep_duration = Time.Span.of_sec 10.0 in
+  let max_archive_memory = 1000.0 in
+  let postgres_memory_increase_threshold = 500.0 in
+
+  (* Set the duration for the archive process *)
+  let duration = Time.Span.of_min 10.0 in
+
+  let%bind previous_postgres_memory =
+    Utils.get_memory_usage_mb_of_process_family postgres_process_name
+  in
+  let previous_postgres_memory = ref previous_postgres_memory in
+
+  [%log info] "Initial Postgres Memory usage: %s MB"
+    (Float.to_string !previous_postgres_memory) ;
+  [%log info] "Max Archive Memory: %s MB" (Float.to_string max_archive_memory) ;
+  [%log info] "Max Postgres Memory: %s MB" (Float.to_string max_postgres_memory) ;
+  [%log info] "Postgres Memory Increase Threshold: %s MB"
+    (Float.to_string postgres_memory_increase_threshold) ;
+  [%log info] "Sleep Duration: %s" (Time.Span.to_string sleep_duration) ;
+
+  let%bind result =
+    let end_time = Time.add (Time.now ()) duration in
+    let rec loop () =
+      if Time.is_later (Time.now ()) ~than:end_time then Deferred.return ()
+      else
+        let memory = Archive.Process.get_memory_usage_mb process in
+        let%bind () =
+          match memory with
+          | Some mem ->
+              [%log info] "Archive Memory usage: %s MB" (Float.to_string mem) ;
+              if Float.( > ) mem max_archive_memory then
+                failwith "Archive process memory exceeds 1GB"
+              else Deferred.return ()
+          | None ->
+              failwith "Error getting memory usage for archive process"
+        in
+        let%bind memory =
+          Utils.get_memory_usage_mb_of_process_family "postgres"
+        in
+        let%bind () =
+          check_postgres_memory_increase_is_below_threshold
+            logger
+            postgres_memory_increase_threshold sleep_duration
+            previous_postgres_memory
+        in
+        [%log info] "Postgres Memory usage: %s MB" (Float.to_string memory) ;
+        if Float.( > ) memory max_postgres_memory then
+          failwith "Postgres memory exceeds 4GB" ;
+        let%bind () = Clock.after sleep_duration in
+        loop ()
+    in
+    Monitor.try_with (fun () -> loop ())
+    >>= function
+    | Ok () ->
+        Deferred.return Mina_automation_fixture.Intf.Passed
+    | Error exn ->
+        [%log error] "Test failed: %s" (Exn.to_string exn) ;
+        Deferred.return
+        @@ Mina_automation_fixture.Intf.Failed (Exn.to_string exn)
+  in
+
+  Deferred.Or_error.return result

--- a/src/test/mina_automation/archive.ml
+++ b/src/test/mina_automation/archive.ml
@@ -68,6 +68,9 @@ module Process = struct
            return
            @@ [%log debug] "Archive stdout: $stdout"
                 ~metadata:[ ("stdout", `String stdout) ] )
+
+  let get_memory_usage_mb t =
+    Utils.get_memory_usage_mb @@ (Process.pid t.process |> Pid.to_int)
 end
 
 (** [start t] starts the archive process using the given configuration [t].

--- a/src/test/mina_automation/runner/runner.ml
+++ b/src/test/mina_automation/runner/runner.ml
@@ -28,7 +28,13 @@ let run (module F : Intf.Fixture) =
           Intf.Failed (Error.to_string_hum err) )
 
 let run_blocking test_case () =
-  let (_ : Intf.test_result) =
+  let (result : Intf.test_result) =
     Async.Thread_safe.block_on_async_exn (fun () -> run test_case)
   in
-  ()
+  match result with
+  | Intf.Passed ->
+      ()
+  | Intf.Warning msg ->
+      Alcotest.fail msg
+  | Intf.Failed msg ->
+      Alcotest.fail msg

--- a/src/test/mina_automation/utils.ml
+++ b/src/test/mina_automation/utils.ml
@@ -30,3 +30,53 @@ let dedup_and_sort_archive_files files : string list =
 let force_kill process =
   Process.send_signal process Core.Signal.kill ;
   Deferred.map (Process.wait process) ~f:Or_error.return
+
+(** [get_memory_usage_mb pid] retrieves the memory usage in megabytes for the process
+  with the given [pid].
+  
+  This function reads the process memory information from [/proc/pid/statm] and
+  extracts the resident set size (RSS) in pages. It then converts this value to
+  megabytes by multiplying by the page size (4096 bytes) and dividing by 1024^2.
+  
+  @param pid The process ID to query memory usage for
+  @return [Some mb] where [mb] is the memory usage in megabytes if successful,
+      [None] if the process doesn't exist or if there's an error reading
+      the memory information *)
+let get_memory_usage_mb pid =
+  let filename = Printf.sprintf "/proc/%d/statm" pid in
+  try
+    let line = In_channel.read_all filename |> String.strip in
+    match String.split ~on:' ' line with
+    | _ :: resident :: _ ->
+        let resident_pages = Int64.of_string resident in
+        let page_size = Int64.of_int 4096 in
+        let bytes = Int64.( * ) resident_pages page_size in
+        let mb = Int64.(to_float bytes /. 1024.0 /. 1024.0) in
+        Some mb
+    | _ ->
+        None
+  with _ -> None
+
+(** [get_memory_usage_mb_of_process_family process_name] returns the total memory usage
+  in megabytes for all processes belonging to the specified user [process_name].
+  
+  This function executes the 'ps' command to retrieve RSS (Resident Set Size) values
+  for all processes owned by the given user, sums them up, and converts the result
+  from kilobytes to megabytes.
+  
+  @param process_name The username whose processes' memory usage should be calculated
+  @return A deferred float representing the total memory usage in megabytes
+  
+  @raise If the 'ps' command fails to execute, an exception will be raised by [Util.run_cmd_exn] *)
+let get_memory_usage_mb_of_process_family process_name =
+  let%bind output =
+    Util.run_cmd_exn "." "ps" [ "-u"; process_name; "-o"; "rss=" ]
+  in
+  let lines = String.split_lines output in
+  let memory_usages =
+    List.filter_map lines ~f:(fun line ->
+        try Some (String.strip line |> Int.of_string) with _ -> None )
+  in
+  let total_memory = List.fold memory_usages ~init:0 ~f:( + ) in
+  let total_memory_mb = Float.of_int total_memory /. 1024.0 in
+  Deferred.return total_memory_mb


### PR DESCRIPTION
Simple test which verifies lack of memory leak in archive node while loading large genesis ledger. 

Issue manifest in abrupt increase of postgres memory as well as excesive amount of RAM used by postgres process.

Currently test should fail as memory leak will be present until we merge caqti upgrade