### PR TITLE
Fix duplicate arc entries

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -427,15 +427,28 @@ let add ~arcs_cache ~transition =
     |> Mina_state.Protocol_state.previous_state_hash
   in
   let parent_arcs = State_hash.Table.find_exn arcs_cache parent_hash in
-  State_hash.Table.set arcs_cache ~key:parent_hash ~data:(hash :: parent_arcs) ;
-  State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
-  let transition_unwrapped =
-    With_hash.data transition |> Mina_block.read_all_proofs_from_disk
-  in
-  fun batch ->
-    Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
-    Batch.set batch ~key:(Arcs hash) ~data:[] ;
-    Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs)
+  (* Guard against duplicate New_node diffs for the same block: if this block
+     is already listed as a successor of its parent, skip the write entirely.
+     Without this check, replaying the same New_node diff (e.g. when
+     add_breadcrumb_exn is called twice for the same block) would append the
+     hash again to the Arcs list, causing crawl_successors to visit the block
+     and all its descendants multiple times during load_full_frontier. *)
+  if List.mem parent_arcs hash ~equal:State_hash.equal then (
+    (* Still populate the cache entry for this block so that any children of
+       this block appearing later in the same batch can find their parent. *)
+    if not (State_hash.Table.mem arcs_cache hash) then
+      State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
+    fun _batch -> () )
+  else (
+    State_hash.Table.set arcs_cache ~key:parent_hash ~data:(hash :: parent_arcs) ;
+    State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
+    let transition_unwrapped =
+      With_hash.data transition |> Mina_block.read_all_proofs_from_disk
+    in
+    fun batch ->
+      Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
+      Batch.set batch ~key:(Arcs hash) ~data:[] ;
+      Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs) )
 
 let move_root ~old_root_hash ~new_root ~garbage =
   let new_root_hash =

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -507,26 +507,38 @@ let get_best_tip t = get t.db ~key:Best_tip ~error:(`Not_found `Best_tip)
 
 let set_best_tip data = Batch.set ~key:Best_tip ~data
 
-let rec crawl_successors ?max_depth ~signature_kind ~proof_cache_db ~init ~f t
-    hash =
-  let open Deferred.Result.Let_syntax in
-  match max_depth with
-  | Some 0 ->
-      (* Depth limit reached, stop crawling *)
-      Deferred.Result.return ()
-  | _ ->
-      let remaining_depth = Option.map max_depth ~f:(fun d -> d - 1) in
-      let%bind successors = Deferred.return (get_arcs t hash) in
-      deferred_list_result_iter successors ~f:(fun succ_hash ->
-          let%bind transition =
-            Deferred.return
-              (get_transition ~signature_kind ~proof_cache_db t succ_hash)
-          in
-          let%bind init' =
-            Deferred.map (f init transition)
-              ~f:(Result.map_error ~f:(fun err -> `Crawl_error err))
-          in
-          crawl_successors ~signature_kind ~proof_cache_db
-            ?max_depth:remaining_depth t succ_hash ~init:init' ~f )
+let crawl_successors ?max_depth ~signature_kind ~proof_cache_db ~init ~f t hash
+    =
+  (* Track visited hashes globally across the traversal.  A hash should appear
+     in at most one node's Arcs list in a well-formed DB, but if the DB was
+     written before the duplicate-arc bug was fixed a hash may appear several
+     times in the same list (or, defensively, in multiple lists).  Skipping
+     already-visited successors prevents the same subtree from being loaded and
+     applied to the in-memory frontier more than once. *)
+  let visited = State_hash.Hash_set.create () in
+  let rec go ?max_depth ~init hash =
+    let open Deferred.Result.Let_syntax in
+    match max_depth with
+    | Some 0 ->
+        (* Depth limit reached, stop crawling *)
+        Deferred.Result.return ()
+    | _ ->
+        let remaining_depth = Option.map max_depth ~f:(fun d -> d - 1) in
+        let%bind successors = Deferred.return (get_arcs t hash) in
+        deferred_list_result_iter successors ~f:(fun succ_hash ->
+            if Hash_set.mem visited succ_hash then Deferred.Result.return ()
+            else (
+              Hash_set.add visited succ_hash ;
+              let%bind transition =
+                Deferred.return
+                  (get_transition ~signature_kind ~proof_cache_db t succ_hash)
+              in
+              let%bind init' =
+                Deferred.map (f init transition)
+                  ~f:(Result.map_error ~f:(fun err -> `Crawl_error err))
+              in
+              go ?max_depth:remaining_depth ~init:init' succ_hash ) )
+  in
+  go ?max_depth ~init hash
 
 let with_batch t = Batch.with_batch t.db


### PR DESCRIPTION
Fix: persistent frontier duplicate arcs causing infinite bootstrap loop

## Problem

Nodes on the ITN testnet were stuck in bootstrap indefinitely. Internal trace analysis showed that `load_full_frontier` was spending the entire bootstrap window (2+ hours) loading blocks from the persistent frontier database, never completing.

### Root cause

`crawl_successors` performs a DFS over the on-disk frontier tree by reading each node's `Arcs` (successor hash list) from RocksDB.  On affected nodes those lists contained duplicate entries — the same child hash appearing 10×,
20×, 40×, or 60× in its parent's list.  Because `crawl_successors` iterated the raw list, every duplicate entry caused the entire subtree rooted at that child to be loaded again.  The explosion was multiplicative: a hash appearing 40× in one level and 10× in the next caused 400 redundant loads of every descendant block.

Concretely, whale-2 had **2 154 `Loaded_transition_from_storage` events** for only **339 unique blocks** (290 distinct global slots, exactly matching the frontier depth k = 290).  Average repetition was 6.4×; the worst single block was loaded 60×.  Whale-3 showed the same pattern (1 305 loads / 327 unique blocks, 4.0× average).

### How duplicates accumulate

`Database.add` appends a new child hash to `Arcs[parent]`:

```
parent_arcs = cache[parent]          (* e.g. [] *)
cache[parent] ← hash :: parent_arcs
write Arcs[parent] ← hash :: parent_arcs
```

`Diff_buffer` batches `New_node` diffs and flushes them to the persistent frontier worker asynchronously.  When `add_breadcrumb_exn` is called with a block that already exists in the in-memory frontier (a known occurrence logged
as *"Same block was applied to transition frontier more than once"* in `full_frontier.ml`), the caller still forwards the `New_node` diff to `notify_sync`.  The worker has no deduplication guard, so on the second flush it reads `Arcs[parent] = [X]` from the DB and writes `Arcs[parent] = [X, X]`.

Each subsequent duplicate adds another copy.  Because the diff buffer compresses `Root_transitioned` and `Best_tip_changed` diffs but passes **all** `New_node` diffs through unchanged, even a handful of duplicate breadcrumb additions accumulates into large multipliers over the lifetime of a long-running node.

### Why this went undetected

The in-memory frontier (`full_frontier.ml:apply_diff`) correctly rejects the second add via `Hashtbl.add` returning `` `Duplicate `` and logs an error, so the in-memory state is never corrupted.  The persistent frontier has no
equivalent guard and silently accumulated the duplicates in RocksDB.

## Fix

Two complementary changes to `src/lib/transition_frontier/persistent_frontier/database.ml`:

### 1 — Prevention (`Database.add`)

Before prepending `hash` to `Arcs[parent]`, check whether it is already present.  If so, return a no-op batch function.  The `arcs_cache` entry for the block is still initialised so that any children of this block appearing later in the same flush batch can find their parent via `find_exn`.

```ocaml
if List.mem parent_arcs hash ~equal:State_hash.equal then (
  if not (State_hash.Table.mem arcs_cache hash) then
    State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
  fun _batch -> () )
else ( ... original write ... )
```

### 2 — Remediation (`crawl_successors`)

Databases already on disk may have corrupted `Arcs` lists.  The fix to `add` prevents future corruption but cannot repair existing data.

`crawl_successors` is converted from a plain recursive function into a wrapper that maintains a global `State_hash.Hash_set` of visited nodes.  Any successor hash already in the set is silently skipped, making `load_full_frontier` idempotent regardless of how many times a hash appears in stored `Arcs` lists.

This also provides a general safeguard against unexpected cycles in the on-disk tree.

```ocaml
let crawl_successors ... =
  let visited = State_hash.Hash_set.create () in
  let rec go ?max_depth ~init hash =
    ...
    deferred_list_result_iter successors ~f:(fun succ_hash ->
        if Hash_set.mem visited succ_hash then Deferred.Result.return ()
        else ( Hash_set.add visited succ_hash ; ... recurse ... ) )
  in
  go ?max_depth ~init hash
```

## Checklist

Explain how you tested your changes:
* [ ] test on cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
