### PR TITLE
[HF Pipeline Improv] 8/7 Explicitly require mina daemon config installation

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -199,6 +199,7 @@ let docker_step
                     , if_ = spec.if_
                     }
                   ]
+                , DaemonConfig = [] : List DockerImage.ReleaseSpec.Type
                 , DaemonAutoHardfork =
                   [ DockerImage.ReleaseSpec::{
                     , deps =

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -15,6 +15,7 @@ let Artifact
     = < Daemon
       | DaemonLegacyHardfork
       | DaemonAutoHardfork
+      | DaemonConfig
       | LogProc
       | Archive
       | TestExecutive
@@ -31,6 +32,7 @@ let AllButTests =
       [ Artifact.Daemon
       , Artifact.DaemonLegacyHardfork
       , Artifact.DaemonAutoHardfork
+      , Artifact.DaemonConfig
       , Artifact.LogProc
       , Artifact.Archive
       , Artifact.BatchTxn
@@ -43,7 +45,12 @@ let AllButTests =
       ]
 
 let Main =
-      [ Artifact.Daemon, Artifact.LogProc, Artifact.Archive, Artifact.Rosetta ]
+      [ Artifact.Daemon
+      , Artifact.DaemonConfig
+      , Artifact.LogProc
+      , Artifact.Archive
+      , Artifact.Rosetta
+      ]
 
 let All = AllButTests # [ Artifact.FunctionalTestSuite ]
 
@@ -53,6 +60,7 @@ let capitalName =
             { Daemon = "Daemon"
             , DaemonLegacyHardfork = "DaemonLegacyHardfork"
             , DaemonAutoHardfork = "DaemonAutoHardfork"
+            , DaemonConfig = "DaemonConfig"
             , LogProc = "LogProc"
             , Archive = "Archive"
             , TestExecutive = "TestExecutive"
@@ -72,6 +80,7 @@ let lowerName =
             { Daemon = "daemon"
             , DaemonLegacyHardfork = "daemon_hardfork"
             , DaemonAutoHardfork = "daemon_auto_hardfork"
+            , DaemonConfig = "daemon_config"
             , LogProc = "logproc"
             , Archive = "archive"
             , TestExecutive = "test_executive"
@@ -101,6 +110,7 @@ let dockerName =
             , Toolchain = "mina-toolchain"
             , CreateLegacyGenesis = "mina-create-legacy-genesis"
             , DelegationVerifier = "mina-delegation-verifier"
+            , DaemonConfig = ""
             }
             artifact
 
@@ -131,6 +141,7 @@ let toDebianName =
             , Toolchain = ""
             , DelegationVerifier = "delegation_verifier"
             , CreateLegacyGenesis = "create_legacy_genesis"
+            , DaemonConfig = "daemon_${Network.lowerName network}_config"
             }
             artifact
 
@@ -143,27 +154,10 @@ let toDebianNames =
                   (List Text)
                   (     \(a : Artifact)
                     ->  merge
-                          { Daemon =
-                              merge
-                                { Devnet =
-                                  [ toDebianName a network
-                                  , "daemon_${Network.lowerName network}_config"
-                                  ]
-                                , Mainnet =
-                                  [ toDebianName a network
-                                  , "daemon_${Network.lowerName network}_config"
-                                  ]
-                                , TestnetGeneric = [ toDebianName a network ]
-                                , DevnetLegacy = [ toDebianName a network ]
-                                , MainnetLegacy = [ toDebianName a network ]
-                                , PreMesa1 = [ toDebianName a network ]
-                                }
-                                network
-                          , DaemonLegacyHardfork =
-                            [ toDebianName a network
-                            , toDebianName Artifact.Daemon network
-                            ]
+                          { Daemon = [ toDebianName a network ]
+                          , DaemonLegacyHardfork = [ toDebianName a network ]
                           , DaemonAutoHardfork = [ toDebianName a network ]
+                          , DaemonConfig = [ toDebianName a network ]
                           , Archive = [ toDebianName a network ]
                           , LogProc = [ "logproc" ]
                           , TestExecutive = [ "test_executive" ]
@@ -246,6 +240,7 @@ let dockerTag =
                 , Toolchain = "${spec.version}"
                 , DelegationVerifier = "${spec.version}"
                 , CreateLegacyGenesis = "${spec.version}"
+                , DaemonConfig = "${spec.version}"
                 }
                 spec.artifact
 

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -8,6 +8,7 @@ let isEssential =
           \(service : Artifacts.Type)
       ->  merge
             { Daemon = True
+            , DaemonConfig = False
             , LogProc = False
             , Archive = True
             , TestExecutive = False

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
@@ -17,6 +17,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnetArm64.dhall
@@ -20,6 +20,7 @@ in  Pipeline.build
           , artifacts =
             [ Artifacts.Type.LogProc
             , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
@@ -17,7 +17,11 @@ let Profiles = ../../Constants/Profiles.dhall
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts = [ Artifacts.Type.LogProc, Artifacts.Type.Daemon ]
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            ]
           , network = Network.Type.Devnet
           , profile = Profiles.Type.Lightnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
@@ -19,7 +19,11 @@ let Profiles = ../../Constants/Profiles.dhall
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts = [ Artifacts.Type.LogProc, Artifacts.Type.Daemon ]
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            ]
           , network = Network.Type.Devnet
           , arch = Arch.Type.Arm64
           , profile = Profiles.Type.Lightnet

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnetArm64.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
@@ -13,6 +13,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
@@ -18,6 +18,7 @@ in  Pipeline.build
           , artifacts =
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
@@ -18,6 +18,7 @@ in  Pipeline.build
           , artifacts =
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -20,6 +20,7 @@ in  Pipeline.build
           , artifacts =
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
@@ -17,6 +17,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
@@ -17,6 +17,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnetArm64.dhall
@@ -20,6 +20,7 @@ in  Pipeline.build
           , artifacts =
             [ Artifacts.Type.LogProc
             , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
@@ -17,7 +17,11 @@ let Profiles = ../../Constants/Profiles.dhall
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts = [ Artifacts.Type.LogProc, Artifacts.Type.Daemon ]
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            ]
           , network = Network.Type.Devnet
           , profile = Profiles.Type.Lightnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnetArm64.dhall
@@ -19,7 +19,11 @@ let Profiles = ../../Constants/Profiles.dhall
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
-          , artifacts = [ Artifacts.Type.LogProc, Artifacts.Type.Daemon ]
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            ]
           , network = Network.Type.Devnet
           , arch = Arch.Type.Arm64
           , profile = Profiles.Type.Lightnet

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnetArm64.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseyeTestnetGenericDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseyeTestnetGenericDevnet.dhall
@@ -13,6 +13,7 @@ in  Pipeline.build
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.BatchTxn

--- a/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
@@ -24,8 +24,6 @@ in  Pipeline.build
               ( S.contains
                   "buildkite/scripts/tests/convert-debian-to-hf-test.sh"
               )
-          , S.strictlyStart
-              (S.contains "scripts/hardfork/convert-daemon-debian-to-hf.sh")
           , S.strictlyStart (S.contains "scripts/debian/session")
           ]
         , path = "Test"


### PR DESCRIPTION
After we merged config split for daemon, there is an open possibility to prebuild apps for hardfork before hf day and on that day just generate config with tarballs and upload.

Previously, this intend was hidden and config was implicitly installed on mina daemon. This is no longer through as for hardfork we want to build mina-daemon without dependency in form of config. Instead of doing some tricks in inner layer of dhall i decided that the most clean way would be to add explicit Artifact for config and then use it in release job which should have id. Contrary to Hardfork pacakge or legacy package or other configuration require such config. 

I'm aware that not everyone is keen on pushing another config change to the top job definition but let's keep it simple stupid. 