### PR TITLE
Snark Worker: remove legacy namespace wrapping in snark_worker.ml

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1732,8 +1732,9 @@ let snark_hashes =
       fun () -> if json then Core.printf "[]\n%!"]
 
 let internal_commands logger ~itn_features =
-  [ ( Snark_worker.Intf.command_name
-    , Snark_worker.command ~proof_level:Genesis_constants.Compiled.proof_level
+  [ ( Snark_worker.Entry.command_name
+    , Snark_worker.Entry.command_from_rpcs
+        ~proof_level:Genesis_constants.Compiled.proof_level
         ~constraint_constants:Genesis_constants.Compiled.constraint_constants
         ~commit_id:Mina_version.commit_id )
   ; ("snark-hashes", snark_hashes)
@@ -1783,7 +1784,7 @@ let internal_commands logger ~itn_features =
           with
           | `Ok sexp -> (
               let%bind worker_state =
-                Snark_worker.Inputs.Worker_state.create ~proof_level
+                Snark_worker.Impl.Worker_state.create ~proof_level
                   ~constraint_constants ~signature_kind ()
               in
               let sok_message =
@@ -1798,7 +1799,7 @@ let internal_commands logger ~itn_features =
                   Snark_work_lib.Work.Single.Spec.t] sexp
               in
               match%map
-                Snark_worker.Inputs.perform_single worker_state
+                Snark_worker.Impl.perform_single worker_state
                   ~message:sok_message spec
               with
               | Ok _ ->

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -384,7 +384,7 @@ let setup_local_server ?(client_trustlist = []) ~rest_server_port
     ]
   in
   let snark_worker_impls =
-    [ implement Snark_worker.Rpcs_versioned.Get_work.Latest.rpc (fun () () ->
+    [ implement Snark_worker.Rpcs.Get_work.Stable.Latest.rpc (fun () () ->
           match Mina_lib.request_work mina with
           | None ->
               Deferred.return None
@@ -411,14 +411,14 @@ let setup_local_server ?(client_trustlist = []) ~rest_server_port
                       @@ read_all_proofs_from_disk zkapp_cmd )
                   ] ;
               Deferred.return None )
-    ; implement Snark_worker.Rpcs_versioned.Submit_work.Latest.rpc
+    ; implement Snark_worker.Rpcs.Submit_work.Stable.Latest.rpc
         (fun () (result : Snark_work_lib.Result.Partitioned.Stable.Latest.t) ->
           [%log debug] "received completed work from a snark worker"
             ~metadata:[ ("work_id", Snark_work_lib.Id.Any.to_yojson result.id) ] ;
           Mina_metrics.(
             Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;
           Deferred.return @@ Mina_lib.add_work mina result )
-    ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
+    ; implement Snark_worker.Rpcs.Failed_to_generate_snark.Stable.Latest.rpc
         (fun () (error, _) ->
           [%str_log error]
             (Snark_worker.Events.Generating_snark_work_failed

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -196,8 +196,8 @@ module Snark_worker = struct
       let our_binary = Sys.executable_name in
       Process.create_exn () ~prog:our_binary ?env
         ~args:
-          ( "internal" :: Snark_worker.Intf.command_name
-          :: Snark_worker.arguments ~proof_level
+          ( "internal" :: Snark_worker.Entry.command_name
+          :: Snark_worker.Entry.arguments ~proof_level
                ~daemon_address:
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
                ~shutdown_on_disconnect:false ~conf_dir ~file_log_level ~log_json

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -1,24 +1,9 @@
-module Prod = Prod
-
-module Intf = struct
-  include Intf
-
-  let command_name = Entry.command_name
+module Rpcs = struct
+  module Get_work = Rpc_get_work
+  module Submit_work = Rpc_submit_work
+  module Failed_to_generate_snark = Rpc_failed_to_generate_snark
 end
 
-module Inputs = Prod.Impl
+module Entry = Entry
 module Events = Events
-
-module Worker = struct
-  include Entry
-
-  module Rpcs_versioned = struct
-    module Get_work = Rpc_get_work.Stable
-    module Submit_work = Rpc_submit_work.Stable
-    module Failed_to_generate_snark = Rpc_failed_to_generate_snark.Stable
-  end
-
-  let command = command_from_rpcs
-end
-
-include Worker
+module Impl = Prod.Impl

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 open Async
-module Prod = Snark_worker.Inputs
+module Impl = Snark_worker.Impl
 module Graphql_client = Graphql_lib.Client
 module Encoders = Mina_graphql.Types.Input
 module Scalars = Graphql_lib.Scalars
@@ -27,7 +27,7 @@ let submit_graphql input graphql_endpoint =
       Format.printf "Graphql error: %s\n" s ;
       exit 1
 
-let perform (s : Prod.Worker_state.t) ~fee ~public_key
+let perform (s : Impl.Worker_state.t) ~fee ~public_key
     (spec :
       ( Transaction_witness.Stable.Latest.t
       , Ledger_proof.t )
@@ -36,7 +36,7 @@ let perform (s : Prod.Worker_state.t) ~fee ~public_key
   One_or_two.Deferred_result.map spec ~f:(fun w ->
       let open Deferred.Or_error.Let_syntax in
       let%map proof, time =
-        Prod.perform_single s
+        Impl.perform_single s
           ~message:(Mina_base.Sok_message.create ~fee ~prover:public_key)
           w
       in
@@ -106,7 +106,7 @@ let command =
 
        let signature_kind = Mina_signature_kind.t_DEPRECATED in
        let%bind worker_state =
-         Prod.Worker_state.create ~constraint_constants ~proof_level
+         Impl.Worker_state.create ~constraint_constants ~proof_level
            ~signature_kind ()
        in
        let%bind spec =

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -3,7 +3,7 @@
 open Core_kernel
 open Async
 open Mina_base
-module Prod = Snark_worker.Inputs
+module Impl = Snark_worker.Impl
 
 module Worker_state = struct
   module type S = sig
@@ -23,11 +23,11 @@ module Worker_state = struct
     Deferred.return
       (let module M = struct
          let perform_single (message, single_spec) =
-           let%bind (worker_state : Prod.Worker_state.t) =
-             Prod.Worker_state.create ~constraint_constants ~proof_level:Full
+           let%bind (worker_state : Impl.Worker_state.t) =
+             Impl.Worker_state.create ~constraint_constants ~proof_level:Full
                ~signature_kind ()
            in
-           Prod.perform_single worker_state ~message single_spec
+           Impl.perform_single worker_state ~message single_spec
        end in
       (module M : S) )
 


### PR DESCRIPTION
These namespace juggling was here because when I'm implementing the refactoring initially, we want to keep the namespace untouched so the downstream code won't be affect every time we're moving definitions around.

Now that the refactor is done, we can remove these jugglings and propagate the effect downstream.

This is a no-op refactor. 