### PR TITLE
Restrict transition frontier load depth to protocol's k value

### DIFF
--- a/changes/18769.md
+++ b/changes/18769.md
@@ -1,0 +1,1 @@
+Limit the transition frontier loading depth to the protocol's k value during bootstrap, preventing nodes from spending hours reconstructing stale fork branches from an overly large persistent frontier database.

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -592,9 +592,13 @@ let run_cycle ~context:(module Context : CONTEXT) ~trust_system ~verifier
                 ( "failed to initialize transition frontier after \
                    bootstrapping: " ^ msg )
             in
+            let max_frontier_depth =
+              (Precomputed_values.genesis_constants Context.precomputed_values)
+                .protocol.k
+            in
             Transition_frontier.load
               ~context:(module Context)
-              ~retry_with_fresh_db:false ~verifier ~consensus_local_state
+              ~retry_with_fresh_db:false ~max_frontier_depth ~verifier ~consensus_local_state
               ~persistent_root ~persistent_frontier ~catchup_mode ()
             >>| function
             | Ok frontier ->

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -254,7 +254,7 @@ module Instance = struct
 
   let load_full_frontier t ~context:(module Context : CONTEXT) ~root_ledger
       ~consensus_local_state ~max_length ~ignore_consensus_local_state
-      ~persistent_root_instance ?max_frontier_depth () =
+      ~persistent_root_instance ~max_frontier_depth () =
     let open Context in
     let open Deferred.Result.Let_syntax in
     let%bind () = Deferred.return (assert_no_sync t) in
@@ -329,7 +329,7 @@ module Instance = struct
     let%map () =
       Deferred.map
         (Database.crawl_successors ~signature_kind ~proof_cache_db t.db
-           ?max_depth:max_frontier_depth root_hash
+           ~max_depth:max_frontier_depth root_hash
            ~init:(Full_frontier.root frontier)
            ~f:visit )
         ~f:

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -100,7 +100,7 @@ let genesis_root_data ~precomputed_values =
 let load_from_persistence_and_start ~context:(module Context : CONTEXT)
     ~verifier ~consensus_local_state ~max_length ~persistent_root
     ~persistent_root_instance ~persistent_frontier ~persistent_frontier_instance
-    ~catchup_mode ?max_frontier_depth ?(set_best_tip = true)
+    ~catchup_mode ~max_frontier_depth ?(set_best_tip = true)
     ignore_consensus_local_state =
   let open Context in
   let open Deferred.Result.Let_syntax in
@@ -143,7 +143,7 @@ let load_from_persistence_and_start ~context:(module Context : CONTEXT)
         ~root_ledger:
           (Persistent_root.Instance.snarked_ledger persistent_root_instance)
         ~consensus_local_state ~ignore_consensus_local_state
-        ~persistent_root_instance ?max_frontier_depth ()
+        ~persistent_root_instance ~max_frontier_depth ()
     with
     | Error `Sync_cannot_be_running ->
         Error (`Failure "sync job is already running on persistent frontier")
@@ -200,7 +200,7 @@ let rec load_with_max_length :
        context:(module CONTEXT)
     -> max_length:int
     -> ?retry_with_fresh_db:bool
-    -> ?max_frontier_depth:int
+    -> max_frontier_depth:int
     -> verifier:Verifier.t
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root:Persistent_root.t
@@ -215,7 +215,7 @@ let rec load_with_max_length :
          | `Failure of string ] )
        Deferred.Result.t =
  fun ~context:(module Context : CONTEXT) ~max_length
-     ?(retry_with_fresh_db = true) ?max_frontier_depth ~verifier
+     ?(retry_with_fresh_db = true) ~max_frontier_depth ~verifier
      ~consensus_local_state ~persistent_root ~persistent_frontier ~catchup_mode
      ?set_best_tip () ->
   let open Context in
@@ -248,7 +248,7 @@ let rec load_with_max_length :
             ~context:(module Context)
             ~verifier ~consensus_local_state ~max_length ~persistent_root
             ~persistent_root_instance ~catchup_mode ~persistent_frontier
-            ~persistent_frontier_instance ?max_frontier_depth ?set_best_tip
+            ~persistent_frontier_instance ~max_frontier_depth ?set_best_tip
             ignore_consensus_local_state
         with
         | Ok _ as result ->
@@ -353,7 +353,7 @@ let rec load_with_max_length :
         in
         load_with_max_length
           ~context:(module Context)
-          ~max_length ~verifier ~consensus_local_state ~persistent_root
+          ~max_length ~max_frontier_depth ~verifier ~consensus_local_state ~persistent_root
           ~persistent_frontier ~retry_with_fresh_db:false ~catchup_mode ()
         >>| Result.map_error ~f:(function
               | `Persistent_frontier_malformed ->
@@ -381,7 +381,7 @@ let rec load_with_max_length :
           [%str_log trace] Transition_frontier_loaded_from_persistence ;
           return res )
 
-let load ?(retry_with_fresh_db = true) ?max_frontier_depth ?set_best_tip
+let load ?(retry_with_fresh_db = true) ~max_frontier_depth ?set_best_tip
     ~context:(module Context : CONTEXT) ~verifier ~consensus_local_state
     ~persistent_root ~persistent_frontier ~catchup_mode () =
   let open Context in
@@ -392,7 +392,7 @@ let load ?(retry_with_fresh_db = true) ?max_frontier_depth ?set_best_tip
       in
       load_with_max_length
         ~context:(module Context)
-        ~max_length ~retry_with_fresh_db ?max_frontier_depth ~verifier
+        ~max_length ~retry_with_fresh_db ~max_frontier_depth ~verifier
         ~consensus_local_state ~persistent_root ~persistent_frontier
         ~catchup_mode ?set_best_tip () )
 
@@ -757,7 +757,7 @@ module For_tests = struct
             |> Mina_block.Validated.state_hash ) ) ;
     let frontier_result =
       Async.Thread_safe.block_on_async_exn (fun () ->
-          load_with_max_length ~max_length ~retry_with_fresh_db:false
+          load_with_max_length ~max_length ~max_frontier_depth:max_length ~retry_with_fresh_db:false
             ~context:(module Context)
             ~verifier ~consensus_local_state ~persistent_root
             ~catchup_mode:`Super ~persistent_frontier () )

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -66,7 +66,7 @@ val global_max_length : Genesis_constants.t -> int
 
 val load :
      ?retry_with_fresh_db:bool
-  -> ?max_frontier_depth:int
+  -> max_frontier_depth:int
   -> ?set_best_tip:bool
   -> context:(module CONTEXT)
   -> verifier:Verifier.t

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -303,10 +303,13 @@ let download_best_tip ~context:(module Context : CONTEXT) ~notify_online
 let load_frontier ~context:(module Context : CONTEXT) ~verifier
     ~persistent_frontier ~persistent_root ~consensus_local_state ~catchup_mode =
   let open Context in
+  let max_frontier_depth =
+    (Precomputed_values.genesis_constants precomputed_values).protocol.k
+  in
   match%map
     Transition_frontier.load
       ~context:(module Context)
-      ~verifier ~consensus_local_state ~persistent_root ~persistent_frontier
+      ~max_frontier_depth ~verifier ~consensus_local_state ~persistent_root ~persistent_frontier
       ~catchup_mode ()
   with
   | Ok frontier ->


### PR DESCRIPTION
## Summary

This PR makes the `max_frontier_depth` parameter mandatory in `Transition_frontier.load` and enforces it to be the protocol's k value (290 for mainnet). Previously, this parameter was optional and could be omitted, potentially allowing unbounded frontier loading depth.

## Motivation

The transition frontier loading process should have a well-defined maximum depth to prevent excessive memory usage and ensure consistent behavior across the network. By enforcing the depth to be the protocol's k value, we ensure that:

1. The frontier loading depth is always properly bounded
2. The depth matches the protocol's security parameter
3. The behavior is consistent and predictable across all nodes