### PR TITLE
hf test go: pretty-print BlockData as JSON in log output

### DIFF
--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -118,6 +118,14 @@ func (block *BlockData) NonEmpty() bool {
 	return block.NumUserCommands > 0 || block.NumFeeTransfers > 0 || block.Coinbase != "0"
 }
 
+func (block BlockData) String() string {
+	b, err := json.MarshalIndent(block, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%+v", block)
+	}
+	return string(b)
+}
+
 const genesisBlockQuery = `
 genesisBlock {
   commandTransactionCount


### PR DESCRIPTION
Add a `String()` method to `BlockData` in the hardfork test Go client so that logging `BlockData` values with `%v` or `%s` produces readable, pretty-printed JSON instead of the default Go struct representation (e.g. `&{56 {3NKi... 38 56 ...}}`).
