### PR TITLE
Revert "Lucy > Payments: wait for another block to be produced so we …

### DIFF
--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -487,7 +487,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              ~amount:Currency.Amount.one ~fee ~node:sender 12
          in
          wait_for t
-           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:3
+           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:2
               ~test_config:config ) )
     in
     let%bind () =


### PR DESCRIPTION
…actually use new key to prove works"

This reverts commit 472f0918fbfdc8b6b6c7d788bf10f5ab11d2edd0 which is https://github.com/MinaProtocol/mina/pull/17579


So I'm curious if we're still timing out on this test after all PRs on SNARK worker optimization is merged. If I can revert this change which degraded our test quality I'm more than happy. 

Nightly: https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3894
