### PR TITLE
[CI][Publishing]  Verify jammy. Fix lack of force parameter

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -440,11 +440,12 @@ function publish_debian() {
     echo "     📦  Target debian version: $(calculate_debian_version $__artifact $__target_version $__codename "$__network" "$__arch")"
     if [[ $__dry_run == 0 ]]; then
         # shellcheck disable=SC2068
+        # shellcheck disable=SC2046
         prefix_cmd "$SUBCOMMAND_TAB" source $SCRIPTPATH/../../../scripts/debian/publish.sh \
             --names "$DEBIAN_CACHE_FOLDER/$__codename/${__new_artifact_name}_${__target_version}_${__arch}.deb" \
             --version $__target_version \
             --bucket $__debian_repo \
-            "$(if [[ $__force_upload_debians == 1 ]]; then echo "--force"; fi)" \
+            $(if [[ $__force_upload_debians == 1 ]]; then echo "--force"; fi) \
             -c $__codename \
             -r $__channel \
             --arch $__arch \

--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -439,8 +439,7 @@ function publish_debian() {
     echo " 🍥  Publishing $__artifact debian to $__channel channel with $__target_version version"
     echo "     📦  Target debian version: $(calculate_debian_version $__artifact $__target_version $__codename "$__network" "$__arch")"
     if [[ $__dry_run == 0 ]]; then
-        # shellcheck disable=SC2068
-        # shellcheck disable=SC2046
+        # shellcheck disable=SC2068,SC2046
         prefix_cmd "$SUBCOMMAND_TAB" source $SCRIPTPATH/../../../scripts/debian/publish.sh \
             --names "$DEBIAN_CACHE_FOLDER/$__codename/${__new_artifact_name}_${__target_version}_${__arch}.deb" \
             --version $__target_version \

--- a/scripts/debian/publish.sh
+++ b/scripts/debian/publish.sh
@@ -109,8 +109,9 @@ for _ in {1..10}; do (
 #>> Repository is locked by another user:  at host dc7eaad3c537
 #>> Attempting to obtain a lock
 #/var/lib/gems/2.3.0/gems/deb-s3-0.10.0/lib/deb/s3/lock.rb:24:in `throw': uncaught throw #"Unable to obtain a lock after 60, giving up."
+# shellcheck disable=SC2046
 deb-s3 upload $BUCKET_ARG $S3_REGION_ARG \
-  "$([ "$FORCE" -eq 0 ] && echo "--fail-if-exists")" \
+  $(if [[ "$FORCE" -eq 0 ]]; then echo "--fail-if-exists"; fi) \
   --lock \
   --arch $ARCH \
   --preserve-versions \

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -96,7 +96,7 @@ SCRIPT=' set -x \
 
 case $CODENAME in
   bullseye|bookworm) DOCKER_IMAGE="debian:$CODENAME" ;;
-  focal|noble) DOCKER_IMAGE="ubuntu:$CODENAME" ;;
+  focal|noble|jammy) DOCKER_IMAGE="ubuntu:$CODENAME" ;;
   *) echo "❌  Unknown codename passed: $CODENAME"; exit 1;;
 esac
 


### PR DESCRIPTION
addded jammy case when verify debian.

Fix lack of presence of --force-upload-debian. Previously it renders to '' which is wrongly treated as argument. Reverted change and disabled shellcheck 

There is no way to test the solution for anyone except release manager (who uses release/manager.sh script with debian and aws keys).