### PR TITLE
Folding accounts across all ledger masks

### DIFF
--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -154,6 +154,7 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
 
     let detached_signal (T ((module Base), t)) = Base.detached_signal t
 
-    let all_accounts_on_masks _ = Location.Map.empty
+    let all_accounts_on_masks (T ((module Base), t)) =
+      Base.all_accounts_on_masks t
   end
 end

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -153,5 +153,7 @@ module Make_base (Inputs : Intf.Inputs.Intf) :
     let depth (T ((module Base), t)) = Base.depth t
 
     let detached_signal (T ((module Base), t)) = Base.detached_signal t
+
+    let all_accounts_on_masks _ = Location.Map.empty
   end
 end

--- a/src/lib/merkle_ledger/converting_merkle_tree.ml
+++ b/src/lib/merkle_ledger/converting_merkle_tree.ml
@@ -202,6 +202,8 @@ end)
     Primary_ledger.get_hash_batch_exn t.primary_ledger locations
 
   let detached_signal t = Primary_ledger.detached_signal t.primary_ledger
+
+  let all_accounts_on_masks _ = Location.Map.empty
 end
 
 module With_database_config = struct

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -680,4 +680,6 @@ module Make (Inputs : Intf.Inputs.DATABASE) = struct
   let merkle_path_at_index_exn t index =
     let addr = Addr.of_int_exn ~ledger_depth:t.depth index in
     merkle_path_at_addr_exn t addr
+
+  let all_accounts_on_masks _ = Location.Map.empty
 end

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -303,11 +303,7 @@ module Ledger = struct
 
     module Path : Merkle_path.S with type hash := hash
 
-    module Location : sig
-      type t [@@deriving sexp, compare, hash]
-
-      include Comparable.S with type t := t
-    end
+    module Location : LOCATION
 
     include
       SYNCABLE

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -419,6 +419,11 @@ module Ledger = struct
       accessed.
   *)
     val detached_signal : t -> unit Async_kernel.Deferred.t
+
+    (** Get all accounts on all masks of current ledger until reaching a 
+        non-mask. Used to migrate root to an potential staged ledger for fork 
+        config generation *)
+    val all_accounts_on_masks : t -> account Location.Map.t
   end
 
   module type NULL = sig

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -171,4 +171,6 @@ end = struct
   let depth t = t.depth
 
   let detached_signal _ = Async_kernel.Deferred.never ()
+
+  let all_accounts_on_masks _ = Location.Map.empty
 end

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -23,7 +23,7 @@ module Make (Inputs : Inputs_intf.S) = struct
   end
 
   type maps_t =
-    { accounts : Account.t Location_binable.Map.t
+    { accounts : Account.t Location.Map.t
     ; token_owners : Account_id.t Token_id.Map.t
     ; hashes : Hash.t Addr.Map.t
     ; locations : Location.t Account_id.Map.t
@@ -92,7 +92,7 @@ module Make (Inputs : Inputs_intf.S) = struct
   type unattached = t
 
   let empty_maps =
-    { accounts = Location_binable.Map.empty
+    { accounts = Location.Map.empty
     ; token_owners = Token_id.Map.empty
     ; hashes = Addr.Map.empty
     ; locations = Account_id.Map.empty

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -1012,6 +1012,15 @@ module Make (Inputs : Inputs_intf.S) = struct
                 add_location () )
       | Some location ->
           Ok (`Existed, location)
+
+    let all_accounts_on_masks { parent; maps; _ } =
+      let base =
+        Result.ok parent
+        |> Option.value_map ~default:Location.Map.empty
+             ~f:Base.all_accounts_on_masks
+      in
+      let combine ~key:_ _ v = v in
+      Map.merge_skewed ~combine base maps.accounts
   end
 
   let set_parent ?accumulated:accumulated_opt t parent =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -1013,14 +1013,10 @@ module Make (Inputs : Inputs_intf.S) = struct
       | Some location ->
           Ok (`Existed, location)
 
-    let all_accounts_on_masks { parent; maps; _ } =
-      let base =
-        Result.ok parent
-        |> Option.value_map ~default:Location.Map.empty
-             ~f:Base.all_accounts_on_masks
-      in
+    let all_accounts_on_masks t =
+      let base = get_parent t |> Base.all_accounts_on_masks in
       let combine ~key:_ _ v = v in
-      Map.merge_skewed ~combine base maps.accounts
+      Map.merge_skewed ~combine base t.maps.accounts
   end
 
   let set_parent ?accumulated:accumulated_opt t parent =


### PR DESCRIPTION
This is a simpler alternative to https://github.com/MinaProtocol/mina/pull/17626. 

As in `Masking_merkle_tree.Make(_).Attached.commit` (see below) only `accounts` is committed in a `maps_t`, there's no point tracking other data. 

Last in train: https://github.com/MinaProtocol/mina/pull/17674
Next in train: https://github.com/MinaProtocol/mina/pull/17677

<img width="1947" height="904" alt="image" src="https://github.com/user-attachments/assets/59e8bced-89b0-4085-ba2d-0aac9ee5a6d5" />
