### PR TITLE
Run no fish in hardfork test

### DIFF
--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -76,7 +76,7 @@ func DefaultConfig() *Config {
 		MainDelayMin:                  7,
 		HfSlotDelta:                   30, // if this is too small and fork network is spawned after fork genesis, it'll fail to create any block
 		NumWhales:                     2,
-		NumFish:                       1,
+		NumFish:                       0,
 		NumNodes:                      0,
 		PaymentInterval:               20,
 		ShutdownTimeoutMinutes:        10,


### PR DESCRIPTION
As title. This is only possible because we merged https://github.com/MinaProtocol/mina/pull/18416