### PR TITLE
Make merkle_ledger_tests a separate package

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -78,6 +78,7 @@
 (package (name logproc_lib))
 (package (name merkle_address))
 (package (name merkle_ledger))
+(package (name merkle_ledger_tests))
 (package (name merkle_list_prover))
 (package (name merkle_list_verifier))
 (package (name merkle_mask))

--- a/src/lib/merkle_ledger/test/dune
+++ b/src/lib/merkle_ledger/test/dune
@@ -1,6 +1,6 @@
 (library
  (name merkle_ledger_tests)
- (public_name merkle_ledger.tests)
+ (public_name merkle_ledger_tests)
  (modules (:standard \ test))
  (flags (:standard -warn-error +a))
  (preprocess
@@ -43,7 +43,7 @@
 
 (test
  (name test)
- (package merkle_ledger)
+ (package merkle_ledger_tests)
  (modules test)
  (flags (:standard -warn-error +a))
  (preprocess


### PR DESCRIPTION
Motivation: otherwise there is a circular package-to-package dependency
between merkle_ledger and merkle_mask because the tests in both packages
use libraries from the other.

This prevents building with granular nix (`nix build mina#exes.mina`).

Explain how you tested your changes:
* [x] `nix build mina#exes.mina` succeeds

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
