### PR TITLE
Add With_database functor to converting merkle tree

### DIFF
--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -42,9 +42,9 @@ end)
        and type account_id := Inputs.Account_id.t
        and type account_id_set := Inputs.Account_id.Set.t
 
-  val create : Primary_ledger.t -> Converting_ledger.t -> t
+  val of_ledgers : Primary_ledger.t -> Converting_ledger.t -> t
 
-  val create_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
+  val of_ledgers_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
 
   val primary_ledger : t -> Primary_ledger.t
 
@@ -67,10 +67,10 @@ end = struct
     ; converting_ledger : Converting_ledger.t
     }
 
-  let create primary_ledger converting_ledger =
+  let of_ledgers primary_ledger converting_ledger =
     { primary_ledger; converting_ledger }
 
-  let create_with_migration primary_ledger converting_ledger =
+  let of_ledgers_with_migration primary_ledger converting_ledger =
     assert (Converting_ledger.num_accounts converting_ledger = 0) ;
     let accounts =
       Primary_ledger.foldi primary_ledger ~init:[] ~f:(fun addr acc account ->
@@ -211,4 +211,118 @@ end = struct
     Primary_ledger.get_hash_batch_exn t.primary_ledger locations
 
   let detached_signal t = Primary_ledger.detached_signal t.primary_ledger
+end
+
+module With_database (Inputs : sig
+  include Intf.Inputs.Intf
+
+  type converted_account
+
+  val convert : Account.t -> converted_account
+
+  val converted_equal : converted_account -> converted_account -> bool
+end)
+(Primary_db : Intf.Ledger.DATABASE
+                with module Location = Inputs.Location
+                 and module Addr = Inputs.Location.Addr
+                 and type key := Inputs.Key.t
+                 and type token_id := Inputs.Token_id.t
+                 and type token_id_set := Inputs.Token_id.Set.t
+                 and type account := Inputs.Account.t
+                 and type root_hash := Inputs.Hash.t
+                 and type hash := Inputs.Hash.t
+                 and type account_id := Inputs.Account_id.t
+                 and type account_id_set := Inputs.Account_id.Set.t)
+(Converting_db : Intf.Ledger.DATABASE
+                   with module Location = Inputs.Location
+                    and module Addr = Inputs.Location.Addr
+                    and type key := Inputs.Key.t
+                    and type token_id := Inputs.Token_id.t
+                    and type token_id_set := Inputs.Token_id.Set.t
+                    and type account := Inputs.converted_account
+                    and type root_hash := Inputs.Hash.t
+                    and type hash := Inputs.Hash.t
+                    and type account_id := Inputs.Account_id.t
+                    and type account_id_set := Inputs.Account_id.Set.t) =
+struct
+  include Make (Inputs) (Primary_db) (Converting_db)
+
+  module Config = struct
+    type 'a config = { primary_directory : string; converting_directory : 'a }
+
+    type create = Temporary | In_directories of string option config
+
+    type checkpoint = string config
+
+    let default_converting_directory_name primary_directory_name =
+      primary_directory_name ^ "_converting"
+
+    let with_primary ~directory_name =
+      { primary_directory = directory_name
+      ; converting_directory = default_converting_directory_name directory_name
+      }
+  end
+
+  let dbs_synced db1 db2 =
+    Primary_db.num_accounts db1 = Converting_db.num_accounts db2
+    &&
+    let is_synced = ref true in
+    Primary_db.iteri db1 ~f:(fun idx stable_account ->
+        let expected_unstable_account = convert stable_account in
+        let actual_unstable_account = Converting_db.get_at_index_exn db2 idx in
+        if
+          not
+            (Inputs.converted_equal expected_unstable_account
+               actual_unstable_account )
+        then is_synced := false ) ;
+    !is_synced
+
+  let create ~config ~logger ~depth () =
+    let primary_directory_name, converting_directory_name =
+      match config with
+      | Config.Temporary ->
+          (None, None)
+      | In_directories { primary_directory; converting_directory } ->
+          (Some primary_directory, converting_directory)
+    in
+    let db1 =
+      Primary_db.create ?directory_name:primary_directory_name ~depth ()
+    in
+    let db2_directory_name =
+      Option.first_some converting_directory_name
+      @@ Option.map
+           (Primary_db.get_directory db1)
+           ~f:Config.default_converting_directory_name
+    in
+    let db2 =
+      Converting_db.create ?directory_name:db2_directory_name ~depth ()
+    in
+    if Converting_db.num_accounts db2 = 0 then of_ledgers_with_migration db1 db2
+    else if dbs_synced db1 db2 then of_ledgers db1 db2
+    else (
+      [%log warn]
+        "Migrating DB desync, cleaning up unstable DB and remigrating..." ;
+      Converting_db.close db2 ;
+      let db2 =
+        Converting_db.create ?directory_name:db2_directory_name ~fresh:true
+          ~depth ()
+      in
+      of_ledgers_with_migration db1 db2 )
+
+  let create_checkpoint t ~config () =
+    let primary' =
+      Primary_db.create_checkpoint (primary_ledger t)
+        ~directory_name:config.Config.primary_directory ()
+    in
+    let converting' =
+      Converting_db.create_checkpoint (converting_ledger t)
+        ~directory_name:config.converting_directory ()
+    in
+    of_ledgers primary' converting'
+
+  let make_checkpoint t ~config =
+    Primary_db.make_checkpoint (primary_ledger t)
+      ~directory_name:config.Config.primary_directory ;
+    Converting_db.make_checkpoint (converting_ledger t)
+      ~directory_name:config.converting_directory
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -248,11 +248,9 @@ struct
   include Make (Inputs) (Primary_db) (Converting_db)
 
   module Config = struct
-    type 'a config = { primary_directory : string; converting_directory : 'a }
+    type t = { primary_directory : string; converting_directory : string }
 
-    type create = Temporary | In_directories of string option config
-
-    type checkpoint = string config
+    type create = Temporary | In_directories of t
 
     let default_converting_directory_name primary_directory_name =
       primary_directory_name ^ "_converting"
@@ -283,7 +281,7 @@ struct
       | Config.Temporary ->
           (None, None)
       | In_directories { primary_directory; converting_directory } ->
-          (Some primary_directory, converting_directory)
+          (Some primary_directory, Some converting_directory)
     in
     let db1 =
       Primary_db.create ?directory_name:primary_directory_name ~depth ()

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -49,16 +49,69 @@ end)
        and type account_id := Inputs.Account_id.t
        and type account_id_set := Inputs.Account_id.Set.t
 
-  val create : Primary_ledger.t -> Converting_ledger.t -> t
+  val of_ledgers : Primary_ledger.t -> Converting_ledger.t -> t
 
   (** Create a converting ledger with an already-existing [Primary_ledger.t] and
       an empty [Converting_ledger.t] that will be initialized with the migrated
       account data. *)
-  val create_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
+  val of_ledgers_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
 
   val primary_ledger : t -> Primary_ledger.t
 
   val converting_ledger : t -> Converting_ledger.t
 
   val convert : Inputs.Account.t -> Inputs.converted_account
+end
+
+(** A variant of [Make] that works with DATABASE ledgers and provides checkpoint operations *)
+module With_database (Inputs : sig
+  include Intf.Inputs.Intf
+
+  type converted_account
+
+  val convert : Account.t -> converted_account
+
+  val converted_equal : converted_account -> converted_account -> bool
+end)
+(Primary_db : Intf.Ledger.DATABASE
+                with module Location = Inputs.Location
+                 and module Addr = Inputs.Location.Addr
+                 and type key := Inputs.Key.t
+                 and type token_id := Inputs.Token_id.t
+                 and type token_id_set := Inputs.Token_id.Set.t
+                 and type account := Inputs.Account.t
+                 and type root_hash := Inputs.Hash.t
+                 and type hash := Inputs.Hash.t
+                 and type account_id := Inputs.Account_id.t
+                 and type account_id_set := Inputs.Account_id.Set.t)
+(Converting_db : Intf.Ledger.DATABASE
+                   with module Location = Inputs.Location
+                    and module Addr = Inputs.Location.Addr
+                    and type key := Inputs.Key.t
+                    and type token_id := Inputs.Token_id.t
+                    and type token_id_set := Inputs.Token_id.Set.t
+                    and type account := Inputs.converted_account
+                    and type root_hash := Inputs.Hash.t
+                    and type hash := Inputs.Hash.t
+                    and type account_id := Inputs.Account_id.t
+                    and type account_id_set := Inputs.Account_id.Set.t) : sig
+  include module type of Make (Inputs) (Primary_db) (Converting_db)
+
+  module Config : sig
+    type 'a config = { primary_directory : string; converting_directory : 'a }
+
+    type create = Temporary | In_directories of string option config
+
+    type checkpoint = string config
+
+    (** Create a [checkpoint] config with the default converting directory
+        name *)
+    val with_primary : directory_name:string -> checkpoint
+  end
+
+  val create : config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
+
+  val create_checkpoint : t -> config:Config.checkpoint -> unit -> t
+
+  val make_checkpoint : t -> config:Config.checkpoint -> unit
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -98,20 +98,26 @@ end)
   include module type of Make (Inputs) (Primary_db) (Converting_db)
 
   module Config : sig
-    type 'a config = { primary_directory : string; converting_directory : 'a }
+    type t = { primary_directory : string; converting_directory : string }
 
-    type create = Temporary | In_directories of string option config
-
-    type checkpoint = string config
+    type create =
+      | Temporary
+          (** Create a converting ledger with databases in temporary directories *)
+      | In_directories of t
+          (** Create a converting ledger with databases in explicit directories *)
 
     (** Create a [checkpoint] config with the default converting directory
         name *)
-    val with_primary : directory_name:string -> checkpoint
+    val with_primary : directory_name:string -> t
   end
 
+  (** Create a new converting ledger with the given configuration *)
   val create : config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
 
-  val create_checkpoint : t -> config:Config.checkpoint -> unit -> t
+  (** Make checkpoints of the databases backing the converting ledger and create
+      a new converting ledger based on those checkpoints *)
+  val create_checkpoint : t -> config:Config.t -> unit -> t
 
-  val make_checkpoint : t -> config:Config.checkpoint -> unit
+  (** Make checkpoints of the databases backing the converting ledger *)
+  val make_checkpoint : t -> config:Config.t -> unit
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -10,8 +10,10 @@
 module Make (Inputs : sig
   include Intf.Inputs.Intf
 
+  (** The type of the converted (unstable) account in the input [Converting_ledger] *)
   type converted_account
 
+  (** A method to convert a stable account into a Converting_ledger account *)
   val convert : Account.t -> converted_account
 end)
 (Primary_ledger : Intf.Ledger.S
@@ -49,6 +51,10 @@ end)
        and type account_id := Inputs.Account_id.t
        and type account_id_set := Inputs.Account_id.Set.t
 
+  (** Create a converting ledger based on two component ledgers. No migration is
+      performed (use [of_ledgers_with_migration] if you need this) but all
+      subsequent write operations on the converting merkle tree will be applied
+      to both ledgers. *)
   val of_ledgers : Primary_ledger.t -> Converting_ledger.t -> t
 
   (** Create a converting ledger with an already-existing [Primary_ledger.t] and
@@ -56,10 +62,13 @@ end)
       account data. *)
   val of_ledgers_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
 
+  (** Retrieve the primary ledger backing the converting merkle tree *)
   val primary_ledger : t -> Primary_ledger.t
 
+  (** Retrieve the converting ledger backing the converting merkle tree *)
   val converting_ledger : t -> Converting_ledger.t
 
+  (** The input account conversion method, re-exposed for convenience *)
   val convert : Inputs.Account.t -> Inputs.converted_account
 end
 
@@ -67,10 +76,13 @@ end
 module With_database (Inputs : sig
   include Intf.Inputs.Intf
 
+  (** The type of the converted (unstable) account in the input [Converting_ledger] *)
   type converted_account
 
+  (** A method to convert a stable account into a Converting_ledger account *)
   val convert : Account.t -> converted_account
 
+  (** An [equal] method for the converted account type, used to check that  *)
   val converted_equal : converted_account -> converted_account -> bool
 end)
 (Primary_db : Intf.Ledger.DATABASE
@@ -111,13 +123,18 @@ end)
     val with_primary : directory_name:string -> t
   end
 
-  (** Create a new converting ledger with the given configuration *)
+  (** Create a new converting merkle tree with the given configuration. If
+      [In_directories] is given, existing databases will be opened and used to
+      back the converting merkle tree. If the converting database does not exist
+      in the directory, or exists but is empty, one will be created by migrating
+      the primary database. Existing but incompatible converting databases (such
+      as out-of-sync databases) will be deleted and re-migrated. *)
   val create : config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
 
-  (** Make checkpoints of the databases backing the converting ledger and create
-      a new converting ledger based on those checkpoints *)
+  (** Make checkpoints of the databases backing the converting merkle tree and
+      create a new converting ledger based on those checkpoints *)
   val create_checkpoint : t -> config:Config.t -> unit -> t
 
-  (** Make checkpoints of the databases backing the converting ledger *)
+  (** Make checkpoints of the databases backing the converting merkle tree *)
   val make_checkpoint : t -> config:Config.t -> unit
 end

--- a/src/lib/merkle_ledger/test/test_converting.ml
+++ b/src/lib/merkle_ledger/test/test_converting.ml
@@ -98,7 +98,7 @@ struct
   let with_instance ~f =
     let db1 = Db.create ~depth:Cfg.depth () in
     let db2 = Db_migrated.create ~depth:Cfg.depth () in
-    let ledger = Db_converting.create db1 db2 in
+    let ledger = Db_converting.of_ledgers db1 db2 in
     try
       let result = f ledger in
       Db_converting.close ledger ; result
@@ -171,7 +171,7 @@ struct
                 (* We don't need the actual converting ledger for this test,
                    only the side effect of migration *)
                 let _converting =
-                  Db_converting.create_with_migration primary migrated
+                  Db_converting.of_ledgers_with_migration primary migrated
                 in
                 let stored_migrated_account =
                   Option.value_exn (Db_migrated.get migrated location)
@@ -187,7 +187,7 @@ struct
             populate_primary_db primary max_height ;
             with_migrated ~f:(fun migrated ->
                 let _converting =
-                  Db_converting.create_with_migration primary migrated
+                  Db_converting.of_ledgers_with_migration primary migrated
                 in
                 assert (
                   Db.num_accounts primary = Db_migrated.num_accounts migrated ) ;


### PR DESCRIPTION
The `With_database` functor adds creation and checkpointing operations to the converting merkle tree when the underlying ledgers are databases.