### PR TITLE
Add notion of chain state location to the daemon

### DIFF
--- a/src/app/heap_usage/heap_usage.ml
+++ b/src/app/heap_usage/heap_usage.ml
@@ -13,7 +13,9 @@ let print_heap_usage name v =
     words (words * bytes_per_word)
 
 let initialize_proof_cache_db ~logger conf_dir =
-  let%map res = Proof_cache_tag.create_db ~logger (conf_dir ^/ "proof_cache") in
+  (* Ad-hoc proof cache location for convenience in this executable *)
+  let proof_cache_location = conf_dir ^/ "proof_cache" in
+  let%map res = Proof_cache_tag.create_db ~logger proof_cache_location in
   Result.(
     map_error ~f:(fun (`Initialization_error e) -> Error.to_exn e) res |> ok_exn)
 

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -32,7 +32,7 @@ module Config = struct
     ; initial_peers : Mina_net2.Multiaddr.t list
     ; addrs_and_ports : Node_addrs_and_ports.t
     ; metrics_port : int option
-    ; conf_dir : string
+    ; mina_net_location : string
     ; chain_id : string
     ; logger : Logger.t
     ; unsafe_no_trust_ip : bool
@@ -246,7 +246,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
         Error.tag err ~tag:"Failed to connect to libp2p_helper process"
         |> Error.raise
       in
-      let conf_dir = config.conf_dir ^/ "mina_net2" in
+      let conf_dir = config.mina_net_location in
       let%bind () = Unix.mkdir ~p:() conf_dir in
       match%bind
         Monitor.try_with ~here:[%here] ~rest:(`Call handle_mina_net2_exception)

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -37,6 +37,8 @@ type t =
   ; persistent_root_location : string
   ; persistent_frontier_location : string
   ; epoch_ledger_location : string
+  ; proof_cache_location : string
+  ; zkapp_vk_cache_location : string
   ; staged_ledger_transition_backup_capacity : int [@default 10]
   ; time_controller : Block_time.Controller.t
   ; snark_work_fee : Currency.Fee.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1748,13 +1748,12 @@ let raise_on_initialization_error (`Initialization_error e) =
   Error.raise @@ Error.tag ~tag:"proof cache initialization error" e
 
 let initialize_proof_cache_db (config : Config.t) =
-  Proof_cache_tag.create_db ~logger:config.logger
-    (config.conf_dir ^/ "proof_cache")
+  Proof_cache_tag.create_db ~logger:config.logger config.proof_cache_location
   >>| function Error e -> raise_on_initialization_error e | Ok db -> db
 
 let initialize_zkapp_vk_cache_db (config : Config.t) =
   Zkapp_vk_cache_tag.create_db ~logger:config.logger
-    (config.conf_dir ^/ "zkapp_vk_cache")
+    config.zkapp_vk_cache_location
   >>| function Error e -> raise_on_initialization_error e | Ok db -> db
 
 let create ~commit_id ?wallets (config : Config.t) =

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -259,6 +259,7 @@ let%test_module "Epoch ledger sync tests" =
       let creatable_gossip_net =
         let chain_id = "dummy_chain_id" in
         let conf_dir = make_dirname "libp2p" in
+        let mina_net_location = Filename.concat conf_dir "mina_net2" in
         let seed_peer_list_url = None in
         let addrs_and_ports =
           let external_ip = Core.Unix.Inet_addr.localhost in
@@ -279,7 +280,7 @@ let%test_module "Epoch ledger sync tests" =
         let gossip_net_params : Gossip_net.Libp2p.Config.t =
           { timeout = Time.Span.of_sec 3.
           ; logger
-          ; conf_dir
+          ; mina_net_location
           ; chain_id
           ; unsafe_no_trust_ip = false
           ; seed_peer_list_url


### PR DESCRIPTION
The Chain_state_locations module tracks the locations on disk of the components that are considered part of the "chain state". These chain state component locations are subdirectories of the chain state directory.

The chain state directory itself is currently the mina config directory, so the chain state components are all still located at their compatible locations at the top level of the mina config directory. Moving the logic of computing these locations into one module will make it easier to change how the chain state directory is computed in future hard forks.

This should be pure refactoring; no component locations have changed.

For reference, the associated MIP draft is here: https://github.com/MinaProtocol/MIPs/pull/32. The `Chain_state_locations` module may need to be adjusted as MIP review proceeds, to reflect what is and is not part of the chain state.

Closes: https://github.com/MinaProtocol/mina/issues/17762