### PR TITLE
mina-local-network: fix shutdown abort when nodes are down

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -186,9 +186,8 @@ stop-node() {
 
     echo "Stopping $tag at $port"
 
-    "$MINA_EXE" client stop-daemon --daemon-port "$port"
-    if [ $? -ne 0 ]; then
-        echo "Failed to stop $tag on port $port" >&2
+    if ! "$MINA_EXE" client stop-daemon --daemon-port "$port"; then
+        echo "Failed to stop $tag on port $port, maybe it has already exited?" >&2
     fi
 }
 

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -260,6 +260,8 @@ on-exit() {
       echo "Unknown ON_EXIT value: $1" >&2
       return 1 ;;
   esac
+
+  echo "Completed shutdown phase of mina local network"
 }
 
 trap on-exit TERM INT


### PR DESCRIPTION
## Problem

When `mina-local-network.sh` shuts down, it calls `stop-node` for each daemon.
If a node has already exited (e.g. the auto mode nodes shutting down early during HF), `mina client stop-daemon` returns non-zero. Because the script
runs with `set -e`, this aborts the entire shutdown sequence — leaving the remaining
nodes running and making the failure harder to diagnose.

The existing error-handling pattern was also silently broken:

```bash
"$MINA_EXE" client stop-daemon --daemon-port "$port"
if [ $? -ne 0 ]; then          # never reached under set -e
    echo "Failed to stop ..." >&2
fi
```

With `set -e`, bash exits on the failing command before the `if` check is ever
evaluated, so the error message was never printed either. 

This PR fixes it by ensuring the exit phase doesn't exit early.

## Testing

Observed in CI [here](https://buildkite.com/organizations/o-1-labs-2/pipelines/mina-mainline-branches-nightlies/builds/1242/jobs/019d50dc-bbde-40ae-b460-7c2e37a2096f/log). Shutting down of main network is aborted because we're trying to kill whale 1 which is forking with auto mode. At that point whale_1 had already generated a fork config and exited. 

As a result, subsequent shutdown of seed is not performed at all and that seed are kept alive until fork genesis is reached, where fork seed is not being spawned at all, getting silently replaced by prefork seed node, causing the post-fork genesis not being agreed across blocks at all. 

One note: this bug is not triggered 100% of time, only when a non-seed is forking with auto mode interrupting the exit phase early.