### PR TITLE
[compatible] Change scan state hashing to load proofs from disk incrementally

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -418,7 +418,7 @@ module T = struct
       ; pending_coinbase_collection
       } : Staged_ledger_hash.t =
     Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
-      Scan_state.(Stable.Latest.hash @@ read_all_proofs_from_disk scan_state)
+      (Scan_state.hash_by_reading_all_proofs_from_disk_incrementally scan_state)
       (Ledger.merkle_root ledger)
       pending_coinbase_collection
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -260,6 +260,9 @@ val all_work_pairs :
      list
      Or_error.t
 
+val hash_by_reading_all_proofs_from_disk_incrementally :
+  t -> Staged_ledger_hash.Aux_hash.t
+
 val write_all_proofs_to_disk :
      signature_kind:Mina_signature_kind.t
   -> proof_cache_db:Proof_cache_tag.cache_db


### PR DESCRIPTION
This PR introduces a helper function `hash_by_reading_all_proofs_from_disk_incrementally` to `Transaction_snark_scan_state`, which avoids the behaviour of the previous `hash` implementation of loading all proofs from disk before starting to hash.

This implementation incurs the same number of disk accesses, but reduces peak memory usage when the scan state is large, by keeping the proofs in the short-term cache and allowing them to be GC'd quickly.