### PR TITLE
Bump protocol version in develop to 4.0.0

### DIFF
--- a/src/lib/node_config/version/node_config_version.ml
+++ b/src/lib/node_config/version/node_config_version.ml
@@ -1,5 +1,5 @@
 (* transaction >= 1, network >= 0, patch >= 0 *)
-let protocol_version_transaction = 3
+let protocol_version_transaction = 4
 
 let protocol_version_network = 0
 


### PR DESCRIPTION
The protocol version needs to be bumped for the next hard fork. Since the planned changes will affect the actual transaction logic, the transaction component of the version number (the major version, essentially) should be the correct component to increase. This matches the version number the mesa archive upgrade script thinks will be Mesa's version:

https://github.com/MinaProtocol/mina/blob/0bd4b30ad889f41665c05e335beae301178ef3e5/src/app/archive/upgrade_to_mesa.sql#L19

I don't think this is strictly necessary to merge right now, because we haven't merged any of the MIPs that require a protocol version bump yet. On the other hand, it is something that is easy to revert. We could also consider merging this into the mesa branch being developed in https://github.com/MinaProtocol/mina/pull/18036.

Closes: https://github.com/MinaProtocol/mina/issues/17817