### PR TITLE
[CI] support for untaring script in Run with postgres test

### DIFF
--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -19,7 +19,9 @@ in  { step =
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
                     , "MINA_TEST_NETWORK_DATA=/etc/mina/test/archive/sample_db"
                     ]
-                    "src/test/archive/sample_db/archive_db.sql"
+                    ( RunWithPostgres.ScriptOrArchive.Script
+                        "src/test/archive/sample_db/archive_db.sql"
+                    )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite

--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -19,7 +19,9 @@ in  { step =
                     [ "PATCH_ARCHIVE_TEST_APP=mina-patch-archive-test"
                     , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
                     ]
-                    "./src/test/archive/sample_db/archive_db.sql"
+                    ( RunWithPostgres.ScriptOrArchive.Script
+                        "./src/test/archive/sample_db/archive_db.sql"
+                    )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -17,7 +17,9 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInDockerWithPostgresConn
                     ([] : List Text)
-                    "./src/test/archive/sample_db/archive_db.sql"
+                    ( RunWithPostgres.ScriptOrArchive.Script
+                        "./src/test/archive/sample_db/archive_db.sql"
+                    )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{
                         , artifact = Artifacts.Type.FunctionalTestSuite

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -54,7 +54,9 @@ in  Pipeline.build
                   "export MINA_DEB_CODENAME=bullseye && source ./buildkite/scripts/export-git-env-vars.sh && echo \\\${MINA_DOCKER_TAG}"
               , RunWithPostgres.runInDockerWithPostgresConn
                   ([] : List Text)
-                  "./src/test/archive/sample_db/archive_db.sql"
+                  ( RunWithPostgres.ScriptOrArchive.Script
+                      "./src/test/archive/sample_db/archive_db.sql"
+                  )
                   rosettaDocker
                   "./buildkite/scripts/rosetta-indexer-test.sh"
               , Cmd.runInDocker


### PR DESCRIPTION
Allow to specify archive which contains the init script instead script alone. That will help us limit space used by our repo but also remove some boilerplate code in the future 