### PR TITLE
Don't clean up stale lock file from another daemon in daemon entrypoint

### DIFF
--- a/dockerfiles/scripts/daemon-entrypoint.sh
+++ b/dockerfiles/scripts/daemon-entrypoint.sh
@@ -55,7 +55,6 @@ fi
 mkdir -p .mina-config
 
 set +e # Allow remaining commands to fail without exiting early
-rm -f .mina-config/.mina-lock
 
 # Export variables that the daemon would read directly
 export MINA_PRIVKEY_PASS MINA_LIBP2P_PASS UPTIME_PRIVKEY_PASS


### PR DESCRIPTION
This logic has been introduced into daemon recently. 
https://github.com/MinaProtocol/mina/blob/9e0cb54c6bb7a6d1d65f1c1502f645aecb3efbc6/src/lib/mina_lib/conf_dir.ml#L82