### PR TITLE
Some nit improvements on libp2p

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/util_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/util_test.go
@@ -55,6 +55,10 @@ func newTestAppWithMaxConnsAndCtxAndGrace(t *testing.T, privkey crypto.PrivKey, 
 	dir, err := ioutil.TempDir("", "mina_test_*")
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		panicOnErr(os.RemoveAll(dir))
+	})
+
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port))
 	require.NoError(t, err)
 
@@ -74,13 +78,13 @@ func newTestAppWithMaxConnsAndCtxAndGrace(t *testing.T, privkey crypto.PrivKey, 
 	)
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		panicOnErr(helper.Host.Close())
+	})
+
 	helper.SetTrustedAddrFilters(ma.NewFilters())
 	helper.Host.SetStreamHandler(testProtocol, testStreamHandler)
 
-	t.Cleanup(func() {
-		panicOnErr(os.RemoveAll(dir))
-		panicOnErr(helper.Host.Close())
-	})
 	outChan := make(chan *capnp.Message, 64)
 	bitswapCtx := NewBitswapCtxWithMaxBlockSize(1<<9, ctx, outChan)
 	bitswapCtx.engine = helper.Bitswap


### PR DESCRIPTION
This PR: 
- rename some variables in codanet.MakeHelper to enhance readability
- ensure dir removal always happen after libp2p helper is closed, also ensure dir is removed when p2p helper creation is failed