### PR TITLE
FIX hf test by adding gawk to nix env

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -47,7 +47,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ -n "${BUILDKITE:-}" ]; then
   # This is a CI run, ensure nix docker has everything what we want.
-  nix-env -iA unstable.{curl,git-lfs,gnused,jq,python311}
+  nix-env -iA unstable.{curl,gawk,git-lfs,gnused,jq,python311}
 
   python -m venv .venv
   source .venv/bin/activate


### PR DESCRIPTION
When extending mina-local-network, I've added awk to have nicer messages printed to console, but forgot to port the corresponding commit that adds gawk to nix's environment. This PR attempts to fix the bug I've introduced.

We might want to port this to, say `develop`, `mesa` and `ci_for_mesa` as well.