### PR TITLE
Remove Config.primary_directory in Root.Make(_).Config

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -464,11 +464,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         if Mina_ledger.Ledger.Root.Config.exists_backing config then (
           [%log info]
             ~metadata:
-              [ ( "location"
-                , `String
-                    (Mina_ledger.Ledger.Root.Config.primary_directory config) )
-              ]
-            "Loading epoch ledger from disk: $location" ;
+              [ ("config", Mina_ledger.Ledger.Root.Config.to_yojson config) ]
+            "Loading epoch ledger from disk: $config" ;
           Snapshot.Ledger_snapshot.Ledger_root
             (Mina_ledger.Ledger.Root.create ~logger ~config
                ~depth:constraint_constants.ledger_depth () ) )
@@ -541,19 +538,17 @@ module Make_str (A : Wire_types.Concrete) = struct
               let next_ledger_config = ledger_config epoch_ledger_uuids.next in
               [%log info]
                 "Cleaning up old epoch ledgers with genesis state $state_hash \
-                 at locations $staking and $next"
+                 with configs $staking and $next"
                 ~metadata:
                   [ ( "state_hash"
                     , Mina_base.State_hash.to_yojson
                         epoch_ledger_uuids.genesis_state_hash )
                   ; ( "staking"
-                    , `String
-                        ( Mina_ledger.Ledger.Root.Config.primary_directory
-                        @@ staking_ledger_config ) )
+                    , Mina_ledger.Ledger.Root.Config.to_yojson
+                        staking_ledger_config )
                   ; ( "next"
-                    , `String
-                        ( Mina_ledger.Ledger.Root.Config.primary_directory
-                        @@ next_ledger_config ) )
+                    , Mina_ledger.Ledger.Root.Config.to_yojson
+                        next_ledger_config )
                   ] ;
               Mina_ledger.Ledger.Root.Config.delete_backing
                 staking_ledger_config ;

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -210,6 +210,7 @@ end
 
 module With_database_config = struct
   type t = { primary_directory : string; converting_directory : string }
+  [@@deriving yojson]
 
   type create = Temporary | In_directories of t
 

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -522,6 +522,7 @@ module Ledger = struct
 
     module type Config = sig
       type t = { primary_directory : string; converting_directory : string }
+      [@@deriving yojson]
 
       type create =
         | Temporary

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -60,11 +60,12 @@ module Make
                             and type converting_ledger = Unstable_db.t) =
 struct
   module Config = struct
-    type backing_type = Stable_db | Converting_db [@@deriving equal]
+    type backing_type = Stable_db | Converting_db [@@deriving equal, yojson]
 
     type t =
       | Stable_db_config of string
       | Converting_db_config of Converting_ledger.Config.t
+    [@@deriving yojson]
 
     let backing_of_config = function
       | Stable_db_config _ ->
@@ -126,11 +127,6 @@ struct
                { backing_1 = backing_of_config cfg1
                ; backing_2 = backing_of_config cfg2
                } )
-
-    let primary_directory = function
-      | Stable_db_config primary_directory
-      | Converting_db_config { primary_directory; _ } ->
-          primary_directory
   end
 
   type root_hash = Ledger_hash.t

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -77,7 +77,7 @@ module Make
   type path = Stable_db.path
 
   module Config : sig
-    type t
+    type t [@@deriving yojson]
 
     (** The kind of database that should be used for this root. Only a single
         database of [Account.Stable.Latest.t] accounts is supported. A future
@@ -103,9 +103,6 @@ module Make
         backing at [dst], and there must be no database connections open for
         [src]. *)
     val move_backing_exn : src:t -> dst:t -> unit
-
-    (** The primary directory of this ledger *)
-    val primary_directory : t -> string
   end
 
   (** Close the root ledger instance *)

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -105,21 +105,17 @@ module Instance = struct
   end
 
   let potential_snarked_ledgers_to_yojson queue =
-    `List
-      (List.map (Queue.to_list queue) ~f:(fun config ->
-           `String (Ledger.Root.Config.primary_directory config) ) )
+    `List (List.map (Queue.to_list queue) ~f:Ledger.Root.Config.to_yojson)
 
-  let potential_snarked_ledgers_of_yojson factory json =
+  let potential_snarked_ledgers_of_yojson json =
     Yojson.Safe.Util.to_list json
-    |> List.map ~f:(fun x ->
-           let directory_name = Yojson.Safe.Util.to_string x in
-           Config.make_instance_config directory_name factory )
+    |> List.map ~f:(fun json ->
+           Ledger.Root.Config.of_yojson json |> Result.ok_or_failwith )
 
   let load_potential_snarked_ledgers_from_disk factory =
     let location = Config.potential_snarked_ledgers factory in
     if phys_equal (Sys.file_exists location) `Yes then
-      Yojson.Safe.from_file location
-      |> potential_snarked_ledgers_of_yojson factory
+      Yojson.Safe.from_file location |> potential_snarked_ledgers_of_yojson
     else []
 
   let write_potential_snarked_ledgers_to_disk t =


### PR DESCRIPTION
This function is only used in debug. It might have some unexpected behavior if we rely on it in our business logics when backing is converting root. Hence, it'd be better to just replace it with a `to_yojson` which is only used for debugging. 

Last in train: https://github.com/MinaProtocol/mina/pull/17669