### PR TITLE
Remove debug_assert library and replace all use with native assert

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -29,7 +29,6 @@
 (package (name currency))
 (package (name daemon_rpcs))
 (package (name data_hash_lib))
-(package (name debug_assert))
 (package (name disk_cache))
 (package (name downloader))
 (package (name dummy_values))

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -808,31 +808,33 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
               ] ;
           Internal_tracing.with_state_hash protocol_state_hashes.state_hash
           @@ fun () ->
-          Debug_assert.debug_assert (fun () ->
-              [%test_result: [ `Take | `Keep ]]
-                (Consensus.Hooks.select
-                   ~context:(module Context)
-                   ~existing:
-                     (With_hash.map ~f:Mina_block.consensus_state
-                        previous_transition )
-                   ~candidate:consensus_state_with_hashes )
-                ~expect:`Take
-                ~message:
-                  "newly generated consensus states should be selected over \
-                   their parent" ;
-              let root_consensus_state_with_hashes =
-                Transition_frontier.root frontier
-                |> Breadcrumb.consensus_state_with_hashes
-              in
-              [%test_result: [ `Take | `Keep ]]
-                (Consensus.Hooks.select
-                   ~context:(module Context)
-                   ~existing:root_consensus_state_with_hashes
-                   ~candidate:consensus_state_with_hashes )
-                ~expect:`Take
-                ~message:
-                  "newly generated consensus states should be selected over \
-                   the tf root" ) ;
+          assert (
+            phys_equal
+              (Consensus.Hooks.select
+                 ~context:(module Context)
+                 ~existing:
+                   (With_hash.map ~f:Mina_block.consensus_state
+                      previous_transition )
+                 ~candidate:consensus_state_with_hashes )
+              `Take
+            || failwith
+                 "newly generated consensus states should be selected over \
+                  their parent" ) ;
+
+          assert (
+            let root_consensus_state_with_hashes =
+              Transition_frontier.root frontier
+              |> Breadcrumb.consensus_state_with_hashes
+            in
+            phys_equal
+              (Consensus.Hooks.select
+                 ~context:(module Context)
+                 ~existing:root_consensus_state_with_hashes
+                 ~candidate:consensus_state_with_hashes )
+              `Take
+            || failwith
+                 "newly generated consensus states should be selected over the \
+                  tf root" ) ;
           Interruptible.uninterruptible
             (let open Deferred.Let_syntax in
             let emit_breadcrumb () =
@@ -1409,31 +1411,32 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
           Header.protocol_state
           @@ Mina_block.header (With_hash.data previous_transition)
         in
-        Debug_assert.debug_assert (fun () ->
-            [%test_result: [ `Take | `Keep ]]
-              (Consensus.Hooks.select
-                 ~context:(module Context)
-                 ~existing:
-                   (With_hash.map ~f:Mina_block.consensus_state
-                      previous_transition )
-                 ~candidate:consensus_state_with_hashes )
-              ~expect:`Take
-              ~message:
-                "newly generated consensus states should be selected over \
-                 their parent" ;
-            let root_consensus_state_with_hashes =
-              Transition_frontier.root frontier
-              |> Breadcrumb.consensus_state_with_hashes
-            in
-            [%test_result: [ `Take | `Keep ]]
-              (Consensus.Hooks.select
-                 ~context:(module Context)
-                 ~existing:root_consensus_state_with_hashes
-                 ~candidate:consensus_state_with_hashes )
-              ~expect:`Take
-              ~message:
-                "newly generated consensus states should be selected over the \
-                 tf root" ) ;
+        assert (
+          phys_equal
+            (Consensus.Hooks.select
+               ~context:(module Context)
+               ~existing:
+                 (With_hash.map ~f:Mina_block.consensus_state
+                    previous_transition )
+               ~candidate:consensus_state_with_hashes )
+            `Take
+          || failwith
+               "newly generated consensus states should be selected over their \
+                parent" ) ;
+        assert (
+          let root_consensus_state_with_hashes =
+            Transition_frontier.root frontier
+            |> Breadcrumb.consensus_state_with_hashes
+          in
+          phys_equal
+            (Consensus.Hooks.select
+               ~context:(module Context)
+               ~existing:root_consensus_state_with_hashes
+               ~candidate:consensus_state_with_hashes )
+            `Take
+          || failwith
+               "newly generated consensus states should be selected over the \
+                tf root" ) ;
         let emit_breadcrumb () =
           let open Deferred.Result.Let_syntax in
           let previous_protocol_state_hash =

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -19,7 +19,6 @@
   consensus
   currency
   data_hash_lib
-  debug_assert
   error_json
   genesis_constants
   internal_tracing

--- a/src/lib/debug_assert/debug_assert.ml
+++ b/src/lib/debug_assert/debug_assert.ml
@@ -1,3 +1,0 @@
-let debug_assert thunk = thunk ()
-
-let debug_assert_deferred thunk = thunk ()

--- a/src/lib/debug_assert/debug_assert.mli
+++ b/src/lib/debug_assert/debug_assert.mli
@@ -1,5 +1,0 @@
-open Async_kernel
-
-val debug_assert : (unit -> unit) -> unit
-
-val debug_assert_deferred : (unit -> unit Deferred.t) -> unit Deferred.t

--- a/src/lib/debug_assert/dune
+++ b/src/lib/debug_assert/dune
@@ -1,9 +1,0 @@
-(library
- (name debug_assert)
- (public_name debug_assert)
- (instrumentation
-  (backend bisect_ppx))
- (preprocess
-  (pps ppx_version))
- (libraries async_kernel)
- (synopsis "Debug assertion library"))

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -34,7 +34,6 @@
   stdio
   yojson
   ;; local libraries
-  debug_assert
   mina_stdlib
   logger
   merkle_ledger

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -623,15 +623,14 @@ module Make (Inputs : Inputs_intf.S) = struct
       let hash_cache = t.maps.hashes in
       t.maps <- empty_maps ;
       Base.set_batch ~hash_cache parent account_data ;
-      Debug_assert.debug_assert (fun () ->
-          [%test_result: Hash.t]
-            ~message:
-              "Parent merkle root after committing should be the same as the \
-               old one in the mask"
-            ~expect:old_root_hash (Base.merkle_root parent) ;
-          [%test_result: Hash.t]
-            ~message:"Merkle root of the mask should delegate to the parent now"
-            ~expect:(merkle_root t) (Base.merkle_root parent) ) ;
+      assert (
+        Hash.equal old_root_hash (Base.merkle_root parent)
+        || failwith
+             "Parent merkle root after committing should be the same as the \
+              old one in the mask" ) ;
+      assert (
+        Hash.equal (merkle_root t) (Base.merkle_root parent)
+        || failwith "Merkle root of the mask should delegate to the parent now" ) ;
       t.is_committing <- false
 
     (* copy tables in t; use same parent *)

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -52,7 +52,6 @@
   bignum_bigint
   codable
   crypto_params
-  debug_assert
   fold_lib
   fields_derivers.zkapps
   fields_derivers.json

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -55,7 +55,6 @@
   mina_transaction_logic
   signature_lib
   mina_numbers
-  debug_assert
   merkle_address
   key_value_database
   data_hash_lib

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -492,8 +492,7 @@ module Ledger_inner = struct
     | `Existed, _ ->
         failwith "create_empty for a key already present"
     | `Added, new_loc ->
-        Debug_assert.debug_assert (fun () ->
-            [%test_eq: Ledger_hash.t] start_hash (merkle_root ledger) ) ;
+        assert (Ledger_hash.equal start_hash (merkle_root ledger)) ;
         (merkle_path ledger new_loc, Account.empty)
 end
 

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -63,10 +63,10 @@ let of_ledger_subset_exn_impl ~path_query ~path_add (oledger : Ledger.t) keys =
       ~f:(fun (sl, accs, ne_paths, epaths) (key, mloc) ->
         process_location sl key (mloc, accs, ne_paths, epaths) )
   in
-  Debug_assert.debug_assert (fun () ->
-      [%test_eq: Ledger_hash.t]
-        (Ledger.merkle_root oledger)
-        ((merkle_root sl :> Random_oracle.Digest.t) |> Ledger_hash.of_hash) ) ;
+  assert (
+    Ledger_hash.equal
+      (Ledger.merkle_root oledger)
+      ((merkle_root sl :> Random_oracle.Digest.t) |> Ledger_hash.of_hash) ) ;
   sl
 
 let of_ledger_subset_exn =

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -22,7 +22,6 @@
   block_time
   currency
   data_hash_lib
-  debug_assert
   genesis_constants
   kimchi_bindings
   kimchi_types

--- a/src/lib/transition_frontier/full_frontier/dune
+++ b/src/lib/transition_frontier/full_frontier/dune
@@ -32,7 +32,6 @@
   mina_stdlib
   staged_ledger_diff
   mina_numbers
-  debug_assert
   internal_tracing
   ; for tests
   async

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -880,34 +880,30 @@ let apply_diffs ({ context = (module Context); _ } as t) diffs
           `Disabled ) )
     && not has_long_catchup_job
   then
-    Debug_assert.debug_assert (fun () ->
-        match
-          Consensus.Hooks.required_local_state_sync
-            ~constants:consensus_constants
-            ~consensus_state:
-              (Breadcrumb.consensus_state
-                 (Hashtbl.find_exn t.table t.best_tip).breadcrumb )
-            ~local_state:t.consensus_local_state
-        with
-        | Some jobs ->
-            (* But if there wasn't sync work to do when we started, then there shouldn't be now. *)
-            if local_state_was_synced_at_start then (
-              [%log' fatal t.logger]
-                "after lock transition, the best tip consensus state is out of \
-                 sync with the local state -- bug in either \
-                 required_local_state_sync or frontier_root_transition."
-                ~metadata:
-                  [ ( "sync_jobs"
-                    , Consensus.Hooks.local_state_sync_to_yojson jobs )
-                  ; ( "local_state"
-                    , Consensus.Data.Local_state.to_yojson
-                        t.consensus_local_state )
-                  ; ("tf_viz", `String (visualize_to_string t))
-                  ] ;
-              failwith
-                "local state desynced after applying diffs to full frontier" )
-        | None ->
-            () ) ;
+    assert (
+      match
+        Consensus.Hooks.required_local_state_sync ~constants:consensus_constants
+          ~consensus_state:
+            (Breadcrumb.consensus_state
+               (Hashtbl.find_exn t.table t.best_tip).breadcrumb )
+          ~local_state:t.consensus_local_state
+      with
+      | Some jobs when local_state_was_synced_at_start ->
+          (* But if there wasn't sync work to do when we started, then there shouldn't be now. *)
+          [%log' fatal t.logger]
+            "after lock transition, the best tip consensus state is out of \
+             sync with the local state -- bug in either \
+             required_local_state_sync or frontier_root_transition."
+            ~metadata:
+              [ ("sync_jobs", Consensus.Hooks.local_state_sync_to_yojson jobs)
+              ; ( "local_state"
+                , Consensus.Data.Local_state.to_yojson t.consensus_local_state
+                )
+              ; ("tf_viz", `String (visualize_to_string t))
+              ] ;
+          failwith "local state desynced after applying diffs to full frontier"
+      | _ ->
+          true ) ;
   `New_root_and_diffs_with_mutants (new_root, diffs_with_mutants)
 
 module For_tests = struct

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -38,7 +38,6 @@
   genesis_constants
   verifier
   with_hash
-  debug_assert
   ppx_version.runtime
   pickles.backend
   snark_params


### PR DESCRIPTION
I think the initial purpose of that library is introducing a virtual library and swap with unit implementation in release profile so we don't pay the cost on assertion. However using native assert gives us same result with `-noassert`. 

Right now it's just ident imeplementation meaning we always pay the assertion overhead.

The only useful one that could possibly benefit from virt library is `debug_assert_deferred` as assert can't be used along a Deferred.t, however, it seems that function is not invoked by any place. 