### PR TITLE
allow HTTP code 429 in xrefcheck

### DIFF
--- a/buildkite/src/Jobs/Lint/Xrefcheck.dhall
+++ b/buildkite/src/Jobs/Lint/Xrefcheck.dhall
@@ -39,7 +39,7 @@ in  Pipeline.build
                   }
                   (     "awesome_bot --allow-dupe "
                     ++  "--allow-redirect "
-                    ++  "--allow 403,401 "
+                    ++  "--allow 403,401,429 "
                     ++  "--skip-save-results "
                     ++  "--files "
                     ++  "`find . -name \"*.md\" "


### PR DESCRIPTION
Xref check is failing occasionally on CI. Here's an example run: https://buildkite.com/organizations/o-1-labs-2/pipelines/mina-end-to-end-nightlies/builds/4214/jobs/019cdbe7-67c2-4a52-aeb8-6f4929098f5e/log

The reason is github is rate limiting the bot. Hence allowing http code 429(Too Many Requests) should make the situation easier. 