### PR TITLE
[Release] fix strip_network_from_archive initial value

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -895,6 +895,7 @@ function promote(){
     local __source_version
     local __target_version
     local __codenames="$DEFAULT_CODENAMES"
+    local __strip_network_from_archive=0
     local __source_channel
     local __target_channel
     local __publish_to_docker_io=0


### PR DESCRIPTION
fixing corner case noticed when running publishing last time. field was uninitialized, while we always provided value for it so it was undetected until i forgot to provide it in one of publishing operation