### PR TITLE
[Debian Build] remove unused ledgers copy

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -209,15 +209,6 @@ copy_common_daemon_configs() {
   sed "s%PEERS_LIST_URL_PLACEHOLDER%https://storage.googleapis.com/${3}%" \
     ../scripts/mina.service > "${BUILDDIR}/usr/lib/systemd/user/mina.service"
 
-  # Copy the genesis ledgers and proofs as these are fairly small and very \
-  # valuable to have
-  # Genesis Ledger/proof/epoch ledger Copy
-  for f in /tmp/coda_cache_dir/genesis*; do
-      if [ -e "$f" ]; then
-          mv /tmp/coda_cache_dir/genesis* "${BUILDDIR}/var/lib/coda/."
-      fi
-  done
-
   # Support bash completion
   # NOTE: We do not list bash-completion as a required package,
   #       but it needs to be present for this to be effective


### PR DESCRIPTION
Removing unused ledger copy operation when building debian.

I checked on one of builds that debian does not contain any ledger afterwards and location is empty all the time:

https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/969#019ba048-cb97-493c-97eb-6a3725c05209/L133