### PR TITLE
Decouple autopromote from tear down pipeline

### DIFF
--- a/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
+++ b/buildkite/src/Jobs/Promote/AutoPromoteNightly.dhall
@@ -88,7 +88,7 @@ in  Pipeline.build
       , spec = JobSpec::{
         , dirtyWhen = [ S.everything ]
         , path = "Promote"
-        , tags = [ PipelineTag.Type.Promote, PipelineTag.Type.TearDown ]
+        , tags = [ PipelineTag.Type.Promote ]
         , name = "AutoPromoteNightly"
         , scope = [ PipelineScope.Type.MainlineNightly ]
         }


### PR DESCRIPTION
Remove TearDown tag from AutoPromoteNightly so that the TearDownOnly filter only picks up coverage gathering. Autopromote can now be triggered independently via the existing Promote filter, preventing small test failures from blocking nightly package promotion.
