### PR TITLE
Remove unused Daemon and DaemonConfig from lightnet pipelines

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
@@ -18,11 +18,7 @@ in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
-            [ Artifacts.Type.LogProc
-            , Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonAppsOnly
-            , Artifacts.Type.DaemonConfig
-            ]
+            [ Artifacts.Type.LogProc, Artifacts.Type.DaemonAppsOnly ]
           , network = Network.Type.Devnet
           , profile = Profiles.Type.Lightnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
@@ -20,11 +20,7 @@ in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
-            [ Artifacts.Type.LogProc
-            , Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonAppsOnly
-            , Artifacts.Type.DaemonConfig
-            ]
+            [ Artifacts.Type.LogProc, Artifacts.Type.DaemonAppsOnly ]
           , network = Network.Type.Devnet
           , arch = Arch.Type.Arm64
           , profile = Profiles.Type.Lightnet

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
@@ -18,11 +18,7 @@ in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
-            [ Artifacts.Type.LogProc
-            , Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonAppsOnly
-            , Artifacts.Type.DaemonConfig
-            ]
+            [ Artifacts.Type.LogProc, Artifacts.Type.DaemonAppsOnly ]
           , network = Network.Type.Devnet
           , profile = Profiles.Type.Lightnet
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnetArm64.dhall
@@ -20,10 +20,7 @@ in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
-            [ Artifacts.Type.LogProc
-            , Artifacts.Type.Daemon
-            , Artifacts.Type.DaemonConfig
-            ]
+            [ Artifacts.Type.LogProc, Artifacts.Type.DaemonAppsOnly ]
           , network = Network.Type.Devnet
           , arch = Arch.Type.Arm64
           , profile = Profiles.Type.Lightnet


### PR DESCRIPTION
- Remove unused `Daemon` and `DaemonConfig` artifact types from all 4 lightnet release pipeline configurations (bookworm/noble x amd64/arm64)
- Lightnet pipelines now only build `LogProc` and `DaemonAppsOnly`, which are the only artifacts actually needed
- Also adds missing `DaemonAppsOnly` to the Noble arm64 lightnet pipeline for consistency
