### PR TITLE
remove trusted tag when fetching debian packages from signed repos

### DIFF
--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -80,7 +80,7 @@ SCRIPT=' set -x \
     && echo installing '$PACKAGE' \
     && apt-get update > /dev/null \
     && apt-get install -y lsb-release ca-certificates wget gnupg > /dev/null \
-    && '$SIGNED' echo "deb [trusted=yes] https://'$REPO' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
+    && '$SIGNED' echo "deb https://'$REPO' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
     && apt-get update > /dev/null \
     && apt list -a '$PACKAGE' \
     && apt-get install -y --allow-downgrades '$PACKAGE'='$VERSION' \


### PR DESCRIPTION
Remove [trusted=yes] tag when verfying debian repositories.

This will test a real user scenario, where no one is trusting our repository like packages.o1test.net.

Also please take a look at pages i created for each repository with guide how to install debians from stable/unstable/nightly

https://nightly.apt.packages.minaprotocol.com

etc.