### PR TITLE
remove duplcated --proof-level arg preventing seed to start

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -836,7 +836,6 @@ if ${DEMO_MODE}; then
     -block-producer-key ${ROOT}/online_whale_keys/online_whale_account_0 \
     --run-snark-worker "$(cat ${ROOT}/snark_coordinator_keys/snark_coordinator_account.pub)" \
     --snark-worker-fee 0.001 \
-    --proof-level ${PROOF_LEVEL} \
     --demo-mode \
     --external-ip "$(hostname -i)" \
     --seed \


### PR DESCRIPTION
Fixing running mina-locl-network script with demo mode. Failing command:

```
./scripts/mina-local-network/mina-local-network.sh -sp 3100 --demo --config inherit -u delay_sec:0 -ll Trace -fll Trace --override-slot-time 20000 -pl none --archive-server-port 3086
```

problem was duplicated `--proof-level` when starting seed