### PR TITLE
Fix unused variable warnings in composition_types.ml

### DIFF
--- a/src/lib/crypto/pickles/composition_types/composition_types.ml
+++ b/src/lib/crypto/pickles/composition_types/composition_types.ml
@@ -89,6 +89,12 @@ module Wrap = struct
         open Pickles_types
 
         module In_circuit = struct
+          [@@@warning "-27"]
+
+          (* 'fp_opt is unused but kept for type compatibility with other
+             In_circuit types. We suppress the warning instead of using a
+             phantom type to preserve the serialization format. *)
+
           (** All scalar values deferred by a verifier circuit.
               We expose them so the next guy (who can do scalar arithmetic) can check that they
               were computed correctly from the evaluations in the proof and the challenges.
@@ -239,9 +245,14 @@ module Wrap = struct
       [@@deriving sexp, compare, yojson, hlist, hash, equal]
 
       module Minimal = struct
+        [@@@warning "-27"]
+
         [%%versioned
         module Stable = struct
           module V1 = struct
+            (* 'fp is unused in Minimal but kept for type compatibility with
+               In_circuit. We suppress the warning instead of using a phantom
+               type to preserve the serialization format. *)
             type ( 'challenge
                  , 'scalar_challenge
                  , 'fp
@@ -732,7 +743,7 @@ module Wrap = struct
 
       (** A layout of the raw data in a statement, which is needed for
           representing it inside the circuit. *)
-      let spec impl lookup feature_flags =
+      let spec _impl lookup feature_flags =
         let feature_flags_spec =
           let [ f1; f2; f3; f4; f5; f6; f7; f8 ] =
             (* Ensure that layout is the same *)


### PR DESCRIPTION
Suppress Warning 27 (unused-var-strict) for phantom type parameters in Plonk.In_circuit and Deferred_values.Minimal types.

The 'fp and 'fp_opt type parameters are unused in these types but are kept for type compatibility with other variants (e.g., In_circuit vs Minimal). We suppress the warning instead of using a phantom type to preserve the serialization format.

Also prefix unused function parameter 'impl' with underscore.
