### PR TITLE
mina-local-network: set slots_per_epoch correctly

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -457,7 +457,7 @@ reset-genesis-ledger() {
   '
   {
     genesis: {
-      slot_per_epoch: 48,
+      slots_per_epoch: 48,
       k: 10,
       grace_period_slots: 3,
       genesis_state_timestamp: $timestamp


### PR DESCRIPTION
This is a bug introduced in b0a3c5656d7eeef8e47a7bb2e16bb48a6849c78b, where I tried to emulate this part of `run-localnet.sh`:

```bash
jq "$update_config_expr" > $CONF_DIR/base.json << EOF
{
  "genesis": {
    "slots_per_epoch": 48,
    "k": 10,
    "grace_period_slots": 3
  },
  "proof": {
    "work_delay": 1,
    "level": "full",
    "transaction_capacity": { "2_to_the": 2 },
    "block_window_duration_ms": ${SLOT}000
  }
}
EOF
```

Apparantly I messed up the field name.