### PR TITLE
Add edition to trace tool Cargo.toml

### DIFF
--- a/src/app/trace-tool/Cargo.toml
+++ b/src/app/trace-tool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "trace-tool"
 version = "0.1.0"
 authors = ["Corey Richardson <cmr@o1labs.org>"]
+edition = "2021"
 
 [dependencies]
 clap = "2.32.0"


### PR DESCRIPTION
When compiling tracetool with `cargo 1.82.0 (8f40fc59f 2024-08-21)`

I got this:

```
warning: /home/lyh/pullground/mina/src/app/trace-tool/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
```

Solution is simple, just set the edition. 