### PR TITLE
Add storage toolbox to hardfork pipeline artifacts

### DIFF
--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -60,6 +60,7 @@ let Spec =
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
+          , deb_storage_repair_version : Text
           }
       , default =
           { codenames =
@@ -78,6 +79,8 @@ let Spec =
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
+          , deb_storage_repair_version =
+              defaultMinaArtifactSpec.deb_storage_repair_version
           }
       }
 
@@ -181,7 +184,7 @@ let generateDockerForCodename =
                                       ++  " --backend local --artifacts mina-logproc,mina-${Network.lowerName
                                                                                               spec.network},mina-archive-${Network.lowerName
                                                                                                                              spec.network},mina-rosetta-${Network.lowerName
-                                                                                                                                                            spec.network},mina-zkapp-test-transaction "
+                                                                                                                                                            spec.network},mina-zkapp-test-transaction,mina-daemon-storage-toolbox "
                                       ++  " --buildkite-build-id ${cached_build_id}"
                                       ++  " --codename ${lowerNameCodename} "
                                       ++  " --target \\\${BUILDKITE_BUILD_ID} "
@@ -206,6 +209,7 @@ let generateDockerForCodename =
                           , Artifacts.Type.RosettaConfig
                           , Artifacts.Type.Rosetta
                           , Artifacts.Type.ZkappTestTransaction
+                          , Artifacts.Type.DaemonStorageToolbox
                           ]
                         , debVersion = codename.DebVersion
                         , profile = profile
@@ -268,6 +272,8 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , generic = True
@@ -282,6 +288,8 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , step_key_suffix =
@@ -295,6 +303,8 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
+                      , deb_storage_repair_version = Some
+                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , step_key_suffix =


### PR DESCRIPTION
Fixing Pipeline CI test on compatible

## Summary
- Add `DaemonStorageToolbox` artifact to build and persist lists in hardfork pipeline
- Add `mina-daemon-storage-toolbox` to cached artifact downloads
- Add `deb_storage_repair_version` field to Spec and pass it to DaemonAppsOnly, Daemon, and Archive docker specs

## Test plan
- [ ] Verify hardfork pipeline generates correct Dhall output with storage toolbox included
- [ ] Confirm storage toolbox artifact is downloaded and persisted in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)