### PR TITLE
[CI] remove soft fail from archive node tests

### DIFF
--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -1,7 +1,3 @@
-let B = ../External/Buildkite.dhall
-
-let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-
 let Artifacts = ../Constants/Artifacts.dhall
 
 let Command = ./Base.dhall
@@ -35,7 +31,6 @@ in  { step =
               , label = "Archive: Node Test"
               , key = key
               , target = Size.Large
-              , soft_fail = Some (B/SoftFail.Boolean True)
               , depends_on = dependsOn
               }
     }

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -66,6 +66,7 @@ let minimalDirtyWhen =
       , S.exactly "buildkite/src/Constants/ContainerImages" "dhall"
       , S.exactly "buildkite/src/Command/MinaArtifact" "dhall"
       , S.exactly "buildkite/src/Command/PatchArchiveTest" "dhall"
+      , S.exactly "buildkite/src/Command/ArchiveNodeTest" "dhall"
       , S.exactly "buildkite/src/Command/Bench/Base" "dhall"
       , S.strictlyStart (S.contains "scripts/benchmarks")
       , S.strictlyStart (S.contains "buildkite/scripts/bench")


### PR DESCRIPTION
as title says. We experience hard to follow issue where Archive Node: Tests is soft failed and developer may missed the real reason for Performance tests to fail. They depends on successful run of Archive Node: Test job since it produces performance metric dump