### PR TITLE
Disable subprocess ITN logging by default

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1565,7 +1565,8 @@ let send_resource_pool_diff_or_wait ~rl ~diff_score ~max_per_15_seconds diff =
 module type Itn_settable = sig
   type t
 
-  val set_itn_logger_data : t -> daemon_port:int -> unit Deferred.Or_error.t
+  val set_itn_logger_data :
+    t -> daemon_port:int option -> unit Deferred.Or_error.t
 end
 
 let start_filtered_log ~commit_id
@@ -1775,7 +1776,13 @@ let create ~commit_id ?wallets (config : Config.t) =
           let ({ client_port; _ } : Node_addrs_and_ports.t) =
             config.gossip_net_params.addrs_and_ports
           in
-          match%map M.set_itn_logger_data t ~daemon_port:client_port with
+          let itn_subprocess_logging =
+            Sys.getenv "ITN_SUBPROCESS_LOGGING" |> Option.is_some
+          in
+          match%map
+            M.set_itn_logger_data t
+              ~daemon_port:(Option.some_if itn_subprocess_logging client_port)
+          with
           | Ok () ->
               ()
           | Error err ->

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -66,7 +66,8 @@ module type S = sig
   (* in ITN logger, sets the client port of daemon to send RPC requests to
      sets the process kind for the Itn logger to "prover"
   *)
-  val set_itn_logger_data : t -> daemon_port:int -> unit Deferred.Or_error.t
+  val set_itn_logger_data :
+    t -> daemon_port:int option -> unit Deferred.Or_error.t
 
   val get_blockchain_verification_key :
     t -> Pickles.Verification_key.t Deferred.Or_error.t

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -55,7 +55,7 @@ module Worker_state = struct
 
     val toggle_internal_tracing : bool -> unit
 
-    val set_itn_logger_data : daemon_port:int -> unit
+    val set_itn_logger_data : daemon_port:int option -> unit
 
     val get_blockchain_verification_key :
       unit -> Pickles.Verification_key.t Deferred.t
@@ -303,7 +303,7 @@ module Functions = struct
         Deferred.unit )
 
   let set_itn_logger_data =
-    create bin_int bin_unit (fun w daemon_port ->
+    create (bin_option bin_int) bin_unit (fun w daemon_port ->
         let (module M) = Worker_state.get w in
         M.set_itn_logger_data ~daemon_port ;
         Deferred.unit )
@@ -331,7 +331,7 @@ module Worker = struct
           ('w, Extend_blockchain_input.t, Blockchain.t Or_error.t) F.t
       ; verify_blockchain : ('w, Blockchain.t, unit Or_error.t) F.t
       ; toggle_internal_tracing : ('w, bool, unit) F.t
-      ; set_itn_logger_data : ('w, int, unit) F.t
+      ; set_itn_logger_data : ('w, int option, unit) F.t
       ; get_blockchain_verification_key :
           ('w, unit, Pickles.Verification_key.t) F.t
       ; get_transaction_verification_key :

--- a/src/lib/testing/itn_logger/itn_logger.ml
+++ b/src/lib/testing/itn_logger/itn_logger.ml
@@ -49,7 +49,7 @@ let daemon_where_to_connect, set_daemon_port =
       (Host_and_port.create ~host:"127.0.0.1" ~port)
   in
   let where = ref None in
-  let set port = where := Some (mk_where port) in
+  let set port = where := Option.map ~f:mk_where port in
   let get_where () = !where in
   (get_where, set)
 
@@ -67,46 +67,37 @@ module Submit_internal_log = struct
       ~bin_response
 end
 
-let dispatch_remote_log log =
+let dispatch_remote_log (log, where_to_connect) =
   let open Async.Deferred.Let_syntax in
   let rpc = Submit_internal_log.rpc in
-  match daemon_where_to_connect () with
-  | None ->
-      (* daemon port is set just after verifier, prover are created
-         so should never happen
-      *)
-      eprintf "No daemon port set for ITN logger" ;
-      Async.Deferred.unit
-  | Some where_to_connect -> (
-      let%map res =
-        Async.Rpc.Connection.with_client
-          ~handshake_timeout:
-            (Time.Span.of_sec
-               Node_config_unconfigurable_constants.rpc_handshake_timeout_sec )
-          ~heartbeat_config:
-            (Async.Rpc.Connection.Heartbeat_config.create
-               ~timeout:
-                 (Time_ns.Span.of_sec
-                    Node_config_unconfigurable_constants
-                    .rpc_heartbeat_timeout_sec )
-               ~send_every:
-                 (Time_ns.Span.of_sec
-                    Node_config_unconfigurable_constants
-                    .rpc_heartbeat_send_every_sec )
-               () )
-          where_to_connect
-          (fun conn -> Async.Rpc.Rpc.dispatch rpc conn log)
-      in
-      (* not ideal that errors are not themselves logged *)
-      match res with
-      | Ok (Ok ()) ->
-          ()
-      | Ok (Error err) ->
-          eprintf "Error sending internal log via RPC: %s"
-            (Error.to_string_mach err)
-      | Error exn ->
-          eprintf "Exception when sending internal log via RPC: %s"
-            (Exn.to_string_mach exn) )
+  let%map res =
+    Async.Rpc.Connection.with_client
+      ~handshake_timeout:
+        (Time.Span.of_sec
+           Node_config_unconfigurable_constants.rpc_handshake_timeout_sec )
+      ~heartbeat_config:
+        (Async.Rpc.Connection.Heartbeat_config.create
+           ~timeout:
+             (Time_ns.Span.of_sec
+                Node_config_unconfigurable_constants.rpc_heartbeat_timeout_sec )
+           ~send_every:
+             (Time_ns.Span.of_sec
+                Node_config_unconfigurable_constants
+                .rpc_heartbeat_send_every_sec )
+           () )
+      where_to_connect
+      (fun conn -> Async.Rpc.Rpc.dispatch rpc conn log)
+  in
+  (* not ideal that errors are not themselves logged *)
+  match res with
+  | Ok (Ok ()) ->
+      ()
+  | Ok (Error err) ->
+      eprintf "Error sending internal log via RPC: %s"
+        (Error.to_string_mach err)
+  | Error exn ->
+      eprintf "Exception when sending internal log via RPC: %s"
+        (Exn.to_string_mach exn)
 
 (* Used to ensure that no more than one log message is in-flight at
    a time to guarantee sequential processing. *)
@@ -126,8 +117,8 @@ let sequential_log_writer_pipe = sequential_dispatcher_loop ()
     to the daemon, resulting in a recursive call of type (2)
 *)
 let log ?process ~timestamp ~message ~metadata () =
-  match get_process_kind () with
-  | Some process ->
+  match (daemon_where_to_connect (), get_process_kind ()) with
+  | Some where_to_connect, Some process ->
       (* prover or verifier, send log to daemon
 
          we can't Bin_prot-serialize JSON, so make it a string
@@ -136,8 +127,9 @@ let log ?process ~timestamp ~message ~metadata () =
         List.map metadata ~f:(fun (s, json) -> (s, Yojson.Safe.to_string json))
       in
       let remote_log = { timestamp; message; metadata; process } in
-      Async.Pipe.write_without_pushback sequential_log_writer_pipe remote_log
-  | None ->
+      Async.Pipe.write_without_pushback sequential_log_writer_pipe
+        (remote_log, where_to_connect)
+  | None, None ->
       (* daemon *)
       (* convert JSON to Basic.t in queue, so we don't have to in GraphQL response *)
       let metadata =
@@ -155,6 +147,9 @@ let log ?process ~timestamp ~message ~metadata () =
       if Queue.length log_queue > get_queue_bound () then
         ignore (Queue.dequeue_exn log_queue : t) ;
       incr_counter ()
+  | _, _ ->
+      (* ignoring: this is not daemon, and daemon didn't provide the port *)
+      ()
 
 let get_logs start_log_id =
   let filtered_queue =

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -59,7 +59,7 @@ module Worker_state = struct
 
     val toggle_internal_tracing : bool -> unit
 
-    val set_itn_logger_data : daemon_port:int -> unit
+    val set_itn_logger_data : daemon_port:int option -> unit
   end
 
   (* bin_io required by rpc_parallel *)
@@ -196,7 +196,7 @@ module Worker = struct
             list )
           F.t
       ; toggle_internal_tracing : ('w, bool, unit) F.t
-      ; set_itn_logger_data : ('w, int, unit) F.t
+      ; set_itn_logger_data : ('w, int option, unit) F.t
       }
 
     module Worker_state = Worker_state
@@ -280,7 +280,7 @@ module Worker = struct
               , toggle_internal_tracing )
         ; set_itn_logger_data =
             f
-              ( [%bin_type_class: int]
+              ( [%bin_type_class: int option]
               , [%bin_type_class: unit]
               , set_itn_logger_data )
         }

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -50,7 +50,8 @@ module Base = struct
     (* in ITN logger, sets the client port of daemon to send RPC requests to
        sets the process kind for the Itn logger to "verifier"
     *)
-    val set_itn_logger_data : t -> daemon_port:int -> unit Or_error.t Deferred.t
+    val set_itn_logger_data :
+      t -> daemon_port:int option -> unit Or_error.t Deferred.t
   end
 end
 


### PR DESCRIPTION
Due to a bug in glibc, certain usages of networking should be avoided, if possible. That includes the pattern present in ITN logging: active repeated creation of TCP connections, that seemed to have made the glibc bug occurance more probable.

To prevent future disruption in ITN testing, it's good to disable reporting of subprocess ITN logs to daemon.

Explain your changes:
* Disable reporting of ITN logs on subrocesses unless an anvironment variable `ITN_SUBPROCESS_LOGGING` is set

Explain how you tested your changes:
* TODO

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
