### PR TITLE
Clean up gitignore Sep 4th

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-.bazel
-bazel-*
-user.bazelrc
-.cpcache/
-
 _build*
 *.pdf
 *.install
@@ -13,22 +8,13 @@ result
 *.aux
 src/config.mlh
 src/config/config.mlh
-.stack-work/
 /wallet-keys/
 test_output
-.firebase/
-node_modules/
 .DS_Store
 .graphql_ppx_cache
 /scripts/archive/output
 accounts.json
 src/app/libp2p_helper/src/libp2p_helper/libp2p_helper
-src/app/validation/_build
-src/app/validation/config/local.exs
-src/app/validation/cover
-src/app/validation/deps
-src/app/validation/doc
-src/app/validation/priv/plts
 src/libp2p_ipc/libp2p_ipc.capnp.go
 src/libp2p_ipc/libp2p_ipc_capnp.ml
 src/libp2p_ipc/libp2p_ipc_capnp.mli
@@ -66,9 +52,5 @@ Pipfile.lock
 # coverage report files
 *.coverage
 _coverage/
-
-# directory removed in this branch, but still existing in berkeley,
-# may appear as an untracked file occasionally
-/src/external
 
 CLAUDE.local.md


### PR DESCRIPTION
I haven't removed entries that I'm not sure if needed, for example ignoring files from terraform. 

The ones I removed are we're of confidence we won't use them. For example, clojure/haskell integration, folders that no longer exists in this repo. 

For situation of checking out running into folders no longer tracked by git, please use `git clean -fd` instead. 