### PR TITLE
trust_system: disable peer banning temporarily

### DIFF
--- a/changes/18678.md
+++ b/changes/18678.md
@@ -1,0 +1,1 @@
+Fixed a bug causing some part of the daemon node to get stucked when dealing with trust system.

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -2,7 +2,9 @@ open Core
 open Async_kernel
 open Pipe_lib
 
-let tmp_bans_are_disabled = false
+(* WARN: everywhere in the codebase nobody is reading upcall_reader, any async
+   thread banning a node will be blocked forever *)
+let tmp_bans_are_disabled = true
 
 module Trust_response = struct
   type t = Insta_ban | Trust_increase of float | Trust_decrease of float


### PR DESCRIPTION
`upcall_reader` (defined in Make0(_).t) is never consumed anywhere in the codebase, so any async thread attempting to ban a node would block forever. Set `tmp_bans_are_disabled = true` until the read path is wired up.

Solves https://github.com/MinaProtocol/mina/issues/18676 partially.

BTW, I remember this component contribute nothing to the system, we might want to just remove it. 

