### PR TITLE
Pass debian version override to all tests

### DIFF
--- a/buildkite/src/Command/ChainIdTest.dhall
+++ b/buildkite/src/Command/ChainIdTest.dhall
@@ -14,6 +14,8 @@ let RunInToolchain = ../Command/RunInToolchain.dhall
 
 let Size = ../Command/Size.dhall
 
+let DebianVersions = ../Constants/DebianVersions.dhall
+
 let Network = ../Constants/Network.dhall
 
 let buildTestStep =
@@ -26,7 +28,7 @@ let buildTestStep =
                 Command.Config::{
                 , commands =
                     RunInToolchain.runInToolchain
-                      ([] : List Text)
+                      DebianVersions.overrideEnvs
                       "buildkite/scripts/test-chain-id.sh ${networkName} ${expectedChainId}"
                 , label = "Test chain-id for ${networkName}"
                 , key = "test-chain-id-${networkName}"

--- a/buildkite/src/Jobs/Test/DebianUpgradeTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianUpgradeTest.dhall
@@ -37,7 +37,7 @@ let buildTestCmd
                 , commands =
                     RunInToolchain.runInToolchainBullseye
                       Arch.Type.Amd64
-                      ([] : List Text)
+                      DebianVersions.overrideEnvs
                       ''
                       ./buildkite/scripts/tests/debian-upgrade-test.sh \
                         --codename bullseye \

--- a/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
@@ -39,7 +39,7 @@ in  Pipeline.build
             Command.Config::{
             , commands =
                 RunInToolchain.runInToolchain
-                  ([] : List Text)
+                  DebianVersions.overrideEnvs
                   "buildkite/scripts/tests/convert-debian-to-hf-test.sh"
             , label = "Hardfork: Package Conversion"
             , key = "hf-package-conversion-test"


### PR DESCRIPTION
## Explain your changes

In a previous commit updating the CI, buildkite environment variables were added so certain debian packaging parameters could be overridden in pipelines, rather than use the git-based defaults. These override environment variables were not passed to every test, causing those tests to fail to find test artifacts that were installed in a previous CI step; this would happen only if the overrides were actually supplied in the pipeline. This PR corrects this oversight and sets the override environment variables in the remaining tests.

For historical background, the PR https://github.com/MinaProtocol/mina/pull/18332/ introduced the environment variable overrides that are being hit here. These are `OVERRIDE_TAG` and `SKIP_GITBRANCH`. The CI pipelines for PRs and the nightly runs do not set these variables, so the git-based fallbacks are used in these pipelines. These fallbacks apply later on in the build process, and are not communicated via the override environment variables in dhall. I believe this is why the CI only started failing when @amc-ie  tried building the Stable pipeline for `release/0.4.0` - [that build](https://buildkite.com/o-1-labs-2/mina-stable/builds/1683#019d6719-12ae-471d-bf80-6dc05bb0a4ac) demonstrates the error that was seen in the "Hardfork: Package Conversion" test:

```
..Copying /var/storagebox/019d583e-8e86-4dad-a3f7-88627408ec94/debians/bullseye/mina-devnet_3.4.0-alpha1-release-3.4.0-6ec2d71_* -> debs
cp: cannot stat '/var/storagebox/019d583e-8e86-4dad-a3f7-88627408ec94/debians/bullseye/mina-devnet_3.4.0-alpha1-release-3.4.0-6ec2d71_*': No such file or directory
 !! There are some errors while copying files to cache. Exiting... 
```

The chain ID test and debian upgrade tests failed similarly. This happened because something in the pipeline set these values:

```
OVERRIDE_TAG=3.3.1
SKIP_GITBRANCH=1
```

and so the "Debian: Build Bullseye Devnet Devnet" job ended up computing paths like this:

```
..Copying _build/mina-archive-devnet_3.3.1-6ec2d71_amd64.deb -> /var/storagebox/019d583e-8e86-4dad-a3f7-88627408ec94/debians/bullseye/
```

If the environment variables had been passed through for all tests as is done in this PR, then there would be no mismatch; the tests in question would also have used the overrides. 

## Explain how you tested your changes

They are untested at the moment. They'll be exercised once the stable pipeline is run.