### PR TITLE
Make payment intg test wait more, then check new key balance

### DIFF
--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -495,7 +495,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ~amount:Currency.Amount.one ~fee ~node:sender 12
          in
          wait_for t
-           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:2
+           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:3
               ~test_config:config ) )
     in
     let%bind () =


### PR DESCRIPTION
Title length limit causes I have to make it short.

After the Snark Worker Optimization is introduced. This integration test is failing, in that new snark worker keys are not used in 2 blocks being produced. Some speculated reasons:
- Snark works are being proved too fast by workers that new keys haven't been able to be used in proving any works included in the following 2 blocks
- Snark coordinators are slow, as some works are being moved into coordinators(namely splitting zkapp commands into segments), and causing it to not being able to generate proof fast enough for proofs to be included in blocks

Anyway, waiting for new blocks to check if keys are being used is a bad synchronization condition. If we have time and effort, we should consider using other structured log events instead of blocks being produced. 

Keep in mind this is an ahead-of-time fix, namely no test are affected, but they will have effect after we merge the PR that upgrades Snark Worker RPC.