### PR TITLE
fix: propagate scope to JobSpec in Bench pipeline

### DIFF
--- a/buildkite/src/Command/Bench/Base.dhall
+++ b/buildkite/src/Command/Bench/Base.dhall
@@ -112,6 +112,7 @@ let pipeline
               , PipelineTag.Type.Test
               , PipelineTag.Type.Stable
               ]
+            , scope = spec.scope
             }
           , steps = [ command spec ]
           }


### PR DESCRIPTION
## Summary
- Bench/Base.dhall was not passing `spec.scope` to the `JobSpec`, so all bench jobs defaulted to `Scope.Full`
- This caused both stable and unstable perf jobs to run on every build type (PR and nightly) regardless of their intended scope
- Fix: add `scope = spec.scope` to the JobSpec construction

## Context
Example of the issue: https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/41088#019d4f80-4a28-4449-901b-2d52323e6735

## Test plan
- [x] Verify generated pipeline YAML for bench jobs now contains correct scope values
- [x] Confirm stable perf jobs no longer run on PR builds
- [x] Confirm unstable perf jobs no longer run on nightly builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)