### PR TITLE
fix: mutually exclusive dune linker clause

### DIFF
--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -7,7 +7,10 @@
 
 (rule
   (target dune-linker)
-  (enabled_if %{bin-available:lld})
+  (enabled_if 
+    (and
+      (= %{env:DUNE_USE_DEFAULT_LINKER=n} n)
+      %{bin-available:lld}))
   (action (with-stdout-to dune-linker (echo "-fuse-ld=lld"))))
 
 (rule


### PR DESCRIPTION
Explain your changes:
* dune-linker target generates two conflicting targets if `DUNE_USE_DEFAULT_LINKER` is `y` and `lld` is available as a `bin` in the environment.

Explain how you tested your changes:
* The change is logic-only, `dune build` will fail otherwise (with an incorrect `dune` config error)

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
