### PR TITLE
[HF][CI] froze staking ledger in hardfork test

### DIFF
--- a/scripts/hardfork/run-localnet.sh
+++ b/scripts/hardfork/run-localnet.sh
@@ -104,7 +104,7 @@ NODE_ARGS_2=( --libp2p-keypair "$PWD/$CONF_DIR/libp2p_2" )
 "$MINA_EXE" libp2p generate-keypair --privkey-path $CONF_DIR/libp2p_2 
 
 if [[ "$CUSTOM_CONF" == "" ]] && [[ ! -f $CONF_DIR/ledger.json ]]; then
-  ( cd $CONF_DIR && "$SCRIPT_DIR/../prepare-test-ledger.sh" --exit-on-old-ledger -c 100000 -b 1000000 "$(cat bp.pub)" >ledger.json )
+  ( cd $CONF_DIR && "$SCRIPT_DIR/../prepare-test-ledger.sh" --ledger-prefix "-staking-30" --exit-on-old-ledger -c 100000 -b 1000000 "$(cat bp.pub)" >ledger.json )
 fi
 
 if [[ "$SLOT_TX_END" != "" ]]; then


### PR DESCRIPTION
The goal of this PR is to fix Ci on compatible before cutting of release branch


We are experiencing issues with our mina-staking-dump temporarily. This is causing disruptions in hardfork test which is using prepare-test-ledger.sh with dynaically evaluated suffix. Change here, propose to use -staking-30 suffix which will always point to correctly formatted ledger. Once we fix issue with mina-staking-dump, i will revert this change.

