### PR TITLE
docs: rename Coda → Mina in user-facing docs (#18825)

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,4 +1,4 @@
-# Care and feeding of your Coda daemon
+# Care and feeding of your Mina daemon
 
 Right now the default config directory is hardcoded to `~/.mina-config`.
 This will be fixed eventually. In the meantime, you can pass `-config-directory`

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,7 +1,8 @@
-# Local Coda Demo
+# Local Mina Demo
 
 If all you need is a running daemon and some blocks, the
-`codaprotocol/coda-demo` container has everything you need! It uses the same
+`minaprotocol/mina-daemon` container has everything you need when started in
+demo mode (set the `RUN_DEMO=true` environment variable). It uses the same
 configuration as the testnet, but instead of the community participants ledger
 it uses a simple ledger with a single demo account.
 
@@ -14,6 +15,6 @@ The public key of the demo account is `B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxy
 This account has 100% of the stake.
 
 The demo container will run a block producer and a snark worker. You need to
-make sure the `--publish` at least the GraphQL port, for example `docker run
---publish 3085:3085 -it codaprotocol/coda-demo`. Any additional arguments will
-be passed to the daemon.
+make sure the `--publish` at least the GraphQL port, for example
+`docker run --publish 3085:3085 -e RUN_DEMO=true -it minaprotocol/mina-daemon:<version>`.
+Any additional arguments will be passed to the daemon.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,57 +1,56 @@
 ## Docker Instructions
 
-It is possible to run the Coda daemon inside a Docker container. This allows for resource and dependency isolation, and homogenization of infrastructure. 
+It is possible to run the Mina daemon inside a Docker container. This allows for resource and dependency isolation, and homogenization of infrastructure.
 
-The Coda Protocol builds one main Docker Image `codaprotocol/coda-daemon` which contains the Coda Daemon and its dependencies. Image Tags follow the release cadence for the Coda Protocol and the goal is to keep them up to date with [Github Releases](https://github.com/CodaProtocol/coda/releases). 
+The Mina Protocol builds one main Docker Image `minaprotocol/mina-daemon` which contains the Mina Daemon and its dependencies. Image Tags follow the release cadence for the Mina Protocol and the goal is to keep them up to date with [GitHub Releases](https://github.com/MinaProtocol/mina/releases).
 
-### Quick Start 
+### Quick Start
 
-Pull and Run the `coda-daemon` image: 
+Pull and Run the `mina-daemon` image:
 
 ```
-docker run --publish 8302:8302 --publish 8303:8303 codaprotocol/coda-daemon:<version> daemon -peer <testnet>.o1test.net:8303
+docker run --publish 8302:8302 --publish 8303:8303 minaprotocol/mina-daemon:<version> daemon -peer <testnet>.o1test.net:8303
 ```
 
 For more details on the `docker run` command, see the [Docker Docs](https://docs.docker.com/engine/reference/run/).
 
-Now, lets break down that command a little bit: 
-- `--publish 8302:8302 --publish 8303:8303` By default, the Coda Daemon exposes two ports (8302 TCP, 8303 UDP) used for Network communication
+Now, lets break down that command a little bit:
+- `--publish 8302:8302 --publish 8303:8303` By default, the Mina Daemon exposes two ports (8302 TCP, 8303 UDP) used for Network communication
 - `daemon` specifies that we should run a mina daemon
 - `-peer` specifies an initial seed to query during the peer discovery process, more than one peer may be specified
 - `-external-port` specifies a non-default
 
-For more details on the Coda Daemon CLI and other flags it supports, you may execute the `help` command: 
+For more details on the Mina Daemon CLI and other flags it supports, you may execute the `help` command:
 
 ```
-docker run codaprotocol/coda-daemon:<version> daemon -help
+docker run minaprotocol/mina-daemon:<version> daemon -help
 ```
 
-### Running Coda with a Container Orchestrator
+### Running Mina with a Container Orchestrator
 
-Currently, the implementation of the Kademlia DHT in use by the Coda Daemon is a tad temperamental, and requires consistent ports to be set on both the host and container.
+Currently, the implementation of the Kademlia DHT in use by the Mina Daemon is a tad temperamental, and requires consistent ports to be set on both the host and container.
 
-There is a bug issue [here](https://github.com/CodaProtocol/coda/issues/2947) that details the problem. In the meantime, it is easiest to avoid any sort of bridge networking and run the Daemon container on the host network, especially if you'd like to use non-default ports. 
+There is a bug issue [here](https://github.com/MinaProtocol/mina/issues/2947) that details the problem. In the meantime, it is easiest to avoid any sort of bridge networking and run the Daemon container on the host network, especially if you'd like to use non-default ports.
 
-Here is a minimal `docker-compose.yml` file that accomplishes this: 
+Here is a minimal `docker-compose.yml` file that accomplishes this:
 
 ```
 version: '3'
 services:
-  coda:
+  mina:
     network: host
-    image: codaprotocol/coda-daemon:<version>
-    command: 
+    image: minaprotocol/mina-daemon:<version>
+    command:
       daemon -peer <testnet>.o1test.net:8303 -rest-port 8304 -external-port 10101 -metrics-port 10000 -block-producer-key /root/wallet-keys/my_wallet -unsafe-track-block-producer-key
-    environment: 
+    environment:
       MINA_PRIVKEY_PASS: <key-password>
     volumes:
       - ~/wallet-keys:/root/wallet-keys
 ```
 
-In addition to running the daemon on the host network, it does a few other things: 
+In addition to running the daemon on the host network, it does a few other things:
 - `-rest-port 8304` it enables the Daemon's GraphQL endpoint on `localhost:8304`
 - `-external-port 10101` it specifies a non-default external communication (TCP) port (also implicitly sets `10102` as the gossip (UDP) port)
 - `-metrics-port 10000` it enables the Daemon's Prometheus metrics endpoint on `localhost:10000`
 - `block-producer-key /root/wallet-keys/my_wallet` it loads an arbitrary wallet key file at runtime to act as a Block Producer
-- `-unsafe-track-block-producer-key` it tells the daemon to *(insecurely)* strip the password from the wallet key file and load it into the internal wallet store for use with GraphQL 
-
+- `-unsafe-track-block-producer-key` it tells the daemon to *(insecurely)* strip the password from the wallet key file and load it into the internal wallet store for use with GraphQL


### PR DESCRIPTION
## Summary
- Quick win from #18825: replace stale "Coda" branding in `docs/{demo,daemon,docker}.md` with "Mina"
- Update broken `codaprotocol/coda-*` Docker image references to current `minaprotocol/mina-daemon` image (with `RUN_DEMO=true` env for demo mode, matching `dockerfiles/auxiliary_entrypoints/01-run-demo.sh:5`)
- Update dead `github.com/CodaProtocol/coda` URLs to `github.com/MinaProtocol/mina`
- Skipped `docs/environment-variables.md`: its only "Coda" mention correctly documents `/var/lib/coda` as the still-hardcoded legacy default path (`src/lib/cache_dir/{native,fake}/cache_dir.ml`)

## Test plan
- [ ] Render the three changed pages on GitHub and confirm no broken links
- [ ] Confirm `RUN_DEMO=true` env-var instruction in `docs/demo.md` matches the entrypoint script

Refs #18825

🤖 Generated with [Claude Code](https://claude.com/claude-code)