### PR TITLE
Abstract the snarked root ledger

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -95,7 +95,7 @@ let received_bad_proof ({ context = (module Context); _ } as t) host e =
             , [ ("error", Error_json.error_to_yojson e) ] ) ))
 
 let done_syncing_root root_sync_ledger =
-  Option.is_some (Sync_ledger.Db.peek_valid_tree root_sync_ledger)
+  Option.is_some (Sync_ledger.Any_ledger.peek_valid_tree root_sync_ledger)
 
 let should_sync ~root_sync_ledger t candidate_state =
   (not @@ done_syncing_root root_sync_ledger)
@@ -127,7 +127,7 @@ let start_sync_job_with_peer ~sender ~root_sync_ledger
   return
   @@
   match
-    Sync_ledger.Db.new_goal root_sync_ledger
+    Sync_ledger.Any_ledger.new_goal root_sync_ledger
       (Frozen_ledger_hash.to_ledger_hash snarked_ledger_hash)
       ~data:
         ( State_hash.With_state_hashes.state_hash
@@ -204,8 +204,8 @@ let on_transition ({ context = (module Context); _ } as t) ~sender
 let sync_ledger ({ context = (module Context); _ } as t) ~preferred
     ~root_sync_ledger ~transition_graph ~sync_ledger_reader =
   let open Context in
-  let query_reader = Sync_ledger.Db.query_reader root_sync_ledger in
-  let response_writer = Sync_ledger.Db.answer_writer root_sync_ledger in
+  let query_reader = Sync_ledger.Any_ledger.query_reader root_sync_ledger in
+  let response_writer = Sync_ledger.Any_ledger.answer_writer root_sync_ledger in
   Mina_networking.glue_sync_ledger ~preferred t.network query_reader
     response_writer ;
   Pipe_lib.Choosable_synchronous_pipe.iter sync_ledger_reader
@@ -272,7 +272,9 @@ let download_snarked_ledger ~trust_system ~preferred_peers ~transition_graph
     ~sync_ledger_reader ~context t temp_snarked_ledger =
   time_deferred
     (let root_sync_ledger =
-       Sync_ledger.Db.create temp_snarked_ledger ~context ~trust_system
+       Sync_ledger.Any_ledger.create
+         (Ledger.Root.as_unmasked temp_snarked_ledger)
+         ~context ~trust_system
      in
      don't_wait_for
        (sync_ledger t ~preferred:preferred_peers ~root_sync_ledger
@@ -280,8 +282,8 @@ let download_snarked_ledger ~trust_system ~preferred_peers ~transition_graph
      (* We ignore the resulting ledger returned here since it will always
         * be the same as the ledger we started with because we are syncing
         * a db ledger. *)
-     let%map _, data = Sync_ledger.Db.valid_tree root_sync_ledger in
-     Sync_ledger.Db.destroy root_sync_ledger ;
+     let%map _, data = Sync_ledger.Any_ledger.valid_tree root_sync_ledger in
+     Sync_ledger.Any_ledger.destroy root_sync_ledger ;
      data )
 
 (** Run one bootstrap cycle *)
@@ -434,7 +436,7 @@ let run_cycle ~context:(module Context : CONTEXT) ~trust_system ~verifier
               let%map staged_ledger_construction_time, construction_result =
                 time_deferred
                   (let open Deferred.Let_syntax in
-                  let temp_mask = Ledger.of_database temp_snarked_ledger in
+                  let temp_mask = Ledger.Root.as_masked temp_snarked_ledger in
                   let%map result =
                     Staged_ledger
                     .of_scan_state_pending_coinbases_and_snarked_ledger ~logger
@@ -833,8 +835,9 @@ let%test_module "Bootstrap_controller tests" =
             make_non_running_bootstrap ~genesis_root ~network:me.network
           in
           let root_sync_ledger =
-            Sync_ledger.Db.create
-              (Transition_frontier.root_snarked_ledger me.state.frontier)
+            Sync_ledger.Any_ledger.create
+              ( Ledger.Root.as_unmasked
+              @@ Transition_frontier.root_snarked_ledger me.state.frontier )
               ~context:(module Context)
               ~trust_system
           in
@@ -971,10 +974,10 @@ let%test_module "Bootstrap_controller tests" =
             ~root:(Transition_frontier.root new_frontier)
             sorted_external_transitions ;
           [%test_result: Ledger_hash.t]
-            ( Ledger.Db.merkle_root
+            ( Ledger.Root.merkle_root
             @@ Transition_frontier.root_snarked_ledger new_frontier )
             ~expect:
-              ( Ledger.Db.merkle_root
+              ( Ledger.Root.merkle_root
               @@ Transition_frontier.root_snarked_ledger peer_net.state.frontier
               ) )
 
@@ -996,7 +999,7 @@ let%test_module "Bootstrap_controller tests" =
               in
               let snarked_ledger =
                 Transition_frontier.root_snarked_ledger frontier
-                |> Ledger.of_database
+                |> Ledger.Root.as_masked
               in
               let snarked_local_state =
                 Transition_frontier.root frontier

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -718,7 +718,7 @@ module type S = sig
          Consensus_state.Value.t
       -> Consensus_state.Value.t
       -> local_state:Local_state.t
-      -> snarked_ledger:Mina_ledger.Ledger.Db.t
+      -> snarked_ledger:Mina_ledger.Ledger.Root.t
       -> genesis_ledger_hash:Mina_base.Frozen_ledger_hash.t
       -> unit
 

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -4,6 +4,10 @@ open Signature_lib
 open Mina_base
 module Ledger = Mina_ledger.Ledger
 module Intf = Intf
+module Ledger_transfer_stable =
+  Mina_ledger.Ledger_transfer.Make (Ledger.Db) (Ledger.Db)
+module Ledger_transfer_any =
+  Mina_ledger.Ledger_transfer.Make (Ledger) (Ledger.Any_ledger.M)
 
 let account_with_timing account_id balance (timing : Intf.Timing.t) =
   match timing with
@@ -62,6 +66,20 @@ module Balances (Balances : Intf.Named_balances_intf) = struct
 end
 
 module Utils = struct
+  (* Populate a [Ledger.Root.t] ledger with the components of a root
+     backing_ledger for a genesis ledger. These components are the underlying
+     root ledger and the stored mask on top of that root that is presented to
+     users of the genesis root. The mask is passed in to this function so we can
+     assert that there are no uncommitted changes to it, allowing us to use the
+     potentially much faster Ledger.Root.transfer_accounts_with function. *)
+  let populate_root_with_backing_root genesis_mask ~src ~dest =
+    assert (
+      Ledger_hash.equal
+        (Ledger.merkle_root genesis_mask)
+        (Ledger.Root.merkle_root src) ) ;
+    Ledger.Root.transfer_accounts_with
+      ~stable:Ledger_transfer_stable.transfer_accounts ~src ~dest
+
   let keypair_of_account_record_exn (private_key, account) =
     let open Account in
     let sk_error_msg =
@@ -101,26 +119,56 @@ module Make (Inputs : Intf.Ledger_input_intf) : Intf.S = struct
   include Inputs
 
   (* TODO: #1488 compute this at compile time instead of lazily *)
-  let t =
+  (* The backing_ledger is either an `Ephemeral ledger, which exists purely as a
+     mask in memory, with a null ledger root, or a `Root ledger, which is backed
+     by a concrete [Ledger.Root.t] on disk. We need a single mask to present to
+     the users of the genesis ledger interface (through the [t] value below), so
+     that is also saved here. *)
+  let backing_ledger =
     let open Lazy.Let_syntax in
     let%map ledger, insert_accounts =
       match directory with
       | `Ephemeral ->
-          lazy (Ledger.create_ephemeral ~depth (), true)
+          lazy (`Ephemeral (Ledger.create_ephemeral ~depth ()), true)
       | `New ->
-          lazy (Ledger.create ~depth (), true)
+          lazy (`Root (Ledger.Root.create_single ~depth ()), true)
       | `Path directory_name ->
-          lazy (Ledger.create ~directory_name ~depth (), false)
+          lazy
+            (`Root (Ledger.Root.create_single ~directory_name ~depth ()), false)
+    in
+    let masked =
+      match ledger with
+      | `Ephemeral ledger ->
+          ledger
+      | `Root ledger ->
+          Ledger.Root.as_masked ledger
     in
     ( if insert_accounts then
       let addrs_and_accounts =
-        let ledger_depth = Ledger.depth ledger in
+        let ledger_depth = Ledger.depth masked in
         Lazy.force accounts
         |> List.mapi ~f:(fun i (_, acct) ->
                (Ledger.Addr.of_int_exn ~ledger_depth i, acct) )
       in
-      Ledger.set_batch_accounts ledger addrs_and_accounts ) ;
-    ledger
+      Ledger.set_batch_accounts masked addrs_and_accounts ) ;
+    (ledger, masked)
+
+  let t = Lazy.map ~f:snd backing_ledger
+
+  let populate_root root =
+    let backing_ledger, mask = Lazy.force backing_ledger in
+    match backing_ledger with
+    | `Ephemeral ledger ->
+        let open Or_error.Let_syntax in
+        (* We are transferring to an unmasked view of the root, so this is
+           used solely for the transfer side effect *)
+        let%map _dest =
+          Ledger_transfer_any.transfer_accounts ~src:ledger
+            ~dest:(Ledger.Root.as_unmasked root)
+        in
+        root
+    | `Root ledger ->
+        populate_root_with_backing_root mask ~src:ledger ~dest:root
 
   include Utils
 
@@ -158,6 +206,8 @@ module Packed = struct
 
   let t ((module L) : t) = L.t
 
+  let populate_root ((module L) : t) ledger = L.populate_root ledger
+
   let depth ((module L) : t) = L.depth
 
   let accounts ((module L) : t) = L.accounts
@@ -181,17 +231,28 @@ module Packed = struct
 end
 
 module Of_ledger (T : sig
-  val t : Ledger.t Lazy.t
+  val backing_ledger : Ledger.Root.t Lazy.t
 
   val depth : int
 end) : Intf.S = struct
   include T
+
+  let backing_ledger =
+    Lazy.map
+      ~f:(fun ledger -> (ledger, Ledger.Root.as_masked ledger))
+      backing_ledger
+
+  let t = Lazy.map ~f:snd backing_ledger
 
   let accounts =
     Lazy.map t
       ~f:(Ledger.foldi ~init:[] ~f:(fun _loc accs acc -> (None, acc) :: accs))
 
   include Utils
+
+  let populate_root dest =
+    let genesis_root, mask = Lazy.force backing_ledger in
+    populate_root_with_backing_root mask ~src:genesis_root ~dest
 
   let find_account_record_exn ~f =
     find_account_record_exn ~f (Lazy.force accounts)

--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -69,6 +69,12 @@ end
 module type S = sig
   val t : Mina_ledger.Ledger.t Lazy.t
 
+  (** Populate a root ledger with the unmasked ledger backing a genesis ledger.
+      Prefer using this to a transfer using [t], for the efficiency reasons
+      described in [Mina_ledger.Ledger.Root.transfer_accounts_with]. *)
+  val populate_root :
+    Mina_ledger.Ledger.Root.t -> Mina_ledger.Ledger.Root.t Or_error.t
+
   val depth : int
 
   val accounts : (Private_key.t option * Account.t) list Lazy.t

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -253,13 +253,13 @@ module Ledger = struct
           end) )
       | None ->
           ( module Genesis_ledger.Of_ledger (struct
-            let t =
+            let backing_ledger =
               lazy
                 (let ledger =
-                   Mina_ledger.Ledger.create ~directory_name:dirname
+                   Mina_ledger.Ledger.Root.create_single ~directory_name:dirname
                      ~depth:constraint_constants.ledger_depth ()
                  in
-                 let ledger_root = Mina_ledger.Ledger.merkle_root ledger in
+                 let ledger_root = Mina_ledger.Ledger.Root.merkle_root ledger in
                  ( match expected_merkle_root with
                  | Some expected_merkle_root ->
                      if not (Ledger_hash.equal ledger_root expected_merkle_root)

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -113,6 +113,9 @@ module T = struct
   let genesis_ledger { genesis_ledger; _ } =
     Genesis_ledger.Packed.t genesis_ledger
 
+  let populate_root { genesis_ledger; _ } =
+    Genesis_ledger.Packed.populate_root genesis_ledger
+
   let genesis_epoch_data { genesis_epoch_data; _ } = genesis_epoch_data
 
   let accounts { genesis_ledger; _ } =

--- a/src/lib/merkle_ledger/test/test_converting.ml
+++ b/src/lib/merkle_ledger/test/test_converting.ml
@@ -129,6 +129,7 @@ struct
                Db.set mdb location account )
 
   let populate_converting_ledger ledger max_height =
+    let primary_ledger = Db_converting.primary_ledger ledger in
     random_primary_accounts max_height
     |> List.iter ~f:(fun account ->
            let action, location =
@@ -137,11 +138,15 @@ struct
                account
              |> Or_error.ok_exn
            in
-           match action with
+           ( match action with
            | `Added ->
                ()
            | `Existed ->
-               Db_converting.set ledger location account )
+               Db_converting.set ledger location account ) ;
+           assert (
+             Account.equal
+               (Db.get primary_ledger location |> Option.value_exn)
+               account ) )
 
   let test_section_name =
     Printf.sprintf "In-memory converting db (depth %d)" Cfg.depth

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -258,6 +258,10 @@ module Ledger_inner = struct
       (Db)
       (Unstable_db)
 
+  let of_any_ledger ledger =
+    let mask = Mask.create ~depth:(Any_ledger.M.depth ledger) () in
+    Maskable.register_mask ledger mask
+
   let of_database db =
     let casted = Any_ledger.cast (module Db) db in
     let mask = Mask.create ~depth:(Db.depth db) () in
@@ -287,6 +291,12 @@ module Ledger_inner = struct
     let mask = Mask.create ~depth () in
     ( Maskable.register_mask casted mask
     , Converting_ledger.converting_ledger converting_ledger )
+
+  module Root = struct
+    include Root.Make (Any_ledger) (Db)
+
+    let as_masked t = as_unmasked t |> of_any_ledger
+  end
 
   (** Create a new empty ledger.
 

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -59,6 +59,12 @@ module Maskable :
      and type accumulated_t := Mask.accumulated_t
      and type t := Any_ledger.M.t
 
+module Root : sig
+  include module type of Root.Make (Any_ledger) (Db)
+
+  val as_masked : t -> Mask.Attached.t
+end
+
 include
   Merkle_mask.Maskable_merkle_tree_intf.S
     with module Location := Location

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -1,0 +1,55 @@
+open Core_kernel
+open Mina_base
+
+module type Stable_db_intf =
+  Merkle_ledger.Intf.Ledger.DATABASE
+    with type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type hash := Ledger_hash.t
+     and type root_hash := Ledger_hash.t
+
+module type Any_ledger_intf =
+  Merkle_ledger.Intf.Ledger.ANY
+    with type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type hash := Ledger_hash.t
+
+module Make
+    (Any_ledger : Any_ledger_intf)
+    (Stable_db : Stable_db_intf
+                   with module Location = Any_ledger.M.Location
+                    and module Addr = Any_ledger.M.Addr) =
+struct
+  type t = Stable_db of Stable_db.t
+
+  let close t = match t with Stable_db db -> Stable_db.close db
+
+  let merkle_root t = match t with Stable_db db -> Stable_db.merkle_root db
+
+  let create_single ?directory_name ~depth () =
+    Stable_db (Stable_db.create ?directory_name ~depth ())
+
+  let create_checkpoint_stable t ~directory_name () =
+    match t with
+    | Stable_db db ->
+        Stable_db.create_checkpoint db ~directory_name ()
+
+  let make_checkpoint t ~directory_name =
+    match t with Stable_db db -> Stable_db.make_checkpoint db ~directory_name
+
+  let as_unmasked t =
+    match t with Stable_db db -> Any_ledger.cast (module Stable_db) db
+
+  let transfer_accounts_with ~stable ~src ~dest =
+    match (src, dest) with
+    | Stable_db db1, Stable_db db2 ->
+        stable ~src:db1 ~dest:db2 |> Or_error.map ~f:(fun x -> Stable_db x)
+end

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -1,0 +1,72 @@
+open Core_kernel
+open Mina_base
+
+module type Stable_db_intf =
+  Merkle_ledger.Intf.Ledger.DATABASE
+    with type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type hash := Ledger_hash.t
+     and type root_hash := Ledger_hash.t
+
+module type Any_ledger_intf =
+  Merkle_ledger.Intf.Ledger.ANY
+    with type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type hash := Ledger_hash.t
+
+(** Make a root ledger. A root ledger is a database-backed, unmasked ledger used
+    at the root of a mina ledger mask tree. Currently only a single stable
+    database is supported; an option will be added in future to create root
+    ledgers backed by a converting merkle tree backed by a pair of stable
+    account and unstable account databases.
+*)
+module Make
+    (Any_ledger : Any_ledger_intf)
+    (Stable_db : Stable_db_intf
+                   with module Location = Any_ledger.M.Location
+                    and module Addr = Any_ledger.M.Addr) : sig
+  type t
+
+  (** Close the root ledger instance *)
+  val close : t -> unit
+
+  (** Retrieve the hash of the merkle root of the root ledger *)
+  val merkle_root : t -> Ledger_hash.t
+
+  (** Create a root ledger backed by a single database in the given
+      directory. *)
+  val create_single : ?directory_name:string -> depth:int -> unit -> t
+
+  (** Checkpoint the stable database backing the root and create a new
+      [Stable_db.t] based on that checkpoint *)
+  val create_checkpoint_stable :
+    t -> directory_name:string -> unit -> Stable_db.t
+
+  (** Make a checkpoint of the full root ledger *)
+  val make_checkpoint : t -> directory_name:string -> unit
+
+  (** View the root ledger as an unmasked [Any_ledger] so it can be used by code
+      that does not need to know how the root is implemented *)
+  val as_unmasked : t -> Any_ledger.witness
+
+  (** Use the given [stable] account transfer method to transfer the accounts
+      from one root ledger instance to another. For a root ledger backed by a
+      single database (currently the only option) it is equivalent to using
+      [stable] or a normal ledger transfer on the root. Future root backings
+      should be able to support more efficient transfers (e.g., for a converting
+      databases the accounts could be transferred directly between the
+      underlying pair of databases)*)
+  val transfer_accounts_with :
+       stable:(src:Stable_db.t -> dest:Stable_db.t -> Stable_db.t Or_error.t)
+    -> src:t
+    -> dest:t
+    -> t Or_error.t
+end

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -691,7 +691,7 @@ let get_snarked_ledger_full t state_hash_opt =
       let root_snarked_ledger =
         Transition_frontier.root_snarked_ledger frontier
       in
-      let ledger = Ledger.of_database root_snarked_ledger in
+      let ledger = Ledger.Root.as_masked root_snarked_ledger in
       let path = Transition_frontier.path_map frontier b ~f:Fn.id in
       let%bind () =
         Mina_stdlib.Deferred.Result.List.iter path ~f:(fun b ->

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -49,7 +49,7 @@ module Make (Inputs : Inputs_intf) :
 
   let get_ledger_by_hash ~frontier ledger_hash =
     let root_ledger =
-      Ledger.Any_ledger.cast (module Ledger.Db)
+      Ledger.Root.as_unmasked
       @@ Transition_frontier.root_snarked_ledger frontier
     in
     let staking_epoch_ledger =

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -462,15 +462,15 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
           t.persistent_root_instance.factory.directory
       in
       let () =
-        Ledger.Db.make_checkpoint t.persistent_root_instance.snarked_ledger
+        Ledger.Root.make_checkpoint t.persistent_root_instance.snarked_ledger
           ~directory_name:location
       in
       [%log' info t.logger]
         ~metadata:
           [ ( "potential_snarked_ledger_hash"
             , Frozen_ledger_hash.to_yojson @@ Frozen_ledger_hash.of_ledger_hash
-              @@ Ledger.Db.merkle_root t.persistent_root_instance.snarked_ledger
-            )
+              @@ Ledger.Root.merkle_root
+                   t.persistent_root_instance.snarked_ledger )
           ]
         "Enqueued a snarked ledger" ;
       Persistent_root.Instance.enqueue_snarked_ledger ~location

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -59,7 +59,8 @@ val protocol_states_for_root_scan_state :
 val apply_diffs :
      t
   -> Diff.Full.E.t list
-  -> enable_epoch_ledger_sync:[ `Enabled of Mina_ledger.Ledger.Db.t | `Disabled ]
+  -> enable_epoch_ledger_sync:
+       [ `Enabled of Mina_ledger.Ledger.Root.t | `Disabled ]
   -> has_long_catchup_job:bool
   -> [ `New_root_and_diffs_with_mutants of
        Root_identifier.t option * Diff.Full.With_mutant.t list ]

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -53,7 +53,7 @@ let construct_staged_ledger_at_root ~proof_cache_db
     | Some protocol_state ->
         Ok protocol_state
   in
-  let mask = Mina_ledger.Ledger.of_database root_ledger in
+  let mask = Mina_ledger.Ledger.Root.as_masked root_ledger in
   let local_state = Blockchain_state.snarked_local_state blockchain_state in
   let staged_ledger_hash =
     Blockchain_state.staged_ledger_hash blockchain_state
@@ -263,10 +263,7 @@ module Instance = struct
               List.map protocol_states
                 ~f:(With_hash.of_data ~hash_data:Protocol_state.hashes)
           }
-        ~root_ledger:
-          (Mina_ledger.Ledger.Any_ledger.cast
-             (module Mina_ledger.Ledger.Db)
-             root_ledger )
+        ~root_ledger:(Mina_ledger.Ledger.Root.as_unmasked root_ledger)
         ~consensus_local_state ~max_length ~persistent_root_instance
     in
     let%bind extensions =

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -87,7 +87,7 @@ val persistent_root : t -> Persistent_root.t
 
 val persistent_frontier : t -> Persistent_frontier.t
 
-val root_snarked_ledger : t -> Mina_ledger.Ledger.Db.t
+val root_snarked_ledger : t -> Mina_ledger.Ledger.Root.t
 
 val extensions : t -> Extensions.t
 
@@ -152,8 +152,10 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?root_ledger_and_accounts:
-         Mina_ledger.Ledger.t * (Private_key.t option * Account.t) list
+    -> ?populate_root_and_accounts:
+         (   Mina_ledger.Ledger.Root.t
+          -> Mina_ledger.Ledger.Root.t Core_kernel.Or_error.t )
+         * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:
          ( Breadcrumb.t
          * Mina_state.Protocol_state.value
@@ -171,8 +173,10 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?root_ledger_and_accounts:
-         Mina_ledger.Ledger.t * (Private_key.t option * Account.t) list
+    -> ?populate_root_and_accounts:
+         (   Mina_ledger.Ledger.Root.t
+          -> Mina_ledger.Ledger.Root.t Core_kernel.Or_error.t )
+         * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:
          ( Breadcrumb.t
          * Mina_state.Protocol_state.value


### PR DESCRIPTION
A new Root mina ledger type has been created, to encapsulate the functionality of the snarked root ledger. A Root ledger is an unmasked, fully-committed and database-backed ledger that can be used as the base of a ledger mask tree. It is only possible to create these with a single backing database, for now; in a future update the root definition will be expanded so that they can be backed by a pair of stable and unstable account databases that are kept in sync by a converting merkle tree.

This new root ledger is also used to back non-ephemeral genesis ledgers. This will be important in the full ledger migration implementation (with a root backed by a converting database), as having a pre-migrated genesis available to construct the initial snarked root will greatly speed up snarked root construction.

Since a root ledger can only be backed by a single database, current behaviour should be unchanged.