### PR TITLE
Fix --state-hash flag doc to mention snarked ledger (port to compatible)

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -770,8 +770,8 @@ let export_ledger =
     Command.Param.(
       flag "--state-hash" ~aliases:[ "state-hash" ]
         ~doc:
-          "STATE-HASH State hash, if printing a staged ledger (default: state \
-           hash for the best tip)"
+          "STATE-HASH State hash, if printing a staged ledger or snarked \
+           ledger (default: state hash for the best tip)"
         (optional string))
   in
   let ledger_kind =


### PR DESCRIPTION
## Summary
- Port of #18589 to `compatible` branch
- Updates `--state-hash` flag docstring in `export_ledger` command to mention snarked ledger in addition to staged ledger

## Change
Single line change in `src/app/cli/src/init/client.ml`:
```
Before: "STATE-HASH State hash, if printing a staged ledger (default: state hash for the best tip)"
After:  "STATE-HASH State hash, if printing a staged ledger or snarked ledger (default: state hash for the best tip)"
```

- Fixes #12704

## Test plan
- [x] Doc-only change, no functional impact
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)