### PR TITLE
Don't use generic-multi for non-amd64 debian build

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -139,7 +139,8 @@ let build_artifacts
                   ]
             , label = "Debian: Build ${labelSuffix spec}"
             , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
-            , target = Size.Multi
+            , target =
+                merge { Amd64 = Size.Multi, Arm64 = Size.XLarge } spec.arch
             , if_ = spec.if_
             , retries =
               [ Command.Retry::{


### PR DESCRIPTION
aarch64 debian couldn't be build on genric-multi because it requires docker. Hence this change.