### PR TITLE
Benchmark hex conversion for `State_hash.t`

### DIFF
--- a/src/app/benchmarks/benchmarks.ml
+++ b/src/app/benchmarks/benchmarks.ml
@@ -7,7 +7,7 @@
 
 open Core_kernel
 
-let available_libraries = [ "vrf_lib_tests"; "mina_base" ]
+let available_libraries = [ "vrf_lib_tests"; "mina_base"; "data_hash_lib" ]
 
 let run_benchmarks_in_lib libname =
   printf "Running inline tests in library \"%s\"\n%!" libname ;

--- a/src/app/benchmarks/dune
+++ b/src/app/benchmarks/dune
@@ -10,7 +10,8 @@
   core_kernel
   core
   base
-  mina_stdlib)
+  mina_stdlib
+  data_hash_lib)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -32,6 +32,8 @@ module Kimchi_backend_common : sig
 
       val hash : t -> Ppx_hash_lib.Std.Hash.hash_value
 
+      val to_hex_string : t -> string
+
       module Bigint : Kimchi_pasta_snarky_backend__.Bigint.Intf
 
       val to_bigint : t -> Bigint.t

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
@@ -75,6 +75,8 @@ end
 module type S = sig
   type t [@@deriving sexp, compare, yojson, bin_io, hash]
 
+  val to_hex_string : t -> string
+
   include Input_intf with type t := t
 
   val size : Bigint.t
@@ -155,6 +157,8 @@ module type S_with_version = sig
           - Returns Error if the string cannot be parsed as a valid number in
             the given format *)
       val of_yojson : Yojson.Safe.t -> (t, string) Result.t
+
+      val to_hex_string : t -> string
     end
   end]
 
@@ -222,8 +226,9 @@ module Make (F : Input_intf) :
 
       let equal = equal
 
-      let to_yojson t : Yojson.Safe.t =
-        `String (Bigint.to_hex_string (to_bigint t))
+      let to_hex_string = Fn.compose Bigint.to_hex_string to_bigint
+
+      let to_yojson t : Yojson.Safe.t = `String (to_hex_string t)
 
       let of_yojson j =
         match j with

--- a/src/lib/data_hash_lib/dune
+++ b/src/lib/data_hash_lib/dune
@@ -32,6 +32,7 @@
   test_util)
  (preprocess
   (pps
+   ppx_bench
    ppx_compare
    ppx_hash
    ppx_inline_test

--- a/src/lib/data_hash_lib/state_hash.ml
+++ b/src/lib/data_hash_lib/state_hash.ml
@@ -20,6 +20,8 @@ let to_decimal_string = to_decimal_string
 
 let of_decimal_string = of_decimal_string
 
+let to_hex_string = Field.to_hex_string
+
 (* Data hash versioned boilerplate below *)
 
 [%%versioned
@@ -50,3 +52,22 @@ let deriver obj =
       ~of_string:of_base58_check_exn
     |> needs_custom_js ~name:"StateHash" ~js_type:field)
     obj
+
+include (
+  struct
+    (* Some inline benchmarks *)
+    let state_hash_for_bench =
+      lazy
+        (Base_quickcheck.Generator.generate gen ~size:1
+           ~random:(Splittable_random.State.create Random.State.default) )
+
+    let%bench "State_hash decimal encode" =
+      to_decimal_string (Lazy.force state_hash_for_bench)
+
+    let%bench "State_hash base58 encode" =
+      to_base58_check (Lazy.force state_hash_for_bench)
+
+    let%bench "State_hash hex encode" =
+      to_hex_string (Lazy.force state_hash_for_bench)
+  end :
+    sig end )

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -162,6 +162,8 @@ module Tick = struct
 
     let of_yojson = Kimchi_pasta_basic.Fp.of_yojson
 
+    let to_hex_string = Kimchi_pasta_basic.Fp.to_hex_string
+
     let size_in_triples = Int.((size_in_bits + 2) / 3)
   end
 


### PR DESCRIPTION
Expose conversion of `State_hash.t` to hex string and benchmark it against base58 and decimal string representations.

To run the benchmark, `dune build src/app/benchmarks` followed by:

```bash
BENCHMARKS_RUNNER=TRUE X_LIBRARY_INLINING=true BENCHMARK_LIBRARIES=data_hash_lib _build/default/src/app/benchmarks/benchmarks.exe time cycles alloc -clear-columns -all-values -width 1000 -run-without-cross-library-inlining -suppress-warnings
```

Which gives the output:

| Name                                                              |   Time/Run | Cycls/Run | mWd/Run |   mjWd/Run |   Prom/Run |
|-------------------------------------------------------------------|------------|-----------|---------|------------|------------|
| `[src/lib/data_hash_lib/state_hash.ml] State_hash decimal encode` |   359.89ns |    1.17kc |  11.00w | 130.15e-6w | 130.15e-6w |
| `[src/lib/data_hash_lib/state_hash.ml] State_hash base58 encode`  | 6_912.07ns |   22.48kc | 567.00w |      0.04w |      0.04w |
| `[src/lib/data_hash_lib/state_hash.ml] State_hash hex encode`     |   348.53ns |    1.13kc |  54.00w |      0.00w |      0.00w |

Which means that we should use either decimal string or hex wherever possible, 7mcs for a single conversion is a lot.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
