### PR TITLE
remove dune-build-root and replace it with workspace_root

### DIFF
--- a/src/lib/crypto/kimchi_bindings/dune
+++ b/src/lib/crypto/kimchi_bindings/dune
@@ -1,9 +1,0 @@
-;; create a `dune-build-root` file that contains the dune workspace root
-
-(rule
- (target dune-build-root)
- (deps
-  ; no sandbox, we want the path to the _build directory
-  (sandbox none))
- (action
-  (system "printf \"%s\" $(realpath %{workspace_root}/..) > %{target}")))

--- a/src/lib/crypto/kimchi_bindings/js/node_js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/dune
@@ -19,13 +19,12 @@
   flags.sexp)
  (deps
   build.sh
-  ../../dune-build-root
   (source_tree ../../../proof-systems))
  (locks /cargo-lock) ; lock for rustup
  (action
   (progn
    (setenv
     CARGO_TARGET_DIR
-    "%{read:../../dune-build-root}/cargo_kimchi_wasm"
+    "%{workspace_root}/cargo_kimchi_wasm"
     (run bash build.sh))
    (write-file flags.sexp "()"))))

--- a/src/lib/crypto/kimchi_bindings/js/web/dune
+++ b/src/lib/crypto/kimchi_bindings/js/web/dune
@@ -19,13 +19,12 @@
   flags.sexp)
  (deps
   build.sh
-  ../../dune-build-root
   (source_tree ../../../proof-systems))
  (locks /cargo-lock) ; lock for rustup
  (action
   (progn
    (setenv
     CARGO_TARGET_DIR
-    "%{read:../../dune-build-root}/cargo_kimchi_wasm"
+    "%{workspace_root}/cargo_kimchi_wasm"
     (run bash build.sh))
    (write-file flags.sexp "()"))))

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -65,11 +65,11 @@
      kimchi-stubs
      --release
      --target-dir
-     %{read:../dune-build-root}/cargo_kimchi_stubs
+     %{workspace_root}/cargo_kimchi_stubs
      --offline))
    (run
     cp
-    %{read:../dune-build-root}/cargo_kimchi_stubs/release/libkimchi_stubs.a
+    %{workspace_root}/cargo_kimchi_stubs/release/libkimchi_stubs.a
     .))))
 
 ;; this is used by nix
@@ -171,7 +171,7 @@
    (run rm -f ./Cargo.lock)
    (setenv
     CARGO_TARGET_DIR
-    "%{read:../dune-build-root}/cargo_kimchi_bindgen"
+    "%{workspace_root}/cargo_kimchi_bindgen"
     (run cargo run %{targets} --offline))
    (run ocamlformat -i %{targets}))))
 


### PR DESCRIPTION
As title.

Previously we're building some libraries out side of dune's sandbox without a good reason. 

This PR make it so that it builds inside sandbox again. 