### PR TITLE
[CI][Fix] install missing python on archive docker 

### DIFF
--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -54,6 +54,7 @@ RUN apt-get update --quiet --yes \
         apt-transport-https \
         dnsutils \
         tzdata \
+        python3 \
         postgresql \
         postgresql-contrib \
         apt-utils \


### PR DESCRIPTION
Fix nightly by installing missing python in archive docker.

Example of failing build: https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1059#019c3e14-a952-4950-bc7a-6c1a6f43555f