### PR TITLE
fix bypass changelog

### DIFF
--- a/buildkite/scripts/changelog.sh
+++ b/buildkite/scripts/changelog.sh
@@ -74,7 +74,7 @@ if [[ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]]; then
     exit 1
 fi
 
-./buildkite/scripts/git/check-bypass.sh "!ci-bypass-changelog"
+./buildkite/scripts/git/check-bypass.sh "!ci-bypass-changelog" && exit 0;
 
 REMOTE_BRANCH="origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
 

--- a/buildkite/scripts/git/check-bypass.sh
+++ b/buildkite/scripts/git/check-bypass.sh
@@ -49,9 +49,9 @@ if [[ "$COMMENTED_CODE" == 0 ]]; then
     echo "⏭️  Skipping run as PR is bypassed"
     exit 0
 elif [[ "$COMMENTED_CODE" == 1 ]]; then
-    echo "⚙️  PR is not bypassed. Proceeding with changelog check..."
+    echo "⚙️  PR is not bypassed. Proceeding with check..."
     exit 2
 else
-    echo "❌ Failed to check PR for being eligible for changelog check bypass"
+    echo "❌ Failed to check PR for being eligible for check bypass"
     exit 1
 fi

--- a/buildkite/scripts/git/check-bypass.sh
+++ b/buildkite/scripts/git/check-bypass.sh
@@ -50,6 +50,7 @@ if [[ "$COMMENTED_CODE" == 0 ]]; then
     exit 0
 elif [[ "$COMMENTED_CODE" == 1 ]]; then
     echo "⚙️  PR is not bypassed. Proceeding with changelog check..."
+    exit 2
 else
     echo "❌ Failed to check PR for being eligible for changelog check bypass"
     exit 1


### PR DESCRIPTION
The script should exit, but moving some code to anther script resulting in it being in a subprocess. exit 0 doesn't work anymore. We need to manual detect that check works. 