### PR TITLE
Prepare fork config inputs in mina_lib

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2613,44 +2613,16 @@ module Queries = struct
           | Some _, Some _ ->
               Deferred.Result.fail "Cannot specify both state hash and height"
         in
-        let%bind breadcrumb =
-          Mina_lib.Hardfork_config.breadcrumb ~breadcrumb_spec mina
-        in
-        let block = Transition_frontier.Breadcrumb.block breadcrumb in
-        let blockchain_length = Mina_block.blockchain_length block in
-        let global_slot_since_genesis =
-          Mina_block.consensus_state block
-          |> Consensus.Data.Consensus_state.global_slot_since_genesis
-        in
-        let staged_ledger =
-          Transition_frontier.Breadcrumb.staged_ledger breadcrumb
-          |> Staged_ledger.ledger
-        in
-        let state_hash = Transition_frontier.Breadcrumb.state_hash breadcrumb in
-        let protocol_state =
-          Transition_frontier.Breadcrumb.protocol_state breadcrumb
-        in
-        let consensus =
-          Mina_state.Protocol_state.consensus_state protocol_state
-        in
-        let staking_epoch =
-          Consensus.Proof_of_stake.Data.Consensus_state.staking_epoch_data
-            consensus
-        in
-        let next_epoch =
-          Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data
-            consensus
-        in
-        let staking_epoch_seed =
-          Mina_base.Epoch_seed.to_base58_check
-            staking_epoch.Mina_base.Epoch_data.Poly.seed
-        in
-        let next_epoch_seed =
-          Mina_base.Epoch_seed.to_base58_check
-            next_epoch.Mina_base.Epoch_data.Poly.seed
-        in
-        let%bind staking_ledger, next_epoch_ledger =
-          Mina_lib.Hardfork_config.epoch_ledgers ~breadcrumb mina
+        let%bind { staged_ledger
+                 ; global_slot_since_genesis
+                 ; state_hash
+                 ; staking_ledger
+                 ; staking_epoch_seed
+                 ; next_epoch_ledger
+                 ; next_epoch_seed
+                 ; blockchain_length
+                 } =
+          Mina_lib.Hardfork_config.prepare_inputs ~breadcrumb_spec mina
         in
         let%bind new_config =
           Runtime_config.make_fork_config ~staged_ledger

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2614,7 +2614,7 @@ module Queries = struct
               Deferred.Result.fail "Cannot specify both state hash and height"
         in
         let%bind breadcrumb =
-          Mina_lib.hard_fork_breadcrumb ~breadcrumb_spec mina
+          Mina_lib.Hardfork_config.breadcrumb ~breadcrumb_spec mina
         in
         let block = Transition_frontier.Breadcrumb.block breadcrumb in
         let blockchain_length = Mina_block.blockchain_length block in
@@ -2650,7 +2650,7 @@ module Queries = struct
             next_epoch.Mina_base.Epoch_data.Poly.seed
         in
         let%bind staking_ledger, next_epoch_ledger =
-          Mina_lib.Hardfork_config.get_epoch_ledgers ~mina breadcrumb
+          Mina_lib.Hardfork_config.epoch_ledgers ~breadcrumb mina
         in
         let%bind new_config =
           Runtime_config.make_fork_config ~staged_ledger

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2625,8 +2625,10 @@ module Queries = struct
         let%bind new_config =
           Runtime_config.make_fork_config ~staged_ledger
             ~global_slot_since_genesis ~state_hash ~staking_ledger
-            ~staking_epoch_seed ~next_epoch_ledger:(Some next_epoch_ledger)
-            ~next_epoch_seed ~blockchain_length
+            ~staking_epoch_seed:(Epoch_seed.to_base58_check staking_epoch_seed)
+            ~next_epoch_ledger:(Some next_epoch_ledger)
+            ~next_epoch_seed:(Epoch_seed.to_base58_check next_epoch_seed)
+            ~blockchain_length
         in
         let%map () =
           let open Async.Deferred.Infix in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2719,11 +2719,11 @@ module Hardfork_config = struct
           , Ledger.Any_ledger.cast (module Ledger) next_epoch_ledger )
     in
     assert (
-      Mina_base.Ledger_hash.equal
+      Ledger_hash.equal
         (Ledger.Any_ledger.M.merkle_root staking_ledger)
         staking_epoch.ledger.hash ) ;
     assert (
-      Mina_base.Ledger_hash.equal
+      Ledger_hash.equal
         (Ledger.Any_ledger.M.merkle_root next_epoch_ledger)
         next_epoch.ledger.hash ) ;
     (staking_ledger, next_epoch_ledger)
@@ -2763,8 +2763,8 @@ module Hardfork_config = struct
     let next_epoch =
       Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data consensus
     in
-    let staking_epoch_seed = staking_epoch.Mina_base.Epoch_data.Poly.seed in
-    let next_epoch_seed = next_epoch.Mina_base.Epoch_data.Poly.seed in
+    let staking_epoch_seed = staking_epoch.Epoch_data.Poly.seed in
+    let next_epoch_seed = next_epoch.Epoch_data.Poly.seed in
     let%map staking_ledger, next_epoch_ledger =
       epoch_ledgers ~breadcrumb mina
     in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2639,6 +2639,92 @@ let hard_fork_breadcrumb ~(breadcrumb_spec : hard_fork_breadcrumb_spec) t =
   | `Block_height block_height ->
       best_chain_block_by_height t block_height |> Deferred.return
 
+module Hardfork_config = struct
+  let get_epoch_ledgers ~mina breadcrumb =
+    let open Deferred.Result.Let_syntax in
+    let mina_config = config mina in
+    let frontier_consensus_local_state = mina_config.consensus_local_state in
+    let consensus_state =
+      breadcrumb |> Transition_frontier.Breadcrumb.protocol_state
+      |> Mina_state.Protocol_state.consensus_state
+    in
+    let staking_epoch =
+      Consensus.Proof_of_stake.Data.Consensus_state.staking_epoch_data
+        consensus_state
+    in
+    let next_epoch =
+      Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data
+        consensus_state
+    in
+    let cast_ledger = function
+      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Genesis_epoch_ledger
+          l ->
+          let l_inner = Lazy.force @@ Genesis_ledger.Packed.t l in
+          Ledger.Any_ledger.cast (module Ledger) l_inner
+      | Consensus.Data.Local_state.Snapshot.Ledger_snapshot.Ledger_root l ->
+          Ledger.Root.as_unmasked l
+    in
+    let root_consensus_state =
+      let frontier =
+        Option.value_exn @@ Pipe_lib.Broadcast_pipe.Reader.peek
+        @@ transition_frontier mina
+      in
+      let frontier_root = Transition_frontier.root frontier in
+      frontier_root |> Transition_frontier.Breadcrumb.protocol_state
+      |> Mina_state.Protocol_state.consensus_state
+    in
+    let%map staking_ledger, next_epoch_ledger =
+      match
+        (* We pretend that the block is finalized, so that we can query it in
+           advance, for redundancy.
+        *)
+        Consensus.Hooks.get_epoch_ledgers_for_finalized_frontier_block
+          ~root_consensus_state ~target_consensus_state:consensus_state
+          ~local_state:frontier_consensus_local_state
+      with
+      | `Both (staking_ledger, next_epoch_ledger) ->
+          return (cast_ledger staking_ledger, cast_ledger next_epoch_ledger)
+      | `Snarked_ledger (staking_ledger, num_parents) ->
+          (* The epoch transition was at a block between the given block and
+             the root. We find it by walking back by `num_parents` blocks.
+          *)
+          let%bind epoch_transition_state_hash =
+            let open Result.Let_syntax in
+            let rec ancestor breadcrumb i =
+              if i = 0 then return breadcrumb
+              else
+                let parent_hash =
+                  Transition_frontier.Breadcrumb.parent_hash breadcrumb
+                in
+                let%bind breadcrumb =
+                  best_chain_block_by_state_hash mina parent_hash
+                in
+                ancestor breadcrumb (i - 1)
+            in
+            ancestor breadcrumb num_parents
+            >>| Transition_frontier.Breadcrumb.state_hash |> Deferred.return
+          in
+          (* When this block reaches the root of the frontier, its snarked
+             ledger will become the next epoch ledger; we simulate that here.
+          *)
+          let%map next_epoch_ledger =
+            get_snarked_ledger_full mina (Some epoch_transition_state_hash)
+            |> Deferred.Result.map_error ~f:Error.to_string_hum
+          in
+          ( cast_ledger staking_ledger
+          , Ledger.Any_ledger.cast (module Ledger) next_epoch_ledger )
+    in
+    assert (
+      Mina_base.Ledger_hash.equal
+        (Ledger.Any_ledger.M.merkle_root staking_ledger)
+        staking_epoch.ledger.hash ) ;
+    assert (
+      Mina_base.Ledger_hash.equal
+        (Ledger.Any_ledger.M.merkle_root next_epoch_ledger)
+        next_epoch.ledger.hash ) ;
+    (staking_ledger, next_epoch_ledger)
+end
+
 let zkapp_cmd_limit t = t.config.zkapp_cmd_limit
 
 let proof_cache_db t = t.proof_cache_db

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2733,9 +2733,9 @@ module Hardfork_config = struct
     ; global_slot_since_genesis : Mina_numbers.Global_slot_since_genesis.t
     ; state_hash : State_hash.t
     ; staking_ledger : Ledger.Any_ledger.witness
-    ; staking_epoch_seed : string
+    ; staking_epoch_seed : Epoch_seed.t
     ; next_epoch_ledger : Ledger.Any_ledger.witness
-    ; next_epoch_seed : string
+    ; next_epoch_seed : Epoch_seed.t
     ; blockchain_length : Mina_numbers.Length.t
     }
 
@@ -2763,14 +2763,8 @@ module Hardfork_config = struct
     let next_epoch =
       Consensus.Proof_of_stake.Data.Consensus_state.next_epoch_data consensus
     in
-    let staking_epoch_seed =
-      Mina_base.Epoch_seed.to_base58_check
-        staking_epoch.Mina_base.Epoch_data.Poly.seed
-    in
-    let next_epoch_seed =
-      Mina_base.Epoch_seed.to_base58_check
-        next_epoch.Mina_base.Epoch_data.Poly.seed
-    in
+    let staking_epoch_seed = staking_epoch.Mina_base.Epoch_data.Poly.seed in
+    let next_epoch_seed = next_epoch.Mina_base.Epoch_data.Poly.seed in
     let%map staking_ledger, next_epoch_ledger =
       epoch_ledgers ~breadcrumb mina
     in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2625,6 +2625,20 @@ let best_chain_block_before_stop_slot (t : t) =
           in
           find_block_older_than_stop_slot breadcrumb )
 
+type hard_fork_breadcrumb_spec =
+  [ `Stop_slot
+  | `State_hash of State_hash.t
+  | `Block_height of Unsigned.UInt32.t ]
+
+let hard_fork_breadcrumb ~(breadcrumb_spec : hard_fork_breadcrumb_spec) t =
+  match breadcrumb_spec with
+  | `Stop_slot ->
+      best_chain_block_before_stop_slot t
+  | `State_hash state_hash_base58 ->
+      best_chain_block_by_state_hash t state_hash_base58 |> Deferred.return
+  | `Block_height block_height ->
+      best_chain_block_by_height t block_height |> Deferred.return
+
 let zkapp_cmd_limit t = t.config.zkapp_cmd_limit
 
 let proof_cache_db t = t.proof_cache_db

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2625,22 +2625,24 @@ let best_chain_block_before_stop_slot (t : t) =
           in
           find_block_older_than_stop_slot breadcrumb )
 
-type hard_fork_breadcrumb_spec =
-  [ `Stop_slot
-  | `State_hash of State_hash.t
-  | `Block_height of Unsigned.UInt32.t ]
-
-let hard_fork_breadcrumb ~(breadcrumb_spec : hard_fork_breadcrumb_spec) t =
-  match breadcrumb_spec with
-  | `Stop_slot ->
-      best_chain_block_before_stop_slot t
-  | `State_hash state_hash_base58 ->
-      best_chain_block_by_state_hash t state_hash_base58 |> Deferred.return
-  | `Block_height block_height ->
-      best_chain_block_by_height t block_height |> Deferred.return
-
 module Hardfork_config = struct
-  let get_epoch_ledgers ~mina breadcrumb =
+  type mina_lib = t
+
+  type breadcrumb_spec =
+    [ `Stop_slot
+    | `State_hash of State_hash.t
+    | `Block_height of Unsigned.UInt32.t ]
+
+  let breadcrumb ~breadcrumb_spec mina =
+    match breadcrumb_spec with
+    | `Stop_slot ->
+        best_chain_block_before_stop_slot mina
+    | `State_hash state_hash_base58 ->
+        best_chain_block_by_state_hash mina state_hash_base58 |> Deferred.return
+    | `Block_height block_height ->
+        best_chain_block_by_height mina block_height |> Deferred.return
+
+  let epoch_ledgers ~breadcrumb mina =
     let open Deferred.Result.Let_syntax in
     let mina_config = config mina in
     let frontier_consensus_local_state = mina_config.consensus_local_state in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2670,12 +2670,9 @@ module Hardfork_config = struct
           Ledger.Root.as_unmasked l
     in
     let root_consensus_state =
-      let frontier =
-        Option.value_exn @@ Pipe_lib.Broadcast_pipe.Reader.peek
-        @@ transition_frontier mina
-      in
-      let frontier_root = Transition_frontier.root frontier in
-      frontier_root |> Transition_frontier.Breadcrumb.protocol_state
+      transition_frontier mina |> Pipe_lib.Broadcast_pipe.Reader.peek
+      |> Option.value_exn |> Transition_frontier.root
+      |> Transition_frontier.Breadcrumb.protocol_state
       |> Mina_state.Protocol_state.consensus_state
     in
     let%map staking_ledger, next_epoch_ledger =

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -270,6 +270,16 @@ val hard_fork_breadcrumb :
   -> t
   -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
 
+module Hardfork_config : sig
+  val get_epoch_ledgers :
+       mina:t
+    -> Transition_frontier.Breadcrumb.t
+    -> ( Mina_ledger.Ledger.Any_ledger.witness
+         * Mina_ledger.Ledger.Any_ledger.witness
+       , string )
+       Deferred.Result.t
+end
+
 val zkapp_cmd_limit : t -> int option ref
 
 val proof_cache_db : t -> Proof_cache_tag.cache_db

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -260,20 +260,22 @@ val best_chain_block_by_state_hash :
 val best_chain_block_before_stop_slot :
   t -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
 
-type hard_fork_breadcrumb_spec =
-  [ `Stop_slot
-  | `State_hash of State_hash.t
-  | `Block_height of Unsigned.UInt32.t ]
-
-val hard_fork_breadcrumb :
-     breadcrumb_spec:hard_fork_breadcrumb_spec
-  -> t
-  -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
-
 module Hardfork_config : sig
-  val get_epoch_ledgers :
-       mina:t
-    -> Transition_frontier.Breadcrumb.t
+  type mina_lib = t
+
+  type breadcrumb_spec =
+    [ `Stop_slot
+    | `State_hash of State_hash.t
+    | `Block_height of Unsigned.UInt32.t ]
+
+  val breadcrumb :
+       breadcrumb_spec:breadcrumb_spec
+    -> mina_lib
+    -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
+
+  val epoch_ledgers :
+       breadcrumb:Transition_frontier.Breadcrumb.t
+    -> mina_lib
     -> ( Mina_ledger.Ledger.Any_ledger.witness
          * Mina_ledger.Ledger.Any_ledger.witness
        , string )

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -285,9 +285,9 @@ module Hardfork_config : sig
     ; global_slot_since_genesis : Mina_numbers.Global_slot_since_genesis.t
     ; state_hash : State_hash.t
     ; staking_ledger : Mina_ledger.Ledger.Any_ledger.witness
-    ; staking_epoch_seed : string
+    ; staking_epoch_seed : Epoch_seed.t
     ; next_epoch_ledger : Mina_ledger.Ledger.Any_ledger.witness
-    ; next_epoch_seed : string
+    ; next_epoch_seed : Epoch_seed.t
     ; blockchain_length : Mina_numbers.Length.t
     }
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -280,6 +280,22 @@ module Hardfork_config : sig
          * Mina_ledger.Ledger.Any_ledger.witness
        , string )
        Deferred.Result.t
+
+  type inputs =
+    { staged_ledger : Mina_ledger.Ledger.t
+    ; global_slot_since_genesis : Mina_numbers.Global_slot_since_genesis.t
+    ; state_hash : State_hash.t
+    ; staking_ledger : Mina_ledger.Ledger.Any_ledger.witness
+    ; staking_epoch_seed : string
+    ; next_epoch_ledger : Mina_ledger.Ledger.Any_ledger.witness
+    ; next_epoch_seed : string
+    ; blockchain_length : Mina_numbers.Length.t
+    }
+
+  val prepare_inputs :
+       breadcrumb_spec:breadcrumb_spec
+    -> mina_lib
+    -> (inputs, string) Deferred.Result.t
 end
 
 val zkapp_cmd_limit : t -> int option ref

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -252,13 +252,13 @@ val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t
 val vrf_evaluation_state : t -> Block_producer.Vrf_evaluation_state.t
 
 val best_chain_block_by_height :
-  t -> Unsigned.UInt32.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
+  t -> Unsigned.UInt32.t -> Transition_frontier.Breadcrumb.t Or_error.t
 
 val best_chain_block_by_state_hash :
-  t -> State_hash.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
+  t -> State_hash.t -> Transition_frontier.Breadcrumb.t Or_error.t
 
 val best_chain_block_before_stop_slot :
-  t -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
+  t -> Transition_frontier.Breadcrumb.t Deferred.Or_error.t
 
 module Hardfork_config : sig
   type mina_lib = t
@@ -271,15 +271,14 @@ module Hardfork_config : sig
   val breadcrumb :
        breadcrumb_spec:breadcrumb_spec
     -> mina_lib
-    -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
+    -> Transition_frontier.Breadcrumb.t Deferred.Or_error.t
 
   val epoch_ledgers :
        breadcrumb:Transition_frontier.Breadcrumb.t
     -> mina_lib
     -> ( Mina_ledger.Ledger.Any_ledger.witness
-         * Mina_ledger.Ledger.Any_ledger.witness
-       , string )
-       Deferred.Result.t
+       * Mina_ledger.Ledger.Any_ledger.witness )
+       Deferred.Or_error.t
 
   type inputs =
     { staged_ledger : Mina_ledger.Ledger.t
@@ -293,9 +292,7 @@ module Hardfork_config : sig
     }
 
   val prepare_inputs :
-       breadcrumb_spec:breadcrumb_spec
-    -> mina_lib
-    -> (inputs, string) Deferred.Result.t
+    breadcrumb_spec:breadcrumb_spec -> mina_lib -> inputs Deferred.Or_error.t
 end
 
 val zkapp_cmd_limit : t -> int option ref

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -260,6 +260,16 @@ val best_chain_block_by_state_hash :
 val best_chain_block_before_stop_slot :
   t -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
 
+type hard_fork_breadcrumb_spec =
+  [ `Stop_slot
+  | `State_hash of State_hash.t
+  | `Block_height of Unsigned.UInt32.t ]
+
+val hard_fork_breadcrumb :
+     breadcrumb_spec:hard_fork_breadcrumb_spec
+  -> t
+  -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
+
 val zkapp_cmd_limit : t -> int option ref
 
 val proof_cache_db : t -> Proof_cache_tag.cache_db

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -257,6 +257,9 @@ val best_chain_block_by_height :
 val best_chain_block_by_state_hash :
   t -> State_hash.t -> (Transition_frontier.Breadcrumb.t, string) Result.t
 
+val best_chain_block_before_stop_slot :
+  t -> (Transition_frontier.Breadcrumb.t, string) Deferred.Result.t
+
 val zkapp_cmd_limit : t -> int option ref
 
 val proof_cache_db : t -> Proof_cache_tag.cache_db

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -606,7 +606,7 @@ module Accounts = struct
 
     let default = Json_layout.Accounts.Single.default
 
-    let of_account (a : Mina_base.Account.t) : (t, string) Result.t =
+    let of_account (a : Mina_base.Account.t) : t Or_error.t =
       let open Result.Let_syntax in
       let open Signature_lib in
       return
@@ -776,7 +776,7 @@ module Accounts = struct
     let gen =
       Quickcheck.Generator.map Mina_base.Account.gen ~f:(fun a ->
           (* This will never fail with a proper account generator. *)
-          of_account a |> Result.ok_or_failwith )
+          of_account a |> Or_error.ok_exn )
   end
 
   type single = Single.t =
@@ -1529,7 +1529,7 @@ let gen =
   }
 
 let ledger_accounts (ledger : Mina_ledger.Ledger.Any_ledger.witness) =
-  let open Async.Deferred.Result.Let_syntax in
+  let open Async.Deferred.Or_error.Let_syntax in
   let yield = Async_unix.Scheduler.yield_every ~n:100 |> Staged.unstage in
   let%bind accounts =
     Mina_ledger.Ledger.Any_ledger.M.to_list ledger
@@ -1560,7 +1560,7 @@ let ledger_of_accounts accounts =
 let make_fork_config ~staged_ledger ~global_slot_since_genesis ~state_hash
     ~blockchain_length ~staking_ledger ~staking_epoch_seed ~next_epoch_ledger
     ~next_epoch_seed =
-  let open Async.Deferred.Result.Let_syntax in
+  let open Async.Deferred.Or_error.Let_syntax in
   let global_slot_since_genesis =
     Mina_numbers.Global_slot_since_genesis.to_int global_slot_since_genesis
   in

--- a/src/lib/testing/integration_test_local_engine/mina_docker.ml
+++ b/src/lib/testing/integration_test_local_engine/mina_docker.ml
@@ -201,7 +201,7 @@ module Network_config = struct
               let genesis_winner_account : Runtime_config.Accounts.single =
                 Runtime_config.Accounts.Single.of_account
                   Mina_state.Consensus_state_hooks.genesis_winner_account
-                |> Result.ok_or_failwith
+                |> Or_error.ok_exn
               in
               let ledger_of_epoch_accounts
                   (epoch_accounts : Test_config.Test_account.t list) =


### PR DESCRIPTION
The inputs necessary to generate the hard fork daemon config and genesis ledgers will need to be available to other parts of the code base, so I have isolated that logic and moved it into `mina_lib`.
