### PR TITLE
Push sig kind out of test executive & network pool test

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -69,7 +69,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let min_resulting_blocks = 12
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let receiver = Network.block_producer_exn network "receiver" in

--- a/src/app/test_executive/block_reward_test.ml
+++ b/src/app/test_executive/block_reward_test.ml
@@ -27,7 +27,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; block_producers = [ { node_name = "node"; account_name = "node-key" } ]
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -33,7 +33,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/epoch_ledger.ml
+++ b/src/app/test_executive/epoch_ledger.ml
@@ -61,7 +61,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; proof_config = { proof_config_default with fork = Some fork_config }
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let all_mina_nodes = Network.all_mina_nodes network in
     let%bind () =

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -31,7 +31,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     [%log info] "gossip_consistency test: starting..." ;

--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -212,7 +212,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
-  let run network t =
+  let run ~config:({ Test_config.signature_kind; _ } as config) network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in
@@ -274,7 +274,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       { Signed_command_payload.Poly.common; body }
     in
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let raw_signature =
       Signed_command.sign_payload ~signature_kind sender.private_key payload
       |> Signature.Raw.encode
@@ -463,15 +462,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            send_payments ~logger ~sender_pub_key ~receiver_pub_key
              ~amount:Currency.Amount.one ~fee ~node:sender 10
          in
-         let constants : Test_config.constants =
-           { genesis_constants = Network.genesis_constants network
-           ; constraint_constants = Network.constraint_constants network
-           ; compile_config = Network.compile_config network
-           }
-         in
          wait_for t
            (Wait_condition.ledger_proofs_emitted_since_genesis
-              ~test_config:(config ~constants) ~num_proofs:1 ) )
+              ~test_config:config ~num_proofs:1 ) )
     in
     let%bind () =
       section_hard "Check vesting of timed3/timed4 account"

--- a/src/app/test_executive/medium_bootstrap.ml
+++ b/src/app/test_executive/medium_bootstrap.ml
@@ -51,7 +51,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   (* this test is the medium bootstrap test *)
 
-  let run network t =
+  let run ~config:_ network t =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -66,7 +66,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
     }
 
-  let run network t =
+  let run ~config:(Test_config.{ signature_kind; _ } as config) network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in
@@ -142,7 +142,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       { Signed_command_payload.Poly.common; body }
     in
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     let raw_signature =
       Signed_command.sign_payload ~signature_kind sender.private_key payload
       |> Signature.Raw.encode
@@ -379,13 +378,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                Malleable_error.soft_error_format ~value:()
                  "Payment failed for unexpected reason: %s" err_str ) )
     in
-    let constants : Test_config.constants =
-      { genesis_constants = Network.genesis_constants network
-      ; constraint_constants = Network.constraint_constants network
-      ; compile_config = Network.compile_config network
-      }
-    in
-    let config = config ~constants in
     let%bind () =
       section_hard
         "send out a bunch more txns to fill up the snark ledger, then wait for \

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -34,7 +34,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in

--- a/src/app/test_executive/slot_end_test.ml
+++ b/src/app/test_executive/slot_end_test.ml
@@ -71,7 +71,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let tx_delay_ms = 5000
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let num_slots = slot_chain_end + 2 in

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -420,7 +420,7 @@ let main inputs =
         let%bind () = Malleable_error.List.iter non_seed_pods ~f:start_print in
         [%log info] "Daemons started" ;
         [%log trace] "executing test" ;
-        T.run network dsl )
+        T.run ~config:test_config network dsl )
   in
   let exit_reason, test_result =
     match monitor_test_result with

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -97,8 +97,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let logger = Logger.create ()
 
-  let run network t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  let run ~config:{ Test_config.signature_kind; _ } network t =
     let open Malleable_error.Let_syntax in
     let%bind () =
       section_hard "Wait for nodes to initialize"
@@ -243,9 +242,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             when Public_key.Compressed.equal public_key account_a_pk ->
               { fee_payer with
                 authorization =
-                  (let signature_kind = Mina_signature_kind.t_DEPRECATED in
-                   Schnorr.Chunked.sign ~signature_kind account_a_kp.private_key
-                     (Random_oracle.Input.Chunked.field full_commitment) )
+                  Schnorr.Chunked.sign ~signature_kind account_a_kp.private_key
+                    (Random_oracle.Input.Chunked.field full_commitment)
               }
           | fee_payer ->
               fee_payer
@@ -264,11 +262,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 in
                 { account_update with
                   authorization =
-                    (let signature_kind = Mina_signature_kind.t_DEPRECATED in
-                     Control.Poly.Signature
-                       (Schnorr.Chunked.sign ~signature_kind
-                          account_a_kp.private_key
-                          (Random_oracle.Input.Chunked.field commitment) ) )
+                    Control.Poly.Signature
+                      (Schnorr.Chunked.sign ~signature_kind
+                         account_a_kp.private_key
+                         (Random_oracle.Input.Chunked.field commitment) )
                 }
             | account_update ->
                 account_update )

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -33,7 +33,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; num_archive_nodes = 1
     }
 
-  let run network t =
+  let run ~config:_ network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -444,7 +444,7 @@ let init_permissionless_ledger ledger account_info =
         { account with balance; permissions = Permissions.empty } )
 
 let apply_to_ledger ledger cmd =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+  let signature_kind = Mina_signature_kind.Testnet in
   match Transaction_hash.User_command_with_valid_signature.command cmd with
   | User_command.Signed_command c ->
       let (`If_this_is_used_it_should_have_a_comment_justifying_it v) =

--- a/src/lib/signature_kind/dune
+++ b/src/lib/signature_kind/dune
@@ -3,7 +3,7 @@
  (public_name mina_signature_kind)
  (libraries mina_signature_kind.type)
  (preprocess
-  (pps ppx_bin_prot ppx_version))
+  (pps ppx_bin_prot ppx_version ppx_deriving_yojson))
  (instrumentation
   (backend bisect_ppx))
  (virtual_modules mina_signature_kind)

--- a/src/lib/signature_kind/mina_signature_kind.mli
+++ b/src/lib/signature_kind/mina_signature_kind.mli
@@ -2,7 +2,7 @@ type t = Mina_signature_kind_type.t =
   | Testnet
   | Mainnet
   | Other_network of string
-[@@deriving bin_io]
+[@@deriving bin_io, to_yojson]
 
 (** The Mina_signature_kind_type in the compiled config. Deprecated - will be
     replaced by a runtime-derived value. *)

--- a/src/lib/signature_kind/type/dune
+++ b/src/lib/signature_kind/type/dune
@@ -3,6 +3,6 @@
  (public_name mina_signature_kind.type)
  (libraries core_kernel)
  (preprocess
-  (pps ppx_version))
+  (pps ppx_version ppx_deriving_yojson))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/lib/signature_kind/type/mina_signature_kind_type.ml
+++ b/src/lib/signature_kind/type/mina_signature_kind_type.ml
@@ -1,4 +1,4 @@
 open Core_kernel
 
 type t = Testnet | Mainnet | Other_network of string
-[@@deriving bin_io_unversioned]
+[@@deriving bin_io_unversioned, to_yojson]

--- a/src/lib/testing/integration_test_lib/intf.ml
+++ b/src/lib/testing/integration_test_lib/intf.ml
@@ -351,7 +351,7 @@ module Test = struct
 
     val config : constants:Test_config.constants -> Test_config.t
 
-    val run : network -> dsl -> unit Malleable_error.t
+    val run : config:Test_config.t -> network -> dsl -> unit Malleable_error.t
   end
 
   (* NB: until the DSL is actually implemented, a test just takes in the engine

--- a/src/lib/testing/integration_test_lib/test_config.ml
+++ b/src/lib/testing/integration_test_lib/test_config.ml
@@ -83,6 +83,7 @@ type t =
   ; network_id : string option
   ; block_window_duration_ms : int
   ; transaction_capacity_log_2 : int
+  ; signature_kind : Mina_signature_kind.t
   }
 
 let proof_config_default : Runtime_config.Proof_keys.t =
@@ -144,6 +145,7 @@ let default ~(constants : constants) =
   ; network_id = None
   ; block_window_duration_ms = constraint_constants.block_window_duration_ms
   ; transaction_capacity_log_2 = constraint_constants.transaction_capacity_log_2
+  ; signature_kind = Mina_signature_kind.t_DEPRECATED
   }
 
 let transaction_capacity_log_2 (config : t) =


### PR DESCRIPTION
Along with change on push sig kind, I've also allow integ tests to accept a new `~config` as param, as it's used by various test already anyway. 