### PR TITLE
Push sig kind out of Archive.Lib.Processor

### DIFF
--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -66,7 +66,8 @@ let command_run =
          ~postgres_address:postgres.value
          ~server_port:
            (Option.value server_port.value ~default:server_port.default)
-         ~delete_older_than ~runtime_config_opt ~missing_blocks_width )
+         ~delete_older_than ~runtime_config_opt ~missing_blocks_width
+         ~signature_kind:Mina_signature_kind.t_DEPRECATED )
 
 let time_arg =
   (* Same timezone as Genesis_constants.genesis_state_timestamp. *)

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -76,7 +76,8 @@ let main ~genesis_constants ~constraint_constants ~archive_uri ~precomputed
         in
         make_add_block of_yojson
           (Processor.add_block_aux_extensional ~proof_cache_db
-             ~genesis_constants ~logger ~pool ~delete_older_than:None )
+             ~genesis_constants ~logger ~pool ~delete_older_than:None
+             ~signature_kind:Mina_signature_kind.t_DEPRECATED )
       in
       Deferred.List.iter files ~f:(fun file ->
           In_channel.with_file file ~f:(fun in_channel ->


### PR DESCRIPTION
This PR pushed signature kind out of archive/lib/processor. 

This is a no-op PR, no functional change is expected. 