### PR TITLE
Release/3.4.0 tag fix

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -116,6 +116,8 @@ let generateStep =
                 "export MINA_DEB_CODENAME=${DebianVersions.lowerName
                                               spec.deb_codename}"
 
+          let exportBranchNameCmd = "export BRANCH_NAME=${spec.branch}"
+
           let maybeCacheOption = if spec.no_cache then "--no-cache" else ""
 
           let maybeStartDebianRepo =
@@ -264,6 +266,8 @@ let generateStep =
           let remoteRepoCmds =
                 [ Cmd.run
                     (     exportMinaDebCmd
+                      ++  " && "
+                      ++  exportBranchNameCmd
                       ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                       ++  " && "
                       ++  buildDockerCmd
@@ -279,6 +283,8 @@ let generateStep =
                   , Local =
                     [ Cmd.run
                         (     exportMinaDebCmd
+                          ++  " && "
+                          ++  exportBranchNameCmd
                           ++  " && "
                           ++  pruneDockerImages
                           ++  maybeStartDebianRepo

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -43,7 +43,7 @@ else
    # Always use actual HEAD for branch resolution — OVERRIDE_GITHASH is a
    # short hash from another commit and git name-rev cannot resolve it.
    _GIT_HEAD_HASH=$(git rev-parse --verify HEAD)
-   GITBRANCH=$(git name-rev --name-only "$_GIT_HEAD_HASH" | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+   GITBRANCH=$(git name-rev --refs='refs/heads/*' --name-only "$_GIT_HEAD_HASH" | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 fi
 
 GITTAG=${OVERRIDE_TAG:-$(find_most_recent_numeric_tag HEAD)}

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -43,7 +43,7 @@ else
    # Always use actual HEAD for branch resolution — OVERRIDE_GITHASH is a
    # short hash from another commit and git name-rev cannot resolve it.
    _GIT_HEAD_HASH=$(git rev-parse --verify HEAD)
-   GITBRANCH=$(git name-rev --refs='refs/heads/*' --name-only "$_GIT_HEAD_HASH" | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
+   GITBRANCH=$(git name-rev --name-only "$_GIT_HEAD_HASH" | sed "s/remotes\/origin\///g" | sed 's!/!-!g; s!_!-!g; s!#!-!g' )
 fi
 
 GITTAG=${OVERRIDE_TAG:-$(find_most_recent_numeric_tag HEAD)}


### PR DESCRIPTION
Fixing branch discovery for docker build. Using BUILDKITE_BRNACH as it is defined by every build