### PR TITLE
[HF] Guardian for not accepting too old ledger in prepare ledger script

### DIFF
--- a/scripts/hardfork/run-localnet.sh
+++ b/scripts/hardfork/run-localnet.sh
@@ -104,7 +104,7 @@ NODE_ARGS_2=( --libp2p-keypair "$PWD/$CONF_DIR/libp2p_2" )
 "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 
 
 if [[ "$CUSTOM_CONF" == "" ]] && [[ ! -f $CONF_DIR/ledger.json ]]; then
-  ( cd $CONF_DIR && "$SCRIPT_DIR/../prepare-test-ledger.sh" -c 100000 -b 1000000 "$(cat bp.pub)" >ledger.json )
+  ( cd $CONF_DIR && "$SCRIPT_DIR/../prepare-test-ledger.sh" --exit-on-old-ledger -c 100000 -b 1000000 "$(cat bp.pub)" >ledger.json )
 fi
 
 if [[ "$SLOT_TX_END" != "" ]]; then


### PR DESCRIPTION
We are experiencing issues in hardfork test which were originally not easy to debug. Therefore we are adding exclusive check for them in hardfork integration test.

Mentioned issue is caused by lack of fairly new staking ledger, which is periodically dumped into mina-staking-ledgers bucket. prepare-test-ledger script is fetching staking ledger to current epoch. However if there is something wrong with dump, like new ledger is missing, and old ledger from 31-epoch is taken. This is causing problem when daemon wants to boot with such ledger as it is almost certain that old ledger has old format, therefore it won't be compatible with mina from compatible branch.

Leger is quite large, so the orginal root cause is well hidden in oversized mina log. Example of such error:

https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/565#01992cfe-b8ea-4394-ba57-670ec11a43e7

As we see above, it would be better to fail fast on ledger creation.

My solution is to introduce optional flag which will exit 2 if ledger is older than 1 year. I think that is conservative enough to solve issue we are experiencing as currently we are fetching staking ledger from 2022

