### PR TITLE
[CI]  FIx only debian job after config/apps debian split

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseyeDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseyeDevnetDevnet.dhall
@@ -8,6 +8,8 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let DebianChannel = ../../Constants/DebianChannel.dhall
 
+let Network = ../../Constants/Network.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.onlyDebianPipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -21,6 +23,7 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta
             ]
           , tags = [ PipelineTag.Type.Docker ]
+          , network = Network.Type.Devnet
           , channel = DebianChannel.Type.Experimental
           , prefix = "MinaArtifactOnlyDebian"
           }


### PR DESCRIPTION
Fixing debian only job after split. This job is run only via special command `!ci-debian-me`, that's why it wasn't discovered during CI run. 