### PR TITLE
Mark Mina Artifact Debian as Multi

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -139,7 +139,7 @@ let build_artifacts
                   ]
             , label = "Debian: Build ${labelSuffix spec}"
             , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
-            , target = Size.XLarge
+            , target = Size.Multi
             , if_ = spec.if_
             , retries =
               [ Command.Retry::{


### PR DESCRIPTION
This PR marks Mina Artifact Debian as Multi to aleviate bk agent starving. 

Building debian package itself doesn't rely on docker so this should be fine. 