### PR TITLE
Increase default slot time in the CI hard fork test

### DIFF
--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -53,8 +53,8 @@ func DefaultConfig() *Config {
 		SlotTxEnd:                     30,
 		SlotChainEnd:                  38, // SlotTxEnd + 8
 		BestChainQueryFrom:            25,
-		MainSlot:                      15,
-		ForkSlot:                      15,
+		MainSlot:                      30,
+		ForkSlot:                      30,
 		MainDelay:                     5,
 		ForkDelay:                     5,
 		ShutdownTimeoutMinutes:        10,


### PR DESCRIPTION
Enabling a snark worker at the block producer daemon appears to slow down block production enough that the BP daemon has trouble producing blocks within the current default slot time of 15s. This results in the problems that I noted in https://github.com/MinaProtocol/mina/pull/17919#issuecomment-3475235535, where the BP daemon and snark worker daemon drift far enough apart that the resulting disagreement about the best tip causes fork validation (and thus the test itself) to fail.

Increasing the default slot time 30s seems to be enough for the test to run reliably locally (on my work laptop) so I'm hoping this will allow the tests to pass reliably in the CI as well, since they've been failing there in similar ways.