### PR TITLE
Add interfaces on Converting Ledgers in Mina Ledgers

### DIFF
--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -28,30 +28,21 @@ end)
                         and type root_hash := Inputs.Hash.t
                         and type hash := Inputs.Hash.t
                         and type account_id := Inputs.Account_id.t
-                        and type account_id_set := Inputs.Account_id.Set.t) : sig
-  include
-    Intf.Ledger.S
-      with module Location = Inputs.Location
-       and module Addr = Inputs.Location.Addr
-       and type key := Inputs.Key.t
-       and type token_id := Inputs.Token_id.t
-       and type token_id_set := Inputs.Token_id.Set.t
-       and type account := Inputs.Account.t
-       and type root_hash := Inputs.Hash.t
-       and type hash := Inputs.Hash.t
-       and type account_id := Inputs.Account_id.t
-       and type account_id_set := Inputs.Account_id.Set.t
-
-  val of_ledgers : Primary_ledger.t -> Converting_ledger.t -> t
-
-  val of_ledgers_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
-
-  val primary_ledger : t -> Primary_ledger.t
-
-  val converting_ledger : t -> Converting_ledger.t
-
-  val convert : Inputs.Account.t -> Inputs.converted_account
-end = struct
+                        and type account_id_set := Inputs.Account_id.Set.t) :
+  Intf.Ledger.CONVERTING
+    with module Location = Inputs.Location
+     and module Addr = Inputs.Location.Addr
+     and type key := Inputs.Key.t
+     and type token_id := Inputs.Token_id.t
+     and type token_id_set := Inputs.Token_id.Set.t
+     and type account := Inputs.Account.t
+     and type root_hash := Inputs.Hash.t
+     and type hash := Inputs.Hash.t
+     and type account_id := Inputs.Account_id.t
+     and type account_id_set := Inputs.Account_id.Set.t
+     and type primary_ledger := Primary_ledger.t
+     and type converting_ledger := Converting_ledger.t
+     and type converted_account := Inputs.converted_account = struct
   let convert = Inputs.convert
 
   module Location = Inputs.Location

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -38,7 +38,7 @@ end)
                         and type hash := Inputs.Hash.t
                         and type account_id := Inputs.Account_id.t
                         and type account_id_set := Inputs.Account_id.Set.t) :
-  Intf.Ledger.CONVERTING
+  Intf.Ledger.Converting.S
     with module Location = Inputs.Location
      and module Addr = Inputs.Location.Addr
      and type key := Inputs.Key.t
@@ -52,6 +52,8 @@ end)
      and type primary_ledger := Primary_ledger.t
      and type converting_ledger := Converting_ledger.t
      and type converted_account := Inputs.converted_account
+
+module With_database_config : Intf.Ledger.Converting.Config
 
 (** A variant of [Make] that works with DATABASE ledgers and provides checkpoint operations *)
 module With_database (Inputs : sig
@@ -88,7 +90,7 @@ end)
                     and type hash := Inputs.Hash.t
                     and type account_id := Inputs.Account_id.t
                     and type account_id_set := Inputs.Account_id.Set.t) :
-  Intf.Ledger.CONVERTING_WITH_DATABASE
+  Intf.Ledger.Converting.WITH_DATABASE
     with module Location = Inputs.Location
      and module Addr = Inputs.Location.Addr
      and type key := Inputs.Key.t

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -87,35 +87,18 @@ end)
                     and type root_hash := Inputs.Hash.t
                     and type hash := Inputs.Hash.t
                     and type account_id := Inputs.Account_id.t
-                    and type account_id_set := Inputs.Account_id.Set.t) : sig
-  include module type of Make (Inputs) (Primary_db) (Converting_db)
-
-  module Config : sig
-    type t = { primary_directory : string; converting_directory : string }
-
-    type create =
-      | Temporary
-          (** Create a converting ledger with databases in temporary directories *)
-      | In_directories of t
-          (** Create a converting ledger with databases in explicit directories *)
-
-    (** Create a [checkpoint] config with the default converting directory
-        name *)
-    val with_primary : directory_name:string -> t
-  end
-
-  (** Create a new converting merkle tree with the given configuration. If
-      [In_directories] is given, existing databases will be opened and used to
-      back the converting merkle tree. If the converting database does not exist
-      in the directory, or exists but is empty, one will be created by migrating
-      the primary database. Existing but incompatible converting databases (such
-      as out-of-sync databases) will be deleted and re-migrated. *)
-  val create : config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
-
-  (** Make checkpoints of the databases backing the converting merkle tree and
-      create a new converting ledger based on those checkpoints *)
-  val create_checkpoint : t -> config:Config.t -> unit -> t
-
-  (** Make checkpoints of the databases backing the converting merkle tree *)
-  val make_checkpoint : t -> config:Config.t -> unit
-end
+                    and type account_id_set := Inputs.Account_id.Set.t) :
+  Intf.Ledger.CONVERTING_WITH_DATABASE
+    with module Location = Inputs.Location
+     and module Addr = Inputs.Location.Addr
+     and type key := Inputs.Key.t
+     and type token_id := Inputs.Token_id.t
+     and type token_id_set := Inputs.Token_id.Set.t
+     and type account := Inputs.Account.t
+     and type root_hash := Inputs.Hash.t
+     and type hash := Inputs.Hash.t
+     and type account_id := Inputs.Account_id.t
+     and type account_id_set := Inputs.Account_id.Set.t
+     and type primary_ledger := Primary_db.t
+     and type converting_ledger := Converting_db.t
+     and type converted_account := Inputs.converted_account

--- a/src/lib/merkle_ledger/converting_merkle_tree.mli
+++ b/src/lib/merkle_ledger/converting_merkle_tree.mli
@@ -37,40 +37,21 @@ end)
                         and type root_hash := Inputs.Hash.t
                         and type hash := Inputs.Hash.t
                         and type account_id := Inputs.Account_id.t
-                        and type account_id_set := Inputs.Account_id.Set.t) : sig
-  include
-    Intf.Ledger.S
-      with module Location = Inputs.Location
-       and module Addr = Inputs.Location.Addr
-       and type key := Inputs.Key.t
-       and type token_id := Inputs.Token_id.t
-       and type token_id_set := Inputs.Token_id.Set.t
-       and type account := Inputs.Account.t
-       and type root_hash := Inputs.Hash.t
-       and type hash := Inputs.Hash.t
-       and type account_id := Inputs.Account_id.t
-       and type account_id_set := Inputs.Account_id.Set.t
-
-  (** Create a converting ledger based on two component ledgers. No migration is
-      performed (use [of_ledgers_with_migration] if you need this) but all
-      subsequent write operations on the converting merkle tree will be applied
-      to both ledgers. *)
-  val of_ledgers : Primary_ledger.t -> Converting_ledger.t -> t
-
-  (** Create a converting ledger with an already-existing [Primary_ledger.t] and
-      an empty [Converting_ledger.t] that will be initialized with the migrated
-      account data. *)
-  val of_ledgers_with_migration : Primary_ledger.t -> Converting_ledger.t -> t
-
-  (** Retrieve the primary ledger backing the converting merkle tree *)
-  val primary_ledger : t -> Primary_ledger.t
-
-  (** Retrieve the converting ledger backing the converting merkle tree *)
-  val converting_ledger : t -> Converting_ledger.t
-
-  (** The input account conversion method, re-exposed for convenience *)
-  val convert : Inputs.Account.t -> Inputs.converted_account
-end
+                        and type account_id_set := Inputs.Account_id.Set.t) :
+  Intf.Ledger.CONVERTING
+    with module Location = Inputs.Location
+     and module Addr = Inputs.Location.Addr
+     and type key := Inputs.Key.t
+     and type token_id := Inputs.Token_id.t
+     and type token_id_set := Inputs.Token_id.Set.t
+     and type account := Inputs.Account.t
+     and type root_hash := Inputs.Hash.t
+     and type hash := Inputs.Hash.t
+     and type account_id := Inputs.Account_id.t
+     and type account_id_set := Inputs.Account_id.Set.t
+     and type primary_ledger := Primary_ledger.t
+     and type converting_ledger := Converting_ledger.t
+     and type converted_account := Inputs.converted_account
 
 (** A variant of [Make] that works with DATABASE ledgers and provides checkpoint operations *)
 module With_database (Inputs : sig

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -514,6 +514,40 @@ module Ledger = struct
     (** The input account conversion method, re-exposed for convenience *)
     val convert : account -> converted_account
   end
+
+  module type CONVERTING_WITH_DATABASE = sig
+    include CONVERTING
+
+    module Config : sig
+      type t = { primary_directory : string; converting_directory : string }
+
+      type create =
+        | Temporary
+            (** Create a converting ledger with databases in temporary directories *)
+        | In_directories of t
+            (** Create a converting ledger with databases in explicit directories *)
+
+      (** Create a [checkpoint] config with the default converting directory
+        name *)
+      val with_primary : directory_name:string -> t
+    end
+
+    (** Create a new converting merkle tree with the given configuration. If
+      [In_directories] is given, existing databases will be opened and used to
+      back the converting merkle tree. If the converting database does not exist
+      in the directory, or exists but is empty, one will be created by migrating
+      the primary database. Existing but incompatible converting databases (such
+      as out-of-sync databases) will be deleted and re-migrated. *)
+    val create :
+      config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
+
+    (** Make checkpoints of the databases backing the converting merkle tree and
+      create a new converting ledger based on those checkpoints *)
+    val create_checkpoint : t -> config:Config.t -> unit -> t
+
+    (** Make checkpoints of the databases backing the converting merkle tree *)
+    val make_checkpoint : t -> config:Config.t -> unit
+  end
 end
 
 module Graphviz = struct

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -484,6 +484,36 @@ module Ledger = struct
         ledger_depth:int -> Location.t Quickcheck.Generator.t
     end
   end
+
+  module type CONVERTING = sig
+    include S
+
+    type primary_ledger
+
+    type converting_ledger
+
+    type converted_account
+
+    (** Create a converting ledger based on two component ledgers. No migration is
+      performed (use [of_ledgers_with_migration] if you need this) but all
+      subsequent write operations on the converting merkle tree will be applied
+      to both ledgers. *)
+    val of_ledgers : primary_ledger -> converting_ledger -> t
+
+    (** Create a converting ledger with an already-existing [Primary_ledger.t] and
+      an empty [Converting_ledger.t] that will be initialized with the migrated
+      account data. *)
+    val of_ledgers_with_migration : primary_ledger -> converting_ledger -> t
+
+    (** Retrieve the primary ledger backing the converting merkle tree *)
+    val primary_ledger : t -> primary_ledger
+
+    (** Retrieve the converting ledger backing the converting merkle tree *)
+    val converting_ledger : t -> converting_ledger
+
+    (** The input account conversion method, re-exposed for convenience *)
+    val convert : account -> converted_account
+  end
 end
 
 module Graphviz = struct

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -17,6 +17,19 @@ module Db :
      and type account_id := Account_id.t
      and type account_id_set := Account_id.Set.t
 
+module Unstable_db :
+  Merkle_ledger.Intf.Ledger.DATABASE
+    with module Location = Location
+    with module Addr = Location.Addr
+    with type root_hash := Ledger_hash.t
+     and type hash := Ledger_hash.t
+     and type account := Account.Unstable.t
+     and type key := Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+
 module Any_ledger :
   Merkle_ledger.Intf.Ledger.ANY
     with module Location = Location
@@ -58,6 +71,22 @@ module Maskable :
      and type attached_mask := Mask.Attached.t
      and type accumulated_t := Mask.accumulated_t
      and type t := Any_ledger.M.t
+
+module Converting_ledger :
+  Merkle_ledger.Intf.Ledger.Converting.WITH_DATABASE
+    with module Location = Location
+     and module Addr = Location.Addr
+    with type root_hash := Ledger_hash.t
+     and type hash := Ledger_hash.t
+     and type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type primary_ledger := Db.t
+     and type converting_ledger := Unstable_db.t
+     and type converted_account := Account.Unstable.t
 
 module Root : sig
   include module type of Root.Make (Any_ledger) (Db)


### PR DESCRIPTION
This is a step toward converting ledgers backed root: make the signatures of potentially required input to `Root.Make` explicit, so we're sure what's the next step. 