### PR TITLE
Create faster genesis root population method and get rid of Root.transfer_accounts_with

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2677,14 +2677,9 @@ module Make_str (A : Wire_types.Concrete) = struct
                       | Ledger_snapshot.Ledger_root ledger ->
                           Ok ledger
                       | Ledger_snapshot.Genesis_epoch_ledger packed ->
-                          let fresh_root_ledger =
-                            Mina_ledger.Ledger.Root.create
-                              ~config:snapshot_config
-                              ~depth:Context.constraint_constants.ledger_depth
-                              ()
-                          in
-                          Genesis_ledger.Packed.populate_root packed
-                            fresh_root_ledger )
+                          Genesis_ledger.Packed.create_root packed
+                            ~config:snapshot_config
+                            ~depth:Context.constraint_constants.ledger_depth () )
                 in
                 match snapshot_id with
                 | Staking_epoch_snapshot ->

--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -69,11 +69,12 @@ end
 module type S = sig
   val t : Mina_ledger.Ledger.t Lazy.t
 
-  (** Populate a root ledger with the unmasked ledger backing a genesis ledger.
-      Prefer using this to a transfer using [t], for the efficiency reasons
-      described in [Mina_ledger.Ledger.Root.transfer_accounts_with]. *)
-  val populate_root :
-    Mina_ledger.Ledger.Root.t -> Mina_ledger.Ledger.Root.t Or_error.t
+  (** Create a new root ledger that is equal in state to the genesis ledger *)
+  val create_root :
+       config:Mina_ledger.Ledger.Root.Config.t
+    -> depth:int
+    -> unit
+    -> Mina_ledger.Ledger.Root.t Or_error.t
 
   val depth : int
 

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -115,8 +115,8 @@ module T = struct
   let genesis_ledger { genesis_ledger; _ } =
     Genesis_ledger.Packed.t genesis_ledger
 
-  let populate_root { genesis_ledger; _ } =
-    Genesis_ledger.Packed.populate_root genesis_ledger
+  let create_root { genesis_ledger; _ } =
+    Genesis_ledger.Packed.create_root genesis_ledger
 
   let genesis_epoch_data { genesis_epoch_data; _ } = genesis_epoch_data
 

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -77,11 +77,6 @@ struct
   let as_unmasked t =
     match t with Stable_db db -> Any_ledger.cast (module Stable_db) db
 
-  let transfer_accounts_with ~stable ~src ~dest =
-    match (src, dest) with
-    | Stable_db db1, Stable_db db2 ->
-        stable ~src:db1 ~dest:db2 |> Or_error.map ~f:(fun x -> Stable_db x)
-
   let depth t = match t with Stable_db db -> Stable_db.depth db
 
   let num_accounts t = match t with Stable_db db -> Stable_db.num_accounts db

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -98,19 +98,6 @@ module Make
       that does not need to know how the root is implemented *)
   val as_unmasked : t -> Any_ledger.witness
 
-  (** Use the given [stable] account transfer method to transfer the accounts
-      from one root ledger instance to another. For a root ledger backed by a
-      single database (currently the only option) it is equivalent to using
-      [stable] or a normal ledger transfer on the root. Future root backings
-      should be able to support more efficient transfers (e.g., for a converting
-      databases the accounts could be transferred directly between the
-      underlying pair of databases)*)
-  val transfer_accounts_with :
-       stable:(src:Stable_db.t -> dest:Stable_db.t -> Stable_db.t Or_error.t)
-    -> src:t
-    -> dest:t
-    -> t Or_error.t
-
   (** Retrieve the depth of the root ledger *)
   val depth : t -> int
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -1029,7 +1029,8 @@ module For_tests = struct
         ~directory:(Filename.temp_file "snarked_ledger" "")
         ~ledger_depth
     in
-    Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values ;
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values ) ;
     let persistent_root_instance =
       Persistent_root.create_instance_exn persistent_root
     in

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -2,13 +2,13 @@ open Core
 open Mina_base
 module Ledger = Mina_ledger.Ledger
 open Frontier_base
-module Ledger_transfer = Mina_ledger.Ledger_transfer.Make (Ledger) (Ledger.Db)
-module Ledger_transfer_stable =
-  Mina_ledger.Ledger_transfer.Make (Ledger.Db) (Ledger.Db)
+module Ledger_transfer_any =
+  Mina_ledger.Ledger_transfer.Make (Ledger.Any_ledger.M) (Ledger.Any_ledger.M)
 
-let transfer_snarked_root =
-  Ledger.Root.transfer_accounts_with
-    ~stable:Ledger_transfer_stable.transfer_accounts
+let transfer_snarked_root ~src ~dest =
+  Ledger_transfer_any.transfer_accounts
+    ~src:(Ledger.Root.as_unmasked src)
+    ~dest:(Ledger.Root.as_unmasked dest)
 
 let genesis_root_identifier ~genesis_state_hash =
   let open Root_identifier.Stable.Latest in

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -320,15 +320,27 @@ let with_instance_exn t ~f =
   let x = f instance in
   Instance.close instance ; x
 
-let reset_to_genesis_exn t ~precomputed_values =
+(** Clear the factory directory and recreate the snarked ledger instance for
+    this factory with [create_root] and [setup] *)
+let reset_factory_root_exn t ~create_root ~setup =
+  let open Async.Deferred.Let_syntax in
   assert (Option.is_none t.instance) ;
-  Mina_stdlib_unix.File_system.rmrf t.directory ;
-  with_instance_exn t ~f:(fun instance ->
-      ignore
-        ( Precomputed_values.populate_root precomputed_values
-            (Instance.snarked_ledger instance)
-          |> Or_error.map ~f:Ledger.Root.as_unmasked
-          : Ledger.Any_ledger.witness Or_error.t ) ;
+  let%map () =
+    Mina_stdlib_unix.File_system.create_dir ~clear_if_exists:true t.directory
+  in
+  let root =
+    create_root
+      ~config:(Instance.Config.snarked_ledger t)
+      ~depth:t.ledger_depth ()
+    |> Or_error.ok_exn
+  in
+  Ledger.Root.close root ;
+  with_instance_exn t ~f:setup
+
+let reset_to_genesis_exn t ~precomputed_values =
+  reset_factory_root_exn t
+    ~create_root:(Precomputed_values.create_root precomputed_values)
+    ~setup:(fun instance ->
       Instance.set_root_identifier instance
         (genesis_root_identifier
            ~genesis_state_hash:

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -283,7 +283,9 @@ let rec load_with_max_length :
           (State_hash.With_state_hashes.state_hash
              precomputed_values.protocol_state_with_hashes )
     in
-    Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values ;
+    let%bind () =
+      Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values
+    in
     let genesis_ledger_hash =
       Precomputed_values.genesis_ledger precomputed_values
       |> Lazy.force |> Ledger.merkle_root |> Frozen_ledger_hash.of_ledger_hash
@@ -682,8 +684,8 @@ module For_tests = struct
 
   let gen ?(logger = Logger.null ()) ~verifier ?trust_system
       ?consensus_local_state ~precomputed_values
-      ?(populate_root_and_accounts =
-        ( Precomputed_values.populate_root precomputed_values
+      ?(create_root_and_accounts =
+        ( Precomputed_values.create_root precomputed_values
         , Lazy.force (Precomputed_values.accounts precomputed_values) ))
       ?(gen_root_breadcrumb =
         gen_genesis_breadcrumb_with_protocol_states ~logger ~verifier
@@ -721,7 +723,7 @@ module For_tests = struct
                (State_hash.With_state_hashes.state_hash
                   precomputed_values.protocol_state_with_hashes ) )
     in
-    let populate_root, root_ledger_accounts = populate_root_and_accounts in
+    let create_root, root_ledger_accounts = create_root_and_accounts in
     (* TODO: ensure that rose_tree cannot be longer than k *)
     let%bind root, branches, protocol_states =
       let%bind root, protocol_states = gen_root_breadcrumb in
@@ -752,12 +754,12 @@ module For_tests = struct
           ~genesis_state_hash:
             (State_hash.With_state_hashes.state_hash
                precomputed_values.protocol_state_with_hashes ) ) ;
-    Persistent_root.with_instance_exn persistent_root ~f:(fun instance ->
-        let transition = Root_data.Limited.transition root_data in
-        Persistent_root.Instance.set_root_state_hash instance
-          (Mina_block.Validated.state_hash transition) ;
-        ignore
-        @@ populate_root (Persistent_root.Instance.snarked_ledger instance) ) ;
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        Persistent_root.reset_factory_root_exn persistent_root ~create_root
+          ~setup:(fun instance ->
+            let transition = Root_data.Limited.transition root_data in
+            Persistent_root.Instance.set_root_state_hash instance
+              (Mina_block.Validated.state_hash transition) ) ) ;
     let frontier_result =
       Async.Thread_safe.block_on_async_exn (fun () ->
           load_with_max_length ~max_length ~retry_with_fresh_db:false
@@ -794,21 +796,21 @@ module For_tests = struct
 
   let gen_with_branch ?logger ~verifier ?trust_system ?consensus_local_state
       ~precomputed_values
-      ?(populate_root_and_accounts =
-        ( Precomputed_values.populate_root precomputed_values
+      ?(create_root_and_accounts =
+        ( Precomputed_values.create_root precomputed_values
         , Lazy.force (Precomputed_values.accounts precomputed_values) ))
       ?gen_root_breadcrumb ?(get_branch_root = root) ~max_length ~frontier_size
       ~branch_size () =
     let open Quickcheck.Generator.Let_syntax in
     let%bind frontier =
       gen ?logger ~verifier ?trust_system ?consensus_local_state
-        ~precomputed_values ?gen_root_breadcrumb ~populate_root_and_accounts
+        ~precomputed_values ?gen_root_breadcrumb ~create_root_and_accounts
         ~max_length ~size:frontier_size ()
     in
     let%map make_branch =
       Breadcrumb.For_tests.gen_seq ?logger ~precomputed_values ~verifier
         ?trust_system
-        ~accounts_with_secret_keys:(snd populate_root_and_accounts)
+        ~accounts_with_secret_keys:(snd create_root_and_accounts)
         branch_size
     in
     let branch =

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -152,8 +152,10 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?populate_root_and_accounts:
-         (   Mina_ledger.Ledger.Root.t
+    -> ?create_root_and_accounts:
+         (   config:Mina_ledger.Ledger.Root.Config.t
+          -> depth:int
+          -> unit
           -> Mina_ledger.Ledger.Root.t Core_kernel.Or_error.t )
          * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:
@@ -173,8 +175,10 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?populate_root_and_accounts:
-         (   Mina_ledger.Ledger.Root.t
+    -> ?create_root_and_accounts:
+         (   config:Mina_ledger.Ledger.Root.Config.t
+          -> depth:int
+          -> unit
           -> Mina_ledger.Ledger.Root.t Core_kernel.Or_error.t )
          * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:


### PR DESCRIPTION
## Explain your changes:

Instead of having a populate_root method to populate an existing, empty root ledger from genesis, the genesis ledger now has a create_root method. This method assumes the responsibility for creating the root ledger itself. The resulting API is more convenient to use elsewhere in the code base. This design also allows the create_root method to checkpoint the genesis ledger directly when the genesis ledger is backed by a database, which is much faster than an account transfer.

The `transfer_accounts_with` method has been removed - it is unclear if it is necessary.

## Explain how you tested your changes:

The nightly tests should cover this change. I also added some temporary log lines to measure the time taken to populate a snarked root from genesis, to compare against the measurements I did in https://github.com/MinaProtocol/mina/issues/17570. I got this result when I synced a daemon to mainnet with an empty config directory:

```
2025-08-21 20:01:35 UTC [Info] Starting genesis reset
2025-08-21 20:01:35 UTC [Info] Done genesis reset
```

So, this should resolve that issue as well.

## Checklist:

- [x] Dependency versions are unchanged
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes https://github.com/MinaProtocol/mina/issues/17570
