### PR TITLE
use Integration agent size instead of small for hardfork test

### DIFF
--- a/buildkite/src/Jobs/Test/HFTest.dhall
+++ b/buildkite/src/Jobs/Test/HFTest.dhall
@@ -57,7 +57,7 @@ in  Pipeline.build
               ]
             , label = "hard fork test"
             , key = "hard-fork-test"
-            , target = Size.Small
+            , target = Size.Integration
             , soft_fail = Some (B/SoftFail.Boolean True)
             , docker = None Docker.Type
             , timeout_in_minutes = Some +420


### PR DESCRIPTION
This pull request includes a single change to the `Pipeline.build` configuration in the `buildkite/src/Jobs/Test/HFTest.dhall` file. The `target` parameter has been updated from `Size.Small` to `Size.Integration`, use more powerful agent as test suffer with some instabilities 