### PR TITLE
Add a flag to pad app_state

### DIFF
--- a/changes/17646.md
+++ b/changes/17646.md
@@ -1,0 +1,1 @@
+Implement --pad-app-state flag for `runtime_genesis_ledger` tool to allow the tool to make conversion from 8 app state elements to 32, as part of legacy hardfork migration process.

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -15,14 +15,14 @@ end
 
 let logger = Logger.create ()
 
-let load_ledger ~ignore_missing_fields
+let load_ledger ~ignore_missing_fields ~pad_app_state
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     (accounts : Runtime_config.Accounts.t) =
   let accounts =
     List.map accounts ~f:(fun account ->
         ( None
         , Runtime_config.Accounts.Single.to_account ~ignore_missing_fields
-            account ) )
+            ~pad_app_state account ) )
   in
   let packed =
     Genesis_ledger_helper.Ledger.packed_genesis_ledger_of_accounts
@@ -121,21 +121,25 @@ let load_config_exn config_file =
   , Option.map ~f:extract_accounts_exn next_ledger )
 
 let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~config_file ~genesis_dir ~hash_output_file ~ignore_missing_fields () =
+    ~config_file ~genesis_dir ~hash_output_file ~ignore_missing_fields
+    ~pad_app_state () =
   let%bind accounts, staking_accounts_opt, next_accounts_opt =
     load_config_exn config_file
   in
   let ledger =
-    load_ledger ~ignore_missing_fields ~constraint_constants accounts
+    load_ledger ~ignore_missing_fields ~pad_app_state ~constraint_constants
+      accounts
   in
   let staking_ledger : Ledger.t =
     Option.value_map ~default:ledger
-      ~f:(load_ledger ~ignore_missing_fields ~constraint_constants)
+      ~f:
+        (load_ledger ~ignore_missing_fields ~pad_app_state ~constraint_constants)
       staking_accounts_opt
   in
   let next_ledger =
     Option.value_map ~default:staking_ledger
-      ~f:(load_ledger ~ignore_missing_fields ~constraint_constants)
+      ~f:
+        (load_ledger ~ignore_missing_fields ~pad_app_state ~constraint_constants)
       next_accounts_opt
   in
   let%bind hash_json =
@@ -176,6 +180,13 @@ let () =
              ~doc:
                "BOOL whether to ignore missing fields in account definition \
                 (and replace with default values)"
+         (* TODO: at later stages replace with a flag to do all
+            ledger transformations necessary for the hardfork *)
+         and pad_app_state =
+           flag "--pad-app-state" no_arg
+             ~doc:
+               "BOOL whether to pad app_state to max allowed size (default: \
+                false)"
          in
          main ~constraint_constants ~config_file ~genesis_dir ~hash_output_file
-           ~ignore_missing_fields) )
+           ~ignore_missing_fields ~pad_app_state) )


### PR DESCRIPTION
With the introduction of hardfork feature (in develop branch) of zkapp
`app_state` containing 32 elements, it's necessary for the
`runtime_genesis_ledger` to support padding the app state to necessary
length.

In future this flag will be replaced by a flag performing all the
necessary ledger transformations required for planned hardfork.

Explain how you tested your changes:
* [x] Ran the tool on app state increase branch with this patch merged, conversion succeeded

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
