### PR TITLE
Use stricter error type in Work partitioner

### DIFF
--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -40,10 +40,24 @@ module Zkapp_command_inputs = struct
         , stmt ) )
 end
 
+module Failed_to_generate_inputs = struct
+  type t = [ `Failed_to_generate_inputs of Zkapp_command.t * Error.t ]
+
+  (* TODO: remove this after fully delivering the snark worker
+     optimization PR series *)
+  let error_of_t (`Failed_to_generate_inputs (tx, e) : t) =
+    Error.tag_s e
+      ~tag:
+        ( Zkapp_command.Stable.Latest.sexp_of_t
+        @@ Zkapp_command.read_all_proofs_from_disk tx )
+    |> Error.tag ~tag:"failed to generate inputs for zkapp command"
+end
+
 let extract_zkapp_segment_works ~m:(module M : S)
     ~(input : Mina_state.Snarked_ledger_state.t)
     ~(witness : Transaction_witness.Stable.Latest.t)
-    ~(zkapp_command : Zkapp_command.t) : Zkapp_command_inputs.t Or_error.t =
+    ~(zkapp_command : Zkapp_command.t) :
+    (Zkapp_command_inputs.t, Failed_to_generate_inputs.t) Result.t =
   let inputs =
     Or_error.try_with (fun () ->
         Transaction_snark.zkapp_command_witnesses_exn
@@ -67,12 +81,7 @@ let extract_zkapp_segment_works ~m:(module M : S)
   in
   match inputs with
   | Error e ->
-      Error
-        (Error.createf
-           !"Failed to generate inputs for zkapp_command : %s: %s"
-           ( Zkapp_command.read_all_proofs_from_disk zkapp_command
-           |> Zkapp_command.Stable.Latest.to_yojson |> Yojson.Safe.to_string )
-           (Error.to_string_hum e) )
+      Result.fail (`Failed_to_generate_inputs (zkapp_command, e))
   | Ok (first_segment :: rest_segments) ->
       Ok (Nonempty_list.init first_segment rest_segments)
   | Ok [] ->

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -70,7 +70,7 @@ let reschedule_if_old ~reassignment_timeout
 let reschedule_old_zkapp_job
     ~partitioner:
       ({ reassignment_timeout; zkapp_jobs_sent_by_partitioner; _ } : t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t option =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t option =
   let%map.Option job =
     Sent_zkapp_job_pool.remove_until_reschedule
       ~f:(reschedule_if_old ~reassignment_timeout)
@@ -81,7 +81,7 @@ let reschedule_old_zkapp_job
 let reschedule_old_single_job
     ~partitioner:
       ({ reassignment_timeout; single_jobs_sent_by_partitioner; _ } : t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t option =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t option =
   let%map.Option job =
     Sent_single_job_pool.remove_until_reschedule
       ~f:(reschedule_if_old ~reassignment_timeout)
@@ -118,7 +118,7 @@ let schedule_from_pending_zkapp_command ~(id : Work.Id.Single.t)
     ~pending
 
 let schedule_from_any_pending_zkapp_command ~(partitioner : t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t option =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t option =
   let spec_generated = ref None in
   (* TODO: Consider remove all works no longer relevant for current frontier,
      this may need changes from underlying work selector. *)
@@ -155,7 +155,7 @@ let convert_zkapp_command_from_selector ~partitioner ~job ~pairing
 
 let convert_single_work_from_selector ~(partitioner : t)
     ~(single_spec : Work.Spec.Single.t) ~sok_message ~pairing :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t =
   let job =
     Work.With_job_meta.
       { spec = single_spec
@@ -208,7 +208,7 @@ let schedule_from_tmp_slot ~(partitioner : t) =
     ~sok_message
 
 let schedule_job_from_partitioner ~(partitioner : t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t option =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t option =
   List.find_map ~f:Lazy.force
     [ lazy (reschedule_old_zkapp_job ~partitioner)
     ; lazy (reschedule_old_single_job ~partitioner)
@@ -220,7 +220,7 @@ let schedule_job_from_partitioner ~(partitioner : t) :
 let consume_job_from_selector ~(partitioner : t)
     ~(sok_message : Mina_base.Sok_message.t)
     ~(instances : Work.Spec.Single.t One_or_two.t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t =
   let pairing_id = Id_generator.next_id partitioner.single_id_gen () in
   Hashtbl.add_exn partitioner.pairing_pool ~key:pairing_id
     ~data:(Spec_only { spec = instances; sok_message }) ;
@@ -248,7 +248,7 @@ let request_from_selector_and_consume_by_partitioner ~(partitioner : t)
 
 let request_partitioned_work ~(sok_message : Mina_base.Sok_message.t)
     ~(work_from_selector : work_from_selector) ~(partitioner : t) :
-    Work.Spec.Partitioned.Stable.Latest.t Or_error.t option =
+    (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t option =
   List.find_map ~f:Lazy.force
     [ lazy (schedule_job_from_partitioner ~partitioner)
     ; lazy

--- a/src/lib/work_partitioner/work_partitioner.mli
+++ b/src/lib/work_partitioner/work_partitioner.mli
@@ -56,7 +56,10 @@ val request_partitioned_work :
      sok_message:Mina_base.Sok_message.t
   -> work_from_selector:work_from_selector
   -> partitioner:t
-  -> Snark_work_lib.Spec.Partitioned.Stable.V1.t Or_error.t option
+  -> ( Snark_work_lib.Spec.Partitioned.Stable.V1.t
+     , Snark_worker_shared.Failed_to_generate_inputs.t )
+     Result.t
+     option
 
 type submit_result =
   | SpecUnmatched  (** Submitted work doesn't match the scheme in pool *)


### PR DESCRIPTION
There is only a single error that may happen for this code path,
and wrapping it into the generic `Error.t` really makes it harder
to analyze the whole code around Snark work production.

So using a stricter type really helps.

Explain how you tested your changes:
* Refactoring, no testing required

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
