### PR TITLE
Merge `compatible` -> `develop` (08 Sep 2025)

### DIFF
--- a/buildkite/scripts/debian/update.sh
+++ b/buildkite/scripts/debian/update.sh
@@ -29,8 +29,7 @@ APT_SOURCES_DIR="/etc/apt/sources.list.d"
 export DEBIAN_FRONTEND=noninteractive
 
 # Configuration
-BLACKLISTED_REPOS=( helm-stable-debian.list )  # Default blacklisted repositories
-# BLACKLISTED_REPOS=()  # Uncomment to start with no blacklisted repos
+BLACKLISTED_REPOS=()  # Uncomment to start with no blacklisted repos
 VERBOSE=false
 DRY_RUN=false
 SUDO_CMD=""

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -1,7 +1,3 @@
-let B = ../External/Buildkite.dhall
-
-let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-
 let Artifacts = ../Constants/Artifacts.dhall
 
 let Command = ./Base.dhall
@@ -35,7 +31,6 @@ in  { step =
               , label = "Archive: Node Test"
               , key = key
               , target = Size.Large
-              , soft_fail = Some (B/SoftFail.Boolean True)
               , depends_on = dependsOn
               }
     }

--- a/buildkite/src/Command/MinaArtifactToolchain.dhall
+++ b/buildkite/src/Command/MinaArtifactToolchain.dhall
@@ -1,0 +1,41 @@
+let Pipeline = ../Pipeline/Dsl.dhall
+
+let PipelineTag = ../Pipeline/Tag.dhall
+
+let JobSpec = ../Pipeline/JobSpec.dhall
+
+let S = ../Lib/SelectFiles.dhall
+
+let DockerImage = ../Command/DockerImage.dhall
+
+let DebianVersions = ../Constants/DebianVersions.dhall
+
+let Arch = ../Constants/Arch.dhall
+
+let toolchainPipeline =
+          \(spec : DockerImage.ReleaseSpec.Type)
+      ->  Pipeline.build
+            Pipeline.Config::{
+            , spec = JobSpec::{
+              , dirtyWhen =
+                [ S.strictlyStart (S.contains "dockerfiles/stages/1-")
+                , S.strictlyStart (S.contains "dockerfiles/stages/2-")
+                , S.strictlyStart (S.contains "dockerfiles/stages/3-")
+                , S.strictlyStart
+                    ( S.contains
+                        "buildkite/src/Jobs/Release/MinaToolchainArtifact"
+                    )
+                , S.strictly (S.contains "opam.export")
+                , S.strictlyEnd (S.contains "rust-toolchain.toml")
+                ]
+              , path = "Release"
+              , name =
+                  "MinaToolchainArtifact${DebianVersions.capitalName
+                                            spec.deb_codename}${Arch.nameSuffix
+                                                                  spec.arch}"
+              , tags = [ PipelineTag.Type.Toolchain ]
+              }
+            , steps = [ DockerImage.generateStep spec ]
+            }
+
+in  { pipeline = toolchainPipeline }

--- a/buildkite/src/Command/Packages/VerifyDockers.dhall
+++ b/buildkite/src/Command/Packages/VerifyDockers.dhall
@@ -14,6 +14,8 @@ let Artifact = ../../Constants/Artifacts.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
+let Arch = ../../Constants/Arch.dhall
+
 let Spec =
       { Type =
           { artifacts : List Artifact.Type
@@ -22,6 +24,7 @@ let Spec =
           , codenames : List DebianVersions.DebVersion
           , published_to_docker_io : Bool
           , suffix : Optional Text
+          , arch : Arch.Type
           }
       , default =
           { artifacts = [] : List Package.Type
@@ -32,6 +35,7 @@ let Spec =
             ]
           , published_to_docker_io = False
           , suffix = None Text
+          , arch = Arch.Type.Amd64
           }
       }
 
@@ -68,17 +72,38 @@ let joinCodenames
 let verify
     : Spec.Type -> Text
     =     \(spec : Spec.Type)
-      ->      ". ./buildkite/scripts/export-git-env-vars.sh && "
-          ++  "./buildkite/scripts/release/manager.sh verify "
-          ++  "--artifacts ${joinArtifacts spec} "
-          ++  "--networks ${joinNetworks spec} "
-          ++  "--version ${spec.version} "
-          ++  "--codenames ${joinCodenames spec} "
-          ++  merge
-                { None = ""
-                , Some = \(suffix : Text) -> "--docker-suffix ${suffix} "
-                }
-                spec.suffix
-          ++  "--only-dockers "
+      ->  let arch = Arch.toOptional spec.arch
+
+          let suffixAndArchFlag =
+                let archFlag =
+                      Prelude.Optional.map
+                        Text
+                        Text
+                        (\(archValue : Text) -> "--arch ${archValue} ")
+                        arch
+
+                let suffixFlag =
+                      Prelude.Optional.map
+                        Text
+                        Text
+                        (\(suffix : Text) -> "--docker-suffix ${suffix} ")
+                        spec.suffix
+
+                in      Prelude.Optional.default Text "" archFlag
+                    ++  Prelude.Optional.default Text "" suffixFlag
+
+          in      ". ./buildkite/scripts/export-git-env-vars.sh && "
+              ++  "./buildkite/scripts/release/manager.sh verify "
+              ++  suffixAndArchFlag
+              ++  "--artifacts ${joinArtifacts spec} "
+              ++  "--networks ${joinNetworks spec} "
+              ++  "--version ${spec.version} "
+              ++  "--codenames ${joinCodenames spec} "
+              ++  merge
+                    { None = ""
+                    , Some = \(suffix : Text) -> "--docker-suffix ${suffix} "
+                    }
+                    spec.suffix
+              ++  "--only-dockers "
 
 in  { verify = verify, Spec = Spec }

--- a/buildkite/src/Command/RunInToolchain.dhall
+++ b/buildkite/src/Command/RunInToolchain.dhall
@@ -4,6 +4,8 @@ let Mina = ../Command/Mina.dhall
 
 let ContainerImages = ../Constants/ContainerImages.dhall
 
+let Arch = ../Constants/Arch.dhall
+
 let runInToolchainImage
     : Text -> List Text -> Text -> List Cmd.Type
     =     \(image : Text)
@@ -16,38 +18,49 @@ let runInToolchainImage
             ]
 
 let runInToolchainNoble
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
+    : Arch.Type -> List Text -> Text -> List Cmd.Type
+    =     \(arch : Arch.Type)
+      ->  \(environment : List Text)
       ->  \(innerScript : Text)
-      ->  runInToolchainImage
-            ContainerImages.minaToolchainNoble
-            environment
-            innerScript
+      ->  let image =
+                merge
+                  { Amd64 = ContainerImages.minaToolchainNoble.amd64
+                  , Arm64 = ContainerImages.minaToolchainNoble.arm64
+                  }
+                  arch
+
+          in  runInToolchainImage image environment innerScript
 
 let runInToolchainJammy
     : List Text -> Text -> List Cmd.Type
     =     \(environment : List Text)
       ->  \(innerScript : Text)
       ->  runInToolchainImage
-            ContainerImages.minaToolchainJammy
+            ContainerImages.minaToolchainJammy.amd64
             environment
             innerScript
 
 let runInToolchainBookworm
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
+    : Arch.Type -> List Text -> Text -> List Cmd.Type
+    =     \(arch : Arch.Type)
+      ->  \(environment : List Text)
       ->  \(innerScript : Text)
-      ->  runInToolchainImage
-            ContainerImages.minaToolchainBookworm
-            environment
-            innerScript
+      ->  let image =
+                merge
+                  { Amd64 = ContainerImages.minaToolchainBookworm.amd64
+                  , Arm64 = ContainerImages.minaToolchainBookworm.arm64
+                  }
+                  arch
+
+          in  runInToolchainImage image environment innerScript
 
 let runInToolchainBullseye
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
+    : Arch.Type -> List Text -> Text -> List Cmd.Type
+    =     \(arch : Arch.Type)
+      ->  \(environment : List Text)
       ->  \(innerScript : Text)
       ->  runInToolchainImage
-            ContainerImages.minaToolchainBullseye
+            ContainerImages.minaToolchainBullseye.amd64
             environment
             innerScript
 

--- a/buildkite/src/Constants/Arch.dhall
+++ b/buildkite/src/Constants/Arch.dhall
@@ -1,0 +1,54 @@
+let Arch
+    : Type
+    = < Amd64 | Arm64 >
+
+let capitalName =
+      \(artifact : Arch) -> merge { Amd64 = "Amd64", Arm64 = "Arm64" } artifact
+
+let lowerName =
+      \(artifact : Arch) -> merge { Amd64 = "amd64", Arm64 = "arm64" } artifact
+
+let system =
+          \(artifact : Arch)
+      ->  merge { Amd64 = "x86_64", Arm64 = "aarch64" } artifact
+
+let labelSuffix =
+      \(artifact : Arch) -> merge { Amd64 = "", Arm64 = " Arm64" } artifact
+
+let nameSuffix =
+      \(artifact : Arch) -> merge { Amd64 = "", Arm64 = "Arm64" } artifact
+
+let toSuffixUppercase =
+      \(artifact : Arch) -> merge { Amd64 = "", Arm64 = "-Arm64" } artifact
+
+let toSuffixLowercase =
+      \(artifact : Arch) -> merge { Amd64 = "", Arm64 = "-arm64" } artifact
+
+let platform =
+          \(artifact : Arch)
+      ->  merge { Amd64 = "linux/amd64", Arm64 = "linux/arm64" } artifact
+
+let toOptionalSuffixLowercase =
+          \(artifact : Arch)
+      ->  merge
+            { Amd64 = None Text, Arm64 = Some (toSuffixLowercase artifact) }
+            artifact
+
+let toOptional =
+          \(artifact : Arch)
+      ->  merge
+            { Amd64 = None Text, Arm64 = Some (lowerName artifact) }
+            artifact
+
+in  { Type = Arch
+    , capitalName = capitalName
+    , lowerName = lowerName
+    , nameSuffix = nameSuffix
+    , labelSuffix = labelSuffix
+    , system = system
+    , platform = platform
+    , toSuffixUppercase = toSuffixUppercase
+    , toSuffixLowercase = toSuffixLowercase
+    , toOptionalSuffixLowercase = toOptionalSuffixLowercase
+    , toOptional = toOptional
+    }

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,15 +4,23 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 { toolchainBase = "codaprotocol/ci-toolchain-base:v3"
 , minaToolchainBookworm =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:33275bbe44bb8e5b2678d1482705f964df3b37e2540a43ef9a1d92433b795f83"
-, minaToolchainBullseye =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:3b17e388d8974fdbe4bbd5f77315519763c78148a4c91434d9add62de87ab792"
+    { arm64 =
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:2578d7b35ef404d6da31179e2d6012e1e451d6254b214c0ecddeb9d281c66195"
+    , amd64 =
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:7473e25c4ab2da533cda28aa31990ed040b9a391e061eb266b4809682fec96a3"
+    }
+, minaToolchainBullseye.amd64 =
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:eefb87b7a0510285fe9d6224bb25968fc451cc03e653129bd11b5a97ea7d8d61"
 , minaToolchainNoble =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:4a2483e94a4bcf03b82e511a4f1ef926659b3c6c42e31e03c0b9765a12225ac1"
-, minaToolchainJammy =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:78486314cf93bafb7e5f8f8be92ade269ad94c311cb9a92fb4b0bcaf0348c385"
+    { arm64 =
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:09f907d15e279e646b9c4cc0182d458befb605a7832d82be40aa3f0e92b9b842"
+    , amd64 =
+        "gcr.io/o1labs-192920/mina-toolchain@sha256:18ae9bef88d9ac769aa48de7ab80909131cf8d307d7eb1bc61d47be15ae534f2"
+    }
+, minaToolchainJammy.amd64 =
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:37d201999d9a4b0f6a112089dde673cd58ddb69ba8b96072f36be6ea5a9008d1"
 , minaToolchain =
-    "gcr.io/o1labs-192920/mina-toolchain@sha256:3b17e388d8974fdbe4bbd5f77315519763c78148a4c91434d9add62de87ab792"
+    "gcr.io/o1labs-192920/mina-toolchain@sha256:eefb87b7a0510285fe9d6224bb25968fc451cc03e653129bd11b5a97ea7d8d61"
 , postgres = "postgres:12.4-alpine"
 , xrefcheck =
     "dkhamsing/awesome_bot@sha256:a8adaeb3b3bd5745304743e4d8a6d512127646e420544a6d22d9f58a07f35884"

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -4,6 +4,8 @@ let Network = ./Network.dhall
 
 let BuildFlags = ./BuildFlags.dhall
 
+let Arch = ./Arch.dhall
+
 let S = ../Lib/SelectFiles.dhall
 
 let DebVersion = < Bookworm | Bullseye | Jammy | Focal | Noble >
@@ -38,6 +40,7 @@ let DepsSpec =
           , build_flag : BuildFlags.Type
           , step : Text
           , prefix : Text
+          , arch : Arch.Type
           }
       , default =
           { deb_version = DebVersion.Bullseye
@@ -46,6 +49,7 @@ let DepsSpec =
           , build_flag = BuildFlags.Type.None
           , step = "build"
           , prefix = "MinaArtifact"
+          , arch = Arch.Type.Amd64
           }
       }
 
@@ -57,7 +61,8 @@ let dependsOn =
                 "${spec.prefix}${capitalName
                                    spec.deb_version}${Network.capitalName
                                                         spec.network}${profileSuffix}${BuildFlags.toSuffixUppercase
-                                                                                         spec.build_flag}"
+                                                                                         spec.build_flag}${Arch.nameSuffix
+                                                                                                             spec.arch}"
 
           in  [ { name = name, key = "${spec.step}-deb-pkg" } ]
 
@@ -66,6 +71,7 @@ let minimalDirtyWhen =
       , S.exactly "buildkite/src/Constants/ContainerImages" "dhall"
       , S.exactly "buildkite/src/Command/MinaArtifact" "dhall"
       , S.exactly "buildkite/src/Command/PatchArchiveTest" "dhall"
+      , S.exactly "buildkite/src/Command/ArchiveNodeTest" "dhall"
       , S.exactly "buildkite/src/Command/Bench/Base" "dhall"
       , S.strictlyStart (S.contains "scripts/benchmarks")
       , S.strictlyStart (S.contains "buildkite/scripts/bench")

--- a/buildkite/src/Constants/Toolchain.dhall
+++ b/buildkite/src/Constants/Toolchain.dhall
@@ -2,46 +2,33 @@ let DebianVersions = ./DebianVersions.dhall
 
 let RunInToolchain = ../Command/RunInToolchain.dhall
 
-let ContainerImages = ./ContainerImages.dhall
+let Arch = ./Arch.dhall
 
 let SelectionMode
     : Type
-    = < ByDebian | Custom : Text >
+    = < ByDebianAndArch | Custom : Text >
 
 let runner =
           \(debVersion : DebianVersions.DebVersion)
+      ->  \(arch : Arch.Type)
       ->  merge
-            { Bookworm = RunInToolchain.runInToolchainBookworm
+            { Bookworm = RunInToolchain.runInToolchainBookworm arch
             , Bullseye = RunInToolchain.runInToolchain
             , Jammy = RunInToolchain.runInToolchainJammy
             , Focal = RunInToolchain.runInToolchain
-            , Noble = RunInToolchain.runInToolchainNoble
+            , Noble = RunInToolchain.runInToolchainNoble arch
             }
             debVersion
 
 let select =
           \(mode : SelectionMode)
       ->  \(debVersion : DebianVersions.DebVersion)
+      ->  \(arch : Arch.Type)
       ->  merge
-            { ByDebian = runner debVersion
+            { ByDebianAndArch = runner debVersion arch
             , Custom =
                 \(image : Text) -> RunInToolchain.runInToolchainImage image
             }
             mode
 
-let image =
-          \(debVersion : DebianVersions.DebVersion)
-      ->  merge
-            { Bookworm = ContainerImages.minaToolchainBookworm
-            , Bullseye = ContainerImages.minaToolchain
-            , Jammy = ContainerImages.minaToolchainJammy
-            , Focal = ContainerImages.minaToolchain
-            , Noble = ContainerImages.minaToolchainNoble
-            }
-            debVersion
-
-in  { SelectionMode = SelectionMode
-    , select = select
-    , runner = runner
-    , image = image
-    }
+in  { SelectionMode = SelectionMode, select = select, runner = runner }

--- a/buildkite/src/Jobs/Lint/Dhall.dhall
+++ b/buildkite/src/Jobs/Lint/Dhall.dhall
@@ -71,7 +71,7 @@ in  Pipeline.build
             Command.Config::{
             , commands =
                   [ dump_pipelines_cmd ]
-                # RunInToolchain.runInToolchainBullseye
+                # RunInToolchain.runInToolchain
                     ([] : List Text)
                     "python3 ./buildkite/scripts/dhall/checker.py --root _pipelines deps"
             , label = "Dhall: deps"

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactBookworm.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactBookworm.dhall
@@ -1,42 +1,15 @@
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-let PipelineTag = ../../Pipeline/Tag.dhall
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
-
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let S = ../../Lib/SelectFiles.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec = JobSpec::{
-        , dirtyWhen =
-          [ S.strictlyStart (S.contains "dockerfiles/stages/1-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/2-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/3-")
-          , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Release/MinaToolchainArtifact")
-          , S.strictly (S.contains "opam.export")
-          , S.strictlyEnd (S.contains "rust-toolchain.toml")
-          ]
-        , path = "Release"
-        , name = "MinaToolchainArtifactBookworm"
-        , tags = [ PipelineTag.Type.Toolchain ]
-        }
-      , steps =
-        [ let toolchainBullseyeSpec =
-                DockerImage.ReleaseSpec::{
-                , service = Artifacts.Type.Toolchain
-                , deb_codename = DebianVersions.DebVersion.Bookworm
-                , no_cache = True
-                , no_debian = True
-                }
-
-          in  DockerImage.generateStep toolchainBullseyeSpec
-        ]
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Bookworm
+      , no_cache = True
+      , no_debian = True
       }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactBullseye.dhall
@@ -1,42 +1,15 @@
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-let PipelineTag = ../../Pipeline/Tag.dhall
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
-
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let S = ../../Lib/SelectFiles.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec = JobSpec::{
-        , dirtyWhen =
-          [ S.strictlyStart (S.contains "dockerfiles/stages/1-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/2-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/3-")
-          , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Release/MinaToolchainArtifact")
-          , S.strictly (S.contains "opam.export")
-          , S.strictlyEnd (S.contains "rust-toolchain.toml")
-          ]
-        , path = "Release"
-        , name = "MinaToolchainArtifactBullseye"
-        , tags = [ PipelineTag.Type.Toolchain, PipelineTag.Type.Release ]
-        }
-      , steps =
-        [ let toolchainBullseyeSpec =
-                DockerImage.ReleaseSpec::{
-                , service = Artifacts.Type.Toolchain
-                , deb_codename = DebianVersions.DebVersion.Bullseye
-                , no_cache = True
-                , no_debian = True
-                }
-
-          in  DockerImage.generateStep toolchainBullseyeSpec
-        ]
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Bullseye
+      , no_cache = True
+      , no_debian = True
       }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactFocal.dhall
@@ -1,42 +1,15 @@
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-let PipelineTag = ../../Pipeline/Tag.dhall
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
-
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let S = ../../Lib/SelectFiles.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec = JobSpec::{
-        , dirtyWhen =
-          [ S.strictlyStart (S.contains "dockerfiles/stages/1-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/2-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/3-")
-          , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Release/MinaToolchainArtifact")
-          , S.strictly (S.contains "opam.export")
-          , S.strictlyEnd (S.contains "rust-toolchain.toml")
-          ]
-        , path = "Release"
-        , name = "MinaToolchainArtifactFocal"
-        , tags = [ PipelineTag.Type.Toolchain ]
-        }
-      , steps =
-        [ let toolchainBullseyeSpec =
-                DockerImage.ReleaseSpec::{
-                , service = Artifacts.Type.Toolchain
-                , deb_codename = DebianVersions.DebVersion.Focal
-                , no_cache = True
-                , no_debian = True
-                }
-
-          in  DockerImage.generateStep toolchainBullseyeSpec
-        ]
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Focal
+      , no_cache = True
+      , no_debian = True
       }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactNoble.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactNoble.dhall
@@ -1,42 +1,15 @@
-let Pipeline = ../../Pipeline/Dsl.dhall
-
-let PipelineTag = ../../Pipeline/Tag.dhall
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
 
 let Artifacts = ../../Constants/Artifacts.dhall
-
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let S = ../../Lib/SelectFiles.dhall
 
 let DockerImage = ../../Command/DockerImage.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec = JobSpec::{
-        , dirtyWhen =
-          [ S.strictlyStart (S.contains "dockerfiles/stages/1-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/2-")
-          , S.strictlyStart (S.contains "dockerfiles/stages/3-")
-          , S.strictlyStart
-              (S.contains "buildkite/src/Jobs/Release/MinaToolchainArtifact")
-          , S.strictly (S.contains "opam.export")
-          , S.strictlyEnd (S.contains "rust-toolchain.toml")
-          ]
-        , path = "Release"
-        , name = "MinaToolchainArtifactNoble"
-        , tags = [ PipelineTag.Type.Toolchain ]
-        }
-      , steps =
-        [ let toolchainBullseyeSpec =
-                DockerImage.ReleaseSpec::{
-                , service = Artifacts.Type.Toolchain
-                , deb_codename = DebianVersions.DebVersion.Noble
-                , no_cache = True
-                , no_debian = True
-                }
-
-          in  DockerImage.generateStep toolchainBullseyeSpec
-        ]
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Artifacts.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Noble
+      , no_cache = True
+      , no_debian = True
       }

--- a/changes/17684.md
+++ b/changes/17684.md
@@ -1,0 +1,1 @@
+Adding a cli arg `--hardfork-mode` for `mina daemon`. This CLI arg is for internal use, and would be removed without notice. When enabled, it would try to construct backing database for all relevant ledgers for an operating node in post-mesa-hardfork format.

--- a/dockerfiles/Dockerfile-mina-test-suite
+++ b/dockerfiles/Dockerfile-mina-test-suite
@@ -47,6 +47,7 @@ RUN apt-get update --quiet --yes \
     libssl1.1 \
     tzdata \
     jq \
+    procps \
     sudo \
     wget \
   && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -31,6 +31,7 @@ RUN apt-get update --yes \
     postgresql \
     postgresql-contrib \
     perl \
+    procps \
     python3 \
     python3-pip \
     python3-sexpdata \
@@ -66,13 +67,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     && rm -rf /var/lib/apt/lists/*
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
-
-# --- Helm tools
-RUN curl https://baltocdn.com/helm/signing.asc | apt-key add - \
-    && echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list \
-    && apt-get update --yes \
-    && apt-get install --yes --no-install-recommends helm \
-    && rm -rf /var/lib/apt/lists/*
 
 # --- yarn + nodejs, pinned version
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \

--- a/scripts/debian/aptly.sh
+++ b/scripts/debian/aptly.sh
@@ -48,15 +48,15 @@ function start_aptly() {
     aptly publish snapshot -distribution="${__distribution}" -skip-signing "${__component}"
 
     if [ "${__background}" = 1 ]; then
-        aptly serve -listen localhost:"${__port}" &
+        aptly serve -listen 0.0.0.0:"${__port}" &
     else
-        aptly serve -listen localhost:"${__port}"
+        aptly serve -listen 0.0.0.0:"${__port}"
     fi
 
     if [ $__wait = 1 ]; then
         local __timeout=300
         local __elapsed=0
-        while ! curl -s "http://localhost:$__port" >/dev/null; do
+        while ! curl -s "http://0.0.0.0:$__port" >/dev/null; do
             sleep 1
             __elapsed=$((__elapsed + 1))
             if [ $__elapsed -ge $__timeout ]; then

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -9,6 +9,7 @@ BUILD_URL=${BUILD_URL:-${BUILDKITE_BUILD_URL:-"local build from '$(hostname)' \
 MINA_DEB_CODENAME=${MINA_DEB_CODENAME:-"bullseye"}
 MINA_DEB_VERSION=${MINA_DEB_VERSION:-"0.0.0-experimental"}
 MINA_DEB_RELEASE=${MINA_DEB_RELEASE:-"unstable"}
+ARCHITECTURE=${ARCHITECTURE:-"amd64"}
 
 # Helper script to include when building deb archives.
 
@@ -101,7 +102,7 @@ Label: MinaProtocol
 Vendor: O(1)Labs
 Codename: ${MINA_DEB_CODENAME}
 Suite: ${MINA_DEB_RELEASE}
-Architecture: amd64
+Architecture: ${ARCHITECTURE}
 Maintainer: O(1)Labs <build@o1labs.org>
 Installed-Size:
 Depends: ${2}
@@ -138,13 +139,13 @@ build_deb() {
   # Docker image, we're examining those packages in buildkite's agent, where
   # `zstd` might not be available.
   fakeroot dpkg-deb -Zgzip --build "${BUILDDIR}" \
-    "${1}"_"${MINA_DEB_VERSION}".deb
+    "${1}"_"${MINA_DEB_VERSION}"_"${ARCHITECTURE}".deb
   echo "build_deb outputs:"
   ls -lh "${1}"_*.deb
   echo "deleting BUILDDIR ${BUILDDIR}"
   rm -rf "${BUILDDIR}"
 
-  echo "--- Built ${1}_${MINA_DEB_VERSION}.deb"
+  echo "--- Built ${1}_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb"
 }
 
 # Function to DRY copying config files into daemon packages

--- a/scripts/docker/release.sh
+++ b/scripts/docker/release.sh
@@ -10,6 +10,8 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 # shellcheck disable=SC1090
 source ${SCRIPTPATH}/helper.sh
 
+export INPUT_PLATFORM="linux/amd64"
+
 function usage() {
   echo "Usage: $0 [-s service-to-release] [-v service-version] [-n network]"
   echo "  -s, --service             The Service being released to Dockerhub"
@@ -22,6 +24,7 @@ function usage() {
   echo "      --deb-version         The version string for the debian package to install"
   echo "      --deb-profile         The profile string for the debian package to install"
   echo "      --deb-build-flags     The build-flags string for the debian package to install"
+  echo "      --platform            The architecture to build the docker image for (linux/amd64, linux/arm64). Default=linux/amd64"
   echo ""
   echo "Example: $0 --service faucet --version v0.1.0"
   echo "Valid Services: ${VALID_SERVICES[*]}"
@@ -35,6 +38,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --deb-version) export DEB_VERSION="--build-arg deb_version=$2"; shift;;
   --deb-profile) export DEB_PROFILE="$2"; shift;;
   --deb-build-flags) export DEB_BUILD_FLAGS="$2"; shift;;
+  --platform) export INPUT_PLATFORM="$2"; shift;;
   --help) usage "$@"; exit 0;;
   *) echo "Unknown parameter passed: $1"; usage "$@"; exit 1;;
 esac; shift; done

--- a/scripts/docker/setup_buildx.sh
+++ b/scripts/docker/setup_buildx.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Docker Buildx Multi-Architecture Builder Setup Script
+#
+# This script automates the creation and configuration of Docker Buildx builders
+# for multi-architecture container image builds. It supports different drivers
+# and can optionally install binary format emulation for cross-compilation.
+#
+# USAGE:
+#   ./setup_buildx.sh [BUILDER_NAME]
+#
+# ARGUMENTS:
+#   BUILDER_NAME    Optional name for the buildx builder (default: "xbuilder")
+#
+# ENVIRONMENT VARIABLES:
+#   BUILDX_NAME       Alternative way to set builder name (default: "xbuilder")
+#   DRIVER            Buildx driver to use: docker | docker-container | kubernetes (default: "docker")
+#   ARCHS             Target architectures for binfmt emulation (default: "arm64")
+#   INSTALL_BINFMT    Enable/disable binfmt installation: 1 | 0 (default: "1")
+#
+# EXAMPLES:
+#   # Create default builder with docker driver
+#   ./setup_buildx.sh
+#
+#   # Create custom builder with docker-container driver
+#   DRIVER=docker-container ./setup_buildx.sh mybuilder
+#
+#   # Setup for multiple architectures without binfmt
+#   ARCHS="arm64,amd64" INSTALL_BINFMT=0 ./setup_buildx.sh
+#
+# FEATURES:
+#   - Validates Docker and Buildx availability
+#   - Handles special case for 'docker' driver (uses default builder)
+#   - Creates or reuses existing builders for other drivers
+#   - Bootstraps builder instances
+#   - Installs binfmt emulation for cross-architecture builds
+#   - Provides summary of available builders
+#
+# REQUIREMENTS:
+#   - Docker with Buildx plugin
+#   - Privileged access (for binfmt installation)
+set -euo pipefail
+
+
+
+# Config (override via env or args)
+NAME="${1:-${BUILDX_NAME:-xbuilder}}"
+DRIVER="${DRIVER:-docker}"            # docker | docker-container | kubernetes
+ARCHS="${ARCHS:-arm64}"               # binfmt architectures to install
+INSTALL_BINFMT="${INSTALL_BINFMT:-1}"
+
+command -v docker >/dev/null || { echo "docker not found"; exit 1; }
+docker buildx version >/dev/null 2>&1 || { echo "docker buildx not available"; exit 1; }
+
+# Helper: ensure we are on a given builder
+use_builder () {
+  local b="$1"
+  docker buildx inspect "$b" >/dev/null 2>&1 || { echo "builder '$b' not found"; return 1; }
+  docker buildx use "$b"
+}
+
+# Special case: docker driver can only have ONE instance (the implicit 'default')
+if [[ "$DRIVER" == "docker" ]]; then
+  echo "[buildx] Using 'docker' driver -> switching to existing 'default' builder"
+  use_builder default || {
+    # On some setups 'default' exists but isn't initialized yet; bootstrap via inspect
+    docker buildx create --name default --driver docker --use || true
+    docker buildx inspect default --bootstrap >/dev/null || true
+    docker buildx use default
+  }
+else
+  # For docker-container (recommended) or other drivers: create or reuse NAME
+  if docker buildx inspect "$NAME" >/dev/null 2>&1; then
+    echo "[buildx] Using existing builder: $NAME"
+    docker buildx use "$NAME"
+  else
+    # Clean any stale handle with same name (safe if it doesn't exist)
+    docker buildx rm "$NAME" >/dev/null 2>&1 || true
+    echo "[buildx] Creating builder: $NAME (driver: $DRIVER)"
+    docker buildx create --name "$NAME" --driver "$DRIVER" --use
+  fi
+fi
+
+echo "[buildx] Bootstrapping current builder"
+docker buildx inspect --bootstrap >/dev/null
+
+# Install binfmt only when using docker-container (useful for cross-building)
+CURRENT_BUILDER="$(docker buildx ls | awk '/\*/{gsub(/\*/, "", $1); print $1}')"
+CURRENT_DRIVER="$(docker buildx inspect "$CURRENT_BUILDER" | awk -F': ' '/Driver:/ {print $2}')"
+
+if [[ "$INSTALL_BINFMT" = "1" && "$CURRENT_DRIVER" = "docker-container" ]]; then
+  echo "[binfmt] Ensuring $ARCHS emulation is installed"
+  docker run --privileged --rm tonistiigi/binfmt --install "$ARCHS" >/dev/null
+fi
+
+echo
+echo "[summary]"
+docker buildx ls

--- a/scripts/docker/verify.sh
+++ b/scripts/docker/verify.sh
@@ -45,7 +45,7 @@ DOCKER_PLATFORM="--platform linux/$ARCH"
 
 DOCKER_IMAGE="$REPO/$PACKAGE:$VERSION-${CODENAME}${SUFFIX}${DOCKER_ARCH_SUFFIX}"
 
-if ! docker  pull "$DOCKER_IMAGE" ; then
+if ! docker pull "$DOCKER_IMAGE" ; then
   echo "❌ Docker verification for $CODENAME $PACKAGE $ARCH failed"
   echo "❌ Please check if the image $DOCKER_IMAGE exists."
   exit 1

--- a/scripts/tests/archive-node-test.sh
+++ b/scripts/tests/archive-node-test.sh
@@ -4,8 +4,6 @@ set -x
 
 buildkite/scripts/debian/update.sh --verbose
 
-apt-get install -y procps
-
 # test archive node on known archive db
 NETWORK_DATA_FOLDER=${NETWORK_DATA_FOLDER:-src/test/archive/sample_db}
 ARCHIVE_TEST_APP=${ARCHIVE_TEST_APP:-_build/default/src/test/archive/archive_node_tests/archive_node_tests.exe}
@@ -15,5 +13,4 @@ ARCHIVE_TEST_APP=${ARCHIVE_TEST_APP:-_build/default/src/test/archive/archive_nod
 MINA_TEST_POSTGRES_URI=${POSTGRES_URI:-"postgres://postgres:postgres@localhost:5432"}
 
 echo "Running archive node test"
-echo "WARN: Silencing the errors from the archive node test app. One of the tests is expected to fail."
 MINA_TEST_POSTGRES_URI=$MINA_TEST_POSTGRES_URI $ARCHIVE_TEST_APP -v

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4686,7 +4686,7 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
           Genesis_ledger_helper.init_from_config_file ~logger
             ~proof_level:Genesis_constants.Compiled.proof_level
             ~genesis_constants ~constraint_constants runtime_config
-            ~cli_proof_level:None
+            ~cli_proof_level:None ~genesis_backing_type:Stable_db
         with
         | Ok (precomputed_values, _) ->
             precomputed_values

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -853,7 +853,7 @@ let hash_ledger =
          let packed_ledger =
            Genesis_ledger_helper.Ledger.packed_genesis_ledger_of_accounts
              ~logger:(Logger.create ()) ~depth:constraint_constants.ledger_depth
-             accounts
+             ~genesis_backing_type:Stable_db accounts
          in
          let ledger = Lazy.force @@ Genesis_ledger.Packed.t packed_ledger in
          Format.printf "%s@."
@@ -1854,6 +1854,7 @@ let compile_time_constants =
            >>= Genesis_ledger_helper.init_from_config_file ~genesis_constants
                  ~constraint_constants ~logger:(Logger.null ()) ~proof_level
                  ~cli_proof_level:None ~genesis_dir
+                 ~genesis_backing_type:Stable_db
            >>| Or_error.ok_exn
          in
          let all_constants =
@@ -2371,7 +2372,8 @@ let test_ledger_application =
        Genesis_constants.Compiled.constraint_constants
      in
      let genesis_constants = Genesis_constants.Compiled.genesis_constants in
-     Test_ledger_application.test ~privkey_path ~ledger_path ?prev_block_path
+     Test_ledger_application.test ~privkey_path
+       ~ledger_path:(ledger_path, Stable_db) ?prev_block_path
        ~first_partition_slots ~no_new_stack ~has_second_partition
        ~num_txs_per_round ~rounds ~no_masks ~max_depth ~tracing
        ~transfer_parties_get_actions_events num_txs ~constraint_constants

--- a/src/app/delegation_verify/delegation_verify.ml
+++ b/src/app/delegation_verify/delegation_verify.ml
@@ -62,7 +62,8 @@ let instantiate_verify_functions ~logger ~genesis_constants
           @@ Runtime_config.of_yojson config_json
         in
         Genesis_ledger_helper.init_from_config_file ~logger ~proof_level
-          ~constraint_constants ~genesis_constants config ~cli_proof_level
+          ~constraint_constants ~genesis_constants ~cli_proof_level
+          ~genesis_backing_type:Stable_db config
       in
       let%map.Deferred precomputed_values =
         match precomputed_values with

--- a/src/app/dump_blocks/dump_blocks.ml
+++ b/src/app/dump_blocks/dump_blocks.ml
@@ -82,7 +82,7 @@ let output_block : type a. a -> a codec io -> unit =
 *)
 let f (type a) ?parent (outputs : a codec io list) make_breadcrumb =
   Async.Thread_safe.block_on_async_exn (fun () ->
-      let frontier = create_frontier () in
+      let frontier = create_frontier ~epoch_ledger_backing_type:Stable_db () in
       let root = Full_frontier.root frontier in
       let open Async_kernel.Deferred.Let_syntax in
       let%map breadcrumb = make_breadcrumb root in

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -671,7 +671,8 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           Genesis_ledger_helper.Ledger.load ~proof_level
             ~genesis_dir:
               (Option.value ~default:Cache_dir.autogen_path genesis_dir_opt)
-            ~logger ~constraint_constants input.genesis_ledger
+            ~logger ~constraint_constants ~genesis_backing_type:Stable_db
+            input.genesis_ledger
         with
         | Error e ->
             [%log fatal]

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -26,7 +26,7 @@ let load_ledger ~ignore_missing_fields ~pad_app_state
   in
   let packed =
     Genesis_ledger_helper.Ledger.packed_genesis_ledger_of_accounts ~logger
-      ~depth:constraint_constants.ledger_depth
+      ~depth:constraint_constants.ledger_depth ~genesis_backing_type:Stable_db
       (lazy accounts)
   in
   Lazy.force (Genesis_ledger.Packed.t packed)

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -337,7 +337,7 @@ let test_zkapp_with_genesis_ledger_main keyfile zkapp_keyfile config_file () =
     let packed =
       Genesis_ledger_helper.Ledger.packed_genesis_ledger_of_accounts
         ~logger:(Logger.create ()) ~depth:constraint_constants.ledger_depth
-        accounts
+        ~genesis_backing_type:Stable_db accounts
     in
     Lazy.force (Genesis_ledger.Packed.t packed)
   in

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -146,3 +146,17 @@ let work_selection_method_to_module :
       (module Work_selector.Selection_methods.Random)
   | Random_offset ->
       (module Work_selector.Selection_methods.Random_offset)
+
+module Hardfork_mode = struct
+  type t = Auto | Legacy
+
+  let of_string = function
+    | "auto" ->
+        Auto
+    | "legacy" ->
+        Legacy
+    | _ ->
+        failwith "Invalid hardfork mode"
+
+  let arg = Command.Arg_type.map Command.Param.string ~f:of_string
+end

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -328,12 +328,14 @@ module type S = sig
       type t [@@deriving to_yojson]
 
       val create :
-           Signature_lib.Public_key.Compressed.Set.t
-        -> context:(module CONTEXT)
+           context:(module CONTEXT)
         -> genesis_ledger:Genesis_ledger.Packed.t
         -> genesis_epoch_data:Genesis_epoch_data.t
         -> epoch_ledger_location:string
         -> genesis_state_hash:State_hash.t
+        -> epoch_ledger_backing_type:
+             Genesis_ledger.Ledger.Root.Config.backing_type
+        -> Signature_lib.Public_key.Compressed.Set.t
         -> t
 
       val current_block_production_keys :

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -471,14 +471,9 @@ module Make_str (A : Wire_types.Concrete) = struct
                ~depth:constraint_constants.ledger_depth () ) )
         else Genesis_epoch_ledger genesis_epoch_ledger
 
-      let create block_producer_pubkeys ~context:(module Context : CONTEXT)
-          ~genesis_ledger ~genesis_epoch_data ~epoch_ledger_location
-          ~genesis_state_hash =
-        (* TODO: Pass in from above. The backing type should ultimately be based
-           on the value of the HF automation flag. *)
-        let epoch_ledger_backing_type =
-          Mina_ledger.Ledger.Root.Config.Stable_db
-        in
+      let create ~context:(module Context : CONTEXT) ~genesis_ledger
+          ~genesis_epoch_data ~epoch_ledger_location ~genesis_state_hash
+          ~epoch_ledger_backing_type block_producer_pubkeys =
         let open Context in
         (* TODO: remove this duplicate of the genesis ledger *)
         let genesis_epoch_ledger_staking, genesis_epoch_ledger_next =

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -238,6 +238,7 @@ module Generator = struct
         ~epoch_ledger_location
         ~genesis_state_hash:
           precomputed_values.protocol_state_with_hashes.hash.state_hash
+        ~epoch_ledger_backing_type:Stable_db
     in
     let%map frontier =
       Transition_frontier.For_tests.gen ~precomputed_values ~verifier
@@ -280,6 +281,7 @@ module Generator = struct
         ~epoch_ledger_location
         ~genesis_state_hash:
           precomputed_values.protocol_state_with_hashes.hash.state_hash
+        ~epoch_ledger_backing_type:Stable_db
     in
     let%map frontier, branch =
       Transition_frontier.For_tests.gen_with_branch ~precomputed_values

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -129,19 +129,17 @@ module Make (Inputs : Intf.Ledger_input_intf) : Intf.S = struct
       match directory with
       | `Ephemeral ->
           lazy (`Ephemeral (Ledger.create_ephemeral ~depth ()), true)
-      | `New ->
+      | `New backing_type ->
           lazy
             ( `Root
-                (Ledger.Root.create_temporary ~logger
-                   ~backing_type:Ledger.Root.Config.Stable_db ~depth () )
+                (Ledger.Root.create_temporary ~logger ~backing_type ~depth ())
             , true )
-      | `Path directory_name ->
+      | `Path (directory_name, backing_type) ->
           lazy
             ( `Root
                 (Ledger.Root.create ~logger
                    ~config:
-                     (Ledger.Root.Config.with_directory
-                        ~backing_type:Ledger.Root.Config.Stable_db
+                     (Ledger.Root.Config.with_directory ~backing_type
                         ~directory_name )
                    ~depth () )
             , false )

--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -61,7 +61,10 @@ end
 module type Ledger_input_intf = sig
   include Accounts_intf
 
-  val directory : [ `Ephemeral | `New | `Path of string ]
+  val directory :
+    [ `Ephemeral
+    | `New of Mina_ledger.Ledger.Root.Config.backing_type
+    | `Path of string * Mina_ledger.Ledger.Root.Config.backing_type ]
 
   val depth : int
 

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -555,7 +555,12 @@ module Ledger = struct
       the primary database. Existing but incompatible converting databases (such
       as out-of-sync databases) will be deleted and re-migrated. *)
       val create :
-        config:Config.create -> logger:Logger.t -> depth:int -> unit -> t
+           config:Config.create
+        -> logger:Logger.t
+        -> depth:int
+        -> ?assert_synced:bool
+        -> unit
+        -> t
 
       (** Make checkpoints of the databases backing the converting merkle tree and
       create a new converting ledger based on those checkpoints *)

--- a/src/lib/merkle_ledger/test/test_mask.ml
+++ b/src/lib/merkle_ledger/test/test_mask.ml
@@ -633,6 +633,76 @@ module Make (Test : Test_intf) = struct
               ~message:"account in mask should be unchanged" ~expect:acct1
               (Mask.Attached.get attached_mask loc |> Option.value_exn) ) )
 
+  let () =
+    add_test "all_accounts_on_masks works on a chain" (fun () ->
+        Test.with_chain (fun base ~mask:m1_lazy ~mask2:m2_lazy ->
+            (* Subtract one for a shared account *)
+            let num_accounts = (1 lsl min Test.depth 5) - 1 in
+            let num_layer_accounts = num_accounts / 3 in
+            let account_ids = Account_id.gen_accounts num_accounts in
+            let balances =
+              Quickcheck.random_value
+                (Quickcheck.Generator.list_with_length num_accounts Balance.gen)
+            in
+            let T = Account_id.eq in
+            let accounts =
+              List.map2_exn account_ids balances ~f:Account.create
+            in
+            let root_accounts, accounts =
+              List.split_n accounts num_layer_accounts
+            in
+            let middle_accounts, top_accounts =
+              List.split_n accounts num_layer_accounts
+            in
+            (* Two accounts with the same id to go in both masks *)
+            let shared_account_id = Account_id.gen_accounts 1 |> List.hd_exn in
+            let shared_account_middle =
+              Account.create shared_account_id (Balance.of_nanomina_int_exn 11)
+            in
+            let shared_account_top =
+              Account.create shared_account_id (Balance.of_nanomina_int_exn 12)
+            in
+            let create_accounts_map ~create ledger accounts =
+              List.map accounts ~f:(fun account ->
+                  let location = create ledger account in
+                  (location, account) )
+              |> Test.Location.Map.of_alist_reduce ~f:(fun x _ -> x)
+            in
+            let _root_map =
+              create_accounts_map ~create:parent_create_new_account_exn base
+                root_accounts
+            in
+            let middle_ledger, _root = Lazy.force m1_lazy in
+            let middle_map =
+              create_accounts_map ~create:create_new_account_exn middle_ledger
+                middle_accounts
+            in
+            let shared_account_loc =
+              Mask.Attached.get_or_create_account middle_ledger
+                shared_account_id shared_account_middle
+              |> Or_error.ok_exn |> snd
+            in
+            let middle_map =
+              middle_map
+              |> Map.add_exn ~key:shared_account_loc ~data:shared_account_middle
+            in
+            let top_ledger = Lazy.force m2_lazy in
+            let top_map =
+              create_accounts_map ~create:create_new_account_exn top_ledger
+                top_accounts
+            in
+            Mask.Attached.set top_ledger shared_account_loc shared_account_top ;
+            let top_map =
+              top_map
+              |> Map.add_exn ~key:shared_account_loc ~data:shared_account_top
+            in
+            let harvested = Mask.Attached.all_accounts_on_masks top_ledger in
+            let expected =
+              Map.merge_skewed middle_map top_map
+                ~combine:(fun ~key:_ _middle top -> top)
+            in
+            [%test_eq: Account.t Test.Location.Map.t] harvested expected ) )
+
   let tests =
     let actual_tests = Stack.fold test_stack ~init:[] ~f:(fun l e -> e :: l) in
     (test_section_name, actual_tests)

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -340,6 +340,7 @@ module type Transition_router_intf = sig
           -> Transaction_snark_work.Checked.t option )
     -> catchup_mode:[ `Super ]
     -> notify_online:(unit -> unit Deferred.t)
+    -> ledger_backing:Mina_ledger.Ledger.Root.Config.backing_type
     -> unit
     -> ( [ `Transition of Mina_block.Validated.t ]
        * [ `Source of [ `Gossip | `Catchup | `Internal ] ]

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -90,8 +90,10 @@ module Make
     (** Test if a root ledger backing already exists with this config *)
     val exists_backing : t -> bool
 
-    (** Delete a backing of any type that might exist with this config, if present. this function will try any backing type *)
-    val delete_any_backing : string -> unit
+    (** Delete a backing of any type that might exist with this config, if 
+        present. this function will try any backing type even if it didn't match
+        up with one provided in the config *)
+    val delete_any_backing : t -> unit
 
     (** Delete backing of a specific config *)
     val delete_backing : t -> unit

--- a/src/lib/mina_ledger/test/dune
+++ b/src/lib/mina_ledger/test/dune
@@ -1,0 +1,14 @@
+(test
+ (name test_mina_ledger)
+ (package mina_ledger)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane))
+ (libraries
+  ; opam libraries
+  alcotest
+  alcotest-async
+  ; local libraries
+  mina_base
+  mina_ledger))

--- a/src/lib/mina_ledger/test/test_mina_ledger.ml
+++ b/src/lib/mina_ledger/test/test_mina_ledger.ml
@@ -1,0 +1,199 @@
+open Core
+open Async
+open Mina_base
+module L = Mina_ledger.Ledger
+
+let logger = Logger.create ~id:"test_mina_ledger" ()
+
+let quickcheck_size = 10
+
+let ledger_depth = 10
+
+let num_accounts = 200
+
+let () = assert (num_accounts <= Int.shift_left 1 ledger_depth)
+
+module Root_test = struct
+  (** populate a root with at most [num] accounts. This is because generated 
+      accounts might duplicate *)
+  let populate_with_random_accounts ~num ~root ~random =
+    let unmasked = L.Root.as_unmasked root in
+    let module LocMap = L.Any_ledger.Location.Map in
+    Quickcheck.Generator.(
+      list_with_length num Mina_base.Account.gen
+      |> generate ~size:quickcheck_size ~random)
+    |> List.fold ~init:LocMap.empty ~f:(fun acc acct ->
+           let acct_id = Account_id.create acct.public_key Token_id.default in
+           match L.Any_ledger.M.get_or_create_account unmasked acct_id acct with
+           | Ok (_, loc) -> (
+               match LocMap.add ~key:loc ~data:acct acc with
+               | `Ok acc ->
+                   acc
+               | `Duplicate ->
+                   (* NOTE: This branch will be ran into if randomly
+                      generated accounts happened to clash *)
+                   acc )
+           | Error _ ->
+               failwith "Could not add starting account" )
+
+  let assert_accounts ~loc_with_accounts ~root =
+    let module LocMap = L.Any_ledger.Location.Map in
+    let locations = LocMap.keys loc_with_accounts in
+    L.Any_ledger.M.get_batch (L.Root.as_unmasked root) locations
+    |> List.iter ~f:(fun (loc, account) ->
+           let actual_account =
+             Option.value_exn account
+               ~message:
+                 "Account is inserted in stable db backed root, but when \
+                  reloading with unstable DB backed root it's gone "
+           in
+           let expected = LocMap.find_exn loc_with_accounts loc in
+           assert (
+             Account.equal expected actual_account
+             || failwith "Inserted account didn't match actual account" ) )
+
+  (* When a node restarts, we should be able to replace the backing type of it
+     with converting without any other change. This corresponds to setting HF
+     mode to auto on a new release *)
+  let test_stable_backing_compatible_with_converting ~random () =
+    Mina_stdlib_unix.File_system.with_temp_dir
+      "stable_backing_compatible_with_converting" ~f:(fun cwd ->
+        (* NOTE: The converting ledger would be created as siblings of the
+           primary ledger, hence we need a sub dir for `with_temp_dir` to clean
+           up the garbages correctly after the test*)
+        (* STEP 1: create a stable root, fill with some accounts, get the locs
+           and closing *)
+        let cfg =
+          L.Root.Config.with_directory ~directory_name:(cwd ^/ "ledger")
+        in
+        let stable_root =
+          L.Root.create ~logger
+            ~config:(cfg ~backing_type:Stable_db)
+            ~depth:ledger_depth ()
+        in
+        let loc_with_accounts =
+          populate_with_random_accounts ~num:num_accounts ~root:stable_root
+            ~random
+        in
+        L.Root.close stable_root ;
+        let converting_root =
+          L.Root.create ~logger
+            ~config:(cfg ~backing_type:Converting_db)
+            ~depth:ledger_depth ()
+        in
+        (* STEP 2: reopening the root now as converting, check accounts are
+           matched up. *)
+        assert_accounts ~loc_with_accounts ~root:converting_root ;
+        L.Root.close converting_root ;
+        Deferred.unit )
+
+  let test_root_moving ~random () =
+    Mina_stdlib_unix.File_system.with_temp_dir "root_moving" ~f:(fun cwd ->
+        (* NOTE: The converting ledger would be created as siblings of the
+           primary ledger, hence we need a sub dir for `with_temp_dir` to clean
+           up the garbages correctly after the test*)
+        (* STEP 1: create a root, fill with some accounts, get the locs and
+           closing *)
+        let backing_type =
+          Quickcheck.Generator.of_list
+            [ L.Root.Config.Stable_db; Converting_db ]
+          |> Quickcheck.Generator.generate ~size:quickcheck_size ~random
+        in
+        let config =
+          L.Root.Config.with_directory ~directory_name:(cwd ^/ "ledger")
+            ~backing_type
+        in
+        let root = L.Root.create ~logger ~config ~depth:ledger_depth () in
+        let loc_with_accounts =
+          populate_with_random_accounts ~num:num_accounts ~root ~random
+        in
+        L.Root.close root ;
+        let moved_primary_dir = cwd ^/ "ledger_moved" in
+        let config_moved =
+          L.Root.Config.with_directory ~directory_name:moved_primary_dir
+            ~backing_type
+        in
+        L.Root.Config.move_backing_exn ~src:config ~dst:config_moved ;
+        assert (
+          (not (L.Root.Config.exists_backing config))
+          && L.Root.Config.exists_backing config_moved
+          || failwith "Config is not moved" ) ;
+        let root_moved =
+          L.Root.create ~logger ~config:config_moved ~depth:ledger_depth ()
+        in
+
+        (* STEP 2: reopening the root in moved location, check accounts is
+           matched up. *)
+        assert_accounts ~loc_with_accounts ~root:root_moved ;
+        L.Root.close root_moved ;
+        ( if phys_equal backing_type Converting_db then
+          L.Converting_ledger.(
+            create
+              ~config:
+                (In_directories
+                   (Config.with_primary ~directory_name:moved_primary_dir) )
+              ~logger ~depth:ledger_depth ~assert_synced:true ()
+            |> close) ) ;
+        Deferred.unit )
+
+  let test_root_make_checkpointing ~random () =
+    Mina_stdlib_unix.File_system.with_temp_dir "root_make_checkpointing"
+      ~f:(fun cwd ->
+        (* NOTE: The converting ledger would be created as siblings of the
+           primary ledger, hence we need a sub dir for `with_temp_dir` to clean
+           up the garbages correctly after the test*)
+        (* STEP 1: create a root, fill with some accounts, get the locs and
+           closing *)
+        let backing_type =
+          Quickcheck.Generator.of_list
+            [ L.Root.Config.Stable_db; Converting_db ]
+          |> Quickcheck.Generator.generate ~size:quickcheck_size ~random
+        in
+        let config =
+          L.Root.Config.with_directory ~directory_name:(cwd ^/ "ledger")
+            ~backing_type
+        in
+        let root = L.Root.create ~logger ~config ~depth:ledger_depth () in
+        let loc_with_accounts =
+          populate_with_random_accounts ~num:num_accounts ~root ~random
+        in
+        let checkpointed_primary_dir = cwd ^/ "ledger_checkpointed" in
+        let config_checkpoint =
+          L.Root.Config.with_directory ~directory_name:checkpointed_primary_dir
+            ~backing_type
+        in
+        L.Root.make_checkpoint root ~config:config_checkpoint ;
+        L.Root.close root ;
+        let root_checkpointed =
+          L.Root.create ~logger ~config:config_checkpoint ~depth:ledger_depth ()
+        in
+        (* STEP 2: opening the checkpointed root, check accounts are matched up. *)
+        assert_accounts ~loc_with_accounts ~root:root_checkpointed ;
+        L.Root.close root_checkpointed ;
+        ( if phys_equal backing_type Converting_db then
+          L.Converting_ledger.(
+            create
+              ~config:
+                (In_directories
+                   (Config.with_primary ~directory_name:checkpointed_primary_dir)
+                )
+              ~logger ~depth:ledger_depth ~assert_synced:true ()
+            |> close) ) ;
+        Deferred.unit )
+end
+
+let () =
+  let random = Splittable_random.State.create Random.State.default in
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      Alcotest_async.run "Mina Ledger"
+        [ ( "Root"
+          , [ Alcotest_async.test_case
+                "closing stable root, reload as converting" `Quick
+                (Root_test.test_stable_backing_compatible_with_converting
+                   ~random )
+            ; Alcotest_async.test_case "moving a root" `Quick
+                (Root_test.test_root_moving ~random)
+            ; Alcotest_async.test_case "make checkpointing a root" `Quick
+                (Root_test.test_root_make_checkpointing ~random)
+            ] )
+        ] )

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -67,5 +67,13 @@ type t =
   ; zkapp_cmd_limit : int option ref
   ; compile_config : Mina_compile_config.t
   ; itn_features : bool
+  ; hardfork_mode : Cli_lib.Arg_type.Hardfork_mode.t
   }
 [@@deriving make]
+
+let ledger_backing ~hardfork_mode =
+  match hardfork_mode with
+  | Cli_lib.Arg_type.Hardfork_mode.Auto ->
+      Mina_ledger.Ledger.Root.Config.Converting_db
+  | _ ->
+      Stable_db

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2158,6 +2158,9 @@ let create ~commit_id ?wallets (config : Config.t) =
             }
           in
 
+          let ledger_backing =
+            Config.ledger_backing ~hardfork_mode:config.hardfork_mode
+          in
           let valid_transitions, initialization_finish_signal =
             Transition_router.run
               ~context:(module Context)
@@ -2174,7 +2177,7 @@ let create ~commit_id ?wallets (config : Config.t) =
               ~most_recent_valid_block_writer
               ~get_completed_work:
                 (Network_pool.Snark_pool.get_completed_work snark_pool)
-              ~notify_online ~transaction_pool_proxy ()
+              ~notify_online ~transaction_pool_proxy ~ledger_backing ()
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api

--- a/src/lib/mina_lmdb_storage/block.ml
+++ b/src/lib/mina_lmdb_storage/block.ml
@@ -181,7 +181,9 @@ let%test_module "Block storage tests" =
       let n = 300 in
       Quickcheck.test (gen_breadcrumb ~verifier ()) ~trials:1
         ~f:(fun make_breadcrumb ->
-          let frontier = create_frontier () in
+          let frontier =
+            create_frontier ~epoch_ledger_backing_type:Stable_db ()
+          in
           let root = Full_frontier.root frontier in
           let reader, writer = Pipe.create () in
           with_helper ~writer (fun conf_dir helper ->
@@ -208,7 +210,9 @@ let%test_module "Block storage tests" =
     let%test_unit "Write a block body to db and read it" =
       Quickcheck.test (gen_breadcrumb ~verifier ()) ~trials:4
         ~f:(fun make_breadcrumb ->
-          let frontier = create_frontier () in
+          let frontier =
+            create_frontier ~epoch_ledger_backing_type:Stable_db ()
+          in
           let root = Full_frontier.root frontier in
           let reader, writer = Pipe.create () in
           with_helper ~writer (fun conf_dir helper ->

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -292,7 +292,7 @@ end)
       Strict_pipe.(
         create ~name:"Network pool transition frontier diffs" Synchronous)
     in
-    let t, locals, remotes =
+    let t, remotes, locals =
       of_resource_pool_and_diffs
         (Resource_pool.create ~constraint_constants ~consensus_constants
            ~time_controller ~config ~logger ~frontier_broadcast_pipe
@@ -302,5 +302,5 @@ end)
     in
     O1trace.background_thread rebroadcast_loop_thread_label (fun () ->
         rebroadcast_loop t logger ) ;
-    (t, locals, remotes)
+    (t, remotes, locals)
 end

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -986,7 +986,7 @@ module For_tests = struct
   module Transfer =
     Mina_ledger.Ledger_transfer.Make (Mina_ledger.Ledger) (Mina_ledger.Ledger)
 
-  let create_frontier () =
+  let create_frontier ~epoch_ledger_backing_type () =
     let open Core in
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
@@ -1002,6 +1002,7 @@ module For_tests = struct
         ~genesis_state_hash:
           (State_hash.With_state_hashes.state_hash
              precomputed_values.protocol_state_with_hashes )
+        ~epoch_ledger_backing_type
     in
     let root_ledger =
       Or_error.ok_exn
@@ -1021,7 +1022,7 @@ module For_tests = struct
       }
     in
     let persistent_root =
-      Persistent_root.create ~logger
+      Persistent_root.create ~logger ~backing_type:Stable_db
         ~directory:(Filename.temp_file "snarked_ledger" "")
         ~ledger_depth
     in

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -86,7 +86,10 @@ module For_tests : sig
         -> Frontier_base.Breadcrumb.t list Async_kernel.Deferred.t )
        Base_quickcheck.Generator.t
 
-  val create_frontier : unit -> t
+  val create_frontier :
+       epoch_ledger_backing_type:Mina_ledger.Ledger.Root.Config.backing_type
+    -> unit
+    -> t
 
   val clean_up_persistent_root : frontier:t -> unit
 

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -124,13 +124,13 @@ module Instance = struct
 
   let dequeue_snarked_ledger t =
     let config = Queue.dequeue_exn t.potential_snarked_ledgers in
-    Ledger.Root.Config.delete_backing config ;
+    Ledger.Root.Config.delete_any_backing config ;
     write_potential_snarked_ledgers_to_disk t
 
   let destroy t =
     List.iter
       (Queue.to_list t.potential_snarked_ledgers)
-      ~f:Ledger.Root.Config.delete_backing ;
+      ~f:Ledger.Root.Config.delete_any_backing ;
     Mina_stdlib_unix.File_system.rmrf
       (Config.potential_snarked_ledgers t.factory) ;
     Ledger.Root.close t.snarked_ledger ;
@@ -191,20 +191,20 @@ module Instance = struct
             with
             | Ok _ ->
                 Ledger.Root.close potential_snarked_ledger ;
-                Ledger.Root.Config.delete_backing
+                Ledger.Root.Config.delete_any_backing
                 @@ Config.snarked_ledger factory ;
                 Ledger.Root.Config.move_backing_exn
                   ~src:(Config.tmp_snarked_ledger factory)
                   ~dst:(Config.snarked_ledger factory) ;
                 List.iter potential_snarked_ledgers
-                  ~f:Ledger.Root.Config.delete_backing ;
+                  ~f:Ledger.Root.Config.delete_any_backing ;
                 Mina_stdlib_unix.File_system.rmrf
                   (Config.potential_snarked_ledgers factory) ;
                 Stop (Some snarked_ledger)
             | Error e ->
                 Ledger.Root.close potential_snarked_ledger ;
                 List.iter potential_snarked_ledgers
-                  ~f:Ledger.Root.Config.delete_backing ;
+                  ~f:Ledger.Root.Config.delete_any_backing ;
                 Mina_stdlib_unix.File_system.rmrf
                   (Config.potential_snarked_ledgers factory) ;
                 [%log' error factory.logger]
@@ -216,7 +216,7 @@ module Instance = struct
             Continue None ) )
         ~finish:(fun _ ->
           List.iter potential_snarked_ledgers
-            ~f:Ledger.Root.Config.delete_backing ;
+            ~f:Ledger.Root.Config.delete_any_backing ;
           Mina_stdlib_unix.File_system.rmrf
             (Config.potential_snarked_ledgers factory) ;
           None )
@@ -288,10 +288,7 @@ end
 
 type t = Factory_type.t
 
-let create ~logger ~directory ~ledger_depth =
-  (* TODO: Pass in from above. This should ultimately be determined by the value
-     of the HF automation flag. *)
-  let backing_type = Ledger.Root.Config.Stable_db in
+let create ~logger ~directory ~backing_type ~ledger_depth =
   { directory; logger; instance = None; ledger_depth; backing_type }
 
 let create_instance_exn t =

--- a/src/lib/transition_frontier/persistent_root/persistent_root.mli
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.mli
@@ -1,0 +1,108 @@
+open Core
+open Mina_base
+open Frontier_base
+open Mina_ledger.Ledger
+
+module rec Instance_type : sig
+  type t =
+    { snarked_ledger : Root.t
+    ; potential_snarked_ledgers : Root.Config.t Queue.t
+    ; factory : Factory_type.t
+    }
+end
+
+and Factory_type : sig
+  type t =
+    { directory : string
+    ; logger : Logger.t
+    ; mutable instance : Instance_type.t option
+    ; ledger_depth : int
+    ; backing_type : Root.Config.backing_type
+    }
+end
+
+module Instance : sig
+  type t = Instance_type.t
+
+  module Config : sig
+    (** Helper to create a filesystem location (for a file or directory) inside
+        the [Factory_type.t] directory. *)
+    val make_instance_location : string -> Factory_type.t -> string
+
+    (** Helper to create a [Root.Config.t] for a snarked ledger based on a
+        subdirectory of the [Factory_type.t] directory *)
+    val make_instance_config : string -> Factory_type.t -> Root.Config.t
+
+    (** The config for the actual snarked ledger that is initialized and used by
+        the daemon *)
+    val snarked_ledger : Factory_type.t -> Root.Config.t
+
+    (** The config for the temporary snarked ledger, used while recovering a
+        vaild potential snarked ledger during startup *)
+    val tmp_snarked_ledger : Factory_type.t -> Root.Config.t
+
+    (** The name of a json file that lists the directory names of the potential
+        snarked ledgers in the [potential_snarked_ledgers] queue *)
+    val potential_snarked_ledgers : Factory_type.t -> string
+
+    (** A method that generates fresh potential snarked ledger configs, each
+        using a distinct root subdirectory *)
+    val make_potential_snarked_ledger : Factory_type.t -> Root.Config.t
+
+    (** The name of the file recording the [Root_identifier.t] of the snarked
+        root *)
+    val root_identifier : Factory_type.t -> string
+  end
+
+  val enqueue_snarked_ledger : config:Root.Config.t -> t -> unit
+
+  val dequeue_snarked_ledger : t -> unit
+
+  val destroy : t -> unit
+
+  val close : t -> unit
+
+  val create : logger:Logger.t -> Factory_type.t -> t
+
+  (** When we load from disk,
+      1. Check the potential_snarked_ledgers to see if any one of these
+         matches the snarked_ledger_hash in persistent_frontier;
+      2. if none of those works, we load the old snarked_ledger and check if
+         the old snarked_ledger matches with persistent_frontier;
+      3. if not, we just reset all the persisted data and start from genesis
+   *)
+  val load_from_disk :
+       Factory_type.t
+    -> snarked_ledger_hash:Frozen_ledger_hash.t
+    -> logger:Logger.t
+    -> (t, [> `Snarked_ledger_mismatch ]) result
+
+  val snarked_ledger : t -> Root.t
+
+  val set_root_identifier : t -> Root_identifier.t -> unit
+
+  val load_root_identifier : t -> Root_identifier.t option
+
+  val set_root_state_hash : t -> Frozen_ledger_hash.t -> unit
+end
+
+type t = Factory_type.t
+
+val create :
+     logger:Logger.t
+  -> directory:string
+  -> backing_type:Root.Config.backing_type
+  -> ledger_depth:int
+  -> t
+
+val create_instance_exn : t -> Instance_type.t
+
+val load_from_disk_exn :
+     t
+  -> snarked_ledger_hash:Frozen_ledger_hash.t
+  -> logger:Logger.t
+  -> (Instance_type.t, [> `Snarked_ledger_mismatch ]) result
+
+val with_instance_exn : t -> f:(Instance_type.t -> 'a) -> 'a
+
+val reset_to_genesis_exn : t -> precomputed_values:Genesis_proof.t -> unit

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -34,7 +34,9 @@ let%test_module "Full_frontier tests" =
       Quickcheck.test (gen_breadcrumb ~verifier ()) ~trials:4
         ~f:(fun make_breadcrumb ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let root = Full_frontier.root frontier in
               let%map breadcrumb = make_breadcrumb root in
               add_breadcrumb frontier breadcrumb ;
@@ -56,7 +58,9 @@ let%test_module "Full_frontier tests" =
       Quickcheck.test gen_branches ~trials:4
         ~f:(fun (make_short_branch, make_long_branch) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let test_best_tip ?message breadcrumb =
                 [%test_eq: State_hash.t] ?message
                   (Breadcrumb.state_hash breadcrumb)
@@ -89,7 +93,9 @@ let%test_module "Full_frontier tests" =
         ~trials:4
         ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let root = Full_frontier.root frontier in
               let%map seq = make_seq root in
               ignore
@@ -117,7 +123,9 @@ let%test_module "Full_frontier tests" =
         ~trials:2
         ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let root = Full_frontier.root frontier in
               let%map rest = make_seq root in
               List.iter rest ~f:(fun breadcrumb ->
@@ -144,7 +152,9 @@ let%test_module "Full_frontier tests" =
       in
       Quickcheck.test gen ~trials:4 ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let root = Full_frontier.root frontier in
               let%map breadcrumbs = make_seq root in
               List.iter breadcrumbs ~f:(fun b ->
@@ -171,7 +181,9 @@ let%test_module "Full_frontier tests" =
       Quickcheck.test gen ~trials:4
         ~f:(fun (make_ancestors, make_branch_a, make_branch_b) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier =
+                create_frontier ~epoch_ledger_backing_type:Stable_db ()
+              in
               let root = Full_frontier.root frontier in
               let%bind ancestors = make_ancestors root in
               let youngest_ancestor = List.last_exn ancestors in

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -651,7 +651,8 @@ module For_tests = struct
         Unix.mkdir root_dir ;
         Unix.mkdir frontier_dir ;
         let persistent_root =
-          Persistent_root.create ~logger ~directory:root_dir
+          Persistent_root.create ~logger ~backing_type:Stable_db
+            ~directory:root_dir
             ~ledger_depth:precomputed_values.constraint_constants.ledger_depth
         in
         let persistent_frontier =
@@ -719,7 +720,8 @@ module For_tests = struct
              ~epoch_ledger_location Public_key.Compressed.Set.empty
              ~genesis_state_hash:
                (State_hash.With_state_hashes.state_hash
-                  precomputed_values.protocol_state_with_hashes ) )
+                  precomputed_values.protocol_state_with_hashes )
+             ~epoch_ledger_backing_type:Stable_db )
     in
     let populate_root, root_ledger_accounts = populate_root_and_accounts in
     (* TODO: ensure that rose_tree cannot be longer than k *)

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -547,7 +547,7 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
     ~frontier_broadcast_writer:frontier_w ~network_transition_reader
     ~producer_transition_reader ~get_most_recent_valid_block
     ~most_recent_valid_block_writer ~get_completed_work ~catchup_mode
-    ~notify_online () =
+    ~notify_online ~ledger_backing () =
   let open Context in
   [%log info] "Starting transition router" ;
   let initialization_finish_signal = Ivar.create () in
@@ -616,7 +616,7 @@ let run ?(sync_local_state = true) ?(cache_exceptions = false)
       in
       let persistent_root =
         Transition_frontier.Persistent_root.create ~logger
-          ~directory:persistent_root_location
+          ~backing_type:ledger_backing ~directory:persistent_root_location
           ~ledger_depth:(Precomputed_values.ledger_depth precomputed_values)
       in
       let network_transition_pipe : _ Strict_pipe.Swappable.t =


### PR DESCRIPTION
Automatic merge of `georgeee/use-stricter-error-type-in-work-paritioner` to `develop`.

It's `georgeee/use-stricter-error-type-in-work-paritioner` not `compatible` to ensure that the compatibility check will be satisfied (the single commit of the PR #17730 was already merged as #17732).
