### PR TITLE
Refactor verify.sh into per-package scripts and enable verification in hf pipeline

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -37,6 +37,9 @@ set -euox pipefail
 #   - Dhall configuration files in buildkite/src/
 #
 
+# Colors for output
+RED='\033[0;31m'
+CLEAR='\033[0m'
 
 DEBIAN_VERSION_DHALL_DEF="(./buildkite/src/Constants/DebianVersions.dhall)"
 ARCH_DHALL_DEF="(./buildkite/src/Constants/Arch.dhall)"

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -238,7 +238,7 @@ let generateStep =
 
           let buildDockerCmd =
                     "./scripts/docker/build.sh"
-                ++  " --service ${Artifacts.dockerName spec.service}"
+                ++  " --service ${Artifacts.dockerServiceName spec.service}"
                 ++  " --network ${Network.debianSuffix spec.network}"
                 ++  " --version ${spec.version}"
                 ++  " --branch ${spec.branch}"

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -114,7 +114,12 @@ let lowerName =
             }
             artifact
 
-let dockerName =
+-- Service name passed to scripts/docker/build.sh --service flag.
+-- build.sh uses this to select the correct Dockerfile for each artifact.
+-- May differ from the actual image name in the registry, because build.sh
+-- can internally rename the service (e.g. mina-daemon-configured builds
+-- using dockerfiles/stages/install-config but pushes as mina-daemon).
+let dockerServiceName =
           \(artifact : Artifact)
       ->  merge
             { Daemon = "mina-daemon"
@@ -136,6 +141,35 @@ let dockerName =
             , DelegationVerifier = "mina-delegation-verifier"
             , DaemonStorageToolbox = "mina-daemon-storage-toolbox"
             , DaemonConfig = "mina-daemon-configured"
+            }
+            artifact
+
+-- Returns the actual image name as it appears in the docker registry.
+-- For most artifacts this is the same as dockerServiceName, but for some
+-- (like DaemonConfig) build.sh renames the image before pushing.
+-- Use this when referring to images by name (verify, promote, pull).
+let dockerName =
+          \(artifact : Artifact)
+      ->  merge
+            { DaemonConfig = "mina-daemon"
+            , Daemon = dockerServiceName artifact
+            , DaemonPrefork = dockerServiceName artifact
+            , DaemonLegacyHardfork = dockerServiceName artifact
+            , DaemonAutoHardfork = dockerServiceName artifact
+            , DaemonAppsOnly = dockerServiceName artifact
+            , Archive = dockerServiceName artifact
+            , TestExecutive = dockerServiceName artifact
+            , LogProc = dockerServiceName artifact
+            , BatchTxn = dockerServiceName artifact
+            , Rosetta = dockerServiceName artifact
+            , RosettaAppsOnly = dockerServiceName artifact
+            , RosettaConfig = "mina-rosetta"
+            , ZkappTestTransaction = dockerServiceName artifact
+            , FunctionalTestSuite = dockerServiceName artifact
+            , Toolchain = dockerServiceName artifact
+            , CreatePreforkGenesis = dockerServiceName artifact
+            , DelegationVerifier = dockerServiceName artifact
+            , DaemonStorageToolbox = dockerServiceName artifact
             }
             artifact
 
@@ -469,6 +503,7 @@ in  { Type = Artifact
     , lowerName = lowerName
     , toDebianName = toDebianName
     , toDebianNames = toDebianNames
+    , dockerServiceName = dockerServiceName
     , dockerName = dockerName
     , dockerNames = dockerNames
     , dockerTag = dockerTag

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -473,9 +473,11 @@ let generateHfRelatedStepsForCodename =
                           Toolchain.SelectionMode.ByDebianAndArch
                           codename.DebVersion
                           codename.Arch
-                          [ "NETWORK_NAME=${Network.lowerName spec.network}"
-                          , "MINA_DEB_CODENAME=${lowerNameCodename}"
-                          ]
+                          (   [ "NETWORK_NAME=${Network.lowerName spec.network}"
+                              , "MINA_DEB_CODENAME=${lowerNameCodename}"
+                              ]
+                            # DebianVersions.overrideEnvs
+                          )
                           "mkdir -p _build && ./buildkite/scripts/cache/manager.sh read hardfork /workdir && RUNTIME_CONFIG_JSON=/workdir/hardfork/new_config.json LEDGER_TARBALLS='/workdir/hardfork/ledgers/*.tar.gz' ./buildkite/scripts/debian/build.sh --codenames ${debianCodenamesList} --arch all daemon_${Network.lowerName
                                                                                                                                                                                                                                                                                                                      spec.network}_hardfork_config"
                     , label =

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -367,7 +367,10 @@ let generateHfRelatedStepsForCodename =
                   , network = spec.network
                   , version =
                       merge
-                        { Some = \(v : Text) -> v
+                        { Some =
+                                \(v : Text)
+                            ->  "${v}-${DebianVersions.lowerName
+                                          codename.DebVersion}"
                         , None = "\\\${MINA_DOCKER_TAG}"
                         }
                         spec.use_generic_dockers_from_version

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -60,6 +60,7 @@ let Spec =
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
+          , deb_storage_repair_version : Text
           }
       , default =
           { codenames =
@@ -78,6 +79,8 @@ let Spec =
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
+          , deb_storage_repair_version =
+              defaultMinaArtifactSpec.deb_storage_repair_version
           }
       }
 
@@ -181,7 +184,7 @@ let generateDockerForCodename =
                                       ++  " --backend local --artifacts mina-logproc,mina-${Network.lowerName
                                                                                               spec.network},mina-archive-${Network.lowerName
                                                                                                                              spec.network},mina-rosetta-${Network.lowerName
-                                                                                                                                                            spec.network},mina-zkapp-test-transaction "
+                                                                                                                                                            spec.network},mina-zkapp-test-transaction,mina-daemon-storage-toolbox "
                                       ++  " --buildkite-build-id ${cached_build_id}"
                                       ++  " --codename ${lowerNameCodename} "
                                       ++  " --target \\\${BUILDKITE_BUILD_ID} "
@@ -206,6 +209,7 @@ let generateDockerForCodename =
                           , Artifacts.Type.RosettaConfig
                           , Artifacts.Type.Rosetta
                           , Artifacts.Type.ZkappTestTransaction
+                          , Artifacts.Type.DaemonStorageToolbox
                           ]
                         , debVersion = codename.DebVersion
                         , profile = profile
@@ -231,6 +235,7 @@ let generateDockerForCodename =
                                 DockerImage.DebianInstallMode.DownloadOnly
                             , deb_legacy_version = spec.deb_legacy_version
                             , size = spec.size
+                            , verify = True
                             , version =
                                 "${version}-${DebianVersions.lowerName
                                                 codename.DebVersion}"
@@ -251,6 +256,7 @@ let generateDockerForCodename =
                             , image_name = Some
                                 (Artifacts.dockerName Artifacts.Type.Rosetta)
                             , size = spec.size
+                            , verify = True
                             , version =
                                 "${version}-${DebianVersions.lowerName
                                                 codename.DebVersion}"
@@ -268,6 +274,8 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , generic = True
@@ -282,7 +290,10 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
+                      , verify = True
                       , deb_version = spec.version
                       , step_key_suffix =
                           "-${DebianVersions.lowerName
@@ -295,6 +306,8 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , step_key_suffix =
@@ -309,6 +322,7 @@ let generateDockerForCodename =
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
                       , size = spec.size
+                      , verify = True
                       , deb_version = spec.version
                       , step_key_suffix =
                           "-${DebianVersions.lowerName

--- a/scripts/debian/verify-inside-docker/setup.sh
+++ b/scripts/debian/verify-inside-docker/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Common setup: add repo, install package. Sourced by per-package verify scripts.
+set -euo pipefail
+set -x
+
+export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+
+PACKAGE="$1"
+VERSION="$2"
+REPO="$3"
+CODENAME="$4"
+CHANNEL="$5"
+SIGNED="${6:-0}"
+TRUSTED_FLAG="${7:-[trusted=yes]}"
+
+echo "Installing $PACKAGE=$VERSION from $REPO ($CODENAME/$CHANNEL)"
+
+apt-get update > /dev/null
+apt-get install -y lsb-release ca-certificates wget gnupg > /dev/null
+
+if [[ "$SIGNED" == "1" ]]; then
+  wget -q "https://${REPO}/repo-signing-key.gpg" -O /etc/apt/trusted.gpg.d/minaprotocol.gpg
+  TRUSTED_FLAG=""
+fi
+
+echo "deb ${TRUSTED_FLAG} https://${REPO} ${CODENAME} ${CHANNEL}" > /etc/apt/sources.list.d/mina.list
+apt-get update > /dev/null
+
+apt list -a "$PACKAGE"
+apt-get install -y --allow-downgrades "${PACKAGE}=${VERSION}"

--- a/scripts/debian/verify.sh
+++ b/scripts/debian/verify.sh
@@ -3,6 +3,9 @@ set -eo pipefail
 
 REPO=packages.o1test.net
 SIGNED=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="$SCRIPT_DIR/verify-inside-docker/setup.sh"
+CHECK_SCRIPTS_DIR="$SCRIPT_DIR/../verify"
 
 function usage() {
   echo "Usage: $0 -c <channel> -r <repository> -v <version> -p <package> -m <codename> [-s]"
@@ -11,6 +14,7 @@ function usage() {
   echo "  -v, --version    Version to install"
   echo "  -p, --package    Package to install"
   echo "  -m, --codename   Codename of the distribution (focal, bullseye)"
+  echo "  -a, --arch       Architecture (default: amd64)"
   echo "  -s, --signed     Add the repository signing key"
 }
 
@@ -23,84 +27,64 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   -a|--arch) ARCH="$2"; shift;;
   -s|--signed) SIGNED=1; ;;
   -h|--help) usage; exit 0;;
-  *) echo "❌  Unknown parameter passed: $1"; usage;  exit 1;;
+  *) echo "Unknown parameter passed: $1"; usage;  exit 1;;
 esac; shift; done
 
-if [ -z $PACKAGE ]; then
-  echo "❌  No package defined. "
-  echo "❌  Did you forget to pass --package?"
-  echo "" 
+if [ -z "${PACKAGE:-}" ]; then
+  echo "No package defined. Did you forget to pass --package?"
   usage; exit 1;
 fi
 
-if [ -z $VERSION ]; then
-  echo "❌  No version defined."; 
-  echo "❌  Did you forget to pass --version?";
-  echo ""
+if [ -z "${VERSION:-}" ]; then
+  echo "No version defined. Did you forget to pass --version?"
   usage; exit 1;
 fi
 
-if [ -z $CODENAME ]; then
-  echo "❌  No codename defined.";
-  echo "❌  Did you forget to pass --codename?";
-  echo ""
+if [ -z "${CODENAME:-}" ]; then
+  echo "No codename defined. Did you forget to pass --codename?"
   usage; exit 1;
 fi
 
-if [ -z $CHANNEL ]; then
-  echo "❌  No channel defined.";
-  echo "❌  Did you forget to pass --channel?";
-  echo ""
+if [ -z "${CHANNEL:-}" ]; then
+  echo "No channel defined. Did you forget to pass --channel?"
   usage; exit 1;
 fi
 
-if [ -z $REPO ]; then
-  echo "❌  No repository defined."; 
-  echo "❌  Did you forget to pass --repo?";
-  echo ""
+if [ -z "${REPO:-}" ]; then
+  echo "No repository defined. Did you forget to pass --repo?"
   usage; exit 1;
 fi
 
-if [ -z $ARCH ]; then
-  ARCH=amd64
-fi
+ARCH="${ARCH:-amd64}"
 
-case $PACKAGE in
-  mina-archive*) COMMAND="mina-archive --version && mina-archive --help" ;;
-  mina-logproc) COMMAND="echo skipped execution for mina-logproc" ;;
-  mina-rosetta*) COMMAND="echo skipped execution for mina-rosetta" ;;
-  mina-*) COMMAND="mina --version && mina --help" ;;
-  *) echo "❌  Unknown package passed: $PACKAGE"; exit 1;;
-esac
-
-if [[ "$SIGNED" == 1 ]]; then
-  SIGNED=" (wget -q https://'$REPO'/repo-signing-key.gpg -O /etc/apt/trusted.gpg.d/minaprotocol.gpg ) && apt-get update > /dev/null && "
-  TRUSTED=""
-else 
-  SIGNED=""
-  TRUSTED="[trusted=yes]"
-fi
-
-
-SCRIPT=' set -x \
-    && export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
-    && echo installing '$PACKAGE' \
-    && apt-get update > /dev/null \
-    && apt-get install -y lsb-release ca-certificates wget gnupg > /dev/null \
-    && '$SIGNED' echo "deb '$TRUSTED' https://'$REPO' '$CODENAME' '$CHANNEL'" > /etc/apt/sources.list.d/mina.list \
-    && apt-get update > /dev/null \
-    && apt list -a '$PACKAGE' \
-    && apt-get install -y --allow-downgrades '$PACKAGE'='$VERSION' \
-    && '$COMMAND' 
-    '
+# Resolve which check script to run
+source "$CHECK_SCRIPTS_DIR/resolve-check-script.sh" "$PACKAGE"
+CHECK_SCRIPT_NAME=$(basename "$CHECK_SCRIPT")
 
 case $CODENAME in
   bullseye|bookworm) DOCKER_IMAGE="debian:$CODENAME" ;;
   focal|noble|jammy) DOCKER_IMAGE="ubuntu:$CODENAME" ;;
-  *) echo "❌  Unknown codename passed: $CODENAME"; exit 1;;
+  *) echo "Unknown codename passed: $CODENAME"; exit 1;;
 esac
 
-echo "📋  Testing $PACKAGE $DOCKER_IMAGE"
+if [[ "$SIGNED" == 1 ]]; then
+  TRUSTED_FLAG=""
+else
+  TRUSTED_FLAG="[trusted=yes]"
+fi
 
-docker run --platform "linux/$ARCH" --rm "$DOCKER_IMAGE" bash -c "$SCRIPT" \
-  && echo '✅  OK: ALL WORKED FINE!' || (echo '❌  KO: ERROR!!!' && exit 1)
+echo "Testing $PACKAGE on $DOCKER_IMAGE"
+
+# Mount the setup script and shared check scripts into the container.
+# 1. setup.sh installs the package from the debian repository
+# 2. The shared check script verifies the installed binaries
+if docker run --platform "linux/$ARCH" --rm \
+  -v "$SETUP_SCRIPT:/verify/setup.sh:ro" \
+  -v "$CHECK_SCRIPTS_DIR:/checks:ro" \
+  "$DOCKER_IMAGE" \
+  bash -c "source /verify/setup.sh '$PACKAGE' '$VERSION' '$REPO' '$CODENAME' '$CHANNEL' '$SIGNED' '$TRUSTED_FLAG' && bash /checks/$CHECK_SCRIPT_NAME"; then
+  echo 'OK: ALL WORKED FINE!'
+else
+  echo 'KO: ERROR!!!'
+  exit 1
+fi

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -221,6 +221,9 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/stages/install-config"
         DOCKER_CONTEXT="dockerfiles/"
         SERVICE="mina-daemon"
+        # The --version arg points to the base generic image for the Dockerfile FROM.
+        # Override VERSION_ARG to keep it, then set VERSION to current commit for output tags.
+        VERSION_ARG_OVERRIDE="--build-arg version=$VERSION"
         ;;
     mina-daemon-legacy-hardfork)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-daemon"
@@ -249,6 +252,7 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/stages/install-config"
         DOCKER_CONTEXT="dockerfiles/"
         SERVICE="mina-rosetta"
+        VERSION_ARG_OVERRIDE="--build-arg version=$VERSION"
         ;;
     mina-zkapp-test-transaction)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-zkapp-test-transaction"
@@ -277,6 +281,13 @@ case "${SERVICE}" in
         exit 1
         ;;
 esac
+
+if [[ -n "${VERSION_ARG_OVERRIDE:-}" ]]; then
+  # For services like mina-daemon-configured, the build arg version (base image)
+  # differs from the output tag version (current commit).
+  VERSION_ARG="$VERSION_ARG_OVERRIDE"
+  VERSION="$MINA_DOCKER_TAG"
+fi
 
 export_version
 export_docker_tag

--- a/scripts/docker/verify.sh
+++ b/scripts/docker/verify.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
 # Verify that the Docker image for a given package and version is working correctly.
-# This script pulls the Docker image and runs a set of simplest commands (fetch help and version) 
-# to ensure that the package dependencies are correctly resolved.
+# This script pulls the Docker image and runs the shared check scripts from scripts/verify/
+# to ensure that the package dependencies are correctly resolved and binaries work.
 # Usage: ./scripts/docker/verify.sh -p <package> -c <codename> [-s <suffix>] [-r <repo>] [-v <version>]
 
 set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPTS_DIR="$SCRIPT_DIR/../verify"
 
 REPO=""
 VERSION=3.0.0-f872d85
@@ -22,29 +25,23 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 esac; shift; done
 
 if [[ -z "$PACKAGE" ]]; then
-  echo "❌  Package is not set! Use -p or --package to set it."
+  echo "Package is not set! Use -p or --package to set it."
   exit 1
 fi
 
 if [[ -z "$CODENAME" ]]; then
-  echo "❌  Codename is not set! Use -c or --codename to set it."
+  echo "Codename is not set! Use -c or --codename to set it."
   exit 1
 fi
 
 if [[ -z "$REPO" ]]; then
-  echo "❌  Repo is not set! Use -r or --repo to set it."
+  echo "Repo is not set! Use -r or --repo to set it."
   exit 1
 fi
 
-COMMANDS=(--version --help)
-
-case $PACKAGE in
-  mina-archive) APPS=mina-archive ;;
-  mina-logproc) APPS=(); echo "skipped execution for mina-logproc" ;;
-  mina-rosetta*) APPS=("mina" "mina-archive" "mina-rosetta") ;;
-  mina-*) APPS=("mina");;
-  *) echo "❌  Unknown package passed: $PACKAGE"; exit 1;;
-esac
+# Resolve which check script to run
+source "$CHECK_SCRIPTS_DIR/resolve-check-script.sh" "$PACKAGE"
+CHECK_SCRIPT_NAME=$(basename "$CHECK_SCRIPT")
 
 case $ARCH in
   amd64)
@@ -53,7 +50,7 @@ case $ARCH in
   arm64)
     DOCKER_ARCH_SUFFIX="-arm64"
     ;;
-  *) echo "❌  Unknown architecture passed: $ARCH"; exit 1 ;;
+  *) echo "Unknown architecture passed: $ARCH"; exit 1 ;;
 esac
 
 DOCKER_PLATFORM="--platform linux/$ARCH"
@@ -61,21 +58,23 @@ DOCKER_PLATFORM="--platform linux/$ARCH"
 DOCKER_IMAGE="$REPO/$PACKAGE:$VERSION-${CODENAME}${SUFFIX}${DOCKER_ARCH_SUFFIX}"
 
 if ! docker pull "$DOCKER_IMAGE" ; then
-  echo "❌ Docker verification for $CODENAME $PACKAGE $ARCH failed"
-  echo "❌ Please check if the image $DOCKER_IMAGE exists."
+  echo "Docker verification for $CODENAME $PACKAGE $ARCH failed"
+  echo "Please check if the image $DOCKER_IMAGE exists."
   exit 1
 fi
 
-for APP in "${APPS[@]}"; do
-  for COMMAND in "${COMMANDS[@]}"; do
-    echo "📋  Testing $APP $COMMAND in $DOCKER_IMAGE"
-    # Do not quote $COMMAND, because it may contain spaces or other special characters
-    # shellcheck disable=SC2086
-    if ! docker run $DOCKER_PLATFORM --entrypoint "$APP" --rm "$DOCKER_IMAGE" $COMMAND; then
-      echo "❌  KO: ERROR running $APP $COMMAND"
-      exit 1
-    fi
-  done
-done
+echo "Running checks for $PACKAGE in $DOCKER_IMAGE"
 
-echo '✅  OK: ALL WORKED FINE!'
+# Mount the shared check scripts into the container and run the appropriate one.
+# The check scripts assume binaries are already installed (which they are in the docker image).
+# shellcheck disable=SC2086
+if docker run $DOCKER_PLATFORM --rm \
+  --entrypoint bash \
+  -v "$CHECK_SCRIPTS_DIR:/checks:ro" \
+  "$DOCKER_IMAGE" \
+  /checks/"$CHECK_SCRIPT_NAME"; then
+  echo 'OK: ALL WORKED FINE!'
+else
+  echo 'KO: ERROR!!!'
+  exit 1
+fi

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -40,7 +40,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 if [[ -v BRANCH_NAME ]]; then
    GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
 else
-   GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+   # Always use actual HEAD for branch resolution — OVERRIDE_GITHASH is a
+   # short hash from another commit and git name-rev cannot resolve it.
+   _GIT_HEAD_HASH=$(git rev-parse --short=7 --verify HEAD)
+   GITBRANCH=$(git name-rev --name-only $_GIT_HEAD_HASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 fi
 
 GITTAG=${OVERRIDE_TAG:-$(find_most_recent_numeric_tag HEAD)}

--- a/scripts/verify/check-archive.sh
+++ b/scripts/verify/check-archive.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Shared verification checks for the mina-archive package.
+# Assumes mina-archive binary is already installed.
+set -euo pipefail
+
+echo "Verifying mina-archive..."
+mina-archive --version
+mina-archive --help

--- a/scripts/verify/check-daemon.sh
+++ b/scripts/verify/check-daemon.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared verification checks for the mina daemon package.
+# Assumes mina binary and config files are already installed.
+#
+# Checks:
+#   1. mina binary runs (--version, --help)
+#   2. The commit hash baked into the mina binary matches the commit hash
+#      embedded in the genesis config filename (config_<hash>.json)
+set -euo pipefail
+
+echo "Running mina --version and --help ..."
+mina --version
+mina --help
+
+# --- Extract commit hash from the mina binary ---
+MINA_VERSION_OUTPUT=$(mina --version 2>&1)
+MINA_COMMIT=$(echo "$MINA_VERSION_OUTPUT" | grep -oP '(?:commit_hash": "|Commit )\K[a-f0-9]+' | head -c 8)
+echo "Mina binary commit hash: $MINA_COMMIT"
+
+# --- Compare with the genesis config file commit hash ---
+# The daemon package ships a config file at /var/lib/coda/config_<hash>.json
+# where <hash> must match the binary's commit hash.
+CONFIG_FILE=$(ls /var/lib/coda/config_*.json 2>/dev/null | head -1 || true)
+
+if [ -z "$CONFIG_FILE" ]; then
+  echo "No genesis config file found in /var/lib/coda/ — skipping hash check"
+  exit 0
+fi
+
+echo "Found genesis config: $CONFIG_FILE"
+
+# Extract the commit hash from the config filename (config_<hash>.json)
+CONFIG_COMMIT=$(basename "$CONFIG_FILE" | grep -oP 'config_\K[a-f0-9]+')
+echo "Config file commit hash: $CONFIG_COMMIT"
+
+if [ "$MINA_COMMIT" = "$CONFIG_COMMIT" ]; then
+  echo "OK: mina binary commit ($MINA_COMMIT) matches genesis config commit ($CONFIG_COMMIT)"
+else
+  echo "FAIL: mina binary commit ($MINA_COMMIT) does not match genesis config commit ($CONFIG_COMMIT)"
+  exit 1
+fi

--- a/scripts/verify/check-logproc.sh
+++ b/scripts/verify/check-logproc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Shared verification checks for the mina-logproc package.
+# Assumes mina-logproc binary is already installed.
+set -euo pipefail
+
+echo "Skipped execution for mina-logproc"

--- a/scripts/verify/check-rosetta.sh
+++ b/scripts/verify/check-rosetta.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Shared verification checks for the mina-rosetta package.
+# Assumes mina, mina-archive, and mina-rosetta binaries are already installed.
+set -euo pipefail
+
+echo "Verifying mina-rosetta..."
+mina --version
+mina --help
+mina-archive --version
+mina-archive --help
+mina-rosetta --version
+mina-rosetta --help

--- a/scripts/verify/resolve-check-script.sh
+++ b/scripts/verify/resolve-check-script.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Maps a package name to the corresponding check script.
+# Usage: source resolve-check-script.sh <package>
+# Sets: CHECK_SCRIPT (path to the check script to run)
+set -euo pipefail
+
+VERIFY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "${1:?package name required}" in
+  mina-archive*) CHECK_SCRIPT="$VERIFY_DIR/check-archive.sh" ;;
+  mina-logproc)  CHECK_SCRIPT="$VERIFY_DIR/check-logproc.sh" ;;
+  mina-rosetta*) CHECK_SCRIPT="$VERIFY_DIR/check-rosetta.sh" ;;
+  mina-*)        CHECK_SCRIPT="$VERIFY_DIR/check-daemon.sh" ;;
+  *) echo "Unknown package: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
Expanded check for config docker for deamon. It validates that `/var/lib/config_XXXX.json` is the prefix of mina commit id. 

This is crucial in order to allow daemon load config file witout specifying --config-file. 