### PR TITLE
[CI][Dhall] Allow not to specify any init script action

### DIFF
--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -19,8 +19,10 @@ in  { step =
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
                     , "MINA_TEST_NETWORK_DATA=/etc/mina/test/archive/sample_db"
                     ]
-                    ( RunWithPostgres.ScriptOrArchive.Script
-                        "src/test/archive/sample_db/archive_db.sql"
+                    ( Some
+                        ( RunWithPostgres.ScriptOrArchive.Script
+                            "src/test/archive/sample_db/archive_db.sql"
+                        )
                     )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{

--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -19,8 +19,10 @@ in  { step =
                     [ "PATCH_ARCHIVE_TEST_APP=mina-patch-archive-test"
                     , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
                     ]
-                    ( RunWithPostgres.ScriptOrArchive.Script
-                        "./src/test/archive/sample_db/archive_db.sql"
+                    ( Some
+                        ( RunWithPostgres.ScriptOrArchive.Script
+                            "./src/test/archive/sample_db/archive_db.sql"
+                        )
                     )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -17,8 +17,10 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInDockerWithPostgresConn
                     ([] : List Text)
-                    ( RunWithPostgres.ScriptOrArchive.Script
-                        "./src/test/archive/sample_db/archive_db.sql"
+                    ( Some
+                        ( RunWithPostgres.ScriptOrArchive.Script
+                            "./src/test/archive/sample_db/archive_db.sql"
+                        )
                     )
                     ( Artifacts.fullDockerTag
                         Artifacts.Tag::{

--- a/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
@@ -54,11 +54,13 @@ in  Pipeline.build
             , commands =
               [ RunWithPostgres.runInDockerWithPostgresConn
                   ([] : List Text)
-                  ( RunWithPostgres.ScriptOrArchive.Archive
-                      { Script = "post_upgrade_archive.sql"
-                      , Archive =
-                          "scripts/tests/archive-hardfork-toolbox/post_upgrade_archive.tar.gz"
-                      }
+                  ( Some
+                      ( RunWithPostgres.ScriptOrArchive.Archive
+                          { Script = "post_upgrade_archive.sql"
+                          , Archive =
+                              "scripts/tests/archive-hardfork-toolbox/post_upgrade_archive.tar.gz"
+                          }
+                      )
                   )
                   ( Artifacts.fullDockerTag
                       Artifacts.Tag::{
@@ -72,11 +74,13 @@ in  Pipeline.build
                   )
               , RunWithPostgres.runInDockerWithPostgresConn
                   ([] : List Text)
-                  ( RunWithPostgres.ScriptOrArchive.Archive
-                      { Script = "hf_archive.sql"
-                      , Archive =
-                          "scripts/tests/archive-hardfork-toolbox/hf_archive.tar.gz"
-                      }
+                  ( Some
+                      ( RunWithPostgres.ScriptOrArchive.Archive
+                          { Script = "hf_archive.sql"
+                          , Archive =
+                              "scripts/tests/archive-hardfork-toolbox/hf_archive.tar.gz"
+                          }
+                      )
                   )
                   ( Artifacts.fullDockerTag
                       Artifacts.Tag::{

--- a/buildkite/src/Jobs/Test/EmergencyHfTest.dhall
+++ b/buildkite/src/Jobs/Test/EmergencyHfTest.dhall
@@ -10,15 +10,19 @@ let Command = ../../Command/Base.dhall
 
 let Size = ../../Command/Size.dhall
 
-let Cmd = ../../Lib/Cmds.dhall
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let BuildFlags = ../../Constants/BuildFlags.dhall
+
+let RunWithPostgres = ../../Command/RunWithPostgres.dhall
+
+let key = "emergency-hf-test"
 
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
         , dirtyWhen =
-          [ S.strictlyStart (S.contains "scripts/archive/emergency_hf")
-          , S.strictlyStart (S.contains "src/app/archive")
-          ]
+          [ S.strictlyStart (S.contains "src/app/archive_hardfork_toolbox") ]
         , path = "Test"
         , name = "EmergencyHfTest"
         , tags =
@@ -31,11 +35,20 @@ in  Pipeline.build
         [ Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run
-                  "PSQL=\"docker exec replayer-postgres psql\" ./scripts/archive/emergency_hf/test/runner.sh "
+              [ RunWithPostgres.runInDockerWithPostgresConn
+                  [ "CONVERT_CANONICAL_BLOCKS_TEST_APP=mina-test-convert-canonical"
+                  ]
+                  (None RunWithPostgres.ScriptOrArchive)
+                  ( Artifacts.fullDockerTag
+                      Artifacts.Tag::{
+                      , artifact = Artifacts.Type.FunctionalTestSuite
+                      , buildFlags = BuildFlags.Type.Instrumented
+                      }
+                  )
+                  "./scripts/tests/archive-hardfork-toolbox/test_convert_canonical_blocks.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} "
               ]
             , label = "Emergency HF test"
-            , key = "emergency-hf-test"
+            , key = key
             , target = Size.Large
             }
         ]

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -54,8 +54,10 @@ in  Pipeline.build
                   "export MINA_DEB_CODENAME=bullseye && source ./buildkite/scripts/export-git-env-vars.sh && echo \\\${MINA_DOCKER_TAG}"
               , RunWithPostgres.runInDockerWithPostgresConn
                   ([] : List Text)
-                  ( RunWithPostgres.ScriptOrArchive.Script
-                      "./src/test/archive/sample_db/archive_db.sql"
+                  ( Some
+                      ( RunWithPostgres.ScriptOrArchive.Script
+                          "./src/test/archive/sample_db/archive_db.sql"
+                      )
                   )
                   rosettaDocker
                   "./buildkite/scripts/rosetta-indexer-test.sh"


### PR DESCRIPTION
In some cases in CI we don't need init script as we are dynamically creating tables in test. We just need postgres connection. 

Therefore relaxing this condition. Now, we are accepting `ScriptOrArrchive Optional`  type .


PR is related to migrating emergency hardfork script to ocaml (https://github.com/MinaProtocol/mina/pull/18053)