### PR TITLE
Fix VersionLint gcloud permission denied in Docker

### DIFF
--- a/buildkite/scripts/gsutil-upload.sh
+++ b/buildkite/scripts/gsutil-upload.sh
@@ -6,6 +6,9 @@ if [ ! -f $KEY_FILE ]; then
     echo "Cannot use gsutil for upload as key file cannot be found in $KEY_FILE"
 fi
 
+# Ensure gcloud config directory is writable (may not be owned by current user in Docker)
+export CLOUDSDK_CONFIG=${CLOUDSDK_CONFIG:-$(mktemp -d)}
+
 gcloud auth activate-service-account --key-file=$KEY_FILE
 
 gsutil cp $1 $2

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -16,7 +16,7 @@ source buildkite/scripts/debian/update.sh --verbose
 source buildkite/scripts/handle-fork.sh
 source buildkite/scripts/export-git-env-vars.sh
 
-pip3 install sexpdata==1.0.0
+pip3 install sexpdata==1.0.0 requests
 
 source ./buildkite/scripts/refresh_code.sh
 

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -59,6 +59,8 @@ in  Pipeline.build
                 , S.exactly
                     "buildkite/scripts/version-linter-patch-missing-type-shapes"
                     "sh"
+                , S.exactly "buildkite/scripts/dump-mina-type-shapes" "sh"
+                , S.exactly "buildkite/scripts/gsutil-upload" "sh"
                 ]
 
           in  JobSpec::{


### PR DESCRIPTION
## Summary
- The VersionLint CI job fails because `gcloud auth activate-service-account` cannot write to `/home/opam/.config/gcloud/credentials.db` (permission denied)
- The `sudo chown -R opam .` step only fixes `/workdir`, not the opam home directory's gcloud config
- Fix: set `CLOUDSDK_CONFIG` to a writable temp directory in `gsutil-upload.sh`

## Test plan
- [ ] VersionLint job passes on this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)