### PR TITLE
Use PREFORK_VERSION env var for automode prefork dependency

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -753,7 +753,8 @@ build_daemon_automode_deb() {
 
   local prefork_pkg="mina-${network}-prefork-${POSTFORK_CODENAME}"
   local postfork_pkg="mina-${network}-postfork-${POSTFORK_CODENAME}"
-  local depends="${postfork_pkg} (>= ${MINA_DEB_VERSION}), ${prefork_pkg} (>= ${MINA_DEB_VERSION})"
+  local prefork_version="${PREFORK_VERSION:-${MINA_DEB_VERSION}}"
+  local depends="${postfork_pkg} (>= ${MINA_DEB_VERSION}), ${prefork_pkg} (>= ${prefork_version})"
 
   create_control_file "${package_name}" "${depends}" \
     "Transitional metapackage for Mina ${network} automode (installs both prefork and postfork runtimes)" \


### PR DESCRIPTION
## Summary
- The automode metapackage hardcoded `MINA_DEB_VERSION` for the prefork dependency version
- The prefork package may come from a different build with a different version
- Now uses `PREFORK_VERSION` env var, falling back to `MINA_DEB_VERSION` if unset

## Test plan
- [x] Build automode deb with `PREFORK_VERSION` set and verify control file has correct dependency version
- [x] Build automode deb without `PREFORK_VERSION` and verify it falls back to `MINA_DEB_VERSION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)