### PR TITLE
Remove specialized build for mainnet/testnet archives

### DIFF
--- a/src/app/archive/archive_mainnet_signatures.ml
+++ b/src/app/archive/archive_mainnet_signatures.ml
@@ -1,5 +1,0 @@
-open Async
-
-let () =
-  Command.run
-    (Command.group ~summary:"Archive node commands" Archive_cli.commands)

--- a/src/app/archive/archive_testnet_signatures.ml
+++ b/src/app/archive/archive_testnet_signatures.ml
@@ -1,5 +1,0 @@
-open Async
-
-let () =
-  Command.run
-    (Command.group ~summary:"Archive node commands" Archive_cli.commands)

--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -10,38 +10,3 @@
  (preprocess
   (pps ppx_version)))
 
-(executable
- (package archive)
- (name archive_testnet_signatures)
- (public_name archive-testnet)
- (modules archive_testnet_signatures)
- (modes native)
- (libraries
-  archive_cli
-  async
-  async_unix
-  core_kernel
-  mina_signature_kind.testnet
-  mina_version)
- (instrumentation
-  (backend bisect_ppx --bisect-sigterm))
- (preprocess
-  (pps ppx_version)))
-
-(executable
- (package archive)
- (name archive_mainnet_signatures)
- (public_name archive-mainnet)
- (modules archive_mainnet_signatures)
- (modes native)
- (libraries
-  archive_cli
-  async
-  async_unix
-  core_kernel
-  mina_signature_kind.mainnet
-  mina_version)
- (instrumentation
-  (backend bisect_ppx --bisect-sigterm))
- (preprocess
-  (pps ppx_version)))


### PR DESCRIPTION
This PR removes 2 executables. They are almost identical to what's being built with `archive.ml`(see [here](https://github.com/MinaProtocol/mina/blob/compatible/src/app/archive/archive.ml)). except they don't intercept versions. 

