### PR TITLE
Add hard_fork_genesis_slot_delta to runtime config

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -473,6 +473,7 @@ module Json_layout = struct
       ; zkapp_cmd_limit_hardcap : int option [@default None]
       ; slot_tx_end : int option [@default None]
       ; slot_chain_end : int option [@default None]
+      ; hard_fork_genesis_slot_delta : int option [@default None]
       ; minimum_user_command_fee : Currency.Fee.t option [@default None]
       ; network_id : string option [@default None]
       ; sync_ledger_max_subtree_depth : int option [@default None]
@@ -1266,6 +1267,7 @@ module Daemon = struct
     ; zkapp_cmd_limit_hardcap : int option [@default None]
     ; slot_tx_end : int option [@default None]
     ; slot_chain_end : int option [@default None]
+    ; hard_fork_genesis_slot_delta : int option [@default None]
     ; minimum_user_command_fee : Currency.Fee.Stable.Latest.t option
           [@default None]
     ; network_id : string option [@default None]
@@ -1310,6 +1312,9 @@ module Daemon = struct
     ; slot_tx_end = opt_fallthrough ~default:t1.slot_tx_end t2.slot_tx_end
     ; slot_chain_end =
         opt_fallthrough ~default:t1.slot_chain_end t2.slot_chain_end
+    ; hard_fork_genesis_slot_delta =
+        opt_fallthrough ~default:t1.hard_fork_genesis_slot_delta
+          t2.hard_fork_genesis_slot_delta
     ; minimum_user_command_fee =
         opt_fallthrough ~default:t1.minimum_user_command_fee
           t2.minimum_user_command_fee
@@ -1346,6 +1351,7 @@ module Daemon = struct
     ; zkapp_cmd_limit_hardcap = Some zkapp_cmd_limit_hardcap
     ; slot_tx_end = None
     ; slot_chain_end = None
+    ; hard_fork_genesis_slot_delta = None
     ; minimum_user_command_fee = Some minimum_user_command_fee
     ; network_id = None
     ; sync_ledger_max_subtree_depth = None

--- a/src/lib/testing/integration_test_lib/test_config.ml
+++ b/src/lib/testing/integration_test_lib/test_config.ml
@@ -80,6 +80,7 @@ type t =
   ; txpool_max_size : int
   ; slot_tx_end : int option
   ; slot_chain_end : int option
+  ; hard_fork_genesis_slot_delta : int option
   ; network_id : string option
   ; block_window_duration_ms : int
   ; transaction_capacity_log_2 : int
@@ -142,6 +143,7 @@ let default ~(constants : constants) =
   ; txpool_max_size = genesis_constants.txpool_max_size
   ; slot_tx_end = None
   ; slot_chain_end = None
+  ; hard_fork_genesis_slot_delta = None
   ; network_id = None
   ; block_window_duration_ms = constraint_constants.block_window_duration_ms
   ; transaction_capacity_log_2 = constraint_constants.transaction_capacity_log_2

--- a/src/lib/testing/integration_test_local_engine/mina_docker.ml
+++ b/src/lib/testing/integration_test_local_engine/mina_docker.ml
@@ -67,6 +67,7 @@ module Network_config = struct
          ; txpool_max_size
          ; slot_tx_end
          ; slot_chain_end
+         ; hard_fork_genesis_slot_delta
          ; network_id
          ; _
          }
@@ -167,6 +168,7 @@ module Network_config = struct
             ; zkapp_cmd_limit_hardcap = None
             ; slot_tx_end
             ; slot_chain_end
+            ; hard_fork_genesis_slot_delta
             ; minimum_user_command_fee = None
             ; network_id
             ; sync_ledger_max_subtree_depth = None


### PR DESCRIPTION
The hard_fork_genesis_slot_delta option tracks the slot span between the slot_chain_end and the planned proof.fork.global_slot_since_genesis of an upcoming hard fork. In a future commit it will be incorporated into the hard fork account migration and the root ledger sync mechanism.

It can't quite be used in the ledger sync code yet (for the vesting parameter adjustment) because the structure of the ledger root code assumes that the conversion function can be determined at compile time. I'll change the converting merkle tree code (or the root code) slightly to compensate in a later update.