### PR TITLE
WIP - Revive PR 16728, the block producer thread refactor revival

### DIFF
--- a/src/app/cli/src/init/test_submit_to_archive.ml
+++ b/src/app/cli/src/init/test_submit_to_archive.ml
@@ -315,10 +315,6 @@ let build_breadcrumb ~transactions ~context ~precomputed_values ~verifier
       ~winner_pk ~block_reward_threshold:None ~zkapp_cmd_limit:None
       ~zkapp_cmd_limit_hardcap:128 ~slot_tx_end:None ~slot_chain_end:None
       ~signature_kind:Testnet
-    |> Interruptible.force
-    >>| Result.map_error ~f:(fun () ->
-            Error.of_string "unexpected interruption" )
-    >>| Or_error.ok_exn
     >>| Option.value_exn ?here:None ?error:None
           ~message:"generate_next_state failed"
   in

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -29,47 +29,6 @@ end
 type Structured_log_events.t += Block_produced
   [@@deriving register_event { msg = "Successfully produced a new block" }]
 
-module Singleton_supervisor : sig
-  type ('data, 'a) t
-
-  val create :
-    task:(unit Ivar.t -> 'data -> ('a, unit) Interruptible.t) -> ('data, 'a) t
-
-  val cancel : (_, _) t -> unit
-
-  val dispatch : ('data, 'a) t -> 'data -> ('a, unit) Interruptible.t
-end = struct
-  type ('data, 'a) t =
-    { mutable task : (unit Ivar.t * ('a, unit) Interruptible.t) option
-    ; f : unit Ivar.t -> 'data -> ('a, unit) Interruptible.t
-    }
-
-  let create ~task = { task = None; f = task }
-
-  let cancel t =
-    match t.task with
-    | Some (ivar, _) ->
-        if Ivar.is_full ivar then
-          [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-        Ivar.fill ivar () ;
-        t.task <- None
-    | None ->
-        ()
-
-  let dispatch t data =
-    cancel t ;
-    let ivar = Ivar.create () in
-    let interruptible =
-      let open Interruptible.Let_syntax in
-      t.f ivar data
-      >>| fun x ->
-      t.task <- None ;
-      x
-    in
-    t.task <- Some (ivar, interruptible) ;
-    interruptible
-end
-
 let time_to_ms = Fn.compose Block_time.Span.to_ms Block_time.to_span_since_epoch
 
 let time_of_ms = Fn.compose Block_time.of_span_since_epoch Block_time.Span.of_ms
@@ -80,54 +39,6 @@ let lift_sync f =
          if Ivar.is_full ivar then
            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
          Ivar.fill ivar (f ()) ) )
-
-module Singleton_scheduler : sig
-  type t
-
-  val create : Block_time.Controller.t -> t
-
-  (** If you reschedule when already scheduled, take the min of the two schedulings *)
-  val schedule : t -> Block_time.t -> f:(unit -> unit) -> unit
-end = struct
-  type t =
-    { mutable timeout : unit Block_time.Timeout.t option
-    ; time_controller : Block_time.Controller.t
-    }
-
-  let create time_controller = { time_controller; timeout = None }
-
-  let cancel t =
-    match t.timeout with
-    | Some timeout ->
-        Block_time.Timeout.cancel t.time_controller timeout () ;
-        t.timeout <- None
-    | None ->
-        ()
-
-  let schedule t time ~f =
-    let remaining_time =
-      Option.map t.timeout ~f:Block_time.Timeout.remaining_time
-    in
-    cancel t ;
-    let span_till_time =
-      Block_time.diff time (Block_time.now t.time_controller)
-    in
-    let wait_span =
-      match remaining_time with
-      | Some remaining
-        when Block_time.Span.(remaining > Block_time.Span.of_ms Int64.zero) ->
-          let min a b = if Block_time.Span.(a < b) then a else b in
-          min remaining span_till_time
-      | None | Some _ ->
-          span_till_time
-    in
-    let timeout =
-      Block_time.Timeout.create t.time_controller wait_span ~f:(fun _ ->
-          t.timeout <- None ;
-          f () )
-    in
-    t.timeout <- Some timeout
-end
 
 (** Sends an error to the reporting service containing as many failed transactions as we can fit. *)
 let report_transaction_inclusion_failures ~commit_id ~logger failed_txns =
@@ -686,7 +597,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
     ~verifier ~trust_system ~get_completed_work ~transaction_resource_pool
     ~frontier_reader ~time_controller ~transition_writer ~log_block_creation
     ~block_reward_threshold ~block_produced_bvar ~slot_tx_end ~slot_chain_end
-    ~net ~zkapp_cmd_limit_hardcap ivar
+    ~net ~zkapp_cmd_limit_hardcap interrupt_ivar
     (scheduled_time, block_data, winner_pubkey) =
   let open Context in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
@@ -787,7 +698,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
         |> Sequence.map
              ~f:Transaction_hash.User_command_with_valid_signature.data
       in
-      let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read ivar) in
+      let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read interrupt_ivar) in
       [%log internal] "Generate_next_state" ;
       let%bind next_state_opt =
         generate_next_state ~commit_id ~constraint_constants ~scheduled_time
@@ -1224,6 +1135,11 @@ let iteration ~schedule_next_vrf_check ~produce_block_now
                  ~frontier_reader () ) ;
             schedule_block_production (scheduled_time, data, winner_pk) )
 
+let schedule ~time_controller time =
+  let span_till_time = Block_time.diff time (Block_time.now time_controller) in
+  Block_time.Timeout.create time_controller span_till_time ~f:Fn.id
+  |> Block_time.Timeout.to_deferred
+
 let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~trust_system ~get_completed_work ~transaction_resource_pool
     ~time_controller ~consensus_local_state ~coinbase_receiver ~frontier_reader
@@ -1231,7 +1147,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~block_reward_threshold ~block_produced_bvar ~vrf_evaluation_state ~net
     ~zkapp_cmd_limit_hardcap =
   let open Context in
-  O1trace.sync_thread "produce_blocks" (fun () ->
+  O1trace.sync_thread "produce_blocks_run" (fun () ->
       let genesis_breadcrumb =
         genesis_breadcrumb_creator ~context:(module Context) prover
       in
@@ -1251,19 +1167,16 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
           ~zkapp_cmd_limit_hardcap
       in
       let module Breadcrumb = Transition_frontier.Breadcrumb in
-      let production_supervisor = Singleton_supervisor.create ~task:produce in
-      let scheduler = Singleton_scheduler.create time_controller in
-      let rec check_next_block_timing slot i () =
+      let iteration_wrapped (slot, i, prev_step) =
         (* Begin checking for the ability to produce a block *)
         match Broadcast_pipe.Reader.peek frontier_reader with
         | None ->
             log_bootstrap_mode ~logger () ;
-            don't_wait_for
-              (let%map () =
-                 Broadcast_pipe.Reader.iter_until frontier_reader
-                   ~f:(Fn.compose Deferred.return Option.is_some)
-               in
-               check_next_block_timing slot i () )
+            let%map () =
+              Broadcast_pipe.Reader.iter_until frontier_reader
+                ~f:(Fn.compose Deferred.return Option.is_some)
+            in
+            (slot, i, prev_step)
         | Some transition_frontier ->
             let consensus_state =
               Transition_frontier.best_tip transition_frontier
@@ -1311,9 +1224,6 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                 "Block producer will begin producing only empty blocks after \
                  $slot_diff slots"
               slot_tx_end ;
-            let next_vrf_check_now =
-              check_next_block_timing new_global_slot i'
-            in
             (* TODO: Re-enable this assertion when it doesn't fail dev demos
              *       (see #5354)
              * assert (
@@ -1321,38 +1231,46 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     ~constants:consensus_constants ~consensus_state
                     ~local_state:consensus_local_state
                    = None ) ; *)
-            let produce_block_now triple =
-              ignore
-                ( Interruptible.finally
-                    (Singleton_supervisor.dispatch production_supervisor triple)
-                    ~f:next_vrf_check_now
-                  : (_, _) Interruptible.t )
+            let next_vrf_check_now () =
+              return (new_global_slot, i', prev_step)
             in
-            don't_wait_for
-              ( iteration
-                  ~schedule_next_vrf_check:
-                    (Fn.compose Deferred.return
-                       (Singleton_scheduler.schedule scheduler
-                          ~f:next_vrf_check_now ) )
-                  ~produce_block_now:
-                    (Fn.compose Deferred.return produce_block_now)
-                  ~schedule_block_production:(fun (time, data, winner) ->
-                    Singleton_scheduler.schedule scheduler time ~f:(fun () ->
-                        produce_block_now (time, data, winner) ) ;
-                    Deferred.unit )
-                  ~next_vrf_check_now:
-                    (Fn.compose Deferred.return next_vrf_check_now)
-                  ~genesis_breadcrumb
-                  ~context:(module Context)
-                  ~vrf_evaluator ~time_controller ~coinbase_receiver
-                  ~frontier_reader ~set_next_producer_timing
-                  ~transition_frontier ~vrf_evaluation_state ~epoch_data_for_vrf
-                  ~ledger_snapshot i slot
-                : unit Deferred.t )
+            let produce_block_now data =
+              Option.iter !prev_step ~f:(fun ivar ->
+                  if Ivar.is_full ivar then
+                    [%log error] "Ivar.fill bug is here!" ;
+                  Ivar.fill ivar () ) ;
+              let intr_ivar = Ivar.create () in
+              let this_step = ref (Some intr_ivar) in
+              let produce_intr =
+                let%map.Interruptible x = produce intr_ivar data in
+                this_step := None ;
+                x
+              in
+              let%map _ = Interruptible.force produce_intr in
+              (new_global_slot, i', this_step)
+            in
+            let schedule_next_vrf_check time =
+              let%map _ = schedule ~time_controller time in
+              (new_global_slot, i', prev_step)
+            in
+            let schedule_block_production (time, data, winner) =
+              let%bind _ = schedule ~time_controller time in
+              produce_block_now (time, data, winner)
+            in
+            iteration ~schedule_next_vrf_check ~produce_block_now
+              ~schedule_block_production ~next_vrf_check_now ~genesis_breadcrumb
+              ~context:(module Context)
+              ~vrf_evaluator ~time_controller ~coinbase_receiver
+              ~frontier_reader ~set_next_producer_timing
+              ~transition_frontier ~vrf_evaluation_state ~epoch_data_for_vrf
+              ~ledger_snapshot i slot
       in
-      let start () =
-        check_next_block_timing Mina_numbers.Global_slot_since_hard_fork.zero
-          Mina_numbers.Length.zero ()
+      let start _ =
+        Deferred.forever
+          ( Mina_numbers.Global_slot_since_hard_fork.zero
+          , Mina_numbers.Length.zero
+          , ref @@ Some (Ivar.create ()) )
+          iteration_wrapped
       in
       let genesis_state_timestamp =
         consensus_constants.genesis_state_timestamp
@@ -1361,20 +1279,18 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
       let now = Block_time.now time_controller in
       if Block_time.( >= ) now genesis_state_timestamp then start ()
       else
-        let time_till_genesis = Block_time.diff genesis_state_timestamp now in
         [%log warn]
           ~metadata:
             [ ( "time_till_genesis"
               , `Int
-                  (Int64.to_int_exn (Block_time.Span.to_ms time_till_genesis))
+                  (Int64.to_int_exn
+                     (Block_time.Span.to_ms
+                        (Block_time.diff genesis_state_timestamp now) ) )
               )
             ]
           "Node started before genesis: waiting $time_till_genesis \
            milliseconds before starting block producer" ;
-        ignore
-          ( Block_time.Timeout.create time_controller time_till_genesis
-              ~f:(fun _ -> start ())
-            : unit Block_time.Timeout.t ) )
+        upon (schedule ~time_controller genesis_state_timestamp) start )
 
 let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
     ~time_controller ~frontier_reader ~transition_writer ~precomputed_blocks =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1232,7 +1232,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
       (* if the producer starts before genesis, sleep until genesis *)
       let now = Block_time.now time_controller in
       if Block_time.( >= ) now genesis_state_timestamp then start ()
-      else
+      else (
         [%log warn]
           ~metadata:
             [ ( "time_till_genesis"
@@ -1243,7 +1243,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
             ]
           "Node started before genesis: waiting $time_till_genesis \
            milliseconds before starting block producer" ;
-      upon (schedule ~time_controller genesis_state_timestamp) start )
+        upon (schedule ~time_controller genesis_state_timestamp) start ) )
 
 let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
     ~time_controller ~frontier_reader ~transition_writer ~precomputed_blocks =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -33,13 +33,6 @@ let time_to_ms = Fn.compose Block_time.Span.to_ms Block_time.to_span_since_epoch
 
 let time_of_ms = Fn.compose Block_time.of_span_since_epoch Block_time.Span.of_ms
 
-let lift_sync f =
-  Interruptible.uninterruptible
-    (Deferred.create (fun ivar ->
-         if Ivar.is_full ivar then
-           [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-         Ivar.fill ivar (f ()) ) )
-
 (** Sends an error to the reporting service containing as many failed transactions as we can fit. *)
 let report_transaction_inclusion_failures ~commit_id ~logger failed_txns =
   let num_failures = List.length failed_txns in
@@ -86,7 +79,6 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
     ~get_completed_work ~logger ~(block_data : Consensus.Data.Block_data.t)
     ~winner_pk ~scheduled_time ~log_block_creation ~block_reward_threshold
     ~zkapp_cmd_limit_hardcap ~slot_tx_end ~slot_chain_end ~signature_kind =
-  let open Interruptible.Let_syntax in
   let global_slot_since_hard_fork =
     Consensus.Data.Block_data.global_slot block_data
   in
@@ -100,7 +92,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
             , Mina_numbers.Global_slot_since_hard_fork.to_yojson slot_chain_end
             )
           ] ;
-      Interruptible.return None
+      Deferred.return None
   | None | Some _ -> (
       let previous_protocol_state_body_hash =
         Protocol_state.body previous_protocol_state |> Protocol_state.Body.hash
@@ -122,229 +114,212 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
         Staged_ledger.can_apply_supercharged_coinbase_exn ~winner:winner_pk
           ~epoch_ledger ~global_slot
       in
-      let%bind res =
-        Interruptible.uninterruptible
-          (let open Deferred.Let_syntax in
-          let coinbase_receiver =
-            Consensus.Data.Block_data.coinbase_receiver block_data
-          in
-          let diff =
-            match slot_tx_end with
-            | Some slot_tx_end
-              when Mina_numbers.Global_slot_since_hard_fork.(
-                     global_slot_since_hard_fork >= slot_tx_end) ->
-                [%log info]
-                  "Reached slot_tx_end $slot_tx_end, producing empty block"
-                  ~metadata:
-                    [ ( "slot_tx_end"
-                      , Mina_numbers.Global_slot_since_hard_fork.to_yojson
-                          slot_tx_end )
-                    ] ;
-                Result.return
-                  Staged_ledger_diff.With_valid_signatures_and_proofs.empty_diff
-            | Some _ | None ->
-                O1trace.sync_thread "create_staged_ledger_diff" (fun () ->
-                    [%log internal] "Create_staged_ledger_diff" ;
-                    (* TODO: handle transaction inclusion failures here *)
-                    let diff_result =
-                      Staged_ledger.create_diff ~constraint_constants
-                        ~global_slot staged_ledger ~coinbase_receiver ~logger
-                        ~current_state_view:previous_state_view
-                        ~transactions_by_fee:transactions ~get_completed_work
-                        ~log_block_creation ~supercharge_coinbase
-                        ~zkapp_cmd_limit
-                      |> Result.map ~f:(fun (diff, failed_txns) ->
-                             if not (List.is_empty failed_txns) then
-                               don't_wait_for
-                                 (report_transaction_inclusion_failures ~logger
-                                    ~commit_id failed_txns ) ;
-                             diff )
-                      |> Result.map_error ~f:(fun err ->
-                             Staged_ledger.Staged_ledger_error.Pre_diff err )
+      let coinbase_receiver =
+        Consensus.Data.Block_data.coinbase_receiver block_data
+      in
+      let diff =
+        match slot_tx_end with
+        | Some slot_tx_end
+          when Mina_numbers.Global_slot_since_hard_fork.(
+                 global_slot_since_hard_fork >= slot_tx_end) ->
+            [%log info]
+              "Reached slot_tx_end $slot_tx_end, producing empty block"
+              ~metadata:
+                [ ( "slot_tx_end"
+                  , Mina_numbers.Global_slot_since_hard_fork.to_yojson
+                      slot_tx_end )
+                ] ;
+            Result.return
+              Staged_ledger_diff.With_valid_signatures_and_proofs.empty_diff
+        | Some _ | None ->
+            O1trace.sync_thread "create_staged_ledger_diff" (fun () ->
+                [%log internal] "Create_staged_ledger_diff" ;
+                (* TODO: handle transaction inclusion failures here *)
+                let diff_result =
+                  Staged_ledger.create_diff ~constraint_constants
+                    ~global_slot staged_ledger ~coinbase_receiver ~logger
+                    ~current_state_view:previous_state_view
+                    ~transactions_by_fee:transactions ~get_completed_work
+                    ~log_block_creation ~supercharge_coinbase
+                    ~zkapp_cmd_limit
+                  |> Result.map ~f:(fun (diff, failed_txns) ->
+                         if not (List.is_empty failed_txns) then
+                           don't_wait_for
+                             (report_transaction_inclusion_failures ~logger
+                                ~commit_id failed_txns ) ;
+                         diff )
+                  |> Result.map_error ~f:(fun err ->
+                         Staged_ledger.Staged_ledger_error.Pre_diff err )
+                in
+                [%log internal] "Create_staged_ledger_diff_done" ;
+                match (diff_result, block_reward_threshold) with
+                | Ok diff, Some threshold ->
+                    let net_return =
+                      Option.value ~default:Currency.Amount.zero
+                        (Staged_ledger_diff.net_return ~constraint_constants
+                           ~supercharge_coinbase
+                           (Staged_ledger_diff.forget diff) )
                     in
-                    [%log internal] "Create_staged_ledger_diff_done" ;
-                    match (diff_result, block_reward_threshold) with
-                    | Ok diff, Some threshold ->
-                        let net_return =
-                          Option.value ~default:Currency.Amount.zero
-                            (Staged_ledger_diff.net_return ~constraint_constants
-                               ~supercharge_coinbase
-                               (Staged_ledger_diff.forget diff) )
-                        in
-                        if Currency.Amount.(net_return >= threshold) then
-                          diff_result
-                        else (
-                          [%log info]
-                            "Block reward $reward is less than the \
-                             min-block-reward $threshold, creating empty block"
-                            ~metadata:
-                              [ ( "threshold"
-                                , Currency.Amount.to_yojson threshold )
-                              ; ("reward", Currency.Amount.to_yojson net_return)
-                              ] ;
-                          Ok
-                            Staged_ledger_diff.With_valid_signatures_and_proofs
-                            .empty_diff )
-                    | _ ->
-                        diff_result )
-          in
-          [%log internal] "Apply_staged_ledger_diff" ;
-          match%map
-            let%bind.Deferred.Result diff = return diff in
-            Staged_ledger.apply_diff_unchecked staged_ledger
-              ~constraint_constants ~global_slot diff ~logger
-              ~current_state_view:previous_state_view
-              ~state_and_body_hash:
-                (previous_protocol_state_hash, previous_protocol_state_body_hash)
-              ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
-              ~signature_kind
-          with
-          | Ok
-              ( `Ledger_proof ledger_proof_opt
-              , `Staged_ledger transitioned_staged_ledger
-              , `Accounts_created _
-              , `Pending_coinbase_update (is_new_stack, pending_coinbase_update)
-              ) ->
-              [%log internal] "Hash_new_staged_ledger" ;
-              let staged_ledger_hash =
-                Staged_ledger.hash transitioned_staged_ledger
-              in
-              [%log internal] "Hash_new_staged_ledger_done" ;
-              (*staged_ledger remains unchanged and transitioned_staged_ledger is discarded because the external transtion created out of this diff will be applied in Transition_frontier*)
-              ignore
-              @@ Mina_ledger.Ledger.unregister_mask_exn ~loc:__LOC__
-                   (Staged_ledger.ledger transitioned_staged_ledger) ;
-              Some
-                ( (match diff with Ok diff -> diff | Error _ -> assert false)
-                , staged_ledger_hash
-                , ledger_proof_opt
-                , is_new_stack
-                , pending_coinbase_update )
-          | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
-              [%log error] "Failed to apply the diff: $error"
-                ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-              None
-          | Error e ->
-              ( match diff with
-              | Ok diff ->
-                  [%log error]
-                    ~metadata:
-                      [ ( "error"
-                        , `String
-                            (Staged_ledger.Staged_ledger_error.to_string e) )
-                      ; ( "diff"
-                        , Staged_ledger_diff.Stable.Latest.to_yojson
-                          @@ Staged_ledger_diff.read_all_proofs_from_disk
-                          @@ Staged_ledger_diff.forget diff )
-                      ]
-                    "Error applying the diff $diff: $error"
-              | Error e ->
-                  [%log error] "Error building the diff: $error"
-                    ~metadata:
-                      [ ( "error"
-                        , `String
-                            (Staged_ledger.Staged_ledger_error.to_string e) )
-                      ] ) ;
-              None)
+                    if Currency.Amount.(net_return >= threshold) then
+                      diff_result
+                    else (
+                      [%log info]
+                        "Block reward $reward is less than the \
+                         min-block-reward $threshold, creating empty block"
+                        ~metadata:
+                          [ ( "threshold"
+                            , Currency.Amount.to_yojson threshold )
+                          ; ("reward", Currency.Amount.to_yojson net_return)
+                          ] ;
+                      Ok
+                        Staged_ledger_diff.With_valid_signatures_and_proofs
+                        .empty_diff )
+                | _ ->
+                    diff_result )
+      in
+      [%log internal] "Apply_staged_ledger_diff" ;
+      let%map res =
+        let%bind.Deferred.Result diff = return diff in
+        Staged_ledger.apply_diff_unchecked staged_ledger
+          ~constraint_constants ~global_slot diff ~logger
+          ~current_state_view:previous_state_view
+          ~state_and_body_hash:
+            (previous_protocol_state_hash, previous_protocol_state_body_hash)
+          ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
+          ~signature_kind
       in
       [%log internal] "Apply_staged_ledger_diff_done" ;
       match res with
-      | None ->
-          Interruptible.return None
-      | Some
-          ( diff
-          , next_staged_ledger_hash
-          , ledger_proof_opt
-          , is_new_stack
-          , pending_coinbase_update ) ->
+      | Ok
+          ( `Ledger_proof ledger_proof_opt
+          , `Staged_ledger transitioned_staged_ledger
+          , `Accounts_created _
+          , `Pending_coinbase_update (is_new_stack, pending_coinbase_update)
+          ) ->
+          [%log internal] "Hash_new_staged_ledger" ;
+          let staged_ledger_hash =
+            Staged_ledger.hash transitioned_staged_ledger
+          in
+          [%log internal] "Hash_new_staged_ledger_done" ;
+          (*staged_ledger remains unchanged and transitioned_staged_ledger is discarded because the external transtion created out of this diff will be applied in Transition_frontier*)
+          ignore
+          @@ Mina_ledger.Ledger.unregister_mask_exn ~loc:__LOC__
+               (Staged_ledger.ledger transitioned_staged_ledger) ;
           let diff_unwrapped =
             Staged_ledger_diff.read_all_proofs_from_disk
-            @@ Staged_ledger_diff.forget diff
+            @@ Staged_ledger_diff.forget
+                 (match diff with Ok diff -> diff | Error _ -> assert false)
           in
-          let%bind protocol_state, consensus_transition_data =
-            lift_sync (fun () ->
-                let previous_ledger_hash =
-                  previous_protocol_state |> Protocol_state.blockchain_state
-                  |> Blockchain_state.snarked_ledger_hash
+          let previous_ledger_hash =
+            previous_protocol_state |> Protocol_state.blockchain_state
+            |> Blockchain_state.snarked_ledger_hash
+          in
+          let ledger_proof_statement =
+            match ledger_proof_opt with
+            | Some proof ->
+                Ledger_proof.Cached.statement proof
+            | None ->
+                let state =
+                  previous_protocol_state
+                  |> Protocol_state.blockchain_state
                 in
-                let ledger_proof_statement =
-                  match ledger_proof_opt with
-                  | Some proof ->
-                      Ledger_proof.Cached.statement proof
-                  | None ->
-                      let state =
-                        previous_protocol_state
-                        |> Protocol_state.blockchain_state
-                      in
-                      Blockchain_state.ledger_proof_statement state
-                in
-                let genesis_ledger_hash =
-                  previous_protocol_state |> Protocol_state.blockchain_state
-                  |> Blockchain_state.genesis_ledger_hash
-                in
-                let supply_increase =
-                  Option.value_map ledger_proof_opt
-                    ~f:(fun proof ->
-                      (Ledger_proof.Cached.statement proof).supply_increase )
-                    ~default:Currency.Amount.Signed.zero
-                in
-                let body_reference =
-                  Staged_ledger_diff.Body.compute_reference
-                    ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
-                    (Body.Stable.Latest.create diff_unwrapped)
-                in
-                let blockchain_state =
-                  (* We use the time of the beginning of the slot because if things
-                     are slower than expected, we may have entered the next slot and
-                     putting the **current** timestamp rather than the expected one
-                     will screw things up.
+                Blockchain_state.ledger_proof_statement state
+          in
+          let genesis_ledger_hash =
+            previous_protocol_state |> Protocol_state.blockchain_state
+            |> Blockchain_state.genesis_ledger_hash
+          in
+          let supply_increase =
+            Option.value_map ledger_proof_opt
+              ~f:(fun proof ->
+                (Ledger_proof.Cached.statement proof).supply_increase )
+              ~default:Currency.Amount.Signed.zero
+          in
+          let body_reference =
+            Staged_ledger_diff.Body.compute_reference
+              ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
+              (Body.Stable.Latest.create diff_unwrapped)
+          in
+          let blockchain_state =
+            (* We use the time of the beginning of the slot because if things
+               are slower than expected, we may have entered the next slot and
+               putting the **current** timestamp rather than the expected one
+               will screw things up.
 
-                     [generate_transition] will log an error if the [current_time]
-                     has a different slot from the [scheduled_time]
-                  *)
-                  Blockchain_state.create_value ~timestamp:scheduled_time
-                    ~genesis_ledger_hash
-                    ~staged_ledger_hash:next_staged_ledger_hash ~body_reference
-                    ~ledger_proof_statement
-                in
-                let current_time =
-                  Block_time.now time_controller
-                  |> Block_time.to_span_since_epoch |> Block_time.Span.to_ms
-                in
-                O1trace.sync_thread "generate_consensus_transition" (fun () ->
-                    Consensus_state_hooks.generate_transition
-                      ~previous_protocol_state ~blockchain_state ~current_time
-                      ~block_data ~supercharge_coinbase
-                      ~snarked_ledger_hash:previous_ledger_hash
-                      ~genesis_ledger_hash ~supply_increase ~logger
-                      ~constraint_constants ) )
+               [generate_transition] will log an error if the [current_time]
+               has a different slot from the [scheduled_time]
+            *)
+            Blockchain_state.create_value ~timestamp:scheduled_time
+              ~genesis_ledger_hash
+              ~staged_ledger_hash ~body_reference
+              ~ledger_proof_statement
           in
-          lift_sync (fun () ->
-              let snark_transition =
-                O1trace.sync_thread "generate_snark_transition" (fun () ->
-                    Snark_transition.create_value
-                      ~blockchain_state:
-                        (Protocol_state.blockchain_state protocol_state)
-                      ~consensus_transition:consensus_transition_data
-                      ~pending_coinbase_update () )
-              in
-              let internal_transition =
-                O1trace.sync_thread "generate_internal_transition" (fun () ->
-                    Internal_transition.create ~snark_transition
-                      ~prover_state:
-                        (Consensus.Data.Block_data.prover_state block_data)
-                      ~staged_ledger_diff:(Staged_ledger_diff.forget diff)
-                      ~ledger_proof:
-                        (Option.map ledger_proof_opt ~f:(fun proof ->
-                             Ledger_proof.Cached.read_proof_from_disk proof ) ) )
-              in
-              let witness =
-                { Pending_coinbase_witness.pending_coinbases =
-                    Staged_ledger.pending_coinbase_collection staged_ledger
-                ; is_new_stack
-                }
-              in
-              Some (protocol_state, internal_transition, witness) ) )
+          let current_time =
+            Block_time.now time_controller
+            |> Block_time.to_span_since_epoch |> Block_time.Span.to_ms
+          in
+          let protocol_state, consensus_transition_data =
+            O1trace.sync_thread "generate_consensus_transition" (fun () ->
+                Consensus_state_hooks.generate_transition
+                  ~previous_protocol_state ~blockchain_state ~current_time
+                  ~block_data ~supercharge_coinbase
+                  ~snarked_ledger_hash:previous_ledger_hash
+                  ~genesis_ledger_hash ~supply_increase ~logger
+                  ~constraint_constants )
+          in
+          let snark_transition =
+            O1trace.sync_thread "generate_snark_transition" (fun () ->
+                Snark_transition.create_value
+                  ~blockchain_state:
+                    (Protocol_state.blockchain_state protocol_state)
+                  ~consensus_transition:consensus_transition_data
+                  ~pending_coinbase_update () )
+          in
+          let internal_transition =
+            O1trace.sync_thread "generate_internal_transition" (fun () ->
+                Internal_transition.create ~snark_transition
+                  ~prover_state:
+                    (Consensus.Data.Block_data.prover_state block_data)
+                  ~staged_ledger_diff:
+                    (Staged_ledger_diff.forget
+                       (match diff with Ok diff -> diff | Error _ -> assert false) )
+                  ~ledger_proof:
+                    (Option.map ledger_proof_opt ~f:(fun proof ->
+                         Ledger_proof.Cached.read_proof_from_disk proof ) ) )
+          in
+          let witness =
+            { Pending_coinbase_witness.pending_coinbases =
+                Staged_ledger.pending_coinbase_collection staged_ledger
+            ; is_new_stack
+            }
+          in
+          Some (protocol_state, internal_transition, witness)
+      | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
+          [%log error] "Failed to apply the diff: $error"
+            ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
+          None
+      | Error e ->
+          ( match diff with
+          | Ok diff ->
+              [%log error]
+                ~metadata:
+                  [ ( "error"
+                    , `String
+                        (Staged_ledger.Staged_ledger_error.to_string e) )
+                  ; ( "diff"
+                    , Staged_ledger_diff.Stable.Latest.to_yojson
+                      @@ Staged_ledger_diff.read_all_proofs_from_disk
+                      @@ Staged_ledger_diff.forget diff )
+                  ]
+                "Error applying the diff $diff: $error"
+          | Error e ->
+              [%log error] "Error building the diff: $error"
+                ~metadata:
+                  [ ( "error"
+                    , `String
+                        (Staged_ledger.Staged_ledger_error.to_string e) )
+                  ] ) ;
+          None )
 
 let handle_block_production_errors ~logger ~rejected_blocks_logger
     ~time_taken:span ~previous_protocol_state ~protocol_state x =
@@ -597,18 +572,17 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
     ~verifier ~trust_system ~get_completed_work ~transaction_resource_pool
     ~frontier_reader ~time_controller ~transition_writer ~log_block_creation
     ~block_reward_threshold ~block_produced_bvar ~slot_tx_end ~slot_chain_end
-    ~net ~zkapp_cmd_limit_hardcap interrupt_ivar
+    ~net ~zkapp_cmd_limit_hardcap
     (scheduled_time, block_data, winner_pubkey) =
   let open Context in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
-  let open Interruptible.Let_syntax in
   let rejected_blocks_logger =
     Logger.create ~id:Logger.Logger_id.rejected_blocks ()
   in
   match Broadcast_pipe.Reader.peek frontier_reader with
   | None ->
       log_bootstrap_mode ~logger () ;
-      Interruptible.return ()
+      return ()
   | Some frontier -> (
       let global_slot =
         Consensus.Data.Block_data.global_slot_since_genesis block_data
@@ -654,7 +628,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                   [ ( "best_tip"
                     , State_hash.to_yojson (Breadcrumb.state_hash best_tip) )
                   ] ;
-              Interruptible.lift (Deferred.never ()) (Deferred.return ()) )
+              Deferred.never () )
         else return best_tip
       in
       let start = Block_time.now time_controller in
@@ -677,15 +651,14 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
             (Protocol_state.consensus_state previous_protocol_state)
           && Option.is_none precomputed_values.proof_data
         then (
-          match%bind Interruptible.uninterruptible (genesis_breadcrumb ()) with
+          match%bind genesis_breadcrumb () with
           | Ok block ->
-              let proof = Blockchain_snark.Blockchain.proof block in
-              Interruptible.lift (Deferred.return proof) (Deferred.never ())
+              return @@ Blockchain_snark.Blockchain.proof block
           | Error err ->
               [%log error]
                 "Aborting block production: cannot generate a genesis proof"
                 ~metadata:[ ("error", Error_json.error_to_yojson err) ] ;
-              Interruptible.lift (Deferred.never ()) (Deferred.return ()) )
+              Deferred.never () )
         else
           return
             ( Header.protocol_state_proof
@@ -698,7 +671,6 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
         |> Sequence.map
              ~f:Transaction_hash.User_command_with_valid_signature.data
       in
-      let%bind () = Interruptible.lift (Deferred.return ()) (Ivar.read interrupt_ivar) in
       [%log internal] "Generate_next_state" ;
       let%bind next_state_opt =
         generate_next_state ~commit_id ~constraint_constants ~scheduled_time
@@ -712,7 +684,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
       [%log internal] "Generate_next_state_done" ;
       match next_state_opt with
       | None ->
-          Interruptible.return ()
+          return ()
       | Some (protocol_state, internal_transition, pending_coinbase_witness) ->
           let diff =
             Internal_transition.staged_ledger_diff internal_transition
@@ -761,206 +733,204 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
             || failwith
                  "newly generated consensus states should be selected over the \
                   tf root" ) ;
-          Interruptible.uninterruptible
-            (let open Deferred.Let_syntax in
-            let emit_breadcrumb () =
-              let open Deferred.Result.Let_syntax in
-              [%log internal]
-                ~metadata:[ ("transactions_count", `Int transactions_count) ]
-                "Produce_state_transition_proof" ;
-              let%bind protocol_state_proof =
-                time ~logger ~time_controller
-                  "Protocol_state_proof proving time(ms)" (fun () ->
-                    O1trace.thread "dispatch_block_proving" (fun () ->
-                        Prover.prove prover ~prev_state:previous_protocol_state
-                          ~prev_state_proof:previous_protocol_state_proof
-                          ~next_state:protocol_state internal_transition
-                          pending_coinbase_witness )
-                    |> Deferred.Result.map_error ~f:(fun err ->
-                           `Prover_error
-                             ( err
-                             , ( previous_protocol_state_proof
-                               , internal_transition
-                               , pending_coinbase_witness ) ) ) )
-              in
-              let staged_ledger_diff =
-                Internal_transition.staged_ledger_diff internal_transition
-              in
-              let previous_state_hash =
-                (Protocol_state.hashes previous_protocol_state).state_hash
-              in
-              [%log internal] "Produce_chain_transition_proof" ;
-              let delta_block_chain_proof =
-                Transition_chain_prover.prove
-                  ~length:(Mina_numbers.Length.to_int consensus_constants.delta)
-                  ~frontier previous_state_hash
-                |> Option.value_exn
-              in
-              [%log internal] "Produce_validated_transition" ;
-              let header =
-                Header.create ~protocol_state ~protocol_state_proof
-                  ~delta_block_chain_proof ()
-              in
-              let body = Body.create staged_ledger_diff in
-              let%bind transition =
-                let open Result.Let_syntax in
-                Validation.wrap_header
-                  { With_hash.hash = protocol_state_hashes; data = header }
-                |> Validation.skip_delta_block_chain_validation
-                     `This_block_was_not_received_via_gossip
-                |> Validation.skip_time_received_validation
-                     `This_block_was_not_received_via_gossip
-                |> Fn.flip Validation.with_body body
-                |> Validation.skip_protocol_versions_validation
-                     `This_block_has_valid_protocol_versions
-                |> Validation.validate_genesis_protocol_state_block
-                     ~genesis_state_hash:
-                       (Protocol_state.genesis_state_hash
-                          ~state_hash:(Some previous_state_hash)
-                          previous_protocol_state )
-                >>| Validation.skip_proof_validation
-                      `This_block_was_generated_internally
-                >>= Validation.validate_frontier_dependencies
-                      ~to_header:Mina_block.header
-                      ~context:(module Context)
-                      ~root_consensus_state:
-                        ( Transition_frontier.root frontier
-                        |> Breadcrumb.consensus_state_with_hashes )
-                      ~is_block_in_frontier:
-                        (Fn.compose Option.is_some
-                           (Transition_frontier.find frontier) )
-                |> Deferred.return
-              in
-              let transition_receipt_time = Some (Time.now ()) in
-              let%bind breadcrumb =
-                time ~logger ~time_controller
-                  "Build breadcrumb on produced block" (fun () ->
-                    Breadcrumb.build ~logger ~precomputed_values ~verifier
-                      ~get_completed_work:(Fn.const None) ~trust_system
-                      ~parent:crumb ~transition
-                      ~sender:None (* Consider skipping `All here *)
-                      ~skip_staged_ledger_verification:`Proofs
-                      ~transition_receipt_time
-                      ~transaction_pool_proxy:
-                        { find_by_hash =
-                            Network_pool.Transaction_pool.Resource_pool
-                            .find_by_hash transaction_resource_pool
-                        }
-                      () )
-                |> Deferred.Result.map_error ~f:(function
-                     | `Invalid_staged_ledger_diff e ->
-                         `Invalid_staged_ledger_diff
-                           ( e
-                           , Staged_ledger_diff.read_all_proofs_from_disk
-                               staged_ledger_diff )
-                     | ( `Fatal_error _
-                       | `Invalid_genesis_protocol_state
-                       | `Invalid_staged_ledger_hash _
-                       | `Not_selected_over_frontier_root
-                       | `Parent_missing_from_frontier
-                       | `Prover_error _ ) as err ->
-                         err )
-              in
-              let txs =
-                Mina_block.transactions ~constraint_constants
-                  (Breadcrumb.block breadcrumb)
-                |> List.map ~f:Transaction.yojson_summary_with_status
-              in
-              [%log internal] "@block_metadata"
-                ~metadata:
-                  [ ( "blockchain_length"
-                    , Mina_numbers.Length.to_yojson
-                      @@ Mina_block.blockchain_length
-                      @@ Breadcrumb.block breadcrumb )
-                  ; ("transactions", `List txs)
-                  ] ;
-              [%str_log info]
-                ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson breadcrumb) ]
-                Block_produced ;
-              (* let uptime service (and any other waiters) know about breadcrumb *)
-              Bvar.broadcast block_produced_bvar breadcrumb ;
-              Mina_metrics.(Counter.inc_one Block_producer.blocks_produced) ;
-              Mina_metrics.Block_producer.(
-                Block_production_delay_histogram.observe block_production_delay
-                  Time.(
-                    Span.to_ms
-                    @@ diff (now ())
-                    @@ Block_time.to_time_exn scheduled_time)) ;
-              [%log internal] "Send_breadcrumb_to_transition_frontier" ;
-              let%bind.Async.Deferred () =
-                Strict_pipe.Writer.write transition_writer breadcrumb
-              in
-              let metadata =
-                [ ( "state_hash"
-                  , State_hash.to_yojson protocol_state_hashes.state_hash )
-                ]
-              in
-              [%log internal] "Wait_for_confirmation" ;
-              [%log debug] ~metadata
-                "Waiting for block $state_hash to be inserted into frontier" ;
-              Deferred.choose
-                [ Deferred.choice
-                    (Transition_registry.register transition_registry
-                       protocol_state_hashes.state_hash )
-                    (Fn.const (Ok `Transition_accepted))
-                ; Deferred.choice
-                    ( Block_time.Timeout.create time_controller
-                        (* We allow up to 20 seconds for the transition
-                           to make its way from the transition_writer to
-                           the frontier.
-                           This value is chosen to be reasonably
-                           generous. In theory, this should not take
-                           terribly long. But long cycles do happen in
-                           our system, and with medium curves those long
-                           cycles can be substantial.
-                        *)
-                        (Block_time.Span.of_ms 20000L)
-                        ~f:(Fn.const ())
-                    |> Block_time.Timeout.to_deferred )
-                    (Fn.const (Ok `Timed_out))
-                ]
-              >>= function
-              | `Transition_accepted ->
-                  [%log internal] "Transition_accepted" ;
-                  [%log info] ~metadata
-                    "Generated transition $state_hash was accepted into \
-                     transition frontier" ;
-                  Deferred.map ~f:Result.return
-                    (Mina_networking.broadcast_state net
-                       ( Breadcrumb.block_with_hash breadcrumb
-                       |> With_hash.map ~f:Mina_block.read_all_proofs_from_disk
-                       ) )
-              | `Timed_out ->
-                  (* FIXME #3167: this should be fatal, and more
-                     importantly, shouldn't happen.
-                  *)
-                  [%log internal] "Transition_accept_timeout" ;
-                  let msg : (_, unit, string, unit) format4 =
-                    "Timed out waiting for generated transition $state_hash to \
-                     enter transition frontier. Continuing to produce new \
-                     blocks anyway. This may mean your CPU is overloaded. \
-                     Consider disabling `-run-snark-worker` if it's \
-                     configured."
-                  in
-                  let span =
-                    Block_time.diff (Block_time.now time_controller) start
-                  in
-                  let metadata =
-                    [ ( "time"
-                      , `Int (Block_time.Span.to_ms span |> Int64.to_int_exn) )
-                    ; ( "protocol_state"
-                      , Protocol_state.Value.to_yojson protocol_state )
-                    ]
-                    @ metadata
-                  in
-                  [%log' debug rejected_blocks_logger] ~metadata msg ;
-                  [%log fatal] ~metadata msg ;
-                  return ()
+          let emit_breadcrumb () =
+            let open Deferred.Result.Let_syntax in
+            [%log internal]
+              ~metadata:[ ("transactions_count", `Int transactions_count) ]
+              "Produce_state_transition_proof" ;
+            let%bind protocol_state_proof =
+              time ~logger ~time_controller
+                "Protocol_state_proof proving time(ms)" (fun () ->
+                  O1trace.thread "dispatch_block_proving" (fun () ->
+                      Prover.prove prover ~prev_state:previous_protocol_state
+                        ~prev_state_proof:previous_protocol_state_proof
+                        ~next_state:protocol_state internal_transition
+                        pending_coinbase_witness )
+                  |> Deferred.Result.map_error ~f:(fun err ->
+                         `Prover_error
+                           ( err
+                           , ( previous_protocol_state_proof
+                             , internal_transition
+                             , pending_coinbase_witness ) ) ) )
             in
-            let%bind res = emit_breadcrumb () in
-            let span = Block_time.diff (Block_time.now time_controller) start in
-            handle_block_production_errors ~logger ~rejected_blocks_logger
-              ~time_taken:span ~previous_protocol_state ~protocol_state res) )
+            let staged_ledger_diff =
+              Internal_transition.staged_ledger_diff internal_transition
+            in
+            let previous_state_hash =
+              (Protocol_state.hashes previous_protocol_state).state_hash
+            in
+            [%log internal] "Produce_chain_transition_proof" ;
+            let delta_block_chain_proof =
+              Transition_chain_prover.prove
+                ~length:(Mina_numbers.Length.to_int consensus_constants.delta)
+                ~frontier previous_state_hash
+              |> Option.value_exn
+            in
+            [%log internal] "Produce_validated_transition" ;
+            let header =
+              Header.create ~protocol_state ~protocol_state_proof
+                ~delta_block_chain_proof ()
+            in
+            let body = Body.create staged_ledger_diff in
+            let%bind transition =
+              let open Result.Let_syntax in
+              Validation.wrap_header
+                { With_hash.hash = protocol_state_hashes; data = header }
+              |> Validation.skip_delta_block_chain_validation
+                   `This_block_was_not_received_via_gossip
+              |> Validation.skip_time_received_validation
+                   `This_block_was_not_received_via_gossip
+              |> Fn.flip Validation.with_body body
+              |> Validation.skip_protocol_versions_validation
+                   `This_block_has_valid_protocol_versions
+              |> Validation.validate_genesis_protocol_state_block
+                   ~genesis_state_hash:
+                     (Protocol_state.genesis_state_hash
+                        ~state_hash:(Some previous_state_hash)
+                        previous_protocol_state )
+              >>| Validation.skip_proof_validation
+                    `This_block_was_generated_internally
+              >>= Validation.validate_frontier_dependencies
+                    ~to_header:Mina_block.header
+                    ~context:(module Context)
+                    ~root_consensus_state:
+                      ( Transition_frontier.root frontier
+                      |> Breadcrumb.consensus_state_with_hashes )
+                    ~is_block_in_frontier:
+                      (Fn.compose Option.is_some
+                         (Transition_frontier.find frontier) )
+              |> Deferred.return
+            in
+            let transition_receipt_time = Some (Time.now ()) in
+            let%bind breadcrumb =
+              time ~logger ~time_controller
+                "Build breadcrumb on produced block" (fun () ->
+                  Breadcrumb.build ~logger ~precomputed_values ~verifier
+                    ~get_completed_work:(Fn.const None) ~trust_system
+                    ~parent:crumb ~transition
+                    ~sender:None (* Consider skipping `All here *)
+                    ~skip_staged_ledger_verification:`Proofs
+                    ~transition_receipt_time
+                    ~transaction_pool_proxy:
+                      { find_by_hash =
+                          Network_pool.Transaction_pool.Resource_pool
+                          .find_by_hash transaction_resource_pool
+                      }
+                    () )
+              |> Deferred.Result.map_error ~f:(function
+                   | `Invalid_staged_ledger_diff e ->
+                       `Invalid_staged_ledger_diff
+                         ( e
+                         , Staged_ledger_diff.read_all_proofs_from_disk
+                             staged_ledger_diff )
+                   | ( `Fatal_error _
+                     | `Invalid_genesis_protocol_state
+                     | `Invalid_staged_ledger_hash _
+                     | `Not_selected_over_frontier_root
+                     | `Parent_missing_from_frontier
+                     | `Prover_error _ ) as err ->
+                       err )
+            in
+            let txs =
+              Mina_block.transactions ~constraint_constants
+                (Breadcrumb.block breadcrumb)
+              |> List.map ~f:Transaction.yojson_summary_with_status
+            in
+            [%log internal] "@block_metadata"
+              ~metadata:
+                [ ( "blockchain_length"
+                  , Mina_numbers.Length.to_yojson
+                    @@ Mina_block.blockchain_length
+                    @@ Breadcrumb.block breadcrumb )
+                ; ("transactions", `List txs)
+                ] ;
+            [%str_log info]
+              ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson breadcrumb) ]
+              Block_produced ;
+            (* let uptime service (and any other waiters) know about breadcrumb *)
+            Bvar.broadcast block_produced_bvar breadcrumb ;
+            Mina_metrics.(Counter.inc_one Block_producer.blocks_produced) ;
+            Mina_metrics.Block_producer.(
+              Block_production_delay_histogram.observe block_production_delay
+                Time.(
+                  Span.to_ms
+                  @@ diff (now ())
+                  @@ Block_time.to_time_exn scheduled_time)) ;
+            [%log internal] "Send_breadcrumb_to_transition_frontier" ;
+            let%bind.Async.Deferred () =
+              Strict_pipe.Writer.write transition_writer breadcrumb
+            in
+            let metadata =
+              [ ( "state_hash"
+                , State_hash.to_yojson protocol_state_hashes.state_hash )
+              ]
+            in
+            [%log internal] "Wait_for_confirmation" ;
+            [%log debug] ~metadata
+              "Waiting for block $state_hash to be inserted into frontier" ;
+            Deferred.choose
+              [ Deferred.choice
+                  (Transition_registry.register transition_registry
+                     protocol_state_hashes.state_hash )
+                  (Fn.const (Ok `Transition_accepted))
+              ; Deferred.choice
+                  ( Block_time.Timeout.create time_controller
+                      (* We allow up to 20 seconds for the transition
+                         to make its way from the transition_writer to
+                         the frontier.
+                         This value is chosen to be reasonably
+                         generous. In theory, this should not take
+                         terribly long. But long cycles do happen in
+                         our system, and with medium curves those long
+                         cycles can be substantial.
+                      *)
+                      (Block_time.Span.of_ms 20000L)
+                      ~f:(Fn.const ())
+                  |> Block_time.Timeout.to_deferred )
+                  (Fn.const (Ok `Timed_out))
+              ]
+            >>= function
+            | `Transition_accepted ->
+                [%log internal] "Transition_accepted" ;
+                [%log info] ~metadata
+                  "Generated transition $state_hash was accepted into \
+                   transition frontier" ;
+                Deferred.map ~f:Result.return
+                  (Mina_networking.broadcast_state net
+                     ( Breadcrumb.block_with_hash breadcrumb
+                     |> With_hash.map ~f:Mina_block.read_all_proofs_from_disk
+                     ) )
+            | `Timed_out ->
+                (* FIXME #3167: this should be fatal, and more
+                   importantly, shouldn't happen.
+                *)
+                [%log internal] "Transition_accept_timeout" ;
+                let msg : (_, unit, string, unit) format4 =
+                  "Timed out waiting for generated transition $state_hash to \
+                   enter transition frontier. Continuing to produce new \
+                   blocks anyway. This may mean your CPU is overloaded. \
+                   Consider disabling `-run-snark-worker` if it's \
+                   configured."
+                in
+                let span =
+                  Block_time.diff (Block_time.now time_controller) start
+                in
+                let metadata =
+                  [ ( "time"
+                    , `Int (Block_time.Span.to_ms span |> Int64.to_int_exn) )
+                  ; ( "protocol_state"
+                    , Protocol_state.Value.to_yojson protocol_state )
+                  ]
+                  @ metadata
+                in
+                [%log' debug rejected_blocks_logger] ~metadata msg ;
+                [%log fatal] ~metadata msg ;
+                return ()
+          in
+          let%bind res = emit_breadcrumb () in
+          let span = Block_time.diff (Block_time.now time_controller) start in
+          handle_block_production_errors ~logger ~rejected_blocks_logger
+            ~time_taken:span ~previous_protocol_state ~protocol_state res )
 
 let generate_genesis_proof_if_needed ~genesis_breadcrumb ~frontier_reader () =
   match Broadcast_pipe.Reader.peek frontier_reader with
@@ -1135,6 +1105,13 @@ let iteration ~schedule_next_vrf_check ~produce_block_now
                  ~frontier_reader () ) ;
             schedule_block_production (scheduled_time, data, winner_pk) )
 
+(** Create a timeout that fires at the given time.
+
+    Because we are using [Block_time.Timeout.create], the timeout will fire even
+    if [Block_time.now] is not yet at the given time when the timeout is created.
+    This is intentional: we want to schedule a block production at a given time,
+    not at a given duration from now.
+*)
 let schedule ~time_controller time =
   let span_till_time = Block_time.diff time (Block_time.now time_controller) in
   Block_time.Timeout.create time_controller span_till_time ~f:Fn.id
@@ -1167,7 +1144,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
           ~zkapp_cmd_limit_hardcap
       in
       let module Breadcrumb = Transition_frontier.Breadcrumb in
-      let iteration_wrapped (slot, i, prev_step) =
+      let iteration_wrapped (slot, i) =
         (* Begin checking for the ability to produce a block *)
         match Broadcast_pipe.Reader.peek frontier_reader with
         | None ->
@@ -1176,7 +1153,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
               Broadcast_pipe.Reader.iter_until frontier_reader
                 ~f:(Fn.compose Deferred.return Option.is_some)
             in
-            (slot, i, prev_step)
+            (slot, i)
         | Some transition_frontier ->
             let consensus_state =
               Transition_frontier.best_tip transition_frontier
@@ -1232,26 +1209,14 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     ~local_state:consensus_local_state
                    = None ) ; *)
             let next_vrf_check_now () =
-              return (new_global_slot, i', prev_step)
+              return (new_global_slot, i')
             in
             let produce_block_now data =
-              Option.iter !prev_step ~f:(fun ivar ->
-                  if Ivar.is_full ivar then
-                    [%log error] "Ivar.fill bug is here!" ;
-                  Ivar.fill ivar () ) ;
-              let intr_ivar = Ivar.create () in
-              let this_step = ref (Some intr_ivar) in
-              let produce_intr =
-                let%map.Interruptible x = produce intr_ivar data in
-                this_step := None ;
-                x
-              in
-              let%map _ = Interruptible.force produce_intr in
-              (new_global_slot, i', this_step)
+              produce data >>| Fn.const (new_global_slot, i')
             in
             let schedule_next_vrf_check time =
               let%map _ = schedule ~time_controller time in
-              (new_global_slot, i', prev_step)
+              (new_global_slot, i')
             in
             let schedule_block_production (time, data, winner) =
               let%bind _ = schedule ~time_controller time in
@@ -1268,8 +1233,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
       let start _ =
         Deferred.forever
           ( Mina_numbers.Global_slot_since_hard_fork.zero
-          , Mina_numbers.Length.zero
-          , ref @@ Some (Ivar.create ()) )
+          , Mina_numbers.Length.zero )
           iteration_wrapped
       in
       let genesis_state_timestamp =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -136,12 +136,11 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 [%log internal] "Create_staged_ledger_diff" ;
                 (* TODO: handle transaction inclusion failures here *)
                 let diff_result =
-                  Staged_ledger.create_diff ~constraint_constants
-                    ~global_slot staged_ledger ~coinbase_receiver ~logger
+                  Staged_ledger.create_diff ~constraint_constants ~global_slot
+                    staged_ledger ~coinbase_receiver ~logger
                     ~current_state_view:previous_state_view
                     ~transactions_by_fee:transactions ~get_completed_work
-                    ~log_block_creation ~supercharge_coinbase
-                    ~zkapp_cmd_limit
+                    ~log_block_creation ~supercharge_coinbase ~zkapp_cmd_limit
                   |> Result.map ~f:(fun (diff, failed_txns) ->
                          if not (List.is_empty failed_txns) then
                            don't_wait_for
@@ -167,8 +166,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                         "Block reward $reward is less than the \
                          min-block-reward $threshold, creating empty block"
                         ~metadata:
-                          [ ( "threshold"
-                            , Currency.Amount.to_yojson threshold )
+                          [ ("threshold", Currency.Amount.to_yojson threshold)
                           ; ("reward", Currency.Amount.to_yojson net_return)
                           ] ;
                       Ok
@@ -180,9 +178,8 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
       [%log internal] "Apply_staged_ledger_diff" ;
       let%map res =
         let%bind.Deferred.Result diff = return diff in
-        Staged_ledger.apply_diff_unchecked staged_ledger
-          ~constraint_constants ~global_slot diff ~logger
-          ~current_state_view:previous_state_view
+        Staged_ledger.apply_diff_unchecked staged_ledger ~constraint_constants
+          ~global_slot diff ~logger ~current_state_view:previous_state_view
           ~state_and_body_hash:
             (previous_protocol_state_hash, previous_protocol_state_body_hash)
           ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
@@ -194,8 +191,8 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
           ( `Ledger_proof ledger_proof_opt
           , `Staged_ledger transitioned_staged_ledger
           , `Accounts_created _
-          , `Pending_coinbase_update (is_new_stack, pending_coinbase_update)
-          ) ->
+          , `Pending_coinbase_update (is_new_stack, pending_coinbase_update) )
+        ->
           [%log internal] "Hash_new_staged_ledger" ;
           let staged_ledger_hash =
             Staged_ledger.hash transitioned_staged_ledger
@@ -220,8 +217,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 Ledger_proof.Cached.statement proof
             | None ->
                 let state =
-                  previous_protocol_state
-                  |> Protocol_state.blockchain_state
+                  previous_protocol_state |> Protocol_state.blockchain_state
                 in
                 Blockchain_state.ledger_proof_statement state
           in
@@ -250,8 +246,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                has a different slot from the [scheduled_time]
             *)
             Blockchain_state.create_value ~timestamp:scheduled_time
-              ~genesis_ledger_hash
-              ~staged_ledger_hash ~body_reference
+              ~genesis_ledger_hash ~staged_ledger_hash ~body_reference
               ~ledger_proof_statement
           in
           let current_time =
@@ -263,9 +258,8 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 Consensus_state_hooks.generate_transition
                   ~previous_protocol_state ~blockchain_state ~current_time
                   ~block_data ~supercharge_coinbase
-                  ~snarked_ledger_hash:previous_ledger_hash
-                  ~genesis_ledger_hash ~supply_increase ~logger
-                  ~constraint_constants )
+                  ~snarked_ledger_hash:previous_ledger_hash ~genesis_ledger_hash
+                  ~supply_increase ~logger ~constraint_constants )
           in
           let snark_transition =
             O1trace.sync_thread "generate_snark_transition" (fun () ->
@@ -282,7 +276,11 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                     (Consensus.Data.Block_data.prover_state block_data)
                   ~staged_ledger_diff:
                     (Staged_ledger_diff.forget
-                       (match diff with Ok diff -> diff | Error _ -> assert false) )
+                       ( match diff with
+                       | Ok diff ->
+                           diff
+                       | Error _ ->
+                           assert false ) )
                   ~ledger_proof:
                     (Option.map ledger_proof_opt ~f:(fun proof ->
                          Ledger_proof.Cached.read_proof_from_disk proof ) ) )
@@ -304,8 +302,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
               [%log error]
                 ~metadata:
                   [ ( "error"
-                    , `String
-                        (Staged_ledger.Staged_ledger_error.to_string e) )
+                    , `String (Staged_ledger.Staged_ledger_error.to_string e) )
                   ; ( "diff"
                     , Staged_ledger_diff.Stable.Latest.to_yojson
                       @@ Staged_ledger_diff.read_all_proofs_from_disk
@@ -316,8 +313,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
               [%log error] "Error building the diff: $error"
                 ~metadata:
                   [ ( "error"
-                    , `String
-                        (Staged_ledger.Staged_ledger_error.to_string e) )
+                    , `String (Staged_ledger.Staged_ledger_error.to_string e) )
                   ] ) ;
           None )
 
@@ -572,8 +568,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
     ~verifier ~trust_system ~get_completed_work ~transaction_resource_pool
     ~frontier_reader ~time_controller ~transition_writer ~log_block_creation
     ~block_reward_threshold ~block_produced_bvar ~slot_tx_end ~slot_chain_end
-    ~net ~zkapp_cmd_limit_hardcap
-    (scheduled_time, block_data, winner_pubkey) =
+    ~net ~zkapp_cmd_limit_hardcap (scheduled_time, block_data, winner_pubkey) =
   let open Context in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
   let rejected_blocks_logger =
@@ -803,8 +798,8 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
             in
             let transition_receipt_time = Some (Time.now ()) in
             let%bind breadcrumb =
-              time ~logger ~time_controller
-                "Build breadcrumb on produced block" (fun () ->
+              time ~logger ~time_controller "Build breadcrumb on produced block"
+                (fun () ->
                   Breadcrumb.build ~logger ~precomputed_values ~verifier
                     ~get_completed_work:(Fn.const None) ~trust_system
                     ~parent:crumb ~transition
@@ -898,8 +893,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                 Deferred.map ~f:Result.return
                   (Mina_networking.broadcast_state net
                      ( Breadcrumb.block_with_hash breadcrumb
-                     |> With_hash.map ~f:Mina_block.read_all_proofs_from_disk
-                     ) )
+                     |> With_hash.map ~f:Mina_block.read_all_proofs_from_disk ) )
             | `Timed_out ->
                 (* FIXME #3167: this should be fatal, and more
                    importantly, shouldn't happen.
@@ -907,10 +901,9 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                 [%log internal] "Transition_accept_timeout" ;
                 let msg : (_, unit, string, unit) format4 =
                   "Timed out waiting for generated transition $state_hash to \
-                   enter transition frontier. Continuing to produce new \
-                   blocks anyway. This may mean your CPU is overloaded. \
-                   Consider disabling `-run-snark-worker` if it's \
-                   configured."
+                   enter transition frontier. Continuing to produce new blocks \
+                   anyway. This may mean your CPU is overloaded. Consider \
+                   disabling `-run-snark-worker` if it's configured."
                 in
                 let span =
                   Block_time.diff (Block_time.now time_controller) start
@@ -1208,9 +1201,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                     ~constants:consensus_constants ~consensus_state
                     ~local_state:consensus_local_state
                    = None ) ; *)
-            let next_vrf_check_now () =
-              return (new_global_slot, i')
-            in
+            let next_vrf_check_now () = return (new_global_slot, i') in
             let produce_block_now data =
               produce data >>| Fn.const (new_global_slot, i')
             in
@@ -1226,9 +1217,8 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
               ~schedule_block_production ~next_vrf_check_now ~genesis_breadcrumb
               ~context:(module Context)
               ~vrf_evaluator ~time_controller ~coinbase_receiver
-              ~frontier_reader ~set_next_producer_timing
-              ~transition_frontier ~vrf_evaluation_state ~epoch_data_for_vrf
-              ~ledger_snapshot i slot
+              ~frontier_reader ~set_next_producer_timing ~transition_frontier
+              ~vrf_evaluation_state ~epoch_data_for_vrf ~ledger_snapshot i slot
       in
       let start _ =
         Deferred.forever
@@ -1249,12 +1239,11 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
               , `Int
                   (Int64.to_int_exn
                      (Block_time.Span.to_ms
-                        (Block_time.diff genesis_state_timestamp now) ) )
-              )
+                        (Block_time.diff genesis_state_timestamp now) ) ) )
             ]
           "Node started before genesis: waiting $time_till_genesis \
            milliseconds before starting block producer" ;
-        upon (schedule ~time_controller genesis_state_timestamp) start )
+      upon (schedule ~time_controller genesis_state_timestamp) start )
 
 let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
     ~time_controller ~frontier_reader ~transition_writer ~precomputed_blocks =


### PR DESCRIPTION
For some background on these changes: the PR https://github.com/MinaProtocol/mina/pull/16728 revived an older PR that refactored the daemon's block producer thread, as part of a larger block producer simplification. It introduced a strange bug that was discovered in a mainnet beta release and reported in https://github.com/MinaProtocol/mina/issues/17595; I developed a simplified manual test that reproduced the bug, and the PR was reverted in https://github.com/MinaProtocol/mina/pull/17616 after observing that the reversion fixed the manual test. The bug was no longer observed by the user that originally reported the bug after the revert.

This PR is a port of https://github.com/MinaProtocol/mina/pull/16728 to the latest compatible. The first few commits are exactly the changes in the original PR, and the final commit f17c8b616f15dd93bf486b527ff7bd90095b26de fixes what I think was the bug in the original PR. The problem appears to be that commit 599ebf09d892c1e38a9aae556bcecf2cd0198a7f [^history] introduced a small scoping error that went unnoticed in review, which caused the block producer thread to run its `start` method twice if the daemon started after the genesis timestamp. The two threads would each take from the _same_ VRF queue, so block production events would end up being scheduled two at a time. Thus when the bug was active the "Next block produced.." in the status would always refer to the second block to be produced in this epoch. This also explains the strange duplicated log lines I was seeing in my manual reproduction: there really were two block producer processing tasks active at once. I think this also confirms my original guess that the blocks would actually have been produced at the right times while the bug was still around.

[^history]: This commit corresponds to f34038cc99facb4caba03b56b2bfdb09f7c9d590 here. The relevant line is [here](https://github.com/MinaProtocol/mina/pull/18694/changes/f34038cc99facb4caba03b56b2bfdb09f7c9d590#diff-1de01378a5967fa5e5996fbbbcc5110334a6f7bbc9309bae4b323aec53fc6582R1293). The same bug exists in the older https://github.com/MinaProtocol/mina/pull/16224, but not the even older 93f645732cb3b54c9af8a672f969ca94badbb1eb, if you were interested in the full history, not that that's particularly relevant. It's pretty difficult to see that the bug was introduced just by looking at the diff, in my opinion.

I'm leaving this up to have a record of this around. I think this can be updated, re-reviewed, and then merged after the hard fork. I would rather not do it now, just in case it introduces any additional bugs that haven't been caught yet. I'd also like to clean up the commits slightly, and probably also add the test case I've been using somewhere.

-------

To expand on the small scope difference here, the block producer's `run` method is written so it waits for the chain's genesis time before it starts up the block production loop. The new code is [here](https://github.com/MinaProtocol/mina/blob/f34038cc99facb4caba03b56b2bfdb09f7c9d590/src/lib/block_producer/block_producer.ml#L1278-L1293) from f34038cc99facb4caba03b56b2bfdb09f7c9d590 in this PR. The old code is [here](https://github.com/MinaProtocol/mina/blob/6aee3d668805aceb577c838e5d4fd31d9ea8d611/src/lib/block_producer/block_producer.ml#L1360-L1377) as of current compatible at 6aee3d668805aceb577c838e5d4fd31d9ea8d611. The old code's `else` branch starts with a `let ... in`. The `in` creates a scope that contains both the following log line and the `ignore` - it contains everything up to the end of the enclosing scope, which is the `)` on that `ignore` line. The entire expression within the `else` branch can thus be written without parentheses. In contrast, the new code inlines the `let` expression into the log line. The `else` branch ends up containing just the log line, and the new `upon` call gets run unconditionally. That's why `start` ends up being called twice. The difference can be seen in the final formatted result; the old code's `ignore` lines up with the `let` and is indented more than the `else`, whereas the new code's `upon` lines up with the `else`.