### PR TITLE
[HF Pipeline improv]  [7/7] Final job refactoring

### DIFF
--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -34,6 +34,10 @@ let Profiles = ../Constants/Profiles.dhall
 
 let Network = ../Constants/Network.dhall
 
+let Toolchain = ../Constants/Toolchain.dhall
+
+let Arch = ../Constants/Arch.dhall
+
 let Spec =
       { Type =
           { codenames : List DebianVersions.DebVersion
@@ -43,6 +47,7 @@ let Spec =
           , version : Text
           , suffix : Text
           , precomputed_block_prefix : Optional Text
+          , use_artifacts_from_buildkite_build : Optional Text
           , size : Size
           }
       , default =
@@ -54,9 +59,77 @@ let Spec =
           , suffix = ""
           , version = "\\\$MINA_DEB_VERSION"
           , precomputed_block_prefix = None Text
+          , use_artifacts_from_buildkite_build = None Text
           , size = Size.XLarge
           }
       }
+
+let generateReferenceTarballsCommand =
+          \(spec : Spec.Type)
+      ->  \(codename : DebianVersions.DebVersion)
+      ->  \(key : Text)
+      ->  \(depends_on : List Command.TaggedKey.Type)
+      ->  let cacheArg =
+                merge
+                  { Some =
+                      \(build : Text) -> "--cached-buildkite-build-id " ++ build
+                  , None = ""
+                  }
+                  spec.use_artifacts_from_buildkite_build
+
+          in  Command.build
+                Command.Config::{
+                , commands =
+                    Toolchain.select
+                      Toolchain.SelectionMode.ByDebianAndArch
+                      codename
+                      Arch.Type.Amd64
+                      [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
+                      "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh --network ${Network.lowerName
+                                                                                                                                       spec.network} --version 3.2.0-f77c8c9  --codename ${DebianVersions.lowerName
+                                                                                                                                                                                             codename} --config-json-gz-url ${spec.config_json_gz_url} ${cacheArg}"
+                , label =
+                    "Generate hardfork reference tarballs for ${DebianVersions.lowerName
+                                                                  codename}"
+                , key = key
+                , depends_on = depends_on
+                , target = Size.Large
+                }
+
+let generateTarballsCommand =
+          \(spec : Spec.Type)
+      ->  \(codename : DebianVersions.DebVersion)
+      ->  \(key : Text)
+      ->  \(depends_on : List Command.TaggedKey.Type)
+      ->  let cacheArg =
+                merge
+                  { Some =
+                      \(build : Text) -> "--cached-buildkite-build-id " ++ build
+                  , None = ""
+                  }
+                  spec.use_artifacts_from_buildkite_build
+
+          in  Command.build
+                Command.Config::{
+                , commands =
+                    Toolchain.select
+                      Toolchain.SelectionMode.ByDebianAndArch
+                      codename
+                      Arch.Type.Amd64
+                      [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
+                      (     "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh "
+                        ++  "--network ${Network.lowerName spec.network} "
+                        ++  "--config-url ${spec.config_json_gz_url} "
+                        ++  "--codename ${DebianVersions.lowerName codename} "
+                        ++  "${cacheArg}"
+                      )
+                , label =
+                    "Generate hardfork tarballs for ${DebianVersions.lowerName
+                                                        codename}"
+                , key = key
+                , depends_on = depends_on
+                , target = Size.Large
+                }
 
 let generateDockerForCodename =
           \(spec : Spec.Type)
@@ -71,13 +144,26 @@ let generateDockerForCodename =
 
           let profile = Profiles.fromNetwork spec.network
 
+          let lowerNameCodename = DebianVersions.lowerName codename
+
+          let artifactsGenKey = "build-deb-pkg-${lowerNameCodename}"
+
+          let tarballGenKey = "generate-hardfork-tarballs-${lowerNameCodename}"
+
+          let buildHfDebian = "build-hf-debian-${lowerNameCodename}"
+
+          let dependsOnTarballs =
+                [ { name = pipelineName, key = tarballGenKey } ]
+
+          let dependsOnBuildHfDebian =
+                [ { name = pipelineName, key = buildHfDebian } ]
+
+          let dependsOnArtifacts =
+                [ { name = pipelineName, key = artifactsGenKey } ]
+
           let dockerDaemonSpec =
                 DockerImage.ReleaseSpec::{
-                , deps =
-                  [ { name = pipelineName
-                    , key = "build-deb-pkg-${DebianVersions.lowerName codename}"
-                    }
-                  ]
+                , deps = dependsOnBuildHfDebian
                 , service = Artifacts.Type.Daemon
                 , network = spec.network
                 , deb_codename = codename
@@ -89,6 +175,9 @@ let generateDockerForCodename =
                 }
 
           let dockerDaemonStep = DockerImage.stepKey dockerDaemonSpec
+
+          let referencesTarballStepKey =
+                "generate-reference-tarballs-" ++ lowerNameCodename
 
           let dependsOnTest =
                 [ { name = pipelineName, key = dockerDaemonStep } ]
@@ -102,102 +191,203 @@ let generateDockerForCodename =
                   }
                   spec.precomputed_block_prefix
 
-          in  [ MinaArtifact.buildArtifacts
-                  MinaArtifact.MinaBuildSpec::{
-                  , artifacts =
-                    [ Artifacts.Type.LogProc
-                    , Artifacts.Type.DaemonLegacyHardfork
-                    , Artifacts.Type.Archive
-                    , Artifacts.Type.Rosetta
-                    , Artifacts.Type.ZkappTestTransaction
+          let buildOrGetArtifacts =
+                merge
+                  { Some =
+                          \(build : Text)
+                      ->  [ generateTarballsCommand
+                              spec
+                              codename
+                              tarballGenKey
+                              ([] : List Command.TaggedKey.Type)
+                          , generateReferenceTarballsCommand
+                              spec
+                              codename
+                              referencesTarballStepKey
+                              ([] : List Command.TaggedKey.Type)
+                          ]
+                  , None =
+                    [ MinaArtifact.buildArtifacts
+                        MinaArtifact.MinaBuildSpec::{
+                        , artifacts =
+                          [ Artifacts.Type.LogProc
+                          , Artifacts.Type.Daemon
+                          , Artifacts.Type.DaemonConfig
+                          , Artifacts.Type.Archive
+                          , Artifacts.Type.Rosetta
+                          , Artifacts.Type.ZkappTestTransaction
+                          ]
+                        , debVersion = codename
+                        , profile = profile
+                        , network = spec.network
+                        , prefix = pipelineName
+                        , suffix = Some "-${lowerNameCodename}"
+                        }
+                    , generateTarballsCommand
+                        spec
+                        codename
+                        tarballGenKey
+                        dependsOnArtifacts
+                    , generateReferenceTarballsCommand
+                        spec
+                        codename
+                        referencesTarballStepKey
+                        dependsOnArtifacts
                     ]
-                  , debVersion = codename
-                  , profile = profile
-                  , network = spec.network
-                  , prefix = pipelineName
-                  , suffix = Some "-${DebianVersions.lowerName codename}"
-                  , extraBuildEnvs =
-                    [ "NETWORK_NAME=${Network.lowerName spec.network}"
-                    , "CONFIG_JSON_GZ_URL=${spec.config_json_gz_url}"
-                    ]
-                  , buildScript =
-                      "./buildkite/scripts/hardfork/build-packages.sh"
                   }
-              , DockerImage.generateStep dockerDaemonSpec
-              , DockerImage.generateStep
-                  DockerImage.ReleaseSpec::{
-                  , deps =
-                    [ { name = pipelineName
-                      , key =
-                          "build-deb-pkg-${DebianVersions.lowerName codename}"
-                      }
-                    ]
-                  , service = Artifacts.Type.Archive
-                  , network = spec.network
-                  , deb_codename = codename
-                  , deb_profile = profile
-                  , deb_repo = DebianRepo.Type.Local
-                  , size = spec.size
-                  , step_key_suffix =
-                      "-${DebianVersions.lowerName codename}-docker-image"
-                  }
-              , DockerImage.generateStep
-                  DockerImage.ReleaseSpec::{
-                  , deps =
-                    [ { name = pipelineName
-                      , key =
-                          "build-deb-pkg-${DebianVersions.lowerName codename}"
-                      }
-                    ]
-                  , service = Artifacts.Type.Rosetta
-                  , network = spec.network
-                  , deb_profile = profile
-                  , deb_repo = DebianRepo.Type.Local
-                  , deb_codename = codename
-                  , size = spec.size
-                  , step_key_suffix =
-                      "-${DebianVersions.lowerName codename}-docker-image"
-                  }
-              , Command.build
-                  Command.Config::{
-                  , commands =
-                    [ Cmd.run
-                        "export MINA_DEB_CODENAME=${DebianVersions.lowerName
-                                                      codename} && source ./buildkite/scripts/export-git-env-vars.sh"
-                    , Cmd.runInDocker
-                        Cmd.Docker::{ image = image }
-                        "curl ${spec.config_json_gz_url} > config.json.gz && gunzip config.json.gz && sed 's/B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X/B62qrTP88hjyU3hq6QNvFafX8sgHrsAW6v7tt5twrcugJM4bBV2eu9k/g' -i config.json && ! (FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
-                                                                                                                                                                                                                                                                                                spec.network}.json mina-verify-packaged-fork-config ${Network.lowerName
-                                                                                                                                                                                                                                                                                                                                                        spec.network} config.json /workdir/verification)"
-                    ]
-                  , label =
-                      "Assert corrupted packaged artifacts are unverifiable"
-                  , key =
-                      "assert-unverify-corrupted-packaged-artifacts-${DebianVersions.lowerName
-                                                                        codename}"
-                  , target = Size.XLarge
-                  , depends_on = dependsOnTest
-                  }
-              , Command.build
-                  Command.Config::{
-                  , commands =
-                    [ Cmd.run
-                        "export MINA_DEB_CODENAME=${DebianVersions.lowerName
-                                                      codename} && source ./buildkite/scripts/export-git-env-vars.sh"
-                    , Cmd.runInDocker
-                        Cmd.Docker::{ image = image }
-                        "curl ${spec.config_json_gz_url} > config.json.gz && gunzip config.json.gz && FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
-                                                                                                                                                 spec.network}.json mina-verify-packaged-fork-config --network ${Network.lowerName
-                                                                                                                                                                                                                   spec.network} --fork-config config.json --working-dir /workdir/verification ${precomputed_block_prefix_arg}"
-                    ]
-                  , label = "Verify packaged artifacts"
-                  , key =
-                      "verify-packaged-artifacts-${DebianVersions.lowerName
-                                                     codename}"
-                  , target = Size.XLarge
-                  , depends_on = dependsOnTest
-                  }
-              ]
+                  spec.use_artifacts_from_buildkite_build
+
+          let cached_tarball_ledgers =
+                "--cached-hardfork-data /var/storagebox/\\\${BUILDKITE_BUILD_ID}/hardfork/ "
+
+          let cached_reference_ledgers =
+                "--reference-data-dir /var/storagebox/\\\${BUILDKITE_BUILD_ID}/hardfork/legacy "
+
+          in    buildOrGetArtifacts
+              # [ Command.build
+                    Command.Config::{
+                    , commands =
+                        Toolchain.select
+                          Toolchain.SelectionMode.ByDebianAndArch
+                          codename
+                          Arch.Type.Amd64
+                          [ "NETWORK_NAME=${Network.lowerName spec.network}"
+                          , "MINA_DEB_CODENAME=${lowerNameCodename}"
+                          ]
+                          (     "mkdir -p _build && ./buildkite/scripts/cache/manager.sh read hardfork /workdir && RUNTIME_CONFIG_JSON=/workdir/hardfork/new_config.json LEDGER_TARBALLS='/workdir/hardfork/ledgers/*.tar.gz' ./buildkite/scripts/debian/build.sh daemon_${Network.lowerName
+                                                                                                                                                                                                                                                                             spec.network}_hardfork_config "
+                            ++  merge
+                                  { Some =
+                                          \(cached_build_id : Text)
+                                      ->      "&& ./buildkite/scripts/release/manager.sh persist "
+                                          ++  " --backend local --artifacts mina-logproc,mina-${Network.lowerName
+                                                                                                  spec.network},mina-archive-${Network.lowerName
+                                                                                                                                 spec.network},mina-rosetta-${Network.lowerName
+                                                                                                                                                                spec.network},mina-zkapp-test-transaction "
+                                          ++  " --buildkite-build-id ${cached_build_id}"
+                                          ++  " --codename ${lowerNameCodename} "
+                                          ++  " --target \\\${BUILDKITE_BUILD_ID} "
+                                  , None = ""
+                                  }
+                                  spec.use_artifacts_from_buildkite_build
+                          )
+                    , label =
+                        "Create hardfork packages for ${lowerNameCodename}"
+                    , key = buildHfDebian
+                    , target = Size.Large
+                    , depends_on = dependsOnTarballs
+                    }
+                , DockerImage.generateStep dockerDaemonSpec
+                , DockerImage.generateStep
+                    DockerImage.ReleaseSpec::{
+                    , deps = dependsOnBuildHfDebian
+                    , service = Artifacts.Type.Archive
+                    , network = spec.network
+                    , deb_codename = codename
+                    , deb_profile = profile
+                    , deb_repo = DebianRepo.Type.Local
+                    , deb_version = spec.version
+                    , size = spec.size
+                    , step_key_suffix =
+                        "-${DebianVersions.lowerName codename}-docker-image"
+                    }
+                , DockerImage.generateStep
+                    DockerImage.ReleaseSpec::{
+                    , deps = dependsOnBuildHfDebian
+                    , service = Artifacts.Type.Rosetta
+                    , network = spec.network
+                    , deb_profile = profile
+                    , deb_repo = DebianRepo.Type.Local
+                    , deb_codename = codename
+                    , deb_version = spec.version
+                    , size = spec.size
+                    , step_key_suffix =
+                        "-${DebianVersions.lowerName codename}-docker-image"
+                    }
+                , Command.build
+                    Command.Config::{
+                    , commands =
+                      [ Cmd.run
+                          "export MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                                        codename} && source ./buildkite/scripts/export-git-env-vars.sh"
+                      , Cmd.runInDocker
+                          Cmd.Docker::{ image = image }
+                          "curl ${spec.config_json_gz_url} > config.json.gz && gunzip config.json.gz && sed 's/B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X/B62qrTP88hjyU3hq6QNvFafX8sgHrsAW6v7tt5twrcugJM4bBV2eu9k/g' -i config.json && ! (FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
+                                                                                                                                                                                                                                                                                                  spec.network}.old.json /workdir/scripts/hardfork/mina-verify-packaged-fork-config --network ${Network.lowerName
+                                                                                                                                                                                                                                                                                                                                                                                                  spec.network} --fork-config config.json --working-dir /workdir/verification --checks config)"
+                      ]
+                    , label =
+                        "Assert corrupted packaged artifacts are unverifiable"
+                    , key =
+                        "assert-unverify-corrupted-packaged-artifacts-${DebianVersions.lowerName
+                                                                          codename}"
+                    , target = Size.XLarge
+                    , depends_on = dependsOnTest
+                    }
+                , Command.build
+                    Command.Config::{
+                    , commands =
+                      [ Cmd.run
+                          "export MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                                        codename} && source ./buildkite/scripts/export-git-env-vars.sh"
+                      , Cmd.runInDocker
+                          Cmd.Docker::{ image = image }
+                          "curl ${spec.config_json_gz_url} > config.json.gz && gunzip config.json.gz && FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
+                                                                                                                                                   spec.network}.old.json /workdir/scripts/hardfork/mina-verify-packaged-fork-config --network ${Network.lowerName
+                                                                                                                                                                                                                                                   spec.network} --fork-config config.json  --cached-hardfork-data /workdir/hardfork --working-dir /workdir/verification ${precomputed_block_prefix_arg} ${cached_tarball_ledgers} ${cached_reference_ledgers} --checks config"
+                      ]
+                    , label = "Verify packaged artifacts: Config check"
+                    , key =
+                        "verify-packaged-artifacts-config-${DebianVersions.lowerName
+                                                              codename}"
+                    , target = Size.Small
+                    , depends_on = dependsOnTest
+                    }
+                , Command.build
+                    Command.Config::{
+                    , commands =
+                          Toolchain.select
+                            Toolchain.SelectionMode.ByDebianAndArch
+                            codename
+                            Arch.Type.Amd64
+                            ([] : List Text)
+                            "./buildkite/scripts/cache/manager.sh read hardfork . && ls -al ./hardfork"
+                        # [ Cmd.run
+                              "export MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                                            codename} && source ./buildkite/scripts/export-git-env-vars.sh"
+                          , Cmd.runInDocker
+                              Cmd.Docker::{ image = image }
+                              "curl -sL ${spec.config_json_gz_url} | gunzip > config.json && MINA_LOG_LEVEL=Spam FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
+                                                                                                                                                            spec.network}.old.json /workdir/scripts/hardfork/mina-verify-packaged-fork-config --network ${Network.lowerName
+                                                                                                                                                                                                                                                            spec.network} --fork-config config.json --cached-hardfork-data /workdir/hardfork --working-dir /workdir/hardfork ${precomputed_block_prefix_arg} ${cached_reference_ledgers} --checks ledgers  ${cached_tarball_ledgers}"
+                          ]
+                    , label = "Verify packaged artifacts: Ledgers check"
+                    , key =
+                        "verify-packaged-artifacts-ledgers-${DebianVersions.lowerName
+                                                               codename}"
+                    , target = Size.XLarge
+                    , depends_on = dependsOnTest
+                    }
+                , Command.build
+                    Command.Config::{
+                    , commands =
+                      [ Cmd.run
+                          "export MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                                        codename} && source ./buildkite/scripts/export-git-env-vars.sh"
+                      , Cmd.runInDocker
+                          Cmd.Docker::{ image = image }
+                          "curl -sL ${spec.config_json_gz_url} | gunzip > config.json && FORKING_FROM_CONFIG_JSON=/var/lib/coda/${Network.lowerName
+                                                                                                                                    spec.network}.old.json /workdir/scripts/hardfork/mina-verify-packaged-fork-config --network ${Network.lowerName
+                                                                                                                                                                                                                                    spec.network} --fork-config config.json --working-dir /workdir/verification ${precomputed_block_prefix_arg} --checks tarballs ${cached_tarball_ledgers} ${cached_reference_ledgers}"
+                      ]
+                    , label = "Verify packaged artifacts: Tarballs check"
+                    , key =
+                        "verify-packaged-artifacts-tarballs-${DebianVersions.lowerName
+                                                                codename}"
+                    , target = Size.XLarge
+                    , depends_on = dependsOnTest
+                    }
+                ]
 
 let pipeline =
           \(spec : Spec.Type)
@@ -233,6 +423,7 @@ let generate_hardfork_package =
       ->  \(suffix : Text)
       ->  \(version : Optional Text)
       ->  \(precomputed_block_prefix : Optional Text)
+      ->  \(use_artifacts_from_buildkite_build : Optional Text)
       ->  ( pipeline
               Spec::{
               , codenames = codenames
@@ -245,6 +436,8 @@ let generate_hardfork_package =
               , config_json_gz_url = config_json_gz_url
               , suffix = suffix
               , precomputed_block_prefix = precomputed_block_prefix
+              , use_artifacts_from_buildkite_build =
+                  use_artifacts_from_buildkite_build
               }
           ).pipeline
 


### PR DESCRIPTION
Final PR to use previous changes in main packaging job. Thanks to that we should be able to speed up hf pipeline from 55 minutes to ~ 28 minutes, preserving the same amount of verification. 

Resolves https://github.com/MinaProtocol/mina/issues/18152

Prior to my change Generate Hardfork Package was perform in sequential order: 

_Legend:_
_if step is suffixed with letter it means that it is run in parallel with another with the same number and different letter_


```
1 - Debian: Build Noble Devnet Devnet
2a - Docker: Daemon Devnet Noble Devnet Amd64
2b - Docker: Archive Devnet Noble Devnet Amd64
2c - Docker: Rosetta Devnet Noble Devnet Amd64
3 - Assert corrupted packaged artifacts are unverifiable
4 - Verify packaged artifacts
```

After my changes some parallelism  was introduced:


```
1 - [Optional] Debian: Build Noble Devnet Devnet # It is possible to skip this step if debians already generated
2a - Generate hardfork tarballs for noble
2b - Generate hardfork reference tarballs for noble
3 Create hardfork packages for noble # by splitting debian into apps and config here we are only building config which takes ~10 secs
4a Docker: Daemon Devnet Noble Devnet Amd64
4b Docker: Archive Devnet Noble Devnet Amd64
4c Docker: Rosetta Devnet Noble Devnet Amd64
5a Assert corrupted packaged artifacts are unverifiable
5b Verify packaged artifacts: Config check
5c Verify packaged artifacts: Ledgers check
5d Verify packaged artifacts: Tarballs check

```

As you see from above we parallelized all verification steps and we are generating reference and actual in the same time .

Gain is 50% of previous duration