### PR TITLE
Pass back spec on successful result combination in partitioner

### DIFF
--- a/src/lib/snark_work_lib/combined_result.mli
+++ b/src/lib/snark_work_lib/combined_result.mli
@@ -1,5 +1,5 @@
-open Mina_wire_types
-
 type t =
-  Transaction_snark_work.Statement.V2.t
-  * Ledger_proof.V2.t One_or_two.V1.t Network_pool_priced_proof.V1.t
+  { spec_with_proof : (Single_spec.t * Ledger_proof.t) One_or_two.t
+  ; fee : Currency.Fee.t
+  ; prover : Signature_lib.Public_key.Compressed.t
+  }


### PR DESCRIPTION
This is needed for:
1. logging metrics after Snark Worker RPC protocol is updated
2. Push back completed but invalid snark works back to the work partitioner pool for rescheduling