### PR TITLE
Fix minimina .deb version on tagged commits (^0 in version)

### DIFF
--- a/buildkite/src/Jobs/Release/Minimina.dhall
+++ b/buildkite/src/Jobs/Release/Minimina.dhall
@@ -36,7 +36,7 @@ in  Pipeline.build
             , commands =
                 RunInToolchain.runInToolchain
                   ([] : List Text)
-                  "PATH=/home/opam/.cargo/bin:\$PATH cargo build --release --manifest-path src/app/minimina/Cargo.toml && ./buildkite/scripts/cache/manager.sh write-to-dir src/app/minimina/target/release/minimina minimina && mkdir -p _build && MINA_DEB_CODENAME=bullseye ./scripts/debian/build.sh minimina && ./buildkite/scripts/cache/manager.sh write-to-dir '_build/minimina_*.deb' debians/bullseye/"
+                  "PATH=/home/opam/.cargo/bin:\$PATH cargo build --release --manifest-path src/app/minimina/Cargo.toml && ./buildkite/scripts/cache/manager.sh write-to-dir src/app/minimina/target/release/minimina minimina && mkdir -p _build && source ./buildkite/scripts/export-git-env-vars.sh && MINA_DEB_CODENAME=bullseye ./scripts/debian/build.sh minimina && ./buildkite/scripts/cache/manager.sh write-to-dir '_build/minimina_*.deb' debians/bullseye/"
             , label = "Build minimina"
             , key = "build-minimina"
             , target = Size.Small


### PR DESCRIPTION
## Summary
- Fixes `dpkg-deb` failure `invalid character in version number` when the minimina build runs on a tagged commit (e.g. build 1693 on `4.0.0-rc1`: version was `4.0.0-rc1-tags-4.0.0-rc1^0-f6e4003`).
- Root cause: `buildkite/src/Jobs/Release/Minimina.dhall` invoked `./scripts/debian/build.sh minimina` directly without exporting `BRANCH_NAME`. When `BRANCH_NAME` is unset, `scripts/export-git-env-vars.sh` falls back to `git name-rev --name-only HEAD`, which returns `tags/<tag>^0` on tagged commits — the stray `^` is not scrubbed by the existing sed and breaks the resulting `MINA_DEB_VERSION`.
- Fix: `source ./buildkite/scripts/export-git-env-vars.sh` before `./scripts/debian/build.sh minimina`, so `BRANCH_NAME=$BUILDKITE_BRANCH` is exported — mirroring what `buildkite/scripts/build-release.sh` already does for every other Debian build job.

Ref failing job: https://buildkite.com/o-1-labs-2/mina-stable/builds/1693#019dbad3-3b54-4ed9-b96d-332fec8a5dad

## Test plan
- [ ] Dhall pipeline compiles (`make all` in `buildkite/`) — verified locally, 37/37 tests pass.
- [ ] Re-trigger minimina build on a tag-pointing commit; `MINA_DEB_VERSION` should be `<tag>-<branch>-<shorthash>` (no `^0`).
- [ ] Re-trigger on a regular branch commit; version format unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)