### PR TITLE
[CI] add packaging for storage recovery tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ build-daemon-utils: ocaml_checks reformat-diff libp2p_helper ## Build daemon uti
 		src/app/validate_keypair/validate_keypair.exe \
 		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
 		src/lib/snark_worker/standalone/run_snark_worker.exe \
+		src/app/rocksdb-scanner/rocksdb_scanner.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 
@@ -583,10 +584,15 @@ debian-build-rosetta-mainnet: ## Build the Debian Rosetta package for mainnet
 debian-build-daemon-devnet-hardfork: ## Build the Debian daemon package for devnet hardfork
 	$(call build_debian_package,daemon_devnet_hardfork)
 
+.PHONY: debian-daemon-storage-toolbox
+debian-daemon-storage-toolbox: ## Build the Debian daemon storage toolbox package
+	$(call build_debian_package,daemon_storage_toolbox)
+
 .PHONY: debian-download-create-legacy-hardfork
 debian-download-create-legacy-hardfork: ## Download and create legacy hardfork Debian packages
 	$(info 📦 Downloading legacy hardfork Debian packages for debian $(CODENAME))
 	@./buildkite/scripts/release/manager.sh pull --artifacts mina-create-legacy-genesis  --from-special-folder legacy/debians/$(CODENAME)  --backend hetzner --target _build
+
 ########################################
 # Docker images
 

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -248,6 +248,8 @@ let docker_step
                     , if = spec.if
                     }
                   ]
+                , DaemonRecoveryStorageToolbox =
+                    [] : List DockerImage.ReleaseSpec.Type
                 , Archive =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -24,6 +24,7 @@ let Artifact
       | FunctionalTestSuite
       | Toolchain
       | CreateLegacyGenesis
+      | DaemonRecoveryStorageToolbox
       >
 
 let AllButTests =
@@ -38,6 +39,7 @@ let AllButTests =
       , Artifact.ZkappTestTransaction
       , Artifact.Toolchain
       , Artifact.CreateLegacyGenesis
+      , Artifact.DaemonRecoveryStorageToolbox
       ]
 
 let Main =
@@ -60,6 +62,7 @@ let capitalName =
             , FunctionalTestSuite = "FunctionalTestSuite"
             , Toolchain = "Toolchain"
             , CreateLegacyGenesis = "CreateLegacyGenesis"
+            , DaemonRecoveryStorageToolbox = "DaemonRecoveryStorageToolbox"
             }
             artifact
 
@@ -77,6 +80,7 @@ let lowerName =
             , ZkappTestTransaction = "zkapp_test_transaction"
             , FunctionalTestSuite = "functional_test_suite"
             , CreateLegacyGenesis = "create_legacy_genesis"
+            , DaemonRecoveryStorageToolbox = "daemon_storage_toolbox"
             , Toolchain = "toolchain"
             }
             artifact
@@ -96,6 +100,8 @@ let dockerName =
             , FunctionalTestSuite = "mina-test-suite"
             , Toolchain = "mina-toolchain"
             , CreateLegacyGenesis = "mina-create-legacy-genesis"
+            , DaemonRecoveryStorageToolbox =
+                "mina-daemon-recovery-storage-toolbox"
             }
             artifact
 
@@ -124,6 +130,7 @@ let toDebianName =
             , FunctionalTestSuite = "functional_test_suite"
             , Toolchain = ""
             , CreateLegacyGenesis = "create_legacy_genesis"
+            , DaemonRecoveryStorageToolbox = "daemon_recovery_storage_toolbox"
             }
             artifact
 
@@ -146,6 +153,8 @@ let toDebianNames =
                           , Rosetta = [ toDebianName a network ]
                           , ZkappTestTransaction = [ "zkapp_test_transaction" ]
                           , FunctionalTestSuite = [ "functional_test_suite" ]
+                          , DaemonRecoveryStorageToolbox =
+                            [ toDebianName a network ]
                           , CreateLegacyGenesis = [ "create_legacy_genesis" ]
                           , Toolchain = [] : List Text
                           }
@@ -218,6 +227,7 @@ let dockerTag =
                 , FunctionalTestSuite = "${spec.version}${build_flags_part}"
                 , Toolchain = "${spec.version}"
                 , CreateLegacyGenesis = "${spec.version}"
+                , DaemonRecoveryStorageToolbox = "${spec.version}"
                 }
                 spec.artifact
 

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -19,6 +19,7 @@ let isEssential =
             , DaemonAutoHardfork = True
             , DaemonLegacyHardfork = True
             , CreateLegacyGenesis = False
+            , DaemonRecoveryStorageToolbox = False
             }
             service
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -628,3 +628,23 @@ build_create_legacy_genesis_deb() {
 
   build_deb mina-create-legacy-genesis
 }
+
+build_daemon_recovery_storage_toolbox_deb() {
+  echo "------------------------------------------------------------"
+  echo "--- Building Mina Berkeley daemon recovery storage toolbox:"
+
+  ROCKSDB_VERSION="5.7.12"
+  MINA_VERSION="${GITTAG}"
+
+  create_control_file mina-daemon-recovery-storage-toolbox \
+    "${SHARED_DEPS}${DAEMON_DEPS}" \
+    "Toolbox for Mina Daemon storage compatible with rocksdb in version $ROCKSDB_VERSION and mina in $MINA_VERSION"
+
+  mkdir -p "${BUILDDIR}/usr/lib/mina/storage/$ROCKSDB_VERSION/$MINA_VERSION"
+
+  # Binaries
+  cp ./default/src/app/rocksdb-scanner/rocksdb_scanner.exe \
+    "${BUILDDIR}/usr/lib/mina/storage/$ROCKSDB_VERSION/$MINA_VERSION/mina-rocksdb-scanner"
+
+  build_deb mina-daemon-recovery-storage-toolbox
+}


### PR DESCRIPTION
Added new debian for storage repair on master. This package will serve as a way to downgrade current storage to compatible with master and (3.3.X) versions. It need to be installed together with a newer version from compatible branch (since we broke compatibility of storage in compatible)