### PR TITLE
Ship prefork config in postfork debian for auto-hardfork mode

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -141,6 +141,7 @@ let build_artifacts
                                                  spec.debVersion}"
                         , "ARCHITECTURE=${Arch.lowerName spec.arch}"
                         , Network.buildMainnetEnv spec.network
+                        , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                         ]
                       # BuildFlags.buildEnvs spec.buildFlags
                       # spec.extraBuildEnvs

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -657,9 +657,13 @@ copy_common_daemon_post_automode_apps_and_configs() {
     local prefork_githash_config
     prefork_githash_config=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
     if [[ -n "$prefork_githash_config" ]]; then
-      echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
-      cp "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json" \
-         "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
+      if [[ "$prefork_githash_config" == "$GITHASH_CONFIG" ]]; then
+        echo "Prefork githash (${prefork_githash_config}) is the same as postfork; skipping config copy."
+      else
+        echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
+        cp "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json" \
+           "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
+      fi
     else
       echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}'. Prefork config not shipped."
     fi

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -650,6 +650,21 @@ copy_common_daemon_post_automode_apps_and_configs() {
 
   copy_common_daemon_configs "${prefork_network}"
 
+  # Also ship config for prefork daemon's commit-id-based config lookup.
+  # The prefork binary looks for config_<its_own_8char_hash>.json at startup.
+  if [[ -n "${PREFORK_LEGACY_VERSION:-}" ]]; then
+    local prefork_short_hash="${PREFORK_LEGACY_VERSION##*-}"
+    local prefork_githash_config
+    prefork_githash_config=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
+    if [[ -n "$prefork_githash_config" ]]; then
+      echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
+      cp "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json" \
+         "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
+    else
+      echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}'. Prefork config not shipped."
+    fi
+  fi
+
   # Copy seed list with correct URL for postfork runtime and
   # bash completion that points to the correct seed list URL
   copy_common_daemon_utils "${seed_list_url}" "${AUTOMODE_POSTFORK_DIR}/mina"

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -291,6 +291,10 @@ case "$*" in
         echo "1.0.0" ;;
     "rev-parse --short=8 --verify HEAD")
         echo "abcd1234" ;;
+    "rev-parse --short=8 ef01abc")
+        echo "ef01abcd" ;;
+    rev-parse\ --short=8\ *)
+        echo "fatal: ambiguous argument" >&2; exit 128 ;;
     name-rev\ --name-only*)
         echo "test-branch" ;;
     "tag --points-at HEAD")
@@ -373,6 +377,7 @@ MOCKEXE
     # hardfork scripts
     create_mock_exe "scripts/hardfork/create_runtime_config.sh" "$PROJECT_ROOT"
     create_mock_exe "scripts/hardfork/mina-verify-packaged-fork-config" "$PROJECT_ROOT"
+    create_mock_exe "scripts/hardfork/dispatcher.sh" "$PROJECT_ROOT"
 
     # archive scripts
     create_mock_exe "scripts/archive/missing-blocks-guardian.sh" "$PROJECT_ROOT"
@@ -398,6 +403,7 @@ SVCEOF
     mkdir -p "${PROJECT_ROOT}/genesis_ledgers"
     echo '{"genesis": "mainnet"}' > "${PROJECT_ROOT}/genesis_ledgers/mainnet.json"
     echo '{"genesis": "devnet"}' > "${PROJECT_ROOT}/genesis_ledgers/devnet.json"
+    echo '{"genesis": "mesa"}' > "${PROJECT_ROOT}/genesis_ledgers/mesa.json"
 
     # rosetta scripts and configs
     create_mock_exe "src/app/rosetta/scripts/run.sh" "$PROJECT_ROOT"
@@ -699,6 +705,105 @@ test_build_daemon_devnet_prefork_deb() {
     # Binaries in alternate directory
     assert_common_daemon_binaries "$CAPTURED_FILES" "usr/lib/mina/berkeley"
     assert_file_not_captured "$CAPTURED_FILES" "usr/local/bin/mina"
+}
+
+################################################################################
+# Tests: Postfork packages
+################################################################################
+
+test_build_daemon_devnet_postfork_deb() {
+    export PREFORK_LEGACY_VERSION="3.3.0-compatible-ef01abc"
+
+    safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_eq "deb name" "mina-devnet-postfork-mesa" "$CAPTURED_DEB_NAME"
+    assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-postfork-mesa"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "libssl1.1"
+    assert_control_contains "$CAPTURED_CONTROL" "Suggests" "jq"
+
+    # Postfork binaries in mesa directory
+    assert_common_daemon_binaries "$CAPTURED_FILES" "usr/lib/mina/mesa"
+
+    # Dispatcher and symlinks in default location
+    assert_file_captured "$CAPTURED_FILES" "usr/local/bin/mina-dispatch"
+    assert_file_captured "$CAPTURED_FILES" "usr/local/bin/mina"
+
+    # Config for postfork (current commit hash)
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/devnet.json"
+
+    # Config for prefork daemon (resolved 8-char hash from legacy version)
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_ef01abcd.json"
+
+    # Both configs should have the same content (devnet genesis ledger)
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
+        "var/lib/coda/config_ef01abcd.json" "devnet"
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
+        "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json" "devnet"
+
+    unset PREFORK_LEGACY_VERSION
+}
+
+test_build_daemon_mainnet_postfork_deb() {
+    export PREFORK_LEGACY_VERSION="3.3.0-compatible-ef01abc"
+
+    safe_build build_daemon_postfork_deb mainnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_eq "deb name" "mina-mainnet-postfork-mesa" "$CAPTURED_DEB_NAME"
+    assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-postfork-mesa"
+
+    # Config for both postfork and prefork
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_ef01abcd.json"
+
+    unset PREFORK_LEGACY_VERSION
+}
+
+test_build_daemon_postfork_deb_without_prefork_version() {
+    # When PREFORK_LEGACY_VERSION is not set, only the postfork config should be shipped
+    unset PREFORK_LEGACY_VERSION 2>/dev/null || true
+
+    safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+
+    # Postfork config present
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+
+    # No prefork config (no PREFORK_LEGACY_VERSION means no extra config_*.json)
+    # Only one config_*.json should exist
+    local config_count
+    config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
+    if [[ "$config_count" -eq 1 ]]; then
+        log_pass
+    else
+        log_fail "Expected 1 config_*.json file, got ${config_count}"
+    fi
+}
+
+test_build_daemon_postfork_deb_unresolvable_prefork_hash() {
+    # When the prefork hash can't be resolved by git, warn but don't fail
+    export PREFORK_LEGACY_VERSION="3.3.0-compatible-badhash"
+
+    safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+
+    # Postfork config present
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+
+    # No prefork config since hash was unresolvable
+    local config_count
+    config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
+    if [[ "$config_count" -eq 1 ]]; then
+        log_pass
+    else
+        log_fail "Expected 1 config_*.json (unresolvable prefork hash), got ${config_count}"
+    fi
+
+    unset PREFORK_LEGACY_VERSION
 }
 
 ################################################################################
@@ -1102,6 +1207,12 @@ main() {
     run_test test_build_daemon_devnet_prefork_deb
     run_test test_build_prefork_devnet_genesis_ledger_deb
     run_test test_build_prefork_mainnet_genesis_ledger_deb
+
+    # Postfork packages
+    run_test test_build_daemon_devnet_postfork_deb
+    run_test test_build_daemon_mainnet_postfork_deb
+    run_test test_build_daemon_postfork_deb_without_prefork_version
+    run_test test_build_daemon_postfork_deb_unresolvable_prefork_hash
 
     # Generic packages
     run_test test_build_daemon_devnet_generic_deb


### PR DESCRIPTION
## Summary
- The prefork daemon binary looks for `config_<its_commit_hash>.json` at startup, but only the postfork (mesa) config was being shipped in the postfork debian package
- Extracts the prefork commit hash from `PREFORK_LEGACY_VERSION` (sourced from `deb_legacy_version` in Dhall), expands it to 8 chars via `git rev-parse`, and copies the config with that name
- Falls back gracefully with a warning if the prefork hash cannot be resolved in the repo

## Changes
- `buildkite/src/Command/MinaArtifact.dhall` — pass `PREFORK_LEGACY_VERSION` env var to debian build
- `scripts/debian/builder-helpers.sh` — duplicate config file for prefork hash in `copy_common_daemon_post_automode_apps_and_configs()`
- `scripts/debian/tests/test_builder_helpers.sh` — 4 new tests covering postfork deb with/without prefork config, including unresolvable hash case

## Test plan
- [x] All 35 builder-helpers unit tests pass (including 4 new postfork tests)
- [x] Verify in CI that the prefork commit hash is resolvable during build
- [x] Confirm prefork daemon picks up config after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)