### PR TITLE
Add dockerfile for patching jemalloc with profiling enabled

### DIFF
--- a/dockerfiles/Dockerfiles-patch-jemalloc
+++ b/dockerfiles/Dockerfiles-patch-jemalloc
@@ -1,0 +1,23 @@
+ARG image=minaprotocol/mina-daemon:3.2.0-97ad487-noble-mainnet
+FROM ${image}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+
+RUN apt-get update --quiet --yes \
+  && apt-get install --quiet --yes --no-install-recommends bzip2 build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/jemalloc
+RUN curl -L https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 | tar xjf - -C .
+
+
+WORKDIR /tmp/jemalloc/jemalloc-5.3.0
+RUN ./configure --enable-prof && make -j$(nproc)
+
+RUN make install LIBDIR=/usr/lib/x86_64-linux-gnu
+
+# https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Leak-Checking
+ENV MALLOC_CONF=prof_leak:true,lg_prof_sample:0,prof_final:true
+
+WORKDIR /RUNDIR


### PR DESCRIPTION
Here's an example docker compose using such daemon.

```yaml
services:
  generate_wallet_key:
    image: 'daemon-jemalloc-prof:latest'
    # image: 'gcr.io/o1labs-192920/mina-daemon:3.3.0-beta1-lyh-memtrace-5a0d9fa-noble-mainnet'
    environment:
      MINA_PRIVKEY_PASS: PssW0rD
    entrypoint: []
    command: >
      bash -c '
        mina advanced generate-keypair --privkey-path /data/.mina-config/keys/wallet-key
        chmod -R 0700 /data/.mina-config/keys
        chmod -R 0600 /data/.mina-config/keys/wallet-key
      '
    volumes:
      - './node/mina-config:/data/.mina-config'
  mina_block_producer:
    image:  'daemon-jemalloc-prof:latest'
    restart: always
    environment:
      MINA_PRIVKEY_PASS: PssW0rD
    entrypoint: []
    command: >
      bash -c '
        mina daemon \
             --peer-list-url https://bootnodes.minaprotocol.com/networks/mainnet.txt \
             --block-producer-key /data/.mina-config/keys/wallet-key \
             --seed
      '
    # use  --peer-list-url https://bootnodes.minaprotocol.com/networks/devnet.txt for Devnet
    volumes:
      - './node/mina-config:/data/.mina-config'
      - './rundir:/rundir'
    ports:
      - '8302:8302'
    depends_on:
      generate_wallet_key:
        condition: service_completed_successfully
```

In `./rundir`, there should be a file named like below for each executable exited.
```
-rw-r--r-- 1 root  root  1490554 Oct 22 07:17 jeprof.1.0.f.heap
-rw-r--r-- 1 root  root   234527 Oct 22 06:49 jeprof.20.0.f.heap
-rw-r--r-- 1 root  root   252784 Oct 22 07:17 jeprof.241.0.f.heap
```

First number seems to be corresponding to PID, not sure about the 2nd. 