### PR TITLE
Enable local docker build on dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ ifeq ($(DUNE_PROFILE),)
 DUNE_PROFILE := dev
 endif
 
+# Default branch name
+# This is used for versioning and release purposes when building docker or debian
+# For example when BRANCH_NAME=fix-branch:
+# Target version : 3.1.2-alpha-fix-branch-bullseye-devnet
+BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
+
 ifeq ($(OPAMSWITCH)$(IN_NIX_SHELL)$(CI)$(BUILDKITE),)
 # Sometimes opam replaces these env variables in shell with
 # an explicit mention of a particular switch (dereferenced from the value)
@@ -63,15 +69,17 @@ clean: ## Remove build artifacts
 
 .PHONY: switch
 switch: ## Set up the opam switch
+ifeq ($(OPAMSWITCH), )
 	./scripts/update-opam-switch.sh
+endif
 
 .PHONY: ocaml_version
 ocaml_version: switch ## Check OCaml version
-	@if ! ocamlopt -config | grep "version:" | grep $(OCAML_VERSION); then echo "incorrect OCaml version, expected version $(OCAML_VERSION)" ; exit 1; fi
+	@if ! ocamlopt -config | grep "version:" | grep -q $(OCAML_VERSION); then echo "❌ incorrect OCaml version, expected version $(OCAML_VERSION)" ; exit 1; else echo "✅ OCaml version is correct"; fi
 
 .PHONY: ocaml_word_size
 ocaml_word_size: switch ## Check OCaml word size
-	@if ! ocamlopt -config | grep "word_size:" | grep $(WORD_SIZE); then echo "invalid machine word size, expected $(WORD_SIZE)" ; exit 1; fi
+	@if ! ocamlopt -config | grep "word_size:" | grep -q $(WORD_SIZE); then echo "❌ invalid machine word size, expected $(WORD_SIZE)" ; exit 1; else echo "✅ OCaml word size is correct"; fi
 
 
 .PHONY: check_opam_switch
@@ -87,12 +95,13 @@ ocaml_checks: switch ocaml_version ocaml_word_size check_opam_switch ## Run OCam
 .PHONY: libp2p_helper
 libp2p_helper: ## Build libp2p helper
 ifeq (, $(MINA_LIBP2P_HELPER_PATH))
+	$(info 🏗️  Building libp2p_helper)
 	make -C src/app/libp2p_helper
 endif
 
 .PHONY: genesis_ledger
 genesis_ledger: ocaml_checks ## Build runtime genesis ledger
-	$(info Building runtime_genesis_ledger)
+	$(info 🏗️  Building runtime_genesis_ledger with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
 	dune exec \
@@ -107,7 +116,7 @@ check: ocaml_checks libp2p_helper ## Check that all OCaml packages build without
 
 .PHONY: build
 build: ocaml_checks reformat-diff libp2p_helper ## Build the main project executables
-	$(info Starting Build)
+	$(info 🏗️  Building Mina with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
 	dune build \
@@ -116,32 +125,70 @@ build: ocaml_checks reformat-diff libp2p_helper ## Build the main project execut
 		src/app/generate_keypair/generate_keypair.exe \
 		src/app/validate_keypair/validate_keypair.exe \
 		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
+		src/lib/snark_worker/standalone/run_snark_worker.exe \
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: build_all_sigs
-build_all_sigs: ocaml_checks reformat-diff libp2p_helper build ## Build all signature variants of the daemon
-	$(info Starting Build)
+.PHONY: build-daemon-utils
+build-daemon-utils: ocaml_checks reformat-diff libp2p_helper ## Build daemon utilities
+	$(info 🏗️  Building Mina Daemon related utils with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
+	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
+	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
+	dune build \
+		src/app/generate_keypair/generate_keypair.exe \
+		src/app/validate_keypair/validate_keypair.exe \
+		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
+		src/lib/snark_worker/standalone/run_snark_worker.exe \
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
+
+
+.PHONY: build-logproc
+build-logproc: ocaml_checks reformat-diff libp2p_helper ## Build the logproc executable
+	$(info 🏗️  Building logproc with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
+	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
+	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
+	dune build \
+		src/app/logproc/logproc.exe \
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
+
+.PHONY: build-mainnet-sigs
+build-mainnet-sigs: ocaml_checks reformat-diff libp2p_helper build ## Build mainnet signature variants of the daemon
+	$(info 🏗️  Building mainnet signature variants with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
+	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
+	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
+	dune build \
+		src/app/cli/src/mina_mainnet_signatures.exe \
+		src/app/rosetta/rosetta_mainnet_signatures.exe \
+		src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe \
+		--profile=mainnet \
+		&& echo "✅ Build complete"
+
+.PHONY: build-devnet-sigs
+build-devnet-sigs: ocaml_checks reformat-diff libp2p_helper build ## Build devnet signature variants of the daemon
+	$(info 🏗️  Building devnet signature variants with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	env MINA_COMMIT_SHA1=$(GITLONGHASH) \
 	dune build \
 		src/app/cli/src/mina_testnet_signatures.exe \
-		src/app/cli/src/mina_mainnet_signatures.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
+		src/app/rosetta/rosetta_testnet_signatures.exe \
+		src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe \
+		--profile=devnet \
+		&& echo "✅ Build complete"
 
-.PHONY: build_archive
-build_archive: ocaml_checks reformat-diff ## Build the archive node
-	$(info Starting Build)
+.PHONY: build-archive
+build-archive: ocaml_checks reformat-diff ## Build the archive node
+	$(info 🏗️  Building archive with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/archive/archive.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) && \
+		echo "✅ Build complete"
 
-.PHONY: build_archive_utils
-build_archive_utils: ocaml_checks reformat-diff ## Build archive node and related utilities
-	$(info Starting Build)
+.PHONY: build-archive-utils
+build-archive-utils: ocaml_checks reformat-diff ## Build archive node and related utilities
+	$(info 🏗️  Building archive utilities with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/archive/archive.exe \
@@ -149,117 +196,122 @@ build_archive_utils: ocaml_checks reformat-diff ## Build archive node and relate
 		src/app/archive_blocks/archive_blocks.exe \
 		src/app/extract_blocks/extract_blocks.exe \
 		src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE)  \
+		&& echo "✅ Build complete"
 
-.PHONY: build_rosetta
-build_rosetta: ocaml_checks ## Build Rosetta API components
-	$(info Starting Build)
+.PHONY: build-test-utils
+build-test-utils: ocaml_checks reformat-diff ## Build test utilities
+	$(info 🏗️  Building test utilities with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
+	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
+	dune build \
+		src/app/test_executive/test_executive.exe \
+		src/app/benchmarks/benchmarks.exe \
+		src/app/batch_txn_tool/batch_txn_tool.exe \
+		src/app/zkapp_test_transaction/zkapp_test_transaction.exe \
+		src/app/rosetta/indexer_test/indexer_test.exe \
+		src/app/ledger_export_bench/ledger_export_benchmark.exe \
+		src/app/disk_caching_stats/disk_caching_stats.exe \
+		src/app/heap_usage/heap_usage.exe \
+		src/app/zkapp_limits/zkapp_limits.exe \
+		src/lib/snark_worker/standalone/run_snark_worker.exe \
+		src/test/command_line_tests/command_line_tests.exe \
+		src/test/archive/patch_archive_test/patch_archive_test.exe \
+		src/test/archive/archive_node_tests/archive_node_tests.exe \
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
+
+
+.PHONY: build-rosetta
+build-rosetta: ocaml_checks ## Build Rosetta API components
+	$(info 🏗️  Building Rosetta API components with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: build_rosetta_all_sigs
-build_rosetta_all_sigs: ocaml_checks ## Build all signature variants of Rosetta
-	$(info Starting Build)
-	(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
-	dune build \
-		src/app/archive/archive.exe \
-		src/app/archive/archive_testnet_signatures.exe \
-		src/app/archive/archive_mainnet_signatures.exe \
-		src/app/rosetta/rosetta.exe \
-		src/app/rosetta/rosetta_testnet_signatures.exe \
-		src/app/rosetta/rosetta_mainnet_signatures.exe \
-		src/app/rosetta/ocaml-signer/signer.exe \
-		src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe \
-		src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe \
-		--profile=$(DUNE_PROFILE)
-	$(info Build complete)
-
-.PHONY: build_intgtest
-build_intgtest: ocaml_checks ## Build integration test tools
-	$(info Starting Build)
+.PHONY: build-intgtest
+build-intgtest: ocaml_checks ## Build integration test tools
+	$(info 🏗️  Building integration test tools with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@dune build \
 		--profile=$(DUNE_PROFILE) \
 		src/app/test_executive/test_executive.exe \
-		src/app/logproc/logproc.exe
-	$(info Build complete)
+		src/app/logproc/logproc.exe \
+		&& echo "✅ Build complete"
 
-.PHONY: rosetta_lib_encodings
-rosetta_lib_encodings: ocaml_checks ## Test Rosetta library encodings
-	$(info Starting Build)
+.PHONY: build-rosetta-mainnet-lib-encodings
+build-rosetta-mainnet-lib-encodings: ocaml_checks ## Test Rosetta library encodings
+	$(info 🏗️  Building Rosetta library encodings with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 	  src/lib/rosetta_lib/test/test_encodings.exe \
-	  --profile=mainnet
-	$(info Build complete)
+	  --profile=mainnet \
+		&& echo "✅ Build complete"
 
-.PHONY: replayer
-replayer: ocaml_checks ## Build the replayer tool
-	$(info Starting Build)
+.PHONY: build-replayer
+build-replayer: ocaml_checks ## Build the replayer tool
+	$(info 🏗️  Building replayer tool with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@ulimit -s 65532 && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/replayer/replayer.exe \
-		--profile=devnet
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: missing_blocks_auditor
-missing_blocks_auditor: ocaml_checks ## Build missing blocks auditor tool
-	$(info Starting Build)
+.PHONY: build-missing-blocks-auditor
+build-missing-blocks-auditor: ocaml_checks ## Build missing blocks auditor tool
+	$(info 🏗️  Building missing blocks auditor tool with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
-		--profile=testnet_postake_medium_curves
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: extract_blocks
-extract_blocks: ocaml_checks ## Build the extract_blocks executable
-	$(info Starting Build)
+.PHONY: extract-blocks
+build-extract-blocks: ocaml_checks ## Build the extract_blocks executable
+	$(info 🏗️  Building extract_blocks with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/extract_blocks/extract_blocks.exe \
-		--profile=testnet_postake_medium_curves
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: archive_blocks
-archive_blocks: ocaml_checks ## Build the archive_blocks executable
-	$(info Starting Build)
+.PHONY: build-archive-blocks
+build-archive-blocks: ocaml_checks ## Build the archive_blocks executable
+	$(info 🏗️  Building archive_blocks with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/archive_blocks/archive_blocks.exe \
-		--profile=testnet_postake_medium_curves
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: patch_archive_test
-patch_archive_test: ocaml_checks ## Build the patch archive test
-	$(info Starting Build)
+.PHONY: build-patch-archive-test
+build-patch-archive-test: ocaml_checks ## Build the patch archive test
+	$(info 🏗️  Building patch archive test with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@ulimit -s 65532 && (ulimit -n 10240 || true) && \
 	dune build \
 	  src/app/patch_archive_test/patch_archive_test.exe \
-		--profile=testnet_postake_medium_curves
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: heap_usage
-heap_usage: ocaml_checks ## Build heap usage analysis tool
-	$(info Starting Build)
+.PHONY: build-heap-usage
+build-heap-usage: ocaml_checks ## Build heap usage analysis tool
+	$(info 🏗️  Building heap usage analysis tool with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@ulimit -s 65532 && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/heap_usage/heap_usage.exe \
-		--profile=devnet
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
-.PHONY: zkapp_limits
-zkapp_limits: ocaml_checks ## Build ZkApp limits tool
-	$(info Starting Build)
+.PHONY: build-zkapp-limits
+build-zkapp-limits: ocaml_checks ## Build ZkApp limits tool
+	$(info 🏗️  Building ZkApp limits tool with profile $(DUNE_PROFILE) and commit $(GITLONGHASH))
 	@ulimit -s 65532 && (ulimit -n 10240 || true) && \
 	dune build \
 		src/app/zkapp_limits/zkapp_limits.exe \
-		--profile=devnet
-	$(info Build complete)
+		--profile=$(DUNE_PROFILE) \
+		&& echo "✅ Build complete"
 
 .PHONY: dev
 dev: build ## Alias for build
@@ -443,15 +495,159 @@ doc_diagram_sources+=$(addprefix src/lib/transition_frontier/res/,*.dot *.tex *.
 .PHONY: doc_diagrams
 doc_diagrams: $(addsuffix .png,$(wildcard $(doc_diagram_sources))) ## Generate documentation diagrams
 
+.PHONY: export_git_env_vars
+export_git_env_vars: ## Export git environment variables for use in scripts
+	KEEP_MY_TAGS_INTACT=true \
+		./scripts/export-git-env-vars.sh
+
+########################################
+# Debian packages
+
+# Helper function for building Debian packages
+define build_debian_package
+	$(info 🏗️  Building Debian package $(1) with profile $(DUNE_PROFILE) and commit $(GITLONGHASH) and codename $(CODENAME))
+	BUILD_DIR="${PWD}/_build" \
+	DUNE_PROFILE=$(DUNE_PROFILE) \
+	MINA_DEB_CODENAME="$(CODENAME)" \
+	BRANCH_NAME="$(BRANCH_NAME)" \
+	./scripts/debian/build.sh $(1)  \
+		&& echo "✅ Build complete"
+endef
+
+.PHONY: debian-build-archive-berkeley
+debian-build-archive-berkeley: ## Build the Debian archive package
+	$(call build_debian_package,archive_berkeley)
+
+.PHONY: debian-build-archive-devnet
+debian-build-archive-devnet: ## Build the Debian archive package for devnet
+	$(call build_debian_package,archive_devnet)
+
+.PHONY: debian-build-archive-mainnet
+debian-build-archive-mainnet: ## Build the Debian archive package for mainnet
+	$(call build_debian_package,archive_mainnet)
+
+.PHONY: debian-build-daemon-berkeley
+debian-build-daemon-berkeley: ## Build the Debian daemon package for berkeley
+	$(call build_debian_package,daemon_berkeley)
+
+.PHONY: debian-build-daemon-devnet
+debian-build-daemon-devnet: ## Build the Debian daemon package for devnet
+	$(call build_debian_package,daemon_devnet)
+
+.PHONY: debian-build-daemon-mainnet
+debian-build-daemon-mainnet: ## Build the Debian daemon package for mainnet
+	$(call build_debian_package,daemon_mainnet)
+
+.PHONY: debian-build-logproc
+debian-build-logproc: ## Build the Debian logproc package
+	$(call build_debian_package,logproc)
+
+.PHONY: debian-build-rosetta-berkeley
+debian-build-rosetta-berkeley: ## Build the Debian Rosetta package
+	$(call build_debian_package,rosetta_berkeley)
+
+.PHONY: debian-build-rosetta-devnet
+debian-build-rosetta-devnet: ## Build the Debian Rosetta package for devnet
+	$(call build_debian_package,rosetta_devnet)
+
+.PHONY: debian-build-rosetta-mainnet
+debian-build-rosetta-mainnet: ## Build the Debian Rosetta package for mainnet
+	$(call build_debian_package,rosetta_mainnet)
+
 ########################################
 # Docker images
 
+.PHONY: start-local-debian-repo
+start-local-debian-repo: ## Start a local Debian repository
+	$(info 📦 Starting local Debian repository with codename $(CODENAME))
+
+	./scripts/debian/aptly.sh stop || true
+
+	./scripts/debian/aptly.sh start \
+		--codename $(CODENAME) \
+		--debians _build \
+		--component unstable \
+		--clean \
+		--background \
+		--wait \
+		&& echo "✅ Build complete"
+
+# General function for building Docker images
+define build_docker_image
+	$(info 🐳 Building Docker image for service $(1) with \
+		codename $(CODENAME) \
+		and version $$MINA_DEB_VERSION \
+		and branch $$GITBRANCH \
+		and network $(2))
+
+	BUILD_DIR=./_build \
+	MINA_DEB_CODENAME=$(CODENAME) \
+	KEEP_MY_TAGS_INTACT=true \
+	. ./scripts/export-git-env-vars.sh \
+	&& ./scripts/docker/build.sh \
+		--deb-codename $(CODENAME) \
+		--service $(1) \
+		--version "$$MINA_DEB_VERSION" \
+		--branch "$$GITBRANCH" \
+		--network $(2) \
+		--no-cache
+
+	./scripts/debian/aptly.sh stop
+endef
+
+
 .PHONY: docker-build-toolchain
 docker-build-toolchain: ## Build the toolchain to be used in CI
-	./scripts/docker/build.sh \
+	BUILD_DIR=./_build \
+		./scripts/docker/build.sh \
 		--deb-codename $(CODENAME) \
 		--service mina-toolchain \
 		--version mina-toolchain-$(CODENAME)-$(GITHASH)
+
+.PHONY: docker-build-archive-berkeley
+docker-build-archive-berkeley: SHELL := /bin/bash
+docker-build-archive-berkeley: start-local-debian-repo ## Build the archive Docker image
+	$(call build_docker_image,mina-archive,berkeley)
+
+.PHONY: docker-build-archive-devnet
+docker-build-archive-devnet: SHELL := /bin/bash
+docker-build-archive-devnet: start-local-debian-repo ## Build the archive Docker image for devnet
+	$(call build_docker_image,mina-archive,devnet)
+
+.PHONY: docker-build-archive-mainnet
+docker-build-archive-mainnet: SHELL := /bin/bash
+docker-build-archive-mainnet: start-local-debian-repo ## Build the archive Docker image for mainnet
+	$(call build_docker_image,mina-archive,mainnet)
+
+.PHONY: docker-build-daemon-berkeley
+docker-build-daemon-berkeley: SHELL := /bin/bash
+docker-build-daemon-berkeley: start-local-debian-repo ## Build the daemon Docker image
+	$(call build_docker_image,mina-daemon,berkeley)
+
+.PHONY: docker-build-daemon-devnet
+docker-build-daemon-devnet: SHELL := /bin/bash
+docker-build-daemon-devnet: start-local-debian-repo ## Build the daemon Docker image for devnet
+	$(call build_docker_image,mina-daemon,devnet)
+
+.PHONY: docker-build-daemon-mainnet
+docker-build-daemon-mainnet: SHELL := /bin/bash
+docker-build-daemon-mainnet: start-local-debian-repo ## Build the daemon Docker image for mainnet
+	$(call build_docker_image,mina-daemon,mainnet)
+
+.PHONY: docker-build-rosetta
+docker-build-rosetta-berkeley: SHELL := /bin/bash
+docker-build-rosetta-berkeley: start-local-debian-repo ## Build the Rosetta Docker image
+	$(call build_docker_image,mina-rosetta,berkeley)
+
+.PHONY: docker-build-rosetta-devnet
+docker-build-rosetta-devnet: SHELL := /bin/bash
+docker-build-rosetta-devnet: start-local-debian-repo ## Build the Rosetta Docker image for devnet
+	$(call build_docker_image,mina-rosetta,devnet)
+
+.PHONY: docker-build-rosetta-mainnet
+docker-build-rosetta-mainnet: SHELL := /bin/bash
+docker-build-rosetta-mainnet: start-local-debian-repo ## Build the Rosetta Docker image for mainnet
+	$(call build_docker_image,mina-rosetta,mainnet)
 
 ########################################
 # Generate odoc documentation

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ ocaml_checks: switch ocaml_version ocaml_word_size check_opam_switch ## Run OCam
 libp2p_helper: ## Build libp2p helper
 ifeq (, $(MINA_LIBP2P_HELPER_PATH))
 	$(info 🏗️  Building libp2p_helper)
-	make -C src/app/libp2p_helper
+	@make -C src/app/libp2p_helper \
+	&& echo "✅ libp2p_helper build complete"
 endif
 
 .PHONY: genesis_ledger
@@ -559,9 +560,9 @@ debian-build-rosetta-mainnet: ## Build the Debian Rosetta package for mainnet
 start-local-debian-repo: ## Start a local Debian repository
 	$(info 📦 Starting local Debian repository with codename $(CODENAME))
 
-	./scripts/debian/aptly.sh stop || true
+	@./scripts/debian/aptly.sh stop || true
 
-	./scripts/debian/aptly.sh start \
+	@./scripts/debian/aptly.sh start \
 		--codename $(CODENAME) \
 		--debians _build \
 		--component unstable \
@@ -578,7 +579,7 @@ define build_docker_image
 		and branch $$GITBRANCH \
 		and network $(2))
 
-	BUILD_DIR=./_build \
+	@BUILD_DIR=./_build \
 	MINA_DEB_CODENAME=$(CODENAME) \
 	KEEP_MY_TAGS_INTACT=true \
 	. ./scripts/export-git-env-vars.sh \
@@ -590,13 +591,14 @@ define build_docker_image
 		--network $(2) \
 		--no-cache
 
-	./scripts/debian/aptly.sh stop
+	$(info 📦 stopping local Debian repository)
+	@./scripts/debian/aptly.sh stop
 endef
 
 
 .PHONY: docker-build-toolchain
 docker-build-toolchain: ## Build the toolchain to be used in CI
-	BUILD_DIR=./_build \
+	@BUILD_DIR=./_build \
 		./scripts/docker/build.sh \
 		--deb-codename $(CODENAME) \
 		--service mina-toolchain \

--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -21,14 +21,14 @@ echo "Rust Version: $(rustc --version)"
 
 make libp2p_helper
 
-make build_logproc
+make build-logproc
 
-[[ ${MINA_BUILD_MAINNET} ]] && make build_mainnet_sigs
+[[ ${MINA_BUILD_MAINNET} ]] && make build-mainnet-sigs
 
-make build_testnet_sigs
+make build-testnet-sigs
 
-make build_daemon_utils
+make build-daemon-utils
 
-make build_archive_utils
+make build-archive-utils
 
-make build_test_utils
+make build-test-utils

--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -25,7 +25,7 @@ make build-logproc
 
 [[ ${MINA_BUILD_MAINNET} ]] && make build-mainnet-sigs
 
-make build-testnet-sigs
+make build-devnet-sigs
 
 make build-daemon-utils
 

--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -9,48 +9,26 @@ source ~/.profile
 
 MINA_COMMIT_SHA1=$(git rev-parse HEAD)
 
-# Somehow defining DUNE_INSTRUMENT_WITH in docker is not enough to propagate it to dune
-# That's why we are converting it to dune argument
+# reexporting DUNE_INSTRUMENT_WITH
 if [[ -v DUNE_INSTRUMENT_WITH ]]; then
-  INSTRUMENTED_PARAM="--instrument-with $DUNE_INSTRUMENT_WITH"
-else 
-  INSTRUMENTED_PARAM=""
+  export DUNE_INSTRUMENT_WITH="$DUNE_INSTRUMENT_WITH"
 fi
 
-
-echo "--- Build libp2p_helper"
-make -C src/app/libp2p_helper
-
-MAINNET_TARGETS=""
-[[ ${MINA_BUILD_MAINNET} ]] && MAINNET_TARGETS="src/app/cli/src/mina_mainnet_signatures.exe src/app/rosetta/rosetta_mainnet_signatures.exe src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe"
 
 echo "--- Build all major targets required for packaging"
 echo "Building from Commit SHA: ${MINA_COMMIT_SHA1}"
 echo "Rust Version: $(rustc --version)"
-dune build "--profile=${DUNE_PROFILE}" $INSTRUMENTED_PARAM \
-  ${MAINNET_TARGETS} \
-  src/app/logproc/logproc.exe \
-  src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
-  src/app/generate_keypair/generate_keypair.exe \
-  src/app/validate_keypair/validate_keypair.exe \
-  src/app/cli/src/mina_testnet_signatures.exe \
-  src/app/archive/archive.exe \
-  src/app/replayer/replayer.exe \
-  src/app/extract_blocks/extract_blocks.exe \
-  src/app/archive_blocks/archive_blocks.exe \
-  src/app/batch_txn_tool/batch_txn_tool.exe \
-  src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
-  src/app/zkapp_test_transaction/zkapp_test_transaction.exe \
-  src/app/rosetta/rosetta_testnet_signatures.exe \
-  src/app/rosetta/indexer_test/indexer_test.exe \
-  src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe \
-  src/app/test_executive/test_executive.exe  \
-  src/app/benchmarks/benchmarks.exe \
-  src/app/ledger_export_bench/ledger_export_benchmark.exe \
-  src/app/disk_caching_stats/disk_caching_stats.exe \
-  src/app/heap_usage/heap_usage.exe \
-  src/app/zkapp_limits/zkapp_limits.exe \
-  src/lib/snark_worker/standalone/run_snark_worker.exe \
-  src/test/command_line_tests/command_line_tests.exe \
-  src/test/archive/patch_archive_test/patch_archive_test.exe \
-  src/test/archive/archive_node_tests/archive_node_tests.exe
+
+make libp2p_helper
+
+make build_logproc
+
+[[ ${MINA_BUILD_MAINNET} ]] && make build_mainnet_sigs
+
+make build_testnet_sigs
+
+make build_daemon_utils
+
+make build_archive_utils
+
+make build_test_utils

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+set -u
 
 if [[ $# -gt 2 ]] || [[ $# -lt 1 ]]; then
     echo "Usage: $0 '<debians>' '[use-sudo]'"
     exit 1
 fi
 
-if [ -z $MINA_DEB_CODENAME ]; then 
+if [ -z "${MINA_DEB_CODENAME:-}" ]; then 
     echo "MINA_DEB_CODENAME env var is not defined"
     exit 1
 fi
@@ -14,6 +15,8 @@ fi
 DEBS=$1
 USE_SUDO=${2:-0}
 
+# Source git environment variables first to get MINA_DEB_CODENAME
+source ./buildkite/scripts/export-git-env-vars.sh
 
 if [ "$USE_SUDO" == "1" ]; then
    SUDO="sudo"
@@ -24,7 +27,6 @@ fi
 
 LOCAL_DEB_FOLDER=debs
 mkdir -p $LOCAL_DEB_FOLDER
-source ./buildkite/scripts/export-git-env-vars.sh
 
 # Download required debians from bucket locally
 if [ -z "$DEBS" ]; then 

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -1,41 +1,21 @@
 #!/bin/bash
 
-function find_most_recent_numeric_tag() {
-    # We use the --prune flag because we've had problems with buildkite agents getting conflicting results here
-    git fetch --tags --prune --prune-tags --force
-    TAG=$(git describe --always --abbrev=0 $1 | sed 's!/!-!g; s!_!-!g; s!#!-!g')
-    if [[ $TAG != [0-9]* ]]; then
-        TAG=$(find_most_recent_numeric_tag $TAG~)
-    fi
-    echo $TAG
-}
+# Export all variables from inner script
+set -a
 
-export GITHASH=$(git rev-parse --short=7 HEAD)
+export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
 
-export THIS_COMMIT_TAG=$(git tag --points-at HEAD)
+if [[ -n "$BUILDKITE_BRANCH" ]]; then
+   # shellcheck disable=SC1090
+   BRANCH_NAME=${BUILDKITE_BRANCH} MINA_DEB_CODENAME=${MINA_DEB_CODENAME} source ./scripts/export-git-env-vars.sh
+else 
+   MINA_DEB_CODENAME=${MINA_DEB_CODENAME} source ./scripts/export-git-env-vars.sh
+fi
+set +a
+
 export PROJECT="mina"
 
 set +u
 export BUILD_NUM=${BUILDKITE_BUILD_NUM}
 export BUILD_URL=${BUILDKITE_BUILD_URL}
 set -u
-
-export MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
-if [[ -n "$BUILDKITE_BRANCH" ]]; then
-   export GITBRANCH=$(echo "$BUILDKITE_BRANCH" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
-else
-   export GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
-fi
-
-export RELEASE=unstable
-# GITTAG is the closest tagged commit to this commit, while THIS_COMMIT_TAG only has a value when the current commit is tagged
-export GITTAG=$(find_most_recent_numeric_tag HEAD)
-
-export MINA_DEB_VERSION="${GITTAG}-${GITBRANCH}-${GITHASH}"
-export MINA_DOCKER_TAG="$(echo "${MINA_DEB_VERSION}-${MINA_DEB_CODENAME}" | sed 's!/!-!g; s!_!-!g')"
-export RELEASE=unstable
-
-echo "Publishing on release channel \"${RELEASE}\""
-[[ -n ${THIS_COMMIT_TAG} ]] && export MINA_COMMIT_TAG="${THIS_COMMIT_TAG}"
-
-export MINA_DEB_RELEASE="${RELEASE}"

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -148,7 +148,8 @@ let generateStep =
 
                 else  ""
 
-          let pruneDockerImages = "docker system prune --all --force --filter until=24h"
+          let pruneDockerImages =
+                "docker system prune --all --force --filter until=24h"
 
           let buildDockerCmd =
                     "./scripts/docker/build.sh"

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -60,7 +60,7 @@ let ReleaseSpec =
           , branch = "\\\${BUILDKITE_BRANCH}"
           , repo = "\\\${BUILDKITE_REPO}"
           , deb_codename = DebianVersions.DebVersion.Bullseye
-          , deb_release = "\\\${MINA_DEB_RELEASE}"
+          , deb_release = "unstable"
           , deb_version = "\\\${MINA_DEB_VERSION}"
           , deb_legacy_version = "3.1.1-alpha1-compatible-14a8b92"
           , deb_profile = Profiles.Type.Devnet
@@ -148,6 +148,8 @@ let generateStep =
 
                 else  ""
 
+          let pruneDockerImages = "docker system prune --all --force --filter until=24h"
+
           let buildDockerCmd =
                     "./scripts/docker/build.sh"
                 ++  " --service ${Artifacts.dockerName spec.service}"
@@ -206,6 +208,9 @@ let generateStep =
                   , Local =
                     [ Cmd.run
                         (     exportMinaDebCmd
+                          ++  " && "
+                          ++  pruneDockerImages
+                          ++  " && "
                           ++  maybeStartDebianRepo
                           ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                           ++  " && "

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -211,7 +211,6 @@ let generateStep =
                         (     exportMinaDebCmd
                           ++  " && "
                           ++  pruneDockerImages
-                          ++  " && "
                           ++  maybeStartDebianRepo
                           ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                           ++  " && "

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -2,9 +2,21 @@
 
 # Script collects binaries and keys and builds deb archives.
 
-set -eox pipefail
+set -eou pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=${BUILD_DIR:-"${SCRIPTPATH}/../../_build"}
+
+# Check if BUILD_DIR exists
+if [[ ! -d "$BUILD_DIR" ]]; then
+  echo "Error: BUILD_DIR '$BUILD_DIR' does not exist."
+  echo "This means the build process has not been completed successfully or the directory is incorrect."
+  echo "Please ensure you have built the applications first, or check if:"
+  echo "  - You are running this script from the correct directory (if not using BUILD_DIR, run it from the root of the project)"
+  echo "  - BUILD_DIR environment variable is set correctly (if using BUILD_DIR)"
+  echo "  - The build process completed successfully"
+  exit 1
+fi
 
 # In case of running this script on detached head, script has difficulties in finding out
 # what is the current branch.
@@ -17,7 +29,7 @@ else
 fi
 
 # shellcheck disable=SC1090
-source "${SCRIPTPATH}/builder-helpers.sh"
+BUILD_DIR="${BUILD_DIR}" source "${SCRIPTPATH}/builder-helpers.sh"
 
 if [ $# -eq 0 ]
   then

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euox pipefail
 
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=${BUILD_DIR:-"${SCRIPTPATH}/../../_build"}
 BUILD_URL=${BUILD_URL:-${BUILDKITE_BUILD_URL:-"local build from '$(hostname)' \
   host"}}
 MINA_DEB_CODENAME=${MINA_DEB_CODENAME:-"bullseye"}
@@ -10,9 +13,8 @@ MINA_DEB_RELEASE=${MINA_DEB_RELEASE:-"unstable"}
 # Helper script to include when building deb archives.
 
 echo "--- Setting up the environment to build debian packages..."
+cd "${BUILD_DIR}" || exit 1
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-cd "${SCRIPTPATH}/../../_build"
 
 GITHASH=$(git rev-parse --short=7 HEAD)
 GITHASH_CONFIG=$(git rev-parse --short=8 --verify HEAD)
@@ -43,6 +45,7 @@ case "${MINA_DEB_CODENAME}" in
 esac
 
 MINA_DEB_NAME="mina-berkeley"
+DUNE_PROFILE="${DUNE_PROFILE}"
 DEB_SUFFIX=""
 
 # Add suffix to debian to distinguish different profiles

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euox pipefail
+set -euo pipefail
 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"

--- a/scripts/debian/clear-s3-lockfile.sh
+++ b/scripts/debian/clear-s3-lockfile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=unstable}
-MINA_DEB_RELEASE=${MINA_DEB_RELEASE:=main}
+MINA_DEB_CODENAME=${MINA_DEB_CODENAME:=bullseye}
+MINA_DEB_RELEASE=${MINA_DEB_RELEASE:=unstable}
 MINA_DEB_BUCKET=${MINA_DEB_BUCKET:=packages.o1test.net}
 
 S3_LOCKFILE_DATE="$(aws s3 ls s3://${MINA_DEB_BUCKET}/dists/${MINA_DEB_CODENAME}/${MINA_DEB_RELEASE}/binary-/lockfile | awk '{print $1 " " $2}')"

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -2,7 +2,7 @@
 
 # Enable debug output only in CI environments
 if [[ -n "$CI" || -n "$BUILDKITE" || -n "$GITHUB_ACTIONS" ]]; then
-    set -x
+  set -x
 fi
 
 # Author's Note: Because the structure of this repo is inconsistent (Dockerfiles and build contexts placed willy-nilly)
@@ -211,3 +211,6 @@ if [[ -z "${DOCKER_CONTEXT}" ]]; then
 else
   docker build $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION "$DOCKER_CONTEXT" -t "$TAG" -f $DOCKERFILE_PATH
 fi
+
+echo "✅ Docker image for service ${SERVICE} built successfully."
+echo "🐳 Full image name: ${HASHTAG}"

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -105,8 +105,8 @@ if [[ -z "$INPUT_VERSION" ]]; then
 fi
 
 if [[ -z "$DEB_PROFILE" ]]; then
-  echo "Debian profile is not set. Using the default (standard)"
-  DEB_PROFILE="standard"
+  echo "Debian profile is not set. Using the default (devnet)"
+  DEB_PROFILE="devnet"
 fi
 
 if [[ -z "$DEB_BUILD_FLAGS" ]]; then
@@ -204,11 +204,6 @@ export_version
 export_docker_tag
 
 BUILD_NETWORK="--network=host"
-
-# Prune old docker images (24 hours) from the cache
-# This is a temporary solution to keep the cache from growing too large.
-# We will also need to evaluate the impact of this on the build process and adjust as necessary.
-docker system prune --all --force --filter until=24h
 
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT}" ]]; then

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -4,10 +4,6 @@ set -euo pipefail
 # If enabled, keep my tags intact, it won't run git fetch --prune
 KEEP_MY_TAGS_INTACT=${KEEP_MY_TAGS_INTACT:-1}
 
-# In case of running this script on detached head, script has difficulties in finding out
-# what is the current
-echo "Exporting Git Variables: "
-
 function find_most_recent_numeric_tag() {
 
     local keep_tags_values=("1" "true" "t" "T" "y" "yes" "Y" "YES")

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-set -x
-
 
 # If enabled, keep my tags intact, it won't run git fetch --prune
 KEEP_MY_TAGS_INTACT=${KEEP_MY_TAGS_INTACT:-1}


### PR DESCRIPTION
Enabling local dev build for major debians and dockers.

Goal of this PR is to make buildkite and local env build process more alike. Enabling developers to build debians and dockers locally without running CI. 

Refactor CI code a bit too. Removed duplication between setting env vars as well as exposed BUILD_DIR env var which may differ.

Example of usage in local dev (building archive):

```
(export OPAMSWITCH=4.14.2 DUNE_PROFILE=devnet && make build-archive && make build-archive-utils)

make debian-build-archive-devnet 

make docker-build-archive-devnet

```