### PR TITLE
Add cacert to nix docker definitions

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,6 +1,6 @@
 { lib, dockerTools, buildEnv, ocamlPackages_mina, linkFarm, runCommand
 , dumb-init, tzdata, coreutils,  findutils, bashInteractive, python3, libp2p_helper, procps
-, postgresql, curl, jq, stdenv, rsync, bash, gnutar, gzip, currentTime
+, postgresql, curl, jq, stdenv, rsync, bash, gnutar, gzip, cacert, currentTime
 , flockenzeit }:
 let
   created = flockenzeit.lib.ISO-8601 currentTime;
@@ -59,6 +59,7 @@ let
       procps
       curl
       jq
+      cacert
       localtime
       zoneinfo
     ] ++ packages;
@@ -67,7 +68,10 @@ let
       chmod 777 tmp
     '';
     config = {
-      env = [ "MINA_TIME_OFFSET=0" ];
+      env = [
+        "MINA_TIME_OFFSET=0"
+        "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
+      ];
       WorkingDir = "/root";
       cmd = [ "/bin/dumb-init" "/entrypoint.sh" ];
     };


### PR DESCRIPTION
## Explain your changes

Without cacert, curl does not have the necessary certificates to download anything. This causes the daemon to fail to fetch genesis ledgers tarballs from S3 (or other remote sources). Adding cacert and the relevant environment variable to the nix docker image fixes the issue.

## Explain how you tested your changes

I built the image locally with `nix build 'git+file:.?submodules=1#mina-image-full'` and tried connecting to devnet, and verified that the daemon got past the ledger downloading stage in the Trace-level logs. Before, it would fail with an error like this:

```
2026-04-02 18:37:22 UTC [Trace] Downloading file from S3: $url to $local_file_path
       url: "https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net/genesis_ledger_b8d10e35e9d5298208f01154a0e1590ef1302626cc5b192df6feed5ce877d2b6.tar.gz"
       local_file_path: "/tmp/s3_cache_dir/genesis_ledger_b8d10e35e9d5298208f01154a0e1590ef1302626cc5b192df6feed5ce877d2b6.tar.gz"
     2026-04-02 18:37:23 UTC [Trace] Could not download "genesis_ledger" from $uri: $error
       uri: "https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net/genesis_ledger_b8d10e35e9d5298208f01154a0e1590ef1302626cc5b192df6feed5ce877d2b6.tar.gz"
       error: "(monitor.ml.Error\n (\"Process.run failed\"\n  ((prog curl)\n   (args\n    (--fail --silent --show-error -o\n
     /tmp/s3_cache_dir/genesis_ledger_b8d10e35e9d5298208f01154a0e1590ef1302626cc5b192df6feed5ce877d2b6.tar.gz\n
     https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net/genesis_ledger_b8d10e35e9d5298208f01154a0e1590ef1302626cc5b192df6feed5ce877d2b6.tar.gz))\n   (exit_status (Exit_non_zero 60)) (stdout \"\")\n
     (stderr\n    (\"curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)\"\n     \"More details here: https://curl.se/docs/sslcerts.html\" \"\"\n     \"curl failed to verify
     the legitimacy of the server and therefore could not\"\n     \"establish a secure connection to it. To learn more about this situation and\"\n     \"how to fix it, please visit the webpage mentioned above.\"
     \"\"))))\n (\"Raised at Base__Error.raise in file \\\"src/error.ml\\\" (inlined), line 8, characters 14-30\"\n  \"Called from Base__Or_error.ok_exn in file \\\"src/or_error.ml\\\", line 84, characters 17-32\"\n
      \"Called from Async_kernel__Deferred1.M.map.(fun) in file \\\"src/deferred1.ml\\\", line 17, characters 40-45\"\n  \"Called from Async_kernel__Job_queue.run_job in file \\\"src/job_queue.ml\\\" (inlined), line
     128, characters 2-5\"\n  \"Called from Async_kernel__Job_queue.run_jobs in file \\\"src/job_queue.ml\\\", line 169, characters 6-47\"\n  \"Caught by monitor at file \\\"src/lib/cache_dir/native/cache_dir.ml\\\",
      line 55, characters 28-28\"))"
```

It now does this:

```
2026-04-02 19:25:12 UTC [Trace] Downloading file from S3: $url to $local_file_path
  url: "https://s3-us-west-2.amazonaws.com/snark-keys-ro.o1test.net/genesis_ledger_7f8e3c72be57f296e86e1083379c7a09c6131b1567510cf0019eb4aff8b87813.tar.gz"
  local_file_path: "/tmp/s3_cache_dir/genesis_ledger_7f8e3c72be57f296e86e1083379c7a09c6131b1567510cf0019eb4aff8b87813.tar.gz"
2026-04-02 19:25:13 UTC [Trace] Download finished
```

Note that the daemon will crash later on if you do that, because `mina-image-full` uses `DUNE_PROFILE=dev` by default. (I did expect that to happen because of the proof-level incompatibilities in the profiles, for the record - I just wanted to verify that the fix worked for curl).