### PR TITLE
Remove tag which excluded bullseye mesa

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
@@ -25,6 +25,7 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta
             , Artifacts.Type.ZkappTestTransaction
             , Artifacts.Type.CreatePreforkGenesis
+            , Artifacts.Type.DaemonStorageToolbox
             ]
           , network = Network.Type.Mesa
           , tags =

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
@@ -32,7 +32,6 @@ in  Pipeline.build
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Rosetta
-            , PipelineTag.Type.Mesa
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bullseye
             ]


### PR DESCRIPTION
Remove mesa tag from bullseye mesa in order to build suitable packages for connecting to mesa testnet