### PR TITLE
Add minimina debian release support

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -13,7 +13,7 @@
 # - FIX: Repair Debian repository manifests when needed
 # - PERSIST: Archive artifacts to long-term storage backends
 #
-# Supported artifacts: mina-daemon, mina-archive, mina-rosetta, mina-logproc, mina-config, mina-generic, rosetta-generic, mina-postfork-mesa, mina-prefork-mesa
+# Supported artifacts: mina-daemon, mina-archive, mina-rosetta, mina-logproc, mina-config, mina-generic, rosetta-generic, mina-postfork-mesa, mina-prefork-mesa, minimina
 # Supported networks: devnet, mainnet
 # Supported platforms: Debian (bullseye, focal), Docker (GCR, Docker.io)
 # Supported channels: unstable, alpha, beta, stable
@@ -142,7 +142,7 @@ function main_help(){
     echo " architectures: $DEFAULT_ARCHITECTURES"
     echo ""
     echo "Available values: "
-    echo " artifacts: mina-logproc,mina-archive,mina-rosetta,mina-daemon,mina-config,mina-generic,rosetta-generic,mina-postfork-mesa,mina-prefork-mesa"
+    echo " artifacts: mina-logproc,mina-archive,mina-rosetta,mina-daemon,mina-config,mina-generic,rosetta-generic,mina-postfork-mesa,mina-prefork-mesa,minimina"
     echo " networks: devnet,mainnet"
     echo " codenames: bullseye,focal"
     echo " channels: unstable,alpha,beta,stable"
@@ -915,7 +915,7 @@ function publish(){
         for artifact in "${__artifacts_arr[@]}"; do
             for __codename in "${__codenames_arr[@]}"; do
                     case $artifact in
-                            mina-logproc)
+                            mina-logproc|minimina)
 
                                 if [[ $__only_dockers == 0 ]]; then
                                         publish_debian $artifact \
@@ -1359,7 +1359,7 @@ function promote(){
     for artifact in "${__artifacts_arr[@]}"; do
         for __codename in "${__codenames_arr[@]}"; do
                     case $artifact in
-                        mina-logproc)
+                        mina-logproc|minimina)
 
                             if [[ $__only_dockers == 0 ]]; then
                                 promote_debian $artifact \
@@ -1377,7 +1377,7 @@ function promote(){
                             fi
 
                             if [[ $__only_debians == 0 ]]; then
-                                echo "   ℹ️  There is no mina-logproc docker image to promote. skipping"
+                                echo "   ℹ️  There is no $artifact docker image to promote. skipping"
                             fi
 
 
@@ -1716,7 +1716,7 @@ function verify(){
         for artifact in "${__artifacts_arr[@]}"; do
             for __codename in "${__codenames_arr[@]}"; do
                         case $artifact in
-                            mina-logproc)
+                            mina-logproc|minimina)
 
                                 if [[ $__only_dockers == 0 ]]; then
                                         echo "     📋  Verifying: $artifact debian on $__channel channel with $__version version for $__codename codename"
@@ -1732,7 +1732,7 @@ function verify(){
                                 fi
 
                                 if [[ $__only_debians == 0 ]]; then
-                                    echo "    ℹ️  There is no mina-logproc docker image. skipping"
+                                    echo "    ℹ️  There is no $artifact docker image. skipping"
                                 fi
 
                             ;;
@@ -2926,7 +2926,7 @@ function progress(){
                     for artifact in "${__artifacts_arr[@]}"; do
                         # Handle artifacts that need network suffix
                         case $artifact in
-                            mina-logproc)
+                            mina-logproc|minimina)
                                 local package_name="$artifact"
                                 ((total_debian_checks=total_debian_checks+1))
 
@@ -3015,7 +3015,7 @@ function progress(){
 
         for artifact in "${__artifacts_arr[@]}"; do
             # Skip artifacts that have no docker image
-            if [[ "$artifact" == "mina-logproc" || "$artifact" == "mina-config" || "$artifact" == "mina-postfork-mesa" || "$artifact" == "mina-prefork-mesa" ]]; then
+            if [[ "$artifact" == "mina-logproc" || "$artifact" == "minimina" || "$artifact" == "mina-config" || "$artifact" == "mina-postfork-mesa" || "$artifact" == "mina-prefork-mesa" ]]; then
                 continue
             fi
 


### PR DESCRIPTION
## Summary
- Add `minimina` as a supported artifact in `buildkite/scripts/release/manager.sh`
- Follows the same pattern as `mina-logproc`: no network argument, debian-only (no docker images)
- Supported across all release operations: publish, promote, verify, and progress

## Test plan
- [ ] Run `./manager.sh publish --artifacts minimina --only-debians ...` and verify it publishes correctly
- [ ] Run `./manager.sh promote --artifacts minimina --only-debians ...` and verify promotion works
- [ ] Run `./manager.sh verify --artifacts minimina --only-debians ...` and verify verification works

🤖 Generated with [Claude Code](https://claude.com/claude-code)