### PR TITLE
Remove non-existent libp2p logger: 'routing/record'

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -128,7 +128,6 @@ func main() {
 	setLogLevel("dht.pb", "debug")
 	setLogLevel("tcp-tpt", "debug")
 	setLogLevel("autonat", "debug")
-	setLogLevel("routing/record", "debug")
 	setLogLevel("pubsub", "info")
 	setLogLevel("badger", "debug")
 	setLogLevel("relay", "info") // Log relayed byte counts spammily


### PR DESCRIPTION
There's occasionally this error message from libp2p helper:
```
{"timestamp":"2025-09-11 01:42:48.356000Z","level":"Error","source":{"module":"Libp2p_helper.Go.helper top-level JSON handling","location":"(not tracked)"},"message":"libp2p_helper: failed to set log level debug for routing/record: error: No such logger","metadata":{"caller":"libp2p_helper/main.go:99","commit_id":"ff54cdaafc304e91117c49255f8f18d06945cc62"}}
```

Grepping through libp2p codebase I can't find this logger at all. I don't know if there's a preferred way to figure out what logger it come from exactly. It seems all libraries are sharing a same namespace dynamically!!

