### PR TITLE
Use correct directories in stopDaemon ITN graphql

### DIFF
--- a/src/lib/graphql/mina_graphql/mina_graphql.ml
+++ b/src/lib/graphql/mina_graphql/mina_graphql.ml
@@ -1543,12 +1543,21 @@ module Mutations = struct
             else
               let clean_config = Option.value ~default:false clean_config in
               let conf_dir = (Mina_lib.config mina).conf_dir in
+              let persistent_root_location =
+                (Mina_lib.config mina).persistent_root_location
+              in
+              let persistent_frontier_location =
+                (Mina_lib.config mina).persistent_frontier_location
+              in
+              let epoch_ledger_location =
+                (Mina_lib.config mina).epoch_ledger_location
+              in
               if clean_config then
                 Mina_stdlib_unix.Exit_handlers.register_async_shutdown_handler
                   ~logger:(Mina_lib.config mina).logger
                   ~description:"Remove configuration data" (fun () ->
                     let epoch_ledger_json_file =
-                      conf_dir ^/ "epoch_ledger.json"
+                      epoch_ledger_location ^/ ".json"
                     in
                     let%bind () =
                       match%bind Sys.file_exists epoch_ledger_json_file with
@@ -1576,9 +1585,7 @@ module Mutations = struct
                               let staking_uuid = find_uuid "staking" in
                               let next_uuid = find_uuid "next" in
                               let rm_epoch_ledger uuid =
-                                let path =
-                                  conf_dir ^/ sprintf "epoch_ledger%s" uuid
-                                in
+                                let path = epoch_ledger_location ^ uuid in
                                 match%bind Sys.file_exists path with
                                 | `Yes ->
                                     Mina_stdlib_unix.File_system.remove_dir path
@@ -1593,11 +1600,12 @@ module Mutations = struct
                           Deferred.unit
                     in
                     let files_to_remove =
-                      [ "epoch_ledger.json"; "root" ^/ "root" ]
+                      [ epoch_ledger_json_file
+                      ; persistent_root_location ^/ "root"
+                      ]
                     in
                     let%bind () =
-                      Deferred.List.iter files_to_remove ~f:(fun file ->
-                          let path = conf_dir ^/ file in
+                      Deferred.List.iter files_to_remove ~f:(fun path ->
                           match%bind Sys.file_exists path with
                           | `Yes ->
                               Sys.remove path
@@ -1605,10 +1613,11 @@ module Mutations = struct
                               Deferred.unit )
                     in
                     let dirs_to_remove =
-                      [ "root" ^/ "snarked_ledger"; "frontier" ]
+                      [ persistent_root_location ^/ "snarked_ledger"
+                      ; persistent_frontier_location
+                      ]
                     in
-                    Deferred.List.iter dirs_to_remove ~f:(fun dir ->
-                        let path = conf_dir ^/ dir in
+                    Deferred.List.iter dirs_to_remove ~f:(fun path ->
                         match%bind Sys.file_exists path with
                         | `Yes ->
                             Mina_stdlib_unix.File_system.remove_dir path


### PR DESCRIPTION
Fix directory paths in `stopDaemon` graphql.

Previous version of the graphql command used the pre-Mesa path structure, i.e. without chain id.

Explain how you tested your changes:
* [ ] Test on ITN cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
