### PR TITLE
Use Hardfork account type in Root ledger

### DIFF
--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -97,13 +97,13 @@ module Converting_ledger :
      and type token_id_set := Token_id.Set.t
      and type account_id := Account_id.t
      and type account_id_set := Account_id.Set.t
-     and type converted_account := Account.Unstable.t
+     and type converted_account := Account.Hardfork.t
      and type primary_ledger = Db.t
-     and type converting_ledger = Unstable_db.t
+     and type converting_ledger = Hardfork_db.t
 
 module Root : sig
   include module type of
-      Root.Make (Any_ledger) (Db) (Unstable_db) (Converting_ledger)
+      Root.Make (Any_ledger) (Db) (Hardfork_db) (Converting_ledger)
 
   val as_masked : t -> Mask.Attached.t
 end

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -12,9 +12,9 @@ module type Stable_db_intf =
      and type hash := Ledger_hash.t
      and type root_hash := Ledger_hash.t
 
-module type Unstable_db_intf =
+module type Migrated_db_intf =
   Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.Unstable.t
+    with type account := Account.Hardfork.t
      and type key := Signature_lib.Public_key.Compressed.t
      and type token_id := Token_id.t
      and type token_id_set := Token_id.Set.t
@@ -43,21 +43,21 @@ module type Converting_ledger_intf =
      and type token_id_set := Token_id.Set.t
      and type account_id := Account_id.t
      and type account_id_set := Account_id.Set.t
-     and type converted_account := Account.Unstable.t
+     and type converted_account := Account.Hardfork.t
 
 module Make
     (Any_ledger : Any_ledger_intf)
     (Stable_db : Stable_db_intf
                    with module Location = Any_ledger.M.Location
                     and module Addr = Any_ledger.M.Addr)
-    (Unstable_db : Unstable_db_intf
+    (Migrated_db : Migrated_db_intf
                      with module Location = Any_ledger.M.Location
                       and module Addr = Any_ledger.M.Addr)
     (Converting_ledger : Converting_ledger_intf
                            with module Location = Any_ledger.M.Location
                             and module Addr = Any_ledger.M.Addr
                            with type primary_ledger = Stable_db.t
-                            and type converting_ledger = Unstable_db.t) =
+                            and type converting_ledger = Migrated_db.t) =
 struct
   module Config = struct
     type backing_type = Stable_db | Converting_db [@@deriving equal, yojson]

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -11,9 +11,9 @@ module type Stable_db_intf =
      and type hash := Ledger_hash.t
      and type root_hash := Ledger_hash.t
 
-module type Unstable_db_intf =
+module type Migrated_db_intf =
   Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.Unstable.t
+    with type account := Account.Hardfork.t
      and type key := Signature_lib.Public_key.Compressed.t
      and type token_id := Token_id.t
      and type token_id_set := Token_id.Set.t
@@ -42,7 +42,7 @@ module type Converting_ledger_intf =
      and type token_id_set := Token_id.Set.t
      and type account_id := Account_id.t
      and type account_id_set := Account_id.Set.t
-     and type converted_account := Account.Unstable.t
+     and type converted_account := Account.Hardfork.t
 
 (** Make a root ledger. A root ledger is a database-backed, unmasked ledger used
     at the root of a mina ledger mask tree. Currently only a single stable
@@ -55,14 +55,14 @@ module Make
     (Stable_db : Stable_db_intf
                    with module Location = Any_ledger.M.Location
                     and module Addr = Any_ledger.M.Addr)
-    (Unstable_db : Unstable_db_intf
+    (Migrated_db : Migrated_db_intf
                      with module Location = Any_ledger.M.Location
                       and module Addr = Any_ledger.M.Addr)
     (Converting_ledger : Converting_ledger_intf
                            with module Location = Any_ledger.M.Location
                             and module Addr = Any_ledger.M.Addr
                            with type primary_ledger = Stable_db.t
-                            and type converting_ledger = Unstable_db.t) : sig
+                            and type converting_ledger = Migrated_db.t) : sig
   type t
 
   type root_hash = Ledger_hash.t


### PR DESCRIPTION
We're intending to use the `Account.Hardfork.t` type to represent the upcoming hard fork account changes and migration, so this should be used in `Ledger.Root`.