### PR TITLE
fix compilation warning from runtime_genesis_ledger

### DIFF
--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -90,6 +90,7 @@ let is_dirty_proof = function
       ; coinbase_amount = None
       ; supercharged_coinbase_factor = None
       ; account_creation_fee = None
+      ; _
       } ->
       false
   | _ ->


### PR DESCRIPTION
I have no idea why this haven't popped out when I'm implementing https://github.com/MinaProtocol/mina/pull/18608