### PR TITLE
Define and use a Config.t type for Root ledgers

### DIFF
--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -131,10 +131,21 @@ module Make (Inputs : Intf.Ledger_input_intf) : Intf.S = struct
       | `Ephemeral ->
           lazy (`Ephemeral (Ledger.create_ephemeral ~depth ()), true)
       | `New ->
-          lazy (`Root (Ledger.Root.create_single ~depth ()), true)
+          lazy
+            ( `Root
+                (Ledger.Root.create_temporary
+                   ~backing_type:Ledger.Root.Config.Stable_db ~depth () )
+            , true )
       | `Path directory_name ->
           lazy
-            (`Root (Ledger.Root.create_single ~directory_name ~depth ()), false)
+            ( `Root
+                (Ledger.Root.create
+                   ~config:
+                     (Ledger.Root.Config.with_directory
+                        ~backing_type:Ledger.Root.Config.Stable_db
+                        ~directory_name )
+                   ~depth () )
+            , false )
     in
     let masked =
       match ledger with

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -398,12 +398,17 @@ module Ledger = struct
   let load_extracted_ledger ~(config : Runtime_config.Ledger.t) ~logger
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~extracted_path : Genesis_ledger.Packed.t =
+    (* TODO: pass in from above *)
+    let genesis_backing_type = Mina_ledger.Ledger.Root.Config.Stable_db in
+    let genesis_config =
+      Mina_ledger.Ledger.Root.Config.with_directory
+        ~backing_type:genesis_backing_type ~directory_name:extracted_path
+    in
     ( module Genesis_ledger.Of_ledger (struct
       let backing_ledger =
         lazy
           (let ledger =
-             Mina_ledger.Ledger.Root.create_single
-               ~directory_name:extracted_path
+             Mina_ledger.Ledger.Root.create ~config:genesis_config
                ~depth:constraint_constants.ledger_depth ()
            in
            let ledger_root = Mina_ledger.Ledger.Root.merkle_root ledger in

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -63,9 +63,11 @@ module Make
     (** Delete a backing of any type that might exist with this config, if present *)
     val delete_any_backing : t -> unit
 
-    (** Move the root backing at [src] to [dst]. The [src] and [dst] configs
-        must have the same configured backing, and there must be a root backing
-        of the appropriate type at [src]. *)
+    (** Move the root backing at [src] to [dst]. Assumptions: the [src] and
+        [dst] configs must have the same configured backing, there must be a
+        root backing of the appropriate type at [src], there must not be a root
+        backing at [dst], and there must be no database connections open for
+        [src]. *)
     val move_backing_exn : src:t -> dst:t -> unit
 
     (** The primary directory of this ledger *)

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -171,7 +171,8 @@ let%test_module "Epoch ledger sync tests" =
     (* TODO: single for now, but the tests might need to be expanded to cover
        other types of Root ledgers when they are implemented *)
     let make_empty_root_ledger (module Context : CONTEXT) =
-      Mina_ledger.Ledger.Root.create_single
+      Mina_ledger.Ledger.Root.create_temporary
+        ~backing_type:Mina_ledger.Ledger.Root.Config.Stable_db
         ~depth:Context.precomputed_values.constraint_constants.ledger_depth ()
 
     (* [instance] and [test_number] are used to make ports distinct

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -457,13 +457,13 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
     (* we need to perform steps 4-7 iff there was a proof emitted in the scan
      * state we are transitioning to *)
     if Breadcrumb.just_emitted_a_proof new_root_node.breadcrumb then (
-      let location =
-        Persistent_root.Instance.Locations.make_potential_snarked_ledger
+      let config =
+        Persistent_root.Instance.Config.make_potential_snarked_ledger
           t.persistent_root_instance.factory
       in
       let () =
         Ledger.Root.make_checkpoint t.persistent_root_instance.snarked_ledger
-          ~directory_name:location
+          ~config
       in
       [%log' info t.logger]
         ~metadata:
@@ -473,7 +473,7 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
                    t.persistent_root_instance.snarked_ledger )
           ]
         "Enqueued a snarked ledger" ;
-      Persistent_root.Instance.enqueue_snarked_ledger ~location
+      Persistent_root.Instance.enqueue_snarked_ledger ~config
         t.persistent_root_instance ;
       let s = t.root_ledger in
       (* STEP 4 *)


### PR DESCRIPTION
The Root.Config module defines how a Root ledger can be created. There are two independently varying options:

1. The directory_name to use for the database(s) backing the Root
2. The backing_type for the Root

Some methods have been defined on the abstract Config.t type, to represent common operations on the locations of the databases backing root ledgers. The intent is to support existing patterns in the ledger handling code (deleting the backing of a root ledger, testing if a backing already exists, creating a root ledger based on a particular directory name) while abstracting the filesystem details of the root ledger backing. This is necessary for the future converting merkle tree backing for root ledgers; the migrated database will need to be created, moved, and deleted properly, and it would be better if the code outside of `Ledger.Root` did not have to worry about there being a migrated database present or not.

My plan with the future converting-database-backed Root was to have the same `Config.with_directory`, and if the primary database was created in `directory_name` then the converting would be created in `directory_name_converting`. This is how the `Ledger.Converting_db` is currently set up. The `potential_snarked_ledgers.json` could be left as just a list of the locations of the primary database if we have that kind of scheme.

This should not change any behaviour.
