### PR TITLE
Add some guards for duplicated arc entries for persistent frontier

### DIFF
--- a/changes/18777.md
+++ b/changes/18777.md
@@ -1,0 +1,1 @@
+Fix a bug where duplicate blocks received via gossip caused the persistent frontier to store redundant arc entries, leading to exponential load times during bootstrap. Affected nodes could see individual blocks visited up to 60x, significantly slowing down bootstrap. Existing databases with duplicate arcs are now handled correctly on load.

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -630,11 +630,15 @@ let calculate_diffs ({ context = (module Context); _ } as t) breadcrumb =
       (* reverse diffs so that they are applied in the correct order *)
       List.rev diffs )
 
+type 'mutant apply_diff_result =
+  | Applied of { mutant : 'mutant; new_root : State_hash.t option }
+  | Duplicate
+
 (* TODO: refactor metrics tracking outside of apply_diff (could maybe even be an extension?) *)
 let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
-    ~enable_epoch_ledger_sync : mutant * State_hash.t option =
+    ~enable_epoch_ledger_sync : mutant apply_diff_result =
   match diff with
-  | New_node (Full breadcrumb) ->
+  | New_node (Full breadcrumb) -> (
       let breadcrumb_hash = Breadcrumb.state_hash breadcrumb in
       let parent_hash = Breadcrumb.parent_hash breadcrumb in
       let parent_node = Hashtbl.find_exn t.table parent_hash in
@@ -644,25 +648,26 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
         ; length = parent_node.length + 1
         }
       in
-      ( match Hashtbl.add t.table ~key:breadcrumb_hash ~data:node with
+      match Hashtbl.add t.table ~key:breadcrumb_hash ~data:node with
       | `Duplicate ->
           [%log' error t.logger]
             "Same block ($state_hash) was applied to transition frontier more \
              than once; this could indicate that you are running multiple \
              block producers with the same keypair"
-            ~metadata:[ ("state_hash", State_hash.to_yojson breadcrumb_hash) ]
+            ~metadata:[ ("state_hash", State_hash.to_yojson breadcrumb_hash) ] ;
+          Duplicate
       | `Ok ->
           Hashtbl.set t.table ~key:parent_hash
             ~data:
               { parent_node with
                 successor_hashes =
                   breadcrumb_hash :: parent_node.successor_hashes
-              } ) ;
-      ((), None)
+              } ;
+          Applied { mutant = (); new_root = None } )
   | Best_tip_changed new_best_tip ->
       let old_best_tip = t.best_tip in
       t.best_tip <- new_best_tip ;
-      (old_best_tip, None)
+      Applied { mutant = old_best_tip; new_root = None }
   | Root_transitioned { new_root; garbage = Full garbage; _ } ->
       let new_root_hash =
         (Root_data.Limited.Stable.Latest.hashes new_root).state_hash
@@ -675,7 +680,7 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
       move_root t ~new_root_hash ~new_root_protocol_states ~garbage
         ~enable_epoch_ledger_sync ;
       [%log' internal t.logger] "Move_frontier_root_done" ;
-      (old_root_hash, Some new_root_hash)
+      Applied { mutant = old_root_hash; new_root = Some new_root_hash }
 
 module Metrics = struct
   (* The max length of a path disjoint from the best tip path. O(n) *)
@@ -891,16 +896,20 @@ let apply_diffs ({ context = (module Context); _ } as t) diffs
   let new_root, diffs_with_mutants =
     List.fold diffs ~init:(None, [])
       ~f:(fun (prev_root, diffs_with_mutants) (Diff.Full.E.E diff) ->
-        let mutant, new_root = apply_diff t diff ~enable_epoch_ledger_sync in
-        update_metrics_with_diff t diff ;
-        let new_root =
-          match new_root with
-          | None ->
-              prev_root
-          | Some state_hash ->
-              Some { state_hash }
-        in
-        (new_root, Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutants) )
+        match apply_diff t diff ~enable_epoch_ledger_sync with
+        | Duplicate ->
+            (prev_root, diffs_with_mutants)
+        | Applied { mutant; new_root } ->
+            update_metrics_with_diff t diff ;
+            let new_root =
+              match new_root with
+              | None ->
+                  prev_root
+              | Some state_hash ->
+                  Some { state_hash }
+            in
+            ( new_root
+            , Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutants ) )
   in
   [%log' trace t.logger] "after applying diffs to full frontier" ;
   if

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -396,8 +396,8 @@ let initialize t ~root_data =
           ( Root_data.Limited.protocol_states root_data
           |> List.map ~f:With_hash.data ) )
 
-let find_arcs_and_root t
-    ~(arcs_cache : State_hash.Hash_set.t State_hash.Table.t) ~parent_hashes =
+let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
+    ~parent_hashes =
   let f h = Rocks.Key.Some_key (Arcs h) in
   let root_hash = get_root_hash t in
   let arcs = get_batch t.db ~keys:(List.map parent_hashes ~f) in
@@ -405,8 +405,7 @@ let find_arcs_and_root t
     let%bind.Result () = res in
     match arc_opt with
     | Some (Key.Some_key_value (Arcs _, (data : State_hash.t list))) ->
-        State_hash.Table.set arcs_cache ~key:parent_hash
-          ~data:(State_hash.Hash_set.of_list data) ;
+        State_hash.Table.set arcs_cache ~key:parent_hash ~data ;
         Result.return ()
     | _ ->
         Error (`Not_found (`Arcs parent_hash))
@@ -428,19 +427,15 @@ let add ~arcs_cache ~transition =
     |> Mina_state.Protocol_state.previous_state_hash
   in
   let parent_arcs = State_hash.Table.find_exn arcs_cache parent_hash in
-  if Hash_set.mem parent_arcs hash then fun _batch -> ()
-  else (
-    Hash_set.add parent_arcs hash ;
-    State_hash.Table.set arcs_cache ~key:hash
-      ~data:(State_hash.Hash_set.create ()) ;
-    let transition_unwrapped =
-      With_hash.data transition |> Mina_block.read_all_proofs_from_disk
-    in
-    fun batch ->
-      Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
-      Batch.set batch ~key:(Arcs hash) ~data:[] ;
-      Batch.set batch ~key:(Arcs parent_hash)
-        ~data:(Hash_set.to_list parent_arcs) )
+  State_hash.Table.set arcs_cache ~key:parent_hash ~data:(hash :: parent_arcs) ;
+  State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
+  let transition_unwrapped =
+    With_hash.data transition |> Mina_block.read_all_proofs_from_disk
+  in
+  fun batch ->
+    Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
+    Batch.set batch ~key:(Arcs hash) ~data:[] ;
+    Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs)
 
 let move_root ~old_root_hash ~new_root ~garbage =
   let new_root_hash =

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -396,8 +396,8 @@ let initialize t ~root_data =
           ( Root_data.Limited.protocol_states root_data
           |> List.map ~f:With_hash.data ) )
 
-let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
-    ~parent_hashes =
+let find_arcs_and_root t
+    ~(arcs_cache : State_hash.Hash_set.t State_hash.Table.t) ~parent_hashes =
   let f h = Rocks.Key.Some_key (Arcs h) in
   let root_hash = get_root_hash t in
   let arcs = get_batch t.db ~keys:(List.map parent_hashes ~f) in
@@ -405,7 +405,8 @@ let find_arcs_and_root t ~(arcs_cache : State_hash.t list State_hash.Table.t)
     let%bind.Result () = res in
     match arc_opt with
     | Some (Key.Some_key_value (Arcs _, (data : State_hash.t list))) ->
-        State_hash.Table.set arcs_cache ~key:parent_hash ~data ;
+        State_hash.Table.set arcs_cache ~key:parent_hash
+          ~data:(State_hash.Hash_set.of_list data) ;
         Result.return ()
     | _ ->
         Error (`Not_found (`Arcs parent_hash))
@@ -427,15 +428,19 @@ let add ~arcs_cache ~transition =
     |> Mina_state.Protocol_state.previous_state_hash
   in
   let parent_arcs = State_hash.Table.find_exn arcs_cache parent_hash in
-  State_hash.Table.set arcs_cache ~key:parent_hash ~data:(hash :: parent_arcs) ;
-  State_hash.Table.set arcs_cache ~key:hash ~data:[] ;
-  let transition_unwrapped =
-    With_hash.data transition |> Mina_block.read_all_proofs_from_disk
-  in
-  fun batch ->
-    Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
-    Batch.set batch ~key:(Arcs hash) ~data:[] ;
-    Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs)
+  if Hash_set.mem parent_arcs hash then fun _batch -> ()
+  else (
+    Hash_set.add parent_arcs hash ;
+    State_hash.Table.set arcs_cache ~key:hash
+      ~data:(State_hash.Hash_set.create ()) ;
+    let transition_unwrapped =
+      With_hash.data transition |> Mina_block.read_all_proofs_from_disk
+    in
+    fun batch ->
+      Batch.set batch ~key:(Transition hash) ~data:transition_unwrapped ;
+      Batch.set batch ~key:(Arcs hash) ~data:[] ;
+      Batch.set batch ~key:(Arcs parent_hash)
+        ~data:(Hash_set.to_list parent_arcs) )
 
 let move_root ~old_root_hash ~new_root ~garbage =
   let new_root_hash =

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -499,26 +499,38 @@ let get_best_tip t = get t.db ~key:Best_tip ~error:(`Not_found `Best_tip)
 
 let set_best_tip data = Batch.set ~key:Best_tip ~data
 
-let rec crawl_successors ?max_depth ~signature_kind ~proof_cache_db ~init ~f t
-    hash =
-  let open Deferred.Result.Let_syntax in
-  match max_depth with
-  | Some 0 ->
-      (* Depth limit reached, stop crawling *)
-      Deferred.Result.return ()
-  | _ ->
-      let remaining_depth = Option.map max_depth ~f:(fun d -> d - 1) in
-      let%bind successors = Deferred.return (get_arcs t hash) in
-      deferred_list_result_iter successors ~f:(fun succ_hash ->
-          let%bind transition =
-            Deferred.return
-              (get_transition ~signature_kind ~proof_cache_db t succ_hash)
-          in
-          let%bind init' =
-            Deferred.map (f init transition)
-              ~f:(Result.map_error ~f:(fun err -> `Crawl_error err))
-          in
-          crawl_successors ~signature_kind ~proof_cache_db
-            ?max_depth:remaining_depth t succ_hash ~init:init' ~f )
+let crawl_successors ?max_depth ~signature_kind ~proof_cache_db ~init ~f t hash
+    =
+  (* Track visited hashes globally across the traversal.  A hash should appear
+     in at most one node's Arcs list in a well-formed DB, but if the DB was
+     written before the duplicate-arc bug was fixed a hash may appear several
+     times in the same list (or, defensively, in multiple lists).  Skipping
+     already-visited successors prevents the same subtree from being loaded and
+     applied to the in-memory frontier more than once. *)
+  let visited = State_hash.Hash_set.create () in
+  let rec go ?max_depth ~init hash =
+    let open Deferred.Result.Let_syntax in
+    match max_depth with
+    | Some 0 ->
+        (* Depth limit reached, stop crawling *)
+        Deferred.Result.return ()
+    | _ ->
+        let remaining_depth = Option.map max_depth ~f:(fun d -> d - 1) in
+        let%bind successors = Deferred.return (get_arcs t hash) in
+        deferred_list_result_iter successors ~f:(fun succ_hash ->
+            if Hash_set.mem visited succ_hash then Deferred.Result.return ()
+            else (
+              Hash_set.add visited succ_hash ;
+              let%bind transition =
+                Deferred.return
+                  (get_transition ~signature_kind ~proof_cache_db t succ_hash)
+              in
+              let%bind init' =
+                Deferred.map (f init transition)
+                  ~f:(Result.map_error ~f:(fun err -> `Crawl_error err))
+              in
+              go ?max_depth:remaining_depth ~init:init' succ_hash ) )
+  in
+  go ?max_depth ~init hash
 
 let with_batch t = Batch.with_batch t.db

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -73,14 +73,14 @@ val initialize : t -> root_data:Root_data.Limited.t -> unit
 
 val find_arcs_and_root :
      t
-  -> arcs_cache:State_hash.Hash_set.t State_hash.Table.t
+  -> arcs_cache:State_hash.t list State_hash.Table.t
   -> parent_hashes:State_hash.t list
   -> ( State_hash.t
      , [> `Not_found of [> `Arcs of State_hash.t | `Old_root_transition ] ] )
      result
 
 val add :
-     arcs_cache:State_hash.Hash_set.t State_hash.Table.t
+     arcs_cache:State_hash.t list State_hash.Table.t
   -> transition:Mina_block.Validated.t
   -> batch_t
   -> unit

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -73,14 +73,14 @@ val initialize : t -> root_data:Root_data.Limited.t -> unit
 
 val find_arcs_and_root :
      t
-  -> arcs_cache:State_hash.t list State_hash.Table.t
+  -> arcs_cache:State_hash.Hash_set.t State_hash.Table.t
   -> parent_hashes:State_hash.t list
   -> ( State_hash.t
      , [> `Not_found of [> `Arcs of State_hash.t | `Old_root_transition ] ] )
      result
 
 val add :
-     arcs_cache:State_hash.t list State_hash.Table.t
+     arcs_cache:State_hash.Hash_set.t State_hash.Table.t
   -> transition:Mina_block.Validated.t
   -> batch_t
   -> unit

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -493,7 +493,8 @@ let add_breadcrumb_exn t breadcrumb =
       ; ("state_hash", State_hash.to_yojson (Breadcrumb.state_hash breadcrumb))
       ] ;
   let lite_diffs =
-    List.map diffs ~f:Diff.(fun (Full.E.E diff) -> Lite.E.E (to_lite diff))
+    List.map diffs_with_mutants
+      ~f:Diff.(fun (Full.With_mutant.E (diff, _)) -> Lite.E.E (to_lite diff))
   in
   [%log internal] "Synchronize_persistent_frontier" ;
   let%bind sync_result =


### PR DESCRIPTION
This is an alternative to https://github.com/MinaProtocol/mina/pull/18773.

- A new commit is added so that full_frontier's apply diff won't trigger storing of arcs if they're duplicated
- the orignal commit deduplicating on persistent frontier store is removed, that function is staging and could have potential bugs, the new commit covered the same case.