### PR TITLE
mina local network: Give some money to online whales

### DIFF
--- a/scripts/mina-local-network/generate-mina-local-network-ledger.py
+++ b/scripts/mina-local-network/generate-mina-local-network-ledger.py
@@ -384,7 +384,8 @@ def generate_ledger(generate_remainder,
             .format(num_whale_accounts,
                     len(ledger_public_keys["online_whale_keys"])))
 
-    whale_offline_balance = 66000 * 175 * (10**9)
+    whale_offline_balance = encode_nanominas(66000 * 175 * (10**9))
+    whale_online_balance = encode_nanominas(499 * (10**9))
 
     # Whale Accounts
     for index, offline_whale in enumerate(
@@ -396,14 +397,14 @@ def generate_ledger(generate_remainder,
                 "sk":
                 None,
                 "balance":
-                encode_nanominas(whale_offline_balance),
+                whale_offline_balance,
                 "delegate":
                 ledger_public_keys["online_whale_keys"][index]
             })
             ledger.append({
                 "pk": ledger_public_keys["online_whale_keys"][index],
                 "sk": None,
-                "balance": encode_nanominas(0),
+                "balance": whale_online_balance,
                 "delegate": None
             })
 
@@ -413,7 +414,7 @@ def generate_ledger(generate_remainder,
                 "sk":
                 None,
                 "balance":
-                encode_nanominas(whale_offline_balance),
+                whale_offline_balance,
                 "delegate":
                 ledger_public_keys["online_whale_keys"][index],
                 "delegate_discord_username":
@@ -425,7 +426,7 @@ def generate_ledger(generate_remainder,
                 "sk":
                 None,
                 "balance":
-                encode_nanominas(0),
+                whale_online_balance,
                 "delegate":
                 None,
                 "discord_username":


### PR DESCRIPTION
We're seeing this error:

```
2026-02-10 16:50:06 CST
	Public key: B62qrYZbq9ck7VfN3YS1rm68S962jLoAENcaiFBPtG3cs5WZo144XUZ
2026-02-10 16:50:28 CST
	[whale_1] 2026-02-10 08:50:28 UTC [Error] Rejecting command because: [ "Insufficient_funds" ]
2026-02-10 16:50:28 CST
	[whale_1]
2026-02-10 16:50:28 CST
	❌ Error: Couldn't send user command: ["Insufficient_funds"] (in ["sendPayment"])
```

in [this HF test run](https://buildkite.com/organizations/o-1-labs-2/pipelines/mina-single-job/builds/14/jobs/019c46af-7c92-4b22-ba12-3b238bbf40c2/log)

It doesn't fail the test, but it does imply we're not being able to send money whenever a whale is selected at random to send payments.

Hence in this PR we gave online whales some money, so that when it's selected as payment cmd generator it won't just fail. 

--------

To test this work indeed, we can build the node with profile devnet, and run below commands:

```
./scripts/mina-local-network/mina-local-network.sh \
                              --seed spawn:3100 \
                              --whales 1 \
                              --fish 0 \
                              --nodes 0 \
                              --log-level Error \
                              --file-log-level Trace \
                              --config reset \
                              --transaction-interval 15 \
                              --override-slot-time 30000 \
                              --value-transfer-txns
```