### PR TITLE
add missing folder creation for delegation verify debian

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -944,6 +944,8 @@ build_delegation_verify_deb () {
     "${SHARED_DEPS}${DAEMON_DEPS}" \
     'Utility to verify delegation in Mina GraphQL format'
 
+  mkdir -p "${BUILDDIR}/usr/local/bin"
+
   # Binaries
   cp ./default/src/app/delegation_verify/delegation_verify.exe \
     "${BUILDDIR}/usr/local/bin/mina-delegation-verify"


### PR DESCRIPTION
Resolves https://github.com/MinaProtocol/mina/issues/18409. Added missing folder creation for delegation verify app. On my defence, This is test is run only on mainline nightly for bookworm arm64 so it was hard to caught it on standard nightly run 