### PR TITLE
Rosetta client and healthcheck CLIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ build-mainnet-sigs: ocaml_checks reformat-diff libp2p_helper build ## Build main
 		src/app/cli/src/mina_mainnet_signatures.exe \
 		src/app/rosetta/rosetta_mainnet_signatures.exe \
 		src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=mainnet \
 		&& echo "✅ Build complete"
 
@@ -221,6 +223,8 @@ build-devnet-sigs: ocaml_checks reformat-diff libp2p_helper build ## Build devne
 		src/app/cli/src/mina_testnet_signatures.exe \
 		src/app/rosetta/rosetta_testnet_signatures.exe \
 		src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=devnet \
 		&& echo "✅ Build complete"
 
@@ -287,6 +291,8 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-mina: ocaml_checks reformat-diff libp2p_helper build ## Build mina apps
 		src/app/cli/src/mina.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		&& echo "✅ Build complete"
 
@@ -296,6 +297,7 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-mina: ocaml_checks reformat-diff libp2p_helper build ## Build mina apps
 		src/app/cli/src/mina.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		&& echo "✅ Build complete"
 
 .PHONY: build-archive
@@ -295,6 +296,7 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -228,6 +228,28 @@ psql -f ./src/test/archive/sample_db/archive_db.sql "${INDEXER_PG_CONN}"
 mina-rosetta-indexer-test --archive_uri "${INDEXER_PG_CONN}"
 sudo -u postgres dropdb "${INDEXER_DBNAME}"
 
+echo "=========================== NEGATIVE TEST: healthcheck against not-yet-running Rosetta ==========================="
+# Sanity check: before Rosetta is up, `rosetta-healthcheck ready` must
+# fail cleanly.  Catches regressions in error formatting and exit codes
+# (e.g. raw OCaml [Unix_error] leaking through to stderr on ECONNREFUSED).
+set +e
+NEGATIVE_OUTPUT=$(rosetta-healthcheck ready \
+  --online-uri "http://127.0.0.1:${MINA_ROSETTA_ONLINE_PORT}" \
+  --json 2>&1)
+NEGATIVE_EXIT=$?
+set -e
+if [ "$NEGATIVE_EXIT" -eq 0 ]; then
+  echo "ERROR: healthcheck reported READY before Rosetta was started" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+if echo "$NEGATIVE_OUTPUT" | grep -q "Unix_error\|Unix\.\|Core\.Unix"; then
+  echo "ERROR: healthcheck leaked raw OCaml exception syntax" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+echo "   ✅  healthcheck correctly reported not-ready with a clean error"
+
 # Mina Rosetta
 echo "=========================== STARTING ROSETTA API ONLINE AND OFFLINE INSTANCES ==========================="
 ports=("$MINA_ROSETTA_ONLINE_PORT" "$MINA_ROSETTA_OFFLINE_PORT")
@@ -237,7 +259,24 @@ for port in "${ports[@]}"; do
     --graphql-uri http://127.0.0.1:${MINA_GRAPHQL_PORT}/graphql \
     --log-level ${LOG_LEVEL} \
     --port ${port} &
-  sleep 5
+  # Wait for the HTTP listener to bind.  We intentionally do NOT probe a
+  # functional Rosetta endpoint here: at this point the Mina daemon isn't
+  # running yet, and any Rosetta route that calls the daemon (e.g.
+  # /network/list) would fail for the full timeout.  Functional readiness
+  # is exercised later by `rosetta-cli configuration:validate` and the
+  # subsequent sweeps, once the daemon is up.
+  echo "Waiting for Rosetta on port ${port} to bind..."
+  for i in $(seq 1 60); do
+    if (echo > "/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+      echo "Rosetta on port ${port} is listening"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Rosetta on port ${port} did not bind within 60s"
+      exit 1
+    fi
+    sleep 1
+  done
 done
 
 # Mina Archive

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -246,6 +246,28 @@ psql -f ./src/test/archive/sample_db/archive_db.sql "${INDEXER_PG_CONN}"
 mina-rosetta-indexer-test --archive_uri "${INDEXER_PG_CONN}"
 sudo -u postgres dropdb "${INDEXER_DBNAME}"
 
+echo "=========================== NEGATIVE TEST: healthcheck against not-yet-running Rosetta ==========================="
+# Sanity check: before Rosetta is up, `rosetta-healthcheck ready` must
+# fail cleanly.  Catches regressions in error formatting and exit codes
+# (e.g. raw OCaml [Unix_error] leaking through to stderr on ECONNREFUSED).
+set +e
+NEGATIVE_OUTPUT=$(rosetta-healthcheck ready \
+  --online-uri "http://127.0.0.1:${MINA_ROSETTA_ONLINE_PORT}" \
+  --json 2>&1)
+NEGATIVE_EXIT=$?
+set -e
+if [ "$NEGATIVE_EXIT" -eq 0 ]; then
+  echo "ERROR: healthcheck reported READY before Rosetta was started" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+if echo "$NEGATIVE_OUTPUT" | grep -q "Unix_error\|Unix\.\|Core\.Unix"; then
+  echo "ERROR: healthcheck leaked raw OCaml exception syntax" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+echo "   ✅  healthcheck correctly reported not-ready with a clean error"
+
 # Mina Rosetta
 echo "=========================== STARTING ROSETTA API ONLINE AND OFFLINE INSTANCES ==========================="
 ports=("$MINA_ROSETTA_ONLINE_PORT" "$MINA_ROSETTA_OFFLINE_PORT")
@@ -255,7 +277,27 @@ for port in "${ports[@]}"; do
     --graphql-uri http://127.0.0.1:${MINA_GRAPHQL_PORT}/graphql \
     --log-level ${LOG_LEVEL} \
     --port ${port} &
-  sleep 5
+  # Wait for the HTTP listener to bind.  We intentionally do NOT probe a
+  # functional Rosetta endpoint here: at this point the Mina daemon isn't
+  # running yet, and any Rosetta route that calls the daemon (e.g.
+  # /network/list) would fail for the full timeout.  Functional readiness
+  # is exercised later by `rosetta-cli configuration:validate` and the
+  # subsequent sweeps, once the daemon is up.
+  echo "Waiting for Rosetta on port ${port} to bind..."
+  for i in $(seq 1 60); do
+    # ":" opens the connection and closes it; "echo" would also write a
+    # newline, which Rosetta logs as a malformed request line on every
+    # attempt.
+    if (: > "/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+      echo "Rosetta on port ${port} is listening"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Rosetta on port ${port} did not bind within 60s"
+      exit 1
+    fi
+    sleep 1
+  done
 done
 
 # Mina Archive

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -65,9 +65,14 @@ let Spec =
       }
 
 let bareBinaries =
+    -- rosetta-client is required by scripts/tests/rosetta-helper.sh, which
+    -- both the sanity and the load test source.  Restoring every binary
+    -- here makes restore-or-install.sh skip the deb install, so anything
+    -- the tests call must be listed.
           "mina.exe:mina"
       ++  ",archive.exe:mina-archive"
       ++  ",rosetta.exe:mina-rosetta"
+      ++  ",rosetta_client_cli.exe:rosetta-client"
       ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -41,6 +41,7 @@ let bareBinaries =
       ++  ",signer.exe:mina-ocaml-signer"
       ++  ",zkapp_test_transaction.exe:mina-zkapp-test-transaction"
       ++  ",indexer_test.exe:mina-rosetta-indexer-test"
+      ++  ",rosetta_healthcheck.exe:rosetta-healthcheck"
       ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =

--- a/changes/18796.md
+++ b/changes/18796.md
@@ -1,0 +1,38 @@
+- New `rosetta-client` CLI: one subcommand per Rosetta endpoint, for debugging
+  and scripting against a running Rosetta server. It fills in the
+  `network_identifier`, prints the response as JSON (`--compact` for one line),
+  and exits non-zero with a short diagnostic on failure. A `--*-json` payload is
+  checked against the Rosetta model its endpoint expects before it is sent, so a
+  malformed request is reported with the name of the offending flag instead of
+  as a server error. See `src/app/rosetta/client/README.md`.
+
+- New `rosetta-healthcheck` CLI: readiness probes for a running Mina Rosetta
+  server. Subcommands are `connectivity` (does `/network/list` advertise the
+  expected network?), `tip-recency` (is the tip returned by `/network/status`
+  newer than `--max-age`?), `ready` (both of those plus `/network/options`), and
+  `wait` (poll `ready` until it passes or `--timeout` expires). Each prints
+  exactly one result — one JSON object with `--json`, one line without it — so
+  it can be used directly as a Kubernetes exec probe or a Docker `HEALTHCHECK`.
+  See `src/app/rosetta/healthcheck/README.md`.
+
+- In JSON mode a field with no value is left out rather than emitted as `null`,
+  so a probe that could not reach the server prints
+  `{"healthy": false, "error": "..."}` instead of a record padded with nulls.
+
+- `ready` and `wait` run every check even after an earlier one has failed, and
+  report all the problems they found, rather than stopping at the first.
+
+- Both binaries read `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
+  `MINA_ROSETTA_NETWORK`, so an operator working against one server can export
+  them once instead of repeating `--rosetta-uri` / `--online-uri`,
+  `--blockchain` and `--network` on every call. A flag always wins over the
+  matching environment variable.
+
+- Error messages from both binaries are short and human-readable: a Rosetta
+  error envelope is rendered as `HTTP <code>: <message>`, a connection failure
+  as `connection refused to <url>`. Raw OCaml exception text no longer reaches
+  the terminal, an HTTP body is never dumped verbatim, and a message is never
+  split over several lines.
+
+- Both binaries ship in the `mina-rosetta` Debian package as
+  `/usr/local/bin/rosetta-client` and `/usr/local/bin/rosetta-healthcheck`.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -512,6 +512,10 @@ build_rosetta_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer_${signature}_signatures.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-healthcheck"
+  cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-client"
 
   mkdir -p "${BUILDDIR}/etc/mina/rosetta/"{rosetta-cli-config,scripts}
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -504,6 +504,8 @@ build_rosetta_generic_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-healthcheck"
   cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
     "${BUILDDIR}/usr/local/bin/rosetta-client"
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -504,6 +504,8 @@ build_rosetta_generic_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-client"
 
   mkdir -p "${BUILDDIR}/etc/mina/rosetta/"{rosetta-cli-config,scripts}
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,8 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-healthcheck"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
 }
@@ -350,6 +352,8 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer_mainnet_signatures.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer_testnet_signatures.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe"
+    create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"
     create_mock_exe "default/src/app/validate_keypair/validate_keypair.exe"

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,7 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
 }
@@ -354,6 +355,7 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/rosetta.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"
     create_mock_exe "default/src/app/validate_keypair/validate_keypair.exe"

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,7 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-healthcheck"
     assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
@@ -355,6 +356,7 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/rosetta.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe"
     create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Helper functions for Rosetta API sanity and load tests
+# Helper functions for Rosetta API sanity and load tests.
 
 readonly BLOCKCHAIN="mina"
 
@@ -118,7 +118,11 @@ function wait_for_sync() {
 
 function test_network_status() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    assert "$(rosetta-client network status \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --compact)" \
         '.sync_status.stage == "Synced"' \
         "   ✅  Rosetta is synced" \
         "   ❌  Rosetta is not synced"
@@ -126,7 +130,11 @@ function test_network_status() {
 
 function test_network_options() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    assert "$(rosetta-client network options \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --compact)" \
         '.version.rosetta_version == "1.4.9"' \
         "   ✅  Rosetta Version is correct" \
         "   ❌  Invalid Rosetta Version (expected 1.4.9)"
@@ -134,7 +142,12 @@ function test_network_options() {
 
 function test_block() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/block" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"block_identifier\":{\"hash\":\"${__test_data[block]}\"}}" | jq)" \
+    assert "$(rosetta-client block get \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --hash "${__test_data[block]}" \
+        --compact)" \
         ".block.block_identifier.hash == \"${__test_data[block]}\" " \
         "   ✅  Block hash correct" \
         "   ❌  Block hash incorrect or not found (expected ${__test_data[block]})"
@@ -142,7 +155,12 @@ function test_block() {
 
 function test_account_balance() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
+    assert "$(rosetta-client account balance \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --address "${__test_data[account]}" \
+        --compact)" \
         '.balances[0].currency.symbol == "MINA"' \
         "   ✅  Account: Balance ok" \
         "   ❌  Account: Invalid balance structure or balance not found"
@@ -150,15 +168,12 @@ function test_account_balance() {
 
 function test_payment_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[payment_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta-client search transactions \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --tx-hash "${__test_data[payment_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[payment_transaction]}\" " \
         "   ✅  Payment transaction found" \
         "   ❌  Payment transaction not found (expected ${__test_data[payment_transaction]})"
@@ -166,15 +181,12 @@ function test_payment_transaction() {
 
 function test_zkapp_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[zkapp_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta-client search transactions \
+        --rosetta-uri "${__test_data[address]}" \
+        --blockchain "${BLOCKCHAIN}" \
+        --network "${__test_data[id]}" \
+        --tx-hash "${__test_data[zkapp_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[zkapp_transaction]}\" " \
         "   ✅  Zkapp transaction found" \
         "   ❌  Zkapp transaction not found (expected ${__test_data[zkapp_transaction]})"

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -1,10 +1,34 @@
 #!/usr/bin/env bash
 
-# Helper functions for Rosetta API sanity and load tests
+# Helper functions for Rosetta API sanity and load tests.
 
+# network_identifier.blockchain, for the raw curl calls below.  It is
+# "mina" on every Mina network, which is also what rosetta-client
+# defaults to, so rosetta-client calls do not pass it at all.
 readonly BLOCKCHAIN="mina"
 
 readonly DEFAULT_HEADERS=(--header "Accept: application/json" --header "Content-Type: application/json")
+
+# Seconds allowed for one rosetta-client request.  The curl calls these
+# tests used before had no timeout at all, and rosetta-load.sh exists to
+# put the server under load, where a /search/transactions sweep can take
+# minutes; the CLI's own 30s default would turn that load into a test
+# failure.  300s is the http_timeout the rosetta-cli audit config uses
+# against the same server.
+readonly ROSETTA_CLIENT_TIMEOUT="${ROSETTA_CLIENT_TIMEOUT:-300}"
+
+# Every test below shells out to rosetta-client, so check for it once,
+# here, while this file is being sourced.  It cannot be checked inside
+# the test functions: those run inside a command substitution, where an
+# exit leaves only the subshell and the message would be captured as the
+# response rather than shown.
+if ! command -v rosetta-client > /dev/null 2>&1; then
+    echo "❌  rosetta-client is not on PATH." >&2
+    echo "    It ships in the mina-rosetta Debian package as" >&2
+    echo "    /usr/local/bin/rosetta-client, or build it with:" >&2
+    echo "        dune build src/app/rosetta/client/rosetta_client_cli.exe" >&2
+    exit 1
+fi
 
 function assert() {
     local __response=$1
@@ -116,17 +140,33 @@ function wait_for_sync() {
     done
 }
 
-function test_network_status() {
+# Runs rosetta-client against the Rosetta instance named by the test data
+# array.  rosetta-client reads the connection details from the
+# environment, so no call site below repeats --rosetta-uri or --network.
+# The blockchain is left unset: rosetta-client already defaults it to
+# "mina".
+#
+# Arguments:
+#   $1 - test data array name (passed by reference)
+#   $@ - rosetta-client subcommand and its flags
+function rosetta_client() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    shift
+
+    MINA_ROSETTA_URI="${__test_data[address]}" \
+    MINA_ROSETTA_NETWORK="${__test_data[id]}" \
+        rosetta-client --timeout "${ROSETTA_CLIENT_TIMEOUT}" "$@"
+}
+
+function test_network_status() {
+    assert "$(rosetta_client "$1" network status --compact)" \
         '.sync_status.stage == "Synced"' \
         "   ✅  Rosetta is synced" \
         "   ❌  Rosetta is not synced"
 }
 
 function test_network_options() {
-    declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" network options --compact)" \
         '.version.rosetta_version == "1.4.9"' \
         "   ✅  Rosetta Version is correct" \
         "   ❌  Invalid Rosetta Version (expected 1.4.9)"
@@ -134,7 +174,9 @@ function test_network_options() {
 
 function test_block() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/block" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"block_identifier\":{\"hash\":\"${__test_data[block]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" block get \
+        --hash "${__test_data[block]}" \
+        --compact)" \
         ".block.block_identifier.hash == \"${__test_data[block]}\" " \
         "   ✅  Block hash correct" \
         "   ❌  Block hash incorrect or not found (expected ${__test_data[block]})"
@@ -142,7 +184,9 @@ function test_block() {
 
 function test_account_balance() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" account balance \
+        --address "${__test_data[account]}" \
+        --compact)" \
         '.balances[0].currency.symbol == "MINA"' \
         "   ✅  Account: Balance ok" \
         "   ❌  Account: Invalid balance structure or balance not found"
@@ -150,15 +194,9 @@ function test_account_balance() {
 
 function test_payment_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[payment_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta_client "$1" search transactions \
+        --tx-hash "${__test_data[payment_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[payment_transaction]}\" " \
         "   ✅  Payment transaction found" \
         "   ❌  Payment transaction not found (expected ${__test_data[payment_transaction]})"
@@ -166,15 +204,9 @@ function test_payment_transaction() {
 
 function test_zkapp_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[zkapp_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta_client "$1" search transactions \
+        --tx-hash "${__test_data[zkapp_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[zkapp_transaction]}\" " \
         "   ✅  Zkapp transaction found" \
         "   ❌  Zkapp transaction not found (expected ${__test_data[zkapp_transaction]})"

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -1,0 +1,101 @@
+# rosetta-client
+
+Generic CLI wrapper for the [Rosetta API](https://www.rosetta-api.org/) as
+implemented by Mina Rosetta.  Think of it as "curl on steroids": every
+subcommand maps to a single endpoint, auto-injects
+`{"blockchain": "mina", "network": "testnet"}` into the request's
+`network_identifier`, and prints the response as JSON (pretty by default,
+`--compact` for one-line output).
+
+For readiness probes, see the sibling
+[`rosetta-healthcheck`](../rosetta_healthcheck/README.md) binary.
+
+## Subcommand tree
+
+```
+rosetta-client
+├── network
+│   ├── list
+│   ├── status
+│   └── options
+├── block
+│   ├── get            --index N | --hash H
+│   └── transaction    --index N --block-hash H --tx-hash H
+├── account
+│   ├── balance        --address B62q... [--token-id T] [--index N]
+│   └── coins          --address B62q... [--include-mempool]
+├── mempool
+│   ├── list
+│   └── transaction    --tx-hash H
+├── search
+│   └── transactions   [--address B62q...] [--tx-hash H] [--limit N]
+├── construction
+│   ├── derive         --public-key-json JSON [--metadata-json JSON]
+│   ├── preprocess     --operations-json JSON [--metadata-json JSON]
+│   ├── metadata       --options-json JSON [--public-keys-json JSON]
+│   ├── payloads       --operations-json JSON [--metadata-json JSON] [--public-keys-json JSON]
+│   ├── parse          --signed|--unsigned --transaction STR
+│   ├── combine        --unsigned-transaction STR --signatures-json JSON
+│   ├── hash           --signed-transaction STR
+│   └── submit         --signed-transaction STR
+└── config
+    ├── show           [--file NAME]
+    └── export         --out-dir DIR
+```
+
+## Global flags
+
+Every leaf command accepts:
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--rosetta-uri` | `http://localhost:3087` | Base URL of the Rosetta server. Can be overridden by `MINA_ROSETTA_URI`. |
+| `--blockchain` | `mina` | Injected into `network_identifier.blockchain`. |
+| `--network` | `testnet` | Injected into `network_identifier.network`. |
+| `--timeout` | `30` | HTTP request timeout in seconds. |
+| `--compact` | off | Emit compact JSON instead of indented. |
+
+## Examples
+
+```bash
+# Readable JSON on a local Rosetta:
+rosetta-client network status
+rosetta-client block get --index 100
+rosetta-client account balance --address B62q...
+
+# Point at a non-default host and override network:
+rosetta-client network options \
+  --rosetta-uri http://rosetta.example.com:3087 \
+  --network mainnet
+
+# Construction flow:
+rosetta-client construction derive \
+  --public-key-json '{"hex_bytes":"abcd","curve_type":"pallas"}'
+
+# Extract embedded rosetta-cli config files for a manual sweep:
+rosetta-client config show > /tmp/config.json
+rosetta-client config export --out-dir /tmp/cfg
+```
+
+## Output contract
+
+On success, the response body is printed as pretty JSON on stdout (or
+compact JSON with `--compact`), followed by a single newline.  Exit 0.
+
+On failure — HTTP non-2xx, transport error, invalid JSON input — the tool
+prints a short diagnostic on stderr and exits 1.  The diagnostic is
+produced by the `Rosetta_client.Errors` module and is guaranteed to:
+
+- Never leak raw OCaml exception syntax (no `Unix_error`, no `(Unix. ...)`).
+- Never dump multi-kilobyte HTTP bodies verbatim; Rosetta error envelopes
+  are parsed and rendered as `HTTP <code>: <message>`.
+
+## Relationship to `rosetta-healthcheck`
+
+- **This tool** — Arbitrary Rosetta API calls for debugging, scripting, and
+  day-to-day operations.
+- **`rosetta-healthcheck`** — Composite readiness (`ready` / `wait`),
+  tip-recency / connectivity probes.
+
+Both binaries share the same underlying HTTP library
+(`src/lib/rosetta_client/`).

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -7,8 +7,8 @@ subcommand maps to a single endpoint, auto-injects
 `network_identifier`, and prints the response as JSON (pretty by default,
 `--compact` for one-line output).
 
-For readiness probes, a sibling `rosetta-healthcheck` binary built on the
-same library follows in a separate change.
+For readiness probes, see the sibling
+[`rosetta-healthcheck`](../healthcheck/README.md) binary.
 
 ## Subcommand tree
 
@@ -58,9 +58,9 @@ Every leaf command accepts:
 
 A flag always wins over its environment variable.  Export the variables
 to talk to the same server repeatedly without repeating the flags; the
-same three variables are read by every binary built on
-`Rosetta_client`.  Their fallback values live in
-`Rosetta_client.Defaults`, so those binaries cannot drift apart.
+same three variables are read by `rosetta-healthcheck`.  Their fallback
+values live in `Rosetta_client.Defaults`, so the two binaries cannot
+drift apart.
 
 ## Examples
 
@@ -99,11 +99,15 @@ produced by the `Rosetta_client.Errors` module and is guaranteed to:
 - Never dump multi-kilobyte HTTP bodies verbatim; Rosetta error envelopes
   are parsed and rendered as `HTTP <code>: <message>`.
 
-## Layout
+## Relationship to `rosetta-healthcheck`
 
-The HTTP client, the typed Rosetta API surface and the shared defaults
-live in the `rosetta_client` library (`src/lib/rosetta_client/`), so any
-other binary can reuse them.
+- **This tool** — Arbitrary Rosetta API calls for debugging, scripting, and
+  day-to-day operations.
+- **`rosetta-healthcheck`** — Composite readiness (`ready` / `wait`),
+  tip-recency / connectivity probes.
+
+Both binaries share the same underlying HTTP library
+(`src/lib/rosetta_client/`).
 
 Inside this binary, `rosetta_client_cli.ml` holds the flags, the
 subcommand tree and the output; `payload.ml` holds the decoding of the

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -1,0 +1,110 @@
+# rosetta-client
+
+Generic CLI wrapper for the [Rosetta API](https://www.rosetta-api.org/) as
+implemented by Mina Rosetta.  Think of it as "curl on steroids": every
+subcommand maps to a single endpoint, auto-injects
+`{"blockchain": "mina", "network": "testnet"}` into the request's
+`network_identifier`, and prints the response as JSON (pretty by default,
+`--compact` for one-line output).
+
+For readiness probes, a sibling `rosetta-healthcheck` binary built on the
+same library follows in a separate change.
+
+## Subcommand tree
+
+```
+rosetta-client
+├── network
+│   ├── list
+│   ├── status
+│   └── options
+├── block
+│   └── get            --index N | --hash H
+├── account
+│   ├── balance        --address B62q... [--token-id T] [--index N]
+│   └── coins          --address B62q... [--include-mempool]
+├── mempool
+│   ├── list
+│   └── transaction    --tx-hash H
+├── search
+│   └── transactions   [--address B62q...] [--tx-hash H] [--limit N]
+├── construction
+│   ├── derive         --public-key-json JSON [--metadata-json JSON]
+│   ├── preprocess     --operations-json JSON [--metadata-json JSON]
+│   ├── metadata       --options-json JSON [--public-keys-json JSON]
+│   ├── payloads       --operations-json JSON [--metadata-json JSON] [--public-keys-json JSON]
+│   ├── parse          --signed|--unsigned --transaction STR
+│   ├── combine        --unsigned-transaction STR --signatures-json JSON
+│   ├── hash           --signed-transaction STR
+│   └── submit         --signed-transaction STR
+```
+
+`block transaction` is deliberately absent: Mina's Rosetta server returns
+every transaction inline in `/block`, does not implement
+`/block/transaction`, and would answer 404.  Use `block get` and filter
+the returned transactions by hash.
+
+## Global flags
+
+Every leaf command accepts:
+
+| Flag | Default | Environment override | Notes |
+|------|---------|----------------------|-------|
+| `--rosetta-uri` | `http://localhost:3087` | `MINA_ROSETTA_URI` | Base URL of the Rosetta server. |
+| `--blockchain` | `mina` | `MINA_ROSETTA_BLOCKCHAIN` | Injected into `network_identifier.blockchain`. |
+| `--network` | `testnet` | `MINA_ROSETTA_NETWORK` | Injected into `network_identifier.network`. |
+| `--timeout` | `30` | | Seconds allowed for one request/response exchange, from sending the request to reading the last byte of the response body. |
+| `--compact` | off | | Emit compact JSON instead of indented. |
+
+A flag always wins over its environment variable.  Export the variables
+to talk to the same server repeatedly without repeating the flags; the
+same three variables are read by every binary built on
+`Rosetta_client`.  Their fallback values live in
+`Rosetta_client.Defaults`, so those binaries cannot drift apart.
+
+## Examples
+
+```bash
+# Readable JSON on a local Rosetta:
+rosetta-client network status
+rosetta-client block get --index 100
+rosetta-client account balance --address B62q...
+
+# Point at a non-default host and override network:
+rosetta-client network options \
+  --rosetta-uri http://rosetta.example.com:3087 \
+  --network mainnet
+
+# The same, for a whole session, without repeating the flags:
+export MINA_ROSETTA_URI=http://rosetta.example.com:3087
+export MINA_ROSETTA_NETWORK=mainnet
+rosetta-client network options
+
+# Construction flow:
+rosetta-client construction derive \
+  --public-key-json '{"hex_bytes":"abcd","curve_type":"pallas"}'
+```
+
+## Output contract
+
+On success, the response body is printed as pretty JSON on stdout (or
+compact JSON with `--compact`), followed by a single newline.  Exit 0.
+
+On failure — HTTP non-2xx, transport error, invalid JSON input, or a
+`--*-json` payload that does not match the Rosetta model the endpoint
+expects — the tool prints a short diagnostic on stderr and exits 1.  The diagnostic is
+produced by the `Rosetta_client.Errors` module and is guaranteed to:
+
+- Never leak raw OCaml exception syntax (no `Unix_error`, no `(Unix. ...)`).
+- Never dump multi-kilobyte HTTP bodies verbatim; Rosetta error envelopes
+  are parsed and rendered as `HTTP <code>: <message>`.
+
+## Layout
+
+The HTTP client, the typed Rosetta API surface and the shared defaults
+live in the `rosetta_client` library (`src/lib/rosetta_client/`), so any
+other binary can reuse them.
+
+Inside this binary, `rosetta_client_cli.ml` holds the flags, the
+subcommand tree and the output; `payload.ml` holds the decoding of the
+JSON-valued flags into Rosetta models, and neither prints nor exits.

--- a/src/app/rosetta/client/dune
+++ b/src/app/rosetta/client/dune
@@ -1,0 +1,23 @@
+(executable
+ (package rosetta)
+ (name rosetta_client_cli)
+ (public_name rosetta-client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  core_unix
+  async
+  async.async_command
+  async_kernel
+  async_unix
+  cohttp
+  cohttp-async
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here)))

--- a/src/app/rosetta/client/dune
+++ b/src/app/rosetta/client/dune
@@ -1,0 +1,24 @@
+(executable
+ (package rosetta)
+ (name rosetta_client_cli)
+ (public_name rosetta-client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  core_unix
+  async
+  async.async_command
+  async_kernel
+  async_unix
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here ppx_deriving_yojson)))

--- a/src/app/rosetta/client/payload.ml
+++ b/src/app/rosetta/client/payload.ml
@@ -1,0 +1,27 @@
+(* Decoding of the JSON-valued command-line flags.  See [payload.mli]. *)
+
+open Core_kernel
+
+let json ~label s =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string s) with
+  | Ok parsed ->
+      Ok parsed
+  | Error _ ->
+      Or_error.errorf "%s: invalid JSON" label
+
+let model ~label of_yojson s =
+  let open Or_error.Let_syntax in
+  let%bind parsed = json ~label s in
+  match of_yojson parsed with
+  | Ok value ->
+      Ok value
+  | Error message ->
+      Or_error.errorf "%s: does not match the Rosetta schema: %s" label message
+
+let model_opt ~label of_yojson s =
+  Option.value_map s ~default:(Ok None) ~f:(fun s ->
+      Or_error.map (model ~label of_yojson s) ~f:Option.some )
+
+let json_opt ~label s =
+  Option.value_map s ~default:(Ok None) ~f:(fun s ->
+      Or_error.map (json ~label s) ~f:Option.some )

--- a/src/app/rosetta/client/payload.mli
+++ b/src/app/rosetta/client/payload.mli
@@ -1,0 +1,41 @@
+(** Decoding of the JSON-valued flags ([--public-key-json],
+    [--operations-json], [--signatures-json], ...) into the Rosetta
+    models the endpoints expect.
+
+    This is the part of [rosetta-client] that is not command-line
+    plumbing: it turns one flag's string into a typed value, or into an
+    error that names the flag.  Nothing here prints or exits — the CLI in
+    [rosetta_client_cli.ml] decides what to do with a failure.
+
+    Validating here rather than at the server means a malformed payload
+    is reported against the flag that carried it, before a request is
+    sent. *)
+
+open Core_kernel
+
+(** [json ~label s] parses [s] as JSON.  [label] is the flag name, and
+    appears in the error. *)
+val json : label:string -> string -> Yojson.Safe.t Or_error.t
+
+(** [model ~label of_yojson s] parses [s] as JSON and then decodes it
+    through a generated Rosetta model's [of_yojson].  The error
+    distinguishes "not JSON at all" from "JSON that does not match the
+    schema". *)
+val model :
+     label:string
+  -> (Yojson.Safe.t -> ('a, string) Result.t)
+  -> string
+  -> 'a Or_error.t
+
+(** [model_opt] is {!model} over an optional flag: [None] in, [None]
+    out. *)
+val model_opt :
+     label:string
+  -> (Yojson.Safe.t -> ('a, string) Result.t)
+  -> string option
+  -> 'a option Or_error.t
+
+(** [json_opt] is {!json} over an optional flag.  Used for the two fields
+    the Rosetta schema itself leaves free-form, [metadata] and
+    [options], which have no model to decode into. *)
+val json_opt : label:string -> string option -> Yojson.Safe.t option Or_error.t

--- a/src/app/rosetta/client/rosetta_client_cli.ml
+++ b/src/app/rosetta/client/rosetta_client_cli.ml
@@ -1,0 +1,452 @@
+(* rosetta_client CLI — a curl-on-steroids for the Rosetta API.
+
+   Every subcommand POSTs to a single Rosetta endpoint through the
+   [Rosetta_client] library, auto-injects the network_identifier
+   ({"blockchain":"mina","network":"testnet"} by default), and prints
+   the response as JSON (pretty by default).  On HTTP or transport
+   failure, prints a short human-readable diagnostic on stderr and exits
+   non-zero; the diagnostic never leaks raw OCaml exception syntax. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+
+(* Operators can set [MINA_ROSETTA_URI] to avoid passing --rosetta-uri on
+   every invocation; --rosetta-uri still overrides it when given. *)
+let rosetta_uri_env_var = "MINA_ROSETTA_URI"
+
+let default_base_uri =
+  Option.value (Sys.getenv rosetta_uri_env_var) ~default:"http://localhost:3087"
+
+let default_blockchain = "mina"
+
+let default_network = "testnet"
+
+let default_timeout = 30.0
+
+(* ---------- Global flags shared by every leaf command ---------- *)
+
+(* A record that every subcommand's [let%map_open] can pull in with a
+   single line.  Keeps per-command preludes short. *)
+type global_flags =
+  { base_uri : string
+  ; blockchain : string
+  ; network : string
+  ; timeout : float
+  ; compact : bool
+  }
+
+let global_flags_param =
+  let open Command.Let_syntax in
+  let open Command.Param in
+  let%map base_uri =
+    flag "--rosetta-uri"
+      ~doc:
+        (sprintf "URI Rosetta base URL (default: %s, overridable via $%s)"
+           default_base_uri rosetta_uri_env_var )
+      (optional_with_default default_base_uri string)
+  and blockchain =
+    flag "--blockchain"
+      ~doc:
+        (sprintf "NAME network_identifier.blockchain (default: %s)"
+           default_blockchain )
+      (optional_with_default default_blockchain string)
+  and network =
+    flag "--network"
+      ~doc:
+        (sprintf "NAME network_identifier.network (default: %s)" default_network)
+      (optional_with_default default_network string)
+  and timeout =
+    flag "--timeout"
+      ~doc:
+        (sprintf "SECONDS HTTP request timeout (default: %.0f)" default_timeout)
+      (optional_with_default default_timeout float)
+  and compact =
+    flag "--compact" ~doc:" Emit compact JSON instead of indented (pretty)"
+      no_arg
+  in
+  { base_uri; blockchain; network; timeout; compact }
+
+let client_of_globals g =
+  MRC.Http.create ~base_uri:(Uri.of_string g.base_uri) ~blockchain:g.blockchain
+    ~network:g.network ~timeout:g.timeout ()
+
+(* Single JSON record on stdout, with a trailing newline.  Bypasses
+   Async's [print_*] wrappers so the output flushes even when we take
+   the [Stdlib.exit] fast path. *)
+let emit_json g json =
+  let s = if g.compact then MRC.Http.compact json else MRC.Http.pretty json in
+  Stdlib.print_string s ; Stdlib.print_newline () ; Stdlib.flush Stdlib.stdout
+
+let emit_error msg =
+  (* No raw OCaml exception text leaks: [msg] is produced by
+     [MRC.Errors] formatters or by the CLI itself. *)
+  Stdlib.prerr_string (msg ^ "\n") ;
+  Stdlib.flush Stdlib.stderr
+
+(* Run a client call, emit the result as JSON (or the error on stderr
+   and exit 1).  Wraps the "happy path" so each leaf command stays a
+   one-liner. *)
+let run g ~(call : MRC.Http.t -> Yojson.Safe.t Deferred.Or_error.t) =
+  let client = client_of_globals g in
+  match%map call client with
+  | Ok j ->
+      emit_json g j
+  | Error e ->
+      emit_error (Error.to_string_hum e) ;
+      Stdlib.exit 1
+
+(* ---------- Data API subcommands ---------- *)
+
+let cmd_network_list =
+  Command.async ~summary:"POST /network/list"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_list )
+
+let cmd_network_status =
+  Command.async ~summary:"POST /network/status"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_status )
+
+let cmd_network_options =
+  Command.async ~summary:"POST /network/options"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_options )
+
+let network_group =
+  Command.group ~summary:"Rosetta /network/* endpoints"
+    [ ("list", cmd_network_list)
+    ; ("status", cmd_network_status)
+    ; ("options", cmd_network_options)
+    ]
+
+let cmd_block_get =
+  Command.async ~summary:"POST /block (by --index or --hash)"
+    (let%map_open.Command g = global_flags_param
+     and index = flag "--index" ~doc:"N Block height" (optional int)
+     and hash = flag "--hash" ~doc:"H Block state hash" (optional string) in
+     fun () ->
+       match (index, hash) with
+       | None, None ->
+           emit_error "block get: one of --index or --hash is required" ;
+           Stdlib.exit 1
+       | _ ->
+           run g ~call:(fun c -> MRC.Data.block c ?index ?hash ()) )
+
+(* Note: there is no [block transaction] subcommand. Mina's Rosetta server
+   does not implement /block/transaction (it returns every transaction inline
+   in /block, so "other_transactions" is always empty) and would 404 on it.
+   Use [block get] and filter the returned transactions by hash instead. *)
+
+let block_group =
+  Command.group ~summary:"Rosetta /block endpoints" [ ("get", cmd_block_get) ]
+
+let cmd_account_balance =
+  Command.async ~summary:"POST /account/balance"
+    (let%map_open.Command g = global_flags_param
+     and address =
+       flag "--address" ~doc:"B62q... Account address" (required string)
+     and token_id = flag "--token-id" ~doc:"ID Token id" (optional string)
+     and block_index =
+       flag "--index" ~doc:"N Block height (default: latest)" (optional int)
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_balance c ~address ?token_id ?block_index () ) )
+
+let cmd_account_coins =
+  Command.async ~summary:"POST /account/coins"
+    (let%map_open.Command g = global_flags_param
+     and address =
+       flag "--address" ~doc:"B62q... Account address" (required string)
+     and include_mempool =
+       flag "--include-mempool" ~doc:" Include mempool transactions" no_arg
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_coins c ~address ~include_mempool () ) )
+
+let account_group =
+  Command.group ~summary:"Rosetta /account/* endpoints"
+    [ ("balance", cmd_account_balance); ("coins", cmd_account_coins) ]
+
+let cmd_mempool_list =
+  Command.async ~summary:"POST /mempool"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.mempool )
+
+let cmd_mempool_transaction =
+  Command.async ~summary:"POST /mempool/transaction"
+    (let%map_open.Command g = global_flags_param
+     and tx_hash =
+       flag "--tx-hash" ~doc:"H Transaction hash" (required string)
+     in
+     fun () -> run g ~call:(fun c -> MRC.Data.mempool_transaction c ~tx_hash) )
+
+let mempool_group =
+  Command.group ~summary:"Rosetta /mempool endpoints"
+    [ ("list", cmd_mempool_list); ("transaction", cmd_mempool_transaction) ]
+
+let cmd_search_transactions =
+  Command.async ~summary:"POST /search/transactions"
+    (let%map_open.Command g = global_flags_param
+     and address =
+       flag "--address" ~doc:"B62q... Filter by account" (optional string)
+     and tx_hash = flag "--tx-hash" ~doc:"H Filter by tx hash" (optional string)
+     and limit = flag "--limit" ~doc:"N Max results" (optional int) in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.search_transactions c ?address ?tx_hash ?limit () ) )
+
+let search_group =
+  Command.group ~summary:"Rosetta /search/* endpoints"
+    [ ("transactions", cmd_search_transactions) ]
+
+(* ---------- Construction API subcommands ---------- *)
+
+let parse_json_flag label s =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string s) with
+  | Ok j ->
+      Ok j
+  | Error _ ->
+      Or_error.errorf "%s: invalid JSON" label
+
+let fail_if_error label = function
+  | Ok v ->
+      v
+  | Error e ->
+      emit_error (sprintf "%s: %s" label (Error.to_string_hum e)) ;
+      Stdlib.exit 1
+
+let cmd_construction_derive =
+  Command.async ~summary:"POST /construction/derive"
+    (let%map_open.Command g = global_flags_param
+     and public_key =
+       flag "--public-key-json"
+         ~doc:
+           "JSON Rosetta PublicKey object (e.g. \
+            '{\"hex_bytes\":\"...\",\"curve_type\":\"pallas\"}')"
+         (required string)
+     and metadata =
+       flag "--metadata-json" ~doc:"JSON Optional metadata object"
+         (optional string)
+     in
+     fun () ->
+       let pk =
+         fail_if_error "--public-key-json"
+           (parse_json_flag "--public-key-json" public_key)
+       in
+       let md =
+         Option.map metadata ~f:(fun s ->
+             fail_if_error "--metadata-json"
+               (parse_json_flag "--metadata-json" s) )
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.derive c ~public_key:pk ?metadata:md () ) )
+
+let cmd_construction_preprocess =
+  Command.async ~summary:"POST /construction/preprocess"
+    (let%map_open.Command g = global_flags_param
+     and operations =
+       flag "--operations-json" ~doc:"JSON Operations array" (required string)
+     and metadata =
+       flag "--metadata-json" ~doc:"JSON Optional metadata object"
+         (optional string)
+     in
+     fun () ->
+       let ops =
+         fail_if_error "--operations-json"
+           (parse_json_flag "--operations-json" operations)
+       in
+       let md =
+         Option.map metadata ~f:(fun s ->
+             fail_if_error "--metadata-json"
+               (parse_json_flag "--metadata-json" s) )
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.preprocess c ~operations:ops ?metadata:md () ) )
+
+let cmd_construction_metadata =
+  Command.async ~summary:"POST /construction/metadata"
+    (let%map_open.Command g = global_flags_param
+     and options =
+       flag "--options-json" ~doc:"JSON Options object" (required string)
+     and public_keys =
+       flag "--public-keys-json" ~doc:"JSON PublicKey array" (optional string)
+     in
+     fun () ->
+       let opts =
+         fail_if_error "--options-json"
+           (parse_json_flag "--options-json" options)
+       in
+       let pks =
+         Option.map public_keys ~f:(fun s ->
+             fail_if_error "--public-keys-json"
+               (parse_json_flag "--public-keys-json" s) )
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.metadata c ~options:opts ?public_keys:pks () ) )
+
+let cmd_construction_payloads =
+  Command.async ~summary:"POST /construction/payloads"
+    (let%map_open.Command g = global_flags_param
+     and operations =
+       flag "--operations-json" ~doc:"JSON Operations array" (required string)
+     and metadata =
+       flag "--metadata-json" ~doc:"JSON Optional metadata object"
+         (optional string)
+     and public_keys =
+       flag "--public-keys-json" ~doc:"JSON PublicKey array" (optional string)
+     in
+     fun () ->
+       let ops =
+         fail_if_error "--operations-json"
+           (parse_json_flag "--operations-json" operations)
+       in
+       let md =
+         Option.map metadata ~f:(fun s ->
+             fail_if_error "--metadata-json"
+               (parse_json_flag "--metadata-json" s) )
+       in
+       let pks =
+         Option.map public_keys ~f:(fun s ->
+             fail_if_error "--public-keys-json"
+               (parse_json_flag "--public-keys-json" s) )
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.payloads c ~operations:ops ?metadata:md
+             ?public_keys:pks () ) )
+
+let cmd_construction_parse =
+  Command.async ~summary:"POST /construction/parse"
+    (let%map_open.Command g = global_flags_param
+     and signed = flag "--signed" ~doc:" Transaction is signed" no_arg
+     and unsigned = flag "--unsigned" ~doc:" Transaction is unsigned" no_arg
+     and transaction =
+       flag "--transaction" ~doc:"STR Transaction blob" (required string)
+     in
+     fun () ->
+       let signed =
+         match (signed, unsigned) with
+         | true, true ->
+             emit_error "--signed and --unsigned are mutually exclusive" ;
+             Stdlib.exit 1
+         | false, false ->
+             emit_error "parse: one of --signed or --unsigned is required" ;
+             Stdlib.exit 1
+         | true, false ->
+             true
+         | false, true ->
+             false
+       in
+       run g ~call:(fun c -> MRC.Construction.parse c ~signed ~transaction) )
+
+let cmd_construction_combine =
+  Command.async ~summary:"POST /construction/combine"
+    (let%map_open.Command g = global_flags_param
+     and unsigned_transaction =
+       flag "--unsigned-transaction" ~doc:"STR Unsigned tx blob"
+         (required string)
+     and signatures =
+       flag "--signatures-json" ~doc:"JSON Signatures array" (required string)
+     in
+     fun () ->
+       let sigs =
+         fail_if_error "--signatures-json"
+           (parse_json_flag "--signatures-json" signatures)
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.combine c ~unsigned_transaction ~signatures:sigs )
+    )
+
+let cmd_construction_hash =
+  Command.async ~summary:"POST /construction/hash"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction =
+       flag "--signed-transaction" ~doc:"STR Signed tx blob" (required string)
+     in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.hash c ~signed_transaction) )
+
+let cmd_construction_submit =
+  Command.async ~summary:"POST /construction/submit"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction =
+       flag "--signed-transaction" ~doc:"STR Signed tx blob" (required string)
+     in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.submit c ~signed_transaction) )
+
+let construction_group =
+  Command.group ~summary:"Rosetta /construction/* endpoints"
+    [ ("derive", cmd_construction_derive)
+    ; ("preprocess", cmd_construction_preprocess)
+    ; ("metadata", cmd_construction_metadata)
+    ; ("payloads", cmd_construction_payloads)
+    ; ("parse", cmd_construction_parse)
+    ; ("combine", cmd_construction_combine)
+    ; ("hash", cmd_construction_hash)
+    ; ("submit", cmd_construction_submit)
+    ]
+
+(* ---------- Config subcommands ---------- *)
+
+let cmd_config_show =
+  Command.basic ~summary:"Print an embedded rosetta-cli config file to stdout"
+    (let%map_open.Command file =
+       flag "--file"
+         ~doc:
+           (sprintf
+              "NAME Which embedded config to print (default: config.json; \
+               available: %s)"
+              (MRC.Config.names ()) )
+         (optional_with_default "config.json" string)
+     in
+     fun () ->
+       match MRC.Config.find_by_name file with
+       | None ->
+           Stdlib.prerr_string
+             (sprintf "unknown embedded config %S; available: %s\n" file
+                (MRC.Config.names ()) ) ;
+           Stdlib.flush Stdlib.stderr ;
+           Stdlib.exit 2
+       | Some f ->
+           Stdlib.print_string (MRC.Config.contents f) ;
+           Stdlib.flush Stdlib.stdout )
+
+let cmd_config_export =
+  Command.basic
+    ~summary:"Write all embedded rosetta-cli config files into a directory"
+    (let%map_open.Command out_dir =
+       flag "--out-dir" ~doc:"DIR Target directory (created if missing)"
+         (required string)
+     in
+     fun () ->
+       match MRC.Config.export_to_dir ~dir:out_dir with
+       | Ok paths ->
+           List.iter paths ~f:print_endline
+       | Error e ->
+           Stdlib.prerr_string (Error.to_string_hum e ^ "\n") ;
+           Stdlib.flush Stdlib.stderr ;
+           Stdlib.exit 2 )
+
+let config_group =
+  Command.group ~summary:"Embedded rosetta-cli config accessors"
+    [ ("show", cmd_config_show); ("export", cmd_config_export) ]
+
+(* ---------- Top-level ---------- *)
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta client CLI — curl-on-steroids for a running Rosetta \
+          server"
+       [ ("network", network_group)
+       ; ("block", block_group)
+       ; ("account", account_group)
+       ; ("mempool", mempool_group)
+       ; ("search", search_group)
+       ; ("construction", construction_group)
+       ; ("config", config_group)
+       ] )

--- a/src/app/rosetta/client/rosetta_client_cli.ml
+++ b/src/app/rosetta/client/rosetta_client_cli.ml
@@ -1,0 +1,428 @@
+(* rosetta_client CLI — a curl-on-steroids for the Rosetta API.
+
+   This file owns the command-line surface: the flags, the subcommand
+   tree, and how a result or an error reaches the terminal.  Decoding a
+   JSON-valued flag into the model an endpoint expects is in
+   [payload.ml], which neither prints nor exits.
+
+   Every subcommand POSTs to a single Rosetta endpoint through the
+   [Rosetta_client] library, auto-injects the network_identifier
+   ({"blockchain":"mina","network":"testnet"} by default), and prints
+   the response as JSON (pretty by default).  On HTTP or transport
+   failure, prints a short human-readable diagnostic on stderr and exits
+   non-zero; the diagnostic never leaks raw OCaml exception syntax.
+
+   Environment variables (each one is overridden by the matching flag,
+   and all three are shared with [rosetta-healthcheck]):
+
+   - [MINA_ROSETTA_URI] — default for [--rosetta-uri].
+   - [MINA_ROSETTA_BLOCKCHAIN] — default for [--blockchain].
+   - [MINA_ROSETTA_NETWORK] — default for [--network].
+
+   The values they fall back to when unset live in
+   [Rosetta_client.Defaults]. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+(* Seconds allowed for one request/response exchange with the Rosetta
+   server, from sending the request to reading the last byte of the
+   response body.  This is deliberately longer than
+   [MRC.Defaults.http_timeout]: a healthcheck probe wants a quick verdict,
+   whereas this CLI is used interactively for queries such as a
+   /search/transactions sweep that legitimately take much longer than a
+   probe would wait. *)
+let default_timeout = 30.0
+
+(* ---------- Global flags shared by every leaf command ---------- *)
+
+(* A record that every subcommand's [let%map_open] can pull in with a
+   single line.  Keeps per-command preludes short. *)
+type global_flags =
+  { base_uri : string
+  ; blockchain : string
+  ; network : string
+  ; timeout : float
+  ; compact : bool
+  }
+
+let global_flags_param =
+  let open Command.Let_syntax in
+  let open Command.Param in
+  let%map base_uri =
+    flag "--rosetta-uri"
+      ~doc:
+        (sprintf "URI Rosetta base URL (default: %s, overridable via $%s)"
+           (MRC.Defaults.base_uri_from_env ())
+           MRC.Defaults.uri_env_var )
+      (optional_with_default (MRC.Defaults.base_uri_from_env ()) string)
+  and blockchain =
+    flag "--blockchain"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.blockchain (default: %s, overridable via \
+            $%s)"
+           (MRC.Defaults.blockchain_from_env ())
+           MRC.Defaults.blockchain_env_var )
+      (optional_with_default (MRC.Defaults.blockchain_from_env ()) string)
+  and network =
+    flag "--network"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.network (default: %s, overridable via $%s)"
+           (MRC.Defaults.network_from_env ())
+           MRC.Defaults.network_env_var )
+      (optional_with_default (MRC.Defaults.network_from_env ()) string)
+  and timeout =
+    flag "--timeout"
+      ~doc:
+        (sprintf "SECONDS HTTP request timeout (default: %.0f)" default_timeout)
+      (optional_with_default default_timeout float)
+  and compact =
+    flag "--compact" ~doc:" Emit compact JSON instead of indented (pretty)"
+      no_arg
+  in
+  { base_uri; blockchain; network; timeout; compact }
+
+let client_of_globals g =
+  MRC.Http.create ~base_uri:(Uri.of_string g.base_uri) ~blockchain:g.blockchain
+    ~network:g.network ~timeout:g.timeout ()
+
+(* Single JSON record on stdout, with a trailing newline.  Bypasses
+   Async's [print_*] wrappers so the output flushes even when we take
+   the [Stdlib.exit] fast path. *)
+let emit_json g json =
+  let s = if g.compact then MRC.Http.compact json else MRC.Http.pretty json in
+  Stdlib.print_string s ; Stdlib.print_newline () ; Stdlib.flush Stdlib.stdout
+
+let emit_error msg =
+  (* No raw OCaml exception text leaks: [msg] is produced by
+     [MRC.Errors] formatters or by the CLI itself. *)
+  Stdlib.prerr_string (msg ^ "\n") ;
+  Stdlib.flush Stdlib.stderr
+
+(* Run a client call, emit the result as JSON (or the error on stderr
+   and exit 1).  Wraps the "happy path" so each leaf command stays a
+   one-liner. *)
+let run g ~(call : MRC.Http.t -> Yojson.Safe.t Deferred.Or_error.t) =
+  let client = client_of_globals g in
+  match%map call client with
+  | Ok j ->
+      emit_json g j
+  | Error e ->
+      emit_error (Error.to_string_hum e) ;
+      Stdlib.exit 1
+
+(* ---------- Flags reused by more than one subcommand ---------- *)
+
+(* Defined once here so a flag that means the same thing in two
+   subcommands also spells and documents itself the same way. *)
+
+let address_flag =
+  Command.Param.(
+    flag "--address" ~doc:"B62q... Account address" (required string))
+
+let address_filter_flag =
+  Command.Param.(
+    flag "--address" ~doc:"B62q... Filter by account" (optional string))
+
+let tx_hash_flag =
+  Command.Param.(flag "--tx-hash" ~doc:"H Transaction hash" (required string))
+
+let tx_hash_filter_flag =
+  Command.Param.(flag "--tx-hash" ~doc:"H Filter by tx hash" (optional string))
+
+let block_index_flag ~doc = Command.Param.(flag "--index" ~doc (optional int))
+
+let metadata_json_flag =
+  Command.Param.(
+    flag "--metadata-json" ~doc:"JSON Optional metadata object"
+      (optional string))
+
+let operations_json_flag =
+  Command.Param.(
+    flag "--operations-json" ~doc:"JSON Operations array" (required string))
+
+let public_keys_json_flag =
+  Command.Param.(
+    flag "--public-keys-json" ~doc:"JSON PublicKey array" (optional string))
+
+let signed_transaction_flag =
+  Command.Param.(
+    flag "--signed-transaction" ~doc:"STR Signed tx blob" (required string))
+
+(* ---------- Data API subcommands ---------- *)
+
+let cmd_network_list =
+  Command.async ~summary:"POST /network/list"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_list )
+
+let cmd_network_status =
+  Command.async ~summary:"POST /network/status"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_status )
+
+let cmd_network_options =
+  Command.async ~summary:"POST /network/options"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_options )
+
+let network_group =
+  Command.group ~summary:"Rosetta /network/* endpoints"
+    [ ("list", cmd_network_list)
+    ; ("status", cmd_network_status)
+    ; ("options", cmd_network_options)
+    ]
+
+let cmd_block_get =
+  Command.async ~summary:"POST /block (by --index or --hash)"
+    (let%map_open.Command g = global_flags_param
+     and index = block_index_flag ~doc:"N Block height"
+     and hash = flag "--hash" ~doc:"H Block state hash" (optional string) in
+     fun () ->
+       match (index, hash) with
+       | None, None ->
+           emit_error "block get: one of --index or --hash is required" ;
+           Stdlib.exit 1
+       | _ ->
+           run g ~call:(fun c -> MRC.Data.block c ?index ?hash ()) )
+
+(* Note: there is no [block transaction] subcommand. Mina's Rosetta server
+   does not implement /block/transaction (it returns every transaction inline
+   in /block, so "other_transactions" is always empty) and would 404 on it.
+   Use [block get] and filter the returned transactions by hash instead. *)
+
+let block_group =
+  Command.group ~summary:"Rosetta /block endpoints" [ ("get", cmd_block_get) ]
+
+let cmd_account_balance =
+  Command.async ~summary:"POST /account/balance"
+    (let%map_open.Command g = global_flags_param
+     and address = address_flag
+     and token_id = flag "--token-id" ~doc:"ID Token id" (optional string)
+     and block_index =
+       block_index_flag ~doc:"N Block height (default: latest)"
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_balance c ~address ?token_id ?block_index () ) )
+
+let cmd_account_coins =
+  Command.async ~summary:"POST /account/coins"
+    (let%map_open.Command g = global_flags_param
+     and address = address_flag
+     and include_mempool =
+       flag "--include-mempool" ~doc:" Include mempool transactions" no_arg
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_coins c ~address ~include_mempool () ) )
+
+let account_group =
+  Command.group ~summary:"Rosetta /account/* endpoints"
+    [ ("balance", cmd_account_balance); ("coins", cmd_account_coins) ]
+
+let cmd_mempool_list =
+  Command.async ~summary:"POST /mempool"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.mempool )
+
+let cmd_mempool_transaction =
+  Command.async ~summary:"POST /mempool/transaction"
+    (let%map_open.Command g = global_flags_param and tx_hash = tx_hash_flag in
+     fun () -> run g ~call:(fun c -> MRC.Data.mempool_transaction c ~tx_hash) )
+
+let mempool_group =
+  Command.group ~summary:"Rosetta /mempool endpoints"
+    [ ("list", cmd_mempool_list); ("transaction", cmd_mempool_transaction) ]
+
+let cmd_search_transactions =
+  Command.async ~summary:"POST /search/transactions"
+    (let%map_open.Command g = global_flags_param
+     and address = address_filter_flag
+     and tx_hash = tx_hash_filter_flag
+     and limit = flag "--limit" ~doc:"N Max results" (optional int) in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.search_transactions c ?address ?tx_hash ?limit () ) )
+
+let search_group =
+  Command.group ~summary:"Rosetta /search/* endpoints"
+    [ ("transactions", cmd_search_transactions) ]
+
+(* ---------- Construction API subcommands ---------- *)
+
+(* [Payload] reports a bad flag as an error; this is where that error
+   becomes a diagnostic on stderr and a non-zero exit. *)
+let or_exit = function
+  | Ok value ->
+      value
+  | Error e ->
+      emit_error (Error.to_string_hum e) ;
+      Stdlib.exit 1
+
+let required_flag label of_yojson s = or_exit (Payload.model ~label of_yojson s)
+
+let optional_flag label of_yojson s =
+  or_exit (Payload.model_opt ~label of_yojson s)
+
+(* [metadata] and [options] stay raw JSON: the Rosetta schema leaves both
+   free-form, so there is no model to decode them into. *)
+let raw_json_flag label s = or_exit (Payload.json ~label s)
+
+let optional_raw_json_flag label s = or_exit (Payload.json_opt ~label s)
+
+let cmd_construction_derive =
+  Command.async ~summary:"POST /construction/derive"
+    (let%map_open.Command g = global_flags_param
+     and public_key =
+       flag "--public-key-json"
+         ~doc:
+           "JSON Rosetta PublicKey object (e.g. \
+            '{\"hex_bytes\":\"...\",\"curve_type\":\"pallas\"}')"
+         (required string)
+     and metadata = metadata_json_flag in
+     fun () ->
+       let pk =
+         required_flag "--public-key-json" [%of_yojson: RM.Public_key.t]
+           public_key
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       run g ~call:(fun c ->
+           MRC.Construction.derive c ~public_key:pk ?metadata:md () ) )
+
+let cmd_construction_preprocess =
+  Command.async ~summary:"POST /construction/preprocess"
+    (let%map_open.Command g = global_flags_param
+     and operations = operations_json_flag
+     and metadata = metadata_json_flag in
+     fun () ->
+       let ops =
+         required_flag "--operations-json" [%of_yojson: RM.Operation.t list]
+           operations
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       run g ~call:(fun c ->
+           MRC.Construction.preprocess c ~operations:ops ?metadata:md () ) )
+
+let cmd_construction_metadata =
+  Command.async ~summary:"POST /construction/metadata"
+    (let%map_open.Command g = global_flags_param
+     and options =
+       flag "--options-json" ~doc:"JSON Options object" (required string)
+     and public_keys = public_keys_json_flag in
+     fun () ->
+       let opts = raw_json_flag "--options-json" options in
+       let pks =
+         optional_flag "--public-keys-json" [%of_yojson: RM.Public_key.t list]
+           public_keys
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.metadata c ~options:opts ?public_keys:pks () ) )
+
+let cmd_construction_payloads =
+  Command.async ~summary:"POST /construction/payloads"
+    (let%map_open.Command g = global_flags_param
+     and operations = operations_json_flag
+     and metadata = metadata_json_flag
+     and public_keys = public_keys_json_flag in
+     fun () ->
+       let ops =
+         required_flag "--operations-json" [%of_yojson: RM.Operation.t list]
+           operations
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       let pks =
+         optional_flag "--public-keys-json" [%of_yojson: RM.Public_key.t list]
+           public_keys
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.payloads c ~operations:ops ?metadata:md
+             ?public_keys:pks () ) )
+
+let cmd_construction_parse =
+  Command.async ~summary:"POST /construction/parse"
+    (let%map_open.Command g = global_flags_param
+     and signed = flag "--signed" ~doc:" Transaction is signed" no_arg
+     and unsigned = flag "--unsigned" ~doc:" Transaction is unsigned" no_arg
+     and transaction =
+       flag "--transaction" ~doc:"STR Transaction blob" (required string)
+     in
+     fun () ->
+       let signed =
+         match (signed, unsigned) with
+         | true, true ->
+             emit_error "--signed and --unsigned are mutually exclusive" ;
+             Stdlib.exit 1
+         | false, false ->
+             emit_error "parse: one of --signed or --unsigned is required" ;
+             Stdlib.exit 1
+         | true, false ->
+             true
+         | false, true ->
+             false
+       in
+       run g ~call:(fun c -> MRC.Construction.parse c ~signed ~transaction) )
+
+let cmd_construction_combine =
+  Command.async ~summary:"POST /construction/combine"
+    (let%map_open.Command g = global_flags_param
+     and unsigned_transaction =
+       flag "--unsigned-transaction" ~doc:"STR Unsigned tx blob"
+         (required string)
+     and signatures =
+       flag "--signatures-json" ~doc:"JSON Signatures array" (required string)
+     in
+     fun () ->
+       let sigs =
+         required_flag "--signatures-json" [%of_yojson: RM.Signature.t list]
+           signatures
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.combine c ~unsigned_transaction ~signatures:sigs )
+    )
+
+let cmd_construction_hash =
+  Command.async ~summary:"POST /construction/hash"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction = signed_transaction_flag in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.hash c ~signed_transaction) )
+
+let cmd_construction_submit =
+  Command.async ~summary:"POST /construction/submit"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction = signed_transaction_flag in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.submit c ~signed_transaction) )
+
+let construction_group =
+  Command.group ~summary:"Rosetta /construction/* endpoints"
+    [ ("derive", cmd_construction_derive)
+    ; ("preprocess", cmd_construction_preprocess)
+    ; ("metadata", cmd_construction_metadata)
+    ; ("payloads", cmd_construction_payloads)
+    ; ("parse", cmd_construction_parse)
+    ; ("combine", cmd_construction_combine)
+    ; ("hash", cmd_construction_hash)
+    ; ("submit", cmd_construction_submit)
+    ]
+
+(* ---------- Top-level ---------- *)
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta client CLI — curl-on-steroids for a running Rosetta \
+          server"
+       [ ("network", network_group)
+       ; ("block", block_group)
+       ; ("account", account_group)
+       ; ("mempool", mempool_group)
+       ; ("search", search_group)
+       ; ("construction", construction_group)
+       ] )

--- a/src/app/rosetta/client/tests/dune
+++ b/src/app/rosetta/client/tests/dune
@@ -1,0 +1,32 @@
+;; Hermetic alcotest smoke tests for rosetta-client.
+;;
+;; These exercise only subcommands that don't need a running Rosetta
+;; server: --help for each subgroup, config show / export, and the
+;; clean error paths of the HTTP and JSON-validation code.
+
+(test
+ (name test_rosetta_client)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_kernel
+  core_unix
+  core_unix.filename_unix
+  core_unix.sys_unix
+  stdio
+  yojson
+  ;; mina libraries
+  rosetta_client)
+ (deps
+  ../rosetta_client_cli.exe
+  ;; Source-of-truth rosetta-cli-config files, read by the byte-equality
+  ;; test for [config export] (see test_config_export_writes_four_files).
+  ../../rosetta-cli-config/config.json
+  ../../rosetta-cli-config/mina.ros
+  ../../rosetta-cli-config/mina-no-delegation-test.ros
+  ../../rosetta-cli-config/mina-with-return-funds.ros)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/client/tests/dune
+++ b/src/app/rosetta/client/tests/dune
@@ -1,0 +1,25 @@
+;; Hermetic alcotest smoke tests for rosetta-client.
+;;
+;; These exercise only subcommands that don't need a running Rosetta
+;; server: --help for each subgroup and the clean error paths of the
+;; HTTP and JSON-validation code.
+
+(test
+ (name test_rosetta_client)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_kernel
+  core_unix
+  core_unix.filename_unix
+  core_unix.sys_unix
+  stdio
+  yojson
+  ;; mina libraries
+  rosetta_client)
+ (deps ../rosetta_client_cli.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/client/tests/test_rosetta_client.ml
+++ b/src/app/rosetta/client/tests/test_rosetta_client.ml
@@ -1,0 +1,239 @@
+(* Hermetic alcotest smoke tests for rosetta-client.
+
+   These exercise only the subcommands that don't need a running
+   Rosetta server: --help for each subgroup, config show / export, and
+   the clean error paths of the HTTP and JSON-validation code.
+
+   The regression guard we care most about is that user-visible error
+   output never leaks raw OCaml exception syntax (e.g. Unix_error,
+   Core.Unix.Unix_error, etc.).  See [assert_no_ocaml_exn_leak]. *)
+
+open Core
+
+(* Path to the binary under test.  dune places the test executable in
+   the same directory as its deps, so [../rosetta_client_cli.exe] is reachable from
+   wherever dune chooses to [chdir] into.  We resolve it once relative
+   to [Sys.get_argv ().(0)] so the tests survive dune sandboxing. *)
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../rosetta_client_cli.exe"
+
+(* Tempdir helper. *)
+let with_tmp_dir f =
+  let dir = Core_unix.mkdtemp (Filename.temp_dir_name ^/ "mrc-test-") in
+  Exn.protect
+    ~f:(fun () -> f dir)
+    ~finally:(fun () ->
+      let pi = Core_unix.create_process ~prog:"rm" ~args:[ "-rf"; dir ] in
+      Core_unix.close pi.stdin ;
+      Core_unix.close pi.stdout ;
+      Core_unix.close pi.stderr ;
+      ignore (Core_unix.waitpid pi.pid : _) )
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args] and an optional env extension, capture
+   stdout and stderr, return [(exit_code, stdout, stderr)]. *)
+let run_cli ?(env = []) args =
+  let pi = Core_unix.create_process_env ~prog:bin ~args ~env:(`Extend env) () in
+  (* Close stdin immediately so the child gets EOF if it ever tried to
+     read. *)
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: no user-facing output must contain raw OCaml
+   exception syntax.  The triggering bug for this whole cleanup was
+   connection-refused paths leaking [Unix_error] through to stderr. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains ?(case_insensitive = false) s ~sub =
+  if case_insensitive then
+    String.is_substring (String.lowercase s) ~substring:(String.lowercase sub)
+  else String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  check_contains ~label:"--help root lists network" out ~sub:"network" ;
+  check_contains ~label:"--help root lists construction" out ~sub:"construction" ;
+  assert_no_ocaml_exn_leak "--help root stderr" err
+
+let test_help_network () =
+  let code, out, err = run_cli [ "network"; "--help" ] in
+  Alcotest.(check int) "network --help exit" 0 code ;
+  check_contains ~label:"network --help lists list" out ~sub:"list" ;
+  check_contains ~label:"network --help lists status" out ~sub:"status" ;
+  check_contains ~label:"network --help lists options" out ~sub:"options" ;
+  assert_no_ocaml_exn_leak "network --help stderr" err
+
+let test_help_construction () =
+  let code, out, err = run_cli [ "construction"; "--help" ] in
+  Alcotest.(check int) "construction --help exit" 0 code ;
+  check_contains ~label:"construction --help lists derive" out ~sub:"derive" ;
+  check_contains ~label:"construction --help lists submit" out ~sub:"submit" ;
+  assert_no_ocaml_exn_leak "construction --help stderr" err
+
+let test_help_config () =
+  let code, out, err = run_cli [ "config"; "--help" ] in
+  Alcotest.(check int) "config --help exit" 0 code ;
+  check_contains ~label:"config --help lists show" out ~sub:"show" ;
+  check_contains ~label:"config --help lists export" out ~sub:"export" ;
+  assert_no_ocaml_exn_leak "config --help stderr" err
+
+let test_config_show_json () =
+  let code, out, err = run_cli [ "config"; "show"; "--file"; "config.json" ] in
+  Alcotest.(check int) "config show --file config.json exit" 0 code ;
+  let trimmed = String.strip out in
+  if String.is_empty trimmed then
+    Alcotest.failf "config show: stdout empty, stderr: %s" err ;
+  let c = String.get trimmed 0 in
+  if not (Char.equal c '{') then
+    Alcotest.failf
+      "config show: stdout should start with '{' (got %C)\nfull:\n%s" c out ;
+  assert_no_ocaml_exn_leak "config show stderr" err
+
+(* The rosetta-cli-config sources are declared as [deps] in the dune
+   file, so dune makes them reachable at this relative path under the
+   test's sandbox cwd.  Keep this in sync with the [(deps ...)] stanza
+   if new files are added. *)
+let rosetta_cli_config_src name = "../../rosetta-cli-config" ^/ name
+
+let read_file_bytes path = In_channel.with_file path ~f:In_channel.input_all
+
+let test_config_export_writes_four_files () =
+  with_tmp_dir (fun dir ->
+      let out_dir = dir ^/ "exp" in
+      let code, _out, err =
+        run_cli [ "config"; "export"; "--out-dir"; out_dir ]
+      in
+      Alcotest.(check int) "config export exit" 0 code ;
+      assert_no_ocaml_exn_leak "config export stderr" err ;
+      let expected =
+        [ "config.json"
+        ; "mina.ros"
+        ; "mina-no-delegation-test.ros"
+        ; "mina-with-return-funds.ros"
+        ]
+      in
+      List.iter expected ~f:(fun name ->
+          let exported = out_dir ^/ name in
+          if not (Sys_unix.file_exists_exn exported) then
+            Alcotest.failf "config export: missing %s in %s" name out_dir ;
+          let source = rosetta_cli_config_src name in
+          let source_bytes = read_file_bytes source in
+          let exported_bytes = read_file_bytes exported in
+          Alcotest.(check string)
+            (name ^ " contents") source_bytes exported_bytes ) )
+
+let test_connection_refused_clean_error () =
+  (* Port 1 is privileged and reliably refuses on loopback. *)
+  let code, out, err =
+    run_cli [ "network"; "status"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  Alcotest.(check int) "network status (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "network status stdout" out ;
+  assert_no_ocaml_exn_leak "network status stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  let has_signal =
+    contains ~case_insensitive:true combined ~sub:"refused"
+    || contains ~case_insensitive:true combined ~sub:"unreachable"
+    || contains combined ~sub:"127.0.0.1:1"
+  in
+  if not has_signal then
+    Alcotest.failf
+      "network status (dead port): stderr should signal refusal / URI, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+let test_block_get_missing_args () =
+  let code, out, err =
+    run_cli [ "block"; "get"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then
+    Alcotest.failf "block get (no --index/--hash): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "block get stdout" out ;
+  assert_no_ocaml_exn_leak "block get stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if String.is_empty (String.strip combined) then
+    Alcotest.failf "block get (no --index/--hash): expected a diagnostic"
+
+let test_construction_derive_invalid_json () =
+  let code, out, err =
+    run_cli
+      [ "construction"
+      ; "derive"
+      ; "--public-key-json"
+      ; "{not valid"
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ]
+  in
+  if code = 0 then
+    Alcotest.failf "construction derive (bad JSON): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "construction derive stdout" out ;
+  assert_no_ocaml_exn_leak "construction derive stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if
+    not
+      ( contains ~case_insensitive:true combined ~sub:"json"
+      || contains combined ~sub:"public-key-json" )
+  then
+    Alcotest.failf
+      "construction derive (bad JSON): stderr should mention JSON, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-client CLI smoke tests"
+    [ ( "help"
+      , [ ("root", `Quick, test_help_root)
+        ; ("network", `Quick, test_help_network)
+        ; ("construction", `Quick, test_help_construction)
+        ; ("config", `Quick, test_help_config)
+        ] )
+    ; ( "config"
+      , [ ("show json", `Quick, test_config_show_json)
+        ; ( "export writes four files"
+          , `Quick
+          , test_config_export_writes_four_files )
+        ] )
+    ; ( "error paths"
+      , [ ( "connection refused is clean"
+          , `Quick
+          , test_connection_refused_clean_error )
+        ; ("block get missing args", `Quick, test_block_get_missing_args)
+        ; ( "construction derive invalid JSON"
+          , `Quick
+          , test_construction_derive_invalid_json )
+        ] )
+    ]

--- a/src/app/rosetta/client/tests/test_rosetta_client.ml
+++ b/src/app/rosetta/client/tests/test_rosetta_client.ml
@@ -1,0 +1,202 @@
+(* Hermetic alcotest smoke tests for rosetta-client.
+
+   These exercise only the subcommands that don't need a running
+   Rosetta server: --help for each subgroup and the clean error paths of
+   the HTTP and JSON-validation code.
+
+   The regression guard we care most about is that user-visible error
+   output never leaks raw OCaml exception syntax (e.g. Unix_error,
+   Core.Unix.Unix_error, etc.).  See [assert_no_ocaml_exn_leak]. *)
+
+open Core
+
+(* Path to the binary under test.  dune places the test executable in
+   the same directory as its deps, so [../rosetta_client_cli.exe] is reachable from
+   wherever dune chooses to [chdir] into.  We resolve it once relative
+   to [Sys.get_argv ().(0)] so the tests survive dune sandboxing. *)
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../rosetta_client_cli.exe"
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args] and an optional env extension, capture
+   stdout and stderr, return [(exit_code, stdout, stderr)]. *)
+let run_cli ?(env = []) args =
+  let pi = Core_unix.create_process_env ~prog:bin ~args ~env:(`Extend env) () in
+  (* Close stdin immediately so the child gets EOF if it ever tried to
+     read. *)
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: no user-facing output must contain raw OCaml
+   exception syntax.  The triggering bug for this whole cleanup was
+   connection-refused paths leaking [Unix_error] through to stderr. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains ?(case_insensitive = false) s ~sub =
+  if case_insensitive then
+    String.is_substring (String.lowercase s) ~substring:(String.lowercase sub)
+  else String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  check_contains ~label:"--help root lists network" out ~sub:"network" ;
+  check_contains ~label:"--help root lists construction" out ~sub:"construction" ;
+  assert_no_ocaml_exn_leak "--help root stderr" err
+
+let test_help_network () =
+  let code, out, err = run_cli [ "network"; "--help" ] in
+  Alcotest.(check int) "network --help exit" 0 code ;
+  check_contains ~label:"network --help lists list" out ~sub:"list" ;
+  check_contains ~label:"network --help lists status" out ~sub:"status" ;
+  check_contains ~label:"network --help lists options" out ~sub:"options" ;
+  assert_no_ocaml_exn_leak "network --help stderr" err
+
+let test_help_construction () =
+  let code, out, err = run_cli [ "construction"; "--help" ] in
+  Alcotest.(check int) "construction --help exit" 0 code ;
+  check_contains ~label:"construction --help lists derive" out ~sub:"derive" ;
+  check_contains ~label:"construction --help lists submit" out ~sub:"submit" ;
+  assert_no_ocaml_exn_leak "construction --help stderr" err
+
+let test_connection_refused_clean_error () =
+  (* Port 1 is privileged and reliably refuses on loopback. *)
+  let code, out, err =
+    run_cli [ "network"; "status"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  Alcotest.(check int) "network status (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "network status stdout" out ;
+  assert_no_ocaml_exn_leak "network status stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  let has_signal =
+    contains ~case_insensitive:true combined ~sub:"refused"
+    || contains ~case_insensitive:true combined ~sub:"unreachable"
+    || contains combined ~sub:"127.0.0.1:1"
+  in
+  if not has_signal then
+    Alcotest.failf
+      "network status (dead port): stderr should signal refusal / URI, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+let test_block_get_missing_args () =
+  let code, out, err =
+    run_cli [ "block"; "get"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then
+    Alcotest.failf "block get (no --index/--hash): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "block get stdout" out ;
+  assert_no_ocaml_exn_leak "block get stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if String.is_empty (String.strip combined) then
+    Alcotest.failf "block get (no --index/--hash): expected a diagnostic"
+
+let test_construction_derive_invalid_json () =
+  let code, out, err =
+    run_cli
+      [ "construction"
+      ; "derive"
+      ; "--public-key-json"
+      ; "{not valid"
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ]
+  in
+  if code = 0 then
+    Alcotest.failf "construction derive (bad JSON): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "construction derive stdout" out ;
+  assert_no_ocaml_exn_leak "construction derive stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if
+    not
+      ( contains ~case_insensitive:true combined ~sub:"json"
+      || contains combined ~sub:"public-key-json" )
+  then
+    Alcotest.failf
+      "construction derive (bad JSON): stderr should mention JSON, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+(* Valid JSON that is not a Rosetta PublicKey: the CLI decodes flag
+   payloads into the endpoint's model, so this must be rejected locally
+   with the flag name rather than sent to the server. *)
+let test_construction_derive_schema_mismatch () =
+  let code, out, err =
+    run_cli
+      [ "construction"
+      ; "derive"
+      ; "--public-key-json"
+      ; {|{"hex_bytes":"aabb"}|}
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ]
+  in
+  if code = 0 then
+    Alcotest.failf "construction derive (bad schema): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "construction derive stdout" out ;
+  assert_no_ocaml_exn_leak "construction derive stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if
+    not
+      ( contains ~case_insensitive:true combined ~sub:"schema"
+      || contains combined ~sub:"public-key-json" )
+  then
+    Alcotest.failf
+      "construction derive (bad schema): stderr should name the flag or the \n\
+       schema, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-client CLI smoke tests"
+    [ ( "help"
+      , [ ("root", `Quick, test_help_root)
+        ; ("network", `Quick, test_help_network)
+        ; ("construction", `Quick, test_help_construction)
+        ] )
+    ; ( "error paths"
+      , [ ( "connection refused is clean"
+          , `Quick
+          , test_connection_refused_clean_error )
+        ; ("block get missing args", `Quick, test_block_get_missing_args)
+        ; ( "construction derive invalid JSON"
+          , `Quick
+          , test_construction_derive_invalid_json )
+        ; ( "construction derive schema mismatch"
+          , `Quick
+          , test_construction_derive_schema_mismatch )
+        ] )
+    ]

--- a/src/app/rosetta/healthcheck/README.md
+++ b/src/app/rosetta/healthcheck/README.md
@@ -1,0 +1,116 @@
+# rosetta-healthcheck
+
+Slim CLI focused on answering **"is the Rosetta server healthy right now?"**
+Designed for Kubernetes exec probes, Docker `HEALTHCHECK`, CI gates, and
+CI pre-flight checks.
+
+For arbitrary Rosetta API calls — `/block`, `/account/*`, `/mempool`,
+`/search/*`, `/construction/*` — use the sibling
+[`rosetta-client`](../rosetta_client/README.md) binary.  Both share
+the same underlying HTTP library (`src/lib/rosetta_client/`).
+
+## Commands
+
+### Probes
+
+| Command | Endpoint(s) | Exit 0 when |
+|---------|-------------|-------------|
+| `ready` | composite | `connectivity` + `tip-recency` + `/network/options` all pass |
+| `wait` | poll `ready` | passes before `--timeout` expires |
+| `tip-recency` | POST `/network/status` | tip returned AND its timestamp is within `--max-age` |
+| `connectivity` | POST `/network/list` | `network_identifier` list advertises the expected network (lists the advertised set on mismatch) |
+
+## Usage
+
+```bash
+# Is the server reachable and advertising our network?
+rosetta-healthcheck connectivity --network testnet
+
+# Is the tip fresh? (default tolerance: 360s)
+rosetta-healthcheck tip-recency --max-age 360
+
+# Composite readiness suitable for k8s readiness probes:
+rosetta-healthcheck ready --max-age 360 --json
+
+# Block until ready (CI / init containers):
+rosetta-healthcheck wait --timeout 600 --interval 10 --json
+```
+
+To extract the embedded rosetta-cli config files, use
+`rosetta-client config show` / `rosetta-client config export`.
+To make a single Rosetta API call for debugging, use
+`rosetta-client network status` / `rosetta-client block get` /
+etc.
+
+## Flags
+
+| Flag | Alias | Default | Applies to |
+|------|-------|---------|------------|
+| `--online-uri` | `-o` | `http://localhost:3087` | all probes |
+| `--network` | `-n` | `testnet` | all probes |
+| `--blockchain` | | `mina` | all probes |
+| `--json` | `-j` | off | every subcommand |
+| `--max-age` | | 360 | `tip-recency`, `ready`, `wait` |
+| `--timeout` | `-t` | 600 | `wait` |
+| `--interval` | `-i` | 10 | `wait` |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed |
+| 1 | Check failed (details on stderr, or in JSON record on stdout) |
+| 2 | Environment / configuration error (malformed URI, etc.) |
+
+## JSON output contract
+
+When `--json` is set, every subcommand emits exactly one JSON record on
+stdout and exits. On success:
+
+```json
+{ "healthy": true, ... }
+{ "ready":   true, ... }
+```
+
+On failure the same record includes `"error": "<msg>"` and any metrics
+gathered up to the point of failure; the process exits with code 1.
+
+All error messages are produced by `Rosetta_client.Errors` and are
+guaranteed to be short, human-readable, and free of raw OCaml exception
+syntax.
+
+## Kubernetes integration
+
+```yaml
+# Liveness: is the Rosetta server answering at all?
+livenessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "connectivity",
+              "--online-uri", "http://localhost:3087",
+              "--network", "testnet"]
+  initialDelaySeconds: 30
+  periodSeconds: 30
+
+# Readiness: are all discovery endpoints healthy and the tip fresh?
+readinessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "ready",
+              "--online-uri", "http://localhost:3087",
+              "--max-age", "360"]
+  initialDelaySeconds: 60
+  periodSeconds: 30
+```
+
+## Docker integration
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD ["rosetta-healthcheck", "connectivity", \
+       "--online-uri", "http://localhost:3087"]
+```
+
+## Building
+
+```bash
+dune build src/app/rosetta/healthcheck/rosetta_healthcheck.exe
+```

--- a/src/app/rosetta/healthcheck/README.md
+++ b/src/app/rosetta/healthcheck/README.md
@@ -1,0 +1,149 @@
+# rosetta-healthcheck
+
+Slim CLI focused on answering **"is the Rosetta server healthy right now?"**
+Designed for Kubernetes exec probes, Docker `HEALTHCHECK`, CI gates, and
+CI pre-flight checks.
+
+For arbitrary Rosetta API calls — `/block`, `/account/*`, `/mempool`,
+`/search/*`, `/construction/*` — use the sibling
+[`rosetta-client`](../client/README.md) binary.  Both share the same
+underlying HTTP library (`src/lib/rosetta_client/`).
+
+## Commands
+
+### Probes
+
+| Command | Endpoint(s) | Exit 0 when |
+|---------|-------------|-------------|
+| `ready` | composite | `connectivity` + `tip-recency` + `/network/options` all pass |
+| `wait` | poll `ready` | passes before `--timeout` expires |
+| `tip-recency` | POST `/network/status` | tip returned AND its timestamp is within `--max-age` |
+| `connectivity` | POST `/network/list` | `network_identifier` list advertises the expected network (lists the advertised set on mismatch) |
+
+## Usage
+
+```bash
+# Is the server reachable and advertising our network?
+rosetta-healthcheck connectivity --network testnet
+
+# Is the tip fresh? (default tolerance: 360s)
+rosetta-healthcheck tip-recency --max-age 360
+
+# Composite readiness suitable for k8s readiness probes:
+rosetta-healthcheck ready --max-age 360 --json
+
+# Block until ready (CI / init containers):
+rosetta-healthcheck wait --timeout 600 --interval 10 --json
+```
+
+The rosetta-cli audit configuration (`config.json` and the Construction
+DSL files it names) is not handled by this binary.  It ships in the
+`mina-rosetta` Debian package at
+`/etc/mina/rosetta/rosetta-cli-config/`, and
+`buildkite/scripts/tests/rosetta/integration-tests.sh` copies it to a
+writable directory and fills in its `PLACEHOLDER_*` fields before
+invoking rosetta-cli.
+
+To make a single Rosetta API call for debugging, use
+`rosetta-client network status` / `rosetta-client block get` /
+etc.
+
+## Flags
+
+| Flag | Alias | Default | Environment override | Applies to |
+|------|-------|---------|----------------------|------------|
+| `--online-uri` | `-o` | `http://localhost:3087` | `MINA_ROSETTA_URI` | all probes |
+| `--network` | `-n` | `testnet` | `MINA_ROSETTA_NETWORK` | all probes |
+| `--blockchain` | | `mina` | `MINA_ROSETTA_BLOCKCHAIN` | all probes |
+| `--json` | `-j` | off | | every subcommand |
+| `--max-age` | | 360 | | `tip-recency`, `ready`, `wait` |
+| `--timeout` | `-t` | 600 | | `wait` |
+| `--interval` | `-i` | 10 | | `wait` |
+
+A flag always wins over its environment variable.  The three variables
+are the same ones `rosetta-client` reads, and their fallback values live
+in `Rosetta_client.Defaults`, so the two binaries cannot drift apart.
+`--timeout` bounds the whole `wait` loop; the per-request HTTP timeout is
+fixed at `Rosetta_client.Defaults.http_timeout` (5s), because a probe
+wants a quick verdict.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed |
+| 1 | Check failed (one line on stdout, or one JSON record on stdout with `--json`) |
+
+## JSON output contract
+
+When `--json` is set, every probe emits exactly one JSON record on stdout
+and exits. On success:
+
+```json
+{ "healthy": true, ... }
+{ "ready":   true, ... }
+```
+
+On failure the same record includes `"error": "<msg>"` and any metrics
+gathered up to the point of failure; the process exits with code 1.
+
+The records are typed (`health_output.ml`), and a field that has no value
+is left out rather than emitted as `null`.  The probes that produce them
+are in `health_probes.ml` and never print or exit; `rosetta_healthcheck.ml`
+owns the flags, the text/JSON choice and the exit code.  A probe that could not reach
+the server therefore prints:
+
+```json
+{ "healthy": false, "error": "connection refused to http://localhost:3087/network/list" }
+```
+
+All error messages are produced by `Rosetta_client.Errors` and are
+guaranteed to be short, human-readable, and free of raw OCaml exception
+syntax.
+
+## Known limitation
+
+A probe that times out closes its connection in every case except one: a
+server that completes the TCP connect and then never sends a response
+line at all. cohttp-async 5.0.0 exposes no handle on that connection, so
+`wait` against such a server holds one socket per attempt until the
+process exits. It is bounded by a single run of a short-lived CLI, and no
+usable `--timeout` / `--interval` pair reaches the default descriptor
+limit. See the comment on `with_request` in
+`src/lib/rosetta_client/http.ml`.
+
+## Kubernetes integration
+
+```yaml
+# Liveness: is the Rosetta server answering at all?
+livenessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "connectivity",
+              "--online-uri", "http://localhost:3087",
+              "--network", "testnet"]
+  initialDelaySeconds: 30
+  periodSeconds: 30
+
+# Readiness: are all discovery endpoints healthy and the tip fresh?
+readinessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "ready",
+              "--online-uri", "http://localhost:3087",
+              "--max-age", "360"]
+  initialDelaySeconds: 60
+  periodSeconds: 30
+```
+
+## Docker integration
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD ["rosetta-healthcheck", "connectivity", \
+       "--online-uri", "http://localhost:3087"]
+```
+
+## Building
+
+```bash
+dune build src/app/rosetta/healthcheck/rosetta_healthcheck.exe
+```

--- a/src/app/rosetta/healthcheck/dune
+++ b/src/app/rosetta/healthcheck/dune
@@ -1,0 +1,20 @@
+(executable
+ (package rosetta)
+ (name rosetta_healthcheck)
+ (public_name rosetta-healthcheck)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async
+  async_kernel
+  async.async_command
+  cohttp
+  cohttp-async
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here)))

--- a/src/app/rosetta/healthcheck/dune
+++ b/src/app/rosetta/healthcheck/dune
@@ -1,0 +1,21 @@
+(executable
+ (package rosetta)
+ (name rosetta_healthcheck)
+ (public_name rosetta-healthcheck)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async
+  async_kernel
+  async.async_command
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here ppx_deriving_yojson)))

--- a/src/app/rosetta/healthcheck/health_output.ml
+++ b/src/app/rosetta/healthcheck/health_output.ml
@@ -1,0 +1,69 @@
+(* The JSON records [rosetta-healthcheck ... --json] prints.
+
+   These are the binary's machine-readable contract: an orchestrator
+   reads them to decide whether a Rosetta instance is usable.  Each
+   record therefore has a type here rather than being assembled field by
+   field at the call site, so a probe cannot silently drop a field or
+   rename one.
+
+   Every optional field carries [@default None] (and every list
+   [@default []]), which makes [to_yojson] omit it when it is absent.
+   A probe that could not reach the server therefore emits
+   [{"healthy":false,"error":"..."}] rather than a record padded with
+   nulls. *)
+
+(* One entry of /network/list's advertised set. *)
+type network_id = { blockchain : string; network : string }
+[@@deriving to_yojson]
+
+(* [connectivity]: does /network/list answer, and does it advertise the
+   network we were asked about? *)
+type connectivity =
+  { healthy : bool
+  ; expected_network : string option [@default None]
+  ; advertised : network_id list [@default []]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [tip-recency]: how old is the tip /network/status reports?
+   [max_age] is echoed back only when the tip failed the check, so the
+   reader can see the bound that was applied. *)
+type tip_recency =
+  { healthy : bool
+  ; block_height : int64 option [@default None]
+  ; block_hash : string option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; max_age : int option [@default None]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [ready] and [wait].  [timed_out] distinguishes "wait gave up" from
+   "ready reported not-ready once"; [problems] lists one line per failed
+   probe. *)
+type readiness =
+  { ready : bool
+  ; timed_out : bool option [@default None]
+  ; block_height : int64 option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; problems : string list [@default []]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+let connectivity_failed error =
+  { healthy = false
+  ; expected_network = None
+  ; advertised = []
+  ; error = Some error
+  }
+
+let tip_recency_failed error =
+  { healthy = false
+  ; block_height = None
+  ; block_hash = None
+  ; age_seconds = None
+  ; max_age = None
+  ; error = Some error
+  }

--- a/src/app/rosetta/healthcheck/health_probes.ml
+++ b/src/app/rosetta/healthcheck/health_probes.ml
@@ -1,0 +1,106 @@
+(* The health probes.  See [health_probes.mli] for the contract, and
+   [rosetta_healthcheck.ml] for the CLI that presents these verdicts. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+type tip = { height : int64; hash : string; age_seconds : int64; fresh : bool }
+
+type readiness = { ready : bool; tip : tip option; problems : string list }
+
+(* Now-time as epoch seconds. *)
+let now_secs () = Time.now () |> Time.to_span_since_epoch |> Time.Span.to_sec
+
+let age_seconds_from_timestamp_ms ts =
+  let now_ms = Int64.of_float (now_secs () *. 1000.0) in
+  let age_ms = Int64.( - ) now_ms ts in
+  let age_secs = Int64.( / ) age_ms 1000L in
+  if Int64.( < ) age_secs 0L then 0L else age_secs
+
+let describe (network_identifier : RM.Network_identifier.t) =
+  sprintf "%s:%s" network_identifier.RM.Network_identifier.blockchain
+    network_identifier.RM.Network_identifier.network
+
+let connectivity client ~expected_blockchain ~expected_network =
+  match%map MRC.Data.network_list_response client with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let advertised = response.RM.Network_list_response.network_identifiers in
+      if List.is_empty advertised then
+        Or_error.error_string "/network/list returned no network_identifiers"
+      else
+        let match_found =
+          List.exists advertised ~f:(fun n ->
+              String.equal n.RM.Network_identifier.blockchain
+                expected_blockchain
+              && String.equal n.RM.Network_identifier.network expected_network )
+        in
+        if match_found then Ok advertised
+        else
+          Or_error.errorf "expected network %s:%s not advertised (got: %s)"
+            expected_blockchain expected_network
+            (String.concat ~sep:", " (List.map advertised ~f:describe))
+
+let tip_recency client ~max_age =
+  match%map MRC.Data.network_status_response client with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let block =
+        response.RM.Network_status_response.current_block_identifier
+      in
+      let age_seconds =
+        age_seconds_from_timestamp_ms
+          response.RM.Network_status_response.current_block_timestamp
+      in
+      Ok
+        { height = block.RM.Block_identifier.index
+        ; hash = block.RM.Block_identifier.hash
+        ; age_seconds
+        ; fresh = Int64.( <= ) age_seconds (Int64.of_int max_age)
+        }
+
+(* [/network/options] is the third readiness signal: a server that
+   answers it with a version and a non-empty operation_types list has
+   finished wiring up its Data API. *)
+let network_options_ok client =
+  match%map MRC.Data.network_options_response client with
+  | Error e ->
+      Error (sprintf "network-options: %s" (Error.to_string_hum e))
+  | Ok response ->
+      let version = response.RM.Network_options_response.version in
+      let allow = response.RM.Network_options_response.allow in
+      if
+        String.is_empty version.RM.Version.rosetta_version
+        || List.is_empty allow.RM.Allow.operation_types
+      then Error "network-options: missing rosetta_version or operation_types"
+      else Ok ()
+
+let readiness client ~expected_blockchain ~expected_network ~max_age =
+  let%bind connectivity_result =
+    connectivity client ~expected_blockchain ~expected_network
+  in
+  let%bind tip_result = tip_recency client ~max_age in
+  let%map options_result = network_options_ok client in
+  let problem_of_error label e =
+    sprintf "%s: %s" label (Error.to_string_hum e)
+  in
+  let problems =
+    List.filter_opt
+      [ Result.error connectivity_result
+        |> Option.map ~f:(problem_of_error "connectivity")
+      ; ( match tip_result with
+        | Error e ->
+            Some (problem_of_error "tip-recency" e)
+        | Ok tip when not tip.fresh ->
+            Some
+              (sprintf "tip-recency: tip age %Lds > %ds" tip.age_seconds max_age)
+        | Ok _ ->
+            None )
+      ; Result.error options_result
+      ]
+  in
+  { ready = List.is_empty problems; tip = Result.ok tip_result; problems }

--- a/src/app/rosetta/healthcheck/health_probes.mli
+++ b/src/app/rosetta/healthcheck/health_probes.mli
@@ -1,0 +1,65 @@
+(** The health probes themselves: what [rosetta-healthcheck] asks a
+    Rosetta server, and how it decides whether the answer is healthy.
+
+    Nothing here touches [Command], prints, or exits.  A probe returns a
+    typed verdict and leaves the presentation of it — text or JSON, which
+    exit code — to {!Rosetta_healthcheck}.  That split is what makes the
+    decisions testable without spawning the binary. *)
+
+(** The chain tip as [/network/status] reported it. *)
+type tip =
+  { height : int64
+  ; hash : string
+  ; age_seconds : int64
+        (** Age of [timestamp] at the moment of the probe, never
+            negative: a server whose clock runs ahead of ours reports 0
+            rather than a negative age. *)
+  ; fresh : bool  (** Whether [age_seconds] is within the caller's bound. *)
+  }
+
+(** Verdict of the composite readiness check. *)
+type readiness =
+  { ready : bool  (** True only when [problems] is empty. *)
+  ; tip : tip option
+        (** The tip, when [/network/status] answered — present even when
+            the tip was too old, so a caller can report how far behind
+            the server is. *)
+  ; problems : string list  (** One line per failed check, in probe order. *)
+  }
+
+(** [connectivity client ~expected_blockchain ~expected_network] asks
+    [/network/list] and returns everything the server advertises.
+
+    It is an error when the server answers with an empty list, or when
+    the expected pair is absent — the error message then names the
+    advertised set, because "wrong network" and "server not up" need
+    different fixes. *)
+val connectivity :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> Rosetta_client.Models.Network_identifier.t list Async.Deferred.Or_error.t
+
+(** [tip_recency client ~max_age] asks [/network/status] and reports the
+    tip with its age.  A tip older than [max_age] seconds is returned
+    with [fresh = false] rather than as an error: the caller still wants
+    the height and the age in order to report them. *)
+val tip_recency :
+  Rosetta_client.Http.t -> max_age:int -> tip Async.Deferred.Or_error.t
+
+(** [readiness client ~expected_blockchain ~expected_network ~max_age]
+    runs {!connectivity}, {!tip_recency} and a [/network/options] sanity
+    check.
+
+    Every check runs even after an earlier one failed, so one invocation
+    reports every problem instead of only the first — an operator
+    debugging a sick server wants the whole picture at once.  For that
+    reason this returns a plain [Deferred.t]: a transport failure is an
+    entry in [problems], not an error channel that would short-circuit
+    the remaining checks. *)
+val readiness :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> max_age:int
+  -> readiness Async.Deferred.t

--- a/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
@@ -1,0 +1,456 @@
+(* rosetta_healthcheck.ml — slim CLI for Mina Rosetta health probes.
+
+   This binary focuses exclusively on readiness and recency checks.
+   Generic Rosetta API calls live in the sibling [rosetta-client] binary
+   so operators don't have to choose between two overlapping CLIs for
+   debugging.  HTTP calls here go through [Rosetta_client] so
+   network_identifier handling, timeout enforcement, and error formatting
+   stay in one place. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+(* Operators can set [MINA_ROSETTA_URI] to avoid passing --online-uri on
+   every invocation; --online-uri still overrides it when given.  Shared with
+   the sibling rosetta-client binary. *)
+let rosetta_uri_env_var = "MINA_ROSETTA_URI"
+
+let default_online_uri =
+  Option.value (Sys.getenv rosetta_uri_env_var) ~default:"http://localhost:3087"
+
+let default_network = "testnet"
+
+let default_blockchain = "mina"
+
+let default_max_age = 360
+
+let default_timeout = 600
+
+let default_interval = 10
+
+let default_http_timeout_secs = 5.0
+
+(* ---------- CLI flag helpers ---------- *)
+
+let online_uri_flag =
+  Command.Param.(
+    flag "--online-uri" ~aliases:[ "-o" ]
+      ~doc:
+        (sprintf
+           "URI Rosetta online base URL (default: %s, overridable via $%s)"
+           default_online_uri rosetta_uri_env_var )
+      (optional_with_default default_online_uri string))
+
+let network_flag =
+  Command.Param.(
+    flag "--network" ~aliases:[ "-n" ]
+      ~doc:
+        (sprintf "NAME network_identifier.network (default: %s)" default_network)
+      (optional_with_default default_network string))
+
+let blockchain_flag =
+  Command.Param.(
+    flag "--blockchain"
+      ~doc:
+        (sprintf "NAME network_identifier.blockchain (default: %s)"
+           default_blockchain )
+      (optional_with_default default_blockchain string))
+
+let json_flag =
+  Command.Param.(
+    flag "--json" ~aliases:[ "-j" ] ~doc:" Output as JSON instead of text"
+      no_arg)
+
+let max_age_flag =
+  Command.Param.(
+    flag "--max-age"
+      ~doc:
+        (sprintf "SECONDS Maximum acceptable age of current tip (default: %d)"
+           default_max_age )
+      (optional_with_default default_max_age int))
+
+let timeout_flag ~default =
+  Command.Param.(
+    flag "--timeout" ~aliases:[ "-t" ]
+      ~doc:(sprintf "SECONDS Max seconds to wait (default: %d)" default)
+      (optional_with_default default int))
+
+let interval_flag =
+  Command.Param.(
+    flag "--interval" ~aliases:[ "-i" ]
+      ~doc:(sprintf "SECONDS Polling interval (default: %d)" default_interval)
+      (optional_with_default default_interval int))
+
+(* ---------- I/O helpers ---------- *)
+
+(* Emit a JSON record to stdout.  We bypass Async's own [print_*]
+   wrappers (which use non-blocking writers that may not flush before
+   a subsequent [Stdlib.exit]) by going straight to [Stdlib.stdout],
+   and flush explicitly so the record appears even when we exit without
+   going through Async's shutdown path. *)
+let output json =
+  Stdlib.print_string (Yojson.Safe.pretty_to_string json) ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+let make_client ~online_uri ~blockchain ~network =
+  MRC.Http.create ~base_uri:(Uri.of_string online_uri) ~blockchain ~network
+    ~timeout:default_http_timeout_secs ()
+
+(* Emit either the success path or a single JSON error record.  Mirrors
+   the contract in [mina_archive_healthcheck]: in [json] mode, never
+   double-print — emit exactly one JSON record and [exit 1] on failure;
+   in text mode, hand the error back to the [async_or_error] wrapper. *)
+let finish ~json ~json_error result =
+  match result with
+  | Ok () ->
+      Deferred.Or_error.return ()
+  | Error e ->
+      if json then (
+        output (json_error e) ;
+        Stdlib.exit 1 )
+      else Deferred.Or_error.fail e
+
+let network_identifier_pair (network_identifier : RM.Network_identifier.t) =
+  ( network_identifier.RM.Network_identifier.blockchain
+  , network_identifier.RM.Network_identifier.network )
+
+let block_height_json h = `Intlit (Int64.to_string h)
+
+(* Now-time as epoch seconds. *)
+let now_secs () = Time.now () |> Time.to_span_since_epoch |> Time.Span.to_sec
+
+let age_seconds_from_timestamp_ms ts =
+  let now_ms = Int64.of_float (now_secs () *. 1000.0) in
+  let age_ms = Int64.( - ) now_ms ts in
+  let age_secs = Int64.( / ) age_ms 1000L in
+  if Int64.( < ) age_secs 0L then 0L else age_secs
+
+(* ---------- connectivity (was: network-list) ---------- *)
+
+let connectivity_probe client ~expected_blockchain ~expected_network =
+  match%map MRC.Data.network_list_response client with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let advertised =
+        List.map response.RM.Network_list_response.network_identifiers
+          ~f:network_identifier_pair
+      in
+      if List.is_empty advertised then
+        Or_error.error_string "/network/list returned no network_identifiers"
+      else
+        let match_found =
+          List.exists advertised ~f:(fun (b, n) ->
+              String.equal b expected_blockchain
+              && String.equal n expected_network )
+        in
+        if match_found then Ok advertised
+        else
+          let adv_str =
+            List.map advertised ~f:(fun (b, n) -> sprintf "%s:%s" b n)
+            |> String.concat ~sep:", "
+          in
+          Or_error.errorf "expected network %s:%s not advertised (got: %s)"
+            expected_blockchain expected_network adv_str
+
+let connectivity_command =
+  Command.async_or_error
+    ~summary:
+      "Verify Rosetta's /network/list advertises the expected network.  Lists \
+       the advertised set when the expected network is absent."
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let%bind result =
+         connectivity_probe client ~expected_blockchain:blockchain
+           ~expected_network:network
+       in
+       let json_error e =
+         `Assoc
+           [ ("healthy", `Bool false)
+           ; ("error", `String (Error.to_string_hum e))
+           ]
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok advertised ->
+             let adv_json =
+               `List
+                 (List.map advertised ~f:(fun (b, n) ->
+                      `Assoc
+                        [ ("blockchain", `String b); ("network", `String n) ] )
+                 )
+             in
+             if json then
+               output
+                 (`Assoc
+                   [ ("healthy", `Bool true)
+                   ; ("expected_network", `String network)
+                   ; ("advertised", adv_json)
+                   ] )
+             else
+               printf "advertises %d networks (contains %s)\n"
+                 (List.length advertised) network ;
+             Ok ()
+       in
+       finish ~json ~json_error inner )
+
+(* ---------- tip-recency (was: network-status) ---------- *)
+
+let tip_recency_probe client = MRC.Data.network_status_response client
+
+let tip_recency_command =
+  Command.async_or_error
+    ~summary:
+      "POST /network/status — exit 0 if tip is returned and its timestamp is \
+       within --max-age"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let%bind result = tip_recency_probe client in
+       let json_error e =
+         `Assoc
+           [ ("healthy", `Bool false)
+           ; ("error", `String (Error.to_string_hum e))
+           ]
+       in
+       let inner =
+         match result with
+         | Error e ->
+             Error e
+         | Ok response ->
+             let tip =
+               response.RM.Network_status_response.current_block_identifier
+             in
+             let idx = tip.RM.Block_identifier.index in
+             let h = tip.RM.Block_identifier.hash in
+             let d =
+               age_seconds_from_timestamp_ms
+                 response.RM.Network_status_response.current_block_timestamp
+             in
+             if Int64.( <= ) d (Int64.of_int max_age) then (
+               if json then
+                 output
+                   (`Assoc
+                     [ ("healthy", `Bool true)
+                     ; ("block_height", block_height_json idx)
+                     ; ("block_hash", `String h)
+                     ; ("age_seconds", `Intlit (Int64.to_string d))
+                     ] )
+               else printf "tip height=%Ld hash=%s age=%Lds\n" idx h d ;
+               Ok () )
+             else
+               let err_msg =
+                 sprintf "tip is %Ld seconds old, exceeds max age %d" d max_age
+               in
+               if json then (
+                 output
+                   (`Assoc
+                     [ ("healthy", `Bool false)
+                     ; ("block_height", block_height_json idx)
+                     ; ("block_hash", `String h)
+                     ; ("age_seconds", `Intlit (Int64.to_string d))
+                     ; ("max_age", `Int max_age)
+                     ; ("error", `String err_msg)
+                     ] ) ;
+                 Stdlib.exit 1 )
+               else (
+                 printf "tip is %Ld seconds old, exceeds max %d\n" d max_age ;
+                 Error (Error.of_string err_msg) )
+       in
+       finish ~json ~json_error inner )
+
+(* ---------- Composite: [ready] and [wait] ---------- *)
+
+(* Runs the three low-cost probes and collects problems.  When
+   [max_age] is set, the recency check on network-status is part of
+   the decision; otherwise we only require that the endpoint returned
+   a tip. *)
+let run_ready_checks client ~expected_blockchain ~expected_network ~max_age =
+  let open Deferred.Let_syntax in
+  let problems = ref [] in
+  let add p = problems := p :: !problems in
+  let%bind list_ok =
+    match%map
+      connectivity_probe client ~expected_blockchain ~expected_network
+    with
+    | Ok _ ->
+        true
+    | Error e ->
+        add (sprintf "connectivity: %s" (Error.to_string_hum e)) ;
+        false
+  in
+  let%bind status_ok, height_opt, age_opt =
+    match%map MRC.Data.network_status_response client with
+    | Error e ->
+        add (sprintf "tip-recency: %s" (Error.to_string_hum e)) ;
+        (false, None, None)
+    | Ok response ->
+        let tip =
+          response.RM.Network_status_response.current_block_identifier
+        in
+        let idx = tip.RM.Block_identifier.index in
+        let age =
+          age_seconds_from_timestamp_ms
+            response.RM.Network_status_response.current_block_timestamp
+        in
+        let recent = Int64.( <= ) age (Int64.of_int max_age) in
+        if not recent then
+          add (sprintf "tip-recency: tip age %Lds > %ds" age max_age) ;
+        (recent, Some idx, Some age)
+  in
+  let%map options_ok =
+    match%map MRC.Data.network_options_response client with
+    | Error e ->
+        add (sprintf "network-options: %s" (Error.to_string_hum e)) ;
+        false
+    | Ok response ->
+        let version = response.RM.Network_options_response.version in
+        let allow = response.RM.Network_options_response.allow in
+        let rosetta_version = version.RM.Version.rosetta_version in
+        let operation_types = allow.RM.Allow.operation_types in
+        let ok =
+          (not (String.is_empty rosetta_version))
+          && not (List.is_empty operation_types)
+        in
+        if not ok then
+          add "network-options: missing rosetta_version or operation_types" ;
+        ok
+  in
+  let ready = list_ok && status_ok && options_ok in
+  (ready, height_opt, age_opt, List.rev !problems)
+
+let ready_command =
+  Command.async_or_error
+    ~summary:
+      "Composite readiness: connectivity + tip-recency + /network/options"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let%bind ready, height_opt, age_opt, problems =
+         run_ready_checks client ~expected_blockchain:blockchain
+           ~expected_network:network ~max_age
+       in
+       (* [run_ready_checks] always returns a plain tuple: transport
+          errors from each probe are captured as entries in [problems]
+          rather than as an [Error] channel.  So we never get a
+          short-circuit error to forward here — the decision is simply
+          ready vs. not-ready, formatted for text or JSON. *)
+       if ready then (
+         if json then
+           output
+             (`Assoc
+               ( [ ("ready", `Bool true) ]
+               @ Option.value_map height_opt ~default:[] ~f:(fun h ->
+                     [ ("block_height", block_height_json h) ] )
+               @ Option.value_map age_opt ~default:[] ~f:(fun d ->
+                     [ ("age_seconds", `Intlit (Int64.to_string d)) ] ) ) )
+         else print_endline "READY" ;
+         Deferred.Or_error.return () )
+       else
+         let err_msg =
+           sprintf "not ready: %s" (String.concat ~sep:", " problems)
+         in
+         if json then (
+           output
+             (`Assoc
+               ( [ ("ready", `Bool false)
+                 ; ( "problems"
+                   , `List (List.map problems ~f:(fun p -> `String p)) )
+                 ; ("error", `String err_msg)
+                 ]
+               @ Option.value_map height_opt ~default:[] ~f:(fun h ->
+                     [ ("block_height", block_height_json h) ] )
+               @ Option.value_map age_opt ~default:[] ~f:(fun d ->
+                     [ ("age_seconds", `Intlit (Int64.to_string d)) ] ) ) ) ;
+           Stdlib.exit 1 )
+         else (
+           printf "NOT READY: %s\n" (String.concat ~sep:", " problems) ;
+           Deferred.Or_error.error_string err_msg ) )
+
+let wait_command =
+  Command.async_or_error
+    ~summary:"Block until Rosetta passes readiness checks or timeout expires"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag
+     and timeout = timeout_flag ~default:default_timeout
+     and interval = interval_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let start = Time.now () in
+       let deadline = Time.add start (Time.Span.of_int_sec timeout) in
+       let timed_out () = Time.( >= ) (Time.now ()) deadline in
+       let elapsed () =
+         Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
+       in
+       let rec loop () =
+         let%bind ready, height_opt, age_opt, problems =
+           run_ready_checks client ~expected_blockchain:blockchain
+             ~expected_network:network ~max_age
+         in
+         if ready then (
+           if json then
+             output
+               (`Assoc
+                 ( [ ("ready", `Bool true) ]
+                 @ Option.value_map height_opt ~default:[] ~f:(fun h ->
+                       [ ("block_height", block_height_json h) ] )
+                 @ Option.value_map age_opt ~default:[] ~f:(fun d ->
+                       [ ("age_seconds", `Intlit (Int64.to_string d)) ] ) ) )
+           else print_endline "READY" ;
+           Deferred.Or_error.return () )
+         else if timed_out () then
+           if json then (
+             output
+               (`Assoc
+                 ( [ ("ready", `Bool false)
+                   ; ("timed_out", `Bool true)
+                   ; ( "problems"
+                     , `List (List.map problems ~f:(fun p -> `String p)) )
+                   ]
+                 @ Option.value_map height_opt ~default:[] ~f:(fun h ->
+                       [ ("block_height", block_height_json h) ] )
+                 @ Option.value_map age_opt ~default:[] ~f:(fun d ->
+                       [ ("age_seconds", `Intlit (Int64.to_string d)) ] ) ) ) ;
+             Stdlib.exit 1 )
+           else
+             Deferred.Or_error.errorf "timed out waiting for readiness: %s"
+               (String.concat ~sep:", " problems)
+         else (
+           eprintf "[%3ds] not ready: %s\n" (elapsed ())
+             (String.concat ~sep:", " problems) ;
+           let%bind () = after (Time.Span.of_int_sec interval) in
+           loop () )
+       in
+       loop () )
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta healthcheck CLI — readiness and recency probes. For \
+          generic Rosetta API calls use 'rosetta-client'."
+       [ ("ready", ready_command)
+       ; ("wait", wait_command)
+       ; ("tip-recency", tip_recency_command)
+       ; ("connectivity", connectivity_command)
+       ] )

--- a/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
@@ -1,0 +1,332 @@
+(* rosetta_healthcheck.ml — the CLI surface of the Rosetta health probes.
+
+   This file owns everything the operator sees: the flags, the choice
+   between text and JSON, and the exit code.  The probes themselves live
+   in [health_probes.ml] and the JSON records they are rendered into in
+   [health_output.ml]; neither of those prints or exits.
+
+   This binary focuses exclusively on readiness and recency checks.
+   Generic Rosetta API calls live in the sibling [rosetta-client] binary
+   so operators don't have to choose between two overlapping CLIs for
+   debugging.  HTTP calls go through [Rosetta_client] so
+   network_identifier handling, timeout enforcement, and error formatting
+   stay in one place.
+
+   Environment variables (each one is overridden by the matching flag,
+   and all three are shared with [rosetta-client]):
+
+   - [MINA_ROSETTA_URI] — base URL of the Rosetta server, i.e. the
+     default for [--online-uri].
+   - [MINA_ROSETTA_BLOCKCHAIN] — default for [--blockchain].
+   - [MINA_ROSETTA_NETWORK] — default for [--network].
+
+   The values they fall back to when unset live in
+   [Rosetta_client.Defaults], which is also where [rosetta-client] reads
+   them from, so the two binaries cannot drift apart. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+module Out = Health_output
+module Probes = Health_probes
+
+(* Probe bounds specific to this binary.  Connection details (URI,
+   blockchain, network) and the per-request HTTP timeout come from
+   [MRC.Defaults] instead. *)
+
+(* Oldest tip, in seconds, that [tip-recency] and [ready] still call
+   healthy.  360s is two 3-minute slots. *)
+let default_max_age = 360
+
+(* How long [wait] keeps polling before it gives up, in seconds. *)
+let default_timeout = 600
+
+(* Seconds [wait] sleeps between two readiness attempts. *)
+let default_interval = 10
+
+(* ---------- Flags ---------- *)
+
+let online_uri_flag =
+  Command.Param.(
+    flag "--online-uri" ~aliases:[ "-o" ]
+      ~doc:
+        (sprintf
+           "URI Rosetta online base URL (default: %s, overridable via $%s)"
+           (MRC.Defaults.base_uri_from_env ())
+           MRC.Defaults.uri_env_var )
+      (optional_with_default (MRC.Defaults.base_uri_from_env ()) string))
+
+let network_flag =
+  Command.Param.(
+    flag "--network" ~aliases:[ "-n" ]
+      ~doc:
+        (sprintf
+           "NAME network_identifier.network (default: %s, overridable via $%s)"
+           (MRC.Defaults.network_from_env ())
+           MRC.Defaults.network_env_var )
+      (optional_with_default (MRC.Defaults.network_from_env ()) string))
+
+let blockchain_flag =
+  Command.Param.(
+    flag "--blockchain"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.blockchain (default: %s, overridable via \
+            $%s)"
+           (MRC.Defaults.blockchain_from_env ())
+           MRC.Defaults.blockchain_env_var )
+      (optional_with_default (MRC.Defaults.blockchain_from_env ()) string))
+
+let json_flag =
+  Command.Param.(
+    flag "--json" ~aliases:[ "-j" ] ~doc:" Output as JSON instead of text"
+      no_arg)
+
+let max_age_flag =
+  Command.Param.(
+    flag "--max-age"
+      ~doc:
+        (sprintf "SECONDS Maximum acceptable age of current tip (default: %d)"
+           default_max_age )
+      (optional_with_default default_max_age int))
+
+let timeout_flag ~default =
+  Command.Param.(
+    flag "--timeout" ~aliases:[ "-t" ]
+      ~doc:(sprintf "SECONDS Max seconds to wait (default: %d)" default)
+      (optional_with_default default int))
+
+let interval_flag =
+  Command.Param.(
+    flag "--interval" ~aliases:[ "-i" ]
+      ~doc:(sprintf "SECONDS Polling interval (default: %d)" default_interval)
+      (optional_with_default default_interval int))
+
+let make_client ~online_uri ~blockchain ~network =
+  MRC.Http.create ~base_uri:(Uri.of_string online_uri) ~blockchain ~network
+    ~timeout:MRC.Defaults.http_timeout ()
+
+(* ---------- Output ---------- *)
+
+(* Emit a JSON record to stdout.  We bypass Async's own [print_*]
+   wrappers (which use non-blocking writers that may not flush before
+   a subsequent [Stdlib.exit]) by going straight to [Stdlib.stdout],
+   and flush explicitly so the record appears even when we exit without
+   going through Async's shutdown path. *)
+let output json =
+  Stdlib.print_string (Yojson.Safe.pretty_to_string json) ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+(* The text-mode counterpart of [output], for the same reason: Async's
+   [printf] buffers, and that buffer is not flushed by [Stdlib.exit]. *)
+let output_line line =
+  Stdlib.print_string line ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+(* Exactly one result per invocation, then exit 1.  Mirrors the contract
+   in [mina_archive_healthcheck]: never double-print -- in JSON mode emit
+   one record, in text mode one line, and in neither case also hand the
+   message back to a [Command] wrapper that would print it again.  The
+   two renderings are lazy so only the one that is asked for is built. *)
+let fail ~json ~record ~line =
+  if json then output (Lazy.force record) else output_line (Lazy.force line) ;
+  Stdlib.exit 1
+
+(* A probe that could not reach the server at all.  Both modes say the
+   same thing, so each command states it once. *)
+let fail_unreachable ~json ~record error =
+  let message = Error.to_string_hum error in
+  fail ~json ~record:(lazy (record message)) ~line:(lazy message)
+
+let advertised_network_id (network_identifier : RM.Network_identifier.t) =
+  { Out.blockchain = network_identifier.RM.Network_identifier.blockchain
+  ; network = network_identifier.RM.Network_identifier.network
+  }
+
+let readiness_json ?timed_out (result : Probes.readiness) =
+  Out.readiness_to_yojson
+    { Out.ready = result.Probes.ready
+    ; timed_out
+    ; block_height =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.height)
+    ; age_seconds =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.age_seconds)
+    ; problems = result.Probes.problems
+    ; error =
+        ( if result.Probes.ready then None
+        else
+          Some
+            (sprintf "not ready: %s"
+               (String.concat ~sep:", " result.Probes.problems) ) )
+    }
+
+(* ---------- connectivity ---------- *)
+
+let connectivity_command =
+  Command.async
+    ~summary:
+      "Verify Rosetta's /network/list advertises the expected network.  Lists \
+       the advertised set when the expected network is absent."
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       match%map
+         Probes.connectivity client ~expected_blockchain:blockchain
+           ~expected_network:network
+       with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.connectivity_to_yojson (Out.connectivity_failed message) )
+       | Ok advertised ->
+           if json then
+             output
+               (Out.connectivity_to_yojson
+                  { Out.healthy = true
+                  ; expected_network = Some network
+                  ; advertised = List.map advertised ~f:advertised_network_id
+                  ; error = None
+                  } )
+           else
+             output_line
+               (sprintf "advertises %d networks (contains %s)"
+                  (List.length advertised) network ) )
+
+(* ---------- tip-recency ---------- *)
+
+let tip_recency_command =
+  Command.async
+    ~summary:
+      "POST /network/status — exit 0 if tip is returned and its timestamp is \
+       within --max-age"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       match%map Probes.tip_recency client ~max_age with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.tip_recency_to_yojson (Out.tip_recency_failed message) )
+       | Ok tip ->
+           let record ~healthy ~max_age_field ~error =
+             Out.tip_recency_to_yojson
+               { Out.healthy
+               ; block_height = Some tip.Probes.height
+               ; block_hash = Some tip.Probes.hash
+               ; age_seconds = Some tip.Probes.age_seconds
+               ; max_age = max_age_field
+               ; error
+               }
+           in
+           if tip.Probes.fresh then
+             if json then
+               output (record ~healthy:true ~max_age_field:None ~error:None)
+             else
+               output_line
+                 (sprintf "tip height=%Ld hash=%s age=%Lds" tip.Probes.height
+                    tip.Probes.hash tip.Probes.age_seconds )
+           else
+             let message =
+               sprintf "tip is %Ld seconds old, exceeds max age %d"
+                 tip.Probes.age_seconds max_age
+             in
+             fail ~json
+               ~record:
+                 ( lazy
+                   (record ~healthy:false ~max_age_field:(Some max_age)
+                      ~error:(Some message) ) )
+               ~line:(lazy message) )
+
+(* ---------- ready and wait ---------- *)
+
+let ready_command =
+  Command.async
+    ~summary:
+      "Composite readiness: connectivity + tip-recency + /network/options"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let%map result =
+         Probes.readiness client ~expected_blockchain:blockchain
+           ~expected_network:network ~max_age
+       in
+       if result.Probes.ready then
+         if json then output (readiness_json result) else output_line "READY"
+       else
+         fail ~json
+           ~record:(lazy (readiness_json result))
+           ~line:
+             ( lazy
+               (sprintf "NOT READY: %s"
+                  (String.concat ~sep:", " result.Probes.problems) ) ) )
+
+let wait_command =
+  Command.async
+    ~summary:"Block until Rosetta passes readiness checks or timeout expires"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag
+     and timeout = timeout_flag ~default:default_timeout
+     and interval = interval_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let start = Time.now () in
+       let deadline = Time.add start (Time.Span.of_int_sec timeout) in
+       let timed_out () = Time.( >= ) (Time.now ()) deadline in
+       let elapsed () =
+         Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
+       in
+       let rec loop () =
+         let%bind result =
+           Probes.readiness client ~expected_blockchain:blockchain
+             ~expected_network:network ~max_age
+         in
+         let problems = String.concat ~sep:", " result.Probes.problems in
+         if result.Probes.ready then (
+           if json then output (readiness_json result) else output_line "READY" ;
+           Deferred.unit )
+         else if timed_out () then
+           fail ~json
+             ~record:(lazy (readiness_json ~timed_out:true result))
+             ~line:
+               (lazy (sprintf "timed out waiting for readiness: %s" problems))
+         else (
+           eprintf "[%3ds] not ready: %s\n" (elapsed ()) problems ;
+           (* Never sleep past the deadline: a plain [--interval] nap
+              would let [--timeout 600 --interval 300] run for 900s
+              before reporting that it had timed out. *)
+           let%bind () =
+             after
+               (Time.Span.min
+                  (Time.Span.of_int_sec interval)
+                  (Time.diff deadline (Time.now ())) )
+           in
+           loop () )
+       in
+       loop () )
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta healthcheck CLI — readiness and recency probes. For \
+          generic Rosetta API calls use 'rosetta-client'."
+       [ ("ready", ready_command)
+       ; ("wait", wait_command)
+       ; ("tip-recency", tip_recency_command)
+       ; ("connectivity", connectivity_command)
+       ] )

--- a/src/app/rosetta/healthcheck/tests/dune
+++ b/src/app/rosetta/healthcheck/tests/dune
@@ -1,0 +1,21 @@
+;; Hermetic alcotest smoke tests for rosetta-healthcheck.
+;;
+;; These exercise only the subcommands that don't require a running
+;; Rosetta server: --help at the top level and the single-JSON-record
+;; contract for [ready --json] / [tip-recency --json] /
+;; [connectivity --json] against a dead port.
+
+(test
+ (name test_rosetta_healthcheck)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_unix
+  stdio
+  yojson)
+ (deps ../rosetta_healthcheck.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
@@ -1,0 +1,169 @@
+(* Hermetic alcotest smoke tests for rosetta-healthcheck.
+
+   These exercise only the subcommands that don't require a running
+   Rosetta server: --help at the top level and the single-JSON-record
+   contract for [ready --json] / [tip-recency --json] /
+   [connectivity --json] against a dead port. *)
+
+open Core
+
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../rosetta_healthcheck.exe"
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args] + optional env overrides, capture
+   stdout/stderr, return [(exit_code, stdout, stderr)]. *)
+let run_cli ?(env = []) args =
+  let pi = Core_unix.create_process_env ~prog:bin ~args ~env:(`Extend env) () in
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: user-visible output must not leak raw OCaml
+   exception syntax.  The original defect was [Unix_error]
+   propagating unwrapped through stderr on ECONNREFUSED. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains s ~sub = String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  List.iter [ "ready"; "wait"; "tip-recency"; "connectivity" ] ~f:(fun sub ->
+      check_contains ~label:(sprintf "--help lists %s" sub) out ~sub ) ;
+  assert_no_ocaml_exn_leak "--help stderr" err
+
+let test_ready_dead_port_text () =
+  let code, out, err =
+    run_cli [ "ready"; "--online-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then Alcotest.failf "ready (dead port): expected non-zero exit" ;
+  let combined = out ^ "\n" ^ err in
+  check_contains ~label:"ready text mentions NOT READY" combined
+    ~sub:"NOT READY" ;
+  assert_no_ocaml_exn_leak "ready stdout" out ;
+  assert_no_ocaml_exn_leak "ready stderr" err
+
+(* Shared helper for "exactly one JSON object on stdout" assertions.
+   Parses [out] as a single Yojson object, returns the field list.
+   Guards against a second JSON object being tacked on, which is the
+   double-print regression the ready/wait/tip-recency/connectivity
+   paths all need to avoid. *)
+let parse_single_json_record ~label out err =
+  let trimmed = String.strip out in
+  if String.is_empty trimmed then
+    Alcotest.failf "%s: stdout empty, stderr:\n%s" label err ;
+  let json =
+    try Yojson.Safe.from_string trimmed
+    with exn ->
+      Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
+        (Exn.to_string exn) out
+  in
+  if String.is_substring trimmed ~substring:"}\n{" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by newlines:\n%s"
+      label out ;
+  if String.is_substring trimmed ~substring:"} {" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by whitespace:\n%s"
+      label out ;
+  match json with
+  | `Assoc fields ->
+      fields
+  | _ ->
+      Alcotest.failf "%s: stdout was not a JSON object: %s" label out
+
+let check_bool_field ~label fields ~field ~expected =
+  match List.Assoc.find fields ~equal:String.equal field with
+  | Some (`Bool b) when Bool.equal b expected ->
+      ()
+  | Some v ->
+      Alcotest.failf "%s: expected %s:%b, got %s" label field expected
+        (Yojson.Safe.to_string v)
+  | None ->
+      Alcotest.failf "%s: missing %S field" label field
+
+(* The key "single JSON record per invocation" contract test: when
+   [ready --json] fails, stdout must contain exactly one well-formed
+   JSON object with [ready: false] and no OCaml exception leakage. *)
+let test_ready_dead_port_json_single_record () =
+  let code, out, err =
+    run_cli [ "ready"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "ready --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "ready --json stdout" out ;
+  assert_no_ocaml_exn_leak "ready --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"ready --json (dead port)" out err
+  in
+  check_bool_field ~label:"ready --json" fields ~field:"ready" ~expected:false
+
+let test_tip_recency_dead_port_json () =
+  let code, out, err =
+    run_cli [ "tip-recency"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "tip-recency --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "tip-recency --json stdout" out ;
+  assert_no_ocaml_exn_leak "tip-recency --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"tip-recency --json (dead port)" out err
+  in
+  check_bool_field ~label:"tip-recency --json" fields ~field:"healthy"
+    ~expected:false
+
+let test_connectivity_dead_port_json () =
+  let code, out, err =
+    run_cli [ "connectivity"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "connectivity --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "connectivity --json stdout" out ;
+  assert_no_ocaml_exn_leak "connectivity --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"connectivity --json (dead port)" out err
+  in
+  check_bool_field ~label:"connectivity --json" fields ~field:"healthy"
+    ~expected:false
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-healthcheck CLI smoke tests"
+    [ ("help", [ ("root", `Quick, test_help_root) ])
+    ; ( "ready against dead port"
+      , [ ("text format", `Quick, test_ready_dead_port_text)
+        ; ( "json is single well-formed record"
+          , `Quick
+          , test_ready_dead_port_json_single_record )
+        ] )
+    ; ( "dead port"
+      , [ ("tip-recency --json", `Quick, test_tip_recency_dead_port_json)
+        ; ("connectivity --json", `Quick, test_connectivity_dead_port_json)
+        ] )
+    ]

--- a/src/dune-project
+++ b/src/dune-project
@@ -122,6 +122,7 @@
 (package (name mina_node_config))
 (package (name mina_numbers))
 (package (name mina_plugins))
+(package (name rosetta_client))
 (package (name mina_runtime_config))
 (package (name mina_signature_kind))
 (package (name mina_snark_worker))

--- a/src/dune-project
+++ b/src/dune-project
@@ -124,6 +124,7 @@
 (package (name mina_node_config))
 (package (name mina_numbers))
 (package (name mina_plugins))
+(package (name rosetta_client))
 (package (name mina_runtime_config))
 (package (name mina_signature_kind))
 (package (name mina_snark_worker))

--- a/src/lib/rosetta_client/config.ml
+++ b/src/lib/rosetta_client/config.ml
@@ -1,0 +1,48 @@
+(* Embedded rosetta-cli config files.  See [config.mli]. *)
+
+open Core_kernel
+
+type file =
+  [ `Config | `Mina_ros | `Mina_no_delegation_ros | `Mina_with_return_funds_ros ]
+
+let filename = function
+  | `Config ->
+      "config.json"
+  | `Mina_ros ->
+      "mina.ros"
+  | `Mina_no_delegation_ros ->
+      "mina-no-delegation-test.ros"
+  | `Mina_with_return_funds_ros ->
+      "mina-with-return-funds.ros"
+
+let contents = function
+  | `Config ->
+      Embedded_configs.config_json
+  | `Mina_ros ->
+      Embedded_configs.mina_ros
+  | `Mina_no_delegation_ros ->
+      Embedded_configs.mina_no_delegation_test_ros
+  | `Mina_with_return_funds_ros ->
+      Embedded_configs.mina_with_return_funds_ros
+
+let files : file list =
+  [ `Config; `Mina_ros; `Mina_no_delegation_ros; `Mina_with_return_funds_ros ]
+
+let all = List.map files ~f:(fun f -> (f, filename f, contents f))
+
+let find_by_name name =
+  List.find files ~f:(fun f -> String.equal (filename f) name)
+
+let names () = String.concat ~sep:", " (List.map files ~f:filename)
+
+let export_to_dir ~dir =
+  Or_error.try_with (fun () ->
+      if not (try Core.Sys.is_directory_exn dir with _ -> false) then
+        Core.Unix.mkdir_p dir ;
+      let abs =
+        match Core.Filename.realpath dir with p -> p | exception _ -> dir
+      in
+      List.map files ~f:(fun f ->
+          let path = Filename.concat abs (filename f) in
+          Out_channel.write_all path ~data:(contents f) ;
+          path ) )

--- a/src/lib/rosetta_client/config.mli
+++ b/src/lib/rosetta_client/config.mli
@@ -1,0 +1,36 @@
+(** Access to the embedded rosetta-cli config files.
+
+    The four files under [src/app/rosetta/rosetta-cli-config/] are
+    baked into the binary at compile time so neither
+    [rosetta-client] nor [rosetta-healthcheck] depend on an
+    installed filesystem path. *)
+
+(** Logical identifier for an embedded file. *)
+type file =
+  [ `Config  (** config.json *)
+  | `Mina_ros  (** mina.ros *)
+  | `Mina_no_delegation_ros  (** mina-no-delegation-test.ros *)
+  | `Mina_with_return_funds_ros  (** mina-with-return-funds.ros *) ]
+
+(** Canonical filename for a logical identifier. *)
+val filename : file -> string
+
+(** Contents of the embedded file corresponding to the given logical
+    identifier. *)
+val contents : file -> string
+
+(** All embedded files as [(logical_id, filename, contents)] triples. *)
+val all : (file * string * string) list
+
+(** [find_by_name n] locates an embedded file by its canonical filename
+    (e.g. ["config.json"]). *)
+val find_by_name : string -> file option
+
+(** [names ()] returns a comma-separated listing of the canonical
+    filenames of embedded files. *)
+val names : unit -> string
+
+(** [export_to_dir ~dir] writes every embedded file into [dir]. Creates
+    the directory if absent.  Returns the list of written absolute
+    paths on success. *)
+val export_to_dir : dir:string -> string list Core_kernel.Or_error.t

--- a/src/lib/rosetta_client/construction.ml
+++ b/src/lib/rosetta_client/construction.ml
@@ -1,0 +1,54 @@
+(* Rosetta Construction API wrappers.  See [construction.mli]. *)
+
+let with_ni t pairs =
+  `Assoc (("network_identifier", Http.network_identifier t) :: pairs)
+
+let opt_field name = function None -> [] | Some v -> [ (name, v) ]
+
+let derive t ~public_key ?metadata () =
+  Http.post_json t ~path:"/construction/derive"
+    ~body:
+      (with_ni t
+         ([ ("public_key", public_key) ] @ opt_field "metadata" metadata) )
+
+let preprocess t ~operations ?metadata () =
+  Http.post_json t ~path:"/construction/preprocess"
+    ~body:
+      (with_ni t
+         ([ ("operations", operations) ] @ opt_field "metadata" metadata) )
+
+let metadata t ~options ?public_keys () =
+  Http.post_json t ~path:"/construction/metadata"
+    ~body:
+      (with_ni t
+         ([ ("options", options) ] @ opt_field "public_keys" public_keys) )
+
+let payloads t ~operations ?metadata ?public_keys () =
+  Http.post_json t ~path:"/construction/payloads"
+    ~body:
+      (with_ni t
+         ( [ ("operations", operations) ]
+         @ opt_field "metadata" metadata
+         @ opt_field "public_keys" public_keys ) )
+
+let parse t ~signed ~transaction =
+  Http.post_json t ~path:"/construction/parse"
+    ~body:
+      (with_ni t
+         [ ("signed", `Bool signed); ("transaction", `String transaction) ] )
+
+let combine t ~unsigned_transaction ~signatures =
+  Http.post_json t ~path:"/construction/combine"
+    ~body:
+      (with_ni t
+         [ ("unsigned_transaction", `String unsigned_transaction)
+         ; ("signatures", signatures)
+         ] )
+
+let hash t ~signed_transaction =
+  Http.post_json t ~path:"/construction/hash"
+    ~body:(with_ni t [ ("signed_transaction", `String signed_transaction) ])
+
+let submit t ~signed_transaction =
+  Http.post_json t ~path:"/construction/submit"
+    ~body:(with_ni t [ ("signed_transaction", `String signed_transaction) ])

--- a/src/lib/rosetta_client/construction.ml
+++ b/src/lib/rosetta_client/construction.ml
@@ -1,0 +1,87 @@
+(* Rosetta Construction API wrappers.  See [construction.mli].
+
+   As in [Data], each request is the generated Rosetta request model for
+   the endpoint, serialised with its own [to_yojson]. *)
+
+module RM = Rosetta_models
+
+let derive t ~public_key ?metadata () =
+  let request =
+    { RM.Construction_derive_request.network_identifier =
+        Http.network_identifier t
+    ; public_key
+    ; metadata
+    }
+  in
+  Http.post_json t ~path:"/construction/derive"
+    ~body:(RM.Construction_derive_request.to_yojson request)
+
+let preprocess t ~operations ?metadata () =
+  let request =
+    { RM.Construction_preprocess_request.network_identifier =
+        Http.network_identifier t
+    ; operations
+    ; metadata
+    }
+  in
+  Http.post_json t ~path:"/construction/preprocess"
+    ~body:(RM.Construction_preprocess_request.to_yojson request)
+
+let metadata t ?options ?(public_keys = []) () =
+  let request =
+    { RM.Construction_metadata_request.network_identifier =
+        Http.network_identifier t
+    ; options
+    ; public_keys
+    }
+  in
+  Http.post_json t ~path:"/construction/metadata"
+    ~body:(RM.Construction_metadata_request.to_yojson request)
+
+let payloads t ~operations ?metadata ?(public_keys = []) () =
+  let request =
+    { RM.Construction_payloads_request.network_identifier =
+        Http.network_identifier t
+    ; operations
+    ; metadata
+    ; public_keys
+    }
+  in
+  Http.post_json t ~path:"/construction/payloads"
+    ~body:(RM.Construction_payloads_request.to_yojson request)
+
+let parse t ~signed ~transaction =
+  let request =
+    RM.Construction_parse_request.create
+      (Http.network_identifier t)
+      signed transaction
+  in
+  Http.post_json t ~path:"/construction/parse"
+    ~body:(RM.Construction_parse_request.to_yojson request)
+
+let combine t ~unsigned_transaction ~signatures =
+  let request =
+    RM.Construction_combine_request.create
+      (Http.network_identifier t)
+      unsigned_transaction signatures
+  in
+  Http.post_json t ~path:"/construction/combine"
+    ~body:(RM.Construction_combine_request.to_yojson request)
+
+let hash t ~signed_transaction =
+  let request =
+    RM.Construction_hash_request.create
+      (Http.network_identifier t)
+      signed_transaction
+  in
+  Http.post_json t ~path:"/construction/hash"
+    ~body:(RM.Construction_hash_request.to_yojson request)
+
+let submit t ~signed_transaction =
+  let request =
+    RM.Construction_submit_request.create
+      (Http.network_identifier t)
+      signed_transaction
+  in
+  Http.post_json t ~path:"/construction/submit"
+    ~body:(RM.Construction_submit_request.to_yojson request)

--- a/src/lib/rosetta_client/construction.mli
+++ b/src/lib/rosetta_client/construction.mli
@@ -1,0 +1,52 @@
+(** Rosetta Construction API wrappers.
+
+    Every function POSTs the given payload (with [network_identifier]
+    injected automatically) to the corresponding endpoint and returns
+    the decoded response. *)
+
+val derive :
+     Http.t
+  -> public_key:Yojson.Safe.t
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val preprocess :
+     Http.t
+  -> operations:Yojson.Safe.t
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val metadata :
+     Http.t
+  -> options:Yojson.Safe.t
+  -> ?public_keys:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val payloads :
+     Http.t
+  -> operations:Yojson.Safe.t
+  -> ?metadata:Yojson.Safe.t
+  -> ?public_keys:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val parse :
+     Http.t
+  -> signed:bool
+  -> transaction:string
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val combine :
+     Http.t
+  -> unsigned_transaction:string
+  -> signatures:Yojson.Safe.t
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val hash :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val submit :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/construction.mli
+++ b/src/lib/rosetta_client/construction.mli
@@ -1,0 +1,58 @@
+(** Rosetta Construction API wrappers.
+
+    Every function builds the generated Rosetta request model for its
+    endpoint (with [network_identifier] injected automatically), POSTs
+    it, and returns the decoded response.  Arguments are the typed
+    models rather than raw JSON, so a malformed payload is rejected
+    while it is still being decoded from the caller's input instead of
+    by the server.
+
+    [metadata] and [options] stay [Yojson.Safe.t] because the Rosetta
+    schema itself leaves those two fields free-form. *)
+
+val derive :
+     Http.t
+  -> public_key:Rosetta_models.Public_key.t
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val preprocess :
+     Http.t
+  -> operations:Rosetta_models.Operation.t list
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val metadata :
+     Http.t
+  -> ?options:Yojson.Safe.t
+  -> ?public_keys:Rosetta_models.Public_key.t list
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val payloads :
+     Http.t
+  -> operations:Rosetta_models.Operation.t list
+  -> ?metadata:Yojson.Safe.t
+  -> ?public_keys:Rosetta_models.Public_key.t list
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val parse :
+     Http.t
+  -> signed:bool
+  -> transaction:string
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val combine :
+     Http.t
+  -> unsigned_transaction:string
+  -> signatures:Rosetta_models.Signature.t list
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val hash :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val submit :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/data.ml
+++ b/src/lib/rosetta_client/data.ml
@@ -1,0 +1,140 @@
+(* Rosetta Data API wrappers.  See [data.mli]. *)
+
+module RM = Rosetta_models
+
+let with_ni t pairs =
+  `Assoc (("network_identifier", Http.network_identifier t) :: pairs)
+
+let decode_response response ~endpoint of_yojson =
+  Async.Deferred.Or_error.bind response ~f:(fun json ->
+      match of_yojson json with
+      | Ok response ->
+          Async.Deferred.Or_error.return response
+      | Error msg ->
+          Async.Deferred.Or_error.errorf
+            "%s response did not match Rosetta schema: %s" endpoint msg )
+
+let network_list t =
+  Http.post_json t ~path:"/network/list"
+    ~body:(`Assoc [ ("metadata", `Assoc []) ])
+
+let network_list_response t =
+  decode_response (network_list t) ~endpoint:"/network/list"
+    RM.Network_list_response.of_yojson
+
+let network_status t =
+  Http.post_json t ~path:"/network/status"
+    ~body:(with_ni t [ ("metadata", `Assoc []) ])
+
+let network_status_response t =
+  decode_response (network_status t) ~endpoint:"/network/status"
+    RM.Network_status_response.of_yojson
+
+let network_options t =
+  Http.post_json t ~path:"/network/options"
+    ~body:(with_ni t [ ("metadata", `Assoc []) ])
+
+let network_options_response t =
+  decode_response (network_options t) ~endpoint:"/network/options"
+    RM.Network_options_response.of_yojson
+
+let block t ?index ?hash () =
+  let id =
+    match (index, hash) with
+    | None, None ->
+        `Assoc []
+    | Some i, None ->
+        `Assoc [ ("index", `Int i) ]
+    | None, Some h ->
+        `Assoc [ ("hash", `String h) ]
+    | Some i, Some h ->
+        `Assoc [ ("index", `Int i); ("hash", `String h) ]
+  in
+  Http.post_json t ~path:"/block" ~body:(with_ni t [ ("block_identifier", id) ])
+
+let account_balance t ~address ?token_id ?block_index () =
+  let account_identifier =
+    match token_id with
+    | Some tid ->
+        `Assoc
+          [ ("address", `String address)
+          ; ("metadata", `Assoc [ ("token_id", `String tid) ])
+          ]
+    | None ->
+        `Assoc [ ("address", `String address) ]
+  in
+  let base = [ ("account_identifier", account_identifier) ] in
+  let with_block =
+    match block_index with
+    | None ->
+        base
+    | Some i ->
+        base @ [ ("block_identifier", `Assoc [ ("index", `Int i) ]) ]
+  in
+  Http.post_json t ~path:"/account/balance" ~body:(with_ni t with_block)
+
+let account_coins t ~address ?(include_mempool = false) () =
+  Http.post_json t ~path:"/account/coins"
+    ~body:
+      (with_ni t
+         [ ("account_identifier", `Assoc [ ("address", `String address) ])
+         ; ("include_mempool", `Bool include_mempool)
+         ] )
+
+let mempool t = Http.post_json t ~path:"/mempool" ~body:(with_ni t [])
+
+let mempool_transaction t ~tx_hash =
+  Http.post_json t ~path:"/mempool/transaction"
+    ~body:
+      (with_ni t
+         [ ("transaction_identifier", `Assoc [ ("hash", `String tx_hash) ]) ] )
+
+let search_transactions_body t ?address ?tx_hash ?limit () =
+  let fields = ref [] in
+  ( match address with
+  | None ->
+      ()
+  | Some a ->
+      fields := ("address", `String a) :: !fields ) ;
+  ( match tx_hash with
+  | None ->
+      ()
+  | Some h ->
+      fields :=
+        ("transaction_identifier", `Assoc [ ("hash", `String h) ]) :: !fields ) ;
+  ( match limit with
+  | None ->
+      ()
+  | Some n ->
+      fields := ("limit", `Int n) :: !fields ) ;
+  with_ni t !fields
+
+let%test_unit "search_transactions uses top-level address filter" =
+  let client = Http.create ~base_uri:(Uri.of_string "http://localhost") () in
+  let rec find_field key = function
+    | [] ->
+        None
+    | (k, v) :: rest ->
+        if String.equal k key then Some v else find_field key rest
+  in
+  match search_transactions_body client ~address:"B62qaddress" () with
+  | `Assoc fields -> (
+      match find_field "address" fields with
+      | Some (`String "B62qaddress") -> (
+          match find_field "account_identifier" fields with
+          | None ->
+              ()
+          | Some _ ->
+              failwith "address-only search should not emit account_identifier"
+          )
+      | Some other ->
+          failwith
+            ("unexpected address filter: " ^ Yojson.Safe.to_string other)
+      | None ->
+          failwith "missing top-level address filter" )
+  | _ ->
+      failwith "search_transactions_body did not return an object"
+
+let search_transactions t ?address ?tx_hash ?limit () =
+  Http.post_json t ~path:"/search/transactions"
+    ~body:(search_transactions_body t ?address ?tx_hash ?limit ())

--- a/src/lib/rosetta_client/data.ml
+++ b/src/lib/rosetta_client/data.ml
@@ -1,0 +1,131 @@
+(* Rosetta Data API wrappers.  See [data.mli].
+
+   Every request is built as the generated Rosetta request model for the
+   endpoint and serialised with its own [to_yojson], so the field names,
+   the required/optional split and the nesting all come from the schema
+   rather than from hand-written JSON objects. *)
+
+open Core_kernel
+module RM = Rosetta_models
+
+(* A Mina token id travels in [account_identifier.metadata], which the
+   Rosetta schema leaves free-form.  Give the one shape we send a type
+   of its own so the endpoint wrappers below never assemble JSON. *)
+module Token_metadata = struct
+  type t = { token_id : string } [@@deriving to_yojson]
+end
+
+let account_identifier ?token_id address =
+  { RM.Account_identifier.address
+  ; sub_account = None
+  ; metadata =
+      Option.map token_id ~f:(fun token_id ->
+          Token_metadata.to_yojson { Token_metadata.token_id } )
+  }
+
+let partial_block_identifier ?index ?hash () =
+  { RM.Partial_block_identifier.index = Option.map index ~f:Int64.of_int; hash }
+
+let decode_response response ~endpoint of_yojson =
+  Async.Deferred.Or_error.bind response ~f:(fun json ->
+      match of_yojson json with
+      | Ok response ->
+          Async.Deferred.Or_error.return response
+      | Error msg ->
+          Async.Deferred.Or_error.errorf
+            "%s response did not match Rosetta schema: %s" endpoint msg )
+
+(* A request whose only content is the network_identifier: /network/status,
+   /network/options and /mempool all take this shape. *)
+let network_request t =
+  RM.Network_request.to_yojson
+    (RM.Network_request.create (Http.network_identifier t))
+
+let network_list t =
+  Http.post_json t ~path:"/network/list"
+    ~body:(RM.Metadata_request.to_yojson (RM.Metadata_request.create ()))
+
+let network_list_response t =
+  decode_response (network_list t) ~endpoint:"/network/list"
+    RM.Network_list_response.of_yojson
+
+let network_status t =
+  Http.post_json t ~path:"/network/status" ~body:(network_request t)
+
+let network_status_response t =
+  decode_response (network_status t) ~endpoint:"/network/status"
+    RM.Network_status_response.of_yojson
+
+let network_options t =
+  Http.post_json t ~path:"/network/options" ~body:(network_request t)
+
+let network_options_response t =
+  decode_response (network_options t) ~endpoint:"/network/options"
+    RM.Network_options_response.of_yojson
+
+let block t ?index ?hash () =
+  let request =
+    RM.Block_request.create
+      (Http.network_identifier t)
+      (partial_block_identifier ?index ?hash ())
+  in
+  Http.post_json t ~path:"/block" ~body:(RM.Block_request.to_yojson request)
+
+let account_balance t ~address ?token_id ?block_index () =
+  let request =
+    { RM.Account_balance_request.network_identifier = Http.network_identifier t
+    ; account_identifier = account_identifier ?token_id address
+    ; block_identifier =
+        Option.map block_index ~f:(fun index ->
+            partial_block_identifier ~index () )
+    ; currencies = []
+    }
+  in
+  Http.post_json t ~path:"/account/balance"
+    ~body:(RM.Account_balance_request.to_yojson request)
+
+let account_coins t ~address ?(include_mempool = false) () =
+  let request =
+    RM.Account_coins_request.create
+      (Http.network_identifier t)
+      (account_identifier address)
+      include_mempool
+  in
+  Http.post_json t ~path:"/account/coins"
+    ~body:(RM.Account_coins_request.to_yojson request)
+
+let mempool t = Http.post_json t ~path:"/mempool" ~body:(network_request t)
+
+let mempool_transaction t ~tx_hash =
+  let request =
+    RM.Mempool_transaction_request.create
+      (Http.network_identifier t)
+      (RM.Transaction_identifier.create tx_hash)
+  in
+  Http.post_json t ~path:"/mempool/transaction"
+    ~body:(RM.Mempool_transaction_request.to_yojson request)
+
+let search_transactions_request t ?address ?tx_hash ?limit () =
+  { (RM.Search_transactions_request.create (Http.network_identifier t)) with
+    RM.Search_transactions_request.address
+  ; transaction_identifier =
+      Option.map tx_hash ~f:RM.Transaction_identifier.create
+  ; limit = Option.map limit ~f:Int64.of_int
+  }
+
+(* [address] is the top-level filter that matches an account regardless
+   of its sub-account; [account_identifier] would additionally require
+   the sub-account to match, so an address-only search must not set it. *)
+let%test_unit "search_transactions uses the top-level address filter" =
+  let client = Http.create ~base_uri:(Uri.of_string "http://localhost") () in
+  let request = search_transactions_request client ~address:"B62qaddress" () in
+  [%test_eq: string option] request.RM.Search_transactions_request.address
+    (Some "B62qaddress") ;
+  if Option.is_some request.RM.Search_transactions_request.account_identifier
+  then failwith "address-only search should not emit account_identifier"
+
+let search_transactions t ?address ?tx_hash ?limit () =
+  Http.post_json t ~path:"/search/transactions"
+    ~body:
+      (RM.Search_transactions_request.to_yojson
+         (search_transactions_request t ?address ?tx_hash ?limit ()) )

--- a/src/lib/rosetta_client/data.mli
+++ b/src/lib/rosetta_client/data.mli
@@ -1,0 +1,59 @@
+(** Rosetta Data API: read-only endpoints.
+
+    The raw endpoint functions POST to the appropriate path and return
+    the decoded response as a [Yojson.Safe.t].  The client's
+    [network_identifier] is injected automatically; callers pass in only
+    the endpoint-specific payload.
+
+    The [*_response] helpers decode selected endpoint responses through
+    the generated Rosetta model Yojson bindings. *)
+
+val network_list : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_list_response :
+  Http.t -> Rosetta_models.Network_list_response.t Async.Deferred.Or_error.t
+
+val network_status : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_status_response :
+  Http.t -> Rosetta_models.Network_status_response.t Async.Deferred.Or_error.t
+
+val network_options : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_options_response :
+  Http.t -> Rosetta_models.Network_options_response.t Async.Deferred.Or_error.t
+
+val block :
+     Http.t
+  -> ?index:int
+  -> ?hash:string
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val account_balance :
+     Http.t
+  -> address:string
+  -> ?token_id:string
+  -> ?block_index:int
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val account_coins :
+     Http.t
+  -> address:string
+  -> ?include_mempool:bool
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val mempool : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val mempool_transaction :
+  Http.t -> tx_hash:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val search_transactions :
+     Http.t
+  -> ?address:string
+  -> ?tx_hash:string
+  -> ?limit:int
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/defaults.ml
+++ b/src/lib/rosetta_client/defaults.ml
@@ -1,0 +1,51 @@
+(* Fallback values and environment-variable names shared by every
+   Rosetta CLI.  See [defaults.mli]. *)
+
+open Core_kernel
+
+let uri_env_var = "MINA_ROSETTA_URI"
+
+let blockchain_env_var = "MINA_ROSETTA_BLOCKCHAIN"
+
+let network_env_var = "MINA_ROSETTA_NETWORK"
+
+let base_uri = "http://localhost:3087"
+
+let blockchain = "mina"
+
+let network = "testnet"
+
+(* Seconds allowed for one request/response exchange with the Rosetta
+   server, measured from sending the request to reading the last byte of
+   the response body. *)
+let http_timeout = 5.0
+
+(* A variable that is declared but blank -- [MINA_ROSETTA_URI=], or a
+   Kubernetes [env:] entry with an empty [value:] -- means "not
+   configured", not "configure this to the empty string".  Taking it
+   literally would build a request against an empty base URI, or send an
+   empty network_identifier.network that every server rejects. *)
+let env_value value ~default =
+  match value with
+  | Some value when not (String.is_empty (String.strip value)) ->
+      value
+  | _ ->
+      default
+
+let%test_unit "a blank environment variable falls back to the default" =
+  let check value = [%test_eq: string] (env_value value ~default:"d") "d" in
+  check None ;
+  check (Some "") ;
+  check (Some "   ") ;
+  [%test_eq: string] (env_value (Some "v") ~default:"d") "v"
+
+(* [Stdlib.Sys] rather than [Core_kernel.Sys]: the latter's [getenv]
+   raises on an unset variable, and an unset variable is the normal case
+   here. *)
+let from_env var ~default = env_value (Stdlib.Sys.getenv_opt var) ~default
+
+let base_uri_from_env () = from_env uri_env_var ~default:base_uri
+
+let blockchain_from_env () = from_env blockchain_env_var ~default:blockchain
+
+let network_from_env () = from_env network_env_var ~default:network

--- a/src/lib/rosetta_client/defaults.mli
+++ b/src/lib/rosetta_client/defaults.mli
@@ -1,0 +1,53 @@
+(** Fallback values shared by every Rosetta CLI.
+
+    Both [rosetta-client] and [rosetta-healthcheck] connect to the same
+    server with the same network_identifier, so the values they fall back
+    to when a flag is omitted are defined once, here, rather than once per
+    binary.  {!Http.create} uses the same values as its optional-argument
+    defaults.
+
+    Each value has an environment-variable override, so an operator who
+    always talks to the same server can export it once instead of
+    repeating flags on every invocation.  A flag, when given, always wins
+    over the environment variable.
+
+    {ul
+    {- [MINA_ROSETTA_URI] — base URL of the Rosetta server.}
+    {- [MINA_ROSETTA_BLOCKCHAIN] — [network_identifier.blockchain].}
+    {- [MINA_ROSETTA_NETWORK] — [network_identifier.network].}} *)
+
+(** Name of the environment variable that overrides {!base_uri}. *)
+val uri_env_var : string
+
+(** Name of the environment variable that overrides {!blockchain}. *)
+val blockchain_env_var : string
+
+(** Name of the environment variable that overrides {!network}. *)
+val network_env_var : string
+
+(** Base URL of a Rosetta server running next to the daemon
+    ([http://localhost:3087]). *)
+val base_uri : string
+
+(** [network_identifier.blockchain] for every Mina network ([mina]). *)
+val blockchain : string
+
+(** [network_identifier.network] ([testnet]). *)
+val network : string
+
+(** Seconds allowed for one request/response exchange with the Rosetta
+    server, from sending the request to reading the last byte of the
+    response body. *)
+val http_timeout : float
+
+(** [base_uri_from_env ()] is [$MINA_ROSETTA_URI] when that variable is
+    set, and {!base_uri} otherwise. *)
+val base_uri_from_env : unit -> string
+
+(** [blockchain_from_env ()] is [$MINA_ROSETTA_BLOCKCHAIN] when that
+    variable is set, and {!blockchain} otherwise. *)
+val blockchain_from_env : unit -> string
+
+(** [network_from_env ()] is [$MINA_ROSETTA_NETWORK] when that variable
+    is set, and {!network} otherwise. *)
+val network_from_env : unit -> string

--- a/src/lib/rosetta_client/dune
+++ b/src/lib/rosetta_client/dune
@@ -1,0 +1,69 @@
+(library
+ (name rosetta_client)
+ (public_name rosetta_client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  async
+  cohttp
+  cohttp-async
+  uri
+  yojson
+  ;; local libraries
+  rosetta_models)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here ppx_inline_test ppx_assert)))
+
+;; Embed the four rosetta-cli config files as string constants so the
+;; [Config] module can expose them without relying on an installed
+;; filesystem path.  We concatenate the files into a generated
+;; [embedded_configs.ml] using raw-string literals with the fixed
+;; delimiter [rosetta].  The runtest rule below guards against any
+;; future config change that would collide with this delimiter.
+
+(rule
+ (targets embedded_configs.ml)
+ (deps
+  (:cfg ../../app/rosetta/rosetta-cli-config/config.json)
+  (:mros ../../app/rosetta/rosetta-cli-config/mina.ros)
+  (:nodel ../../app/rosetta/rosetta-cli-config/mina-no-delegation-test.ros)
+  (:retfn ../../app/rosetta/rosetta-cli-config/mina-with-return-funds.ros))
+ (action
+  (with-stdout-to
+   %{targets}
+   (progn
+    (echo
+     "(* Auto-generated from src/app/rosetta/rosetta-cli-config/. Do not edit. *)\n\n")
+    (echo "let config_json = {rosetta|")
+    (cat %{cfg})
+    (echo "|rosetta}\n\n")
+    (echo "let mina_ros = {rosetta|")
+    (cat %{mros})
+    (echo "|rosetta}\n\n")
+    (echo "let mina_no_delegation_test_ros = {rosetta|")
+    (cat %{nodel})
+    (echo "|rosetta}\n\n")
+    (echo "let mina_with_return_funds_ros = {rosetta|")
+    (cat %{retfn})
+    (echo "|rosetta}\n")))))
+
+;; Collision guard: the raw-string delimiter above is fixed at
+;; [rosetta].  Fail loudly on [dune runtest] if any of the embedded
+;; files ever grows a literal "|rosetta}" that would terminate the
+;; raw-string literal prematurely.
+
+(rule
+ (alias runtest)
+ (deps
+  (:cfg ../../app/rosetta/rosetta-cli-config/config.json)
+  (:mros ../../app/rosetta/rosetta-cli-config/mina.ros)
+  (:nodel ../../app/rosetta/rosetta-cli-config/mina-no-delegation-test.ros)
+  (:retfn ../../app/rosetta/rosetta-cli-config/mina-with-return-funds.ros))
+ (action
+  (bash
+   "for f in %{cfg} %{mros} %{nodel} %{retfn}; do if grep -q '|rosetta}' \"$f\"; then echo \"ERROR: $f contains the raw-string delimiter |rosetta} used by embedded_configs.ml. Change the delimiter in dune.\" >&2; exit 1; fi; done")))

--- a/src/lib/rosetta_client/dune
+++ b/src/lib/rosetta_client/dune
@@ -1,0 +1,27 @@
+(library
+ (name rosetta_client)
+ (public_name rosetta_client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  async
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_models)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps
+   ppx_version
+   ppx_let
+   ppx_here
+   ppx_inline_test
+   ppx_assert
+   ppx_deriving_yojson)))

--- a/src/lib/rosetta_client/errors.ml
+++ b/src/lib/rosetta_client/errors.ml
@@ -1,0 +1,103 @@
+(* Rosetta error-envelope and transport-exception formatting.  See
+   [errors.mli] for contract.  The goal is to produce one-line human
+   messages that are safe to splat into a [{"error": "..."}] JSON field:
+   no raw OCaml exception syntax, no giant HTTP bodies. *)
+
+open Core_kernel
+
+(* Use [Core.Unix] for the [Unix.Unix_error] constructor (Core_kernel
+   shadows Unix).  Aliased locally so the pattern-match syntax stays
+   natural. *)
+module Unix = Core.Unix
+
+let max_body_chars = 500
+
+let truncate s =
+  if String.length s <= max_body_chars then s
+  else String.sub s ~pos:0 ~len:max_body_chars ^ "... (truncated)"
+
+let try_parse_envelope body =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string body) with
+  | Error _ ->
+      None
+  | Ok (`Assoc fields) ->
+      List.Assoc.find fields ~equal:String.equal "message"
+      |> Option.bind ~f:(function `String s -> Some s | _ -> None)
+  | Ok _ ->
+      None
+
+let format_http_body ~status ~body =
+  match try_parse_envelope body with
+  | Some msg ->
+      sprintf "HTTP %d: %s" status msg
+  | None ->
+      if String.is_empty (String.strip body) then sprintf "HTTP %d" status
+      else sprintf "HTTP %d: %s" status (truncate body)
+
+let format_exn ~url exn =
+  let url_s = Uri.to_string url in
+  match exn with
+  | Unix.Unix_error (Unix.ECONNREFUSED, _, _) ->
+      sprintf "connection refused to %s" url_s
+  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) ->
+      sprintf "timeout connecting to %s" url_s
+  | Unix.Unix_error (Unix.ENETUNREACH, _, _) ->
+      sprintf "network unreachable to %s" url_s
+  | Unix.Unix_error (Unix.EHOSTUNREACH, _, _) ->
+      sprintf "host unreachable to %s" url_s
+  | Unix.Unix_error (Unix.ECONNRESET, _, _) ->
+      sprintf "connection reset by %s" url_s
+  | Unix.Unix_error (err, _, _) ->
+      sprintf "request to %s failed: %s" url_s (Unix.Error.message err)
+  | Failure m ->
+      sprintf "request to %s failed: %s" url_s m
+  | _ ->
+      (* Last-resort fallback for exceptions we haven't pattern-matched
+         above. Keep the message generic so user-visible output never
+         leaks raw OCaml exception constructor syntax. *)
+      sprintf "request to %s failed" url_s
+
+let%test_unit "format_http_body parses Rosetta envelope" =
+  let body =
+    {|{"code":4,"message":"Network doesn't exist","details":{"x":1}}|}
+  in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Network doesn't exist"
+
+let%test_unit "format_http_body falls back to truncated body on non-envelope" =
+  let body = "Internal Server Error" in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Internal Server Error"
+
+let%test_unit "format_http_body truncates very long bodies" =
+  let body = String.make (max_body_chars + 100) 'x' in
+  let rendered = format_http_body ~status:502 ~body in
+  [%test_pred: string] (String.is_substring ~substring:"truncated") rendered
+
+let%test_unit "format_http_body handles empty body" =
+  [%test_eq: string] (format_http_body ~status:504 ~body:"") "HTTP 504"
+
+let%test_unit "format_exn ECONNREFUSED is readable" =
+  let url = Uri.of_string "http://localhost:9999" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "127.0.0.1:9999") in
+  [%test_eq: string] (format_exn ~url exn)
+    "connection refused to http://localhost:9999"
+
+let%test_unit "format_exn never leaks OCaml Unix_error syntax" =
+  let url = Uri.of_string "http://example.invalid" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "x") in
+  let s = format_exn ~url exn in
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix_error"))
+    s ;
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix."))
+    s
+
+let%test_unit "format_exn handles ETIMEDOUT" =
+  let url = Uri.of_string "http://slow.example" in
+  let exn = Unix.Unix_error (Unix.ETIMEDOUT, "connect", "x") in
+  [%test_eq: string] (format_exn ~url exn)
+    "timeout connecting to http://slow.example"

--- a/src/lib/rosetta_client/errors.ml
+++ b/src/lib/rosetta_client/errors.ml
@@ -1,0 +1,142 @@
+(* Rosetta error-envelope and transport-exception formatting.  See
+   [errors.mli] for contract.  The goal is to produce one-line human
+   messages that are safe to splat into a [{"error": "..."}] JSON field:
+   no raw OCaml exception syntax, no giant HTTP bodies. *)
+
+open Core_kernel
+
+(* Use [Core.Unix] for the [Unix.Unix_error] constructor (Core_kernel
+   shadows Unix).  Aliased locally so the pattern-match syntax stays
+   natural. *)
+module Unix = Core.Unix
+
+let max_body_chars = 500
+
+(* Collapse every run of whitespace, newlines included, into one space.
+   A reverse proxy answers with a multi-line HTML page, and [errors.mli]
+   promises a message that is safe to put on one log line or in a JSON
+   [error] field. *)
+let single_line s =
+  String.split_on_chars s ~on:[ ' '; '\t'; '\n'; '\r' ]
+  |> List.filter ~f:(fun part -> not (String.is_empty part))
+  |> String.concat ~sep:" "
+
+let truncate s =
+  let s = single_line s in
+  if String.length s <= max_body_chars then s
+  else String.sub s ~pos:0 ~len:max_body_chars ^ "... (truncated)"
+
+(* The [message] of a Rosetta error envelope
+   ({"code":_,"message":_,"retriable":_,...}).  We decode only that one
+   field, and tolerate an envelope that omits the other required fields,
+   because the sole purpose here is to recover a readable message from
+   whatever the server sent -- a strict decode would throw the message
+   away over an unrelated missing field. *)
+module Envelope = struct
+  type t = { message : string } [@@deriving of_yojson { strict = false }]
+end
+
+let try_parse_envelope body =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string body) with
+  | Error _ ->
+      None
+  | Ok json -> (
+      match Envelope.of_yojson json with
+      | Ok envelope ->
+          Some envelope.Envelope.message
+      | Error _ ->
+          None )
+
+let format_http_body ~status ~body =
+  match try_parse_envelope body with
+  | Some msg ->
+      (* [truncate], not just [single_line]: Mina's Rosetta propagates
+         Postgres and GraphQL errors into [message], so the envelope can
+         carry as much text as a raw body. *)
+      sprintf "HTTP %d: %s" status (truncate msg)
+  | None ->
+      if String.is_empty (String.strip body) then sprintf "HTTP %d" status
+      else sprintf "HTTP %d: %s" status (truncate body)
+
+let format_exn ~url exn =
+  let url_s = Uri.to_string url in
+  match exn with
+  | Unix.Unix_error (Unix.ECONNREFUSED, _, _) ->
+      sprintf "connection refused to %s" url_s
+  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) ->
+      sprintf "timeout connecting to %s" url_s
+  | Unix.Unix_error (Unix.ENETUNREACH, _, _) ->
+      sprintf "network unreachable to %s" url_s
+  | Unix.Unix_error (Unix.EHOSTUNREACH, _, _) ->
+      sprintf "host unreachable to %s" url_s
+  | Unix.Unix_error (Unix.ECONNRESET, _, _) ->
+      sprintf "connection reset by %s" url_s
+  | Unix.Unix_error (err, _, _) ->
+      sprintf "request to %s failed: %s" url_s (Unix.Error.message err)
+  | Failure m ->
+      sprintf "request to %s failed: %s" url_s m
+  | _ ->
+      (* Last-resort fallback for exceptions we haven't pattern-matched
+         above. Keep the message generic so user-visible output never
+         leaks raw OCaml exception constructor syntax. *)
+      sprintf "request to %s failed" url_s
+
+let%test_unit "format_http_body parses Rosetta envelope" =
+  let body =
+    {|{"code":4,"message":"Network doesn't exist","details":{"x":1}}|}
+  in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Network doesn't exist"
+
+let%test_unit "format_http_body falls back to truncated body on non-envelope" =
+  let body = "Internal Server Error" in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Internal Server Error"
+
+let%test_unit "format_http_body truncates very long bodies" =
+  let body = String.make (max_body_chars + 100) 'x' in
+  let rendered = format_http_body ~status:502 ~body in
+  [%test_pred: string] (String.is_substring ~substring:"truncated") rendered
+
+let%test_unit "format_http_body truncates a long envelope message" =
+  let message = String.make (max_body_chars + 100) 'x' in
+  let body = Yojson.Safe.to_string (`Assoc [ ("message", `String message) ]) in
+  [%test_pred: string]
+    (String.is_substring ~substring:"truncated")
+    (format_http_body ~status:500 ~body)
+
+let%test_unit "format_http_body renders a multi-line body on one line" =
+  let body = "<html>\n<head><title>502 Bad Gateway</title></head>\n</html>" in
+  let rendered = format_http_body ~status:502 ~body in
+  [%test_pred: string] (fun s -> not (String.contains s '\n')) rendered ;
+  [%test_pred: string]
+    (String.is_substring ~substring:"502 Bad Gateway")
+    rendered
+
+let%test_unit "format_http_body handles empty body" =
+  [%test_eq: string] (format_http_body ~status:504 ~body:"") "HTTP 504"
+
+let%test_unit "format_exn ECONNREFUSED is readable" =
+  let url = Uri.of_string "http://localhost:9999" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "127.0.0.1:9999") in
+  [%test_eq: string] (format_exn ~url exn)
+    "connection refused to http://localhost:9999"
+
+let%test_unit "format_exn never leaks OCaml Unix_error syntax" =
+  let url = Uri.of_string "http://example.invalid" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "x") in
+  let s = format_exn ~url exn in
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix_error"))
+    s ;
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix."))
+    s
+
+let%test_unit "format_exn handles ETIMEDOUT" =
+  let url = Uri.of_string "http://slow.example" in
+  let exn = Unix.Unix_error (Unix.ETIMEDOUT, "connect", "x") in
+  [%test_eq: string] (format_exn ~url exn)
+    "timeout connecting to http://slow.example"

--- a/src/lib/rosetta_client/errors.mli
+++ b/src/lib/rosetta_client/errors.mli
@@ -1,0 +1,24 @@
+(** Rosetta-friendly formatting for HTTP errors and transport exceptions.
+
+    These helpers produce short, human-readable strings that are safe to
+    splat into a JSON [error] field or print on stderr.  They MUST NOT
+    leak raw OCaml exception syntax (e.g. [(Unix_error ...)]) or dump
+    multi-kilobyte HTTP bodies verbatim. *)
+
+(** [format_http_body ~status ~body] renders a non-2xx HTTP response as
+    a short diagnostic like ["HTTP 500: Network doesn't exist"]. If
+    [body] is a Rosetta error envelope ({"code":_,"message":_,...}), the
+    [message] field is used; otherwise the body is included truncated to
+    [max_body_chars] characters. *)
+val format_http_body : status:int -> body:string -> string
+
+(** [format_exn ~url e] renders a transport exception (typically from
+    Cohttp_async or Async_unix) as a short diagnostic like
+    ["connection refused to http://localhost:9999"].  No raw OCaml
+    exception syntax leaks through. *)
+val format_exn : url:Uri.t -> exn -> string
+
+(** Character cap used by [format_http_body] when falling back to the
+    raw body.  Exposed so callers can reference the same bound in tests
+    and documentation. *)
+val max_body_chars : int

--- a/src/lib/rosetta_client/http.ml
+++ b/src/lib/rosetta_client/http.ml
@@ -1,0 +1,118 @@
+(* HTTP core for the Rosetta client library.  See [http.mli]. *)
+
+open Core_kernel
+open Async
+
+type t =
+  { base_uri : Uri.t; blockchain : string; network : string; timeout : float }
+
+let default_blockchain = "mina"
+
+let default_network = "testnet"
+
+let default_timeout = 5.0
+
+let create ~base_uri ?(blockchain = default_blockchain)
+    ?(network = default_network) ?(timeout = default_timeout) () =
+  { base_uri; blockchain; network; timeout }
+
+let base_uri t = t.base_uri
+
+let blockchain t = t.blockchain
+
+let network t = t.network
+
+let timeout t = t.timeout
+
+let network_identifier t =
+  `Assoc
+    [ ("blockchain", `String t.blockchain); ("network", `String t.network) ]
+
+let join_uri base path =
+  let s = Uri.to_string base in
+  let s = String.rstrip ~drop:(Char.equal '/') s in
+  let path = String.lstrip ~drop:(Char.equal '/') path in
+  Uri.of_string (s ^ "/" ^ path)
+
+let pretty j = Yojson.Safe.pretty_to_string j
+
+let compact j = Yojson.Safe.to_string j
+
+(* Common envelope for HTTP requests: enforces [t.timeout], folds all
+   transport/decode failures into the error channel, and renders any
+   error via [Errors] so callers never see raw OCaml exception text. *)
+let with_request t ~uri ~make_req ~describe =
+  let req =
+    Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true (fun () ->
+        let%bind response, body_pipe = make_req () in
+        let%map body_str = Cohttp_async.Body.to_string body_pipe in
+        (response, body_str) )
+  in
+  match%bind Async.with_timeout (Time.Span.of_sec t.timeout) req with
+  | `Timeout ->
+      Deferred.Or_error.errorf "timeout after %.1fs: %s %s" t.timeout describe
+        (Uri.to_string uri)
+  | `Result (Error e) ->
+      let msg =
+        match Error.to_exn e with exn -> Errors.format_exn ~url:uri exn
+      in
+      Deferred.Or_error.error_string msg
+  | `Result (Ok (response, body_str)) -> (
+      let status = Cohttp_async.Response.status response in
+      let code = Cohttp.Code.code_of_status status in
+      if code < 200 || code >= 300 then
+        Deferred.Or_error.error_string
+          (Errors.format_http_body ~status:code ~body:body_str)
+      else
+        match
+          Or_error.try_with (fun () -> Yojson.Safe.from_string body_str)
+        with
+        | Ok j ->
+            Deferred.Or_error.return j
+        | Error _ ->
+            Deferred.Or_error.errorf
+              "invalid JSON response from %s (first 200 chars: %s)"
+              (Uri.to_string uri)
+              ( if String.length body_str > 200 then
+                String.sub body_str ~pos:0 ~len:200
+              else body_str ) )
+
+let post_json t ~path ~body =
+  let uri = join_uri t.base_uri path in
+  let headers =
+    Cohttp.Header.of_list
+      [ ("Content-Type", "application/json"); ("Accept", "application/json") ]
+  in
+  let body_str = Yojson.Safe.to_string body in
+  with_request t ~uri ~describe:"POST" ~make_req:(fun () ->
+      Cohttp_async.Client.post ~headers
+        ~body:(Cohttp_async.Body.of_string body_str)
+        uri )
+
+let get_json t ~path =
+  let uri = join_uri t.base_uri path in
+  let headers = Cohttp.Header.of_list [ ("Accept", "application/json") ] in
+  with_request t ~uri ~describe:"GET" ~make_req:(fun () ->
+      Cohttp_async.Client.get ~headers uri )
+
+let%test_unit "with_request times out stalled response body" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let t =
+        create ~base_uri:(Uri.of_string "http://localhost") ~timeout:0.01 ()
+      in
+      let uri = join_uri (base_uri t) "/slow" in
+      let body_reader, _body_writer = Pipe.create () in
+      let response = Cohttp_async.Response.make ~status:`OK () in
+      let body = Cohttp_async.Body.of_pipe body_reader in
+      match%map
+        with_request t ~uri ~describe:"GET" ~make_req:(fun () ->
+            Deferred.return (response, body) )
+      with
+      | Ok json ->
+          failwith
+            ( "expected stalled response body to time out, got "
+            ^ Yojson.Safe.to_string json )
+      | Error e ->
+          [%test_pred: string]
+            (String.is_substring ~substring:"timeout after")
+            (Error.to_string_hum e) )

--- a/src/lib/rosetta_client/http.ml
+++ b/src/lib/rosetta_client/http.ml
@@ -1,0 +1,175 @@
+(* HTTP core for the Rosetta client library.  See [http.mli]. *)
+
+open Core_kernel
+open Async
+
+type t =
+  { base_uri : Uri.t; blockchain : string; network : string; timeout : float }
+
+(* Normalise the base URI once, here, rather than on every request: drop
+   any trailing slash from its path so that appending an endpoint path
+   (which always starts with "/") cannot produce a double slash.  Every
+   other part of the URI -- scheme, userinfo, host, port, query,
+   fragment, percent-encoding -- is left to [Uri]. *)
+let normalize_base base_uri =
+  Uri.with_path base_uri
+    (String.rstrip ~drop:(Char.equal '/') (Uri.path base_uri))
+
+let create ~base_uri ?(blockchain = Defaults.blockchain)
+    ?(network = Defaults.network) ?(timeout = Defaults.http_timeout) () =
+  { base_uri = normalize_base base_uri; blockchain; network; timeout }
+
+let base_uri t = t.base_uri
+
+let blockchain t = t.blockchain
+
+let network t = t.network
+
+let timeout t = t.timeout
+
+let network_identifier t =
+  Rosetta_models.Network_identifier.create t.blockchain t.network
+
+(* Append an endpoint path to the (already normalised) base path.  A
+   base URI may carry a path of its own -- a Rosetta server behind a
+   reverse proxy at http://host/rosetta -- so the endpoint is appended to
+   [Uri.path base] instead of replacing it. *)
+let join_uri base path =
+  let path = if String.is_prefix path ~prefix:"/" then path else "/" ^ path in
+  Uri.with_path base (Uri.path base ^ path)
+
+let pretty j = Yojson.Safe.pretty_to_string j
+
+let compact j = Yojson.Safe.to_string j
+
+(* One request/response exchange: enforces [t.timeout], folds all
+   transport/decode failures into the error channel, and renders any
+   error via [Errors] so callers never see raw OCaml exception text.
+
+   Racing the deferred against [with_timeout] is not enough on its own:
+   it stops us waiting, but leaves the socket open until the far end
+   closes it, and [rosetta-healthcheck wait] is a probe loop, so one
+   invocation against a sick server would pile up file descriptors.  Two
+   levers close it instead:
+
+   - [interrupt], which Cohttp passes to the TCP connect, so a connect
+     that never completes is abandoned with its socket;
+   - closing the response body's pipe, which is what Cohttp itself waits
+     on before it closes the reader and writer (see [Pipe.closed] in
+     cohttp-async's [Client.request]), so a response whose body stalls
+     is torn down too.
+
+   One case is left: a server that completes the TCP connect and then
+   never sends a response line.  Cohttp-async 5.0.0 exposes no handle on
+   that connection -- [Client.Connection.close] cannot preempt its own
+   in-flight request either, because the throttle runs its [at_kill]
+   only once the blocked job finishes -- so closing it would mean owning
+   the transport here rather than using [Cohttp_async.Client].  The leak
+   that remains is bounded by one run of a short-lived CLI and cannot
+   reach the default descriptor limit at any usable --timeout/--interval
+   pair. *)
+let with_request t ~uri ~make_req ~describe =
+  let timed_out = Ivar.create () in
+  let body_pipe = Ivar.create () in
+  let exchange () =
+    let%bind response, body = make_req ~interrupt:(Ivar.read timed_out) in
+    let pipe = Cohttp_async.Body.to_pipe body in
+    Ivar.fill body_pipe pipe ;
+    let%map chunks = Pipe.to_list pipe in
+    (response, String.concat chunks)
+  in
+  let result =
+    Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true exchange
+  in
+  match%bind Async.with_timeout (Time.Span.of_sec t.timeout) result with
+  | `Timeout ->
+      Ivar.fill_if_empty timed_out () ;
+      Option.iter (Ivar.peek body_pipe) ~f:Pipe.close_read ;
+      Deferred.Or_error.errorf "timeout after %.1fs: %s %s" t.timeout describe
+        (Uri.to_string uri)
+  | `Result (Error e) ->
+      let msg =
+        match Error.to_exn e with exn -> Errors.format_exn ~url:uri exn
+      in
+      Deferred.Or_error.error_string msg
+  | `Result (Ok (response, body_str)) -> (
+      let status = Cohttp_async.Response.status response in
+      let code = Cohttp.Code.code_of_status status in
+      if code < 200 || code >= 300 then
+        Deferred.Or_error.error_string
+          (Errors.format_http_body ~status:code ~body:body_str)
+      else
+        match
+          Or_error.try_with (fun () -> Yojson.Safe.from_string body_str)
+        with
+        | Ok j ->
+            Deferred.Or_error.return j
+        | Error _ ->
+            Deferred.Or_error.errorf
+              "invalid JSON response from %s (first 200 chars: %s)"
+              (Uri.to_string uri)
+              ( if String.length body_str > 200 then
+                String.sub body_str ~pos:0 ~len:200
+              else body_str ) )
+
+(* Every Rosetta endpoint answers JSON; only the ones we send a body to
+   also need to declare the request's own content type.  [request_headers]
+   is derived from [response_headers] so the shared Accept is stated once. *)
+let response_headers = Cohttp.Header.init_with "Accept" "application/json"
+
+let request_headers =
+  Cohttp.Header.add response_headers "Content-Type" "application/json"
+
+let post_json t ~path ~body =
+  let uri = join_uri t.base_uri path in
+  let body_str = Yojson.Safe.to_string body in
+  with_request t ~uri ~describe:"POST" ~make_req:(fun ~interrupt ->
+      Cohttp_async.Client.post ~interrupt ~headers:request_headers
+        ~body:(Cohttp_async.Body.of_string body_str)
+        uri )
+
+let get_json t ~path =
+  let uri = join_uri t.base_uri path in
+  with_request t ~uri ~describe:"GET" ~make_req:(fun ~interrupt ->
+      Cohttp_async.Client.get ~interrupt ~headers:response_headers uri )
+
+(* Regression guard: when a response's body stalls, the timeout must
+   close the connection, not merely stop waiting on it.  The server here
+   sends a complete set of response headers promising 100 bytes and then
+   sends nothing, so the only way its reader reaches EOF is if the client
+   hangs up. *)
+let%test_unit "a timed-out response body closes its connection" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let hung_up = Ivar.create () in
+      let%bind server =
+        Tcp.Server.create ~on_handler_error:`Ignore
+          Tcp.Where_to_listen.of_port_chosen_by_os (fun _addr reader writer ->
+            Writer.write writer "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n" ;
+            let%bind () = Writer.flushed writer in
+            let%map (_ : string) = Reader.contents reader in
+            Ivar.fill_if_empty hung_up () )
+      in
+      let port = Tcp.Server.listening_on server in
+      let t =
+        create
+          ~base_uri:(Uri.of_string (sprintf "http://127.0.0.1:%d" port))
+          ~timeout:0.2 ()
+      in
+      let%bind result = post_json t ~path:"/stalled-body" ~body:(`Assoc []) in
+      [%test_pred: string]
+        (String.is_substring ~substring:"timeout after")
+        ( match result with
+        | Ok json ->
+            "expected a timeout, got " ^ Yojson.Safe.to_string json
+        | Error e ->
+            Error.to_string_hum e ) ;
+      let%bind () =
+        match%map
+          Async.with_timeout (Time.Span.of_sec 5.0) (Ivar.read hung_up)
+        with
+        | `Timeout ->
+            failwith "the timed-out request left its connection open"
+        | `Result () ->
+            ()
+      in
+      Tcp.Server.close server )

--- a/src/lib/rosetta_client/http.mli
+++ b/src/lib/rosetta_client/http.mli
@@ -1,0 +1,54 @@
+(** Thin HTTP wrapper around Cohttp_async for talking to a Rosetta
+    server.
+
+    A value of type {!t} bundles a base URI with the default
+    [network_identifier] ({"blockchain": _, "network": _}) to splice
+    into outgoing POST bodies.  The defaults for the identifier are
+    [blockchain = "mina"] and [network = "testnet"] per the project's
+    convention; override via optional arguments to {!create}. *)
+
+type t
+
+(** [create ~base_uri ?blockchain ?network ?timeout ()] builds a client.
+    Defaults: [blockchain = "mina"], [network = "testnet"],
+    [timeout = 5.0] seconds. *)
+val create :
+     base_uri:Uri.t
+  -> ?blockchain:string
+  -> ?network:string
+  -> ?timeout:float
+  -> unit
+  -> t
+
+val base_uri : t -> Uri.t
+
+val blockchain : t -> string
+
+val network : t -> string
+
+val timeout : t -> float
+
+(** The default network_identifier payload injected into request bodies
+    that need one. *)
+val network_identifier : t -> Yojson.Safe.t
+
+(** [post_json t ~path ~body] POSTs [body] to [base_uri ^ path] with a
+    JSON content type and [timeout] enforcement.  Non-2xx responses and
+    decode failures are folded into the error channel via
+    {!Errors.format_http_body} and {!Errors.format_exn}; the resulting
+    strings never contain raw OCaml exception syntax. *)
+val post_json :
+     t
+  -> path:string
+  -> body:Yojson.Safe.t
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** GET variant of {!post_json}.  Rosetta endpoints are POST-only in
+    practice, but this is useful for sidecar endpoints and tests. *)
+val get_json : t -> path:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** Pretty-print (indented) a JSON value to a string. *)
+val pretty : Yojson.Safe.t -> string
+
+(** Compact-print a JSON value to a string. *)
+val compact : Yojson.Safe.t -> string

--- a/src/lib/rosetta_client/http.mli
+++ b/src/lib/rosetta_client/http.mli
@@ -1,0 +1,54 @@
+(** Thin HTTP wrapper around Cohttp_async for talking to a Rosetta
+    server.
+
+    A value of type {!t} bundles a base URI with the
+    [network_identifier] to splice into outgoing request bodies.  The
+    identifier and the timeout default to the shared values in
+    {!Defaults}; override them via the optional arguments to
+    {!create}. *)
+
+type t
+
+(** [create ~base_uri ?blockchain ?network ?timeout ()] builds a client.
+    Defaults: {!Defaults.blockchain}, {!Defaults.network} and
+    {!Defaults.http_timeout}. *)
+val create :
+     base_uri:Uri.t
+  -> ?blockchain:string
+  -> ?network:string
+  -> ?timeout:float
+  -> unit
+  -> t
+
+val base_uri : t -> Uri.t
+
+val blockchain : t -> string
+
+val network : t -> string
+
+val timeout : t -> float
+
+(** The network_identifier injected into every request body that needs
+    one. *)
+val network_identifier : t -> Rosetta_models.Network_identifier.t
+
+(** [post_json t ~path ~body] POSTs [body] to [base_uri ^ path] with a
+    JSON content type and [timeout] enforcement.  Non-2xx responses and
+    decode failures are folded into the error channel via
+    {!Errors.format_http_body} and {!Errors.format_exn}; the resulting
+    strings never contain raw OCaml exception syntax. *)
+val post_json :
+     t
+  -> path:string
+  -> body:Yojson.Safe.t
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** GET variant of {!post_json}.  Rosetta endpoints are POST-only in
+    practice, but this is useful for sidecar endpoints and tests. *)
+val get_json : t -> path:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** Pretty-print (indented) a JSON value to a string. *)
+val pretty : Yojson.Safe.t -> string
+
+(** Compact-print a JSON value to a string. *)
+val compact : Yojson.Safe.t -> string

--- a/src/lib/rosetta_client/rosetta_client.ml
+++ b/src/lib/rosetta_client/rosetta_client.ml
@@ -1,0 +1,14 @@
+(* Public surface of the [rosetta_client] library.  Callers use
+   the nested module names:
+
+   {[
+     let client = Rosetta_client.Http.create ~base_uri () in
+     Rosetta_client.Data.network_status client
+   ]} *)
+
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Config = Config
+module Errors = Errors
+module Models = Rosetta_models

--- a/src/lib/rosetta_client/rosetta_client.ml
+++ b/src/lib/rosetta_client/rosetta_client.ml
@@ -1,0 +1,14 @@
+(* Public surface of the [rosetta_client] library.  Callers use
+   the nested module names:
+
+   {[
+     let client = Rosetta_client.Http.create ~base_uri () in
+     Rosetta_client.Data.network_status client
+   ]} *)
+
+module Defaults = Defaults
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Errors = Errors
+module Models = Rosetta_models

--- a/src/lib/rosetta_client/rosetta_client.mli
+++ b/src/lib/rosetta_client/rosetta_client.mli
@@ -1,0 +1,23 @@
+(** Mina Rosetta client library.
+
+    Thin HTTP client, typed Rosetta API surface, and embedded
+    rosetta-cli config accessors.  Used by both [rosetta-client]
+    (the generic CLI) and [rosetta-healthcheck] (which only
+    exposes readiness probes).
+
+    {[
+      open Async
+
+      let client =
+        Rosetta_client.Http.create
+          ~base_uri:(Uri.of_string "http://localhost:3087") ()
+
+      let%bind status = Rosetta_client.Data.network_status client
+    ]} *)
+
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Config = Config
+module Errors = Errors
+module Models = Rosetta_models

--- a/src/lib/rosetta_client/rosetta_client.mli
+++ b/src/lib/rosetta_client/rosetta_client.mli
@@ -1,0 +1,22 @@
+(** Mina Rosetta client library.
+
+    Thin HTTP client and typed Rosetta API surface, shared by
+    [rosetta-client] (the generic CLI) and [rosetta-healthcheck] (which
+    only exposes readiness probes).
+
+    {[
+      open Async
+
+      let client =
+        Rosetta_client.Http.create
+          ~base_uri:(Uri.of_string "http://localhost:3087") ()
+
+      let%bind status = Rosetta_client.Data.network_status client
+    ]} *)
+
+module Defaults = Defaults
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Errors = Errors
+module Models = Rosetta_models


### PR DESCRIPTION
Two CLIs for talking to a running Mina Rosetta server, and the shared
library underneath them. Four commits, in dependency order:

| Commit | What it adds |
|---|---|
| `Add rosetta_client library and rosetta-client CLI` | `src/lib/rosetta_client/` and the generic client |
| `Add rosetta-healthcheck CLI` | the readiness probes |
| `Use rosetta-client in the Rosetta test helpers` | the sanity/load tests move off `curl` |
| `Add changelog entry for PR 18796` | `changes/18796.md` |

## `src/lib/rosetta_client/`

A thin HTTP client, so neither binary grows its own copy of
network_identifier handling, timeout enforcement or error formatting.

- `Http` — one request/response exchange with a per-request timeout. The
  base URI is normalised once at creation, so a trailing slash and a
  reverse-proxy path prefix (`http://host/rosetta`) both work.
- `Data` / `Construction` — one function per endpoint. Requests are built as
  the generated models in `src/lib/rosetta_models/` and serialised with their
  own `to_yojson`, so field names, the required/optional split and the nesting
  come from the schema rather than from hand-written JSON objects.
- `Errors` — renders a failure as one short line: a Rosetta error envelope
  becomes `HTTP <code>: <message>`, a transport failure becomes
  `connection refused to <url>`. Raw OCaml exception text never reaches the
  terminal, and a body is never dumped verbatim.
- `Defaults` — the values both CLIs fall back to, defined once, each with an
  environment override.

## `rosetta-client`

One subcommand per endpoint, for debugging and scripting — curl on steroids.

```bash
rosetta-client network status
rosetta-client block get --index 100
rosetta-client account balance --address B62q...
```

A `--*-json` payload is decoded into the model its endpoint expects before
anything is sent, so a malformed request is reported against the flag that
carried it:

```
$ rosetta-client construction derive --public-key-json '{"hex_bytes":"aabb"}'
--public-key-json: does not match the Rosetta schema: Public_key.t.curve_type
```

## `rosetta-healthcheck`

| Command | Exit 0 when |
|---|---|
| `connectivity` | `/network/list` advertises the expected network (lists the advertised set on mismatch) |
| `tip-recency` | `/network/status` returns a tip whose timestamp is within `--max-age` |
| `ready` | both of those, plus `/network/options` |
| `wait` | `ready` passes before `--timeout` expires |

Each prints exactly one result — one JSON object with `--json`, one line
without it — and exits 0 or 1, so it drops straight into a Kubernetes exec
probe, a Docker `HEALTHCHECK`, or a CI gate.

```
$ rosetta-healthcheck ready --json
{ "ready": true, "block_height": 428113, "age_seconds": 84 }

$ rosetta-healthcheck ready --json          # server down
{ "healthy": false, "error": "connection refused to http://localhost:3087/network/list" }
```

A field with no value is left out rather than emitted as `null`. Every check
runs even after an earlier one failed, so one invocation reports every
problem instead of only the first.

Each binary keeps its command-line surface and its logic apart:
`payload.ml` decodes the client's JSON flags, `health_probes.ml` holds the
probes and their verdicts, and neither prints or exits — the CLI files own
the flags, the text/JSON choice and the exit codes.

## Environment

Both binaries read `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
`MINA_ROSETTA_NETWORK`, so an operator working against one server exports
them once instead of repeating flags. A flag always wins over its variable,
and a variable that is set but blank counts as unset.

## Tests and CI

- `scripts/tests/rosetta-helper.sh` builds no more JSON request bodies in
  bash; every call goes through one `rosetta_client` wrapper that supplies
  the connection details from the environment. Its timeout defaults to 300 s,
  matching the `http_timeout` the rosetta-cli audit config uses, because the
  `curl` calls it replaces had none and `rosetta-load.sh` exists to put the
  server under load.
- `Command/Rosetta/Connectivity.dhall` gains `rosetta-client` in its
  `bareBinaries`: that job restores every binary from the apps cache, which
  makes `restore-or-install.sh` skip the deb install, so anything the tests
  call has to be listed.
- The Rosetta integration test gains a negative check — before Rosetta is
  started, `rosetta-healthcheck ready` must fail cleanly and must not leak
  raw OCaml exception syntax — and waits for each Rosetta port to bind
  instead of sleeping a fixed 5 s.
- Library inline tests cover URI joining, request shape, error rendering, and
  a timeout regression test against a real TCP server that stalls a response
  body, asserting the client hangs up rather than leaking the connection.
  Both binaries have hermetic alcotest suites.

## Packaging

Both ship in `mina-rosetta`, as `/usr/local/bin/rosetta-client` and
`/usr/local/bin/rosetta-healthcheck`, built by `make build-mina` and
`make build-rosetta`.

## Known limitation

A probe that times out closes its connection in every case except one: a
server that completes the TCP connect and then never sends a response line
at all. cohttp-async 5.0.0 exposes no handle on that connection —
`Client.Connection.close` cannot preempt its own in-flight request either —
so closing it would mean owning the transport rather than using
`Cohttp_async.Client`. The leak is bounded by a single run of a short-lived
CLI, and no usable `--timeout` / `--interval` pair reaches the default
descriptor limit. Recorded on `with_request` in `http.ml` and in the README.
