### PR TITLE
Fix docker tagging for config images and override githash

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -37,6 +37,9 @@ set -euox pipefail
 #   - Dhall configuration files in buildkite/src/
 #
 
+# Colors for output
+RED='\033[0;31m'
+CLEAR='\033[0m'
 
 DEBIAN_VERSION_DHALL_DEF="(./buildkite/src/Constants/DebianVersions.dhall)"
 ARCH_DHALL_DEF="(./buildkite/src/Constants/Arch.dhall)"

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -238,7 +238,7 @@ let generateStep =
 
           let buildDockerCmd =
                     "./scripts/docker/build.sh"
-                ++  " --service ${Artifacts.dockerName spec.service}"
+                ++  " --service ${Artifacts.dockerServiceName spec.service}"
                 ++  " --network ${Network.debianSuffix spec.network}"
                 ++  " --version ${spec.version}"
                 ++  " --branch ${spec.branch}"

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -114,12 +114,12 @@ let lowerName =
             }
             artifact
 
-let dockerName =
+let dockerServiceName =
           \(artifact : Artifact)
       ->  merge
             { Daemon = "mina-daemon"
             , DaemonPrefork = ""
-            , DaemonLegacyHardfork = "mina-daemon-pre-hardfork"
+            , DaemonLegacyHardfork = "mina-daemon-legacy-hardfork"
             , DaemonAutoHardfork = "mina-daemon-auto-hardfork"
             , DaemonAppsOnly = "mina-daemon"
             , Archive = "mina-archive"
@@ -136,6 +136,31 @@ let dockerName =
             , DelegationVerifier = "mina-delegation-verifier"
             , DaemonStorageToolbox = "mina-daemon-storage-toolbox"
             , DaemonConfig = "mina-daemon-configured"
+            }
+            artifact
+
+let dockerName =
+          \(artifact : Artifact)
+      ->  merge
+            { DaemonConfig = "mina-daemon"
+            , Daemon = dockerServiceName artifact
+            , DaemonPrefork = dockerServiceName artifact
+            , DaemonLegacyHardfork = dockerServiceName artifact
+            , DaemonAutoHardfork = dockerServiceName artifact
+            , DaemonAppsOnly = dockerServiceName artifact
+            , Archive = dockerServiceName artifact
+            , TestExecutive = dockerServiceName artifact
+            , LogProc = dockerServiceName artifact
+            , BatchTxn = dockerServiceName artifact
+            , Rosetta = dockerServiceName artifact
+            , RosettaAppsOnly = dockerServiceName artifact
+            , RosettaConfig = "mina-rosetta"
+            , ZkappTestTransaction = dockerServiceName artifact
+            , FunctionalTestSuite = dockerServiceName artifact
+            , Toolchain = dockerServiceName artifact
+            , CreatePreforkGenesis = dockerServiceName artifact
+            , DelegationVerifier = dockerServiceName artifact
+            , DaemonStorageToolbox = dockerServiceName artifact
             }
             artifact
 
@@ -469,6 +494,7 @@ in  { Type = Artifact
     , lowerName = lowerName
     , toDebianName = toDebianName
     , toDebianNames = toDebianNames
+    , dockerServiceName = dockerServiceName
     , dockerName = dockerName
     , dockerNames = dockerNames
     , dockerTag = dockerTag

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -367,7 +367,10 @@ let generateHfRelatedStepsForCodename =
                   , network = spec.network
                   , version =
                       merge
-                        { Some = \(v : Text) -> v
+                        { Some =
+                                \(v : Text)
+                            ->  "${v}-${DebianVersions.lowerName
+                                          codename.DebVersion}"
                         , None = "\\\${MINA_DOCKER_TAG}"
                         }
                         spec.use_generic_dockers_from_version
@@ -473,9 +476,11 @@ let generateHfRelatedStepsForCodename =
                           Toolchain.SelectionMode.ByDebianAndArch
                           codename.DebVersion
                           codename.Arch
-                          [ "NETWORK_NAME=${Network.lowerName spec.network}"
-                          , "MINA_DEB_CODENAME=${lowerNameCodename}"
-                          ]
+                          (   [ "NETWORK_NAME=${Network.lowerName spec.network}"
+                              , "MINA_DEB_CODENAME=${lowerNameCodename}"
+                              ]
+                            # DebianVersions.overrideEnvs
+                          )
                           "mkdir -p _build && ./buildkite/scripts/cache/manager.sh read hardfork /workdir && RUNTIME_CONFIG_JSON=/workdir/hardfork/new_config.json LEDGER_TARBALLS='/workdir/hardfork/ledgers/*.tar.gz' ./buildkite/scripts/debian/build.sh --codenames ${debianCodenamesList} --arch all daemon_${Network.lowerName
                                                                                                                                                                                                                                                                                                                      spec.network}_hardfork_config"
                     , label =

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -221,6 +221,9 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/stages/install-config"
         DOCKER_CONTEXT="dockerfiles/"
         SERVICE="mina-daemon"
+        # The --version arg points to the base generic image for the Dockerfile FROM.
+        # Override VERSION_ARG to keep it, then set VERSION to current commit for output tags.
+        VERSION_ARG_OVERRIDE="--build-arg version=$VERSION"
         ;;
     mina-daemon-legacy-hardfork)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-daemon"
@@ -249,6 +252,7 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/stages/install-config"
         DOCKER_CONTEXT="dockerfiles/"
         SERVICE="mina-rosetta"
+        VERSION_ARG_OVERRIDE="--build-arg version=$VERSION"
         ;;
     mina-zkapp-test-transaction)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-zkapp-test-transaction"
@@ -277,6 +281,13 @@ case "${SERVICE}" in
         exit 1
         ;;
 esac
+
+if [[ -n "${VERSION_ARG_OVERRIDE:-}" ]]; then
+  # For services like mina-daemon-configured, the build arg version (base image)
+  # differs from the output tag version (current commit).
+  VERSION_ARG="$VERSION_ARG_OVERRIDE"
+  VERSION="$MINA_DOCKER_TAG"
+fi
 
 export_version
 export_docker_tag

--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -5,7 +5,7 @@ set -eox pipefail
 source "$(dirname "$0")/../export-git-env-vars.sh"
 
 # Array of valid service names
-export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-generic' 'mina-daemon-configured' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-rosetta-generic' 'mina-rosetta-configured' 'mina-test-suite' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'mina-delegation-verifier' 'delegation-backend-toolchain')
+export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-generic' 'mina-daemon-configured' 'mina-daemon-legacy-hardfork' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-rosetta-generic' 'mina-rosetta-configured' 'mina-test-suite' 'mina-batch-txn' 'mina-zkapp-test-transaction' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'mina-delegation-verifier' 'delegation-backend-toolchain')
 
 function export_base_image () {
     # Determine the proper image for ubuntu or debian

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -40,7 +40,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 if [[ -v BRANCH_NAME ]]; then
    GITBRANCH=$(echo "$BRANCH_NAME" | sed 's!/!-!g; s!_!-!g; s!#!-!g')
 else
-   GITBRANCH=$(git name-rev --name-only $GITHASH | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+   # Always use actual HEAD for branch resolution — OVERRIDE_GITHASH is a
+   # short hash from another commit and git name-rev cannot resolve it.
+   _GIT_HEAD_HASH=$(git rev-parse --verify HEAD)
+   GITBRANCH=$(git name-rev --name-only "$_GIT_HEAD_HASH" | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 fi
 
 GITTAG=${OVERRIDE_TAG:-$(find_most_recent_numeric_tag HEAD)}


### PR DESCRIPTION
## Summary
- Add `dockerServiceName`/`dockerName` distinction in Artifacts.dhall — `dockerServiceName` is the service name passed to `build.sh --service` (e.g. `mina-daemon-configured`), `dockerName` is the actual registry image name (e.g. `mina-daemon`)
- Fix config docker images (`mina-daemon-configured`, `mina-rosetta-configured`) to tag with current commit instead of the base generic image version
- Fix hardfork verification image tag to include codename when `use_generic_dockers_from_version` is set, so the verification step pulls the correct image

**Stacked on #18672**

## Test plan
- [ ] Verify config docker images are tagged with correct commit hash
- [ ] Confirm verification step can find docker images when OVERRIDE_GITHASH is set
- [ ] Run hardfork pipeline end-to-end with `USE_GENERIC_DOCKERS_FROM_VERSION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)