### PR TITLE
Fix config deb packages being built with host architecture instead of 'all'

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -474,6 +474,9 @@ build_daemon_config_deb() {
   # Config package doesn't have any binaries, but we need to include
   # the common utils for hardfork packages that rely on some of the configs here.
   # that's why we are using all as architecture.
+
+  # Save and reset architecture to all for config package, since it doesn't contain any binaries but we want to make sure it's available for all architectures.
+  # We will restore the original architecture after building the package.
   local saved_arch="${ARCHITECTURE}"
   ARCHITECTURE=all
 
@@ -659,6 +662,9 @@ build_daemon_hardfork_config_deb() {
   # Config package doesn't have any binaries, but we need to include
   # the common utils for hardfork packages that rely on some of the configs here.
   # that's why we are using all as architecture.
+
+  # Save and reset architecture to all for hardfork config package, since it doesn't contain any binaries but we want to make sure it's available for all architectures.
+  # We will restore the original architecture after building the package.
   local saved_arch="${ARCHITECTURE}"
   ARCHITECTURE=all
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -471,15 +471,19 @@ build_daemon_config_deb() {
 
   local package_name="mina-${network}-config"
 
+  # Config package doesn't have any binaries, but we need to include
+  # the common utils for hardfork packages that rely on some of the configs here.
+  # that's why we are using all as architecture.
+  local saved_arch="${ARCHITECTURE}"
+  ARCHITECTURE=all
+
   create_control_file "${package_name}" "" \
      "Mina Protocol Config for daemons running under ${network}" "" "mina-${network} (<< ${MINA_DEB_VERSION})"
 
   copy_common_daemon_configs "${network}"
 
-  # Config package doesn't have any binaries, but we need to include
-  # the common utils for hardfork packages that rely on some of the configs here.
-  # that's why we are using all as architecture.
-  ARCHITECTURE=all build_deb "${package_name}"
+  build_deb "${package_name}"
+  ARCHITECTURE="${saved_arch}"
 }
 ## END CONFIG PACKAGE ##
 
@@ -652,15 +656,19 @@ build_daemon_hardfork_config_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building hardfork config for ${network} network deb without keys:"
 
+  # Config package doesn't have any binaries, but we need to include
+  # the common utils for hardfork packages that rely on some of the configs here.
+  # that's why we are using all as architecture.
+  local saved_arch="${ARCHITECTURE}"
+  ARCHITECTURE=all
+
   create_control_file "${package_name}" "" \
     "Mina Protocol hardfork config for the ${network} Network" "" "mina-${network} (<< ${MINA_DEB_VERSION})"
 
   copy_common_daemon_hardfork_configs "${network}"
 
-  # Config package doesn't have any binaries, but we need to include
-  # the common utils for hardfork packages that rely on some of the configs here.
-  # that's why we are using all as architecture.
-  ARCHITECTURE=all build_deb "${package_name}"
+  build_deb "${package_name}"
+  ARCHITECTURE="${saved_arch}"
 }
 
 ## END HARDFORK PACKAGE ##

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -471,12 +471,12 @@ build_daemon_config_deb() {
 
   local package_name="mina-${network}-config"
 
-  # Config package doesn't have any binaries, but we need to include
-  # the common utils for hardfork packages that rely on some of the configs here.
-  # that's why we are using all as architecture.
+  # Config package contains only architecture-independent configuration data
+  # (no binaries), so we build it with Architecture: all to make it usable on
+  # all supported architectures.
 
-  # Save and reset architecture to all for config package, since it doesn't contain any binaries but we want to make sure it's available for all architectures.
-  # We will restore the original architecture after building the package.
+  # Save and override architecture to "all" for the config package; restore
+  # the original architecture after building the package.
   local saved_arch="${ARCHITECTURE}"
   ARCHITECTURE=all
 
@@ -643,12 +643,11 @@ copy_common_daemon_hardfork_configs() {
 ## HARDFORK PACKAGE ##
 
 #
-# Builds mina-${NETWORK}-hardfork package for specified network
+# Builds mina-${NETWORK}-config package for specified network with hardfork configuration
 #
-# Output: mina-${NETWORK}-hardfork_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
-# Dependencies: ${SHARED_DEPS}${DAEMON_DEPS}
+# Output: mina-${NETWORK}-config_${MINA_DEB_VERSION}_all.deb
 #
-# Config only package with hardfork-specific runtime config and ledgers. 
+# Config only package with hardfork-specific runtime config and ledgers.
 # Requires RUNTIME_CONFIG_JSON and LEDGER_TARBALLS environment variables.
 #
 build_daemon_hardfork_config_deb() {
@@ -659,12 +658,12 @@ build_daemon_hardfork_config_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building hardfork config for ${network} network deb without keys:"
 
-  # Config package doesn't have any binaries, but we need to include
-  # the common utils for hardfork packages that rely on some of the configs here.
-  # that's why we are using all as architecture.
+  # Config package contains only architecture-independent configuration data
+  # (no binaries), so we build it with Architecture: all to make it usable on
+  # all supported architectures.
 
-  # Save and reset architecture to all for hardfork config package, since it doesn't contain any binaries but we want to make sure it's available for all architectures.
-  # We will restore the original architecture after building the package.
+  # Save and override architecture to "all" for the hardfork config package; restore
+  # the original architecture after building the package.
   local saved_arch="${ARCHITECTURE}"
   ARCHITECTURE=all
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -609,6 +609,7 @@ test_build_daemon_mainnet_config_deb() {
     load_captured_state
     assert_eq "deb name" "mina-mainnet-config" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-config"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
 
     # Config-only package: no Depends on libraries
     assert_control_no_field "$CAPTURED_CONTROL" "Depends"
@@ -653,6 +654,7 @@ test_build_daemon_devnet_config_deb() {
     load_captured_state
     assert_eq "deb name" "mina-devnet-config" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-config"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
     assert_control_no_field "$CAPTURED_CONTROL" "Depends"
 
     assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
@@ -790,6 +792,7 @@ test_build_daemon_devnet_hardfork_config_deb() {
     load_captured_state
     assert_eq "deb name" "mina-devnet-config" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-config"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
     assert_control_no_field "$CAPTURED_CONTROL" "Depends"
 
     # Hardfork runtime config replaces the standard one
@@ -821,6 +824,7 @@ test_build_daemon_mainnet_hardfork_config_deb() {
     load_captured_state
     assert_eq "deb name" "mina-mainnet-config" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-config"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
     assert_control_no_field "$CAPTURED_CONTROL" "Depends"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-mainnet"
 
@@ -836,6 +840,45 @@ test_build_daemon_mainnet_hardfork_config_deb() {
 
     assert_file_captured "$CAPTURED_FILES" "var/lib/coda/mainnet.json"
     assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" "var/lib/coda/mainnet.json" '{"fork": true}'
+
+    unset RUNTIME_CONFIG_JSON LEDGER_TARBALLS
+}
+
+################################################################################
+# Tests: Architecture restoration after config packages
+################################################################################
+
+# Verifies that building a config deb (Architecture: all) followed by a
+# non-config deb preserves the original architecture for the second package.
+test_config_deb_restores_architecture() {
+    # Build config package (sets ARCHITECTURE=all internally)
+    safe_build build_daemon_config_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    # ARCHITECTURE should be restored to "amd64" after build_daemon_config_deb
+    assert_eq "ARCHITECTURE restored after config deb" "amd64" "$ARCHITECTURE"
+
+    # Build a non-config package and verify it uses the original architecture
+    safe_build build_logproc_deb || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
+}
+
+test_hardfork_config_deb_restores_architecture() {
+    export RUNTIME_CONFIG_JSON="${TEST_TMPDIR}/fork_config.json"
+    export LEDGER_TARBALLS="${TEST_TMPDIR}/ledger1.tar.gz ${TEST_TMPDIR}/ledger2.tar.gz"
+
+    # Build hardfork config package (sets ARCHITECTURE=all internally)
+    safe_build build_daemon_hardfork_config_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    # ARCHITECTURE should be restored to "amd64" after build_daemon_hardfork_config_deb
+    assert_eq "ARCHITECTURE restored after hardfork config deb" "amd64" "$ARCHITECTURE"
+
+    # Build a non-config package and verify it uses the original architecture
+    safe_build build_logproc_deb || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
 
     unset RUNTIME_CONFIG_JSON LEDGER_TARBALLS
 }
@@ -1085,6 +1128,10 @@ main() {
     # Codename dependency variants
     run_test test_codename_noble_deps
     run_test test_codename_noble_archive_deps
+
+    # Architecture restoration after config packages
+    run_test test_config_deb_restores_architecture
+    run_test test_hardfork_config_deb_restores_architecture
 
     # Control file structure
     run_test test_control_file_common_fields


### PR DESCRIPTION
ARCHITECTURE=all was only set as env prefix to build_deb, affecting the filename but not the control file written by create_control_file earlier. This caused deb-s3 to see arm64 in the package metadata despite the filename saying _all.deb. 

This is causing issue like https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1204. This is develop bu t compatible is affected as well


Move ARCHITECTURE=all before create_control_file so both the control file and filename use the correct architecture.
