### PR TITLE
Some improvement on Archive

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4277,21 +4277,20 @@ module Block = struct
           height < ? ORDER BY height DESC LIMIT 1" )
       height
 
-  let mark_as_canonical (module Conn : Mina_caqti.CONNECTION) ~state_hash =
-    Conn.exec
-      (Mina_caqti.exec_req Caqti_type.string
-         "UPDATE blocks SET chain_status='canonical' WHERE state_hash = ?" )
-      state_hash
-
-  let mark_as_orphaned (module Conn : Mina_caqti.CONNECTION) ~state_hash ~height
-      =
+  let decide_canonical_at_height (module Conn : Mina_caqti.CONNECTION)
+      ~state_hash ~height =
     Conn.exec
       (Mina_caqti.exec_req
          Caqti_type.(t2 string int64)
-         {sql| UPDATE blocks SET chain_status='orphaned'
-               WHERE height = $2
-               AND state_hash <> $1
-         |sql} )
+         {sql|
+         UPDATE blocks
+         SET chain_status =
+           CASE
+             WHEN state_hash = $1 THEN 'canonical'
+             ELSE 'orphaned'
+           END
+         WHERE height = $2;
+       |sql} )
       (state_hash, height)
 
   (* update chain_status for blocks now known to be canonical or orphaned *)
@@ -4328,10 +4327,7 @@ module Block = struct
             ~logger (fun () ->
               Mina_caqti.deferred_result_list_fold canonical_blocks ~init:()
                 ~f:(fun () block ->
-                  let%bind () =
-                    mark_as_canonical (module Conn) ~state_hash:block.state_hash
-                  in
-                  mark_as_orphaned
+                  decide_canonical_at_height
                     (module Conn)
                     ~state_hash:block.state_hash ~height:block.height ) )
         else if Int64.( < ) block.height greatest_canonical_height then
@@ -4361,10 +4357,7 @@ module Block = struct
             (fun () ->
               Mina_caqti.deferred_result_list_fold canonical_blocks ~init:()
                 ~f:(fun () block ->
-                  let%bind () =
-                    mark_as_canonical (module Conn) ~state_hash:block.state_hash
-                  in
-                  mark_as_orphaned
+                  decide_canonical_at_height
                     (module Conn)
                     ~state_hash:block.state_hash ~height:block.height ) )
         else

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4351,6 +4351,7 @@ module Block = struct
           let%bind canonical_blocks =
             Metrics.time ~label:"get_subchain (< canonical_height)" ~logger
               (fun () ->
+                (* NOTE: we some how assumed blocks are continuous here *)
                 get_subchain
                   (module Conn)
                   ~start_block_id:canonical_block_below_id


### PR DESCRIPTION
I'll open a follow-up PR to fix the bug that blocks are not known to be orphaned faster. This is so we can support exchange better, that they don't need a recursive SQL query to decide if a block is guaranteed to be dropped. 

This PR:
-  Morphed together 2 functions to better reflect their intent
- Add some comments around the codebase 