### PR TITLE
Increase rosetta test postgres memory threshold

### DIFF
--- a/scripts/tests/rosetta-load.sh
+++ b/scripts/tests/rosetta-load.sh
@@ -59,7 +59,7 @@ readonly DEFAULT_PAYMENT_TX_INTERVAL="2"
 readonly DEFAULT_ZKAPP_TX_INTERVAL="1"
 
 # Default memory threshold for PostgreSQL processes
-readonly DEFAULT_POSTGRES_MEMORY_THRESHOLD="2500"  # MB
+readonly DEFAULT_POSTGRES_MEMORY_THRESHOLD="3000"  # MB
 
 # Default memory threshold for Rosetta API processes
 readonly DEFAULT_ROSETTA_MEMORY_THRESHOLD="300"   # MB


### PR DESCRIPTION
The postgres instance in the rosetta tests is exceeding the current default memory limit of 2500MB somewhat regularly; it seems as though it was close to this limit in past tests, and is now finally exceeding it. The limit is now temporarily 3000MB until we either decide that the memory usage is still fine, or we find out why the memory usage is increasing and fix that issue.

Waiting on nightly run: https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/3907

Some components of the nightly build seem to be failing for unrelated reasons (git issues). The connectivity tests did run, however, and the highest transitory memory value I saw was this:

```
2025-09-30 19:24:30 - 🔄 Current TPS: 2.99, 📈 Average TPS: 3.15, 📊 Total Requests: 1730
  📊 Memory Usage:
   - 🐘 PostgreSQL: 2654.4 MB
   - 📦 Mina-archive: 147.621 MB
   - 🌹 Mina-rosetta: 224.027 MB
```

The averages at the end of the devnet connectivity doesn't seem too bad:

```
Duration limit reached (600s). Stopping load test.
2025-09-30 19:25:21 - 🏁 FINAL STATISTICS:
  ⏱️  Total Duration: 600.051879352s
  📊 Total Requests: 1888
  📈 Average TPS: 3.14
  📊 Memory Usage:
   - 🐘 PostgreSQL: 2141.64 MB
   - 📦 Mina-archive: 147.621 MB
   - 🌹 Mina-rosetta: 224.156 MB
```

considering that in the PR https://github.com/MinaProtocol/mina/pull/16704 that introduced the caqti upgrade and this memory monitoring, the average was `2074.36 MiB`. (For reference, the highest transitory memory usage I could see reported in the original run done in that PR was 2357.15 MB).