### PR TITLE
Add GAR whitelist update step to promoter pipeline

### DIFF
--- a/buildkite/src/Entrypoints/PromoteNightly.dhall
+++ b/buildkite/src/Entrypoints/PromoteNightly.dhall
@@ -81,6 +81,12 @@ let promote_nightly =
                     ++  " --only-dockers"
                   )
 
+          let updateGarWhitelistCmd =
+                Cmd.run
+                  (     ". ./buildkite/scripts/export-git-env-vars.sh && "
+                    ++  "./scripts/docker/update-gar-whitelist.sh"
+                  )
+
           let pipeline =
                 Pipeline.build
                   Pipeline.Config::{
@@ -98,6 +104,7 @@ let promote_nightly =
                             # [ buildGoBinaryCmd ]
                             # [ publishDebiansCmd ]
                             # [ publishDockersCmd ]
+                            # [ updateGarWhitelistCmd ]
                         , label = "Promote Nightly (${branch}/${profile})"
                         , key = "promote-nightly-${branch}-${profile}"
                         , target = Size.Small

--- a/scripts/docker/update-gar-whitelist.sh
+++ b/scripts/docker/update-gar-whitelist.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+# Update GAR Cleanup Policy Whitelist
+#
+# Creates a PR to gitops-infrastructure adding the release tag prefix
+# to the gcr.io "Keep protected mina releases" KEEP policy.
+# This protects release Docker images from automatic cleanup deletion.
+#
+# Designed to run as a post-promotion step in the promoter pipeline.
+# On non-release branches, exits cleanly (no-op for nightly promotions).
+#
+# Prerequisites:
+#   - GITTAG and GITHASH exported (via export-git-env-vars.sh)
+#   - GITHUB_TOKEN or GH_TOKEN set for GitHub API access
+#   - gh CLI available
+#
+# Optional env vars:
+#   - GAR_TAG_PREFIX: override the tag prefix (default: GITTAG-GITHASH)
+#   - DRY_RUN=1: print what would be done without making changes
+
+set -euo pipefail
+
+# Guard: only run on release branches.
+# The promoter pipeline handles both nightly and release promotions.
+# GAR whitelist updates are only needed for releases — nightly images
+# are protected by "keep recent N versions" policies and have short lifetimes.
+BRANCH="${BUILDKITE_BRANCH:-unknown}"
+if [[ ! "${BRANCH}" =~ ^release/ ]]; then
+    echo "⏭️  Skipping GAR whitelist update (branch '${BRANCH}' is not a release branch)"
+    exit 0
+fi
+
+# Compute release tag prefix.
+# Default: GITTAG-GITHASH (e.g., 3.4.0-alpha1-22d9374).
+# This prefix protects all codename/network variants via GAR prefix matching.
+TAG_PREFIX="${GAR_TAG_PREFIX:-${GITTAG}-${GITHASH}}"
+
+GITOPS_REPO="MinaProtocol/gitops-infrastructure"
+TFVARS_PATH="platform/gcloud/artifact-registry/registries.tfvars"
+BRANCH_NAME="auto/gar-whitelist-${TAG_PREFIX}"
+
+echo "🏷️  Release tag prefix: ${TAG_PREFIX}"
+echo "📦 Target: ${GITOPS_REPO} / ${TFVARS_PATH}"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[DRY RUN] Would create PR to add '${TAG_PREFIX}' to GAR whitelist"
+    exit 0
+fi
+
+# Check prerequisites
+if ! command -v gh &>/dev/null; then
+    echo "❌ gh CLI not found. Skipping GAR whitelist update."
+    echo "   Install gh CLI or set GITHUB_TOKEN to enable this step."
+    exit 0
+fi
+
+if [[ -z "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]]; then
+    echo "⚠️  GITHUB_TOKEN or GH_TOKEN not set. Skipping GAR whitelist update."
+    echo "   Set one of these env vars to enable automated whitelist PRs."
+    exit 0
+fi
+
+# Idempotency: skip if PR already exists for this tag
+if gh pr list --repo "${GITOPS_REPO}" --head "${BRANCH_NAME}" --state open --json number 2>/dev/null | grep -q "number"; then
+    echo "✅ PR already exists for ${TAG_PREFIX}, skipping."
+    exit 0
+fi
+
+# Clone, modify, create PR
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+echo "📥 Cloning ${GITOPS_REPO}..."
+gh repo clone "${GITOPS_REPO}" "${WORKDIR}" -- --depth 1 -q
+
+cd "${WORKDIR}"
+git checkout -b "${BRANCH_NAME}"
+
+# Insert tag prefix into gcr.io "Keep protected mina releases" tag_prefixes list
+echo "📝 Inserting '${TAG_PREFIX}' into GAR whitelist..."
+python3 -c "
+import re
+import sys
+
+tfvars_path = '${TFVARS_PATH}'
+tag_prefix = '${TAG_PREFIX}'
+
+with open(tfvars_path, 'r') as f:
+    content = f.read()
+
+quoted_tag = '\"' + tag_prefix + '\"'
+
+# Find the 'Keep protected mina releases' policy block's tag_prefixes list
+# Pattern: locate the policy by name, then find tag_prefixes = [ ... ]
+pattern = r'(\"Keep protected mina releases\".*?tag_prefixes\s*=\s*\[)(.*?)(\])'
+match = re.search(pattern, content, re.DOTALL)
+
+if not match:
+    print('Could not find \"Keep protected mina releases\" tag_prefixes block')
+    print('The registries.tfvars structure may have changed — update the pattern.')
+    sys.exit(1)
+
+if quoted_tag in match.group(2):
+    print(f'{quoted_tag} already in whitelist, no changes needed')
+    sys.exit(0)
+
+# Insert before the closing ]
+existing = match.group(2).rstrip()
+if existing.endswith('\"'):
+    new_content = existing + ',\n            ' + quoted_tag
+else:
+    new_content = existing + '\n            ' + quoted_tag
+
+content = content[:match.start(2)] + new_content + '\n          ' + content[match.end(2):]
+
+with open(tfvars_path, 'w') as f:
+    f.write(content)
+
+print(f'Added {quoted_tag} to gcr.io whitelist')
+"
+
+# Check if any changes were made
+if git diff --quiet "${TFVARS_PATH}" 2>/dev/null; then
+    echo "✅ No changes needed (tag already whitelisted)."
+    exit 0
+fi
+
+# Commit and push
+git add "${TFVARS_PATH}"
+git commit -m "auto: Add GAR whitelist entry for release ${TAG_PREFIX}"
+git push origin "${BRANCH_NAME}"
+
+# Create PR
+echo "🔀 Creating PR..."
+gh pr create \
+    --repo "${GITOPS_REPO}" \
+    --title "Add GAR whitelist for release ${TAG_PREFIX}" \
+    --body "$(cat <<EOF
+Automated PR from Mina promoter pipeline.
+
+**Build**: ${BUILDKITE_BUILD_URL:-unknown}
+**Branch**: ${BRANCH}
+**Tag prefix**: \`${TAG_PREFIX}\`
+
+Adds \`${TAG_PREFIX}\` to the KEEP policy \`tag_prefixes\` for the \`gcr.io\` registry
+in \`${TFVARS_PATH}\`.
+
+This protects release Docker images from automatic cleanup deletion by the
+GAR cleanup policies. The prefix covers all codename/network/arch variants
+(e.g., \`${TAG_PREFIX}-noble-devnet\`, \`${TAG_PREFIX}-bookworm-mainnet\`, etc.).
+EOF
+)" \
+    --base main
+
+echo "✅ GAR whitelist PR created successfully."

--- a/scripts/docker/update-gar-whitelist.sh
+++ b/scripts/docker/update-gar-whitelist.sh
@@ -35,7 +35,7 @@ fi
 # This prefix protects all codename/network variants via GAR prefix matching.
 TAG_PREFIX="${GAR_TAG_PREFIX:-${GITTAG}-${GITHASH}}"
 
-GITOPS_REPO="MinaProtocol/gitops-infrastructure"
+GITOPS_REPO="o1-labs/gitops-infrastructure"
 TFVARS_PATH="platform/gcloud/artifact-registry/registries.tfvars"
 BRANCH_NAME="auto/gar-whitelist-${TAG_PREFIX}"
 
@@ -74,6 +74,9 @@ echo "📥 Cloning ${GITOPS_REPO}..."
 gh repo clone "${GITOPS_REPO}" "${WORKDIR}" -- --depth 1 -q
 
 cd "${WORKDIR}"
+git config user.email "mina-promoter-pipeline@o1labs.org"
+git config user.name "Mina Promoter Pipeline"
+gh auth setup-git 2>/dev/null || true
 git checkout -b "${BRANCH_NAME}"
 
 # Insert tag prefix into gcr.io "Keep protected mina releases" tag_prefixes list
@@ -150,6 +153,7 @@ GAR cleanup policies. The prefix covers all codename/network/arch variants
 (e.g., \`${TAG_PREFIX}-noble-devnet\`, \`${TAG_PREFIX}-bookworm-mainnet\`, etc.).
 EOF
 )" \
-    --base main
+    --base main \
+    --head "${BRANCH_NAME}"
 
 echo "✅ GAR whitelist PR created successfully."


### PR DESCRIPTION
## Add GAR whitelist update step to promoter pipeline

### Summary

After Docker images are promoted to `gcr.io`, this adds a step that automatically creates a PR to [`gitops-infrastructure`](https://github.com/o1-labs/gitops-infrastructure) adding the release tag prefix to the GAR cleanup policy whitelist. This prevents release images from being garbage-collected.

- Adds `scripts/docker/update-gar-whitelist.sh` (standalone, self-contained)
- Adds a 5th command to the promoter pipeline in `PromoteNightly.dhall`

### Problem

When a release is promoted to `gcr.io/o1labs-192920`, the images are subject to GAR cleanup policies defined in [`registries.tfvars`](https://github.com/o1-labs/gitops-infrastructure/blob/main/platform/gcloud/artifact-registry/registries.tfvars). The `gcr.io` registry has time-based DELETE policies (180 days for tagged mina images) and a "Keep protected mina releases" KEEP policy with an explicit `tag_prefixes` list.

Today, adding new releases to this whitelist is a manual process. If forgotten, release images can be deleted after the retention window.

### Solution

A new script runs as the final step of the promoter pipeline. It:

1. **Gates on `release/*` branches** — exits cleanly (no-op) for nightly promotions since nightly images are ephemeral and covered by "keep recent N versions" policies
2. **Computes the tag prefix** from `GITTAG-GITHASH` (e.g., `3.4.0-alpha1-22d9374`). A single prefix protects all codename/network/arch variants via GAR prefix matching
3. **Creates a PR** to `o1-labs/gitops-infrastructure` inserting the prefix into the `gcr.io` "Keep protected mina releases" `tag_prefixes` list
4. **Is idempotent** — skips if a PR for the same tag already exists
5. **Degrades gracefully** — if `gh` CLI or `GITHUB_TOKEN` are not available, logs a warning and exits 0 (doesn't fail the pipeline)

### Changes

| File | Change |
|---|---|
| `scripts/docker/update-gar-whitelist.sh` | New script. Handles branch gating, tag computation, tfvars editing, and PR creation |
| `buildkite/src/Entrypoints/PromoteNightly.dhall` | +7 lines. Adds `updateGarWhitelistCmd` after `publishDockersCmd` |

### Prerequisites

Already provisioned on Hetzner rivendell-1 Buildkite agents:

- **`GITHUB_TOKEN`** — fine-grained PAT from GCP secret `buildkiteGithubGitOpsInfrastructure`, mounted as env var via K8s secret
- **`gh` CLI** — installed via `02-install-gh-cli` entrypoint script

### E2E Tested

Validated on agent pod `hetzner-k8s-buildkite-generic-0-agent-0`:

```
$ BUILDKITE_BRANCH=release/3.4.0 GITTAG=0.0.0-test GITHASH=deadbee ./update-gar-whitelist.sh
🏷️  Release tag prefix: 0.0.0-test-deadbee
📦 Target: o1-labs/gitops-infrastructure / platform/gcloud/artifact-registry/registries.tfvars
📥 Cloning o1-labs/gitops-infrastructure...
📝 Inserting '0.0.0-test-deadbee' into GAR whitelist...
Added "0.0.0-test-deadbee" to gcr.io whitelist
🔀 Creating PR...
https://github.com/o1-labs/gitops-infrastructure/pull/1050
✅ GAR whitelist PR created successfully.

$ # Re-run (idempotency):
✅ PR already exists for 0.0.0-test-deadbee, skipping.

$ # Non-release branch:
⏭️  Skipping GAR whitelist update (branch 'compatible' is not a release branch)
```

### Example flow

```
Promoter pipeline runs for release/3.4.0
  1. Build nightly-promoter binary     (existing)
  2. Publish Debian packages           (existing)
  3. Publish Docker images to gcr.io   (existing)
  4. Update GAR whitelist              (NEW)
     → Computes tag prefix: 3.4.0-alpha1-22d9374
     → Creates PR to o1-labs/gitops-infrastructure
     → Adds "3.4.0-alpha1-22d9374" to gcr.io KEEP policy tag_prefixes
```

### Testing

- `DRY_RUN=1 ./scripts/docker/update-gar-whitelist.sh` — prints what would be done
- Dhall type-checks: `dhall type --file buildkite/src/Entrypoints/PromoteNightly.dhall`
- Verify rendered YAML includes the step: `dhall-to-yaml --quoted <<< '(./buildkite/src/Entrypoints/PromoteNightly.dhall).promote_nightly "release/3.4.0" "devnet" "unstable" False'`
