### PR TITLE
Implement RPC shutdown for Archive

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4857,6 +4857,9 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
     ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
         (fun () extensional_block ->
           Strict_pipe.Writer.write extensional_block_writer extensional_block )
+    ; Async.Rpc.Rpc.implement Archive_rpc.shutdown (fun () () ->
+          [%log info] "Received shutdown signal from daemon!, shutting down" ;
+          Shutdown.exit 0 )
     ]
   in
   match Mina_caqti.connect_pool ~max_size:30 postgres_address with

--- a/src/app/archive/lib/rpc.ml
+++ b/src/app/archive/lib/rpc.ml
@@ -15,3 +15,9 @@ let extensional_block : (Extensional.Block.t, Unit.Stable.V1.t) Rpc.Rpc.t =
   Rpc.Rpc.create ~name:"Send_extensional_block" ~version:0
     ~bin_query:Extensional.Block.Stable.Latest.bin_t
     ~bin_response:Unit.Stable.V1.bin_t
+
+(* Used for HF, when daemon has exited and would be restarted by a script with a
+   new version. Same should happen for archive *)
+let shutdown : (Unit.Stable.V1.t, Unit.Stable.V1.t) Rpc.Rpc.t =
+  Rpc.Rpc.create ~name:"Signal_migrate_exit" ~version:0
+    ~bin_query:Unit.Stable.V1.bin_t ~bin_response:Unit.Stable.V1.bin_t


### PR DESCRIPTION
This is needed so when daemon exit, it notify archive to shutdown as well. Then an external monitoring script should be able to restart both daemon & archive with post-mesa binaries. 

Not sure if similar mechanism is needed for mesa ATM. 