### PR TITLE
HF test go: bump up delta between slot tx end and chain end to allow …

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -161,7 +161,7 @@ nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#hardfork_test" --out-link "hardfor
 # 5. Execute hardfork_test on them.
 
 SLOT_TX_END=${SLOT_TX_END:-$((RANDOM%120+30))}      
-SLOT_CHAIN_END=${SLOT_CHAIN_END:-$((SLOT_TX_END+8))}
+SLOT_CHAIN_END=${SLOT_CHAIN_END:-$((SLOT_TX_END+16))}
 
 NETWORK_ROOT=$(mktemp -d --tmpdir hardfork-network.XXXXXXX)
 


### PR DESCRIPTION
…more grace period for consensus

This is intended to fix the failing mainline CI runs on HF test
