### PR TITLE
Use app state increase in Account.Unstable

### DIFF
--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -456,3 +456,50 @@ let gen : t Quickcheck.Generator.t =
   ; proved_state = false
   ; zkapp_uri
   }
+
+module Unstable = struct
+  type t =
+    ( Zkapp_state.Unstable.Value.t
+    , Verification_key_wire.Stable.V1.t option
+    , Mina_numbers.Zkapp_version.Stable.V1.t
+    , F.Stable.V1.t
+    , Mina_numbers.Global_slot_since_genesis.Stable.V1.t
+    , bool
+    , Zkapp_uri.Stable.V1.t )
+    Poly.Stable.Latest.t
+  [@@deriving sexp, equal, hash, compare, yojson, bin_io_unversioned]
+
+  let of_stable (account : Stable.Latest.t) : t =
+    { app_state = Zkapp_state.Unstable.Value.of_stable account.app_state
+    ; verification_key = account.verification_key
+    ; zkapp_version = account.zkapp_version
+    ; action_state = account.action_state
+    ; last_action_slot = account.last_action_slot
+    ; proved_state = account.proved_state
+    ; zkapp_uri = account.zkapp_uri
+    }
+
+  let to_input (t : t) : _ Random_oracle.Input.Chunked.t =
+    let open Random_oracle.Input.Chunked in
+    let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
+    let app_state v =
+      Random_oracle.Input.Chunked.field_elements
+        (Pickles_types.Vector.to_array v)
+    in
+    Poly.Fields.fold ~init:[] ~app_state:(f app_state)
+      ~verification_key:
+        (f
+           (Fn.compose field
+              (Option.value_map ~default:(dummy_vk_hash ()) ~f:With_hash.hash) ) )
+      ~zkapp_version:(f Mina_numbers.Zkapp_version.to_input)
+      ~action_state:(f app_state)
+      ~last_action_slot:(f Mina_numbers.Global_slot_since_genesis.to_input)
+      ~proved_state:
+        (f (fun b -> Random_oracle.Input.Chunked.packed (field_of_bool b, 1)))
+      ~zkapp_uri:(f zkapp_uri_to_input)
+    |> List.reduce_exn ~f:append
+
+  let digest (t : t) =
+    Random_oracle.(
+      hash ~init:Hash_prefix_states.zkapp_account (pack_input (to_input t)))
+end

--- a/src/lib/mina_base/zkapp_state.ml
+++ b/src/lib/mina_base/zkapp_state.ml
@@ -71,3 +71,24 @@ let deriver inner obj =
   iso ~map:V.of_list_exn ~contramap:V.to_list
     ((list ~static_length:max_size_int @@ inner @@ o ()) (o ()))
     obj
+
+module Unstable = struct
+  module Max_state_size = Nat.N32
+
+  module State_length_vec :
+    Vector.VECTOR with type 'a t = ('a, Max_state_size.n) Vector.vec =
+    Vector.Vector_32
+
+  module V = struct
+    type 'a t = 'a State_length_vec.Stable.V1.t
+    [@@deriving sexp, equal, hash, compare, yojson, bin_io_unversioned]
+  end
+
+  module Value = struct
+    type t = Zkapp_basic.F.Stable.V1.t V.t
+    [@@deriving sexp, equal, hash, compare, yojson, bin_io_unversioned]
+
+    let of_stable (value : Value.Stable.Latest.t) : t =
+      Vector.extend_front_exn value Nat.N32.n Zkapp_basic.F.zero
+  end
+end

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -918,8 +918,8 @@ let%test_unit "user_command application on converting ledger" =
                 Mina_base.Account.Key.(
                   equal account.public_key account_converted.public_key) ) ;
               assert (
-                Mina_base.Account.Nonce.(
-                  equal account_converted.nonce account_converted.unstable_field) ) ) ;
+                Mina_base.Account.Unstable.(
+                  equal account_converted (of_stable account)) ) ) ;
           (* Assert that the converted ledger doesn't have anything "extra" compared to the primary ledger *)
           Unstable_db.iteri cl ~f:(fun index account_converted ->
               let account = L.get_at_index_exn l index in


### PR DESCRIPTION
## Explain your changes:

The testing `Account.Unstable` type now uses the zkapp state size increase as its example hard fork change. Previously, it was just a duplicated `nonce` field.

## Explain how you tested your changes:

The existing converting ledger tests use this `Account.Unstable` type. 

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? No.