### PR TITLE
docs: fix broken link to Foreign Field Multiplication RFC

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml.disabled
+++ b/src/lib/crypto/kimchi_backend/gadgets/foreign_field.ml.disabled
@@ -1049,7 +1049,7 @@ let sub (type f) (module Circuit : Snark_intf.Run with type field = f)
 (* Compute non-zero intermediate products
  *
  *   For more details see the "Intermediate products" Section of
- *   the [Foreign Field Multiplication RFC](https://o1-labs.github.io/proof-systems/rfcs/foreign_field_mul.html)
+ *   the [Foreign Field Multiplication RFC](https://o1-labs.github.io/proof-systems/kimchi/foreign_field_mul.html)
  *
  *   Preconditions: this entire function is witness code and, therefore, must be
  *                  only called from an exists construct.
@@ -1092,7 +1092,7 @@ let compute_intermediate_products (type f)
 
 (* Compute intermediate sums
  *   For more details see the "Optimizations" Section of
- *   the [Foreign Field Multiplication RFC](https://o1-labs.github.io/proof-systems/rfcs/foreign_field_mul.html) *)
+ *   the [Foreign Field Multiplication RFC](https://o1-labs.github.io/proof-systems/kimchi/foreign_field_mul.html) *)
 let compute_intermediate_sums (type f)
     (module Circuit : Snark_intf.Run with type field = f)
     (quotient : f standard_limbs) (neg_foreign_field_modulus : f standard_limbs)


### PR DESCRIPTION
- Updated links in gadets/foreign_field.ml.disabled to point to the correct Kimchi RFC location
