### PR TITLE
[Nightly CI Fix] introduce one publish job per branch

### DIFF
--- a/buildkite/src/Command/Packages/Publish.dhall
+++ b/buildkite/src/Command/Packages/Publish.dhall
@@ -67,6 +67,7 @@ let Spec =
           , publish_to_docker_io : Bool
           , depends_on : List Command.TaggedKey.Type
           , branch : Text
+          , if : Optional Text
           }
       , default =
           { artifacts = [] : List Package.Type
@@ -82,6 +83,7 @@ let Spec =
           , publish_to_docker_io = False
           , verify = True
           , branch = ""
+          , if = None Text
           }
       }
 
@@ -198,9 +200,12 @@ let publish
                               )
                           ]
                     , label = "Debian Packages Publishing"
-                    , key = "publish-debians"
+                    , key =
+                        "publish-debians-${DebianChannel.lowerName
+                                             spec.channel}"
                     , target = Size.Small
                     , depends_on = spec.depends_on
+                    , if = spec.if
                     }
                 ]
               # Prelude.List.map
@@ -227,9 +232,13 @@ let publish
                                 )
                             ]
                           , label = "Docker Packages Publishing"
-                          , key = "publish-dockers-${Natural/show r.index}"
+                          , key =
+                              "publish-dockers-${DebianChannel.lowerName
+                                                   spec.channel}-${Natural/show
+                                                                     r.index}"
                           , target = Size.Small
                           , depends_on = spec.depends_on
+                          , if = spec.if
                           }
                   )
                   indexedAdditionalTags

--- a/buildkite/src/Constants/DebianChannel.dhall
+++ b/buildkite/src/Constants/DebianChannel.dhall
@@ -3,6 +3,7 @@ let Channel
     = < Unstable
       | Develop
       | Compatible
+      | Master
       | Itn
       | Umt
       | UmtMainnet
@@ -19,6 +20,7 @@ let capitalName =
             { Unstable = "Unstable"
             , Develop = "Develop"
             , Compatible = "Compatible"
+            , Master = "Master"
             , Itn = "Itn"
             , Umt = "Umt"
             , UmtMainnet = "UmtMainnet"
@@ -36,6 +38,7 @@ let lowerName =
             { Unstable = "unstable"
             , Develop = "develop"
             , Compatible = "compatible"
+            , Master = "master"
             , Itn = "itn"
             , Umt = "umt"
             , UmtMainnet = "umt-mainnet"

--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -51,6 +51,36 @@ let targetVersion =
                                             codename}-${DebianChannel.lowerName
                                                           channel}"
 
+let specs_for_branch =
+          \(branch : Text)
+      ->  \(channel : DebianChannel.Type)
+      ->  PublishPackages.Spec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon
+            , Artifacts.Type.Archive
+            , Artifacts.Type.Rosetta
+            ]
+          , profile = Profiles.Type.Devnet
+          , networks = [ Network.Type.Devnet ]
+          , codenames =
+            [ DebianVersions.DebVersion.Bullseye
+            , DebianVersions.DebVersion.Focal
+            , DebianVersions.DebVersion.Noble
+            , DebianVersions.DebVersion.Bookworm
+            ]
+          , debian_repo = DebianRepo.Type.Nightly
+          , channel = channel
+          , new_docker_tags = new_tags
+          , target_version = targetVersion
+          , publish_to_docker_io = False
+          , backend = "local"
+          , verify = True
+          , branch = "\\\${BUILDKITE_BRANCH}"
+          , source_version = "\\\${MINA_DEB_VERSION}"
+          , build_id = "\\\${BUILDKITE_BUILD_ID}"
+          , if = Some "build.branch == \"${branch}\""
+          }
+
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -60,28 +90,10 @@ in  Pipeline.build
         , name = "AutoPromoteNightly"
         }
       , steps =
-          PublishPackages.publish
-            PublishPackages.Spec::{
-            , artifacts =
-              [ Artifacts.Type.Daemon
-              , Artifacts.Type.Archive
-              , Artifacts.Type.Rosetta
-              ]
-            , profile = Profiles.Type.Devnet
-            , networks = [ Network.Type.Devnet ]
-            , codenames =
-              [ DebianVersions.DebVersion.Bullseye
-              , DebianVersions.DebVersion.Focal
-              ]
-            , debian_repo = DebianRepo.Type.Nightly
-            , channel = DebianChannel.Type.Compatible
-            , new_docker_tags = new_tags
-            , target_version = targetVersion
-            , publish_to_docker_io = False
-            , backend = "local"
-            , verify = True
-            , branch = "\\\${BUILDKITE_BRANCH}"
-            , source_version = "\\\${MINA_DEB_VERSION}"
-            , build_id = "\\\${BUILDKITE_BUILD_ID}"
-            }
+            PublishPackages.publish
+              (specs_for_branch "compatible" DebianChannel.Type.Compatible)
+          # PublishPackages.publish
+              (specs_for_branch "develop" DebianChannel.Type.Develop)
+          # PublishPackages.publish
+              (specs_for_branch "master" DebianChannel.Type.Master)
       }


### PR DESCRIPTION
Introduced 3 different publishing job per branch. This is solving issue where compatible branch is used for all three branches (develop,compatible,master) therefore we couldn't find master debian package