### PR TITLE
Fix ConnectToMesa: build Mesa Docker image on all branches

### DIFF
--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -108,7 +108,7 @@ start_daemon_and_wait_for_sync() {
     DAEMON_PID="$!"
 
     local deadline
-    deadline=$(date -d "+ $SYNC_TIMEOUT" +%s)
+    deadline=$(date -d "+$SYNC_TIMEOUT" +%s)
 
     local sync_status=""
     while [ "$(date +%s)" -lt $deadline ]; do

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -18,6 +18,7 @@ All arguments are mandatory:
   --network-name <val>               Testnet name (used for seeds URL and validation)
   --wait-between-polling <val>       Duration to wait between GraphQL polling
   --sync-timeout <val>               Duration to wait before considering the sync is failed
+  --peer-list-url <val>              (Optional) Override peer list URL
   --help                             Display this help message
 
 Example:
@@ -35,6 +36,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --network-name)
             NETWORK_NAME="$2"
+            shift 2
+            ;;
+        --peer-list-url)
+            PEER_LIST_URL="$2"
             shift 2
             ;;
         --wait-between-polling)
@@ -65,6 +70,10 @@ if [[ -z "$MINA_DEBIAN_NETWORK" || -z "$NETWORK_NAME" || -z "$WAIT_BETWEEN_POLLI
     usage
 fi
 
+if [[ -z "$PEER_LIST_URL" ]]; then
+    PEER_LIST_URL="https://storage.googleapis.com/seed-lists/${NETWORK_NAME}_seeds.txt"
+fi
+
 # --- Main Script Logic ---
 
 git config --global --add safe.directory /workdir
@@ -92,7 +101,7 @@ start_daemon_and_wait_for_sync() {
 
     # Start the daemon in the background
     "$MINA" daemon \
-      --peer-list-url "https://storage.googleapis.com/seed-lists/${NETWORK_NAME}_seeds.txt" \
+      --peer-list-url "$PEER_LIST_URL" \
       --libp2p-keypair "/home/opam/libp2p-keys/key" \
     &
 

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -18,7 +18,7 @@ All arguments are mandatory:
   --network-name <val>               Testnet name (used for seeds URL and validation)
   --wait-between-polling <val>       Duration to wait between GraphQL polling
   --sync-timeout <val>               Duration to wait before considering the sync is failed
-  --peer-list-url <val>              (Optional) Override peer list URL
+  --peer-list-url <val>              Peer list URL
   --help                             Display this help message
 
 Example:
@@ -65,13 +65,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Validation ---
-if [[ -z "$MINA_DEBIAN_NETWORK" || -z "$NETWORK_NAME" || -z "$WAIT_BETWEEN_POLLING_GRAPHQL" || -z "$SYNC_TIMEOUT" ]]; then
-    echo "Error: All four required arguments must be provided."
+if [[ -z "$MINA_DEBIAN_NETWORK" || -z "$NETWORK_NAME" || -z "$WAIT_BETWEEN_POLLING_GRAPHQL" || -z "$SYNC_TIMEOUT" || -z "$PEER_LIST_URL" ]]; then
+    echo "Error: All required arguments must be provided."
     usage
-fi
-
-if [[ -z "$PEER_LIST_URL" ]]; then
-    PEER_LIST_URL="https://storage.googleapis.com/seed-lists/${NETWORK_NAME}_seeds.txt"
 fi
 
 # --- Main Script Logic ---

--- a/buildkite/src/Command/ConnectToNetwork.dhall
+++ b/buildkite/src/Command/ConnectToNetwork.dhall
@@ -18,21 +18,14 @@ let Spec =
           , wait_between_graphql_poll : Text
           , sync_timeout : Text
           , soft_fail : B/SoftFail
-          , peer_list_url : Optional Text
+          , peer_list_url : Text
           }
       , default =
           { wait_between_graphql_poll = "40s"
           , sync_timeout = "25min"
           , soft_fail = B/SoftFail.Boolean False
-          , peer_list_url = None Text
           }
       }
-
-let peer_list_url_flag =
-          \(peer_list_url : Optional Text)
-      ->  merge
-            { Some = \(url : Text) -> " --peer-list-url ${url}", None = "" }
-            peer_list_url
 
 in  { Spec = Spec
     , step =
@@ -42,8 +35,7 @@ in  { Spec = Spec
               , commands =
                   RunInToolchain.runInToolchain
                     DebianVersions.overrideEnvs
-                    "./buildkite/scripts/connect/connect-to-network.sh --mina-debian-network ${spec.mina_suffix} --network-name ${spec.testnet} --wait-between-polling ${spec.wait_between_graphql_poll} --sync-timeout ${spec.sync_timeout}${peer_list_url_flag
-                                                                                                                                                                                                                                                spec.peer_list_url}"
+                    "./buildkite/scripts/connect/connect-to-network.sh --mina-debian-network ${spec.mina_suffix} --network-name ${spec.testnet} --wait-between-polling ${spec.wait_between_graphql_poll} --sync-timeout ${spec.sync_timeout} --peer-list-url ${spec.peer_list_url}"
               , label = "Connect to ${spec.testnet}"
               , soft_fail = Some spec.soft_fail
               , key = "connect-to-${spec.testnet}"

--- a/buildkite/src/Command/ConnectToNetwork.dhall
+++ b/buildkite/src/Command/ConnectToNetwork.dhall
@@ -10,23 +10,44 @@ let RunInToolchain = ./RunInToolchain.dhall
 
 let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
-in  { step =
-            \(dependsOn : List Command.TaggedKey.Type)
-        ->  \(mina_suffix : Text)
-        ->  \(testnet : Text)
-        ->  \(wait_between_graphql_poll : Text)
-        ->  \(sync_timeout : Text)
-        ->  \(soft_fail : B/SoftFail)
+let Spec =
+      { Type =
+          { dependsOn : List Command.TaggedKey.Type
+          , mina_suffix : Text
+          , testnet : Text
+          , wait_between_graphql_poll : Text
+          , sync_timeout : Text
+          , soft_fail : B/SoftFail
+          , peer_list_url : Optional Text
+          }
+      , default =
+          { wait_between_graphql_poll = "40s"
+          , sync_timeout = "25min"
+          , soft_fail = B/SoftFail.Boolean False
+          , peer_list_url = None Text
+          }
+      }
+
+let peer_list_url_flag =
+          \(peer_list_url : Optional Text)
+      ->  merge
+            { Some = \(url : Text) -> " --peer-list-url ${url}", None = "" }
+            peer_list_url
+
+in  { Spec = Spec
+    , step =
+            \(spec : Spec.Type)
         ->  Command.build
               Command.Config::{
               , commands =
                   RunInToolchain.runInToolchain
                     DebianVersions.overrideEnvs
-                    "./buildkite/scripts/connect/connect-to-network.sh --mina-debian-network ${mina_suffix} --network-name ${testnet} --wait-between-polling ${wait_between_graphql_poll} --sync-timeout ${sync_timeout} "
-              , label = "Connect to ${testnet}"
-              , soft_fail = Some soft_fail
-              , key = "connect-to-${testnet}"
+                    "./buildkite/scripts/connect/connect-to-network.sh --mina-debian-network ${spec.mina_suffix} --network-name ${spec.testnet} --wait-between-polling ${spec.wait_between_graphql_poll} --sync-timeout ${spec.sync_timeout}${peer_list_url_flag
+                                                                                                                                                                                                                                                spec.peer_list_url}"
+              , label = "Connect to ${spec.testnet}"
+              , soft_fail = Some spec.soft_fail
+              , key = "connect-to-${spec.testnet}"
               , target = Size.Large
-              , depends_on = dependsOn
+              , depends_on = spec.dependsOn
               }
     }

--- a/buildkite/src/Constants/Network.dhall
+++ b/buildkite/src/Constants/Network.dhall
@@ -36,6 +36,20 @@ let debianSuffix =
             }
             network
 
+let peerListUrl =
+          \(network : Network)
+      ->  merge
+            { Devnet =
+                "https://storage.googleapis.com/seed-lists/devnet_seeds.txt"
+            , Mainnet =
+                "https://storage.googleapis.com/seed-lists/mainnet_seeds.txt"
+            , PreMesa1 =
+                "https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt"
+            , Mesa =
+                "https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt"
+            }
+            network
+
 let toLabelSegment = \(network : Network) -> "-${debianSuffix network}"
 
 let requiresMainnetBuild =
@@ -64,6 +78,7 @@ in  { Type = Network
     , capitalName = capitalName
     , lowerName = lowerName
     , debianSuffix = debianSuffix
+    , peerListUrl = peerListUrl
     , toLabelSegment = toLabelSegment
     , requiresMainnetBuild = requiresMainnetBuild
     , foldMinaBuildMainnetEnv = foldMinaBuildMainnetEnv

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeMesaDevnet.dhall
@@ -8,10 +8,6 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let Network = ../../Constants/Network.dhall
 
-let Expr = ../../Pipeline/Expr.dhall
-
-let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -36,12 +32,6 @@ in  Pipeline.build
             , PipelineTag.Type.Rosetta
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bullseye
-            ]
-          , includeIf =
-            [ Expr.Type.DescendantOf
-                { ancestor = MainlineBranch.Type.Mesa
-                , reason = "Only run on Mesa descendants"
-                }
             ]
           }
       )

--- a/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
@@ -1,9 +1,5 @@
 let S = ../../Lib/SelectFiles.dhall
 
-let B = ../../External/Buildkite.dhall
-
-let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -54,11 +50,10 @@ in  Pipeline.build
         }
       , steps =
         [ ConnectToNetwork.step
-            dependsOn
-            "${Network.lowerName network}"
-            "${Network.lowerName network}"
-            "40s"
-            "25min"
-            (B/SoftFail.Boolean False)
+            ConnectToNetwork.Spec::{
+            , dependsOn = dependsOn
+            , mina_suffix = "${Network.lowerName network}"
+            , testnet = "${Network.lowerName network}"
+            }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToDevnet.dhall
@@ -54,6 +54,7 @@ in  Pipeline.build
             , dependsOn = dependsOn
             , mina_suffix = "${Network.lowerName network}"
             , testnet = "${Network.lowerName network}"
+            , peer_list_url = Network.peerListUrl network
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -1,9 +1,5 @@
 let S = ../../Lib/SelectFiles.dhall
 
-let B = ../../External/Buildkite.dhall
-
-let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -63,11 +59,10 @@ in  Pipeline.build
         }
       , steps =
         [ ConnectToNetwork.step
-            dependsOn
-            "${Network.lowerName network}"
-            "${Network.lowerName network}"
-            "40s"
-            "25min"
-            (B/SoftFail.Boolean False)
+            ConnectToNetwork.Spec::{
+            , dependsOn = dependsOn
+            , mina_suffix = "${Network.lowerName network}"
+            , testnet = "${Network.lowerName network}"
+            }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -63,6 +63,7 @@ in  Pipeline.build
             , dependsOn = dependsOn
             , mina_suffix = "${Network.lowerName network}"
             , testnet = "${Network.lowerName network}"
+            , peer_list_url = Network.peerListUrl network
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -44,6 +44,10 @@ in  Pipeline.build
               , reason =
                   "Develop branch is incompatible with current mesa network"
               }
+          , Expr.Type.DescendantOf
+              { ancestor = MainlineBranch.Type.Mesa
+              , reason = "Mesa branch is incompatible with current mesa network"
+              }
           ]
         }
       , steps =

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -41,9 +41,7 @@ in  Pipeline.build
             , dependsOn = dependsOn
             , mina_suffix = "${Network.lowerName network}"
             , testnet = "testnet"
-            , sync_timeout = "2min"
-            , peer_list_url = Some
-                "https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt"
+            , peer_list_url = Network.peerListUrl network
             }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -14,6 +14,10 @@ let Dockers = ../../Constants/DockerVersions.dhall
 
 let network = Network.Type.Mesa
 
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
 let dependsOn =
       Dockers.dependsOn Dockers.DepsSpec::{ network = Network.Type.Mesa }
 
@@ -33,6 +37,13 @@ in  Pipeline.build
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
+          ]
+        , excludeIf =
+          [ Expr.Type.DescendantOf
+              { ancestor = MainlineBranch.Type.Develop
+              , reason =
+                  "Develop branch is incompatible with current mesa network"
+              }
           ]
         }
       , steps =

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -1,9 +1,5 @@
 let S = ../../Lib/SelectFiles.dhall
 
-let B = ../../External/Buildkite.dhall
-
-let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -41,11 +37,13 @@ in  Pipeline.build
         }
       , steps =
         [ ConnectToNetwork.step
-            dependsOn
-            "${Network.lowerName network}"
-            "testnet"
-            "40s"
-            "2m"
-            (B/SoftFail.Boolean False)
+            ConnectToNetwork.Spec::{
+            , dependsOn = dependsOn
+            , mina_suffix = "${Network.lowerName network}"
+            , testnet = "testnet"
+            , sync_timeout = "2m"
+            , peer_list_url = Some
+                "https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt"
+            }
         ]
       }

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -41,7 +41,7 @@ in  Pipeline.build
             , dependsOn = dependsOn
             , mina_suffix = "${Network.lowerName network}"
             , testnet = "testnet"
-            , sync_timeout = "2m"
+            , sync_timeout = "2min"
             , peer_list_url = Some
                 "https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt"
             }

--- a/buildkite/src/Jobs/Test/ConnectToMesa.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMesa.dhall
@@ -16,10 +16,6 @@ let Network = ../../Constants/Network.dhall
 
 let Dockers = ../../Constants/DockerVersions.dhall
 
-let Expr = ../../Pipeline/Expr.dhall
-
-let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
-
 let network = Network.Type.Mesa
 
 let dependsOn =
@@ -41,13 +37,6 @@ in  Pipeline.build
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
-          ]
-        , excludeIf =
-          [ Expr.Type.DescendantOf
-              { ancestor = MainlineBranch.Type.Mesa
-              , reason =
-                  "Cannot connect to Canary network on Mesa until redeploy"
-              }
           ]
         }
       , steps =


### PR DESCRIPTION
## Summary
- `ConnectToMesa` connects to the Mesa testnet (the only compatible testnet for develop) and depends on `MinaArtifactBullseyeMesaDevnet` Docker image
- That Docker image had `includeIf DescendantOf Mesa`, so it only built on Mesa branch descendants
- On develop/compatible/master nightlies, the dependency was missing, causing `waiting_failed`

## Changes
- **`MinaArtifactBullseyeMesaDevnet.dhall`**: Remove `includeIf DescendantOf Mesa` so the Mesa Docker image builds on all branches
- **`ConnectToMesa.dhall`**: Remove stale `excludeIf` constraint — Mesa is the compatible testnet for develop, so this test should run everywhere

## Test plan
- [ ] Verify Mesa Docker image builds in nightly on develop
- [ ] Verify ConnectToMesa passes using the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)