### PR TITLE
Fix rosetta mainnet connectivity test attempt 2

### DIFF
--- a/scripts/tests/ROSETTA_TESTS.md
+++ b/scripts/tests/ROSETTA_TESTS.md
@@ -82,13 +82,12 @@ The Rosetta API test suite consists of four main scripts that work together to p
 
 **Usage**:
 ```bash
-./rosetta-sanity.sh [--network mainnet|devnet] [--address <address>] [--wait-for-sync] [--timeout <seconds>]
+./rosetta-sanity.sh [--network mainnet|devnet] [--address <address>] [--timeout <seconds>]
 ```
 
 **Command-line Options**:
 - `--network`: Target network (mainnet or devnet, default: mainnet)
 - `--address`: Override Rosetta API endpoint address
-- `--wait-for-sync`: Wait for Rosetta to sync before running tests
 - `--timeout`: Sync timeout in seconds (default: 900)
 
 **Test Data Configuration**:
@@ -124,9 +123,6 @@ The Rosetta API test suite consists of four main scripts that work together to p
 
 # Devnet testing with custom endpoint
 ./rosetta-sanity.sh --network devnet --address http://localhost:3087
-
-# Wait for sync before testing
-./rosetta-sanity.sh --network mainnet --wait-for-sync --timeout 1200
 ```
 
 ### 3. rosetta-load.sh

--- a/scripts/tests/ROSETTA_TESTS.md
+++ b/scripts/tests/ROSETTA_TESTS.md
@@ -82,13 +82,12 @@ The Rosetta API test suite consists of four main scripts that work together to p
 
 **Usage**:
 ```bash
-./rosetta-sanity.sh [--network mainnet|devnet] [--address <address>] [--timeout <seconds>]
+./rosetta-sanity.sh [--network mainnet|devnet] [--address <address>]
 ```
 
 **Command-line Options**:
 - `--network`: Target network (mainnet or devnet, default: mainnet)
 - `--address`: Override Rosetta API endpoint address
-- `--timeout`: Sync timeout in seconds (default: 900)
 
 **Test Data Configuration**:
 

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -148,7 +148,7 @@ execute_script() {
 # Wait for the container to start
 sleep 5
 #run sanity test
-./scripts/tests/rosetta-sanity.sh --address "http://localhost:3087" --network $NETWORK --wait-for-sync --timeout $TIMEOUT
+./scripts/tests/rosetta-sanity.sh --address "http://localhost:3087" --network $NETWORK --timeout $TIMEOUT
 
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then

--- a/scripts/tests/rosetta-connectivity.sh
+++ b/scripts/tests/rosetta-connectivity.sh
@@ -98,7 +98,8 @@ if [[ -z "$TAG" ]]; then usage "Docker tag is not set!"; usage; exit 1; fi;
 
 set -x
 
-container_id=$(docker run -v .:/workdir -p 3087:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
+container_id=$(docker run -v .:/workdir -p 0:3087 -d --env MINA_NETWORK=$NETWORK gcr.io/o1labs-192920/mina-rosetta:$TAG-$NETWORK )
+rosetta_address_on_host=$(docker port $container_id 3087 | head -n1)
 
 stop_docker() {
         { docker stop "$container_id" ; docker rm "$container_id" ; } || true
@@ -148,7 +149,7 @@ execute_script() {
 # Wait for the container to start
 sleep 5
 #run sanity test
-./scripts/tests/rosetta-sanity.sh --address "http://localhost:3087" --network $NETWORK --timeout $TIMEOUT
+./scripts/tests/rosetta-sanity.sh --address "http://$rosetta_address_on_host" --network $NETWORK --timeout $TIMEOUT
 
 # Run load test
 if [[ "$RUN_LOAD_TEST" == true ]]; then

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -54,8 +54,12 @@ function wait_for_sync() {
     done
 }
 
+# TODO: make it configurable.
+DAEMON_SYNC_TIMEOUT=900
+
 function test_network_status() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
         '.sync_status.stage == "Synced"' \
         "   ✅  Rosetta is synced" \
@@ -64,6 +68,7 @@ function test_network_status() {
 
 function test_network_options() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
         '.version.rosetta_version == "1.4.9"' \
         "   ✅  Rosetta Version is correct" \
@@ -72,6 +77,7 @@ function test_network_options() {
 
 function test_block() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/block" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"block_identifier\":{\"hash\":\"${__test_data[block]}\"}}" | jq)" \
         ".block.block_identifier.hash == \"${__test_data[block]}\" " \
         "   ✅  Block hash correct" \
@@ -80,6 +86,7 @@ function test_block() {
 
 function test_account_balance() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
         '.balances[0].currency.symbol == "MINA"' \
         "   ✅  Account: Balance ok" \
@@ -88,6 +95,7 @@ function test_account_balance() {
 
 function test_payment_transaction() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
         \"network_identifier\": {
             \"blockchain\": \"$BLOCKCHAIN\",
@@ -104,6 +112,7 @@ function test_payment_transaction() {
 
 function test_zkapp_transaction() {
     declare -n __test_data=$1
+    wait_for_sync "$1" $DAEMON_SYNC_TIMEOUT
     assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
         \"network_identifier\": {
             \"blockchain\": \"$BLOCKCHAIN\",

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -115,9 +115,4 @@ function run_tests_with_test_data() {
     echo "🎉  All tests passed successfully!"
 }
 
-echo "⏳  Waiting for Rosetta to sync on $NETWORK..."
-if ! wait_for_sync "$NETWORK" "$TIMEOUT"; then
-    echo "❌  Failed to sync with $NETWORK within timeout period"
-    exit 1
-fi
 run_tests_with_test_data "$NETWORK"

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -11,14 +11,13 @@
 #
 # OPTIONS:
 #   --network <mainnet|devnet>    Specify the network to test (default: mainnet)
-#   --wait-for-sync               Wait for Rosetta node to sync before running tests
 #   --timeout <seconds>           Timeout for sync wait in seconds (default: 900)
 #   --address <url>               Override the default Rosetta endpoint address
 #   -h, --help                    Display this help message
 #
 # EXAMPLES:
 #   ./rosetta-sanity.sh --network mainnet
-#   ./rosetta-sanity.sh --network devnet --wait-for-sync --timeout 1200
+#   ./rosetta-sanity.sh --network devnet --timeout 1200
 #   ./rosetta-sanity.sh --address http://localhost:3087 --network mainnet
 #
 # TEST COVERAGE:
@@ -42,7 +41,6 @@
 # VERSION: 1.0
 
 NETWORK="mainnet"
-WAIT_FOR_SYNC=false
 TIMEOUT=900
 
 declare -A mainnet
@@ -72,7 +70,6 @@ while [[ "$#" -gt 0 ]]; do
             fi
             shift
             ;;
-        --wait-for-sync) WAIT_FOR_SYNC=true ;;
         --timeout) TIMEOUT="$2"; shift ;;
         --address) 
                    
@@ -118,11 +115,9 @@ function run_tests_with_test_data() {
     echo "🎉  All tests passed successfully!"
 }
 
-if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
-    echo "⏳  Waiting for Rosetta to sync on $NETWORK..."
-    if ! wait_for_sync "$NETWORK" "$TIMEOUT"; then
-        echo "❌  Failed to sync with $NETWORK within timeout period"
-        exit 1
-    fi
+echo "⏳  Waiting for Rosetta to sync on $NETWORK..."
+if ! wait_for_sync "$NETWORK" "$TIMEOUT"; then
+    echo "❌  Failed to sync with $NETWORK within timeout period"
+    exit 1
 fi
 run_tests_with_test_data "$NETWORK"

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -64,7 +64,14 @@ devnet[zkapp_transaction]="5JuJuyKtrMvxGroWyNE3sxwpuVsupvj7SA8CDX4mqWms4ZZT4Arz"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        --network) NETWORK="$2"; shift ;;
+        --network) 
+            NETWORK="$2"; 
+            if [[ "$NETWORK" != "mainnet" && "$NETWORK" != "devnet" ]]; then
+                echo "Unknown network: $NETWORK. Available networks: mainnet, devnet. Exiting..."
+                exit 1
+            fi
+            shift
+            ;;
         --wait-for-sync) WAIT_FOR_SYNC=true ;;
         --timeout) TIMEOUT="$2"; shift ;;
         --address) 
@@ -111,25 +118,11 @@ function run_tests_with_test_data() {
     echo "🎉  All tests passed successfully!"
 }
 
-if [[ "$NETWORK" == "mainnet" ]]; then
-    if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
-        echo "⏳  Waiting for Rosetta to sync on mainnet..."
-        if ! wait_for_sync "mainnet" "$TIMEOUT"; then
-            echo "❌  Failed to sync with mainnet within timeout period"
-            exit 1
-        fi
+if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
+    echo "⏳  Waiting for Rosetta to sync on $NETWORK..."
+    if ! wait_for_sync "$NETWORK" "$TIMEOUT"; then
+        echo "❌  Failed to sync with $NETWORK within timeout period"
+        exit 1
     fi
-    run_tests_with_test_data "mainnet"
-elif [[ "$NETWORK" == "devnet" ]]; then
-    if [[ "$WAIT_FOR_SYNC" == "true" ]]; then
-        echo "⏳  Waiting for Rosetta to sync on devnet..."
-        if ! wait_for_sync "devnet" "$TIMEOUT"; then
-            echo "❌  Failed to sync with devnet within timeout period"
-            exit 1
-        fi
-    fi
-    run_tests_with_test_data "devnet"
-else
-    echo "Unknown network: $NETWORK. available networks: mainnet, devnet. Exiting..."
-    exit 1
 fi
+run_tests_with_test_data "$NETWORK"

--- a/scripts/tests/rosetta-sanity.sh
+++ b/scripts/tests/rosetta-sanity.sh
@@ -11,13 +11,12 @@
 #
 # OPTIONS:
 #   --network <mainnet|devnet>    Specify the network to test (default: mainnet)
-#   --timeout <seconds>           Timeout for sync wait in seconds (default: 900)
 #   --address <url>               Override the default Rosetta endpoint address
 #   -h, --help                    Display this help message
 #
 # EXAMPLES:
 #   ./rosetta-sanity.sh --network mainnet
-#   ./rosetta-sanity.sh --network devnet --timeout 1200
+#   ./rosetta-sanity.sh --network devnet
 #   ./rosetta-sanity.sh --address http://localhost:3087 --network mainnet
 #
 # TEST COVERAGE:
@@ -41,7 +40,6 @@
 # VERSION: 1.0
 
 NETWORK="mainnet"
-TIMEOUT=900
 
 declare -A mainnet
 mainnet[id]="mainnet"
@@ -70,7 +68,6 @@ while [[ "$#" -gt 0 ]]; do
             fi
             shift
             ;;
-        --timeout) TIMEOUT="$2"; shift ;;
         --address) 
                    
                    # shellcheck disable=SC2034


### PR DESCRIPTION
This PR checks daemon status before querying on rosetta for every query. So if daemon decides to go back to bootstrap, this test is unaffected. 

After multiple retry mainnet connectivity passes. The failed attempt seems to pointing issue to archive instability, which is good cause it's no longer due to rosetta/daemon instability. 