### PR TITLE
Fix reversion to update versioned dependencies

### DIFF
--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -84,6 +84,26 @@ if [[ "$UPDATED_VERSION" != "$NEW_VERSION" ]]; then
 fi
 
 echo "✓ Version replaced successfully"
+
+# Update versioned references in dependency fields (Depends, Replaces, Breaks)
+# When a dependency pins the old version (e.g. "mina-devnet-config (>=1.0.0)"),
+# replace it with the new version so the package stays internally consistent.
+ESCAPED_OLD=$(sed 's/[.[\*^$/]/\\&/g' <<< "$OLD_VERSION")
+ESCAPED_NEW=$(sed 's/[&/]/\\&/g' <<< "$NEW_VERSION")
+
+DEP_CHANGED=0
+for FIELD in Depends Replaces Breaks; do
+  if grep -q "^${FIELD}:.*${ESCAPED_OLD}" "$CONTROL_FILE"; then
+    sed -i "/^${FIELD}:/s/${ESCAPED_OLD}/${ESCAPED_NEW}/g" "$CONTROL_FILE"
+    DEP_CHANGED=1
+    echo "✓ Updated $OLD_VERSION → $NEW_VERSION in ${FIELD} field"
+  fi
+done
+
+if [[ "$DEP_CHANGED" -eq 0 ]]; then
+  echo "  (no versioned dependencies referencing $OLD_VERSION found)"
+fi
+
 echo ""
 echo "Updated control file:"
-grep -E "^(Package|Version|Architecture):" "$CONTROL_FILE" || true
+grep -E "^(Package|Version|Architecture|Depends|Replaces|Breaks):" "$CONTROL_FILE" || true

--- a/scripts/debian/session/deb-session-reversion.sh
+++ b/scripts/debian/session/deb-session-reversion.sh
@@ -92,7 +92,7 @@ ESCAPED_OLD=$(sed 's/[.[\*^$/]/\\&/g' <<< "$OLD_VERSION")
 ESCAPED_NEW=$(sed 's/[&/]/\\&/g' <<< "$NEW_VERSION")
 
 DEP_CHANGED=0
-for FIELD in Depends Replaces Breaks; do
+for FIELD in Depends Replaces Breaks Conflicts; do
   if grep -q "^${FIELD}:.*${ESCAPED_OLD}" "$CONTROL_FILE"; then
     sed -i "/^${FIELD}:/s/${ESCAPED_OLD}/${ESCAPED_NEW}/g" "$CONTROL_FILE"
     DEP_CHANGED=1
@@ -106,4 +106,4 @@ fi
 
 echo ""
 echo "Updated control file:"
-grep -E "^(Package|Version|Architecture|Depends|Replaces|Breaks):" "$CONTROL_FILE" || true
+grep -E "^(Package|Version|Architecture|Depends|Replaces|Breaks|Conflicts):" "$CONTROL_FILE" || true

--- a/scripts/debian/session/tests/run-deb-session-tests.sh
+++ b/scripts/debian/session/tests/run-deb-session-tests.sh
@@ -88,6 +88,9 @@ Priority: optional
 Architecture: amd64
 Suite: unstable
 Maintainer: Mina Protocol <test@example.com>
+Depends: libssl1.1, libffi7, mina-devnet-config (>=1.0)
+Replaces: mina-devnet (<< 1.0)
+Breaks: mina-devnet (<< 1.0)
 Description: Sample package for deb-session tests
 EOF
 
@@ -196,6 +199,27 @@ log "Testing deb-session-reversion.sh"
 CURRENT_VERSION=$(awk '/^Version:/ {print $2}' "$SESSION_DIR/control/control")
 if [[ "$CURRENT_VERSION" != "2.0.0-rc1" ]]; then
   fail "control file not updated with new version (got: $CURRENT_VERSION)"
+fi
+
+# Verify versioned dependencies were updated
+CURRENT_DEPENDS=$(grep '^Depends:' "$SESSION_DIR/control/control")
+if [[ "$CURRENT_DEPENDS" != *"mina-devnet-config (>=2.0.0-rc1)"* ]]; then
+  fail "Depends not updated with new version (got: $CURRENT_DEPENDS)"
+fi
+
+CURRENT_REPLACES=$(grep '^Replaces:' "$SESSION_DIR/control/control")
+if [[ "$CURRENT_REPLACES" != *"mina-devnet (<< 2.0.0-rc1)"* ]]; then
+  fail "Replaces not updated with new version (got: $CURRENT_REPLACES)"
+fi
+
+CURRENT_BREAKS=$(grep '^Breaks:' "$SESSION_DIR/control/control")
+if [[ "$CURRENT_BREAKS" != *"mina-devnet (<< 2.0.0-rc1)"* ]]; then
+  fail "Breaks not updated with new version (got: $CURRENT_BREAKS)"
+fi
+
+# Verify non-versioned dependencies were NOT changed
+if [[ "$CURRENT_DEPENDS" != *"libssl1.1"* ]] || [[ "$CURRENT_DEPENDS" != *"libffi7"* ]]; then
+  fail "Non-versioned dependencies were corrupted (got: $CURRENT_DEPENDS)"
 fi
 
 # ------------------------------------------------------------------------------

--- a/scripts/debian/session/tests/run-deb-session-tests.sh
+++ b/scripts/debian/session/tests/run-deb-session-tests.sh
@@ -91,6 +91,7 @@ Maintainer: Mina Protocol <test@example.com>
 Depends: libssl1.1, libffi7, mina-devnet-config (>=1.0)
 Replaces: mina-devnet (<< 1.0)
 Breaks: mina-devnet (<< 1.0)
+Conflicts: mina-devnet (<< 1.0)
 Description: Sample package for deb-session tests
 EOF
 
@@ -215,6 +216,11 @@ fi
 CURRENT_BREAKS=$(grep '^Breaks:' "$SESSION_DIR/control/control")
 if [[ "$CURRENT_BREAKS" != *"mina-devnet (<< 2.0.0-rc1)"* ]]; then
   fail "Breaks not updated with new version (got: $CURRENT_BREAKS)"
+fi
+
+CURRENT_CONFLICTS=$(grep '^Conflicts:' "$SESSION_DIR/control/control")
+if [[ "$CURRENT_CONFLICTS" != *"mina-devnet (<< 2.0.0-rc1)"* ]]; then
+  fail "Conflicts not updated with new version (got: $CURRENT_CONFLICTS)"
 fi
 
 # Verify non-versioned dependencies were NOT changed

--- a/scripts/docker/promote.sh
+++ b/scripts/docker/promote.sh
@@ -52,7 +52,7 @@ SOURCE_TAG="${PULL_REGISTRY}/${NAME}:${VERSION}${DOCKER_ARCH_SUFFIX}"
 
 echo "📎 Adding new tag ($TAG) for docker ${SOURCE_TAG}"
 echo "   📥 pulling ${SOURCE_TAG}"
-docker pull $QUIET ${SOURCE_TAG}
+docker pull $QUIET --platform "linux/${ARCH}" ${SOURCE_TAG}
 
 if [[ -z "$PUSH_REGISTRY" ]]; then
   PUSH_REGISTRY=$PULL_REGISTRY


### PR DESCRIPTION
## Summary
- When reversioning a `.deb` package, `Depends`, `Replaces`, `Breaks`, and `Conflicts` fields that pinned the old version (e.g. `mina-devnet-config (>=1.0.0)`) were left unchanged, causing dependency mismatches
- `deb-session-reversion.sh` now replaces occurrences of the old version in those fields with the new version
- Test fixture updated with versioned dependencies and assertions added to verify correctness
- During development we also noticed that `scripts/docker/promote.sh` was missing the `--platform` flag on `docker pull`, causing cross-architecture pulls (e.g. arm64 on an amd64 host) to fail with "no matching manifest" errors. Fixed by passing `--platform linux/${ARCH}` to the pull command.

## Test plan
- [x] `run-deb-session-tests.sh` passes with new assertions for Depends, Replaces, Breaks, Conflicts updates
- [x] Non-versioned dependencies (libssl1.1, libffi7) are verified unchanged
- [x] Verified arm64 docker publish works with the `--platform` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)