### PR TITLE
Move Chain_state_locations to a separate file

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -49,43 +49,6 @@ let plugin_flag =
          times"
   else Command.Param.return []
 
-module Chain_state_locations = struct
-  (** The locations of the chain state in a daemon. These will be computed by
-      [chain_state_locations] based on the runtime daemon config. By default,
-      the [chain_state] will be located in the mina config directory and the
-      other directories will be located in the [chain_state]. *)
-  type t =
-    { chain_state : string  (** The top-level chain state directory *)
-    ; mina_net : string  (** Mina networking information *)
-    ; trust : string  (** P2P trust information *)
-    ; root : string  (** The root snarked ledgers *)
-    ; genesis : string  (** The genesis ledgers *)
-    ; frontier : string  (** The transition frontier *)
-    ; epoch_ledger : string  (** The epoch ledger snapshots *)
-    ; proof_cache : string  (** The proof cache *)
-    ; zkapp_vk_cache : string  (** The zkApp vk cache *)
-    ; snark_pool : string  (** The snark pool *)
-    }
-
-  (** Determine the locations of the chain state components based on the daemon
-      runtime config *)
-  let of_config ~conf_dir (config : Runtime_config.t) : t =
-    (* TODO: post hard fork, we should not be ignoring this *)
-    let _config = config in
-    let chain_state = conf_dir in
-    { chain_state
-    ; mina_net = chain_state ^/ "mina_net2"
-    ; trust = chain_state ^/ "trust"
-    ; root = chain_state ^/ "root"
-    ; genesis = chain_state ^/ "genesis"
-    ; frontier = chain_state ^/ "frontier"
-    ; epoch_ledger = chain_state
-    ; proof_cache = chain_state ^/ "proof_cache"
-    ; zkapp_vk_cache = chain_state ^/ "zkapp_vk_cache"
-    ; snark_pool = chain_state ^/ "snark_pool"
-    }
-end
-
 let load_config_files ~logger ~genesis_constants ~constraint_constants ~conf_dir
     ~genesis_dir ~cli_proof_level ~proof_level ~genesis_backing_type
     config_files =
@@ -136,7 +99,7 @@ let load_config_files ~logger ~genesis_constants ~constraint_constants ~conf_dir
             failwithf "Could not parse configuration file: %s" err () )
   in
   let chain_state_locations =
-    Chain_state_locations.of_config ~conf_dir config
+    Init.Chain_state_locations.of_config ~conf_dir config
   in
   let genesis_dir =
     Option.value ~default:chain_state_locations.genesis genesis_dir

--- a/src/app/cli/src/init/chain_state_locations.ml
+++ b/src/app/cli/src/init/chain_state_locations.ml
@@ -1,0 +1,36 @@
+open Core
+
+(** The locations of the chain state in a daemon. These will be computed by
+      [chain_state_locations] based on the runtime daemon config. By default,
+      the [chain_state] will be located in the mina config directory and the
+      other directories will be located in the [chain_state]. *)
+type t =
+  { chain_state : string  (** The top-level chain state directory *)
+  ; mina_net : string  (** Mina networking information *)
+  ; trust : string  (** P2P trust information *)
+  ; root : string  (** The root snarked ledgers *)
+  ; genesis : string  (** The genesis ledgers *)
+  ; frontier : string  (** The transition frontier *)
+  ; epoch_ledger : string  (** The epoch ledger snapshots *)
+  ; proof_cache : string  (** The proof cache *)
+  ; zkapp_vk_cache : string  (** The zkApp vk cache *)
+  ; snark_pool : string  (** The snark pool *)
+  }
+
+(** Determine the locations of the chain state components based on the daemon
+      runtime config *)
+let of_config ~conf_dir (config : Runtime_config.t) : t =
+  (* TODO: post hard fork, we should not be ignoring this *)
+  let _config = config in
+  let chain_state = conf_dir in
+  { chain_state
+  ; mina_net = chain_state ^/ "mina_net2"
+  ; trust = chain_state ^/ "trust"
+  ; root = chain_state ^/ "root"
+  ; genesis = chain_state ^/ "genesis"
+  ; frontier = chain_state ^/ "frontier"
+  ; epoch_ledger = chain_state
+  ; proof_cache = chain_state ^/ "proof_cache"
+  ; zkapp_vk_cache = chain_state ^/ "zkapp_vk_cache"
+  ; snark_pool = chain_state ^/ "snark_pool"
+  }


### PR DESCRIPTION
Move `Chain_state_locations` to a separate file.

A simple refactoring.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
