### PR TITLE
Fix Rosetta CLI arg doc for `--graphql-uri`

### DIFF
--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -163,7 +163,7 @@ let command ?signature_kind ~minimum_user_command_fee ~account_creation_fee () =
       Cli.optional_uri
   and graphql_uri =
     flag "--graphql-uri" ~aliases:[ "graphql-uri" ]
-      ~doc:"URI of Mina GraphQL endpoint to connect to" Cli.optional_uri
+      ~doc:"URI of Mina Daemon GraphQL endpoint to connect to" Cli.optional_uri
   and log_json =
     flag "--log-json" ~aliases:[ "log-json" ]
       ~doc:"Print log output as JSON (default: plain text)" no_arg


### PR DESCRIPTION
As title, this is a simple Noop