### PR TITLE
Remove transfer_accounts_with from Root

### DIFF
--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -71,9 +71,7 @@ end
 module type S = sig
   val t : Mina_ledger.Ledger.t Lazy.t
 
-  (** Populate a root ledger with the unmasked ledger backing a genesis ledger.
-      Prefer using this to a transfer using [t], for the efficiency reasons
-      described in [Mina_ledger.Ledger.Root.transfer_accounts_with]. *)
+  (** Populate a root ledger with the content of the genesis ledger *)
   val populate_root :
     Mina_ledger.Ledger.Root.t -> Mina_ledger.Ledger.Root.t Or_error.t
 

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -211,13 +211,6 @@ struct
     | Converting_db db ->
         Any_ledger.cast (module Converting_ledger) db
 
-  let transfer_accounts_with ~stable ~src ~dest =
-    match (src, dest) with
-    | Stable_db db1, Stable_db db2 ->
-        stable ~src:db1 ~dest:db2 |> Or_error.map ~f:(fun x -> Stable_db x)
-    | _ ->
-        failwith "TODO: this function should be removed"
-
   let depth t =
     match t with
     | Stable_db db ->

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -1,4 +1,3 @@
-open Core_kernel
 open Mina_base
 
 module type Stable_db_intf =
@@ -132,19 +131,6 @@ module Make
   (** View the root ledger as an unmasked [Any_ledger] so it can be used by code
       that does not need to know how the root is implemented *)
   val as_unmasked : t -> Any_ledger.witness
-
-  (** Use the given [stable] account transfer method to transfer the accounts
-      from one root ledger instance to another. For a root ledger backed by a
-      single database (currently the only option) it is equivalent to using
-      [stable] or a normal ledger transfer on the root. Future root backings
-      should be able to support more efficient transfers (e.g., for a converting
-      databases the accounts could be transferred directly between the
-      underlying pair of databases)*)
-  val transfer_accounts_with :
-       stable:(src:Stable_db.t -> dest:Stable_db.t -> Stable_db.t Or_error.t)
-    -> src:t
-    -> dest:t
-    -> t Or_error.t
 
   (** Retrieve the depth of the root ledger *)
   val depth : t -> int

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -2,13 +2,8 @@ open Core
 open Mina_base
 module Ledger = Mina_ledger.Ledger
 open Frontier_base
-module Ledger_transfer = Mina_ledger.Ledger_transfer.Make (Ledger) (Ledger.Db)
-module Ledger_transfer_stable =
-  Mina_ledger.Ledger_transfer.Make (Ledger.Db) (Ledger.Db)
-
-let transfer_snarked_root =
-  Ledger.Root.transfer_accounts_with
-    ~stable:Ledger_transfer_stable.transfer_accounts
+module Ledger_transfer_any =
+  Mina_ledger.Ledger_transfer.Make (Ledger.Any_ledger.M) (Ledger.Any_ledger.M)
 
 let genesis_root_identifier ~genesis_state_hash =
   let open Root_identifier.Stable.Latest in
@@ -190,8 +185,9 @@ module Instance = struct
                 ()
             in
             match
-              transfer_snarked_root ~src:potential_snarked_ledger
-                ~dest:snarked_ledger
+              Ledger_transfer_any.transfer_accounts
+                ~src:(Ledger.Root.as_unmasked potential_snarked_ledger)
+                ~dest:(Ledger.Root.as_unmasked snarked_ledger)
             with
             | Ok _ ->
                 Ledger.Root.close potential_snarked_ledger ;


### PR DESCRIPTION
This method was supposed to be implementable in a more efficient way with a converting database backing. However, the most convenient way of doing that involves a different API, where the method is responsible for creating the destination database itself. If avoiding the re-hashing that Ledger_transfer does is found to be desirable then this new API can be implemented and used when populating a Root from genesis or a recovered potential snarked ledger.