### PR TITLE
Syncable_ledger: throw an exception instead of failing silently

### DIFF
--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -635,11 +635,11 @@ end = struct
     let open (val t.context) in
     if Addr.depth addr >= MT.depth t.tree - account_subtree_height then (
       expect_content t addr exp_hash ;
-      Linear_pipe.write_without_pushback_if_open t.queries
+      Linear_pipe.write_without_pushback t.queries
         (desired_root_exn t, What_contents addr) )
     else (
       expect_children t addr exp_hash ;
-      Linear_pipe.write_without_pushback_if_open t.queries
+      Linear_pipe.write_without_pushback t.queries
         ( desired_root_exn t
         , What_child_hashes (addr, ledger_sync_config.default_subtree_depth) ) )
 
@@ -702,7 +702,7 @@ end = struct
         (* If a peer misbehaves we still need the information we asked them for,
            so requeue in that case. *)
         let requeue_query () =
-          Linear_pipe.write_without_pushback_if_open t.queries (root_hash, query)
+          Linear_pipe.write_without_pushback t.queries (root_hash, query)
         in
         let credit_fulfilled_request () =
           record_envelope_sender t.trust_system logger sender
@@ -830,7 +830,7 @@ end = struct
       t.validity_listener <- Ivar.create () ;
       t.desired_root <- Some h ;
       t.auxiliary_data <- Some data ;
-      Linear_pipe.write_without_pushback_if_open t.queries (h, Num_accounts) ;
+      Linear_pipe.write_without_pushback t.queries (h, Num_accounts) ;
       `New )
     else if
       Option.fold t.auxiliary_data ~init:false ~f:(fun _ saved_data ->

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -702,6 +702,11 @@ end = struct
         (* If a peer misbehaves we still need the information we asked them for,
            so requeue in that case. *)
         let requeue_query () =
+          [%log warn] "Requeuing query that's not resolved"
+            ~metadata:
+              [ ("root_hash", Root_hash.to_yojson root_hash)
+              ; ("query", Query.to_yojson Addr.to_yojson query)
+              ] ;
           Linear_pipe.write_without_pushback t.queries (root_hash, query)
         in
         let credit_fulfilled_request () =


### PR DESCRIPTION
Currently, syncable ledger would get stucked if the out-going query pipe is closed during operation of main syncing loop. This is because the use of `write_without_pushback_if_open` instead of  `write_without_pushback`.

It's still unclear to me why such situation will happen because we only close the pipe by hand when the sync is done. It could be some lower-level details but it's very hard to reproduce this issue -- once per week.

Having this fixed will not solve the accidental close of the pipe, but it'll make the bug more visible by just causing the whole program to crash. 

We can do future refactor to hind these pipes from external consumers so the ownership is clear.
