### PR TITLE
Fix epoch snapshot loading when first booting with ledger sync enabled

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -461,7 +461,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let create_epoch_ledger ~config ~context:(module Context : CONTEXT)
           ~genesis_epoch_ledger =
         let open Context in
-        if Mina_ledger.Ledger.Root.Config.exists_backing config then (
+        if Mina_ledger.Ledger.Root.Config.exists_any_backing config then (
           [%log info]
             ~metadata:
               [ ("config", Mina_ledger.Ledger.Root.Config.to_yojson config) ]

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -86,6 +86,12 @@ struct
       | Converting_db_config { primary_directory; converting_directory } ->
           file_exists primary_directory && file_exists converting_directory
 
+    let exists_any_backing = function
+      | Stable_db_config path ->
+          file_exists path
+      | Converting_db_config { primary_directory; converting_directory = _ } ->
+          file_exists primary_directory
+
     let with_directory ~backing_type ~directory_name =
       match backing_type with
       | Stable_db ->

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -90,6 +90,10 @@ module Make
     (** Test if a root ledger backing already exists with this config *)
     val exists_backing : t -> bool
 
+    (** Test if a root ledger backing already exists with this config, ignoring
+        the specific backing type of the root *)
+    val exists_any_backing : t -> bool
+
     (** Delete a backing of any type that might exist with this config, if 
         present. this function will try any backing type even if it didn't match
         up with one provided in the config *)

--- a/src/lib/mina_ledger/test/test_mina_ledger.ml
+++ b/src/lib/mina_ledger/test/test_mina_ledger.ml
@@ -115,7 +115,7 @@ module Root_test = struct
         in
         L.Root.Config.move_backing_exn ~src:config ~dst:config_moved ;
         assert (
-          (not (L.Root.Config.exists_backing config))
+          (not (L.Root.Config.exists_any_backing config))
           && L.Root.Config.exists_backing config_moved
           || failwith "Config is not moved" ) ;
         let root_moved =


### PR DESCRIPTION
This will partially fix https://github.com/MinaProtocol/mina/issues/17899, in particular the bit of incorrect code I noted in https://github.com/MinaProtocol/mina/issues/17899#issuecomment-3362695503.

For context: when the daemon first boots up, it will try to load existing epoch ledger snapshots from disk. These snapshots might have been created without `--hardfork-mode auto`. If they were, then there will be no migrated database present alongside the stable one. This would cause `exists_backing` to fail. The new `exists_any_backing` checks for only the presence of the stable database. This allows the daemon to load a pre-existing snapshot, potentially by migrating the existing stable database.

I haven't added a test for this yet, but I can confirm based on manual testing that this issue is now resolved. I'll open an issue with some ideas for ledger sync/auto hard fork component tests that we'll want to write.