### PR TITLE
Disable HardforkPipelineTest

### DIFF
--- a/buildkite/src/Jobs/Test/HardforkPipelineTest.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPipelineTest.dhall
@@ -23,14 +23,10 @@ let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
-        , dirtyWhen =
-          [ S.strictlyStart (S.contains "src")
-          , S.exactly "buildkite/src/Jobs/Test/HardforkPipelineTest" "dhall"
-          , S.strictlyStart (S.contains "buildkite/scripts/pipeline")
-          ]
+        , dirtyWhen = [] : List S.Type
         , path = "Test"
         , name = "HardforkPipelineTest"
-        , scope = PipelineScope.AllButPullRequest
+        , scope = [] : List PipelineScope.Type
         , tags =
           [ PipelineTag.Type.Long
           , PipelineTag.Type.Test


### PR DESCRIPTION
## Summary
- Stop-gap: disable `HardforkPipelineTest` so it does not run in any state while the underlying hardfork-vs-standard docker/debian collision is sorted out (see #18797).
- Two-field neutralisation, original step left intact:
  - `dirtyWhen = []` — monorepo triage will never mark it dirty
  - `scope = []` — no pipeline scope (PullRequest / Nightly / MainlineNightly / Release) picks it up
- Re-enable = revert these two fields. Original command, label, timeout, etc. are untouched on purpose so we can't forget to restore them.

## Test plan
- [ ] Verify monorepo triage no longer schedules `HardforkPipelineTest` for any change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)