### PR TITLE
Close ledgers generated by runtime_genesis_ledger after creating them…

### DIFF
--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -53,8 +53,8 @@ func DefaultConfig() *Config {
 		SlotTxEnd:                     30,
 		SlotChainEnd:                  38, // SlotTxEnd + 8
 		BestChainQueryFrom:            25,
-		MainSlot:                      15,
-		ForkSlot:                      15,
+		MainSlot:                      30,
+		ForkSlot:                      30,
 		MainDelay:                     5,
 		ForkDelay:                     5,
 		ShutdownTimeoutMinutes:        10,

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -145,6 +145,9 @@ let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
   let%bind hash_json =
     generate_hash_json ~genesis_dir ledger staking_ledger next_ledger
   in
+  Ledger.close ledger ;
+  Ledger.close staking_ledger ;
+  Ledger.close next_ledger ;
   Async.Writer.save hash_output_file
     ~contents:(Yojson.Safe.to_string (Hash_json.to_yojson hash_json))
 


### PR DESCRIPTION
… so we don't have a lockfile there

This PR aims to patch errors seen 
https://buildkite.com/organizations/o-1-labs-2/pipelines/mina-end-to-end-nightlies/builds/3967/jobs/019a4d9a-491c-40f7-87b3-976b6446807e/log

Previous in train: https://github.com/MinaProtocol/mina/pull/18059