### PR TITLE
[HF] test upgrade script on devnet

### DIFF
--- a/buildkite/scripts/archive/upgrade-script-check.sh
+++ b/buildkite/scripts/archive/upgrade-script-check.sh
@@ -81,10 +81,8 @@ has_changes() {
 
     # Fetch latest branch to ensure accurate comparison
     git fetch origin "$BRANCH" >/dev/null 2>&1 || {
-        if [[ "$MODE" == "verbose" ]]; then
-            echo "Error: Failed to fetch origin/$BRANCH" >&2
-        fi
-        return 1
+        echo "Error: Failed to fetch origin/$BRANCH" >&2
+        exit 1
     }
 
     # Check if file has differences

--- a/buildkite/scripts/archive/upgrade-script-check.sh
+++ b/buildkite/scripts/archive/upgrade-script-check.sh
@@ -28,7 +28,7 @@
 set -euo pipefail
 
 MODE="default"
-BRANCH="develop"
+COMPARISION_BRANCH="develop"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # Parse command line arguments
@@ -44,7 +44,7 @@ parse_args() {
                 shift 2
                 ;;
             -b|--comparison-branch)
-                BRANCH="$2"
+                COMPARISION_BRANCH="$2"
                 shift 2
                 ;;
             -h|--help)
@@ -80,13 +80,13 @@ has_changes() {
     fi
 
     # Fetch latest branch to ensure accurate comparison
-    git fetch origin "$BRANCH" >/dev/null 2>&1 || {
-        echo "Error: Failed to fetch origin/$BRANCH" >&2
+    git fetch origin "$COMPARISION_BRANCH" >/dev/null 2>&1 || {
+        echo "Error: Failed to fetch origin/$COMPARISION_BRANCH" >&2
         exit 1
     }
 
     # Check if file has differences
-    if ! git diff --quiet "origin/$BRANCH" -- "$REPO_ROOT/$file" 2>/dev/null; then
+    if ! git diff --quiet "origin/$COMPARISION_BRANCH" -- "$REPO_ROOT/$file" 2>/dev/null; then
         return 0
     else
         return 1
@@ -100,9 +100,9 @@ has_changes_in_git() {
     fi
 
     # Fetch latest branch to ensure accurate comparison
-    git fetch origin "$BRANCH" >/dev/null 2>&1 || {
+    git fetch origin "$COMPARISION_BRANCH" >/dev/null 2>&1 || {
         if [[ "$MODE" == "verbose" ]]; then
-            echo "Error: Failed to fetch origin/$BRANCH" >&2
+            echo "Error: Failed to fetch origin/$COMPARISION_BRANCH" >&2
         fi
         return 1
     }

--- a/buildkite/scripts/changelog.sh
+++ b/buildkite/scripts/changelog.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eou pipefail
+
 # This script checks if a changelog entry is required for a given pull request.
 # It compares the current commit with the base branch of the pull request and looks for changes
 # in the specified trigger files. If changes are found, it checks if the required changelog entry
@@ -20,9 +22,6 @@ BASE_PATH=""
 CHANGELOG_FILE=""
 # List of users who can bypass the changelog check by commenting !ci-bypass-changelog
 # separated by space
-GITHUB_USERS_ELIGIBLE_FOR_BYPASS="amc-ie deepthiskumar Trivo25 45930 SanabriaRusso nicc georgeee dannywillems cjjdespres"
-
-BYPASS_PHRASE="!ci-bypass-changelog"
 
 PIPELINE_SLUG="mina-o-1-labs"
 
@@ -75,23 +74,7 @@ if [[ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]]; then
     exit 1
 fi
 
-# Check if PR is bypassed by a !ci-bypass-changelog comment
-pip install -r scripts/github/github_info/requirements.txt
-
-COMMENTED_CODE=0
-(python3 scripts/github/github_info is_pr_commented --comment "$BYPASS_PHRASE" \
-  --by $GITHUB_USERS_ELIGIBLE_FOR_BYPASS --pr "$BUILDKITE_PULL_REQUEST") \
-   || COMMENTED_CODE=$?
-
-if [[ "$COMMENTED_CODE" == 0 ]]; then
-    echo "⏭️  Skipping run as PR is bypassed"
-    exit 0
-elif [[ "$COMMENTED_CODE" == 1 ]]; then
-    echo "⚙️  PR is not bypassed. Proceeding with changelog check..."
-else
-    echo "❌ Failed to check PR for being eligible for changelog check bypass"
-    exit 1
-fi
+./buildkite/scripts/git/check-bypass.sh "!ci-bypass-changelog"
 
 REMOTE_BRANCH="origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
 

--- a/buildkite/scripts/git/check-bypass.sh
+++ b/buildkite/scripts/git/check-bypass.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Git Bypass Check Script
+#
+# This script checks if a pull request has been bypassed for certain CI checks
+# by authorized users through GitHub comments.
+#
+# DESCRIPTION:
+#   Verifies if a PR contains a bypass comment (e.g., !ci-bypass-changelog)
+#   made by users who are eligible to bypass CI checks. Uses a Python script
+#   to interact with GitHub API and check for the presence of bypass comments.
+#
+# USAGE:
+#   ./check-bypass.sh <bypass_phrase>
+#
+# ARGUMENTS:
+#   bypass_phrase - The comment phrase to look for (e.g., "!ci-bypass-changelog")
+#
+# ENVIRONMENT VARIABLES:
+#   BUILDKITE_PULL_REQUEST - Pull request number (set by Buildkite)
+#
+# EXIT CODES:
+#   0 - PR is bypassed, skip the check
+#   1 - Error occurred during bypass check
+#   (continues execution if PR is not bypassed)
+#
+# DEPENDENCIES:
+#   - Python 3
+#   - pip packages from scripts/github/github_info/requirements.txt
+#   - scripts/github/github_info Python module
+#
+# AUTHORIZED USERS:
+#   Only users listed in GITHUB_USERS_ELIGIBLE_FOR_BYPASS can bypass checks
+
+GITHUB_USERS_ELIGIBLE_FOR_BYPASS="amc-ie deepthiskumar Trivo25 45930 SanabriaRusso nicc georgeee dannywillems cjjdespres"
+
+BYPASS_PHRASE=$1
+
+
+# Check if PR is bypassed by a !ci-bypass-changelog comment
+pip install -r scripts/github/github_info/requirements.txt
+
+COMMENTED_CODE=0
+(python3 scripts/github/github_info is_pr_commented --comment "$BYPASS_PHRASE" \
+  --by $GITHUB_USERS_ELIGIBLE_FOR_BYPASS --pr "$BUILDKITE_PULL_REQUEST") \
+   || COMMENTED_CODE=$?
+
+if [[ "$COMMENTED_CODE" == 0 ]]; then
+    echo "⏭️  Skipping run as PR is bypassed"
+    exit 0
+elif [[ "$COMMENTED_CODE" == 1 ]]; then
+    echo "⚙️  PR is not bypassed. Proceeding with changelog check..."
+else
+    echo "❌ Failed to check PR for being eligible for changelog check bypass"
+    exit 1
+fi

--- a/buildkite/scripts/git/check-bypass.sh
+++ b/buildkite/scripts/git/check-bypass.sh
@@ -32,7 +32,7 @@
 # AUTHORIZED USERS:
 #   Only users listed in GITHUB_USERS_ELIGIBLE_FOR_BYPASS can bypass checks
 
-GITHUB_USERS_ELIGIBLE_FOR_BYPASS="amc-ie deepthiskumar Trivo25 45930 SanabriaRusso nicc georgeee dannywillems cjjdespres"
+GITHUB_USERS_ELIGIBLE_FOR_BYPASS="amc-ie deepthiskumar Trivo25 45930 SanabriaRusso georgeee dannywillems cjjdespres"
 
 BYPASS_PHRASE=$1
 

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -59,7 +59,7 @@ let command
                   , "source ./buildkite/scripts/export-git-env-vars.sh"
                   , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
                                                                          spec.network} --tag \\\${MINA_DOCKER_TAG} --timeout ${Natural/show
-                                                                                                                                 spec.timeout} --run-load-test --run-compatibility-test dkijania/test_upgrade_script"
+                                                                                                                                 spec.timeout} --run-compatibility-test dkijania/test_upgrade_script"
                   ]
               ]
             , label =

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -96,10 +96,7 @@ let pipeline
                       "buildkite/src/Command/Rosetta/Connectivity"
                       "dhall"
                   , S.exactly "scripts/tests/rosetta-connectivity" "sh"
-                  , S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
-                  , S.exactly
-                      "buildkite/scripts/rosetta-integration-tests-full"
-                      "sh"
+                  , S.exactly "buildkite/scripts/tests/rosetta-integration-tests" "sh"
                   ]
                 # spec.additionalDirtyWhen
             , path = "Test"

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -59,7 +59,7 @@ let command
                   , "source ./buildkite/scripts/export-git-env-vars.sh"
                   , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
                                                                          spec.network} --tag \\\${MINA_DOCKER_TAG} --timeout ${Natural/show
-                                                                                                                                 spec.timeout} --run-compatibility-test dkijania/test_upgrade_script"
+                                                                                                                                 spec.timeout} --run-compatibility-test develop --run-load-test "
                   ]
               ]
             , label =

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -96,7 +96,9 @@ let pipeline
                       "buildkite/src/Command/Rosetta/Connectivity"
                       "dhall"
                   , S.exactly "scripts/tests/rosetta-connectivity" "sh"
-                  , S.exactly "buildkite/scripts/tests/rosetta-integration-tests" "sh"
+                  , S.exactly
+                      "buildkite/scripts/tests/rosetta-integration-tests"
+                      "sh"
                   ]
                 # spec.additionalDirtyWhen
             , path = "Test"

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -59,7 +59,7 @@ let command
                   , "source ./buildkite/scripts/export-git-env-vars.sh"
                   , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
                                                                          spec.network} --tag \\\${MINA_DOCKER_TAG} --timeout ${Natural/show
-                                                                                                                                 spec.timeout} --run-load-test"
+                                                                                                                                 spec.timeout} --run-load-test --run-compatibility-test develop"
                   ]
               ]
             , label =
@@ -96,8 +96,9 @@ let pipeline
                       "buildkite/src/Command/Rosetta/Connectivity"
                       "dhall"
                   , S.exactly "scripts/tests/rosetta-connectivity" "sh"
+                  , S.exactly "buildkite/scripts/rosetta-integration-tests" "sh"
                   , S.exactly
-                      "buildkite/scripts/tests/rosetta-integration-tests"
+                      "buildkite/scripts/rosetta-integration-tests-full"
                       "sh"
                   ]
                 # spec.additionalDirtyWhen

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -59,7 +59,7 @@ let command
                   , "source ./buildkite/scripts/export-git-env-vars.sh"
                   , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
                                                                          spec.network} --tag \\\${MINA_DOCKER_TAG} --timeout ${Natural/show
-                                                                                                                                 spec.timeout} --run-load-test --run-compatibility-test develop"
+                                                                                                                                 spec.timeout} --run-load-test --run-compatibility-test dkijania/test_upgrade_script"
                   ]
               ]
             , label =

--- a/buildkite/src/Jobs/Lint/ArchiveUpgrade.dhall
+++ b/buildkite/src/Jobs/Lint/ArchiveUpgrade.dhall
@@ -36,7 +36,7 @@ in  Pipeline.build
             Command.Config::{
             , commands =
               [ Cmd.run
-                  "buildkite/scripts/archive/upgrade-script-check.sh --mode verbose --branch develop"
+                  "buildkite/scripts/archive/upgrade-script-check.sh --mode verbose --comparison-branch develop"
               ]
             , label = "Archive: Check upgrade script need"
             , key = "archive-check-upgrade-script"

--- a/changes/17713.md
+++ b/changes/17713.md
@@ -1,0 +1,1 @@
+Added guardian test to CI, which will verify if there is a mismatch in content of create_schema.sql / drop_tables.sql. If yes, then test will demand change in upgrade-to-mesa.sh script

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -544,8 +544,7 @@ copy_common_archive_configs() {
   cp ./default/src/app/replayer/replayer.exe \
     "${BUILDDIR}/usr/local/bin/mina-replayer"
 
-  cp ../src/app/archive/create_schema.sql "${BUILDDIR}/etc/mina/archive"
-  cp ../src/app/archive/drop_tables.sql "${BUILDDIR}/etc/mina/archive"
+  rsync -Huav ../src/app/archive/*.sql "${BUILDDIR}/etc/mina/archive"
 
   build_deb "$ARCHIVE_DEB"
 }

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -9,6 +9,7 @@
 #   - Starts a Mina Rosetta Docker container with specified network configuration
 #   - Runs sanity tests to verify basic connectivity and synchronization
 #   - Optionally runs load tests to stress-test the Rosetta API
+#   - Optionally runs compatibility tests to verify schema upgrade functionality
 #   - Automatically cleans up Docker resources on completion or error
 #
 # REQUIREMENTS:
@@ -21,11 +22,13 @@
 #   -n, --network       Network configuration: devnet or mainnet (default: devnet)
 #   --timeout           Timeout duration in seconds for tests (default: 900)
 #   --run-load-test     Enable load testing (default: false)
+#   --run-compatibility-test  Enable compatibility testing with specified branch
 #   -h, --help          Display usage information
 #
 # EXAMPLES:
 #   ./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --network devnet
 #   ./rosetta-connectivity.sh --tag 3.0.3 --network mainnet --run-load-test --timeout 1200
+#   ./rosetta-connectivity.sh --tag 3.0.3 --run-compatibility-test develop
 #
 # EXIT CODES:
 #   0 - Success
@@ -40,16 +43,21 @@
 set -x
 CLEAR='\033[0m'
 RED='\033[0;31m'
+GREEN='\033[0;32m'
 
 NETWORK=devnet
 TIMEOUT=900
+DB_CONN_STR="postgres://pguser:pguser@localhost:5432/archive"
 
 LOAD_TEST_DURATION=600
 RUN_LOAD_TEST=false
+RUN_COMPATIBILITY_TEST=false
+COMPATIBILITY_BRANCH=""
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   -n|--network) NETWORK="$2"; shift;;
   --run-load-test) RUN_LOAD_TEST=true ;;
+  --run-compatibility-test) RUN_COMPATIBILITY_TEST=true; COMPATIBILITY_BRANCH="$2"; shift;;
   -t|--tag) TAG="$2"; shift;;
   --timeout) TIMEOUT="$2"; shift;;
   -h|--help) usage; exit 0;;
@@ -65,9 +73,11 @@ function usage() {
   echo "  -t, --version             The version to be used in the docker image tag"
   echo "  -n, --network             The network configuration to use (devnet or mainnet). Default=$NETWORK"
   echo "  --timeout                 The timeout duration in seconds. Default=$TIMEOUT"
+  echo "  --run-compatibility-test  Enable compatibility testing with specified branch"
   echo "  -h, --help                Show help"
   echo ""
   echo "Example: $0 --network devnet --tag 3.0.3-bullseye-berkeley "
+  echo "Example: $0 --network devnet --tag 3.0.3 --run-compatibility-test develop"
   echo ""
   echo "Warning:"
   echo "Please execute this script from the root of the mina repository."
@@ -75,6 +85,10 @@ function usage() {
 }   
 
 if [[ -z "$TAG" ]]; then usage "Docker tag is not set!"; usage; exit 1; fi;
+if [[ "$RUN_COMPATIBILITY_TEST" == true && -z "$COMPATIBILITY_BRANCH" ]]; then
+    usage "Compatibility branch is required when running compatibility test!";
+    exit 1;
+fi;
 
 container_id=$(docker run -v .:/workdir -p 3087:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
 
@@ -92,9 +106,55 @@ sleep 5
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
     echo "Running load test for $LOAD_TEST_DURATION seconds..."
-    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str postgres://pguser:pguser@localhost:5432/archive --duration $LOAD_TEST_DURATION --network $NETWORK "
+    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str $DB_CONN_STR --duration $LOAD_TEST_DURATION --network $NETWORK "
 else
     echo "Skipping load test."
+fi
+
+# Run compatibility test
+if [[ "$RUN_COMPATIBILITY_TEST" == true ]]; then
+    echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
+
+    # Check if there are schema differences
+    if buildkite/scripts/archive/upgrade-script-check.sh --mode conditional --branch "$COMPATIBILITY_BRANCH"; then
+        echo -e "${GREEN}No schema differences found. Compatibility test passed.${CLEAR}"
+    else
+        echo "Schema differences detected. Running upgrade script..."
+
+        # Get initial block count
+        initial_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+
+        # Apply upgrade script
+        if docker exec $container_id bash -c "/workdir/src/app/archive/upgrade-to-mesa.sh $DB_CONN_STR"; then
+            echo "Upgrade script applied successfully. Waiting for new blocks..."
+
+            # Wait for new blocks with timeout
+            timeout_counter=0
+            max_wait=300  # 5 minutes
+
+            while [[ $timeout_counter -lt $max_wait ]]; do
+                current_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+
+                if [[ "$current_blocks" -gt "$initial_blocks" ]]; then
+                    echo -e "${GREEN}New blocks detected after upgrade. Compatibility test passed.${CLEAR}"
+                    break
+                fi
+
+                sleep 10
+                timeout_counter=$((timeout_counter + 10))
+            done
+
+            if [[ $timeout_counter -ge $max_wait ]]; then
+                echo -e "${RED}Timeout waiting for new blocks. Compatibility test failed.${CLEAR}"
+                exit 1
+            fi
+        else
+            echo -e "${RED}Upgrade script failed. Compatibility test failed.${CLEAR}"
+            exit 1
+        fi
+    fi
+else
+    echo "Skipping compatibility test."
 fi
 
 stop_docker

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -163,8 +163,8 @@ fi
 if [[ "$RUN_COMPATIBILITY_TEST" == true ]]; then
         echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
 
-        upgrade_script_path="/etc/mina/archive/upgrade-to-mesa.sh"
-        rollback_script_path="/etc/mina/archive/downgrade-to-berkeley.sh"
+        upgrade_script_path="/etc/mina/archive/upgrade-to-mesa.sql"
+        rollback_script_path="/etc/mina/archive/downgrade-to-berkeley.sql"
 
         # Get initial block count
         initial_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -107,7 +107,7 @@ wait_for_new_blocks() {
         local previous_blocks=$1
         local test_name=$2
         local timeout_counter=0
-        local max_wait=300  # 5 minutes
+        local max_wait=600  # 10 minutes
 
         echo "Waiting for new blocks after $test_name..."
 

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -23,12 +23,14 @@
 #   --timeout           Timeout duration in seconds for tests (default: 900)
 #   --run-load-test     Enable load testing (default: false)
 #   --run-compatibility-test  Enable compatibility testing with specified branch
+#   --upgrade-scripts-workdir  Working directory for upgrade/downgrade scripts (default: src/app/archive)
 #   -h, --help          Display usage information
 #
 # EXAMPLES:
 #   ./rosetta-connectivity.sh --tag 3.0.3-bullseye-berkeley --network devnet
 #   ./rosetta-connectivity.sh --tag 3.0.3 --network mainnet --run-load-test --timeout 1200
 #   ./rosetta-connectivity.sh --tag 3.0.3 --run-compatibility-test develop
+#   ./rosetta-connectivity.sh --tag 3.0.3 --run-compatibility-test develop --upgrade-scripts-workdir /custom/path
 #
 # EXIT CODES:
 #   0 - Success
@@ -39,7 +41,6 @@
 #   - Container runs on port 3087 and mounts current directory as /workdir
 #   - Load test duration is fixed at 600 seconds when enabled
 
-
 set -x
 CLEAR='\033[0m'
 RED='\033[0;31m'
@@ -48,6 +49,7 @@ GREEN='\033[0;32m'
 NETWORK=devnet
 TIMEOUT=900
 DB_CONN_STR="postgres://pguser:pguser@localhost:5432/archive"
+UPGRADE_SCRIPTS_WORKDIR="src/app/archive"
 
 LOAD_TEST_DURATION=600
 RUN_LOAD_TEST=false
@@ -55,48 +57,89 @@ RUN_COMPATIBILITY_TEST=false
 COMPATIBILITY_BRANCH=""
 
 while [[ "$#" -gt 0 ]]; do case $1 in
-  -n|--network) NETWORK="$2"; shift;;
-  --run-load-test) RUN_LOAD_TEST=true ;;
-  --run-compatibility-test) RUN_COMPATIBILITY_TEST=true; COMPATIBILITY_BRANCH="$2"; shift;;
-  -t|--tag) TAG="$2"; shift;;
-  --timeout) TIMEOUT="$2"; shift;;
-  -h|--help) usage; exit 0;;
-  *) echo "Unknown parameter passed: $1"; usage; exit 1;;
+    -n|--network) NETWORK="$2"; shift;;
+    --run-load-test) RUN_LOAD_TEST=true ;;
+    --run-compatibility-test) RUN_COMPATIBILITY_TEST=true; COMPATIBILITY_BRANCH="$2"; shift;;
+    -t|--tag) TAG="$2"; shift;;
+    --timeout) TIMEOUT="$2"; shift;;
+    --upgrade-scripts-workdir) UPGRADE_SCRIPTS_WORKDIR="$2"; shift;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown parameter passed: $1"; usage; exit 1;;
 esac; shift; done
 
-
 function usage() {
-  if [[ -n "$1" ]]; then
-    echo -e "${RED}☞  $1${CLEAR}\n";
-  fi
-  echo "Usage: $0 [-t docker-tag] [-n network]"
-  echo "  -t, --version             The version to be used in the docker image tag"
-  echo "  -n, --network             The network configuration to use (devnet or mainnet). Default=$NETWORK"
-  echo "  --timeout                 The timeout duration in seconds. Default=$TIMEOUT"
-  echo "  --run-compatibility-test  Enable compatibility testing with specified branch"
-  echo "  -h, --help                Show help"
-  echo ""
-  echo "Example: $0 --network devnet --tag 3.0.3-bullseye-berkeley "
-  echo "Example: $0 --network devnet --tag 3.0.3 --run-compatibility-test develop"
-  echo ""
-  echo "Warning:"
-  echo "Please execute this script from the root of the mina repository."
-  echo ""
+    if [[ -n "$1" ]]; then
+        echo -e "${RED}☞  $1${CLEAR}\n";
+    fi
+    echo "Usage: $0 [-t docker-tag] [-n network]"
+    echo "  -t, --version             The version to be used in the docker image tag"
+    echo "  -n, --network             The network configuration to use (devnet or mainnet). Default=$NETWORK"
+    echo "  --timeout                 The timeout duration in seconds. Default=$TIMEOUT"
+    echo "  --run-compatibility-test  Enable compatibility testing with specified branch"
+    echo "  --upgrade-scripts-workdir Working directory for upgrade/downgrade scripts. Default=$UPGRADE_SCRIPTS_WORKDIR"
+    echo "  -h, --help                Show help"
+    echo ""
+    echo "Example: $0 --network devnet --tag 3.0.3-bullseye-berkeley "
+    echo "Example: $0 --network devnet --tag 3.0.3 --run-compatibility-test develop"
+    echo "Example: $0 --network devnet --tag 3.0.3 --run-compatibility-test develop --upgrade-scripts-workdir /custom/path"
+    echo ""
+    echo "Warning:"
+    echo "Please execute this script from the root of the mina repository."
+    echo ""
 }   
 
 if [[ -z "$TAG" ]]; then usage "Docker tag is not set!"; usage; exit 1; fi;
 if [[ "$RUN_COMPATIBILITY_TEST" == true && -z "$COMPATIBILITY_BRANCH" ]]; then
-    usage "Compatibility branch is required when running compatibility test!";
-    exit 1;
+        usage "Compatibility branch is required when running compatibility test!";
+        exit 1;
 fi;
 
 container_id=$(docker run -v .:/workdir -p 3087:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
 
 stop_docker() {
-    { docker stop "$container_id" ; docker rm "$container_id" ; } || true
+        { docker stop "$container_id" ; docker rm "$container_id" ; } || true
 }
 
 trap stop_docker ERR
+
+# Function to wait for new blocks
+wait_for_new_blocks() {
+        local previous_blocks=$1
+        local test_name=$2
+        local timeout_counter=0
+        local max_wait=300  # 5 minutes
+
+        echo "Waiting for new blocks after $test_name..."
+
+        while [[ $timeout_counter -lt $max_wait ]]; do
+                current_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+
+                if [[ "$current_blocks" -gt "$previous_blocks" ]]; then
+                        echo -e "${GREEN}New blocks detected after $test_name. Test passed.${CLEAR}"
+                        return 0
+                fi
+
+                sleep 10
+                timeout_counter=$((timeout_counter + 10))
+        done
+
+        echo -e "${RED}Timeout waiting for new blocks after $test_name. Test failed.${CLEAR}"
+        exit 1
+}
+
+# Function to execute upgrade/rollback operations
+execute_operation() {
+        local operation=$1
+        local operation_name=$2
+
+        if docker exec $container_id bash -c "$UPGRADE_SCRIPTS_WORKDIR/$operation $DB_CONN_STR"; then
+                echo "$operation_name completed successfully."
+                return 0
+        else
+                echo -e "${RED}$operation_name failed.${CLEAR}"
+                exit 1
+        fi
+}
 
 # Wait for the container to start
 sleep 5
@@ -105,56 +148,49 @@ sleep 5
 
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
-    echo "Running load test for $LOAD_TEST_DURATION seconds..."
-    docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str $DB_CONN_STR --duration $LOAD_TEST_DURATION --network $NETWORK "
+        echo "Running load test for $LOAD_TEST_DURATION seconds..."
+        docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str $DB_CONN_STR --duration $LOAD_TEST_DURATION --network $NETWORK "
 else
-    echo "Skipping load test."
+        echo "Skipping load test."
 fi
 
 # Run compatibility test
 if [[ "$RUN_COMPATIBILITY_TEST" == true ]]; then
-    echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
+        echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
 
-    # Check if there are schema differences
-    if buildkite/scripts/archive/upgrade-script-check.sh --mode conditional --branch "$COMPATIBILITY_BRANCH"; then
-        echo -e "${GREEN}No schema differences found. Compatibility test passed.${CLEAR}"
-    else
-        echo "Schema differences detected. Running upgrade script..."
-
-        # Get initial block count
-        initial_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
-
-        # Apply upgrade script
-        if docker exec $container_id bash -c "/workdir/src/app/archive/upgrade-to-mesa.sh $DB_CONN_STR"; then
-            echo "Upgrade script applied successfully. Waiting for new blocks..."
-
-            # Wait for new blocks with timeout
-            timeout_counter=0
-            max_wait=300  # 5 minutes
-
-            while [[ $timeout_counter -lt $max_wait ]]; do
-                current_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
-
-                if [[ "$current_blocks" -gt "$initial_blocks" ]]; then
-                    echo -e "${GREEN}New blocks detected after upgrade. Compatibility test passed.${CLEAR}"
-                    break
-                fi
-
-                sleep 10
-                timeout_counter=$((timeout_counter + 10))
-            done
-
-            if [[ $timeout_counter -ge $max_wait ]]; then
-                echo -e "${RED}Timeout waiting for new blocks. Compatibility test failed.${CLEAR}"
-                exit 1
-            fi
+        # Check if there are schema differences
+        if buildkite/scripts/archive/upgrade-script-check.sh --mode conditional --branch "$COMPATIBILITY_BRANCH"; then
+                echo -e "${GREEN}No schema differences found. Compatibility test passed.${CLEAR}"
         else
-            echo -e "${RED}Upgrade script failed. Compatibility test failed.${CLEAR}"
-            exit 1
+                echo "Schema differences detected. Running upgrade/rollback test cycle..."
+
+                # Get initial block count
+                initial_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+
+                # Test 1: Double upgrade test
+                echo "Test 1: Running double upgrade test..."
+                execute_operation "upgrade-to-mesa.sh" "First upgrade"
+                execute_operation "upgrade-to-mesa.sh" "Second upgrade (should handle already upgraded state)"
+                wait_for_new_blocks "$initial_blocks" "double upgrade"
+
+                # Test 2: Rollback and upgrade test
+                echo "Test 2: Running rollback and upgrade test..."
+                execute_operation "rollback-from-mesa.sh" "Rollback"
+                rollback_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+                execute_operation "upgrade-to-mesa.sh" "Upgrade after rollback"
+                wait_for_new_blocks "$rollback_blocks" "rollback and upgrade"
+
+                # Test 3: Second rollback and upgrade test
+                echo "Test 3: Running second rollback and upgrade test..."
+                execute_operation "rollback-from-mesa.sh" "Second rollback"
+                second_rollback_blocks=$(docker exec $container_id bash -c "psql $DB_CONN_STR -t -c 'SELECT COUNT(*) FROM blocks;'" | tr -d ' ')
+                execute_operation "upgrade-to-mesa.sh" "Second upgrade after rollback"
+                wait_for_new_blocks "$second_rollback_blocks" "second rollback and upgrade"
+
+                echo -e "${GREEN}All compatibility tests completed successfully.${CLEAR}"
         fi
-    fi
 else
-    echo "Skipping compatibility test."
+        echo "Skipping compatibility test."
 fi
 
 stop_docker

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -149,7 +149,12 @@ sleep 5
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then
         echo "Running load test for $LOAD_TEST_DURATION seconds..."
-        docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str $DB_CONN_STR --duration $LOAD_TEST_DURATION --network $NETWORK "
+        if docker exec $container_id bash -c "/workdir/scripts/tests/rosetta-load.sh --address \"http://localhost:3087\" --db-conn-str $DB_CONN_STR --duration $LOAD_TEST_DURATION --network $NETWORK "; then
+                echo -e "${GREEN}Load test completed successfully.${CLEAR}"
+        else
+                echo -e "${RED}Load test failed.${CLEAR}"
+                exit 1
+        fi
 else
         echo "Skipping load test."
 fi
@@ -159,7 +164,7 @@ if [[ "$RUN_COMPATIBILITY_TEST" == true ]]; then
         echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
 
         # Check if there are schema differences
-        if buildkite/scripts/archive/upgrade-script-check.sh --mode conditional --branch "$COMPATIBILITY_BRANCH"; then
+        if buildkite/scripts/archive/upgrade-script-check.sh --mode default --branch "$COMPATIBILITY_BRANCH"; then
                 echo -e "${GREEN}No schema differences found. Compatibility test passed.${CLEAR}"
         else
                 echo "Schema differences detected. Running upgrade/rollback test cycle..."


### PR DESCRIPTION
Adding test step to rosetta devnet connectivity test. 

We are checking if upgraded database is backward compatible and still can accept blocks from berkeley. We are also doing upgrade rollback couple times to ensure script won't cause irreversible changes

How to test:

Run locally script with some already built docker tag:

```
"scripts/tests/rosetta-connectivity.sh --network devnet--tag ${TAG} --timeout 900  --run-compatibility-test develop"
```

Where TAG can be for example : `3.3.0-alpha1-dkijania-archive-compatibility-test-8795846-bullseye-devnet`

Closes #17745