### PR TITLE
refactor: move zkApp version inline test to Alcotest

### DIFF
--- a/src/lib/mina_base/test/main.ml
+++ b/src/lib/mina_base/test/main.ml
@@ -169,6 +169,7 @@ let () =
           ; test_case "Wire embedded in t." `Quick wire_embedded_in_t
           ; test_case "Wire embedded in graphql." `Quick
               wire_embedded_in_graphql
+          ; test_case "Latest zkApp version." `Quick latest_zkapp_version
           ; test_case "JSON roundtrip dummy." `Quick
               Test_derivers.json_roundtrip_dummy
           ; test_case "Full circuit." `Quick Test_derivers.full_circuit

--- a/src/lib/mina_base/test/zkapp_command_test.ml
+++ b/src/lib/mina_base/test/zkapp_command_test.ml
@@ -140,3 +140,8 @@ end = struct
       ( Zkapp_command.read_all_proofs_from_disk
       @@ Lazy.force (dummy ~signature_kind) )
 end
+
+(* Verify zkApp command version is as expected. *)
+let latest_zkapp_version () =
+  Alcotest.(check int)
+    "Stable.Latest.version is 2" 2 Zkapp_command.Stable.Latest.version

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1479,9 +1479,3 @@ module For_tests = struct
       account_updates = Call_forest.map t.account_updates ~f:(replace_vk vk)
     }
 end
-
-let%test "latest zkApp version" =
-  (* if this test fails, update `Transaction_hash.hash_of_transaction_id`
-     for latest version, then update this test
-  *)
-  Stable.Latest.version = 2


### PR DESCRIPTION
Counterparty of https://github.com/MinaProtocol/mina/pull/18209/commits on `develop`.