### PR TITLE
Fix zkapp proof combination

### DIFF
--- a/src/lib/mina_stdlib/nonempty_list.ml
+++ b/src/lib/mina_stdlib/nonempty_list.ml
@@ -28,6 +28,8 @@ let tail_opt t = of_list_opt (tail t)
 
 let map (x, xs) ~f = (f x, List.map ~f xs)
 
+let mapi (x, xs) ~f = (f 0 x, List.mapi ~f:(fun idx x -> f (idx + 1) x) xs)
+
 let rev (x, xs) = List.fold xs ~init:(singleton x) ~f:(Fn.flip cons)
 
 (* As the Base.Container docs state, we'll add each function from C explicitly

--- a/src/lib/mina_stdlib/nonempty_list.mli
+++ b/src/lib/mina_stdlib/nonempty_list.mli
@@ -45,6 +45,9 @@ val tail_opt : 'a t -> 'a t option
 
 (** Apply a function to each element of the non empty list *)
 val map : 'a t -> f:('a -> 'b) -> 'b t
+(** Apply a function to each element of the non empty list, along with its index
+    starting from 0 *)
+val mapi : 'a t -> f:(int -> 'a -> 'b) -> 'b t
 
 (* The following functions are computed from {!module:Base.Container.Make}. See
  * {!modtype:Base.Container_intf} for more information *)

--- a/src/lib/snark_work_lib/sub_zkapp_spec.ml
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.ml
@@ -1,5 +1,15 @@
 open Core_kernel
 
+module Range = struct
+  type t = { first : int; last : int } [@@deriving sexp]
+
+  let compare { first = first_left; _ } { first = first_right; _ } =
+    compare first_left first_right
+
+  let is_consecutive { last = last_left; _ } { first = first_right; _ } =
+    succ last_left = first_right
+end
+
 [%%versioned
 module Stable = struct
   [@@@no_toplevel_latest_type]
@@ -11,12 +21,22 @@ module Stable = struct
           ; witness :
               Transaction_snark.Zkapp_command_segment.Witness.Stable.V1.t
           ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          ; which_segment : int
           }
       | Merge of
           { proof1 : Ledger_proof.Stable.V2.t
           ; proof2 : Ledger_proof.Stable.V2.t
+          ; first_segment_of_proof1 : int
+          ; last_segment_of_proof2 : int
           }
     [@@deriving sexp, yojson]
+
+    let get_range = function
+      | Segment { which_segment; _ } ->
+          Range.{ first = which_segment; last = which_segment }
+      | Merge { first_segment_of_proof1; last_segment_of_proof2; _ } ->
+          Range.
+            { first = first_segment_of_proof1; last = last_segment_of_proof2 }
 
     let statement : t -> Transaction_snark.Statement.t = function
       | Segment { statement; _ } ->
@@ -42,38 +62,50 @@ type t =
       { statement : Transaction_snark.Statement.With_sok.t
       ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
+      ; which_segment : int
       }
-  | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
+  | Merge of
+      { proof1 : Ledger_proof.Cached.t
+      ; proof2 : Ledger_proof.Cached.t
+      ; first_segment_of_proof1 : int
+      ; last_segment_of_proof2 : int
+      }
 
 let read_all_proofs_from_disk : t -> Stable.Latest.t = function
-  | Segment { statement; witness; spec } ->
+  | Segment { statement; witness; spec; which_segment } ->
       Segment
         { statement
         ; witness =
             Transaction_snark.Zkapp_command_segment.Witness
             .read_all_proofs_from_disk witness
         ; spec
+        ; which_segment
         }
-  | Merge { proof1; proof2 } ->
+  | Merge { proof1; proof2; first_segment_of_proof1; last_segment_of_proof2 } ->
       Merge
         { proof1 = Ledger_proof.Cached.read_proof_from_disk proof1
         ; proof2 = Ledger_proof.Cached.read_proof_from_disk proof2
+        ; first_segment_of_proof1
+        ; last_segment_of_proof2
         }
 
 let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
     Stable.Latest.t -> t = function
-  | Segment { statement; witness; spec } ->
+  | Segment { statement; witness; spec; which_segment } ->
       Segment
         { statement
         ; witness =
             Transaction_snark.Zkapp_command_segment.Witness
             .write_all_proofs_to_disk ~proof_cache_db witness
         ; spec
+        ; which_segment
         }
-  | Merge { proof1; proof2 } ->
+  | Merge { proof1; proof2; first_segment_of_proof1; last_segment_of_proof2 } ->
       Merge
         { proof1 =
             Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof1
         ; proof2 =
             Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof2
+        ; first_segment_of_proof1
+        ; last_segment_of_proof2
         }

--- a/src/lib/snark_work_lib/sub_zkapp_spec.mli
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.mli
@@ -1,5 +1,12 @@
 open Core_kernel
 
+(** A range correspond to a consecutive range of segments (both inclusive) *)
+module Range : sig
+  type t = { first : int; last : int } [@@deriving compare, sexp]
+
+  val is_consecutive : t -> t -> bool
+end
+
 [%%versioned:
 module Stable : sig
   [@@@no_toplevel_latest_type]
@@ -11,12 +18,17 @@ module Stable : sig
           ; witness :
               Transaction_snark.Zkapp_command_segment.Witness.Stable.V1.t
           ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          ; which_segment : int
           }
       | Merge of
           { proof1 : Ledger_proof.Stable.V2.t
           ; proof2 : Ledger_proof.Stable.V2.t
+          ; first_segment_of_proof1 : int
+          ; last_segment_of_proof2 : int
           }
     [@@deriving sexp, yojson]
+
+    val get_range : t -> Range.t
 
     val statement : t -> Transaction_snark.Statement.t
 
@@ -29,8 +41,14 @@ type t =
       { statement : Transaction_snark.Statement.With_sok.t
       ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
+      ; which_segment : int
       }
-  | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
+  | Merge of
+      { proof1 : Ledger_proof.Cached.t
+      ; proof2 : Ledger_proof.Cached.t
+      ; first_segment_of_proof1 : int
+      ; last_segment_of_proof2 : int
+      }
 
 val read_all_proofs_from_disk : t -> Stable.Latest.t
 

--- a/src/lib/work_partitioner/pending_zkapp_command.ml
+++ b/src/lib/work_partitioner/pending_zkapp_command.ml
@@ -1,17 +1,21 @@
-(* NOTE: Assumption: order of merging segment proofs is irrelvant to the
-   correctness of the final proof. *)
+(* NOTE: Assumption: order of merging segments satisfy associativity. *)
 
 open Core_kernel
 open Snark_work_lib
+
+open struct
+  module Range = Spec.Sub_zkapp.Range
+  module RangeMap = Map.Make (Range)
+end
 
 type t =
   { job : (Spec.Single.t, Id.Single.t) With_job_meta.t
         (** the original work being split, contains `Work_selector.work` with
             some metadata. *)
   ; unscheduled_segments : Spec.Sub_zkapp.Stable.Latest.t Queue.t
-  ; pending_mergeable_proofs : Ledger_proof.t Deque.t
-        (* we may need to insert proofs to merge back to the queue, hence a Deque
-         *)
+  ; mutable pending_mergeable_proofs : Ledger_proof.t RangeMap.t
+        (* A map tracking all proofs for this zkapp we have in coordinator and
+           their corresponding range of segments. *)
   ; mutable elapsed : Time.Stable.Span.V1.t
         (** The total work time for all SNARK workers combined to prove this
             specific zkapp command. I.e. the time it would take a single SNARK
@@ -30,7 +34,7 @@ let create_and_yield_segment ~job
   in
   ( { job
     ; unscheduled_segments = Queue.of_list unscheduled_segments
-    ; pending_mergeable_proofs = Deque.create ()
+    ; pending_mergeable_proofs = RangeMap.empty
     ; elapsed = Time.Span.zero
     ; proofs_in_flight = 1
     }
@@ -38,24 +42,38 @@ let create_and_yield_segment ~job
 
 let zkapp_job t = t.job
 
-let try_take2 (q : 'a Deque.t) : ('a * 'a) option =
-  match Deque.dequeue_front q with
-  | None ->
-      None
-  | Some fst -> (
-      match Deque.dequeue_front q with
-      | Some snd ->
-          Some (fst, snd)
-      | None ->
-          Deque.enqueue_front q fst ; None )
-
 (** [next_merge t] attempts dequeuing 2 proofs from [t.pending_mergeable_proofs]
-    and generate a sub-zkapp level spec merging them together. *)
+    corresponding to consecutive states and generate a sub-zkapp level spec
+    merging them together. *)
 let next_merge (t : t) =
-  let open Option.Let_syntax in
-  let%map proof1, proof2 = try_take2 t.pending_mergeable_proofs in
-  t.proofs_in_flight <- t.proofs_in_flight + 1 ;
-  Spec.Sub_zkapp.Stable.Latest.Merge { proof1; proof2 }
+  let last_element = ref None in
+  RangeMap.to_sequence ~order:`Increasing_key t.pending_mergeable_proofs
+  |> Sequence.fold_until ~init:None ~finish:Fn.id
+       ~f:(fun
+            _
+            ((Range.{ last = last_segment_of_proof2; _ } as this_range), proof2)
+          ->
+         match !last_element with
+         | Some
+             ( (Range.{ first = first_segment_of_proof1; _ } as last_range)
+             , proof1 )
+           when Range.is_consecutive last_range this_range ->
+             t.proofs_in_flight <- t.proofs_in_flight + 1 ;
+             t.pending_mergeable_proofs <-
+               RangeMap.remove
+                 (RangeMap.remove t.pending_mergeable_proofs last_range)
+                 this_range ;
+             Stop
+               (Some
+                  (Spec.Sub_zkapp.Stable.Latest.Merge
+                     { proof1
+                     ; proof2
+                     ; first_segment_of_proof1
+                     ; last_segment_of_proof2
+                     } ) )
+         | _ ->
+             last_element := Some (this_range, proof2) ;
+             Continue None )
 
 (** [next_segment t] dequeus a segment from [t.unscheduled_segments] and generate a
    sub-zkapp level spec proving that segment. *)
@@ -69,15 +87,43 @@ let next_subzkapp_job_spec (t : t) : Spec.Sub_zkapp.Stable.Latest.t option =
   match next_merge t with Some _ as ret -> ret | None -> next_segment t
 
 let submit_proof (t : t) ~(proof : Ledger_proof.t)
-    ~(elapsed : Time.Stable.Span.V1.t) =
-  Deque.enqueue_back t.pending_mergeable_proofs proof ;
-  t.proofs_in_flight <- t.proofs_in_flight - 1 ;
-  t.elapsed <- Time.Span.(t.elapsed + elapsed)
+    ~(elapsed : Time.Stable.Span.V1.t) ~range:(Range.{ first; last } as range) =
+  let should_accept =
+    first <= last
+    && RangeMap.closest_key t.pending_mergeable_proofs `Greater_or_equal_to
+         Range.{ first = last; last }
+       |> Option.map ~f:(fun (Range.{ first = next_first; _ }, _) ->
+              last < next_first )
+       |> Option.value ~default:true
+    && RangeMap.closest_key t.pending_mergeable_proofs `Less_or_equal_to
+         Range.{ first; last = first }
+       |> Option.map ~f:(fun (Range.{ last = previous_last; _ }, _) ->
+              previous_last < first )
+       |> Option.value ~default:true
+  in
+  if should_accept then (
+    t.pending_mergeable_proofs <-
+      RangeMap.add_exn ~key:range ~data:proof t.pending_mergeable_proofs ;
+    t.proofs_in_flight <- t.proofs_in_flight - 1 ;
+    t.elapsed <- Time.Span.(t.elapsed + elapsed) ;
+    Ok () )
+  else
+    let msg =
+      Printf.sprintf
+        "Pending zkapp command has a submission of range [%d, %d], that \
+         doesn't fit"
+        first last
+    in
+    Error (Error.of_string msg)
 
 let try_finalize (t : t) =
   if
     t.proofs_in_flight = 0
     && Queue.is_empty t.unscheduled_segments
-    && Deque.length t.pending_mergeable_proofs = 1
-  then Some (t.job, Deque.dequeue_back_exn t.pending_mergeable_proofs, t.elapsed)
+    && RangeMap.length t.pending_mergeable_proofs = 1
+  then
+    Some
+      ( t.job
+      , RangeMap.min_elt_exn t.pending_mergeable_proofs |> Tuple2.get2
+      , t.elapsed )
   else None

--- a/src/lib/work_partitioner/pending_zkapp_command.mli
+++ b/src/lib/work_partitioner/pending_zkapp_command.mli
@@ -20,8 +20,15 @@ val zkapp_job : t -> (Spec.Single.t, Id.Single.t) With_job_meta.t
     submitted back to [t] with [submit_proof] *)
 val next_subzkapp_job_spec : t -> Spec.Sub_zkapp.Stable.Latest.t option
 
+(* val [submit_proof t ~proof ~elapsed ~range] submit a proof corresponding to
+   a range of segments(both inclusive). This throws error if either the range is
+   invalid or some corresponded segment proof is already present in [t] *)
 val submit_proof :
-  t -> proof:Ledger_proof.t -> elapsed:Core_kernel_private.Span_float.t -> unit
+     t
+  -> proof:Ledger_proof.t
+  -> elapsed:Core_kernel_private.Span_float.t
+  -> range:Spec.Sub_zkapp.Range.t
+  -> (unit, Error.t) result
 
 (** [try_finalize t] attempts to unwrap completed proof, metric and spec from
     [t] if the proof for entire zkapp transaction is completed *)


### PR DESCRIPTION
Previously, zkapp segments proof are merged arbitrarily without an order being enforced. This is wrong because merging on subzkapp level proof only satisfy associativity, but not commutativity. 

This PR completely redesigned the structure to fix this issue.

I am aware we're passing more garbage around the network, but I intend to fix them after this feature series are merged, as they are non-crucial. 