### PR TITLE
Add mina-archive-healthcheck CLI and shared archive_health_queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ build-archive-utils: ocaml_checks reformat-diff ## Build archive node and relate
 		src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
 		src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.exe \
 		src/app/dump_slot_ledger/dump_slot_ledger.exe \
+		src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe \
 		--profile=$(DUNE_PROFILE)  \
 		&& echo "✅ Build complete"
 

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ build-archive-utils: ocaml_checks reformat-diff ## Build archive node and relate
 		src/app/missing_blocks_auditor/missing_blocks_auditor.exe \
 		src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.exe \
 		src/app/dump_slot_ledger/dump_slot_ledger.exe \
+		src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe \
 		--profile=$(DUNE_PROFILE)  \
 		&& echo "✅ Build complete"
 

--- a/buildkite/scripts/tests/archive-node-unit-tests.sh
+++ b/buildkite/scripts/tests/archive-node-unit-tests.sh
@@ -59,6 +59,13 @@ echo "Setting up database for archive node tests..."
 source ./buildkite/scripts/setup-database-for-archive-node.sh ${user} ${password} ${db} 
 
 echo "Database setup complete, accessible via $MINA_TEST_POSTGRES . Running archive node unit tests..."
-dune runtest src/app/archive 
+dune runtest src/app/archive
+
+# Hermetic CLI smoke tests for mina-archive-healthcheck: --help shape
+# and the single-JSON-record contract on the dead-PG error path.  These
+# don't need MINA_TEST_POSTGRES (they exercise only failure paths) but
+# are run from this job because it's the natural component-tests home
+# for the healthcheck binary.
+dune runtest src/app/mina_archive_healthcheck
 
 ./buildkite/scripts/upload-partial-coverage-data.sh ${command_key} "dev"

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -22,7 +22,7 @@ in  { step =
                     , "MINA_TEST_NETWORK_DATA=src/test/archive/sample_db"
                     , "APPS_BUILD_FLAG=instrumented"
                     , "MINA_PROFILE=devnet"
-                    , "APPS_BARE_BINARIES=archive_node_tests.exe:mina-archive-node-test,archive.exe:mina-archive,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
+                    , "APPS_BARE_BINARIES=archive_node_tests.exe:mina-archive-node-test,archive.exe:mina-archive,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis,mina_archive_healthcheck.exe:mina-archive-healthcheck"
                     ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script

--- a/changes/18771.md
+++ b/changes/18771.md
@@ -1,0 +1,24 @@
+- New `mina-archive-healthcheck` CLI: lightweight probes that read archive
+  health straight from PostgreSQL, with no dependency on a running daemon or
+  on `archive-node-api`. Subcommands are `db-ready`, `block-height`,
+  `block-recency`, `missing-blocks`, `unparented-blocks`, `ready` and `wait`.
+  Each prints exactly one result — one JSON object with `--json`, one line
+  without it — so it can be used directly as a Kubernetes exec probe or a
+  Docker `HEALTHCHECK`. See `src/app/mina_archive_healthcheck/README.md`.
+
+- `mina-missing-blocks-auditor` now counts missing blocks from the lowest
+  block the archive actually holds, instead of always counting from height 1.
+  On a hardfork archive the earliest block is the fork genesis, and there is
+  nothing below it, so the old rule reported every block below the fork point
+  as missing. A healthy forked archive could therefore report hundreds of
+  thousands of missing blocks. Operators who alert on that count will see it
+  drop to the real figure.
+
+- Unparented (orphan) blocks are counted the same way: the earliest block in
+  the archive is excluded, because its parent belongs to the pre-fork chain
+  and is legitimately absent. Previously every healthy archive reported one
+  permanent orphan.
+
+- `mina-missing-blocks-auditor` now distinguishes "the archive holds no
+  canonical block" from "the canonical chain tops out at height 0". The first
+  case is reported explicitly; it used to be inferred from a coalesced 0.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -961,6 +961,8 @@ copy_common_archive_configs() {
     "${BUILDDIR}/usr/local/bin/mina-replayer"
   cp ./default/src/app/dump_slot_ledger/dump_slot_ledger.exe \
     "${BUILDDIR}/usr/local/bin/mina-dump-slot-ledger"
+  cp ./default/src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/mina-archive-healthcheck"
 
   rsync -Huav ../src/app/archive/*.sql "${BUILDDIR}/etc/mina/archive"
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -1101,6 +1101,8 @@ copy_common_archive_configs() {
     "${BUILDDIR}/usr/local/bin/mina-replayer"
   cp ./default/src/app/dump_slot_ledger/dump_slot_ledger.exe \
     "${BUILDDIR}/usr/local/bin/mina-dump-slot-ledger"
+  cp ./default/src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/mina-archive-healthcheck"
 
   rsync -Huav ../src/app/archive/*.sql "${BUILDDIR}/etc/mina/archive"
 

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -24,6 +24,7 @@
   sexplib0
   uri
   ;;local libraries
+  archive_health_queries
   block_time
   mina_stdlib
   child_processes

--- a/src/app/archive/lib/metrics.ml
+++ b/src/app/archive/lib/metrics.ml
@@ -33,15 +33,13 @@ let time ~label ~logger f =
 
 let default_missing_blocks_width = 2000
 
-module Max_block_height = struct
-  let query =
-    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
-      "SELECT GREATEST(0, MAX(height)) FROM blocks"
+module Q = Archive_health_queries
 
+module Max_block_height = struct
   let update ~logger (module Conn : Mina_caqti.CONNECTION) metric_server =
     time ~label:"max_block_height" ~logger (fun () ->
         let open Deferred.Result.Let_syntax in
-        let%map max_height = Conn.find query () in
+        let%map max_height = Q.Max_block_height.run (module Conn) () in
         Mina_metrics.(
           Gauge.set
             (Archive.max_block_height metric_server)
@@ -49,23 +47,13 @@ module Max_block_height = struct
 end
 
 module Missing_blocks = struct
-  (*A block is missing if there is no entry for a specific height. However, if there is an entry then it doesn't necessarily mean that it is part of the main chain. Unparented_blocks will show value > 1 in that case. Look for the last 2000 blocks*)
-  let query missing_blocks_width =
-    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
-      (Core_kernel.sprintf
-         {sql| 
-        SELECT COUNT( * )
-        FROM (SELECT h::int FROM generate_series(GREATEST(1, (SELECT MAX(height) FROM blocks) - %d) , (SELECT MAX(height) FROM blocks)) h
-        LEFT JOIN blocks b 
-        ON h = b.height WHERE b.height IS NULL) as v
-      |sql}
-         missing_blocks_width )
-
   let update ~logger ~missing_blocks_width (module Conn : Mina_caqti.CONNECTION)
       metric_server =
     let open Deferred.Result.Let_syntax in
     time ~label:"missing_blocks" ~logger (fun () ->
-        let%map missing_blocks = Conn.find (query missing_blocks_width) () in
+        let%map missing_blocks =
+          Q.Missing_blocks_count.run (module Conn) ~missing_blocks_width ()
+        in
         Mina_metrics.(
           Gauge.set
             (Archive.missing_blocks metric_server)
@@ -73,19 +61,12 @@ module Missing_blocks = struct
 end
 
 module Unparented_blocks = struct
-  (* parent_hashes represent ends of chains leading to an orphan block *)
-
-  let query =
-    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
-      {sql|
-           SELECT COUNT( * ) FROM blocks
-           WHERE parent_id IS NULL
-      |sql}
-
   let update ~logger (module Conn : Mina_caqti.CONNECTION) metric_server =
     let open Deferred.Result.Let_syntax in
     time ~label:"unparented_blocks" ~logger (fun () ->
-        let%map unparented_block_count = Conn.find query () in
+        let%map unparented_block_count =
+          Q.Unparented_blocks_count.run (module Conn) ()
+        in
         Mina_metrics.(
           Gauge.set
             (Archive.unparented_blocks metric_server)

--- a/src/app/mina_archive_healthcheck/README.md
+++ b/src/app/mina_archive_healthcheck/README.md
@@ -1,0 +1,116 @@
+# mina-archive-healthcheck
+
+Lightweight CLI for probing the health of a Mina archive node via PostgreSQL.
+Designed for Kubernetes exec probes, Docker HEALTHCHECK, and monitoring.
+
+## Commands
+
+| Command | Description | Exit 0 when |
+|---------|-------------|-------------|
+| `db-ready` | Check database connectivity | DB reachable |
+| `block-height` | Report max block height | Always (if DB reachable) |
+| `block-recency` | Check latest block timestamp | Within `--max-delay` seconds |
+| `missing-blocks` | Count height gaps in sliding window | Count <= `--max-missing` |
+| `unparented-blocks` | Count orphan blocks | Count <= `--max-unparented` |
+| `ready` | Combined readiness check | All checks pass |
+| `wait` | Block until ready or timeout | Archive becomes ready |
+
+## Usage
+
+```bash
+# Check if archive DB is reachable
+mina-archive-healthcheck db-ready --postgres-uri postgres://user@localhost:5432/archive
+
+# Get current block height
+mina-archive-healthcheck block-height --postgres-uri postgres://...
+
+# Check if latest block is recent (within 6 minutes)
+mina-archive-healthcheck block-recency --postgres-uri postgres://... --max-delay 360
+
+# Check for missing blocks in the last 2000 block window
+mina-archive-healthcheck missing-blocks --postgres-uri postgres://... --max-missing 10
+
+# Combined readiness check
+mina-archive-healthcheck ready --postgres-uri postgres://... --max-delay 360 --max-missing 10
+
+# Wait for archive to become ready (init container / CI)
+mina-archive-healthcheck wait --postgres-uri postgres://... --timeout 600 --interval 10
+
+# Wait only for the DB schema to respond — useful for "is the archive
+# process up at all?" gates where you can't wait for ingestion (e.g. a
+# freshly-bootstrapped archive that hasn't received any blocks yet,
+# init containers, integration test fixtures).  Skips recency /
+# missing / unparented checks.
+mina-archive-healthcheck wait --db-only --postgres-uri postgres://... --timeout 30 --interval 1
+```
+
+## Flags
+
+Flags are accepted per-subcommand.
+
+| Flag | Alias | Default | Description |
+|------|-------|---------|-------------|
+| `--postgres-uri` | `-p` | (required) | PostgreSQL connection URI |
+| `--json` | `-j` | off | Output as JSON instead of text |
+| `--max-delay` | | 360 | Max seconds since last block |
+| `--max-missing` | | 10 | Max acceptable missing blocks |
+| `--max-unparented` | | 5 | Max acceptable unparented blocks |
+| `--window` | | 2000 | Block window for missing blocks check |
+| `--timeout` | `-t` | 600 | Max seconds to wait (wait only) |
+| `--interval` | `-i` | 10 | Poll interval in seconds (wait only) |
+| `--db-only` | | off | Wait only for the DB to respond, skip recency / missing / unparented (wait only) |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed |
+| 1 | Check failed (details on stderr) |
+
+## Kubernetes integration
+
+```yaml
+# Liveness: is the archive DB reachable?
+livenessProbe:
+  exec:
+    command: ["mina-archive-healthcheck", "db-ready",
+              "--postgres-uri", "$(ARCHIVE_URI)"]
+  initialDelaySeconds: 30
+  periodSeconds: 30
+
+# Readiness: is the archive up-to-date?
+readinessProbe:
+  exec:
+    command: ["mina-archive-healthcheck", "ready",
+              "--postgres-uri", "$(ARCHIVE_URI)",
+              "--max-delay", "360"]
+  initialDelaySeconds: 60
+  periodSeconds: 30
+```
+
+## Docker integration
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD ["mina-archive-healthcheck", "db-ready", \
+       "--postgres-uri", "postgres://user@localhost:5432/archive"]
+```
+
+## Relationship to missing-blocks-auditor
+
+Both tools share SQL queries via the `archive_health_queries` library.
+
+- **mina-archive-healthcheck**: Fast, lightweight probes for operational health.
+  Answers "is the archive working right now?"
+- **mina-missing-blocks-auditor**: Deep integrity audit with bitmask exit codes.
+  Answers "is the archive data complete and consistent?"
+  Paired with the guardian script for auto-repair.
+
+Use the healthcheck for k8s probes (every 10-30s) and the auditor for
+periodic deep checks (every 10min via the guardian daemon).
+
+## Building
+
+```bash
+dune build src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe
+```

--- a/src/app/mina_archive_healthcheck/README.md
+++ b/src/app/mina_archive_healthcheck/README.md
@@ -8,6 +8,7 @@ Designed for Kubernetes exec probes, Docker HEALTHCHECK, and monitoring.
 | Command | Description | Exit 0 when |
 |---------|-------------|-------------|
 | `db-ready` | Check DB is reachable and schema is loaded (`blocks` queryable) | Schema queryable |
+| `server-ready` | Check the archive server accepts TCP connections on `--server-port` | Connect accepted |
 | `block-height` | Report max block height | Always (if DB reachable) |
 | `block-recency` | Check latest block timestamp | Within `--max-delay` seconds |
 | `missing-blocks` | Count height gaps in sliding window | Count <= `--max-missing` |
@@ -35,6 +36,15 @@ mina-archive-healthcheck ready --postgres-uri postgres://... --max-delay 360 --m
 
 # Wait for archive to become ready (init container / CI)
 mina-archive-healthcheck wait --postgres-uri postgres://... --timeout 600 --interval 10
+
+# Check the archive server itself accepts connections (the DB probes
+# cannot see this: the schema answers queries before the server listens)
+mina-archive-healthcheck server-ready --server-port 3086
+
+# Gate on both: schema queryable AND server accepting connections.
+# This is the correct "safe to send blocks" gate for tests and init
+# containers — a block dispatched before the server listens is lost.
+mina-archive-healthcheck wait --db-only --server-port 3086 --postgres-uri postgres://...
 
 # Wait only for the DB schema to respond — useful for "is the archive
 # process up at all?" gates where you can't wait for ingestion (e.g. a

--- a/src/app/mina_archive_healthcheck/README.md
+++ b/src/app/mina_archive_healthcheck/README.md
@@ -65,7 +65,52 @@ Flags are accepted per-subcommand.
 | Code | Meaning |
 |------|---------|
 | 0 | Check passed |
-| 1 | Check failed (details on stderr) |
+| 1 | Check failed |
+| 2 | Usage error (no PostgreSQL URI given) |
+
+## Output
+
+Each run prints exactly one result: one JSON object with `--json`, one line
+without it. Nothing else is written to that stream, so a probe can parse it
+without filtering.
+
+- With `--json`, the object goes to **stdout** whether the check passed or
+  failed, so a consumer reads one stream.
+- Without `--json`, the line goes to **stdout** when the check passed and to
+  **stderr** when it failed.
+- Progress messages from `wait` are logs, not results. They go to **stderr**,
+  through the standard Mina logger, and follow `--json` as well: one JSON log
+  line per poll with the flag, interpolated plain text without it.
+
+The verdict is keyed `healthy` for a single-signal check and `ready` for
+`ready` and `wait`. A check reports the metrics it measured, so a failure
+still carries its numbers:
+
+```json
+{ "healthy": false, "missing_blocks": 41, "max_missing": 10, "window": 2000,
+  "error": { "sexp": [ "Thresholds_exceeded", [ "missing blocks 41 > 10" ] ] } }
+```
+
+A check that failed before it could measure anything reports no metrics:
+
+```json
+{ "healthy": false,
+  "error": { "sexp": [ "Db_unreachable", "Failed to connect to ..." ] } }
+```
+
+`error` is the structured Mina error encoding (`Error_json`), not a bare
+string, so a consumer can branch on the reason instead of matching prose. The
+reasons are `Db_unreachable`, `Db_query_failed`, `No_blocks`,
+`Invalid_timestamp`, `Thresholds_exceeded` and `Timed_out`.
+
+`ready` and `wait` also list each breached threshold under `problems`, and
+`wait` always carries `timed_out` and `db_only`:
+
+```json
+{ "ready": false, "timed_out": true, "db_only": true,
+  "error": { "sexp": [ "Timed_out", [ "after_seconds", "600" ],
+                       [ "last_failure", [ [ "Db_query_failed", "..." ] ] ] ] } }
+```
 
 ## Kubernetes integration
 

--- a/src/app/mina_archive_healthcheck/README.md
+++ b/src/app/mina_archive_healthcheck/README.md
@@ -7,7 +7,7 @@ Designed for Kubernetes exec probes, Docker HEALTHCHECK, and monitoring.
 
 | Command | Description | Exit 0 when |
 |---------|-------------|-------------|
-| `db-ready` | Check database connectivity | DB reachable |
+| `db-ready` | Check DB is reachable and schema is loaded (`blocks` queryable) | Schema queryable |
 | `block-height` | Report max block height | Always (if DB reachable) |
 | `block-recency` | Check latest block timestamp | Within `--max-delay` seconds |
 | `missing-blocks` | Count height gaps in sliding window | Count <= `--max-missing` |

--- a/src/app/mina_archive_healthcheck/dune
+++ b/src/app/mina_archive_healthcheck/dune
@@ -1,0 +1,23 @@
+(executable
+ (package mina_archive_healthcheck)
+ (name mina_archive_healthcheck)
+ (public_name mina-archive-healthcheck)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async
+  async_kernel
+  async_unix
+  async.async_command
+  uri
+  caqti
+  caqti-async
+  caqti-driver-postgresql
+  yojson
+  ;; local libraries
+  archive_health_queries
+  mina_caqti)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_deriving_yojson)))

--- a/src/app/mina_archive_healthcheck/dune
+++ b/src/app/mina_archive_healthcheck/dune
@@ -16,8 +16,11 @@
   yojson
   ;; local libraries
   archive_health_queries
+  error_json
+  interpolator_lib
+  logger
   mina_caqti)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_let ppx_deriving_yojson)))
+  (pps ppx_version ppx_let ppx_sexp_conv ppx_deriving_yojson ppx_mina)))

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -160,8 +160,6 @@ module Output = struct
     ; problems = None
     ; error = None
     }
-
-  let to_json = to_yojson
 end
 
 (* The [json_error] callback for every [healthy]-keyed subcommand is
@@ -169,12 +167,12 @@ end
    same failure as [{ready=false; error}] instead. *)
 let health_error e =
   Output.(
-    to_json
+    to_yojson
       { empty with healthy = Some false; error = Some (Error.to_string_hum e) })
 
 let readiness_error e =
   Output.(
-    to_json
+    to_yojson
       { empty with ready = Some false; error = Some (Error.to_string_hum e) })
 
 let with_pool ~postgres_uri f =
@@ -237,7 +235,7 @@ let db_ready_command =
          ( match result with
          | Ok _height ->
              if json then
-               output Output.(to_json { empty with healthy = Some true })
+               output Output.(to_yojson { empty with healthy = Some true })
              else printf "OK\n" ;
              Ok ()
          | Error e ->
@@ -258,7 +256,7 @@ let block_height_command =
              if json then
                output
                  Output.(
-                   to_json
+                   to_yojson
                      { empty with
                        healthy = Some true
                      ; block_height = Some height
@@ -303,7 +301,7 @@ let block_recency_command =
                    if json then
                      output
                        Output.(
-                         to_json
+                         to_yojson
                            { empty with
                              healthy = Some true
                            ; delay_seconds = Some delay_secs
@@ -322,7 +320,7 @@ let block_recency_command =
                    if json then (
                      output
                        Output.(
-                         to_json
+                         to_yojson
                            { empty with
                              healthy = Some false
                            ; delay_seconds = Some delay_secs
@@ -360,7 +358,7 @@ let missing_blocks_command =
                if json then
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          healthy = Some true
                        ; missing_blocks = Some count
@@ -379,7 +377,7 @@ let missing_blocks_command =
                if json then (
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          healthy = Some false
                        ; missing_blocks = Some count
@@ -415,7 +413,7 @@ let unparented_blocks_command =
                if json then
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          healthy = Some true
                        ; unparented_blocks = Some count
@@ -432,7 +430,7 @@ let unparented_blocks_command =
                if json then (
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          healthy = Some false
                        ; unparented_blocks = Some count
@@ -521,7 +519,7 @@ let ready_command =
                if json then
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          ready = Some true
                        ; block_height = Some height
@@ -538,7 +536,7 @@ let ready_command =
                if json then (
                  output
                    Output.(
-                     to_json
+                     to_yojson
                        { empty with
                          ready = Some false
                        ; block_height = Some height
@@ -597,7 +595,7 @@ let wait_command =
            if json then (
              output
                Output.(
-                 to_json
+                 to_yojson
                    { empty with
                      ready = Some false
                    ; timed_out = Some false
@@ -633,7 +631,7 @@ let wait_command =
                  if json then
                    output
                      Output.(
-                       to_json
+                       to_yojson
                          { empty with ready = Some true; db_only = Some true })
                  else print_endline "READY (db-only)" ;
                  Deferred.Or_error.return ()
@@ -641,7 +639,7 @@ let wait_command =
                  if json then (
                    output
                      Output.(
-                       to_json
+                       to_yojson
                          { empty with
                            ready = Some false
                          ; timed_out = Some true
@@ -676,7 +674,7 @@ let wait_command =
                    if json then (
                      output
                        Output.(
-                         to_json
+                         to_yojson
                            { empty with
                              ready = Some false
                            ; timed_out = Some true
@@ -700,7 +698,7 @@ let wait_command =
                    if json then
                      output
                        Output.(
-                         to_json
+                         to_yojson
                            { empty with
                              ready = Some true
                            ; block_height = Some height
@@ -714,7 +712,7 @@ let wait_command =
                    if json then (
                      output
                        Output.(
-                         to_json
+                         to_yojson
                            { empty with
                              ready = Some false
                            ; timed_out = Some true

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -6,6 +6,10 @@ module Q = Archive_health_queries
 
 let default_missing_blocks_width = 2000
 
+(* "delay" throughout this CLI means archive-tip staleness: the number
+   of seconds between wall-clock now and the timestamp of the most
+   recent block, i.e. [now - latest_block_timestamp].  A large delay
+   means the archive has not ingested a block recently. *)
 let default_max_delay = 360
 
 let default_max_missing = 10
@@ -56,7 +60,8 @@ let max_delay_flag =
     flag "--max-delay"
       ~doc:
         (sprintf
-           "SECONDS Maximum acceptable delay since last block (default: %d)"
+           "SECONDS Maximum acceptable archive-tip staleness, i.e. (now - \
+            latest block timestamp); fail if it exceeds this (default: %d)"
            default_max_delay )
       (optional_with_default default_max_delay int))
 

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -1,0 +1,746 @@
+(* mina_archive_healthcheck.ml -- CLI for archive node health probes *)
+
+open Core_kernel
+open Async
+module Q = Archive_health_queries
+
+let default_missing_blocks_width = 2000
+
+let default_max_delay = 360
+
+let default_max_missing = 10
+
+let default_max_unparented = 5
+
+let postgres_uri_env = "MINA_POSTGRES_URI"
+
+(* Resolve the connection URI from [--postgres-uri] if given, otherwise
+   fall back to the [MINA_POSTGRES_URI] environment variable.  Exits
+   with code 2 (usage error) if neither is provided, rather than
+   surfacing an opaque connection failure later. *)
+let resolve_postgres_uri = function
+  | Some uri ->
+      uri
+  | None -> (
+      match Sys.getenv postgres_uri_env with
+      | Some uri ->
+          uri
+      | None ->
+          Stdlib.prerr_string
+            (sprintf
+               "error: no PostgreSQL URI given: pass --postgres-uri/-p or set \
+                $%s\n"
+               postgres_uri_env ) ;
+          Stdlib.flush Stdlib.stderr ;
+          Stdlib.exit 2 )
+
+let postgres_uri_flag =
+  Command.Param.(
+    map
+      (flag "--postgres-uri" ~aliases:[ "-p" ]
+         ~doc:
+           (sprintf
+              "URI PostgreSQL connection URI (e.g., \
+               postgres://user@localhost:5432/archive). Defaults to $%s."
+              postgres_uri_env )
+         (optional string) )
+      ~f:resolve_postgres_uri)
+
+let json_flag =
+  Command.Param.(
+    flag "--json" ~aliases:[ "-j" ] ~doc:" Output as JSON instead of text"
+      no_arg)
+
+let max_delay_flag =
+  Command.Param.(
+    flag "--max-delay"
+      ~doc:
+        (sprintf
+           "SECONDS Maximum acceptable delay since last block (default: %d)"
+           default_max_delay )
+      (optional_with_default default_max_delay int))
+
+let max_missing_flag =
+  Command.Param.(
+    flag "--max-missing"
+      ~doc:
+        (sprintf "N Maximum acceptable missing blocks (default: %d)"
+           default_max_missing )
+      (optional_with_default default_max_missing int))
+
+let max_unparented_flag =
+  Command.Param.(
+    flag "--max-unparented"
+      ~doc:
+        (sprintf "N Maximum acceptable unparented blocks (default: %d)"
+           default_max_unparented )
+      (optional_with_default default_max_unparented int))
+
+let missing_blocks_width_flag =
+  Command.Param.(
+    flag "--window"
+      ~doc:
+        (sprintf "N Block window for missing blocks check (default: %d)"
+           default_missing_blocks_width )
+      (optional_with_default default_missing_blocks_width int))
+
+(* Emit one JSON record on stdout and flush immediately.  The explicit
+   flush matters because several failure paths follow [output] with a
+   hard [Stdlib.exit]: under Async, relying on the at-exit flush can
+   drop the buffered write, so we flush while the fd is still in a known
+   state. *)
+let output json =
+  print_endline (Yojson.Safe.pretty_to_string json) ;
+  Out_channel.flush Out_channel.stdout
+
+(* Print a final text line and exit non-zero.  Used by the
+   threshold-failure paths so they report a single human-readable line
+   and set exit status without ALSO returning an error to the
+   [async_or_error] wrapper (which would print a second ["Error: ..."]
+   line). *)
+let fail_text fmt =
+  ksprintf
+    (fun s ->
+      print_string s ;
+      Out_channel.flush Out_channel.stdout ;
+      Stdlib.exit 1 )
+    fmt
+
+(* Typed model for every JSON envelope emitted by the subcommands.
+
+   Previously each command hand-rolled its own [`Assoc [...]] list,
+   duplicating the same keys ("healthy"/"error"/"block_height"/…)
+   across success, threshold-failure and connect-failure paths.  A
+   single deriving record removes that duplication: a command builds
+   the value it wants from [empty] (via record-update) and serializes
+   it with one [to_yojson].
+
+   Every field is optional with [@default None] so it is omitted from
+   the rendered object when left unset — preserving the prior shape
+   where each envelope carried only its relevant keys.  [int64] fields
+   render as bare JSON number literals, matching the prior [`Intlit]
+   encoding. *)
+module Output = struct
+  type t =
+    { healthy : bool option [@default None]
+    ; ready : bool option [@default None]
+    ; timed_out : bool option [@default None]
+    ; db_only : bool option [@default None]
+    ; block_height : int option [@default None]
+    ; delay_seconds : int64 option [@default None]
+    ; max_delay : int option [@default None]
+    ; missing_blocks : int option [@default None]
+    ; max_missing : int option [@default None]
+    ; unparented_blocks : int option [@default None]
+    ; max_unparented : int option [@default None]
+    ; window : int option [@default None]
+    ; problems : string list option [@default None]
+    ; error : string option [@default None]
+    }
+  [@@deriving to_yojson]
+
+  let empty =
+    { healthy = None
+    ; ready = None
+    ; timed_out = None
+    ; db_only = None
+    ; block_height = None
+    ; delay_seconds = None
+    ; max_delay = None
+    ; missing_blocks = None
+    ; max_missing = None
+    ; unparented_blocks = None
+    ; max_unparented = None
+    ; window = None
+    ; problems = None
+    ; error = None
+    }
+
+  let to_json = to_yojson
+end
+
+(* The [json_error] callback for every [healthy]-keyed subcommand is
+   identical — render [{healthy=false; error}].  [ready]/[wait] key the
+   same failure as [{ready=false; error}] instead. *)
+let health_error e =
+  Output.(
+    to_json
+      { empty with healthy = Some false; error = Some (Error.to_string_hum e) })
+
+let readiness_error e =
+  Output.(
+    to_json
+      { empty with ready = Some false; error = Some (Error.to_string_hum e) })
+
+let with_pool ~postgres_uri f =
+  let uri = Uri.of_string postgres_uri in
+  match Mina_caqti.connect_pool ~max_size:4 uri with
+  | Error e ->
+      let msg =
+        sprintf "Failed to connect to PostgreSQL: %s" (Caqti_error.show e)
+      in
+      Deferred.Or_error.fail (Error.of_string msg)
+  | Ok pool ->
+      Mina_caqti.Pool.use f pool
+      |> Deferred.map
+           ~f:
+             (Result.map_error ~f:(fun e ->
+                  Error.of_string (Caqti_error.show e) ) )
+
+(* Run a subcommand body for an error path where nothing has been
+   printed yet (e.g. DB connect failure, query error).  In [json]
+   mode, emits exactly one JSON record via [json_error] on stdout and
+   exits 1 directly — this avoids the [async_or_error] wrapper
+   printing an extra plain-text ["Error: ..."] line on stderr, which
+   would otherwise produce mixed-format output for machine consumers.
+   In text mode we keep the previous behavior and return the error so
+   the wrapper prints the message.
+
+   Callers MUST NOT have already emitted any JSON on stdout before
+   invoking [finish] in [json] mode — otherwise the invocation would
+   produce two JSON records on stdout.  Threshold-failure paths that
+   want to include their metric fields alongside the error should
+   instead emit a single merged JSON directly and [exit 1], bypassing
+   [finish] (see e.g. [block_recency_command]). *)
+let finish ~json ~json_error result =
+  match result with
+  | Ok () ->
+      Deferred.Or_error.return ()
+  | Error e ->
+      if json then (
+        output (json_error e) ;
+        exit 1 )
+      else Deferred.Or_error.fail e
+
+(* Current wall-clock time as epoch milliseconds. The archive
+   [blocks.timestamp] column stores the block timestamp as a string
+   representation of epoch milliseconds (see create_schema.sql:
+   "timestamp text NOT NULL"), so comparisons are in the same unit. *)
+let now_ms () =
+  Time.now () |> Time.to_span_since_epoch |> Time.Span.to_ms |> Int64.of_float
+
+let db_ready_command =
+  Command.async_or_error
+    ~summary:"Check if archive database is reachable (exit 0 if connected)"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db -> Q.Max_block_height.run db ())
+       in
+       finish ~json ~json_error:health_error
+         ( match result with
+         | Ok _height ->
+             if json then
+               output Output.(to_json { empty with healthy = Some true })
+             else printf "OK\n" ;
+             Ok ()
+         | Error e ->
+             Error e ) )
+
+let block_height_command =
+  Command.async_or_error
+    ~summary:"Report the maximum block height in the archive database"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db -> Q.Max_block_height.run db ())
+       in
+       finish ~json ~json_error:health_error
+         ( match result with
+         | Ok height ->
+             if json then
+               output
+                 Output.(
+                   to_json
+                     { empty with
+                       healthy = Some true
+                     ; block_height = Some height
+                     })
+             else printf "%d\n" height ;
+             Ok ()
+         | Error e ->
+             Error e ) )
+
+let block_recency_command =
+  Command.async_or_error
+    ~summary:
+      "Check if latest block is recent enough (exit 0 if within --max-delay \
+       seconds)"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag
+     and max_delay = max_delay_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db -> Q.Latest_block_timestamp.run db ())
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok None ->
+             Error (Error.of_string "no blocks in archive database")
+         | Ok (Some ts_str) -> (
+             match Option.try_with (fun () -> Int64.of_string ts_str) with
+             | None ->
+                 Error
+                   (Error.of_string
+                      (sprintf "invalid timestamp format: %s" ts_str) )
+             | Some ts_ms ->
+                 let delay_secs =
+                   Int64.( / ) (Int64.( - ) (now_ms ()) ts_ms) 1000L
+                 in
+                 let healthy =
+                   Int64.( <= ) delay_secs (Int64.of_int max_delay)
+                 in
+                 if healthy then (
+                   if json then
+                     output
+                       Output.(
+                         to_json
+                           { empty with
+                             healthy = Some true
+                           ; delay_seconds = Some delay_secs
+                           ; max_delay = Some max_delay
+                           })
+                   else
+                     printf "Last block: %Lds ago (max: %ds)\n" delay_secs
+                       max_delay ;
+                   Ok () )
+                 else
+                   let err_msg =
+                     sprintf
+                       "latest block is %Ld seconds old, exceeds max delay %d"
+                       delay_secs max_delay
+                   in
+                   if json then (
+                     output
+                       Output.(
+                         to_json
+                           { empty with
+                             healthy = Some false
+                           ; delay_seconds = Some delay_secs
+                           ; max_delay = Some max_delay
+                           ; error = Some err_msg
+                           }) ;
+                     Stdlib.exit 1 )
+                   else
+                     fail_text "Last block: %Lds ago (max: %ds)\n" delay_secs
+                       max_delay )
+       in
+       finish ~json ~json_error:health_error inner )
+
+let missing_blocks_command =
+  Command.async_or_error
+    ~summary:
+      "Check missing blocks count in sliding window (exit 0 if within \
+       threshold)"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag
+     and max_missing = max_missing_flag
+     and window = missing_blocks_width_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db ->
+             Q.Missing_blocks_count.run db ~missing_blocks_width:window () )
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok count ->
+             let healthy = count <= max_missing in
+             if healthy then (
+               if json then
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         healthy = Some true
+                       ; missing_blocks = Some count
+                       ; max_missing = Some max_missing
+                       ; window = Some window
+                       })
+               else
+                 printf "%d missing blocks (max: %d, window: %d)\n" count
+                   max_missing window ;
+               Ok () )
+             else
+               let err_msg =
+                 sprintf "missing blocks count %d exceeds threshold %d" count
+                   max_missing
+               in
+               if json then (
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         healthy = Some false
+                       ; missing_blocks = Some count
+                       ; max_missing = Some max_missing
+                       ; window = Some window
+                       ; error = Some err_msg
+                       }) ;
+                 Stdlib.exit 1 )
+               else
+                 fail_text "%d missing blocks (max: %d, window: %d)\n" count
+                   max_missing window
+       in
+       finish ~json ~json_error:health_error inner )
+
+let unparented_blocks_command =
+  Command.async_or_error
+    ~summary:
+      "Check unparented (orphan) blocks count (exit 0 if within threshold)"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag
+     and max_unparented = max_unparented_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db -> Q.Unparented_blocks_count.run db ())
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok count ->
+             let healthy = count <= max_unparented in
+             if healthy then (
+               if json then
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         healthy = Some true
+                       ; unparented_blocks = Some count
+                       ; max_unparented = Some max_unparented
+                       })
+               else
+                 printf "%d unparented blocks (max: %d)\n" count max_unparented ;
+               Ok () )
+             else
+               let err_msg =
+                 sprintf "unparented blocks count %d exceeds threshold %d" count
+                   max_unparented
+               in
+               if json then (
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         healthy = Some false
+                       ; unparented_blocks = Some count
+                       ; max_unparented = Some max_unparented
+                       ; error = Some err_msg
+                       }) ;
+                 Stdlib.exit 1 )
+               else
+                 fail_text "%d unparented blocks (max: %d)\n" count
+                   max_unparented
+       in
+       finish ~json ~json_error:health_error inner )
+
+(* Evaluate readiness from the four underlying metrics. Returns the
+   [(ready, delay_secs, problems)] triple. [latest_ts] is the raw
+   [text]-typed timestamp from the [blocks] table, which we interpret
+   as epoch milliseconds (see [now_ms] above). *)
+let evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay ~max_missing
+    ~max_unparented =
+  let future_ts, delay_secs =
+    match latest_ts with
+    | None ->
+        (false, Int64.max_value)
+    | Some ts_str -> (
+        match Option.try_with (fun () -> Int64.of_string ts_str) with
+        | None ->
+            (false, Int64.max_value)
+        | Some ts_ms ->
+            let now = now_ms () in
+            let delay_secs = Int64.( / ) (Int64.( - ) now ts_ms) 1000L in
+            (Int64.( > ) ts_ms now, delay_secs) )
+  in
+  let recent =
+    (not future_ts) && Int64.( <= ) delay_secs (Int64.of_int max_delay)
+  in
+  let missing_ok = missing <= max_missing in
+  let unparented_ok = unparented <= max_unparented in
+  let ready = recent && missing_ok && unparented_ok in
+  let problems = ref [] in
+  if not recent then
+    problems :=
+      ( if future_ts then "latest block timestamp is in the future"
+      else sprintf "block delay %Lds > %ds" delay_secs max_delay )
+      :: !problems ;
+  if not missing_ok then
+    problems :=
+      sprintf "missing blocks %d > %d" missing max_missing :: !problems ;
+  if not unparented_ok then
+    problems :=
+      sprintf "unparented blocks %d > %d" unparented max_unparented :: !problems ;
+  (ready, delay_secs, List.rev !problems)
+
+let ready_command =
+  Command.async_or_error
+    ~summary:
+      "Combined readiness: db reachable + recent block + missing/unparented \
+       within thresholds"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag
+     and max_delay = max_delay_flag
+     and max_missing = max_missing_flag
+     and max_unparented = max_unparented_flag
+     and window = missing_blocks_width_flag in
+     fun () ->
+       let%bind result =
+         with_pool ~postgres_uri (fun db ->
+             let open Deferred.Result.Let_syntax in
+             let%bind height = Q.Max_block_height.run db () in
+             let%bind latest_ts = Q.Latest_block_timestamp.run db () in
+             let%bind missing =
+               Q.Missing_blocks_count.run db ~missing_blocks_width:window ()
+             in
+             let%bind unparented = Q.Unparented_blocks_count.run db () in
+             return (height, latest_ts, missing, unparented) )
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok (height, latest_ts, missing, unparented) ->
+             let ready, delay_secs, problems =
+               evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay
+                 ~max_missing ~max_unparented
+             in
+             if ready then (
+               if json then
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         ready = Some true
+                       ; block_height = Some height
+                       ; delay_seconds = Some delay_secs
+                       ; missing_blocks = Some missing
+                       ; unparented_blocks = Some unparented
+                       })
+               else print_endline "READY" ;
+               Ok () )
+             else
+               let err_msg =
+                 sprintf "not ready: %s" (String.concat ~sep:", " problems)
+               in
+               if json then (
+                 output
+                   Output.(
+                     to_json
+                       { empty with
+                         ready = Some false
+                       ; block_height = Some height
+                       ; delay_seconds = Some delay_secs
+                       ; missing_blocks = Some missing
+                       ; unparented_blocks = Some unparented
+                       ; problems = Some problems
+                       ; error = Some err_msg
+                       }) ;
+                 Stdlib.exit 1 )
+               else
+                 fail_text "NOT READY: %s\n" (String.concat ~sep:", " problems)
+       in
+       finish ~json ~json_error:readiness_error inner )
+
+let wait_command =
+  Command.async_or_error
+    ~summary:"Block until archive passes readiness checks or timeout expires"
+    (let%map_open.Command postgres_uri = postgres_uri_flag
+     and json = json_flag
+     and max_delay = max_delay_flag
+     and max_missing = max_missing_flag
+     and max_unparented = max_unparented_flag
+     and window = missing_blocks_width_flag
+     and timeout =
+       flag "--timeout" ~aliases:[ "-t" ]
+         ~doc:"SECONDS Maximum time to wait (default: 600)"
+         (optional_with_default 600 int)
+     and interval =
+       flag "--interval" ~aliases:[ "-i" ]
+         ~doc:"SECONDS Polling interval (default: 10)"
+         (optional_with_default 10 int)
+     and db_only =
+       flag "--db-only"
+         ~doc:
+           " Wait only for the archive DB to respond; skip the recency / \
+            missing / unparented checks.  Useful as an init-container or 'is \
+            the archive process up at all' gate, where you want to block until \
+            the schema is queryable but cannot wait for ingestion (e.g. a \
+            freshly-initialized DB with no blocks yet)."
+         no_arg
+     in
+     fun () ->
+       (* Connect the pool once up front and reuse it across every
+          poll.  Previously every iteration called [with_pool], which
+          opened a brand new Caqti pool — wasteful and noisy for
+          long-running waits. *)
+       let uri = Uri.of_string postgres_uri in
+       match Mina_caqti.connect_pool ~max_size:4 uri with
+       | Error e ->
+           let err =
+             Error.of_string
+               (sprintf "Failed to connect to PostgreSQL: %s"
+                  (Caqti_error.show e) )
+           in
+           if json then (
+             output
+               Output.(
+                 to_json
+                   { empty with
+                     ready = Some false
+                   ; timed_out = Some false
+                   ; db_only = Some db_only
+                   ; error = Some (Error.to_string_hum err)
+                   }) ;
+             exit 1 )
+           else Deferred.Or_error.fail err
+       | Ok pool ->
+           let start = Time.now () in
+           let deadline = Time.add start (Time.Span.of_int_sec timeout) in
+           let timed_out () = Time.( >= ) (Time.now ()) deadline in
+           let elapsed () =
+             Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
+           in
+           let use f =
+             Mina_caqti.Pool.use f pool
+             |> Deferred.map
+                  ~f:
+                    (Result.map_error ~f:(fun e ->
+                         Error.of_string (Caqti_error.show e) ) )
+           in
+           (* In [--db-only] mode we deliberately skip recency / missing
+              / unparented checks: the only signal we wait for is "the
+              [blocks] table responds to a [SELECT MAX(height)]."  This
+              exists because the full readiness check requires a
+              non-None [latest_ts] and so cannot succeed against a
+              freshly-bootstrapped, empty archive.  See the README for
+              the full rationale. *)
+           let rec db_only_loop () =
+             match%bind use (fun db -> Q.Max_block_height.run db ()) with
+             | Ok _height ->
+                 if json then
+                   output
+                     Output.(
+                       to_json
+                         { empty with ready = Some true; db_only = Some true })
+                 else print_endline "READY (db-only)" ;
+                 Deferred.Or_error.return ()
+             | Error e when timed_out () ->
+                 if json then (
+                   output
+                     Output.(
+                       to_json
+                         { empty with
+                           ready = Some false
+                         ; timed_out = Some true
+                         ; db_only = Some true
+                         ; error = Some (Error.to_string_hum e)
+                         }) ;
+                   exit 1 )
+                 else
+                   Deferred.Or_error.errorf "timed out waiting for DB: %s"
+                     (Error.to_string_hum e)
+             | Error e ->
+                 eprintf "[%3ds] DB unreachable: %s\n" (elapsed ())
+                   (Error.to_string_hum e) ;
+                 let%bind () = after (Time.Span.of_int_sec interval) in
+                 db_only_loop ()
+           in
+           let rec loop () =
+             match%bind
+               use (fun db ->
+                   let open Deferred.Result.Let_syntax in
+                   let%bind height = Q.Max_block_height.run db () in
+                   let%bind latest_ts = Q.Latest_block_timestamp.run db () in
+                   let%bind missing =
+                     Q.Missing_blocks_count.run db ~missing_blocks_width:window
+                       ()
+                   in
+                   let%bind unparented = Q.Unparented_blocks_count.run db () in
+                   return (height, latest_ts, missing, unparented) )
+             with
+             | Error e ->
+                 if timed_out () then
+                   if json then (
+                     output
+                       Output.(
+                         to_json
+                           { empty with
+                             ready = Some false
+                           ; timed_out = Some true
+                           ; error = Some (Error.to_string_hum e)
+                           }) ;
+                     exit 1 )
+                   else
+                     Deferred.Or_error.errorf "timed out: %s"
+                       (Error.to_string_hum e)
+                 else (
+                   eprintf "[%3ds] DB unreachable: %s\n" (elapsed ())
+                     (Error.to_string_hum e) ;
+                   let%bind () = after (Time.Span.of_int_sec interval) in
+                   loop () )
+             | Ok (height, latest_ts, missing, unparented) ->
+                 let ready, delay_secs, _problems =
+                   evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay
+                     ~max_missing ~max_unparented
+                 in
+                 if ready then (
+                   if json then
+                     output
+                       Output.(
+                         to_json
+                           { empty with
+                             ready = Some true
+                           ; block_height = Some height
+                           ; delay_seconds = Some delay_secs
+                           ; missing_blocks = Some missing
+                           ; unparented_blocks = Some unparented
+                           })
+                   else print_endline "READY" ;
+                   Deferred.Or_error.return () )
+                 else if timed_out () then
+                   if json then (
+                     output
+                       Output.(
+                         to_json
+                           { empty with
+                             ready = Some false
+                           ; timed_out = Some true
+                           ; block_height = Some height
+                           ; delay_seconds = Some delay_secs
+                           ; missing_blocks = Some missing
+                           ; unparented_blocks = Some unparented
+                           }) ;
+                     exit 1 )
+                   else
+                     Deferred.Or_error.errorf "timed out waiting for readiness"
+                 else (
+                   eprintf
+                     "[%3ds] height=%d delay=%Lds missing=%d unparented=%d\n"
+                     (elapsed ()) height delay_secs missing unparented ;
+                   let%bind () = after (Time.Span.of_int_sec interval) in
+                   loop () )
+           in
+           if db_only then db_only_loop () else loop () )
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina archive healthcheck CLI — lightweight probe commands for \
+          archive node monitoring"
+       [ ("db-ready", db_ready_command)
+       ; ("block-height", block_height_command)
+       ; ("block-recency", block_recency_command)
+       ; ("missing-blocks", missing_blocks_command)
+       ; ("unparented-blocks", unparented_blocks_command)
+       ; ("ready", ready_command)
+       ; ("wait", wait_command)
+       ] )

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -21,6 +21,12 @@ let default_wait_timeout = 600
 
 let default_wait_interval = 10
 
+let default_server_host = "127.0.0.1"
+
+(* Bound on a single TCP connect attempt; [wait] retries failed
+   attempts on its own --interval. *)
+let server_connect_timeout_sec = 5
+
 let postgres_uri_env = "MINA_POSTGRES_URI"
 
 (* Exit 2 (usage) rather than surfacing an opaque connection failure
@@ -84,6 +90,14 @@ let max_unparented_flag =
            default_max_unparented )
       (optional_with_default default_max_unparented int))
 
+let server_host_flag =
+  Command.Param.(
+    flag "--server-host"
+      ~doc:
+        (sprintf "HOST Archive server host to probe (default: %s)"
+           default_server_host )
+      (optional_with_default default_server_host string))
+
 let missing_blocks_width_flag =
   Command.Param.(
     flag "--window"
@@ -104,6 +118,7 @@ module Failure = struct
   type t =
     | Db_unreachable of string
     | Db_query_failed of string
+    | Server_unreachable of string
     | No_blocks
     | Invalid_timestamp of string
     | Thresholds_exceeded of string list
@@ -118,6 +133,8 @@ module Failure = struct
         sprintf "Failed to connect to PostgreSQL: %s" message
     | Db_query_failed message ->
         sprintf "Archive query failed: %s" message
+    | Server_unreachable message ->
+        sprintf "Failed to connect to archive server: %s" message
     | No_blocks ->
         "no blocks in archive database"
     | Invalid_timestamp raw ->
@@ -140,6 +157,7 @@ module Metrics = struct
      so an envelope cannot claim a field the probe never read. *)
   type t =
     | Db_reachable
+    | Server_reachable
     | Block_height of int
     | Recency of { delay_seconds : int64; max_delay : int }
     | Missing_blocks of
@@ -161,7 +179,7 @@ module Metrics = struct
         [ (name, to_json value) ]
 
   let to_json_fields = function
-    | Db_reachable ->
+    | Db_reachable | Server_reachable ->
         []
     | Block_height height ->
         [ ("block_height", `Int height) ]
@@ -189,7 +207,7 @@ module Metrics = struct
   (* The text-mode line: what was measured, against which limit. The
      same line whether the probe passed or failed. *)
   let to_text = function
-    | Db_reachable ->
+    | Db_reachable | Server_reachable ->
         "OK"
     | Block_height height ->
         Int.to_string height
@@ -379,6 +397,33 @@ let with_pool ~postgres_uri f =
       Mina_caqti.Pool.use f pool
       |> Deferred.map
            ~f:(Result.map_error ~f:(fun e -> failure_of_caqti_pool_error e))
+
+(* The archive's client-facing RPC port.  A plain TCP connect proves
+   the server is accepting connections — something no DB probe can
+   see, because the schema answers queries before the archive process
+   has started listening. *)
+let probe_server ~host ~port =
+  match%map
+    Monitor.try_with (fun () ->
+        Tcp.with_connection
+          ~timeout:(Time.Span.of_int_sec server_connect_timeout_sec)
+          (Tcp.Where_to_connect.of_host_and_port
+             (Host_and_port.create ~host ~port) )
+          (fun _socket _reader _writer -> Deferred.unit) )
+  with
+  | Ok () ->
+      Ok ()
+  | Error exn ->
+      (* Render the errno as prose: raw OCaml exception syntax must not
+         reach user-visible output (see the leak guard in tests/). *)
+      let reason =
+        match Monitor.extract_exn exn with
+        | Unix.Unix_error (err, _, _) ->
+            Unix.Error.message err
+        | exn ->
+            Exn.to_string_mach exn
+      in
+      Error (Failure.Server_unreachable (sprintf "%s:%d: %s" host port reason))
 
 let evaluation_of_result ~evaluate : (_, Failure.t) Result.t -> evaluation =
   function
@@ -590,6 +635,30 @@ let ready_command =
        in
        emit ~json report )
 
+let server_ready_command =
+  Command.async_or_error
+    ~summary:
+      "Check if the archive server accepts TCP connections (exit 0 if \
+       connected)"
+    (let%map_open.Command json = json_flag
+     and host = server_host_flag
+     and port =
+       flag "--server-port" ~doc:"PORT Archive server port to probe (e.g. 3086)"
+         (required int)
+     in
+     fun () ->
+       setup_logging ~json ;
+       let%bind outcome = probe_server ~host ~port in
+       let metrics =
+         match outcome with
+         | Ok () ->
+             Some Metrics.Server_reachable
+         | Error _ ->
+             None
+       in
+       emit ~json (Report.of_evaluation ~kind:Report.Probe (metrics, outcome))
+    )
+
 (* Both wait modes share this loop; they differ only in [attempt]. On
    expiry the last failure is wrapped in [Timed_out]. *)
 let rec poll ~start ~deadline ~interval ~kind attempt =
@@ -648,6 +717,15 @@ let wait_command =
             the schema is queryable but cannot wait for ingestion (e.g. a \
             freshly-initialized DB with no blocks yet)."
          no_arg
+     and server_host = server_host_flag
+     and server_port =
+       flag "--server-port"
+         ~doc:
+           "PORT Also require the archive server to accept a TCP connection on \
+            this port before reporting ready.  The DB probes cannot see the \
+            server: the schema answers queries before the archive process \
+            starts listening, so a block sent then is silently lost."
+         (optional int)
      in
      fun () ->
        setup_logging ~json ;
@@ -684,7 +762,22 @@ let wait_command =
                            evaluate_readiness ~now:(now_ms ()) ~max_delay
                              ~max_missing ~max_unparented answer ) )
            in
-           let%bind report = poll ~start ~deadline ~interval ~kind attempt in
+           (* Server first: it is the cheaper probe, and until it
+              listens the DB answer alone would falsely report ready. *)
+           let gated_attempt () =
+             match server_port with
+             | None ->
+                 attempt ()
+             | Some port -> (
+                 match%bind probe_server ~host:server_host ~port with
+                 | Ok () ->
+                     attempt ()
+                 | Error failure ->
+                     return (None, Error failure) )
+           in
+           let%bind report =
+             poll ~start ~deadline ~interval ~kind gated_attempt
+           in
            emit ~json report )
 
 let () =
@@ -694,6 +787,7 @@ let () =
          "Mina archive healthcheck CLI — lightweight probe commands for \
           archive node monitoring"
        [ ("db-ready", db_ready_command)
+       ; ("server-ready", server_ready_command)
        ; ("block-height", block_height_command)
        ; ("block-recency", block_recency_command)
        ; ("missing-blocks", missing_blocks_command)

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -17,6 +17,10 @@ let default_max_missing = 10
 
 let default_max_unparented = 5
 
+let default_wait_timeout = 600
+
+let default_wait_interval = 10
+
 let postgres_uri_env = "MINA_POSTGRES_URI"
 
 (* Exit 2 (usage) rather than surfacing an opaque connection failure
@@ -143,12 +147,18 @@ module Metrics = struct
     | Unparented_blocks of { unparented_blocks : int; max_unparented : int }
     | Readiness of
         { block_height : int
-        ; delay_seconds : int64
+        ; delay_seconds : int64 option
         ; missing_blocks : int
         ; unparented_blocks : int
         }
 
   let int64_json n = `Intlit (Int64.to_string n)
+
+  let optional_json_field name to_json = function
+    | None ->
+        []
+    | Some value ->
+        [ (name, to_json value) ]
 
   let to_json_fields = function
     | Db_reachable ->
@@ -170,11 +180,11 @@ module Metrics = struct
         ]
     | Readiness
         { block_height; delay_seconds; missing_blocks; unparented_blocks } ->
-        [ ("block_height", `Int block_height)
-        ; ("delay_seconds", int64_json delay_seconds)
-        ; ("missing_blocks", `Int missing_blocks)
-        ; ("unparented_blocks", `Int unparented_blocks)
-        ]
+        [ ("block_height", `Int block_height) ]
+        @ optional_json_field "delay_seconds" int64_json delay_seconds
+        @ [ ("missing_blocks", `Int missing_blocks)
+          ; ("unparented_blocks", `Int unparented_blocks)
+          ]
 
   (* The text-mode line: what was measured, against which limit. The
      same line whether the probe passed or failed. *)
@@ -193,8 +203,12 @@ module Metrics = struct
           max_unparented
     | Readiness
         { block_height; delay_seconds; missing_blocks; unparented_blocks } ->
-        sprintf "height=%d delay=%Lds missing=%d unparented=%d" block_height
-          delay_seconds missing_blocks unparented_blocks
+        let delay =
+          Option.value_map delay_seconds ~default:"n/a" ~f:(fun delay ->
+              sprintf "%Lds" delay )
+        in
+        sprintf "height=%d delay=%s missing=%d unparented=%d" block_height delay
+          missing_blocks unparented_blocks
 end
 
 type evaluation = Metrics.t option * (unit, Failure.t) Result.t
@@ -274,7 +288,15 @@ module Report = struct
         Metrics.to_text metrics
     | (Readiness | Wait _), Some metrics ->
         if passed t then banner t
-        else sprintf "%s: %s" (banner t) (Metrics.to_text metrics)
+        else
+          let failure =
+            match outcome with
+            | Ok () ->
+                ""
+            | Error failure ->
+                sprintf " (%s)" (Failure.to_string failure)
+          in
+          sprintf "%s: %s%s" (banner t) (Metrics.to_text metrics) failure
     | _, None -> (
         match outcome with
         | Ok () ->
@@ -317,16 +339,46 @@ let emit ~json report =
   if Report.passed report then Deferred.Or_error.return () else exit 1
 
 (* Nothing above this point deals in [Caqti_error]. *)
+let failure_of_caqti_call_error e = Failure.Db_query_failed (Caqti_error.show e)
+
+let failure_of_caqti_load_error = function
+  | `Load_rejected e ->
+      Failure.Db_unreachable (Caqti_error.show (`Load_rejected e))
+  | `Load_failed e ->
+      Failure.Db_unreachable (Caqti_error.show (`Load_failed e))
+  | _ ->
+      Failure.Db_unreachable "database driver failed to load"
+
+let failure_of_caqti_pool_error = function
+  | `Connect_rejected e ->
+      Failure.Db_unreachable (Caqti_error.show (`Connect_rejected e))
+  | `Connect_failed e ->
+      Failure.Db_unreachable (Caqti_error.show (`Connect_failed e))
+  | `Post_connect e ->
+      failure_of_caqti_call_error e
+  | `Encode_rejected e ->
+      Failure.Db_query_failed (Caqti_error.show (`Encode_rejected e))
+  | `Encode_failed e ->
+      Failure.Db_query_failed (Caqti_error.show (`Encode_failed e))
+  | `Request_failed e ->
+      Failure.Db_query_failed (Caqti_error.show (`Request_failed e))
+  | `Decode_rejected e ->
+      Failure.Db_query_failed (Caqti_error.show (`Decode_rejected e))
+  | `Response_failed e ->
+      Failure.Db_query_failed (Caqti_error.show (`Response_failed e))
+  | `Response_rejected e ->
+      Failure.Db_query_failed (Caqti_error.show (`Response_rejected e))
+  | _ ->
+      Failure.Db_query_failed "unknown database error"
+
 let with_pool ~postgres_uri f =
   match Mina_caqti.connect_pool ~max_size:4 (Uri.of_string postgres_uri) with
   | Error e ->
-      Deferred.return (Error (Failure.Db_unreachable (Caqti_error.show e)))
+      Deferred.return (Error (failure_of_caqti_load_error e))
   | Ok pool ->
       Mina_caqti.Pool.use f pool
       |> Deferred.map
-           ~f:
-             (Result.map_error ~f:(fun e ->
-                  Failure.Db_query_failed (Caqti_error.show e) ) )
+           ~f:(Result.map_error ~f:(fun e -> failure_of_caqti_pool_error e))
 
 let evaluation_of_result ~evaluate : (_, Failure.t) Result.t -> evaluation =
   function
@@ -375,10 +427,10 @@ let delay_of_timestamp ~now latest_ts =
           Ok (Int64.( / ) (Int64.( - ) now ts_ms) 1000L, Int64.( > ) ts_ms now)
       )
 
-let evaluate_recency ~now ~max_delay latest_ts : evaluation =
+let recency_status ~now ~max_delay latest_ts =
   match delay_of_timestamp ~now latest_ts with
   | Error failure ->
-      (None, Error failure)
+      (None, [ Failure.to_string failure ], Some failure)
   | Ok (delay_seconds, in_future) ->
       let problems =
         if in_future then [ "latest block timestamp is in the future" ]
@@ -386,8 +438,17 @@ let evaluate_recency ~now ~max_delay latest_ts : evaluation =
           [ sprintf "block delay %Lds > %ds" delay_seconds max_delay ]
         else []
       in
+      (Some delay_seconds, problems, None)
+
+let evaluate_recency ~now ~max_delay latest_ts : evaluation =
+  match recency_status ~now ~max_delay latest_ts with
+  | None, _, Some failure ->
+      (None, Error failure)
+  | Some delay_seconds, problems, _ ->
       ( Some (Metrics.Recency { delay_seconds; max_delay })
       , threshold_failure problems )
+  | None, problems, None ->
+      (None, threshold_failure problems)
 
 let evaluate_missing_blocks ~max_missing ~window missing_blocks : evaluation =
   let problems =
@@ -411,17 +472,8 @@ let evaluate_unparented_blocks ~max_unparented unparented_blocks : evaluation =
    thresholds rather than only the first. *)
 let evaluate_readiness ~now ~max_delay ~max_missing ~max_unparented
     (block_height, latest_ts, missing_blocks, unparented_blocks) : evaluation =
-  let delay_seconds, recency_problems =
-    match delay_of_timestamp ~now latest_ts with
-    | Error failure ->
-        (Int64.max_value, [ Failure.to_string failure ])
-    | Ok (delay_seconds, true) ->
-        (delay_seconds, [ "latest block timestamp is in the future" ])
-    | Ok (delay_seconds, false) ->
-        if Int64.( > ) delay_seconds (Int64.of_int max_delay) then
-          ( delay_seconds
-          , [ sprintf "block delay %Lds > %ds" delay_seconds max_delay ] )
-        else (delay_seconds, [])
+  let delay_seconds, recency_problems, _ =
+    recency_status ~now ~max_delay latest_ts
   in
   let problems =
     recency_problems
@@ -577,12 +629,16 @@ let wait_command =
      and window = missing_blocks_width_flag
      and timeout =
        flag "--timeout" ~aliases:[ "-t" ]
-         ~doc:"SECONDS Maximum time to wait (default: 600)"
-         (optional_with_default 600 int)
+         ~doc:
+           (sprintf "SECONDS Maximum time to wait (default: %d)"
+              default_wait_timeout )
+         (optional_with_default default_wait_timeout int)
      and interval =
        flag "--interval" ~aliases:[ "-i" ]
-         ~doc:"SECONDS Polling interval (default: 10)"
-         (optional_with_default 10 int)
+         ~doc:
+           (sprintf "SECONDS Polling interval (default: %d)"
+              default_wait_interval )
+         (optional_with_default default_wait_interval int)
      and db_only =
        flag "--db-only"
          ~doc:
@@ -603,15 +659,14 @@ let wait_command =
          Mina_caqti.connect_pool ~max_size:4 (Uri.of_string postgres_uri)
        with
        | Error e ->
-           emit ~json
-             (Report.fail ~kind (Failure.Db_unreachable (Caqti_error.show e)))
+           emit ~json (Report.fail ~kind (failure_of_caqti_load_error e))
        | Ok pool ->
            let run query =
              Mina_caqti.Pool.use query pool
              |> Deferred.map
                   ~f:
                     (Result.map_error ~f:(fun e ->
-                         Failure.Db_query_failed (Caqti_error.show e) ) )
+                         failure_of_caqti_pool_error e ) )
            in
            (* [--db-only] waits only for the [blocks] table to answer:
               the full check needs a non-empty table and so can never

--- a/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/mina_archive_healthcheck.ml
@@ -1,4 +1,7 @@
-(* mina_archive_healthcheck.ml -- CLI for archive node health probes *)
+(* mina_archive_healthcheck.ml -- CLI for archive node health probes
+
+   Every subcommand: run one query set, turn the answer into a
+   [Report.t] with a pure evaluator, hand it to [emit]. *)
 
 open Core_kernel
 open Async
@@ -6,10 +9,8 @@ module Q = Archive_health_queries
 
 let default_missing_blocks_width = 2000
 
-(* "delay" throughout this CLI means archive-tip staleness: the number
-   of seconds between wall-clock now and the timestamp of the most
-   recent block, i.e. [now - latest_block_timestamp].  A large delay
-   means the archive has not ingested a block recently. *)
+(* "delay" throughout this CLI means archive-tip staleness:
+   [now - latest_block_timestamp]. *)
 let default_max_delay = 360
 
 let default_max_missing = 10
@@ -18,10 +19,8 @@ let default_max_unparented = 5
 
 let postgres_uri_env = "MINA_POSTGRES_URI"
 
-(* Resolve the connection URI from [--postgres-uri] if given, otherwise
-   fall back to the [MINA_POSTGRES_URI] environment variable.  Exits
-   with code 2 (usage error) if neither is provided, rather than
-   surfacing an opaque connection failure later. *)
+(* Exit 2 (usage) rather than surfacing an opaque connection failure
+   later. *)
 let resolve_postgres_uri = function
   | Some uri ->
       uri
@@ -89,138 +88,355 @@ let missing_blocks_width_flag =
            default_missing_blocks_width )
       (optional_with_default default_missing_blocks_width int))
 
-(* Emit one JSON record on stdout and flush immediately.  The explicit
-   flush matters because several failure paths follow [output] with a
-   hard [Stdlib.exit]: under Async, relying on the at-exit flush can
-   drop the buffered write, so we flush while the fd is still in a known
-   state. *)
-let output json =
-  print_endline (Yojson.Safe.pretty_to_string json) ;
-  Out_channel.flush Out_channel.stdout
+(* [blocks.timestamp] is epoch milliseconds held as text (see
+   create_schema.sql), so comparisons are in the same unit. *)
+let now_ms () =
+  Time.now () |> Time.to_span_since_epoch |> Time.Span.to_ms |> Int64.of_float
 
-(* Print a final text line and exit non-zero.  Used by the
-   threshold-failure paths so they report a single human-readable line
-   and set exit status without ALSO returning an error to the
-   [async_or_error] wrapper (which would print a second ["Error: ..."]
-   line). *)
-let fail_text fmt =
-  ksprintf
-    (fun s ->
-      print_string s ;
-      Out_channel.flush Out_channel.stdout ;
-      Stdlib.exit 1 )
-    fmt
-
-(* Typed model for every JSON envelope emitted by the subcommands.
-
-   Previously each command hand-rolled its own [`Assoc [...]] list,
-   duplicating the same keys ("healthy"/"error"/"block_height"/…)
-   across success, threshold-failure and connect-failure paths.  A
-   single deriving record removes that duplication: a command builds
-   the value it wants from [empty] (via record-update) and serializes
-   it with one [to_yojson].
-
-   Every field is optional with [@default None] so it is omitted from
-   the rendered object when left unset — preserving the prior shape
-   where each envelope carried only its relevant keys.  [int64] fields
-   render as bare JSON number literals, matching the prior [`Intlit]
-   encoding. *)
-module Output = struct
+module Failure = struct
+  (* Kept as a variant so the reason survives from where it is detected
+     to where it is rendered: [wait] matches on it to build [Timed_out],
+     and the JSON envelope renders it structurally. *)
   type t =
-    { healthy : bool option [@default None]
-    ; ready : bool option [@default None]
-    ; timed_out : bool option [@default None]
-    ; db_only : bool option [@default None]
-    ; block_height : int option [@default None]
-    ; delay_seconds : int64 option [@default None]
-    ; max_delay : int option [@default None]
-    ; missing_blocks : int option [@default None]
-    ; max_missing : int option [@default None]
-    ; unparented_blocks : int option [@default None]
-    ; max_unparented : int option [@default None]
-    ; window : int option [@default None]
-    ; problems : string list option [@default None]
-    ; error : string option [@default None]
-    }
-  [@@deriving to_yojson]
+    | Db_unreachable of string
+    | Db_query_failed of string
+    | No_blocks
+    | Invalid_timestamp of string
+    | Thresholds_exceeded of string list
+    | Timed_out of { after_seconds : int; last_failure : t option }
+  [@@deriving sexp_of]
 
-  let empty =
-    { healthy = None
-    ; ready = None
-    ; timed_out = None
-    ; db_only = None
-    ; block_height = None
-    ; delay_seconds = None
-    ; max_delay = None
-    ; missing_blocks = None
-    ; max_missing = None
-    ; unparented_blocks = None
-    ; max_unparented = None
-    ; window = None
-    ; problems = None
-    ; error = None
-    }
+  (* Via [Error.t] so the JSON encoding matches the rest of the daemon's. *)
+  let to_error t = Error.create_s (sexp_of_t t)
+
+  let rec to_string = function
+    | Db_unreachable message ->
+        sprintf "Failed to connect to PostgreSQL: %s" message
+    | Db_query_failed message ->
+        sprintf "Archive query failed: %s" message
+    | No_blocks ->
+        "no blocks in archive database"
+    | Invalid_timestamp raw ->
+        sprintf "invalid timestamp format: %s" raw
+    | Thresholds_exceeded problems ->
+        String.concat ~sep:", " problems
+    | Timed_out { after_seconds; last_failure } ->
+        let cause =
+          match last_failure with
+          | None ->
+              ""
+          | Some failure ->
+              sprintf ": %s" (to_string failure)
+        in
+        sprintf "timed out after %ds%s" after_seconds cause
 end
 
-(* The [json_error] callback for every [healthy]-keyed subcommand is
-   identical — render [{healthy=false; error}].  [ready]/[wait] key the
-   same failure as [{ready=false; error}] instead. *)
-let health_error e =
-  Output.(
-    to_yojson
-      { empty with healthy = Some false; error = Some (Error.to_string_hum e) })
+module Metrics = struct
+  (* One constructor per probe, carrying only what that probe measures,
+     so an envelope cannot claim a field the probe never read. *)
+  type t =
+    | Db_reachable
+    | Block_height of int
+    | Recency of { delay_seconds : int64; max_delay : int }
+    | Missing_blocks of
+        { missing_blocks : int; max_missing : int; window : int }
+    | Unparented_blocks of { unparented_blocks : int; max_unparented : int }
+    | Readiness of
+        { block_height : int
+        ; delay_seconds : int64
+        ; missing_blocks : int
+        ; unparented_blocks : int
+        }
 
-let readiness_error e =
-  Output.(
-    to_yojson
-      { empty with ready = Some false; error = Some (Error.to_string_hum e) })
+  let int64_json n = `Intlit (Int64.to_string n)
 
+  let to_json_fields = function
+    | Db_reachable ->
+        []
+    | Block_height height ->
+        [ ("block_height", `Int height) ]
+    | Recency { delay_seconds; max_delay } ->
+        [ ("delay_seconds", int64_json delay_seconds)
+        ; ("max_delay", `Int max_delay)
+        ]
+    | Missing_blocks { missing_blocks; max_missing; window } ->
+        [ ("missing_blocks", `Int missing_blocks)
+        ; ("max_missing", `Int max_missing)
+        ; ("window", `Int window)
+        ]
+    | Unparented_blocks { unparented_blocks; max_unparented } ->
+        [ ("unparented_blocks", `Int unparented_blocks)
+        ; ("max_unparented", `Int max_unparented)
+        ]
+    | Readiness
+        { block_height; delay_seconds; missing_blocks; unparented_blocks } ->
+        [ ("block_height", `Int block_height)
+        ; ("delay_seconds", int64_json delay_seconds)
+        ; ("missing_blocks", `Int missing_blocks)
+        ; ("unparented_blocks", `Int unparented_blocks)
+        ]
+
+  (* The text-mode line: what was measured, against which limit. The
+     same line whether the probe passed or failed. *)
+  let to_text = function
+    | Db_reachable ->
+        "OK"
+    | Block_height height ->
+        Int.to_string height
+    | Recency { delay_seconds; max_delay } ->
+        sprintf "Last block: %Lds ago (max: %ds)" delay_seconds max_delay
+    | Missing_blocks { missing_blocks; max_missing; window } ->
+        sprintf "%d missing blocks (max: %d, window: %d)" missing_blocks
+          max_missing window
+    | Unparented_blocks { unparented_blocks; max_unparented } ->
+        sprintf "%d unparented blocks (max: %d)" unparented_blocks
+          max_unparented
+    | Readiness
+        { block_height; delay_seconds; missing_blocks; unparented_blocks } ->
+        sprintf "height=%d delay=%Lds missing=%d unparented=%d" block_height
+          delay_seconds missing_blocks unparented_blocks
+end
+
+type evaluation = Metrics.t option * (unit, Failure.t) Result.t
+
+module Report = struct
+  (* [kind] fixes the verdict key and the extra envelope fields, once,
+     instead of at each print site. *)
+  type kind = Probe | Readiness | Wait of { db_only : bool }
+
+  type t =
+    { kind : kind
+    ; metrics : Metrics.t option  (** [None] when nothing was measured *)
+    ; outcome : (unit, Failure.t) Result.t
+    }
+
+  let fail ~kind ?metrics failure = { kind; metrics; outcome = Error failure }
+
+  let of_evaluation ~kind (metrics, outcome) = { kind; metrics; outcome }
+
+  let passed t = Result.is_ok t.outcome
+
+  (* The word a check is judged by: lower case as the JSON key, upper
+     case as the text banner. *)
+  let verdict_name = function
+    | Probe ->
+        "healthy"
+    | Readiness | Wait _ ->
+        "ready"
+
+  let banner t =
+    let name = String.uppercase (verdict_name t.kind) in
+    if passed t then name else "NOT " ^ name
+
+  let to_yojson ({ kind; metrics; outcome } as t) : Yojson.Safe.t =
+    let failure = Result.error outcome in
+    let verdict = [ (verdict_name kind, `Bool (passed t)) ] in
+    let wait_flags =
+      match kind with
+      | Probe | Readiness ->
+          []
+      | Wait { db_only } ->
+          let timed_out =
+            match failure with
+            | Some (Failure.Timed_out _) ->
+                true
+            | Some _ | None ->
+                false
+          in
+          [ ("timed_out", `Bool timed_out); ("db_only", `Bool db_only) ]
+    in
+    let measured =
+      Option.value_map metrics ~default:[] ~f:Metrics.to_json_fields
+    in
+    (* Only the combined probes list their breached thresholds; a
+       single-signal probe has one, already implied by its metrics. *)
+    let problems =
+      match (kind, failure) with
+      | (Readiness | Wait _), Some (Failure.Thresholds_exceeded problems) ->
+          [ ( "problems"
+            , `List (List.map problems ~f:(fun problem -> `String problem)) )
+          ]
+      | _ ->
+          []
+    in
+    let error =
+      Option.value_map failure ~default:[] ~f:(fun failure ->
+          [ ("error", Error_json.error_to_yojson (Failure.to_error failure)) ] )
+    in
+    `Assoc (verdict @ wait_flags @ measured @ problems @ error)
+
+  (* A single-signal probe reports what it measured, in both outcomes —
+     the exit status carries the verdict.  The combined checks report
+     the verdict, with the measurements after it when it is negative. *)
+  let to_text ({ kind; metrics; outcome } as t) =
+    match (kind, metrics) with
+    | Probe, Some metrics ->
+        Metrics.to_text metrics
+    | (Readiness | Wait _), Some metrics ->
+        if passed t then banner t
+        else sprintf "%s: %s" (banner t) (Metrics.to_text metrics)
+    | _, None -> (
+        match outcome with
+        | Ok () ->
+            banner t
+        | Error failure ->
+            Failure.to_string failure )
+end
+
+(* Diagnostics go to stderr through [Logger], which already renders
+   JSON or plain text; stdout carries the probe result and nothing
+   else, because k8s exec probes and [mina_automation] parse it as a
+   single record. *)
+let logger = Logger.create ~id:"mina-archive-healthcheck" ()
+
+let setup_logging ~json =
+  let processor =
+    if json then Logger.Processor.raw ~log_level:Logger.Level.Info ()
+    else
+      Logger.Processor.pretty ~log_level:Logger.Level.Info
+        ~config:
+          { Interpolator_lib.Interpolator.mode = Inline
+          ; max_interpolation_length = 50
+          ; pretty_print = true
+          }
+  in
+  Logger.Consumer_registry.register ~id:"mina-archive-healthcheck" ~processor
+    ~transport:(Logger.Transport.raw Stdlib.prerr_endline)
+    ()
+
+(* The only place that writes probe output or sets the exit status, so
+   the pass and fail paths cannot drift and a failure keeps the metrics
+   it measured. *)
+let emit ~json report =
+  let channel = if Report.passed report then stdout else stderr in
+  if json then
+    print_endline (Yojson.Safe.pretty_to_string (Report.to_yojson report))
+  else Out_channel.output_lines channel [ Report.to_text report ] ;
+  Out_channel.flush stdout ;
+  Out_channel.flush stderr ;
+  if Report.passed report then Deferred.Or_error.return () else exit 1
+
+(* Nothing above this point deals in [Caqti_error]. *)
 let with_pool ~postgres_uri f =
-  let uri = Uri.of_string postgres_uri in
-  match Mina_caqti.connect_pool ~max_size:4 uri with
+  match Mina_caqti.connect_pool ~max_size:4 (Uri.of_string postgres_uri) with
   | Error e ->
-      let msg =
-        sprintf "Failed to connect to PostgreSQL: %s" (Caqti_error.show e)
-      in
-      Deferred.Or_error.fail (Error.of_string msg)
+      Deferred.return (Error (Failure.Db_unreachable (Caqti_error.show e)))
   | Ok pool ->
       Mina_caqti.Pool.use f pool
       |> Deferred.map
            ~f:
              (Result.map_error ~f:(fun e ->
-                  Error.of_string (Caqti_error.show e) ) )
+                  Failure.Db_query_failed (Caqti_error.show e) ) )
 
-(* Run a subcommand body for an error path where nothing has been
-   printed yet (e.g. DB connect failure, query error).  In [json]
-   mode, emits exactly one JSON record via [json_error] on stdout and
-   exits 1 directly — this avoids the [async_or_error] wrapper
-   printing an extra plain-text ["Error: ..."] line on stderr, which
-   would otherwise produce mixed-format output for machine consumers.
-   In text mode we keep the previous behavior and return the error so
-   the wrapper prints the message.
+let evaluation_of_result ~evaluate : (_, Failure.t) Result.t -> evaluation =
+  function
+  | Ok answer ->
+      evaluate answer
+  | Error failure ->
+      (None, Error failure)
 
-   Callers MUST NOT have already emitted any JSON on stdout before
-   invoking [finish] in [json] mode — otherwise the invocation would
-   produce two JSON records on stdout.  Threshold-failure paths that
-   want to include their metric fields alongside the error should
-   instead emit a single merged JSON directly and [exit 1], bypassing
-   [finish] (see e.g. [block_recency_command]). *)
-let finish ~json ~json_error result =
-  match result with
-  | Ok () ->
-      Deferred.Or_error.return ()
-  | Error e ->
-      if json then (
-        output (json_error e) ;
-        exit 1 )
-      else Deferred.Or_error.fail e
+let probe ~postgres_uri ~kind ~evaluate query =
+  let%map result = with_pool ~postgres_uri query in
+  Report.of_evaluation ~kind (evaluation_of_result ~evaluate result)
 
-(* Current wall-clock time as epoch milliseconds. The archive
-   [blocks.timestamp] column stores the block timestamp as a string
-   representation of epoch milliseconds (see create_schema.sql:
-   "timestamp text NOT NULL"), so comparisons are in the same unit. *)
-let now_ms () =
-  Time.now () |> Time.to_span_since_epoch |> Time.Span.to_ms |> Int64.of_float
+let readiness_query ~window db =
+  let open Deferred.Result.Let_syntax in
+  let%bind block_height = Q.Max_block_height.run db () in
+  let%bind latest_ts = Q.Latest_block_timestamp.run db () in
+  let%bind missing_blocks =
+    Q.Missing_blocks_count.run db ~missing_blocks_width:window ()
+  in
+  let%map unparented_blocks = Q.Unparented_blocks_count.run db () in
+  (block_height, latest_ts, missing_blocks, unparented_blocks)
+
+(* Evaluators: pure, one per probe, so the threshold rules read on
+   their own. *)
+
+let threshold_failure problems : (unit, Failure.t) Result.t =
+  if List.is_empty problems then Ok ()
+  else Error (Failure.Thresholds_exceeded problems)
+
+let evaluate_db_ready (_ : int) : evaluation = (Some Metrics.Db_reachable, Ok ())
+
+let evaluate_block_height height : evaluation =
+  (Some (Metrics.Block_height height), Ok ())
+
+(* A tip dated ahead of wall clock yields a negative delay; callers
+   treat that as a failure, not as an extremely fresh block. *)
+let delay_of_timestamp ~now latest_ts =
+  match latest_ts with
+  | None ->
+      Error Failure.No_blocks
+  | Some raw -> (
+      match Option.try_with (fun () -> Int64.of_string raw) with
+      | None ->
+          Error (Failure.Invalid_timestamp raw)
+      | Some ts_ms ->
+          Ok (Int64.( / ) (Int64.( - ) now ts_ms) 1000L, Int64.( > ) ts_ms now)
+      )
+
+let evaluate_recency ~now ~max_delay latest_ts : evaluation =
+  match delay_of_timestamp ~now latest_ts with
+  | Error failure ->
+      (None, Error failure)
+  | Ok (delay_seconds, in_future) ->
+      let problems =
+        if in_future then [ "latest block timestamp is in the future" ]
+        else if Int64.( > ) delay_seconds (Int64.of_int max_delay) then
+          [ sprintf "block delay %Lds > %ds" delay_seconds max_delay ]
+        else []
+      in
+      ( Some (Metrics.Recency { delay_seconds; max_delay })
+      , threshold_failure problems )
+
+let evaluate_missing_blocks ~max_missing ~window missing_blocks : evaluation =
+  let problems =
+    if missing_blocks > max_missing then
+      [ sprintf "missing blocks %d > %d" missing_blocks max_missing ]
+    else []
+  in
+  ( Some (Metrics.Missing_blocks { missing_blocks; max_missing; window })
+  , threshold_failure problems )
+
+let evaluate_unparented_blocks ~max_unparented unparented_blocks : evaluation =
+  let problems =
+    if unparented_blocks > max_unparented then
+      [ sprintf "unparented blocks %d > %d" unparented_blocks max_unparented ]
+    else []
+  in
+  ( Some (Metrics.Unparented_blocks { unparented_blocks; max_unparented })
+  , threshold_failure problems )
+
+(* Every signal is evaluated, so the report lists all breached
+   thresholds rather than only the first. *)
+let evaluate_readiness ~now ~max_delay ~max_missing ~max_unparented
+    (block_height, latest_ts, missing_blocks, unparented_blocks) : evaluation =
+  let delay_seconds, recency_problems =
+    match delay_of_timestamp ~now latest_ts with
+    | Error failure ->
+        (Int64.max_value, [ Failure.to_string failure ])
+    | Ok (delay_seconds, true) ->
+        (delay_seconds, [ "latest block timestamp is in the future" ])
+    | Ok (delay_seconds, false) ->
+        if Int64.( > ) delay_seconds (Int64.of_int max_delay) then
+          ( delay_seconds
+          , [ sprintf "block delay %Lds > %ds" delay_seconds max_delay ] )
+        else (delay_seconds, [])
+  in
+  let problems =
+    recency_problems
+    @ ( if missing_blocks > max_missing then
+        [ sprintf "missing blocks %d > %d" missing_blocks max_missing ]
+      else [] )
+    @
+    if unparented_blocks > max_unparented then
+      [ sprintf "unparented blocks %d > %d" unparented_blocks max_unparented ]
+    else []
+  in
+  ( Some
+      (Metrics.Readiness
+         { block_height; delay_seconds; missing_blocks; unparented_blocks } )
+  , threshold_failure problems )
 
 let db_ready_command =
   Command.async_or_error
@@ -228,18 +444,12 @@ let db_ready_command =
     (let%map_open.Command postgres_uri = postgres_uri_flag
      and json = json_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db -> Q.Max_block_height.run db ())
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Probe ~evaluate:evaluate_db_ready
+           (fun db -> Q.Max_block_height.run db ())
        in
-       finish ~json ~json_error:health_error
-         ( match result with
-         | Ok _height ->
-             if json then
-               output Output.(to_yojson { empty with healthy = Some true })
-             else printf "OK\n" ;
-             Ok ()
-         | Error e ->
-             Error e ) )
+       emit ~json report )
 
 let block_height_command =
   Command.async_or_error
@@ -247,24 +457,12 @@ let block_height_command =
     (let%map_open.Command postgres_uri = postgres_uri_flag
      and json = json_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db -> Q.Max_block_height.run db ())
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Probe ~evaluate:evaluate_block_height
+           (fun db -> Q.Max_block_height.run db ())
        in
-       finish ~json ~json_error:health_error
-         ( match result with
-         | Ok height ->
-             if json then
-               output
-                 Output.(
-                   to_yojson
-                     { empty with
-                       healthy = Some true
-                     ; block_height = Some height
-                     })
-             else printf "%d\n" height ;
-             Ok ()
-         | Error e ->
-             Error e ) )
+       emit ~json report )
 
 let block_recency_command =
   Command.async_or_error
@@ -275,64 +473,14 @@ let block_recency_command =
      and json = json_flag
      and max_delay = max_delay_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db -> Q.Latest_block_timestamp.run db ())
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Probe
+           ~evaluate:(fun latest_ts ->
+             evaluate_recency ~now:(now_ms ()) ~max_delay latest_ts )
+           (fun db -> Q.Latest_block_timestamp.run db ())
        in
-       let inner =
-         match result with
-         | Error e ->
-             Error e
-         | Ok None ->
-             Error (Error.of_string "no blocks in archive database")
-         | Ok (Some ts_str) -> (
-             match Option.try_with (fun () -> Int64.of_string ts_str) with
-             | None ->
-                 Error
-                   (Error.of_string
-                      (sprintf "invalid timestamp format: %s" ts_str) )
-             | Some ts_ms ->
-                 let delay_secs =
-                   Int64.( / ) (Int64.( - ) (now_ms ()) ts_ms) 1000L
-                 in
-                 let healthy =
-                   Int64.( <= ) delay_secs (Int64.of_int max_delay)
-                 in
-                 if healthy then (
-                   if json then
-                     output
-                       Output.(
-                         to_yojson
-                           { empty with
-                             healthy = Some true
-                           ; delay_seconds = Some delay_secs
-                           ; max_delay = Some max_delay
-                           })
-                   else
-                     printf "Last block: %Lds ago (max: %ds)\n" delay_secs
-                       max_delay ;
-                   Ok () )
-                 else
-                   let err_msg =
-                     sprintf
-                       "latest block is %Ld seconds old, exceeds max delay %d"
-                       delay_secs max_delay
-                   in
-                   if json then (
-                     output
-                       Output.(
-                         to_yojson
-                           { empty with
-                             healthy = Some false
-                           ; delay_seconds = Some delay_secs
-                           ; max_delay = Some max_delay
-                           ; error = Some err_msg
-                           }) ;
-                     Stdlib.exit 1 )
-                   else
-                     fail_text "Last block: %Lds ago (max: %ds)\n" delay_secs
-                       max_delay )
-       in
-       finish ~json ~json_error:health_error inner )
+       emit ~json report )
 
 let missing_blocks_command =
   Command.async_or_error
@@ -344,53 +492,13 @@ let missing_blocks_command =
      and max_missing = max_missing_flag
      and window = missing_blocks_width_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db ->
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Probe
+           ~evaluate:(evaluate_missing_blocks ~max_missing ~window) (fun db ->
              Q.Missing_blocks_count.run db ~missing_blocks_width:window () )
        in
-       let inner =
-         match result with
-         | Error e ->
-             Error e
-         | Ok count ->
-             let healthy = count <= max_missing in
-             if healthy then (
-               if json then
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         healthy = Some true
-                       ; missing_blocks = Some count
-                       ; max_missing = Some max_missing
-                       ; window = Some window
-                       })
-               else
-                 printf "%d missing blocks (max: %d, window: %d)\n" count
-                   max_missing window ;
-               Ok () )
-             else
-               let err_msg =
-                 sprintf "missing blocks count %d exceeds threshold %d" count
-                   max_missing
-               in
-               if json then (
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         healthy = Some false
-                       ; missing_blocks = Some count
-                       ; max_missing = Some max_missing
-                       ; window = Some window
-                       ; error = Some err_msg
-                       }) ;
-                 Stdlib.exit 1 )
-               else
-                 fail_text "%d missing blocks (max: %d, window: %d)\n" count
-                   max_missing window
-       in
-       finish ~json ~json_error:health_error inner )
+       emit ~json report )
 
 let unparented_blocks_command =
   Command.async_or_error
@@ -400,88 +508,13 @@ let unparented_blocks_command =
      and json = json_flag
      and max_unparented = max_unparented_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db -> Q.Unparented_blocks_count.run db ())
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Probe
+           ~evaluate:(evaluate_unparented_blocks ~max_unparented) (fun db ->
+             Q.Unparented_blocks_count.run db () )
        in
-       let inner =
-         match result with
-         | Error e ->
-             Error e
-         | Ok count ->
-             let healthy = count <= max_unparented in
-             if healthy then (
-               if json then
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         healthy = Some true
-                       ; unparented_blocks = Some count
-                       ; max_unparented = Some max_unparented
-                       })
-               else
-                 printf "%d unparented blocks (max: %d)\n" count max_unparented ;
-               Ok () )
-             else
-               let err_msg =
-                 sprintf "unparented blocks count %d exceeds threshold %d" count
-                   max_unparented
-               in
-               if json then (
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         healthy = Some false
-                       ; unparented_blocks = Some count
-                       ; max_unparented = Some max_unparented
-                       ; error = Some err_msg
-                       }) ;
-                 Stdlib.exit 1 )
-               else
-                 fail_text "%d unparented blocks (max: %d)\n" count
-                   max_unparented
-       in
-       finish ~json ~json_error:health_error inner )
-
-(* Evaluate readiness from the four underlying metrics. Returns the
-   [(ready, delay_secs, problems)] triple. [latest_ts] is the raw
-   [text]-typed timestamp from the [blocks] table, which we interpret
-   as epoch milliseconds (see [now_ms] above). *)
-let evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay ~max_missing
-    ~max_unparented =
-  let future_ts, delay_secs =
-    match latest_ts with
-    | None ->
-        (false, Int64.max_value)
-    | Some ts_str -> (
-        match Option.try_with (fun () -> Int64.of_string ts_str) with
-        | None ->
-            (false, Int64.max_value)
-        | Some ts_ms ->
-            let now = now_ms () in
-            let delay_secs = Int64.( / ) (Int64.( - ) now ts_ms) 1000L in
-            (Int64.( > ) ts_ms now, delay_secs) )
-  in
-  let recent =
-    (not future_ts) && Int64.( <= ) delay_secs (Int64.of_int max_delay)
-  in
-  let missing_ok = missing <= max_missing in
-  let unparented_ok = unparented <= max_unparented in
-  let ready = recent && missing_ok && unparented_ok in
-  let problems = ref [] in
-  if not recent then
-    problems :=
-      ( if future_ts then "latest block timestamp is in the future"
-      else sprintf "block delay %Lds > %ds" delay_secs max_delay )
-      :: !problems ;
-  if not missing_ok then
-    problems :=
-      sprintf "missing blocks %d > %d" missing max_missing :: !problems ;
-  if not unparented_ok then
-    problems :=
-      sprintf "unparented blocks %d > %d" unparented max_unparented :: !problems ;
-  (ready, delay_secs, List.rev !problems)
+       emit ~json report )
 
 let ready_command =
   Command.async_or_error
@@ -495,62 +528,43 @@ let ready_command =
      and max_unparented = max_unparented_flag
      and window = missing_blocks_width_flag in
      fun () ->
-       let%bind result =
-         with_pool ~postgres_uri (fun db ->
-             let open Deferred.Result.Let_syntax in
-             let%bind height = Q.Max_block_height.run db () in
-             let%bind latest_ts = Q.Latest_block_timestamp.run db () in
-             let%bind missing =
-               Q.Missing_blocks_count.run db ~missing_blocks_width:window ()
-             in
-             let%bind unparented = Q.Unparented_blocks_count.run db () in
-             return (height, latest_ts, missing, unparented) )
+       setup_logging ~json ;
+       let%bind report =
+         probe ~postgres_uri ~kind:Report.Readiness
+           ~evaluate:(fun answer ->
+             evaluate_readiness ~now:(now_ms ()) ~max_delay ~max_missing
+               ~max_unparented answer )
+           (readiness_query ~window)
        in
-       let inner =
-         match result with
-         | Error e ->
-             Error e
-         | Ok (height, latest_ts, missing, unparented) ->
-             let ready, delay_secs, problems =
-               evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay
-                 ~max_missing ~max_unparented
-             in
-             if ready then (
-               if json then
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         ready = Some true
-                       ; block_height = Some height
-                       ; delay_seconds = Some delay_secs
-                       ; missing_blocks = Some missing
-                       ; unparented_blocks = Some unparented
-                       })
-               else print_endline "READY" ;
-               Ok () )
-             else
-               let err_msg =
-                 sprintf "not ready: %s" (String.concat ~sep:", " problems)
-               in
-               if json then (
-                 output
-                   Output.(
-                     to_yojson
-                       { empty with
-                         ready = Some false
-                       ; block_height = Some height
-                       ; delay_seconds = Some delay_secs
-                       ; missing_blocks = Some missing
-                       ; unparented_blocks = Some unparented
-                       ; problems = Some problems
-                       ; error = Some err_msg
-                       }) ;
-                 Stdlib.exit 1 )
-               else
-                 fail_text "NOT READY: %s\n" (String.concat ~sep:", " problems)
-       in
-       finish ~json ~json_error:readiness_error inner )
+       emit ~json report )
+
+(* Both wait modes share this loop; they differ only in [attempt]. On
+   expiry the last failure is wrapped in [Timed_out]. *)
+let rec poll ~start ~deadline ~interval ~kind attempt =
+  let elapsed () =
+    Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
+  in
+  let%bind metrics, outcome = attempt () in
+  match outcome with
+  | Ok () ->
+      return (Report.of_evaluation ~kind (metrics, Ok ()))
+  | Error failure ->
+      if Time.( >= ) (Time.now ()) deadline then
+        return
+          (Report.fail ~kind ?metrics
+             (Failure.Timed_out
+                { after_seconds = elapsed (); last_failure = Some failure } ) )
+      else (
+        [%log info] "archive not ready after $elapsed_seconds s: $reason"
+          ~metadata:
+            [ ("elapsed_seconds", `Int (elapsed ()))
+            ; ("reason", `String (Failure.to_string failure))
+            ; ( "measured"
+              , Option.value_map metrics ~default:`Null ~f:(fun metrics ->
+                    `Assoc (Metrics.to_json_fields metrics) ) )
+            ] ;
+        let%bind () = after (Time.Span.of_int_sec interval) in
+        poll ~start ~deadline ~interval ~kind attempt )
 
 let wait_command =
   Command.async_or_error
@@ -580,158 +594,43 @@ let wait_command =
          no_arg
      in
      fun () ->
-       (* Connect the pool once up front and reuse it across every
-          poll.  Previously every iteration called [with_pool], which
-          opened a brand new Caqti pool — wasteful and noisy for
-          long-running waits. *)
-       let uri = Uri.of_string postgres_uri in
-       match Mina_caqti.connect_pool ~max_size:4 uri with
+       setup_logging ~json ;
+       let kind = Report.Wait { db_only } in
+       let start = Time.now () in
+       let deadline = Time.add start (Time.Span.of_int_sec timeout) in
+       (* One pool for every poll, not one per iteration. *)
+       match
+         Mina_caqti.connect_pool ~max_size:4 (Uri.of_string postgres_uri)
+       with
        | Error e ->
-           let err =
-             Error.of_string
-               (sprintf "Failed to connect to PostgreSQL: %s"
-                  (Caqti_error.show e) )
-           in
-           if json then (
-             output
-               Output.(
-                 to_yojson
-                   { empty with
-                     ready = Some false
-                   ; timed_out = Some false
-                   ; db_only = Some db_only
-                   ; error = Some (Error.to_string_hum err)
-                   }) ;
-             exit 1 )
-           else Deferred.Or_error.fail err
+           emit ~json
+             (Report.fail ~kind (Failure.Db_unreachable (Caqti_error.show e)))
        | Ok pool ->
-           let start = Time.now () in
-           let deadline = Time.add start (Time.Span.of_int_sec timeout) in
-           let timed_out () = Time.( >= ) (Time.now ()) deadline in
-           let elapsed () =
-             Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
-           in
-           let use f =
-             Mina_caqti.Pool.use f pool
+           let run query =
+             Mina_caqti.Pool.use query pool
              |> Deferred.map
                   ~f:
                     (Result.map_error ~f:(fun e ->
-                         Error.of_string (Caqti_error.show e) ) )
+                         Failure.Db_query_failed (Caqti_error.show e) ) )
            in
-           (* In [--db-only] mode we deliberately skip recency / missing
-              / unparented checks: the only signal we wait for is "the
-              [blocks] table responds to a [SELECT MAX(height)]."  This
-              exists because the full readiness check requires a
-              non-None [latest_ts] and so cannot succeed against a
-              freshly-bootstrapped, empty archive.  See the README for
-              the full rationale. *)
-           let rec db_only_loop () =
-             match%bind use (fun db -> Q.Max_block_height.run db ()) with
-             | Ok _height ->
-                 if json then
-                   output
-                     Output.(
-                       to_yojson
-                         { empty with ready = Some true; db_only = Some true })
-                 else print_endline "READY (db-only)" ;
-                 Deferred.Or_error.return ()
-             | Error e when timed_out () ->
-                 if json then (
-                   output
-                     Output.(
-                       to_yojson
-                         { empty with
-                           ready = Some false
-                         ; timed_out = Some true
-                         ; db_only = Some true
-                         ; error = Some (Error.to_string_hum e)
-                         }) ;
-                   exit 1 )
-                 else
-                   Deferred.Or_error.errorf "timed out waiting for DB: %s"
-                     (Error.to_string_hum e)
-             | Error e ->
-                 eprintf "[%3ds] DB unreachable: %s\n" (elapsed ())
-                   (Error.to_string_hum e) ;
-                 let%bind () = after (Time.Span.of_int_sec interval) in
-                 db_only_loop ()
+           (* [--db-only] waits only for the [blocks] table to answer:
+              the full check needs a non-empty table and so can never
+              pass against a freshly-bootstrapped archive. *)
+           let attempt () =
+             if db_only then
+               run (fun db -> Q.Max_block_height.run db ())
+               |> Deferred.map
+                    ~f:(evaluation_of_result ~evaluate:evaluate_db_ready)
+             else
+               run (readiness_query ~window)
+               |> Deferred.map
+                    ~f:
+                      (evaluation_of_result ~evaluate:(fun answer ->
+                           evaluate_readiness ~now:(now_ms ()) ~max_delay
+                             ~max_missing ~max_unparented answer ) )
            in
-           let rec loop () =
-             match%bind
-               use (fun db ->
-                   let open Deferred.Result.Let_syntax in
-                   let%bind height = Q.Max_block_height.run db () in
-                   let%bind latest_ts = Q.Latest_block_timestamp.run db () in
-                   let%bind missing =
-                     Q.Missing_blocks_count.run db ~missing_blocks_width:window
-                       ()
-                   in
-                   let%bind unparented = Q.Unparented_blocks_count.run db () in
-                   return (height, latest_ts, missing, unparented) )
-             with
-             | Error e ->
-                 if timed_out () then
-                   if json then (
-                     output
-                       Output.(
-                         to_yojson
-                           { empty with
-                             ready = Some false
-                           ; timed_out = Some true
-                           ; error = Some (Error.to_string_hum e)
-                           }) ;
-                     exit 1 )
-                   else
-                     Deferred.Or_error.errorf "timed out: %s"
-                       (Error.to_string_hum e)
-                 else (
-                   eprintf "[%3ds] DB unreachable: %s\n" (elapsed ())
-                     (Error.to_string_hum e) ;
-                   let%bind () = after (Time.Span.of_int_sec interval) in
-                   loop () )
-             | Ok (height, latest_ts, missing, unparented) ->
-                 let ready, delay_secs, _problems =
-                   evaluate_readiness ~latest_ts ~missing ~unparented ~max_delay
-                     ~max_missing ~max_unparented
-                 in
-                 if ready then (
-                   if json then
-                     output
-                       Output.(
-                         to_yojson
-                           { empty with
-                             ready = Some true
-                           ; block_height = Some height
-                           ; delay_seconds = Some delay_secs
-                           ; missing_blocks = Some missing
-                           ; unparented_blocks = Some unparented
-                           })
-                   else print_endline "READY" ;
-                   Deferred.Or_error.return () )
-                 else if timed_out () then
-                   if json then (
-                     output
-                       Output.(
-                         to_yojson
-                           { empty with
-                             ready = Some false
-                           ; timed_out = Some true
-                           ; block_height = Some height
-                           ; delay_seconds = Some delay_secs
-                           ; missing_blocks = Some missing
-                           ; unparented_blocks = Some unparented
-                           }) ;
-                     exit 1 )
-                   else
-                     Deferred.Or_error.errorf "timed out waiting for readiness"
-                 else (
-                   eprintf
-                     "[%3ds] height=%d delay=%Lds missing=%d unparented=%d\n"
-                     (elapsed ()) height delay_secs missing unparented ;
-                   let%bind () = after (Time.Span.of_int_sec interval) in
-                   loop () )
-           in
-           if db_only then db_only_loop () else loop () )
+           let%bind report = poll ~start ~deadline ~interval ~kind attempt in
+           emit ~json report )
 
 let () =
   Command.run

--- a/src/app/mina_archive_healthcheck/tests/dune
+++ b/src/app/mina_archive_healthcheck/tests/dune
@@ -1,0 +1,21 @@
+;; Hermetic alcotest smoke tests for mina-archive-healthcheck.
+;;
+;; These exercise only the subcommands that don't require a running
+;; archive PostgreSQL: --help at the top level and per-subcommand,
+;; plus the single-JSON-record contract for each subcommand against a
+;; non-routable [postgres://...:1/...] URI.
+
+(test
+ (name test_mina_archive_healthcheck)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_unix
+  stdio
+  yojson)
+ (deps ../mina_archive_healthcheck.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/mina_archive_healthcheck/tests/dune
+++ b/src/app/mina_archive_healthcheck/tests/dune
@@ -18,4 +18,4 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version)))
+  (pps ppx_version ppx_deriving_yojson)))

--- a/src/app/mina_archive_healthcheck/tests/dune
+++ b/src/app/mina_archive_healthcheck/tests/dune
@@ -13,6 +13,7 @@
   core
   core_unix
   stdio
+  uri
   yojson)
  (deps ../mina_archive_healthcheck.exe)
  (instrumentation

--- a/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
@@ -1,0 +1,255 @@
+(* Hermetic alcotest smoke tests for mina-archive-healthcheck.
+
+   These exercise only the subcommands that don't require a running
+   archive PostgreSQL: --help at the top level and per-subcommand, plus
+   the single-JSON-record contract for each subcommand against a
+   non-routable [postgres://...:1/...] URI.
+
+   The dead-PG URI deliberately points at a port that no local service
+   listens on (127.0.0.1:1), so the connect attempt fails fast with
+   ECONNREFUSED, the [with_pool] error path runs, and we get one
+   well-formed JSON record on stdout in [--json] mode.  This is the
+   same contract regression the original defect — [Caqti_error]
+   propagating unwrapped — could violate. *)
+
+open Core
+
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../mina_archive_healthcheck.exe"
+
+(* Non-routable URI: caqti will try to TCP-connect to 127.0.0.1:1,
+   get ECONNREFUSED, surface a Caqti_error which the CLI must format
+   into a single JSON record (or single text line) without leaking. *)
+let dead_pg = "postgres://test:test@127.0.0.1:1/test"
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args], capture stdout/stderr, return
+   [(exit_code, stdout, stderr)]. *)
+let run_cli args =
+  let pi = Core_unix.create_process ~prog:bin ~args in
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: user-visible output must not leak raw OCaml
+   exception syntax.  The original defect was [Caqti_error] /
+   [Unix_error] propagating unwrapped through stderr on
+   ECONNREFUSED. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix"; "Caqti_error" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains s ~sub = String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* Shared "exactly one JSON object on stdout" assertion.  Parses [out]
+   as a single Yojson object, returns the field list.  Guards against
+   a second JSON object being tacked on, which is the double-print
+   regression every subcommand needs to avoid. *)
+let parse_single_json_record ~label out err =
+  let trimmed = String.strip out in
+  if String.is_empty trimmed then
+    Alcotest.failf "%s: stdout empty, stderr:\n%s" label err ;
+  let json =
+    try Yojson.Safe.from_string trimmed
+    with exn ->
+      Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
+        (Exn.to_string exn) out
+  in
+  if String.is_substring trimmed ~substring:"}\n{" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by newlines:\n%s"
+      label out ;
+  if String.is_substring trimmed ~substring:"} {" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by whitespace:\n%s"
+      label out ;
+  match json with
+  | `Assoc fields ->
+      fields
+  | _ ->
+      Alcotest.failf "%s: stdout was not a JSON object: %s" label out
+
+let check_bool_field ~label fields ~field ~expected =
+  match List.Assoc.find fields ~equal:String.equal field with
+  | Some (`Bool b) when Bool.equal b expected ->
+      ()
+  | Some v ->
+      Alcotest.failf "%s: expected %s:%b, got %s" label field expected
+        (Yojson.Safe.to_string v)
+  | None ->
+      Alcotest.failf "%s: missing %S field" label field
+
+let check_string_field_present ~label fields ~field =
+  match List.Assoc.find fields ~equal:String.equal field with
+  | Some (`String _) ->
+      ()
+  | Some v ->
+      Alcotest.failf "%s: expected %s to be a string, got %s" label field
+        (Yojson.Safe.to_string v)
+  | None ->
+      Alcotest.failf "%s: missing %S field" label field
+
+let all_subcommands =
+  [ "db-ready"
+  ; "block-height"
+  ; "block-recency"
+  ; "missing-blocks"
+  ; "unparented-blocks"
+  ; "ready"
+  ; "wait"
+  ]
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  List.iter all_subcommands ~f:(fun sub ->
+      check_contains ~label:(sprintf "--help lists %s" sub) out ~sub ) ;
+  assert_no_ocaml_exn_leak "--help stderr" err
+
+(* Each subcommand must respond to its own --help with exit 0.  This
+   catches typos / orphaned [Command.Param.flag] definitions that only
+   blow up at CLI construction time. *)
+let test_help_subs () =
+  List.iter all_subcommands ~f:(fun sub ->
+      let code, _out, err = run_cli [ sub; "--help" ] in
+      Alcotest.(check int) (sprintf "%s --help exit" sub) 0 code ;
+      assert_no_ocaml_exn_leak (sprintf "%s --help stderr" sub) err )
+
+(* Single text-mode regression: db-ready against a dead PG must fail
+   non-zero without leaking raw exception syntax.  The other
+   subcommands all share the same [finish ~json ~json_error] error
+   path, so JSON-mode coverage below is sufficient and we don't
+   duplicate text-mode coverage here. *)
+let test_db_ready_dead_pg_text () =
+  let code, out, err = run_cli [ "db-ready"; "--postgres-uri"; dead_pg ] in
+  if code = 0 then Alcotest.failf "db-ready (dead PG): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "db-ready text stdout" out ;
+  assert_no_ocaml_exn_leak "db-ready text stderr" err
+
+(* Generic dead-PG JSON test: every subcommand whose top-level JSON
+   error envelope keys the failure as ["healthy": false] uses this. *)
+let test_dead_pg_healthy_false ~sub ?(extra_args = []) () =
+  let args = [ sub; "--postgres-uri"; dead_pg; "--json" ] @ extra_args in
+  let label = sprintf "%s --json (dead PG)" sub in
+  let code, out, err = run_cli args in
+  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  let fields = parse_single_json_record ~label out err in
+  check_bool_field ~label fields ~field:"healthy" ~expected:false ;
+  check_string_field_present ~label fields ~field:"error"
+
+let test_db_ready_dead_pg_json () =
+  test_dead_pg_healthy_false ~sub:"db-ready" ()
+
+let test_block_height_dead_pg_json () =
+  test_dead_pg_healthy_false ~sub:"block-height" ()
+
+let test_block_recency_dead_pg_json () =
+  test_dead_pg_healthy_false ~sub:"block-recency" ()
+
+let test_missing_blocks_dead_pg_json () =
+  test_dead_pg_healthy_false ~sub:"missing-blocks" ()
+
+let test_unparented_blocks_dead_pg_json () =
+  test_dead_pg_healthy_false ~sub:"unparented-blocks" ()
+
+(* The composite [ready] envelope keys the failure as ["ready": false]
+   instead of [healthy], hence its own assertion. *)
+let test_ready_dead_pg_json () =
+  let label = "ready --json (dead PG)" in
+  let code, out, err =
+    run_cli [ "ready"; "--postgres-uri"; dead_pg; "--json" ]
+  in
+  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  let fields = parse_single_json_record ~label out err in
+  check_bool_field ~label fields ~field:"ready" ~expected:false ;
+  check_string_field_present ~label fields ~field:"error"
+
+(* [wait] enters a polling loop; bound it tightly (--timeout/--interval
+   1) so the test exits quickly.  Against a dead PG the failure shape is
+   the same envelope as [ready] plus a [timed_out] boolean.
+
+   The plain and [--db-only] variants are identical apart from the flag
+   and the extra [db_only: true] field assertion, so they share this
+   body.  [--db-only] is the polling variant used by integration tests
+   and init containers: it skips recency / missing / unparented and
+   waits only for the [blocks] table to respond.  Its failure envelope
+   must carry [db_only: true] so JSON consumers can distinguish a
+   db-only timeout from a full readiness timeout. *)
+let test_wait_dead_pg_json ~db_only () =
+  let label =
+    sprintf "wait%s --json (dead PG)" (if db_only then " --db-only" else "")
+  in
+  let args =
+    [ "wait" ]
+    @ (if db_only then [ "--db-only" ] else [])
+    @ [ "--postgres-uri"
+      ; dead_pg
+      ; "--json"
+      ; "--timeout"
+      ; "1"
+      ; "--interval"
+      ; "1"
+      ]
+  in
+  let code, out, err = run_cli args in
+  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  let fields = parse_single_json_record ~label out err in
+  check_bool_field ~label fields ~field:"ready" ~expected:false ;
+  if db_only then check_bool_field ~label fields ~field:"db_only" ~expected:true ;
+  check_string_field_present ~label fields ~field:"error"
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "mina-archive-healthcheck CLI smoke tests"
+    [ ( "help"
+      , [ ("root", `Quick, test_help_root)
+        ; ("each subcommand", `Quick, test_help_subs)
+        ] )
+    ; ( "db-ready against dead PG"
+      , [ ("text format", `Quick, test_db_ready_dead_pg_text)
+        ; ( "json is single well-formed record"
+          , `Quick
+          , test_db_ready_dead_pg_json )
+        ] )
+    ; ( "json single-record contract against dead PG"
+      , [ ("block-height", `Quick, test_block_height_dead_pg_json)
+        ; ("block-recency", `Quick, test_block_recency_dead_pg_json)
+        ; ("missing-blocks", `Quick, test_missing_blocks_dead_pg_json)
+        ; ("unparented-blocks", `Quick, test_unparented_blocks_dead_pg_json)
+        ; ("ready", `Quick, test_ready_dead_pg_json)
+        ; ("wait", `Quick, test_wait_dead_pg_json ~db_only:false)
+        ; ("wait --db-only", `Quick, test_wait_dead_pg_json ~db_only:true)
+        ] )
+    ]

--- a/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
@@ -1,9 +1,11 @@
-(* Hermetic alcotest smoke tests for mina-archive-healthcheck.
+(* Alcotest smoke tests for mina-archive-healthcheck.
 
-   These exercise only the subcommands that don't require a running
+   These always exercise the subcommands that don't require a running
    archive PostgreSQL: --help at the top level and per-subcommand, plus
    the single-JSON-record contract for each subcommand against a
-   non-routable [postgres://...:1/...] URI.
+   non-routable [postgres://...:1/...] URI.  When [MINA_TEST_POSTGRES]
+   is set, they also create temporary DBs for success-path envelope and
+   query-regression coverage.
 
    The dead-PG URI deliberately points at a port that no local service
    listens on (127.0.0.1:1), so the connect attempt fails fast with
@@ -37,6 +39,51 @@ module Envelope = struct
   type wait =
     { ready : bool; timed_out : bool; db_only : bool; error : Yojson.Safe.t }
   [@@deriving of_yojson]
+
+  type db_ready_success = { healthy : bool } [@@deriving of_yojson]
+
+  type block_height_success = { healthy : bool; block_height : int }
+  [@@deriving of_yojson]
+
+  type recency_success =
+    { healthy : bool; delay_seconds : int64; max_delay : int }
+  [@@deriving of_yojson]
+
+  type missing_blocks_success =
+    { healthy : bool; missing_blocks : int; max_missing : int; window : int }
+  [@@deriving of_yojson]
+
+  type missing_blocks_failure =
+    { healthy : bool
+    ; missing_blocks : int
+    ; max_missing : int
+    ; window : int
+    ; error : Yojson.Safe.t
+    }
+  [@@deriving of_yojson]
+
+  type unparented_blocks_success =
+    { healthy : bool; unparented_blocks : int; max_unparented : int }
+  [@@deriving of_yojson]
+
+  type readiness_success =
+    { ready : bool
+    ; block_height : int
+    ; delay_seconds : int64
+    ; missing_blocks : int
+    ; unparented_blocks : int
+    }
+  [@@deriving of_yojson]
+
+  type readiness_no_delay_failure =
+    { ready : bool
+    ; block_height : int
+    ; missing_blocks : int
+    ; unparented_blocks : int
+    ; problems : string list
+    ; error : Yojson.Safe.t
+    }
+  [@@deriving of_yojson]
 end
 
 let read_all_fd fd =
@@ -44,10 +91,10 @@ let read_all_fd fd =
   let s = In_channel.input_all ic in
   In_channel.close ic ; s
 
-(* Spawn the CLI with [args], capture stdout/stderr, return
+(* Spawn a process with [args], capture stdout/stderr, return
    [(exit_code, stdout, stderr)]. *)
-let run_cli args =
-  let pi = Core_unix.create_process ~prog:bin ~args in
+let run_program ~prog args =
+  let pi = Core_unix.create_process ~prog ~args in
   Core_unix.close pi.stdin ;
   let out = read_all_fd pi.stdout in
   let err = read_all_fd pi.stderr in
@@ -62,6 +109,8 @@ let run_cli args =
         128 + Signal.to_system_int s
   in
   (code, out, err)
+
+let run_cli args = run_program ~prog:bin args
 
 (* Regression guard: user-visible output must not leak raw OCaml
    exception syntax.  The original defect was [Caqti_error] /
@@ -108,6 +157,40 @@ let check_error_reported ~label error =
   | _ ->
       ()
 
+let rec json_contains_string (json : Yojson.Safe.t) expected =
+  match json with
+  | `String s ->
+      String.equal s expected
+  | `List xs ->
+      List.exists xs ~f:(fun json -> json_contains_string json expected)
+  | `Tuple xs ->
+      List.exists xs ~f:(fun json -> json_contains_string json expected)
+  | `Assoc fields ->
+      List.exists fields ~f:(fun (_key, json) ->
+          json_contains_string json expected )
+  | `Variant (tag, payload) ->
+      String.equal tag expected
+      || Option.exists payload ~f:(fun json ->
+             json_contains_string json expected )
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null ->
+      false
+
+let check_error_constructor ~label error expected =
+  check_error_reported ~label error ;
+  if not (json_contains_string error expected) then
+    Alcotest.failf "%s: expected error constructor %S in %s" label expected
+      (Yojson.Safe.to_string error)
+
+let check_absent_field ~label (json : Yojson.Safe.t) field =
+  match json with
+  | `Assoc fields ->
+      if List.Assoc.mem fields field ~equal:String.equal then
+        Alcotest.failf "%s: expected field %S to be absent in %s" label field
+          (Yojson.Safe.to_string json)
+  | _ ->
+      Alcotest.failf "%s: expected JSON object, got %s" label
+        (Yojson.Safe.to_string json)
+
 (* Run [sub] against a dead PG in JSON mode and return its one record. *)
 let run_dead_pg_json ~sub ?(extra_args = []) () =
   let label = sprintf "%s --json (dead PG)" sub in
@@ -128,6 +211,104 @@ let all_subcommands =
   ; "ready"
   ; "wait"
   ]
+
+let test_postgres_env = "MINA_TEST_POSTGRES"
+
+let current_epoch_ms () =
+  Time.now () |> Time.to_span_since_epoch |> Time.Span.to_ms |> Int64.of_float
+
+let quote_ident s =
+  "\"" ^ String.substr_replace_all s ~pattern:"\"" ~with_:"\"\"" ^ "\""
+
+let admin_uri raw_uri =
+  let uri = Uri.of_string raw_uri in
+  match Uri.path uri with
+  | "" | "/" ->
+      Uri.with_path uri "/postgres" |> Uri.to_string
+  | _ ->
+      raw_uri
+
+let database_uri raw_uri db_name =
+  Uri.with_path (Uri.of_string raw_uri) ("/" ^ db_name) |> Uri.to_string
+
+let random_db_name () =
+  sprintf "mina_archive_healthcheck_%d_%06d"
+    (Core_unix.getpid () |> Pid.to_int)
+    (Random.int 1_000_000)
+
+let run_psql_exn ~uri sql =
+  let code, out, err =
+    run_program ~prog:"psql"
+      [ "-v"; "ON_ERROR_STOP=1"; "-qAt"; "-d"; uri; "-c"; sql ]
+  in
+  if code <> 0 then
+    Alcotest.failf "psql failed with exit %d\nsql=%s\nstdout=%s\nstderr=%s" code
+      sql out err ;
+  out
+
+let create_blocks_schema_sql =
+  {sql|
+    CREATE TABLE blocks (
+      id serial PRIMARY KEY,
+      height bigint NOT NULL,
+      timestamp text NOT NULL,
+      parent_id int
+    );
+  |sql}
+
+let with_test_db f =
+  match Sys.getenv test_postgres_env with
+  | None ->
+      printf "Skipping DB-backed healthcheck tests: $%s is not set\n%!"
+        test_postgres_env
+  | Some raw_uri ->
+      let admin_uri = admin_uri raw_uri in
+      let db_name = random_db_name () in
+      let db_ident = quote_ident db_name in
+      let test_uri = database_uri raw_uri db_name in
+      let created = ref false in
+      Exn.protect
+        ~f:(fun () ->
+          ignore
+            (run_psql_exn ~uri:admin_uri
+               (sprintf "CREATE DATABASE %s" db_ident) ) ;
+          created := true ;
+          f test_uri )
+        ~finally:(fun () ->
+          if !created then
+            ignore
+              (run_program ~prog:"psql"
+                 [ "-v"
+                 ; "ON_ERROR_STOP=1"
+                 ; "-qAt"
+                 ; "-d"
+                 ; admin_uri
+                 ; "-c"
+                 ; sprintf "DROP DATABASE IF EXISTS %s" db_ident
+                 ] ) )
+
+let run_success_json ~postgres_uri ~sub ?(extra_args = []) () =
+  let label = sprintf "%s --json (test DB)" sub in
+  let code, out, err =
+    run_cli ([ sub; "--postgres-uri"; postgres_uri; "--json" ] @ extra_args)
+  in
+  if code <> 0 then
+    Alcotest.failf "%s: expected exit 0\nstdout=%s\nstderr=%s" label out err ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  (label, parse_single_json_record ~label out err)
+
+let run_failure_json ~postgres_uri ~sub ?(extra_args = []) () =
+  let label = sprintf "%s --json (test DB)" sub in
+  let code, out, err =
+    run_cli ([ sub; "--postgres-uri"; postgres_uri; "--json" ] @ extra_args)
+  in
+  if code = 0 then
+    Alcotest.failf "%s: expected non-zero exit\nstdout=%s\nstderr=%s" label out
+      err ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  (label, parse_single_json_record ~label out err)
 
 (* ---------- Tests ---------- *)
 
@@ -161,13 +342,13 @@ let test_dead_pg_healthy_false ~sub () =
   let label, json = run_dead_pg_json ~sub () in
   let envelope = of_yojson_exn ~label Envelope.probe_of_yojson json in
   Alcotest.(check bool) (label ^ ": healthy") false envelope.healthy ;
-  check_error_reported ~label envelope.error
+  check_error_constructor ~label envelope.error "Db_unreachable"
 
 let test_ready_dead_pg_json () =
   let label, json = run_dead_pg_json ~sub:"ready" () in
   let envelope = of_yojson_exn ~label Envelope.readiness_of_yojson json in
   Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
-  check_error_reported ~label envelope.error
+  check_error_constructor ~label envelope.error "Db_unreachable"
 
 (* [wait] enters a polling loop; bound it tightly (--timeout/--interval
    1) so the test exits quickly.  Its envelope always carries
@@ -185,7 +366,159 @@ let test_wait_dead_pg_json ~db_only () =
   let envelope = of_yojson_exn ~label Envelope.wait_of_yojson json in
   Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
   Alcotest.(check bool) (label ^ ": db_only") db_only envelope.db_only ;
-  check_error_reported ~label envelope.error
+  if envelope.timed_out then
+    check_error_constructor ~label envelope.error "Timed_out" ;
+  check_error_constructor ~label envelope.error "Db_unreachable"
+
+let test_success_envelopes_against_db () =
+  with_test_db (fun postgres_uri ->
+      ignore (run_psql_exn ~uri:postgres_uri create_blocks_schema_sql) ;
+      let timestamp = Int64.to_string (current_epoch_ms ()) in
+      ignore
+        (run_psql_exn ~uri:postgres_uri
+           (sprintf
+              {sql|
+                INSERT INTO blocks (height, timestamp, parent_id) VALUES
+                  (10, '%s', NULL),
+                  (10, '%s', NULL),
+                  (12, '%s', 1);
+              |sql}
+              timestamp timestamp timestamp ) ) ;
+      let label, json = run_success_json ~postgres_uri ~sub:"db-ready" () in
+      let envelope =
+        of_yojson_exn ~label Envelope.db_ready_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") true envelope.healthy ;
+      let label, json = run_success_json ~postgres_uri ~sub:"block-height" () in
+      let envelope =
+        of_yojson_exn ~label Envelope.block_height_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") true envelope.healthy ;
+      Alcotest.(check int) (label ^ ": block_height") 12 envelope.block_height ;
+      let label, json =
+        run_success_json ~postgres_uri ~sub:"block-recency"
+          ~extra_args:[ "--max-delay"; "3600" ] ()
+      in
+      let envelope =
+        of_yojson_exn ~label Envelope.recency_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") true envelope.healthy ;
+      Alcotest.(check int) (label ^ ": max_delay") 3600 envelope.max_delay ;
+      let label, json =
+        run_success_json ~postgres_uri ~sub:"missing-blocks"
+          ~extra_args:[ "--window"; "3"; "--max-missing"; "1" ]
+          ()
+      in
+      let envelope =
+        of_yojson_exn ~label Envelope.missing_blocks_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") true envelope.healthy ;
+      Alcotest.(check int)
+        (label ^ ": missing_blocks")
+        1 envelope.missing_blocks ;
+      Alcotest.(check int) (label ^ ": max_missing") 1 envelope.max_missing ;
+      Alcotest.(check int) (label ^ ": window") 3 envelope.window ;
+      let label, json =
+        run_success_json ~postgres_uri ~sub:"unparented-blocks" ()
+      in
+      let envelope =
+        of_yojson_exn ~label Envelope.unparented_blocks_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") true envelope.healthy ;
+      Alcotest.(check int)
+        (label ^ ": unparented_blocks")
+        0 envelope.unparented_blocks ;
+      let label, json =
+        run_success_json ~postgres_uri ~sub:"ready"
+          ~extra_args:
+            [ "--window"
+            ; "3"
+            ; "--max-delay"
+            ; "3600"
+            ; "--max-missing"
+            ; "1"
+            ; "--max-unparented"
+            ; "0"
+            ]
+          ()
+      in
+      let envelope =
+        of_yojson_exn ~label Envelope.readiness_success_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": ready") true envelope.ready ;
+      Alcotest.(check int) (label ^ ": block_height") 12 envelope.block_height ;
+      Alcotest.(check int)
+        (label ^ ": missing_blocks")
+        1 envelope.missing_blocks ;
+      Alcotest.(check int)
+        (label ^ ": unparented_blocks")
+        0 envelope.unparented_blocks )
+
+let test_missing_blocks_counts_distinct_heights () =
+  with_test_db (fun postgres_uri ->
+      ignore (run_psql_exn ~uri:postgres_uri create_blocks_schema_sql) ;
+      let timestamp = Int64.to_string (current_epoch_ms ()) in
+      ignore
+        (run_psql_exn ~uri:postgres_uri
+           (sprintf
+              {sql|
+                INSERT INTO blocks (height, timestamp, parent_id) VALUES
+                  (10, '%s', NULL),
+                  (10, '%s', NULL),
+                  (12, '%s', 1);
+              |sql}
+              timestamp timestamp timestamp ) ) ;
+      let label, json =
+        run_failure_json ~postgres_uri ~sub:"missing-blocks"
+          ~extra_args:[ "--window"; "3"; "--max-missing"; "0" ]
+          ()
+      in
+      let envelope =
+        of_yojson_exn ~label Envelope.missing_blocks_failure_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": healthy") false envelope.healthy ;
+      Alcotest.(check int)
+        (label ^ ": missing_blocks")
+        1 envelope.missing_blocks ;
+      check_error_constructor ~label envelope.error "Thresholds_exceeded" )
+
+let test_ready_empty_db_omits_delay () =
+  with_test_db (fun postgres_uri ->
+      ignore (run_psql_exn ~uri:postgres_uri create_blocks_schema_sql) ;
+      let label, json =
+        run_failure_json ~postgres_uri ~sub:"ready"
+          ~extra_args:
+            [ "--window"
+            ; "3"
+            ; "--max-delay"
+            ; "3600"
+            ; "--max-missing"
+            ; "0"
+            ; "--max-unparented"
+            ; "0"
+            ]
+          ()
+      in
+      check_absent_field ~label json "delay_seconds" ;
+      let envelope =
+        of_yojson_exn ~label Envelope.readiness_no_delay_failure_of_yojson json
+      in
+      Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
+      Alcotest.(check int) (label ^ ": block_height") 0 envelope.block_height ;
+      Alcotest.(check int)
+        (label ^ ": missing_blocks")
+        0 envelope.missing_blocks ;
+      Alcotest.(check int)
+        (label ^ ": unparented_blocks")
+        0 envelope.unparented_blocks ;
+      if
+        not
+          (List.mem envelope.problems "no blocks in archive database"
+             ~equal:String.equal )
+      then
+        Alcotest.failf "%s: expected no-blocks problem, got %s" label
+          (String.concat envelope.problems ~sep:", ") ;
+      check_error_constructor ~label envelope.error "Thresholds_exceeded" )
 
 (* ---------- Runner ---------- *)
 
@@ -217,5 +550,14 @@ let () =
         ; ("ready", `Quick, test_ready_dead_pg_json)
         ; ("wait", `Quick, test_wait_dead_pg_json ~db_only:false)
         ; ("wait --db-only", `Quick, test_wait_dead_pg_json ~db_only:true)
+        ] )
+    ; ( "json envelope against test DB"
+      , [ ("success paths", `Quick, test_success_envelopes_against_db)
+        ; ( "missing-blocks counts distinct heights"
+          , `Quick
+          , test_missing_blocks_counts_distinct_heights )
+        ; ( "ready omits unavailable delay"
+          , `Quick
+          , test_ready_empty_db_omits_delay )
         ] )
     ]

--- a/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
@@ -204,6 +204,7 @@ let run_dead_pg_json ~sub ?(extra_args = []) () =
 
 let all_subcommands =
   [ "db-ready"
+  ; "server-ready"
   ; "block-height"
   ; "block-recency"
   ; "missing-blocks"
@@ -343,6 +344,43 @@ let test_dead_pg_healthy_false ~sub () =
   let envelope = of_yojson_exn ~label Envelope.probe_of_yojson json in
   Alcotest.(check bool) (label ^ ": healthy") false envelope.healthy ;
   check_error_constructor ~label envelope.error "Db_unreachable"
+
+(* [server-ready] probes the archive's TCP port, not PostgreSQL; port 1
+   on localhost is never listening, so the connect fails fast and must
+   surface as [Server_unreachable] without leaking exception syntax. *)
+let test_server_ready_dead_port_json () =
+  let label = "server-ready --json (dead port)" in
+  let code, out, err =
+    run_cli [ "server-ready"; "--server-port"; "1"; "--json" ]
+  in
+  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  let json = parse_single_json_record ~label out err in
+  let envelope = of_yojson_exn ~label Envelope.probe_of_yojson json in
+  Alcotest.(check bool) (label ^ ": healthy") false envelope.healthy ;
+  check_error_constructor ~label envelope.error "Server_unreachable"
+
+(* [wait --server-port] must gate on the server socket even when the
+   DB side would pass; a dead port is checked first, so the timeout's
+   last failure is the server one. *)
+let test_wait_dead_server_port_json () =
+  let label, json =
+    run_dead_pg_json ~sub:"wait"
+      ~extra_args:
+        [ "--db-only"
+        ; "--server-port"
+        ; "1"
+        ; "--timeout"
+        ; "1"
+        ; "--interval"
+        ; "1"
+        ]
+      ()
+  in
+  let envelope = of_yojson_exn ~label Envelope.wait_of_yojson json in
+  Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
+  check_error_constructor ~label envelope.error "Server_unreachable"
 
 let test_ready_dead_pg_json () =
   let label, json = run_dead_pg_json ~sub:"ready" () in
@@ -550,6 +588,10 @@ let () =
         ; ("ready", `Quick, test_ready_dead_pg_json)
         ; ("wait", `Quick, test_wait_dead_pg_json ~db_only:false)
         ; ("wait --db-only", `Quick, test_wait_dead_pg_json ~db_only:true)
+        ; ("server-ready", `Quick, test_server_ready_dead_port_json)
+        ; ( "wait --server-port gates on the server socket"
+          , `Quick
+          , test_wait_dead_server_port_json )
         ] )
     ; ( "json envelope against test DB"
       , [ ("success paths", `Quick, test_success_envelopes_against_db)

--- a/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
+++ b/src/app/mina_archive_healthcheck/tests/test_mina_archive_healthcheck.ml
@@ -23,6 +23,22 @@ let bin =
    into a single JSON record (or single text line) without leaking. *)
 let dead_pg = "postgres://test:test@127.0.0.1:1/test"
 
+(* The envelope is the contract, so each shape is stated as a type and
+   checked by its derived [of_yojson]: an extra, missing or wrongly
+   typed field fails the parse and names itself.  [error] is typed as
+   raw JSON because it is the structured [Error_json] encoding, whose
+   inner shape is not part of the contract. *)
+module Envelope = struct
+  type probe = { healthy : bool; error : Yojson.Safe.t } [@@deriving of_yojson]
+
+  type readiness = { ready : bool; error : Yojson.Safe.t }
+  [@@deriving of_yojson]
+
+  type wait =
+    { ready : bool; timed_out : bool; db_only : bool; error : Yojson.Safe.t }
+  [@@deriving of_yojson]
+end
+
 let read_all_fd fd =
   let ic = Core_unix.in_channel_of_descr fd in
   let s = In_channel.input_all ic in
@@ -58,59 +74,50 @@ let assert_no_ocaml_exn_leak label s =
         Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
           label needle s )
 
-let contains s ~sub = String.is_substring s ~substring:sub
-
 let check_contains ~label s ~sub =
-  if not (contains s ~sub) then
+  if not (String.is_substring s ~substring:sub) then
     Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
 
-(* Shared "exactly one JSON object on stdout" assertion.  Parses [out]
-   as a single Yojson object, returns the field list.  Guards against
-   a second JSON object being tacked on, which is the double-print
-   regression every subcommand needs to avoid. *)
+(* Parse stdout as exactly one JSON object.  A second object tacked on
+   is the double-print regression every subcommand must avoid. *)
 let parse_single_json_record ~label out err =
   let trimmed = String.strip out in
   if String.is_empty trimmed then
     Alcotest.failf "%s: stdout empty, stderr:\n%s" label err ;
-  let json =
-    try Yojson.Safe.from_string trimmed
-    with exn ->
-      Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
-        (Exn.to_string exn) out
-  in
-  if String.is_substring trimmed ~substring:"}\n{" then
-    Alcotest.failf
-      "%s: stdout contains multiple JSON objects separated by newlines:\n%s"
-      label out ;
-  if String.is_substring trimmed ~substring:"} {" then
-    Alcotest.failf
-      "%s: stdout contains multiple JSON objects separated by whitespace:\n%s"
-      label out ;
-  match json with
-  | `Assoc fields ->
-      fields
+  List.iter [ "}\n{"; "} {" ] ~f:(fun separator ->
+      if String.is_substring trimmed ~substring:separator then
+        Alcotest.failf "%s: stdout contains multiple JSON objects:\n%s" label
+          out ) ;
+  try Yojson.Safe.from_string trimmed
+  with exn ->
+    Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
+      (Exn.to_string exn) out
+
+let of_yojson_exn ~label of_yojson json =
+  match of_yojson json with
+  | Ok envelope ->
+      envelope
+  | Error where ->
+      Alcotest.failf "%s: unexpected envelope (at %s): %s" label where
+        (Yojson.Safe.to_string json)
+
+let check_error_reported ~label error =
+  match error with
+  | `Null ->
+      Alcotest.failf "%s: error field is null" label
   | _ ->
-      Alcotest.failf "%s: stdout was not a JSON object: %s" label out
-
-let check_bool_field ~label fields ~field ~expected =
-  match List.Assoc.find fields ~equal:String.equal field with
-  | Some (`Bool b) when Bool.equal b expected ->
       ()
-  | Some v ->
-      Alcotest.failf "%s: expected %s:%b, got %s" label field expected
-        (Yojson.Safe.to_string v)
-  | None ->
-      Alcotest.failf "%s: missing %S field" label field
 
-let check_string_field_present ~label fields ~field =
-  match List.Assoc.find fields ~equal:String.equal field with
-  | Some (`String _) ->
-      ()
-  | Some v ->
-      Alcotest.failf "%s: expected %s to be a string, got %s" label field
-        (Yojson.Safe.to_string v)
-  | None ->
-      Alcotest.failf "%s: missing %S field" label field
+(* Run [sub] against a dead PG in JSON mode and return its one record. *)
+let run_dead_pg_json ~sub ?(extra_args = []) () =
+  let label = sprintf "%s --json (dead PG)" sub in
+  let code, out, err =
+    run_cli ([ sub; "--postgres-uri"; dead_pg; "--json" ] @ extra_args)
+  in
+  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
+  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+  (label, parse_single_json_record ~label out err)
 
 let all_subcommands =
   [ "db-ready"
@@ -140,94 +147,45 @@ let test_help_subs () =
       Alcotest.(check int) (sprintf "%s --help exit" sub) 0 code ;
       assert_no_ocaml_exn_leak (sprintf "%s --help stderr" sub) err )
 
-(* Single text-mode regression: db-ready against a dead PG must fail
-   non-zero without leaking raw exception syntax.  The other
-   subcommands all share the same [finish ~json ~json_error] error
-   path, so JSON-mode coverage below is sufficient and we don't
-   duplicate text-mode coverage here. *)
+(* Every subcommand reaches text output through the same [emit], so one
+   text-mode case is enough; the rest is covered in JSON mode below. *)
 let test_db_ready_dead_pg_text () =
   let code, out, err = run_cli [ "db-ready"; "--postgres-uri"; dead_pg ] in
   if code = 0 then Alcotest.failf "db-ready (dead PG): expected non-zero exit" ;
   assert_no_ocaml_exn_leak "db-ready text stdout" out ;
   assert_no_ocaml_exn_leak "db-ready text stderr" err
 
-(* Generic dead-PG JSON test: every subcommand whose top-level JSON
-   error envelope keys the failure as ["healthy": false] uses this. *)
-let test_dead_pg_healthy_false ~sub ?(extra_args = []) () =
-  let args = [ sub; "--postgres-uri"; dead_pg; "--json" ] @ extra_args in
-  let label = sprintf "%s --json (dead PG)" sub in
-  let code, out, err = run_cli args in
-  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
-  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
-  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
-  let fields = parse_single_json_record ~label out err in
-  check_bool_field ~label fields ~field:"healthy" ~expected:false ;
-  check_string_field_present ~label fields ~field:"error"
+(* A connection that never opened measured nothing, so the envelope
+   carries the verdict and the error and no metric field. *)
+let test_dead_pg_healthy_false ~sub () =
+  let label, json = run_dead_pg_json ~sub () in
+  let envelope = of_yojson_exn ~label Envelope.probe_of_yojson json in
+  Alcotest.(check bool) (label ^ ": healthy") false envelope.healthy ;
+  check_error_reported ~label envelope.error
 
-let test_db_ready_dead_pg_json () =
-  test_dead_pg_healthy_false ~sub:"db-ready" ()
-
-let test_block_height_dead_pg_json () =
-  test_dead_pg_healthy_false ~sub:"block-height" ()
-
-let test_block_recency_dead_pg_json () =
-  test_dead_pg_healthy_false ~sub:"block-recency" ()
-
-let test_missing_blocks_dead_pg_json () =
-  test_dead_pg_healthy_false ~sub:"missing-blocks" ()
-
-let test_unparented_blocks_dead_pg_json () =
-  test_dead_pg_healthy_false ~sub:"unparented-blocks" ()
-
-(* The composite [ready] envelope keys the failure as ["ready": false]
-   instead of [healthy], hence its own assertion. *)
 let test_ready_dead_pg_json () =
-  let label = "ready --json (dead PG)" in
-  let code, out, err =
-    run_cli [ "ready"; "--postgres-uri"; dead_pg; "--json" ]
-  in
-  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
-  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
-  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
-  let fields = parse_single_json_record ~label out err in
-  check_bool_field ~label fields ~field:"ready" ~expected:false ;
-  check_string_field_present ~label fields ~field:"error"
+  let label, json = run_dead_pg_json ~sub:"ready" () in
+  let envelope = of_yojson_exn ~label Envelope.readiness_of_yojson json in
+  Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
+  check_error_reported ~label envelope.error
 
 (* [wait] enters a polling loop; bound it tightly (--timeout/--interval
-   1) so the test exits quickly.  Against a dead PG the failure shape is
-   the same envelope as [ready] plus a [timed_out] boolean.
-
-   The plain and [--db-only] variants are identical apart from the flag
-   and the extra [db_only: true] field assertion, so they share this
-   body.  [--db-only] is the polling variant used by integration tests
-   and init containers: it skips recency / missing / unparented and
-   waits only for the [blocks] table to respond.  Its failure envelope
-   must carry [db_only: true] so JSON consumers can distinguish a
-   db-only timeout from a full readiness timeout. *)
+   1) so the test exits quickly.  Its envelope always carries
+   [timed_out] and [db_only], so a consumer can tell a db-only wait from
+   a full readiness wait, and a timeout from an outright connection
+   failure. *)
 let test_wait_dead_pg_json ~db_only () =
-  let label =
-    sprintf "wait%s --json (dead PG)" (if db_only then " --db-only" else "")
+  let label, json =
+    run_dead_pg_json ~sub:"wait"
+      ~extra_args:
+        ( (if db_only then [ "--db-only" ] else [])
+        @ [ "--timeout"; "1"; "--interval"; "1" ] )
+      ()
   in
-  let args =
-    [ "wait" ]
-    @ (if db_only then [ "--db-only" ] else [])
-    @ [ "--postgres-uri"
-      ; dead_pg
-      ; "--json"
-      ; "--timeout"
-      ; "1"
-      ; "--interval"
-      ; "1"
-      ]
-  in
-  let code, out, err = run_cli args in
-  if code = 0 then Alcotest.failf "%s: expected non-zero exit" label ;
-  assert_no_ocaml_exn_leak (label ^ " stdout") out ;
-  assert_no_ocaml_exn_leak (label ^ " stderr") err ;
-  let fields = parse_single_json_record ~label out err in
-  check_bool_field ~label fields ~field:"ready" ~expected:false ;
-  if db_only then check_bool_field ~label fields ~field:"db_only" ~expected:true ;
-  check_string_field_present ~label fields ~field:"error"
+  let envelope = of_yojson_exn ~label Envelope.wait_of_yojson json in
+  Alcotest.(check bool) (label ^ ": ready") false envelope.ready ;
+  Alcotest.(check bool) (label ^ ": db_only") db_only envelope.db_only ;
+  check_error_reported ~label envelope.error
 
 (* ---------- Runner ---------- *)
 
@@ -241,13 +199,21 @@ let () =
       , [ ("text format", `Quick, test_db_ready_dead_pg_text)
         ; ( "json is single well-formed record"
           , `Quick
-          , test_db_ready_dead_pg_json )
+          , test_dead_pg_healthy_false ~sub:"db-ready" )
         ] )
     ; ( "json single-record contract against dead PG"
-      , [ ("block-height", `Quick, test_block_height_dead_pg_json)
-        ; ("block-recency", `Quick, test_block_recency_dead_pg_json)
-        ; ("missing-blocks", `Quick, test_missing_blocks_dead_pg_json)
-        ; ("unparented-blocks", `Quick, test_unparented_blocks_dead_pg_json)
+      , [ ( "block-height"
+          , `Quick
+          , test_dead_pg_healthy_false ~sub:"block-height" )
+        ; ( "block-recency"
+          , `Quick
+          , test_dead_pg_healthy_false ~sub:"block-recency" )
+        ; ( "missing-blocks"
+          , `Quick
+          , test_dead_pg_healthy_false ~sub:"missing-blocks" )
+        ; ( "unparented-blocks"
+          , `Quick
+          , test_dead_pg_healthy_false ~sub:"unparented-blocks" )
         ; ("ready", `Quick, test_ready_dead_pg_json)
         ; ("wait", `Quick, test_wait_dead_pg_json ~db_only:false)
         ; ("wait --db-only", `Quick, test_wait_dead_pg_json ~db_only:true)

--- a/src/app/missing_blocks_auditor/dune
+++ b/src/app/missing_blocks_auditor/dune
@@ -16,6 +16,7 @@
   async_unix
   async.async_command
   ;; local libraries
+  archive_health_queries
   logger
   mina_stdlib
   mina_caqti)

--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -92,30 +92,30 @@ let main ~archive_uri () =
                   Core_kernel.exit 1 ) )
       in
       [%log info] "Querying for gaps in chain statuses" ;
+      (* [Highest_canonical_height] returns [None] when the archive holds
+         no canonical block.  The auditor must not silently succeed on an
+         empty canonical chain, so we fail loudly in that case rather than
+         treating it as height 0. *)
       let%bind highest_canonical =
         match%bind
           Mina_caqti.Pool.use
             (fun db -> Sql.Chain_status.run_highest_canonical db ())
             pool
         with
-        | Ok height ->
+        | Ok (Some height) ->
             return height
+        | Ok None ->
+            [%log error] "Error getting greatest height of canonical blocks"
+              ~metadata:
+                [ ( "error"
+                  , `String "no canonical blocks found in archive database" )
+                ] ;
+            Core.exit 1
         | Error msg ->
             [%log error] "Error getting greatest height of canonical blocks"
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
-      (* The shared [Archive_health_queries.Highest_canonical_height] query
-         coalesces a NULL max height to 0 so the healthcheck CLI can run
-         against a fresh / empty archive. The auditor, however, must not
-         silently succeed on an empty canonical chain — preserve the
-         pre-refactor behavior of failing loudly in that case. *)
-      if Int64.equal highest_canonical Int64.zero then (
-        [%log error] "Error getting greatest height of canonical blocks"
-          ~metadata:
-            [ ("error", `String "no canonical blocks found in archive database")
-            ] ;
-        Core.exit 1 ) ;
       let%bind pending_below =
         match%bind
           Mina_caqti.Pool.use

--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -33,7 +33,9 @@ let main ~archive_uri () =
       [%log info] "Querying missing blocks" ;
       let%bind missing_blocks_raw =
         match%bind
-          Mina_caqti.Pool.use (fun db -> Sql.Unparented_blocks.run db ()) pool
+          Mina_caqti.Pool.use
+            (fun db -> Sql.Unparented_blocks_detail.run db ())
+            pool
         with
         | Ok blocks ->
             return blocks
@@ -103,6 +105,17 @@ let main ~archive_uri () =
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
+      (* The shared [Archive_health_queries.Highest_canonical_height] query
+         coalesces a NULL max height to 0 so the healthcheck CLI can run
+         against a fresh / empty archive. The auditor, however, must not
+         silently succeed on an empty canonical chain — preserve the
+         pre-refactor behavior of failing loudly in that case. *)
+      if Int64.equal highest_canonical Int64.zero then (
+        [%log error] "Error getting greatest height of canonical blocks"
+          ~metadata:
+            [ ("error", `String "no canonical blocks found in archive database")
+            ] ;
+        Core.exit 1 ) ;
       let%bind pending_below =
         match%bind
           Mina_caqti.Pool.use

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -43,6 +43,22 @@ module Missing_blocks_gap = struct
 end
 
 module Chain_status = struct
+  (* The auditor's chain-status gap check runs in two steps, each a thin
+     wrapper over a shared {!Archive_health_queries} query so the SQL is
+     defined once and reused by the healthcheck CLI and metrics:
+
+     1. [run_highest_canonical] — the height of the chain tip we trust
+        ({!Archive_health_queries.Highest_canonical_height}, [None] when
+        there is no canonical block at all).
+     2. [run_count_pending_below] — how many blocks at or below that
+        canonical height are still [pending]
+        ({!Archive_health_queries.Pending_blocks_below_canonical}).
+
+     In a healthy archive (2) is 0: everything at or below the canonical
+     tip should itself be canonical.  A non-zero count means
+     canonicalization stalled and the chain-status bookkeeping has a gap,
+     which the auditor reports.  See [missing_blocks_auditor.ml] for the
+     call site that threads (1) into (2). *)
   let run_highest_canonical db () =
     Archive_health_queries.Highest_canonical_height.run db ()
 

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -1,7 +1,11 @@
-(* sql.ml -- (Postgresql) SQL queries for missing blocks auditor *)
+(* sql.ml -- (Postgresql) SQL queries specific to the missing blocks auditor.
+   Common queries (max height, missing count, unparented count, etc.) live in
+   {!Archive_health_queries}. *)
 
-module Unparented_blocks = struct
-  (* parent_hashes represent ends of chains leading to an orphan block *)
+module Unparented_blocks_detail = struct
+  (* Returns full rows for blocks with no parent — used by the auditor
+     to report each orphan.  For a simple count, use
+     {!Archive_health_queries.Unparented_blocks_count}. *)
 
   let query =
     Mina_caqti.collect_req Caqti_type.unit
@@ -39,24 +43,11 @@ module Missing_blocks_gap = struct
 end
 
 module Chain_status = struct
-  let query_highest_canonical =
-    Mina_caqti.find_req Caqti_type.unit Caqti_type.int64
-      {sql| SELECT max(height) FROM blocks
-            WHERE chain_status = 'canonical'
-      |sql}
+  let run_highest_canonical db () =
+    Archive_health_queries.Highest_canonical_height.run db ()
 
-  let run_highest_canonical (module Conn : Mina_caqti.CONNECTION) () =
-    Conn.find query_highest_canonical ()
-
-  let query_count_pending_below =
-    Mina_caqti.find_req Caqti_type.int64 Caqti_type.int64
-      {sql| SELECT count(*) FROM blocks
-            WHERE chain_status = 'pending'
-            AND height <= ?
-      |sql}
-
-  let run_count_pending_below (module Conn : Mina_caqti.CONNECTION) height =
-    Conn.find query_count_pending_below height
+  let run_count_pending_below db height =
+    Archive_health_queries.Pending_blocks_below_canonical.run db height
 
   let query_canonical_chain =
     Mina_caqti.collect_req Caqti_type.int64

--- a/src/dune-project
+++ b/src/dune-project
@@ -3,8 +3,9 @@
 
 (package (name allocation_functor))
 (package (name archive))
-(package (name archive_hardfork_toolbox))
 (package (name archive_blocks))
+(package (name archive_hardfork_toolbox))
+(package (name archive_health_queries))
 (package (name archive_lib))
 (package (name base58_check))
 (package (name best_tip_merger))
@@ -85,6 +86,7 @@
 (package (name merkle_list_prover))
 (package (name merkle_list_verifier))
 (package (name merkle_mask))
+(package (name mina_archive_healthcheck))
 (package (name mina_automation))
 (package (name mina_base))
 (package (name mina_batch_txn))

--- a/src/dune-project
+++ b/src/dune-project
@@ -3,8 +3,9 @@
 
 (package (name allocation_functor))
 (package (name archive))
-(package (name archive_hardfork_toolbox))
 (package (name archive_blocks))
+(package (name archive_hardfork_toolbox))
+(package (name archive_health_queries))
 (package (name archive_lib))
 (package (name backoff) (synopsis "Exponential backoff with jitter for retry loops"))
 (package (name base58_check))
@@ -85,6 +86,7 @@
 (package (name merkle_list_prover))
 (package (name merkle_list_verifier))
 (package (name merkle_mask))
+(package (name mina_archive_healthcheck))
 (package (name mina_automation))
 (package (name mina_base))
 (package (name mina_batch_txn))

--- a/src/lib/archive_health_queries/archive_health_queries.ml
+++ b/src/lib/archive_health_queries/archive_health_queries.ml
@@ -78,12 +78,22 @@ module Latest_block_timestamp = struct
 end
 
 module Highest_canonical_height = struct
+  (* Highest height among canonical blocks, or [None] when the archive
+     holds no canonical block yet.  We deliberately do NOT
+     [COALESCE(MAX(height), 0)]: a height of 0 is indistinguishable from
+     a genuine genesis-only chain, and callers (e.g. the missing-blocks
+     auditor) need to tell "no canonical chain" apart from "canonical
+     chain tops out at height 0".  Selecting the top row with [LIMIT 1]
+     rather than [MAX] makes the empty case return zero rows, which
+     [find_opt] surfaces as [None] — mirroring [Latest_block_timestamp]. *)
   let query =
-    Mina_caqti.find_req Caqti_type.unit Caqti_type.int64
-      {sql| SELECT COALESCE(MAX(height), 0) FROM blocks
-            WHERE chain_status = 'canonical' |sql}
+    Mina_caqti.find_opt_req Caqti_type.unit Caqti_type.int64
+      {sql| SELECT height FROM blocks
+            WHERE chain_status = 'canonical'
+            ORDER BY height DESC
+            LIMIT 1 |sql}
 
-  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find query ()
+  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find_opt query ()
 end
 
 module Pending_blocks_below_canonical = struct

--- a/src/lib/archive_health_queries/archive_health_queries.ml
+++ b/src/lib/archive_health_queries/archive_health_queries.ml
@@ -97,6 +97,14 @@ module Highest_canonical_height = struct
 end
 
 module Pending_blocks_below_canonical = struct
+  (* Count blocks still marked [pending] at or below the given height
+     (in practice the highest canonical height — see
+     [Highest_canonical_height]).  In a healthy archive every block at or
+     below the canonical tip should itself have been finalized as
+     canonical, so this count is expected to be 0.  A non-zero result
+     means canonicalization has lagged or stalled: blocks below the
+     canonical watermark are still pending, which the missing-blocks
+     auditor flags as a gap in the chain-status bookkeeping. *)
   let query =
     Mina_caqti.find_req Caqti_type.int64 Caqti_type.int64
       {sql| SELECT COUNT(*) FROM blocks

--- a/src/lib/archive_health_queries/archive_health_queries.ml
+++ b/src/lib/archive_health_queries/archive_health_queries.ml
@@ -1,0 +1,82 @@
+(* archive_health_queries.ml -- shared SQL queries for archive node health *)
+
+module Max_block_height = struct
+  let query =
+    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
+      "SELECT COALESCE(MAX(height), 0) FROM blocks"
+
+  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find query ()
+end
+
+module Missing_blocks_count = struct
+  (* Count heights with no block row inside a sliding window ending at
+     the chain tip.  The window's lower bound is clamped to the lowest
+     block actually present ([MIN(height)]), NOT to height 1: in a
+     hardfork archive the earliest block is the fork genesis (e.g.
+     height 296372) and nothing exists below it, so heights below
+     [MIN(height)] are not "missing" — they simply predate this
+     archive.  This keeps the count consistent with
+     missing_blocks_guardian, which only looks for gaps within the
+     range of blocks the archive actually holds. *)
+  let query missing_blocks_width =
+    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
+      (Core_kernel.sprintf
+         {sql|
+        SELECT COUNT(*)
+        FROM (SELECT h::int FROM generate_series(
+                GREATEST((SELECT MIN(height) FROM blocks),
+                         (SELECT MAX(height) FROM blocks) - %d),
+                (SELECT MAX(height) FROM blocks)) h
+              LEFT JOIN blocks b ON h = b.height
+              WHERE b.height IS NULL) AS v
+      |sql}
+         missing_blocks_width )
+
+  let run (module Conn : Mina_caqti.CONNECTION) ~missing_blocks_width () =
+    Conn.find (query missing_blocks_width) ()
+end
+
+module Unparented_blocks_count = struct
+  (* Count blocks whose parent row is absent, EXCLUDING the earliest
+     block in the archive.  The earliest block ([MIN(height)] — the
+     genesis on a fresh chain, or the fork genesis on a hardfork
+     archive) legitimately has [parent_id IS NULL] because its parent
+     belongs to the pre-fork chain and is not stored here.  Counting it
+     would make every healthy archive report one permanent "orphan", so
+     we exclude it and count only genuinely unparented blocks above the
+     earliest height. *)
+  let query =
+    Mina_caqti.find_req Caqti_type.unit Caqti_type.int
+      {sql| SELECT COUNT(*) FROM blocks
+            WHERE parent_id IS NULL
+            AND height > (SELECT MIN(height) FROM blocks) |sql}
+
+  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find query ()
+end
+
+module Latest_block_timestamp = struct
+  let query =
+    Mina_caqti.find_opt_req Caqti_type.unit Caqti_type.string
+      {sql| SELECT timestamp FROM blocks ORDER BY height DESC LIMIT 1 |sql}
+
+  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find_opt query ()
+end
+
+module Highest_canonical_height = struct
+  let query =
+    Mina_caqti.find_req Caqti_type.unit Caqti_type.int64
+      {sql| SELECT COALESCE(MAX(height), 0) FROM blocks
+            WHERE chain_status = 'canonical' |sql}
+
+  let run (module Conn : Mina_caqti.CONNECTION) () = Conn.find query ()
+end
+
+module Pending_blocks_below_canonical = struct
+  let query =
+    Mina_caqti.find_req Caqti_type.int64 Caqti_type.int64
+      {sql| SELECT COUNT(*) FROM blocks
+            WHERE chain_status = 'pending'
+            AND height <= ? |sql}
+
+  let run (module Conn : Mina_caqti.CONNECTION) height = Conn.find query height
+end

--- a/src/lib/archive_health_queries/archive_health_queries.ml
+++ b/src/lib/archive_health_queries/archive_health_queries.ml
@@ -17,18 +17,33 @@ module Missing_blocks_count = struct
      [MIN(height)] are not "missing" — they simply predate this
      archive.  This keeps the count consistent with
      missing_blocks_guardian, which only looks for gaps within the
-     range of blocks the archive actually holds. *)
+     range of blocks the archive actually holds.
+
+     The count is computed purely arithmetically: the number of heights
+     in the window ([window_end - window_start + 1]) minus the number of
+     blocks actually present in that range.  This avoids materialising a
+     [generate_series] row per height and the LEFT JOIN against it.  On
+     an empty [blocks] table [MIN]/[MAX] are NULL, so the whole
+     expression is NULL; the outer [COALESCE(..., 0)] keeps the
+     mli contract (returns 0, never NULL). *)
   let query missing_blocks_width =
     Mina_caqti.find_req Caqti_type.unit Caqti_type.int
       (Core_kernel.sprintf
          {sql|
-        SELECT COUNT(*)
-        FROM (SELECT h::int FROM generate_series(
-                GREATEST((SELECT MIN(height) FROM blocks),
-                         (SELECT MAX(height) FROM blocks) - %d),
-                (SELECT MAX(height) FROM blocks)) h
-              LEFT JOIN blocks b ON h = b.height
-              WHERE b.height IS NULL) AS v
+        WITH extremes AS (
+          SELECT MIN(height) AS min_block, MAX(height) AS max_block
+          FROM blocks
+        ), window_bounds AS (
+          SELECT GREATEST(min_block, max_block - %d) AS window_start,
+                 max_block AS window_end
+          FROM extremes
+        )
+        SELECT COALESCE(
+                 (window_end - window_start + 1)
+                 - (SELECT COUNT(*) FROM blocks
+                    WHERE height BETWEEN window_start AND window_end),
+                 0)::int AS missing_blocks
+        FROM window_bounds
       |sql}
          missing_blocks_width )
 

--- a/src/lib/archive_health_queries/archive_health_queries.ml
+++ b/src/lib/archive_health_queries/archive_health_queries.ml
@@ -21,7 +21,7 @@ module Missing_blocks_count = struct
 
      The count is computed purely arithmetically: the number of heights
      in the window ([window_end - window_start + 1]) minus the number of
-     blocks actually present in that range.  This avoids materialising a
+     distinct heights present in that range.  This avoids materialising a
      [generate_series] row per height and the LEFT JOIN against it.  On
      an empty [blocks] table [MIN]/[MAX] are NULL, so the whole
      expression is NULL; the outer [COALESCE(..., 0)] keeps the
@@ -40,7 +40,7 @@ module Missing_blocks_count = struct
         )
         SELECT COALESCE(
                  (window_end - window_start + 1)
-                 - (SELECT COUNT(*) FROM blocks
+                 - (SELECT COUNT(DISTINCT height) FROM blocks
                     WHERE height BETWEEN window_start AND window_end),
                  0)::int AS missing_blocks
         FROM window_bounds

--- a/src/lib/archive_health_queries/archive_health_queries.mli
+++ b/src/lib/archive_health_queries/archive_health_queries.mli
@@ -1,0 +1,58 @@
+(** Shared SQL queries for archive node health monitoring.
+
+    These queries are used by the archive healthcheck CLI, the
+    missing blocks auditor, and archive metrics reporting. *)
+
+(** Maximum block height stored in the archive database.
+    Returns 0 if the database is empty. *)
+module Max_block_height : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> unit
+    -> (int, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+end
+
+(** Count of missing blocks (height gaps) within a sliding window
+    of the most recent [missing_blocks_width] blocks. *)
+module Missing_blocks_count : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> missing_blocks_width:int
+    -> unit
+    -> (int, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+end
+
+(** Count of blocks with no parent in the database (orphaned blocks). *)
+module Unparented_blocks_count : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> unit
+    -> (int, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+end
+
+(** Timestamp of the most recent block (as a string of milliseconds
+    since epoch), or [None] if the database is empty. *)
+module Latest_block_timestamp : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> unit
+    -> (string option, [> Caqti_error.call_or_retrieve ]) result
+       Async.Deferred.t
+end
+
+(** Maximum height among blocks with [chain_status = 'canonical'].
+    Returns 0L if no canonical blocks exist. *)
+module Highest_canonical_height : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> unit
+    -> (int64, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+end
+
+(** Count of pending blocks at or below the given height. *)
+module Pending_blocks_below_canonical : sig
+  val run :
+       (module Mina_caqti.CONNECTION)
+    -> int64
+    -> (int64, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+end

--- a/src/lib/archive_health_queries/archive_health_queries.mli
+++ b/src/lib/archive_health_queries/archive_health_queries.mli
@@ -40,13 +40,14 @@ module Latest_block_timestamp : sig
        Async.Deferred.t
 end
 
-(** Maximum height among blocks with [chain_status = 'canonical'].
-    Returns 0L if no canonical blocks exist. *)
+(** Maximum height among blocks with [chain_status = 'canonical'],
+    or [None] if no canonical blocks exist. *)
 module Highest_canonical_height : sig
   val run :
        (module Mina_caqti.CONNECTION)
     -> unit
-    -> (int64, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
+    -> (int64 option, [> Caqti_error.call_or_retrieve ]) result
+       Async.Deferred.t
 end
 
 (** Count of pending blocks at or below the given height. *)

--- a/src/lib/archive_health_queries/archive_health_queries.mli
+++ b/src/lib/archive_health_queries/archive_health_queries.mli
@@ -46,8 +46,7 @@ module Highest_canonical_height : sig
   val run :
        (module Mina_caqti.CONNECTION)
     -> unit
-    -> (int64 option, [> Caqti_error.call_or_retrieve ]) result
-       Async.Deferred.t
+    -> (int64 option, [> Caqti_error.call_or_retrieve ]) result Async.Deferred.t
 end
 
 (** Count of pending blocks at or below the given height. *)

--- a/src/lib/archive_health_queries/dune
+++ b/src/lib/archive_health_queries/dune
@@ -1,0 +1,14 @@
+(library
+ (name archive_health_queries)
+ (public_name archive_health_queries)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async
+  caqti
+  ;; local libraries
+  mina_caqti)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
+++ b/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
@@ -123,7 +123,7 @@ let test_case (test_data : t) =
   in
   let log_file = output ^/ "precomputed_blocks_test.log" in
   Archive.Process.start_logging test_data.archive ~log_file ;
-  match%bind Archive.wait_until_ready ~log_file with
+  match%bind Archive_healthcheck.wait_db_ready ~postgres_uri:archive_uri () with
   | Ok () ->
       let%bind () =
         Daemon.archive_blocks_from_files daemon.executor

--- a/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
+++ b/src/test/archive/archive_node_tests/archive_precomputed_blocks_test.ml
@@ -123,7 +123,10 @@ let test_case (test_data : t) =
   in
   let log_file = output ^/ "precomputed_blocks_test.log" in
   Archive.Process.start_logging test_data.archive ~log_file ;
-  match%bind Archive_healthcheck.wait_db_ready ~postgres_uri:archive_uri () with
+  match%bind
+    Archive_healthcheck.wait_db_and_server_ready ~postgres_uri:archive_uri
+      ~server_port:test_data.archive.config.server_port ()
+  with
   | Ok () ->
       let%bind () =
         Daemon.archive_blocks_from_files daemon.executor

--- a/src/test/archive/archive_node_tests/dune
+++ b/src/test/archive/archive_node_tests/dune
@@ -15,7 +15,13 @@
    mina_automation
    mina_automation.fixture
    mina_automation.runner)
- 
+ ;; The tests shell out to mina-archive-healthcheck via
+ ;; [Mina_automation.Healthcheck], so make sure the binary is built
+ ;; before the tests run.  At runtime the path is resolved via
+ ;; [Executor.PathFinder] (look in [_build/default] first, fall back
+ ;; to PATH for deb-installed packages), so this dep is purely a
+ ;; build-ordering constraint.
+ (deps ../../../app/mina_archive_healthcheck/mina_archive_healthcheck.exe)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_jane ppx_mina ppx_compare)))
 

--- a/src/test/archive/archive_node_tests/dune
+++ b/src/test/archive/archive_node_tests/dune
@@ -16,7 +16,7 @@
    mina_automation.fixture
    mina_automation.runner)
  ;; The tests shell out to mina-archive-healthcheck via
- ;; [Mina_automation.Healthcheck], so make sure the binary is built
+ ;; [Mina_automation.Archive_healthcheck], so make sure the binary is built
  ;; before the tests run.  At runtime the path is resolved via
  ;; [Executor.PathFinder] (look in [_build/default] first, fall back
  ;; to PATH for deb-installed packages), so this dep is purely a
@@ -24,4 +24,3 @@
  (deps ../../../app/mina_archive_healthcheck/mina_archive_healthcheck.exe)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_jane ppx_mina ppx_compare)))
-

--- a/src/test/archive/archive_node_tests/live_upgrade_archive.ml
+++ b/src/test/archive/archive_node_tests/live_upgrade_archive.ml
@@ -45,6 +45,11 @@ let test_case (test_data : t) =
   Archive.Process.start_logging test_data.archive ~log_file ;
 
   let%bind () =
+    Archive_healthcheck.wait_db_and_server_ready ~postgres_uri:archive_uri
+      ~server_port:test_data.archive.config.server_port ()
+    >>| Or_error.ok_exn
+  in
+  let%bind () =
     Daemon.archive_blocks_from_files daemon.executor
       ~archive_address:test_data.archive.config.server_port ~format:`Precomputed
       ~sleep:5 precomputed_blocks

--- a/src/test/archive/archive_node_tests/load_genesis_ledger.ml
+++ b/src/test/archive/archive_node_tests/load_genesis_ledger.ml
@@ -27,8 +27,44 @@ let test_case (test_data : t) =
   in
   let logger = Logger.create () in
   let log_file = test_data.temp_dir ^/ "archive.load_genesis_ledger.log" in
+  (* Sanity: before the archive process has started, [db-ready] must
+     report failure.  The fixture has created an empty random database
+     but no [blocks] table yet, so [SELECT MAX(height) FROM blocks]
+     returns a Caqti error which the healthcheck surfaces as a
+     non-zero exit.  This is the "before bootstrap → false" half of
+     the assertion the integration suite owes the healthcheck binary. *)
+  let%bind () =
+    match%map
+      Archive_healthcheck.db_ready ~postgres_uri:config.postgres_uri ()
+    with
+    | Ok () ->
+        failwith
+          "Archive_healthcheck.db_ready unexpectedly succeeded against a fresh \
+           archive DB before Archive.start — the test's before/after invariant \
+           is broken."
+    | Error _ ->
+        ()
+  in
   let%bind process = Archive.of_config config |> Archive.start in
   Archive.Process.start_logging process ~log_file ;
+  (* Bootstrap is in progress: the daemon is loading the schema and
+     genesis ledger.  Wait until [db-ready] passes — this is the
+     "after bootstrap → true" half of the assertion above, and also
+     gates the rest of this test on a working archive process. *)
+  let%bind () =
+    match%map
+      Archive_healthcheck.wait_db_ready ~postgres_uri:config.postgres_uri
+        ~timeout:120 ()
+    with
+    | Ok () ->
+        ()
+    | Error e ->
+        failwithf
+          "Healthcheck.wait_db_ready timed out after Archive.start; the \
+           archive process did not initialize its DB schema within the \
+           expected window: %s"
+          (Error.to_string_hum e) ()
+  in
 
   let sleep_duration = Time.Span.of_sec 10.0 in
 

--- a/src/test/archive/archive_node_tests/load_genesis_ledger.ml
+++ b/src/test/archive/archive_node_tests/load_genesis_ledger.ml
@@ -27,23 +27,22 @@ let test_case (test_data : t) =
   in
   let logger = Logger.create () in
   let log_file = test_data.temp_dir ^/ "archive.load_genesis_ledger.log" in
-  (* Sanity: before the archive process has started, [db-ready] must
-     report failure.  The fixture has created an empty random database
-     but no [blocks] table yet, so [SELECT MAX(height) FROM blocks]
-     returns a Caqti error which the healthcheck surfaces as a
-     non-zero exit.  This is the "before bootstrap → false" half of
-     the assertion the integration suite owes the healthcheck binary. *)
+  (* Sanity: before the archive process has started, [db-ready] should
+     already pass.  The fixture creates an empty random archive DB with
+     the schema loaded, so [SELECT COALESCE(MAX(height), 0) FROM blocks]
+     is queryable even before the archive process bootstraps genesis. *)
   let%bind () =
     match%map
       Archive_healthcheck.db_ready ~postgres_uri:config.postgres_uri ()
     with
     | Ok () ->
-        failwith
-          "Archive_healthcheck.db_ready unexpectedly succeeded against a fresh \
-           archive DB before Archive.start — the test's before/after invariant \
-           is broken."
-    | Error _ ->
         ()
+    | Error e ->
+        failwithf
+          "Archive_healthcheck.db_ready failed against a schema-only archive \
+           DB before Archive.start; expected the healthcheck to verify schema \
+           reachability independently of block ingestion: %s"
+          (Error.to_string_hum e) ()
   in
   let%bind process = Archive.of_config config |> Archive.start in
   Archive.Process.start_logging process ~log_file ;

--- a/src/test/archive/archive_node_tests/upgrade_archive.ml
+++ b/src/test/archive/archive_node_tests/upgrade_archive.ml
@@ -37,6 +37,11 @@ let test_case (test_data : t) =
 
   Archive.Process.start_logging test_data.archive ~log_file ;
   let%bind () =
+    Archive_healthcheck.wait_db_and_server_ready ~postgres_uri:archive_uri
+      ~server_port:test_data.archive.config.server_port ()
+    >>| Or_error.ok_exn
+  in
+  let%bind () =
     Daemon.archive_blocks_from_files daemon.executor
       ~archive_address:test_data.archive.config.server_port ~format:`Precomputed
       precomputed_blocks

--- a/src/test/mina_automation/archive.ml
+++ b/src/test/mina_automation/archive.ml
@@ -88,7 +88,7 @@ module Process = struct
     let logger = Logger.create () in
     don't_wait_for
     @@ Pipe.iter
-         (Process.stdout t.process |> Reader.pipe)
+         (Process.stdout t.process |> Reader.lines)
          ~f:(fun stdout ->
            let%bind () =
              Writer.with_file log_file ~append:true ~f:(fun writer ->

--- a/src/test/mina_automation/archive.ml
+++ b/src/test/mina_automation/archive.ml
@@ -112,57 +112,9 @@ let start t =
   let open Deferred.Let_syntax in
   let args = Config.to_args t.config in
   let%bind _, process = Executor.run_in_background t.executor ~args () in
-  (* TODO: consider internalize [wait_until_ready] here and replace this wait *)
+  (* Callers that need to gate on archive readiness should use
+     [Healthcheck.wait_db_ready] rather than relying on this fixed
+     sleep — it polls the DB directly and survives schema-load
+     latency variation. *)
   let%map () = after (Time.Span.of_sec 5.) in
   Process.{ process; config = t.config }
-
-let wait_until_ready ~log_file =
-  let timeout = Time.Span.of_sec 30.0 in
-  let poll_interval = Time.Span.of_sec 1.0 in
-  let start_time = Time.now () in
-  let is_timeout () =
-    let elapsed = Time.(diff (now ()) start_time) in
-    Time.Span.( > ) elapsed timeout
-  in
-  let expected_message = "Archive process ready. Clients can now connect" in
-  let rec wait_until_log_created () =
-    let%bind () = after poll_interval in
-    match%bind Sys.file_exists log_file with
-    | `Yes ->
-        Deferred.Or_error.return ()
-    | _ when is_timeout () ->
-        Deferred.Or_error.error_string
-          "Timeout waiting for archive log file to be created"
-    | _ ->
-        wait_until_log_created ()
-  in
-  let%bind.Deferred.Or_error () = wait_until_log_created () in
-  let lines_to_check_from = ref 0 in
-  let rec wait_til_log_ready_emitted () =
-    if is_timeout () then
-      Deferred.Or_error.error_string
-        "Timeout waiting for archive process to be ready"
-    else
-      let%bind reader = Reader.open_file log_file in
-      let rec check_lines_from cur_line =
-        match%bind Reader.read_line reader with
-        | `Eof ->
-            let%bind () = after poll_interval in
-            lines_to_check_from := cur_line ;
-            wait_til_log_ready_emitted ()
-        | `Ok line when cur_line >= !lines_to_check_from -> (
-            if String.is_empty line then check_lines_from (cur_line + 1)
-            else
-              match
-                Yojson.Safe.from_string line |> Logger.Message.of_yojson
-              with
-              | Ok { message; _ } when String.equal message expected_message ->
-                  Deferred.Or_error.return ()
-              | _ ->
-                  check_lines_from (cur_line + 1) )
-        | `Ok _ ->
-            check_lines_from (cur_line + 1)
-      in
-      check_lines_from 0
-  in
-  wait_til_log_ready_emitted ()

--- a/src/test/mina_automation/archive.ml
+++ b/src/test/mina_automation/archive.ml
@@ -112,9 +112,11 @@ let start t =
   let open Deferred.Let_syntax in
   let args = Config.to_args t.config in
   let%bind _, process = Executor.run_in_background t.executor ~args () in
-  (* Callers that need to gate on archive readiness should use
-     [Archive_healthcheck.wait_db_ready] rather than relying on this fixed
-     sleep — it polls the DB directly and survives schema-load
-     latency variation. *)
+  (* Callers that need to gate on archive readiness must use
+     [Archive_healthcheck.wait_db_and_server_ready] rather than relying
+     on this fixed sleep: on a slow agent the archive takes longer than
+     5 s to start listening, and a block sent before then is silently
+     lost.  [wait_db_ready] alone is not a gate either — the schema is
+     loaded before this process starts. *)
   let%map () = after (Time.Span.of_sec 5.) in
   Process.{ process; config = t.config }

--- a/src/test/mina_automation/archive.ml
+++ b/src/test/mina_automation/archive.ml
@@ -113,7 +113,7 @@ let start t =
   let args = Config.to_args t.config in
   let%bind _, process = Executor.run_in_background t.executor ~args () in
   (* Callers that need to gate on archive readiness should use
-     [Healthcheck.wait_db_ready] rather than relying on this fixed
+     [Archive_healthcheck.wait_db_ready] rather than relying on this fixed
      sleep — it polls the DB directly and survives schema-load
      latency variation. *)
   let%map () = after (Time.Span.of_sec 5.) in

--- a/src/test/mina_automation/archive_healthcheck.ml
+++ b/src/test/mina_automation/archive_healthcheck.ml
@@ -1,0 +1,74 @@
+(** Thin wrapper around the [mina-archive-healthcheck] binary for
+    integration tests.  Resolves the binary via the same auto-detect
+    rules as the rest of [mina_automation] (look in [_build/default]
+    first, fall back to PATH for deb-installed packages), then shells
+    out and surfaces exit codes as [Or_error]: [Ok ()] on exit 0,
+    [Error] otherwise.
+
+    Only exposes the subcommands actually used by integration tests
+    today; for the full surface see [src/app/mina_archive_healthcheck/]. *)
+
+open Async
+open Core
+
+module Paths = struct
+  let dune_name =
+    "src/app/mina_archive_healthcheck/mina_archive_healthcheck.exe"
+
+  let official_name = "mina-archive-healthcheck"
+end
+
+module PathFinder = Executor.Make_PathFinder (Paths)
+
+let exit_status_to_string = function
+  | Ok () ->
+      "0"
+  | Error (`Exit_non_zero n) ->
+      Int.to_string n
+  | Error (`Signal s) ->
+      sprintf "signal %s" (Signal.to_string s)
+
+let run args =
+  let open Deferred.Let_syntax in
+  let%bind prog = PathFinder.standalone_path_exn in
+  let%bind proc = Process.create_exn ~prog ~args () in
+  let%map output = Process.collect_output_and_wait proc in
+  match output.exit_status with
+  | Ok () ->
+      Ok output.stdout
+  | Error _ as status ->
+      Or_error.errorf
+        "mina-archive-healthcheck %s exited %s\nstdout=%s\nstderr=%s"
+        (String.concat ~sep:" " args)
+        (exit_status_to_string status)
+        output.stdout output.stderr
+
+(** [db_ready ~postgres_uri ()] runs [mina-archive-healthcheck db-ready]
+    once.  Returns [Ok ()] if the [blocks] table responds to a
+    [SELECT MAX(height)], otherwise [Error] (DB unreachable, schema
+    not loaded, etc.). *)
+let db_ready ~postgres_uri () =
+  let%map result = run [ "db-ready"; "--postgres-uri"; postgres_uri ] in
+  Result.ignore_m result
+
+(** [wait_db_ready ~postgres_uri ()] blocks until [db-ready] passes or
+    [timeout] seconds elapse.  This is the natural replacement for the
+    log-tailing [Archive.wait_until_ready] — it talks to the DB
+    directly, so it doesn't depend on the daemon emitting any
+    particular log line, and it works against integration archives
+    that haven't yet ingested any blocks (the full readiness check
+    cannot, because it requires a non-None [latest_ts]). *)
+let wait_db_ready ~postgres_uri ?(timeout = 30) ?(interval = 1) () =
+  let%map result =
+    run
+      [ "wait"
+      ; "--db-only"
+      ; "--postgres-uri"
+      ; postgres_uri
+      ; "--timeout"
+      ; Int.to_string timeout
+      ; "--interval"
+      ; Int.to_string interval
+      ]
+  in
+  Result.ignore_m result

--- a/src/test/mina_automation/archive_healthcheck.ml
+++ b/src/test/mina_automation/archive_healthcheck.ml
@@ -72,3 +72,28 @@ let wait_db_ready ~postgres_uri ?(timeout = 30) ?(interval = 1) () =
       ]
   in
   Result.ignore_m result
+
+(** [wait_db_and_server_ready ~postgres_uri ~server_port ()] blocks
+    until the archive DB schema answers AND the archive server accepts
+    a TCP connection on [server_port].  Tests that send blocks to the
+    archive's RPC port must use this, not [wait_db_ready]: the schema
+    is loaded before the archive process even starts, so the DB probe
+    alone gates nothing, and a block dispatched before the server
+    listens is silently lost. *)
+let wait_db_and_server_ready ~postgres_uri ~server_port ?(timeout = 30)
+    ?(interval = 1) () =
+  let%map result =
+    run
+      [ "wait"
+      ; "--db-only"
+      ; "--postgres-uri"
+      ; postgres_uri
+      ; "--server-port"
+      ; Int.to_string server_port
+      ; "--timeout"
+      ; Int.to_string timeout
+      ; "--interval"
+      ; Int.to_string interval
+      ]
+  in
+  Result.ignore_m result

--- a/src/test/mina_automation/runner/runner.ml
+++ b/src/test/mina_automation/runner/runner.ml
@@ -27,10 +27,18 @@ let run (module F : Intf.Fixture) =
           return result )
 
 let run_blocking test_case () =
-  match Async.Thread_safe.block_on_async_exn (fun () -> run test_case) with
-  | Intf.Passed ->
-      ()
-  | Warning msg ->
-      Alcotest.fail msg
-  | Failed err ->
-      Alcotest.fail (Error.to_string_hum err)
+  try
+    match Async.Thread_safe.block_on_async_exn (fun () -> run test_case) with
+    | Intf.Passed ->
+        ()
+    | Warning msg ->
+        Alcotest.fail msg
+    | Failed err ->
+        Alcotest.fail (Error.to_string_hum err)
+  with exn ->
+    let backtrace = Stdlib.Printexc.get_backtrace () in
+    if String.is_empty backtrace then
+      Alcotest.failf "Unhandled exception: %s" (Exn.to_string exn)
+    else
+      Alcotest.failf "Unhandled exception: %s\nBacktrace:\n%s"
+        (Exn.to_string exn) backtrace


### PR DESCRIPTION
## Summary

- Extracts common archive SQL queries into a shared `archive_health_queries` library, used by the archive healthcheck, `missing_blocks_auditor`, and archive metrics
- Adds `mina-archive-healthcheck`, a lightweight CLI for probing archive node health via PostgreSQL
- Subcommands: `db-ready`, `block-height`, `block-recency`, `missing-blocks`, `unparented-blocks`, `ready`, `wait`
- All commands support `--json` output for machine consumption
- Refactors `missing_blocks_auditor` and `archive/lib/metrics.ml` to use the shared query library

## Design

The archive healthcheck talks directly to PostgreSQL (no dependency on a running daemon or archive-node-api). Health signals:

| Check | What it queries |
|-------|----------------|
| `db-ready` | `SELECT MAX(height) FROM blocks` (connectivity test) |
| `block-recency` | Latest block timestamp vs wall clock |
| `missing-blocks` | Height gaps in sliding window |
| `unparented-blocks` | Blocks with no parent |
| `ready` | All of the above combined |
| `wait` | Polls `ready` until pass or timeout |

**Relationship to `missing-blocks-auditor`**: The auditor does deep integrity checks (recursive CTE chain walk, bitmask exit codes) for periodic audit + auto-repair via the guardian script. The healthcheck does fast, lightweight probes for k8s readiness/liveness. Both share SQL via `archive_health_queries`.

## Test plan

- [ ] CI build passes
- [ ] Manual testing against archive database
- [ ] Verify `missing_blocks_auditor` still works after refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)