### PR TITLE
[Nightly fix] Introduce two hf packages 

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -176,7 +176,7 @@ let docker_step
                     , if = spec.if
                     }
                   ]
-                , DaemonHardfork =
+                , DaemonAutoHardfork =
                   [ DockerImage.ReleaseSpec::{
                     , deps =
                           deps
@@ -187,7 +187,28 @@ let docker_step
                             , profile = spec.profile
                             , artifact = Artifacts.Type.Daemon
                             }
-                    , service = Artifacts.Type.DaemonHardfork
+                    , service = Artifacts.Type.DaemonAutoHardfork
+                    , network = spec.network
+                    , deb_codename = spec.debVersion
+                    , deb_profile = spec.profile
+                    , build_flags = spec.buildFlags
+                    , docker_publish = docker_publish
+                    , deb_repo = DebianRepo.Type.Local
+                    , deb_legacy_version = spec.deb_legacy_version
+                    }
+                  ]
+                , DaemonLegacyHardfork =
+                  [ DockerImage.ReleaseSpec::{
+                    , deps =
+                          deps
+                        # DockerVersion.dependsOn
+                            DockerVersion.DepsSpec::{
+                            , codename = DockerVersion.ofDebian spec.debVersion
+                            , network = spec.network
+                            , profile = spec.profile
+                            , artifact = Artifacts.Type.DaemonLegacyHardfork
+                            }
+                    , service = Artifacts.Type.DaemonLegacyHardfork
                     , network = spec.network
                     , deb_codename = spec.debVersion
                     , deb_profile = spec.profile

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -13,7 +13,8 @@ let Repo = ./DockerRepo.dhall
 let Artifact
     : Type
     = < Daemon
-      | DaemonHardfork
+      | DaemonLegacyHardfork
+      | DaemonAutoHardfork
       | LogProc
       | Archive
       | TestExecutive
@@ -27,7 +28,8 @@ let Artifact
 
 let AllButTests =
       [ Artifact.Daemon
-      , Artifact.DaemonHardfork
+      , Artifact.DaemonLegacyHardfork
+      , Artifact.DaemonAutoHardfork
       , Artifact.LogProc
       , Artifact.Archive
       , Artifact.BatchTxn
@@ -41,18 +43,14 @@ let AllButTests =
 let Main =
       [ Artifact.Daemon, Artifact.LogProc, Artifact.Archive, Artifact.Rosetta ]
 
-let All =
-        AllButTests
-      # [ Artifact.FunctionalTestSuite
-        , Artifact.Toolchain
-        , Artifact.DaemonHardfork
-        ]
+let All = AllButTests # [ Artifact.FunctionalTestSuite ]
 
 let capitalName =
           \(artifact : Artifact)
       ->  merge
             { Daemon = "Daemon"
-            , DaemonHardfork = "DaemonHardfork"
+            , DaemonLegacyHardfork = "DaemonLegacyHardfork"
+            , DaemonAutoHardfork = "DaemonAutoHardfork"
             , LogProc = "LogProc"
             , Archive = "Archive"
             , TestExecutive = "TestExecutive"
@@ -69,7 +67,8 @@ let lowerName =
           \(artifact : Artifact)
       ->  merge
             { Daemon = "daemon"
-            , DaemonHardfork = "daemon_hardfork"
+            , DaemonLegacyHardfork = "daemon_hardfork"
+            , DaemonAutoHardfork = "daemon_auto_hardfork"
             , LogProc = "logproc"
             , Archive = "archive"
             , TestExecutive = "test_executive"
@@ -86,7 +85,8 @@ let dockerName =
           \(artifact : Artifact)
       ->  merge
             { Daemon = "mina-daemon"
-            , DaemonHardfork = "mina-daemon-hardfork"
+            , DaemonLegacyHardfork = "mina-daemon-hardfork"
+            , DaemonAutoHardfork = "mina-daemon-auto-hardfork"
             , Archive = "mina-archive"
             , TestExecutive = "mina-test-executive"
             , LogProc = "mina-logproc"
@@ -112,7 +112,9 @@ let toDebianName =
       ->  \(network : Network.Type)
       ->  merge
             { Daemon = "daemon_${Network.lowerName network}"
-            , DaemonHardfork = "daemon_${Network.lowerName network}_hardfork"
+            , DaemonLegacyHardfork =
+                "daemon_${Network.lowerName network}_hardfork"
+            , DaemonAutoHardfork = ""
             , LogProc = "logproc"
             , Archive = "archive_${Network.lowerName network}"
             , TestExecutive = "test_executive"
@@ -135,7 +137,8 @@ let toDebianNames =
                   (     \(a : Artifact)
                     ->  merge
                           { Daemon = [ toDebianName a network ]
-                          , DaemonHardfork = [ toDebianName a network ]
+                          , DaemonLegacyHardfork = [ toDebianName a network ]
+                          , DaemonAutoHardfork = [ toDebianName a network ]
                           , Archive = [ toDebianName a network ]
                           , LogProc = [ "logproc" ]
                           , TestExecutive = [ "test_executive" ]
@@ -200,7 +203,10 @@ let dockerTag =
                 { Daemon =
                     "${spec.version}-${Network.lowerName
                                          spec.network}${profile_part}${build_flags_part}"
-                , DaemonHardfork =
+                , DaemonLegacyHardfork =
+                    "${spec.version}-${Network.lowerName
+                                         spec.network}${profile_part}"
+                , DaemonAutoHardfork =
                     "${spec.version}-${Network.lowerName
                                          spec.network}${profile_part}"
                 , Archive = "${spec.version}${build_flags_part}"

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -16,7 +16,8 @@ let isEssential =
             , ZkappTestTransaction = False
             , FunctionalTestSuite = True
             , Toolchain = True
-            , DaemonHardfork = True
+            , DaemonAutoHardfork = True
+            , DaemonLegacyHardfork = True
             , CreateLegacyGenesis = False
             }
             service

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -87,7 +87,7 @@ let generateDockerForCodename =
                   MinaArtifact.MinaBuildSpec::{
                   , artifacts =
                     [ Artifacts.Type.LogProc
-                    , Artifacts.Type.DaemonHardfork
+                    , Artifacts.Type.DaemonLegacyHardfork
                     , Artifacts.Type.Archive
                     , Artifacts.Type.Rosetta
                     , Artifacts.Type.ZkappTestTransaction

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
@@ -17,7 +17,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonHardfork
+            , Artifacts.Type.DaemonAutoHardfork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
@@ -17,7 +17,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonHardfork
+            , Artifacts.Type.DaemonAutoHardfork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -19,7 +19,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonHardfork
+            , Artifacts.Type.DaemonAutoHardfork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -141,9 +141,13 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-daemon"
         DOCKER_CONTEXT="dockerfiles/"
         ;;
-    mina-daemon-hardfork)
+    mina-daemon-legacy-hardfork)
+        DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-daemon"
+        DOCKER_CONTEXT="dockerfiles/"
+        ;;
+    mina-daemon-auto-hardfork)
         if [[ -z "$INPUT_LEGACY_VERSION" ]]; then
-          echo "Legacy version is not set for mina-daemon-hardfork."
+          echo "Legacy version is not set for mina-daemon-auto-hardfork."
           echo "Please provide the --deb-legacy-version argument."
           exit 1
         fi

--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Array of valid service names
-export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-hardfork' 'mina-rosetta' 'mina-test-suite' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain')
+export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-legacy-hardfork' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-test-suite' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain')
 
 function export_base_image () {
     # Determine the proper image for ubuntu or debian
@@ -21,7 +21,7 @@ function export_base_image () {
 
 function export_version () {
     case "${SERVICE}" in
-        mina-daemon|mina-archive|mina-batch-txn|mina-rosetta|mina-daemon-hardfork) export VERSION="${VERSION}-${NETWORK##*=}" ;;
+        mina-daemon|mina-archive|mina-batch-txn|mina-rosetta|mina-daemon-legacy-hardfork|mina-daemon-auto-hardfork) export VERSION="${VERSION}-${NETWORK##*=}" ;;
         *)  ;;
 esac
 }


### PR DESCRIPTION
Issue:
   NIghtly build for 3 codename/network combination. Job requires env vars which were not provided. Root cause of issue is that we mixed old style hf with new auto hardfork package. 

Example:
    https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/529

Fixing nightly by differentiating two hardfork packages (auto and legacy):

- legacy - it's the hf package build using https://buildkite.com/o-1-labs-2/hardfork-package-generation-new
- auto -> we bake docker with two versions (legacy and new) and mina is automatically switching from old to new


Therefore i introduced two hf packages old fashion and new one so env vars for legacy one won't be required when running new on