### PR TITLE
Push sig kind out of txn witness

### DIFF
--- a/src/lib/snark_work_lib/sub_zkapp_spec.ml
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.ml
@@ -67,7 +67,9 @@ let write_all_proofs_to_disk ~(proof_cache_db : Proof_cache_tag.cache_db) :
         { statement
         ; witness =
             Transaction_snark.Zkapp_command_segment.Witness
-            .write_all_proofs_to_disk ~proof_cache_db witness
+            .write_all_proofs_to_disk
+              ~signature_kind:Mina_signature_kind.t_DEPRECATED ~proof_cache_db
+              witness
         ; spec
         }
   | Merge { proof1; proof2 } ->

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -318,7 +318,7 @@ module Impl = struct
             } ->
             let witness =
               Transaction_witness.Zkapp_command_segment_witness
-              .write_all_proofs_to_disk ~proof_cache_db witness
+              .write_all_proofs_to_disk ~signature_kind ~proof_cache_db witness
             in
 
             let%map proof, elapsed =

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -107,7 +107,7 @@ module Zkapp_command_segment_witness = struct
     ; block_global_slot
     }
 
-  let write_all_proofs_to_disk ~proof_cache_db
+  let write_all_proofs_to_disk ~signature_kind ~proof_cache_db
       ({ global_first_pass_ledger
        ; global_second_pass_ledger
        ; local_state_init
@@ -117,7 +117,6 @@ module Zkapp_command_segment_witness = struct
        ; block_global_slot
        } :
         Stable.V1.t ) : t =
-    let signature_kind = Mina_signature_kind.t_DEPRECATED in
     { global_first_pass_ledger
     ; global_second_pass_ledger
     ; local_state_init =

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -78,7 +78,10 @@ module Zkapp_command_segment_witness : sig
   val read_all_proofs_from_disk : t -> Stable.Latest.t
 
   val write_all_proofs_to_disk :
-    proof_cache_db:Proof_cache_tag.cache_db -> Stable.Latest.t -> t
+       signature_kind:Mina_signature_kind.t
+    -> proof_cache_db:Proof_cache_tag.cache_db
+    -> Stable.Latest.t
+    -> t
 end
 
 [%%versioned:

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -28,7 +28,8 @@ module Zkapp_command_inputs = struct
 
   let write_all_proofs_to_disk ~proof_cache_db : Stable.V1.t -> t =
     Nonempty_list.map ~f:(fun (witness, segment, stmt) ->
-        ( Zkapp_command_segment.Witness.write_all_proofs_to_disk ~proof_cache_db
+        ( Zkapp_command_segment.Witness.write_all_proofs_to_disk
+            ~signature_kind:Mina_signature_kind.t_DEPRECATED ~proof_cache_db
             witness
         , segment
         , stmt ) )


### PR DESCRIPTION
A simple noop PR pushing sig kind out of txn witness. 

It's previously suggested by @georgeee we should store txn kind in proof cache db. But it seems they're not actually attached to proofs stored in proof cache DB. hence I'm leaning toward pushing upward, and here is this PR. 