### PR TITLE
Use Root ledger in epoch snapshots

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -308,8 +308,11 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
               | Genesis_epoch_ledger l ->
                   let%map accts = Mina_ledger.Ledger.to_list l in
                   Ok accts
-              | Ledger_db db ->
-                  let%map accts = Mina_ledger.Ledger.Db.to_list db in
+              | Ledger_root l ->
+                  let casted = Mina_ledger.Ledger.Root.as_unmasked l in
+                  let%map accts =
+                    Mina_ledger.Ledger.Any_ledger.M.to_list casted
+                  in
                   Ok accts )
           | Error err ->
               return (Error err) )

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -317,7 +317,7 @@ module type S = sig
         module Ledger_snapshot : sig
           type t =
             | Genesis_epoch_ledger of Mina_ledger.Ledger.t
-            | Ledger_db of Mina_ledger.Ledger.Db.t
+            | Ledger_root of Mina_ledger.Ledger.Root.t
 
           val close : t -> unit
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2602,8 +2602,8 @@ module Queries = struct
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           l ->
           Ledger.Any_ledger.cast (module Ledger) l
-      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_db l ->
-          Ledger.Any_ledger.cast (module Ledger.Db) l
+      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_root l ->
+          Ledger.Root.as_unmasked l
     in
     let root_consensus_state =
       let frontier =

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -1509,14 +1509,15 @@ module AccountObj = struct
                             genesis ledger. The account was not present in the \
                             ledger." ;
                          None )
-                 | Ledger_db staking_ledger -> (
+                 | Ledger_root staking_ledger -> (
+                     let casted = Ledger.Root.as_unmasked staking_ledger in
                      try
                        let index =
-                         Ledger.Db.index_of_account_exn staking_ledger
+                         Ledger.Any_ledger.M.index_of_account_exn casted
                            account_id
                        in
                        let account =
-                         Ledger.Db.get_at_index_exn staking_ledger index
+                         Ledger.Any_ledger.M.get_at_index_exn casted index
                        in
                        let%bind delegate_key = account.delegate in
                        Some (get_best_ledger_account_pk mina delegate_key)

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -28,6 +28,16 @@ module Make
                    with module Location = Any_ledger.M.Location
                     and module Addr = Any_ledger.M.Addr) =
 struct
+  type root_hash = Ledger_hash.t
+
+  type hash = Ledger_hash.t
+
+  type account = Account.t
+
+  type addr = Stable_db.Addr.t
+
+  type path = Stable_db.path
+
   type t = Stable_db of Stable_db.t
 
   let close t = match t with Stable_db db -> Stable_db.close db
@@ -52,4 +62,23 @@ struct
     match (src, dest) with
     | Stable_db db1, Stable_db db2 ->
         stable ~src:db1 ~dest:db2 |> Or_error.map ~f:(fun x -> Stable_db x)
+
+  let depth t = match t with Stable_db db -> Stable_db.depth db
+
+  let num_accounts t = match t with Stable_db db -> Stable_db.num_accounts db
+
+  let merkle_path_at_addr_exn t =
+    match t with Stable_db db -> Stable_db.merkle_path_at_addr_exn db
+
+  let get_inner_hash_at_addr_exn t =
+    match t with Stable_db db -> Stable_db.get_inner_hash_at_addr_exn db
+
+  let set_all_accounts_rooted_at_exn t =
+    match t with Stable_db db -> Stable_db.set_all_accounts_rooted_at_exn db
+
+  let set_batch_accounts t =
+    match t with Stable_db db -> Stable_db.set_batch_accounts db
+
+  let get_all_accounts_rooted_at_exn t =
+    match t with Stable_db db -> Stable_db.get_all_accounts_rooted_at_exn db
 end

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -47,10 +47,10 @@ struct
   let create_single ?directory_name ~depth () =
     Stable_db (Stable_db.create ?directory_name ~depth ())
 
-  let create_checkpoint_stable t ~directory_name () =
+  let create_checkpoint t ~directory_name () =
     match t with
     | Stable_db db ->
-        Stable_db.create_checkpoint db ~directory_name ()
+        Stable_db (Stable_db.create_checkpoint db ~directory_name ())
 
   let make_checkpoint t ~directory_name =
     match t with Stable_db db -> Stable_db.make_checkpoint db ~directory_name

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -35,11 +35,21 @@ module Make
                     and module Addr = Any_ledger.M.Addr) : sig
   type t
 
+  type root_hash = Ledger_hash.t
+
+  type hash = Ledger_hash.t
+
+  type account = Account.t
+
+  type addr = Stable_db.Addr.t
+
+  type path = Stable_db.path
+
   (** Close the root ledger instance *)
   val close : t -> unit
 
   (** Retrieve the hash of the merkle root of the root ledger *)
-  val merkle_root : t -> Ledger_hash.t
+  val merkle_root : t -> root_hash
 
   (** Create a root ledger backed by a single database in the given
       directory. *)
@@ -69,4 +79,36 @@ module Make
     -> src:t
     -> dest:t
     -> t Or_error.t
+
+  (** Retrieve the depth of the root ledger *)
+  val depth : t -> int
+
+  (** Retrieve the number of accounts in the root ledger *)
+  val num_accounts : t -> int
+
+  (** Calculate the address path from [addr] to the merkle root. *)
+  val merkle_path_at_addr_exn : t -> addr -> path
+
+  (** Get the hash at the given [addr] in the ledger. Throws an exception if the
+      [addr] doesn't point to a hash. *)
+  val get_inner_hash_at_addr_exn : t -> addr -> hash
+
+  (** Calculate all the addresses that lie in the ledger, starting at [addr] and
+      going downward in the merkle tree. Then, set the accounts at those
+      addresses to the values in the list. Throws an exception if the [addr] is
+      not in the ledger, or if there are not exactly enough accounts in the list
+      to set the values at all the addresses. *)
+
+  (* TODO: see if the hashes of the accounts can be passed in here too *)
+  val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
+
+  (** For each addr-account pair, replace the account in the root with the given
+      account. This is done as a single batch write. *)
+
+  (* TODO: investigate if this can be removed from the syncable interface *)
+  val set_batch_accounts : t -> (addr * account) list -> unit
+
+  (** Get all of the accounts that are in a subtree of the underlying Merkle
+    tree rooted at `address`. The accounts are ordered by their addresses. *)
+  val get_all_accounts_rooted_at_exn : t -> addr -> (addr * account) list
 end

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -55,12 +55,11 @@ module Make
       directory. *)
   val create_single : ?directory_name:string -> depth:int -> unit -> t
 
-  (** Checkpoint the stable database backing the root and create a new
-      [Stable_db.t] based on that checkpoint *)
-  val create_checkpoint_stable :
-    t -> directory_name:string -> unit -> Stable_db.t
+  (** Make a checkpoint of the root ledger and return a new root ledger backed
+      by that checkpoint *)
+  val create_checkpoint : t -> directory_name:string -> unit -> t
 
-  (** Make a checkpoint of the full root ledger *)
+  (** Make a checkpoint of the root ledger *)
   val make_checkpoint : t -> directory_name:string -> unit
 
   (** View the root ledger as an unmasked [Any_ledger] so it can be used by code
@@ -93,19 +92,14 @@ module Make
       [addr] doesn't point to a hash. *)
   val get_inner_hash_at_addr_exn : t -> addr -> hash
 
-  (** Calculate all the addresses that lie in the ledger, starting at [addr] and
-      going downward in the merkle tree. Then, set the accounts at those
-      addresses to the values in the list. Throws an exception if the [addr] is
-      not in the ledger, or if there are not exactly enough accounts in the list
-      to set the values at all the addresses. *)
-
-  (* TODO: see if the hashes of the accounts can be passed in here too *)
+  (** Set the accounts at the leaves underneath [addr] in the ledger to the
+      accounts in the given list. Throws an exception if the [addr] is not in
+      the ledger, or if there are not exactly enough accounts in the list to set
+      the values at the leaves. *)
   val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
 
   (** For each addr-account pair, replace the account in the root with the given
       account. This is done as a single batch write. *)
-
-  (* TODO: investigate if this can be removed from the syncable interface *)
   val set_batch_accounts : t -> (addr * account) list -> unit
 
   (** Get all of the accounts that are in a subtree of the underlying Merkle

--- a/src/lib/mina_ledger/sync_ledger.ml
+++ b/src/lib/mina_ledger/sync_ledger.ml
@@ -39,9 +39,9 @@ module Any_ledger = Syncable_ledger.Make (struct
   let account_subtree_height = 6
 end)
 
-module Db = Syncable_ledger.Make (struct
-  module Addr = Ledger.Db.Addr
-  module MT = Ledger.Db
+module Root = Syncable_ledger.Make (struct
+  module Addr = Ledger.Location.Addr
+  module MT = Ledger.Root
   module Account = Account.Stable.Latest
   module Hash = Hash
   module Root_hash = Root_hash

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -73,8 +73,8 @@ module Make (Inputs : Inputs_intf) :
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           _ ->
           None
-      | Ledger_db ledger ->
-          Some (Ledger.Any_ledger.cast (module Ledger.Db) ledger)
+      | Ledger_root ledger ->
+          Some (Ledger.Root.as_unmasked ledger)
     else if
       Ledger_hash.equal ledger_hash
         (Consensus.Data.Local_state.Snapshot.Ledger_snapshot.merkle_root
@@ -84,8 +84,8 @@ module Make (Inputs : Inputs_intf) :
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           _ ->
           None
-      | Ledger_db ledger ->
-          Some (Ledger.Any_ledger.cast (module Ledger.Db) ledger)
+      | Ledger_root ledger ->
+          Some (Ledger.Root.as_unmasked ledger)
     else None
 
   let answer_query :


### PR DESCRIPTION
As part of the hard fork automation, the epoch ledger snapshots will need to be available in migrated form when the hard fork config is generated. This is a preliminary change that modifies the epoch ledger snapshot code so they are handled as `Root` ledgers and not `Db` ledgers. When the `Converting_ledger` backing is added to `Root`, the snapshots (which are created by checkpointing the `Root`) will automatically be saved in both unmigrated and migrated form. The initial creation of the epoch snapshots (now done by `Ledger.Root.create_single`) will also need to change when that backing is added, based ultimately on the runtime flag enabling the hard fork automation feature.

The existing code expects to be able to construct a syncable ledger given an epoch snapshot, so the syncable interface was implemented on `Root` directly as well; the methods just delegate to the underlying database. This made it possible to add a `Sync_ledger.Root`  ledger definition to `sync_ledger.ml`. The `Converting_ledger` implements this same interface, so it will be easy to delegate to that when that backing is added.

Since the only possible backing to the `Root` ledger is a single database, this should not change any behaviour.