### PR TITLE
Reduce root history size from 2k to k+10

### DIFF
--- a/changes/18311.md
+++ b/changes/18311.md
@@ -1,0 +1,3 @@
+Change root history size from 2*k to k+10. The network will maintain its ability
+to satisfy catchup requests with this root size, and node memory usage should
+improve slightly with this change.

--- a/src/lib/transition_frontier/extensions/root_history.ml
+++ b/src/lib/transition_frontier/extensions/root_history.ml
@@ -17,7 +17,7 @@ module T = struct
   let name = "root_registry"
 
   let create ~logger:_ frontier =
-    let capacity = Full_frontier.max_length frontier in
+    let capacity = Full_frontier.max_length frontier + 10 in
     let history = Queue.create () in
     let current_root =
       Root_data.Historical.of_breadcrumb (Full_frontier.root frontier)


### PR DESCRIPTION
## Explain your changes

The root history size has been changed from `2 * k` to `k+10`. The `k` here is the depth of finality (`k = 290` on mainnet), which is accessed in this part of the code as the `Full_frontier.max_length`.

The motivation is improving the memory usage of the daemon - we anticipate that the improvements will be (counterfactually) greater after Mesa.

## Explain how you tested your changes

Currently untested, aside from the existing CI tests.

## Context

The `Root_history` in a daemon records block data for roots at a depth greater than `k = 290`; when the daemon transitions to a new root, it will add the old root's information as a `Root_data.Historical.t` entry in the root history queue. This information is used in a few ways:

1. The `Get_staged_ledger_aux_and_pending_coinbases_at_hash` RPC query is used at bootstrap, right after downloading a root snarked ledger from the network, to get the scan state and other protocol data for the frontier root. A daemon fulfilling this request will look through the frontier and the root history to find this data.
2. The `Get_transition_chain_proof` RPC query is used in super catchup, to figure out what blocks need to be downloaded to connect a point in the daemon's current frontier to a target consensus state
3. The `Get_transition_chain` RPC query is also used in super catchup, to download a batch of full block data
4. The trust system uses the root history to score gossiped blocks. There is a trust score decrease if a peer sends a block that is known to be outdated or useless (i.e., it or its parent are in the frontier history), though that doesn't matter in practice with the trust score system being disabled. However, if the gossiped block or its parent is not found in the history, then the daemon says the block comes from a `Disconnected_chain`, which is an `Insta_ban`. That penalty does actually do something - it causes the daemon to drop that peer entirely.

The root history seems to exist to give nodes time to catch up to the network, since they catch up at the same time as their peers are transitioning to new roots. Without some amount of buffer, the daemon would have a fairly strict limit on the amount of time an individual catchup transition can take.