### PR TITLE
Move Zkapp_precondition inline tests to Alcotest

### DIFF
--- a/src/lib/mina_base/test/main.ml
+++ b/src/lib/mina_base/test/main.ml
@@ -192,4 +192,16 @@ let () =
           ; test_case "No odd slot difference discrepancies" `Quick
               no_odd_vesting_discrepancies
           ] )
+    ; Zkapp_precondition_test.
+        ( "zkApp preconditions"
+        , [ test_case "ClosedInterval JSON roundtrip" `Quick
+              closed_interval_roundtrip_json
+          ; test_case "Numeric JSON roundtrip" `Quick numeric_roundtrip_json
+          ; test_case "Account precondition JSON roundtrip" `Quick
+              account_json_roundtrip
+          ; test_case "Epoch_data JSON roundtrip" `Quick
+              epoch_data_json_roundtrip
+          ; test_case "Protocol_state JSON roundtrip" `Quick
+              protocol_state_json_roundtrip
+          ] )
     ]

--- a/src/lib/mina_base/test/zkapp_precondition_test.ml
+++ b/src/lib/mina_base/test/zkapp_precondition_test.ml
@@ -1,0 +1,104 @@
+(** {1 ClosedInterval tests} *)
+
+let closed_interval_roundtrip_json () =
+  let open Fields_derivers_zkapps.Derivers in
+  let v =
+    { Mina_base.Zkapp_precondition.Closed_interval.lower = 10; upper = 100 }
+  in
+  let full = o () in
+  let _a : _ Unified_input.t =
+    Mina_base.Zkapp_precondition.Closed_interval.deriver ~name:"Int" int full
+  in
+  let result = !(full#of_json) (!(full#to_json) v) in
+  Alcotest.(check bool)
+    "roundtrip json" true
+    (Mina_base.Zkapp_precondition.Closed_interval.equal Int.equal result v)
+
+(** {1 Numeric tests} *)
+
+let numeric_roundtrip_json () =
+  (* Test that Numeric.deriver correctly serializes a Numeric.t value.
+     Since we can't easily create the wrapper type T here without ppx_annot,
+     we test the underlying Account.deriver which uses Numeric internally. *)
+  let b = Currency.Balance.of_nanomina_int_exn 1000 in
+  let predicate : Mina_base.Zkapp_precondition.Account.t =
+    { Mina_base.Zkapp_precondition.Account.accept with
+      balance =
+        Mina_base.Zkapp_basic.Or_ignore.Check
+          { Mina_base.Zkapp_precondition.Closed_interval.lower = b; upper = b }
+    }
+  in
+  let module Fd = Fields_derivers_zkapps.Derivers in
+  let full = Mina_base.Zkapp_precondition.Account.deriver (Fd.o ()) in
+  let result = predicate |> Fd.to_json full |> Fd.of_json full in
+  Alcotest.(check bool)
+    "roundtrip json" true
+    (Mina_base.Zkapp_precondition.Account.equal predicate result)
+
+(** {1 Account precondition tests} *)
+
+let account_json_roundtrip () =
+  let b = Currency.Balance.of_nanomina_int_exn 1000 in
+  let predicate : Mina_base.Zkapp_precondition.Account.t =
+    { Mina_base.Zkapp_precondition.Account.accept with
+      balance =
+        Mina_base.Zkapp_basic.Or_ignore.Check
+          { Mina_base.Zkapp_precondition.Closed_interval.lower = b; upper = b }
+    ; action_state =
+        Mina_base.Zkapp_basic.Or_ignore.Check
+          (Snark_params.Tick.Field.of_int 99)
+    ; proved_state = Mina_base.Zkapp_basic.Or_ignore.Check true
+    }
+  in
+  let module Fd = Fields_derivers_zkapps.Derivers in
+  let full = Mina_base.Zkapp_precondition.Account.deriver (Fd.o ()) in
+  let result = predicate |> Fd.to_json full |> Fd.of_json full in
+  Alcotest.(check bool)
+    "json roundtrip" true
+    (Mina_base.Zkapp_precondition.Account.equal predicate result)
+
+(** {1 Protocol_state.Epoch_data tests} *)
+
+let epoch_data_json_roundtrip () =
+  let f = Mina_base.Zkapp_basic.Or_ignore.Check Snark_params.Tick.Field.one in
+  let u = Mina_numbers.Length.zero in
+  let a = Currency.Amount.zero in
+  let predicate : Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.t =
+    { Mina_base.Epoch_data.Poly.ledger =
+        { Mina_base.Epoch_ledger.Poly.hash = f
+        ; total_currency =
+            Mina_base.Zkapp_basic.Or_ignore.Check
+              { Mina_base.Zkapp_precondition.Closed_interval.lower = a
+              ; upper = a
+              }
+        }
+    ; seed = f
+    ; start_checkpoint = f
+    ; lock_checkpoint = f
+    ; epoch_length =
+        Mina_base.Zkapp_basic.Or_ignore.Check
+          { Mina_base.Zkapp_precondition.Closed_interval.lower = u; upper = u }
+    }
+  in
+  let module Fd = Fields_derivers_zkapps.Derivers in
+  let full =
+    Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.deriver (Fd.o ())
+  in
+  let result = predicate |> Fd.to_json full |> Fd.of_json full in
+  Alcotest.(check bool)
+    "json roundtrip" true
+    (Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.equal predicate
+       result )
+
+(** {1 Protocol_state tests} *)
+
+let protocol_state_json_roundtrip () =
+  let predicate : Mina_base.Zkapp_precondition.Protocol_state.t =
+    Mina_base.Zkapp_precondition.Protocol_state.accept
+  in
+  let module Fd = Fields_derivers_zkapps.Derivers in
+  let full = Mina_base.Zkapp_precondition.Protocol_state.deriver (Fd.o ()) in
+  let result = predicate |> Fd.to_json full |> Fd.of_json full in
+  Alcotest.(check bool)
+    "json roundtrip" true
+    (Mina_base.Zkapp_precondition.Protocol_state.equal predicate result)

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -38,26 +38,6 @@ module Closed_interval = struct
     let ( !. ) = ( !. ) ~t_fields_annots in
     Fields.make_creator obj ~lower:!.inner ~upper:!.inner
     |> finish (name ^ "Interval") ~t_toplevel_annots
-
-  let%test_module "ClosedInterval" =
-    ( module struct
-      module IntClosedInterval = struct
-        type t_ = int t [@@deriving sexp, equal, compare]
-
-        (* Note: nonrec doesn't work with ppx-deriving *)
-        type t = t_ [@@deriving sexp, equal, compare]
-
-        let v = { lower = 10; upper = 100 }
-      end
-
-      let%test_unit "roundtrip json" =
-        let open Fields_derivers_zkapps.Derivers in
-        let full = o () in
-        let _a : _ Unified_input.t = deriver ~name:"Int" int full in
-        [%test_eq: IntClosedInterval.t]
-          (!(full#of_json) (!(full#to_json) IntClosedInterval.v))
-          IntClosedInterval.v
-    end )
 end
 
 let assert_ b e = if b then Ok () else Or_error.error_string e
@@ -193,36 +173,6 @@ module Numeric = struct
 
     let block_time obj = deriver "BlockTime" block_time_inner range_uint64 obj
   end
-
-  let%test_module "Numeric" =
-    ( module struct
-      module Int_numeric = struct
-        type t_ = int t [@@deriving sexp, equal, compare]
-
-        (* Note: nonrec doesn't work with ppx-deriving *)
-        type t = t_ [@@deriving sexp, equal, compare]
-      end
-
-      module T = struct
-        type t = { foo : Int_numeric.t }
-        [@@deriving annot, sexp, equal, compare, fields]
-
-        let v : t =
-          { foo = Or_ignore.Check { Closed_interval.lower = 10; upper = 100 } }
-
-        let deriver obj =
-          let open Fields_derivers_zkapps.Derivers in
-          let ( !. ) = ( !. ) ~t_fields_annots in
-          Fields.make_creator obj ~foo:!.(deriver "Int" int ("0", "1000"))
-          |> finish "T" ~t_toplevel_annots
-      end
-
-      let%test_unit "roundtrip json" =
-        let open Fields_derivers_zkapps.Derivers in
-        let full = o () in
-        let _a : _ Unified_input.t = T.deriver full in
-        [%test_eq: T.t] (of_json full (to_json full T.v)) T.v
-    end )
 
   let gen gen_a compare_a = Or_ignore.gen (Closed_interval.gen gen_a compare_a)
 
@@ -545,19 +495,6 @@ module Account = struct
       ~is_new:!.(Or_ignore.deriver bool)
     |> finish "AccountPrecondition" ~t_toplevel_annots
 
-  let%test_unit "json roundtrip" =
-    let b = Balance.of_nanomina_int_exn 1000 in
-    let predicate : t =
-      { accept with
-        balance = Or_ignore.Check { Closed_interval.lower = b; upper = b }
-      ; action_state = Or_ignore.Check (Field.of_int 99)
-      ; proved_state = Or_ignore.Check true
-      }
-    in
-    let module Fd = Fields_derivers_zkapps.Derivers in
-    let full = deriver (Fd.o ()) in
-    [%test_eq: t] predicate (predicate |> Fd.to_json full |> Fd.of_json full)
-
   let to_input
       ({ balance
        ; nonce
@@ -817,27 +754,6 @@ module Protocol_state = struct
         ~epoch_length:!.Numeric.Derivers.length
       |> finish "EpochDataPrecondition"
            ~t_toplevel_annots:Poly.t_toplevel_annots
-
-    let%test_unit "json roundtrip" =
-      let f = Or_ignore.Check Field.one in
-      let u = Length.zero in
-      let a = Amount.zero in
-      let predicate : t =
-        { Poly.ledger =
-            { Epoch_ledger.Poly.hash = f
-            ; total_currency =
-                Or_ignore.Check { Closed_interval.lower = a; upper = a }
-            }
-        ; seed = f
-        ; start_checkpoint = f
-        ; lock_checkpoint = f
-        ; epoch_length =
-            Or_ignore.Check { Closed_interval.lower = u; upper = u }
-        }
-      in
-      let module Fd = Fields_derivers_zkapps.Derivers in
-      let full = deriver (Fd.o ()) in
-      [%test_eq: t] predicate (predicate |> Fd.to_json full |> Fd.of_json full)
 
     let gen : t Quickcheck.Generator.t =
       let open Quickcheck.Let_syntax in
@@ -1258,12 +1174,6 @@ module Protocol_state = struct
     ; staking_epoch_data = epoch_data
     ; next_epoch_data = epoch_data
     }
-
-  let%test_unit "json roundtrip" =
-    let predicate : t = accept in
-    let module Fd = Fields_derivers_zkapps.Derivers in
-    let full = deriver (Fd.o ()) in
-    [%test_eq: t] predicate (predicate |> Fd.to_json full |> Fd.of_json full)
 
   let check
       (* Bind all the fields explicity so we make sure they are all used. *)


### PR DESCRIPTION
Migrate the inline tests from zkapp_precondition.ml to a dedicated Alcotest test file. This removes the ppx_inline_test dependency and makes the tests more explicit.

Tests migrated:
- ClosedInterval JSON roundtrip
- Numeric JSON roundtrip (via Account.deriver)
- Account precondition JSON roundtrip
- Protocol_state.Epoch_data JSON roundtrip
- Protocol_state JSON roundtrip