### PR TITLE
Improve HF test network bandwitdth usage

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -66,7 +66,7 @@ fi
 
 if [[ ! -L compatible-devnet ]]; then
   if [[ $# == 0 ]]; then
-    compatible_build=$(mktemp -d)
+    compatible_build=$(mktemp --tmpdir -d mina-compatible-worktree.XXXXXXXXXX)
     git fetch origin compatible
     git worktree add "$compatible_build" origin/compatible
     cd "$compatible_build"


### PR DESCRIPTION
This PR improves HF test network bandwidth usage by:
- Don't clone the whole repo just to build under another branch, but create a worktree. 
- Update submodule with `--depth 1`

On my end network is poor so it's very helpful.