### PR TITLE
Set add genesis ledger winner explicitly in rosetta integration test, remove duplicate test lines

### DIFF
--- a/buildkite/scripts/tests/rosetta-integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta-integration-tests.sh
@@ -295,8 +295,6 @@ while [[ ${current_block_height} -lt 11 ]]; do
 done
 
 echo "========================= ROSETTA CLI: CHECK:DATA ==========================="
-
-echo "========================= ROSETTA CLI: CHECK:DATA ==========================="
 rosetta-cli check:data --configuration-file ${ROSETTA_CONFIGURATION_FILE}
 
 echo "========================= ROSETTA CLI: CHECK:PERF ==========================="


### PR DESCRIPTION
This PR primarily fixes a failure in this test caused by a race condition involving the archive and daemon disagreeing about the identity of the test genesis ledger, and thus the genesis block. Setting add_genesis_winner to true preserves the current test behaviour and guarantees a stable layout of the genesis ledger regardless of compiled proof level.

I also noticed that there was a duplicate key in the genesis ledger in the test, and a duplicate `echo` line. I've removed these as well. The duplicate key in the genesis ledger doesn't cause a failure in this particular test, but it does lead to a mismatch between the real genesis ledger and the archive's record of it. I don't think this is a problem in practice with our mainnet/devnet ledgers (I don't believe they have duplicates) but I'm going to make a note to look into that more.

--------

For context, if the genesis ledger is given as an inline list of accounts and the proof level is above none, the genesis ledger initialization code will default to adding a special genesis winner account to the head of the ledger, if the head isn't already this genesis winner account. Otherwise, the default will be to not add this account. Importantly, once this decision has been made the daemon will create a "named" ledger tar file in the coda cache directory. ~The name of this file does not depend on the genesis ledger hash, or even proof level, and it will be reused on subsequent daemon runs with the same consensus config.~ (EDIT - looking back on this - the file name *does* take into account the hash of the accounts, but it's the `Blake2.digest` of just the accounts in the config file! This is why there's a name collision - the loading code inserts the genesis winner in a different place).

The mina daemon in this test is run with --proof-level none and add_genesis_winner was not previously set in the config, so the daemon would not add the genesis winner to its ledger. The mina-archive has no proof level command line flag, so it would use its compiled default. This is full in our current CI setup. Thus the archive would add the genesis winner to the ledger in this test.

The daemon and archive would typically agree on the genesis ledger layout, because one of them would have cached the ledger tar file before the other checked to see if the tar file existed. It was not guaranteed which ledger (with genesis winner or without) would be used, but they would at least agree. The test would succeed if this happens.

In rare cases, the daemon and the archive would start up in such a way that the cached genesis ledger database tar file would be absent when they looked for it. When this happens, the archive would insert what it thought the genesis block was into the database, and mark it canonical automatically. The daemon, meanwhile, would send what it thought the genesis block was to the archive. The archive would insert it as canonical as well. The existence of two canonical blocks at the same height in the archive database caused the /block endpoint query (and thus the test) to fail for this block height.

Setting add_genesis_ledger to true in the config file avoids the potential for disagreement about the genesis ledger entirely, and so eliminates this race condition.
