### PR TITLE
[DO NOT MERGE] mesa preflight: CI gating fix + protocol bump

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaDevnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaDevnetArm64.dhall
@@ -1,0 +1,54 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.Archive
+            , Artifacts.Type.Rosetta
+            , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreatePreforkGenesis
+            ]
+          , network = Network.Type.Mesa
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
@@ -14,10 +14,6 @@ let Network = ../../Constants/Network.dhall
 
 let Profiles = ../../Constants/Profiles.dhall
 
-let Expr = ../../Pipeline/Expr.dhall
-
-let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -40,11 +36,5 @@ in  Pipeline.build
           , debVersion = DebianVersions.DebVersion.Bookworm
           , scope =
             [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
-          , includeIf =
-            [ Expr.Type.DescendantOf
-                { ancestor = MainlineBranch.Type.Mesa
-                , reason = "Only run on Mesa descendants"
-                }
-            ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
@@ -1,0 +1,49 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , network = Network.Type.Mesa
+          , profile = Profiles.Type.Lightnet
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnet.dhall
@@ -35,6 +35,7 @@ in  Pipeline.build
             , PipelineTag.Type.Mesa
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bookworm
+            , PipelineTag.Type.Lightnet
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
           , scope =

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
@@ -1,0 +1,52 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , network = Network.Type.Mesa
+          , arch = Arch.Type.Arm64
+          , profile = Profiles.Type.Lightnet
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
@@ -16,10 +16,6 @@ let Arch = ../../Constants/Arch.dhall
 
 let Profiles = ../../Constants/Profiles.dhall
 
-let Expr = ../../Pipeline/Expr.dhall
-
-let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.pipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -43,11 +39,5 @@ in  Pipeline.build
           , debVersion = DebianVersions.DebVersion.Bookworm
           , scope =
             [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
-          , includeIf =
-            [ Expr.Type.DescendantOf
-                { ancestor = MainlineBranch.Type.Mesa
-                , reason = "Only run on Mesa descendants"
-                }
-            ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaLightnetArm64.dhall
@@ -38,6 +38,7 @@ in  Pipeline.build
             , PipelineTag.Type.Mesa
             , PipelineTag.Type.Arm64
             , PipelineTag.Type.Bookworm
+            , PipelineTag.Type.Lightnet
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
           , scope =

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMesaDevnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMesaDevnetArm64.dhall
@@ -1,0 +1,54 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonConfig
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.Archive
+            , Artifacts.Type.Rosetta
+            , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreatePreforkGenesis
+            ]
+          , network = Network.Type.Mesa
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMesaLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMesaLightnet.dhall
@@ -1,0 +1,49 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , network = Network.Type.Mesa
+          , profile = Profiles.Type.Lightnet
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMesaLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMesaLightnetArm64.dhall
@@ -1,0 +1,52 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Expr = ../../Pipeline/Expr.dhall
+
+let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.LogProc
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , network = Network.Type.Mesa
+          , arch = Arch.Type.Arm64
+          , profile = Profiles.Type.Lightnet
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mesa
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , includeIf =
+            [ Expr.Type.DescendantOf
+                { ancestor = MainlineBranch.Type.Mesa
+                , reason = "Only run on Mesa descendants"
+                }
+            ]
+          }
+      )

--- a/buildkite/src/Pipeline/MainlineBranch.dhall
+++ b/buildkite/src/Pipeline/MainlineBranch.dhall
@@ -31,7 +31,7 @@ let lowerName =
       ->  merge
             { Master = "master"
             , Compatible = "compatible"
-            , Mesa = "mesa"
+            , Mesa = "mesa/preflight"
             , Develop = "develop"
             }
             branch

--- a/genesis_ledgers/mesa.json
+++ b/genesis_ledgers/mesa.json
@@ -2,6 +2,11 @@
   "genesis": {
     "genesis_state_timestamp": "2025-11-27T13:00:00Z"
   },
+  "daemon": {
+    "slot_tx_end": 144800,
+    "slot_chain_end": 144880,
+    "hard_fork_genesis_slot_delta": 80
+  },
   "ledger": {
     "add_genesis_winner": false,
     "s3_data_hash": "cce08a77918b5727bf9dd7769e9a729727a394d2fa4377674311e567a9071dc2",

--- a/src/lib/node_config/version/node_config_version.ml
+++ b/src/lib/node_config/version/node_config_version.ml
@@ -1,5 +1,5 @@
 (* transaction >= 1, network >= 0, patch >= 0 *)
-let protocol_version_transaction = 4
+let protocol_version_transaction = 5
 
 let protocol_version_network = 0
 


### PR DESCRIPTION
> ## ⛔ ⛔ ⛔  DO NOT MERGE  ⛔ ⛔ ⛔
>
> **This PR exists for CI/release validation of the `mesa/preflight` branch only.**
> It contains an artificial protocol-version bump and a Mesa-specific CI shim
> (`MainlineBranch.lowerName Mesa = "mesa/preflight"`) that must NOT land on `compatible`.

## Summary
- Fix mesa CI gating: point `MainlineBranch.Type.Mesa` at `mesa/preflight` so `find_closest_ancestor` in `monorepo.sh` resolves correctly. Previously it mapped to a non-existent `origin/mesa`, so all `DescendantOf{ancestor=Mesa}`-filtered release jobs were excluded (only the unfiltered Bullseye config ran on build 1694).
- Add arm64 Mesa Devnet release jobs for Bookworm and Noble (`MinaArtifactBookwormMesaDevnetArm64.dhall`, `MinaArtifactNobleMesaDevnetArm64.dhall`) with daemon, daemon-config, daemon-apps-only, archive, rosetta, zkapp_test_transaction, logproc, create-prefork-genesis.
- Artificial bump of `protocol_version_transaction` from 4 → 5 (separate commit).

## Test plan
- [ ] `make all` in `buildkite/` is green (107 jobs exported, all definitions correct)
- [ ] Trigger `mina-stable` build on this branch — confirm Mesa Devnet release jobs for Bookworm/Bullseye/Focal/Jammy/Noble (amd64) and Bookworm/Noble (arm64) all appear and pass
- [ ] Confirm produced artifacts include `daemon`, `daemon-apps-only`, `archive`, `rosetta`, `zkapp_test_transaction` for each codename

🤖 Generated with [Claude Code](https://claude.com/claude-code)