### PR TITLE
extend rocksdb_scanner to support recovering DB from a text file

### DIFF
--- a/scripts/hardfork/mina-verify-packaged-fork-config
+++ b/scripts/hardfork/mina-verify-packaged-fork-config
@@ -364,7 +364,7 @@ if checks_contains tarballs; then
 
         declare -A scanner_pids
         for kind in packaged web generated; do
-            $MINA_ROCKSDB_SCANNER --db-path "$tardir/$kind" --output-file "$WORKDIR/$kind.scan" &
+            $MINA_ROCKSDB_SCANNER dump --db-path "$tardir/$kind" --output-file "$WORKDIR/$kind.scan" &
             scanner_pids[$kind]=$!
         done
 

--- a/src/app/rocksdb-scanner/rocksdb_scanner.ml
+++ b/src/app/rocksdb-scanner/rocksdb_scanner.ml
@@ -1,38 +1,90 @@
 open Core
 open Async
 
-(* RocksDB scanning function that replaces ldb command *)
-let scan_rocksdb_to_and_dump_hex_kvs db_path output_file =
-  let db = Rocksdb.Database.create db_path in
-  let kv_pairs = Rocksdb.Database.to_alist db in
-  let%bind writer = Writer.open_file output_file in
-  List.iter kv_pairs ~f:(fun (key, value) ->
-      let key_hex =
-        Bigstring.to_string key
-        |> String.concat_map ~f:(fun c -> sprintf "%02x" (Char.to_int c))
-      in
-      let value_hex =
-        Bigstring.to_string value
-        |> String.concat_map ~f:(fun c -> sprintf "%02x" (Char.to_int c))
-      in
-      Writer.writef writer "%s : %s\n" key_hex value_hex ) ;
-  let%map () = Writer.close writer in
-  Rocksdb.Database.close db
+module Hex_util = struct
+  (* Converts Bigstring to hex string *)
+  let to_hex bs =
+    Bigstring.to_string bs
+    |> String.concat_map ~f:(fun c -> sprintf "%02x" (Char.to_int c))
 
-let root_command =
-  Command.async ~summary:"Scan RocksDB and dump key-value pairs as hex strings"
+  (* Converts hex string to Bigstring *)
+  let of_hex hex_str =
+    let hex_str = String.strip hex_str in
+    let len = String.length hex_str in
+    if len % 2 <> 0 then failwithf "Invalid hex string length %d" len () ;
+    let bs = Bigstring.create (len / 2) in
+    for i = 0 to (len / 2) - 1 do
+      let byte_str = String.sub hex_str ~pos:(i * 2) ~len:2 in
+      let byte = Int.of_string ("0x" ^ byte_str) in
+      Bigstring.set_int8_exn bs ~pos:i byte
+    done ;
+    bs
+end
+
+let dump_cmd =
+  Command.async ~summary:"Scan RocksDB and dump KV pairs as hex"
     (let%map_open.Command db_path =
-       flag "--db-path" (required string)
-         ~doc:"PATH address of Rocksdb database"
+       flag "--db-path" (required string) ~doc:"PATH to source RocksDB"
      and output_file =
-       flag "--output-file" (required string)
-         ~doc:"PATH of file to dump scanning result"
+       flag "--output-file" (required string) ~doc:"PATH to output hex file"
      in
      fun () ->
-       let logger = Logger.create () in
-       [%log info] "Scanning RocksDB at %s to output file %s" db_path
-         output_file ;
-       let%map () = scan_rocksdb_to_and_dump_hex_kvs db_path output_file in
-       [%log info] "Successfully dumped data to %s" output_file )
+       let db = Rocksdb.Database.create db_path in
+       let kv_pairs = Rocksdb.Database.to_alist db in
+       let%bind writer = Writer.open_file output_file in
+       List.iter kv_pairs ~f:(fun (k, v) ->
+           Writer.writef writer "%s : %s\n" (Hex_util.to_hex k)
+             (Hex_util.to_hex v) ) ;
+       let%bind () = Writer.close writer in
+       Rocksdb.Database.close db ;
+       printf "Dump complete: %s\n" output_file ;
+       Writer.flushed (Lazy.force Writer.stdout) )
 
-let () = Command.run root_command
+let restore_cmd =
+  Command.async ~summary:"Restore RocksDB from a hex-encoded file"
+    (let%map_open.Command input_file =
+       flag "--input-file" (required string) ~doc:"PATH to hex dump"
+     and db_path =
+       flag "--db-path" (required string) ~doc:"PATH to target RocksDB"
+     in
+     fun () ->
+       let db = Rocksdb.Database.create db_path in
+       let%bind reader = Reader.open_file input_file in
+       let kv_of_line line =
+         Scanf.sscanf line "%s : %s" (fun k_hex v_hex ->
+             let key = Hex_util.of_hex k_hex in
+             let data = Hex_util.of_hex v_hex in
+             (key, data) )
+       in
+       let chunk_size = 256 in
+       let buffer = Queue.create ~capacity:chunk_size () in
+       let process_batch () =
+         Rocksdb.Database.set_batch db ?remove_keys:None
+           ~key_data_pairs:(Queue.to_list buffer) ;
+         Queue.clear buffer
+       in
+       Monitor.protect
+         (fun () ->
+           let%bind () =
+             Reader.lines reader
+             |> Pipe.iter_without_pushback ~f:(fun line ->
+                    try
+                      let kv = kv_of_line line in
+                      Queue.enqueue buffer kv ;
+                      if Queue.length buffer >= chunk_size then process_batch ()
+                    with e ->
+                      failwithf "Can't parse data line `%s` in dump file: %s"
+                        line (Exn.to_string e) () )
+           in
+           if not (Queue.is_empty buffer) then process_batch () ;
+           printf "Restore complete: %s\n" db_path ;
+           Writer.flushed (Lazy.force Writer.stdout) )
+         ~finally:(fun () ->
+           let%map () = Reader.close reader in
+           Rocksdb.Database.close db ) )
+
+let main =
+  Command.group ~summary:"RocksDB Hex Dump/Restore Tool"
+    [ ("dump", dump_cmd); ("restore", restore_cmd) ]
+
+let () = Command.run main


### PR DESCRIPTION
As title. This is needed because we have an non-forward compatible upgrade of RocksDB, and we want to provide utilities for people trying to downgrade their system. 

We'll need to port this to a previous release for this to be acually useful. Also we need to gurantee that the serialization of KVs stored in RocksDB is stable across these release(which is probably true for any releases that doesn't bump the protocol number)