### PR TITLE
More reafctor on snark worker metrics

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -417,10 +417,13 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
             Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;
           One_or_two.zip_exn work.spec.instances work.metrics
           |> One_or_two.iter ~f:(fun (single_spec, (elapsed, _tag)) ->
-                 Snark_work_lib.Metrics.(
-                   emit_single_metrics ~logger ~single_spec
-                     ~data:{ data = elapsed; proof = () }
-                     ~on_zkapp_command:emit_zkapp_metrics_legacy ()) ) ;
+                 let open Snark_work_lib in
+                 let single_spec =
+                   Spec.Single.Poly.map
+                     ~f_witness:(fun w -> Metrics.Stable w)
+                     ~f_proof:Fn.id single_spec
+                 in
+                 Metrics.emit_single_metrics ~logger ~single_spec ~elapsed ) ;
           Deferred.return @@ Mina_lib.add_work mina work )
     ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
         (fun

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -127,10 +127,13 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
         | Ok result ->
             One_or_two.zip_exn work.instances result.metrics
             |> One_or_two.iter ~f:(fun (single_spec, (elapsed, _tag)) ->
+                   let single_spec =
+                     Spec.Single.Poly.map
+                       ~f_witness:(fun w -> Metrics.Stable w)
+                       ~f_proof:Fn.id single_spec
+                   in
                    (* [_tag]'s purpose is replaced by the whole single spec *)
-                   Metrics.emit_single_metrics ~logger ~single_spec
-                     ~data:{ data = elapsed; proof = () }
-                     ~on_zkapp_command:Metrics.emit_zkapp_metrics_legacy () ) ;
+                   Metrics.emit_single_metrics ~logger ~single_spec ~elapsed ) ;
             [%log info] "Submitted completed SNARK work $work_ids to $address"
               ~metadata:
                 [ ("address", `String (Host_and_port.to_string daemon_address))


### PR DESCRIPTION
This PR refactor the metrcs tracking again:
- Allow passing in any kind of specs in emit_single_metrics
- Removed emit_partitioned_spce
   - In partitioner's side, we can always track spec after combining, which is more robust
   - On worker's side, we simply can't track a correct metrics due to the current architecture, so I think it's better to throw the metrics tracking at the implementation's side. Avoiding it being reused by any other functions
 - Added a new function `emit_sub_zkapp_metrics` specifically designed to track new sub-zkApp level metrics


Hopefully with this refactor the metrics tracking architecture is clearer. 