### PR TITLE
reintroduce mina-create-legacy-genesis for hf artifacts verifications

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -190,6 +190,7 @@ let docker_step
                   ]
                 , TestExecutive = [] : List DockerImage.ReleaseSpec.Type
                 , LogProc = [] : List DockerImage.ReleaseSpec.Type
+                , CreateLegacyGenesis = [] : List DockerImage.ReleaseSpec.Type
                 , BatchTxn =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -22,6 +22,7 @@ let Artifact
       | ZkappTestTransaction
       | FunctionalTestSuite
       | Toolchain
+      | CreateLegacyGenesis
       >
 
 let AllButTests =
@@ -34,6 +35,7 @@ let AllButTests =
       , Artifact.Rosetta
       , Artifact.ZkappTestTransaction
       , Artifact.Toolchain
+      , Artifact.CreateLegacyGenesis
       ]
 
 let Main =
@@ -59,6 +61,7 @@ let capitalName =
             , ZkappTestTransaction = "ZkappTestTransaction"
             , FunctionalTestSuite = "FunctionalTestSuite"
             , Toolchain = "Toolchain"
+            , CreateLegacyGenesis = "CreateLegacyGenesis"
             }
             artifact
 
@@ -74,6 +77,7 @@ let lowerName =
             , Rosetta = "rosetta"
             , ZkappTestTransaction = "zkapp_test_transaction"
             , FunctionalTestSuite = "functional_test_suite"
+            , CreateLegacyGenesis = "create_legacy_genesis"
             , Toolchain = "toolchain"
             }
             artifact
@@ -91,6 +95,7 @@ let dockerName =
             , ZkappTestTransaction = "mina-zkapp-test-transaction"
             , FunctionalTestSuite = "mina-test-suite"
             , Toolchain = "mina-toolchain"
+            , CreateLegacyGenesis = "mina-create-legacy-genesis"
             }
             artifact
 
@@ -107,7 +112,7 @@ let toDebianName =
       ->  \(network : Network.Type)
       ->  merge
             { Daemon = "daemon_${Network.lowerName network}"
-            , DaemonHardfork = ""
+            , DaemonHardfork = "daemon_${Network.lowerName network}_hardfork"
             , LogProc = "logproc"
             , Archive = "archive_${Network.lowerName network}"
             , TestExecutive = "test_executive"
@@ -116,6 +121,7 @@ let toDebianName =
             , ZkappTestTransaction = "zkapp_test_transaction"
             , FunctionalTestSuite = "functional_test_suite"
             , Toolchain = ""
+            , CreateLegacyGenesis = "create_legacy_genesis"
             }
             artifact
 
@@ -137,6 +143,7 @@ let toDebianNames =
                           , Rosetta = [ toDebianName a network ]
                           , ZkappTestTransaction = [ "zkapp_test_transaction" ]
                           , FunctionalTestSuite = [ "functional_test_suite" ]
+                          , CreateLegacyGenesis = [ "create_legacy_genesis" ]
                           , Toolchain = [] : List Text
                           }
                           a
@@ -204,6 +211,7 @@ let dockerTag =
                 , ZkappTestTransaction = "${spec.version}"
                 , FunctionalTestSuite = "${spec.version}${build_flags_part}"
                 , Toolchain = "${spec.version}"
+                , CreateLegacyGenesis = "${spec.version}"
                 }
                 spec.artifact
 

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -17,6 +17,7 @@ let isEssential =
             , FunctionalTestSuite = True
             , Toolchain = True
             , DaemonHardfork = True
+            , CreateLegacyGenesis = False
             }
             service
 

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Devnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
@@ -23,6 +23,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
           , network = Network.Type.Mainnet

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeBerkeleyDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeBerkeleyDevnet.dhall
@@ -17,6 +17,7 @@ in  Pipeline.build
             , Artifacts.Type.TestExecutive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , tags =
             [ PipelineTag.Type.Long

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeBerkeleyDevnetInstrumented.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeBerkeleyDevnetInstrumented.dhall
@@ -16,6 +16,7 @@ in  Pipeline.build
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.FunctionalTestSuite
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , buildFlags = BuildFlags.Type.Instrumented
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
@@ -18,6 +18,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Devnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
@@ -22,6 +22,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Mainnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalBerkeleyDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalBerkeleyDevnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
             , Artifacts.Type.TestExecutive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , scope =
             [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
@@ -22,6 +22,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Devnet
           , scope =

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -24,6 +24,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , debVersion = DebianVersions.DebVersion.Focal
           , network = Network.Type.Mainnet

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Devnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
@@ -23,6 +23,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreateLegacyGenesis
             ]
           , network = Network.Type.Mainnet
           , tags =

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -75,6 +75,7 @@ RUN echo "Building image with version $deb_version from repo $deb_release $deb_c
   && echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
   && apt-get update --quiet --yes \
   && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "${MINA_DEB}=$deb_version" \
+  && apt-get install --quiet --yes --allow-downgrades "mina-create-legacy-genesis=1.4.0beta2-compatible-97f7d8c" \
   && rm -rf /var/lib/apt/lists/*
 
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -521,3 +521,20 @@ build_zkapp_test_transaction_deb () {
   build_deb mina-zkapp-test-transaction
 }
 ## END ZKAPP TEST TXN PACKAGE ##
+
+
+
+build_create_legacy_genesis_deb() {
+  echo "------------------------------------------------------------"
+  echo "--- Building Mina Berkeley create legacy genesis tool:"
+
+  create_control_file mina-create-legacy-genesis \
+    "${SHARED_DEPS}${DAEMON_DEPS}" \
+    'Utility to verify post hardfork ledger for Mina'
+
+  # Binaries
+  cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
+    "${BUILDDIR}/usr/local/bin/mina-create-legacy-genesis"
+
+  build_deb mina-create-legacy-genesis
+}


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
