### PR TITLE
upload tarball ledger after tarball generation

### DIFF
--- a/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
+++ b/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
@@ -63,6 +63,8 @@ echo "--- Generating ledger tarballs for hardfork network: $NETWORK_NAME"
 
 ./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh --network "$NETWORK_NAME" --config-url "$CONFIG_JSON_GZ_URL" --runtime-ledger mina-create-genesis --logproc mina-logproc
 
+./scripts/hardfork/release/upload-ledger-tarballs.sh hardfork_ledgers new_config.json
+
 # Write to cache
 ./buildkite/scripts/cache/manager.sh write-to-dir hardfork_ledgers/*.tar.gz hardfork/ledgers/
 ./buildkite/scripts/cache/manager.sh write-to-dir hashes.json new_config.json hardfork/


### PR DESCRIPTION
Added operation to upload ledger tarballs to aws in generation tarballs script since upload can alter genesis config if ledger is already at s3 bucket and we don't need to upload it just change config hashes