### PR TITLE
[CI] mina-toolchain-base v4

### DIFF
--- a/dockerfiles/Dockerfile-toolchain-base
+++ b/dockerfiles/Dockerfile-toolchain-base
@@ -7,7 +7,6 @@ ENV YQ_VERSION=4.44.3
 
 ENV GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
 
-# Pin package versions and use --no-install-recommends
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	bash \
 	curl \
@@ -19,27 +18,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	make \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Use bash and pipefail for all RUN commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 
 RUN git config --system --add safe.directory '*'
 
-
-# Install dhall and dhall-to-yaml
 RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/${DHALL_VERSION}/dhall-${DHALL_VERSION}-x86_64-linux.tar.bz2 | tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall
 RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/${DHALL_VERSION}/dhall-json-${DHALL_JSON_VERSION}-x86_64-linux.tar.bz2 | tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall-to-yaml
 
 
-# Install yq
 RUN curl -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o "/usr/local/bin/yq" && chmod +x "/usr/local/bin/yq"
 
 
-# Add Buildkite APT key
 RUN curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" > /etc/apt/sources.list.d/buildkite-agent.list
 
-
-# Install Buildkite Agent (pin version and use --no-install-recommends)
 RUN apt-get update && apt-get install -y --no-install-recommends buildkite-agent \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Added new version of mina-toolchain base docker. This docker is used as a base docker for running dhall initial jobs during Prepare and Monorepo phases. 

We were struggling before as sources for currently used codaprotocol.ci-toolchain-base:v3 are unavailable. I explored what packages such docker needs by running pipelines and filling missing packages or configuration. Docker which is commited in this PR is an effect of such reverse engineering effort. 

I tested configuration with docker on build:

https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/859

Note that we need to change pipeline steps if we want to incorporate above docker:

From:

```
    plugins:
      "docker#v3.5.0":
        environment:
          - BUILDKITE_AGENT_ACCESS_TOKEN
          - "BUILDKITE_PIPELINE_MODE=Stable"
          - "BUILDKITE_PIPELINE_SCOPE=StableOnly"
          - "BUILDKITE_PIPELINE_JOB_SELECTION=Full"
          - "BUILDKITE_PIPELINE_STAGE=Test"
          - "BUILDKITE_PIPELINE_FILTER=FastOnly"
        image: codaprotocol/ci-toolchain-base:v3
        mount-buildkite-agent: true
        propagate-environment: true
```


to
```
    plugins:
      "docker#v3.5.0":
        environment:
          - BUILDKITE_AGENT_ACCESS_TOKEN
          - "BUILDKITE_PIPELINE_MODE=Stable"
          - "BUILDKITE_PIPELINE_SCOPE=StableOnly"
          - "BUILDKITE_PIPELINE_JOB_SELECTION=Full"
          - "BUILDKITE_PIPELINE_STAGE=Test"
          - "BUILDKITE_PIPELINE_FILTER=FastOnly"
        image: minaprotocol/ci-toolchain-base:v4 <-- new docker
        mount-buildkite-agent: false <--- don't mount buildkite agent now
        propagate-environment: true
```

Also i added yq package as it i is needed for new enhancements for CI. In Ci we are not building such docker as it barely changes, but we are running linters against it. it should be enough IMHO