### PR TITLE
Do not install yarn on toolchain

### DIFF
--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -8,6 +8,7 @@ ARG DOCKER_VERSION=28.3.1
 ARG DEBS3_VERSION=0.11.7
 ARG INFLUXDB_CLI_VERSION=2.7.5
 ARG HADOLINT_VERSION=2.12.0
+ARG GCLOUD_VERSION=476.0.0
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG BUILDPLATFORM
@@ -68,12 +69,22 @@ RUN curl -sL https://download.docker.com/linux/static/stable/${CANONICAL_ARCH}/d
     | tar --extract --gzip --strip-components 1 --directory=/usr/bin --file=-
 
 # --- Google Cloud tools
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
-    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-    gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
-    && apt-get update -y && apt-get install --no-install-recommends -y google-cloud-sdk kubectl \
-    && rm -rf /var/lib/apt/lists/*
+RUN case "${DEBIAN_ARCH}" in \
+        "amd64")  GCLOUD_ARCH="x86_64" ;; \
+        "arm64")  GCLOUD_ARCH="arm" ;; \
+        *)        echo "Unsupported architecture: ${DEBIAN_ARCH}"; exit 1 ;; \
+    esac && \
+    # Download the specific tarball
+    curl -sSfL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz" | \
+    tar -xz -C /opt/ && \
+    # Run the install script (includes bundled python support)
+    /opt/google-cloud-sdk/install.sh --quiet && \
+    # Install kubectl via gcloud (this ensures the binary matches the arch)
+    /opt/google-cloud-sdk/bin/gcloud components install kubectl --quiet && \
+    # Clean up
+    rm gcloud.tar.gz
+
+ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 


### PR DESCRIPTION
As title. This is to fix the below issue
```
darek@darek-o1labs:~/work/minaprotocol/mina$ docker run -it --entrypoint bash gcr.io/o1labs-192920/mina-toolchain@sha256:aa79d803512e2c7d7f3944a4658eec2280383df4db64be921393d93abf3782fc
opam@6c8874f324b4:~/mina$ apt-get update
Reading package lists... Done
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
opam@6c8874f324b4:~/mina$ sudo apt-get update
Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]                                                                                  
Get:3 https://deb.nodesource.com/node_24.x nodistro InRelease [12.1 kB]                   
Get:4 https://dl.yarnpkg.com/debian stable InRelease                                      
Get:5 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]                   
Get:6 https://packages.cloud.google.com/apt cloud-sdk InRelease [1620 B]
Get:7 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
Err:4 https://dl.yarnpkg.com/debian stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
Get:8 https://deb.nodesource.com/node_24.x nodistro/main amd64 Packages [5264 B]
Get:9 https://packages.cloud.google.com/apt cloud-sdk/main all Packages [1923 kB]
Get:10 https://packages.cloud.google.com/apt cloud-sdk/main amd64 Packages [4451 kB]
Get:11 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [443 kB]
Get:12 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]        
Reading package lists... Done                                                                
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

Status: exprimenting on https://github.com/MinaProtocol/mina/pull/18390