### PR TITLE
fix: use mktemp path in missing-blocks-guardian populate_db

### DIFF
--- a/scripts/archive/missing-blocks-guardian.sh
+++ b/scripts/archive/missing-blocks-guardian.sh
@@ -108,14 +108,14 @@ jq_parent_hash() {
 populate_db() {
   tempfile=$(mktemp)
   echo  "${ARCHIVE_BLOCKS} --${BLOCKS_FORMAT} --archive-uri ${1} ${2}"
-  ${ARCHIVE_BLOCKS} "--${BLOCKS_FORMAT}" --archive-uri "${1}" "${2}" > tempfile
+  ${ARCHIVE_BLOCKS} "--${BLOCKS_FORMAT}" --archive-uri "${1}" "${2}" > "$tempfile"
   
   if [ $? -ne 0 ]; then
     echo $'[ERROR] mina-archive-blocks failed. The database remains unhealthy.\n Make sure the environment variables are set correctly and the database is accessible.'
     rm "${2}" "$tempfile"
     exit 1
   fi
-  jq -rs '"[BOOTSTRAP] Populated database with block: \(.[-1].message)"' < tempfile
+  jq -rs '"[BOOTSTRAP] Populated database with block: \(.[-1].message)"' < "$tempfile"
   rm "$tempfile"
   rm "${2}"
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
- `populate_db` in `scripts/archive/missing-blocks-guardian.sh` called `mktemp` but redirected `mina-archive-blocks` output to a literal file `tempfile` in the working directory instead of the temp path.
- Point the redirect and `jq` stdin at `"$tempfile"` so bootstrap uses the actual temp file.

## Test plan
- [ ] Run `make check-bash` or manually exercise `populate_db` in a test environment.