### PR TITLE
publish arm64 and amd64

### DIFF
--- a/buildkite/src/Command/Packages/Publish.dhall
+++ b/buildkite/src/Command/Packages/Publish.dhall
@@ -8,6 +8,8 @@ let Optional/map = Prelude.Optional.map
 
 let Optional/default = Prelude.Optional.default
 
+let List/map = Prelude.List.map
+
 let Artifacts = ../../Constants/Artifacts.dhall
 
 let Size = ../../Command/Size.dhall
@@ -33,6 +35,8 @@ let Cmd = ../../Lib/Cmds.dhall
 let Mina = ../Mina.dhall
 
 let Artifact = ../../Constants/Artifacts.dhall
+
+let Architecture = ../../Constants/Arch.dhall
 
 let Spec =
       { Type =
@@ -67,6 +71,7 @@ let Spec =
           , publish_to_docker_io : Bool
           , depends_on : List Command.TaggedKey.Type
           , branch : Text
+          , architectures : List Architecture.Type
           , if : Optional Text
           }
       , default =
@@ -83,6 +88,7 @@ let Spec =
           , publish_to_docker_io = False
           , verify = True
           , branch = ""
+          , architectures = [ Architecture.Type.Amd64, Architecture.Type.Arm64 ]
           , if = None Text
           }
       }
@@ -152,11 +158,12 @@ let publish
 
                 else  ""
 
-          in    [ Command.build
-                    Command.Config::{
-                    , commands =
-                          [ Mina.fixPermissionsCommand ]
-                        # [ Cmd.runInDocker
+          let commands =
+                List/map
+                  Architecture.Type
+                  (List Cmd.Type)
+                  (     \(architecture : Architecture.Type)
+                    ->    [ Cmd.runInDocker
                               Cmd.Docker::{
                               , image = ContainerImages.minaToolchain
                               , extraEnv =
@@ -181,6 +188,8 @@ let publish
                                 ++  "--debian-repo ${DebianRepo.bucket_or_default
                                                        spec.debian_repo} "
                                 ++  "--only-debians "
+                                ++  "--arch ${Architecture.lowerName
+                                                architecture} "
                                 ++  "${keyArg}"
                               )
                           ]
@@ -196,9 +205,19 @@ let publish
                                 ++  "--debian-repo ${DebianRepo.bucket_or_default
                                                        spec.debian_repo} "
                                 ++  "--only-debians "
+                                ++  "--arch ${Architecture.lowerName
+                                                architecture} "
                                 ++  "${signedArg}"
                               )
                           ]
+                  )
+                  spec.architectures
+
+          let flatCommands = Prelude.List.concat Cmd.Type commands
+
+          in    [ Command.build
+                    Command.Config::{
+                    , commands = [ Mina.fixPermissionsCommand ] # flatCommands
                     , label = "Debian Packages Publishing"
                     , key =
                         "publish-debians-${DebianChannel.lowerName


### PR DESCRIPTION
### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
