### PR TITLE
Fix replayer hardfork checkpoint generation

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -658,16 +658,21 @@ let create_genesis_db_and_tar ~logger ~genesis_dir ~ledger_depth ~populate
 let apply_hard_fork_migration ~logger
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~ledger
     ~genesis_dir ~scheduled_genesis_since_hf ~hard_fork_output_file
-    ~hard_fork_target =
+    ~hard_fork_target ~stop_slot_since_genesis =
   [%log info] "Applying hard fork migration to produce post-fork input" ;
-  (* Get the last block's slots from global_slot_hashes_tbl *)
-  let slots = Int64.Table.keys global_slot_hashes_tbl in
+  (* Get the last block's slots from global_slot_hashes_tbl, filtering out
+     blocks at or beyond slot_chain_end *)
+  let slots =
+    Int64.Table.keys global_slot_hashes_tbl
+    |> List.filter ~f:(fun s -> Int64.( < ) s stop_slot_since_genesis)
+  in
   let last_slot_since_genesis =
     match List.max_elt slots ~compare:Int64.compare with
     | Some s ->
         s
     | None ->
-        [%log fatal] "No blocks found in global slot hashes table" ;
+        [%log fatal]
+          "No blocks found before slot_chain_end in global slot hashes table" ;
         Core_kernel.exit 1
   in
   let _state_hash, _ledger_hash, _snarked_hash, last_slot_since_hard_fork =
@@ -836,11 +841,13 @@ let hard_fork_params ~logger ~stop_slot_config_file ~hard_fork_output_file =
               ~metadata:[ ("file", `String file); ("error", `String msg) ] ;
             Core_kernel.exit 1
       in
-      match
+      let genesis_slot =
         Runtime_config.scheduled_hard_fork_genesis_slot hf_runtime_config
-      with
-      | Some slot ->
-          Some (slot, output_file)
+      in
+      let slot_chain_end = Runtime_config.slot_chain_end hf_runtime_config in
+      match Option.both genesis_slot slot_chain_end with
+      | Some (slot, slot_chain_end_hf) ->
+          Some (slot, slot_chain_end_hf, output_file, hf_runtime_config)
       | None ->
           [%log fatal]
             "Hard fork config must have daemon.slot_chain_end and \
@@ -1290,6 +1297,22 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
         ; "3NLHTdvTPXxUn8YFy4z59NxDcX9DYhthFtv8aPNMmpm2pYuA6Tf6"
         ]
       in
+      (* Compute the stop slot in global-slot-since-genesis terms so that
+         apply_commands can stop replaying at slot_chain_end. *)
+      let stop_slot_since_genesis_opt =
+        Option.map hard_fork_params_opt ~f:(fun (_, slot_chain_end_hf, _, _) ->
+            let chain_end_i64 =
+              Mina_numbers.Global_slot_since_hard_fork.to_uint32
+                slot_chain_end_hf
+              |> Unsigned.UInt32.to_int64
+            in
+            let offset =
+              Hashtbl.choose global_slot_hashes_tbl
+              |> Option.value_map ~default:0L ~f:(fun (sg, (_, _, _, shf)) ->
+                     Int64.(sg - shf) )
+            in
+            Int64.(chain_end_i64 + offset) )
+      in
       (* apply commands in global slot, sequence order *)
       let rec apply_commands ~last_global_slot_since_genesis ~last_block_id
           ~(block_txns : Mina_transaction.Transaction.t list)
@@ -1685,188 +1708,235 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
             []
           else return block_txns
         in
-        match (internal_cmds, user_cmds, zkapp_cmds) with
-        | [], [], [] ->
-            (* all done *)
-            let%bind _ =
-              run_transactions_on_slot_change ~last_block:true block_txns ()
-            in
-            Deferred.return
-              (staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed)
-        | ic :: ics, [], [] ->
-            (* only internal commands *)
-            let%bind block_txns0 =
-              check_for_complete_block
-                ~cmd_global_slot_since_genesis:ic.global_slot_since_genesis
-            in
-            let%bind block_txns, ics' =
-              let%map txn, ics' =
-                internal_cmds_to_transaction ~logger ~pool ic ics
+        (* Stop replaying if the next command is at or beyond slot_chain_end *)
+        let next_cmd_slot =
+          List.filter_opt
+            [ Option.map (List.hd internal_cmds)
+                ~f:(fun (ic : Sql.Internal_command.t) ->
+                  ic.global_slot_since_genesis )
+            ; Option.map (List.hd user_cmds)
+                ~f:(fun (uc : Sql.User_command.t) ->
+                  uc.global_slot_since_genesis )
+            ; Option.map (List.hd zkapp_cmds)
+                ~f:(fun (zkc : Sql.Zkapp_command.t) ->
+                  zkc.global_slot_since_genesis )
+            ]
+          |> List.min_elt ~compare:Int64.compare
+        in
+        let reached_chain_end =
+          Option.both stop_slot_since_genesis_opt next_cmd_slot
+          |> Option.value_map ~default:false ~f:(fun (stop_slot, next) ->
+                 Int64.( >= ) next stop_slot )
+        in
+        if reached_chain_end then (
+          [%log info] "Reached slot_chain_end, stopping replay at slot %Ld"
+            (Option.value_exn next_cmd_slot) ;
+          let%bind _ =
+            run_transactions_on_slot_change ~last_block:true block_txns ()
+          in
+          Deferred.return
+            (staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed) )
+        else
+          match (internal_cmds, user_cmds, zkapp_cmds) with
+          | [], [], [] ->
+              (* all done *)
+              let%bind _ =
+                run_transactions_on_slot_change ~last_block:true block_txns ()
               in
-              ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
-                    txn :: block_txns0 )
-              , ics' )
-            in
-            apply_commands ~block_txns
-              ~last_global_slot_since_genesis:ic.global_slot_since_genesis
-              ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
-        | [], uc :: ucs, [] ->
-            (* only user commands *)
-            let%bind block_txns =
-              check_for_complete_block
-                ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
-            in
-            let%bind txn = user_command_to_transaction ~logger ~pool uc in
-            apply_commands ~block_txns:(txn :: block_txns)
-              ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-              ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
-        | [], [], zkc :: zkcs ->
-            (* only zkApp commands *)
-            let%bind block_txns =
-              check_for_complete_block
-                ~cmd_global_slot_since_genesis:zkc.global_slot_since_genesis
-            in
-            let%bind txn =
-              zkapp_command_to_transaction ~proof_cache_db ~logger ~pool zkc
-            in
-            apply_commands ~block_txns:(txn :: block_txns)
-              ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
-              ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs
-        | [], uc :: ucs, zkc :: zkcs -> (
-            (* no internal commands *)
-            let seqs =
-              [ get_user_cmd_sequence uc; get_zkapp_cmd_sequence zkc ]
-            in
-            match command_type_of_sequences seqs with
-            | `User_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
+              Deferred.return
+                ( staking_epoch_ledger
+                , staking_seed
+                , next_epoch_ledger
+                , next_seed )
+          | ic :: ics, [], [] ->
+              (* only internal commands *)
+              let%bind block_txns0 =
+                check_for_complete_block
+                  ~cmd_global_slot_since_genesis:ic.global_slot_since_genesis
+              in
+              let%bind block_txns, ics' =
+                let%map txn, ics' =
+                  internal_cmds_to_transaction ~logger ~pool ic ics
                 in
-                let%bind txn = user_command_to_transaction ~logger ~pool uc in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-                  ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
-            | `Zkapp_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:zkc.global_slot_since_genesis
-                in
-                let%bind txn =
-                  zkapp_command_to_transaction ~proof_cache_db ~logger ~pool zkc
-                in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
-                  ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs )
-        | ic :: ics, [], zkc :: zkcs -> (
-            (* no user commands *)
-            let seqs =
-              [ get_internal_cmd_sequence ic; get_zkapp_cmd_sequence zkc ]
-            in
-            match command_type_of_sequences seqs with
-            | `Internal_command ->
-                let%bind block_txns0 =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:ic.global_slot_since_genesis
-                in
-                let%bind block_txns, ics' =
-                  let%map txn, ics' =
-                    internal_cmds_to_transaction ~logger ~pool ic ics
+                ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
+                      txn :: block_txns0 )
+                , ics' )
+              in
+              apply_commands ~block_txns
+                ~last_global_slot_since_genesis:ic.global_slot_since_genesis
+                ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
+          | [], uc :: ucs, [] ->
+              (* only user commands *)
+              let%bind block_txns =
+                check_for_complete_block
+                  ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
+              in
+              let%bind txn = user_command_to_transaction ~logger ~pool uc in
+              apply_commands ~block_txns:(txn :: block_txns)
+                ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+                ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
+          | [], [], zkc :: zkcs ->
+              (* only zkApp commands *)
+              let%bind block_txns =
+                check_for_complete_block
+                  ~cmd_global_slot_since_genesis:zkc.global_slot_since_genesis
+              in
+              let%bind txn =
+                zkapp_command_to_transaction ~proof_cache_db ~logger ~pool zkc
+              in
+              apply_commands ~block_txns:(txn :: block_txns)
+                ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
+                ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs
+          | [], uc :: ucs, zkc :: zkcs -> (
+              (* no internal commands *)
+              let seqs =
+                [ get_user_cmd_sequence uc; get_zkapp_cmd_sequence zkc ]
+              in
+              match command_type_of_sequences seqs with
+              | `User_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        uc.global_slot_since_genesis
                   in
-                  ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
-                        txn :: block_txns0 )
-                  , ics' )
-                in
-                apply_commands ~block_txns
-                  ~last_global_slot_since_genesis:ic.global_slot_since_genesis
-                  ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
-            | `Zkapp_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:zkc.global_slot_since_genesis
-                in
-                let%bind txn =
-                  zkapp_command_to_transaction ~proof_cache_db ~logger ~pool zkc
-                in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
-                  ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs )
-        | ic :: ics, uc :: ucs, [] -> (
-            (* no zkApp commands *)
-            let seqs =
-              [ get_internal_cmd_sequence ic; get_user_cmd_sequence uc ]
-            in
-            match command_type_of_sequences seqs with
-            | `Internal_command ->
-                let%bind block_txns0 =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:ic.global_slot_since_genesis
-                in
-                let%bind block_txns, ics' =
-                  let%map txn, ics' =
-                    internal_cmds_to_transaction ~logger ~pool ic ics
+                  let%bind txn = user_command_to_transaction ~logger ~pool uc in
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+                    ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
+              | `Zkapp_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        zkc.global_slot_since_genesis
                   in
-                  ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
-                        txn :: block_txns0 )
-                  , ics' )
-                in
-                apply_commands ~block_txns
-                  ~last_global_slot_since_genesis:ic.global_slot_since_genesis
-                  ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
-            | `User_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
-                in
-                let%bind txn = user_command_to_transaction ~logger ~pool uc in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-                  ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds )
-        | ic :: ics, uc :: ucs, zkc :: zkcs -> (
-            (* internal, user, and zkApp commands *)
-            let seqs =
-              [ get_internal_cmd_sequence ic
-              ; get_user_cmd_sequence uc
-              ; get_zkapp_cmd_sequence zkc
-              ]
-            in
-            match command_type_of_sequences seqs with
-            | `Internal_command ->
-                let%bind block_txns0 =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:ic.global_slot_since_genesis
-                in
-                let%bind block_txns, ics' =
-                  let%map txn, ics' =
-                    internal_cmds_to_transaction ~logger ~pool ic ics
+                  let%bind txn =
+                    zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
+                      zkc
                   in
-                  ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
-                        txn :: block_txns0 )
-                  , ics' )
-                in
-                apply_commands ~block_txns
-                  ~last_global_slot_since_genesis:ic.global_slot_since_genesis
-                  ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
-            | `User_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:uc.global_slot_since_genesis
-                in
-                let%bind txn = user_command_to_transaction ~logger ~pool uc in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-                  ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
-            | `Zkapp_command ->
-                let%bind block_txns =
-                  check_for_complete_block
-                    ~cmd_global_slot_since_genesis:zkc.global_slot_since_genesis
-                in
-                let%bind txn =
-                  zkapp_command_to_transaction ~proof_cache_db ~logger ~pool zkc
-                in
-                apply_commands ~block_txns:(txn :: block_txns)
-                  ~last_global_slot_since_genesis:zkc.global_slot_since_genesis
-                  ~last_block_id:zkc.block_id internal_cmds user_cmds zkcs )
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:
+                      zkc.global_slot_since_genesis ~last_block_id:zkc.block_id
+                    internal_cmds user_cmds zkcs )
+          | ic :: ics, [], zkc :: zkcs -> (
+              (* no user commands *)
+              let seqs =
+                [ get_internal_cmd_sequence ic; get_zkapp_cmd_sequence zkc ]
+              in
+              match command_type_of_sequences seqs with
+              | `Internal_command ->
+                  let%bind block_txns0 =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        ic.global_slot_since_genesis
+                  in
+                  let%bind block_txns, ics' =
+                    let%map txn, ics' =
+                      internal_cmds_to_transaction ~logger ~pool ic ics
+                    in
+                    ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
+                          txn :: block_txns0 )
+                    , ics' )
+                  in
+                  apply_commands ~block_txns
+                    ~last_global_slot_since_genesis:ic.global_slot_since_genesis
+                    ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
+              | `Zkapp_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        zkc.global_slot_since_genesis
+                  in
+                  let%bind txn =
+                    zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
+                      zkc
+                  in
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:
+                      zkc.global_slot_since_genesis ~last_block_id:zkc.block_id
+                    internal_cmds user_cmds zkcs )
+          | ic :: ics, uc :: ucs, [] -> (
+              (* no zkApp commands *)
+              let seqs =
+                [ get_internal_cmd_sequence ic; get_user_cmd_sequence uc ]
+              in
+              match command_type_of_sequences seqs with
+              | `Internal_command ->
+                  let%bind block_txns0 =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        ic.global_slot_since_genesis
+                  in
+                  let%bind block_txns, ics' =
+                    let%map txn, ics' =
+                      internal_cmds_to_transaction ~logger ~pool ic ics
+                    in
+                    ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
+                          txn :: block_txns0 )
+                    , ics' )
+                  in
+                  apply_commands ~block_txns
+                    ~last_global_slot_since_genesis:ic.global_slot_since_genesis
+                    ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
+              | `User_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        uc.global_slot_since_genesis
+                  in
+                  let%bind txn = user_command_to_transaction ~logger ~pool uc in
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+                    ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds )
+          | ic :: ics, uc :: ucs, zkc :: zkcs -> (
+              (* internal, user, and zkApp commands *)
+              let seqs =
+                [ get_internal_cmd_sequence ic
+                ; get_user_cmd_sequence uc
+                ; get_zkapp_cmd_sequence zkc
+                ]
+              in
+              match command_type_of_sequences seqs with
+              | `Internal_command ->
+                  let%bind block_txns0 =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        ic.global_slot_since_genesis
+                  in
+                  let%bind block_txns, ics' =
+                    let%map txn, ics' =
+                      internal_cmds_to_transaction ~logger ~pool ic ics
+                    in
+                    ( Option.value_map txn ~default:block_txns0 ~f:(fun txn ->
+                          txn :: block_txns0 )
+                    , ics' )
+                  in
+                  apply_commands ~block_txns
+                    ~last_global_slot_since_genesis:ic.global_slot_since_genesis
+                    ~last_block_id:ic.block_id ics' user_cmds zkapp_cmds
+              | `User_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        uc.global_slot_since_genesis
+                  in
+                  let%bind txn = user_command_to_transaction ~logger ~pool uc in
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+                    ~last_block_id:uc.block_id internal_cmds ucs zkapp_cmds
+              | `Zkapp_command ->
+                  let%bind block_txns =
+                    check_for_complete_block
+                      ~cmd_global_slot_since_genesis:
+                        zkc.global_slot_since_genesis
+                  in
+                  let%bind txn =
+                    zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
+                      zkc
+                  in
+                  apply_commands ~block_txns:(txn :: block_txns)
+                    ~last_global_slot_since_genesis:
+                      zkc.global_slot_since_genesis ~last_block_id:zkc.block_id
+                    internal_cmds user_cmds zkcs )
       in
       let%bind start_slot_since_genesis =
         let%map slot_opt =
@@ -1906,14 +1976,24 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
       in
       let%bind () =
         match hard_fork_params_opt with
-        | Some (scheduled_genesis_since_hf, hard_fork_output_file) ->
+        | Some
+            ( scheduled_genesis_since_hf
+            , _slot_chain_end_hf
+            , hard_fork_output_file
+            , _hf_runtime_config ) ->
             (* Note that the [ledger] here is a mutable ledger mask, so
                apply_commands does modify it in-place when it applies the
                transactions to the ledger. Thus the [ledger] here will be the
                final staged ledger of the replayer run. *)
+            let stop_slot =
+              Option.value_exn stop_slot_since_genesis_opt
+                ~message:
+                  "stop_slot_since_genesis_opt must be set when \
+                   hard_fork_params_opt is set"
+            in
             apply_hard_fork_migration ~logger ~constraint_constants ~ledger
               ~genesis_dir ~scheduled_genesis_since_hf ~hard_fork_output_file
-              ~hard_fork_target
+              ~hard_fork_target ~stop_slot_since_genesis:stop_slot
         | None ->
             Deferred.unit
       in


### PR DESCRIPTION
## Problem

When running the replayer with hard fork arguments (`--hard-fork-target`, `--stop-slot-config-file`, `--hard-fork-output-file`), the generated hardfork checkpoint file contains incorrect data. The replayer processes blocks **beyond** `slot_chain_end`, including their transactions in the final ledger state, which produces a wrong hardfork output file.

### How to reproduce

```bash
_build/default/src/app/replayer/replayer.exe \
  --archive-uri postgres://postgres:postgres@localhost:5432/archive \
  --input-file genesis-replayer-config.json \
  --hard-fork-target mesa \
  --stop-slot-config-file stop-slot-config.json \
  --hard-fork-output-file output-hf.json \
  --log-json \
  --log-level spam
```

Where `genesis-replayer-config.json`:

```json
{
  "target_epoch_ledgers_state_hash": "3NKhd6scsxTazcEWpnxR2LBLJZS9ARZy64T2fGSoZHhzVALyU3Ld",
  "genesis_ledger": {
    "add_genesis_winner": false,
    "s3_data_hash": "d0f921c9db97265e5e8c25cfecbb08ae259e735c0bb5acd0912e43aaec10fced",
    "hash": "jwXMfukdwJVNpZ3wMEZbuq4zwucYS4cJnij23buAnNYo1GKKrFB"
  }
}
```

And `stop-slot-config.json`:

```json
{
  "genesis": {
    "genesis_state_timestamp": "2026-02-24T19:30:00Z"
  },
  "ledger": {
    "add_genesis_winner": false,
    "s3_data_hash": "d0f921c9db97265e5e8c25cfecbb08ae259e735c0bb5acd0912e43aaec10fced",
    "hash": "jwXMfukdwJVNpZ3wMEZbuq4zwucYS4cJnij23buAnNYo1GKKrFB"
  },
  "daemon": {
    "slot_tx_end": 1900,
    "hard_fork_genesis_slot_delta": 40,
    "slot_chain_end": 1920
  },
  "epoch_data": {
    "staking": {
      "seed": "2vahsgRV5nDPmtgr2Xo2Uq2dkngfSgvg7d1TKqQbY3wUS2ZDxCC3",
      "s3_data_hash": "8053060205998762d7eb07804edda4723fcc31aac9c819142acac4aed80282d5",
      "hash": "jwkUfFHU5xnAYNZzHPWGRNuZCve2SkbwuuXXETZuH6hdBup77D7"
    },
    "next": {
      "seed": "2vbH4D8B76WMYPRFgeuVvdWVhv6tAFoCJtg83yuJT1dud3QVSiZn",
      "s3_data_hash": "7554a3b0333018e2e7d1dacebb3f5b114c85fddb65b3ae6f8e295f28a7cd75d4",
      "hash": "jxqJ5NT4txXQKLnxJyDBwAAHysWAiAezV8agV7Qg5Md2yRGaAWq"
    }
  }
}
```

**Expected**: Replayer stops processing at `slot_chain_end` (1920) and the hardfork output reflects the ledger state at that boundary.

**Actual**: Replayer continues processing commands past `slot_chain_end`, and `apply_hard_fork_migration` picks up blocks beyond the cutoff when computing the last slot, producing a hardfork checkpoint based on a ledger that includes transactions that should not be part of the pre-fork state.

For example we are receiving error which comes from incompatibility of first block on mesa format:

```
{"timestamp":"2026-03-12 20:27:19.588459Z","level":"Spam","message":"Replaying transactions in block with state hash $state_hash","metadata":{"block_id":1248,"global_slot_since_genesis":"1899","no_coinbases":1,"no_fee_transfers":1,"no_signed_commands":1,"no_zkapp_commands":0,"state_hash":"3NLFNvH2oV2ERa1gGdRcYpT26Fc378i8RbXzJ8qr63NvPF7DpTTY"}}
{"timestamp":"2026-03-12 20:27:19.596536Z","level":"Info","source":{"module":"Dune__exe__Replayer","location":"File \"src/app/replayer/replayer.ml\", line 1301, characters 12-23"},"message":"Applied all commands at global slot since genesis 1899, got expected ledger hash","metadata":{"block_id":1248,"global_slot_since_genesis":"1899","ledger_hash":"jxR6ygXkPjRG6B6pN3NzqKWsZbuk3XdErFchLNESFiN2rENF8Bh","state_hash":"3NLFNvH2oV2ERa1gGdRcYpT26Fc378i8RbXzJ8qr63NvPF7DpTTY"}}
{"timestamp":"2026-03-12 20:27:19.596558Z","level":"Spam","message":"Checking accounts accessed in block just processed","metadata":{"block_id":1248,"global_slot_since_genesis":"1899","state_hash":"3NLFNvH2oV2ERa1gGdRcYpT26Fc378i8RbXzJ8qr63NvPF7DpTTY"}}
{"timestamp":"2026-03-12 20:27:19.596816Z","level":"Spam","message":"Verifying that accounts created are also deemed accessed in block with global slot since genesis 1899","metadata":{}}
{"timestamp":"2026-03-12 20:27:19.596821Z","level":"Spam","message":"Verifying accounts accessed in block with global slot since genesis 1899","metadata":{}}
{"timestamp":"2026-03-12 20:27:19.598389Z","level":"Spam","message":"Starting processing of commands in block with state_hash $state_hash at global slot since genesis 1899","metadata":{"state_hash":"3NLFNvH2oV2ERa1gGdRcYpT26Fc378i8RbXzJ8qr63NvPF7DpTTY"}}
{"timestamp":"2026-03-12 20:27:19.598404Z","level":"Spam","message":"Converting internal command (coinbase) with global slot since genesis 1962, sequence number 0, and secondary sequence number 0 to transaction","metadata":{}}
{"timestamp":"2026-03-12 20:27:19.599054Z","level":"Info","source":{"module":"Dune__exe__Replayer","location":"File \"src/app/replayer/replayer.ml\", line 1620, characters 22-33"},"message":"Current snarked ledger hash not among first-pass ledger hashes, but we haven't yet found one. The transaction that created this ledger hash might have been in an older replayer run that created a checkpoint file without saved first-pass ledger hashes","metadata":{}}
{"timestamp":"2026-03-12 20:27:19.599079Z","level":"Spam","message":"Replaying transactions in block with state hash $state_hash","metadata":{"block_id":1272,"global_slot_since_genesis":"1962","no_coinbases":1,"no_fee_transfers":0,"no_signed_commands":0,"no_zkapp_commands":0,"state_hash":"3NKhd6scsxTazcEWpnxR2LBLJZS9ARZy64T2fGSoZHhzVALyU3Ld"}}
{"timestamp":"2026-03-12 20:27:19.606712Z","level":"Error","source":{"module":"Dune__exe__Replayer","location":"File \"src/app/replayer/replayer.ml\", line 1324, characters 12-24"},"message":"Applied all commands at global slot since genesis 1962, ledger hash differs from expected ledger hash","metadata":{"expected_ledger_hash":"jwYwUts7jQQ87UmQF33uf6MwrCLZQeJmd2a37qTGbs1mizqsrkT","global_slot_since_genesis":"1962","ledger_hash":"jxPH1vm3oh7zpnW4884Y5Vbjwh8KBh7um9dGx9j42RHA4tLtWFL","state_hash":"3NKhd6scsxTazcEWpnxR2LBLJZS9ARZy64T2fGSoZHhzVALyU3Ld"}}

```

## Root Cause

Two issues:

1. **`apply_commands` had no awareness of `slot_chain_end`** — it replayed every command from the archive DB regardless of slot boundaries, so the ledger kept accumulating transactions past the point where the chain should have stopped.

2. **`apply_hard_fork_migration` used all slots in `global_slot_hashes_tbl`** — when selecting the "last block" for the hardfork output, it picked the maximum slot from the entire table without filtering, which could be well beyond `slot_chain_end`.

## Fix

1. **Stop replay at `slot_chain_end`**: Compute `stop_slot_since_genesis` from the hard fork config (converting `slot_chain_end` from since-hard-fork to since-genesis coordinates). Before processing the next command in `apply_commands`, check if its slot is `>= stop_slot_since_genesis` and stop early if so.

2. **Filter slots in `apply_hard_fork_migration`**: When selecting the last block slot, filter `global_slot_hashes_tbl` to only include slots `< stop_slot_since_genesis`, ensuring the hardfork output is derived from the correct chain-end boundary.

3. **Parse `slot_chain_end` from the hard fork config**: `hard_fork_params` now extracts both `scheduled_hard_fork_genesis_slot` and `slot_chain_end` from the runtime config, requiring both to be present.