### PR TITLE
Add runtime config method for hard fork config

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -833,6 +833,8 @@ module Accounts = struct
     Result.bind ~f:of_json_layout (Json_layout.Accounts.of_yojson json)
 end
 
+(** Parameters for protocol constants that specify the genesis ledger used by
+    the network *)
 module Ledger = struct
   type base =
     | Named of string  (** One of the named ledgers in [Genesis_ledger] *)
@@ -1186,6 +1188,8 @@ module Proof_keys = struct
     }
 end
 
+(** Parameters for protocol constants that specify slot spans, and relate slot
+    spans to system times *)
 module Genesis = struct
   type t = Json_layout.Genesis.t =
     { k : int option (* the depth of finality constant (in slots) *)
@@ -1349,6 +1353,8 @@ module Daemon = struct
     }
 end
 
+(** Parameters for protocol constants that specify the genesis epoch ledger
+    snapshots used by the network *)
 module Epoch_data = struct
   module Data = struct
     type t = { ledger : Ledger.t; seed : string }


### PR DESCRIPTION
The `fork_config_of_ledgers` is a combination of the existing `make_fork_config` and the semi-manual steps of the previous semi-manual hard fork config generation procedure. It will generate the `daemon.json` for the automatic hard fork procedure. See https://github.com/MinaProtocol/mina/blob/compatible/docs/upgrading-to-berkeley.md for more information on how the manual process worked.

To summarize, this method needs to do exactly what `make_fork_config` does, except that:
- the caller needs to compute the genesis ledger hashes (merkle root and s3 hash) and the genesis timestamp
- the method should include the genesis timestamp in the config, rather than relying on someone doing that manually
- the method should include the ledger hashes in the config instead of the actual lists of accounts

This method is not yet tested; it will at the very least be tested when we start full hard fork runs that have some nodes doing the legacy hard fork procedure and some doing the automated procedure; we can compare the legacy `daemon.json` to the one generated by this method and make sure they're compatible. (They won't be exactly equal, because the s3 hash might differ). It will also be tested in single-node tests.