### PR TITLE
Validate GENESIS_TIMESTAMP is UTC in hardfork package gen

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -96,6 +96,12 @@ if [[ -z "${CONFIG_JSON_GZ_URL:-}" ]]; then
   usage "CONFIG_JSON_GZ_URL environment variable is required"
 fi
 
+# Validate GENESIS_TIMESTAMP is in UTC (must end with 'Z') to avoid
+# inconsistencies between auto hardfork mode (UTC) and legacy pipeline (local time)
+if [[ -n "${GENESIS_TIMESTAMP:-}" && ! "${GENESIS_TIMESTAMP}" =~ Z$ ]]; then
+  usage "GENESIS_TIMESTAMP must be in UTC format (ending with 'Z'), got: ${GENESIS_TIMESTAMP}"
+fi
+
 # Format GENESIS_TIMESTAMP as Optional Text for Dhall
 if [[ -z "${GENESIS_TIMESTAMP:-}" ]]; then
   GENESIS_TIMESTAMP="(None Text)"


### PR DESCRIPTION
## Summary
- Adds early UTC validation for `GENESIS_TIMESTAMP` in `run-hardfork-package-gen.sh` (must end with `Z` suffix)
- Prevents inconsistencies between auto hardfork mode (which produces UTC timestamps) and legacy pipeline (which was using local time)
- Validation happens at the entry point before the value is wrapped into Dhall `Optional Text`, so invalid timestamps fail fast with a clear error

## Test plan
- [ ] Set `GENESIS_TIMESTAMP="2024-04-07T11:45:00Z"` — should pass validation
- [ ] Set `GENESIS_TIMESTAMP="2024-04-07T11:45:00+02:00"` — should fail with usage error
- [ ] Set `GENESIS_TIMESTAMP="2024-04-07T11:45:00"` — should fail with usage error
- [ ] Unset `GENESIS_TIMESTAMP` — should pass (optional, defaults handled downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)