### PR TITLE
Fix Archive Migration Script for Berkeley -> Mesa

### DIFF
--- a/src/app/archive/downgrade_to_berkeley.sql
+++ b/src/app/archive/downgrade_to_berkeley.sql
@@ -18,7 +18,7 @@ SET archive.current_protocol_version = '4.0.0';
 -- Post-HF protocol version. This one corresponds to Mesa, specifically
 SET archive.target_protocol_version = '3.0.0';
 -- The version of this script. If you modify the script, please bump the version
-SET archive.migration_version = '0.0.4';
+SET archive.migration_version = '0.0.5';
 
 -- TODO: put below in a common script
 


### PR DESCRIPTION
Previously this is broken because I've assigned FK to use 0(literal value we want in that field), instead of the FK ID that points to a 0 field. 

This PR fixed it by querying zkapp_field to find that ID first and then set that to default. 

This has a side effect, that the default value would not be stable across different schema, in theory. Because that depends on when the first field 0 has been inserted to the DB. But in practice should be fine as its always the record {id: 1, field: 0}