### PR TITLE
Refactor `first_and_second_pass_transactions_per_tree`

### DIFF
--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -742,16 +742,16 @@ struct
     |> List.filter_map ~f:Mina_stdlib.Nonempty_list.of_list_opt
 
   let fold_tx (first_pass_txns, second_pass_txns, _old_root) txn =
-    let target_first_pass_ledger = Tx.target_first_pass_ledger txn in
-    match Tx.transaction_type txn with
-    | `Coinbase | `Fee_transfer | `Signed_command ->
-        (txn :: first_pass_txns, second_pass_txns, target_first_pass_ledger)
-    | `Zkapp_command ->
-        ( txn :: first_pass_txns
-        , txn :: second_pass_txns
-        , target_first_pass_ledger )
+    let second_pass_txns =
+      match Tx.transaction_type txn with
+      | `Zkapp_command ->
+          txn :: second_pass_txns
+      | _ ->
+          second_pass_txns
+    in
+    (txn :: first_pass_txns, second_pass_txns, Tx.target_first_pass_ledger txn)
 
-  (** Compoutes representation for the sequence of transactions extracted from scan state
+  (** Computes representation for the sequence of transactions extracted from scan state
       when it emitted a proof, split into:
 
       * [first_pass] - transactions that went through first pass


### PR DESCRIPTION
Move `first_and_second_pass_transactions_per_tree` to a functor parametrized with data used in the implementation of the function.

Rename functions: `{first_and_second_pass -> categorize}_transactions_xx`.

While functor is used for a single type of transaction now, in future PRs there will be two instantiations.


Explain how you tested your changes:
* A simple refactoring. Wasn't tested standalone, but was tested on a cluster as part of a larger OOM fix package.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
