### PR TITLE
[CI][HF] add pull/reversion/persist operation

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -1928,7 +1928,8 @@ function persist(){
 
             local __cn
             __cn=$(basename "$__codename_dir")
-            local __remote_target="$(storage_root "$__backend")/$__target/debians/$__cn/"
+            local __remote_target
+            __remote_target="$(storage_root "$__backend")/$__target/debians/$__cn/"
 
             for __deb_file in "$__codename_dir"*.deb; do
                 if [[ ! -f "$__deb_file" ]]; then


### PR DESCRIPTION
Added/Extended pull/reversion/persist command for release/manger in order to support full process of pormoting/reversion and pushing packages to static folder. 

This is needed if we want to update debians like mina-prefork etc. Which are persisted as we need them for autohf .   The full workflow now looks like:

```

  # 1. Pull debs from cache
  manager.sh pull --artifacts mina-devnet-prefork-mesa --buildkite-build-id 123 --target-folder ./debians

  # 2. Reversion them
  manager.sh reversion --source-folder ./debians --output-folder ./reversioned --new-version 3.0.0-rc1 --suite stable

  # 3. Persist back to storage
  manager.sh persist --source-folder ./reversioned --target some/target/path

```