### PR TITLE
Fix nix build warning/errors

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
     "nixpkgs-mozilla": {
       "flake": false,
       "locked": {
-        "lastModified": 1704373101,
-        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
+        "lastModified": 1774550046,
+        "narHash": "sha256-sgbaoy4molgqDLS24CmycN5v4b9FKt0YtALkfVhCWps=",
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
+        "rev": "58356aa021c5d2f53958c3405e0ce4b8ea3dca44",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -375,11 +375,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1756988401,
-        "narHash": "sha256-S+zc1RYWZBGKnbrEWbyJ6fGt8ft/9d4BzpigSN2PpqE=",
+        "lastModified": 1771067167,
+        "narHash": "sha256-XSw8dQIkdr+6eLvbUHo3cJPtTU7o5SMODz3qlnzmGpQ=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "0c9c0e0c058dfb8de56adff612f2c776530f7f1e",
+        "rev": "2e20bbbe8130d1880338291446fd4e710a4db9a1",
         "type": "github"
       },
       "original": {

--- a/opam.export
+++ b/opam.export
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 compiler: ["ocaml-base-compiler.4.14.2"]
 roots: [
-  "alcotest.1.1.0"
   "alcotest-async.1.1.0"
   "angstrom.0.15.0"
   "bisect_ppx.2.8.1"


### PR DESCRIPTION
This PR contains 2 fixes.


1. For 

```
 File "_none_", line 1:                

Error: Files /nix/store/yplg9mrkk1b3mhj996dbqpvwcca2ml9s-alcotest-async-1.1.0/lib/ocaml/4.14.2/site-lib/alcotest-async/alcotest_async.cmxa

       and /nix/store/p1y0qz8kwawbwrgs75yi6xfjjz7w63im-alcotest-1.1.0/lib/ocaml/4.14.2/site-lib/alcotest/alcotest.cmxa

       make inconsistent assumptions over implementation Alcotest
```

This is because `alcotest-async` pulls in `alcotest`, and for some reason that version is not consistent with the `alcotest` packaged by nix. Removing `alcotest` fixed it. We need to be careful next time regenarting this export file, so that we're not including `alcotest` in root. 

2. For 

```
evaluation warning: `rust.toRustTarget platform` is deprecated. Use `platform.rust.rustcTarget` instead.
```

This is fixed by bumping up ocaml-nix.