### PR TITLE
Port CI tag fix to develop (cherry-pick from release/3.4.0)

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -116,6 +116,8 @@ let generateStep =
                 "export MINA_DEB_CODENAME=${DebianVersions.lowerName
                                               spec.deb_codename}"
 
+          let exportBranchNameCmd = "export BRANCH_NAME=${spec.branch}"
+
           let maybeCacheOption = if spec.no_cache then "--no-cache" else ""
 
           let maybeStartDebianRepo =
@@ -265,6 +267,8 @@ let generateStep =
           let remoteRepoCmds =
                 [ Cmd.run
                     (     exportMinaDebCmd
+                      ++  " && "
+                      ++  exportBranchNameCmd
                       ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                       ++  " && "
                       ++  buildDockerCmd
@@ -280,6 +284,8 @@ let generateStep =
                   , Local =
                     [ Cmd.run
                         (     exportMinaDebCmd
+                          ++  " && "
+                          ++  exportBranchNameCmd
                           ++  " && "
                           ++  pruneDockerImages
                           ++  maybeStartDebianRepo


### PR DESCRIPTION
## Summary
- Cherry-picks the docker build branch-discovery fix from PR #18812 (`release/3.4.0-tag-fix`) onto `develop`.
- Mirrors PR #18817, which ports the same fix into `compatible` via merge; this PR ports it into `develop` via cherry-pick.
- Net change: exports `BRANCH_NAME` in `buildkite/src/Command/DockerImage.dhall` so docker builds use the build-time branch instead of relying on tag discovery.

## Cherry-picked commit
- `23c704609e` — export BRANCH_NAME on docker build

The companion commit on the original PR ("prefer branches over tags") was reverted there, so it is intentionally omitted here.

## Test plan
- [x] `make check_syntax` passes locally
- [ ] CI green on develop base
- [ ] Verify a docker build job emits the expected `BRANCH_NAME` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)