### PR TITLE
Remove product eng as /frontend codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,5 @@
 /CODEOWNERS @dannywillems @deepthiskumar @georgeee
 /buildkite @MinaProtocol/infra-eng-reviewers
-/frontend/ @MinaProtocol/product-eng-reviewers
 /dockerfiles/ @MinaProtocol/infra-eng-reviewers
 /scripts/ @MinaProtocol/infra-eng-reviewers @MinaProtocol/protocol-eng-reviewers
 /Makefile @MinaProtocol/infra-eng-reviewers


### PR DESCRIPTION
This folder contains tools that's used for CI only. As I understand that product eng groups are people from o1js end that might get affect by changes in this repo? (Hence js-compatible promise implementation is tagged to be reviewed by product eng)

As a result I don't see it necessary for this folder to be reviewed by product eng. 

