### PR TITLE
fix information disclosure in keypair generation

### DIFF
--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -13,7 +13,7 @@ let generate_keypair =
      @@ fun () ->
      let env = Secrets.Keypair.env in
      if Option.is_some (Sys.getenv env) then
-       eprintf "Using password from environment variable %s\n" env ;
+       eprintf "Using password from environment variable\n" ;
      let kp = Keypair.create () in
      let%bind () = Secrets.Keypair.Terminal_stdin.write_exn kp ~privkey_path in
      printf "Keypair generated\nPublic key: %s\nRaw public key: %s\n"


### PR DESCRIPTION


## Description

**Security improvement:** Remove environment variable name disclosure in CLI output.

### What changed
- Removed environment variable name from `eprintf` output in `generate_keypair` command
- Changed from: `"Using password from environment variable %s"` 
- Changed to: `"Using password from environment variable"`

### Why
- **Information disclosure vulnerability:** CLI was revealing internal environment variable names
- **Security best practice:** Follows principle of least privilege by not exposing unnecessary details
- **Reconnaissance protection:** Prevents attackers from learning about internal password storage structure

### Impact
- ✅ No functional changes
- ✅ Improved security posture  
- ✅ Follows CLI security standards

**Files changed:** `src/lib/cli_lib/commands.ml`