### PR TITLE
Testing out improved zkapp integration test failure messages

### DIFF
--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -104,6 +104,21 @@ module Block = struct
   let get_height (module Conn : Mina_caqti.CONNECTION) ~block_id =
     Conn.find get_height_query block_id
 
+  let get_height_by_state_hash_query =
+    Mina_caqti.find_req Caqti_type.string Caqti_type.int64
+      {sql| SELECT height FROM blocks WHERE state_hash = $1 |sql}
+
+  let get_height_by_state_hash (module Conn : Mina_caqti.CONNECTION) state_hash
+      =
+    Conn.find get_height_by_state_hash_query state_hash
+
+  let get_state_hashes_by_height_query =
+    Mina_caqti.collect_req Caqti_type.int64 Caqti_type.string
+      {sql| SELECT state_hash FROM blocks WHERE height = $1 |sql}
+
+  let get_state_hashes_by_height (module Conn : Mina_caqti.CONNECTION) height =
+    Conn.collect_list get_state_hashes_by_height_query height
+
   let max_slot_query =
     Mina_caqti.find_req Caqti_type.unit Caqti_type.int64
       {sql| SELECT MAX(global_slot_since_genesis) FROM blocks |sql}


### PR DESCRIPTION
- The replayer will now gather and print information related to the chain it has constructed when trying to replay from genesis.