### PR TITLE
stop accepting --hardfork-slot override in runtime_genesis_ledger.exe

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -58,7 +58,6 @@ function usage() {
   VERSION                            (Optional) The version of the hardfork package to generate (e.g. 3.0.0devnet-tooling-dkijania-hardfork-package-gen-in-nightly-b37f50e)
   PRECOMPUTED_FORK_BLOCK_PREFIX      (Optional) The prefix for precomputed fork block URLs (e.g. gs://mina_network_block_data/mainnet)
   USE_ARTIFACTS_FROM_BUILDKITE_BUILD (Optional) The Buildkite build number to use artifacts from (e.g. 1234)
-  PREFORK_GENESIS_CONFIG             (Optional) Path to prefork genesis config containing daemon.slot_chain_end and daemon.hard_fork_genesis_slot_delta
   USE_GENERIC_DOCKERS_FROM_VERSION   (Optional) Docker version to build config docker on top of (e.g. 3.3.0-compatible-aa34232)
 EOF
   exit 1
@@ -121,14 +120,6 @@ else
   USE_ARTIFACTS_FROM_BUILDKITE_BUILD="(Some \"${USE_ARTIFACTS_FROM_BUILDKITE_BUILD}\")"
 fi
 
-# Format PREFORK_GENESIS_CONFIG as Optional Text for Dhall
-if [[ -z "${PREFORK_GENESIS_CONFIG:-}" ]]; then
-  PREFORK_GENESIS_CONFIG="(None Text)"
-else
-  # shellcheck disable=SC2089
-  PREFORK_GENESIS_CONFIG="(Some \"${PREFORK_GENESIS_CONFIG}\")"
-fi
-
 # Format USE_GENERIC_DOCKERS_FROM_VERSION as Optional Text for Dhall
 if [[ -z "${USE_GENERIC_DOCKERS_FROM_VERSION:-}" ]]; then
   USE_GENERIC_DOCKERS_FROM_VERSION="(None Text)"
@@ -165,7 +156,7 @@ else
 fi
 
 # shellcheck disable=SC2089
-printf '%s.generate_hardfork_package %s %s.Type.%s %s "%s" "%s" %s %s %s %s %s\n' \
+printf '%s.generate_hardfork_package %s %s.Type.%s %s "%s" "%s" %s %s %s %s\n' \
   "$GENERATE_HARDFORK_PACKAGE_DHALL_DEF" \
   "$DHALL_CODENAMES" \
   "$NETWORK_DHALL_DEF" \
@@ -176,6 +167,5 @@ printf '%s.generate_hardfork_package %s %s.Type.%s %s "%s" "%s" %s %s %s %s %s\n
   "$VERSION" \
   "$PRECOMPUTED_FORK_BLOCK_PREFIX" \
   "$USE_ARTIFACTS_FROM_BUILDKITE_BUILD" \
-  "$PREFORK_GENESIS_CONFIG" \
   "$USE_GENERIC_DOCKERS_FROM_VERSION" \
    | dhall-to-yaml --quoted

--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -58,7 +58,7 @@ function usage() {
   VERSION                            (Optional) The version of the hardfork package to generate (e.g. 3.0.0devnet-tooling-dkijania-hardfork-package-gen-in-nightly-b37f50e)
   PRECOMPUTED_FORK_BLOCK_PREFIX      (Optional) The prefix for precomputed fork block URLs (e.g. gs://mina_network_block_data/mainnet)
   USE_ARTIFACTS_FROM_BUILDKITE_BUILD (Optional) The Buildkite build number to use artifacts from (e.g. 1234)
-  HARDFORK_GENESIS_SLOT_DELTA        (Optional) Number of slots to delay the hard fork genesis slot by (e.g. 0 for no delay)
+  PREFORK_GENESIS_CONFIG             (Optional) Path to prefork genesis config containing daemon.slot_chain_end and daemon.hard_fork_genesis_slot_delta
   USE_GENERIC_DOCKERS_FROM_VERSION   (Optional) Docker version to build config docker on top of (e.g. 3.3.0-compatible-aa34232)
 EOF
   exit 1
@@ -121,12 +121,12 @@ else
   USE_ARTIFACTS_FROM_BUILDKITE_BUILD="(Some \"${USE_ARTIFACTS_FROM_BUILDKITE_BUILD}\")"
 fi
 
-# Format HARDFORK_GENESIS_SLOT_DELTA as Optional Natural for Dhall
-if [[ -z "${HARDFORK_GENESIS_SLOT_DELTA:-}" ]]; then
-  HARDFORK_GENESIS_SLOT_DELTA="(None Natural)"
+# Format PREFORK_GENESIS_CONFIG as Optional Text for Dhall
+if [[ -z "${PREFORK_GENESIS_CONFIG:-}" ]]; then
+  PREFORK_GENESIS_CONFIG="(None Text)"
 else
   # shellcheck disable=SC2089
-  HARDFORK_GENESIS_SLOT_DELTA="(Some ${HARDFORK_GENESIS_SLOT_DELTA})"
+  PREFORK_GENESIS_CONFIG="(Some \"${PREFORK_GENESIS_CONFIG}\")"
 fi
 
 # Format USE_GENERIC_DOCKERS_FROM_VERSION as Optional Text for Dhall
@@ -176,6 +176,6 @@ printf '%s.generate_hardfork_package %s %s.Type.%s %s "%s" "%s" %s %s %s %s %s\n
   "$VERSION" \
   "$PRECOMPUTED_FORK_BLOCK_PREFIX" \
   "$USE_ARTIFACTS_FROM_BUILDKITE_BUILD" \
-  "$HARDFORK_GENESIS_SLOT_DELTA" \
+  "$PREFORK_GENESIS_CONFIG" \
   "$USE_GENERIC_DOCKERS_FROM_VERSION" \
    | dhall-to-yaml --quoted

--- a/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh
+++ b/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh
@@ -8,8 +8,6 @@ WORKDIR=$(pwd)
 FORCE_VERSION="*"
 CACHED_BUILDKITE_BUILD_ID="${CACHED_BUILDKITE_BUILD_ID:-}"
 CONFIG_JSON_GZ_URL=""
-PREFORK_GENESIS_CONFIG=""
-
 while [[ $# -gt 0 ]]; do
   case $1 in
     --network)
@@ -32,13 +30,9 @@ while [[ $# -gt 0 ]]; do
       CONFIG_JSON_GZ_URL="$2"
       shift 2
       ;;
-    --prefork-genesis-config)
-      PREFORK_GENESIS_CONFIG="$2"
-      shift 2
-      ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: $0 --network <network> --config-json-gz-url <url> [--version <version>] --codename <codename> [--cached-buildkite-build-id <id>] [--prefork-genesis-config <config>]"
+      echo "Usage: $0 --network <network> --config-json-gz-url <url> [--version <version>] --codename <codename> [--cached-buildkite-build-id <id>]"
       exit 1
       ;;
   esac
@@ -47,11 +41,6 @@ done
 if [ -z "$NETWORK" ] || [ -z "$CODENAME" ]; then
   echo "Usage: $0 --network <network> [--version <version>] --codename <codename>"
   exit 1
-fi
-
-PREFORK_GENESIS_CONFIG_ARG=""
-if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
-  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $PREFORK_GENESIS_CONFIG"
 fi
 
 # Install mina-logproc from cached build if available, else from current build
@@ -65,7 +54,7 @@ MINA_DEB_CODENAME=$CODENAME FORCE_VERSION=$FORCE_VERSION ROOT="legacy" ./buildki
 
 curl "${CONFIG_JSON_GZ_URL}" > config.json.gz && gunzip config.json.gz
 
-./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe mina-create-prefork-genesis --config "config.json" --workdir "$WORKDIR" $PREFORK_GENESIS_CONFIG_ARG
+./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe mina-create-prefork-genesis --config "config.json" --workdir "$WORKDIR" --prefork-genesis-config "genesis_ledgers/${NETWORK}.json"
 
 echo "--- Caching legacy ledger tarballs and hashes"
 

--- a/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh
+++ b/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh
@@ -8,7 +8,6 @@ WORKDIR=$(pwd)
 FORCE_VERSION="*"
 CACHED_BUILDKITE_BUILD_ID="${CACHED_BUILDKITE_BUILD_ID:-}"
 CONFIG_JSON_GZ_URL=""
-HARD_FORK_SHIFT_SLOT_DELTA=""
 PREFORK_GENESIS_CONFIG=""
 
 while [[ $# -gt 0 ]]; do
@@ -33,17 +32,13 @@ while [[ $# -gt 0 ]]; do
       CONFIG_JSON_GZ_URL="$2"
       shift 2
       ;;
-    --hardfork-shift-slot-delta)
-      HARD_FORK_SHIFT_SLOT_DELTA="$2"
-      shift 2
-      ;;
     --prefork-genesis-config)
       PREFORK_GENESIS_CONFIG="$2"
       shift 2
       ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: $0 --network <network> --config-json-gz-url <url> [--version <version>] --codename <codename> [--cached-buildkite-build-id <id>]"
+      echo "Usage: $0 --network <network> --config-json-gz-url <url> [--version <version>] --codename <codename> [--cached-buildkite-build-id <id>] [--prefork-genesis-config <config>]"
       exit 1
       ;;
   esac
@@ -54,12 +49,9 @@ if [ -z "$NETWORK" ] || [ -z "$CODENAME" ]; then
   exit 1
 fi
 
-HARD_FORK_SHIFT_SLOT_DELTA_ARG=""
-if [[ -n "$HARD_FORK_SHIFT_SLOT_DELTA" ]]; then
-  # Extract ledger object to new file
-  jq '.ledger' "$PREFORK_GENESIS_CONFIG" > prefork_ledger.json
-  cat prefork_ledger.json
-  HARD_FORK_SHIFT_SLOT_DELTA_ARG="--hardfork-shift-slot-delta $HARD_FORK_SHIFT_SLOT_DELTA --prefork-genesis-config prefork_ledger.json"
+PREFORK_GENESIS_CONFIG_ARG=""
+if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
+  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $PREFORK_GENESIS_CONFIG"
 fi
 
 # Install mina-logproc from cached build if available, else from current build
@@ -73,7 +65,7 @@ MINA_DEB_CODENAME=$CODENAME FORCE_VERSION=$FORCE_VERSION ROOT="legacy" ./buildki
 
 curl "${CONFIG_JSON_GZ_URL}" > config.json.gz && gunzip config.json.gz
 
-./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe mina-create-prefork-genesis --config "config.json" --workdir "$WORKDIR"
+./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe mina-create-prefork-genesis --config "config.json" --workdir "$WORKDIR" $PREFORK_GENESIS_CONFIG_ARG
 
 echo "--- Caching legacy ledger tarballs and hashes"
 

--- a/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
+++ b/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
@@ -11,8 +11,6 @@ NETWORK_NAME=""
 CONFIG_JSON_GZ_URL=""
 CODENAME=""
 CACHED_BUILDKITE_BUILD_ID=""
-PREFORK_GENESIS_CONFIG=""
-
 while [[ $# -gt 0 ]]; do
   case $1 in
     --network)
@@ -29,10 +27,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cached-buildkite-build-id)
       CACHED_BUILDKITE_BUILD_ID="$2"
-      shift 2
-      ;;
-    --prefork-genesis-config)
-      PREFORK_GENESIS_CONFIG="$2"
       shift 2
       ;;
     -h|--help)
@@ -60,11 +54,6 @@ if [[ -z "$CODENAME" ]]; then
 fi
 
 
-PREFORK_GENESIS_CONFIG_ARG=""
-if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
-  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $PREFORK_GENESIS_CONFIG"
-fi
-
 echo "--- Restoring cached build artifacts for apps/${CODENAME}/"
 
 # Install mina-logproc from cached build if available, else from current build
@@ -76,7 +65,7 @@ fi
 
 echo "--- Generating ledger tarballs for hardfork network: $NETWORK_NAME"
 
-./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh --network "$NETWORK_NAME" --config-url "$CONFIG_JSON_GZ_URL" --runtime-ledger mina-create-genesis --logproc mina-logproc $PREFORK_GENESIS_CONFIG_ARG
+./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh --network "$NETWORK_NAME" --config-url "$CONFIG_JSON_GZ_URL" --runtime-ledger mina-create-genesis --logproc mina-logproc
 
 ./scripts/hardfork/release/upload-ledger-tarballs.sh hardfork_ledgers new_config.json
 

--- a/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
+++ b/buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh
@@ -11,7 +11,6 @@ NETWORK_NAME=""
 CONFIG_JSON_GZ_URL=""
 CODENAME=""
 CACHED_BUILDKITE_BUILD_ID=""
-HARD_FORK_SHIFT_SLOT_DELTA=""
 PREFORK_GENESIS_CONFIG=""
 
 while [[ $# -gt 0 ]]; do
@@ -30,10 +29,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cached-buildkite-build-id)
       CACHED_BUILDKITE_BUILD_ID="$2"
-      shift 2
-      ;;
-    --hardfork-shift-slot-delta)
-      HARD_FORK_SHIFT_SLOT_DELTA="$2"
       shift 2
       ;;
     --prefork-genesis-config)
@@ -65,11 +60,9 @@ if [[ -z "$CODENAME" ]]; then
 fi
 
 
-HARD_FORK_SHIFT_SLOT_DELTA_ARG=""
-if [[ -n "$HARD_FORK_SHIFT_SLOT_DELTA" ]]; then
-  jq '.ledger' "$PREFORK_GENESIS_CONFIG" > prefork_ledger.json
-  cat prefork_ledger.json
-  HARD_FORK_SHIFT_SLOT_DELTA_ARG="--hardfork-shift-slot-delta $HARD_FORK_SHIFT_SLOT_DELTA --prefork-genesis-config prefork_ledger.json"
+PREFORK_GENESIS_CONFIG_ARG=""
+if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
+  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $PREFORK_GENESIS_CONFIG"
 fi
 
 echo "--- Restoring cached build artifacts for apps/${CODENAME}/"
@@ -83,7 +76,7 @@ fi
 
 echo "--- Generating ledger tarballs for hardfork network: $NETWORK_NAME"
 
-./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh --network "$NETWORK_NAME" --config-url "$CONFIG_JSON_GZ_URL" --runtime-ledger mina-create-genesis --logproc mina-logproc $HARD_FORK_SHIFT_SLOT_DELTA_ARG
+./scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh --network "$NETWORK_NAME" --config-url "$CONFIG_JSON_GZ_URL" --runtime-ledger mina-create-genesis --logproc mina-logproc $PREFORK_GENESIS_CONFIG_ARG
 
 ./scripts/hardfork/release/upload-ledger-tarballs.sh hardfork_ledgers new_config.json
 

--- a/buildkite/scripts/pipeline/run-hardfork-pipeline.go
+++ b/buildkite/scripts/pipeline/run-hardfork-pipeline.go
@@ -360,7 +360,6 @@ func main() {
 		"PRECOMPUTED_FORK_BLOCK_PREFIX":     *precomputedPrefix,
 		"USE_ARTIFACTS_FROM_BUILDKITE_BUILD": *useArtifactsFrom,
 		"USE_GENERIC_DOCKERS_FROM_VERSION":   "",
-		"PREFORK_GENESIS_CONFIG":             "",
 	}
 
 	// Print configuration

--- a/buildkite/scripts/pipeline/run-hardfork-pipeline.go
+++ b/buildkite/scripts/pipeline/run-hardfork-pipeline.go
@@ -360,7 +360,7 @@ func main() {
 		"PRECOMPUTED_FORK_BLOCK_PREFIX":     *precomputedPrefix,
 		"USE_ARTIFACTS_FROM_BUILDKITE_BUILD": *useArtifactsFrom,
 		"USE_GENERIC_DOCKERS_FROM_VERSION":   "",
-		"HARDFORK_GENESIS_SLOT_DELTA":        "",
+		"PREFORK_GENESIS_CONFIG":             "",
 	}
 
 	// Print configuration

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -57,7 +57,7 @@ let Spec =
           , suffix : Text
           , precomputed_block_prefix : Optional Text
           , use_artifacts_from_buildkite_build : Optional Text
-          , hardfork_shift_slot_delta : Optional Natural
+          , prefork_genesis_config : Optional Text
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
@@ -77,7 +77,7 @@ let Spec =
           , version = "\\\${MINA_DEB_VERSION}"
           , precomputed_block_prefix = None Text
           , use_artifacts_from_buildkite_build = None Text
-          , hardfork_shift_slot_delta = None Natural
+          , prefork_genesis_config = None Text
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
@@ -101,6 +101,15 @@ let generateReferenceTarballsCommand =
                   }
                   spec.use_artifacts_from_buildkite_build
 
+          let preforkGenesisConfigArg =
+                merge
+                  { Some =
+                          \(config : Text)
+                      ->  "--prefork-genesis-config " ++ config
+                  , None = ""
+                  }
+                  spec.prefork_genesis_config
+
           in  Command.build
                 Command.Config::{
                 , commands =
@@ -111,7 +120,7 @@ let generateReferenceTarballsCommand =
                       [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
                       "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh --network ${Network.lowerName
                                                                                                                                        spec.network} --version ${spec.deb_legacy_version}  --codename ${DebianVersions.lowerName
-                                                                                                                                                                                                          codename.DebVersion} --config-json-gz-url ${spec.config_json_gz_url} ${cacheArg}"
+                                                                                                                                                                                                          codename.DebVersion} --config-json-gz-url ${spec.config_json_gz_url} ${cacheArg} ${preforkGenesisConfigArg}"
                 , label =
                     "Generate hardfork reference tarballs for ${DebianVersions.lowerName
                                                                   codename.DebVersion}"
@@ -134,17 +143,14 @@ let generateTarballsCommand =
                   }
                   spec.use_artifacts_from_buildkite_build
 
-          let hardforkShiftSlotDeltaArg =
+          let preforkGenesisConfigArg =
                 merge
                   { Some =
-                          \(delta : Natural)
-                      ->      "--hardfork-shift-slot-delta "
-                          ++  Natural/show delta
-                          ++  " --prefork-genesis-config /workdir/genesis_ledgers/${Network.lowerName
-                                                                                      spec.network}.json"
+                          \(config : Text)
+                      ->  "--prefork-genesis-config " ++ config
                   , None = ""
                   }
-                  spec.hardfork_shift_slot_delta
+                  spec.prefork_genesis_config
 
           let genesis_timestamp_env =
                 merge
@@ -171,7 +177,7 @@ let generateTarballsCommand =
                         ++  "--config-url ${spec.config_json_gz_url} "
                         ++  "--codename ${DebianVersions.lowerName
                                             codename.DebVersion} "
-                        ++  "${hardforkShiftSlotDeltaArg} "
+                        ++  "${preforkGenesisConfigArg} "
                         ++  "${cacheArg}"
                       )
                 , label =
@@ -657,7 +663,7 @@ let generate_hardfork_package =
       ->  \(version : Optional Text)
       ->  \(precomputed_block_prefix : Optional Text)
       ->  \(use_artifacts_from_buildkite_build : Optional Text)
-      ->  \(hardfork_shift_slot_delta : Optional Natural)
+      ->  \(prefork_genesis_config : Optional Text)
       ->  \(use_generic_dockers_from_version : Optional Text)
       ->  ( pipeline
               Spec::{
@@ -673,7 +679,7 @@ let generate_hardfork_package =
               , precomputed_block_prefix = precomputed_block_prefix
               , use_artifacts_from_buildkite_build =
                   use_artifacts_from_buildkite_build
-              , hardfork_shift_slot_delta = hardfork_shift_slot_delta
+              , prefork_genesis_config = prefork_genesis_config
               , use_generic_dockers_from_version =
                   use_generic_dockers_from_version
               }

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -57,7 +57,6 @@ let Spec =
           , suffix : Text
           , precomputed_block_prefix : Optional Text
           , use_artifacts_from_buildkite_build : Optional Text
-          , prefork_genesis_config : Optional Text
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
@@ -77,7 +76,6 @@ let Spec =
           , version = "\\\${MINA_DEB_VERSION}"
           , precomputed_block_prefix = None Text
           , use_artifacts_from_buildkite_build = None Text
-          , prefork_genesis_config = None Text
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
@@ -101,15 +99,6 @@ let generateReferenceTarballsCommand =
                   }
                   spec.use_artifacts_from_buildkite_build
 
-          let preforkGenesisConfigArg =
-                merge
-                  { Some =
-                          \(config : Text)
-                      ->  "--prefork-genesis-config " ++ config
-                  , None = ""
-                  }
-                  spec.prefork_genesis_config
-
           in  Command.build
                 Command.Config::{
                 , commands =
@@ -120,7 +109,7 @@ let generateReferenceTarballsCommand =
                       [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
                       "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh --network ${Network.lowerName
                                                                                                                                        spec.network} --version ${spec.deb_legacy_version}  --codename ${DebianVersions.lowerName
-                                                                                                                                                                                                          codename.DebVersion} --config-json-gz-url ${spec.config_json_gz_url} ${cacheArg} ${preforkGenesisConfigArg}"
+                                                                                                                                                                                                          codename.DebVersion} --config-json-gz-url ${spec.config_json_gz_url} ${cacheArg}"
                 , label =
                     "Generate hardfork reference tarballs for ${DebianVersions.lowerName
                                                                   codename.DebVersion}"
@@ -142,15 +131,6 @@ let generateTarballsCommand =
                   , None = ""
                   }
                   spec.use_artifacts_from_buildkite_build
-
-          let preforkGenesisConfigArg =
-                merge
-                  { Some =
-                          \(config : Text)
-                      ->  "--prefork-genesis-config " ++ config
-                  , None = ""
-                  }
-                  spec.prefork_genesis_config
 
           let genesis_timestamp_env =
                 merge
@@ -177,7 +157,6 @@ let generateTarballsCommand =
                         ++  "--config-url ${spec.config_json_gz_url} "
                         ++  "--codename ${DebianVersions.lowerName
                                             codename.DebVersion} "
-                        ++  "${preforkGenesisConfigArg} "
                         ++  "${cacheArg}"
                       )
                 , label =
@@ -663,7 +642,6 @@ let generate_hardfork_package =
       ->  \(version : Optional Text)
       ->  \(precomputed_block_prefix : Optional Text)
       ->  \(use_artifacts_from_buildkite_build : Optional Text)
-      ->  \(prefork_genesis_config : Optional Text)
       ->  \(use_generic_dockers_from_version : Optional Text)
       ->  ( pipeline
               Spec::{
@@ -679,7 +657,6 @@ let generate_hardfork_package =
               , precomputed_block_prefix = precomputed_block_prefix
               , use_artifacts_from_buildkite_build =
                   use_artifacts_from_buildkite_build
-              , prefork_genesis_config = prefork_genesis_config
               , use_generic_dockers_from_version =
                   use_generic_dockers_from_version
               }

--- a/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh
+++ b/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe <mina_legacy_genesis_exe> --config <fork_config> --workdir <workdir> --ledger-name <ledger_name> --hash-name <hash_name> --prefork-genesis-config <prefork_genesis_config>
+# Usage: generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe <mina_legacy_genesis_exe> --config <fork_config> --workdir <workdir> [--ledger-name <ledger_name>] [--hash-name <hash_name>] [--prefork-genesis-config <prefork_genesis_config>]
 
 set -e
 

--- a/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh
+++ b/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs-using-legacy-app.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: generate-fork-config-with-ledger-tarballs-using-legacy-app.sh.sh --exe <mina_legacy_genesis_exe> --config <fork_config> --workdir <workdir> --ledger-name <ledger_name> --hash-name <hash_name> --hardfork-shift-slot-delta <hardfork_shift_slot_delta>
+# Usage: generate-fork-config-with-ledger-tarballs-using-legacy-app.sh --exe <mina_legacy_genesis_exe> --config <fork_config> --workdir <workdir> --ledger-name <ledger_name> --hash-name <hash_name> --prefork-genesis-config <prefork_genesis_config>
 
 set -e
 
@@ -8,7 +8,6 @@ set -e
 LEDGER_NAME="legacy_ledgers"
 HASH_NAME="legacy_hashes.json"
 MINA_LEGACY_GENESIS_EXE="mina-create-prefork-genesis"
-HARD_FORK_SHIFT_SLOT_DELTA=""
 PREFORK_GENESIS_CONFIG=""
 
 TMP=$(mktemp -d)
@@ -34,10 +33,6 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--hash-name)
 			HASH_NAME="$2"
-			shift 2
-			;;
-		--hardfork-shift-slot-delta)
-			HARD_FORK_SHIFT_SLOT_DELTA="$2"
 			shift 2
 			;;
 		--prefork-genesis-config)
@@ -74,10 +69,10 @@ echo "generating genesis ledgers ... (this may take a while)" >&2
 # make sure files does not have genesis key
 jq 'del(.genesis)' "$FORK_CONFIG" > "$TMP/fork_config_no_genesis.json"
 
-HARD_FORK_SHIFT_SLOT_DELTA_ARG=""
-if [[ -n "$HARD_FORK_SHIFT_SLOT_DELTA" ]]; then
+PREFORK_GENESIS_CONFIG_ARG=""
+if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
   jq 'del(.genesis)' "$PREFORK_GENESIS_CONFIG" > "$TMP/config_no_genesis.json"
-  HARD_FORK_SHIFT_SLOT_DELTA_ARG="--hardfork-slot $HARD_FORK_SHIFT_SLOT_DELTA --prefork-genesis-config $TMP/config_no_genesis.json"
+  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $TMP/config_no_genesis.json"
 fi
 
-"$MINA_LEGACY_GENESIS_EXE" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" --genesis-dir "$LEDGER_PATH" --hash-output-file "$HASH_PATH" $HARD_FORK_SHIFT_SLOT_DELTA_ARG
+"$MINA_LEGACY_GENESIS_EXE" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" --genesis-dir "$LEDGER_PATH" --hash-output-file "$HASH_PATH" $PREFORK_GENESIS_CONFIG_ARG

--- a/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh
+++ b/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh
@@ -3,7 +3,7 @@
 set -ex
 
 usage() {
-  echo "Usage: $0 --network NETWORK_NAME --config-url CONFIG_JSON_GZ_URL --runtime-ledger RUNTIME_GENESIS_LEDGER --hard-fork-genesis-slot-delta HARD_FORK_GENESIS_SLOT_DELTA --logproc LOGPROC --output-dir OUTPUT_DIR"
+  echo "Usage: $0 --network NETWORK_NAME --config-url CONFIG_JSON_GZ_URL --runtime-ledger RUNTIME_GENESIS_LEDGER --logproc LOGPROC --output-dir OUTPUT_DIR [--prefork-genesis-config PREFORK_GENESIS_CONFIG]"
   echo ""
   echo "Generates hardfork ledger tarballs and runtime config for the specified network."
   echo ""
@@ -13,6 +13,7 @@ usage() {
   echo "  --runtime-ledger RUNTIME_GENESIS_LEDGER   Path to the runtime genesis ledger generator executable"
   echo "  --logproc LOGPROC                      Command to process log output (e.g., cat, grep)"
   echo "  --output-dir OUTPUT_DIR                Directory to output the generated ledger tarballs. WARNING: will be cleared if it exists."
+  echo "  --prefork-genesis-config PREFORK_GENESIS_CONFIG  Path to the prefork genesis config (must contain daemon.slot_chain_end and daemon.hard_fork_genesis_slot_delta for vesting updates)"
 }
 
 NETWORK_NAME=""
@@ -23,7 +24,6 @@ OUTPUT_DIR="hardfork_ledgers"
 
 TMP=$(mktemp -d)
 
-HARD_FORK_SHIFT_SLOT_DELTA=0
 PREFORK_GENESIS_CONFIG=""
 
 while [[ $# -gt 0 ]]; do
@@ -38,10 +38,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --runtime-ledger)
       RUNTIME_GENESIS_LEDGER="$2"
-      shift 2
-      ;;
-    --hardfork-shift-slot-delta)
-      HARD_FORK_SHIFT_SLOT_DELTA="$2"
       shift 2
       ;;
     --prefork-genesis-config)
@@ -115,14 +111,13 @@ jq 'del(.genesis)' "$TMP/config.json" > "$TMP/fork_config_no_genesis.json"
 echo "--- Generate hardfork ledger tarballs"
 mkdir "$OUTPUT_DIR"
 
-HARD_FORK_SHIFT_SLOT_DELTA_ARG=""
-if [[ "$HARD_FORK_SHIFT_SLOT_DELTA" -ne 0 ]]; then
+PREFORK_GENESIS_CONFIG_ARG=""
+if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
   jq 'del(.genesis)' "$PREFORK_GENESIS_CONFIG" > "$TMP/config_no_genesis.json"
-
-  HARD_FORK_SHIFT_SLOT_DELTA_ARG="--hardfork-slot $HARD_FORK_SHIFT_SLOT_DELTA --prefork-genesis-config $TMP/config_no_genesis.json"
+  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $TMP/config_no_genesis.json"
 fi
 
-"$RUNTIME_GENESIS_LEDGER" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" $HARD_FORK_SHIFT_SLOT_DELTA_ARG --genesis-dir "$OUTPUT_DIR"/ --hash-output-file hashes.json | tee runtime_genesis_ledger.log | $LOGPROC
+"$RUNTIME_GENESIS_LEDGER" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" $PREFORK_GENESIS_CONFIG_ARG --genesis-dir "$OUTPUT_DIR"/ --hash-output-file hashes.json | tee runtime_genesis_ledger.log | $LOGPROC
 
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON="$TMP/fork_config_no_genesis.json" LEDGER_HASHES_JSON=hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json

--- a/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh
+++ b/scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh
@@ -3,7 +3,7 @@
 set -ex
 
 usage() {
-  echo "Usage: $0 --network NETWORK_NAME --config-url CONFIG_JSON_GZ_URL --runtime-ledger RUNTIME_GENESIS_LEDGER --logproc LOGPROC --output-dir OUTPUT_DIR [--prefork-genesis-config PREFORK_GENESIS_CONFIG]"
+  echo "Usage: $0 --network NETWORK_NAME --config-url CONFIG_JSON_GZ_URL --runtime-ledger RUNTIME_GENESIS_LEDGER --logproc LOGPROC --output-dir OUTPUT_DIR"
   echo ""
   echo "Generates hardfork ledger tarballs and runtime config for the specified network."
   echo ""
@@ -13,7 +13,6 @@ usage() {
   echo "  --runtime-ledger RUNTIME_GENESIS_LEDGER   Path to the runtime genesis ledger generator executable"
   echo "  --logproc LOGPROC                      Command to process log output (e.g., cat, grep)"
   echo "  --output-dir OUTPUT_DIR                Directory to output the generated ledger tarballs. WARNING: will be cleared if it exists."
-  echo "  --prefork-genesis-config PREFORK_GENESIS_CONFIG  Path to the prefork genesis config (must contain daemon.slot_chain_end and daemon.hard_fork_genesis_slot_delta for vesting updates)"
 }
 
 NETWORK_NAME=""
@@ -23,8 +22,6 @@ LOGPROC="cat"
 OUTPUT_DIR="hardfork_ledgers"
 
 TMP=$(mktemp -d)
-
-PREFORK_GENESIS_CONFIG=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -38,10 +35,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --runtime-ledger)
       RUNTIME_GENESIS_LEDGER="$2"
-      shift 2
-      ;;
-    --prefork-genesis-config)
-      PREFORK_GENESIS_CONFIG="$2"
       shift 2
       ;;
     --logproc)
@@ -111,13 +104,9 @@ jq 'del(.genesis)' "$TMP/config.json" > "$TMP/fork_config_no_genesis.json"
 echo "--- Generate hardfork ledger tarballs"
 mkdir "$OUTPUT_DIR"
 
-PREFORK_GENESIS_CONFIG_ARG=""
-if [[ -n "$PREFORK_GENESIS_CONFIG" ]]; then
-  jq 'del(.genesis)' "$PREFORK_GENESIS_CONFIG" > "$TMP/config_no_genesis.json"
-  PREFORK_GENESIS_CONFIG_ARG="--prefork-genesis-config $TMP/config_no_genesis.json"
-fi
+jq 'del(.genesis)' "$FORKING_FROM_CONFIG_JSON" > "$TMP/config_no_genesis.json"
 
-"$RUNTIME_GENESIS_LEDGER" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" $PREFORK_GENESIS_CONFIG_ARG --genesis-dir "$OUTPUT_DIR"/ --hash-output-file hashes.json | tee runtime_genesis_ledger.log | $LOGPROC
+"$RUNTIME_GENESIS_LEDGER" --pad-app-state --config-file "$TMP/fork_config_no_genesis.json" --prefork-genesis-config "$TMP/config_no_genesis.json" --genesis-dir "$OUTPUT_DIR"/ --hash-output-file hashes.json | tee runtime_genesis_ledger.log | $LOGPROC
 
 echo "--- Create hardfork config"
 FORK_CONFIG_JSON="$TMP/fork_config_no_genesis.json" LEDGER_HASHES_JSON=hashes.json scripts/hardfork/create_runtime_config.sh > new_config.json

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -167,12 +167,12 @@ let load_config_exn config_file =
 
 let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~config_file ~genesis_dir ~hash_output_file ~ignore_missing_fields
-    ~pad_app_state ~hardfork_slot ~prefork_genesis_config () =
+    ~pad_app_state ~prefork_genesis_config () =
   let hardfork_slot =
-    match (hardfork_slot, prefork_genesis_config) with
-    | None, None ->
+    match prefork_genesis_config with
+    | None ->
         None
-    | Some hardfork_slot, Some prefork_genesis_config ->
+    | Some prefork_genesis_config -> (
         let runtime_config =
           Yojson.Safe.from_file prefork_genesis_config
           |> Runtime_config.of_yojson |> Result.ok_or_failwith
@@ -184,17 +184,28 @@ let main ~(constraint_constants : Genesis_constants.Constraint_constants.t)
           Mina_numbers.Global_slot_since_genesis.of_int
             global_slot_since_genesis
         in
-        Option.some
-        @@ Mina_numbers.Global_slot_since_hard_fork.to_global_slot_since_genesis
-             ~current_genesis_global_slot hardfork_slot
-    | Some _, None ->
-        failwith
-          "hardfork slot is present but no prefork genesis config is provided"
-    | None, Some _ ->
-        [%log info]
-          "prefork genesis config is provided with no hardfork slot provided, \
-           ignoring" ;
-        None
+        match
+          Runtime_config.scheduled_hard_fork_genesis_slot runtime_config
+        with
+        | None ->
+            [%log info]
+              "prefork genesis config does not contain slot_chain_end and \
+               hard_fork_genesis_slot_delta, skipping vesting parameter update" ;
+            None
+        | Some hardfork_slot_since_hf ->
+            let slot =
+              Mina_numbers.Global_slot_since_hard_fork
+              .to_global_slot_since_genesis ~current_genesis_global_slot
+                hardfork_slot_since_hf
+            in
+            [%log info]
+              "Computed hardfork slot since genesis from prefork config: $slot"
+              ~metadata:
+                [ ( "slot"
+                  , `String
+                      (Mina_numbers.Global_slot_since_genesis.to_string slot) )
+                ] ;
+            Some slot )
   in
   let%bind accounts, staking_accounts_opt, next_accounts_opt =
     load_config_exn config_file
@@ -261,21 +272,14 @@ let () =
              ~doc:
                "BOOL whether to pad app_state to max allowed size (default: \
                 false)"
-         and hardfork_slot =
-           flag "--hardfork-slot"
-             (optional Cli_lib.Arg_type.hardfork_slot)
-             ~doc:
-               "INT the scheduled hardfork slot since last hardfork at which \
-                vesting parameter update should happen. If absent, don't \
-                update the vesting parameters"
          and prefork_genesis_config =
            flag "--prefork-genesis-config" (optional string)
              ~doc:
-               "STRING path to prefork genesis confg, should be present if \
-                `--hardfork-slot` is set, the program would read the genesis \
-                timestamps in the config to calculate the proper hardfork \
-                slot."
+               "STRING path to prefork genesis config. The hardfork slot for \
+                vesting parameter updates is computed from \
+                daemon.slot_chain_end + daemon.hard_fork_genesis_slot_delta in \
+                this config. If those fields are absent, no vesting parameter \
+                update is performed."
          in
          main ~constraint_constants ~config_file ~genesis_dir ~hash_output_file
-           ~ignore_missing_fields ~pad_app_state ~hardfork_slot
-           ~prefork_genesis_config) )
+           ~ignore_missing_fields ~pad_app_state ~prefork_genesis_config) )


### PR DESCRIPTION
Hopefully prevents future problems with legacy vs auto-mode determination of hardfork slots