### PR TITLE
[local network] don't let whale/fish/plain wait snark coord

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -1055,35 +1055,19 @@ printf "$SEED_PEER_ID" > "${ROOT}/seed_peer_id.txt"
 
 #---------- Starting snark coordinator
 
-if [ "${SNARK_WORKERS_COUNT}" -eq "0" ]; then
-  echo "Skipping snark coordinator because SNARK_WORKERS_COUNT is 0"
-  SNARK_COORDINATOR_PID=""
 
-elif [[ -z "${SNARK_COORDINATOR_PORT}" ]]; then
+if [[ -z "${SNARK_COORDINATOR_PORT}" ]]; then
   echo "Skipping snark coordinator because no SNARK_COORDINATOR_PORT is provided"
-  SNARK_COORDINATOR_PID=""
-else
+elif [ "${SNARK_WORKERS_COUNT}" -eq "0" ]; then
+  echo "Skipping snark coordinator because SNARK_WORKERS_COUNT is 0"
+  SNARK_COORDINATOR_PORT=""
+fi
 
+if [[ -n "${SNARK_COORDINATOR_PORT}" ]]; then
   SNARK_COORDINATOR_FLAGS="-snark-worker-fee ${SNARK_WORKER_FEE} -run-snark-coordinator ${SNARK_COORDINATOR_PUBKEY} -work-selection seq"
   spawn-daemon snark_coordinator "${NODES_FOLDER}"/snark_coordinator "${SNARK_COORDINATOR_PORT}" -peer ${SEED_PEER_ID} -libp2p-keypair ${SNARK_COORDINATOR_PEER_KEY} ${SNARK_COORDINATOR_FLAGS}
   SNARK_COORDINATOR_PID=$!
-
-  echo 'Waiting for snark coordinator to go up...'
-  printf "\n"
-
-  until ${MINA_EXE} client status -daemon-port "${SNARK_COORDINATOR_PORT}" &>/dev/null; do
-    sleep ${POLL_INTERVAL}
-  done
 fi
-
-#---------- Starting snark workers
-
-for ((i = 0; i < SNARK_WORKERS_COUNT; i++)); do
-  FOLDER=${NODES_FOLDER}/snark_workers/worker_${i}
-  mkdir -p "${FOLDER}"
-  spawn-snark-worker "snark_worker_${i}" "${FOLDER}" "${SNARK_COORDINATOR_PORT}"
-  SNARK_WORKERS_PIDS[${i}]=$!
-done
 
 # ----------
 
@@ -1116,6 +1100,25 @@ for ((i = 0; i < NODES; i++)); do
     -libp2p-keypair "${ROOT}"/libp2p_keys/node_${i} "${ARCHIVE_ADDRESS_CLI_ARG}"
   NODE_PIDS[${i}]=$!
 done
+
+#---------- Starting snark workers
+
+
+if [[ -n "${SNARK_COORDINATOR_PORT}" ]]; then
+  echo 'Waiting for snark coordinator to go up before spawning snark workers...'
+  printf "\n"
+
+  until ${MINA_EXE} client status -daemon-port "${SNARK_COORDINATOR_PORT}" &>/dev/null; do
+    sleep ${POLL_INTERVAL}
+  done
+
+  for ((i = 0; i < SNARK_WORKERS_COUNT; i++)); do
+    FOLDER=${NODES_FOLDER}/snark_workers/worker_${i}
+    mkdir -p "${FOLDER}"
+    spawn-snark-worker "snark_worker_${i}" "${FOLDER}" "${SNARK_COORDINATOR_PORT}"
+    SNARK_WORKERS_PIDS[${i}]=$!
+  done
+fi
 
 # ================================================
 


### PR DESCRIPTION
As title. Only snark workers would require snark coordinators to be functional. However snark workers are configured so it'll never exit on its own, and as a result we'd be fine leaving snark workers not able to connect to coordinators for a while.

To test this work indeed:
```
./scripts/mina-local-network/mina-local-network.sh \
                        --seed spawn:3100 \
                        --whales 1 \
                        --fish 0 \
                        --nodes 0 \
                        --log-level Error \
                        --file-log-level Trace \
                        --config reset \
                        --transaction-interval 15 \
                        --override-slot-time 30000 \
                        --value-transfer-txns
```

We'll still get error of insufficient fund, but that should be fixed by https://github.com/MinaProtocol/mina/pull/18465 and it's only softfailing tests.