### PR TITLE
simplify mina version resolution and remove support for MINA_ROOT

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -354,7 +354,6 @@ let
         PLONK_WASM_WEB = "${pkgs.plonk_wasm}/web";
 
         configurePhase = ''
-          export MINA_ROOT="$PWD"
           export -f patchShebangs isScript
           fd . --type executable -x bash -c "patchShebangs {}"
           export -n patchShebangs isScript

--- a/src/lib/mina_version/normal/dune
+++ b/src/lib/mina_version/normal/dune
@@ -9,10 +9,9 @@
  (implements mina_version))
 
 (rule
- (targets mina_version.ml)
+ (target mina_version.ml)
  (deps
-  (sandbox none)
   (:< gen.sh)
   (universe))
  (action
-  (run bash %{<} %{targets})))
+  (run %{<} %{target})))

--- a/src/lib/mina_version/normal/gen.sh
+++ b/src/lib/mina_version/normal/gen.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# we are nested 6 directories deep (_build/<context>/src/lib/mina_version/normal)
-if [ -z ${MINA_COMMIT_SHA1+x} ]; then
-  root="${MINA_ROOT-$(git rev-parse --show-toplevel || echo ../../../../../..)}"
-  pushd "$root" > /dev/null
-  id="${MINA_COMMIT_SHA1-$(git rev-parse --verify HEAD || echo "<unknown>")}"
-  popd > /dev/null
-else
-  id="${MINA_COMMIT_SHA1}"
-fi
+target=$1
 
+id="${MINA_COMMIT_SHA1:-$(git rev-parse --verify HEAD 2>/dev/null || echo "<unknown>")}"
 id_short="$(printf "%s" "$id" | cut -c1-8)"
 
 {


### PR DESCRIPTION
As title. 

This also prevents us to introduce some ppxes like https://github.com/ocaml-ppx/ppx_import/

because sandbox mode is disabled here, which is required for staged_pps.