### PR TITLE
MIP Ref Impl: Increase events&actions limit 2

### DIFF
--- a/src/app/zkapps_examples/actions/zkapps_actions.ml
+++ b/src/app/zkapps_examples/actions/zkapps_actions.ml
@@ -44,7 +44,7 @@ let initialize_rule public_key : _ Pickles.Inductive_rule.t =
   }
 
 let update_actions_rule public_key : _ Pickles.Inductive_rule.t =
-  { identifier = "Update sequence events"
+  { identifier = "Update actions"
   ; prevs = []
   ; main = update_actions public_key
   ; feature_flags = Pickles_types.Plonk_types.Features.none_bool

--- a/src/app/zkapps_examples/test/actions/actions.ml
+++ b/src/app/zkapps_examples/test/actions/actions.ml
@@ -197,11 +197,11 @@ let%test_module "Actions test" =
       let account_updates =
         Zkapp_command.Call_forest.to_list zkapp_command.account_updates
       in
-      (* we haven't added any sequence events *)
+      (* we haven't added any actions *)
       List.iter account_updates ~f:(fun account_update ->
           assert (List.is_empty account_update.body.actions) )
 
-    let%test_unit "Initialize and add sequence events" =
+    let%test_unit "Initialize and add actions" =
       let zkapp_command0, account0 =
         let ledger = create_ledger () in
         []
@@ -265,7 +265,7 @@ let%test_module "Actions test" =
       assert (
         Mina_numbers.Global_slot_since_genesis.(equal zero) last_action_slot1 )
 
-    let%test_unit "Add sequence events in different slots" =
+    let%test_unit "Add actions in different slots" =
       let ledger = create_ledger () in
       let slot1 = Mina_numbers.Global_slot_since_genesis.of_int 1 in
       let _zkapp_command0, account0 =

--- a/src/lib/mina_base/test/valid_size.ml
+++ b/src/lib/mina_base/test/valid_size.ml
@@ -76,8 +76,8 @@ let%test_unit "valid_size_errors_actions" =
       [%test_eq: unit Or_error.t]
         (Error
            ( Error.of_string
-           @@ sprintf "too many sequence event elements (%d, max allowed is %d)"
-                (2 * y) y ) )
+           @@ sprintf "too many action elements (%d, max allowed is %d)" (2 * y)
+                y ) )
         ( valid_size
             ~genesis_constants:(genesis_constant_error 100000. (2 * y) y)
         @@ of_wire x ) )

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1390,7 +1390,7 @@ let valid_size (type aux) ~(genesis_constants : Genesis_constants.t)
       if valid_action_elements then None
       else
         Some
-          (sprintf "too many sequence event elements (%d, max allowed is %d)"
+          (sprintf "too many action elements (%d, max allowed is %d)"
              num_action_elements max_action_elements )
     in
     let err_msg =

--- a/src/lib/node_config/unconfigurable_constants/node_config_unconfigurable_constants.ml
+++ b/src/lib/node_config/unconfigurable_constants/node_config_unconfigurable_constants.ml
@@ -21,9 +21,9 @@ let zkapp_signed_single_update_cost = 9.14
 
 let zkapp_transaction_cost_limit = 69.45
 
-let max_event_elements = 100
+let max_event_elements = 1024
 
-let max_action_elements = 100
+let max_action_elements = 1024
 
 let zkapp_cmd_limit_hardcap = 128
 


### PR DESCRIPTION
This is a different reference implementation, in that inner batch limit 16 is not bumped. 

Here's some doc in the MIP, just for reference:

> account update consists of multiple events/actions; An event/action consists of multiple batches of event elements, which are just field elements; A single batch of event element could consist of at most 16 elements. 

> On top of that, the number of field elements denoting events per zkApp command is at most `max_event_elements`, which is 100; The number of field elements denoting actions per zkApp command is at most `max_action_elements` , which is also 100.