### PR TITLE
Add mina-*-automode transitional metapackage for seamless hardfork up…

### DIFF
--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+
+# Integration test for the full automode transition lifecycle:
+#   mina-devnet (v1) → mina-devnet-automode (v2) → mina-devnet (v3)
+#
+# Validates that:
+# - mina-devnet installs cleanly
+# - mina-devnet-automode replaces mina-devnet via apt
+# - mina-devnet (higher version) replaces automode and restores normal layout
+# - No automode-specific files remain after the final transition
+#
+# Prerequisites:
+#   - Built debs available in cache (depends on debian build CI step)
+#   - Running inside a toolchain container with apt/dpkg/fakeroot/aptly
+#
+# Usage:
+#   debian-automode-transition-test.sh --codename <codename> --network <network>
+
+set -euox pipefail
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+
+export DEBIAN_FRONTEND=noninteractive
+
+git config --global --add safe.directory /workdir
+source buildkite/scripts/export-git-env-vars.sh
+
+SESSION_DIR="./scripts/debian/session"
+
+################################################################################
+# Logging
+################################################################################
+
+log_info()  { echo -e "${GREEN}[INFO]${CLEAR} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${CLEAR} $*"; }
+log_error() { echo -e "${RED}[ERROR]${CLEAR} $*"; }
+
+################################################################################
+# CLI
+################################################################################
+
+CODENAME="bullseye"
+NETWORK="devnet"
+APTLY_PORT=8080
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -c, --codename    Debian codename (default: bullseye)"
+    echo "  -N, --network     Network name (default: devnet)"
+    echo "  -h, --help        Show this help"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -c|--codename) CODENAME="$2"; shift 2 ;;
+        -N|--network)  NETWORK="$2"; shift 2 ;;
+        -h|--help)     usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "${BUILDKITE_BUILD_ID:-}" ]]; then
+    log_error "BUILDKITE_BUILD_ID must be set"
+    exit 1
+fi
+
+################################################################################
+# Setup
+################################################################################
+
+WORKDIR=$(mktemp -d)
+DEB_DIR="${WORKDIR}/debs"
+REPO_DIR="${WORKDIR}/repo"
+VERSIONED_DIR="${WORKDIR}/versioned"
+
+mkdir -p "${DEB_DIR}" "${REPO_DIR}" "${VERSIONED_DIR}"
+
+cleanup() {
+    log_info "Cleaning up..."
+    ./scripts/debian/aptly.sh stop --clean 2>/dev/null || true
+    rm -rf "${WORKDIR}"
+}
+trap cleanup EXIT
+
+# Detect sudo
+if [[ "${EUID}" -eq 0 ]]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+PKG_DAEMON="mina-${NETWORK}"
+PKG_AUTOMODE="mina-${NETWORK}-automode"
+PKG_CONFIG="mina-${NETWORK}-config"
+PKG_POSTFORK="mina-${NETWORK}-postfork-mesa"
+PKG_PREFORK="mina-${NETWORK}-prefork-mesa"
+
+# Automode-specific paths that should NOT exist after restoring mina-devnet
+AUTOMODE_PATHS=(
+    "/usr/local/bin/mina-dispatch"
+    "/etc/default/mina-dispatch"
+    "/usr/lib/mina/mesa"
+    "/usr/lib/mina/berkeley"
+)
+
+# Normal mina-devnet paths that SHOULD exist after restore
+DAEMON_PATHS=(
+    "/usr/local/bin/mina"
+    "/usr/local/bin/coda-libp2p_helper"
+    "/usr/local/bin/mina-create-genesis"
+)
+
+################################################################################
+# Step 1: Download debs from cache
+################################################################################
+
+log_info "=== Step 1: Download debs from cache ==="
+
+# Download all relevant debs for this codename
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/${PKG_DAEMON}_*" "${DEB_DIR}"
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/${PKG_AUTOMODE}_*" "${DEB_DIR}"
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/${PKG_CONFIG}_*" "${DEB_DIR}"
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/${PKG_POSTFORK}_*" "${DEB_DIR}"
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/${PKG_PREFORK}_*" "${DEB_DIR}"
+./buildkite/scripts/cache/manager.sh read "debians/${CODENAME}/mina-logproc_*" "${DEB_DIR}"
+
+log_info "Downloaded debs:"
+ls -la "${DEB_DIR}"/*.deb
+
+################################################################################
+# Step 2: Create versioned variants using deb-session
+################################################################################
+
+log_info "=== Step 2: Create versioned package variants ==="
+
+# Original version from the build
+ORIG_DAEMON_DEB=$(ls "${DEB_DIR}"/${PKG_DAEMON}_*.deb | head -1)
+ORIG_AUTOMODE_DEB=$(ls "${DEB_DIR}"/${PKG_AUTOMODE}_*.deb | head -1)
+ORIG_CONFIG_DEB=$(ls "${DEB_DIR}"/${PKG_CONFIG}_*.deb | head -1)
+ORIG_POSTFORK_DEB=$(ls "${DEB_DIR}"/${PKG_POSTFORK}_*.deb | head -1)
+ORIG_PREFORK_DEB=$(ls "${DEB_DIR}"/${PKG_PREFORK}_*.deb | head -1)
+ORIG_LOGPROC_DEB=$(ls "${DEB_DIR}"/mina-logproc_*.deb | head -1)
+
+reversion_deb() {
+    local input_deb="$1"
+    local new_version="$2"
+    local output_deb="$3"
+    local session_dir="${WORKDIR}/session_tmp"
+
+    rm -rf "${session_dir}"
+    "${SESSION_DIR}/deb-session-open.sh" "${input_deb}" "${session_dir}"
+    "${SESSION_DIR}/deb-session-reversion.sh" "${session_dir}" "${new_version}"
+    "${SESSION_DIR}/deb-session-save.sh" "${session_dir}" "${output_deb}"
+    rm -rf "${session_dir}"
+}
+
+V1="1.0.0-transition-test"
+V2="2.0.0-transition-test"
+V3="3.0.0-transition-test"
+
+# V1: mina-devnet + config + logproc (pre-hardfork)
+reversion_deb "${ORIG_DAEMON_DEB}"  "${V1}" "${REPO_DIR}/${PKG_DAEMON}_${V1}_amd64.deb"
+reversion_deb "${ORIG_CONFIG_DEB}"  "${V1}" "${REPO_DIR}/${PKG_CONFIG}_${V1}_all.deb"
+reversion_deb "${ORIG_LOGPROC_DEB}" "${V1}" "${REPO_DIR}/mina-logproc_${V1}_amd64.deb"
+
+# V2: automode + postfork + prefork + config + logproc (hardfork)
+reversion_deb "${ORIG_AUTOMODE_DEB}" "${V2}" "${REPO_DIR}/${PKG_AUTOMODE}_${V2}_all.deb"
+reversion_deb "${ORIG_POSTFORK_DEB}" "${V2}" "${REPO_DIR}/${PKG_POSTFORK}_${V2}_amd64.deb"
+reversion_deb "${ORIG_PREFORK_DEB}"  "${V2}" "${REPO_DIR}/${PKG_PREFORK}_${V2}_amd64.deb"
+reversion_deb "${ORIG_CONFIG_DEB}"   "${V2}" "${REPO_DIR}/${PKG_CONFIG}_${V2}_all.deb"
+reversion_deb "${ORIG_LOGPROC_DEB}"  "${V2}" "${REPO_DIR}/mina-logproc_${V2}_amd64.deb"
+
+# V3: mina-devnet + config + logproc (post-hardfork, back to normal)
+reversion_deb "${ORIG_DAEMON_DEB}"  "${V3}" "${REPO_DIR}/${PKG_DAEMON}_${V3}_amd64.deb"
+reversion_deb "${ORIG_CONFIG_DEB}"  "${V3}" "${REPO_DIR}/${PKG_CONFIG}_${V3}_all.deb"
+reversion_deb "${ORIG_LOGPROC_DEB}" "${V3}" "${REPO_DIR}/mina-logproc_${V3}_amd64.deb"
+
+log_info "Versioned packages:"
+ls -la "${REPO_DIR}"/*.deb
+
+################################################################################
+# Step 3: Start local apt repo
+################################################################################
+
+log_info "=== Step 3: Start local apt repository ==="
+
+./scripts/debian/aptly.sh start \
+    --codename "${CODENAME}" \
+    --debians "${REPO_DIR}" \
+    --component unstable \
+    --clean \
+    --background \
+    --wait \
+    --port "${APTLY_PORT}"
+
+# Add local repo to apt sources
+$SUDO bash -c "echo 'deb [trusted=yes] http://localhost:${APTLY_PORT}/ ${CODENAME} unstable' > /etc/apt/sources.list.d/transition-test.list"
+$SUDO apt-get update -qq
+
+log_info "Available packages:"
+apt-cache showpkg "${PKG_DAEMON}" 2>/dev/null | head -20 || true
+apt-cache showpkg "${PKG_AUTOMODE}" 2>/dev/null | head -20 || true
+
+################################################################################
+# Step 4: Install mina-devnet v1 (pre-hardfork state)
+################################################################################
+
+log_info "=== Step 4: Install ${PKG_DAEMON} v1 ==="
+
+$SUDO apt-get install -y -qq --allow-downgrades "${PKG_DAEMON}=${V1}"
+
+log_info "Installed ${PKG_DAEMON} v1"
+dpkg -l "${PKG_DAEMON}" 2>/dev/null | tail -1
+
+# Verify mina binary is a real file (not a symlink to dispatcher)
+if [[ -L "/usr/local/bin/mina" ]]; then
+    log_error "/usr/local/bin/mina should be a real binary in v1, not a symlink"
+    exit 1
+fi
+log_info "PASS: /usr/local/bin/mina is a real binary"
+
+# Verify no automode paths exist
+for path in "${AUTOMODE_PATHS[@]}"; do
+    if [[ -e "$path" ]]; then
+        log_error "Automode path should not exist in v1: $path"
+        exit 1
+    fi
+done
+log_info "PASS: No automode paths in v1"
+
+################################################################################
+# Step 5: Upgrade to mina-devnet-automode v2 (hardfork transition)
+################################################################################
+
+log_info "=== Step 5: Upgrade to ${PKG_AUTOMODE} v2 ==="
+
+$SUDO apt-get install -y -qq --allow-downgrades "${PKG_AUTOMODE}=${V2}"
+
+log_info "Package state after automode install:"
+dpkg -l "${PKG_AUTOMODE}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_POSTFORK}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_PREFORK}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_DAEMON}" 2>/dev/null | tail -1 || true
+
+# mina-devnet should be removed (replaced by automode)
+if dpkg -l "${PKG_DAEMON}" 2>/dev/null | grep -q "^ii"; then
+    log_error "${PKG_DAEMON} should have been replaced by ${PKG_AUTOMODE}"
+    exit 1
+fi
+log_info "PASS: ${PKG_DAEMON} removed by automode transition"
+
+# mina-dispatch should exist (from postfork package)
+if [[ ! -e "/usr/local/bin/mina-dispatch" ]]; then
+    log_error "mina-dispatch should exist after automode install"
+    exit 1
+fi
+log_info "PASS: mina-dispatch present"
+
+# /usr/local/bin/mina should be a symlink to mina-dispatch
+if [[ ! -L "/usr/local/bin/mina" ]]; then
+    log_error "/usr/local/bin/mina should be a symlink in automode"
+    exit 1
+fi
+log_info "PASS: /usr/local/bin/mina is a symlink (automode dispatcher)"
+
+################################################################################
+# Step 6: Restore mina-devnet v3 (post-hardfork, back to normal)
+################################################################################
+
+log_info "=== Step 6: Restore ${PKG_DAEMON} v3 ==="
+
+$SUDO apt-get install -y -qq --allow-downgrades "${PKG_DAEMON}=${V3}"
+
+# automode metapackage conflicts with mina-devnet, so apt should remove it.
+# The prefork/postfork sub-packages were only dependencies of automode, so
+# they become orphans. Run autoremove to clean them up (simulates operator
+# running apt autoremove after a transition).
+$SUDO apt-get autoremove -y -qq
+
+log_info "Package state after restore:"
+dpkg -l "${PKG_DAEMON}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_AUTOMODE}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_POSTFORK}" 2>/dev/null | tail -1 || true
+dpkg -l "${PKG_PREFORK}" 2>/dev/null | tail -1 || true
+
+# mina-devnet v3 should be installed
+if ! dpkg -l "${PKG_DAEMON}" 2>/dev/null | grep -q "^ii"; then
+    log_error "${PKG_DAEMON} v3 should be installed"
+    exit 1
+fi
+log_info "PASS: ${PKG_DAEMON} v3 installed"
+
+# Automode metapackage should be gone
+if dpkg -l "${PKG_AUTOMODE}" 2>/dev/null | grep -q "^ii"; then
+    log_error "${PKG_AUTOMODE} should have been removed"
+    exit 1
+fi
+log_info "PASS: ${PKG_AUTOMODE} removed"
+
+# Postfork/prefork should be gone (removed by autoremove)
+if dpkg -l "${PKG_POSTFORK}" 2>/dev/null | grep -q "^ii"; then
+    log_error "${PKG_POSTFORK} should have been removed by autoremove"
+    exit 1
+fi
+log_info "PASS: ${PKG_POSTFORK} removed"
+
+if dpkg -l "${PKG_PREFORK}" 2>/dev/null | grep -q "^ii"; then
+    log_error "${PKG_PREFORK} should have been removed by autoremove"
+    exit 1
+fi
+log_info "PASS: ${PKG_PREFORK} removed"
+
+# Verify /usr/local/bin/mina is a real binary again (not a symlink)
+if [[ -L "/usr/local/bin/mina" ]]; then
+    log_error "/usr/local/bin/mina should be a real binary after restore, not a symlink"
+    exit 1
+fi
+log_info "PASS: /usr/local/bin/mina is a real binary again"
+
+# Verify daemon binaries exist
+for path in "${DAEMON_PATHS[@]}"; do
+    if [[ ! -e "$path" ]]; then
+        log_error "Daemon path should exist after restore: $path"
+        exit 1
+    fi
+done
+log_info "PASS: All daemon binaries present"
+
+# Verify automode-specific files are gone
+AUTOMODE_LEFTOVER=0
+for path in "${AUTOMODE_PATHS[@]}"; do
+    if [[ -e "$path" ]]; then
+        log_error "Automode leftover found: $path"
+        AUTOMODE_LEFTOVER=1
+    fi
+done
+
+if [[ "${AUTOMODE_LEFTOVER}" -eq 1 ]]; then
+    log_error "Automode files were not cleaned up during transition back to ${PKG_DAEMON}"
+    exit 1
+fi
+log_info "PASS: No automode files remain"
+
+################################################################################
+# Done
+################################################################################
+
+log_info "=== Debian Automode Transition Test PASSED ==="
+log_info "Successfully tested: ${PKG_DAEMON}(v1) → ${PKG_AUTOMODE}(v2) → ${PKG_DAEMON}(v3)"

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -154,20 +154,7 @@ reversion_deb() {
 
     rm -rf "${session_dir}"
     "${SESSION_DIR}/deb-session-open.sh" "${input_deb}" "${session_dir}"
-
-    # Get the original version before reversion so we can update deps too
-    local old_version
-    old_version=$(grep '^Version:' "${session_dir}/control/control" | awk '{print $2}')
-
-    "${SESSION_DIR}/deb-session-reversion.sh" "${session_dir}" "${new_version}"
-
-    # Also update dependency version constraints that reference the old version,
-    # so that pinned deps (e.g., mina-logproc (= OLD)) match the test repo versions.
-    local control_file="${session_dir}/control/control"
-    sed -i "s/(= ${old_version})/(= ${new_version})/g" "${control_file}"
-    sed -i "s/(>= ${old_version})/(>= ${new_version})/g" "${control_file}"
-    sed -i "s/(<= ${old_version})/(<= ${new_version})/g" "${control_file}"
-
+    "${SESSION_DIR}/deb-session-reversion.sh" --update-deps "${session_dir}" "${new_version}"
     "${SESSION_DIR}/deb-session-save.sh" "${session_dir}" "${output_deb}"
     rm -rf "${session_dir}"
 }

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -216,7 +216,7 @@ log_info "Package dependencies for ${PKG_DAEMON}=${V1}:"
 apt-cache depends "${PKG_DAEMON}=${V1}" 2>/dev/null || true
 apt-cache policy "${PKG_DAEMON}=${V1}" 2>/dev/null || true
 
-$SUDO apt-get install -y --allow-downgrades "${PKG_DAEMON}=${V1}"
+$SUDO apt-get install -y --allow-downgrades "${PKG_DAEMON}=${V1}" "${PKG_CONFIG}=${V1}" "mina-logproc=${V1}"
 
 log_info "Installed ${PKG_DAEMON} v1"
 dpkg -l "${PKG_DAEMON}" 2>/dev/null | tail -1
@@ -243,7 +243,7 @@ log_info "PASS: No automode paths in v1"
 
 log_info "=== Step 5: Upgrade to ${PKG_AUTOMODE} v2 ==="
 
-$SUDO apt-get install -y -qq --allow-downgrades "${PKG_AUTOMODE}=${V2}"
+$SUDO apt-get install -y -qq --allow-downgrades "${PKG_AUTOMODE}=${V2}" "${PKG_CONFIG}=${V2}" "mina-logproc=${V2}"
 
 log_info "Package state after automode install:"
 dpkg -l "${PKG_AUTOMODE}" 2>/dev/null | tail -1 || true
@@ -278,7 +278,7 @@ log_info "PASS: /usr/local/bin/mina is a symlink (automode dispatcher)"
 
 log_info "=== Step 6: Restore ${PKG_DAEMON} v3 ==="
 
-$SUDO apt-get install -y -qq --allow-downgrades "${PKG_DAEMON}=${V3}"
+$SUDO apt-get install -y -qq --allow-downgrades "${PKG_DAEMON}=${V3}" "${PKG_CONFIG}=${V3}" "mina-logproc=${V3}"
 
 # automode metapackage conflicts with mina-devnet, so apt should remove it.
 # The prefork/postfork sub-packages were only dependencies of automode, so

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -154,7 +154,20 @@ reversion_deb() {
 
     rm -rf "${session_dir}"
     "${SESSION_DIR}/deb-session-open.sh" "${input_deb}" "${session_dir}"
+
+    # Get the original version before reversion so we can update deps too
+    local old_version
+    old_version=$(grep '^Version:' "${session_dir}/control/control" | awk '{print $2}')
+
     "${SESSION_DIR}/deb-session-reversion.sh" "${session_dir}" "${new_version}"
+
+    # Also update dependency version constraints that reference the old version,
+    # so that pinned deps (e.g., mina-logproc (= OLD)) match the test repo versions.
+    local control_file="${session_dir}/control/control"
+    sed -i "s/(= ${old_version})/(= ${new_version})/g" "${control_file}"
+    sed -i "s/(>= ${old_version})/(>= ${new_version})/g" "${control_file}"
+    sed -i "s/(<= ${old_version})/(<= ${new_version})/g" "${control_file}"
+
     "${SESSION_DIR}/deb-session-save.sh" "${session_dir}" "${output_deb}"
     rm -rf "${session_dir}"
 }

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -212,7 +212,11 @@ apt-cache showpkg "${PKG_AUTOMODE}" 2>/dev/null | head -20 || true
 
 log_info "=== Step 4: Install ${PKG_DAEMON} v1 ==="
 
-$SUDO apt-get install -y -qq --allow-downgrades "${PKG_DAEMON}=${V1}"
+log_info "Package dependencies for ${PKG_DAEMON}=${V1}:"
+apt-cache depends "${PKG_DAEMON}=${V1}" 2>/dev/null || true
+apt-cache policy "${PKG_DAEMON}=${V1}" 2>/dev/null || true
+
+$SUDO apt-get install -y --allow-downgrades "${PKG_DAEMON}=${V1}"
 
 log_info "Installed ${PKG_DAEMON} v1"
 dpkg -l "${PKG_DAEMON}" 2>/dev/null | tail -1

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -165,6 +165,7 @@ let generateStep =
                   , DaemonAppsOnly = ""
                   , DaemonPrefork = ""
                   , DaemonAutoHardfork = ""
+                  , DaemonAutomode = ""
                   , LogProc = ""
                   , Archive = ""
                   , TestExecutive = ""

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -303,6 +303,7 @@ let docker_step
                 , LogProc = [] : List DockerImage.ReleaseSpec.Type
                 , CreatePreforkGenesis = [] : List DockerImage.ReleaseSpec.Type
                 , DaemonPrefork = [] : List DockerImage.ReleaseSpec.Type
+                , DaemonAutomode = [] : List DockerImage.ReleaseSpec.Type
                 , BatchTxn =
                   [ DockerImage.ReleaseSpec::{
                     , deps = deps

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -153,6 +153,7 @@ let dockerName =
             , DaemonLegacyHardfork = dockerServiceName artifact
             , DaemonAutoHardfork = dockerServiceName artifact
             , DaemonAppsOnly = dockerServiceName artifact
+            , DaemonAutomode = dockerServiceName artifact
             , Archive = dockerServiceName artifact
             , TestExecutive = dockerServiceName artifact
             , LogProc = dockerServiceName artifact

--- a/buildkite/src/Constants/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifacts.dhall
@@ -17,6 +17,7 @@ let Artifact
       | DaemonAppsOnly
       | DaemonPrefork
       | DaemonAutoHardfork
+      | DaemonAutomode
       | DaemonConfig
       | LogProc
       | Archive
@@ -38,6 +39,7 @@ let AllButTests =
       , Artifact.DaemonLegacyHardfork
       , Artifact.DaemonPrefork
       , Artifact.DaemonAutoHardfork
+      , Artifact.DaemonAutomode
       , Artifact.DaemonAppsOnly
       , Artifact.DaemonConfig
       , Artifact.LogProc
@@ -71,6 +73,7 @@ let capitalName =
             , DaemonPrefork = "DaemonPrefork"
             , DaemonLegacyHardfork = "DaemonLegacyHardfork"
             , DaemonAutoHardfork = "DaemonAutoHardfork"
+            , DaemonAutomode = "DaemonAutomode"
             , DaemonAppsOnly = "DaemonAppsOnly"
             , DaemonConfig = "DaemonConfig"
             , LogProc = "LogProc"
@@ -96,6 +99,7 @@ let lowerName =
             , DaemonPrefork = "daemon_prefork"
             , DaemonLegacyHardfork = "daemon_hardfork"
             , DaemonAutoHardfork = "daemon_auto_hardfork"
+            , DaemonAutomode = "daemon_automode"
             , DaemonAppsOnly = "daemon_apps_only"
             , DaemonConfig = "daemon_config"
             , LogProc = "logproc"
@@ -121,6 +125,7 @@ let dockerServiceName =
             , DaemonPrefork = ""
             , DaemonLegacyHardfork = "mina-daemon-legacy-hardfork"
             , DaemonAutoHardfork = "mina-daemon-auto-hardfork"
+            , DaemonAutomode = ""
             , DaemonAppsOnly = "mina-daemon"
             , Archive = "mina-archive"
             , TestExecutive = "mina-test-executive"
@@ -182,6 +187,7 @@ let toDebianName =
                 "daemon_${Network.lowerName network}_hardfork_config"
             , DaemonAutoHardfork =
                 "daemon_${Network.lowerName network}_postfork"
+            , DaemonAutomode = "daemon_${Network.lowerName network}_automode"
             , DaemonAppsOnly = "daemon_${Network.lowerName network}_generic"
             , LogProc = "logproc"
             , Archive = "archive_${Network.lowerName network}"
@@ -214,6 +220,7 @@ let toDebianNames =
                           , DaemonPrefork = [ toDebianName a network ]
                           , DaemonLegacyHardfork = [ toDebianName a network ]
                           , DaemonAutoHardfork = [ toDebianName a network ]
+                          , DaemonAutomode = [ toDebianName a network ]
                           , DaemonConfig = [ toDebianName a network ]
                           , DaemonAppsOnly = [ toDebianName a network ]
                           , Archive = [ toDebianName a network ]
@@ -287,6 +294,7 @@ let dockerTag =
                 { Daemon =
                     "${spec.version}${network_part}${extraordinary_profile_part}${extra_build_flags_part}"
                 , DaemonPrefork = ""
+                , DaemonAutomode = ""
                 , DaemonLegacyHardfork =
                     "${spec.version}${network_part}${extraordinary_profile_part}"
                 , DaemonAutoHardfork =

--- a/buildkite/src/Constants/DockerPublish.dhall
+++ b/buildkite/src/Constants/DockerPublish.dhall
@@ -22,6 +22,7 @@ let isEssential =
             , FunctionalTestSuite = True
             , Toolchain = True
             , DaemonAutoHardfork = True
+            , DaemonAutomode = False
             , DaemonLegacyHardfork = True
             , CreatePreforkGenesis = False
             , DelegationVerifier = True

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
@@ -23,6 +23,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeDevnetDevnet.dhall
@@ -16,6 +16,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.CreatePreforkGenesis
             , Artifacts.Type.LogProc

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMainnetMainnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.LogProc

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
@@ -20,6 +20,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
@@ -19,6 +19,7 @@ in  Pipeline.build
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.LogProc

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.LogProc

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMesaDevnet.dhall
@@ -24,6 +24,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
@@ -20,6 +20,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             [ Artifacts.Type.Daemon
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.LogProc

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonConfig
             , Artifacts.Type.DaemonPrefork
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.LogProc
             , Artifacts.Type.Archive
             , Artifacts.Type.Rosetta

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
@@ -26,6 +26,7 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta
             , Artifacts.Type.RosettaAppsOnly
             , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
             , Artifacts.Type.DaemonAppsOnly
             , Artifacts.Type.ZkappTestTransaction
             , Artifacts.Type.CreatePreforkGenesis

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -27,11 +27,14 @@ let dependsOnDevnet =
         , network = Network.Type.Devnet
         }
 
+let Profiles = ../../Constants/Profiles.dhall
+
 let dependsOnMainnet =
       DebianVersions.dependsOn
         DebianVersions.DepsSpec::{
         , deb_version = DebianVersions.DebVersion.Bullseye
         , network = Network.Type.Mainnet
+        , profile = Profiles.Type.Mainnet
         }
 
 let buildTestCmd

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -20,21 +20,11 @@ let Docker = ../../Command/Docker/Type.dhall
 
 let Size = ../../Command/Size.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let dependsOnDevnet =
       DebianVersions.dependsOn
         DebianVersions.DepsSpec::{
         , deb_version = DebianVersions.DebVersion.Bullseye
         , network = Network.Type.Devnet
-        }
-
-let dependsOnMainnet =
-      DebianVersions.dependsOn
-        DebianVersions.DepsSpec::{
-        , deb_version = DebianVersions.DebVersion.Bullseye
-        , network = Network.Type.Mainnet
-        , profile = Profiles.Type.Mainnet
         }
 
 let buildTestCmd
@@ -64,34 +54,26 @@ let buildTestCmd
                 , depends_on = deps
                 }
 
+let dirtyWhen =
+      [ S.strictlyStart (S.contains "src")
+      , S.strictly (S.contains "Makefile")
+      , S.exactly "buildkite/src/Jobs/Test/DebianAutomodeTransitionTest" "dhall"
+      , S.exactly "buildkite/scripts/tests/debian-automode-transition-test" "sh"
+      , S.strictlyStart (S.contains "scripts/debian")
+      , S.exactly "buildkite/scripts/cache/manager" "sh"
+      ]
+
 in  Pipeline.build
       Pipeline.Config::{
-      , spec =
-          let dirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.strictly (S.contains "Makefile")
-                , S.exactly
-                    "buildkite/src/Jobs/Test/DebianAutomodeTransitionTest"
-                    "dhall"
-                , S.exactly
-                    "buildkite/scripts/tests/debian-automode-transition-test"
-                    "sh"
-                , S.strictlyStart (S.contains "scripts/debian")
-                , S.exactly "buildkite/scripts/cache/manager" "sh"
-                ]
-
-          in  JobSpec::{
-              , dirtyWhen = dirtyWhen
-              , path = "Test"
-              , name = "DebianAutomodeTransitionTest"
-              , tags =
-                [ PipelineTag.Type.Long
-                , PipelineTag.Type.Test
-                , PipelineTag.Type.Stable
-                ]
-              }
-      , steps =
-        [ buildTestCmd "devnet" "devnet" dependsOnDevnet Size.Large
-        , buildTestCmd "mainnet" "mainnet" dependsOnMainnet Size.Large
-        ]
+      , spec = JobSpec::{
+        , dirtyWhen = dirtyWhen
+        , path = "Test"
+        , name = "DebianAutomodeTransitionTest"
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps = [ buildTestCmd "devnet" "devnet" dependsOnDevnet Size.Large ]
       }

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -20,14 +20,14 @@ let Docker = ../../Command/Docker/Type.dhall
 
 let Size = ../../Command/Size.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 let dependsOnDevnet =
       DebianVersions.dependsOn
         DebianVersions.DepsSpec::{
         , deb_version = DebianVersions.DebVersion.Bullseye
         , network = Network.Type.Devnet
         }
-
-let Profiles = ../../Constants/Profiles.dhall
 
 let dependsOnMainnet =
       DebianVersions.dependsOn

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -20,17 +20,27 @@ let Docker = ../../Command/Docker/Type.dhall
 
 let Size = ../../Command/Size.dhall
 
-let dependsOn =
+let dependsOnDevnet =
       DebianVersions.dependsOn
         DebianVersions.DepsSpec::{
         , deb_version = DebianVersions.DebVersion.Bullseye
         , network = Network.Type.Devnet
         }
 
+let dependsOnMainnet =
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = Network.Type.Mainnet
+        }
+
 let buildTestCmd
-    : Size -> Command.Type
-    =     \(cmd_target : Size)
-      ->  let key = "debian-automode-transition-test"
+    : Text -> Text -> List { name : Text, key : Text } -> Size -> Command.Type
+    =     \(network : Text)
+      ->  \(keySuffix : Text)
+      ->  \(deps : List { name : Text, key : Text })
+      ->  \(cmd_target : Size)
+      ->  let key = "debian-automode-transition-test-${keySuffix}"
 
           in  Command.build
                 Command.Config::{
@@ -41,13 +51,14 @@ let buildTestCmd
                       ''
                       ./buildkite/scripts/tests/debian-automode-transition-test.sh \
                         --codename bullseye \
-                        --network devnet
+                        --network ${network}
                       ''
-                , label = "Debian automode transition test (bullseye)"
+                , label =
+                    "Debian automode transition test (bullseye, ${network})"
                 , key = key
                 , target = cmd_target
                 , docker = None Docker.Type
-                , depends_on = dependsOn
+                , depends_on = deps
                 }
 
 in  Pipeline.build
@@ -76,5 +87,8 @@ in  Pipeline.build
                 , PipelineTag.Type.Stable
                 ]
               }
-      , steps = [ buildTestCmd Size.Large ]
+      , steps =
+        [ buildTestCmd "devnet" "devnet" dependsOnDevnet Size.Large
+        , buildTestCmd "mainnet" "mainnet" dependsOnMainnet Size.Large
+        ]
       }

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -1,0 +1,80 @@
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+let dependsOn =
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = Network.Type.Devnet
+        }
+
+let buildTestCmd
+    : Size -> Command.Type
+    =     \(cmd_target : Size)
+      ->  let key = "debian-automode-transition-test"
+
+          in  Command.build
+                Command.Config::{
+                , commands =
+                    RunInToolchain.runInToolchainBullseye
+                      Arch.Type.Amd64
+                      ([] : List Text)
+                      ''
+                      ./buildkite/scripts/tests/debian-automode-transition-test.sh \
+                        --codename bullseye \
+                        --network devnet
+                      ''
+                , label = "Debian automode transition test (bullseye)"
+                , key = key
+                , target = cmd_target
+                , docker = None Docker.Type
+                , depends_on = dependsOn
+                }
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec =
+          let dirtyWhen =
+                [ S.strictlyStart (S.contains "src")
+                , S.strictly (S.contains "Makefile")
+                , S.exactly
+                    "buildkite/src/Jobs/Test/DebianAutomodeTransitionTest"
+                    "dhall"
+                , S.exactly
+                    "buildkite/scripts/tests/debian-automode-transition-test"
+                    "sh"
+                , S.strictlyStart (S.contains "scripts/debian")
+                , S.exactly "buildkite/scripts/cache/manager" "sh"
+                ]
+
+          in  JobSpec::{
+              , dirtyWhen = dirtyWhen
+              , path = "Test"
+              , name = "DebianAutomodeTransitionTest"
+              , tags =
+                [ PipelineTag.Type.Long
+                , PipelineTag.Type.Test
+                , PipelineTag.Type.Stable
+                ]
+              }
+      , steps = [ buildTestCmd Size.Large ]
+      }

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTestMainnet.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTestMainnet.dhall
@@ -1,0 +1,78 @@
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let dependsOnMainnet =
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = Network.Type.Mainnet
+        , profile = Profiles.Type.Mainnet
+        }
+
+let dirtyWhen =
+      [ S.strictlyStart (S.contains "src")
+      , S.strictly (S.contains "Makefile")
+      , S.exactly
+          "buildkite/src/Jobs/Test/DebianAutomodeTransitionTestMainnet"
+          "dhall"
+      , S.exactly "buildkite/scripts/tests/debian-automode-transition-test" "sh"
+      , S.strictlyStart (S.contains "scripts/debian")
+      , S.exactly "buildkite/scripts/cache/manager" "sh"
+      ]
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen = dirtyWhen
+        , path = "Test"
+        , name = "DebianAutomodeTransitionTestMainnet"
+        , scope = [ PipelineScope.Type.MainlineNightly ]
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+                RunInToolchain.runInToolchainBullseye
+                  Arch.Type.Amd64
+                  ([] : List Text)
+                  ''
+                  ./buildkite/scripts/tests/debian-automode-transition-test.sh \
+                    --codename bullseye \
+                    --network mainnet
+                  ''
+            , label = "Debian automode transition test (bullseye, mainnet)"
+            , key = "debian-automode-transition-test-mainnet"
+            , target = Size.Large
+            , docker = None Docker.Type
+            , depends_on = dependsOnMainnet
+            }
+        ]
+      }

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -38,7 +38,7 @@ resolve_and_build_package() {
     return
   fi
 
-  if [[ "$package" =~ ^daemon_(mainnet|devnet|mesa)_(config|generic|hardfork_config|prefork|postfork)$ ]]; then
+  if [[ "$package" =~ ^daemon_(mainnet|devnet|mesa)_(config|generic|hardfork_config|prefork|postfork|automode)$ ]]; then
     "build_daemon_${BASH_REMATCH[2]}_deb" "${BASH_REMATCH[1]}"
     return
   fi

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -534,7 +534,7 @@ build_daemon_deb() {
   esac
 
   create_control_file "${package_name}" "${SHARED_DEPS}${DAEMON_DEPS}, mina-${network}-config (>=${MINA_DEB_VERSION})" \
-    'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}" "mina-${network} (<< ${MINA_DEB_VERSION})"
+    'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}" "mina-${network} (<< ${MINA_DEB_VERSION}), mina-${network}-postfork-${POSTFORK_CODENAME}"
 
   copy_common_daemon_apps "${network}"
 
@@ -648,10 +648,10 @@ copy_common_daemon_post_automode_apps_and_configs() {
   # dispatch to the correct runtime based on env var set in /etc/default/mina-dispatch
   create_symlinks_for_shared_apps "${prefork_network}"
 
-  copy_common_daemon_configs "${prefork_network}"
-
-  # Also ship config for prefork daemon's commit-id-based config lookup.
-  # The prefork binary looks for config_<its_own_8char_hash>.json at startup.
+  # Config files (config_<hash>.json, <network>.json) are provided by the
+  # mina-<network>-config package, so we do NOT ship them here to avoid
+  # dpkg file conflicts.  Only ship the prefork config when it differs from
+  # the postfork hash, since the config package won't contain it.
   if [[ -n "${PREFORK_LEGACY_VERSION:-}" ]]; then
     local prefork_short_hash="${PREFORK_LEGACY_VERSION##*-}"
     local prefork_githash_config
@@ -661,7 +661,8 @@ copy_common_daemon_post_automode_apps_and_configs() {
         echo "Prefork githash (${prefork_githash_config}) is the same as postfork; skipping config copy."
       else
         echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
-        cp "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json" \
+        mkdir -p "${BUILDDIR}/var/lib/coda"
+        cp "../genesis_ledgers/${prefork_network}.json" \
            "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
       fi
     else
@@ -686,7 +687,8 @@ build_daemon_postfork_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building ${prefork_network} postfork deb for hardfork automode:"
 
-  create_control_file "$package_name" "${SHARED_DEPS}${DAEMON_DEPS}" \
+  local config_dep="mina-${prefork_network}-config (>= ${MINA_DEB_VERSION})"
+  create_control_file "$package_name" "${SHARED_DEPS}${DAEMON_DEPS}, ${config_dep}" \
     'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}"
 
   local seed_list_url

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -702,8 +702,7 @@ build_daemon_postfork_deb() {
   echo "------------------------------------------------------------"
   echo "--- Building ${prefork_network} postfork deb for hardfork automode:"
 
-  local config_dep="mina-${prefork_network}-config (>= ${MINA_DEB_VERSION})"
-  create_control_file "$package_name" "${SHARED_DEPS}${DAEMON_DEPS}, ${config_dep}" \
+  create_control_file "$package_name" "${SHARED_DEPS}${DAEMON_DEPS}" \
     'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}"
 
   local seed_list_url

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -103,7 +103,16 @@ create_control_file() {
   echo "Dependencies: ${2}"
   echo "Description: ${3}"
   if [ -n "${4:-}" ]; then
-    echo "Broken/Replaces: ${4}"
+    echo "Suggests: ${4}"
+  fi
+  if [ -n "${5:-}" ]; then
+    echo "Replaces/Breaks: ${5}"
+  fi
+  if [ -n "${6:-}" ]; then
+    echo "Provides: ${6}"
+  fi
+  if [ -n "${7:-}" ]; then
+    echo "Conflicts: ${7}"
   fi
   # Make sure the directory exists
   mkdir -p "${BUILDDIR}/DEBIAN"
@@ -137,6 +146,12 @@ EOF
   if [ -n "${5:-}" ]; then
     echo "Replaces: ${5}" >> ${CONTROL}
     echo "Breaks: ${5}" >> ${CONTROL}
+  fi
+  if [ -n "${6:-}" ]; then
+    echo "Provides: ${6}" >> ${CONTROL}
+  fi
+  if [ -n "${7:-}" ]; then
+    echo "Conflicts: ${7}" >> ${CONTROL}
   fi
 
   cat <<EOF >> ${CONTROL}
@@ -747,16 +762,7 @@ build_daemon_automode_deb() {
 
   create_control_file "${package_name}" "${depends}" \
     "Transitional metapackage for Mina ${network} automode (installs both prefork and postfork runtimes)" \
-    "" "mina-${network}"
-
-  # Add Provides and Conflicts fields (create_control_file only writes Replaces+Breaks)
-  local CONTROL="${BUILDDIR}/DEBIAN/control"
-  echo "Provides: mina-${network}" >> "${CONTROL}"
-  echo "Conflicts: mina-${network}" >> "${CONTROL}"
-
-  echo "------------------------------------------------------------"
-  echo "Control File (with Provides/Conflicts):"
-  cat "${CONTROL}"
+    "" "mina-${network}" "mina-${network}" "mina-${network}"
 
   build_deb "${package_name}"
   ARCHITECTURE="${saved_arch}"

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -713,6 +713,54 @@ build_daemon_postfork_deb() {
 
 }
 
+## AUTOMODE METAPACKAGE ##
+
+#
+# Builds mina-NETWORK-automode transitional metapackage
+#
+# Output: mina-${NETWORK}-automode_${MINA_DEB_VERSION}_all.deb
+#
+# This is an empty metapackage that depends on both prefork and postfork
+# automode packages. It Conflicts/Replaces/Provides mina-${NETWORK} so that
+# running `apt-get install mina-${NETWORK}-automode` will automatically
+# remove mina-${NETWORK} and pull in both automode runtimes.
+#
+
+build_daemon_automode_deb() {
+
+  local network="$1"
+
+  echo "------------------------------------------------------------"
+  echo "--- Building ${network} automode transitional metapackage:"
+
+  local package_name="mina-${network}-automode"
+
+  # Automode metapackage is architecture-independent (no binaries).
+  local saved_arch="${ARCHITECTURE}"
+  ARCHITECTURE=all
+
+  local prefork_pkg="mina-${network}-prefork-${POSTFORK_CODENAME}"
+  local postfork_pkg="mina-${network}-postfork-${POSTFORK_CODENAME}"
+  local depends="${postfork_pkg} (>= ${MINA_DEB_VERSION}), ${prefork_pkg} (>= ${MINA_DEB_VERSION})"
+
+  create_control_file "${package_name}" "${depends}" \
+    "Transitional metapackage for Mina ${network} automode (installs both prefork and postfork runtimes)" \
+    "" "mina-${network}"
+
+  # Add Provides and Conflicts fields (create_control_file only writes Replaces+Breaks)
+  local CONTROL="${BUILDDIR}/DEBIAN/control"
+  echo "Provides: mina-${network}" >> "${CONTROL}"
+  echo "Conflicts: mina-${network}" >> "${CONTROL}"
+
+  echo "------------------------------------------------------------"
+  echo "Control File (with Provides/Conflicts):"
+  cat "${CONTROL}"
+
+  build_deb "${package_name}"
+  ARCHITECTURE="${saved_arch}"
+}
+## END AUTOMODE METAPACKAGE ##
+
 ## GENERIC PACKAGE ##
 
 #

--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -73,13 +73,6 @@ fi
 # Update the Version field
 sed -i "s/^Version: .*$/Version: $NEW_VERSION/" "$CONTROL_FILE"
 
-# Also update dependency version constraints that reference the old version.
-# This ensures that pinned dependencies (e.g., Depends: mina-logproc (= OLD_VERSION))
-# are updated to reference the new version, keeping the package installable.
-sed -i "s/(= ${OLD_VERSION})/(= ${NEW_VERSION})/g" "$CONTROL_FILE"
-sed -i "s/(>= ${OLD_VERSION})/(>= ${NEW_VERSION})/g" "$CONTROL_FILE"
-sed -i "s/(<= ${OLD_VERSION})/(<= ${NEW_VERSION})/g" "$CONTROL_FILE"
-
 # Verify the change
 UPDATED_VERSION=$(grep '^Version:' "$CONTROL_FILE" | awk '{print $2}' || true)
 
@@ -93,4 +86,4 @@ fi
 echo "✓ Version replaced successfully"
 echo ""
 echo "Updated control file:"
-grep -E "^(Package|Version|Architecture|Depends):" "$CONTROL_FILE" || true
+grep -E "^(Package|Version|Architecture):" "$CONTROL_FILE" || true

--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -73,6 +73,13 @@ fi
 # Update the Version field
 sed -i "s/^Version: .*$/Version: $NEW_VERSION/" "$CONTROL_FILE"
 
+# Also update dependency version constraints that reference the old version.
+# This ensures that pinned dependencies (e.g., Depends: mina-logproc (= OLD_VERSION))
+# are updated to reference the new version, keeping the package installable.
+sed -i "s/(= ${OLD_VERSION})/(= ${NEW_VERSION})/g" "$CONTROL_FILE"
+sed -i "s/(>= ${OLD_VERSION})/(>= ${NEW_VERSION})/g" "$CONTROL_FILE"
+sed -i "s/(<= ${OLD_VERSION})/(<= ${NEW_VERSION})/g" "$CONTROL_FILE"
+
 # Verify the change
 UPDATED_VERSION=$(grep '^Version:' "$CONTROL_FILE" | awk '{print $2}' || true)
 
@@ -86,4 +93,4 @@ fi
 echo "✓ Version replaced successfully"
 echo ""
 echo "Updated control file:"
-grep -E "^(Package|Version|Architecture):" "$CONTROL_FILE" || true
+grep -E "^(Package|Version|Architecture|Depends):" "$CONTROL_FILE" || true

--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/deb-session-common.sh"
 
 usage() {
   cat <<EOF
-Usage: $0 <session-dir> <new-version>
+Usage: $0 [OPTIONS] <session-dir> <new-version>
 
 Replaces the Version field in the Debian package control file.
 
@@ -16,15 +16,33 @@ Arguments:
   <session-dir>         Session directory created by deb-session-open.sh
   <new-version>         New version string (e.g., "2.0.0-rc1")
 
+Options:
+  --update-deps         Also update dependency version constraints (=, >=, <=)
+                        that reference the old version to the new version
+
 Example:
-  # Change package version
+  # Change package version only
   $0 ./my-session 2.0.0-rc1
 
+  # Change package version and update pinned dependency versions
+  $0 --update-deps ./my-session 2.0.0-rc1
+
 Notes:
-  - Only modifies the Version: field in the control file
+  - Only modifies the Version: field in the control file (unless --update-deps)
   - Package name, architecture, and all other metadata remain unchanged
 EOF
 }
+
+UPDATE_DEPS=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --update-deps) UPDATE_DEPS=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "ERROR: Unknown option: $1" >&2; usage; exit 1 ;;
+    *) break ;;
+  esac
+done
 
 if [[ $# -ne 2 ]]; then
   usage
@@ -72,6 +90,14 @@ fi
 
 # Update the Version field
 sed -i "s/^Version: .*$/Version: $NEW_VERSION/" "$CONTROL_FILE"
+
+# Optionally update dependency version constraints
+if [[ "$UPDATE_DEPS" == "true" ]]; then
+  echo "Updating dependency version constraints..."
+  sed -i "s/(= ${OLD_VERSION})/(= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(>= ${OLD_VERSION})/(>= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(<= ${OLD_VERSION})/(<= ${NEW_VERSION})/g" "$CONTROL_FILE"
+fi
 
 # Verify the change
 UPDATED_VERSION=$(grep '^Version:' "$CONTROL_FILE" | awk '{print $2}' || true)

--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -94,9 +94,11 @@ sed -i "s/^Version: .*$/Version: $NEW_VERSION/" "$CONTROL_FILE"
 # Optionally update dependency version constraints
 if [[ "$UPDATE_DEPS" == "true" ]]; then
   echo "Updating dependency version constraints..."
-  sed -i "s/(= ${OLD_VERSION})/(= ${NEW_VERSION})/g" "$CONTROL_FILE"
-  sed -i "s/(>= ${OLD_VERSION})/(>= ${NEW_VERSION})/g" "$CONTROL_FILE"
-  sed -i "s/(<= ${OLD_VERSION})/(<= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(= *${OLD_VERSION})/(= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(>= *${OLD_VERSION})/(>= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(<= *${OLD_VERSION})/(<= ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(>> *${OLD_VERSION})/(>> ${NEW_VERSION})/g" "$CONTROL_FILE"
+  sed -i "s/(<< *${OLD_VERSION})/(<< ${NEW_VERSION})/g" "$CONTROL_FILE"
 fi
 
 # Verify the change

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -807,6 +807,45 @@ test_build_daemon_postfork_deb_unresolvable_prefork_hash() {
 }
 
 ################################################################################
+# Tests: Automode metapackages
+################################################################################
+
+test_build_daemon_devnet_automode_deb() {
+    safe_build build_daemon_automode_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_eq "deb name" "mina-devnet-automode" "$CAPTURED_DEB_NAME"
+    assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-automode"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa"
+    assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-devnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Breaks" "mina-devnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Provides" "mina-devnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Conflicts" "mina-devnet"
+
+    # Metapackage should have NO binaries
+    assert_file_not_captured "$CAPTURED_FILES" "usr/local/bin/mina"
+}
+
+test_build_daemon_mainnet_automode_deb() {
+    safe_build build_daemon_automode_deb mainnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_eq "deb name" "mina-mainnet-automode" "$CAPTURED_DEB_NAME"
+    assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-automode"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa"
+    assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-mainnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Breaks" "mina-mainnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Provides" "mina-mainnet"
+    assert_control_contains "$CAPTURED_CONTROL" "Conflicts" "mina-mainnet"
+
+    assert_file_not_captured "$CAPTURED_FILES" "usr/local/bin/mina"
+}
+
+################################################################################
 # Tests: Generic packages
 ################################################################################
 
@@ -1213,6 +1252,10 @@ main() {
     run_test test_build_daemon_mainnet_postfork_deb
     run_test test_build_daemon_postfork_deb_without_prefork_version
     run_test test_build_daemon_postfork_deb_unresolvable_prefork_hash
+
+    # Automode metapackages
+    run_test test_build_daemon_devnet_automode_deb
+    run_test test_build_daemon_mainnet_automode_deb
 
     # Generic packages
     run_test test_build_daemon_devnet_generic_deb

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -729,18 +729,17 @@ test_build_daemon_devnet_postfork_deb() {
     assert_file_captured "$CAPTURED_FILES" "usr/local/bin/mina-dispatch"
     assert_file_captured "$CAPTURED_FILES" "usr/local/bin/mina"
 
-    # Config for postfork (current commit hash)
-    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
-    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/devnet.json"
+    # Config files (config_<hash>.json, <network>.json) are provided by
+    # the mina-<network>-config package, not the postfork package
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/devnet.json"
 
     # Config for prefork daemon (resolved 8-char hash from legacy version)
     assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_ef01abcd.json"
 
-    # Both configs should have the same content (devnet genesis ledger)
+    # Prefork config should have correct content
     assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
         "var/lib/coda/config_ef01abcd.json" "devnet"
-    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
-        "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json" "devnet"
 
     unset PREFORK_LEGACY_VERSION
 }
@@ -754,32 +753,31 @@ test_build_daemon_mainnet_postfork_deb() {
     assert_eq "deb name" "mina-mainnet-postfork-mesa" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-postfork-mesa"
 
-    # Config for both postfork and prefork
-    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+    # Postfork config comes from the config package, not this one
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+
+    # Prefork config shipped here (different hash)
     assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_ef01abcd.json"
 
     unset PREFORK_LEGACY_VERSION
 }
 
 test_build_daemon_postfork_deb_without_prefork_version() {
-    # When PREFORK_LEGACY_VERSION is not set, only the postfork config should be shipped
+    # When PREFORK_LEGACY_VERSION is not set, no config files should be shipped
+    # (config comes from the mina-<network>-config package)
     unset PREFORK_LEGACY_VERSION 2>/dev/null || true
 
     safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
 
     load_captured_state
 
-    # Postfork config present
-    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
-
-    # No prefork config (no PREFORK_LEGACY_VERSION means no extra config_*.json)
-    # Only one config_*.json should exist
+    # No config files at all — neither postfork nor prefork
     local config_count
     config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
-    if [[ "$config_count" -eq 1 ]]; then
+    if [[ "$config_count" -eq 0 ]]; then
         log_pass
     else
-        log_fail "Expected 1 config_*.json file, got ${config_count}"
+        log_fail "Expected 0 config_*.json files, got ${config_count}"
     fi
 }
 
@@ -791,16 +789,14 @@ test_build_daemon_postfork_deb_unresolvable_prefork_hash() {
 
     load_captured_state
 
-    # Postfork config present
-    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
-
-    # No prefork config since hash was unresolvable
+    # No config files — postfork config comes from config package,
+    # and prefork config can't be shipped because hash is unresolvable
     local config_count
     config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
-    if [[ "$config_count" -eq 1 ]]; then
+    if [[ "$config_count" -eq 0 ]]; then
         log_pass
     else
-        log_fail "Expected 1 config_*.json (unresolvable prefork hash), got ${config_count}"
+        log_fail "Expected 0 config_*.json (unresolvable prefork hash), got ${config_count}"
     fi
 
     unset PREFORK_LEGACY_VERSION


### PR DESCRIPTION
Introduce a new DaemonAutomode debian package that acts as a transitional metapackage, allowing operators to switch from mina-{network} to the automode (prefork+postfork) setup via `apt-get install mina-{network}-automode`. The metapackage declares Conflicts/Replaces/Provides on mina-{network} so APT handles the transition automatically.

