### PR TITLE
Fix local state loading in epoch one

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -531,19 +531,38 @@ module Make_str (A : Wire_types.Concrete) = struct
               create_new_uuids () )
           else create_new_uuids ()
         in
-        let staking_epoch_ledger_config =
-          ledger_config epoch_ledger_uuids.staking
-        in
-        let staking_epoch_ledger =
-          create_epoch_ledger ~config:staking_epoch_ledger_config
-            ~context:(module Context)
-            ~genesis_epoch_ledger:genesis_epoch_ledger_staking
-        in
         let next_epoch_ledger_config = ledger_config epoch_ledger_uuids.next in
         let next_epoch_ledger =
           create_epoch_ledger ~config:next_epoch_ledger_config
             ~context:(module Context)
             ~genesis_epoch_ledger:genesis_epoch_ledger_next
+        in
+        let is_next_loaded_from_genesis =
+          match next_epoch_ledger with
+          | Genesis_epoch_ledger _ ->
+              true
+          | _ ->
+              false
+        in
+        let staking_epoch_ledger_config =
+          ledger_config epoch_ledger_uuids.staking
+        in
+        let staking_epoch_ledger =
+          (* If next epoch ledger is loaded from disk, then we know that
+           * at least one epoch transition has happened, hence either the staking
+           * ledger will also be loaded from disk or the genesis next ledger must
+           * be the used.
+           *
+           * This code heavily relies on the fact that we writer only non-genesis
+           * ledgers to disk.
+           *)
+          let genesis_epoch_ledger =
+            if is_next_loaded_from_genesis then genesis_epoch_ledger_staking
+            else genesis_epoch_ledger_next
+          in
+          create_epoch_ledger ~config:staking_epoch_ledger_config
+            ~context:(module Context)
+            ~genesis_epoch_ledger
         in
         ref
           { Data.staking_epoch_snapshot =


### PR DESCRIPTION
# Problem

When a Mina node restarts after having witnessed at least one epoch transition, it could incorrectly load the genesis staking epoch ledger instead of the genesis *next* epoch ledger in the staking position. This caused the node to enter a broken sync state where it attempts to download the genesis next epoch ledger from peers — but peers reject such requests, since ledger sync endpoints ignore requests for genesis ledgers. The node then stalls indefinitely in bootstrap.

The root cause is in `proof_of_stake.ml`'s local state loading logic. After one epoch transition:

- The staking epoch ledger should be the **genesis next epoch ledger**
- The next epoch ledger should be some **new non-genesis ledger** (present on disk)

However, when the staking epoch ledger database is absent on disk (because we only write non-genesis ledgers to disk), the code was unconditionally falling back to `genesis_epoch_ledger_staking` — even when the correct fallback should have been `genesis_epoch_ledger_next`.

# Fix

Load the next epoch ledger first, and use whether it was loaded from genesis or from disk to determine the correct fallback for the staking epoch ledger:

- If next epoch ledger loaded from **genesis** → no epoch transition has occurred → staking fallback is `genesis_epoch_ledger_staking` (previous behavior, correct for epoch 0)
- If next epoch ledger loaded from **disk** → at least one epoch transition has occurred → staking fallback should be `genesis_epoch_ledger_next`

This relies on the invariant that only non-genesis ledgers are written to disk, which is documented in the code comment.

# Root cause analysis

This failure mode was initially investigated as a variant of #18380 (bootstrap stall due to failed best tip download), but is distinct: the node successfully downloads a best tip, loads its frontier from disk, and enters epoch ledger sync normally. Sync receives valid `Num_accounts` responses from peers but never progresses to `What_child_hashes` or `What_contents` — because the ledger hash being synced is the genesis next epoch ledger hash, and peers silently drop sync requests for genesis ledgers.

The incorrect staking ledger loaded on restart is the source of the mismatch that triggers the failed sync.

# Checklist

Explain how you tested your changes:
* [ ] TODO Not tested yet

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #18676
