### PR TITLE
fix: make apt proxy a runtime fallback instead of static config

### DIFF
--- a/dockerfiles/scripts/configure-apt-proxy.sh
+++ b/dockerfiles/scripts/configure-apt-proxy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Configure APT caching proxy with a bypass for the Mina debian package repository.
+# Configure APT caching proxy with runtime fallback for the Mina debian package repository.
 #
 # Usage: configure-apt-proxy.sh [APT_CACHE_URL] [DEB_REPO]
 #   APT_CACHE_URL  - URL of the apt-cacher-ng or similar caching proxy (e.g. http://apt-cache:3142)
@@ -7,6 +7,10 @@
 #
 # If APT_CACHE_URL is empty the script exits cleanly without writing anything,
 # so it is always safe to call unconditionally.
+#
+# Instead of hardcoding a static proxy, this script installs a Proxy-Auto-Detect
+# script that probes the proxy at runtime. If the proxy is unreachable (e.g. the
+# image runs outside the build cluster), APT falls back to direct upstream access.
 #
 # This script can be used both:
 #  - Inside Dockerfiles (via COPY + RUN)
@@ -20,10 +24,24 @@ DEB_REPO="${2:-}"
 # Nothing to configure when no proxy is requested.
 [ -n "$APT_CACHE_URL" ] || exit 0
 
+# --- Write the auto-detect probe script ---
+probe=/usr/local/bin/apt-proxy-detect.sh
+cat > "$probe" <<PROBE_EOF
+#!/bin/sh
+# Auto-detect APT proxy: use the cache if reachable, otherwise go DIRECT.
+if curl --connect-timeout 2 -sf "${APT_CACHE_URL}/acng-report.html" >/dev/null 2>&1; then
+  echo "${APT_CACHE_URL}"
+else
+  echo "DIRECT"
+fi
+PROBE_EOF
+chmod +x "$probe"
+
+# --- Write APT config that delegates to the probe ---
 conf=/etc/apt/apt.conf.d/01proxy
 {
-  echo "Acquire::http::Proxy \"${APT_CACHE_URL}\";"
-  echo "Acquire::https::Proxy \"${APT_CACHE_URL}\";"
+  echo "Acquire::http::Proxy-Auto-Detect \"${probe}\";"
+  echo "Acquire::https::Proxy-Auto-Detect \"${probe}\";"
   if [ -n "$DEB_REPO" ]; then
     host="${DEB_REPO#*://}"
     host="${host%%[:/]*}"
@@ -32,6 +50,8 @@ conf=/etc/apt/apt.conf.d/01proxy
   fi
 } > "$conf"
 
-echo "--- APT proxy config ---"
+echo "--- APT proxy config (auto-detect) ---"
 cat "$conf"
-echo "------------------------"
+echo "--- Probe script ---"
+cat "$probe"
+echo "--------------------"


### PR DESCRIPTION
  The static /etc/apt/apt.conf.d/01proxy baked into images hardcodes the
  apt-cache proxy URL, which is only reachable from hetzner-rivendell-1.
  Replace with Acquire::http::Proxy-Auto-Detect that probes the proxy at
  runtime and falls back to DIRECT when unreachable.
