### PR TITLE
Node_config: add profile value

### DIFF
--- a/src/lib/node_config/dune
+++ b/src/lib/node_config/dune
@@ -6,7 +6,6 @@
   node_config_version
   node_config_unconfigurable_constants
   node_config_profiled)
-  
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
+++ b/src/lib/node_config/for_unit_tests/node_config_for_unit_tests.ml
@@ -52,6 +52,8 @@ let compaction_interval = None
 
 let (network : string) = ("testnet" : string)
 
+let (profile : string) = ("dev" : string)
+
 let (vrf_poll_interval : int) = (0 : int)
 
 let zkapp_cmd_limit = None

--- a/src/lib/node_config/intf/node_config_intf.mli
+++ b/src/lib/node_config/intf/node_config_intf.mli
@@ -80,6 +80,8 @@ module type Profiled = sig
 
   val network : string
 
+  val profile : string
+
   val zkapp_cmd_limit : int option
 
   val sync_ledger_max_subtree_depth : int

--- a/src/lib/node_config/profiled/dev.ml
+++ b/src/lib/node_config/profiled/dev.ml
@@ -44,6 +44,8 @@ let block_window_duration = 2000
 
 let network = "testnet"
 
+let profile = "dev"
+
 let compaction_interval = None
 
 let vrf_poll_interval = 0

--- a/src/lib/node_config/profiled/devnet.ml
+++ b/src/lib/node_config/profiled/devnet.ml
@@ -3,3 +3,5 @@ include Mainnet
 let genesis_state_timestamp = "2021-09-24T00:00:00Z"
 
 let network = "testnet"
+
+let profile = "devnet"

--- a/src/lib/node_config/profiled/dune
+++ b/src/lib/node_config/profiled/dune
@@ -4,4 +4,5 @@
  (libraries comptime core_kernel node_config_intf)
  (instrumentation
   (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (preprocess
+  (pps ppx_version)))

--- a/src/lib/node_config/profiled/lightnet.ml
+++ b/src/lib/node_config/profiled/lightnet.ml
@@ -44,6 +44,8 @@ let block_window_duration = 20000
 
 let network = "testnet"
 
+let profile = "lightnet"
+
 let compaction_interval = Some (2 * block_window_duration)
 
 let vrf_poll_interval = 5000

--- a/src/lib/node_config/profiled/mainnet.ml
+++ b/src/lib/node_config/profiled/mainnet.ml
@@ -44,6 +44,8 @@ let block_window_duration = 180000
 
 let network = "mainnet"
 
+let profile = "mainnet"
+
 let compaction_interval = Some (2 * block_window_duration)
 
 let vrf_poll_interval = 5000


### PR DESCRIPTION
Will be used in future PRs to filter on the profile name, for instance to get circuit dependent values.