### PR TITLE
[ARM64] unhardcode amd64 architecture in dockerfiles

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -5,22 +5,22 @@
 { toolchainBase = "codaprotocol/ci-toolchain-base:v3"
 , minaToolchainBookworm =
     { arm64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:38e5e769f856531fafe37da39aa21d1f9d7d770d4d45ab2d38a6bed553830260"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:d3a479556ebd293ffdd1fe2cd552fe1a03ceaf118c9fcbd29d3ecb5cfad62326"
     , amd64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:e9e5e0cf840de54b1d096fe4d0a128b169bba5ba753e902fdcec9d4bc27094a6"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:4d0f55b32c072d59a4a09c5b4484c6afb6600da90e55aed645a59c841cb6ee36"
     }
 , minaToolchainBullseye.amd64 =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:a2a91ff49a7f8f2e7dca02cca629930e502b79ec76a77b1acd33ae028f9f52eb"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:20e86f1931599826c888a88ac956de0cdbad326bf155b6cf8e1536c3509b7a17"
 , minaToolchainNoble =
     { arm64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:626a709c5ada4234436badae48173053882a9fdb2036d75ffcf65ac76f572669"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:6fa48067fea8d81e15379781ad22ba99ffec0623a2613ea5b1447b32dbdd3114"
     , amd64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:92046c8910bb2e1d8487822f7e358637da32a50c0f1f4eba5186bb89509ddcdc"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:d81adae569e02eb5295f7cd56aa53df95576d8ad001358066bcae3a612cc39b7"
     }
 , minaToolchainJammy.amd64 =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:62bfc14a6a92714d7be7dce4a10927bc5e74351e86e483dc312ee19fc3566266"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:42d55ac7521096ade25c9b0d24062894fa433bf214c07cc4f991df2d2d5392f3"
 , minaToolchain =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:a2a91ff49a7f8f2e7dca02cca629930e502b79ec76a77b1acd33ae028f9f52eb"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:20e86f1931599826c888a88ac956de0cdbad326bf155b6cf8e1536c3509b7a17"
 , postgres = "postgres:12.4-alpine"
 , xrefcheck =
     "dkhamsing/awesome_bot@sha256:a8adaeb3b3bd5745304743e4d8a6d512127646e420544a6d22d9f58a07f35884"

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -5,22 +5,22 @@
 { toolchainBase = "codaprotocol/ci-toolchain-base:v3"
 , minaToolchainBookworm =
     { arm64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:2578d7b35ef404d6da31179e2d6012e1e451d6254b214c0ecddeb9d281c66195"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:38e5e769f856531fafe37da39aa21d1f9d7d770d4d45ab2d38a6bed553830260"
     , amd64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:7473e25c4ab2da533cda28aa31990ed040b9a391e061eb266b4809682fec96a3"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:e9e5e0cf840de54b1d096fe4d0a128b169bba5ba753e902fdcec9d4bc27094a6"
     }
 , minaToolchainBullseye.amd64 =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:eefb87b7a0510285fe9d6224bb25968fc451cc03e653129bd11b5a97ea7d8d61"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:a2a91ff49a7f8f2e7dca02cca629930e502b79ec76a77b1acd33ae028f9f52eb"
 , minaToolchainNoble =
     { arm64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:09f907d15e279e646b9c4cc0182d458befb605a7832d82be40aa3f0e92b9b842"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:626a709c5ada4234436badae48173053882a9fdb2036d75ffcf65ac76f572669"
     , amd64 =
-        "gcr.io/o1labs-192920/mina-toolchain@sha256:18ae9bef88d9ac769aa48de7ab80909131cf8d307d7eb1bc61d47be15ae534f2"
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:92046c8910bb2e1d8487822f7e358637da32a50c0f1f4eba5186bb89509ddcdc"
     }
 , minaToolchainJammy.amd64 =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:37d201999d9a4b0f6a112089dde673cd58ddb69ba8b96072f36be6ea5a9008d1"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:62bfc14a6a92714d7be7dce4a10927bc5e74351e86e483dc312ee19fc3566266"
 , minaToolchain =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:eefb87b7a0510285fe9d6224bb25968fc451cc03e653129bd11b5a97ea7d8d61"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:a2a91ff49a7f8f2e7dca02cca629930e502b79ec76a77b1acd33ae028f9f52eb"
 , postgres = "postgres:12.4-alpine"
 , xrefcheck =
     "dkhamsing/awesome_bot@sha256:a8adaeb3b3bd5745304743e4d8a6d512127646e420544a6d22d9f58a07f35884"

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactBookwormArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactBookwormArm64.dhall
@@ -1,0 +1,18 @@
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let DockerImage = ../../Command/DockerImage.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Bookworm
+      , no_cache = True
+      , no_debian = True
+      , arch = Arch.Type.Arm64
+      }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactNobleArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactNobleArm64.dhall
@@ -1,0 +1,18 @@
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let DockerImage = ../../Command/DockerImage.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Noble
+      , no_cache = True
+      , no_debian = True
+      , arch = Arch.Type.Arm64
+      }

--- a/changes/17709.md
+++ b/changes/17709.md
@@ -1,0 +1,3 @@
+Removed hardcoded amd64 or x86_64 segment in various paths to toolchain tooling. This enable other architectures as arm64 to be provided instead amd64.
+
+However, there were some issues in consolidation of naming convention (canonical and debian alike) which lead to introduce both cases x86_64/arm64 and x86_64/aarch64 to satisfy every possible case 

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -75,7 +75,7 @@ RUN echo "Building image with version $deb_version from repo $deb_release $deb_c
   && echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
   && apt-get update --quiet --yes \
   && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "${MINA_DEB}=$deb_version" \
-  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "mina-create-legacy-genesis=3.2.0-d06c972" \
+  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "mina-create-legacy-genesis=3.2.0-f77c8c9" \
   && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -5,6 +5,7 @@ ARG deb_version
 ARG deb_release=unstable
 ARG network=mainnet
 ARG deb_repo="http://packages.o1test.net"
+ARG TARGETARCH
 
 ARG psql_version=15
 # Golang version number used to detemine tarball name
@@ -87,7 +88,7 @@ RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 
 # --- Golang install of a given GO_VERSION (add -v for spam output of each file from the go dist)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/lib/
+RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -xz -C /usr/lib/
 
 # --- Install rosetta-cli
 # The following commands install rosetta-cli with an updated rosetta-sdk-go dependency, which supports delegation transactions.

--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -23,7 +23,7 @@ ARG BUILDPLATFORM
 ARG CANONICAL_ARCH
 # Debian style naming convention
 # : arm64/amd64
-ARG DEBIANARCH
+ARG DEBIAN_ARCH
 
 # We need to define the target architecture as it is still different from CANONICAL_ARCH
 # For example: Canonical names are aarch64/x86_64 while TARGETARCH: aarch64/amd64
@@ -117,7 +117,7 @@ RUN git config --global advice.detachedHead false
 
 # --- Opam install of a given OPAM_VERSION from github release
 RUN curl -sL \
-  "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-${DEBIANARCH}-linux" \
+  "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-${DEBIAN_ARCH}-linux" \
   -o /usr/bin/opam \
   && chmod +x /usr/bin/opam
 

--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -12,6 +12,23 @@ ARG deb_codename
 
 FROM ${image} AS build-deps
 
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+# Unfortunately we cannot use the same naming convention for all architectures
+# for all tooling, therefore we need to define couple of naming conventions
+
+# Canonical style naming convention
+# : aarch/x86_64
+ARG CANONICAL_ARCH
+# Debian style naming convention
+# : arm64/amd64
+ARG DEBIANARCH
+
+# We need to define the target architecture as it is still different from CANONICAL_ARCH
+# For example: Canonical names are aarch64/x86_64 while TARGETARCH: aarch64/amd64
+ARG TARGETARCH
+
 # OCaml Version
 # The version must be the same as the version used in:
 # - dockerfiles/1-build-deps
@@ -100,13 +117,13 @@ RUN git config --global advice.detachedHead false
 
 # --- Opam install of a given OPAM_VERSION from github release
 RUN curl -sL \
-  "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
+  "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-${DEBIANARCH}-linux" \
   -o /usr/bin/opam \
   && chmod +x /usr/bin/opam
 
 # --- Golang install of a given GO_VERSION (add -v for spam output of each file from the go dist)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/lib/
+RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -xz -C /usr/lib/
 
 # --- Rust install via rustup-init to a given RUST_VERSION
 # --- Additionally, install RUST_NIGHTLY via rustup
@@ -118,7 +135,7 @@ RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar 
 USER opam
 RUN curl --proto "=https" \
   --tlsv1.2 -sSf -o /tmp/rustup-init \
-  https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
+  https://static.rust-lang.org/rustup/dist/${CANONICAL_ARCH}-unknown-linux-gnu/rustup-init \
   && chmod +x /tmp/rustup-init \
   && /tmp/rustup-init -y --default-toolchain \
     "${RUST_VERSION}" \

--- a/dockerfiles/stages/1-build-deps-bookworm
+++ b/dockerfiles/stages/1-build-deps-bookworm
@@ -1,8 +1,8 @@
 FROM build-deps AS build-deps-bookworm
 
-# Debian style naming convention
-# : arm64/amd64
-ARG DEBIAN_ARCH
+# Canonical naming convention
+# : aarch64/x86_64
+ARG CANONICAL_ARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,7 +15,7 @@ RUN apt-get update --quiet \
     libproc2-0 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${DEBIAN_ARCH}.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${CANONICAL_ARCH}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -rf awscliv2.zip aws

--- a/dockerfiles/stages/1-build-deps-bookworm
+++ b/dockerfiles/stages/1-build-deps-bookworm
@@ -1,5 +1,9 @@
 FROM build-deps AS build-deps-bookworm
 
+# Debian style naming convention
+# : arm64/amd64
+ARG DEBIANARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
@@ -11,7 +15,7 @@ RUN apt-get update --quiet \
     libproc2-0 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${DEBIANARCH}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -rf awscliv2.zip aws

--- a/dockerfiles/stages/1-build-deps-bookworm
+++ b/dockerfiles/stages/1-build-deps-bookworm
@@ -2,7 +2,7 @@ FROM build-deps AS build-deps-bookworm
 
 # Debian style naming convention
 # : arm64/amd64
-ARG DEBIANARCH
+ARG DEBIAN_ARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,7 +15,7 @@ RUN apt-get update --quiet \
     libproc2-0 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${DEBIANARCH}.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${DEBIAN_ARCH}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -rf awscliv2.zip aws

--- a/dockerfiles/stages/1-build-deps-jammy
+++ b/dockerfiles/stages/1-build-deps-jammy
@@ -1,5 +1,9 @@
 FROM build-deps AS build-deps-jammy
 
+# Canonical naming convention
+# : aarch64/x86_64
+ARG CANONICAL_ARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
@@ -11,7 +15,7 @@ RUN apt-get update --quiet \
     libprocps8 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${CANONICAL_ARCH}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -rf awscliv2.zip aws

--- a/dockerfiles/stages/1-build-deps-noble
+++ b/dockerfiles/stages/1-build-deps-noble
@@ -1,5 +1,9 @@
 FROM build-deps AS build-deps-noble
 
+# Canonical naming convention
+# : aarch64/x86_64
+ARG CANONICAL_ARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
@@ -11,7 +15,7 @@ RUN apt-get update --quiet \
     libproc2-0 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${CANONICAL_ARCH}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -rf awscliv2.zip aws

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -16,6 +16,10 @@ ARG BUILDPLATFORM
 # : aarch64/x86_64
 ARG CANONICAL_ARCH
 
+# Debian naming convention
+# : arm64/x86_64
+ARG DEBIAN_ARCH
+
 USER root
 
 # OS package dependencies
@@ -81,7 +85,7 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Hadolint
-RUN curl -sL https://github.com/hadolint/hadolint/releases/download/v$HADOLINT_VERSION/hadolint-Linux-${TARGETARCH} \
+RUN curl -sL https://github.com/hadolint/hadolint/releases/download/v$HADOLINT_VERSION/hadolint-Linux-${DEBIAN_ARCH} \
     -o /usr/bin/hadolint \
     && chmod +x /usr/bin/hadolint
 

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -6,11 +6,15 @@ FROM opam-deps AS toolchain
 
 ARG DOCKER_VERSION=28.3.1
 ARG DEBS3_VERSION=0.11.7
-ARG DHALL_VERSION=1.41.1
-ARG DHALL_JSON_VERSION=1.7.10
-ARG DHALL_BASH_VERSION=1.0.40
 ARG INFLUXDB_CLI_VERSION=2.7.5
 ARG HADOLINT_VERSION=2.12.0
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG BUILDPLATFORM
+
+# Canonical naming convention
+# : aarch64/x86_64
+ARG CANONICAL_ARCH
 
 USER root
 
@@ -48,14 +52,14 @@ RUN curl -sLO https://github.com/MinaProtocol/deb-s3/releases/download/${DEBS3_V
 # --- influx db tool
 # Custom version, with lock only on manifest upload
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -L -o influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-amd64.tar.gz https://download.influxdata.com/influxdb/releases/influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-amd64.tar.gz \
-    && mkdir -p "influx_dir" && tar xvzf influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-amd64.tar.gz -C influx_dir \
+RUN curl -L -o influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz https://download.influxdata.com/influxdb/releases/influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz \
+    && mkdir -p "influx_dir" && tar xvzf influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz -C influx_dir \
     && cp influx_dir/influx /usr/local/bin/ \
-    && rm influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-amd64.tar.gz \
+    && rm influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz \
     && rm -rf influx_dir
 
 # --- Docker Daemon
-RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
+RUN curl -sL https://download.docker.com/linux/static/stable/${CANONICAL_ARCH}/docker-${DOCKER_VERSION}.tgz \
     | tar --extract --gzip --strip-components 1 --directory=/usr/bin --file=-
 
 # --- Google Cloud tools
@@ -76,16 +80,8 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install --yes --no-install-recommends nodejs yarn \
     && rm -rf /var/lib/apt/lists/*
 
-# Dhall
-RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-$DHALL_VERSION-x86_64-linux.tar.bz2 \
-    | tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall
-RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-bash-$DHALL_BASH_VERSION-x86_64-linux.tar.bz2 \
-    | tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall-to-bash
-RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-json-$DHALL_JSON_VERSION-x86_64-linux.tar.bz2 \
-    | tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall-to-yaml
-
 # --- Hadolint
-RUN curl -sL https://github.com/hadolint/hadolint/releases/download/v$HADOLINT_VERSION/hadolint-Linux-x86_64 \
+RUN curl -sL https://github.com/hadolint/hadolint/releases/download/v$HADOLINT_VERSION/hadolint-Linux-${TARGETARCH} \
     -o /usr/bin/hadolint \
     && chmod +x /usr/bin/hadolint
 

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -104,32 +104,27 @@ fi
 
 PLATFORM="--platform ${INPUT_PLATFORM}"
 
+# Unfortunately we cannot use the same naming convention for all architectures
+# for all tooling in toolchain or mina docker
+# therefore we need to define couple of naming conventions
+
+# Canonical style naming convention : aarch/x86_64
+# Debian style naming convention : arm64/amd64
 case "${INPUT_PLATFORM}" in
       linux/amd64)
-        RUSTARCH="x86_64"
+        CANONICAL_ARCH="x86_64"
+        DEBIAN_ARCH="x86_64"
         ;;
       linux/arm64)
-        RUSTARCH="aarch64"
+        CANONICAL_ARCH="aarch64"
+        DEBIAN_ARCH="arm64"
         ;;
       *)
         echo "unsupported platform"; exit 1
         ;;
 esac
-RUSTARCH_ARG="--build-arg RUSTARCH=$RUSTARCH"
-
-case "${INPUT_PLATFORM}" in
-      linux/amd64)
-        OPAMARCH="x86_64"
-        ;;
-      linux/arm64)
-        OPAMARCH="arm64"
-        ;;
-      *)
-        echo "unsupported platform"; exit 1
-        ;;
-esac
-OPAMARCH_ARG="--build-arg OPAMARCH=$OPAMARCH"
-
+CANONICAL_ARCH_ARG="--build-arg CANONICAL_ARCH=$CANONICAL_ARCH"
+DEBIAN_ARCH_ARG="--build-arg DEBIAN_ARCH=$DEBIAN_ARCH"
 
 DEB_RELEASE="--build-arg deb_release=$INPUT_RELEASE"
 if [[ -z "$INPUT_RELEASE" ]]; then
@@ -257,9 +252,9 @@ BUILD_NETWORK="--allow=network.host"
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT}" ]]; then
   cat $DOCKERFILE_PATH | docker buildx build  --network=host \
-  --load --progress=plain $PLATFORM $RUSTARCH_ARG $OPAMARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION -t "$TAG" -
+  --load --progress=plain $PLATFORM $DEBIAN_ARCH_ARG $CANONICAL_ARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION -t "$TAG" -
 else
-  docker buildx build --load --network=host --progress=plain $PLATFORM $RUSTARCH_ARG $OPAMARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION "$DOCKER_CONTEXT" -t "$TAG" -f $DOCKERFILE_PATH
+  docker buildx build --load --network=host --progress=plain $PLATFORM $DEBIAN_ARCH_ARG $CANONICAL_ARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION "$DOCKER_CONTEXT" -t "$TAG" -f $DOCKERFILE_PATH
 fi
 
 echo "✅ Docker image for service ${SERVICE} built successfully."


### PR DESCRIPTION
Removed hardcoded amd64 or x86_64 segment in various paths to toolchain tooling. This enable other architectures as arm64 to be provided instead amd64.

However, there were some issues in consolidation of naming convention (canonical and debian alike) which lead to introduce both cases x86_64/arm64 and x86_64/aarch64 to satisfy every possible case 