### PR TITLE
HF test go: fork into develop instead of mesa

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -3,7 +3,7 @@
 # This scripts builds a designated PREFORK branch and current branch with nix
 # 0. Prepare environment if needed
 # 1. Build PREFORK as a prefork build;
-# 2. Build "mesa" branch as a postfork build
+# 2. Build "develop" branch as a postfork build
 # 3. Upload to nix cache, the reason for not uploading cache for following 2 
 # steps is that they change for each PR. 
 # 4. Build hardfork_test on current branch;
@@ -133,8 +133,8 @@ git checkout $PREFORK
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "prefork-devnet"
 
-# 2. Build "mesa" branch as a postfork build
-git checkout mesa
+# 2. Build "develop" branch as a postfork build
+git checkout develop
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "postfork-devnet"
 


### PR DESCRIPTION
Since we've merged & deleted mesa, there's no point forking into mesa in hf test, and it'll fail the test in the future as well. 