### PR TITLE
Backward compatible yojson parser for root ledger config

### DIFF
--- a/src/lib/mina_ledger/root.ml
+++ b/src/lib/mina_ledger/root.ml
@@ -14,6 +14,17 @@ module Config = struct
         Merkle_ledger.Converting_merkle_tree.With_database_config.t
   [@@deriving yojson]
 
+  (* Pre Mesa hardfork the only config option was equivalent to
+     Stable_db_config which was a type alias of string. This requires
+     overriding the ppx yojson instances to maintain backward compatibility.
+  *)
+  let of_yojson json =
+    match json with
+    | `String filename ->
+        Ok (Stable_db_config filename)
+    | _ ->
+        of_yojson json
+
   let backing_of_config = function
     | Stable_db_config _ ->
         Stable_db


### PR DESCRIPTION
Fixes #17764

Based on the [previous type](https://github.com/MinaProtocol/mina/blame/745b23fdb1b0cf74d0d3564b324bcc87ee5dec2c/src/lib/mina_ledger/root.ml#L63) , the new json parser needs to be able to treat a raw `'String` variant as `Stable_db_config`. This should fix the problem. 

Not sure if this needs tests