### PR TITLE
Random_oracle: move to Alcotest

### DIFF
--- a/src/lib/crypto/random_oracle/dune
+++ b/src/lib/crypto/random_oracle/dune
@@ -8,16 +8,11 @@
    ppx_version
    ppx_sexp_conv
    ppx_compare
-   ppx_inline_test
-   ppx_assert
    ppx_compare
    ppx_deriving_yojson
    ppx_let))
- (inline_tests
-  (flags -verbose -show-counts))
  (libraries
   ;; opam libraries
-  ppx_inline_test.config
   base
   core_kernel
   sexplib0

--- a/src/lib/crypto/random_oracle/permutation/external/dune
+++ b/src/lib/crypto/random_oracle/permutation/external/dune
@@ -4,12 +4,9 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_inline_test ppx_assert))
- (inline_tests
-  (flags -verbose -show-counts))
+  (pps ppx_version))
  (libraries
   ;; opam libraries
-  ppx_inline_test.config
   base
   core_kernel
   sexplib0

--- a/src/lib/crypto/random_oracle/permutation/external/random_oracle_permutation.ml
+++ b/src/lib/crypto/random_oracle/permutation/external/random_oracle_permutation.ml
@@ -14,16 +14,3 @@ let block_cipher _params (s : Field.t array) =
   Array.iter s ~f:(Kimchi_bindings.FieldVectors.Fp.emplace_back v) ;
   Kimchi_pasta_fp_poseidon.block_cipher params v ;
   Array.init (Array.length s) ~f:(Kimchi_bindings.FieldVectors.Fp.get v)
-
-let%test_unit "check rust implementation of block-cipher" =
-  let params' : Field.t Sponge.Params.t =
-    Kimchi_pasta_basic.poseidon_params_fp
-  in
-  let open Pickles.Impls.Step in
-  let module T = Internal_Basic in
-  Quickcheck.test (Quickcheck.Generator.list_with_length 3 T.Field.gen)
-    ~f:(fun s ->
-      let s () = Array.of_list s in
-      [%test_eq: T.Field.t array]
-        (Ocaml_permutation.block_cipher params' (s ()))
-        (block_cipher params' (s ())) )

--- a/src/lib/crypto/random_oracle/random_oracle.ml
+++ b/src/lib/crypto/random_oracle/random_oracle.ml
@@ -99,29 +99,6 @@ let prefix_to_field (s : string) =
 
 let salt (s : string) = update ~state:initial_state [| prefix_to_field s |]
 
-let%test_unit "iterativeness" =
-  let x1 = Field.random () in
-  let x2 = Field.random () in
-  let x3 = Field.random () in
-  let x4 = Field.random () in
-  let s_full = update ~state:initial_state [| x1; x2; x3; x4 |] in
-  let s_it =
-    update ~state:(update ~state:initial_state [| x1; x2 |]) [| x3; x4 |]
-  in
-  [%test_eq: Field.t array] s_full s_it
-
-let%test_unit "sponge checked-unchecked" =
-  let open Pickles.Impls.Step in
-  let module T = Internal_Basic in
-  let x = T.Field.random () in
-  let y = T.Field.random () in
-  T.Test.test_equal ~equal:T.Field.equal ~sexp_of_t:T.Field.sexp_of_t
-    T.Typ.(field * field)
-    T.Typ.field
-    (fun (x, y) -> make_checked (fun () -> Checked.hash [| x; y |]))
-    (fun (x, y) -> hash [| x; y |])
-    (x, y)
-
 module Legacy = struct
   module Input = Random_oracle_input.Legacy
   module State = State

--- a/src/lib/crypto/random_oracle/test/dune
+++ b/src/lib/crypto/random_oracle/test/dune
@@ -1,0 +1,19 @@
+(tests
+ (names test_random_oracle test_permutation)
+ (flags
+  (:standard -warn-error +a))
+ (preprocess
+  (pps ppx_jane))
+ (package random_oracle)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core_kernel
+  sexplib0
+  ;; local libraries
+  kimchi_backend
+  kimchi_pasta.basic
+  pickles
+  random_oracle
+  random_oracle.permutation
+  sponge))

--- a/src/lib/crypto/random_oracle/test/test_permutation.ml
+++ b/src/lib/crypto/random_oracle/test/test_permutation.ml
@@ -1,0 +1,40 @@
+(** Testing
+    -------
+
+    Component: Random_oracle
+    Subject: Test Rust block-cipher implementation against OCaml reference
+    Invocation: \
+     dune exec \
+      src/lib/crypto/random_oracle/test/test_permutation.exe
+*)
+
+open Core_kernel
+module Ocaml_permutation = Sponge.Poseidon (Pickles.Tick_field_sponge.Inputs)
+
+let field_testable =
+  let open Pickles.Impls.Step.Internal_Basic in
+  Alcotest.testable
+    (fun fmt f -> Format.pp_print_string fmt (Field.to_string f))
+    Field.equal
+
+let state_testable = Alcotest.array field_testable
+
+let test_rust_block_cipher () =
+  let params' : Kimchi_backend.Pasta.Basic.Fp.t Sponge.Params.t =
+    Kimchi_pasta_basic.poseidon_params_fp
+  in
+  let open Pickles.Impls.Step in
+  let module T = Internal_Basic in
+  Quickcheck.test (Quickcheck.Generator.list_with_length 3 T.Field.gen)
+    ~f:(fun s ->
+      let s () = Array.of_list s in
+      Alcotest.check state_testable "block cipher equality"
+        (Ocaml_permutation.block_cipher params' (s ()))
+        (Random_oracle_permutation.block_cipher params' (s ())) )
+
+let () =
+  let open Alcotest in
+  run "Random_oracle_permutation"
+    [ ( "block_cipher"
+      , [ test_case "rust matches ocaml" `Quick test_rust_block_cipher ] )
+    ]

--- a/src/lib/crypto/random_oracle/test/test_random_oracle.ml
+++ b/src/lib/crypto/random_oracle/test/test_random_oracle.ml
@@ -1,0 +1,58 @@
+(** Testing
+    -------
+
+    Component: Random_oracle
+    Subject: Test iterativeness and checked-unchecked consistency
+    Invocation: \
+     dune exec src/lib/crypto/random_oracle/test/test_random_oracle.exe
+*)
+
+let field_testable =
+  let open Pickles.Impls.Step.Internal_Basic in
+  Alcotest.testable
+    (fun fmt f -> Format.pp_print_string fmt (Field.to_string f))
+    Field.equal
+
+let state_testable = Alcotest.array field_testable
+
+let test_iterativeness () =
+  let open Pickles.Impls.Step.Internal_Basic in
+  let x1 = Field.random () in
+  let x2 = Field.random () in
+  let x3 = Field.random () in
+  let x4 = Field.random () in
+  let s_full =
+    Random_oracle.update ~state:Random_oracle.initial_state [| x1; x2; x3; x4 |]
+  in
+  let s_it =
+    Random_oracle.update
+      ~state:
+        (Random_oracle.update ~state:Random_oracle.initial_state [| x1; x2 |])
+      [| x3; x4 |]
+  in
+  Alcotest.check state_testable "state equality"
+    (Random_oracle.State.to_array s_full)
+    (Random_oracle.State.to_array s_it)
+
+let test_sponge_checked_unchecked () =
+  let open Pickles.Impls.Step in
+  let module T = Internal_Basic in
+  let x = T.Field.random () in
+  let y = T.Field.random () in
+  T.Test.test_equal ~equal:T.Field.equal ~sexp_of_t:T.Field.sexp_of_t
+    T.Typ.(field * field)
+    T.Typ.field
+    (fun (x, y) ->
+      make_checked (fun () -> Random_oracle.Checked.hash [| x; y |]) )
+    (fun (x, y) -> Random_oracle.hash [| x; y |])
+    (x, y)
+
+let () =
+  let open Alcotest in
+  run "Random_oracle"
+    [ ( "hash"
+      , [ test_case "iterativeness" `Quick test_iterativeness
+        ; test_case "sponge checked-unchecked" `Quick
+            test_sponge_checked_unchecked
+        ] )
+    ]


### PR DESCRIPTION
As part of a work to provide test vectors for hashed values of the protocol, see Slack on the Rust node channel.