### PR TITLE
Actor: implement Async-based actor model

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.3)
 (implicit_transitive_deps true)
 
+(package (name actor))
 (package (name allocation_functor))
 (package (name archive))
 (package (name archive_hardfork_toolbox))

--- a/src/lib/actor/actor.ml
+++ b/src/lib/actor/actor.ml
@@ -1,0 +1,340 @@
+open Async
+open Core_kernel
+
+type 'state msg_processed = MNext of 'state | MExit | MUnprocessed
+
+type ('state, 'response) req_processed =
+  | RNext of ('state * 'response)
+  | RExit of 'response
+  | RUnprocessed
+
+type (_, _, _, _) overflow_behavior =
+  | Throw : ('state, 'data, unit Or_error.t, [ `Throw ]) overflow_behavior
+  | Drop_head :
+      [ `Warns | `No_warns ]
+      -> ('state, 'data, unit, [ `Drop_head ]) overflow_behavior
+  | Drop_and_call_head :
+      ('state -> 'data -> 'returns)
+      -> ( 'state
+         , 'data
+         , 'returns option
+         , [ `Drop_and_call_head ] )
+         overflow_behavior
+  | Push_back
+      : ('state, 'data, unit Deferred.t, [ `Push_back ]) overflow_behavior
+
+type (_, _, _, _) channel_type =
+  | Infinity : ('state, 'data, unit, [ `Infinity ]) channel_type
+  | With_capacity :
+      [ `Capacity of int ]
+      * [ `Overflow of ('state, 'data, 'returns, 'behavior) overflow_behavior ]
+      -> ('state, 'data, 'returns, 'behavior) channel_type
+
+module DummyMessage = struct
+  type t = unit [@@deriving to_yojson]
+
+  let handler ~state ~message:() = Deferred.return (MNext state)
+end
+
+module DummyRequest = struct
+  type _ t = Nothing : unit t
+
+  let handler :
+      type response.
+         state:'state
+      -> request:response t
+      -> ('state, response) req_processed Deferred.t =
+   fun ~state ~request:Nothing -> Deferred.return (RNext (state, ()))
+end
+
+(** Named record type for polymorphic request handlers, parameterized by the
+    request module. Logic modules reference this type from outside the functor. *)
+module RequestHandler (Request : sig
+  type _ t
+end) =
+struct
+  type 'state t =
+    { f :
+        'response.
+           state:'state
+        -> request:'response Request.t
+        -> ('state, 'response) req_processed Deferred.t
+    }
+end
+
+module WithRequest (DataMessage : sig
+  type t [@@deriving to_yojson]
+end) (Request : sig
+  type _ t
+end) (Logic : sig
+  type state
+
+  type data_returns
+
+  type data_overflew
+
+  type control_msg
+
+  val data_channel_type :
+    (state, DataMessage.t, data_returns, data_overflew) channel_type
+
+  val request_handler : state RequestHandler(Request).t
+
+  val control_handler :
+    state:state -> message:control_msg -> state msg_processed Deferred.t
+
+  val data_handler :
+    state:state -> message:DataMessage.t -> state msg_processed Deferred.t
+end) : sig
+  type instance
+
+  val create :
+    logger:Logger.t -> name:Yojson.Safe.t -> state:Logic.state -> instance
+
+  val terminate : instance:instance -> unit
+
+  val send_request :
+    instance:instance -> request:'response Request.t -> 'response Deferred.t
+
+  val send_control : instance:instance -> message:Logic.control_msg -> unit
+
+  val send_data :
+    instance:instance -> message:DataMessage.t -> Logic.data_returns
+
+  val spawn : instance -> unit Deferred.t Or_error.t
+end = struct
+  exception
+    ActorDataInboxOverflow of
+      { name : Yojson.Safe.t; capacity : int; attempt_enqueing : DataMessage.t }
+
+  type request_e = EReq : 'response Request.t * 'response Ivar.t -> request_e
+
+  type instance =
+    { logger : Logger.t
+    ; name : Yojson.Safe.t
+    ; request_inbox : request_e Deque.t
+    ; control_inbox : Logic.control_msg Deque.t
+    ; data_inbox : DataMessage.t Deque.t
+    ; spawned : unit Ivar.t
+    ; terminated : unit Ivar.t
+    ; mutable work_available : unit Ivar.t
+    ; mutable state : Logic.state
+    }
+
+  let create ~logger ~name ~state =
+    { logger
+    ; name
+    ; request_inbox = Deque.create ()
+    ; control_inbox = Deque.create ()
+    ; data_inbox = Deque.create ()
+    ; spawned = Ivar.create ()
+    ; terminated = Ivar.create ()
+    ; work_available = Ivar.create ()
+    ; state
+    }
+
+  let terminate ~(instance : instance) =
+    Ivar.fill_if_empty instance.terminated ()
+
+  let send_request :
+      type response.
+      instance:instance -> request:response Request.t -> response Deferred.t =
+   fun ~instance ~request ->
+    let response = Ivar.create () in
+    Deque.enqueue_back instance.request_inbox (EReq (request, response)) ;
+    Ivar.fill_if_empty instance.work_available () ;
+    Ivar.read response
+
+  let send_control ~(instance : instance) ~message =
+    Deque.enqueue_back instance.control_inbox message ;
+    Ivar.fill_if_empty instance.work_available ()
+
+  let send_data ~(instance : instance) ~(message : DataMessage.t) :
+      Logic.data_returns =
+    match Logic.data_channel_type with
+    | Infinity ->
+        Deque.enqueue_back instance.data_inbox message ;
+        Ivar.fill_if_empty instance.work_available ()
+    | With_capacity (`Capacity capacity, `Overflow Push_back) ->
+        let open Deferred.Let_syntax in
+        let rec wait_then_enqueue () =
+          if Deque.length instance.data_inbox >= capacity then
+            let%bind () = Scheduler.yield () in
+            wait_then_enqueue ()
+          else (
+            Deque.enqueue_back instance.data_inbox message ;
+            Ivar.fill_if_empty instance.work_available () ;
+            Deferred.unit )
+        in
+        wait_then_enqueue ()
+    | With_capacity (`Capacity capacity, `Overflow Throw) ->
+        if Deque.length instance.data_inbox >= capacity then
+          Or_error.of_exn
+            (ActorDataInboxOverflow
+               { name = instance.name; capacity; attempt_enqueing = message } )
+        else (
+          Deque.enqueue_back instance.data_inbox message ;
+          Ivar.fill_if_empty instance.work_available () ;
+          Ok () )
+    | With_capacity (`Capacity capacity, `Overflow (Drop_head warns_or_not))
+      -> (
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Deque.enqueue_back instance.data_inbox message ;
+        Ivar.fill_if_empty instance.work_available () ;
+        if Deque.length instance.data_inbox > capacity then
+          let dropped = Deque.dequeue_front_exn instance.data_inbox in
+          match warns_or_not with
+          | `Warns ->
+              [%log' info instance.logger]
+                "Actor $actor_id has data inbox capacity %d, dropping head \
+                 message $message"
+                capacity
+                ~metadata:
+                  [ ("actor_id", instance.name)
+                  ; ("message", DataMessage.to_yojson dropped)
+                  ; ("capacity", `Int capacity)
+                  ]
+          | `No_warns ->
+              () )
+    | With_capacity (`Capacity cap, `Overflow (Drop_and_call_head callback)) ->
+        (* NOTE: always enqueue first to deal with capacity 0/negative *)
+        Deque.enqueue_back instance.data_inbox message ;
+        Ivar.fill_if_empty instance.work_available () ;
+        if Deque.length instance.data_inbox > cap then
+          let head = Deque.dequeue_front_exn instance.data_inbox in
+          Some (callback instance.state head)
+        else None
+
+  let spawn (instance : instance) : unit Deferred.t Or_error.t =
+    if Ivar.is_full instance.spawned then
+      Or_error.errorf "Actor %s already spawned"
+        (Yojson.Safe.to_string instance.name)
+    else (
+      Ivar.fill instance.spawned () ;
+      let process_msg ~state ~deque ~handler () =
+        match Deque.dequeue_front deque with
+        | Some message -> (
+            match%map handler ~state ~message with
+            | MUnprocessed ->
+                Deque.enqueue_front deque message ;
+                MUnprocessed
+            | result ->
+                result )
+        | None ->
+            Deferred.return MUnprocessed
+      in
+      let process_request ~state ~(deque : request_e Deque.t)
+          ~(handler : Logic.state RequestHandler(Request).t) () =
+        match Deque.dequeue_front deque with
+        | Some (EReq (request, response_ivar) as e) -> (
+            match%map handler.f ~state ~request with
+            | RNext (state, resp) ->
+                Ivar.fill response_ivar resp ;
+                MNext state
+            | RExit resp ->
+                Ivar.fill response_ivar resp ;
+                MExit
+            | RUnprocessed ->
+                Deque.enqueue_front deque e ;
+                MUnprocessed )
+        | None ->
+            Deferred.return MUnprocessed
+      in
+      let rec loop () =
+        if Ivar.is_full instance.terminated then Deferred.unit
+        else
+          let dispatchers =
+            [ process_request ~state:instance.state
+                ~deque:instance.request_inbox ~handler:Logic.request_handler
+            ; process_msg ~state:instance.state ~deque:instance.control_inbox
+                ~handler:Logic.control_handler
+            ; process_msg ~state:instance.state ~deque:instance.data_inbox
+                ~handler:Logic.data_handler
+            ]
+          in
+          let rec iter_dispatch = function
+            | [] ->
+                Deferred.return None
+            | dispatcher :: dispatchers -> (
+                match%bind dispatcher () with
+                | MUnprocessed ->
+                    iter_dispatch dispatchers
+                | (MExit | MNext _) as processed ->
+                    Deferred.return (Some processed) )
+          in
+          match%bind iter_dispatch dispatchers with
+          | Some (MNext state) ->
+              instance.state <- state ;
+              loop ()
+          | Some MExit ->
+              Ivar.fill_if_empty instance.terminated () ;
+              Deferred.unit
+          | Some MUnprocessed ->
+              (* WARN: all handler decide not to handle the message, only thing
+                 we could do is busy wait *)
+              let%bind () = Scheduler.yield () in
+              loop ()
+          | None ->
+              let%bind () = Ivar.read instance.work_available in
+              instance.work_available <- Ivar.create () ;
+              loop ()
+      in
+      Ok (loop ()) )
+end
+
+module type S = sig
+  type instance
+
+  type state
+
+  type message
+
+  type data_returns
+
+  val create : logger:Logger.t -> name:Yojson.Safe.t -> state:state -> instance
+
+  val spawn : instance -> unit Deferred.t Or_error.t
+
+  val send_data : instance:instance -> message:message -> data_returns
+
+  val terminate : instance:instance -> unit
+end
+
+module Regular (DataMessage : sig
+  type t
+
+  val to_yojson : t -> Yojson.Safe.t
+end) (Logic : sig
+  type state
+
+  type data_returns
+
+  type data_overflew
+
+  type control_msg
+
+  val data_channel_type :
+    (state, DataMessage.t, data_returns, data_overflew) channel_type
+
+  val control_handler :
+    state:state -> message:control_msg -> state msg_processed Deferred.t
+
+  val data_handler :
+    state:state -> message:DataMessage.t -> state msg_processed Deferred.t
+end) =
+struct
+  type state = Logic.state
+
+  type message = DataMessage.t
+
+  type data_returns = Logic.data_returns
+
+  include
+    WithRequest (DataMessage) (DummyRequest)
+      (struct
+        include Logic
+
+        let request_handler : state RequestHandler(DummyRequest).t =
+          { f = DummyRequest.handler }
+      end)
+end

--- a/src/lib/actor/dune
+++ b/src/lib/actor/dune
@@ -1,0 +1,17 @@
+(library
+ (name actor)
+ (public_name actor)
+ (libraries
+  ;; OPAM libraries
+  async
+  core_kernel
+  ;; MINA libraries
+  logger)
+ (preprocess
+  (pps
+   ppx_let
+   ppx_mina
+   ppx_version))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Actor pattern for mass concurrency"))

--- a/src/lib/actor/tests/dune
+++ b/src/lib/actor/tests/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_actor)
+ (libraries
+  ;; OPAM libraries
+  alcotest
+  async
+  core
+  ;; MINA libraries
+  actor
+  logger)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_let)))

--- a/src/lib/actor/tests/ping_pong.ml
+++ b/src/lib/actor/tests/ping_pong.ml
@@ -1,0 +1,138 @@
+open Async
+open Core
+open Actor
+
+module PingMessage = struct
+  type t = Ping [@@deriving yojson]
+end
+
+module PongMessage = struct
+  type t = Pong [@@deriving yojson]
+end
+
+module rec PingerLogic : sig
+  type state =
+    { count : int; partner : Ponger.instance Lazy.t; emitted : int Queue.t }
+
+  type data_returns = unit Deferred.t
+
+  type data_overflew = [ `Push_back ]
+
+  type control_msg = unit
+
+  val data_channel_type :
+    (state, PongMessage.t, data_returns, data_overflew) channel_type
+
+  val data_handler :
+    state:state -> message:PongMessage.t -> state msg_processed Deferred.t
+
+  val control_handler :
+    state:state -> message:control_msg -> state msg_processed Deferred.t
+end = struct
+  type state =
+    { count : int; partner : Ponger.instance Lazy.t; emitted : int Queue.t }
+
+  type data_returns = unit Deferred.t
+
+  type data_overflew = [ `Push_back ]
+
+  type control_msg = unit
+
+  let data_channel_type = With_capacity (`Capacity 1, `Overflow Push_back)
+
+  let data_handler ~state ~message:PongMessage.Pong =
+    Queue.enqueue state.emitted state.count ;
+    if state.count - 1 = 0 then (
+      Ponger.terminate ~instance:(Lazy.force state.partner) ;
+      Deferred.return MExit )
+    else
+      let%map.Deferred () =
+        Ponger.send_data ~instance:(Lazy.force state.partner)
+          ~message:PingMessage.Ping
+      in
+      MNext { state with count = state.count - 1 }
+
+  let control_handler ~state ~message:() = Deferred.return (MNext state)
+end
+
+and PongerLogic : sig
+  type state =
+    { count : int; partner : Pinger.instance Lazy.t; emitted : int Queue.t }
+
+  type data_returns = unit Deferred.t
+
+  type data_overflew = [ `Push_back ]
+
+  type control_msg = unit
+
+  val data_channel_type :
+    (state, PingMessage.t, data_returns, data_overflew) channel_type
+
+  val data_handler :
+    state:state -> message:PingMessage.t -> state msg_processed Deferred.t
+
+  val control_handler :
+    state:state -> message:control_msg -> state msg_processed Deferred.t
+end = struct
+  type state =
+    { count : int; partner : Pinger.instance Lazy.t; emitted : int Queue.t }
+
+  type data_returns = unit Deferred.t
+
+  type data_overflew = [ `Push_back ]
+
+  type control_msg = unit
+
+  let data_channel_type = With_capacity (`Capacity 1, `Overflow Push_back)
+
+  let data_handler ~state ~message:PingMessage.Ping =
+    Queue.enqueue state.emitted state.count ;
+    let%map.Deferred () =
+      Pinger.send_data ~instance:(Lazy.force state.partner)
+        ~message:PongMessage.Pong
+    in
+    MNext { state with count = state.count - 1 }
+
+  let control_handler ~state ~message:() = Deferred.return (MNext state)
+end
+
+and Pinger :
+  (Actor.S
+    with type state = PingerLogic.state
+     and type message = PongMessage.t
+     and type data_returns = unit Deferred.t) =
+  Actor.Regular (PongMessage) (PingerLogic)
+
+and Ponger :
+  (Actor.S
+    with type state = PongerLogic.state
+     and type message = PingMessage.t
+     and type data_returns = unit Deferred.t) =
+  Actor.Regular (PingMessage) (PongerLogic)
+
+let test_case () =
+  let emitted_numbers = Queue.create () in
+  let logger = Logger.create () in
+  let rec pinger =
+    lazy
+      (Pinger.create
+         ~state:{ count = 10; partner = ponger; emitted = emitted_numbers }
+         ~logger ~name:(`String "pinger") )
+  and ponger =
+    lazy
+      (Ponger.create
+         ~state:{ count = 99; partner = pinger; emitted = emitted_numbers }
+         ~logger ~name:(`String "ponger") )
+  in
+  let all_deferred () =
+    Deferred.all
+      [ Or_error.ok_exn (Ponger.spawn @@ Lazy.force ponger)
+      ; Or_error.ok_exn (Pinger.spawn @@ Lazy.force pinger)
+      ; Pinger.send_data ~instance:(Lazy.force pinger) ~message:PongMessage.Pong
+      ]
+  in
+  let _ = Async.Thread_safe.block_on_async all_deferred in
+  Alcotest.(check (list int))
+    "ping pong emitted number is expected"
+    (Queue.to_list emitted_numbers)
+    [ 10; 99; 9; 98; 8; 97; 7; 96; 6; 95; 5; 94; 4; 93; 3; 92; 2; 91; 1 ]

--- a/src/lib/actor/tests/test_actor.ml
+++ b/src/lib/actor/tests/test_actor.ml
@@ -1,0 +1,5 @@
+let () =
+  let open Alcotest in
+  run "Actor"
+    [ ("ping pong", [ test_case "Simple ping pong" `Quick Ping_pong.test_case ])
+    ]


### PR DESCRIPTION
Revival of https://github.com/MinaProtocol/mina/pull/17214 with improvement of API usability and correctness.

Adds a new `actor` library providing an Elixir-inspired actor abstraction
built on Async/Ivar primitives. Key design points:

Inbox priority and structure:
- Each actor has three inboxes processed in strict priority order:
  request/response > control > data
- Control messages can therefore interrupt data processing, enabling
  graceful shutdown or reconfiguration without head-of-line blocking

Typed overflow via GADTs:
- `overflow_behavior` and `channel_type` are GADTs whose type parameters
  carry the return type of `send_data`, making overflow policy visible
  at the call site:
    Infinity / Drop_head  -> send_data returns unit
    Throw                 -> send_data returns unit Or_error.t
    Push_back             -> send_data returns unit Deferred.t
    Drop_and_call_head f  -> send_data returns 'a option

Cooperative non-blocking with MUnprocessed:
- Handlers may return MUnprocessed to decline a message; the message is
  re-queued at the front and the loop tries the next inbox. This avoids
  stalling the actor when the data inbox is momentarily non-actionable.
- If all inboxes return MUnprocessed, the loop yields before retrying.

Lifecycle:
- `spawn` is idempotent-safe: returns an error if called twice, so
  double-spawn is caught without runtime crashes
- `terminate` is safe to call multiple times (fill_if_empty)

Two entry points:
- `WithRequest`: full functor with typed request/response (GADT requests)
- `Regular`: convenience wrapper using a no-op DummyRequest, exposing
  only data and control channels