### PR TITLE
Display downloader jobs in console debug log

### DIFF
--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -1076,7 +1076,7 @@ end = struct
     every ~stop (Time.Span.of_sec 30.) (fun () ->
         [%log' debug t.logger]
           ~metadata:[ ("jobs", to_yojson t) ]
-          "Downloader jobs" ) ;
+          "Downloader $jobs" ) ;
     refresh_peers t peers ;
     t
 


### PR DESCRIPTION
The string for this particular log message (displaying the downloader jobs every 30s) was missing a `$` before `jobs`, so the list of jobs was not being displayed in the console output.

I tested this change by syncing a node to devnet and observing that the downloader jobs were in fact printed. (I've omitted the full list to save space).

```
2025-10-01 18:26:28 UTC [Debug] Downloader $jobs
  jobs: {
  "total_jobs": 0,
  "useful_peers": {
    "all": {
```

Before this change, this line would just be this:

```
2025-10-01 18:26:28 UTC [Debug] Downloader jobs
```