### PR TITLE
Increase timeout to 10 seconds for http test

### DIFF
--- a/src/test/command_line_tests/command_line_tests.ml
+++ b/src/test/command_line_tests/command_line_tests.ml
@@ -788,7 +788,7 @@ module PeerListUrlHttpWarning = struct
     in
     (* The daemon should not crash immediately from URL validation.
        Give it a few seconds to get past the peer-list-url check. *)
-    let%bind () = after (Core.Time.Span.of_sec 5.) in
+    let%bind () = after (Core.Time.Span.of_sec 10.) in
     (* Check if the process is still running *)
     let%bind process_status =
       Async.Clock.with_timeout (Core.Time.Span.of_sec 1.)


### PR DESCRIPTION
The daemon takes a non-trivial amount of time to load and initialize its config, because config initialization is tied up with genesis ledger initialization. The current timeout of 5 seconds in this test is just barely enough to have the test pass in most cases; differences in test environment seem to be able to slow down the initialization process enough to cause it to fail intermittently.

The new timeout is a more generous 10 seconds. The proper fix for this is to restructure config loading so that the daemon can front-load most of the config loading before having to fetch or construct its genesis ledgers, but that is a larger change that should not be made right now. I would like to do that in future, though. If it were done, then the warning would appear almost instantly after the daemon started up, without any heavy computation preceding it.

This PR was prompted by a failure in this test, observed in https://github.com/MinaProtocol/mina/pull/18511#issuecomment-4046801388 from [this build](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/40862#019ce064-a283-4333-bf80-dca660042644).