### PR TITLE
Remove internal_tracing.opam

### DIFF
--- a/src/internal_tracing.opam
+++ b/src/internal_tracing.opam
@@ -1,5 +1,0 @@
-opam-version: "2.0"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]


### PR DESCRIPTION
Not sure why do we need this file here at all.

----------

Looking at 2411c74 it seems all opam definitions are thrown in the same folder. 