### PR TITLE
Fix test executive for mainnet build

### DIFF
--- a/src/app/test_executive/hard_fork.ml
+++ b/src/app/test_executive/hard_fork.ml
@@ -305,7 +305,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-        zkapp_command_spec
+        ~signature_kind zkapp_command_spec
     in
 
     let%bind zkapp_command_update_vk_proof, zkapp_command_update_vk_impossible =

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -34,7 +34,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ]
     }
 
-  let run ~config:_ network t =
+  let run ~config:Test_config.{ signature_kind; _ } network t =
     let open Network in
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
@@ -143,7 +143,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            Malleable_error.lift
            @@ Transaction_snark.For_tests.deploy_snapp
                 ~constraint_constants:(Network.constraint_constants network)
-                parties_spec
+                ~signature_kind parties_spec
          in
          let%bind () =
            send_zkapp ~logger

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -207,7 +207,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       Malleable_error.lift
-      @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants spec
+      @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants
+           ~signature_kind spec
     in
     let call_forest_to_zkapp ~call_forest ~nonce : Zkapp_command.t =
       let memo = Signed_command_memo.empty in

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -178,7 +178,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       Malleable_error.lift
       @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-           zkapp_command_spec
+           ~signature_kind zkapp_command_spec
     in
     let%bind.Deferred zkapp_command_update_permissions, permissions_updated =
       (* construct a Zkapp_command.t, similar to zkapp_test_transaction
@@ -347,7 +347,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           }
         in
         Transaction_snark.For_tests.single_account_update ~constraint_constants
-          spec
+          ~signature_kind spec
       in
       ( snapp_update
       , zkapp_command_update_all

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -33,7 +33,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; num_archive_nodes = 1
     }
 
-  let run ~config:_ network t =
+  let run ~config:Test_config.{ signature_kind; _ } network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_mina_nodes = Network.all_mina_nodes network in
@@ -104,7 +104,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       let%map.Async.Deferred deploy_zkapp =
         Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-          zkapp_command_spec
+          ~signature_kind zkapp_command_spec
       in
       ( deploy_zkapp
       , timing_account_id
@@ -151,7 +151,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       Malleable_error.lift
       @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-           zkapp_command_spec
+           ~signature_kind zkapp_command_spec
     in
     (* Create a timed account that with initial liquid balance being 0, and vesting 1 mina at each slot.
        This account would be used to test the edge case of vesting. See `zkapp_command_transfer_from_third_timed_account`
@@ -202,7 +202,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       let%map.Async.Deferred deploy_zkapp =
         Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-          zkapp_command_spec
+          ~signature_kind zkapp_command_spec
       in
       (deploy_zkapp, timing_account_id, zkapp_keypair)
     in
@@ -244,7 +244,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-        zkapp_command_spec
+        ~signature_kind zkapp_command_spec
     in
     let%bind zkapp_command_transfer_from_timed_account =
       let open Mina_base in

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -368,7 +368,8 @@ let create_zkapp_account ~debug ~sender ~sender_nonce ~fee ~fee_payer
   in
   let%bind zkapp_command =
     Transaction_snark.For_tests.deploy_snapp
-      ~permissions:Permissions.user_default ~constraint_constants spec
+      ~permissions:Permissions.user_default ~constraint_constants
+      ~signature_kind:Testnet spec
   in
   let%map () =
     if debug then

--- a/src/lib/mina_graphql/itn_zkapps.ml
+++ b/src/lib/mina_graphql/itn_zkapps.ml
@@ -54,6 +54,7 @@ let deploy_zkapps ~scheduler_tbl ~mina ~ledger ~deployment_fee ~max_cost
         in
         let zkapp_command =
           Transaction_snark.For_tests.deploy_snapp ~constraint_constants
+            ~signature_kind:Mina_signature_kind.t_DEPRECATED
             ~permissions:
               ( if max_cost then
                 { Permissions.user_default with

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2016,7 +2016,7 @@ let%test_module _ =
       in
       let%map zkapp_command =
         Transaction_snark.For_tests.single_account_update ~constraint_constants
-          spec
+          ~signature_kind spec
       in
       Or_error.ok_exn
         (Zkapp_command.Verifiable.create ~failed:false

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -5208,7 +5208,7 @@ let%test_module "staged ledger tests" =
                   in
                   let%bind zkapp_command =
                     single_account_update ~zkapp_prover_and_vk
-                      ~constraint_constants spec
+                      ~constraint_constants ~signature_kind spec
                   in
                   Mina_transaction_logic.For_tests.Init_ledger.init
                     (module Ledger.Ledger_inner)

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -1674,7 +1674,7 @@ let%test_module "account timing check" =
       in
       let zkapp_command, _, _, _ =
         ( Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-            create_timed_account_spec
+            ~signature_kind create_timed_account_spec
         , timed_account_id
         , create_timed_account_spec.snapp_update
         , zkapp_keypair )
@@ -2269,7 +2269,7 @@ let%test_module "account timing check" =
       in
       let create_timed_account_zkapp_command, _, _, _ =
         ( Transaction_snark.For_tests.deploy_snapp ~no_auth:true
-            ~constraint_constants create_timed_account_spec
+            ~constraint_constants ~signature_kind create_timed_account_spec
         , timing_account_id
         , create_timed_account_spec.snapp_update
         , zkapp_keypair )

--- a/src/lib/transaction_snark/test/account_update_network_id/account_update_network_id.ml
+++ b/src/lib/transaction_snark/test/account_update_network_id/account_update_network_id.ml
@@ -37,7 +37,8 @@ let%test_module "Account update network id tests" =
                   in
                   let%bind zkapp_command =
                     Transaction_snark.For_tests.single_account_update
-                      ~constraint_constants:U.constraint_constants spec
+                      ~constraint_constants:U.constraint_constants
+                      ~signature_kind spec
                   in
                   Transaction_snark.For_tests.create_trivial_zkapp_account
                     ~permissions:

--- a/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
+++ b/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
@@ -165,8 +165,8 @@ let%test_module "Fee payer tests" =
               in
               let zkapp_command =
                 Async.Thread_safe.block_on_async_exn (fun () ->
-                    Transaction_snark.For_tests.deploy_snapp test_spec
-                      ~constraint_constants )
+                    Transaction_snark.For_tests.deploy_snapp
+                      ~constraint_constants ~signature_kind test_spec )
               in
               let txn_state_view =
                 Mina_state.Protocol_state.Body.view U.genesis_state_body

--- a/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
+++ b/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
@@ -40,8 +40,8 @@ let%test_module "zkApp deploy tests" =
                   in
                   let zkapp_command =
                     Async.Thread_safe.block_on_async_exn (fun () ->
-                        Transaction_snark.For_tests.deploy_snapp test_spec
-                          ~constraint_constants )
+                        Transaction_snark.For_tests.deploy_snapp ~signature_kind
+                          ~constraint_constants test_spec )
                   in
                   Init_ledger.init
                     (module Ledger.Ledger_inner)
@@ -79,8 +79,8 @@ let%test_module "zkApp deploy tests" =
                   in
                   let zkapp_command =
                     Async.Thread_safe.block_on_async_exn (fun () ->
-                        Transaction_snark.For_tests.deploy_snapp test_spec
-                          ~constraint_constants )
+                        Transaction_snark.For_tests.deploy_snapp
+                          ~constraint_constants ~signature_kind test_spec )
                   in
                   Init_ledger.init
                     (module Ledger.Ledger_inner)
@@ -112,8 +112,8 @@ let%test_module "zkApp deploy tests" =
                   in
                   let zkapp_command =
                     Async.Thread_safe.block_on_async_exn (fun () ->
-                        Transaction_snark.For_tests.deploy_snapp test_spec
-                          ~constraint_constants )
+                        Transaction_snark.For_tests.deploy_snapp
+                          ~constraint_constants ~signature_kind test_spec )
                   in
                   Init_ledger.init
                     (module Ledger.Ledger_inner)
@@ -146,8 +146,8 @@ let%test_module "zkApp deploy tests" =
                   in
                   let zkapp_command =
                     Async.Thread_safe.block_on_async_exn (fun () ->
-                        Transaction_snark.For_tests.deploy_snapp test_spec
-                          ~constraint_constants )
+                        Transaction_snark.For_tests.deploy_snapp
+                          ~constraint_constants ~signature_kind test_spec )
                   in
                   Init_ledger.init
                     (module Ledger.Ledger_inner)
@@ -180,8 +180,8 @@ let%test_module "zkApp deploy tests" =
                   in
                   let zkapp_command =
                     Async.Thread_safe.block_on_async_exn (fun () ->
-                        Transaction_snark.For_tests.deploy_snapp test_spec
-                          ~constraint_constants )
+                        Transaction_snark.For_tests.deploy_snapp
+                          ~constraint_constants ~signature_kind test_spec )
                   in
                   Init_ledger.init
                     (module Ledger.Ledger_inner)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4632,8 +4632,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     end
 
     let deploy_snapp ?(no_auth = false) ?permissions ~constraint_constants
-        (spec : Deploy_snapp_spec.t) =
-      let signature_kind = Mina_signature_kind.Testnet in
+        ~signature_kind (spec : Deploy_snapp_spec.t) =
       let `VK vk, `Prover _trivial_prover = create_trivial_snapp () in
       let%map.Async.Deferred vk = vk in
       (* only allow timing on a single new snapp account
@@ -4754,9 +4753,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     end
 
     let single_account_update ?zkapp_prover_and_vk ~constraint_constants
-        (spec : Single_account_update_spec.t) : Zkapp_command.t Async.Deferred.t
-        =
-      let signature_kind = Mina_signature_kind.Testnet in
+        ~signature_kind (spec : Single_account_update_spec.t) :
+        Zkapp_command.t Async.Deferred.t =
       let `VK vk, `Prover prover =
         match zkapp_prover_and_vk with
         | Some (prover, vk) ->

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -294,6 +294,7 @@ module type Full = sig
          ?no_auth:bool
       -> ?permissions:Permissions.t
       -> constraint_constants:Genesis_constants.Constraint_constants.t
+      -> signature_kind:Mina_signature_kind.t
       -> Deploy_snapp_spec.t
       -> Zkapp_command.t Async.Deferred.t
 
@@ -325,6 +326,7 @@ module type Full = sig
              With_hash.t
              Async.Deferred.t
       -> constraint_constants:Genesis_constants.Constraint_constants.t
+      -> signature_kind:Mina_signature_kind.t
       -> Single_account_update_spec.t
       -> Zkapp_command.t Async.Deferred.t
 


### PR DESCRIPTION
So apparently, some methods in `Transaction_snark.For_test` are used out of unit test, e.g. test executive. 

Hence a push of sig kind out of these methods are need. So we can for example run mainnet artifacts with test executive. 