### PR TITLE
fix: discover rocksdb scanner paths dynamically in connect-to-network test

### DIFF
--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -146,29 +146,12 @@ mina client stop-daemon
 wait "$DAEMON_PID"
 
 # --- Step 3: Convert RocksDB to legacy format ---
-# Discover scanner paths dynamically since the mina version in the path changes with each build
-CURRENT_SCANNER=$(find /usr/lib/mina/storage/10.5.2 -name mina-rocksdb-scanner -type f | head -1)
-STABLE_SCANNER=$(find /usr/lib/mina/storage/5.7.12 -name mina-rocksdb-scanner -type f | head -1)
-
-if [[ -z "$CURRENT_SCANNER" ]]; then
-    echo "Error: Could not find current rocksdb scanner under /usr/lib/mina/storage/10.5.2/"
-    ls -laR /usr/lib/mina/storage/ || true
-    exit 1
-fi
-
-if [[ -z "$STABLE_SCANNER" ]]; then
-    echo "Error: Could not find stable rocksdb scanner under /usr/lib/mina/storage/5.7.12/"
-    ls -laR /usr/lib/mina/storage/ || true
-    exit 1
-fi
-
-echo "Using current scanner: $CURRENT_SCANNER"
-echo "Using stable scanner: $STABLE_SCANNER"
+LEGACY_MINA_VERSION="3.3.0"
 
 mina-storage-converter \
     --node-dir /home/opam/.mina-config \
-    --current-scanner "$CURRENT_SCANNER" \
-    --stable-scanner "$STABLE_SCANNER" \
+    --current-scanner /usr/lib/mina/storage/10.5.2/${GITTAG}/mina-rocksdb-scanner \
+    --stable-scanner /usr/lib/mina/storage/5.7.12/${LEGACY_MINA_VERSION}/mina-rocksdb-scanner \
     --yes --verbose
 
 if [[ "$MINA_DEBIAN_NETWORK" == "mainnet" ]]; then

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -146,10 +146,29 @@ mina client stop-daemon
 wait "$DAEMON_PID"
 
 # --- Step 3: Convert RocksDB to legacy format ---
+# Discover scanner paths dynamically since the mina version in the path changes with each build
+CURRENT_SCANNER=$(find /usr/lib/mina/storage/10.5.2 -name mina-rocksdb-scanner -type f | head -1)
+STABLE_SCANNER=$(find /usr/lib/mina/storage/5.7.12 -name mina-rocksdb-scanner -type f | head -1)
+
+if [[ -z "$CURRENT_SCANNER" ]]; then
+    echo "Error: Could not find current rocksdb scanner under /usr/lib/mina/storage/10.5.2/"
+    ls -laR /usr/lib/mina/storage/ || true
+    exit 1
+fi
+
+if [[ -z "$STABLE_SCANNER" ]]; then
+    echo "Error: Could not find stable rocksdb scanner under /usr/lib/mina/storage/5.7.12/"
+    ls -laR /usr/lib/mina/storage/ || true
+    exit 1
+fi
+
+echo "Using current scanner: $CURRENT_SCANNER"
+echo "Using stable scanner: $STABLE_SCANNER"
+
 mina-storage-converter \
     --node-dir /home/opam/.mina-config \
-    --current-scanner /usr/lib/mina/storage/10.5.2/3.3.0/mina-rocksdb-scanner \
-    --stable-scanner /usr/lib/mina/storage/5.7.12/3.3.0/mina-rocksdb-scanner \
+    --current-scanner "$CURRENT_SCANNER" \
+    --stable-scanner "$STABLE_SCANNER" \
     --yes --verbose
 
 if [[ "$MINA_DEBIAN_NETWORK" == "mainnet" ]]; then


### PR DESCRIPTION
## Summary
- The `connect-to-network.sh` test hardcoded the mina version tag `3.3.0` in rocksdb scanner paths (`/usr/lib/mina/storage/<rocksdb_ver>/3.3.0/mina-rocksdb-scanner`)
- The deb package installs scanners at `/usr/lib/mina/storage/<rocksdb_ver>/<GITTAG>/mina-rocksdb-scanner` where `GITTAG` changes every build
- Now uses `find` to discover scanner binaries dynamically under each rocksdb version directory, with error messages that dump the storage layout if not found

Fixes: https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1242#019d5247-1795-4209-9896-4525495fbf2e

## Test plan
- [ ] ConnectToMainnet CI job passes with dynamically resolved scanner paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)