### PR TITLE
remove unused bindings, add compiler check

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1501,8 +1501,7 @@ let start t =
     ~graphql_control_port:t.config.graphql_control_port ~built_with_commit_sha
     ~get_next_producer_timing:(fun () -> t.next_producer_timing)
     ~get_snark_work_fee:(fun () -> snark_work_fee t)
-    ~get_peer:(fun () -> t.config.gossip_net_params.addrs_and_ports.peer)
-    ~signature_kind:t.signature_kind ;
+    ~get_peer:(fun () -> t.config.gossip_net_params.addrs_and_ports.peer) ;
   stop_long_running_daemon t ;
   Snark_worker.start t
 

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -1,6 +1,7 @@
 (library
  (name uptime_service)
  (public_name uptime_service)
+ (flags (:standard -w +26))
  (inline_tests
   (flags -verbose -show-counts))
  (libraries

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -203,7 +203,7 @@ let read_all_proofs_for_work_single_spec =
 let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
     ~url ~snark_worker ~transition_frontier ~peer_id
     ~(submitter_keypair : Keypair.t) ~snark_work_fee ~graphql_control_port
-    ~built_with_commit_sha ~signature_kind =
+    ~built_with_commit_sha =
   match Broadcast_pipe.Reader.peek transition_frontier with
   | None ->
       (* expected during daemon boot, so not logging as error *)
@@ -327,13 +327,6 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
                 send_uptime_data ~logger ~interruptor ~submitter_keypair ~url
                   ~state_hash ~produced:false block_data
             | Some single_spec -> (
-                let module T = Transaction_snark.Make (struct
-                  let signature_kind = signature_kind
-
-                  let constraint_constants = constraint_constants
-
-                  let proof_level = Genesis_constants.Proof_level.Full
-                end) in
                 let s =
                   match single_spec with
                   | Transition (input, witness) -> (
@@ -409,8 +402,7 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
 let start ~logger ~uptime_url ~snark_worker_opt ~constraint_constants
     ~protocol_constants ~transition_frontier ~time_controller
     ~block_produced_bvar ~uptime_submitter_keypair ~get_next_producer_timing
-    ~get_snark_work_fee ~get_peer ~graphql_control_port ~built_with_commit_sha
-    ~signature_kind =
+    ~get_snark_work_fee ~get_peer ~graphql_control_port ~built_with_commit_sha =
   match uptime_url with
   | None ->
       [%log info] "Not running uptime service, no URL given" ;
@@ -512,7 +504,7 @@ let start ~logger ~uptime_url ~snark_worker_opt ~constraint_constants
                   send_block_and_transaction_snark ~logger ~interruptor ~url
                     ~constraint_constants ~snark_worker ~transition_frontier
                     ~peer_id ~submitter_keypair ~snark_work_fee
-                    ~graphql_control_port ~built_with_commit_sha ~signature_kind
+                    ~graphql_control_port ~built_with_commit_sha
                 in
                 match get_next_producer_time_opt () with
                 | None ->


### PR DESCRIPTION
#18123 had some unused let bindings/variables, there was no compiler check in the uptime_service library to catch the mistake. This PR fixes these mistakes