### PR TITLE
[CI][FIx] Soft Fail release manager tests

### DIFF
--- a/buildkite/src/Jobs/Test/ReleaseManagerTest.dhall
+++ b/buildkite/src/Jobs/Test/ReleaseManagerTest.dhall
@@ -1,5 +1,7 @@
 let S = ../../Lib/SelectFiles.dhall
 
+let B = ../../External/Buildkite.dhall
+
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
@@ -13,6 +15,8 @@ let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
 let Cmd = ../../Lib/Cmds.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 let command_key = "release-manager-tests"
 
@@ -47,6 +51,7 @@ in  Pipeline.build
             , key = command_key
             , target = Size.Small
             , docker = None Docker.Type
+            , soft_fail = Some (B/SoftFail.Boolean True)
             , artifact_paths = [ S.contains "*.log" ]
             }
         ]


### PR DESCRIPTION
Release manager tests are failing due to lock condition on aws (some test cases are pushing into test repository located on aws) :

https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1063#019c4126-503e-4be6-8722-5d0272791b2b

The reason is that test is running too often and starts to look himself out 
Solution is to split test into part which does not interact with AWS and the one which is testing E2E. However, there biggest priority is to softfail the test so CI is green

