### PR TITLE
Downloader: ensure refresh_knowledge thread are properly closed

### DIFF
--- a/changes/18709.md
+++ b/changes/18709.md
@@ -1,0 +1,1 @@
+Fix memory leak: refresh_knowledge thread in Downloader now also terminates on downloader shutdown, not just when the peer is forgotten. 

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -1012,7 +1012,8 @@ end = struct
       Strict_pipe.create ~name:"knowledge-requests" Strict_pipe.Synchronous
     in
     upon stop (fun () -> Strict_pipe.Writer.close request_w) ;
-    let refresh_knowledge stop peer =
+    let refresh_knowledge forgot_peer peer =
+      let stop = Deferred.any [ forgot_peer; stop ] in
       Clock.every' (Time.Span.of_min 7.) ~stop (fun () ->
           match%bind jobs_to_download stop with
           | `Finished ->


### PR DESCRIPTION
## Summary                                                                                                                            
                                                                                                                                        
Each peer tracked by the `Downloader` spawns a `refresh_knowledge` async thread that periodically polls for downloadable jobs. This thread was previously stopped only when the peer was forgotten (via the `finished` ivar). However, the thread held no reference to the top-level `stop` deferred, so if the downloader was shut down while peers were still active, these threads would remain alive indefinitely — leaking async jobs and memory.

## Fix

`refresh_knowledge` now derives its internal `stop` as `Deferred.any [ forgot_peer; stop ]`, combining the per-peer termination signal with the downloader-level shutdown signal. The thread now terminates on whichever comes first.