### PR TITLE
Add SUFFIX to hardfork docker tags & debian versions

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -20,6 +20,7 @@ set -euox pipefail
 #   PRECOMPUTED_FORK_BLOCK_PREFIX      - (Optional) Prefix for precomputed fork block URLs (e.g., "gs://mina_network_block_data/mainnet")
 #   USE_ARTIFACTS_FROM_BUILDKITE_BUILD - (Optional) Buildkite build number to use artifacts from (e.g., "1234")
 #   USE_GENERIC_DOCKERS_FROM_VERSION   - (Optional) Docker version to build config docker on top of (e.g., "3.3.0-compatible-aa34232")
+#   SUFFIX                             - (Optional) Suffix appended to docker tags and debian package versions (e.g., "-hardfork")
 #
 # EXAMPLE:
 #   export CODENAMES_CONFIG="Bullseye_Amd64,Focal_Arm64"
@@ -59,6 +60,7 @@ function usage() {
   PRECOMPUTED_FORK_BLOCK_PREFIX      (Optional) The prefix for precomputed fork block URLs (e.g. gs://mina_network_block_data/mainnet)
   USE_ARTIFACTS_FROM_BUILDKITE_BUILD (Optional) The Buildkite build number to use artifacts from (e.g. 1234)
   USE_GENERIC_DOCKERS_FROM_VERSION   (Optional) Docker version to build config docker on top of (e.g. 3.3.0-compatible-aa34232)
+  SUFFIX                             (Optional) Suffix appended to docker tags and debian package versions (e.g. -hardfork)
 EOF
   exit 1
 }
@@ -163,7 +165,7 @@ printf '%s.generate_hardfork_package %s %s.Type.%s %s "%s" "%s" %s %s %s %s\n' \
   "$NETWORK" \
   "$GENESIS_TIMESTAMP" \
   "$CONFIG_JSON_GZ_URL" \
-  "" \
+  "${SUFFIX:-}" \
   "$VERSION" \
   "$PRECOMPUTED_FORK_BLOCK_PREFIX" \
   "$USE_ARTIFACTS_FROM_BUILDKITE_BUILD" \

--- a/buildkite/scripts/pipeline/run-hardfork-pipeline.go
+++ b/buildkite/scripts/pipeline/run-hardfork-pipeline.go
@@ -283,6 +283,7 @@ func main() {
 		useArtifactsFrom  = flag.String("use-artifacts-from", "", "USE_ARTIFACTS_FROM_BUILDKITE_BUILD environment variable")
 		codenamesConfig   = flag.String("codenames-config", "", "CODENAMES_CONFIG environment variable (e.g. Noble_Amd64,Bullseye_Amd64). Defaults to <codename>_Amd64")
 		ledgerBucket      = flag.String("ledger-bucket", "https://s3-us-west-2.amazonaws.com/snark-keys.o1test.net", "MINA_LEDGER_S3_BUCKET environment variable")
+		suffix            = flag.String("suffix", "-hardfork", "SUFFIX environment variable. Appended to docker tags and debian package versions to prevent collision with standard builds")
 		monitor           = flag.Bool("monitor", false, "Monitor build progress in real-time")
 		pollInterval      = flag.Int("poll-interval", 10, "Polling interval in seconds")
 		showAllUpdates    = flag.Bool("show-all-updates", false, "Show all job states, not just changes")
@@ -347,9 +348,9 @@ func main() {
 	// All pipeline-level env vars must be explicitly set here (even to empty)
 	// to prevent stale values from the pipeline's env: block leaking into
 	// API-created builds.
-	// OVERRIDE_GITHASH is set to the literal "fake" so the hardfork build
-	// produces a distinct GITHASH/MINA_DOCKER_TAG and cannot overwrite the
-	// standard docker images published from the same commit.
+	// SUFFIX is appended to docker tags and debian package versions so the
+	// hardfork build cannot overwrite standard docker images / debian packages
+	// published from the same commit.
 	env := map[string]string{
 		"CODENAMES":                          *codename,
 		"CODENAMES_CONFIG":                   resolvedCodenamesConfig,
@@ -363,7 +364,7 @@ func main() {
 		"USE_ARTIFACTS_FROM_BUILDKITE_BUILD": *useArtifactsFrom,
 		"USE_GENERIC_DOCKERS_FROM_VERSION":   "",
 		"HARDFORK_GENESIS_SLOT_DELTA":        "",
-		"OVERRIDE_GITHASH":                   "fake",
+		"SUFFIX":                             *suffix,
 	}
 
 	// Print configuration

--- a/buildkite/scripts/pipeline/run-hardfork-pipeline.go
+++ b/buildkite/scripts/pipeline/run-hardfork-pipeline.go
@@ -347,19 +347,23 @@ func main() {
 	// All pipeline-level env vars must be explicitly set here (even to empty)
 	// to prevent stale values from the pipeline's env: block leaking into
 	// API-created builds.
+	// OVERRIDE_GITHASH is set to the literal "fake" so the hardfork build
+	// produces a distinct GITHASH/MINA_DOCKER_TAG and cannot overwrite the
+	// standard docker images published from the same commit.
 	env := map[string]string{
 		"CODENAMES":                          *codename,
 		"CODENAMES_CONFIG":                   resolvedCodenamesConfig,
 		"NETWORK":                            *network,
 		"REPO":                               *repo,
-		"MINA_LEDGER_S3_BUCKET":             *ledgerBucket,
+		"MINA_LEDGER_S3_BUCKET":              *ledgerBucket,
 		"VERSION":                            *version,
-		"CONFIG_JSON_GZ_URL":                resolvedConfigURL,
-		"GENESIS_TIMESTAMP":                 *genesisTimestamp,
-		"PRECOMPUTED_FORK_BLOCK_PREFIX":     *precomputedPrefix,
+		"CONFIG_JSON_GZ_URL":                 resolvedConfigURL,
+		"GENESIS_TIMESTAMP":                  *genesisTimestamp,
+		"PRECOMPUTED_FORK_BLOCK_PREFIX":      *precomputedPrefix,
 		"USE_ARTIFACTS_FROM_BUILDKITE_BUILD": *useArtifactsFrom,
 		"USE_GENERIC_DOCKERS_FROM_VERSION":   "",
 		"HARDFORK_GENESIS_SLOT_DELTA":        "",
+		"OVERRIDE_GITHASH":                   "fake",
 	}
 
 	// Print configuration

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -238,7 +238,7 @@ let generateDockerForCodename =
                             , verify = True
                             , version =
                                 "${version}-${DebianVersions.lowerName
-                                                codename.DebVersion}"
+                                                codename.DebVersion}${spec.suffix}"
                             , deb_version = spec.version
                             , step_key_suffix =
                                 "-${DebianVersions.lowerName
@@ -259,7 +259,7 @@ let generateDockerForCodename =
                             , verify = True
                             , version =
                                 "${version}-${DebianVersions.lowerName
-                                                codename.DebVersion}"
+                                                codename.DebVersion}${spec.suffix}"
                             , deb_version = spec.version
                             , step_key_suffix =
                                 "-${DebianVersions.lowerName
@@ -277,6 +277,7 @@ let generateDockerForCodename =
                       , deb_storage_repair_version = Some
                           spec.deb_storage_repair_version
                       , size = spec.size
+                      , version = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                       , deb_version = spec.version
                       , generic = True
                       , step_key_suffix =
@@ -294,6 +295,7 @@ let generateDockerForCodename =
                           spec.deb_storage_repair_version
                       , size = spec.size
                       , verify = True
+                      , version = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                       , deb_version = spec.version
                       , step_key_suffix =
                           "-${DebianVersions.lowerName
@@ -309,6 +311,7 @@ let generateDockerForCodename =
                       , deb_storage_repair_version = Some
                           spec.deb_storage_repair_version
                       , size = spec.size
+                      , version = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                       , deb_version = spec.version
                       , step_key_suffix =
                           "-${DebianVersions.lowerName
@@ -323,6 +326,7 @@ let generateDockerForCodename =
                       , deb_legacy_version = spec.deb_legacy_version
                       , size = spec.size
                       , verify = True
+                      , version = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                       , deb_version = spec.version
                       , step_key_suffix =
                           "-${DebianVersions.lowerName
@@ -336,6 +340,7 @@ let generateDockerForCodename =
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
                       , size = spec.size
+                      , version = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                       , deb_version = spec.version
                       , generic = True
                       , step_key_suffix =
@@ -370,8 +375,8 @@ let generateHfRelatedStepsForCodename =
                         { Some =
                                 \(v : Text)
                             ->  "${v}-${DebianVersions.lowerName
-                                          codename.DebVersion}"
-                        , None = "\\\${MINA_DOCKER_TAG}"
+                                          codename.DebVersion}${spec.suffix}"
+                        , None = "\\\${MINA_DOCKER_TAG}${spec.suffix}"
                         }
                         spec.use_generic_dockers_from_version
                   }
@@ -478,6 +483,7 @@ let generateHfRelatedStepsForCodename =
                           codename.Arch
                           (   [ "NETWORK_NAME=${Network.lowerName spec.network}"
                               , "MINA_DEB_CODENAME=${lowerNameCodename}"
+                              , "MINA_DEB_VERSION_SUFFIX=${spec.suffix}"
                               ]
                             # DebianVersions.overrideEnvs
                           )
@@ -637,7 +643,9 @@ let generate_hardfork_package =
               , network = network
               , version =
                   merge
-                    { Some = \(v : Text) -> v, None = "\\\$MINA_DEB_VERSION" }
+                    { Some = \(v : Text) -> "${v}${suffix}"
+                    , None = "\\\$MINA_DEB_VERSION${suffix}"
+                    }
                     version
               , genesis_timestamp = genesis_timestamp
               , config_json_gz_url = config_json_gz_url

--- a/scripts/debian/build.sh
+++ b/scripts/debian/build.sh
@@ -20,6 +20,15 @@ fi
 
 source "${SCRIPTPATH}"/../export-git-env-vars.sh
 
+# Append optional suffix to MINA_DEB_VERSION so the produced .deb file name and
+# its internal Version: field carry the suffix. Used by the hardfork pipeline
+# to avoid collision with standard packages built from the same commit.
+if [[ -n "${MINA_DEB_VERSION_SUFFIX:-}" ]]; then
+  echo "Appending MINA_DEB_VERSION_SUFFIX='${MINA_DEB_VERSION_SUFFIX}' to MINA_DEB_VERSION='${MINA_DEB_VERSION}'"
+  MINA_DEB_VERSION="${MINA_DEB_VERSION}${MINA_DEB_VERSION_SUFFIX}"
+  export MINA_DEB_VERSION
+fi
+
 # shellcheck disable=SC1090
 BUILD_DIR="${BUILD_DIR}" source "${SCRIPTPATH}/builder-helpers.sh"
 


### PR DESCRIPTION
## Summary
- Hardfork builds were colliding with standard builds (same git commit → same `MINA_DOCKER_TAG` / `MINA_DEB_VERSION`), causing the hardfork pipeline to overwrite standard docker images.
- Initial attempt set `OVERRIDE_GITHASH` via the Create Build API, but Buildkite's pipeline-YAML `env:` block takes precedence over API-passed env, so it didn't reliably reach `export-git-env-vars.sh`.
- New approach: plumb a `SUFFIX` (default `-hardfork`) through `run-hardfork-pipeline.go` → `SUFFIX` env → `run-hardfork-package-gen.sh` → `generate_hardfork_package` Dhall function (already had an unused `suffix` parameter) → `spec.suffix`.
- In `GenerateHardforkPackage.dhall` the suffix is baked into:
  - docker image tag (`--version`)
  - docker `--deb-version` arg
  - verifier image lookup
  - `MINA_DEB_VERSION_SUFFIX` env in the deb-build step
- `scripts/debian/build.sh` now appends `MINA_DEB_VERSION_SUFFIX` to `MINA_DEB_VERSION` after sourcing `export-git-env-vars.sh`, so the produced `.deb` file name and its internal `Version:` field carry the suffix too.
- `scripts/export-git-env-vars.sh` is intentionally untouched.

## Test plan
- [ ] `!ci-single-me HardforkPipelineTest` passes; resulting docker tags and `.deb` versions end in `-hardfork`.
- [ ] No collision with standard docker images / debian packages built from the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)