### PR TITLE
Fix flaky mina_ledger root test timeout

### DIFF
--- a/src/lib/mina_ledger/test/test_mina_ledger.ml
+++ b/src/lib/mina_ledger/test/test_mina_ledger.ml
@@ -241,14 +241,21 @@ let () =
       Alcotest_async.run "Mina Ledger"
         [ ( "Root"
           , [ Alcotest_async.test_case
+                ~timeout:(Core.Time.Span.of_sec 30.)
                 "closing stable root, reload as converting" `Quick
                 (Root_test.test_stable_backing_compatible_with_converting
                    ~random )
-            ; Alcotest_async.test_case "moving a root" `Quick
+            ; Alcotest_async.test_case
+                ~timeout:(Core.Time.Span.of_sec 30.)
+                "moving a root" `Quick
                 (Root_test.test_root_moving ~random)
-            ; Alcotest_async.test_case "make checkpointing a root" `Quick
+            ; Alcotest_async.test_case
+                ~timeout:(Core.Time.Span.of_sec 30.)
+                "make checkpointing a root" `Quick
                 (Root_test.test_root_make_checkpointing ~random)
-            ; Alcotest_async.test_case "make converting a root" `Quick
+            ; Alcotest_async.test_case
+                ~timeout:(Core.Time.Span.of_sec 30.)
+                "make converting a root" `Quick
                 (Root_test.test_root_make_converting ~random)
             ] )
         ] )


### PR DESCRIPTION
## Summary
- Increase Alcotest_async timeout from default 2s to 30s for all Root test cases in `mina_ledger`
- The default 2s is too tight for tests that create, populate (200 accounts), close, and reopen RocksDB-backed ledgers under CI load

Fixes #18754

## Test plan
- [ ] Verify mina_ledger tests pass locally: `dune runtest src/lib/mina_ledger`
- [ ] Confirm no more "timed out after 2s" failures in nightly builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)