### PR TITLE
Add a preliminary Hardfork variant to account types

### DIFF
--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -1042,18 +1042,18 @@ let deriver obj =
    and storing all writes to the original ledger to the new ledger. *)
 module Unstable = struct
   type t =
-    { public_key : Public_key.Compressed.Stable.V1.t
-    ; token_id : Token_id.Stable.V2.t
-    ; token_symbol : Token_symbol.Stable.V1.t
-    ; balance : Balance.Stable.V1.t
-    ; nonce : Nonce.Stable.V1.t
-    ; receipt_chain_hash : Receipt.Chain_hash.Stable.V1.t
-    ; delegate : Public_key.Compressed.Stable.V1.t option
-    ; voting_for : State_hash.Stable.V1.t
-    ; timing : Timing.Stable.V2.t
-    ; permissions : Permissions.Stable.V2.t
-    ; zkapp : Zkapp_account.Stable.V2.t option
-    ; unstable_field : Nonce.Stable.V1.t
+    { public_key : Public_key.Compressed.Stable.Latest.t
+    ; token_id : Token_id.Stable.Latest.t
+    ; token_symbol : Token_symbol.Stable.Latest.t
+    ; balance : Balance.Stable.Latest.t
+    ; nonce : Nonce.Stable.Latest.t
+    ; receipt_chain_hash : Receipt.Chain_hash.Stable.Latest.t
+    ; delegate : Public_key.Compressed.Stable.Latest.t option
+    ; voting_for : State_hash.Stable.Latest.t
+    ; timing : Timing.Stable.Latest.t
+    ; permissions : Permissions.Stable.Latest.t
+    ; zkapp : Zkapp_account.Stable.Latest.t option
+    ; unstable_field : Nonce.Stable.Latest.t
     }
   [@@deriving
     sexp, equal, hash, compare, yojson, hlist, fields, bin_io_unversioned]


### PR DESCRIPTION
A preliminary `Hardfork` variant of account types has now been defined, which can be used while developing the actual hard fork automation feature. I added the proposed zkapp state size increase in its definition to make it different from `Account.Stable.Latest.t`; this will be useful for testing the HF automation feature. This type can be edited as the actual account format/migration changes necessary for planned hard forks become known; it doesn't commit us to any changes.

The existing `Unstable` account type is unchanged, other than having it use `Stable.Latest`. I think it'll be useful to keep that `Unstable` type around for unit tests, and it will be simpler to manage if it's just equal in definition to `Account.Stable.Latest.t` but with an `unstable_field` that duplicates the nonce.