### PR TITLE
docs: improve zkapp_command_builder module documentation

### DIFF
--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -1,4 +1,21 @@
-(* zkapp_command_builder.ml -- combinators to build Zkapp_command.t for tests *)
+(** Combinators to build [Zkapp_command.t] for tests.
+
+    This module provides helper functions for constructing zkApp commands
+    in test code, including:
+    - [mk_forest], [mk_node]: build account update call forests
+    - [mk_account_update_body]: create account update bodies with sensible defaults
+    - [mk_zkapp_command]: assemble a complete zkApp command with dummy authorizations
+    - [replace_authorizations]: replace dummy signatures/proofs with valid ones
+
+    The [replace_authorizations] function mirrors the signing logic that is
+    verified in the transaction snark (see [Transaction_snark.Transaction_commitment]):
+    1. Compute transaction commitments via [Zkapp_command.get_transaction_commitments]
+    2. Fee payer signs the full commitment
+    3. Account updates sign either partial or full commitment based on [use_full_commitment]
+
+    The transaction snark enforces that signatures match these commitments,
+    so tests using this module verify the same signing behavior.
+*)
 
 open Core_kernel
 open Mina_base


### PR DESCRIPTION
Expand the module documentation to describe all helper functions and explain how replace_authorizations mirrors the signing logic verified in the transaction snark.

Closes: o1-labs/mina-rust#1751

Dummy PR. Simply to clarify the content. It should be explain somewhere that it is only used for tests. Not obvious when traveling in the codebase.

Cherry-picked from https://github.com/MinaProtocol/mina/pull/18203/