### PR TITLE
make rest port default value human readable

### DIFF
--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -129,7 +129,7 @@ module Port = struct
 
   let default_client = 8301
 
-  let default_rest = 0xc0d
+  let default_rest = 3085
 
   let default_archive = default_rest + 1
 


### PR DESCRIPTION
As title. I have no idea why it's represented as hex in the 1st place. 