### PR TITLE
fix: improve batcher verification error logging

### DIFF
--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -284,7 +284,7 @@ module Transaction_pool = struct
       | `Init d ->
           (* Initially, the status of all the transactions in a never-before-seen
              diff are unknown. *)
-          `In_progress (Array.of_list_map d.data ~f:(fun _ -> `Unknown))
+          `In_progress (Array.create ~len:(List.length d.data) `Unknown)
       | `Partially_validated d ->
           (* We've seen this diff before, so we have some information about its
              transactions. *)

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -267,7 +267,8 @@ module Transaction_pool = struct
       * ( Pickles.Side_loaded.Verification_key.t
         * Zkapp_statement.t
         * Pickles.Side_loaded.Proof.t )
-        list ]
+        list
+      * Error.t ]
   [@@deriving sexp_of]
 
   type partial = partial_item list [@@deriving sexp_of]
@@ -323,7 +324,7 @@ module Transaction_pool = struct
                           match c with
                           | `Valid _ ->
                               None
-                          | `Valid_assuming (v, _) ->
+                          | `Valid_assuming (v, _, _) ->
                               (* TODO: This rechecks the signatures on zkApp transactions... oh well for now *)
                               Some ((i, j), v) ) )
             in
@@ -356,7 +357,7 @@ module Transaction_pool = struct
                 | `Invalid_proof err ->
                     (* Invalidate the whole diff *)
                     result.(i) <- `Invalid_proof err
-                | `Valid_assuming xs -> (
+                | `Valid_assuming (xs, err) -> (
                     match result.(i) with
                     | `Invalid_keys _
                     | `Invalid_signature _
@@ -369,7 +370,7 @@ module Transaction_pool = struct
                         ()
                     | `In_progress a ->
                         (* The diff may still be valid. *)
-                        a.(j) <- `Valid_assuming (v, xs) )
+                        a.(j) <- `Valid_assuming (v, xs, err) )
                 | `Valid c -> (
                     (* Similar to the above. *)
                     match result.(i) with
@@ -402,15 +403,24 @@ module Transaction_pool = struct
                   | Some res ->
                       `Valid res
                   | None ->
+                      let collected_errors =
+                        Array.to_sequence a
+                        |> Sequence.filter_map ~f:(function
+                             | `Valid_assuming (_, _, err) ->
+                                 Some err
+                             | _ ->
+                                 None )
+                        |> Sequence.to_list
+                      in
                       `Potentially_invalid
                         ( list_of_array_map a ~f:(function
                             | `Unknown ->
                                 assert false
                             | `Valid c ->
                                 `Valid c
-                            | `Valid_assuming (v, xs) ->
-                                `Valid_assuming (v, xs) )
-                        , Error.of_string "In progress" ) ) ) ) )
+                            | `Valid_assuming (v, xs, err) ->
+                                `Valid_assuming (v, xs, err) )
+                        , Error.of_list collected_errors ) ) ) ) )
 
   let verify (t : t) = verify t
 end

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -412,6 +412,13 @@ module Transaction_pool = struct
                                  None )
                         |> Sequence.to_list
                       in
+                      let error_attached =
+                        match collected_errors with
+                        | [] ->
+                            Error.of_string "In progress"
+                        | errors ->
+                            Error.of_list errors
+                      in
                       `Potentially_invalid
                         ( list_of_array_map a ~f:(function
                             | `Unknown ->
@@ -420,7 +427,7 @@ module Transaction_pool = struct
                                 `Valid c
                             | `Valid_assuming (v, xs, err) ->
                                 `Valid_assuming (v, xs, err) )
-                        , Error.of_list collected_errors ) ) ) ) )
+                        , error_attached ) ) ) ) )
 
   let verify (t : t) = verify t
 end

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -35,14 +35,18 @@ let invalid_to_error (invalid : invalid) : Error.t =
       Error.tag ~tag:"Invalid_proof" err
 
 let check_signed_command ~signature_kind c =
-  if not (Signed_command.check_valid_keys c) then
-    Result.Error (`Invalid_keys (Signed_command.public_keys c))
-  else
-    match Signed_command.check_only_for_signature ~signature_kind c with
-    | Some _ ->
-        Result.Ok (`Assuming [])
-    | None ->
-        Result.Error (`Invalid_signature (Signed_command.public_keys c))
+  let public_keys = Signed_command.public_keys c in
+  let invalid_keys =
+    List.filter public_keys ~f:(fun pk ->
+        Option.is_none (Signature_lib.Public_key.decompress pk) )
+  in
+  match (invalid_keys, Signed_command.check_signature ~signature_kind c) with
+  | [], true ->
+      Result.Ok (`Assuming [])
+  | (_ :: _ as invalid_keys), _ ->
+      Error (`Invalid_keys invalid_keys)
+  | _, false ->
+      Error (`Invalid_signature (Signed_command.public_keys c))
 
 let collect_vk_assumption
     ( (p : (Account_update.Body.t, _ Control.Poly.t, _) Account_update.Poly.t)

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -90,6 +90,7 @@ let verify_commands { proof_level; signature_kind; _ }
       * Mina_base.Zkapp_statement.t
       * Pickles.Side_loaded.Proof.t )
       list
+      * Error.t
     | Common.invalid ]
     list
     Deferred.Or_error.t =
@@ -138,9 +139,12 @@ let verify_commands { proof_level; signature_kind; _ }
             invalid
         | Ok (`Assuming []) ->
             valid cmd
-        | Ok (`Assuming xs) ->
-            if Or_error.is_ok all_verified then valid cmd
-            else `Valid_assuming xs
+        | Ok (`Assuming xs) -> (
+            match all_verified with
+            | Ok () ->
+                valid cmd
+            | Error err ->
+                `Valid_assuming (xs, err) )
       in
       Ok (List.map2_exn cs results ~f)
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -31,8 +31,16 @@ module Processor = struct
           (* The command is dropped here to avoid decoding it later in the caller
              which would create a duplicate.*)
           `Valid
-      | Ok (`Assuming xs) ->
-          if Or_error.is_ok all_verified then `Valid else `Valid_assuming xs
+      | Ok (`Assuming xs) -> (
+          (* NOTE: `Valid_assuming branch indicates some commands are invalid
+             and the verification failed partially. Since we're batching the
+             verification there's no way to know which particular command failed
+             to pass verification. *)
+          match all_verified with
+          | Ok () ->
+              `Valid
+          | Error err ->
+              `Valid_assuming (xs, err) )
     in
     List.map results ~f
 end
@@ -50,6 +58,7 @@ module Worker_state = struct
            * Zkapp_statement.t
            * Pickles.Side_loaded.Proof.t )
            list
+           * Error.t
          | invalid ]
          list
          Deferred.t
@@ -192,6 +201,7 @@ module Worker = struct
               * Zkapp_statement.t
               * Pickles.Side_loaded.Proof.t )
               list
+              * Error.t
             | invalid ]
             list )
           F.t
@@ -270,6 +280,7 @@ module Worker = struct
                     * Zkapp_statement.Stable.Latest.t
                     * Pickles.Side_loaded.Proof.Stable.Latest.t )
                     list
+                    * Error.Stable.V2.t
                   | invalid ]
                   list]
               , verify_commands )

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -31,6 +31,7 @@ module Base = struct
            * Mina_base.Zkapp_statement.t
            * Pickles.Side_loaded.Proof.t )
            list
+           * Error.t
          | invalid ]
          list
          Deferred.Or_error.t


### PR DESCRIPTION
Should fix https://github.com/MinaProtocol/mina/issues/18731.

## Summary

This PR improves error reporting in the transaction pool batcher's verification pipeline. Previously, verification failures in the `Valid_assuming` path silently dropped the underlying error, making it impossible to diagnose why a batch of transactions was rejected. The error is now threaded through the entire pipeline and collected when a diff is marked as `Potentially_invalid`.

## Changes

### `src/lib/verifier/common.ml`
- `check_signed_command` now filters and returns only the invalid public keys individually, rather than checking all keys at once via `check_valid_keys`.
- Switched from `check_only_for_signature` to `check_signature` for cleaner signature validation.

### `src/lib/verifier/verifier_intf.ml`, `dummy.ml`, `prod.ml`
- Extended the `` `Valid_assuming `` variant to carry an `Error.t` alongside the list of assumptions.
- The actual error from batch verification is now attached instead of being discarded.

### `src/lib/network_pool/batcher.ml`
- Updated all match arms on `` `Valid_assuming `` to handle the new `Error.t` field.
- When building a `Potentially_invalid` result, errors from all `` `Valid_assuming `` entries are collected and combined via `Error.of_list`. Falls back to a placeholder string when no errors were collected (guards against `Error.of_list` raising on an empty list).
- Minor cleanup: use `Array.create` instead of `Array.of_list_map` for initializing unknown-status arrays.

## Testing

No new tests — this is an error propagation fix. Existing tests cover the verification paths.

