### PR TITLE
Force full recompilation for coverage on nightly builds

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -26,12 +26,26 @@ time make libp2p_helper
 export ERROR_ON_PROOF=true
 
 
+# When coverage instrumentation is enabled and this is not a PR build (i.e. nightly),
+# force full recompilation so bisect_ppx generates .coverage files for all source files,
+# not just changed ones. Without --force, dune's incremental compilation skips unchanged
+# files, leading to incomplete and inconsistent coverage reports across builds.
+# A clean is needed before --force to avoid symlink race conditions where parallel
+# rebuilds of shared dependencies (e.g. Rust/kimchi) collide on stale build artifacts.
+FORCE_FLAG=""
+if [ -n "${DUNE_INSTRUMENT_WITH}" ] && [ "${BUILDKITE_PULL_REQUEST:-false}" = "false" ]; then
+    echo "--- Coverage instrumentation detected on non-PR build, forcing full recompilation"
+    echo "--- Cleaning build directory to avoid symlink races under --force"
+    dune clean
+    FORCE_FLAG="--force"
+fi
+
 # Note: By attempting a re-run on failure here, we can avoid rebuilding and
 # skip running all of the tests that have already succeeded, since dune will
 # only retry those tests that failed.
 echo "--- Run unit tests"
-time dune runtest "${path}" || \
+time dune runtest ${FORCE_FLAG} "${path}" || \
 (./scripts/link-coredumps.sh && \
  echo "--- Retrying failed unit tests" && \
- time dune runtest "${path}" || \
+ time dune runtest ${FORCE_FLAG} "${path}" || \
  (./scripts/link-coredumps.sh && false))

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -33,6 +33,9 @@ export ERROR_ON_PROOF=true
 # A clean is needed before --force to avoid symlink race conditions where parallel
 # rebuilds of shared dependencies (e.g. Rust/kimchi) collide on stale build artifacts.
 FORCE_FLAG=""
+# Note: We check BUILDKITE_PULL_REQUEST rather than BUILDKITE because both PR
+# and nightly builds run under Buildkite. We only want --force on nightlies —
+# forcing full recompilation on every PR build would waste CI time.
 if [ -n "${DUNE_INSTRUMENT_WITH}" ] && [ "${BUILDKITE_PULL_REQUEST:-false}" = "false" ]; then
     echo "--- Coverage instrumentation detected on non-PR build, forcing full recompilation"
     echo "--- Cleaning build directory to avoid symlink races under --force"


### PR DESCRIPTION
## Summary
- Add `--force` flag to `dune runtest` for nightly coverage builds so bisect_ppx generates `.coverage` files for all source files, not just changed ones
- Precede `--force` with `dune clean` to avoid symlink race conditions where parallel rebuilds of shared Rust/kimchi dependencies collide on stale build artifacts
- Only activates when `DUNE_INSTRUMENT_WITH` is set and it's not a PR build

Fixes #18755

## Test plan
- [x] Nightly build [#1277](https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1277) passes with this change
- [x] Coverage instrumentation message appears in logs
- [x] No symlink race errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)