### PR TITLE
add a tag `Archive` for all archive tests

### DIFF
--- a/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
@@ -46,6 +46,7 @@ in  Pipeline.build
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
           ]
         }
       , steps =

--- a/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeTest.dhall
@@ -43,6 +43,7 @@ in  Pipeline.build
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
           ]
         }
       , steps = [ ArchiveNodeTest.step dependsOn ]

--- a/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
@@ -39,6 +39,7 @@ in  Pipeline.build
           [ PipelineTag.Type.Fast
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
           ]
         }
       , steps =

--- a/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
+++ b/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
@@ -36,6 +36,7 @@ in  Pipeline.build
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
           ]
         }
       , steps = [ PatchArchiveTest.step dependsOn ]

--- a/buildkite/src/Pipeline/Tag.dhall
+++ b/buildkite/src/Pipeline/Tag.dhall
@@ -36,6 +36,7 @@ let Tag
       | Noble
       | Focal
       | Jammy
+      | Archive
       >
 
 let toNatural
@@ -66,6 +67,7 @@ let toNatural
             , Noble = 22
             , Focal = 23
             , Jammy = 24
+            , Archive = 25
             }
             tag
 
@@ -133,6 +135,7 @@ let capitalName =
             , Noble = "Noble"
             , Focal = "Focal"
             , Jammy = "Jammy"
+            , Archive = "Archive"
             }
             tag
 
@@ -163,6 +166,7 @@ let lowerName =
             , Noble = "noble"
             , Focal = "focal"
             , Jammy = "jammy"
+            , Archive = "archive"
             }
             tag
 


### PR DESCRIPTION
Archive tests are known to be unstable. This is so we can have a separate pipeline for archive tests in the future whenever there's regression. 