### PR TITLE
[CI] push docker to new euro repo

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -33,6 +33,7 @@ set -E # inherit -e
 set -e # exit immediately on errors
 set -u # exit on not assigned variables
 set -o pipefail # exit on pipe failure
+set -x
 
 CLEAR='\033[0m'
 RED='\033[0;31m'
@@ -1376,7 +1377,7 @@ function verify(){
             ;;
             --docker-repo )
                 __docker_repo=${2:?$error_message}
-                shift 1;
+                shift 2;
             ;;
             --only-dockers )
                 __only_dockers=1

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -75,7 +75,7 @@ let ReleaseSpec =
           , docker_publish = DockerPublish.Type.Essential
           , no_cache = False
           , no_debian = False
-          , docker_repo = DockerRepo.Type.Internal
+          , docker_repo = DockerRepo.Type.InternalEurope
           , step_key_suffix = "-docker-image"
           , verify = False
           , deb_suffix = None Text
@@ -144,6 +144,7 @@ let generateStep =
                             , profile = spec.deb_profile
                             , buildFlag = spec.build_flags
                             , archs = [ spec.arch ]
+                            , repo = spec.docker_repo
                             }
 
                 else  ""

--- a/buildkite/src/Command/Packages/VerifyDockers.dhall
+++ b/buildkite/src/Command/Packages/VerifyDockers.dhall
@@ -20,6 +20,8 @@ let BuildFlags = ../../Constants/BuildFlags.dhall
 
 let Profiles = ../../Constants/Profiles.dhall
 
+let DockerRepo = ../../Constants/DockerRepo.dhall
+
 let Spec =
       { Type =
           { artifacts : List Artifact.Type
@@ -30,6 +32,7 @@ let Spec =
           , profile : Profiles.Type
           , archs : List Arch.Type
           , buildFlag : BuildFlags.Type
+          , repo : DockerRepo.Type
           }
       , default =
           { artifacts = [] : List Package.Type
@@ -42,6 +45,7 @@ let Spec =
           , profile = Profiles.Type.Devnet
           , buildFlag = BuildFlags.Type.None
           , archs = [ Arch.Type.Amd64 ]
+          , repo = DockerRepo.Type.InternalEurope
           }
       }
 
@@ -108,6 +112,7 @@ let verify
               ++  "--networks ${joinNetworks spec} "
               ++  "--version ${spec.version} "
               ++  "--codenames ${joinCodenames spec} "
+              ++  "--docker-repo ${DockerRepo.show spec.repo} "
               ++  profileFlag
               ++  archFlag
               ++  buildFlag

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -50,7 +50,7 @@ let Spec =
           , timeout = 1000
           , profile = Profiles.Type.Devnet
           , scope = PipelineScope.Full
-          , repo = DockerRepo.Type.Internal
+          , repo = DockerRepo.Type.InternalEurope
           , if_ =
               "build.pull_request.base_branch != \"develop\" && build.branch != \"develop\""
           }

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -16,7 +16,7 @@ in  { executeLocal =
               , commands =
                 [ Cmd.run
                     "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive-local.sh ${testName} ${DockerRepo.show
-                                                                                                                                                                       DockerRepo.Type.Internal}"
+                                                                                                                                                                       DockerRepo.Type.InternalEurope}"
                 ]
               , artifact_paths =
                 [ SelectFiles.exactly "." "${testName}.local.test.log" ]

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -223,8 +223,9 @@ let dockerTag =
 
 let fullDockerTag =
           \(spec : Tag.Type)
-      ->  "${Repo.show Repo.Type.Internal}/${dockerName
-                                               spec.artifact}:${dockerTag spec}"
+      ->  "${Repo.show Repo.Type.InternalEurope}/${dockerName
+                                                     spec.artifact}:${dockerTag
+                                                                        spec}"
 
 in  { Type = Artifact
     , Tag = Tag

--- a/buildkite/src/Constants/DockerRepo.dhall
+++ b/buildkite/src/Constants/DockerRepo.dhall
@@ -1,12 +1,13 @@
 let Repo
     : Type
-    = < Internal | Public >
+    = < Internal | InternalEurope >
 
 let show =
           \(repo : Repo)
       ->  merge
             { Internal = "gcr.io/o1labs-192920"
-            , Public = "docker.io/minaprotocol"
+            , InternalEurope =
+                "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo"
             }
             repo
 


### PR DESCRIPTION
Replace gcr.io with new europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo repo for cost saving. 

I added new variant for docker repo. Then updated every occurence of gcr.io by argument or env var which supposed to be provided from caller. 

In case of release/manager.sh i opened up possibliity to specify source and target repo instead of flag which tell us to push either to gcr or dockerhub. 