### PR TITLE
Actually kill snark workers on network shutdown

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -400,6 +400,13 @@ spawn-daemon() {
   FOLDER=${2}
   shift 2
 
+  # NOTE:
+  # Process Substitution >(...): This creates a "named pipe" under the hood. 
+  # `exec-daemon` treats it like a file output, but the data is actually being 
+  # piped into the logging functions.
+  # The `&` placement: By putting the & immediately after the exec-daemon 
+  # command (and its redirections), $! specifically tracks that process.
+
   # shellcheck disable=SC2068
   exec-daemon $@ \
     --config-directory "$FOLDER" \


### PR DESCRIPTION
A bug is introduced in e391031877, where killing snark workers will now only kill the stdout tagging command. We fix this by killing the whole pipeline when attempting to kill snark workers