### PR TITLE
Block Time: Remove Controller.create

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -725,9 +725,7 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
         in
         Parallel.init_master () ;
         let monitor = Async.Monitor.create ~name:"coda" () in
-        let time_controller =
-          Block_time.Controller.create @@ Block_time.Controller.basic ~logger
-        in
+        let time_controller = Block_time.Controller.basic ~logger in
         let pids = Child_processes.Termination.create_pid_table () in
         let mina_initialization_deferred () =
           let config_file_installed =

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -69,8 +69,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
         | None | Some false ->
             failwith "Cannot mutate the time offset"
 
-      let create offset = offset
-
       let basic ~logger () =
         match !time_offset with
         | Some offset ->

--- a/src/lib/block_time/intf.ml
+++ b/src/lib/block_time/intf.ml
@@ -18,8 +18,6 @@ module type S = sig
     module Controller : sig
       type t [@@deriving sexp, equal, compare]
 
-      val create : t -> t
-
       val basic : logger:Logger.t -> t
 
       (** Override the time offset set by the [MINA_TIME_OFFSET] environment

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -183,8 +183,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
         Linear_pipe.create ()
       in
       let time_controller =
-        Block_time.Controller.create
-        @@ Block_time.Controller.basic ~logger:(Logger.create ())
+        Block_time.Controller.basic ~logger:(Logger.create ())
       in
       let t =
         { network

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -187,9 +187,7 @@ let%test_module "Epoch ledger sync tests" =
         Strict_pipe.create Synchronous
       in
       let precomputed_values = Context.precomputed_values in
-      let time_controller =
-        Block_time.Controller.create @@ Block_time.Controller.basic ~logger
-      in
+      let time_controller = Block_time.Controller.basic ~logger in
       let on_remote_push () = Deferred.unit in
       let%bind verifier = make_verifier (module Context) in
       let block_reader, block_sink =


### PR DESCRIPTION
That function is misleading as it's just `id`.

Even if we want some kind of side effect in evaluating a module. It doesn't make sense because if we ever hold a value of type `t`, the whole module should've been force evaluated. 