### PR TITLE
Remove unused Storage_locations ledger component

### DIFF
--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -205,10 +205,6 @@ module type Key_value_database = sig
     -> 'b
 end
 
-module type Storage_locations = sig
-  val key_value_db_dir : string
-end
-
 module type SYNCABLE = sig
   type root_hash
 
@@ -269,8 +265,6 @@ module Inputs = struct
     module Location_binable : Hashable.S_binable with type t := Location.t
 
     module Kvdb : Key_value_database with type config := string
-
-    module Storage_locations : Storage_locations
   end
 end
 

--- a/src/lib/merkle_ledger/test/test_database_in_mem.ml
+++ b/src/lib/merkle_ledger/test/test_database_in_mem.ml
@@ -57,7 +57,6 @@ struct
   module Addr = Location.Addr
   module Location_binable = Location_binable
   module Kvdb = In_memory_kvdb
-  module Storage_locations = Storage_locations
 end
 
 module type Test_intf = sig

--- a/src/lib/merkle_ledger/test/test_database_integration.ml
+++ b/src/lib/merkle_ledger/test/test_database_integration.ml
@@ -40,7 +40,6 @@ module Inputs = struct
   module Location = Location
   module Location_binable = Location_binable
   module Kvdb = In_memory_kvdb
-  module Storage_locations = Storage_locations
 end
 
 module DB = Database.Make (Inputs)

--- a/src/lib/merkle_ledger/test/test_mask.ml
+++ b/src/lib/merkle_ledger/test/test_mask.ml
@@ -741,7 +741,6 @@ module Make_maskable_and_mask_with_depth (Depth : Depth_S) = struct
     module Location = Location
     module Location_binable = Location_binable
     module Kvdb = In_memory_kvdb
-    module Storage_locations = Storage_locations
   end
 
   (* underlying Merkle tree *)

--- a/src/lib/merkle_ledger/test/test_stubs.ml
+++ b/src/lib/merkle_ledger/test/test_stubs.ml
@@ -79,11 +79,6 @@ struct
     List.fold_until alist ~init ~f ~finish
 end
 
-module Storage_locations : Intf.Storage_locations = struct
-  (* TODO: The name of this value should be dynamically generated per test run*)
-  let key_value_db_dir = ""
-end
-
 module Key : sig
   include Merkle_ledger.Intf.Key with type t = Mina_base.Account.Key.t
 

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -29,10 +29,6 @@ module Ledger_inner = struct
   module Kvdb : Intf.Key_value_database with type config := string =
     Rocksdb.Database
 
-  module Storage_locations : Intf.Storage_locations = struct
-    let key_value_db_dir = "mina_key_value_db"
-  end
-
   module Hash = struct
     module Arg = struct
       type t = Ledger_hash.Stable.Latest.t
@@ -183,7 +179,6 @@ module Ledger_inner = struct
     module Kvdb = Kvdb
     module Location = Location_at_depth
     module Location_binable = Location_binable
-    module Storage_locations = Storage_locations
   end
 
   module type Account_Db =


### PR DESCRIPTION
The Storage_locations module and its key_value_db_dir value are not used anywhere in the code base. Looking at the git history, it seems as though they were superceded by the ~directory_name parameter being added to the create method of the database ledger.

The string `"mina_key_value_db"` also does not appear in this repo, for what it's worth.