### PR TITLE
Fix format of reporting merge SW traces

### DIFF
--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -9,7 +9,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
   let yojson_summary t =
     let f = function
       | Work_spec.Merge _ ->
-          `String "merge"
+          `List [ `String "merge" ]
       | Transition (_, witness) ->
           Inputs.Transaction.yojson_summary
             (Inputs.Transaction_witness.transaction witness)


### PR DESCRIPTION
A small follow-up on a recently merged #17879.

Fixes the format to be `string array` for either tx-based SW job and merge SW job. The latter was just `string`, by accident.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
