### PR TITLE
chore: MacOS compatibility lateral changes

### DIFF
--- a/opam.export
+++ b/opam.export
@@ -65,7 +65,7 @@ installed: [
   "async.v0.14.0"
   "async_kernel.v0.14.0"
   "async_rpc_kernel.v0.14.0"
-  "async_ssl.v0.14.0"
+  "async_ssl.v0.14.0-o1labs"
   "async_unix.v0.14.0"
   "base.v0.14.3"
   "base-bigarray.base"

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -18,7 +18,9 @@
 
 (rule
  (enabled_if
-  (<> %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
+  (and
+   (<> %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n)
+   (<> %{architecture} arm64)))
  (targets rustflags.sexp)
  (action
   (with-stdout-to
@@ -27,12 +29,23 @@
 
 (rule
  (enabled_if
-  (= %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
+  (and
+   (= %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n)
+   (<> %{architecture} arm64)))
  (targets rustflags.sexp)
  (action
   (with-stdout-to
    rustflags.sexp
    (echo "-C target-feature=-bmi2,-adx"))))
+
+(rule
+ (enabled_if
+  (= %{architecture} arm64))
+ (targets rustflags.sexp)
+ (action
+  (with-stdout-to
+   rustflags.sexp
+   (echo ""))))
 
 ;;
 ;; rules to build the static library for kimchi


### PR DESCRIPTION
moves `async_ssl` from public package (v0.14.0) to our own pin (v0.14.0-o1labs), since its not compatible with macos.

also, adds another case to `src/lib/crypto/kimchi_bindings/stubs/dune` that removes optimization flags not supported on `arm64`. (these flags are intel only, and only pollute the build log).

Explain your changes:
* in description

Explain how you tested your changes:
* `opam switch import opam.export`
* `dune build`
* go to `o1js`, `cd src/mina`, `git checkout leon/async-ssl-macos-compat`, `cd ..`, `git submodule update --init --recursive`, and then `npm run build:bindings-all`. (I did this on mac). You will see significant build log shrinkage because of the dune change, and it will also build natively on macos (woo).

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
