### PR TITLE
fix: use by_peer_id initial capacity in rate limiter summary

### DIFF
--- a/src/lib/network_pool/rate_limiter.ml
+++ b/src/lib/network_pool/rate_limiter.ml
@@ -176,7 +176,8 @@ let summary ({ by_ip; by_peer_id } : t) =
         Peer_id.Hash_queue.foldi by_peer_id.table ~init:[]
           ~f:(fun acc ~key ~data ->
             ( Peer.Id.to_string key
-            , { capacity_used = by_ip.initial_capacity - data.remaining_capacity
+            , { capacity_used =
+                  by_peer_id.initial_capacity - data.remaining_capacity
               } )
             :: acc )
     }


### PR DESCRIPTION
## Summary
- Fix `summary` for the peer-id rate limiter: `capacity_used` now uses `by_peer_id.initial_capacity` instead of `by_ip.initial_capacity` when folding the peer-id table.

## Test plan
- [ ] `dune runtest src/lib/network_pool` (or full CI)

This corrects the metric when IP and peer-id limiters are configured with different initial capacities.