### PR TITLE
Revert #17774

### DIFF
--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -36,245 +36,134 @@ let dispatch rpc shutdown_on_disconnect query address =
   | Ok res ->
       res
 
-(** retry interval with jitter *)
-let retry_pause sec = Random.float_range (sec -. 2.0) (sec +. 2.0)
-
-let submit_work ~logger ~metadata ~shutdown_on_disconnect ~daemon_address
-    result_without_spec () =
-  let log_result msg =
-    [%log info] msg ~metadata ;
-    Deferred.Or_error.return ()
-  in
-  match%bind
-    dispatch Rpc_submit_work.Stable.Latest.rpc shutdown_on_disconnect
-      result_without_spec daemon_address
-  with
-  | Error e ->
-      Deferred.Or_error.fail e
-  | Ok `Ok ->
-      log_result "Submitted completed SNARK work $work_ids to $address"
-  | Ok `Removed ->
-      log_result "Result $work_ids slashed by $address"
-  | Ok `SpecUnmatched ->
-      log_result
-        "Result $work_ids rejected by $address since it has wrong shape"
-
-(** Reads daemon address from a local coordinator file or uses a default.
-
-    Looks for snark_coordinator file; if present parses as host:port.
-    Falls back to default on parse failure or missing/unknown file.  *)
-let get_daemon_address default =
-  let path = "snark_coordinator" in
-  match%bind Sys.file_exists path with
-  | `Yes -> (
-      let%map s = Reader.file_contents path in
-      try Host_and_port.of_string (String.strip s) with _ -> default )
-  | `No | `Unknown ->
-      return default
-
-let emit_metrics ~elapsed ~logger = function
-  | Spec.Partitioned.Poly.Single { spec = single_spec; _ } ->
-      Metrics.emit_single_metrics_stable ~logger ~single_spec ~elapsed
-  | Spec.Partitioned.Poly.Sub_zkapp_command { spec = sub_zkapp_spec; _ } ->
-      Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec ~elapsed
-
-(** Handle the `Result case - submits completed SNARK work to the daemon with retry logic.
-    
-    This handler processes successfully generated SNARK proofs by:
-    1. Submitting the work result to the daemon via RPC
-    2. On success: transitions to `No_spec state to request new work
-    3. On failure: retries a limited number of times with exponential backoff (1.5x factor)
-    4. After exhausting retries: logs rejection and transitions to `No_spec
-    
-    @param result_without_spec The completed SNARK work result
-    @param retry_count Number of retries remaining
-    @return Next state, either `No_spec or `Result with decremented retry count *)
-let handle_result ~logger ~shutdown_on_disconnect daemon_address
-    result_without_spec metadata retry_count retry_delay =
-  match%bind
-    submit_work ~logger ~metadata ~shutdown_on_disconnect ~daemon_address
-      result_without_spec ()
-  with
-  | Error e when retry_count <= 0 ->
-      [%log error] "Work submission failed after all retries. Work rejected"
-        ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-      return `No_spec
-  | Error e ->
-      [%log error] "Error submitting work (retries remaining: %d)" retry_count
-        ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-      let%map () = after @@ Time.Span.of_sec @@ retry_pause retry_delay in
-      let retry_delay = retry_delay *. 1.5 in
-      `Result
-        ( daemon_address
-        , result_without_spec
-        , metadata
-        , retry_count - 1
-        , retry_delay )
-  | Ok () ->
-      return `No_spec
-
-(** Handle the `Failed case - reports SNARK work generation failures to the daemon.
-    
-    This handler processes failed SNARK work generation by:
-    1. Notifying the daemon about the failure via RPC
-    2. Logging the error details for debugging
-    3. Transitioning to `No_spec state after a retry delay
-    
-    @param e The error that caused the work generation to fail
-    @param partitioned_id Identifier of the failed work partition
-    @return Next state, `No_spec *)
-let handle_failed ~logger ~shutdown_on_disconnect daemon_address e
-    partitioned_id =
-  let%bind () =
-    match%map
-      dispatch Rpc_failed_to_generate_snark.Stable.Latest.rpc
-        shutdown_on_disconnect (e, partitioned_id) daemon_address
-    with
-    | Error e ->
-        [%log error] "Couldn't inform the daemon about the snark work failure"
-          ~metadata:[ ("error", Error_json.error_to_yojson e) ]
-    | Ok () ->
-        ()
-  in
-  [%log error] "Error performing work"
-    ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-  after @@ Time.Span.of_sec @@ retry_pause 10. >>| const `No_spec
-
-(** Handle the `Spec case - processes new SNARK work specifications.
-    
-    This handler performs the actual SNARK proof generation by:
-    1. Logging the received work specification
-    2. Executing the partitioned SNARK work using the worker state
-    3. On success: emits metrics and transitions to `Result state
-    4. On failure: transitions to `Failed state with error details
-    
-    @param state SNARK worker state
-    @param partitioned_spec The SNARK work specification to process
-    @return Next state, either `Result or `Failed *)
-let handle_spec ~logger ~state daemon_address partitioned_spec =
-  let metadata =
-    [ ("address", `String (Host_and_port.to_string daemon_address))
-    ; ( "work_ids"
-      , Spec.Partitioned.Stable.Latest.statement partitioned_spec
-        |> Mina_state.Snarked_ledger_state.to_yojson )
-    ]
-  in
-  [%log info]
-    "SNARK work $work_ids received from $address. Starting proof generation"
-    ~metadata ;
-
-  let id = Spec.Partitioned.Poly.get_id partitioned_spec in
-  match%bind Prod.Impl.perform_partitioned ~state ~spec:partitioned_spec with
-  | Error e ->
-      return (`Failed (daemon_address, e, id))
-  | Ok ({ data = elapsed; _ } as data) ->
-      let wire_result = Result.Partitioned.Stable.Latest.{ id; data } in
-      emit_metrics ~elapsed ~logger partitioned_spec ;
-      return (`Result (daemon_address, wire_result, metadata, 3, 10.))
-
-(** Handle the `No_spec case - requests new SNARK work from the daemon.
-    
-    This handler manages the work request cycle by:
-    1. Determining the daemon address (from file or default)
-    2. Requesting available work from the daemon via RPC
-    3. On work available: transitions to `Spec state with the work
-    4. On no work: sleeps with jitter and stays in `No_spec state
-    5. On error: retries after delay, staying in `No_spec state
-    
-    @param default_daemon_address Default daemon address if no coordinator file
-    @return Next state, either `Spec or `No_spec *)
-let handle_no_spec ~logger ~shutdown_on_disconnect default_daemon_address =
-  let%bind daemon_address = get_daemon_address default_daemon_address in
-  [%log debug]
-    !"Snark worker using daemon $addr"
-    ~metadata:[ ("addr", `String (Host_and_port.to_string daemon_address)) ] ;
-  match%bind
-    dispatch Rpc_get_work.Stable.Latest.rpc shutdown_on_disconnect ()
-      daemon_address
-  with
-  | Error e ->
-      [%log error] "Error getting work: "
-        ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-      after @@ Time.Span.of_sec @@ retry_pause 10. >>| const `No_spec
-  | Ok None ->
-      let random_delay =
-        Prod.Impl.Worker_state.worker_wait_time
-        +. (0.5 *. Random.float Prod.Impl.Worker_state.worker_wait_time)
-      in
-      (* No work to be done -- quietly take a brief nap *)
-      [%log info] "No jobs available. Napping for $time seconds"
-        ~metadata:[ ("time", `Float random_delay) ] ;
-      after (Time.Span.of_sec random_delay) >>| const `No_spec
-  | Ok (Some partitioned_spec) ->
-      return (`Spec (daemon_address, partitioned_spec))
-
-(** Main SNARK worker event loop implementing a state machine for work processing.
-    
-    The worker operates as a finite state machine with four states, continuously
-    cycling through work request, processing, and submission phases:
-    
-    Flow Diagram:
-    ┌─────────────┐    get_work RPC     ┌──────────────┐
-    │   No_spec   │ ──────────────────> │     Spec     │
-    │ (idle/wait) │                     │ (processing) │
-    └─────────────┘                     └──────────────┘
-           ^                                     │
-           │                                     │ perform_partitioned
-           │ retry_delay                         │
-           │                                     v
-    ┌─────────────┐                     ┌──────────────┐
-    │   Failed    │                     │    Result    │
-    │ (error rpt) │ <─────────────────  │ (completed)  │
-    └─────────────┘    on failure       └──────────────┘
-           │                                     │
-           │ report_failure RPC                  │ submit_work RPC
-           │                                     │
-           └─────────────────────────────────────┘
-                         │
-                         v
-                   ┌─────────────┐
-                   │   No_spec   │
-                   │ (next cycle)│
-                   └─────────────┘
-    
-    State Transitions:
-    • No_spec → Spec: When work is available from daemon
-    • No_spec → No_spec: When no work available (with sleep)
-    • Spec → Result: When SNARK proof generation succeeds
-    • Spec → Failed: When SNARK proof generation fails
-    • Result → No_spec: When work submission succeeds
-    • Result → Result: When work submission fails (infinite retry)
-    • Failed → No_spec: After reporting failure to daemon (no retry on failure to report)
-    
-    Error Handling:
-    • Network failures: Retry for get_work and submit_work RPCs
-    • Work generation failures: Report to daemon and continue
-    
-    Worker loop runs indefinitely. *)
 let main ~logger ~proof_level ~constraint_constants ~signature_kind
-    default_daemon_address shutdown_on_disconnect =
+    daemon_address shutdown_on_disconnect =
   let%bind state =
     Prod.Impl.Worker_state.create ~constraint_constants ~proof_level
       ~signature_kind ()
   in
-  let%map cwd = Sys.getcwd () in
-  [%log debug]
-    !"Snark worker working directory $dir"
-    ~metadata:[ ("dir", `String cwd) ] ;
-  Deferred.forever `No_spec
-  @@ function
-  | `Result
-      (daemon_address, result_without_spec, metadata, retry_count, retry_delay)
-    ->
-      handle_result ~logger ~shutdown_on_disconnect daemon_address
-        result_without_spec metadata retry_count retry_delay
-  | `Failed (daemon_address, e, partitioned_id) ->
-      handle_failed ~logger ~shutdown_on_disconnect daemon_address e
-        partitioned_id
-  | `Spec (daemon_address, partitioned_spec) ->
-      handle_spec ~logger ~state daemon_address partitioned_spec
-  | `No_spec ->
-      handle_no_spec ~logger ~shutdown_on_disconnect default_daemon_address
+  let wait ?(sec = 0.5) () = after (Time.Span.of_sec sec) in
+  (* retry interval with jitter *)
+  let retry_pause sec = Random.float_range (sec -. 2.0) (sec +. 2.0) in
+  let log_and_retry label error sec k =
+    let error_str = Error.to_string_hum error in
+    (* HACK: the bind before the call to go () produces an evergrowing
+         backtrace history which takes forever to print and fills our disks.
+         If the string becomes too long, chop off the first 10 lines and include
+         only that *)
+    ( if String.length error_str < 4096 then
+      [%log error] !"Error %s: %{sexp:Error.t}" label error
+    else
+      let lines = String.split ~on:'\n' error_str in
+      [%log error] !"Error %s: %s" label
+        (String.concat ~sep:"\\n" (List.take lines 10)) ) ;
+    let%bind () = wait ~sec () in
+    (* FIXME: Use a backoff algo here *)
+    k ()
+  in
+  let rec go () =
+    let%bind daemon_address =
+      let%bind cwd = Sys.getcwd () in
+      [%log debug]
+        !"Snark worker working directory $dir"
+        ~metadata:[ ("dir", `String cwd) ] ;
+      let path = "snark_coordinator" in
+      match%bind Sys.file_exists path with
+      | `Yes -> (
+          let%map s = Reader.file_contents path in
+          try Host_and_port.of_string (String.strip s)
+          with _ -> daemon_address )
+      | `No | `Unknown ->
+          return daemon_address
+    in
+    [%log debug]
+      !"Snark worker using daemon $addr"
+      ~metadata:[ ("addr", `String (Host_and_port.to_string daemon_address)) ] ;
+    match%bind
+      dispatch Rpc_get_work.Stable.Latest.rpc shutdown_on_disconnect ()
+        daemon_address
+    with
+    | Error e ->
+        log_and_retry "getting work" e (retry_pause 10.) go
+    | Ok None ->
+        let random_delay =
+          Prod.Impl.Worker_state.worker_wait_time
+          +. (0.5 *. Random.float Prod.Impl.Worker_state.worker_wait_time)
+        in
+        (* No work to be done -- quietly take a brief nap *)
+        [%log info] "No jobs available. Napping for $time seconds"
+          ~metadata:[ ("time", `Float random_delay) ] ;
+        let%bind () = wait ~sec:random_delay () in
+        go ()
+    | Ok (Some partitioned_spec) -> (
+        let address_json =
+          ("address", `String (Host_and_port.to_string daemon_address))
+        in
+        let work_ids_json =
+          ( "work_ids"
+          , Spec.Partitioned.Stable.Latest.statement partitioned_spec
+            |> Mina_state.Snarked_ledger_state.to_yojson )
+        in
+        [%log info]
+          "SNARK work $work_ids received from $address. Starting proof \
+           generation"
+          ~metadata:[ address_json; work_ids_json ] ;
+        let%bind () = wait () in
+        (* Pause to wait for stdout to flush *)
+        let id = Spec.Partitioned.Poly.get_id partitioned_spec in
+        match%bind
+          Prod.Impl.perform_partitioned ~state ~spec:partitioned_spec
+        with
+        | Error e ->
+            let%bind () =
+              match%map
+                dispatch Rpc_failed_to_generate_snark.Stable.Latest.rpc
+                  shutdown_on_disconnect (e, id) daemon_address
+              with
+              | Error e ->
+                  [%log error]
+                    "Couldn't inform the daemon about the snark work failure"
+                    ~metadata:[ ("error", Error_json.error_to_yojson e) ]
+              | Ok () ->
+                  ()
+            in
+            log_and_retry "performing work" e (retry_pause 10.) go
+        | Ok ({ data = elapsed; _ } as data) ->
+            let wire_result = Result.Partitioned.Stable.Latest.{ id; data } in
+            ( match partitioned_spec with
+            | Spec.Partitioned.Poly.Single { spec = single_spec; _ } ->
+                Metrics.emit_single_metrics_stable ~logger ~single_spec ~elapsed
+            | Spec.Partitioned.Poly.Sub_zkapp_command
+                { spec = sub_zkapp_spec; _ } ->
+                Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec ~elapsed
+            ) ;
+            let rec submit_work () =
+              match%bind
+                dispatch Rpc_submit_work.Stable.Latest.rpc
+                  shutdown_on_disconnect wire_result daemon_address
+              with
+              | Error e ->
+                  log_and_retry "submitting work" e (retry_pause 10.)
+                    submit_work
+              | Ok `Ok ->
+                  [%log info]
+                    "Submitted completed SNARK work $work_ids to $address"
+                    ~metadata:[ address_json; work_ids_json ] ;
+                  go ()
+              | Ok `Removed ->
+                  [%log info] "Result $work_ids slashed by $address"
+                    ~metadata:[ address_json; work_ids_json ] ;
+                  go ()
+              | Ok `SpecUnmatched ->
+                  [%log info]
+                    "Result $work_ids rejected by $address since it has wrong \
+                     shape"
+                    ~metadata:[ address_json; work_ids_json ] ;
+                  go ()
+            in
+            submit_work () )
+  in
+  go ()
 
 let command_from_rpcs ~commit_id ~proof_level:default_proof_level
     ~constraint_constants =


### PR DESCRIPTION
Reverting potential CI breaker to test if that will make Ci happy. Copying full message from my investigation:

Nightly integration tests are failing: [example](https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/880#019aeed4-d3c1-41e3-a4d9-e42740af8dd4)
payment:
```
× send out txns to fill up the snark ledger
    [2025-12-05 15:02:01.242467Z] hit a hard timeout waiting for [1] snarked_ledgers to be generated since genesis   
```
zkapp integration
```× Wait for zkApp transaction to update all fields to be included in transition frontier
    [2025-12-05 14:35:57.086504Z] hit a hard timeout waiting for zkApp with fee payer B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7 and other zkapp_command (B62qmLvic6nzFyj3XPXPnoTbQU3mRZb44Tg48u48uYVi6C8wiWi58Ny, B62qmMgiXYqJfjQyMkS6P55pGRaKPQAfFryyMu5n9VeGNdqJo3VvF34, B62qipuXGcmp9PgsMx3Jo4MB9dQQ9CdozD67Rmc4P2JsH8E9RGpuEig), memo: Zkapp update all
```
post-hardfork
```× send out txns to fill up the snark ledger
    [2025-12-05 15:02:01.242467Z] hit a hard timeout waiting for [1] snarked_ledgers to be generated since genesis```
zkapp 
```[2025-12-7 02:52:32.360748]Dune__exe__Test_executive: (monitor.ml.Error(Failure"Aborted because of required offline node")("Raised at Stdlib.failwith in file \"stdlib.ml\", line 29, characters 17-33""Called from Dune__exe__Test_executive.main.(fun) in file \"src/app/test_executive/test_executive.ml\", line 394, characters 16-67""Called from Integration_test_lib__Event_router.Make.dispatch_event.(fun) in file \"src/lib/testing/integration_test_lib/event_router.ml\", line 56, characters 12-97""Called from Base__List.rev_mapi.loop in file \"src/list.ml\", line 515, characters 30-35""Called from Base__List.mapi in file \"src/list.ml\" (inlined), line 520, characters 20-35""Called from Async_kernel__Deferred_list.mapi in file \"src/deferred_list.ml\", line 37, characters 8-73""Called from Async_kernel__Deferred_list.filter_mapi in file \"src/deferred_list.ml\", line 46, characters 28-42""Called from Integration_test_lib__Event_router.Make.dispatch_event in file \"src/lib/testing/integration_test_lib/event_router.ml\", line 45, characters 6-748""Called from Async_kernel__Pipe.iter.(fun) in file \"src/pipe.ml\", line 825, characters 4-56""Called from Async_kernel__Job_queue.run_job in file \"src/job_queue.ml\" (inlined), line 128, characters 2-5""Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 169, characters 6-47""Caught by monitor at file \"src/app/test_executive/test_executive.ml\", line 330, characters 27-27"))
```
__The above is less straight forward, nodes are dying very often and there is no clear connection with others, so I'm not sure about this one. However, it crashes constantly together with others__

Are failing consistently from 4th of December. (I overlook their failure as many others jobs were failing (arm64/rosetta/archive-node), now those are the only red tests on compatible). I tracked potential commits which might cause it:

:green_circle: 3rd Decemeber ([e280868fc4](https://github.com/MinaProtocol/mina/commit/e280868fc4a3fa21dbd911ee9812590f517e3fd8))

:green_circle: 4th December  (42ec1eb7)  https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/876

:red_circle: 5th December nightlyt (f5bf72d4)  https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/880.
       -  Changes
 [#18034](https://github.com/MinaProtocol/mina/pull/18034) from leon/wasm-macos branch :large_green_circle: quite harmless  change
[#18185](https://github.com/MinaProtocol/mina/pull/18185) from dkijania/fix_rosetta_load_measurements :large_green_circle:  as above, targeted fix for rosetta connectivity test
:bangbang: [#17774](https://github.com/MinaProtocol/mina/pull/17774) from georgeee/refactor-worker :red_circle: potential breaker - change around snark worker