### PR TITLE
Add dhall 1.30.0 to the nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -347,19 +347,31 @@
         # Nix-built `dpkg` archives with Mina in them
         debianPackages = pkgs.callPackage ./nix/debian.nix { };
 
-        # Pinned to match the version used in CI (dockerfiles/Dockerfile-toolchain-base)
-        dhall = pkgs.stdenv.mkDerivation {
-          pname = "dhall";
-          version = "1.30.0";
-          src = pkgs.fetchurl {
-            url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-1.30.0-x86_64-linux.tar.bz2";
-            sha256 = "sha256-aEVCHenDzED0FAoSeMQI3470m/gIbufzdzDS7ajOlAI=";
+        # Pinned to match the version used in CI (dockerfiles/Dockerfile-toolchain-base).
+        # Only x86_64 binaries are available from upstream.
+        dhall = let
+          srcs = {
+            x86_64-linux = pkgs.fetchurl {
+              url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-1.30.0-x86_64-linux.tar.bz2";
+              sha256 = "sha256-aEVCHenDzED0FAoSeMQI3470m/gIbufzdzDS7ajOlAI=";
+            };
+            x86_64-darwin = pkgs.fetchurl {
+              url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-1.30.0-x86_64-macos.tar.bz2";
+              sha256 = "sha256-mYXQ6yTBv23Fzl2CEAuSvndD3jkNR+XGlHbLEY90RA8=";
+            };
           };
-          sourceRoot = ".";
-          installPhase = ''
-            install -Dm755 bin/dhall $out/bin/dhall
-          '';
-        };
+        in if srcs ? ${system} then
+          pkgs.stdenv.mkDerivation {
+            pname = "dhall";
+            version = "1.30.0";
+            src = srcs.${system};
+            sourceRoot = ".";
+            installPhase = ''
+              install -Dm755 bin/dhall $out/bin/dhall
+            '';
+          }
+        else
+          null;
 
         # Packages for the development environment that are not needed to build mina-dev.
         # For instance dependencies for tests.
@@ -376,8 +388,7 @@
             (python-pkgs: [ python-pkgs.click python-pkgs.requests ]))
           jq
           rocksdb-mina.tools
-          dhall
-        ];
+        ] ++ lib.optional (dhall != null) dhall;
       in {
 
         inherit ocamlPackages;


### PR DESCRIPTION
This PR brings the `dhall` into the nix dev shell, with the same version used in the CI. With this, you can run `make lint format` in the `buildkite/` directory to format your dhall files locally. This was possible previously by running that command inside a toolchain docker image, but I like having dhall around in my shell, personally.

I had to use `mkDerivation` to fetch the exact version rather than using a `github:nixos/nixpkgs/nixos-*-small` source, because the version in `20.09` is 1.32.0 and the version in `20.03` is 1.29.0. The newer 1.32.0 and later use different formatting defaults (and possibly the language standard changed between the two versions), and I didn't want to use an even older version of dhall than what the CI uses.

I tested this by running `make lint format` in `buildkite/` locally and noting that it did not change the dhall files.