### PR TITLE
Improve Genesis Ledger Creation

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1144,8 +1144,7 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
           let consensus_local_state =
             Consensus.Data.Local_state.create
               ~context:(module Context)
-              ~genesis_ledger:
-                (Precomputed_values.genesis_ledger precomputed_values)
+              ~genesis_ledger:precomputed_values.genesis_ledger
               ~genesis_epoch_data:precomputed_values.genesis_epoch_data
               ~epoch_ledger_location
               ( Option.map block_production_keypair ~f:(fun keypair ->

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -306,7 +306,8 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           | Ok ledger -> (
               match ledger with
               | Genesis_epoch_ledger l ->
-                  let%map accts = Mina_ledger.Ledger.to_list l in
+                  let l_inner = Lazy.force @@ Genesis_ledger.Packed.t l in
+                  let%map accts = Mina_ledger.Ledger.to_list l_inner in
                   Ok accts
               | Ledger_root l ->
                   let casted = Mina_ledger.Ledger.Root.as_unmasked l in

--- a/src/app/cli/src/init/test_ledger_application.ml
+++ b/src/app/cli/src/init/test_ledger_application.ml
@@ -85,10 +85,8 @@ let mk_tx ~transfer_parties_get_actions_events ~event_elements ~action_elements
 let generate_protocol_state_stub ~consensus_constants ~constraint_constants
     ledger =
   let open Staged_ledger_diff in
-  Protocol_state.negative_one
-    ~genesis_ledger:(lazy ledger)
-    ~genesis_epoch_data:None ~constraint_constants ~consensus_constants
-    ~genesis_body_reference
+  Protocol_state.negative_one ~genesis_ledger:ledger ~genesis_epoch_data:None
+    ~constraint_constants ~consensus_constants ~genesis_body_reference
 
 let apply_txs ~transfer_parties_get_actions_events ~action_elements
     ~event_elements ~constraint_constants ~first_partition_slots ~no_new_stack
@@ -186,9 +184,16 @@ let test ~privkey_path ~ledger_path ?prev_block_path ~first_partition_slots
   O1trace.thread "mina"
   @@ fun () ->
   let%bind keypair = read_privkey privkey_path in
+
+  let module Test_genesis_ledger = Genesis_ledger.Make (struct
+    include Test_genesis_ledger
+
+    let directory = `Path ledger_path
+
+    let depth = constraint_constants.ledger_depth
+  end) in
   let init_ledger =
-    Ledger.create ~directory_name:ledger_path
-      ~depth:constraint_constants.ledger_depth ()
+    Lazy.force @@ Genesis_ledger.Packed.t (module Test_genesis_ledger)
   in
   let prev_protocol_state =
     let%map.Option prev_block_path = prev_block_path in
@@ -207,7 +212,7 @@ let test ~privkey_path ~ledger_path ?prev_block_path ~first_partition_slots
     match prev_protocol_state with
     | None ->
         generate_protocol_state_stub ~consensus_constants ~constraint_constants
-          init_ledger
+          (module Test_genesis_ledger)
     | Some p ->
         p
   in

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -109,7 +109,7 @@ let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t)
       let open Staged_ledger_diff in
       (*not using Precomputed_values.for_unit_test because of dependency cycle*)
       Mina_state.Genesis_protocol_state.t
-        ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+        ~genesis_ledger:Genesis_ledger.for_unit_tests
         ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
         ~constraint_constants ~consensus_constants ~genesis_body_reference
     in
@@ -171,7 +171,7 @@ let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
   let compile_time_genesis =
     (*not using Precomputed_values.for_unit_test because of dependency cycle*)
     Mina_state.Genesis_protocol_state.t
-      ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+      ~genesis_ledger:Genesis_ledger.for_unit_tests
       ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
       ~constraint_constants ~consensus_constants ~genesis_body_reference
   in

--- a/src/lib/consensus/genesis_epoch_data.ml
+++ b/src/lib/consensus/genesis_epoch_data.ml
@@ -1,6 +1,5 @@
 module Data = struct
-  type t =
-    { ledger : Mina_ledger.Ledger.t Lazy.t; seed : Mina_base.Epoch_seed.t }
+  type t = { ledger : Genesis_ledger.Packed.t; seed : Mina_base.Epoch_seed.t }
 end
 
 type tt = { staking : Data.t; next : Data.t option }

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -297,7 +297,7 @@ module type S = sig
   module Genesis_epoch_data : sig
     module Data : sig
       type t =
-        { ledger : Mina_ledger.Ledger.t Lazy.t; seed : Mina_base.Epoch_seed.t }
+        { ledger : Genesis_ledger.Packed.t; seed : Mina_base.Epoch_seed.t }
     end
 
     type tt = { staking : Data.t; next : Data.t option }
@@ -316,7 +316,7 @@ module type S = sig
 
         module Ledger_snapshot : sig
           type t =
-            | Genesis_epoch_ledger of Mina_ledger.Ledger.t
+            | Genesis_epoch_ledger of Genesis_ledger.Packed.t
             | Ledger_root of Mina_ledger.Ledger.Root.t
 
           val close : t -> unit
@@ -330,7 +330,7 @@ module type S = sig
       val create :
            Signature_lib.Public_key.Compressed.Set.t
         -> context:(module CONTEXT)
-        -> genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+        -> genesis_ledger:Genesis_ledger.Packed.t
         -> genesis_epoch_data:Genesis_epoch_data.t
         -> epoch_ledger_location:string
         -> genesis_state_hash:State_hash.t
@@ -507,7 +507,7 @@ module type S = sig
         -> (var, Value.t) Snark_params.Tick.Typ.t
 
       val negative_one :
-           genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+           genesis_ledger:Genesis_ledger.Packed.t
         -> genesis_epoch_data:Genesis_epoch_data.t
         -> constants:Constants.t
         -> constraint_constants:Genesis_constants.Constraint_constants.t
@@ -516,7 +516,7 @@ module type S = sig
       val create_genesis_from_transition :
            negative_one_protocol_state_hash:Mina_base.State_hash.t
         -> consensus_transition:Consensus_transition.Value.t
-        -> genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+        -> genesis_ledger:Genesis_ledger.Packed.t
         -> genesis_epoch_data:Genesis_epoch_data.t
         -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> constants:Constants.t
@@ -524,7 +524,7 @@ module type S = sig
 
       val create_genesis :
            negative_one_protocol_state_hash:Mina_base.State_hash.t
-        -> genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+        -> genesis_ledger:Genesis_ledger.Packed.t
         -> genesis_epoch_data:Genesis_epoch_data.t
         -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> constants:Constants.t

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -230,11 +230,10 @@ module Generator = struct
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
     in
-    let genesis_ledger = Precomputed_values.genesis_ledger precomputed_values in
     let consensus_local_state =
       Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
         ~context:(module Context)
-        ~genesis_ledger
+        ~genesis_ledger:precomputed_values.genesis_ledger
         ~genesis_epoch_data:precomputed_values.genesis_epoch_data
         ~epoch_ledger_location
         ~genesis_state_hash:
@@ -273,11 +272,10 @@ module Generator = struct
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
     in
-    let genesis_ledger = Precomputed_values.genesis_ledger precomputed_values in
     let consensus_local_state =
       Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
         ~context:(module Context)
-        ~genesis_ledger
+        ~genesis_ledger:precomputed_values.genesis_ledger
         ~genesis_epoch_data:precomputed_values.genesis_epoch_data
         ~epoch_ledger_location
         ~genesis_state_hash:

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -604,8 +604,7 @@ module Epoch_data = struct
           in
           [%log trace] "Loaded staking epoch ledger from $ledger_file"
             ~metadata:[ ("ledger_file", `String ledger_file) ] ;
-          ( { Consensus.Genesis_epoch_data.Data.ledger =
-                Genesis_ledger.Packed.t staking_ledger
+          ( { Consensus.Genesis_epoch_data.Data.ledger = staking_ledger
             ; seed = Epoch_seed.of_base58_check_exn config.staking.seed
             }
           , { config.staking with ledger = config' } )
@@ -622,8 +621,7 @@ module Epoch_data = struct
               [%log trace] "Loaded next epoch ledger from $ledger_file"
                 ~metadata:[ ("ledger_file", `String ledger_file) ] ;
               ( Some
-                  { Consensus.Genesis_epoch_data.Data.ledger =
-                      Genesis_ledger.Packed.t next_ledger
+                  { Consensus.Genesis_epoch_data.Data.ledger = next_ledger
                   ; seed = Epoch_seed.of_base58_check_exn seed
                   }
               , Some { Runtime_config.Epoch_data.Data.ledger = config''; seed }
@@ -707,8 +705,7 @@ module Genesis_proof = struct
     in
     let open Staged_ledger_diff in
     let protocol_state_with_hashes =
-      Mina_state.Genesis_protocol_state.t
-        ~genesis_ledger:(Genesis_ledger.Packed.t ledger)
+      Mina_state.Genesis_protocol_state.t ~genesis_ledger:ledger
         ~genesis_epoch_data ~constraint_constants ~consensus_constants
         ~genesis_body_reference
     in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2096,10 +2096,8 @@ module Queries = struct
             ; hash = { State_hash.State_hashes.state_hash = hash; _ }
             } =
           let open Staged_ledger_diff in
-          Genesis_protocol_state.t
-            ~genesis_ledger:(Genesis_ledger.Packed.t genesis_ledger)
-            ~genesis_epoch_data ~constraint_constants ~consensus_constants
-            ~genesis_body_reference
+          Genesis_protocol_state.t ~genesis_ledger ~genesis_epoch_data
+            ~constraint_constants ~consensus_constants ~genesis_body_reference
         in
         let winner = fst Consensus_state_hooks.genesis_winner in
         { With_hash.data =
@@ -2601,7 +2599,8 @@ module Queries = struct
     let cast_ledger = function
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
           l ->
-          Ledger.Any_ledger.cast (module Ledger) l
+          let l_inner = Lazy.force @@ Genesis_ledger.Packed.t l in
+          Ledger.Any_ledger.cast (module Ledger) l_inner
       | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_root l ->
           Ledger.Root.as_unmasked l
     in

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -1494,11 +1494,14 @@ module AccountObj = struct
                  let account_id = account_id account in
                  match%bind Mina_lib.staking_ledger mina with
                  | Genesis_epoch_ledger staking_ledger -> (
+                     let staking_ledger_inner =
+                       Lazy.force @@ Genesis_ledger.Packed.t staking_ledger
+                     in
                      match
                        let open Option.Let_syntax in
                        account_id
-                       |> Ledger.location_of_account staking_ledger
-                       >>= Ledger.get staking_ledger
+                       |> Ledger.location_of_account staking_ledger_inner
+                       >>= Ledger.get staking_ledger_inner
                      with
                      | Some account ->
                          let%bind delegate_key = account.delegate in

--- a/src/lib/mina_state/genesis_protocol_state.ml
+++ b/src/lib/mina_state/genesis_protocol_state.ml
@@ -2,8 +2,11 @@ open Core_kernel
 
 let t ~genesis_ledger ~genesis_epoch_data ~constraint_constants
     ~consensus_constants ~genesis_body_reference =
+  let genesis_ledger_forced =
+    Lazy.force @@ Genesis_ledger.Packed.t genesis_ledger
+  in
   let genesis_ledger_hash =
-    Mina_ledger.Ledger.merkle_root (Lazy.force genesis_ledger)
+    Mina_ledger.Ledger.merkle_root genesis_ledger_forced
   in
   let protocol_constants =
     Consensus.Constants.to_protocol_constants consensus_constants

--- a/src/lib/mina_state/genesis_protocol_state.mli
+++ b/src/lib/mina_state/genesis_protocol_state.mli
@@ -1,7 +1,7 @@
 open Mina_base
 
 val t :
-     genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+     genesis_ledger:Genesis_ledger.Packed.t
   -> genesis_epoch_data:Consensus.Genesis_epoch_data.t
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -302,7 +302,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             Blockchain_state.negative_one ~constraint_constants
               ~consensus_constants
               ~genesis_ledger_hash:
-                (Mina_ledger.Ledger.merkle_root (Lazy.force genesis_ledger))
+                (Mina_ledger.Ledger.merkle_root
+                   (Lazy.force (Genesis_ledger.Packed.t genesis_ledger)) )
               ~genesis_body_reference
         ; genesis_state_hash = State_hash.of_hash Outside_hash_image.t
         ; consensus_state =

--- a/src/lib/mina_state/protocol_state_intf.ml
+++ b/src/lib/mina_state/protocol_state_intf.ml
@@ -148,7 +148,7 @@ module type Full = sig
   val constants : (_, (_, _, _, 'a) Body.t) Poly.t -> 'a
 
   val negative_one :
-       genesis_ledger:Mina_ledger.Ledger.t Lazy.t
+       genesis_ledger:Genesis_ledger.Packed.t
     -> genesis_epoch_data:Consensus.Genesis_epoch_data.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -407,7 +407,7 @@ let dummy_state_view =
     let compile_time_genesis =
       (*not using Precomputed_values.for_unit_test because of dependency cycle*)
       Mina_state.Genesis_protocol_state.t
-        ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+        ~genesis_ledger:Genesis_ledger.for_unit_tests
         ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
         ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
         ~constraint_constants ~consensus_constants

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1711,7 +1711,7 @@ let%test_module _ =
         let compile_time_genesis =
           (*not using Precomputed_values.for_unit_test because of dependency cycle*)
           Mina_state.Genesis_protocol_state.t
-            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+            ~genesis_ledger:Genesis_ledger.for_unit_tests
             ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
             ~constraint_constants ~consensus_constants
             ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference

--- a/src/lib/precomputed_values/precomputed_values.ml
+++ b/src/lib/precomputed_values/precomputed_values.ml
@@ -24,9 +24,7 @@ let for_unit_tests =
     (let open Staged_ledger_diff in
     let protocol_state_with_hashes =
       Mina_state.Genesis_protocol_state.t
-        ~genesis_ledger:
-          (let open Genesis_ledger in
-          Packed.t for_unit_tests)
+        ~genesis_ledger:Genesis_ledger.for_unit_tests
         ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
         ~constraint_constants:
           Genesis_constants.For_unit_tests.Constraint_constants.t

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -570,7 +570,7 @@ let create_genesis_block_inputs (genesis_inputs : Genesis_proof.Inputs.t) =
   let consensus_constants = genesis_inputs.consensus_constants in
   let prev_state =
     let open Staged_ledger_diff in
-    Protocol_state.negative_one ~genesis_ledger
+    Protocol_state.negative_one ~genesis_ledger:genesis_inputs.genesis_ledger
       ~genesis_epoch_data:genesis_inputs.genesis_epoch_data
       ~constraint_constants ~consensus_constants ~genesis_body_reference
   in
@@ -579,7 +579,7 @@ let create_genesis_block_inputs (genesis_inputs : Genesis_proof.Inputs.t) =
     | None ->
         genesis_ledger
     | Some data ->
-        data.staking.ledger
+        Genesis_ledger.Packed.t data.staking.ledger
   in
   let open Pickles_types in
   let blockchain_dummy =

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -470,16 +470,15 @@ let state_body ~(genesis_constants : Genesis_constants.t)
      (* TODO: Do we really need to create a whole ledger just to compute this?
         Probably not..
      *)
-     let module Test_genesis_ledger = struct
-       include Genesis_ledger.Make (struct
-         include Test_genesis_ledger
+     let module Test_genesis_ledger = Genesis_ledger.Make (struct
+       include Test_genesis_ledger
 
-         let directory = `Ephemeral
+       let directory = `Ephemeral
 
-         let depth = constraint_constants.ledger_depth
-       end)
-     end in
-     Mina_state.Genesis_protocol_state.t ~genesis_ledger:Test_genesis_ledger.t
+       let depth = constraint_constants.ledger_depth
+     end) in
+     Mina_state.Genesis_protocol_state.t
+       ~genesis_ledger:(module Test_genesis_ledger)
        ~genesis_epoch_data ~constraint_constants ~consensus_constants
        ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
      |> With_hash.data |> Mina_state.Protocol_state.body )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2308,7 +2308,7 @@ module Test_helpers = struct
         let open Staged_ledger_diff in
         (*not using Precomputed_values.for_unit_test because of dependency cycle*)
         Mina_state.Genesis_protocol_state.t
-          ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+          ~genesis_ledger:Genesis_ledger.for_unit_tests
           ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
           ~constraint_constants ~consensus_constants ~genesis_body_reference
       in

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -585,7 +585,7 @@ let%test_module "Transaction union tests" =
         let open Staged_ledger_diff in
         let state_body0 =
           Mina_state.Protocol_state.negative_one
-            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+            ~genesis_ledger:Genesis_ledger.for_unit_tests
             ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
             ~constraint_constants ~consensus_constants ~genesis_body_reference
           |> Mina_state.Protocol_state.body
@@ -608,7 +608,7 @@ let%test_module "Transaction union tests" =
         let state_body0 =
           let open Staged_ledger_diff in
           Mina_state.Protocol_state.negative_one
-            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+            ~genesis_ledger:Genesis_ledger.for_unit_tests
             ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
             ~constraint_constants ~consensus_constants ~genesis_body_reference
           |> Mina_state.Protocol_state.body

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -50,7 +50,7 @@ let genesis_state_body =
     let open Staged_ledger_diff in
     (*not using Precomputed_values.for_unit_test because of dependency cycle*)
     Mina_state.Genesis_protocol_state.t
-      ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+      ~genesis_ledger:Genesis_ledger.for_unit_tests
       ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
       ~constraint_constants ~consensus_constants ~genesis_body_reference
   in

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -999,7 +999,8 @@ module For_tests = struct
     let consensus_local_state =
       Consensus.Data.Local_state.create
         ~context:(module Context)
-        Public_key.Compressed.Set.empty ~genesis_ledger:Genesis_ledger.t
+        Public_key.Compressed.Set.empty
+        ~genesis_ledger:(module Genesis_ledger)
         ~genesis_epoch_data:precomputed_values.genesis_epoch_data
         ~epoch_ledger_location
         ~genesis_state_hash:

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -714,8 +714,7 @@ module For_tests = struct
         ~default:
           (Consensus.Data.Local_state.create
              ~context:(module Context)
-             ~genesis_ledger:
-               (Precomputed_values.genesis_ledger precomputed_values)
+             ~genesis_ledger:precomputed_values.genesis_ledger
              ~genesis_epoch_data:precomputed_values.genesis_epoch_data
              ~epoch_ledger_location Public_key.Compressed.Set.empty
              ~genesis_state_hash:


### PR DESCRIPTION
This is the PR for https://www.notion.so/o1labs/Improve-genesis-epoch-ledger-snapshot-creation-23fe79b1f91080299e0edd9bd7a7e21a

I did it slightly different in that: in Genesis_epoch_ledger, store `Genesis_ledger.Packed.t` instead of `Mina_ledger.Ledger.t`

This would allow access to any function in `Genesis_ledger.Packed`, with `populate_root` included. 

Nightly: https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3852
^ Seems to be passing