### PR TITLE
Soft fail mesa replayer hardfork test

### DIFF
--- a/buildkite/src/Command/ReplayerMesaHfTest.dhall
+++ b/buildkite/src/Command/ReplayerMesaHfTest.dhall
@@ -1,3 +1,7 @@
+let B = ../External/Buildkite.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
 let Artifacts = ../Constants/Artifacts.dhall
 
 let BuildFlags = ../Constants/BuildFlags.dhall
@@ -36,6 +40,7 @@ in  { step =
               , label = "Archive: Replayer mesa hard fork test"
               , key = key
               , target = Size.Large
+              , soft_fail = Some (B/SoftFail.Boolean True)
               , depends_on = dependsOn
               }
     }


### PR DESCRIPTION
## Summary
- Set `soft_fail = True` on the ReplayerMesaHfTest CI step so failures don't block the pipeline

## Test plan
- [ ] Verify CI pipeline renders correctly with soft_fail enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)