### PR TITLE
Port #16118: Test_executive: minor changes

### DIFF
--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -6,7 +6,7 @@ open Integration_test_lib
 
 type test = string * (module Intf.Test.Functor_intf)
 
-type engine = string * (module Intf.Engine.S)
+type engine = (module Intf.Engine.S)
 
 module Make_test_inputs (Engine : Intf.Engine.S) () :
   Intf.Test.Inputs_intf
@@ -47,7 +47,7 @@ let validate_inputs ~logger inputs (test_config : Test_config.t) :
   else Deferred.return ()
 
 let engines : engine list =
-  [ ("local", (module Integration_test_local_engine : Intf.Engine.S)) ]
+  [ (module Integration_test_local_engine : Intf.Engine.S) ]
 
 let tests : test list =
   [ ( "block-prod-prio"
@@ -468,11 +468,8 @@ let debug_arg =
 
 let help_term = Term.(ret @@ const (`Help (`Plain, None)))
 
-let engine_cmd ((engine_name, (module Engine)) : engine) =
-  let info =
-    let doc = "Run mina integration test(s) on engine." in
-    Term.info engine_name ~doc ~exits:Term.default_exits
-  in
+let engine_cmd ((module Engine) : engine) =
+  let info = Term.info Engine.name ~doc:Engine.doc ~exits:Term.default_exits in
   let test_inputs_with_cli_inputs_arg =
     let wrap_cli_inputs cli_inputs =
       Test_inputs_with_cli_inputs

--- a/src/lib/testing/integration_test_lib/intf.ml
+++ b/src/lib/testing/integration_test_lib/intf.ml
@@ -155,6 +155,9 @@ module Engine = struct
     (* unique name identifying the engine (used in test executive cli) *)
     val name : string
 
+    (* Short description of what the engine is used for. *)
+    val doc : string
+
     module Network_config : Network_config_intf
 
     module Network : Network_intf

--- a/src/lib/testing/integration_test_local_engine/integration_test_local_engine.ml
+++ b/src/lib/testing/integration_test_local_engine/integration_test_local_engine.ml
@@ -1,5 +1,7 @@
 let name = "local"
 
+let doc = "Run mina integration test(s) locally."
+
 module Network = Docker_network
 module Network_config = Mina_docker.Network_config
 module Network_manager = Mina_docker.Network_manager


### PR DESCRIPTION
## Summary
- Port of #16118 onto compatible
- Changes `type engine` to remove redundant string name, using `Engine.name` and `Engine.doc` directly
- Adds `name` and `doc` to Engine.S signature
- Adds `doc` field to integration_test_local_engine

## Test plan
- [ ] CI passes
- [ ] Code compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)