### PR TITLE
Drop use of deprecated Bin_prot functors

### DIFF
--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -79,6 +79,9 @@ module Make () = struct
         type nonrec t = t
 
         [%%define_locally T1.(to_string, of_string)]
+
+        let caller_identity =
+          Bin_prot.Shape.Uuid.of_string "9c63d313-dd19-40f3-ad94-aaee29599322"
       end
 
       include Mina_stdlib.Bounded_types.String.Of_stringable (Arg)

--- a/src/lib/mina_stdlib/bigstring.ml
+++ b/src/lib/mina_stdlib/bigstring.ml
@@ -20,6 +20,9 @@ module Stable = struct
       let of_string s = Bigstring.of_string s
 
       let to_string s = Bigstring.to_string s
+
+      let caller_identity =
+        Bin_prot.Shape.Uuid.of_string "f721f4fa-3ad6-4831-b445-fb38c57b5577"
     end)
   end
 end]

--- a/src/lib/mina_stdlib/bounded_types.ml
+++ b/src/lib/mina_stdlib/bounded_types.ml
@@ -123,8 +123,12 @@ module String = struct
     include Stable.V1
   end
 
-  module Of_stringable (M : Stringable.S) =
-  Bin_prot.Utils.Make_binable_without_uuid (struct
+  module Of_stringable (M : sig
+    include Stringable.S
+
+    val caller_identity : Bin_prot.Shape.Uuid.t
+  end) =
+  Bin_prot.Utils.Make_binable_with_uuid (struct
     module Binable = Stable.V1
 
     type t = M.t
@@ -135,6 +139,8 @@ module String = struct
     exception Of_binable of string * exn [@@deriving sexp]
 
     let of_binable s = try M.of_string s with x -> raise (Of_binable (s, x))
+
+    let caller_identity = M.caller_identity
   end)
 end
 
@@ -155,6 +161,9 @@ module Wrapped_error = struct
 
         let of_string s =
           Core_kernel.Error.t_of_sexp (Core_kernel.Sexp.of_string s)
+
+        let caller_identity =
+          Bin_prot.Shape.Uuid.of_string "165dc5d5-46a6-4b98-b896-cbe3cf4f5869"
       end)
     end
   end

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -41,6 +41,9 @@ module Inet_addr = struct
         type nonrec t = t
 
         [%%define_locally Unix.Inet_addr.(to_string, of_string)]
+
+        let caller_identity =
+          Bin_prot.Shape.Uuid.of_string "734478a6-8b6f-4910-8c2f-25f1a9b0d3ae"
       end)
     end
   end]


### PR DESCRIPTION
As title. This is a blocker for us from using core_kernel v0.16. 

HF test should give us some assurance this works. That test needs to be hardened to check pre/post-fork serialization though. 