### PR TITLE
hf test: detect incomplete network shutdown via exit code

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -262,6 +262,7 @@ on-exit() {
   esac
 
   echo "Completed shutdown phase of mina local network"
+  exit 0
 }
 
 trap on-exit TERM INT

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -61,9 +61,15 @@ func (t *HardforkTest) gracefulShutdown(cmd *exec.Cmd, processName string) {
 	case <-shutdownTimeout.C:
 		t.Logger.Info("%s process did not stop gracefully after %d minutes, forcing kill", processName, t.Config.ShutdownTimeoutMinutes)
 		cmd.Process.Kill()
-	case <-processDone:
-		t.Logger.Info("%s process stopped gracefully", processName)
+	case err := <-processDone:
 		shutdownTimeout.Stop()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
+				t.Logger.Error("%s shutdown was incomplete (exit code %d), some nodes may not have been stopped cleanly", processName, exitErr.ExitCode())
+			}
+		} else {
+			t.Logger.Info("%s process stopped gracefully", processName)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`gracefulShutdown` in the hardfork test discarded the exit code from `cmd.Wait()`, so an interrupted shutdown trap in `mina-local-network.sh` went unnoticed — the test continued as if everything stopped cleanly.

## Changes

- **`mina-local-network.sh`**: add `exit 0` at the end of `on-exit` so a fully completed shutdown is distinguishable from an interrupted one (bash otherwise exits with `128+signal`).
- **`test.go`**: `gracefulShutdown` now checks the exit code. With `exit 0` in the trap, a clean SIGTERM shutdown causes `cmd.Wait()` to return nil; a non-zero exit code means the trap was aborted early and is logged as an error.
