### PR TITLE
Add raku to toolchain 

### DIFF
--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -46,6 +46,7 @@ RUN apt-get update --yes \
     python3-sexpdata \
     rubygems \
     wget \
+    rakudo \
   && rm -rf /var/lib/apt/lists/*
 
 # --- deb-s3 tool


### PR DESCRIPTION
This PR attempts to add raku to toolchain. I want to migrate some of our legacy bash/python script that are poorly designed into raku. 

### Rationale

- Turing Complete (in contrast to dhall)
-  Familiar to dev-ops & can rely on rich ecosystem from Perl5 (in constrast to my random scripting language)
- Have a real gradually-typed typing system (in contrast to python/ruby)
- No compilation needed (in contrast to rust/ocaml)