### PR TITLE
Fix merge of zkapp proof in work partitioner V2

### DIFF
--- a/src/lib/mina_stdlib/nonempty_list.ml
+++ b/src/lib/mina_stdlib/nonempty_list.ml
@@ -28,6 +28,8 @@ let tail_opt t = of_list_opt (tail t)
 
 let map (x, xs) ~f = (f x, List.map ~f xs)
 
+let mapi (x, xs) ~f = (f 0 x, List.mapi ~f:(fun idx x -> f (idx + 1) x) xs)
+
 let rev (x, xs) = List.fold xs ~init:(singleton x) ~f:(Fn.flip cons)
 
 (* As the Base.Container docs state, we'll add each function from C explicitly

--- a/src/lib/mina_stdlib/nonempty_list.mli
+++ b/src/lib/mina_stdlib/nonempty_list.mli
@@ -46,6 +46,10 @@ val tail_opt : 'a t -> 'a t option
 (** Apply a function to each element of the non empty list *)
 val map : 'a t -> f:('a -> 'b) -> 'b t
 
+(** Apply a function to each element of the non empty list, along with its index
+    starting from 0 *)
+val mapi : 'a t -> f:(int -> 'a -> 'b) -> 'b t
+
 (* The following functions are computed from {!module:Base.Container.Make}. See
  * {!modtype:Base.Container_intf} for more information *)
 

--- a/src/lib/snark_work_lib/id.ml
+++ b/src/lib/snark_work_lib/id.ml
@@ -12,6 +12,26 @@ module Single = struct
   end]
 end
 
+module Range = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = { first : int; last : int }
+      [@@deriving hash, sexp, equal, yojson]
+
+      let compare { first = first_left; _ } { first = first_right; _ } =
+        compare first_left first_right
+
+      let is_consecutive { last = last_left; _ } { first = first_right; _ } =
+        succ last_left = first_right
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let compare = Stable.Latest.compare
+end
+
 module Sub_zkapp = struct
   [%%versioned
   module Stable = struct
@@ -19,7 +39,7 @@ module Sub_zkapp = struct
       type t =
         { which_one : [ `First | `Second | `One ]
         ; pairing_id : int64
-        ; job_id : int64
+        ; range : Range.Stable.V1.t
         }
       [@@deriving compare, hash, sexp, yojson, equal]
 
@@ -27,8 +47,8 @@ module Sub_zkapp = struct
     end
   end]
 
-  let of_single ~(job_id : int64) Single.{ which_one; pairing_id } =
-    { which_one; pairing_id; job_id }
+  let of_single ~(range : Range.t) Single.{ which_one; pairing_id } =
+    { which_one; pairing_id; range }
 
   let to_single ({ which_one; pairing_id; _ } : t) : Single.t =
     { which_one; pairing_id }

--- a/src/lib/snark_work_lib/id.mli
+++ b/src/lib/snark_work_lib/id.mli
@@ -15,6 +15,20 @@ module Single : sig
   end]
 end
 
+module Range : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type t = { first : int; last : int }
+      [@@deriving compare, hash, sexp, equal, yojson]
+
+      val is_consecutive : t -> t -> bool
+
+      val to_latest : t -> t
+    end
+  end]
+end
+
 (** A Sub_zkapp.t identifies a sub-zkapp level work *)
 module Sub_zkapp : sig
   [%%versioned:
@@ -25,7 +39,7 @@ module Sub_zkapp : sig
       type t =
         { which_one : [ `First | `Second | `One ]
         ; pairing_id : int64
-        ; job_id : int64
+        ; range : Range.Stable.V1.t
         }
       [@@deriving compare, hash, sexp, yojson, equal]
 
@@ -33,7 +47,7 @@ module Sub_zkapp : sig
     end
   end]
 
-  val of_single : job_id:int64 -> Single.t -> t
+  val of_single : range:Range.t -> Single.t -> t
 
   val to_single : t -> Single.t
 end

--- a/src/lib/work_partitioner/pending_zkapp_command.ml
+++ b/src/lib/work_partitioner/pending_zkapp_command.ml
@@ -1,17 +1,21 @@
-(* NOTE: Assumption: order of merging segment proofs is irrelvant to the
-   correctness of the final proof. *)
+(* NOTE: Assumption: order of merging segments satisfy associativity. *)
 
 open Core_kernel
 open Snark_work_lib
+
+open struct
+  module Range = Id.Range.Stable.Latest
+  module RangeMap = Map.Make (Range)
+end
 
 type t =
   { job : (Spec.Single.t, Id.Single.t) With_job_meta.t
         (** the original work being split, contains `Work_selector.work` with
             some metadata. *)
-  ; unscheduled_segments : Spec.Sub_zkapp.Stable.Latest.t Queue.t
-  ; pending_mergeable_proofs : Ledger_proof.t Deque.t
-        (* we may need to insert proofs to merge back to the queue, hence a Deque
-         *)
+  ; unscheduled_segments : (Spec.Sub_zkapp.Stable.Latest.t * Range.t) Queue.t
+  ; mutable pending_mergeable_proofs : Ledger_proof.t RangeMap.t
+        (* A map tracking all proofs for this zkapp we have in coordinator and
+           their corresponding range of segments. *)
   ; mutable elapsed : Time.Stable.Span.V1.t
         (** The total work time for all SNARK workers combined to prove this
             specific zkapp command. I.e. the time it would take a single SNARK
@@ -24,13 +28,14 @@ type t =
 
 let create_and_yield_segment ~job
     ~(unscheduled_segments :
-       Spec.Sub_zkapp.Stable.Latest.t Mina_stdlib.Nonempty_list.t ) =
+       (Spec.Sub_zkapp.Stable.Latest.t * Range.t) Mina_stdlib.Nonempty_list.t )
+    =
   let first_segment, unscheduled_segments =
     Mina_stdlib.Nonempty_list.uncons unscheduled_segments
   in
   ( { job
     ; unscheduled_segments = Queue.of_list unscheduled_segments
-    ; pending_mergeable_proofs = Deque.create ()
+    ; pending_mergeable_proofs = RangeMap.empty
     ; elapsed = Time.Span.zero
     ; proofs_in_flight = 1
     }
@@ -38,24 +43,40 @@ let create_and_yield_segment ~job
 
 let zkapp_job t = t.job
 
-let try_take2 (q : 'a Deque.t) : ('a * 'a) option =
-  match Deque.dequeue_front q with
-  | None ->
-      None
-  | Some fst -> (
-      match Deque.dequeue_front q with
-      | Some snd ->
-          Some (fst, snd)
-      | None ->
-          Deque.enqueue_front q fst ; None )
-
 (** [next_merge t] attempts dequeuing 2 proofs from [t.pending_mergeable_proofs]
-    and generate a sub-zkapp level spec merging them together. *)
+    corresponding to consecutive states and generate a sub-zkapp level spec
+    merging them together. *)
 let next_merge (t : t) =
-  let open Option.Let_syntax in
-  let%map proof1, proof2 = try_take2 t.pending_mergeable_proofs in
-  t.proofs_in_flight <- t.proofs_in_flight + 1 ;
-  Spec.Sub_zkapp.Stable.Latest.Merge { proof1; proof2 }
+  let last_element = ref None in
+  RangeMap.to_sequence ~order:`Increasing_key t.pending_mergeable_proofs
+  |> Sequence.fold_until ~init:None ~finish:Fn.id
+       ~f:(fun
+            _
+            ((Range.{ last = last_segment_of_proof2; _ } as this_range), proof2)
+          ->
+         match !last_element with
+         | Some
+             ( (Range.{ first = first_segment_of_proof1; _ } as last_range)
+             , proof1 )
+           when Range.is_consecutive last_range this_range ->
+             t.proofs_in_flight <- t.proofs_in_flight + 1 ;
+             t.pending_mergeable_proofs <-
+               RangeMap.remove
+                 (RangeMap.remove t.pending_mergeable_proofs last_range)
+                 this_range ;
+             let new_range =
+               Range.
+                 { first = first_segment_of_proof1
+                 ; last = last_segment_of_proof2
+                 }
+             in
+             Stop
+               (Some
+                  ( Spec.Sub_zkapp.Stable.Latest.Merge { proof1; proof2 }
+                  , new_range ) )
+         | _ ->
+             last_element := Some (this_range, proof2) ;
+             Continue None )
 
 (** [next_segment t] dequeus a segment from [t.unscheduled_segments] and generate a
    sub-zkapp level spec proving that segment. *)
@@ -65,19 +86,48 @@ let next_segment (t : t) =
   t.proofs_in_flight <- t.proofs_in_flight + 1 ;
   segment
 
-let next_subzkapp_job_spec (t : t) : Spec.Sub_zkapp.Stable.Latest.t option =
+let next_subzkapp_job_spec (t : t) :
+    (Spec.Sub_zkapp.Stable.Latest.t * Range.t) option =
   match next_merge t with Some _ as ret -> ret | None -> next_segment t
 
-let submit_proof (t : t) ~(proof : Ledger_proof.t)
-    ~(elapsed : Time.Stable.Span.V1.t) =
-  Deque.enqueue_back t.pending_mergeable_proofs proof ;
-  t.proofs_in_flight <- t.proofs_in_flight - 1 ;
-  t.elapsed <- Time.Span.(t.elapsed + elapsed)
+let submit_proof ~(proof : Ledger_proof.t) ~(elapsed : Time.Stable.Span.V1.t)
+    ~range:(Range.{ first; last } as range) (t : t) =
+  let should_accept =
+    first <= last
+    && RangeMap.closest_key t.pending_mergeable_proofs `Greater_or_equal_to
+         Range.{ first = last; last }
+       |> Option.map ~f:(fun (Range.{ first = next_first; _ }, _) ->
+              last < next_first )
+       |> Option.value ~default:true
+    && RangeMap.closest_key t.pending_mergeable_proofs `Less_or_equal_to
+         Range.{ first; last = first }
+       |> Option.map ~f:(fun (Range.{ last = previous_last; _ }, _) ->
+              previous_last < first )
+       |> Option.value ~default:true
+  in
+  if should_accept then (
+    t.pending_mergeable_proofs <-
+      RangeMap.add_exn ~key:range ~data:proof t.pending_mergeable_proofs ;
+    t.proofs_in_flight <- t.proofs_in_flight - 1 ;
+    t.elapsed <- Time.Span.(t.elapsed + elapsed) ;
+    Ok () )
+  else
+    let msg =
+      Printf.sprintf
+        "Pending zkapp command has a submission of range [%d, %d], that \
+         doesn't fit"
+        first last
+    in
+    Error (Error.of_string msg)
 
 let try_finalize (t : t) =
   if
     t.proofs_in_flight = 0
     && Queue.is_empty t.unscheduled_segments
-    && Deque.length t.pending_mergeable_proofs = 1
-  then Some (t.job, Deque.dequeue_back_exn t.pending_mergeable_proofs, t.elapsed)
+    && RangeMap.length t.pending_mergeable_proofs = 1
+  then
+    Some
+      ( t.job
+      , RangeMap.min_elt_exn t.pending_mergeable_proofs |> Tuple2.get2
+      , t.elapsed )
   else None

--- a/src/lib/work_partitioner/pending_zkapp_command.mli
+++ b/src/lib/work_partitioner/pending_zkapp_command.mli
@@ -10,18 +10,27 @@ type t
 val create_and_yield_segment :
      job:(Spec.Single.t, Id.Single.t) With_job_meta.t
   -> unscheduled_segments:
-       Spec.Sub_zkapp.Stable.V1.t Mina_stdlib.Nonempty_list.Stable.V1.t
-  -> t * Spec.Sub_zkapp.Stable.V1.t
+       (Spec.Sub_zkapp.Stable.V1.t * Id.Range.Stable.V1.t)
+       Mina_stdlib.Nonempty_list.Stable.V1.t
+  -> t * (Spec.Sub_zkapp.Stable.V1.t * Id.Range.Stable.V1.t)
 
 val zkapp_job : t -> (Spec.Single.t, Id.Single.t) With_job_meta.t
 
 (** [next_subzkapp_job_spec t] extracts another job spec from t, mutating the internal
     state of [t]. Once any job spec returned is completed, it's expected to be
     submitted back to [t] with [submit_proof] *)
-val next_subzkapp_job_spec : t -> Spec.Sub_zkapp.Stable.Latest.t option
+val next_subzkapp_job_spec :
+  t -> (Spec.Sub_zkapp.Stable.V1.t * Id.Range.Stable.V1.t) option
 
+(* [submit_proof t ~proof ~elapsed ~range] submit a proof corresponding to
+   a range of segments(both inclusive). This throws error if either the range is
+   invalid or some corresponded segment proof is already present in [t] *)
 val submit_proof :
-  t -> proof:Ledger_proof.t -> elapsed:Core_kernel_private.Span_float.t -> unit
+     proof:Ledger_proof.t
+  -> elapsed:Core_kernel_private.Span_float.t
+  -> range:Id.Range.Stable.V1.t
+  -> t
+  -> (unit, Error.t) result
 
 (** [try_finalize t] attempts to unwrap completed proof, metric and spec from
     [t] if the proof for entire zkapp transaction is completed *)


### PR DESCRIPTION
Revamp of https://github.com/MinaProtocol/mina/pull/17584 where we no longer store range in subzkapp specs, instead we store it in id. 

Previously, zkapp segments proof are merged arbitrarily without an order being enforced. This is wrong because merging on subzkapp level proof only satisfy associativity, but not commutativity.

This PR completely redesigned the structure to fix this issue.

I am aware we're passing more garbage around the network, but I intend to fix them after this feature series are merged.
