### PR TITLE
Snark Worker & Snark Coordinator: disable metrics generation

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -371,7 +371,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           return @@ Itn_logger.log ~process ~timestamp ~message ~metadata () )
     ]
   in
-  let log_snark_work_metrics
+  let _log_snark_work_metrics
       (work : Snark_work_lib.Selector.Result.Stable.Latest.t) =
     Mina_metrics.(Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;
     One_or_two.iter
@@ -464,7 +464,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                 , Snark_work_lib.Selector.Spec.Stable.Latest.to_yojson work.spec
                 )
               ] ;
-          log_snark_work_metrics work ;
+          (* log_snark_work_metrics work ; *)
           Deferred.return @@ Mina_lib.add_work mina work )
     ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
         (fun

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -37,7 +37,7 @@ let dispatch rpc shutdown_on_disconnect query address =
   | Ok res ->
       res
 
-let emit_proof_metrics metrics instances logger =
+let _emit_proof_metrics metrics instances logger =
   One_or_two.iter (One_or_two.zip_exn metrics instances)
     ~f:(fun ((time, tag), single) ->
       match tag with
@@ -198,9 +198,9 @@ let main (module Rpcs_versioned : Intf.Rpcs_versioned_S) ~logger ~proof_level
             in
             log_and_retry "performing work" e (retry_pause 10.) go
         | Ok result ->
-            emit_proof_metrics result.metrics
-              (Selector.Result.Stable.Latest.transactions result)
-              logger ;
+            (* emit_proof_metrics result.metrics *)
+            (*   (Selector.Result.Stable.Latest.transactions result) *)
+            (*   logger ; *)
             [%log info] "Submitted completed SNARK work $work_ids to $address"
               ~metadata:
                 [ ("address", `String (Host_and_port.to_string daemon_address))


### PR DESCRIPTION
When we're updating the RPC, metrics generation should be updated as well. This would cause PRs to be bigger than expected. A better route is disabled the metrics generation. And when we're ready with an updated version of the protocol, we could bring it back. 