### PR TITLE
Push sig kind out of snark worker

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1686,7 +1686,8 @@ let internal_commands logger ~itn_features =
   [ ( Snark_worker.Intf.command_name
     , Snark_worker.command ~proof_level:Genesis_constants.Compiled.proof_level
         ~constraint_constants:Genesis_constants.Compiled.constraint_constants
-        ~commit_id:Mina_version.commit_id )
+        ~commit_id:Mina_version.commit_id
+        ~signature_kind:Mina_signature_kind.t_DEPRECATED )
   ; ("snark-hashes", snark_hashes)
   ; ( "run-prover"
     , Command.async

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -109,9 +109,9 @@ let emit_proof_metrics metrics instances logger =
                ; proof_zkapp_command_count
                } ) )
 
-let main (module Rpcs_versioned : Intf.Rpcs_versioned_S) ~logger ~proof_level
-    ~constraint_constants daemon_address shutdown_on_disconnect =
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
+let main ~logger ~proof_level ~constraint_constants ~signature_kind
+    (module Rpcs_versioned : Intf.Rpcs_versioned_S) daemon_address
+    shutdown_on_disconnect =
   let%bind state =
     Prod.Impl.Worker_state.create ~constraint_constants ~proof_level
       ~signature_kind ()
@@ -225,7 +225,8 @@ let main (module Rpcs_versioned : Intf.Rpcs_versioned_S) ~logger ~proof_level
   go ()
 
 let command_from_rpcs ~commit_id ~proof_level:default_proof_level
-    ~constraint_constants (module Rpcs_versioned : Intf.Rpcs_versioned_S) =
+    ~constraint_constants ~signature_kind
+    (module Rpcs_versioned : Intf.Rpcs_versioned_S) =
   Command.async ~summary:"Snark worker"
     (let open Command.Let_syntax in
     let%map_open daemon_port =
@@ -266,9 +267,9 @@ let command_from_rpcs ~commit_id ~proof_level:default_proof_level
           [%log info]
             !"Received signal to terminate. Aborting snark worker process" ;
           Core.exit 0 ) ;
-      main
+      main ~logger ~proof_level ~constraint_constants ~signature_kind
         (module Rpcs_versioned)
-        ~logger ~proof_level ~constraint_constants daemon_port
+        daemon_port
         (Option.value ~default:true shutdown_on_disconnect))
 
 let arguments ~proof_level ~daemon_address ~shutdown_on_disconnect ~conf_dir


### PR DESCRIPTION
This noop PR pushes sig kind out of snark worker

I think I've opened a PR with same intention before, but it shows up again during refactoring it seems. Hence another sig kind pushing PR. 

Note for self: when removing snark worker cli arg from snark worker standalone entry, we need to patch the string cli arg passed in to it in Mina_lib as well. 