### PR TITLE
Add additional SW internal trace logging

### DIFF
--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -171,7 +171,7 @@ type t =
   ; status : Mina_base.Transaction_status.t
   ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
   }
-[@@deriving sexp_of, to_yojson]
+[@@deriving fields, sexp_of, to_yojson]
 
 let read_all_proofs_from_disk
     { transaction

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -108,7 +108,7 @@ type t =
   ; status : Mina_base.Transaction_status.t
   ; block_global_slot : Mina_numbers.Global_slot_since_genesis.t
   }
-[@@deriving sexp_of, to_yojson]
+[@@deriving fields, sexp_of, to_yojson]
 
 val read_all_proofs_from_disk : t -> Stable.Latest.t
 

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -2,10 +2,21 @@ open Core_kernel
 open Currency
 
 module Test_inputs = struct
-  module Transaction_witness = Int
+  module Transaction_witness = struct
+    type t = Int.t
+
+    let transaction = Fn.id
+  end
+
   module Ledger_hash = Int
   module Sparse_ledger = Int
-  module Transaction = Int
+
+  module Transaction = struct
+    type t = Int.t
+
+    let yojson_summary t = `Int t
+  end
+
   module Ledger_proof_statement = Fee
 
   module Transaction_protocol_state = struct

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -20,10 +20,14 @@ module type Inputs_intf = sig
 
   module Transaction : sig
     type t
+
+    val yojson_summary : t -> Yojson.Safe.t
   end
 
   module Transaction_witness : sig
     type t
+
+    val transaction : t -> Transaction.t
   end
 
   module Ledger_proof : sig

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -117,7 +117,8 @@ module type Lib_intf = sig
 
     (** [mark_scheduled t work] Mark [work] as scheduled in [t] *)
     val mark_scheduled :
-         t
+         logger:Logger.t
+      -> t
       -> ( Transaction_witness.t
          , Ledger_proof.Cached.t )
          Snark_work_lib.Work.Single.Spec.t

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -1,14 +1,14 @@
 open Core_kernel
 
 module Make (Lib : Intf.Lib_intf) = struct
-  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
     match Lib.State.all_unscheduled_expensive_works ~snark_pool ~fee state with
     | [] ->
         None
     | expensive_work ->
         let i = Random.int (List.length expensive_work) in
         let x = List.nth_exn expensive_work i in
-        Lib.State.mark_scheduled state x ;
+        Lib.State.mark_scheduled ~logger state x ;
         Some x
 end
 

--- a/src/lib/work_selector/random_offset.ml
+++ b/src/lib/work_selector/random_offset.ml
@@ -42,14 +42,14 @@ module Make (Lib : Intf.Lib_intf) = struct
         List.nth_exn expensive_work !offset
   end
 
-  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
     match Lib.State.all_unscheduled_expensive_works ~snark_pool ~fee state with
     | [] ->
         None
     | expensive_work ->
         Offset.update ~new_length:(List.length expensive_work) ;
         let x = Offset.get_nth expensive_work in
-        Lib.State.mark_scheduled state x ;
+        Lib.State.mark_scheduled ~logger state x ;
         Some x
 end
 

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -1,10 +1,10 @@
 module Make (Lib : Intf.Lib_intf) = struct
-  let work ~snark_pool ~fee ~logger:_ (state : Lib.State.t) =
+  let work ~snark_pool ~fee ~logger (state : Lib.State.t) =
     match Lib.State.all_unscheduled_expensive_works ~snark_pool ~fee state with
     | [] ->
         None
     | x :: _ ->
-        Lib.State.mark_scheduled state x ;
+        Lib.State.mark_scheduled ~logger state x ;
         Some x
 end
 


### PR DESCRIPTION
Add internal trace logging for snark work being added to the work selector, and then scheduled.

This would allow measurement of real time required to process SWs during experiments.

Explain how you tested your changes:
* To be tested on cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
