### PR TITLE
Fix & improve HF package verification script

### DIFF
--- a/scripts/mina-verify-packaged-fork-config
+++ b/scripts/mina-verify-packaged-fork-config
@@ -170,7 +170,8 @@ if [ -z ${NO_TEST_LEDGER_DOWNLOAD+z} ]; then
     # We removed all *.tar.gz from GENESIS_LEDGER_DIR (in case it's one of default paths)
     # and expect Mina node to be able to download these from S3
     extract_ledgers "$PACKAGED_DAEMON_CONFIG" "$workdir/ledgers-downloaded" "$workdir/downloaded"
-    rm -Rf /tmp/coda_cache_dir/*.tar.gz /tmp/s3_cache_dir/*.tar.gz
+    TMPDIR="${TMPDIR:-/tmp}"
+    rm -Rf "$TMPDIR"/coda_cache_dir/*.tar.gz "$TMPDIR"/s3_cache_dir/*.tar.gz
 fi
 extract_ledgers "$workdir/config-substituted.json" "$workdir/ledgers" "$workdir/reference"
 mv -t "$GENESIS_LEDGER_DIR" "$workdir/ledgers-backup"/*


### PR DESCRIPTION
1. Fix condition related to providing precomputed block explicitly (and
   a related check of gsutil utility being installed/provided)
2. Fix condition related to PACKAGED_DAEMON_CONFIG being provided
   explicitly
3. Read MINA_LEDGER_S3_BUCKET for ledger S3 URL, if provided (useful for
   testing without touching the production snark-keys-ro bucket)
4. Support mina log level to bbe set via env variable

Tested the script via command:

```bash
MINA_LOG_LEVEL=trace MINA_LEDGER_S3_BUCKET=https://s3-us-west-2.amazonaws.com/snark-keys.o1test.net MINA_LIBP2P_HELPER_PATH=libp2p_helper/bin/mina-libp2p_helper TMPDIR=tmp GSUTIL=false MINA_EXE=$PWD/mina/bin/mina MINA_GENESIS_EXE=$PWD/gl/bin/runtime_genesis_ledger MINA_LEGACY_GENESIS_EXE=$PWD/gl/bin/runtime_genesis_ledger PRECOMPUTED_FORK_BLOCK=$PWD/449631.json PACKAGED_DAEMON_CONFIG=$(echo $PWD/packaged-449631/config_*.json) CREATE_RUNTIME_CONFIG=$PWD/scripts/hardfork/create_runtime_config.sh GENESIS_LEDGER_DIR=$PWD/packaged-449631 FORKING_FROM_CONFIG_JSON=$PWD/genesis_ledgers/devnet.json scripts/hardfork/mina-verify-packaged-fork-config devnet fork-config-449631.json $PWD/bla
```

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
