### PR TITLE
update CODEOWNERS to remove all review groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,24 +1,3 @@
-/CODEOWNERS @dannywillems @deepthiskumar @georgeee
-/buildkite @MinaProtocol/infra-eng-reviewers
-/dockerfiles/ @MinaProtocol/infra-eng-reviewers
-/scripts/ @MinaProtocol/infra-eng-reviewers @MinaProtocol/protocol-eng-reviewers
-/Makefile @MinaProtocol/infra-eng-reviewers
-/src/lib/node_config/profiled/ @MinaProtocol/infra-eng-reviewers @MinaProtocol/protocol-eng-reviewers
+/CODEOWNERS @deepthiskumar @georgeee
 /CODE_OF_CONDUCT.md @deepthiskumar
-/CONTRIBUTING.md @MinaProtocol/product-eng-reviewers
 /LICENSE @deepthiskumar
-/README.md @MinaProtocol/product-eng-reviewers
-/README-dev.md @MinaProtocol/protocol-eng-reviewers
-
-/src/app/reformat/ @MinaProtocol/infra-eng-reviewers
-
-/src/app/ @MinaProtocol/protocol-eng-reviewers
-/src/lib/ @MinaProtocol/protocol-eng-reviewers
-
-/src/lib/mina_numbers/ @MinaProtocol/crypto-eng-reviewers
-/src/lib/crypto @MinaProtocol/crypto-eng-reviewers
-/src/lib/dummy_values/ @MinaProtocol/crypto-eng-reviewers
-/src/lib/hash_prefixes/ @MinaProtocol/crypto-eng-reviewers
-/src/lib/precomputed_values/ @MinaProtocol/crypto-eng-reviewers
-/src/lib/concurrency/promise @MinaProtocol/protocol-eng-reviewers @MinaProtocol/product-eng-reviewers
-/src/lib/unsigned_extended/ @MinaProtocol/crypto-eng-reviewers


### PR DESCRIPTION
This PR removed all review groups, from now on each PR needs only one reviewer