### PR TITLE
Improve zkapp cmd validity check error report

### DIFF
--- a/changes/17805.md
+++ b/changes/17805.md
@@ -1,0 +1,1 @@
+Improve error messages on checking zkApp command validity. Now the validity check won't short-circuit, but will check all potential errors in all account updates before reporting it.

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -569,7 +569,7 @@ end = struct
       let account_updates =
         Call_forest.mapi account_updates ~f:(fun update_idx p ->
             let account_id = Account_update.account_id p in
-            let vks_overriden' =
+            let vks_overridden' =
               match Account_update.verification_key_update_to_option p with
               | Zkapp_basic.Set_or_keep.Set vk_next ->
                   Account_id.Map.set !vks_overridden ~key:account_id
@@ -636,10 +636,10 @@ end = struct
                 Account_id.Table.update tbl account_id
                   ~f:(const @@ With_hash.hash prioritized_vk) ;
                 (* return the updated overrides *)
-                vks_overridden := vks_overriden' ;
+                vks_overridden := vks_overridden' ;
                 (p, Some prioritized_vk)
             | _ ->
-                vks_overridden := vks_overriden' ;
+                vks_overridden := vks_overridden' ;
                 (p, None) )
       in
       match Queue.to_list error_messages with

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -101,5 +101,12 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_jane ppx_mina ppx_version ppx_inline_test ppx_deriving.std))
+  (pps 
+    ppx_jane 
+    ppx_mina
+    ppx_version
+    ppx_inline_test
+    ppx_deriving.std
+    ppx_sexp_conv
+    ppx_here))
  (synopsis "Mina gut layer"))

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -986,28 +986,20 @@ let add_zkapp_transactions t
     |> Deferred.don't_wait_for ;
     Ivar.read result_ivar
   in
-  let well_formed_errors =
-    List.find_map zkapp_commands ~f:(fun cmd ->
-        match
-          User_command.check_well_formedness
-            ~genesis_constants:t.config.precomputed_values.genesis_constants
-            (Zkapp_command cmd)
-        with
-        | Ok () ->
-            None
-        | Error errs ->
-            Some errs )
-  in
-  match well_formed_errors with
-  | None ->
+  let all_errs = Queue.create () in
+  List.iteri zkapp_commands ~f:(fun idx cmd ->
+      User_command.check_well_formedness
+        ~genesis_constants:t.config.precomputed_values.genesis_constants
+        (Zkapp_command cmd)
+      |> Result.iter_error ~f:(fun this_errs ->
+             Queue.enqueue all_errs (idx, this_errs) ) ) ;
+  match Queue.to_list all_errs with
+  | [] ->
       add_all_txns ()
-  | Some errs ->
-      let error =
-        Error.of_string
-          ( List.map errs ~f:User_command.Well_formedness_error.to_string
-          |> String.concat ~sep:"," )
-      in
-      Deferred.Result.fail error
+  | errs ->
+      Error.create ~here:[%here] "zkapp transaction invalid" errs
+        [%sexp_of: (int * User_command.Well_formedness_error.t list) list]
+      |> Deferred.Result.fail
 
 let next_producer_timing t = t.next_producer_timing
 


### PR DESCRIPTION
This partially solves https://github.com/MinaProtocol/mina/discussions/17766

In short, the error reporting for zkApp command check short circuits. This PR make it so even if any error is reached, the logic will still go through all other checks to report all errors occurred in the input. 


For the other part will open another PR
