### PR TITLE
Add docker-based daemon sync test and fix some shutdown bugs

### DIFF
--- a/buildkite/src/Command/DaemonDockerSync.dhall
+++ b/buildkite/src/Command/DaemonDockerSync.dhall
@@ -1,0 +1,121 @@
+let Cmd = ../Lib/Cmds.dhall
+
+let B = ../External/Buildkite.dhall
+
+let S = ../Lib/SelectFiles.dhall
+
+let Pipeline = ../Pipeline/Dsl.dhall
+
+let PipelineTag = ../Pipeline/Tag.dhall
+
+let PipelineScope = ../Pipeline/Scope.dhall
+
+let JobSpec = ../Pipeline/JobSpec.dhall
+
+let Command = ../Command/Base.dhall
+
+let Size = ../Command/Size.dhall
+
+let Network = ../Constants/Network.dhall
+
+let Artifacts = ../Constants/Artifacts.dhall
+
+let Dockers = ../Constants/DockerVersions.dhall
+
+let Profiles = ../Constants/Profiles.dhall
+
+let DockerRepo = ../Constants/DockerRepo.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
+let B/If = B.definitions/commandStep/properties/if/Type
+
+let Spec =
+      { Type =
+          { dockerType : Dockers.Type
+          , network : Network.Type
+          , softFail : B/SoftFail
+          , timeout : Natural
+          , profile : Profiles.Type
+          , scope : List PipelineScope.Type
+          , repo : DockerRepo.Type
+          , if_ : B/If
+          }
+      , default =
+          { dockerType = Dockers.Type.Bullseye
+          , network = Network.Type.Devnet
+          , softFail = B/SoftFail.Boolean False
+          , timeout = 1500
+          , profile = Profiles.Type.Devnet
+          , scope = PipelineScope.Full
+          , repo = DockerRepo.Type.InternalEurope
+          , if_ =
+              "build.pull_request.base_branch != \"develop\" && build.branch != \"develop\""
+          }
+      }
+
+let command
+    : Spec.Type -> Command.Type
+    =     \(spec : Spec.Type)
+      ->  Command.build
+            Command.Config::{
+            , commands =
+                [ Cmd.chain
+                    [ "export MINA_DEB_CODENAME=${Dockers.lowerName
+                                                    spec.dockerType}"
+                    , "source ./buildkite/scripts/export-git-env-vars.sh"
+                    , "scripts/tests/daemon-docker-sync.sh --network ${Network.lowerName
+                                                                         spec.network} --tag \\\${MINA_DOCKER_TAG}-${Network.lowerName
+                                                                                                                       spec.network} --timeout ${Natural/show
+                                                                                                                                                   spec.timeout} --repo ${DockerRepo.show
+                                                                                                                                                                            spec.repo}"
+                    ]
+                ]
+            , label =
+                "Daemon docker sync ${Network.lowerName spec.network} test"
+            , key =
+                "daemon-docker-sync-${Network.lowerName spec.network}-test"
+            , target = Size.XLarge
+            , artifact_paths = [ S.contains "test_output/artifacts/**/*" ]
+            , soft_fail = Some spec.softFail
+            , if_ = Some spec.if_
+            , depends_on =
+                Dockers.dependsOn
+                  Dockers.DepsSpec::{
+                  , codename = spec.dockerType
+                  , network = spec.network
+                  , artifact = Artifacts.Type.Daemon
+                  , profile = spec.profile
+                  }
+            }
+
+let pipeline
+    : Spec.Type -> Pipeline.Config.Type
+    =     \(spec : Spec.Type)
+      ->  Pipeline.Config::{
+          , spec = JobSpec::{
+            , dirtyWhen =
+                [ S.strictlyStart (S.contains "src")
+                , S.exactly
+                    "buildkite/src/Jobs/Test/DaemonDockerSync${Network.capitalName
+                                                                  spec.network}"
+                    "dhall"
+                , S.exactly
+                    "buildkite/src/Command/DaemonDockerSync"
+                    "dhall"
+                , S.exactly "scripts/tests/daemon-docker-sync" "sh"
+                ]
+            , path = "Test"
+            , name =
+                "DaemonDockerSync${Network.capitalName spec.network}"
+            , scope = spec.scope
+            , tags =
+              [ PipelineTag.Type.Long
+              , PipelineTag.Type.Test
+              , PipelineTag.Type.Stable
+              ]
+            }
+          , steps = [ command spec ]
+          }
+
+in  { command = command, pipeline = pipeline, Spec = Spec }

--- a/buildkite/src/Command/DaemonDockerSync.dhall
+++ b/buildkite/src/Command/DaemonDockerSync.dhall
@@ -60,21 +60,20 @@ let command
       ->  Command.build
             Command.Config::{
             , commands =
-                [ Cmd.chain
-                    [ "export MINA_DEB_CODENAME=${Dockers.lowerName
-                                                    spec.dockerType}"
-                    , "source ./buildkite/scripts/export-git-env-vars.sh"
-                    , "scripts/tests/daemon-docker-sync.sh --network ${Network.lowerName
-                                                                         spec.network} --tag \\\${MINA_DOCKER_TAG}-${Network.lowerName
-                                                                                                                       spec.network} --timeout ${Natural/show
-                                                                                                                                                   spec.timeout} --repo ${DockerRepo.show
-                                                                                                                                                                            spec.repo}"
-                    ]
-                ]
+              [ Cmd.chain
+                  [ "export MINA_DEB_CODENAME=${Dockers.lowerName
+                                                  spec.dockerType}"
+                  , "source ./buildkite/scripts/export-git-env-vars.sh"
+                  , "scripts/tests/daemon-docker-sync.sh --network ${Network.lowerName
+                                                                       spec.network} --tag \\\${MINA_DOCKER_TAG}-${Network.lowerName
+                                                                                                                     spec.network} --timeout ${Natural/show
+                                                                                                                                                 spec.timeout} --repo ${DockerRepo.show
+                                                                                                                                                                          spec.repo}"
+                  ]
+              ]
             , label =
                 "Daemon docker sync ${Network.lowerName spec.network} test"
-            , key =
-                "daemon-docker-sync-${Network.lowerName spec.network}-test"
+            , key = "daemon-docker-sync-${Network.lowerName spec.network}-test"
             , target = Size.XLarge
             , artifact_paths = [ S.contains "test_output/artifacts/**/*" ]
             , soft_fail = Some spec.softFail
@@ -95,19 +94,16 @@ let pipeline
       ->  Pipeline.Config::{
           , spec = JobSpec::{
             , dirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.exactly
-                    "buildkite/src/Jobs/Test/DaemonDockerSync${Network.capitalName
-                                                                  spec.network}"
-                    "dhall"
-                , S.exactly
-                    "buildkite/src/Command/DaemonDockerSync"
-                    "dhall"
-                , S.exactly "scripts/tests/daemon-docker-sync" "sh"
-                ]
+              [ S.strictlyStart (S.contains "src")
+              , S.exactly
+                  "buildkite/src/Jobs/Test/DaemonDockerSync${Network.capitalName
+                                                               spec.network}"
+                  "dhall"
+              , S.exactly "buildkite/src/Command/DaemonDockerSync" "dhall"
+              , S.exactly "scripts/tests/daemon-docker-sync" "sh"
+              ]
             , path = "Test"
-            , name =
-                "DaemonDockerSync${Network.capitalName spec.network}"
+            , name = "DaemonDockerSync${Network.capitalName spec.network}"
             , scope = spec.scope
             , tags =
               [ PipelineTag.Type.Long

--- a/buildkite/src/Jobs/Test/DaemonDockerSyncDevnet.dhall
+++ b/buildkite/src/Jobs/Test/DaemonDockerSyncDevnet.dhall
@@ -1,0 +1,15 @@
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let DaemonDockerSync = ../../Command/DaemonDockerSync.dhall
+
+in  Pipeline.build
+      ( DaemonDockerSync.pipeline
+          DaemonDockerSync.Spec::{
+          , network = Network.Type.Devnet
+          , scope = PipelineScope.AllButPullRequest
+          }
+      )

--- a/dockerfiles/scripts/daemon-entrypoint.sh
+++ b/dockerfiles/scripts/daemon-entrypoint.sh
@@ -60,9 +60,15 @@ rm -f .mina-config/.mina-lock
 # Export variables that the daemon would read directly
 export MINA_PRIVKEY_PASS MINA_LIBP2P_PASS UPTIME_PRIVKEY_PASS
 
-# Run the daemon in the foreground
+# Run the daemon in the foreground. We ignore terminating signals while the
+# daemon is running because this entrypoint script is expected to run under
+# dumb-init, and a signal sent to dumb-init (e.g., the signal from docker stop)
+# will automatically be forwarded to the daemon too.
+trap '' TERM INT HUP QUIT
 ${MINA_APP} ${INPUT_ARGS} ${EXTRA_FLAGS} ${APPENDED_FLAGS} 2>mina-stderr.log
 export MINA_EXIT_CODE="$?"
+trap - TERM INT HUP QUIT
+
 echo "Mina process exited with status code ${MINA_EXIT_CODE}"
 
 # Don't export variables to exitpoint scripts

--- a/dockerfiles/scripts/daemon-entrypoint.sh
+++ b/dockerfiles/scripts/daemon-entrypoint.sh
@@ -95,6 +95,12 @@ if [[ ${VERBOSE} ]]; then
   tail -n 5 ".mina-config/mina-best-tip.log" | jq -rc '.metadata.added_transitions[0] | {state_hash: .state_hash, height: '${CONSENSUS_STATE}'.blockchain_length, slot: '${CONSENSUS_STATE}'.global_slot_since_genesis}'
 fi
 
-sleep 15 # to allow all mina proccesses to quit, cleanup, and finish logging
+# Sleep to allow all mina proccesses to quit, cleanup, and finish logging. This
+# is necessary because the daemon does not wait for its children to shut down;
+# it relies on them noticing the daemon has shut down to initiate their own
+# shutdown. Though not ideal, it does work, but it does also mean that the
+# daemon exiting is not a reliable indication that all the mina processes have
+# stopped.
+sleep 5
 
 exit ${MINA_EXIT_CODE}

--- a/scripts/tests/daemon-docker-sync.sh
+++ b/scripts/tests/daemon-docker-sync.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+# Daemon Docker Sync and Shutdown Test
+#
+# Tests that a Mina daemon Docker container can sync to the network and shut
+# down cleanly. After syncing, `docker stop` is sent and the container's exit
+# code is verified to be 130 (the daemon's signal handler exit code).
+#
+# DESCRIPTION:
+#   - Starts a Mina daemon container connected to the specified network
+#   - Waits for the daemon to sync (sync status and best tip freshness check)
+#   - Sends `docker stop` and asserts the container exit code is 130
+#
+# REQUIREMENTS:
+#   - Docker must be installed and running
+#
+# PARAMETERS:
+#   -t, --tag       Docker image tag (required)
+#   -r, --repo      Docker image repo (required)
+#   -n, --network   Network configuration: devnet or mainnet (default: devnet)
+#   --timeout       Sync timeout in seconds (default: 900)
+#   -h, --help      Display usage information
+#
+# EXAMPLES:
+#   ./daemon-docker-sync.sh -r gcr.io/o1labs-192920/mina-daemon -t 3.3.1-7b34378-bullseye-devnet -n devnet
+#
+# EXIT CODES:
+#   0 - Success (daemon synced and exited with code 130 after docker stop)
+#   1 - Failure (sync timeout, wrong exit code, or other error)
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+NETWORK=devnet
+TIMEOUT=900
+
+USAGE="Usage: $0 -r repo -t tag [-n network] [--timeout seconds]
+  -t, --tag       Docker image tag (required)
+  -r, --repo      Docker image repo (required)
+  -n, --network   Network configuration: devnet or mainnet (default: $NETWORK)
+  --timeout        Sync timeout in seconds (default: $TIMEOUT)
+  -h, --help      Show help
+
+Example: $0 -r gcr.io/o1labs-192920/mina-daemon -t 3.3.1-7b34378-bullseye-devnet -n devnet
+"
+
+function usage() {
+    if [[ -n "$1" ]]; then
+        echo -e "${RED}$1${CLEAR}\n";
+    fi
+    echo "$USAGE"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    -t|--tag) TAG="$2"; shift;;
+    -r|--repo) REPO="$2"; shift;;
+    -n|--network) NETWORK="$2"; shift;;
+    --timeout) TIMEOUT="$2"; shift;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown parameter passed: $1"; usage; exit 1;;
+esac; shift; done
+
+if [[ "$NETWORK" != "devnet" && "$NETWORK" != "mainnet" ]]; then
+    echo "Invalid network: $NETWORK (must be devnet or mainnet)"
+    usage; exit 1
+fi
+
+if [[ -z "$REPO" ]]; then
+    usage "Docker repo is not set! Use -r or --repo to set it."
+    exit 1
+fi
+
+if [[ -z "$TAG" ]]; then
+    usage "Docker tag is not set! Use -t or --tag to set it."
+    exit 1
+fi
+
+IMAGE="$REPO/mina-daemon:$TAG"
+# Note: the expected exit code matches what the daemon currently ought to
+# produce if it shuts down cleanly in response to `docker stop`. This code is
+# the usual exit code for SIGINT. I'd argue it should actually be 0. This will
+# need to be adjusted if that daemon behaviour is changed.
+EXPECTED_EXIT_CODE=130
+ # How far in the past the daemon's best tip must be before it's considered too
+ # old. The daemon has some issues related to establishing a frontier at
+ # genesis, so we include this just to make sure the daemon's "synced" status is
+ # plausible.
+BEST_TIP_AGE_THRESHOLD_MS=$((4 * 60 * 60 * 1000))
+
+echo "=== Daemon Docker Stop Test ==="
+echo "Image:   $IMAGE"
+echo "Network: $NETWORK"
+echo "Timeout: ${TIMEOUT}s"
+
+# --- Start daemon container ---
+
+CONFIG_DIR=$(mktemp -d)
+
+echo ""
+echo "Starting daemon container..."
+container_id=$(docker run -d \
+    -v "$CONFIG_DIR:/root/.mina-config" \
+    --env PEER_LIST_URL="https://storage.googleapis.com/seed-lists/${NETWORK}_seeds.txt" \
+    "$IMAGE" \
+    daemon)
+
+echo "Container started: $container_id"
+
+# --- Stream docker logs to files ---
+
+mkdir -p test_output/artifacts
+docker logs --follow "$container_id" > test_output/artifacts/container-stdout.log 2> test_output/artifacts/container-stderr.log &
+docker_logs_pid=$!
+
+# --- Cleanup trap ---
+
+collect_logs() {
+    echo "========================= COLLECTING LOGS ==========================="
+    mkdir -p test_output/artifacts/mina-logs
+    cp "$CONFIG_DIR"/mina.log* test_output/artifacts/mina-logs/ 2>/dev/null || true
+
+    echo "Logs collected in test_output/artifacts/"
+}
+
+check_daemon_logs() {
+    local log_files
+    log_files=("$CONFIG_DIR"/mina.log*)
+    if [[ ! -e "${log_files[0]}" ]]; then
+        echo "Warning: no daemon log files found in $CONFIG_DIR"
+        return 0
+    fi
+
+    local fatal_lines
+    fatal_lines=$(grep '"level":"Fatal"' "${log_files[@]}" || true)
+    if [[ -n "$fatal_lines" ]]; then
+        echo -e "${RED}Fatal errors found in daemon logs:${CLEAR}"
+        echo "$fatal_lines"
+        return 1
+    fi
+
+    echo "No Fatal errors found in daemon logs."
+    return 0
+}
+
+cleanup() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        collect_logs
+    fi
+    kill "$docker_logs_pid" 2>/dev/null; wait "$docker_logs_pid" 2>/dev/null || true
+    { docker stop "$container_id" 2>/dev/null; docker rm "$container_id" 2>/dev/null; } || true
+    exit $exit_code
+}
+trap cleanup EXIT
+
+# --- Sync check function ---
+
+# Queries the daemon's GraphQL endpoint for sync status and best tip freshness.
+# Returns 0 if the daemon reports SYNCED and the best tip is fresh, 1 otherwise.
+# Prints a status message on each call.
+check_daemon_synced() {
+    local response
+    response=$(docker exec "$container_id" curl --no-progress-meter --request POST \
+        "http://localhost:3085/graphql" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --data-raw '{"query":"{ syncStatus, bestChain(maxLength: 1) { protocolState { blockchainState { utcDate } } } }"}' 2>/dev/null) || true
+
+    if [[ -z "$response" ]]; then
+        echo "GraphQL endpoint not available yet. Waiting..."
+        return 1
+    fi
+
+    local sync_status
+    sync_status=$(echo "$response" | jq -r '.data.syncStatus' 2>/dev/null) || true
+
+    if [[ "$sync_status" != "SYNCED" ]]; then
+        echo "Daemon sync status: ${sync_status:-unknown}. Waiting..."
+        return 1
+    fi
+
+    local best_tip_timestamp_ms
+    best_tip_timestamp_ms=$(echo "$response" | jq -r '.data.bestChain[0].protocolState.blockchainState.utcDate' 2>/dev/null) || true
+
+    if [[ -z "$best_tip_timestamp_ms" || "$best_tip_timestamp_ms" == "null" ]]; then
+        echo "Daemon reports SYNCED but no best tip yet. Waiting..."
+        return 1
+    fi
+
+    local current_timestamp_ms time_since_best_tip_ms
+    current_timestamp_ms=$(( $(date +%s) * 1000 ))
+    time_since_best_tip_ms=$(( current_timestamp_ms - best_tip_timestamp_ms ))
+
+    if [[ $time_since_best_tip_ms -lt $BEST_TIP_AGE_THRESHOLD_MS ]]; then
+        echo -e "${GREEN}Daemon is synced (best tip is ${time_since_best_tip_ms}ms old)${CLEAR}"
+        return 0
+    else
+        echo "Daemon reports SYNCED but best tip is stale (${time_since_best_tip_ms}ms old, threshold: ${BEST_TIP_AGE_THRESHOLD_MS}ms). Waiting..."
+        return 1
+    fi
+}
+
+# --- Wait for sync ---
+
+echo ""
+echo "Waiting for daemon to sync (timeout: ${TIMEOUT}s)..."
+
+start_time=$(date +%s)
+end_time=$((start_time + TIMEOUT))
+
+while true; do
+    # Check that the container is still running
+    container_running=$(docker inspect --format='{{.State.Running}}' "$container_id" 2>/dev/null) || true
+    if [[ "$container_running" != "true" ]]; then
+        echo -e "${RED}Container is no longer running!${CLEAR}"
+        actual_exit=$(docker inspect --format='{{.State.ExitCode}}' "$container_id" 2>/dev/null) || true
+        echo "Container exit code: $actual_exit"
+        tail -10 test_output/artifacts/container-stdout.log 2>/dev/null || true
+        exit 1
+    fi
+
+    if check_daemon_synced; then
+        break
+    fi
+
+    if [[ $(date +%s) -gt $end_time ]]; then
+        echo -e "${RED}Timeout reached. Daemon did not sync within ${TIMEOUT}s${CLEAR}"
+        exit 1
+    fi
+
+    sleep 30
+done
+
+# --- Stop container and check exit code ---
+
+echo ""
+echo "Stopping container..."
+docker stop "$container_id"
+exit_code=$(docker wait "$container_id")
+
+echo "Container exit code: $exit_code (expected: $EXPECTED_EXIT_CODE)"
+
+echo ""
+echo "Checking daemon logs for Fatal errors..."
+if ! check_daemon_logs; then
+    collect_logs
+    exit 1
+fi
+
+if [[ "$exit_code" -eq "$EXPECTED_EXIT_CODE" ]]; then
+    echo -e "${GREEN}PASS: Container exited with expected code $EXPECTED_EXIT_CODE${CLEAR}"
+else
+    # Some unexpected error codes we might see here:
+    # 143 - SIGTERM, likely from the `docker stop` signal not being handled properly
+    # 137 - SIGKILL, likely from `docker stop` timing out and forcibly killing the daemon
+    echo -e "${RED}FAIL: Container exited with code $exit_code, expected $EXPECTED_EXIT_CODE${CLEAR}"
+    echo ""
+    echo "Last 10 lines of container logs:"
+    tail -10 test_output/artifacts/container-stdout.log 2>/dev/null || true
+    # Docker container cleanup handled in exit trap
+    exit 1
+fi

--- a/scripts/tests/daemon-docker-sync.sh
+++ b/scripts/tests/daemon-docker-sync.sh
@@ -95,12 +95,9 @@ echo "Timeout: ${TIMEOUT}s"
 
 # --- Start daemon container ---
 
-CONFIG_DIR=$(mktemp -d)
-
 echo ""
 echo "Starting daemon container..."
 container_id=$(docker run -d \
-    -v "$CONFIG_DIR:/root/.mina-config" \
     --env PEER_LIST_URL="https://storage.googleapis.com/seed-lists/${NETWORK}_seeds.txt" \
     "$IMAGE" \
     daemon)
@@ -115,19 +112,21 @@ docker_logs_pid=$!
 
 # --- Cleanup trap ---
 
-collect_logs() {
-    echo "========================= COLLECTING LOGS ==========================="
+# Copy daemon log files out of the (stopped) container. This uses docker cp
+# instead of a volume mount because volume mounts don't work reliably when the
+# test runs inside a CI container that shares a Docker socket with the host.
+copy_logs_from_container() {
     mkdir -p test_output/artifacts/mina-logs
-    cp "$CONFIG_DIR"/mina.log* test_output/artifacts/mina-logs/ 2>/dev/null || true
-
-    echo "Logs collected in test_output/artifacts/"
+    docker cp "$container_id:/root/.mina-config/" test_output/artifacts/mina-config/ 2>/dev/null || true
 }
 
 check_daemon_logs() {
+    copy_logs_from_container
+
     local log_files
-    log_files=("$CONFIG_DIR"/mina.log*)
+    log_files=(test_output/artifacts/mina-config/mina.log*)
     if [[ ! -e "${log_files[0]}" ]]; then
-        echo "Warning: no daemon log files found in $CONFIG_DIR"
+        echo "Warning: no daemon log files found in container"
         return 0
     fi
 
@@ -146,7 +145,7 @@ check_daemon_logs() {
 cleanup() {
     local exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
-        collect_logs
+        copy_logs_from_container
     fi
     kill "$docker_logs_pid" 2>/dev/null; wait "$docker_logs_pid" 2>/dev/null || true
     { docker stop "$container_id" 2>/dev/null; docker rm "$container_id" 2>/dev/null; } || true
@@ -243,10 +242,7 @@ echo "Container exit code: $exit_code (expected: $EXPECTED_EXIT_CODE)"
 
 echo ""
 echo "Checking daemon logs for Fatal errors..."
-if ! check_daemon_logs; then
-    collect_logs
-    exit 1
-fi
+check_daemon_logs || exit 1
 
 if [[ "$exit_code" -eq "$EXPECTED_EXIT_CODE" ]]; then
     echo -e "${GREEN}PASS: Container exited with expected code $EXPECTED_EXIT_CODE${CLEAR}"

--- a/scripts/tests/daemon-docker-sync.sh
+++ b/scripts/tests/daemon-docker-sync.sh
@@ -88,7 +88,7 @@ EXPECTED_EXIT_CODE=130
  # plausible.
 BEST_TIP_AGE_THRESHOLD_MS=$((4 * 60 * 60 * 1000))
 
-echo "=== Daemon Docker Stop Test ==="
+echo "=== Daemon Docker Sync Test ==="
 echo "Image:   $IMAGE"
 echo "Network: $NETWORK"
 echo "Timeout: ${TIMEOUT}s"

--- a/src/lib/mina_net2/libp2p_helper.ml
+++ b/src/lib/mina_net2/libp2p_helper.ml
@@ -154,6 +154,15 @@ let handle_libp2p_helper_termination t ~pids ~killed result =
   Mina_metrics.Process_memory.Libp2p_helper.clear_pid () ;
   if (not killed) && not t.finished then (
     match result with
+    | Ok (Error (`Signal _) as e) when Async_unix.Shutdown.is_shutting_down ()
+      ->
+        [%log' info t.logger]
+          "libp2p_helper process terminated due to signal during shutdown: \
+           $exit_status"
+          ~metadata:
+            [ ("exit_status", `String (Unix.Exit_or_signal.to_string_hum e)) ] ;
+        t.finished <- true ;
+        Deferred.unit
     | Ok ((Error (`Exit_non_zero _) | Error (`Signal _)) as e) ->
         [%log' fatal t.logger]
           !"libp2p_helper process died unexpectedly: $exit_status"

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -472,10 +472,15 @@ let create ~logger ?(enable_internal_tracing = false) ?internal_trace_filename
           ~metadata:[ ("exit_code", `Int n) ] ;
         Async.exit 1
     | Ok (Error (`Signal signal)) ->
-        let signal_str = Signal.to_string signal in
-        [%log fatal] "Prover terminated due to signal, terminating daemon"
-          ~metadata:[ ("signal", `String signal_str) ] ;
-        Async.exit 1
+        if Async_unix.Shutdown.is_shutting_down () then (
+          [%log info] "Prover terminated due to signal during shutdown"
+            ~metadata:[ ("signal", `String (Signal.to_string signal)) ] ;
+          Deferred.unit )
+        else
+          let signal_str = Signal.to_string signal in
+          [%log fatal] "Prover terminated due to signal, terminating daemon"
+            ~metadata:[ ("signal", `String signal_str) ] ;
+          Async.exit 1
     | Error err ->
         let err_str = Error.to_string_hum err in
         [%log fatal] "Error waiting on prover process, terminating daemon"


### PR DESCRIPTION
The new daemon-docker-sync.sh test starts up a daemon with a given docker tag, waits for it to sync, then shuts it down with `docker stop`. The test makes sure the best tip is actually fresh, and waits more if it is not. The test also does some basic checking to make sure the daemon shut down cleanly. The test is based on the "wait for sync" portion of the rosetta tests. At some point I would like to consolidate some of this logic into a single ocaml definition, because there are a few bash shell scripts and scattered ocaml tests that do this too.

I had to fix a few bugs in the daemon entrypoint script to get the test to pass. To give some background, I'll mention that our docker packaging uses `ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]` as the default entrypoint. The resulting process tree looks like `dumb-init -> entrypoint.sh -> mina daemon -> mina helpers`. Everything under `dumb-init` will be in a single process group rooted at `entrypoint.sh`. If you run `docker stop` on the container, it sends `SIGTERM` to `dumb-init`, which then sends that on to everything in that process group. Thus *every* process gets the `SIGTERM`, so everything will start shutting down at once. The problem is that `dumb-init` will for `entrypoint.sh` to exit, not `mina daemon`. The entrypoint script will exit basically instantly, which causes `dumb-init` to exit instantly. This leaves the still-shutting-down daemon inside the container; when the container is torn down the daemon process just ceases to exist.

You can observe this in our current docker image's behaviour in two ways after `docker stop`:

1. The daemon logs do not say "running async hook..." or mention closing the frontier or anything like that
2. The exit code of the docker container will be 143 (unhandled SIGTERM) and not 130 (what the daemon's exit code is after it handles any terminating signal successfully). The exit code is 143 because the entrypoint script was SIGTERM'd; this skips the `exit ${MINA_EXIT_CODE}` it does at the end. (As an aside, I think the daemon should have exit code 0 and not 130 here, but that's a separate issue.)

This test detects (2) and was failing after I implemented it. Commit 5a20f3fffde437120e23fd9dc21314b15bec046b fixes the issue by trapping and ignoring all terminating signals in the entrypoint script when running the daemon. This does technically make the entrypoint script itself unresponsive to SIGTERM. This should not be a problem; as I said above, `dumb-init` still forwards signals to the daemon itself, so both the daemon process itself and the container overall will still be responsive to signals. It's only the entrypoint script that will be ignoring them.

The second issue I saw was that the entrypoint script had a `sleep 15` at the end of it to make sure the daemon's child processes had a chance to shut down cleanly. This conflicts with the default `docker stop` timeout of 10 seconds, so the container will end up being SIGKILL'd by `docker`. I think this is overly generous and have reduced it to 5 seconds. Arguably even this is too generous, but it should be fine for now. Also, the daemon should really have some better coordination around its child processes (shutting them down explicitly, notably) but that's also a separate issue.

The third issue I encountered was a race that can occur when a terminating signal is delivered to a process group that contains the daemon and also its helper subprocesses. I noticed an instance of this in https://github.com/MinaProtocol/mina/issues/17502, but it can happen here because `dumb-init` sends terminating signals to the entire process group of `entrypoint.sh`. It is possible for the daemon to start shutting down in response to a signal, and then be notified that a child process exited before it's finished shutting down. If this happens with the libp2p helper or the prover, the daemon treats this as a fatal error and either throws an unhandled exception or exits with an inconsistent exit code. This makes the daemon exit logs more chaotic than they should be. I've addressed this by having the daemon check for `Shutdown.is_shutting_down ()` before deciding that the child shutdown is a bad thing.

--------

I've added it to the CI as a devnet nightly/mainline nightly test. It does succeed, according to https://buildkite.com/o-1-labs-2/mina-single-job/builds/61:

```
Starting daemon container...
Container started: 545e8832af60fc5b291354945dcd9a8e4b243edc39e06af98e7c8399e57236c9
Waiting for daemon to sync (timeout: 1500s)...
GraphQL endpoint not available yet. Waiting...
GraphQL endpoint not available yet. Waiting...
Daemon sync status: BOOTSTRAP. Waiting...
Daemon sync status: BOOTSTRAP. Waiting...
Daemon sync status: BOOTSTRAP. Waiting...
Daemon sync status: BOOTSTRAP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon sync status: CATCHUP. Waiting...
Daemon is synced (best tip is 112000ms old)
Stopping container...
545e8832af60fc5b291354945dcd9a8e4b243edc39e06af98e7c8399e57236c9
Container exit code: 130 (expected: 130)
Checking daemon logs for Fatal errors...
No Fatal errors found in daemon logs.
PASS: Container exited with expected code 130
```