### PR TITLE
Don't broadcast empty snark diff

### DIFF
--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -116,7 +116,7 @@ module Make
     | Empty ->
         "empty Snark_pool_diff"
 
-  let is_empty _ = false
+  let is_empty = function Add_solved_work _ -> false | Empty -> true
 
   let of_result
       (res :


### PR DESCRIPTION
Currently a snark pool diff is never considered empty, hence it'll always be broadcasted in `Network_pool.Network_pool_base.apply_and_broadcast`

This PR fixed it. 

I'll look at git blame to see why it's defined as what we current have. 