### PR TITLE
Support suffix for archive in CI publisher

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -1290,7 +1290,7 @@ function verify(){
                                     echo "     📋  Verifying: $artifact debian on $__channel channel with $__version version for $__codename codename"
                                     
                                     prefix_cmd "$SUBCOMMAND_TAB" $SCRIPTPATH/../../../scripts/debian/verify.sh \
-                                        -p $artifact \
+                                        -p $__artifact_full_name \
                                         --version $__version \
                                         -m $__codename \
                                         -r $__debian_repo \

--- a/buildkite/src/Command/Packages/Publish.dhall
+++ b/buildkite/src/Command/Packages/Publish.dhall
@@ -143,6 +143,13 @@ let publish
 
           let indexedAdditionalTags = Prelude.List.indexed Text additional_tags
 
+          let signedArg =
+                      if DebianRepo.isSigned spec.debian_repo
+
+                then  "--signed-debian-repo "
+
+                else  ""
+
           in    [ Command.build
                     Command.Config::{
                     , commands =
@@ -172,8 +179,22 @@ let publish
                                 ++  "--debian-repo ${DebianRepo.bucket_or_default
                                                        spec.debian_repo} "
                                 ++  "--only-debians "
-                                ++  "--verify "
                                 ++  "${keyArg}"
+                              )
+                          ]
+                        # [ Cmd.run
+                              (     ". ./buildkite/scripts/export-git-env-vars.sh && "
+                                ++  "./buildkite/scripts/release/manager.sh verify "
+                                ++  "--artifacts ${artifacts} "
+                                ++  "--networks ${networks} "
+                                ++  "--channel ${DebianChannel.lowerName
+                                                   spec.channel} "
+                                ++  "--version ${target_version} "
+                                ++  "--codenames ${codenames} "
+                                ++  "--debian-repo ${DebianRepo.bucket_or_default
+                                                       spec.debian_repo} "
+                                ++  "--only-debians "
+                                ++  "${signedArg}"
                               )
                           ]
                     , label = "Debian Packages Publishing"

--- a/buildkite/src/Command/Packages/Publish.dhall
+++ b/buildkite/src/Command/Packages/Publish.dhall
@@ -143,13 +143,6 @@ let publish
 
           let indexedAdditionalTags = Prelude.List.indexed Text additional_tags
 
-          let signedArg =
-                      if DebianRepo.isSigned spec.debian_repo
-
-                then  "--signed-debian-repo "
-
-                else  ""
-
           in    [ Command.build
                     Command.Config::{
                     , commands =
@@ -179,22 +172,8 @@ let publish
                                 ++  "--debian-repo ${DebianRepo.bucket_or_default
                                                        spec.debian_repo} "
                                 ++  "--only-debians "
+                                ++  "--verify "
                                 ++  "${keyArg}"
-                              )
-                          ]
-                        # [ Cmd.run
-                              (     ". ./buildkite/scripts/export-git-env-vars.sh && "
-                                ++  "./buildkite/scripts/release/manager.sh verify "
-                                ++  "--artifacts ${artifacts} "
-                                ++  "--networks ${networks} "
-                                ++  "--channel ${DebianChannel.lowerName
-                                                   spec.channel} "
-                                ++  "--version ${target_version} "
-                                ++  "--codenames ${codenames} "
-                                ++  "--debian-repo ${DebianRepo.bucket_or_default
-                                                       spec.debian_repo} "
-                                ++  "--only-debians "
-                                ++  "${signedArg}"
                               )
                           ]
                     , label = "Debian Packages Publishing"

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -47,9 +47,7 @@ let targetVersion =
       ->  \(commit : Text)
       ->  \(latestGitTag : Text)
       ->  \(todayDate : Text)
-      ->  "${latestGitTag}-${todayDate}-${DebianVersions.lowerName
-                                            codename}-${DebianChannel.lowerName
-                                                          channel}"
+      ->  "${latestGitTag}-${todayDate}"
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
Small patch for CI publisher. When veryfing if debian is pushed correctly we omit suffix which is causing that  debian cannot be found.

I also joined publish and verify commands for debian, since there is no point in separating them like for dockers