### PR TITLE
Remove redundant proof read/write loop

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -890,7 +890,7 @@ let work_selection_method t = t.config.work_selection_method
 let add_complete_work ~logger ~fee ~prover
     ~(results :
        ( Snark_work_lib.Spec.Single.t
-       , Ledger_proof.Cached.t )
+       , Ledger_proof.t )
        Snark_work_lib.Result.Single.Poly.t
        One_or_two.t ) t =
   let update_metrics () =
@@ -943,12 +943,8 @@ let add_complete_work ~logger ~fee ~prover
     Local_sink.push t.pipes.snark_local_sink
       ( Add_solved_work
           ( stmts
-          , Network_pool.Priced_proof.
-              { proof =
-                  proofs
-                  |> One_or_two.map ~f:Ledger_proof.Cached.read_proof_from_disk
-              ; fee = fee_with_prover
-              } )
+          , Network_pool.Priced_proof.{ proof = proofs; fee = fee_with_prover }
+          )
       , cb ))
   |> Deferred.don't_wait_for
 

--- a/src/lib/snark_work_lib/combined_result.mli
+++ b/src/lib/snark_work_lib/combined_result.mli
@@ -1,6 +1,5 @@
 type t =
-  { results :
-      (Single_spec.t, Ledger_proof.Cached.t) Single_result.Poly.t One_or_two.t
+  { results : (Single_spec.t, Ledger_proof.t) Single_result.Poly.t One_or_two.t
   ; fee : Currency.Fee.t
   ; prover : Signature_lib.Public_key.Compressed.t
   }

--- a/src/lib/snark_work_lib/partitioned_result.ml
+++ b/src/lib/snark_work_lib/partitioned_result.ml
@@ -23,14 +23,3 @@ type t =
   , unit
   , (Core.Time.Span.t, Ledger_proof.Cached.t) Proof_carrying_data.t )
   Partitioned_spec.Poly.Stable.V1.t
-
-let read_all_proofs_from_disk : t -> Stable.Latest.t =
-  Partitioned_spec.Poly.map ~f_single_spec:Fn.id ~f_subzkapp_spec:Fn.id
-    ~f_data:
-      (Proof_carrying_data.map_proof ~f:Ledger_proof.Cached.read_proof_from_disk)
-
-let write_all_proofs_to_disk ~proof_cache_db : Stable.Latest.t -> t =
-  Partitioned_spec.Poly.map ~f_single_spec:Fn.id ~f_subzkapp_spec:Fn.id
-    ~f_data:
-      (Proof_carrying_data.map_proof
-         ~f:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db) )

--- a/src/lib/snark_work_lib/partitioned_result.mli
+++ b/src/lib/snark_work_lib/partitioned_result.mli
@@ -23,8 +23,3 @@ type t =
   , unit
   , (Core.Time.Span.t, Ledger_proof.Cached.t) Proof_carrying_data.t )
   Partitioned_spec.Poly.Stable.V1.t
-
-val read_all_proofs_from_disk : t -> Stable.Latest.t
-
-val write_all_proofs_to_disk :
-  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/snark_work_lib/partitioned_spec.ml
+++ b/src/lib/snark_work_lib/partitioned_spec.ml
@@ -81,32 +81,3 @@ module Stable = struct
 end]
 
 type t = (Single_spec.t, Sub_zkapp_spec.t, unit) Poly.t
-
-let read_all_proofs_from_disk : t -> Stable.Latest.t = function
-  | Single { job; data } ->
-      let job =
-        With_job_meta.map ~f_spec:Single_spec.read_all_proofs_from_disk job
-      in
-      Single { job; data }
-  | Sub_zkapp_command { job; data } ->
-      let job =
-        With_job_meta.map ~f_spec:Sub_zkapp_spec.read_all_proofs_from_disk job
-      in
-      Sub_zkapp_command { job; data }
-
-let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-    Stable.Latest.t -> t = function
-  | Single { job; data } ->
-      let job =
-        With_job_meta.map
-          ~f_spec:(Single_spec.write_all_proofs_to_disk ~proof_cache_db)
-          job
-      in
-      Single { job; data }
-  | Sub_zkapp_command { job; data } ->
-      let job =
-        With_job_meta.map
-          ~f_spec:(Sub_zkapp_spec.write_all_proofs_to_disk ~proof_cache_db)
-          job
-      in
-      Sub_zkapp_command { job; data }

--- a/src/lib/snark_work_lib/partitioned_spec.mli
+++ b/src/lib/snark_work_lib/partitioned_spec.mli
@@ -56,8 +56,3 @@ module Stable : sig
 end]
 
 type t = (Single_spec.t, Sub_zkapp_spec.t, unit) Poly.t
-
-val read_all_proofs_from_disk : t -> Stable.Latest.t
-
-val write_all_proofs_to_disk :
-  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/snark_work_lib/selector.ml
+++ b/src/lib/snark_work_lib/selector.ml
@@ -32,13 +32,6 @@ module Spec = struct
   end]
 
   type t = Single.Spec.t Work.Spec.t
-
-  let read_all_proofs_from_disk : t -> Stable.Latest.t =
-    Work.Spec.map ~f:Single.Spec.read_all_proofs_from_disk
-
-  let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-      Stable.Latest.t -> t =
-    Work.Spec.map ~f:(Single.Spec.write_all_proofs_to_disk ~proof_cache_db)
 end
 
 module Result = struct
@@ -59,14 +52,4 @@ module Result = struct
   end]
 
   type t = (Spec.t, Ledger_proof.Cached.t) Work.Result.Stable.V1.t
-
-  let read_all_proofs_from_disk : t -> Stable.Latest.t =
-    Work.Result.map ~f_spec:Spec.read_all_proofs_from_disk
-      ~f_single:Ledger_proof.Cached.read_proof_from_disk
-
-  let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-      Stable.Latest.t -> t =
-    Work.Result.map
-      ~f_spec:(Spec.write_all_proofs_to_disk ~proof_cache_db)
-      ~f_single:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)
 end

--- a/src/lib/snark_work_lib/single_result.ml
+++ b/src/lib/snark_work_lib/single_result.ml
@@ -31,13 +31,3 @@ module Stable = struct
 end]
 
 type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
-
-let read_all_proofs_from_disk : t -> Stable.Latest.t =
-  Poly.map ~f_spec:Single_spec.read_all_proofs_from_disk
-    ~f_proof:Ledger_proof.Cached.read_proof_from_disk
-
-let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-    Stable.Latest.t -> t =
-  Poly.map
-    ~f_spec:(Single_spec.write_all_proofs_to_disk ~proof_cache_db)
-    ~f_proof:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)

--- a/src/lib/snark_work_lib/single_result.mli
+++ b/src/lib/snark_work_lib/single_result.mli
@@ -29,8 +29,3 @@ module Stable : sig
 end]
 
 type t = (Single_spec.t, Ledger_proof.Cached.t) Poly.t
-
-val read_all_proofs_from_disk : t -> Stable.Latest.t
-
-val write_all_proofs_to_disk :
-  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/snark_work_lib/single_spec.ml
+++ b/src/lib/snark_work_lib/single_spec.ml
@@ -70,9 +70,3 @@ type t = (Transaction_witness.t, Ledger_proof.Cached.t) Poly.t
 let read_all_proofs_from_disk : t -> Stable.Latest.t =
   Poly.map ~f_witness:Transaction_witness.read_all_proofs_from_disk
     ~f_proof:Ledger_proof.Cached.read_proof_from_disk
-
-let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-    Stable.Latest.t -> t =
-  Poly.map
-    ~f_witness:(Transaction_witness.write_all_proofs_to_disk ~proof_cache_db)
-    ~f_proof:(Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db)

--- a/src/lib/snark_work_lib/single_spec.mli
+++ b/src/lib/snark_work_lib/single_spec.mli
@@ -47,6 +47,3 @@ end]
 type t = (Transaction_witness.t, Ledger_proof.Cached.t) Poly.t
 
 val read_all_proofs_from_disk : t -> Stable.Latest.t
-
-val write_all_proofs_to_disk :
-  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/snark_work_lib/sub_zkapp_spec.ml
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.ml
@@ -44,36 +44,3 @@ type t =
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
       }
   | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
-
-let read_all_proofs_from_disk : t -> Stable.Latest.t = function
-  | Segment { statement; witness; spec } ->
-      Segment
-        { statement
-        ; witness =
-            Transaction_snark.Zkapp_command_segment.Witness
-            .read_all_proofs_from_disk witness
-        ; spec
-        }
-  | Merge { proof1; proof2 } ->
-      Merge
-        { proof1 = Ledger_proof.Cached.read_proof_from_disk proof1
-        ; proof2 = Ledger_proof.Cached.read_proof_from_disk proof2
-        }
-
-let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
-    Stable.Latest.t -> t = function
-  | Segment { statement; witness; spec } ->
-      Segment
-        { statement
-        ; witness =
-            Transaction_snark.Zkapp_command_segment.Witness
-            .write_all_proofs_to_disk ~proof_cache_db witness
-        ; spec
-        }
-  | Merge { proof1; proof2 } ->
-      Merge
-        { proof1 =
-            Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof1
-        ; proof2 =
-            Ledger_proof.Cached.write_proof_to_disk ~proof_cache_db proof2
-        }

--- a/src/lib/snark_work_lib/sub_zkapp_spec.mli
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.mli
@@ -31,8 +31,3 @@ type t =
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
       }
   | Merge of { proof1 : Ledger_proof.Cached.t; proof2 : Ledger_proof.Cached.t }
-
-val read_all_proofs_from_disk : t -> Stable.Latest.t
-
-val write_all_proofs_to_disk :
-  proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t

--- a/src/lib/work_partitioner/combining_result.mli
+++ b/src/lib/work_partitioner/combining_result.mli
@@ -9,23 +9,12 @@ type half = [ `First | `Second ]
 type submitted_half = [ `First | `Second | `One ]
 
 (** Items inside the pairing pool. *)
-type t =
-  | Spec_only of
-      { spec : Snark_work_lib.Selector.Single.Spec.t One_or_two.t
-      ; sok_message : Mina_base.Sok_message.t
-      }
-      (** We only have a spec, we need to track spec here because SNARK worker
-          will not submit spec -- IDs are enough to identify them. [sok_message]
-          is just a tuple of [prover] and [fee], which are shared meta for the
-          one/two works *)
-  | One_of_two of
-      { other_spec : Snark_work_lib.Selector.Single.Spec.t
-      ; sok_message : Mina_base.Sok_message.t
-      ; in_pool_half : half
-      ; in_pool_result : Snark_work_lib.Result.Single.t
-      }
-      (** In additional to spec, we have one result [in_pool_result]
-      corresponding to [in_pool_half], waiting for the other half. *)
+type t
+
+val of_spec :
+     sok_message:Mina_base.Sok_message.t
+  -> Snark_work_lib.Selector.Single.Spec.t One_or_two.t
+  -> t
 
 (** The result of calling [merge_single_result] *)
 type merge_outcome =
@@ -45,8 +34,7 @@ type merge_outcome =
     to combine what we have in pool, [t], with the incoming single result 
     [submitted_result] corresponding to incoming half [submitted_half] *)
 val merge_single_result :
-     submitted_result:
-       (unit, Ledger_proof.Cached.t) Snark_work_lib.Result.Single.Poly.t
+     submitted_result:(unit, Ledger_proof.t) Snark_work_lib.Result.Single.Poly.t
   -> submitted_half:submitted_half
   -> t
   -> merge_outcome

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -26,13 +26,6 @@ module Zkapp_command_inputs = struct
     * Statement.With_sok.t )
     Nonempty_list.t
 
-  let write_all_proofs_to_disk ~proof_cache_db : Stable.V1.t -> t =
-    Nonempty_list.map ~f:(fun (witness, segment, stmt) ->
-        ( Zkapp_command_segment.Witness.write_all_proofs_to_disk ~proof_cache_db
-            witness
-        , segment
-        , stmt ) )
-
   let read_all_proofs_from_disk : t -> Stable.V1.t =
     Nonempty_list.map ~f:(fun (witness, segment, stmt) ->
         ( Zkapp_command_segment.Witness.read_all_proofs_from_disk witness

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -223,7 +223,7 @@ let consume_job_from_selector ~(partitioner : t)
     (Work.Spec.Partitioned.Stable.Latest.t, _) Result.t =
   let pairing_id = Id_generator.next_id partitioner.single_id_gen () in
   Hashtbl.add_exn partitioner.pairing_pool ~key:pairing_id
-    ~data:(Spec_only { spec = instances; sok_message }) ;
+    ~data:(Combining_result.of_spec ~sok_message instances) ;
 
   match instances with
   | `One single_spec ->
@@ -263,16 +263,9 @@ type submit_result =
 
 let submit_into_combining_result ~submitted_result ~partitioner
     ~combining_result ~submitted_half =
-  let submitted_result_cached =
-    Snark_work_lib.Result.Single.Poly.map ~f_spec:Fn.id
-      ~f_proof:
-        (Ledger_proof.Cached.write_proof_to_disk
-           ~proof_cache_db:partitioner.proof_cache_db )
-      submitted_result
-  in
   match
-    Combining_result.merge_single_result
-      ~submitted_result:submitted_result_cached ~submitted_half combining_result
+    Combining_result.merge_single_result ~submitted_result ~submitted_half
+      combining_result
   with
   | Pending new_combining_result ->
       `Pending new_combining_result


### PR DESCRIPTION
Do not cache/uncache proofs without need.

Bonus: remove some unused functions/

Explain how you tested your changes:
* A simple refactoring, compiler confirms it's good

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
