### PR TITLE
Add pad-state for mesa

### DIFF
--- a/scripts/hardfork/build-packages.sh
+++ b/scripts/hardfork/build-packages.sh
@@ -57,7 +57,7 @@ gunzip config.json.gz
 
 echo "--- Generate hardfork ledger tarballs"
 mkdir hardfork_ledgers
-_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file config.json --genesis-dir hardfork_ledgers/ --hash-output-file hardfork_ledger_hashes.json | tee runtime_genesis_ledger.log | _build/default/src/app/logproc/logproc.exe
+_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --pad-app-state --config-file config.json --genesis-dir hardfork_ledgers/ --hash-output-file hardfork_ledger_hashes.json | tee runtime_genesis_ledger.log | _build/default/src/app/logproc/logproc.exe
 
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON=config.json LEDGER_HASHES_JSON=hardfork_ledger_hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json

--- a/scripts/hardfork/mina-verify-packaged-fork-config
+++ b/scripts/hardfork/mina-verify-packaged-fork-config
@@ -185,7 +185,7 @@ if [ "$result" != "true" ]; then
     exit 1
 fi
 
-"$MINA_GENESIS_EXE" --config-file "$FORK_CONFIG" --genesis-dir "$WORKDIR/ledgers" --hash-output-file "$WORKDIR/hashes.json"
+"$MINA_GENESIS_EXE" --pad-app-state --config-file "$FORK_CONFIG" --genesis-dir "$WORKDIR/ledgers" --hash-output-file "$WORKDIR/hashes.json"
 
 FORK_CONFIG_JSON="$FORK_CONFIG" \
 LEDGER_HASHES_JSON="$WORKDIR/hashes.json" \


### PR DESCRIPTION
Post mortem fixes for mesa hardfork creation. On one of the dryrun we experienced invalid vector length error. It appears we need to add --pad-state argument when creating ledger