### PR TITLE
allow to build hf packages locally using Makefile

### DIFF
--- a/buildkite/scripts/generate-genesis-config.sh
+++ b/buildkite/scripts/generate-genesis-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/buildkite/scripts/generate-genesis-config.sh
+++ b/buildkite/scripts/generate-genesis-config.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eo pipefail
+
+([ -z ${CONFIG_JSON_GZ_URL+x} ]) && echo "required env vars were not provided" && exit 1
+
+echo "--- Download and extract previous network config"
+curl -o config.json.gz $CONFIG_JSON_GZ_URL
+gunzip config.json.gz
+
+# Patch against a bug in 1.4 which is fixed by PR #15462
+mv config.json config_orig.json
+jq 'del(.ledger.num_accounts) | del(.ledger.name)' config_orig.json > config.json 
+
+echo "--- Migrate accounts to new network format"
+# TODO: At this stage, we need to migrate the json accounts into the new network's format.
+#       For now, this is hard-coded to the mainnet -> berkeley migration, but we need to select
+#       a migration to perform in the future.
+# NB: we use sed here instead of jq, because jq is extremely slow at processing this file
+sed -i -e 's/"set_verification_key": "signature"/"set_verification_key": {"auth": "signature", "txn_version": "2"}/' config.json
+
+echo "--- Generate hardfork ledger tarballs"
+mkdir hardfork_ledgers
+mina-create-genesis --config-file config.json --genesis-dir hardfork_ledgers/ --hash-output-file hardfork_ledger_hashes.json | tee runtime_genesis_ledger.log | mina-logproc
+
+echo "--- Create hardfork config"
+FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
+
+echo "--- New genesis config"
+jq 'del(.ledger.s3_data_hash, .epoch_data.staking.s3_data_hash, .epoch_data.next.s3_data_hash)' new_config.json

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -190,7 +190,7 @@ copy_common_daemon_configs() {
     "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
   cp ../scripts/hardfork/create_runtime_config.sh \
     "${BUILDDIR}/usr/local/bin/mina-hf-create-runtime-config"
-  cp ../scripts/mina-verify-packaged-fork-config \
+  cp ../scripts/hardfork/mina-verify-packaged-fork-config \
     "${BUILDDIR}/usr/local/bin/mina-verify-packaged-fork-config"
   # Update the mina.service with a new default PEERS_URL based on Seed List \
   # URL $3
@@ -441,6 +441,89 @@ build_daemon_berkeley_deb() {
 }
 ## END BERKELEY PACKAGE ##
 
+replace_runtime_config_and_ledgers_with_hardforked_ones() {
+  local NETWORK_NAME="${1}"
+
+  # Create the directory for the runtime config and ledgers if it doesn't exist
+  mkdir -p "${BUILDDIR}/var/lib/coda"
+
+  { [ -z ${RUNTIME_CONFIG_JSON+x} ] || [ -z ${LEDGER_TARBALLS+x} ]; }  \
+    && echo "required env vars were not provided" && exit 1
+
+  # Replace the runtime config and ledgers with the hardfork ones
+  cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
+  for ledger_tarball in $LEDGER_TARBALLS; do
+    cp "${ledger_tarball}" "${BUILDDIR}/var/lib/coda/"
+  done
+
+  # Overwrite outdated ledgers that are being updated by the hardfork (backing up the outdated ledgers)
+  if [ -f "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json" ]; then
+    mv "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.old.json"
+  fi
+  cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json"
+}
+
+
+## DEVNET HARDFORK PACKAGE ##
+build_daemon_devnet_hardfork_deb() {
+  local __deb_name=mina-devnet-hardfork
+
+  echo "------------------------------------------------------------"
+  echo "--- Building hardfork testnet signatures deb without keys:"
+
+  create_control_file "${__deb_name}" "${SHARED_DEPS}${DAEMON_DEPS}" \
+    'Mina Protocol Client and Daemon for the Devnet Network' "${SUGGESTED_DEPS}"
+
+  copy_common_daemon_configs devnet testnet 'seed-lists/devnet_seeds.txt'
+
+  replace_runtime_config_and_ledgers_with_hardforked_ones devnet
+
+  build_deb "${__deb_name}"
+
+}
+
+## END DEVNET HARDFORK PACKAGE ##
+
+## BERKELEY HARDFORK PACKAGE ##
+build_daemon_berkeley_hardfork_deb() {
+  local __deb_name=mina-berkeley-hardfork
+
+  echo "------------------------------------------------------------"
+  echo "--- Building hardfork berkeley signatures deb without keys:"
+
+  create_control_file "${__deb_name}" "${SHARED_DEPS}${DAEMON_DEPS}" \
+    'Mina Protocol Client and Daemon for the Berkeley Network' "${SUGGESTED_DEPS}"
+
+  copy_common_daemon_configs berkeley testnet 'seed-lists/berkeley_seeds.txt'
+
+  replace_runtime_config_and_ledgers_with_hardforked_ones berkeley
+
+  build_deb "${__deb_name}"
+
+}
+
+## END BERKELEY HARDFORK PACKAGE ##
+
+## MAINNET HARDFORK PACKAGE ##
+build_daemon_mainnet_hardfork_deb() {
+  local __deb_name=mina-mainnet-hardfork
+
+  echo "------------------------------------------------------------"
+  echo "--- Building hardfork mainnet signatures deb without keys:"
+
+  create_control_file "${__deb_name}" "${SHARED_DEPS}${DAEMON_DEPS}" \
+    'Mina Protocol Client and Daemon for the Mainnet Network' "${SUGGESTED_DEPS}"
+
+  copy_common_daemon_configs mainnet testnet 'seed-lists/mainnet_seeds.txt'
+
+  replace_runtime_config_and_ledgers_with_hardforked_ones mainnet
+
+  build_deb "${__deb_name}"
+
+}
+
+## END MAINNET HARDFORK PACKAGE ##
+
 copy_common_archive_configs() {
   local ARCHIVE_DEB="${1}"
 
@@ -512,7 +595,6 @@ build_archive_mainnet_deb () {
 }
 ## END ARCHIVE MAINNET PACKAGE ##
 
-
 ## ZKAPP TEST TXN ##
 build_zkapp_test_transaction_deb () {
   echo "------------------------------------------------------------"
@@ -529,7 +611,6 @@ build_zkapp_test_transaction_deb () {
   build_deb mina-zkapp-test-transaction
 }
 ## END ZKAPP TEST TXN PACKAGE ##
-
 
 
 build_create_legacy_genesis_deb() {

--- a/scripts/hardfork/build-packages.sh
+++ b/scripts/hardfork/build-packages.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -eox pipefail
+
+# shellcheck source=./scripts/export-git-env-vars.sh
+source ./scripts/export-git-env-vars.sh
+
+PWD=$(pwd)
+
+if [ -z "${CONFIG_JSON_GZ_URL+x}" ] || [ -z "${NETWORK_NAME+x}" ] || [ -z "${MINA_DEB_CODENAME+x}" ]; then
+    echo "❌ Error: Required environment variables not provided:"
+    [ -z "${CONFIG_JSON_GZ_URL+x}" ] && echo "  - CONFIG_JSON_GZ_URL: URL to download the network configuration JSON file 🌐"
+    [ -z "${NETWORK_NAME+x}" ] && echo "  - NETWORK_NAME: Name of the network to create hardfork package for 🔗"
+    [ -z "${MINA_DEB_CODENAME+x}" ] && echo "  - MINA_DEB_CODENAME: Debian codename for package building 📦"
+    exit 1
+fi
+
+echo "--- Starting hardfork package generation for network: ${NETWORK_NAME} with Debian codename: ${MINA_DEB_CODENAME}"
+
+if [ "${NETWORK_NAME}" = "mainnet" ]; then
+  export MINA_BUILD_MAINNET=1
+fi
+
+export OPAMSWITCH=4.14.2
+export BYPASS_OPAM_SWITCH_UPDATE=1
+export DUNE_PROFILE=${NETWORK_NAME}
+
+make build
+make build-daemon-utils
+make build-devnet-sigs
+make build-archive
+make build-archive-utils
+make build-test-utils
+
+echo "--- Clean up any existing config files"
+rm -f config.json config.json.gz
+rm -rf hardfork_ledgers
+
+# Set the base network config for ./scripts/hardfork/create_runtime_config.sh
+export FORKING_FROM_CONFIG_JSON="genesis_ledgers/${NETWORK_NAME}.json"
+[ ! -f "${FORKING_FROM_CONFIG_JSON}" ] && echo "${NETWORK_NAME} is not a known network name; check for existing network configs in 'genesis_ledgers/'" && exit 1
+
+echo "--- Download and extract previous network config"
+curl -o config.json.gz $CONFIG_JSON_GZ_URL
+gunzip config.json.gz
+
+echo "--- Generate hardfork ledger tarballs"
+mkdir hardfork_ledgers
+_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file config.json --genesis-dir hardfork_ledgers/ --hash-output-file hardfork_ledger_hashes.json | tee runtime_genesis_ledger.log | _build/default/src/app/logproc/logproc.exe
+
+echo "--- Create hardfork config"
+FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json
+
+existing_files=$(aws s3 ls s3://snark-keys.o1test.net/ | awk '{print $4}')
+for file in hardfork_ledgers/*; do
+  filename=$(basename "$file")
+  
+  if echo "$existing_files" | grep -q "$filename"; then
+    echo "Info: $filename already exists in the bucket, packaging it instead."
+    oldhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
+    aws s3 cp "s3://snark-keys.o1test.net/$filename" "$file"
+    newhash=$(openssl dgst -r -sha3-256 "$file" | awk '{print $1}')
+    sed -i "s/$oldhash/$newhash/g" new_config.json 
+  else
+    aws s3 cp --acl public-read "$file" s3://snark-keys.o1test.net/
+  fi
+done
+
+echo "--- New genesis config"
+head new_config.json
+
+echo "--- Build hardfork package for Debian ${MINA_DEB_CODENAME}"
+RUNTIME_CONFIG_JSON=$PWD/new_config.json LEDGER_TARBALLS="$(echo $PWD/hardfork_ledgers/*.tar.gz)" ./scripts/debian/build.sh "$@"

--- a/scripts/hardfork/mina-verify-packaged-fork-config
+++ b/scripts/hardfork/mina-verify-packaged-fork-config
@@ -56,16 +56,16 @@ MINA_EXE=${MINA_EXE:-$(source_build_fallback mina ./_build/default/src/app/cli/s
 MINA_GENESIS_EXE=${MINA_GENESIS_EXE:-$(source_build_fallback mina-create-genesis ./_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe)}
 MINA_LEGACY_GENESIS_EXE=${MINA_LEGACY_GENESIS_EXE:-$(source_build_fallback mina-create-legacy-genesis ./runtime_genesis_ledger_of_mainnet.exe)}
 CREATE_RUNTIME_CONFIG=${CREATE_RUNTIME_CONFIG:-$(source_build_fallback mina-hf-create-runtime-config ./scripts/hardfork/create_runtime_config.sh)}
-GSUTIL=${GSUTIL:-$(source_build_fallback gsutil false)}
+GSUTIL=${GSUTIL:-$(command -v gsutil || echo "")}
 
-if [[ -e "$PRECOMPUTED_FORK_BLOCK"  && ! -x "$GSUTIL" ]]; then
+if [[ ! -e "$PRECOMPUTED_FORK_BLOCK" && ( -z "$GSUTIL" || ! -x "$GSUTIL" ) ]]; then
     echo "Error: gsutil is required when PRECOMPUTED_FORK_BLOCK is nonexistent path"
     exit 1
 fi
 
 installed_config=$(echo /var/lib/coda/config_*.json)
 PACKAGED_DAEMON_CONFIG=${PACKAGED_DAEMON_CONFIG:-$installed_config}
-if [ ! -e "$installed_config" ]; then
+if [ ! -e "$PACKAGED_DAEMON_CONFIG" ]; then
     echo "Error: set PACKAGED_DAEMON_CONFIG to the path to the JSON file to verify"
     exit 1
 fi
@@ -116,9 +116,9 @@ jq 'del(.ledger.num_accounts) | del(.ledger.name)' "$workdir/config_orig.json" >
 
 result=$(jq --slurpfile block "$workdir/precomputed_fork_block.json" \
   --slurpfile legacy_hashes "$workdir/legacy_hashes.json" -n '
-  ($legacy_hashes[0].epoch_data.staking.hash == $block[0].protocol_state.body.consensus_state.staking_epoch_data.ledger.hash and
-   $legacy_hashes[0].epoch_data.next.hash == $block[0].protocol_state.body.consensus_state.next_epoch_data.ledger.hash and
-   $legacy_hashes[0].ledger.hash == $block[0].protocol_state.body.blockchain_state.staged_ledger_hash.non_snark.ledger_hash)')
+  ($legacy_hashes[0].epoch_data.staking.hash == $block[0].data.protocol_state.body.consensus_state.staking_epoch_data.ledger.hash and
+   $legacy_hashes[0].epoch_data.next.hash == $block[0].data.protocol_state.body.consensus_state.next_epoch_data.ledger.hash and
+   $legacy_hashes[0].ledger.hash == $block[0].data.protocol_state.body.blockchain_state.staged_ledger_hash.non_snark.ledger_hash)')
 
 if [ "$result" != "true" ]; then
     echo "Hashes in config $2 don't match hashes from the precomputed block $PRECOMPUTED_FORK_BLOCK" >&2
@@ -143,9 +143,11 @@ function extract_ledgers() {
     config_file=$1
     ledger_dir=$2
     json_prefix=$3
+    
     "$MINA_EXE" daemon --libp2p-keypair "$workdir/keys/p2p" \
       --config-file "$config_file" --config-file "$override_file" \
-      --seed --genesis-ledger-dir "$ledger_dir" &
+      --seed --genesis-ledger-dir "$ledger_dir" \
+      --log-level "${MINA_LOG_LEVEL:-info}" &
 
     while ! "$MINA_EXE" ledger export staged-ledger  | jq . 2>/dev/null >"$json_prefix-staged.json"; do
         sleep 1m
@@ -212,7 +214,9 @@ for file in "$workdir"/ledgers/*.tar.gz; do
     mkdir -p "$tardir"/{packaged,generated,web}
     tar -xzf "$file" -C "$tardir/generated"
     tar -xzf "$GENESIS_LEDGER_DIR/$tarname.tar.gz" -C "$tardir/packaged"
-    curl "https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net/$tarname.tar.gz" | tar -xz -C "$tardir/web"
+
+    base_s3_url="${MINA_LEDGER_S3_BUCKET:-https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net}"
+    curl "$base_s3_url/$tarname.tar.gz" | tar -xz -C "$tardir/web"
 
     $ldb_cmd --hex --db="$tardir/packaged" scan > "$workdir/packaged.scan"
     $ldb_cmd --hex --db="$tardir/web" scan > "$workdir/web.scan"


### PR DESCRIPTION
Applied newest changes to makefile to allow locally build hardfork package.

How to test:

setup your opam using opam.export file.
```
opam switch create 
opam switch import opam.export

eval $(opam env)
```

then run build with some examples
```
DUNE_PROFILE=devnet OPAMSWITCH=4.14.2 BYPASS_OPAM_SWITCH_UPDATE=y  CONFIG_JSON_GZ_URL=https://storage.googleapis.com/o1labs-gitops-infrastructure/devnet/devnet-state-dump-3NL1tz1m4SY9eh1pGWo6B9ZAB64fz5WKXdyDhLJivZbXCU1P1SsP-9bce84dccd98c83b0e494daa356caee7713ff940db85bf1d6947c2ddc6864b93.json.gz NETWORK_NAME=devnet make hardfork-debian
```