### PR TITLE
Skip more verification on load persistent frontier

### DIFF
--- a/changes/18774.md
+++ b/changes/18774.md
@@ -1,0 +1,3 @@
+Faster node startup when loading blocks from persistent frontier
+
+Nodes now skip redundant re-verification of blocks that were already validated before being saved to disk. This reduces startup time by roughly 3x when the persistent frontier contains blocks with user transactions.

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -480,16 +480,25 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
   let global_slot = Consensus_state.global_slot_since_genesis consensus_state in
   let body = Block.body block in
   let apply_start_time = Core.Time.now () in
-  let body_ref_from_header = Blockchain_state.body_reference blockchain_state in
-  let body_ref_computed =
-    Staged_ledger_diff.Body.compute_reference
-      ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
-    @@ Staged_ledger_diff.Body.read_all_proofs_from_disk body
-  in
   let%bind.Deferred.Result () =
-    if Blake2.equal body_ref_computed body_ref_from_header then
-      Deferred.Result.return ()
-    else Deferred.Result.fail `Invalid_body_reference
+    match skip_staged_ledger_verification with
+    | Some `All ->
+        (* Block was already validated before persistence; body reference
+           cannot have changed. Skip the expensive proof deserialization
+           and hashing. *)
+        Deferred.Result.return ()
+    | _ ->
+        let body_ref_from_header =
+          Blockchain_state.body_reference blockchain_state
+        in
+        let body_ref_computed =
+          Staged_ledger_diff.Body.compute_reference
+            ~tag:Mina_net2.Bitswap_tag.(to_enum Body)
+          @@ Staged_ledger_diff.Body.read_all_proofs_from_disk body
+        in
+        if Blake2.equal body_ref_computed body_ref_from_header then
+          Deferred.Result.return ()
+        else Deferred.Result.fail `Invalid_body_reference
   in
   let%bind.Deferred.Result ( `Ledger_proof proof_opt
                            , `Staged_ledger transitioned_staged_ledger

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1232,12 +1232,27 @@ module T = struct
                 t.scan_state work )
     in
     [%log internal] "Prediff" ;
+    let check =
+      match skip_verification with
+      | Some `All ->
+          (* These blocks were already fully verified before persistence;
+             skip signature/proof verification when loading from disk. *)
+          fun cs ->
+           Deferred.Or_error.return
+             (Ok
+                (List.map cs ~f:(fun { With_status.data; _ } ->
+                     let (`If_this_is_used_it_should_have_a_comment_justifying_it
+                           v ) =
+                       User_command.to_valid_unsafe data
+                     in
+                     v ) ) )
+      | _ ->
+          Check_commands.check_commands t.ledger ~verifier
+            ~transaction_pool_proxy
+    in
     let%bind prediff =
       Pre_diff_info.get witness ~constraint_constants ~coinbase_receiver
-        ~supercharge_coinbase
-        ~check:
-          (Check_commands.check_commands t.ledger ~verifier
-             ~transaction_pool_proxy )
+        ~supercharge_coinbase ~check
       |> Deferred.map
            ~f:
              (Result.map_error ~f:(fun error ->


### PR DESCRIPTION
Closes https://github.com/MinaProtocol/mina/issues/18775

## Summary

During `load_full_frontier`, each block is rebuilt via `Breadcrumb.build` with `~skip_staged_ledger_verification:`All`. However, two expensive operations were **not** guarded by this flag:

1. **Command verification** (~3.2s/block for blocks with transactions): `Pre_diff_info.get` unconditionally calls `Check_commands.check_commands`, which loads verification keys, hashes every command, and sends them to the verifier subprocess for signature/proof re-verification — despite these blocks having been fully verified before persistence.

2. **Body reference computation** (~23ms/block): `validate_staged_ledger_diff` unconditionally deserializes all SNARK proofs from LMDB (`read_all_proofs_from_disk`) and computes a Blake2 body reference hash for comparison, even though the block data cannot have changed since persistence.

## Changes

- **`staged_ledger.ml`**: When `skip_verification = Some All`, swap the `~check` callback from `Check_commands.check_commands` (verifier RPC) to an inline function that uses `User_command.to_valid_unsafe` — safe because these commands were already verified before persistence.

- **`validation.ml`**: When `skip_staged_ledger_verification = Some All`, skip the `read_all_proofs_from_disk` + `compute_reference` + hash comparison entirely.

## Not implemented: skip sparse ledger witness creation

The analysis document also recommended skipping `Sparse_ledger.of_ledger_subset_exn` during loading (~100-200ms/block). This was **not** implemented because the recommendation's premise was incorrect: it claimed the sparse ledger is only used to compute source/target ledger hashes, but the witnesses are also stored in `Scan_state.Transaction_with_witness` entries and are needed by snark workers for proof generation after loading completes. Skipping witness creation would leave the scan state with missing data and break SNARK proof generation.

## Expected impact

Based on traces from whale-2/whale-3/whale-4 (bp-bootstrap-cluster-apr15):

| | whale-2 (2,153 blocks) | whale-3 (1,304 blocks) | whale-4 (360 blocks) |
|---|---|---|---|
| Before | 61.2 min | 33.2 min | 6.8 min |
| After (projected) | ~21 min | ~12 min | ~3 min |
| Speedup | ~2.9x | ~2.8x | ~2.3x |

The speedup is proportional to the fraction of blocks with user transactions (which trigger the expensive verification). Empty blocks already load in ~12ms.

## Test plan

- [x] `dune build @check` passes
- [ ] Run `load_full_frontier` on a node with a populated persistent frontier and verify loading time improvement via internal traces
- [ ] Verify the node produces blocks normally after loading (scan state integrity, snark work generation)
