### PR TITLE
support multi arch publishing

### DIFF
--- a/scripts/debian/aptly.sh
+++ b/scripts/debian/aptly.sh
@@ -48,15 +48,15 @@ function start_aptly() {
     aptly publish snapshot -distribution="${__distribution}" -skip-signing "${__component}"
 
     if [ "${__background}" = 1 ]; then
-        aptly serve -listen localhost:"${__port}" &
+        aptly serve -listen 0.0.0.0:"${__port}" &
     else
-        aptly serve -listen localhost:"${__port}"
+        aptly serve -listen 0.0.0.0:"${__port}"
     fi
 
     if [ $__wait = 1 ]; then
         local __timeout=300
         local __elapsed=0
-        while ! curl -s "http://localhost:$__port" >/dev/null; do
+        while ! curl -s "http://0.0.0.0:$__port" >/dev/null; do
             sleep 1
             __elapsed=$((__elapsed + 1))
             if [ $__elapsed -ge $__timeout ]; then

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -9,6 +9,7 @@ BUILD_URL=${BUILD_URL:-${BUILDKITE_BUILD_URL:-"local build from '$(hostname)' \
 MINA_DEB_CODENAME=${MINA_DEB_CODENAME:-"bullseye"}
 MINA_DEB_VERSION=${MINA_DEB_VERSION:-"0.0.0-experimental"}
 MINA_DEB_RELEASE=${MINA_DEB_RELEASE:-"unstable"}
+ARCHITECTURE=${ARCHITECTURE:-"amd64"}
 
 # Helper script to include when building deb archives.
 
@@ -101,7 +102,7 @@ Label: MinaProtocol
 Vendor: O(1)Labs
 Codename: ${MINA_DEB_CODENAME}
 Suite: ${MINA_DEB_RELEASE}
-Architecture: amd64
+Architecture: ${ARCHITECTURE}
 Maintainer: O(1)Labs <build@o1labs.org>
 Installed-Size:
 Depends: ${2}
@@ -138,13 +139,13 @@ build_deb() {
   # Docker image, we're examining those packages in buildkite's agent, where
   # `zstd` might not be available.
   fakeroot dpkg-deb -Zgzip --build "${BUILDDIR}" \
-    "${1}"_"${MINA_DEB_VERSION}".deb
+    "${1}"_"${MINA_DEB_VERSION}"_"${ARCHITECTURE}".deb
   echo "build_deb outputs:"
   ls -lh "${1}"_*.deb
   echo "deleting BUILDDIR ${BUILDDIR}"
   rm -rf "${BUILDDIR}"
 
-  echo "--- Built ${1}_${MINA_DEB_VERSION}.deb"
+  echo "--- Built ${1}_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb"
 }
 
 # Function to DRY copying config files into daemon packages

--- a/scripts/debian/publish.sh
+++ b/scripts/debian/publish.sh
@@ -9,6 +9,7 @@ BUCKET=packages.o1test.net
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--names) DEB_NAMES="$2"; shift;;
+  -a|--arch) ARCH="$2"; shift;;
   -r|--release) DEB_RELEASE="$2"; shift;;
   -v|--version) DEB_VERSION="$2"; shift;;
   -c|--codename) DEB_CODENAME="$2"; shift;;
@@ -70,6 +71,7 @@ for _ in {1..10}; do (
 deb-s3 upload $BUCKET_ARG $S3_REGION_ARG \
   --fail-if-exists \
   --lock \
+  --arch $ARCH \
   --preserve-versions \
   --cache-control=max-age=120 \
   $SIGN_ARG \
@@ -82,9 +84,9 @@ deb-s3 upload $BUCKET_ARG $S3_REGION_ARG \
 for deb in $DEB_NAMES
 do
   # extracting name from debian package path. E.g:
-  # _build/mina-archive_3.0.1-develop-a2a872a.deb -> mina-archive
+  # _build/mina-archive_3.0.1-develop-a2a872a_arm64.deb -> mina-archive
   deb=$(basename "$deb")
-  deb="${deb%_*}"
+  deb="${deb%%_*}"
   debs+=("$deb")
 done
 

--- a/scripts/debian/reversion-helper.sh
+++ b/scripts/debian/reversion-helper.sh
@@ -10,6 +10,7 @@ function reversion() {
     local __suite
     local __new_suite
     local __new_name
+    local __arch
 
     while [[ "$#" -gt 0 ]]; do
         case "${1}" in
@@ -41,6 +42,10 @@ function reversion() {
                 __new_name=${2}
                 shift
                 ;;
+            --arch)
+                __arch=${2}
+                shift
+                ;;
             *)
                 echo "$0 Unknown parameter in reversion() : ${1}" >&2
                 exit 1
@@ -52,21 +57,21 @@ function reversion() {
         fi
     done
 
-    local __new_deb="${__new_name}_${__new_version}"
+    local __new_deb="${__new_name}_${__new_version}_${__arch}"
     local __parent_dir
-    __parent_dir=$(dirname "${__deb}_${__source_version}.deb")
+    __parent_dir=$(dirname "${__deb}_${__source_version}_${__arch}.deb")
     
     rm -rf "${__new_deb}"
     # shellcheck disable=SC2140
     rm -rf "${__parent_dir}"/"${__new_deb}.deb"
 
-    if [[ ! -f "${__deb}_${__source_version}.deb" ]]; then
-        echo "Error: File ${__deb}_${__source_version}.deb does not exist" >&2
+    if [[ ! -f "${__deb}_${__source_version}_${__arch}.deb" ]]; then
+        echo "Error: File ${__deb}_${__source_version}_${__arch}.deb does not exist" >&2
         echo "Contents of ${__parent_dir}:" >&2
         ls -la "${__parent_dir}"
         exit 1
     fi
-    dpkg-deb -R "${__deb}_${__source_version}.deb" "${__new_deb}"
+    dpkg-deb -R "${__deb}_${__source_version}_${__arch}.deb" "${__new_deb}"
     # shellcheck disable=SC2140
     sed -i 's/Version: '"${__source_version}"'/Version: '"${__new_version}"'/g' "${__new_deb}/DEBIAN/control"
     # shellcheck disable=SC2140
@@ -74,7 +79,7 @@ function reversion() {
     # shellcheck disable=SC2140
     sed -i 's/Suite: '"${__suite}"'/Suite: '"${__new_suite}"'/g' "${__new_deb}/DEBIAN/control"
     # shellcheck disable=SC2140
-    dpkg-deb --build "${__new_name}_${__new_version}" "${__parent_dir}"/"${__new_deb}.deb"
+    dpkg-deb --build "${__new_name}_${__new_version}_${__arch}" "${__parent_dir}"/"${__new_deb}.deb"
 
     rm -rf "${__new_deb}"
 }

--- a/scripts/debian/reversion.sh
+++ b/scripts/debian/reversion.sh
@@ -11,6 +11,7 @@ function usage() {
   echo "Usage: $0 [-d deb-name] [-v new-version] "
   echo "  -d, --deb         The Debian name"
   echo "  --version         The Current Debian version"
+  echo "  --arch            The Debian architecture"
   echo "  --new-version     The New Debian version"
   echo "  --suite           The Current Debian suite"
   echo "  --repo            The Source Debian repo"
@@ -29,6 +30,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --new-repo) NEW_REPO="$2"; shift;;
   --suite) SUITE="$2"; shift;;
   --version) VERSION="$2"; shift;;
+  --arch) ARCH="$2"; shift;;
   --repo) REPO="$2"; shift;;
   --sign) SIGN="$2"; shift;;
   *) echo "❌ Unknown parameter passed: $1"; usage exit 1;;
@@ -38,6 +40,7 @@ if [[ ! -v SUITE ]]; then echo "❌ No suite specified"; echo ""; usage "$0" "$1
 if [[ ! -v VERSION ]]; then echo "❌ No version specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v REPO ]]; then echo "❌ No repo specified"; echo ""; usage "$0" "$1" ; exit 1; fi
 if [[ ! -v NEW_NAME ]]; then NEW_NAME=$DEB; fi;
+if [[ ! -v ARCH ]]; then ARCH=amd64; fi;
 if [[ ! -v NEW_VERSION ]]; then NEW_VERSION=$VERSION; fi;
 if [[ ! -v NEW_SUITE ]]; then NEW_SUITE=$SUITE; fi;
 if [[ ! -v NEW_REPO ]]; then NEW_REPO=$REPO; fi;
@@ -58,8 +61,9 @@ function rebuild_deb() {
             --new-version ${NEW_VERSION} \
             --suite ${SUITE} \
             --new-suite ${NEW_SUITE} \
-            --new-name ${NEW_NAME}
+            --new-name ${NEW_NAME} \
+            --arch ${ARCH}
 }
 
 rebuild_deb
-source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}.deb" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_SUITE}" --bucket "${NEW_REPO}" ${SIGN_ARG}
+source scripts/debian/publish.sh --names "${NEW_NAME}_${NEW_VERSION}_${ARCH}.deb" --arch "${ARCH}" --version "${NEW_VERSION}" --codename "${CODENAME}" --release "${NEW_SUITE}" --bucket "${NEW_REPO}" ${SIGN_ARG}

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -20,6 +20,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   -v|--version) VERSION="$2"; shift;;
   -p|--package) PACKAGE="$2"; shift;;
   -m|--codename) CODENAME="$2"; shift;;
+  -a|--arch) ARCH="$2"; shift;;
   -s|--signed) SIGNED=1; ;;
   -h|--help) usage; exit 0;;
   *) echo "❌  Unknown parameter passed: $1"; usage;  exit 1;;
@@ -60,6 +61,10 @@ if [ -z $REPO ]; then
   usage; exit 1;
 fi
 
+if [ -z $ARCH ]; then
+  ARCH=amd64
+fi
+
 case $PACKAGE in
   mina-archive*) COMMAND="mina-archive --version && mina-archive --help" ;;
   mina-logproc) COMMAND="echo skipped execution for mina-logproc" ;;
@@ -95,6 +100,7 @@ case $CODENAME in
   *) echo "❌  Unknown codename passed: $CODENAME"; exit 1;;
 esac
 
-echo "📋  Testing $PACKAGE $DOCKER_IMAGE" \
-  && docker run --rm $DOCKER_IMAGE bash -c "$SCRIPT" \
+echo "📋  Testing $PACKAGE $DOCKER_IMAGE"
+
+docker run --platform "linux/$ARCH" --rm "$DOCKER_IMAGE" bash -c "$SCRIPT" \
   && echo '✅  OK: ALL WORKED FINE!' || (echo '❌  KO: ERROR!!!' && exit 1)

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -32,7 +32,6 @@ function usage() {
   echo "      --deb-profile         The profile string for the debian package to install"
   echo "      --deb-build-flags     The build-flags string for the debian package to install"
   echo "      --deb-suffix          The debian suffix to use for the docker image"
-  echo "  -p, --platform            The target platform for the docker build (e.g. linux/amd64). Default=linux/amd64"
   echo ""
   echo "Example: $0 --service faucet --version v0.1.0"
   echo "Valid Services: ${VALID_SERVICES[*]}"
@@ -46,7 +45,6 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   -b|--branch) INPUT_BRANCH="$2"; shift;;
   -c|--cache-from) INPUT_CACHE="$2"; shift;;
   -r|--repo) MINA_REPO="$2"; shift;;
-  -p|--platform) INPUT_PLATFORM="$2"; shift;;
   --no-cache) NO_CACHE="--no-cache"; ;;
   --deb-codename) INPUT_CODENAME="$2"; shift;;
   --deb-release) INPUT_RELEASE="$2"; shift;;
@@ -98,39 +96,6 @@ if [[ -z "$INPUT_CODENAME" ]]; then
   DEB_CODENAME="--build-arg deb_codename=bullseye"
 fi
 
-if [[ -z "$INPUT_PLATFORM" ]]; then
-  INPUT_PLATFORM="linux/amd64"
-fi
-
-PLATFORM="--platform ${INPUT_PLATFORM}"
-
-case "${INPUT_PLATFORM}" in
-      linux/amd64)
-        RUSTARCH="x86_64"
-        ;;
-      linux/arm64)
-        RUSTARCH="aarch64"
-        ;;
-      *)
-        echo "unsupported platform"; exit 1
-        ;;
-esac
-RUSTARCH_ARG="--build-arg RUSTARCH=$RUSTARCH"
-
-case "${INPUT_PLATFORM}" in
-      linux/amd64)
-        OPAMARCH="x86_64"
-        ;;
-      linux/arm64)
-        OPAMARCH="arm64"
-        ;;
-      *)
-        echo "unsupported platform"; exit 1
-        ;;
-esac
-OPAMARCH_ARG="--build-arg OPAMARCH=$OPAMARCH"
-
-
 DEB_RELEASE="--build-arg deb_release=$INPUT_RELEASE"
 if [[ -z "$INPUT_RELEASE" ]]; then
   echo "Debian release is not set. Using the default (unstable)"
@@ -158,15 +123,9 @@ if [[ -z "$INPUT_CACHE" ]]; then
 fi
 
 DEB_REPO="--build-arg deb_repo=$INPUT_REPO"
-GW=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')
-LOCALHOST_REPLACEMENT=$GW
 if [[ -z "$INPUT_REPO" ]]; then
-  echo "Debian repository is not set. Using the default (http://$LOCALHOST_REPLACEMENT:8080)"
-  DEB_REPO="--build-arg deb_repo=http://$LOCALHOST_REPLACEMENT:8080"
-else
-  echo "Converting localhost to $LOCALHOST_REPLACEMENT in repository URL"
-  CONVERTED_REPO=$(echo "$INPUT_REPO" | sed "s/localhost/$LOCALHOST_REPLACEMENT/g")
-  DEB_REPO="--build-arg deb_repo=$CONVERTED_REPO"
+  echo "Debian repository is not set. Using the default (http://localhost:8080)"
+  DEB_REPO="--build-arg deb_repo=http://localhost:8080"
 fi
 
 if [[ $(echo "${VALID_SERVICES[@]}" | grep -o "$SERVICE" - | wc -w) -eq 0 ]]; then usage "Invalid service!"; fi
@@ -252,14 +211,13 @@ esac
 export_version
 export_docker_tag
 
-BUILD_NETWORK="--allow=network.host"
+BUILD_NETWORK="--network=host"
 
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT}" ]]; then
-  cat $DOCKERFILE_PATH | docker buildx build  --network=host \
-  --load --progress=plain $PLATFORM $RUSTARCH_ARG $OPAMARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION -t "$TAG" -
+  cat $DOCKERFILE_PATH | docker build $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION -t "$TAG" -
 else
-  docker buildx build --load --network=host --progress=plain $PLATFORM $RUSTARCH_ARG $OPAMARCH_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION "$DOCKER_CONTEXT" -t "$TAG" -f $DOCKERFILE_PATH
+  docker build $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX $DEB_REPO $BRANCH $REPO $LEGACY_VERSION "$DOCKER_CONTEXT" -t "$TAG" -f $DOCKERFILE_PATH
 fi
 
 echo "✅ Docker image for service ${SERVICE} built successfully."

--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eox pipefail
+
 # Array of valid service names
 export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-legacy-hardfork' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-test-suite' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'delegation-backend-toolchain')
 
@@ -73,14 +75,32 @@ function export_suffixes () {
     esac
 }
 
+function get_platform_suffix() {
+    case "${INPUT_PLATFORM}" in
+        linux/amd64)
+            echo ""
+            ;;
+        linux/arm64)
+            echo "-arm64"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+
 function export_docker_tag() {
     export_suffixes
 
     export DOCKER_REGISTRY="gcr.io/o1labs-192920"
-    export TAG="${DOCKER_REGISTRY}/${SERVICE}:${VERSION}${BUILD_FLAG_SUFFIX}"
+
+    PLATFORM_SUFFIX="$(get_platform_suffix)"
+    export TAG="${DOCKER_REGISTRY}/${SERVICE}:${VERSION}${BUILD_FLAG_SUFFIX}${PLATFORM_SUFFIX}"
     # friendly, predictable tag
     GITHASH=$(git rev-parse --short=7 HEAD)
+    export PLATFORM_SUFFIX
     export GITHASH
-    export HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}${BUILD_FLAG_SUFFIX}"
+    export HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}${BUILD_FLAG_SUFFIX}${PLATFORM_SUFFIX}"
 
 }

--- a/scripts/docker/promote.sh
+++ b/scripts/docker/promote.sh
@@ -7,12 +7,14 @@ RED='\033[0;31m'
 PUBLISH=0
 GCR_REPO=gcr.io/o1labs-192920
 QUIET=""
+ARCH=amd64
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--name) NAME="$2"; shift;;
   -v|--version) VERSION="$2"; shift;;
   -t|--tag) TAG="$2"; shift;;
   -p|--publish) PUBLISH=1; ;;
   -q|--quiet) QUIET="-q"; ;;
+  -a|--arch) ARCH="$2"; shift;;
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
@@ -26,6 +28,7 @@ function usage() {
   echo "  -t, --tag       The Additional tag"
   echo "  -p, --publish   The Publish to docker.io flag. If defined script will publish docker do docker.io. Otherwise it will still resides in gcr.io"
   echo "  -q, --quiet     The Quiet mode. If defined script will output limited logs"
+  echo "  -a, --arch      The Architecture of docker (amd64, arm64)"
   echo ""
   echo "Example: $0 --name mina-archive --version 2.0.0-rc1-48efea4 --tag devnet-latest-nightly-bullseye "
   exit 1
@@ -38,23 +41,26 @@ if [[ -z "$TAG" ]]; then usage "Tag is not set!"; fi;
 # Sanitize the tag to ensure it is compliant with Docker tag format
 TAG=$(echo "$TAG" | sed 's/[^a-zA-Z0-9_.-]/-/g')
 
-echo "📎 Adding new tag ($TAG) for docker ${GCR_REPO}/${NAME}:${VERSION}"
-echo "   📥 pulling ${GCR_REPO}/${NAME}:${VERSION}"
+case $ARCH in
+  amd64) DOCKER_ARCH_SUFFIX="" ;;
+  arm64) DOCKER_ARCH_SUFFIX="-arm64" ;;
+  *) echo "❌  Unknown architecture passed: $ARCH"; exit 1 ;;
+esac
 
-docker pull $QUIET ${GCR_REPO}/${NAME}:${VERSION}
+SOURCE_TAG="${GCR_REPO}/${NAME}:${VERSION}${DOCKER_ARCH_SUFFIX}"
+
+echo "📎 Adding new tag ($TAG) for docker ${SOURCE_TAG}"
+echo "   📥 pulling ${SOURCE_TAG}"
+docker pull $QUIET ${SOURCE_TAG}
 
 if [[ $PUBLISH == 1 ]]; then
   TARGET_REPO=docker.io/minaprotocol
-  
-  echo "   📎 tagging ${GCR_REPO}/${NAME}:${VERSION} as ${TARGET_REPO}/${NAME}:${TAG}"
-
-  docker tag ${GCR_REPO}/${NAME}:${VERSION} ${TARGET_REPO}/${NAME}:${TAG}
-  echo "   📤 pushing ${TARGET_REPO}/${NAME}:${TAG}"
-  docker push $QUIET "${TARGET_REPO}/${NAME}:${TAG}"
-else 
+else
   TARGET_REPO=$GCR_REPO
-  echo "   📎 retagging ${GCR_REPO}/${NAME}:${VERSION} as ${TARGET_REPO}/${NAME}:${TAG}"
-  docker tag "${GCR_REPO}/${NAME}:${VERSION}" "${TARGET_REPO}/${NAME}:${TAG}"
-  echo "   📤 pushing ${TARGET_REPO}/${NAME}:${TAG}"
-  docker push $QUIET "${TARGET_REPO}/${NAME}:${TAG}"
 fi
+
+TARGET_TAG="${TARGET_REPO}/${NAME}:${TAG}${DOCKER_ARCH_SUFFIX}"
+
+docker tag "${SOURCE_TAG}" "${TARGET_TAG}"
+echo "   📤 pushing ${TARGET_TAG}"
+docker push $QUIET "${TARGET_TAG}"

--- a/scripts/docker/release.sh
+++ b/scripts/docker/release.sh
@@ -4,11 +4,13 @@
 # we have to trustlist and configure image builds individually because each one is going to be slightly different.
 # This is needed as opposed to trusting the structure of the each project to be consistent for every deployable.
 
-set -eo pipefail
+set -eox pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 # shellcheck disable=SC1090
 source ${SCRIPTPATH}/helper.sh
+
+export INPUT_PLATFORM="linux/amd64"
 
 function usage() {
   echo "Usage: $0 [-s service-to-release] [-v service-version] [-n network]"
@@ -22,6 +24,7 @@ function usage() {
   echo "      --deb-version         The version string for the debian package to install"
   echo "      --deb-profile         The profile string for the debian package to install"
   echo "      --deb-build-flags     The build-flags string for the debian package to install"
+  echo "      --platform            The architecture to build the docker image for (linux/amd64, linux/arm64). Default=linux/amd64"
   echo ""
   echo "Example: $0 --service faucet --version v0.1.0"
   echo "Valid Services: ${VALID_SERVICES[*]}"
@@ -35,6 +38,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --deb-version) export DEB_VERSION="--build-arg deb_version=$2"; shift;;
   --deb-profile) export DEB_PROFILE="$2"; shift;;
   --deb-build-flags) export DEB_BUILD_FLAGS="$2"; shift;;
+  --platform) export INPUT_PLATFORM="$2"; shift;;
   --help) usage "$@"; exit 0;;
   *) echo "Unknown parameter passed: $1"; usage "$@"; exit 1;;
 esac; shift; done

--- a/scripts/docker/setup_buildx.sh
+++ b/scripts/docker/setup_buildx.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# Config (override via env or args)
+NAME="${1:-${BUILDX_NAME:-xbuilder}}"
+DRIVER="${DRIVER:-docker}"            # docker | docker-container | kubernetes
+ARCHS="${ARCHS:-arm64}"               # binfmt architectures to install
+INSTALL_BINFMT="${INSTALL_BINFMT:-1}"
+
+command -v docker >/dev/null || { echo "docker not found"; exit 1; }
+docker buildx version >/dev/null 2>&1 || { echo "docker buildx not available"; exit 1; }
+
+# Helper: ensure we are on a given builder
+use_builder () {
+  local b="$1"
+  docker buildx inspect "$b" >/dev/null 2>&1 || { echo "builder '$b' not found"; return 1; }
+  docker buildx use "$b"
+}
+
+# Special case: docker driver can only have ONE instance (the implicit 'default')
+if [[ "$DRIVER" == "docker" ]]; then
+  echo "[buildx] Using 'docker' driver -> switching to existing 'default' builder"
+  use_builder default || {
+    # On some setups 'default' exists but isn't initialized yet; bootstrap via inspect
+    docker buildx create --name default --driver docker --use || true
+    docker buildx inspect default --bootstrap >/dev/null || true
+    docker buildx use default
+  }
+else
+  # For docker-container (recommended) or other drivers: create or reuse NAME
+  if docker buildx inspect "$NAME" >/dev/null 2>&1; then
+    echo "[buildx] Using existing builder: $NAME"
+    docker buildx use "$NAME"
+  else
+    # Clean any stale handle with same name (safe if it doesn't exist)
+    docker buildx rm "$NAME" >/dev/null 2>&1 || true
+    echo "[buildx] Creating builder: $NAME (driver: $DRIVER)"
+    docker buildx create --name "$NAME" --driver "$DRIVER" --use
+  fi
+fi
+
+echo "[buildx] Bootstrapping current builder"
+docker buildx inspect --bootstrap >/dev/null
+
+# Install binfmt only when using docker-container (useful for cross-building)
+CURRENT_BUILDER="$(docker buildx ls | awk '/\*/{gsub(/\*/, "", $1); print $1}')"
+CURRENT_DRIVER="$(docker buildx inspect "$CURRENT_BUILDER" | awk -F': ' '/Driver:/ {print $2}')"
+
+if [[ "$INSTALL_BINFMT" = "1" && "$CURRENT_DRIVER" = "docker-container" ]]; then
+  echo "[binfmt] Ensuring $ARCHS emulation is installed"
+  docker run --privileged --rm tonistiigi/binfmt --install "$ARCHS" >/dev/null
+fi
+
+echo
+echo "[summary]"
+docker buildx ls


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
