### PR TITLE
Improve Block Producer Readbility + Fix VRF data update

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1200,6 +1200,10 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     ~local_state:consensus_local_state
                    = None ) ; *)
             let next_vrf_check_now () =
+              (* WARN: This recursive call will update [epoch_data_for_vrf] and
+                 in turn [new_epoch] and [new_global_slot]. Refactors aiming at
+                 removing this should consider structuring the code so updating
+                 on those data are included. *)
               iteration_wrapped (new_global_slot, new_epoch)
             in
             let produce_block_now data =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1134,7 +1134,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
           ~zkapp_cmd_limit_hardcap
       in
       let module Breadcrumb = Transition_frontier.Breadcrumb in
-      let iteration_wrapped (slot, epoch) =
+      let rec iteration_wrapped (slot, epoch) =
         (* Begin checking for the ability to produce a block *)
         match Broadcast_pipe.Reader.peek frontier_reader with
         | None ->
@@ -1199,7 +1199,9 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     ~constants:consensus_constants ~consensus_state
                     ~local_state:consensus_local_state
                    = None ) ; *)
-            let next_vrf_check_now () = return (new_global_slot, new_epoch) in
+            let next_vrf_check_now () =
+              iteration_wrapped (new_global_slot, new_epoch)
+            in
             let produce_block_now data =
               produce data >>| const (new_global_slot, new_epoch)
             in

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -937,7 +937,7 @@ let iteration ~schedule_next_vrf_check ~produce_block_now
     ~context:(module Context : CONTEXT) ~vrf_evaluator ~time_controller
     ~coinbase_receiver ~frontier_reader ~set_next_producer_timing
     ~transition_frontier ~vrf_evaluation_state ~epoch_data_for_vrf
-    ~ledger_snapshot ~epoch slot =
+    ~ledger_snapshot ~epoch ~slot =
   O1trace.thread "block_producer_iteration"
   @@ fun () ->
   let consensus_state =
@@ -1215,7 +1215,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
               ~vrf_evaluator ~time_controller ~coinbase_receiver
               ~frontier_reader ~set_next_producer_timing ~transition_frontier
               ~vrf_evaluation_state ~epoch_data_for_vrf ~ledger_snapshot ~epoch
-              slot
+              ~slot
       in
       let start _ =
         Deferred.forever


### PR DESCRIPTION
BP is specifically hard to read due to non-standard naming. This PR:
- improve readability a bit
- Fixed a bug VRF input is not updated on call to `next_vrf_check_now`