### PR TITLE
Fix and prettify child processs unit tests

### DIFF
--- a/src/lib/child_processes/tester.sh
+++ b/src/lib/child_processes/tester.sh
@@ -8,13 +8,12 @@ for _ in $(seq 1 10)
 do
     echo hello
     echo '{"timestamp":"2019-10-22 00:41:37.963244Z","level":"Info","source":{"module":"Test_script","location":"File \"src/lib/child_processes/tester.sh\", line 321, characters 11-98"},"message":"test of json logging passthrough","metadata":{}}' 1>&2
-    sleep 0.1
 done
 
 if [ "$1" = "loop" ]
 then
     while true
     do
-        sleep 100
+        sleep 999999
     done
 fi

--- a/src/lib/child_processes/tester.sh
+++ b/src/lib/child_processes/tester.sh
@@ -12,8 +12,5 @@ done
 
 if [ "$1" = "loop" ]
 then
-    while true
-    do
-        sleep 999999
-    done
+    sleep infinity
 fi


### PR DESCRIPTION
This PR touches on Child process module:
- Simplifies use of Let_syntax with Async in some unit test 
- Fix a bug where output is not produced per line
- Do not repeatedly check for lockfile existence

Here's an example of failing dev unit test:

https://buildkite.com/organizations/o-1-labs-2/pipelines/mina-o-1-labs/builds/38968/jobs/01991f76-95ae-4b8e-851e-d2b686881d15/log