### PR TITLE
Enforce delegation permission present in SNARK

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2903,6 +2903,15 @@ module Make_str (A : Wire_types.Concrete) = struct
                 let permitted_to_update_delegate =
                   Account.Checked.has_permission ~to_:`Set_delegate account
                 in
+                let%bind () =
+                  [%with_label_
+                    "Stake delegation must have set_delegate permission"]
+                    (fun () ->
+                      Boolean.Assert.any
+                        [ Boolean.not is_stake_delegation
+                        ; permitted_to_update_delegate
+                        ] )
+                in
                 let permitted_to_send =
                   Account.Checked.has_permission ~to_:`Send account
                 in


### PR DESCRIPTION
## Summary

- Fix a soundness gap in the transaction SNARK circuit where a signed
  `stake_delegation` against an account whose `set_delegate` permission is
  `Proof` or `Impossible` would silently produce a valid proof — the fee was
  deducted and the nonce incremented, but the delegate change was dropped.
- Add an in-circuit assertion that `permitted_to_update_delegate` holds for
  every `stake_delegation`. When it doesn't, the constraint becomes
  unsatisfiable and no valid proof can be generated, matching the non-SNARK
  path's `Update_not_permitted_delegate` rejection.

## Test plan

- [ ] Existing transaction SNARK tests pass (`dune runtest src/lib/transaction_snark`)
- [ ] A stake_delegation against an account with `set_delegate = Proof` can no
  longer produce a valid transaction SNARK proof
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
