### PR TITLE
Dune: disable assertion in mainnet build

### DIFF
--- a/dune
+++ b/dune
@@ -1,3 +1,7 @@
+(env
+ (mainnet
+  (flags (:standard -noassert))))
+
 (rule
  (target graphql_schema.json)
  (mode promote)


### PR DESCRIPTION
This would give perf boost to mainnet builds, but in trade of we need more thorough test on devnet before a confident release. 