### PR TITLE
Replayer should not exit on hardfork block

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1626,12 +1626,12 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                          hashes" ;
                       First_pass_ledger_hashes.set_last_snarked_hash
                         snarked_hash )
-                    else
+                    else (
                       [%log error]
                         "Current snarked ledger hash does not appear among \
                          first-pass ledger hashes" ;
-                    if continue_on_error then incr error_count
-                    else Core_kernel.exit 1
+                      if continue_on_error then incr error_count
+                      else Core_kernel.exit 1 )
                 | Some (_hash, n) ->
                     [%log spam]
                       "Found snarked ledger hash among first-pass ledger hashes" ;


### PR DESCRIPTION
## Problem

Fix for invalid replayer behavior when running with hardfork related arguments.

For given arguments:

```
_build/default/src/app/replayer/replayer.exe  \
  --archive-uri postgres://postgres:postgres@localhost:5432/archive \
  --input-file genesis-replayer-config.json \
  --hard-fork-target mesa \
  --stop-slot-config-file stop-slot-config.json \
  --hard-fork-output-file output-hf.json 
  --log-json \
  --log-level spam
```

Where:

`genesis-replayer-config.json`

```
{
  "target_epoch_ledgers_state_hash": "3NKhd6scsxTazcEWpnxR2LBLJZS9ARZy64T2fGSoZHhzVALyU3Ld",
  "genesis_ledger": {
    "add_genesis_winner": false,
    "s3_data_hash": "d0f921c9db97265e5e8c25cfecbb08ae259e735c0bb5acd0912e43aaec10fced",
    "hash": "jwXMfukdwJVNpZ3wMEZbuq4zwucYS4cJnij23buAnNYo1GKKrFB"
  }
}
```
`stop-slot-config.json`

```
{
  "genesis": {
    "genesis_state_timestamp": "2026-02-24T19:30:00Z"
  },
  "ledger": {
    "add_genesis_winner": false,
    "s3_data_hash": "d0f921c9db97265e5e8c25cfecbb08ae259e735c0bb5acd0912e43aaec10fced",
    "hash": "jwXMfukdwJVNpZ3wMEZbuq4zwucYS4cJnij23buAnNYo1GKKrFB"
  },
  "daemon": {
    "slot_tx_end": 1900,
    "hard_fork_genesis_slot_delta": 40,
    "slot_chain_end": 1920
  },
  "epoch_data": {
    "staking": {
      "seed": "2vahsgRV5nDPmtgr2Xo2Uq2dkngfSgvg7d1TKqQbY3wUS2ZDxCC3",
      "s3_data_hash": "8053060205998762d7eb07804edda4723fcc31aac9c819142acac4aed80282d5",
      "hash": "jwkUfFHU5xnAYNZzHPWGRNuZCve2SkbwuuXXETZuH6hdBup77D7"
    },
    "next": {
      "seed": "2vbH4D8B76WMYPRFgeuVvdWVhv6tAFoCJtg83yuJT1dud3QVSiZn",
      "s3_data_hash": "7554a3b0333018e2e7d1dacebb3f5b114c85fddb65b3ae6f8e295f28a7cd75d4",
      "hash": "jxqJ5NT4txXQKLnxJyDBwAAHysWAiAezV8agV7Qg5Md2yRGaAWq"
    }
  }
}
```


Outcome:

```
....
{"timestamp":"2026-03-12 19:40:35.989715Z","level":"Spam","message":"Starting processing of commands in block with state_hash $state_hash at global slot since genesis 1899","metadata":{"state_hash":"3NLFNvH2oV2ERa1gGdRcYpT26Fc378i8RbXzJ8qr63NvPF7DpTTY"}}
{"timestamp":"2026-03-12 19:40:35.989726Z","level":"Spam","message":"Converting internal command (coinbase) with global slot since genesis 1962, sequence number 0, and secondary sequence number 0 to transaction","metadata":{}}
{"timestamp":"2026-03-12 19:40:35.990493Z","level":"Info","source":{"module":"Dune__exe__Replayer","location":"File \"src/app/replayer/replayer.ml\", line 1620, characters 22-33"},"message":"Current snarked ledger hash not among first-pass ledger hashes, but we haven't yet found one. The transaction that created this ledger hash might have been in an older replayer run that created a checkpoint file without saved first-pass ledger hashes","metadata":{}}

```
## Root Cause

This was an **indentation/scoping bug** in OCaml. The original code was:

```ocaml
    else
      [%log error] "Current snarked ledger hash does not appear..." ;
    if continue_on_error then incr error_count
    else Core_kernel.exit 1
```

Due to OCaml's parsing rules, the semicolon (`;`) after the `[%log error]` call terminates the outer `if/else` expression. This means the `if continue_on_error then ... else exit 1` block was **not** part of the `else` branch — it was a **separate, unconditionally executed statement** that ran on every iteration regardless of whether the snarked hash was found or not.

So even when the `if not !found_snarked_ledger_hash` branch matched (a benign case that just logs `[%log info]` and sets the hash), the code would fall through and execute `exit 1`.

## Fix

Wrap the `else` branch body in parentheses so that both the error log and the `exit 1` / `incr error_count` logic are properly scoped inside the `else`:

```ocaml
    else (
      [%log error] "Current snarked ledger hash does not appear..." ;
      if continue_on_error then incr error_count
      else Core_kernel.exit 1 )
```

Now `exit 1` is only reached when `found_snarked_ledger_hash` is true **and** the snarked hash is genuinely missing from first-pass ledger hashes — which is the actual error condition.