### PR TITLE
Remove sigkind from most of Rosetta

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -618,13 +618,14 @@ module Parse = struct
             -> unit
             -> (bool, Errors.t) M.t
         ; lift : 'a 'e. ('a, 'e) Result.t -> ('a, 'e) M.t
+        ; signature_kind : Mina_signature_kind.t
         }
     end
 
     module Real = T (Deferred.Result)
     module Mock = T (Result)
 
-    let real : Real.t =
+    let real ~signature_kind : Real.t =
       { verify_payment_signature =
           (fun ~payment ~signature () ->
             let open Deferred.Result in
@@ -675,11 +676,11 @@ module Parse = struct
               Signed_command_payload.create ~fee ~fee_payer_pk ~nonce
                 ~valid_until ~memo ~body
             in
-            let signature_kind = Mina_signature_kind.t_DEPRECATED in
             Option.is_some
             @@ Signed_command.create_with_signature_checked ~signature_kind
                  signature signer payload )
       ; lift = Deferred.return
+      ; signature_kind
       }
   end
 
@@ -1082,8 +1083,8 @@ module Submit = struct
   module Mock = Impl (Result)
 end
 
-let router ~get_graphql_uri_or_error ~with_db ~logger ~account_creation_fee
-    ~minimum_user_command_fee (route : string list) body =
+let router ~signature_kind ~get_graphql_uri_or_error ~with_db ~logger
+    ~account_creation_fee ~minimum_user_command_fee (route : string list) body =
   [%log debug] "Handling /construction/ $route"
     ~metadata:[ ("route", `List (List.map route ~f:(fun s -> `String s))) ] ;
   let open Deferred.Result.Let_syntax in
@@ -1151,7 +1152,9 @@ let router ~get_graphql_uri_or_error ~with_db ~logger ~account_creation_fee
         |> Errors.Lift.wrap
       in
       let%map res =
-        Parse.Real.handle ~minimum_user_command_fee ~env:Parse.Env.real req
+        Parse.Real.handle ~minimum_user_command_fee
+          ~env:(Parse.Env.real ~signature_kind)
+          req
         |> Errors.Lift.wrap
       in
       Construction_parse_response.to_yojson res

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -39,7 +39,7 @@ module Keys = struct
 end
 
 (* Returns signed_transaction_string *)
-let sign ~(keys : Keys.t) ~unsigned_transaction_string =
+let sign ~signature_kind ~(keys : Keys.t) ~unsigned_transaction_string =
   let open Result.Let_syntax in
   let%bind json =
     try return (Yojson.Safe.from_string unsigned_transaction_string)
@@ -57,7 +57,6 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
     |> Result.ok
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   (* TODO: Should we use the signer_input explicitly here to dogfood it? *)
   (* Should we just inline that here? *)
   let signature =
@@ -71,7 +70,7 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
   [%test_eq: Signature.t] signature signature' ;
   signature |> Signature.Raw.encode
 
-let verify ~public_key_hex_bytes ~signed_transaction_string =
+let verify ~signature_kind ~public_key_hex_bytes ~signed_transaction_string =
   let open Result.Let_syntax in
   let%bind json =
     try return (Yojson.Safe.from_string signed_transaction_string)
@@ -90,7 +89,6 @@ let verify ~public_key_hex_bytes ~signed_transaction_string =
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
   let message = Signed_command.to_input_legacy user_command_payload in
-  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   Schnorr.Legacy.verify ~signature_kind signed_transaction.signature
     (Snark_params.Tick.Inner_curve.of_affine public_key)
     message

--- a/src/app/rosetta/ocaml-signer/signer.ml
+++ b/src/app/rosetta/ocaml-signer/signer.ml
@@ -2,5 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
-       Signer_cli.commands )
+    ( Command.group ~summary:"OCaml reference signer implementation for Rosetta."
+    @@ Signer_cli.commands ~signature_kind:Mina_signature_kind.t_DEPRECATED )

--- a/src/app/rosetta/ocaml-signer/signer_mainnet_signatures.ml
+++ b/src/app/rosetta/ocaml-signer/signer_mainnet_signatures.ml
@@ -2,5 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
-       Signer_cli.commands )
+    ( Command.group ~summary:"OCaml reference signer implementation for Rosetta."
+    @@ Signer_cli.commands ~signature_kind:Mina_signature_kind.Mainnet )

--- a/src/app/rosetta/ocaml-signer/signer_testnet_signatures.ml
+++ b/src/app/rosetta/ocaml-signer/signer_testnet_signatures.ml
@@ -2,5 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
-       Signer_cli.commands )
+    ( Command.group ~summary:"OCaml reference signer implementation for Rosetta."
+    @@ Signer_cli.commands ~signature_kind:Mina_signature_kind.Testnet )

--- a/src/app/rosetta/rosetta.ml
+++ b/src/app/rosetta/rosetta.ml
@@ -6,5 +6,6 @@ let () =
   let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
     (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
+       (command ~signature_kind:Mina_signature_kind.t_DEPRECATED
+          ~account_creation_fee:constraint_constants.account_creation_fee
           ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )

--- a/src/app/rosetta/rosetta_mainnet_signatures.ml
+++ b/src/app/rosetta/rosetta_mainnet_signatures.ml
@@ -6,5 +6,6 @@ let () =
   let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
     (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
+       (command ~signature_kind:Mina_signature_kind.Mainnet
+          ~account_creation_fee:constraint_constants.account_creation_fee
           ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )

--- a/src/app/rosetta/rosetta_testnet_signatures.ml
+++ b/src/app/rosetta/rosetta_testnet_signatures.ml
@@ -6,5 +6,6 @@ let () =
   let constraint_constants = Genesis_constants.Compiled.constraint_constants in
   Command.run
     (Command.async ~summary:"Run Rosetta process on top of Mina"
-       (command ~account_creation_fee:constraint_constants.account_creation_fee
+       (command ~signature_kind:Mina_signature_kind.Testnet
+          ~account_creation_fee:constraint_constants.account_creation_fee
           ~minimum_user_command_fee:genesis_constants.minimum_user_command_fee ) )

--- a/src/lib/string_sign/string_sign.ml
+++ b/src/lib/string_sign/string_sign.ml
@@ -53,17 +53,11 @@ let string_to_input s =
     ; bitstrings = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s)))
     }
 
-let verify ?signature_kind signature pk s =
+let verify ~signature_kind signature pk s =
   let m = string_to_input s in
   let inner_curve = Inner_curve.of_affine pk in
-  let signature_kind =
-    Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-  in
   Schnorr.Legacy.verify ~signature_kind signature inner_curve m
 
-let sign ?signature_kind sk s =
+let sign ~signature_kind sk s =
   let m = string_to_input s in
-  let signature_kind =
-    Option.value signature_kind ~default:Mina_signature_kind.t_DEPRECATED
-  in
   Schnorr.Legacy.sign ~signature_kind sk m

--- a/src/lib/string_sign/tests/test_string_sign.ml
+++ b/src/lib/string_sign/tests/test_string_sign.ml
@@ -29,10 +29,11 @@ let test_default_network () =
   let s =
     "Now is the time for all good men to come to the aid of their party"
   in
-  let signature = sign keypair.private_key s in
+  let signature_kind = Mina_signature_kind.Testnet in
+  let signature = sign ~signature_kind keypair.private_key s in
   Alcotest.(check bool)
     "Sign and verify with default network" true
-    (verify signature keypair.public_key s)
+    (verify ~signature_kind signature keypair.public_key s)
 
 (* Test signing and verification with mainnet *)
 let test_mainnet () =


### PR DESCRIPTION
Move usage of `t_DEPRECATED` to executables.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
