### PR TITLE
[CI] do not build mainnet signatures for devnet

### DIFF
--- a/buildkite/src/Constants/Network.dhall
+++ b/buildkite/src/Constants/Network.dhall
@@ -51,7 +51,7 @@ let debianSuffix =
 let requiresMainnetBuild =
           \(network : Network)
       ->  merge
-            { Devnet = True
+            { Devnet = False
             , Mainnet = True
             , TestnetGeneric = True
             , DevnetLegacy = True


### PR DESCRIPTION
as title. This issue slip through review some time ago. We definitely don't need mainnet signatures to be build when devnet network is required