### PR TITLE
Refactor root ledger in preparation for the vesting parameter update changes

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -9,7 +9,7 @@ open Async
 module Graphql_cohttp_async =
   Graphql_internal.Make (Graphql_async.Schema) (Cohttp_async.Io)
     (Cohttp_async.Body)
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 let snark_job_list_json t =
   let open Participating_state.Let_syntax in

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -7,7 +7,7 @@ open Pipe_lib.Strict_pipe
 open Network_peer
 open Mina_stdlib
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 module Sync_ledger = Mina_ledger.Sync_ledger
 module Transition_cache = Transition_cache
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -4,7 +4,7 @@ open Async
 open Currency
 open Signature_lib
 open Mina_base
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module type CONTEXT = sig
   val logger : Logger.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -7,7 +7,7 @@ open Fold_lib
 open Signature_lib
 open Snark_params
 open Num_util
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module Segment_id = Mina_numbers.Nat.Make32 ()
 

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -3,7 +3,7 @@ open Currency
 open Signature_lib
 open Mina_base
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 module Intf = Intf
 module Ledger_transfer_mask =
   Mina_ledger.Ledger_transfer.Make (Ledger) (Ledger.Any_ledger.M)

--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -1,7 +1,7 @@
 open Mina_base
 open Signature_lib
 open Core_kernel
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module Timing = struct
   type t = (int, int, int, int) Account_timing.Poly.t

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -3,7 +3,7 @@ open Async
 open Signature_lib
 open Mina_base
 include Genesis_ledger_helper_lib
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 type exn += Genesis_state_initialization_error
 

--- a/src/lib/mina_graphql/types.ml
+++ b/src/lib/mina_graphql/types.ml
@@ -3,7 +3,7 @@ open Async
 open Mina_base
 open Mina_transaction
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 open Signature_lib
 open Currency
 open Schema

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -4,7 +4,7 @@ open Pipe_lib
 open Cache_lib
 open Mina_base
 open Network_peer
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module type CONTEXT = sig
   val logger : Logger.t
@@ -343,7 +343,7 @@ module type Transition_router_intf = sig
           -> Transaction_snark_work.Checked.t option )
     -> catchup_mode:[ `Super ]
     -> notify_online:(unit -> unit Deferred.t)
-    -> ledger_backing:Root_ledger.Config.backing_type
+    -> ledger_backing:Mina_ledger.Root.Config.backing_type
     -> unit
     -> ( [ `Transition of Mina_block.Validated.t ]
        * [ `Source of [ `Gossip | `Catchup | `Internal ] ]

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -101,12 +101,23 @@ module Converting_ledger :
      and type primary_ledger = Db.t
      and type converting_ledger = Hardfork_db.t
 
-module Root : sig
-  include module type of
-      Root.Make (Any_ledger) (Db) (Hardfork_db) (Converting_ledger)
-
-  val as_masked : t -> Mask.Attached.t
-end
+module Make_converting (Converting_inputs : sig
+  val convert : Account.t -> Account.Hardfork.t
+end) :
+  Merkle_ledger.Intf.Ledger.Converting.WITH_DATABASE
+    with module Location = Location
+     and module Addr = Location.Addr
+    with type root_hash := Ledger_hash.t
+     and type hash := Ledger_hash.t
+     and type account := Account.t
+     and type key := Signature_lib.Public_key.Compressed.t
+     and type token_id := Token_id.t
+     and type token_id_set := Token_id.Set.t
+     and type account_id := Account_id.t
+     and type account_id_set := Account_id.Set.t
+     and type converted_account := Account.Hardfork.t
+     and type primary_ledger = Db.t
+     and type converting_ledger = Hardfork_db.t
 
 include
   Merkle_mask.Maskable_merkle_tree_intf.S
@@ -147,6 +158,8 @@ val create : ?directory_name:string -> depth:int -> unit -> t
 val create_ephemeral : depth:int -> unit -> t
 
 val of_database : Db.t -> t
+
+val of_any_ledger : Any_ledger.witness -> t
 
 (** This is not _really_ copy, merely a stop-gap until we remove usages of copy in our codebase. What this actually does is creates a new empty mask on top of the current ledger *)
 val copy : t -> t

--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -1,150 +1,98 @@
 open Core
 open Mina_base
 
-module type Stable_db_intf =
-  Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
-     and type root_hash := Ledger_hash.t
+module Config = struct
+  type backing_type = Stable_db | Converting_db [@@deriving equal, yojson]
 
-module type Migrated_db_intf =
-  Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.Hardfork.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
-     and type root_hash := Ledger_hash.t
+  (* WARN: always construct Converting_db_config with
+     [with_directory ~backing_type ~directory_name], instead of manual
+     creation. This is because [delete_any_backing] expect there's a
+     relation between primary dir and converting dir name *)
+  type t =
+    | Stable_db_config of string
+    | Converting_db_config of
+        Merkle_ledger.Converting_merkle_tree.With_database_config.t
+  [@@deriving yojson]
 
-module type Any_ledger_intf =
-  Merkle_ledger.Intf.Ledger.ANY
-    with type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
+  let backing_of_config = function
+    | Stable_db_config _ ->
+        Stable_db
+    | Converting_db_config _ ->
+        Converting_db
 
-module type Converting_ledger_intf =
-  Merkle_ledger.Intf.Ledger.Converting.WITH_DATABASE
-    with type root_hash := Ledger_hash.t
-     and type hash := Ledger_hash.t
-     and type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type converted_account := Account.Hardfork.t
+  let file_exists path =
+    Sys.file_exists path |> [%equal: [ `No | `Unknown | `Yes ]] `Yes
 
-module Make
-    (Any_ledger : Any_ledger_intf)
-    (Stable_db : Stable_db_intf
-                   with module Location = Any_ledger.M.Location
-                    and module Addr = Any_ledger.M.Addr)
-    (Migrated_db : Migrated_db_intf
-                     with module Location = Any_ledger.M.Location
-                      and module Addr = Any_ledger.M.Addr)
-    (Converting_ledger : Converting_ledger_intf
-                           with module Location = Any_ledger.M.Location
-                            and module Addr = Any_ledger.M.Addr
-                           with type primary_ledger = Stable_db.t
-                            and type converting_ledger = Migrated_db.t) =
-struct
-  module Config = struct
-    type backing_type = Stable_db | Converting_db [@@deriving equal, yojson]
+  let exists_backing = function
+    | Stable_db_config path ->
+        file_exists path
+    | Converting_db_config { primary_directory; converting_directory } ->
+        file_exists primary_directory && file_exists converting_directory
 
-    (* WARN: always construct Converting_db_config with
-       [with_directory ~backing_type ~directory_name], instead of manual
-       creation. This is because [delete_any_backing] expect there's a
-       relation between primary dir and converting dir name *)
-    type t =
-      | Stable_db_config of string
-      | Converting_db_config of Converting_ledger.Config.t
-    [@@deriving yojson]
+  let exists_any_backing = function
+    | Stable_db_config path ->
+        file_exists path
+    | Converting_db_config { primary_directory; converting_directory = _ } ->
+        file_exists primary_directory
 
-    let backing_of_config = function
-      | Stable_db_config _ ->
-          Stable_db
-      | Converting_db_config _ ->
-          Converting_db
+  let with_directory ~backing_type ~directory_name =
+    match backing_type with
+    | Stable_db ->
+        Stable_db_config directory_name
+    | Converting_db ->
+        Converting_db_config
+          (Merkle_ledger.Converting_merkle_tree.With_database_config
+           .with_primary ~directory_name )
 
-    let file_exists path =
-      Sys.file_exists path |> [%equal: [ `No | `Unknown | `Yes ]] `Yes
-
-    let exists_backing = function
-      | Stable_db_config path ->
-          file_exists path
-      | Converting_db_config { primary_directory; converting_directory } ->
-          file_exists primary_directory && file_exists converting_directory
-
-    let exists_any_backing = function
-      | Stable_db_config path ->
-          file_exists path
-      | Converting_db_config { primary_directory; converting_directory = _ } ->
-          file_exists primary_directory
-
-    let with_directory ~backing_type ~directory_name =
-      match backing_type with
-      | Stable_db ->
-          Stable_db_config directory_name
-      | Converting_db ->
-          Converting_db_config
-            (Converting_ledger.Config.with_primary ~directory_name)
-
-    let delete_any_backing config =
-      let primary, converting =
-        match config with
-        | Stable_db_config primary ->
-            let converting =
-              Converting_ledger.Config.default_converting_directory_name primary
-            in
-            (primary, converting)
-        | Converting_db_config { primary_directory; converting_directory } ->
-            (primary_directory, converting_directory)
-      in
-      Mina_stdlib_unix.File_system.rmrf primary ;
-      Mina_stdlib_unix.File_system.rmrf converting
-
-    let delete_backing = function
+  let delete_any_backing config =
+    let primary, converting =
+      match config with
       | Stable_db_config primary ->
-          Mina_stdlib_unix.File_system.rmrf primary
+          let converting =
+            Merkle_ledger.Converting_merkle_tree.With_database_config
+            .default_converting_directory_name primary
+          in
+          (primary, converting)
       | Converting_db_config { primary_directory; converting_directory } ->
-          Mina_stdlib_unix.File_system.rmrf primary_directory ;
-          Mina_stdlib_unix.File_system.rmrf converting_directory
+          (primary_directory, converting_directory)
+    in
+    Mina_stdlib_unix.File_system.rmrf primary ;
+    Mina_stdlib_unix.File_system.rmrf converting
 
-    exception
-      Backing_mismatch of { backing_1 : backing_type; backing_2 : backing_type }
+  let delete_backing = function
+    | Stable_db_config primary ->
+        Mina_stdlib_unix.File_system.rmrf primary
+    | Converting_db_config { primary_directory; converting_directory } ->
+        Mina_stdlib_unix.File_system.rmrf primary_directory ;
+        Mina_stdlib_unix.File_system.rmrf converting_directory
 
-    let move_backing_exn ~src ~dst =
-      match (src, dst) with
-      | Stable_db_config src, Stable_db_config dst ->
-          Sys.rename src dst
-      | ( Converting_db_config
-            { primary_directory = src_primary
-            ; converting_directory = src_converted
-            }
-        , Converting_db_config
-            { primary_directory = dst_primary
-            ; converting_directory = dst_converted
-            } ) ->
-          Sys.rename src_primary dst_primary ;
-          Sys.rename src_converted dst_converted
-      | cfg1, cfg2 ->
-          raise
-            (Backing_mismatch
-               { backing_1 = backing_of_config cfg1
-               ; backing_2 = backing_of_config cfg2
-               } )
-  end
+  exception
+    Backing_mismatch of { backing_1 : backing_type; backing_2 : backing_type }
+
+  let move_backing_exn ~src ~dst =
+    match (src, dst) with
+    | Stable_db_config src, Stable_db_config dst ->
+        Sys.rename src dst
+    | ( Converting_db_config
+          { primary_directory = src_primary
+          ; converting_directory = src_converted
+          }
+      , Converting_db_config
+          { primary_directory = dst_primary
+          ; converting_directory = dst_converted
+          } ) ->
+        Sys.rename src_primary dst_primary ;
+        Sys.rename src_converted dst_converted
+    | cfg1, cfg2 ->
+        raise
+          (Backing_mismatch
+             { backing_1 = backing_of_config cfg1
+             ; backing_2 = backing_of_config cfg2
+             } )
+end
+
+module type Intf = sig
+  type t
 
   type root_hash = Ledger_hash.t
 
@@ -152,11 +100,62 @@ struct
 
   type account = Account.t
 
-  type addr = Stable_db.Addr.t
+  type addr = Ledger.Db.Addr.t
 
-  type path = Stable_db.path
+  type path = Ledger.Db.path
 
-  type t = Stable_db of Stable_db.t | Converting_db of Converting_ledger.t
+  val close : t -> unit
+
+  val merkle_root : t -> root_hash
+
+  val create_checkpoint : t -> config:Config.t -> unit -> t
+
+  val make_checkpoint : t -> config:Config.t -> unit
+
+  val create_checkpoint_with_directory : t -> directory_name:string -> t
+
+  val make_converting : t -> t Async.Deferred.t
+
+  val as_unmasked : t -> Ledger.Any_ledger.witness
+
+  val as_masked : t -> Ledger.t
+
+  val depth : t -> int
+
+  val num_accounts : t -> int
+
+  val merkle_path_at_addr_exn : t -> addr -> path
+
+  val get_inner_hash_at_addr_exn : t -> addr -> hash
+
+  val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
+
+  val set_batch_accounts : t -> (addr * account) list -> unit
+
+  val get_all_accounts_rooted_at_exn : t -> addr -> (addr * account) list
+
+  val unsafely_decompose_root : t -> Ledger.Db.t * Ledger.Hardfork_db.t option
+end
+
+(** An internal functor to create a converting root ledger implementation given
+    a (possibly runtime-determined) account conversion function. *)
+module Make (Inputs : sig
+  val convert : Account.t -> Account.Hardfork.t
+end) =
+struct
+  module Converting_ledger = Ledger.Make_converting (Inputs)
+
+  type root_hash = Ledger_hash.t
+
+  type hash = Ledger_hash.t
+
+  type account = Account.t
+
+  type addr = Ledger.Db.Addr.t
+
+  type path = Ledger.Db.path
+
+  type t = Stable_db of Ledger.Db.t | Converting_db of Converting_ledger.t
 
   let backing_of_t = function
     | Stable_db _ ->
@@ -167,22 +166,25 @@ struct
   let close t =
     match t with
     | Stable_db db ->
-        Stable_db.close db
+        Ledger.Db.close db
     | Converting_db db ->
         Converting_ledger.close db
 
   let merkle_root t =
     match t with
     | Stable_db db ->
-        Stable_db.merkle_root db
+        Ledger.Db.merkle_root db
     | Converting_db db ->
         Converting_ledger.merkle_root db
 
   let create ~logger ~config ~depth ?(assert_synced = false) () =
     match config with
     | Config.Stable_db_config directory_name ->
-        Stable_db (Stable_db.create ~directory_name ~depth ())
-    | Converting_db_config config ->
+        Stable_db (Ledger.Db.create ~directory_name ~depth ())
+    | Converting_db_config { primary_directory; converting_directory } ->
+        let config : Converting_ledger.Config.t =
+          { primary_directory; converting_directory }
+        in
         Converting_db
           (Converting_ledger.create ~config:(In_directories config) ~logger
              ~depth ~assert_synced () )
@@ -190,7 +192,7 @@ struct
   let create_temporary ~logger ~backing_type ~depth () =
     match backing_type with
     | Config.Stable_db ->
-        Stable_db (Stable_db.create ~depth ())
+        Stable_db (Ledger.Db.create ~depth ())
     | Converting_db ->
         Converting_db
           (Converting_ledger.create ~config:Temporary ~logger ~depth ())
@@ -198,8 +200,12 @@ struct
   let create_checkpoint t ~config () =
     match (t, config) with
     | Stable_db db, Config.Stable_db_config directory_name ->
-        Stable_db (Stable_db.create_checkpoint db ~directory_name ())
-    | Converting_db db, Converting_db_config config ->
+        Stable_db (Ledger.Db.create_checkpoint db ~directory_name ())
+    | ( Converting_db db
+      , Converting_db_config { primary_directory; converting_directory } ) ->
+        let config : Converting_ledger.Config.t =
+          { primary_directory; converting_directory }
+        in
         Converting_db (Converting_ledger.create_checkpoint db ~config ())
     | t, config ->
         raise
@@ -211,8 +217,12 @@ struct
   let make_checkpoint t ~config =
     match (t, config) with
     | Stable_db db, Config.Stable_db_config directory_name ->
-        Stable_db.make_checkpoint db ~directory_name
-    | Converting_db db, Converting_db_config config ->
+        Ledger.Db.make_checkpoint db ~directory_name
+    | ( Converting_db db
+      , Converting_db_config { primary_directory; converting_directory } ) ->
+        let config : Converting_ledger.Config.t =
+          { primary_directory; converting_directory }
+        in
         Converting_ledger.make_checkpoint db ~config
     | t, config ->
         raise
@@ -239,10 +249,10 @@ struct
   let chunked_migration ?(chunk_size = 1 lsl 6) stable_locations_and_accounts
       empty_migrated_db =
     let open Async.Deferred.Let_syntax in
-    let ledger_depth = Migrated_db.depth empty_migrated_db in
+    let ledger_depth = Ledger.Hardfork_db.depth empty_migrated_db in
     let addrs_and_accounts =
       List.mapi stable_locations_and_accounts ~f:(fun i acct ->
-          ( Migrated_db.Addr.of_int_exn ~ledger_depth i
+          ( Ledger.Hardfork_db.Addr.of_int_exn ~ledger_depth i
           , Account.Hardfork.of_stable acct ) )
     in
     let rec set_chunks accounts =
@@ -250,7 +260,7 @@ struct
       let chunk, accounts' = List.split_n accounts chunk_size in
       if List.is_empty chunk then return empty_migrated_db
       else (
-        Migrated_db.set_batch_accounts empty_migrated_db chunk ;
+        Ledger.Hardfork_db.set_batch_accounts empty_migrated_db chunk ;
         set_chunks accounts' )
     in
     set_chunks addrs_and_accounts
@@ -262,7 +272,7 @@ struct
         return t
     | Stable_db db ->
         let directory_name =
-          Stable_db.get_directory db
+          Ledger.Db.get_directory db
           |> Option.value_exn
                ~message:"Invariant: database must be in a directory"
         in
@@ -270,68 +280,70 @@ struct
           Converting_ledger.Config.with_primary ~directory_name
         in
         let migrated_db =
-          Migrated_db.create
+          Ledger.Hardfork_db.create
             ~directory_name:converting_config.converting_directory
-            ~depth:(Stable_db.depth db) ()
+            ~depth:(Ledger.Db.depth db) ()
         in
         let%map migrated_db =
-          chunked_migration (Stable_db.to_list_sequential db) migrated_db
+          chunked_migration (Ledger.Db.to_list_sequential db) migrated_db
         in
         Converting_db (Converting_ledger.of_ledgers db migrated_db)
 
   let as_unmasked t =
     match t with
     | Stable_db db ->
-        Any_ledger.cast (module Stable_db) db
+        Ledger.Any_ledger.cast (module Ledger.Db) db
     | Converting_db db ->
-        Any_ledger.cast (module Converting_ledger) db
+        Ledger.Any_ledger.cast (module Converting_ledger) db
+
+  let as_masked t = as_unmasked t |> Ledger.of_any_ledger
 
   let depth t =
     match t with
     | Stable_db db ->
-        Stable_db.depth db
+        Ledger.Db.depth db
     | Converting_db db ->
         Converting_ledger.depth db
 
   let num_accounts t =
     match t with
     | Stable_db db ->
-        Stable_db.num_accounts db
+        Ledger.Db.num_accounts db
     | Converting_db db ->
         Converting_ledger.depth db
 
   let merkle_path_at_addr_exn t =
     match t with
     | Stable_db db ->
-        Stable_db.merkle_path_at_addr_exn db
+        Ledger.Db.merkle_path_at_addr_exn db
     | Converting_db db ->
         Converting_ledger.merkle_path_at_addr_exn db
 
   let get_inner_hash_at_addr_exn t =
     match t with
     | Stable_db db ->
-        Stable_db.get_inner_hash_at_addr_exn db
+        Ledger.Db.get_inner_hash_at_addr_exn db
     | Converting_db db ->
         Converting_ledger.get_inner_hash_at_addr_exn db
 
   let set_all_accounts_rooted_at_exn t =
     match t with
     | Stable_db db ->
-        Stable_db.set_all_accounts_rooted_at_exn db
+        Ledger.Db.set_all_accounts_rooted_at_exn db
     | Converting_db db ->
         Converting_ledger.set_all_accounts_rooted_at_exn db
 
   let set_batch_accounts t =
     match t with
     | Stable_db db ->
-        Stable_db.set_batch_accounts db
+        Ledger.Db.set_batch_accounts db
     | Converting_db db ->
         Converting_ledger.set_batch_accounts db
 
   let get_all_accounts_rooted_at_exn t =
     match t with
     | Stable_db db ->
-        Stable_db.get_all_accounts_rooted_at_exn db
+        Ledger.Db.get_all_accounts_rooted_at_exn db
     | Converting_db db ->
         Converting_ledger.get_all_accounts_rooted_at_exn db
 
@@ -343,3 +355,94 @@ struct
         ( Converting_ledger.primary_ledger db
         , Some (Converting_ledger.converting_ledger db) )
 end
+
+(** A temporary root ledger implementation that does not take the vesting
+    parameter adjustment into account. In future this will be removed, once the
+    account conversion method is modified to be dependent on the hard fork stop
+    slots and genesis delta. *)
+module Compat = Make (struct
+  let convert = Account.Hardfork.of_stable
+end)
+
+(** A wrapper for specific root ledger implementations, using the same technique
+    as [Ledger.Any_ledger] implementation. Concrete root ledgers can be cast to
+    an [Any_root.witness] and then passed to other components that do not need
+    to know how the root ledger is implemented.
+
+    The [Any_root] is exposed as the root ledger implementation because the
+    [Root.create] functions need the ability to select between one of a fixed
+    number of root implementations at runtime.
+*)
+module Any_root = struct
+  type witness = T : (module Intf with type t = 't) * 't -> witness
+
+  let cast (m : (module Intf with type t = 'a)) (t : 'a) = T (m, t)
+
+  module M : Intf with type t = witness = struct
+    type t = witness
+
+    type root_hash = Ledger_hash.t
+
+    type hash = Ledger_hash.t
+
+    type account = Account.t
+
+    type addr = Ledger.Db.Addr.t
+
+    type path = Ledger.Db.path
+
+    let close (T ((module Root), t)) = Root.close t
+
+    let merkle_root (T ((module Root), t)) = Root.merkle_root t
+
+    let create_checkpoint (T ((module Root), t)) ~config () =
+      T ((module Root), Root.create_checkpoint t ~config ())
+
+    let make_checkpoint (T ((module Root), t)) ~config =
+      Root.make_checkpoint t ~config
+
+    let create_checkpoint_with_directory (T ((module Root), t)) ~directory_name
+        =
+      T ((module Root), Root.create_checkpoint_with_directory t ~directory_name)
+
+    let make_converting (T ((module Root), t)) =
+      let open Async.Deferred.Let_syntax in
+      let%map t' = Root.make_converting t in
+      T ((module Root), t')
+
+    let as_unmasked (T ((module Root), t)) = Root.as_unmasked t
+
+    let as_masked (T ((module Root), t)) = Root.as_masked t
+
+    let depth (T ((module Root), t)) = Root.depth t
+
+    let num_accounts (T ((module Root), t)) = Root.num_accounts t
+
+    let merkle_path_at_addr_exn (T ((module Root), t)) =
+      Root.merkle_path_at_addr_exn t
+
+    let get_inner_hash_at_addr_exn (T ((module Root), t)) =
+      Root.get_inner_hash_at_addr_exn t
+
+    let set_all_accounts_rooted_at_exn (T ((module Root), t)) =
+      Root.set_all_accounts_rooted_at_exn t
+
+    let set_batch_accounts (T ((module Root), t)) = Root.set_batch_accounts t
+
+    let get_all_accounts_rooted_at_exn (T ((module Root), t)) =
+      Root.get_all_accounts_rooted_at_exn t
+
+    let unsafely_decompose_root (T ((module Root), t)) =
+      Root.unsafely_decompose_root t
+  end
+end
+
+include Any_root.M
+
+let create ~logger ~config ~depth ?(assert_synced = false) () =
+  let r = Compat.create ~logger ~config ~depth ~assert_synced () in
+  Any_root.cast (module Compat) r
+
+let create_temporary ~logger ~backing_type ~depth () =
+  let r = Compat.create_temporary ~logger ~backing_type ~depth () in
+  Any_root.cast (module Compat) r

--- a/src/lib/mina_ledger/root.mli
+++ b/src/lib/mina_ledger/root.mli
@@ -1,191 +1,136 @@
 open Mina_base
 
-module type Stable_db_intf =
-  Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
-     and type root_hash := Ledger_hash.t
+module Config : sig
+  type t [@@deriving yojson]
 
-module type Migrated_db_intf =
-  Merkle_ledger.Intf.Ledger.DATABASE
-    with type account := Account.Hardfork.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
-     and type root_hash := Ledger_hash.t
+  (** The kind of database backing that should be used for this root. *)
+  type backing_type = Stable_db | Converting_db
 
-module type Any_ledger_intf =
-  Merkle_ledger.Intf.Ledger.ANY
-    with type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type hash := Ledger_hash.t
+  (** Create a root ledger configuration with the given backing type, using
+      the [directory_name] as a template for its location *)
+  val with_directory : backing_type:backing_type -> directory_name:string -> t
 
-module type Converting_ledger_intf =
-  Merkle_ledger.Intf.Ledger.Converting.WITH_DATABASE
-    with type root_hash := Ledger_hash.t
-     and type hash := Ledger_hash.t
-     and type account := Account.t
-     and type key := Signature_lib.Public_key.Compressed.t
-     and type token_id := Token_id.t
-     and type token_id_set := Token_id.Set.t
-     and type account_id := Account_id.t
-     and type account_id_set := Account_id.Set.t
-     and type converted_account := Account.Hardfork.t
+  (** Test if a root ledger backing already exists with this config *)
+  val exists_backing : t -> bool
 
-(** Make a root ledger. A root ledger is a database-backed, unmasked ledger used
-    at the root of a mina ledger mask tree. Currently only a single stable
-    database is supported; an option will be added in future to create root
-    ledgers backed by a converting merkle tree backed by a pair of stable
-    account and unstable account databases.
+  (** Test if a root ledger backing already exists with this config, ignoring
+      the specific backing type of the root *)
+  val exists_any_backing : t -> bool
+
+  (** Delete a backing of any type that might exist with this config, if
+      present. this function will try any backing type even if it didn't match
+      up with one provided in the config *)
+  val delete_any_backing : t -> unit
+
+  (** Delete backing of a specific config *)
+  val delete_backing : t -> unit
+
+  (** Move the root backing at [src] to [dst]. Assumptions: the [src] and
+      [dst] configs must have the same configured backing, there must be a
+      root backing of the appropriate type at [src], there must not be a root
+      backing at [dst], and there must be no database connections open for
+      [src]. *)
+  val move_backing_exn : src:t -> dst:t -> unit
+end
+
+(** The interface for an abstract root ledger. Root ledgers are used to
+    represent the root snarked ledger and the epoch ledger snapshots, and so
+    they are the base of the ledger mask tree that is maintained by the daemon
+    as it participates in network consensus.
+
+    This interface only contains root ledger methods that can transform existing
+    root ledgers, or create new root ledgers from existing ones. Specific root
+    ledger implementations will implement the [Intf_concrete] interface; once
+    specific root ledgers are created, they can be cast to an [Any_root.witness]
+    and passed to code that does not need to know the specific implementation of
+    the root.
 *)
-module Make
-    (Any_ledger : Any_ledger_intf)
-    (Stable_db : Stable_db_intf
-                   with module Location = Any_ledger.M.Location
-                    and module Addr = Any_ledger.M.Addr)
-    (Migrated_db : Migrated_db_intf
-                     with module Location = Any_ledger.M.Location
-                      and module Addr = Any_ledger.M.Addr)
-    (Converting_ledger : Converting_ledger_intf
-                           with module Location = Any_ledger.M.Location
-                            and module Addr = Any_ledger.M.Addr
-                           with type primary_ledger = Stable_db.t
-                            and type converting_ledger = Migrated_db.t) : sig
-  type t
+type t
 
-  type root_hash = Ledger_hash.t
+type root_hash = Ledger_hash.t
 
-  type hash = Ledger_hash.t
+type hash = Ledger_hash.t
 
-  type account = Account.t
+type account = Account.t
 
-  type addr = Stable_db.Addr.t
+type addr = Ledger.Db.Addr.t
 
-  type path = Stable_db.path
+type path = Ledger.Db.path
 
-  module Config : sig
-    type t [@@deriving yojson]
+(** Close the root ledger instance *)
+val close : t -> unit
 
-    (** The kind of database that should be used for this root. Only a single
-        database of [Account.Stable.Latest.t] accounts is supported. A future
-        update will add a converting merkle tree backing. *)
-    type backing_type = Stable_db | Converting_db
-
-    (** Create a root ledger configuration with the given backing type, using
-        the [directory_name] as a template for its location *)
-    val with_directory : backing_type:backing_type -> directory_name:string -> t
-
-    (** Test if a root ledger backing already exists with this config *)
-    val exists_backing : t -> bool
-
-    (** Test if a root ledger backing already exists with this config, ignoring
-        the specific backing type of the root *)
-    val exists_any_backing : t -> bool
-
-    (** Delete a backing of any type that might exist with this config, if 
-        present. this function will try any backing type even if it didn't match
-        up with one provided in the config *)
-    val delete_any_backing : t -> unit
-
-    (** Delete backing of a specific config *)
-    val delete_backing : t -> unit
-
-    (** Move the root backing at [src] to [dst]. Assumptions: the [src] and
-        [dst] configs must have the same configured backing, there must be a
-        root backing of the appropriate type at [src], there must not be a root
-        backing at [dst], and there must be no database connections open for
-        [src]. *)
-    val move_backing_exn : src:t -> dst:t -> unit
-  end
-
-  (** Close the root ledger instance *)
-  val close : t -> unit
-
-  (** Retrieve the hash of the merkle root of the root ledger *)
-  val merkle_root : t -> root_hash
-
-  (** Create a root ledger backed by a single database in the given
+(** Create a root ledger backed by a single database in the given
       directory. *)
-  val create :
-       logger:Logger.t
-    -> config:Config.t
-    -> depth:int
-    -> ?assert_synced:bool
-    -> unit
-    -> t
+val create :
+     logger:Logger.t
+  -> config:Config.t
+  -> depth:int
+  -> ?assert_synced:bool
+  -> unit
+  -> t
 
-  val create_temporary :
-       logger:Logger.t
-    -> backing_type:Config.backing_type
-    -> depth:int
-    -> unit
-    -> t
+val create_temporary :
+  logger:Logger.t -> backing_type:Config.backing_type -> depth:int -> unit -> t
 
-  (** Make a checkpoint of the root ledger and return a new root ledger backed
+(** Retrieve the hash of the merkle root of the root ledger *)
+val merkle_root : t -> root_hash
+
+(** Make a checkpoint of the root ledger and return a new root ledger backed
       by that checkpoint. Throws an exception if the config does not match the
       backing type of the root.  *)
-  val create_checkpoint : t -> config:Config.t -> unit -> t
+val create_checkpoint : t -> config:Config.t -> unit -> t
 
-  (** Make a checkpoint of the root ledger. Throws an exception if the config
+(** Make a checkpoint of the root ledger. Throws an exception if the config
       does not match the backing type of the root. *)
-  val make_checkpoint : t -> config:Config.t -> unit
+val make_checkpoint : t -> config:Config.t -> unit
 
-  (** Make a checkpoint of the root ledger [t] of the same backing type using
+(** Make a checkpoint of the root ledger [t] of the same backing type using
       [directory_name] as a template for its location. Return a new root ledger
       backed by that checkpoint. *)
-  val create_checkpoint_with_directory : t -> directory_name:string -> t
+val create_checkpoint_with_directory : t -> directory_name:string -> t
 
-  (** Convert a root backed by a [Config.Stable_db] to one backed by a
+(** Convert a root backed by a [Config.Stable_db] to one backed by a
       [Config.Converting_db] by gradually migrating the stable database. Does
       nothing if the backing is already [Config.Converting_db]. *)
-  val make_converting : t -> t Async.Deferred.t
+val make_converting : t -> t Async.Deferred.t
 
-  (** View the root ledger as an unmasked [Any_ledger] so it can be used by code
+(** View the root ledger as an unmasked [Any_ledger] so it can be used by code
       that does not need to know how the root is implemented *)
-  val as_unmasked : t -> Any_ledger.witness
+val as_unmasked : t -> Ledger.Any_ledger.witness
 
-  (** Retrieve the depth of the root ledger *)
-  val depth : t -> int
+(** Create a mask and attach it to the root *)
+val as_masked : t -> Ledger.t
 
-  (** Retrieve the number of accounts in the root ledger *)
-  val num_accounts : t -> int
+(** Retrieve the depth of the root ledger *)
+val depth : t -> int
 
-  (** Calculate the address path from [addr] to the merkle root. *)
-  val merkle_path_at_addr_exn : t -> addr -> path
+(** Retrieve the number of accounts in the root ledger *)
+val num_accounts : t -> int
 
-  (** Get the hash at the given [addr] in the ledger. Throws an exception if the
+(** Calculate the address path from [addr] to the merkle root. *)
+val merkle_path_at_addr_exn : t -> addr -> path
+
+(** Get the hash at the given [addr] in the ledger. Throws an exception if the
       [addr] doesn't point to a hash. *)
-  val get_inner_hash_at_addr_exn : t -> addr -> hash
+val get_inner_hash_at_addr_exn : t -> addr -> hash
 
-  (** Set the accounts at the leaves underneath [addr] in the ledger to the
+(** Set the accounts at the leaves underneath [addr] in the ledger to the
       accounts in the given list. Throws an exception if the [addr] is not in
       the ledger, or if there are not exactly enough accounts in the list to set
       the values at the leaves. *)
-  val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
+val set_all_accounts_rooted_at_exn : t -> addr -> account list -> unit
 
-  (** For each addr-account pair, replace the account in the root with the given
+(** For each addr-account pair, replace the account in the root with the given
       account. This is done as a single batch write. *)
-  val set_batch_accounts : t -> (addr * account) list -> unit
+val set_batch_accounts : t -> (addr * account) list -> unit
 
-  (** Get all of the accounts that are in a subtree of the underlying Merkle
+(** Get all of the accounts that are in a subtree of the underlying Merkle
     tree rooted at `address`. The accounts are ordered by their addresses. *)
-  val get_all_accounts_rooted_at_exn : t -> addr -> (addr * account) list
+val get_all_accounts_rooted_at_exn : t -> addr -> (addr * account) list
 
-  (** Decompose a root into its components parts. Users of this method must be
+(** Decompose a root into its components parts. Users of this method must be
       careful to ensure that either the underlying databases remain in sync, or
       that they are not later used to back a root ledger. Use this on temporary
       copies of root ledgers if possible. *)
-  val unsafely_decompose_root : t -> Stable_db.t * Migrated_db.t option
-end
+val unsafely_decompose_root : t -> Ledger.Db.t * Ledger.Hardfork_db.t option

--- a/src/lib/mina_ledger/sync_ledger.ml
+++ b/src/lib/mina_ledger/sync_ledger.ml
@@ -41,7 +41,7 @@ end)
 
 module Root = Syncable_ledger.Make (struct
   module Addr = Ledger.Location.Addr
-  module MT = Ledger.Root
+  module MT = Root
   module Account = Account.Stable.Latest
   module Hash = Hash
   module Root_hash = Root_hash

--- a/src/lib/mina_ledger/test/test_mina_ledger.ml
+++ b/src/lib/mina_ledger/test/test_mina_ledger.ml
@@ -2,7 +2,7 @@ open Core
 open Async
 open Mina_base
 module L = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 let logger = Logger.create ~id:"test_mina_ledger" ()
 

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -1,7 +1,7 @@
 open Core_kernel
 open Async_kernel
 open Signature_lib
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 (* TODO: Pass banlist to modules discussed in Ban Reasons issue: https://github.com/CodaProtocol/coda/issues/852 *)
 

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -3,7 +3,7 @@ open Async
 open Mina_base
 open Mina_transaction
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 open Mina_block
 open Pipe_lib
 open Strict_pipe

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -14,7 +14,7 @@ module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Mina_subscriptions
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 type t
 

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -5,7 +5,7 @@ let%test_module "Epoch ledger sync tests" =
     open Mina_base
     open Pipe_lib
     open Network_peer
-    module Root_ledger = Mina_ledger.Ledger.Root
+    module Root_ledger = Mina_ledger.Root
 
     module type CONTEXT = sig
       include Mina_lib.CONTEXT

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Async
 open Mina_base
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 module Sync_ledger = Mina_ledger.Sync_ledger
 open Frontier_base
 open Network_peer

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -1,7 +1,7 @@
 open Core_kernel
 open Mina_base
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 open Mina_state
 open Frontier_base
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -12,7 +12,7 @@
 open Mina_base
 open Frontier_base
 open Mina_state
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module type CONTEXT = sig
   val logger : Logger.t
@@ -87,7 +87,7 @@ module For_tests : sig
        Base_quickcheck.Generator.t
 
   val create_frontier :
-       epoch_ledger_backing_type:Root_ledger.Config.backing_type
+       epoch_ledger_backing_type:Mina_ledger.Root.Config.backing_type
     -> unit
     -> t Async_kernel.Deferred.t
 

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -5,7 +5,7 @@ open Mina_state
 open Mina_block
 open Frontier_base
 module Database = Database
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module type CONTEXT = sig
   val logger : Logger.t

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -4,7 +4,7 @@ module Ledger = Mina_ledger.Ledger
 open Frontier_base
 module Ledger_transfer_any =
   Mina_ledger.Ledger_transfer.Make (Ledger.Any_ledger.M) (Ledger.Any_ledger.M)
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 let genesis_root_identifier ~genesis_state_hash =
   let open Root_identifier.Stable.Latest in

--- a/src/lib/transition_frontier/persistent_root/persistent_root.mli
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.mli
@@ -2,7 +2,7 @@ open Core
 open Mina_base
 open Frontier_base
 open Mina_ledger
-module Root_ledger = Ledger.Root
+module Root_ledger = Root
 
 module rec Instance_type : sig
   type t =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -7,7 +7,7 @@ open Core
 open Async_kernel
 open Mina_base
 module Ledger = Mina_ledger.Ledger
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 include Frontier_base
 module Full_frontier = Full_frontier
 module Extensions = Extensions

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -17,7 +17,7 @@ module Root_data = Root_data
 module Catchup_state = Catchup_state
 module Full_catchup_tree = Full_catchup_tree
 module Catchup_hash_tree = Catchup_hash_tree
-module Root_ledger = Mina_ledger.Ledger.Root
+module Root_ledger = Mina_ledger.Root
 
 module type CONTEXT = sig
   val logger : Logger.t
@@ -156,7 +156,7 @@ module For_tests : sig
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
     -> ?create_root_and_accounts:
-         (   config:Root_ledger.Config.t
+         (   config:Mina_ledger.Root.Config.t
           -> depth:int
           -> unit
           -> Root_ledger.t Core_kernel.Or_error.t )
@@ -179,7 +179,7 @@ module For_tests : sig
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
     -> ?create_root_and_accounts:
-         (   config:Root_ledger.Config.t
+         (   config:Mina_ledger.Root.Config.t
           -> depth:int
           -> unit
           -> Root_ledger.t Core_kernel.Or_error.t )


### PR DESCRIPTION
## Explain your changes

The existing `Root` ledger implementation assumes that the `Account.t -> Account.Hardfork.t` conversion method will be known fully at compile time. This is not quite true; the vesting parameter update depends on the configured stop slots and genesis delta for the upcoming hard fork. These parameters are part of the runtime config, so the `Root` ledger implementation will eventually need to accept these parameters when root ledgers are created/opened by the daemon.

The task of modifying the `Root` ledger to accept these parameters as inputs is slightly complicated by the fact that the `Converting_merkle_tree` is written as a functor that accepts a mandatory `convert` method to instantiate a merkle ledger module. Rather than refactor *that* (which is potentially still an option) I have decided to refactor the `Root` ledger implementation a bit. It is now an existential wrapper around a concrete root ledger implementation, similar to the existing `any_ledger.ml`. It is defined as `Any_root` in `root.ml` and its methods are exposed directly in `root.mli`, along with `create` and `create_temporary` methods.

For now, the only concrete root ledger implementation is the existing one, which is now called `Compat` internally and not exposed to the rest of the code. That concrete implementation is unchanged. In a follow-up PR the concrete root ledger implementation itself will need to change, as will the `Root.create` methods, since they will need to accept a `convert` method that is only known at runtime.

To make the `Root.Intf` interface easier to declare, I did make it so that the `Root` module depends explicitly on the `Ledger` module. That means the rest of the code now needs to refer to the root ledger module as `Mina_ledger.Root` and not `Mina_ledger.Ledger.Root`, which has caused the change to appear bigger than I think it actually is. This change does make the `root.mli` significantly cleaner in my opinion, which is a nice side benefit.

## Explain how you tested your changes

Our existing tests should be sufficient to cover this refactor, especially for the behaviour of the daemon with ledger sync disabled.