### PR TITLE
Fix automode metapackage architecture from 'all' to actual arch

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -734,7 +734,7 @@ build_daemon_postfork_deb() {
 #
 # Builds mina-NETWORK-automode transitional metapackage
 #
-# Output: mina-${NETWORK}-automode_${MINA_DEB_VERSION}_all.deb
+# Output: mina-${NETWORK}-automode_${MINA_DEB_VERSION}_${ARCHITECTURE}.deb
 #
 # This is an empty metapackage that depends on both prefork and postfork
 # automode packages. It Conflicts/Replaces/Provides mina-${NETWORK} so that
@@ -751,10 +751,6 @@ build_daemon_automode_deb() {
 
   local package_name="mina-${network}-automode"
 
-  # Automode metapackage is architecture-independent (no binaries).
-  local saved_arch="${ARCHITECTURE}"
-  ARCHITECTURE=all
-
   local prefork_pkg="mina-${network}-prefork-${POSTFORK_CODENAME}"
   local postfork_pkg="mina-${network}-postfork-${POSTFORK_CODENAME}"
   local depends="${postfork_pkg} (>= ${MINA_DEB_VERSION}), ${prefork_pkg} (>= ${MINA_DEB_VERSION})"
@@ -764,7 +760,6 @@ build_daemon_automode_deb() {
     "" "mina-${network}" "mina-${network}" "mina-${network}"
 
   build_deb "${package_name}"
-  ARCHITECTURE="${saved_arch}"
 }
 ## END AUTOMODE METAPACKAGE ##
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -812,7 +812,7 @@ test_build_daemon_devnet_automode_deb() {
     load_captured_state
     assert_eq "deb name" "mina-devnet-automode" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-automode"
-    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-devnet"
@@ -830,7 +830,7 @@ test_build_daemon_mainnet_automode_deb() {
     load_captured_state
     assert_eq "deb name" "mina-mainnet-automode" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-automode"
-    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-mainnet"


### PR DESCRIPTION
The automode metapackage depends on arch-specific prefork and postfork packages, so it should use the build architecture (amd64/arm64) instead of 'all'.

