### PR TITLE
Implement hard fork config dump when at a genesis epoch

### DIFF
--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -79,6 +79,11 @@ module type S = sig
   val create_root :
     config:Root_ledger.Config.t -> depth:int -> unit -> Root_ledger.t Or_error.t
 
+  (** Create a new root ledger that is equal in state to the genesis ledger,
+      using a directory path instead of a config *)
+  val create_root_with_directory :
+    directory:string -> depth:int -> unit -> Root_ledger.t Or_error.t
+
   val depth : int
 
   val accounts : (Private_key.t option * Account.t) list Lazy.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2984,10 +2984,15 @@ module Hardfork_config = struct
     let genesis_staking_ledger_data =
       let directory_name = parent_directory ^/ "staking_ledger" in
       match source_ledgers.staking_ledger with
-      | `Genesis _l ->
-          failwith
-            "Daemon has genesis staking ledger - hard fork dump currently \
-             unsupported"
+      | `Genesis l ->
+          let depth = Genesis_ledger.Packed.depth l in
+          let root =
+            Genesis_ledger.Packed.create_root_with_directory l
+              ~directory:directory_name ~depth ()
+            |> Or_error.ok_exn
+          in
+          let diff = Ledger.Location.Map.empty in
+          (root, diff)
       | `Root l ->
           let root =
             Root_ledger.create_checkpoint_with_directory l ~directory_name
@@ -2998,10 +3003,15 @@ module Hardfork_config = struct
     let genesis_next_epoch_ledger_data =
       let directory_name = parent_directory ^/ "next_epoch_ledger" in
       match source_ledgers.next_epoch_ledger with
-      | `Genesis _l ->
-          failwith
-            "Daemon has genesis epoch ledger - hard fork dump currently \
-             unsupported"
+      | `Genesis l ->
+          let depth = Genesis_ledger.Packed.depth l in
+          let root =
+            Genesis_ledger.Packed.create_root_with_directory l
+              ~directory:directory_name ~depth ()
+            |> Or_error.ok_exn
+          in
+          let diff = Ledger.Location.Map.empty in
+          (root, diff)
       | `Root l ->
           let root =
             Root_ledger.create_checkpoint_with_directory l ~directory_name


### PR DESCRIPTION
This PR implements dumping a hard fork config when the daemon is still in the genesis epoch (i.e., either the staking or next epoch ledger is still a `Genesis_ledger`). To fit in with the rest of the hard fork config dumping code, I added a `create_root_with_directory` to the genesis ledger interface, which will copy the root ledger underling the genesis ledger to a new location, without changing the backing type of the root. It does this with the already-existing `Root.create_checkpoint_with_directory`. If the genesis ledger is ephemeral, then a new stable-db-backed root is created and populated with the content of that ledger, as a fallback.

Closes: https://github.com/MinaProtocol/mina/issues/18045