### PR TITLE
Remove unused get_some_initial_peers RPC

### DIFF
--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -132,11 +132,7 @@ include struct
   open Mina_networking
 
   type 'a fn_with_mocks =
-       ?get_some_initial_peers:
-         ( Rpcs.Get_some_initial_peers.query
-         , Rpcs.Get_some_initial_peers.response )
-         Gossip_net.Fake.rpc_mock
-    -> ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
+       ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
          ( Rpcs.Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
          , Rpcs.Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )
          Gossip_net.Fake.rpc_mock
@@ -176,8 +172,7 @@ include struct
        -> consensus_local_state:Consensus.Data.Local_state.t
        -> peer_state )
       fn_with_mocks =
-   fun ?get_some_initial_peers
-       ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+   fun ?get_staged_ledger_aux_and_pending_coinbases_at_hash
        ?answer_sync_ledger_query ?get_transition_chain ?get_transition_knowledge
        ?get_transition_chain_proof ?get_ancestry ?get_best_tip
        ?get_completed_snarks ~frontier ~snark ~consensus_local_state ->
@@ -185,8 +180,6 @@ include struct
       let get_mock (type q r) (rpc : (q, r) Rpcs.rpc) :
           (q, r) Gossip_net.Fake.rpc_mock option =
         match rpc with
-        | Get_some_initial_peers ->
-            get_some_initial_peers
         | Get_staged_ledger_aux_and_pending_coinbases_at_hash ->
             get_staged_ledger_aux_and_pending_coinbases_at_hash
         | Answer_sync_ledger_query ->
@@ -221,7 +214,7 @@ module Generator = struct
     -> max_frontier_length:int
     -> peer_state Generator.t
 
-  let fresh_peer_custom_rpc ?get_some_initial_peers
+  let fresh_peer_custom_rpc
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash
       ?answer_sync_ledger_query ?get_transition_chain ?get_transition_knowledge
       ?get_transition_chain_proof ?get_ancestry ?get_best_tip
@@ -249,22 +242,21 @@ module Generator = struct
     let snark = None in
     make_peer_state ~frontier ~snark ~consensus_local_state
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash
-      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
-      ?get_best_tip ?get_completed_snarks ?get_transition_knowledge
+      ?answer_sync_ledger_query ?get_ancestry ?get_best_tip
+      ?get_completed_snarks ?get_transition_knowledge
       ?get_transition_chain_proof ?get_transition_chain
 
   let fresh_peer ~context:(module Context : CONTEXT) ~verifier
       ~max_frontier_length =
     fresh_peer_custom_rpc
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
-      ?get_some_initial_peers:None ?answer_sync_ledger_query:None
-      ?get_ancestry:None ?get_best_tip:None ?get_transition_knowledge:None
-      ?get_transition_chain_proof:None ?get_transition_chain:None
-      ?get_completed_snarks:None
+      ?answer_sync_ledger_query:None ?get_ancestry:None ?get_best_tip:None
+      ?get_transition_knowledge:None ?get_transition_chain_proof:None
+      ?get_transition_chain:None ?get_completed_snarks:None
       ~context:(module Context)
       ~verifier ~max_frontier_length
 
-  let peer_with_branch_custom_rpc ~frontier_branch_size ?get_some_initial_peers
+  let peer_with_branch_custom_rpc ~frontier_branch_size
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash
       ?answer_sync_ledger_query ?get_transition_chain ?get_transition_knowledge
       ?get_transition_chain_proof ?get_ancestry ?get_best_tip
@@ -296,18 +288,17 @@ module Generator = struct
 
     make_peer_state ~frontier ~snark:None ~consensus_local_state
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash
-      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
-      ?get_best_tip ?get_completed_snarks ?get_transition_knowledge
+      ?answer_sync_ledger_query ?get_ancestry ?get_best_tip
+      ?get_completed_snarks ?get_transition_knowledge
       ?get_transition_chain_proof ?get_transition_chain
 
   let peer_with_branch ~frontier_branch_size ~context:(module Context : CONTEXT)
       ~verifier ~max_frontier_length =
     peer_with_branch_custom_rpc ~frontier_branch_size
       ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
-      ?get_some_initial_peers:None ?answer_sync_ledger_query:None
-      ?get_ancestry:None ?get_best_tip:None ?get_completed_snarks:None
-      ?get_transition_knowledge:None ?get_transition_chain_proof:None
-      ?get_transition_chain:None
+      ?answer_sync_ledger_query:None ?get_ancestry:None ?get_best_tip:None
+      ?get_completed_snarks:None ?get_transition_knowledge:None
+      ?get_transition_chain_proof:None ?get_transition_chain:None
       ~context:(module Context)
       ~verifier ~max_frontier_length
 

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -40,11 +40,7 @@ include sig
   open Mina_networking
 
   type 'a fn_with_mocks =
-       ?get_some_initial_peers:
-         ( Rpcs.Get_some_initial_peers.query
-         , Rpcs.Get_some_initial_peers.response )
-         Gossip_net.Fake.rpc_mock
-    -> ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
+       ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
          ( Rpcs.Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
          , Rpcs.Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )
          Gossip_net.Fake.rpc_mock

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1841,21 +1841,21 @@ let%test_module "Ledger_catchup tests" =
             ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
                 ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
-                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?answer_sync_ledger_query:None
                 ?get_ancestry:None ?get_best_tip:None ?get_completed_snarks:None
                 ?get_transition_knowledge:None ?get_transition_chain_proof:None
                 ?get_transition_chain:(Some impl_rpc)
             ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
                 ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
-                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?answer_sync_ledger_query:None
                 ?get_ancestry:None ?get_best_tip:None ?get_completed_snarks:None
                 ?get_transition_knowledge:None ?get_transition_chain_proof:None
                 ?get_transition_chain:(Some impl_rpc)
             ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
                 ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
-                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?answer_sync_ledger_query:None
                 ?get_ancestry:None ?get_best_tip:None ?get_completed_snarks:None
                 ?get_transition_knowledge:None ?get_transition_chain_proof:None
                 ?get_transition_chain:(Some impl_rpc)

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -233,14 +233,6 @@ module Network : sig
 
   val rpc_requests_sent : Counter.t
 
-  val get_some_initial_peers_rpcs_sent : Counter.t * Gauge.t
-
-  val get_some_initial_peers_rpcs_received : Counter.t * Gauge.t
-
-  val get_some_initial_peers_rpc_requests_failed : Counter.t
-
-  val get_some_initial_peers_rpc_responses_failed : Counter.t
-
   val get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_sent :
     Counter.t * Gauge.t
 

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -222,14 +222,6 @@ module Network = struct
 
   let rpc_requests_sent : Counter.t = ()
 
-  let get_some_initial_peers_rpcs_sent : Counter.t * Gauge.t = ((), ())
-
-  let get_some_initial_peers_rpcs_received : Counter.t * Gauge.t = ((), ())
-
-  let get_some_initial_peers_rpc_requests_failed : Counter.t = ()
-
-  let get_some_initial_peers_rpc_responses_failed : Counter.t = ()
-
   let get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_sent :
       Counter.t * Gauge.t =
     ((), ())

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -749,28 +749,6 @@ module Network = struct
 
   let surfix = "_five_slots"
 
-  let get_some_initial_peers_rpcs_sent =
-    let help = "# of Get_some_initial_peers rpc requests sent" in
-    let name = "get_some_initial_peers_rpcs_sent" in
-    ( Counter.v name ~help ~namespace ~subsystem
-    , Gauge.v (name ^ surfix) ~help ~namespace ~subsystem )
-
-  let get_some_initial_peers_rpcs_received =
-    let help = "# of Get_some_initial_peers rpc requests received" in
-    let name = "get_some_initial_peers_rpcs_received" in
-    ( Counter.v name ~help ~namespace ~subsystem
-    , Gauge.v (name ^ surfix) ~help ~namespace ~subsystem )
-
-  let get_some_initial_peers_rpc_requests_failed : Counter.t =
-    let help = "# of Get_some_initial_peers rpc requests failed" in
-    Counter.v "get_some_initial_peers_rpc_requests_failed" ~help ~namespace
-      ~subsystem
-
-  let get_some_initial_peers_rpc_responses_failed : Counter.t =
-    let help = "# of Get_some_initial_peers rpc requests failed to respond" in
-    Counter.v "get_some_initial_peers_rpc_responses_failed" ~help ~namespace
-      ~subsystem
-
   let get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_sent =
     let help =
       "# of Get_staged_ledger_aux_and_pending_coinbases_at_hash rpc requests \
@@ -848,7 +826,7 @@ module Network = struct
     , Gauge.v (name ^ surfix) ~help ~namespace ~subsystem )
 
   let get_transition_chain_rpc_requests_failed : Counter.t =
-    let help = "# of Get_some_initial_peers rpc requests failed" in
+    let help = "# of Get_transition_chain rpc requests failed" in
     Counter.v "get_transition_chain_rpc_requests_failed" ~help ~namespace
       ~subsystem
 

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -86,15 +86,6 @@ let create (module Context : CONTEXT) (config : Config.t) ~sinks
   let module Rpc_context = struct
     include Context
 
-    let list_peers () =
-      match !gossip_net_ref with
-      | None ->
-          (* should be unreachable; without a network, we wouldn't receive this RPC call *)
-          [%log error] "Network not instantiated when initial peers requested" ;
-          return []
-      | Some gossip_net ->
-          Gossip_net.Any.peers gossip_net
-
     let get_transition_frontier = get_transition_frontier
 
     let get_snark_pool = get_snark_pool

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -43,12 +43,6 @@ module Sinks = Sinks
 module Gossip_net : Gossip_net.S with module Rpc_interface := Rpcs
 
 module Rpcs : sig
-  module Get_some_initial_peers : sig
-    type query = unit
-
-    type response = Peer.t list
-  end
-
   module Get_staged_ledger_aux_and_pending_coinbases_at_hash : sig
     type query = State_hash.t
 
@@ -122,8 +116,6 @@ module Rpcs : sig
   end
 
   type ('query, 'response) rpc = ('query, 'response) Rpcs.rpc =
-    | Get_some_initial_peers
-        : (Get_some_initial_peers.query, Get_some_initial_peers.response) rpc
     | Get_staged_ledger_aux_and_pending_coinbases_at_hash
         : ( Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
           , Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )

--- a/src/lib/mina_networking/rpcs.ml
+++ b/src/lib/mina_networking/rpcs.ml
@@ -30,8 +30,6 @@ module type CONTEXT = sig
 
   val consensus_constants : Consensus.Constants.t
 
-  val list_peers : unit -> Peer.t list Deferred.t
-
   val get_transition_frontier : unit -> Transition_frontier.t option
 
   val get_snark_pool : unit -> Network_pool.Snark_pool.t option
@@ -120,87 +118,6 @@ let validate_protocol_versions ~logger ~trust_system ~rpc_name ~sender headers =
           (action, msg) )
   in
   List.is_empty version_errors
-
-[%%versioned_rpc
-module Get_some_initial_peers = struct
-  type nonrec ctx = ctx
-
-  module Master = struct
-    let name = "get_some_initial_peers"
-
-    module T = struct
-      type query = unit [@@deriving sexp, yojson]
-
-      type response = Peer.t list [@@deriving sexp, yojson]
-    end
-
-    module Caller = T
-    module Callee = T
-  end
-
-  include Master.T
-
-  let sent_counter = Mina_metrics.Network.get_some_initial_peers_rpcs_sent
-
-  let received_counter =
-    Mina_metrics.Network.get_some_initial_peers_rpcs_received
-
-  let failed_request_counter =
-    Mina_metrics.Network.get_some_initial_peers_rpc_requests_failed
-
-  let failed_response_counter =
-    Mina_metrics.Network.get_some_initial_peers_rpc_responses_failed
-
-  module M = Versioned_rpc.Both_convert.Plain.Make (Master)
-  include M
-
-  include Perf_histograms.Rpc.Plain.Extend (struct
-    include M
-    include Master
-  end)
-
-  module V1 = struct
-    module T = struct
-      type query = unit
-
-      type response = Network_peer.Peer.Stable.V1.t list
-
-      let query_of_caller_model = Fn.id
-
-      let callee_model_of_query = Fn.id
-
-      let response_of_callee_model = Fn.id
-
-      let caller_model_of_response = Fn.id
-    end
-
-    module T' =
-      Perf_histograms.Rpc.Plain.Decorate_bin_io
-        (struct
-          include M
-          include Master
-        end)
-        (T)
-
-    include T'
-    include Register (T')
-  end
-
-  let receipt_trust_action_message _ = ("Get_some_initial_peers query", [])
-
-  let log_request_received ~logger ~sender () =
-    [%log trace] "Sending some initial peers to $peer"
-      ~metadata:[ ("peer", Peer.to_yojson sender) ]
-
-  let response_is_successful peer_list = not (List.is_empty peer_list)
-
-  let handle_request (module Context : CONTEXT) ~version:_ _request =
-    Context.list_peers ()
-
-  let rate_limit_budget = (1, `Per Time.Span.minute)
-
-  let rate_limit_cost = Fn.const 1
-end]
 
 [%%versioned_rpc
 module Get_staged_ledger_aux_and_pending_coinbases_at_hash = struct
@@ -1176,8 +1093,6 @@ module Get_best_tip = struct
 end]
 
 type ('query, 'response) rpc =
-  | Get_some_initial_peers
-      : (Get_some_initial_peers.query, Get_some_initial_peers.response) rpc
   | Get_staged_ledger_aux_and_pending_coinbases_at_hash
       : ( Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
         , Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )
@@ -1201,8 +1116,7 @@ type ('query, 'response) rpc =
 type any_rpc = Rpc : ('q, 'r) rpc -> any_rpc
 
 let all_rpcs =
-  [ Rpc Get_some_initial_peers
-  ; Rpc Get_staged_ledger_aux_and_pending_coinbases_at_hash
+  [ Rpc Get_staged_ledger_aux_and_pending_coinbases_at_hash
   ; Rpc Answer_sync_ledger_query
   ; Rpc Get_best_tip
   ; Rpc Get_ancestry
@@ -1215,8 +1129,6 @@ let all_rpcs =
 
 let implementation :
     type q r. (q, r) rpc -> (ctx, q, r) Gossip_net.rpc_implementation = function
-  | Get_some_initial_peers ->
-      (module Get_some_initial_peers)
   | Get_staged_ledger_aux_and_pending_coinbases_at_hash ->
       (module Get_staged_ledger_aux_and_pending_coinbases_at_hash)
   | Answer_sync_ledger_query ->

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -14,8 +14,7 @@ type catchup_job_states = Transition_frontier.Full_catchup_tree.job_states =
 [@@deriving to_yojson]
 
 type rpc_count =
-  { get_some_initial_peers : int
-  ; get_staged_ledger_aux_and_pending_coinbases_at_hash : int
+  { get_staged_ledger_aux_and_pending_coinbases_at_hash : int
   ; answer_sync_ledger_query : int
   ; get_transition_chain : int
   ; get_transition_knowledge : int
@@ -153,9 +152,7 @@ let reset_gauges () =
     ; snark_pool_diff_broadcasted
     ]
     @ List.map ~f:snd
-        [ get_some_initial_peers_rpcs_sent
-        ; get_some_initial_peers_rpcs_received
-        ; get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_sent
+        [ get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_sent
         ; get_staged_ledger_aux_and_pending_coinbases_at_hash_rpcs_received
         ; answer_sync_ledger_query_rpcs_sent
         ; answer_sync_ledger_query_rpcs_received
@@ -270,10 +267,7 @@ let start ~commit_id ~logger ~node_status_url ~transition_frontier ~sync_status
                 Time.Span.to_sec @@ Time.diff (Time.now ()) start_time
             ; peer_count = List.length peers
             ; rpc_sent =
-                { get_some_initial_peers =
-                    Float.to_int @@ Mina_metrics.Gauge.value
-                    @@ snd Mina_metrics.Network.get_some_initial_peers_rpcs_sent
-                ; get_staged_ledger_aux_and_pending_coinbases_at_hash =
+                { get_staged_ledger_aux_and_pending_coinbases_at_hash =
                     Float.to_int @@ Mina_metrics.Gauge.value
                     @@ snd
                          Mina_metrics.Network
@@ -313,12 +307,7 @@ let start ~commit_id ~logger ~node_status_url ~transition_frontier ~sync_status
                     @@ snd Mina_metrics.Network.get_epoch_ledger_rpcs_sent
                 }
             ; rpc_received =
-                { get_some_initial_peers =
-                    Float.to_int @@ Mina_metrics.Gauge.value
-                    @@ snd
-                         Mina_metrics.Network
-                         .get_some_initial_peers_rpcs_received
-                ; get_staged_ledger_aux_and_pending_coinbases_at_hash =
+                { get_staged_ledger_aux_and_pending_coinbases_at_hash =
                     Float.to_int @@ Mina_metrics.Gauge.value
                     @@ snd
                          Mina_metrics.Network


### PR DESCRIPTION
Closes https://github.com/MinaProtocol/mina/issues/18741

## Summary
- remove the unused `get_some_initial_peers` RPC from the production networking API
- delete remaining fake-network, metrics, and node-status references tied only to that RPC
- keep bootstrap peer discovery behavior unchanged by leaving the existing `initial_peers` / libp2p peer paths intact

## Notes
- I found no in-tree production caller for `get_some_initial_peers`.
- This change also removes the corresponding node-status RPC count fields, so note that schema change for any out-of-tree consumers.
