### PR TITLE
Lift jemalloc check from dune.alloc.inc to a separate script

### DIFF
--- a/src/check_jemalloc.sh
+++ b/src/check_jemalloc.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+printf 'Checking if jemalloc is available... ' 1>&2
+if [ -z "${CC-}" ]; then
+  if command -v gcc >/dev/null 2>&1; then
+    CC=gcc
+  else
+    CC=clang
+  fi
+fi
+
+# Try to link against jemalloc
+if echo 'int main(){}' | "$CC" -x c - -ljemalloc -o /dev/null >/dev/null 2>&1; then
+  echo 'Yes, using jemalloc as an allocator' 1>&2
+  printf jemalloc
+else
+  echo 'No, using the default allocator from libc' 1>&2
+  printf c
+fi

--- a/src/dune.alloc.inc
+++ b/src/dune.alloc.inc
@@ -2,12 +2,4 @@
 (rule
   (target dune-alloc)
   (action (with-stdout-to dune-alloc
-    (bash "
-        printf 'Checking if jemalloc is available... ' 1>&2
-        echo 'int main(){}' > .jemalloc_test.c
-        if [ -z ${CC-} ]; then if command -v gcc > /dev/null; then CC=gcc; else CC=clang; fi; fi
-        if $CC -ljemalloc .jemalloc_test.c -o /dev/null
-            then printf 'Yes, using jemalloc as an allocator\n' 1>&2; printf jemalloc
-            else printf 'No, using the default allocator from libc\n' 1>&2; printf c
-        fi
-    "))))
+    (run %{dep:./check_jemalloc.sh}))))


### PR DESCRIPTION
This is originally hardcoded in dune.alloc.inc. 

BTW I think standard tool is `pkg-config`, but I'm not sure if every build environment has it available.