### PR TITLE
[HF Pipeline improv]  3/7 fix corner cases in caching manager in CI 

### DIFF
--- a/buildkite/scripts/cache/manager.sh
+++ b/buildkite/scripts/cache/manager.sh
@@ -49,9 +49,10 @@ function main_help(){
     echo ""
     echo "Sub-commands:"
     echo ""
-    echo " read - read file/files from cache";
-    echo " write - write file/files to cache";
-    echo " help - show this help message";
+    echo " read         - read file/files from cache";
+    echo " write        - write file/files to cache (destination is a file path)";
+    echo " write-to-dir - write file/files to cache (destination is a directory)";
+    echo " help         - show this help message";
     echo ""
     exit "${1:-0}";
 }
@@ -68,10 +69,10 @@ function version(){
 
 # Display the help message for the read command
 function read_help(){
-    echo "Read file or files from CI cache"
+    echo "Read multiple files from CI cache into a local directory."
     echo "Script requires to be executed in buildkite context. e.g (BUILDKITE_BUILD_ID env var to be defined)"
     echo ""
-    echo "     $CLI_NAME read [-options] INPUT_CACHE_LOCATION OUTPUT_LOCAL_LOCATION"
+    echo "     $CLI_NAME read [-options] INPUT_CACHE_LOCATION_1 [INPUT_CACHE_LOCATION_2 ...] OUTPUT_LOCAL_LOCATION"
     echo ""
     echo "Parameters:"
     echo ""
@@ -82,20 +83,19 @@ function read_help(){
     echo ""
     echo "Values:"
     echo ""
-    echo " INPUT_CACHE_LOCATION - path from which we will read (copy) cached artifact(s) (supports wildcard)"
-    echo " OUTPUT_LOCAL_LOCATION - local destination"
+    echo " INPUT_CACHE_LOCATION_X - path(s) from which to read (copy) cached artifact(s) (supports wildcard)"
+    echo " OUTPUT_LOCAL_LOCATION - local destination directory"
     echo ""
     echo "Example:"
     echo ""
-    echo "  " "$CLI_NAME" read  debians/mina-devnet*.deb /workdir
+    echo "  $CLI_NAME read debians/mina-devnet*.deb debians/mina-archive*.deb /workdir"
     echo ""
-    echo " Above command will copy 'debians/mina-devnet*.deb' files from CACHE_MOUNTPOINT/BUILDKITE_BUILD_ID/debians to /workdir"
-    echo ""
+    echo " Above command will copy all matching files from CACHE_MOUNTPOINT/BUILDKITE_BUILD_ID/debians to /workdir"
     echo ""
     exit 0
 }
 
-# Read files from the cache
+# Read multiple files from the cache
 function read(){
     if [[ "$#" == 0 ]]; then
         read_help;
@@ -104,7 +104,7 @@ function read(){
     local __override=0
     local __root="$BUILDKITE_BUILD_ID"
     local __skip_dirs_creation=0
-    local __from=""
+    local __inputs=()
     local __to=""
 
     while [ "$#" -gt 0 ]; do
@@ -126,32 +126,20 @@ function read(){
                 shift 1;
             ;;
             * )
-                if [[ -z ${__from} ]]; then
-                   __from="$CACHE_BASE_URL/$__root/$1"
-                   shift 1;
-                   continue
+                # Collect all but last argument as inputs
+                if [[ "$#" -eq 1 ]]; then
+                    __to="$1"
+                    shift 1;
+                    continue
                 fi
-
-                if [[ -z ${__to} ]]; then
-                   __to="$1"
-                   shift 1;
-                   continue
-                fi
-                echo -e "${RED} !! Unknown option or missing argument: $1${CLEAR}\n";
-                echo "";
-                read_help;
+                __inputs+=("$CACHE_BASE_URL/$__root/$1")
+                shift 1;
             ;;
         esac
     done
 
-    # Validate required arguments
-    if [[ -z ${__from} ]]; then
-        echo -e "${RED} !! Missing required argument: INPUT_CACHE_LOCATION${CLEAR}\n";
-        read_help;
-    fi
-
-    if [[ -z ${__to} ]]; then
-        echo -e "${RED} !! Missing required argument: OUTPUT_LOCAL_LOCATION${CLEAR}\n";
+    if [[ -z "$__to" ]]; then
+        echo -e "${RED} !! Missing destination directory ('to')${CLEAR}\n";
         read_help;
     fi
 
@@ -167,22 +155,20 @@ function read(){
         exit 1
     fi
 
-    echo "..Copying $__from -> $__to"
-
-    if [[ $__override == 1 ]]; then 
+    if [[ $__override == 1 ]]; then
         EXTRA_FLAGS=""
-    else 
+    else
         EXTRA_FLAGS="-f"
     fi
 
-    mkdir -p "$__to"
-
-    if ! cp -R "${EXTRA_FLAGS}" $__from "$__to"; then
-        echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
-        exit 2
-    fi
+    for input_path in "${__inputs[@]}"; do
+        echo "..Copying $input_path -> $__to"
+        if ! cp -R ${EXTRA_FLAGS} $input_path "$__to"; then
+            echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
+            exit 2
+        fi
+    done
 }
-
 
 #==============
 # write
@@ -190,11 +176,11 @@ function read(){
 
 # Display the help message for the write command
 function write_help(){
-    echo Writes file or files to CI cache
+    echo "Write a file to CI cache (destination is treated as a file path)."
     echo "Script requires to be executed in buildkite context. e.g (BUILDKITE_BUILD_ID env var to be defined)"
+    echo "For writing multiple files to a directory, use 'write-to-dir' instead."
     echo ""
-    echo "     $CLI_NAME write [-options] INPUT_LOCAL_LOCATION OUTPUT_CACHE_LOCATION"
-    echo ""
+    echo "     $CLI_NAME write [-options] INPUT_LOCAL_FILE OUTPUT_CACHE_FILE_PATH"
     echo ""
     echo "Parameters:"
     echo ""
@@ -204,40 +190,37 @@ function write_help(){
     echo ""
     echo "Values:"
     echo ""
-    echo " INPUT_LOCAL_LOCATION - single or multiple files to write (supports wildcard)"
-    echo " OUTPUT_CACHE_LOCATION - destination at cache mount"
+    echo " INPUT_LOCAL_FILE - local file to write to cache"
+    echo " OUTPUT_CACHE_FILE_PATH - destination file path at cache mount"
     echo ""
     echo "Example:"
     echo ""
-    echo "  " $CLI_NAME write  mina-devnet*.deb debians/
+    echo "  $CLI_NAME write mina-devnet.deb debians/mina-devnet.deb"
     echo ""
-    echo " Above command will write mina-devnet*.deb files to CACHE_MOUNTPOINT/BUILDKITE_BUILD_ID/debians"
-    echo ""
+    echo " Above command will write file to CACHE_MOUNTPOINT/BUILDKITE_BUILD_ID/debians/mina-devnet.deb"
     echo ""
     exit 0
 }
 
-# Writes files to the cache
+# Write multiple files to the cache (destination is treated as a file path)
 function write(){
-
     if [[ "$#" == 0 ]]; then
         write_help;
     fi
 
-
     local __override=0
     local __root="$BUILDKITE_BUILD_ID"
-    local __from=""
+    local __inputs=()
     local __to=""
 
-    while [ ${#} -gt 0 ]; do
+    while [ "$#" -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
         case $1 in
             -h | --help )
                 write_help;
             ;;
             -o | --override )
-               __override=1
+                __override=1
                 shift 1;
             ;;
             -r | --root )
@@ -245,51 +228,132 @@ function write(){
                 shift 2;
             ;;
             * )
-                if [[ -z ${__from} ]]; then
-                   __from="$1"
-                   shift 1;
-                   continue
+                # Collect all but last argument as inputs
+                if [[ "$#" -eq 1 ]]; then
+                    __to=$CACHE_BASE_URL/$__root/"$1"
+                    shift 1;
+                    continue
                 fi
-
-                if [[ -z ${__to} ]]; then
-                   __to=$CACHE_BASE_URL/$__root/"$1"
-                   shift 1;
-                   continue
-                fi
-                echo -e "${RED} !! Unknown option or missing argument: $1${CLEAR}\n";
-                echo "";
-                write_help;
+                __inputs+=("$1")
+                shift 1;
             ;;
         esac
     done
 
-    # Validate required arguments
-    if [[ -z ${__from} ]]; then
-        echo -e "${RED} !! Missing required argument: INPUT_LOCAL_LOCATION${CLEAR}\n";
+    if [[ -z "$__to" ]]; then
+        echo -e "${RED} !! Missing destination file path ('to')${CLEAR}\n";
         write_help;
     fi
 
-    if [[ -z ${__to} ]]; then
-        echo -e "${RED} !! Missing required argument: OUTPUT_CACHE_LOCATION${CLEAR}\n";
-        write_help;
-    fi
-
-    echo "..Copying $__from -> $__to"
-    
-    if [[ $__override == 1 ]]; then 
+    if [[ $__override == 1 ]]; then
         EXTRA_FLAGS=""
-    else 
+    else
         EXTRA_FLAGS="-f"
     fi
 
-    mkdir -p "$__to"
-    
-    if ! cp -R "${EXTRA_FLAGS}" "$__from" "$__to"; then
-        echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
-        exit 2
-    fi
+    # Destination is treated as a file path - create parent directory only
+    mkdir -p "$(dirname "$__to")"
+
+    for input_path in "${__inputs[@]}"; do
+        echo "..Copying $input_path -> $__to"
+        if ! cp -R ${EXTRA_FLAGS} $input_path "$__to"; then
+            echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
+            exit 2
+        fi
+    done
 }
 
+#==================
+# write-to-dir
+#==================
+
+# Display the help message for the write-to-dir command
+function write-to-dir_help(){
+    echo "Write multiple files to CI cache into a cache directory."
+    echo "Script requires to be executed in buildkite context. e.g (BUILDKITE_BUILD_ID env var to be defined)"
+    echo ""
+    echo "     $CLI_NAME write-to-dir [-options] INPUT_LOCAL_LOCATION_1 [INPUT_LOCAL_LOCATION_2 ...] OUTPUT_CACHE_DIRECTORY"
+    echo ""
+    echo "Parameters:"
+    echo ""
+    printf "  %-25s %s\n" "-h  | --help" "show help";
+    printf "  %-25s %s\n" "-o  | --override" "[bool] override existing files";
+    printf "  %-25s %s\n" "-r  | --root" "[path] override cache root folder. WARNING it does not override cache mount point. Do not add leading slash at the beginning or end.";
+    echo ""
+    echo "Values:"
+    echo ""
+    echo " INPUT_LOCAL_LOCATION_X - path(s) of files to write (supports wildcard)"
+    echo " OUTPUT_CACHE_DIRECTORY - destination directory at cache mount (will be created if not exists)"
+    echo ""
+    echo "Example:"
+    echo ""
+    echo "  $CLI_NAME write-to-dir mina-devnet*.deb mina-archive*.deb debians"
+    echo ""
+    echo " Above command will write all matching files to CACHE_MOUNTPOINT/BUILDKITE_BUILD_ID/debians/"
+    echo ""
+    exit 0
+}
+
+# Write multiple files to a cache directory
+function write-to-dir(){
+    if [[ "$#" == 0 ]]; then
+        write-to-dir_help;
+    fi
+
+    local __override=0
+    local __root="$BUILDKITE_BUILD_ID"
+    local __inputs=()
+    local __to=""
+
+    while [ "$#" -gt 0 ]; do
+        error_message="Error: a value is needed for '$1'";
+        case $1 in
+            -h | --help )
+                write-to-dir_help;
+            ;;
+            -o | --override )
+                __override=1
+                shift 1;
+            ;;
+            -r | --root )
+                __root=${2:?$error_message}
+                shift 2;
+            ;;
+            * )
+                # Collect all but last argument as inputs
+                if [[ "$#" -eq 1 ]]; then
+                    __to=$CACHE_BASE_URL/$__root/"$1"
+                    shift 1;
+                    continue
+                fi
+                __inputs+=("$1")
+                shift 1;
+            ;;
+        esac
+    done
+
+    if [[ -z "$__to" ]]; then
+        echo -e "${RED} !! Missing destination directory ('to')${CLEAR}\n";
+        write-to-dir_help;
+    fi
+
+    if [[ $__override == 1 ]]; then
+        EXTRA_FLAGS=""
+    else
+        EXTRA_FLAGS="-f"
+    fi
+
+    # Destination is treated as a directory - create it
+    mkdir -p "$__to"
+
+    for input_path in "${__inputs[@]}"; do
+        echo "..Copying $input_path -> $__to"
+        if ! cp -R ${EXTRA_FLAGS} $input_path "$__to"; then
+            echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
+            exit 2
+        fi
+    done
+}
 # Main function to handle the CLI
 function main(){
     if (( "$#" == 0 )); then
@@ -300,7 +364,7 @@ function main(){
         help )
             main_help 0;
         ;;
-        read | write )
+        read | write | write-to-dir )
             $1 "${@:2}";
         ;;
         *)

--- a/buildkite/scripts/debian/install.sh
+++ b/buildkite/scripts/debian/install.sh
@@ -14,9 +14,12 @@ fi
 
 DEBS=$1
 USE_SUDO=${2:-0}
+ROOT="${ROOT:-${BUILDKITE_BUILD_ID}}"
 
 # Source git environment variables first to get MINA_DEB_CODENAME
 source ./buildkite/scripts/export-git-env-vars.sh
+
+VERSION="${FORCE_VERSION:-"${MINA_DEB_VERSION}"}"
 
 if [ "$USE_SUDO" == "1" ]; then
    SUDO="sudo"
@@ -25,33 +28,31 @@ else
 fi
 
 
+
 LOCAL_DEB_FOLDER=debs
 mkdir -p $LOCAL_DEB_FOLDER
 
 # Download required debians from bucket locally
 if [ -z "$DEBS" ]; then 
-    echo "DEBS env var is empty. It should contains comma delimitered names of debians to install"
+    echo "DEBS env var is empty. It should contains comma separated names of debians to install"
     exit 1
 else
   # shellcheck disable=SC2206
   debs=(${DEBS//,/ })
   for i in "${debs[@]}"; do
     case $i in
-      mina-testnet-generic*|mina-devnet|mina-mainnet)
+      mina-testnet-generic*|mina-berkeley*|mina-devnet|mina-mainnet)
         # Downaload mina-logproc too
         ./buildkite/scripts/cache/manager.sh read "debians/$MINA_DEB_CODENAME/mina-logproc*" $LOCAL_DEB_FOLDER
       ;;
-      mina-devnet-legacy|mina-mainnet-legacy)
-        # Download mina-logproc legacy too
-        ./buildkite/scripts/cache/manager.sh read --root "legacy" "debians/$MINA_DEB_CODENAME/${i}*" $LOCAL_DEB_FOLDER
     esac
-    ./buildkite/scripts/cache/manager.sh read "debians/$MINA_DEB_CODENAME/${i}_*" $LOCAL_DEB_FOLDER
+    ./buildkite/scripts/cache/manager.sh read --root "$ROOT" "debians/$MINA_DEB_CODENAME/${i}_${VERSION}_*" $LOCAL_DEB_FOLDER
   done
 fi
 
 debs_with_version=()
 for i in "${debs[@]}"; do
-   debs_with_version+=("${i}=${MINA_DEB_VERSION}")
+   debs_with_version+=("${i}=${VERSION}")
 done
 
 # Start aptly

--- a/buildkite/scripts/debian/start_local_repo.sh
+++ b/buildkite/scripts/debian/start_local_repo.sh
@@ -7,11 +7,16 @@ fi
 
 # Parse command line arguments
 ARCH="amd64"  # default architecture
+ROOT=${BUILDKITE_BUILD_ID}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --arch)
             ARCH="$2"
+            shift 2
+            ;;
+        --root)
+            ROOT="$2"
             shift 2
             ;;
         *)
@@ -31,5 +36,5 @@ set -x
 mkdir -p $LOCAL_DEB_FOLDER
 source ./buildkite/scripts/export-git-env-vars.sh
 ./buildkite/scripts/cache/manager.sh read --root legacy/debians "$MINA_DEB_CODENAME/*" _build
-./buildkite/scripts/cache/manager.sh read "debians/$MINA_DEB_CODENAME/*" _build
+./buildkite/scripts/cache/manager.sh read --root "${ROOT}" "debians/$MINA_DEB_CODENAME/*" _build
 ./scripts/debian/aptly.sh start --codename $MINA_DEB_CODENAME --debians $LOCAL_DEB_FOLDER --component unstable --clean --background --wait --archs $ARCH

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -30,7 +30,7 @@ in  { step =
                         , buildFlags = BuildFlags.Type.Instrumented
                         }
                     )
-                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} && ls -al && ./buildkite/scripts/cache/manager.sh write archive.perf archive-node-test"
+                    "./scripts/tests/archive-node-test.sh && buildkite/scripts/upload-partial-coverage-data.sh ${key} && ls -al && ./buildkite/scripts/cache/manager.sh write-to-dir archive.perf archive-node-test"
                 ]
               , label = "Archive: Node Test"
               , key = key

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -46,6 +46,7 @@ let ReleaseSpec =
           , deb_codename : DebianVersions.DebVersion
           , deb_release : Text
           , deb_version : Text
+          , deb_root_folder : Text
           , deb_legacy_version : Text
           , deb_suffix : Optional Text
           , deb_profile : Profiles.Type
@@ -66,6 +67,7 @@ let ReleaseSpec =
           , service = Artifacts.Type.Daemon
           , branch = "\\\${BUILDKITE_BRANCH}"
           , repo = "\\\${BUILDKITE_REPO}"
+          , deb_root_folder = "\\\${BUILDKITE_BUILD_ID}"
           , deb_codename = DebianVersions.DebVersion.Bullseye
           , deb_release = "unstable"
           , deb_version = "\\\${MINA_DEB_VERSION}"
@@ -112,8 +114,8 @@ let generateStep =
                 then  " && echo Skipping local debian repo setup "
 
                 else      " && ./buildkite/scripts/debian/update.sh --verbose"
-                      ++  " && apt-get install aptly -y && ./buildkite/scripts/debian/start_local_repo.sh --arch ${Arch.lowerName
-                                                                                                                     spec.arch}"
+                      ++  " && apt-get install aptly -y && ./buildkite/scripts/debian/start_local_repo.sh --root ${spec.deb_root_folder} --arch ${Arch.lowerName
+                                                                                                                                                    spec.arch}"
 
           let maybeStopDebianRepo =
                       if spec.no_debian


### PR DESCRIPTION
Apply improvements to caching manager regarding read/write operations.

- converted single file write/read to multi-file read/write 
- added exclusive write-to-dir for writing into folders
- pass root debian folder when installing debians, so we can install debians from different build not only from buildkite-build-id, but from build we preserved into different folder