### PR TITLE
Rosetta: fix some uncaught async exceptions causing 502s

### DIFF
--- a/changes/18720.md
+++ b/changes/18720.md
@@ -1,0 +1,1 @@
+Rosetta: return proper error responses instead of crashing when the Mina daemon returns a 200 with a non-JSON body, or when an uncaught exception occurs inside a route handler.

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -126,8 +126,7 @@ let%test_module "parse_response_body" =
           failwith "expected Error"
       | Error e ->
           let expected =
-            Errors.create
-              ~context:"Response from Mina Daemon is not a 200"
+            Errors.create ~context:"Response from Mina Daemon is not a 200"
               (`Graphql_mina_query "Status code 500 -- server error")
           in
           assert (Errors.equal e expected)

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -2,6 +2,22 @@ open Core_kernel
 open Async
 open Rosetta_lib
 
+let parse_response_body ~status_code body_str =
+  match status_code with
+  | 200 -> (
+      try Ok (Yojson.Basic.from_string body_str)
+      with _ ->
+        Error
+          (Errors.create
+             ~context:"Can't parse mina daemon's GraphQL response as json"
+             (`Graphql_mina_query
+               (Printf.sprintf "Can't parse as json: %s" body_str) ) ) )
+  | code ->
+      Error
+        (Errors.create ~context:"Response from Mina Daemon is not a 200"
+           (`Graphql_mina_query
+             (Printf.sprintf "Status code %d -- %s" code body_str) ) )
+
 let graphql_error_to_string e =
   let error_obj_to_string obj =
     let open Yojson.Basic in
@@ -49,25 +65,10 @@ let query ~minimum_user_command_fee query_obj uri =
   in
   let%bind body_json =
     Deferred.return
-    @@
-    match
-      Cohttp.Code.code_of_status (Cohttp_async.Response.status response)
-    with
-    | 200 -> (
-        try
-          let parsed = Yojson.Basic.from_string body_str in
-          Ok parsed
-        with _ ->
-          Error
-            (Errors.create
-               ~context:"Can't parse mina daemon's GraphQL response as json"
-               (`Graphql_mina_query
-                 (Printf.sprintf "Can't parse as json: %s" body_str) ) ) )
-    | code ->
-        Error
-          (Errors.create ~context:"Response from Mina Daemon is not a 200"
-             (`Graphql_mina_query
-               (Printf.sprintf "Status code %d -- %s" code body_str) ) )
+    @@ parse_response_body
+         ~status_code:
+           (Cohttp.Code.code_of_status (Cohttp_async.Response.status response))
+         body_str
   in
   let open Yojson.Basic.Util in
   ( match (member "errors" body_json, member "data" body_json) with
@@ -97,3 +98,44 @@ let query_and_catch ~minimum_user_command_fee query_obj uri =
   let open Deferred.Let_syntax in
   let%map res = query ~minimum_user_command_fee query_obj uri in
   match res with Ok r -> Ok (`Successful r) | Error e -> Ok (`Failed e)
+
+let%test_module "parse_response_body" =
+  ( module struct
+    let%test_unit "200 with valid JSON returns Ok" =
+      match parse_response_body ~status_code:200 "{\"key\":true}" with
+      | Ok _ ->
+          ()
+      | Error _ ->
+          failwith "expected Ok"
+
+    let%test_unit "200 with invalid JSON returns Error" =
+      match parse_response_body ~status_code:200 "not valid json" with
+      | Ok _ ->
+          failwith "expected Error"
+      | Error e ->
+          let expected =
+            Errors.create
+              ~context:"Can't parse mina daemon's GraphQL response as json"
+              (`Graphql_mina_query "Can't parse as json: not valid json")
+          in
+          assert (Errors.equal e expected)
+
+    let%test_unit "non-200 returns Error with status code" =
+      match parse_response_body ~status_code:500 "server error" with
+      | Ok _ ->
+          failwith "expected Error"
+      | Error e ->
+          let expected =
+            Errors.create
+              ~context:"Response from Mina Daemon is not a 200"
+              (`Graphql_mina_query "Status code 500 -- server error")
+          in
+          assert (Errors.equal e expected)
+
+    let%test_unit "200 with empty JSON object returns Ok" =
+      match parse_response_body ~status_code:200 "{}" with
+      | Ok _ ->
+          ()
+      | Error _ ->
+          failwith "expected Ok"
+  end )

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -48,17 +48,26 @@ let query ~minimum_user_command_fee query_obj uri =
     Cohttp_async.Body.to_string body |> Deferred.map ~f:Result.return
   in
   let%bind body_json =
+    Deferred.return
+    @@
     match
       Cohttp.Code.code_of_status (Cohttp_async.Response.status response)
     with
-    | 200 ->
-        Deferred.return (Ok (Yojson.Basic.from_string body_str))
+    | 200 -> (
+        try
+          let parsed = Yojson.Basic.from_string body_str in
+          Ok parsed
+        with _ ->
+          Error
+            (Errors.create
+               ~context:"Can't parse mina daemon's GraphQL response as json"
+               (`Graphql_mina_query
+                 (Printf.sprintf "Can't parse as json: %s" body_str) ) ) )
     | code ->
-        Deferred.return
-          (Error
-             (Errors.create ~context:"Response from Mina Daemon is not a 200"
-                (`Graphql_mina_query
-                  (Printf.sprintf "Status code %d -- %s" code body_str) ) ) )
+        Error
+          (Errors.create ~context:"Response from Mina Daemon is not a 200"
+             (`Graphql_mina_query
+               (Printf.sprintf "Status code %d -- %s" code body_str) ) )
   in
   let open Yojson.Basic.Util in
   ( match (member "errors" body_json, member "data" body_json) with

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -38,33 +38,35 @@ let router ~signature_kind ~graphql_uri ~minimum_user_command_fee
       | `App _ as x ->
           x )
   in
-  try
-    match route with
-    | "network" :: tl ->
-        Network.router tl body ~get_graphql_uri_or_error ~logger
-          ~with_db:with_db' ~minimum_user_command_fee
-    | "account" :: tl ->
-        let%bind graphql_uri = get_graphql_uri_or_error () in
-        Account.router tl body ~graphql_uri ~logger ~with_db
-          ~minimum_user_command_fee
-    | "mempool" :: tl when not safe_mode ->
-        let%bind graphql_uri = get_graphql_uri_or_error () in
-        Mempool.router tl body ~graphql_uri ~logger ~minimum_user_command_fee
-    | "block" :: tl ->
-        let%bind graphql_uri = get_graphql_uri_or_error () in
-        Block.router tl body ~graphql_uri ~logger ~with_db:with_db'
-          ~minimum_user_command_fee
-    | "construction" :: tl when not safe_mode ->
-        Construction.router tl body ~signature_kind ~get_graphql_uri_or_error
-          ~logger ~with_db:with_db' ~minimum_user_command_fee
-          ~account_creation_fee
-    | "search" :: tl ->
-        let%bind graphql_uri = get_graphql_uri_or_error () in
-        Search.router tl body ~graphql_uri ~logger ~with_db:with_db'
-          ~minimum_user_command_fee
-    | _ ->
-        Deferred.return (Error `Page_not_found)
-  with exn -> Deferred.return (Error (`Exception exn))
+  Monitor.try_with ~extract_exn:true (fun () ->
+      match route with
+      | "network" :: tl ->
+          Network.router tl body ~get_graphql_uri_or_error ~logger
+            ~with_db:with_db' ~minimum_user_command_fee
+      | "account" :: tl ->
+          let%bind graphql_uri = get_graphql_uri_or_error () in
+          Account.router tl body ~graphql_uri ~logger ~with_db
+            ~minimum_user_command_fee
+      | "mempool" :: tl when not safe_mode ->
+          let%bind graphql_uri = get_graphql_uri_or_error () in
+          Mempool.router tl body ~graphql_uri ~logger ~minimum_user_command_fee
+      | "block" :: tl ->
+          let%bind graphql_uri = get_graphql_uri_or_error () in
+          Block.router tl body ~graphql_uri ~logger ~with_db:with_db'
+            ~minimum_user_command_fee
+      | "construction" :: tl when not safe_mode ->
+          Construction.router tl body ~signature_kind ~get_graphql_uri_or_error
+            ~logger ~with_db:with_db' ~minimum_user_command_fee
+            ~account_creation_fee
+      | "search" :: tl ->
+          let%bind graphql_uri = get_graphql_uri_or_error () in
+          Search.router tl body ~graphql_uri ~logger ~with_db:with_db'
+            ~minimum_user_command_fee
+      | _ ->
+          Deferred.return (Error `Page_not_found) )
+  |> Deferred.map ~f:(function
+       | Ok x -> x
+       | Error exn -> Error (`Exception exn) )
 
 let pg_log_data ~logger ~pool : unit Deferred.t =
   match%bind Lazy.force pool with

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -249,3 +249,63 @@ let command ?signature_kind ~minimum_user_command_fee ~account_creation_fee () =
       ~metadata:[ ("port", `Int port) ]
       "Rosetta process running on http://localhost:$port" ;
     Cohttp_async.Server.close_finished server
+
+
+let%test_module "router" =
+  ( module struct
+    let%test_unit "unknown route returns page_not_found" =
+      let pool =
+        lazy
+          (Deferred.Result.fail (`App (Errors.create `Graphql_uri_not_set)))
+      in
+      let result =
+        Thread_safe.block_on_async_exn (fun () ->
+          router ~signature_kind:Mina_signature_kind.Testnet ~graphql_uri:None
+            ~minimum_user_command_fee:Currency.Fee.zero
+            ~account_creation_fee:Currency.Fee.zero ~pool
+            ~logger:(Logger.null ()) ~safe_mode:false
+            [ "unknown" ] (`Null) )
+      in
+      match result with
+      | Error `Page_not_found ->
+          ()
+      | _ ->
+          failwith "expected Error `Page_not_found"
+
+    let%test_unit "Monitor.try_with catches sync exception" =
+      let result =
+        Thread_safe.block_on_async_exn (fun () ->
+          Monitor.try_with ~extract_exn:true (fun () ->
+            failwith "test sync exception" )
+          |> Deferred.map ~f:(function
+            | Ok _ ->
+                Error `Unexpected_ok
+            | Error _ ->
+                Ok () ) )
+      in
+      match result with
+      | Ok () ->
+          ()
+      | Error `Unexpected_ok ->
+          failwith "expected exception to be caught"
+
+    let%test_unit "Monitor.try_with exception maps to Exception error variant"
+        =
+      let result =
+        Thread_safe.block_on_async_exn (fun () ->
+          Monitor.try_with ~extract_exn:true (fun () ->
+            failwith "router exception test" )
+          |> Deferred.map ~f:(function
+            | Ok x ->
+                x
+            | Error exn ->
+                Error (`Exception exn) ) )
+      in
+      match result with
+      | Error (`Exception exn) ->
+          let msg = Exn.to_string exn in
+          assert (
+            String.is_substring msg ~substring:"router exception test" )
+      | Ok _ ->
+          failwith "expected Error (`Exception _)"
+  end )

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -64,9 +64,7 @@ let router ~signature_kind ~graphql_uri ~minimum_user_command_fee
             ~minimum_user_command_fee
       | _ ->
           Deferred.return (Error `Page_not_found) )
-  |> Deferred.map ~f:(function
-       | Ok x -> x
-       | Error exn -> Error (`Exception exn) )
+  |> Deferred.map ~f:(function Ok x -> x | Error exn -> Error (`Exception exn))
 
 let pg_log_data ~logger ~pool : unit Deferred.t =
   match%bind Lazy.force pool with
@@ -250,21 +248,18 @@ let command ?signature_kind ~minimum_user_command_fee ~account_creation_fee () =
       "Rosetta process running on http://localhost:$port" ;
     Cohttp_async.Server.close_finished server
 
-
 let%test_module "router" =
   ( module struct
     let%test_unit "unknown route returns page_not_found" =
       let pool =
-        lazy
-          (Deferred.Result.fail (`App (Errors.create `Graphql_uri_not_set)))
+        lazy (Deferred.Result.fail (`App (Errors.create `Graphql_uri_not_set)))
       in
       let result =
         Thread_safe.block_on_async_exn (fun () ->
-          router ~signature_kind:Mina_signature_kind.Testnet ~graphql_uri:None
-            ~minimum_user_command_fee:Currency.Fee.zero
-            ~account_creation_fee:Currency.Fee.zero ~pool
-            ~logger:(Logger.null ()) ~safe_mode:false
-            [ "unknown" ] (`Null) )
+            router ~signature_kind:Mina_signature_kind.Testnet ~graphql_uri:None
+              ~minimum_user_command_fee:Currency.Fee.zero
+              ~account_creation_fee:Currency.Fee.zero ~pool
+              ~logger:(Logger.null ()) ~safe_mode:false [ "unknown" ] `Null )
       in
       match result with
       | Error `Page_not_found ->
@@ -275,13 +270,13 @@ let%test_module "router" =
     let%test_unit "Monitor.try_with catches sync exception" =
       let result =
         Thread_safe.block_on_async_exn (fun () ->
-          Monitor.try_with ~extract_exn:true (fun () ->
-            failwith "test sync exception" )
-          |> Deferred.map ~f:(function
-            | Ok _ ->
-                Error `Unexpected_ok
-            | Error _ ->
-                Ok () ) )
+            Monitor.try_with ~extract_exn:true (fun () ->
+                failwith "test sync exception" )
+            |> Deferred.map ~f:(function
+                 | Ok _ ->
+                     Error `Unexpected_ok
+                 | Error _ ->
+                     Ok () ) )
       in
       match result with
       | Ok () ->
@@ -289,23 +284,21 @@ let%test_module "router" =
       | Error `Unexpected_ok ->
           failwith "expected exception to be caught"
 
-    let%test_unit "Monitor.try_with exception maps to Exception error variant"
-        =
+    let%test_unit "Monitor.try_with exception maps to Exception error variant" =
       let result =
         Thread_safe.block_on_async_exn (fun () ->
-          Monitor.try_with ~extract_exn:true (fun () ->
-            failwith "router exception test" )
-          |> Deferred.map ~f:(function
-            | Ok x ->
-                x
-            | Error exn ->
-                Error (`Exception exn) ) )
+            Monitor.try_with ~extract_exn:true (fun () ->
+                failwith "router exception test" )
+            |> Deferred.map ~f:(function
+                 | Ok x ->
+                     x
+                 | Error exn ->
+                     Error (`Exception exn) ) )
       in
       match result with
       | Error (`Exception exn) ->
           let msg = Exn.to_string exn in
-          assert (
-            String.is_substring msg ~substring:"router exception test" )
+          assert (String.is_substring msg ~substring:"router exception test")
       | Ok _ ->
           failwith "expected Error (`Exception _)"
   end )


### PR DESCRIPTION
## Problem

The Rosetta `/network/status` endpoint (and all other routes) was producing 502 errors under daemon stress. Two bugs combined to cause this:

**Bug 1 — `Yojson.Basic.from_string` could throw an uncaught exception (`graphql.ml`)**

When the Mina daemon returns a HTTP 200 with a non-JSON body (e.g. during restart or under load), `Yojson.Basic.from_string` throws `Yojson.Json_error`. This call lived inside an Async deferred callback, so it was never caught by the synchronous `try...with` in `rosetta.ml`. The exception escaped to `on_handler_error`, leaving the HTTP connection in a broken state (or killing the process if `MINA_ROSETTA_TERMINATE_ON_SERVER_ERROR` was set) — both visible as 502s from any reverse proxy.

**Bug 2 — `try...with` in `router` does not cover async exceptions (`rosetta.ml`)**

The top-level exception handler in `router` was a plain OCaml `try...with`. In Async, this only catches exceptions raised synchronously during deferred construction. Any exception raised inside a `let%bind`/`let%map` callback fires later in the event loop, outside the `try...with` scope, and propagates unhandled to `on_handler_error`.
