### PR TITLE
[CI] support bookworm and noble in publishing

### DIFF
--- a/buildkite/Makefile
+++ b/buildkite/Makefile
@@ -20,6 +20,8 @@ check_filter:
 	# Ensure Jobs.dhall is generated before proceeding
 	(cd ../ && ./buildkite/scripts/generate-jobs.sh > ./buildkite/src/gen/Jobs.dhall)
 	python3 ./unit-tests/parse_triage.py
+	# Clean up
+	git checkout -- ./src/gen/Jobs.dhall
 	
 dump_pipelines:
 	$(eval TMP := $(shell mktemp -d))

--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -1269,7 +1269,6 @@ function verify(){
                                         -m $__codename \
                                         -r $__debian_repo \
                                         -c $__channel \
-                                        -s "$__docker_suffix" \
                                         ${__signed_debian_repo:+--signed}
                             fi
 

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -57,8 +57,8 @@ in  Pipeline.build
         , dirtyWhen = [ S.everything ]
         , path = "Promote"
         , tags = [ PipelineTag.Type.Promote, PipelineTag.Type.TearDown ]
-        , name = "AutoPromoteNightly"
         , scope = [ PipelineScope.Type.MainlineNightly ]
+        , name = "AutoPromoteNightly"
         }
       , steps =
           PublishPackages.publish

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -57,8 +57,8 @@ in  Pipeline.build
         , dirtyWhen = [ S.everything ]
         , path = "Promote"
         , tags = [ PipelineTag.Type.Promote, PipelineTag.Type.TearDown ]
-        , scope = [ PipelineScope.Type.MainlineNightly ]
         , name = "AutoPromoteNightly"
+        , scope = [ PipelineScope.Type.MainlineNightly ]
         }
       , steps =
           PublishPackages.publish

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -64,7 +64,8 @@ in  Pipeline.build
           PublishPackages.publish
             PublishPackages.Spec::{
             , artifacts =
-              [ Artifacts.Type.Daemon
+              [ Artifacts.Type.LogProc
+              , Artifacts.Type.Daemon
               , Artifacts.Type.Archive
               , Artifacts.Type.Rosetta
               ]

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -73,6 +73,8 @@ in  Pipeline.build
             , codenames =
               [ DebianVersions.DebVersion.Bullseye
               , DebianVersions.DebVersion.Focal
+              , DebianVersions.DebVersion.Bookworm
+              , DebianVersions.DebVersion.Noble
               ]
             , debian_repo = DebianRepo.Type.Nightly
             , channel = DebianChannel.Type.Compatible

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -69,7 +69,7 @@ case $PACKAGE in
 esac
 
 if [[ "$SIGNED" == 1 ]]; then
-  SIGNED=" (wget -q https://'$REPO'/repo-signing-key.asc -O- | apt-key add) && apt-get update > /dev/null && "
+  SIGNED=" (wget -q https://'$REPO'/repo-signing-key.asc -O /etc/apt/trusted.gpg.d/minaprotocol-nightly.asc ) && apt-get update > /dev/null && "
 else 
   SIGNED=""
 fi

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -69,7 +69,7 @@ case $PACKAGE in
 esac
 
 if [[ "$SIGNED" == 1 ]]; then
-  SIGNED=" (wget -q https://'$REPO'/repo-signing-key.asc -O /etc/apt/trusted.gpg.d/minaprotocol-nightly.asc ) && apt-get update > /dev/null && "
+  SIGNED=" (wget -q https://'$REPO'/repo-signing-key.gpg -O /etc/apt/trusted.gpg.d/minaprotocol.gpg ) && apt-get update > /dev/null && "
 else 
   SIGNED=""
 fi


### PR DESCRIPTION
Added bookworm and noble debians or nightly publishing. 


Also fixed warning when dealing with repo public key: 

```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```
