### PR TITLE
Downloader: flush immediately when there's too many requests

### DIFF
--- a/changes/18688.md
+++ b/changes/18688.md
@@ -1,0 +1,1 @@
+Fix downloader flush starvation — the previous flush timer was cancelled and rescheduled on every enqueue, allowing indefinite delay; now delay is bounded: at most one extra `max_wait` extension is permitted while the pending queue stays below 3× batch size.

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -714,7 +714,7 @@ end = struct
   let enqueue t e =
     match Q.enqueue t.pending e with
     | `Ok ->
-        jobs_added t ; `Ok
+        jobs_added t ; flush_soon t ; `Ok
     | `Key_already_present ->
         `Key_already_present
 
@@ -798,8 +798,7 @@ end = struct
               enqueue_exn t
                 { x with
                   attempts = Map.set x.attempts ~key:peer ~data:Attempt.download
-                } ) ;
-          flush_soon t
+                } )
         in
         List.iter xs ~f:(fun x ->
             Hashtbl.set t.downloading ~key:x.key ~data:(peer, x, Time.now ()) ) ;
@@ -876,8 +875,7 @@ end = struct
                       { x with
                         attempts =
                           Map.set x.attempts ~key:peer ~data:Attempt.download
-                      } ) ;
-                flush_soon t ) )
+                      } ) ) )
 
   let to_yojson t : Yojson.Safe.t =
     check_invariant t ;
@@ -1113,5 +1111,5 @@ end = struct
         x
     | None, None ->
         let e = { J.key; attempts; res = Ivar.create () } in
-        enqueue_exn t e ; flush_soon t ; e
+        enqueue_exn t e ; e
 end

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -600,7 +600,8 @@ end = struct
   end
 
   type t =
-    { mutable next_flush : (unit, unit) Clock.Event.t option
+    { mutable proposed_new_flush_at : Time.t option
+    ; mutable flush_scheduled : bool
     ; mutable all_peers : Peer.Set.t
     ; pending : Job.t Q.t
     ; downloading : (Peer.t * Job.t * Time.t) Key.Table.t
@@ -661,16 +662,37 @@ end = struct
 
   let kill_job _t j = Ivar.fill_if_empty j.J.res (Error `Finished)
 
+  let hard_flush_batch_rate = 3
+
+  (* WARN: we should ensure we're always enqueuing jobs before invoking
+     [flush_soon], o.w. this function can delay flushing indefinitely *)
   let flush_soon t =
-    Option.iter t.next_flush ~f:(fun e -> Clock.Event.abort_if_possible e ()) ;
-    t.next_flush <-
-      Some
-        (Clock.Event.run_after max_wait
-           (* <-- TODO: pretty sure this is a bug (this can infinitely delay flushes *)
-             (fun () ->
-             if not (Strict_pipe.Writer.is_closed t.flush_w) then
-               Strict_pipe.Writer.write t.flush_w () )
-           () )
+    let flush_now () =
+      if not (Strict_pipe.Writer.is_closed t.flush_w) then
+        Strict_pipe.Writer.write t.flush_w () ;
+      t.flush_scheduled <- false ;
+      t.proposed_new_flush_at <- None
+    in
+    let rec schedule_flush ~at =
+      let%bind () = after Time.(diff at (now ())) in
+      match t.proposed_new_flush_at with
+      | None ->
+          Deferred.return @@ flush_now ()
+      | Some proposed_new_flush_at ->
+          let possible_delayed_flush_time =
+            Time.add proposed_new_flush_at max_wait
+          in
+          if
+            Time.is_later possible_delayed_flush_time ~than:at
+            && Q.length t.pending < t.max_batch_size * hard_flush_batch_rate
+          then schedule_flush ~at:possible_delayed_flush_time
+          else Deferred.return @@ flush_now ()
+    in
+    if not t.flush_scheduled then (
+      t.flush_scheduled <- true ;
+      Deferred.don't_wait_for (schedule_flush ~at:Time.(add (now ()) max_wait))
+      )
+    else t.proposed_new_flush_at <- Some (Time.now ())
 
   let cancel t h =
     let job =
@@ -719,7 +741,8 @@ end = struct
     |> don't_wait_for
 
   let tear_down
-      ( { next_flush
+      ( { proposed_new_flush_at = _
+        ; flush_scheduled = _
         ; all_peers = _
         ; flush_w
         ; get = _
@@ -742,7 +765,6 @@ end = struct
       | Some j ->
           kill_job t j ; clear_queue q
     in
-    Option.iter next_flush ~f:(fun e -> Clock.Event.abort_if_possible e ()) ;
     Strict_pipe.Writer.close flush_w ;
     Useful_peers.tear_down useful_peers ;
     Strict_pipe.Writer.close got_new_peers_w ;
@@ -968,7 +990,8 @@ end = struct
     let t =
       { all_peers = Peer.Set.of_list all_peers
       ; pending = Q.create ()
-      ; next_flush = None
+      ; proposed_new_flush_at = None
+      ; flush_scheduled = false
       ; flush_r
       ; flush_w
       ; jobs_added_bvar = Bvar.create ()
@@ -1089,7 +1112,6 @@ end = struct
     | Some x, None | None, Some (_, x, _) ->
         x
     | None, None ->
-        flush_soon t ;
         let e = { J.key; attempts; res = Ivar.create () } in
-        enqueue_exn t e ; e
+        enqueue_exn t e ; flush_soon t ; e
 end


### PR DESCRIPTION
## Problem

`flush_soon` used a `Clock.Event.t option` (`next_flush`) that was cancelled and
rescheduled on every call. This meant that as long as new jobs kept arriving within
`max_wait` (100ms) of each other, the flush would never fire — jobs would sit in the
pending queue indefinitely.

## Solution

Replace `next_flush` with two fields:

- `flush_scheduled : bool` — ensures only one flush fiber is running at a time.
  Subsequent `flush_soon` calls don't spawn a new fiber; they just update the deadline.
- `proposed_new_flush_at : Time.t option` — set to `Some (now ())` when `flush_soon`
  is called while a flush is already scheduled. The running fiber checks this after
  waking to decide whether to extend its deadline.

The `schedule_flush` fiber wakes after `max_wait`. If `proposed_new_flush_at` is set
to a time later than the original wake time, it reschedules once — but only if the
pending queue is below `max_batch_size * 3`. This bounds the total delay while still
allowing limited batching.

Also fixes a pre-existing ordering bug in `download`: `flush_soon` was called before
`enqueue_exn`, violating the new invariant that jobs must be enqueued before scheduling a
flush (which could itself delay flushing indefinitely if the queue appeared empty).

## Choice of parameter

The parameter 3 is just randomly picked, I haven't read into the protocol too deep but from a surface it seems peer can return less info than requested. 

## Side note

I'm not sure this fixes https://github.com/MinaProtocol/mina/issues/18676 but if many requests arrived repetitively it could prevent downloader to work. 