### PR TITLE
[CI] Fix packages name conflict between mina-devnet and mina-devnet-lightnet

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILD_DIR=${BUILD_DIR:-"${SCRIPTPATH}/../../_build"}
 BUILD_URL=${BUILD_URL:-${BUILDKITE_BUILD_URL:-"local build from '$(hostname)' \
@@ -219,6 +218,15 @@ copy_common_daemon_configs() {
 }
 
 ## LOGPROC PACKAGE ##
+
+#
+# Builds mina-logproc package for log processing utility
+#
+# Output: mina-logproc_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS} (basic system libraries)
+#
+# Simple utility package containing only the logproc binary.
+#
 build_logproc_deb() {
   create_control_file mina-logproc "${SHARED_DEPS}" \
     'Utility for processing mina-daemon log output'
@@ -232,6 +240,15 @@ build_logproc_deb() {
 ## END LOGPROC PACKAGE ##
 
 ## GENERATE TEST_EXECUTIVE PACKAGE ##
+
+#
+# Builds mina-test-executive package for automated testing
+#
+# Output: mina-test-executive_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${TEST_EXECUTIVE_DEPS} (includes docker, python3)
+#
+# Package for running automated tests against full mina testnets.
+#
 build_test_executive_deb () {
   create_control_file mina-test-executive \
     "${SHARED_DEPS}${TEST_EXECUTIVE_DEPS}" \
@@ -247,6 +264,15 @@ build_test_executive_deb () {
 ## END TEST_EXECUTIVE PACKAGE ##
 
 ## GENERATE BATCH TXN TOOL PACKAGE ##
+
+#
+# Builds mina-batch-txn package for transaction load testing
+#
+# Output: mina-batch-txn_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}
+#
+# Tool for generating transaction load against mina nodes.
+#
 build_batch_txn_deb() {
 
   create_control_file mina-batch-txn "${SHARED_DEPS}" \
@@ -261,6 +287,16 @@ build_batch_txn_deb() {
 ## END BATCH TXN TOOL PACKAGE ##
 
 ## GENERATE TEST SUITE PACKAGE ##
+
+#
+# Builds mina-test-suite package containing various testing utilities
+#
+# Output: mina-test-suite_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}
+#
+# Comprehensive package with command line tests, benchmarks, archive tests,
+# and performance analysis tools. Includes sample database for archive testing.
+#
 build_functional_test_suite_deb() {
   create_control_file mina-test-suite "${SHARED_DEPS}" \
     'Test suite apps for mina.'
@@ -319,6 +355,15 @@ function copy_common_rosetta_configs () {
 }
 
 ## ROSETTA MAINNET PACKAGE ##
+
+#
+# Builds mina-rosetta-mainnet package for mainnet Rosetta API
+#
+# Output: mina-rosetta-mainnet_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}
+#
+# Rosetta API implementation for mainnet with mainnet signature binaries.
+#
 build_rosetta_mainnet_deb() {
 
   echo "------------------------------------------------------------"
@@ -334,6 +379,15 @@ build_rosetta_mainnet_deb() {
 ## END ROSETTA MAINNET PACKAGE ##
 
 ## ROSETTA DEVNET PACKAGE ##
+
+#
+# Builds mina-rosetta-devnet package for devnet Rosetta API
+#
+# Output: mina-rosetta-devnet_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}
+#
+# Rosetta API implementation for devnet with testnet signature binaries.
+#
 build_rosetta_devnet_deb() {
 
   echo "------------------------------------------------------------"
@@ -349,6 +403,15 @@ build_rosetta_devnet_deb() {
 ## END ROSETTA DEVNET PACKAGE ##
 
 ## ROSETTA BERKELEY PACKAGE ##
+
+#
+# Builds mina-rosetta-berkeley package for Berkeley testnet Rosetta API
+#
+# Output: mina-rosetta-berkeley_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}
+#
+# Rosetta API implementation for Berkeley testnet with testnet signature binaries.
+#
 build_rosetta_berkeley_deb() {
 
   echo "------------------------------------------------------------"
@@ -364,6 +427,16 @@ build_rosetta_berkeley_deb() {
 ## END BERKELEY PACKAGE ##
 
 ## MAINNET PACKAGE ##
+
+#
+# Builds mina-mainnet package for mainnet daemon
+#
+# Output: mina-mainnet_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS} (includes libpq-dev, jemalloc, logproc)
+#
+# Full mainnet daemon package with mainnet signatures and mainnet genesis ledger
+# as default. Uses mainnet seed list and mainnet configuration.
+#
 build_daemon_mainnet_deb() {
 
   echo "------------------------------------------------------------"
@@ -379,6 +452,22 @@ build_daemon_mainnet_deb() {
 ## END MAINNET PACKAGE ##
 
 ## DEVNET PACKAGE ##
+
+#
+# Builds devnet daemon package with profile-aware naming
+#
+# Output: ${MINA_DEVNET_DEB_NAME}_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Where MINA_DEVNET_DEB_NAME can be:
+#   - "mina-devnet" (default)
+#   - "mina-devnet-lightnet" (if DUNE_PROFILE=lightnet)
+#   - "mina-devnet-instrumented" (if DUNE_INSTRUMENT_WITH is set)
+#   - "mina-devnet-lightnet-instrumented" (both conditions)
+#
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Devnet daemon with testnet signatures and devnet genesis ledger as default.
+# Package name includes suffixes for different profiles and instrumentation.
+#
 build_daemon_devnet_deb() {
 
   echo "------------------------------------------------------------"
@@ -394,6 +483,16 @@ build_daemon_devnet_deb() {
 ## END DEVNET PACKAGE ##
 
 ## MAINNET LEGACY PACKAGE ##
+
+#
+# Builds mina-mainnet-legacy package with legacy binary
+#
+# Output: mina-mainnet-legacy_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Contains only the legacy mainnet binary as "mina-legacy" without
+# configuration files or genesis ledgers.
+#
 build_daemon_mainnet_legacy_deb() {
 
   echo "------------------------------------------------------------"
@@ -411,6 +510,16 @@ build_daemon_mainnet_legacy_deb() {
 ## END MAINNET LEGACY PACKAGE ##
 
 ## DEVNET LEGACY PACKAGE ##
+
+#
+# Builds mina-devnet-legacy package with legacy testnet binary
+#
+# Output: mina-devnet-legacy_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Contains only the legacy testnet binary as "mina-legacy" without
+# configuration files or genesis ledgers.
+#
 build_daemon_devnet_legacy_deb() {
 
   echo "------------------------------------------------------------"
@@ -428,6 +537,22 @@ build_daemon_devnet_legacy_deb() {
 ## END DEVNET LEGACY PACKAGE ##
 
 ## BERKELEY PACKAGE ##
+
+#
+# Builds Berkeley testnet daemon package with profile-aware naming
+#
+# Output: ${MINA_DEB_NAME}_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Where MINA_DEB_NAME can be:
+#   - "mina-berkeley" (default)
+#   - "mina-berkeley-lightnet" (if DUNE_PROFILE=lightnet)
+#   - "mina-berkeley-instrumented" (if DUNE_INSTRUMENT_WITH is set)
+#   - "mina-berkeley-lightnet-instrumented" (both conditions)
+#
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Berkeley testnet daemon with testnet signatures and berkeley genesis ledger
+# as default. Package name includes suffixes for different profiles.
+#
 build_daemon_berkeley_deb() {
 
   echo "------------------------------------------------------------"
@@ -444,6 +569,19 @@ build_daemon_berkeley_deb() {
 }
 ## END BERKELEY PACKAGE ##
 
+#
+# Replaces runtime config and genesis ledgers with hardfork versions
+#
+# Parameters:
+#   $1 - Network name (mainnet, devnet, berkeley)
+#
+# Environment variables required:
+#   RUNTIME_CONFIG_JSON - path to hardfork runtime configuration
+#   LEDGER_TARBALLS - space-separated list of ledger tarball paths
+#
+# Copies hardfork-specific runtime config and ledgers, backing up existing
+# network ledger as .old.json before replacement.
+#
 replace_runtime_config_and_ledgers_with_hardforked_ones() {
   local NETWORK_NAME="${1}"
 
@@ -468,6 +606,16 @@ replace_runtime_config_and_ledgers_with_hardforked_ones() {
 
 
 ## DEVNET HARDFORK PACKAGE ##
+
+#
+# Builds mina-devnet-hardfork package for devnet hardfork
+#
+# Output: mina-devnet-hardfork_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Devnet daemon package with hardfork-specific runtime config and ledgers.
+# Requires RUNTIME_CONFIG_JSON and LEDGER_TARBALLS environment variables.
+#
 build_daemon_devnet_hardfork_deb() {
   local __deb_name=mina-devnet-hardfork
 
@@ -488,6 +636,16 @@ build_daemon_devnet_hardfork_deb() {
 ## END DEVNET HARDFORK PACKAGE ##
 
 ## BERKELEY HARDFORK PACKAGE ##
+
+#
+# Builds mina-berkeley-hardfork package for Berkeley hardfork
+#
+# Output: mina-berkeley-hardfork_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Berkeley daemon package with hardfork-specific runtime config and ledgers.
+# Requires RUNTIME_CONFIG_JSON and LEDGER_TARBALLS environment variables.
+#
 build_daemon_berkeley_hardfork_deb() {
   local __deb_name=mina-berkeley-hardfork
 
@@ -508,6 +666,17 @@ build_daemon_berkeley_hardfork_deb() {
 ## END BERKELEY HARDFORK PACKAGE ##
 
 ## MAINNET HARDFORK PACKAGE ##
+
+#
+# Builds mina-mainnet-hardfork package for mainnet hardfork
+#
+# Output: mina-mainnet-hardfork_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+#
+# Mainnet daemon package with hardfork-specific runtime config and ledgers.
+# Requires RUNTIME_CONFIG_JSON and LEDGER_TARBALLS environment variables.
+# Note: Uses testnet signatures despite being mainnet hardfork package.
+#
 build_daemon_mainnet_hardfork_deb() {
   local __deb_name=mina-mainnet-hardfork
 
@@ -527,6 +696,15 @@ build_daemon_mainnet_hardfork_deb() {
 
 ## END MAINNET HARDFORK PACKAGE ##
 
+#
+# Copies common binaries and configuration for archive packages
+#
+# Parameters:
+#   $1 - Archive package name (used for build_deb call)
+#
+# Sets up archive daemon, archive blocks tool, extract blocks tool,
+# missing blocks utilities, replayer, and SQL migration scripts.
+#
 copy_common_archive_configs() {
   local ARCHIVE_DEB="${1}"
 
@@ -552,6 +730,15 @@ copy_common_archive_configs() {
 }
 
 ## ARCHIVE DEVNET PACKAGE ##
+
+#
+# Builds mina-archive-devnet package for devnet archive node
+#
+# Output: mina-archive-devnet_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${ARCHIVE_DEPS} (libssl, libgomp, libpq-dev, libjemalloc)
+#
+# Archive node package for devnet with all archive utilities and SQL scripts.
+#
 build_archive_devnet_deb () {
   ARCHIVE_DEB=mina-archive-devnet
 
@@ -567,6 +754,21 @@ build_archive_devnet_deb () {
 ## END ARCHIVE DEVNET PACKAGE ##
 
 ## ARCHIVE BERKELEY PACKAGE ##
+
+#
+# Builds Berkeley archive package with profile-aware naming
+#
+# Output: mina-archive-berkeley${DEB_SUFFIX}_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Where DEB_SUFFIX can be:
+#   - "" (empty, default)
+#   - "-lightnet" (if DUNE_PROFILE=lightnet)
+#   - "-instrumented" (if DUNE_INSTRUMENT_WITH is set)
+#   - "-lightnet-instrumented" (both conditions)
+#
+# Dependencies: ${ARCHIVE_DEPS}
+#
+# Archive node package for Berkeley with suffix-aware naming for different profiles.
+#
 build_archive_berkeley_deb () {
   ARCHIVE_DEB=mina-archive-berkeley${DEB_SUFFIX}
 
@@ -583,6 +785,15 @@ build_archive_berkeley_deb () {
 ## END ARCHIVE PACKAGE ##
 
 ## ARCHIVE MAINNET PACKAGE ##
+
+#
+# Builds mina-archive-mainnet package for mainnet archive node
+#
+# Output: mina-archive-mainnet_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${ARCHIVE_DEPS}
+#
+# Archive node package for mainnet with all archive utilities and SQL scripts.
+#
 build_archive_mainnet_deb () {
   ARCHIVE_DEB=mina-archive-mainnet
 
@@ -598,6 +809,15 @@ build_archive_mainnet_deb () {
 ## END ARCHIVE MAINNET PACKAGE ##
 
 ## ZKAPP TEST TXN ##
+
+#
+# Builds mina-zkapp-test-transaction package for zkApp testing
+#
+# Output: mina-zkapp-test-transaction_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEBS}
+#
+# Utility for generating zkApp transactions in Mina GraphQL format for testing.
+#
 build_zkapp_test_transaction_deb () {
   echo "------------------------------------------------------------"
   echo "--- Building Mina Berkeley ZkApp test transaction tool:"
@@ -614,7 +834,17 @@ build_zkapp_test_transaction_deb () {
 }
 ## END ZKAPP TEST TXN PACKAGE ##
 
+## CREATE LEGACY GENESIS PACKAGE ##
 
+#
+# Builds mina-create-legacy-genesis package for legacy genesis creation
+#
+# Output: mina-create-legacy-genesis_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
+# Dependencies: ${SHARED_DEPS}${DAEMON_DEBS}
+#
+# Utility for creating legacy genesis ledgers for post-hardfork verification.
+# Contains the runtime_genesis_ledger tool for Mina protocol.
+#
 build_create_legacy_genesis_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building Mina Berkeley create legacy genesis tool:"
@@ -629,3 +859,4 @@ build_create_legacy_genesis_deb() {
 
   build_deb mina-create-legacy-genesis
 }
+## END CREATE LEGACY GENESIS PACKAGE ##


### PR DESCRIPTION
Recently we are experiencing issues in CI: https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/694

This is caues by conflict in package name between lightnet and standard mina-devnet. 

mina-devnet-lightnet package name was the same like in mina-devnet (despite fact that that they were placed in different debians).

