### PR TITLE
docs: update README-branching.md for post-Berkeley reality (#18825)

### DIFF
--- a/README-branching.md
+++ b/README-branching.md
@@ -1,75 +1,143 @@
 # Mina Branching Policy
 
-Mina's current public release is "mainnet", version 1.X. The next hardfork release is "berkeley" 2.0, and the one planned after is "izmir" 3.0.
+Mina's current public release is "berkeley", version 2.X. The next hardfork
+release is "mesa" 3.X, staged on the `release/mesa` branch.
 
 The development branches in progress in `mina` are as follows:
-- `master`: current stable release, currently mainnet 1.X.
-  - It is frozen from the crypto side, does not depend on `proof-systems`.
+
+- `master`: current stable release, currently berkeley 2.X.
   - Never commit to it directly, except to introduce a hotfix.
-- `compatible`: scheduled to be softwork released.
-  - The staging branch for mainnet soft fork releases.
-  - It contains all the changes which are literally backwards compatible with the current mainnet deployment. Any nodes running a version of mina based off of compatible should connect to the current mainnet.
-  - It serves as the preparation ground for the next mainnet soft fork release.
-- `rampup`: what is deployed on the testnet
-  - The public incentivized network where an early version of the 2.0 hardfork is deployed for community testing.
-  - `rampup` is a temporary branch maintained until public testnets requiring compatibility are running.
-  - Never make PRs to `rampup` unless you're explicitly fixing a testnet bug.
-- `berkeley`/`izmir`: next hardfork branch / release candidate.
-  - Contains all the new features that are scheduled for the release (berkeley or izmir).
-  - `berkeley` is a 2.0 temporary branch maintained until the hard fork after which compatible will include all berkeley changes.
-  - The "devnet" testnet is running from `master`, sometimes `compatible`, and features only the current release (not cutting edge/berkeley).
-- `develop`: 2.0 compatible changes not scoped for the 2.0 hard fork upgrade.
-  - In other words, `develop` is next non-harmful release (after `berkeley`).
-  - Is not *the most cutting edge: might not contain protocol features that scheduled for the subsequent (3.0) release.
-  - Contains changes which break backwards compatibility, or changes that depend on past compatibility-breaking changes.  “Not backwards compatible” means that a daemon running this version of mina will not connect to mainnet.
-  - Major changes to the daemon, protocol, or crypto will sometimes cause backwards-compatibility breaking changes, and of course such changes need to be done with deliberation and are not to be taken lightly.  Changes to infrastructure, auxiliary develop scripts, tests, CI, are usually not be backwards compatibility breaking, and thereby should go into compatible (unless you are doing something very special and you know what you’re doing).
-  - The difference between `develop` and `berkeley` is that `berkeley` will be the actual hardfork release, while `develop` is subsequent softfork release candidate, softfork after `berkeley`. `develop` is just not tested as rigorously, but it's softfork compatible with `berkeley`. So if `berkeley` can be thought of as 2.0, then `develop` is 2.01.
-- `o1js-main`: compatible with testnet, but has latest `proof-systems` features so that they can be used in `o1js`
-  - Contains mina changes from `rampup`
-  - But `proof-systems/develop` which by default is used by `mina/develop`.
-  - Uses `o1js/main` and `o1js-bindings/main` as explained [here](https://github.com/o1-labs/o1js/blob/main/README-dev.md#branch-compatibility?).
-  - When `proof-systems/develop` is too cutting-edge and the adaptations of its changes haven't been landed in mina, `o1js` will use the `proof-systems/o1js-main` branch which is lagging behind `proof-systems/develop` a bit.
+- `compatible`: scheduled to be soft-fork released.
+  - The staging branch for mainnet soft-fork releases.
+  - It contains all the changes which are literally backwards compatible with
+    the current mainnet deployment. Any nodes running a version of mina based
+    off of `compatible` should connect to the current mainnet.
+  - It serves as the preparation ground for the next mainnet soft-fork release.
+- `release/mesa`: next hard-fork release branch / release candidate.
+  - Contains all the new features that are scheduled for the mesa hard fork.
+  - It is the active hard-fork branch maintained until the mesa hard fork
+    upgrade, after which `compatible` will absorb its changes.
+  - Replaces the legacy `berkeley`/`izmir` branches that were retired after the
+    berkeley hard fork.
+- `develop`: post-mesa changes not scoped for the mesa hard-fork upgrade.
+  - In other words, `develop` is the next non-harmful release (after mesa).
+  - Contains changes which break backwards compatibility, or changes that
+    depend on past compatibility-breaking changes. "Not backwards compatible"
+    means that a daemon running this version of mina will not connect to
+    mainnet.
+  - Major changes to the daemon, protocol, or crypto will sometimes cause
+    backwards-compatibility breaking changes, and of course such changes need
+    to be done with deliberation and are not to be taken lightly. Changes to
+    infrastructure, auxiliary develop scripts, tests, CI, are usually not
+    backwards-compatibility breaking, and thereby should go into `compatible`
+    (unless you are doing something very special and you know what you're
+    doing).
+  - The difference between `develop` and `release/mesa` is that `release/mesa`
+    will be the actual hardfork release, while `develop` is the subsequent
+    softfork release candidate, softfork after mesa. `develop` is just not
+    tested as rigorously, but it's softfork compatible with `release/mesa`.
+- `o1js-main`: compatible with mainnet, but has latest `proof-systems`
+  features so that they can be used in `o1js`.
+  - Uses `o1js/main` and `o1js-bindings/main` as explained
+    [here](https://github.com/o1-labs/o1js/blob/main/README-dev.md#branch-compatibility?).
+  - When `proof-systems/develop` is too cutting-edge and the adaptations of
+    its changes haven't been landed in mina, `o1js` will use the
+    `proof-systems/o1js-main` branch which is lagging behind
+    `proof-systems/develop` a bit.
 
+The relationship between the branches is as presented:
+`master ⊆ compatible ⊆ release/mesa ⊆ develop`.
 
-The relationship between the branches is as presented: `master ⊆ compatible ⊆ rampup ⊆ berkeley ⊆ develop`.
-- This means `compatible` includes all the changes in `master`, `rampup` all the changes in `compatible` and so on. So `develop` contains all the changes from *all* the stable branches, but also contains features that do not exist in any of the "subsets".
-- The back-merging direction is thus left-to-right: whenever a feature lands in this chain, it has to be periodically "back-merged" to the right.
-- The branches are merged in the other direction (upstream) only when released.
-- When merely a new feature is introduced, it should aim at the exact target branch. This place depends on the feature, e.g. `compatible` for softfork features, `develop` for more experimental/next release, etc. And then the merged feature is back-propagated downstream (to the right).
-
+- This means `compatible` includes all the changes in `master`, `release/mesa`
+  all the changes in `compatible`, and so on. So `develop` contains all the
+  changes from _all_ the stable branches, but also contains features that do
+  not exist in any of the "subsets".
+- The back-merging direction is thus left-to-right: whenever a feature lands
+  in this chain, it has to be periodically "back-merged" to the right.
+- The branches are merged in the other direction (upstream) only when
+  released.
+- When merely a new feature is introduced, it should aim at the exact target
+  branch. This place depends on the feature, e.g. `compatible` for soft-fork
+  features, `release/mesa` for the upcoming hard fork, `develop` for
+  post-mesa / experimental work.
 
 ![Illustration of the branching strategy](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/branching_flow_david_wong.png)
 
+### Hard forks / releases
 
+Whenever a hard fork happens, the code in the corresponding release branch
+(e.g. `release/mesa`) is released to become the new `master`.
 
-### Hard forks / releases:
-
-Whenever a hard fork happens, the code in the corresponding release branch, e.g. `berkeley`, is released to become the new `master`.
-- The intention is then to again have `compatible` as a next soft-fork branch.
-  - The transition will be gradual: right after HF, `berkeley` will be copied into both `master` *and* `compatible`, and `develop` will remain as is for a while. PRs from `develop` will be gradually picked based on release scope and included in `compatible` for subsequent soft-fork releases.
-  - The pre-Berkeley `compatible` is entirely discarded. The pre-Berkeley branch `berkeley` is completely removed from both `mina` and `proof-systems`.
-- `release/1.X.X` branches are made off of `compatible` and tagged with alpha and beta tags until the code is deemed stable, then the `release/1.X.X` branch is merged into `master` and given a stable tag. Whenever code is tagged, if anything is missing in the downstream branches (compatible, develop) then the tagged branch is also merged back for consistency.
+- The intention is then to again have `compatible` as the next soft-fork
+  branch.
+  - The transition will be gradual: right after HF, `release/mesa` will be
+    copied into both `master` _and_ `compatible`, and `develop` will remain as
+    is for a while. PRs from `develop` will be gradually picked based on
+    release scope and included in `compatible` for subsequent soft-fork
+    releases.
+  - The pre-mesa `compatible` is entirely discarded. The pre-mesa branch
+    `release/mesa` is completely removed from both `mina` and `proof-systems`.
+- `release/<version>` branches (e.g. `release/3.4.0`) are made off of
+  `compatible` and tagged with alpha and beta tags until the code is deemed
+  stable, then the `release/<version>` branch is merged into `master` and
+  given a stable tag. Whenever code is tagged, if anything is missing in the
+  downstream branches (`compatible`, `develop`) then the tagged branch is also
+  merged back for consistency.
 
 ## Day to day: which branch should I use?
 
-When developing a feature, use the general description of the branches above to decide. Here's a quick rule:
-- If a feature/enhancement/bug fix is not feature breaking, and scoped for a mainnet then base it off of `compatible`. If you’re not sure whether or not your changes are breaking, they probably are not and should build upon `compatible`.
-- If the feature is scoped for hardfork and is not compatible against a running public testnet, then base it off of the hardfork branch (for example, `berkeley`).
-- If it is a bug fix required for a public testnet testing upcoming hardfork then base it off of `rampup`.
+When developing a feature, use the general description of the branches above
+to decide. Here's a quick rule:
+
+- If a feature/enhancement/bug fix is not feature breaking, and scoped for
+  mainnet, then base it off of `compatible`. If you're not sure whether or not
+  your changes are breaking, they probably are not and should build upon
+  `compatible`.
+- If the feature is scoped for the next hard fork and is not compatible with
+  running public mainnet, then base it off of the hard-fork branch
+  (currently `release/mesa`).
+- If a change is post-hard-fork (depends on mesa shipping, or is otherwise
+  cutting-edge / not yet release-scoped), base it off of `develop`.
 
 ### Handling back-merging conflicts
 
-We have CI jobs named `check-merges-cleanly-into-BRANCH` that fail if a PR introduces changes conflicting with changes in a downstream branch `BRANCH`. E.g. `check-merges-cleanly-into-develop` will check that a PR aimed at `compatible` is easily back-mergable downstream up to `develop`. PR authors must create new PRs against those branches to resolve conflicts before merging the original PR.
+We have CI jobs named `check-merges-cleanly-into-BRANCH` that fail if a PR
+introduces changes conflicting with changes in a downstream branch `BRANCH`.
+E.g. `check-merges-cleanly-into-develop` will check that a PR aimed at
+`compatible` is easily back-mergable downstream up to `develop`. PR authors
+must create new PRs against those branches to resolve conflicts before merging
+the original PR.
 
 If that CI job passes, then you can proceed and no further action is needed.
 
-PRs resolving merge conflicts (merge-PRs) should only be merged after the original PR is approved, and all changes from the original PR are incorporated into the merge-PRs. Consider a PR which is made from `mybranch` branch against `rampup`, and causes conflicts in `berkeley` and `develop`. In this case the workflow is as follows:
-- Review and approve the original PR against `rampup` (PR-rampup). CI passes except for `check-merges-cleanly-into-*` jobs.
-- Incorporate all changes from PR-rampup into a new PR against `berkeley` (PR-berkeley) and resolve conflicts. Concretely, make a new branch+PR based off of `mybranch` called `mybranch-berkeley` (for example), and then merge `berkeley` into `mybranch-berkeley`. Fix any merge errors that result.
-  - Keeping branches in sync: If after making e.g. `mybranch-berkeley`, you need to make changes to `mybranch`, then do so, but make sure to merge the newly updated `mybranch` into `mybranch-berkeley`. In order for the git magic to work, `mybranch-berkeley` needs to be a superset of the commits from `mybranch`, and it also needs to be merged first.
-- Similarly, incorporate all changes from PR-rampup into a new PR against `develop` (PR-develop) and resolve conflicts.
-- Review, approve, and merge PR-berkeley and PR-develop. They can be done in parallel.
-- Rerun failing `check-merges-cleanly-into-*` jobs against the original PR-rampup and merge PR-rampup after CI is green.
+PRs resolving merge conflicts (merge-PRs) should only be merged after the
+original PR is approved, and all changes from the original PR are incorporated
+into the merge-PRs. Consider a PR which is made from `mybranch` against
+`compatible`, and causes conflicts in `release/mesa` and `develop`. In this
+case the workflow is as follows:
 
+- Review and approve the original PR against `compatible` (PR-compatible). CI
+  passes except for `check-merges-cleanly-into-*` jobs.
+- Incorporate all changes from PR-compatible into a new PR against
+  `release/mesa` (PR-mesa) and resolve conflicts. Concretely, make a new
+  branch+PR based off of `mybranch` called `mybranch-mesa` (for example), and
+  then merge `release/mesa` into `mybranch-mesa`. Fix any merge errors that
+  result.
+  - Keeping branches in sync: If after making e.g. `mybranch-mesa`, you need
+    to make changes to `mybranch`, then do so, but make sure to merge the
+    newly updated `mybranch` into `mybranch-mesa`. In order for the git magic
+    to work, `mybranch-mesa` needs to be a superset of the commits from
+    `mybranch`, and it also needs to be merged first.
+- Similarly, incorporate all changes from PR-compatible into a new PR against
+  `develop` (PR-develop) and resolve conflicts.
+- Review, approve, and merge PR-mesa and PR-develop. They can be done in
+  parallel.
+- Rerun failing `check-merges-cleanly-into-*` jobs against the original
+  PR-compatible and merge PR-compatible after CI is green.
 
-The protocol team at o1labs will conduct weekly synchronization of all branches for all non-conflicting changes to ensure a smooth experience for everyone involved in the Mina repository. The protocol team will reach out to respective teams if there are any conflicting changes (due to force-merges performed mistakenly) and/or failing tests caused by code changes in the upstream branches.
+The protocol team at o1labs will conduct weekly synchronization of all
+branches for all non-conflicting changes to ensure a smooth experience for
+everyone involved in the Mina repository. The protocol team will reach out to
+respective teams if there are any conflicting changes (due to force-merges
+performed mistakenly) and/or failing tests caused by code changes in the
+upstream branches.

--- a/README-branching.md
+++ b/README-branching.md
@@ -1,9 +1,12 @@
 # Mina Branching Policy
 
 Mina's current public release is "berkeley", version 2.X. The next hardfork
-release is "mesa" 3.X, staged on the `release/mesa` branch.
+release is "mesa" 3.X.
 
-The development branches in progress in `mina` are as follows:
+## Long-lived development branches
+
+These are the branches contributors target. PRs are made against one of
+these:
 
 - `master`: current stable release, currently berkeley 2.X.
   - Never commit to it directly, except to introduce a hotfix.
@@ -13,14 +16,8 @@ The development branches in progress in `mina` are as follows:
     the current mainnet deployment. Any nodes running a version of mina based
     off of `compatible` should connect to the current mainnet.
   - It serves as the preparation ground for the next mainnet soft-fork release.
-- `release/mesa`: next hard-fork release branch / release candidate.
-  - Contains all the new features that are scheduled for the mesa hard fork.
-  - It is the active hard-fork branch maintained until the mesa hard fork
-    upgrade, after which `compatible` will absorb its changes.
-  - Replaces the legacy `berkeley`/`izmir` branches that were retired after the
-    berkeley hard fork.
-- `develop`: post-mesa changes not scoped for the mesa hard-fork upgrade.
-  - In other words, `develop` is the next non-harmful release (after mesa).
+- `develop`: changes that break mainnet compatibility, including features
+  scoped for the next hard fork.
   - Contains changes which break backwards compatibility, or changes that
     depend on past compatibility-breaking changes. "Not backwards compatible"
     means that a daemon running this version of mina will not connect to
@@ -32,10 +29,6 @@ The development branches in progress in `mina` are as follows:
     backwards-compatibility breaking, and thereby should go into `compatible`
     (unless you are doing something very special and you know what you're
     doing).
-  - The difference between `develop` and `release/mesa` is that `release/mesa`
-    will be the actual hardfork release, while `develop` is the subsequent
-    softfork release candidate, softfork after mesa. `develop` is just not
-    tested as rigorously, but it's softfork compatible with `release/mesa`.
 - `o1js-main`: compatible with mainnet, but has latest `proof-systems`
   features so that they can be used in `o1js`.
   - Uses `o1js/main` and `o1js-bindings/main` as explained
@@ -45,59 +38,73 @@ The development branches in progress in `mina` are as follows:
     `proof-systems/o1js-main` branch which is lagging behind
     `proof-systems/develop` a bit.
 
-The relationship between the branches is as presented:
-`master ⊆ compatible ⊆ release/mesa ⊆ develop`.
+The relationship between the long-lived branches is:
+`master ⊆ compatible ⊆ develop`.
 
-- This means `compatible` includes all the changes in `master`, `release/mesa`
-  all the changes in `compatible`, and so on. So `develop` contains all the
-  changes from _all_ the stable branches, but also contains features that do
-  not exist in any of the "subsets".
+- `compatible` includes all the changes in `master`, and `develop` includes
+  all the changes in `compatible`. So `develop` contains all the changes from
+  _all_ the stable branches, but also contains features that do not exist in
+  the "subsets".
 - The back-merging direction is thus left-to-right: whenever a feature lands
   in this chain, it has to be periodically "back-merged" to the right.
 - The branches are merged in the other direction (upstream) only when
   released.
 - When merely a new feature is introduced, it should aim at the exact target
   branch. This place depends on the feature, e.g. `compatible` for soft-fork
-  features, `release/mesa` for the upcoming hard fork, `develop` for
-  post-mesa / experimental work.
+  features and `develop` for breaking / hard-fork-scoped / experimental work.
 
 ![Illustration of the branching strategy](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/branching_flow_david_wong.png)
 
-### Hard forks / releases
+## Short-lived release branches
 
-Whenever a hard fork happens, the code in the corresponding release branch
-(e.g. `release/mesa`) is released to become the new `master`.
+`release/<name>` branches are **not** development targets — they are
+short-lived branches cut from a long-lived branch when it is time to actually
+ship a release. Examples:
+
+- `release/<version>` (e.g. `release/3.4.0`) — soft-fork release candidates,
+  cut from `compatible`. Tagged with alpha and beta tags until the code is
+  deemed stable, then merged into `master` and given a stable tag.
+- `release/<hardfork-name>` (e.g. `release/mesa`) — hard-fork release
+  candidate, cut when a hard fork is ready to ship.
+
+Whenever code is tagged, if anything is missing in the downstream long-lived
+branches (`compatible`, `develop`) then the tagged branch is also merged back
+for consistency.
+
+Contributors should **not** open PRs against `release/*` branches as part of
+normal feature work. If a feature is hard-fork-scoped, target `develop`; if
+it's soft-fork-scoped, target `compatible`. The release manager will pick the
+work into a release branch when ready.
+
+### Hard forks
+
+Whenever a hard fork happens, the code in the corresponding hard-fork release
+branch (e.g. `release/mesa`) is released to become the new `master`.
 
 - The intention is then to again have `compatible` as the next soft-fork
   branch.
-  - The transition will be gradual: right after HF, `release/mesa` will be
-    copied into both `master` _and_ `compatible`, and `develop` will remain as
-    is for a while. PRs from `develop` will be gradually picked based on
-    release scope and included in `compatible` for subsequent soft-fork
-    releases.
-  - The pre-mesa `compatible` is entirely discarded. The pre-mesa branch
-    `release/mesa` is completely removed from both `mina` and `proof-systems`.
-- `release/<version>` branches (e.g. `release/3.4.0`) are made off of
-  `compatible` and tagged with alpha and beta tags until the code is deemed
-  stable, then the `release/<version>` branch is merged into `master` and
-  given a stable tag. Whenever code is tagged, if anything is missing in the
-  downstream branches (`compatible`, `develop`) then the tagged branch is also
-  merged back for consistency.
+  - The transition will be gradual: right after HF, the hard-fork release
+    branch will be copied into both `master` _and_ `compatible`, and
+    `develop` will remain as is for a while. PRs from `develop` will be
+    gradually picked based on release scope and included in `compatible` for
+    subsequent soft-fork releases.
+  - The pre-HF `compatible` is entirely discarded. The hard-fork release
+    branch is then removed from both `mina` and `proof-systems`.
 
 ## Day to day: which branch should I use?
 
-When developing a feature, use the general description of the branches above
-to decide. Here's a quick rule:
+When developing a feature, use the general description of the long-lived
+branches above to decide. Here's a quick rule:
 
 - If a feature/enhancement/bug fix is not feature breaking, and scoped for
-  mainnet, then base it off of `compatible`. If you're not sure whether or not
-  your changes are breaking, they probably are not and should build upon
+  mainnet, then base it off of `compatible`. If you're not sure whether or
+  not your changes are breaking, they probably are not and should build upon
   `compatible`.
-- If the feature is scoped for the next hard fork and is not compatible with
-  running public mainnet, then base it off of the hard-fork branch
-  (currently `release/mesa`).
-- If a change is post-hard-fork (depends on mesa shipping, or is otherwise
-  cutting-edge / not yet release-scoped), base it off of `develop`.
+- If the change is breaking — for example, scoped for the next hard fork, or
+  otherwise incompatible with running public mainnet — base it off of
+  `develop`.
+- Do not target `release/*` branches; those are managed by the release
+  process.
 
 ### Handling back-merging conflicts
 
@@ -105,39 +112,35 @@ We have CI jobs named `check-merges-cleanly-into-BRANCH` that fail if a PR
 introduces changes conflicting with changes in a downstream branch `BRANCH`.
 E.g. `check-merges-cleanly-into-develop` will check that a PR aimed at
 `compatible` is easily back-mergable downstream up to `develop`. PR authors
-must create new PRs against those branches to resolve conflicts before merging
-the original PR.
+must create new PRs against those branches to resolve conflicts before
+merging the original PR.
 
 If that CI job passes, then you can proceed and no further action is needed.
 
 PRs resolving merge conflicts (merge-PRs) should only be merged after the
-original PR is approved, and all changes from the original PR are incorporated
-into the merge-PRs. Consider a PR which is made from `mybranch` against
-`compatible`, and causes conflicts in `release/mesa` and `develop`. In this
-case the workflow is as follows:
+original PR is approved, and all changes from the original PR are
+incorporated into the merge-PRs. Consider a PR which is made from `mybranch`
+against `compatible` and causes conflicts in `develop`. In this case the
+workflow is as follows:
 
-- Review and approve the original PR against `compatible` (PR-compatible). CI
-  passes except for `check-merges-cleanly-into-*` jobs.
-- Incorporate all changes from PR-compatible into a new PR against
-  `release/mesa` (PR-mesa) and resolve conflicts. Concretely, make a new
-  branch+PR based off of `mybranch` called `mybranch-mesa` (for example), and
-  then merge `release/mesa` into `mybranch-mesa`. Fix any merge errors that
-  result.
-  - Keeping branches in sync: If after making e.g. `mybranch-mesa`, you need
+- Review and approve the original PR against `compatible` (PR-compatible).
+  CI passes except for `check-merges-cleanly-into-*` jobs.
+- Incorporate all changes from PR-compatible into a new PR against `develop`
+  (PR-develop) and resolve conflicts. Concretely, make a new branch+PR based
+  off of `mybranch` called `mybranch-develop` (for example), and then merge
+  `develop` into `mybranch-develop`. Fix any merge errors that result.
+  - Keeping branches in sync: If after making `mybranch-develop`, you need
     to make changes to `mybranch`, then do so, but make sure to merge the
-    newly updated `mybranch` into `mybranch-mesa`. In order for the git magic
-    to work, `mybranch-mesa` needs to be a superset of the commits from
-    `mybranch`, and it also needs to be merged first.
-- Similarly, incorporate all changes from PR-compatible into a new PR against
-  `develop` (PR-develop) and resolve conflicts.
-- Review, approve, and merge PR-mesa and PR-develop. They can be done in
-  parallel.
+    newly updated `mybranch` into `mybranch-develop`. In order for the git
+    magic to work, `mybranch-develop` needs to be a superset of the commits
+    from `mybranch`, and it also needs to be merged first.
+- Review, approve, and merge PR-develop.
 - Rerun failing `check-merges-cleanly-into-*` jobs against the original
   PR-compatible and merge PR-compatible after CI is green.
 
 The protocol team at o1labs will conduct weekly synchronization of all
 branches for all non-conflicting changes to ensure a smooth experience for
-everyone involved in the Mina repository. The protocol team will reach out to
-respective teams if there are any conflicting changes (due to force-merges
+everyone involved in the Mina repository. The protocol team will reach out
+to respective teams if there are any conflicting changes (due to force-merges
 performed mistakenly) and/or failing tests caused by code changes in the
 upstream branches.

--- a/README-branching.md
+++ b/README-branching.md
@@ -1,7 +1,7 @@
 # Mina Branching Policy
 
 Mina's current public release is "berkeley", version 2.X. The next hardfork
-release is "mesa" 3.X.
+release is "mesa" 3.X, staged on the `release/mesa` branch.
 
 ## Long-lived development branches
 
@@ -16,8 +16,19 @@ these:
     the current mainnet deployment. Any nodes running a version of mina based
     off of `compatible` should connect to the current mainnet.
   - It serves as the preparation ground for the next mainnet soft-fork release.
-- `develop`: changes that break mainnet compatibility, including features
-  scoped for the next hard fork.
+- `release/mesa`: next hard-fork release branch.
+  - Contains all the new features that are scheduled for the mesa hard
+    fork. It is the active hard-fork branch maintained until the mesa
+    hard fork upgrade, after which `compatible` will absorb its changes
+    (see "Hard fork transition" below).
+  - Replaces the legacy `berkeley`/`izmir` branches that were retired
+    after the berkeley hard fork.
+  - Unlike `release/<version>` branches (see below), this is a
+    development target: PRs introducing hard-fork-scoped features should
+    be opened against it.
+- `develop`: post-mesa changes — breaks mainnet compatibility and is not
+  scoped for the upcoming mesa hard fork.
+  - In other words, `develop` is the next soft-fork release candidate after mesa.
   - Contains changes which break backwards compatibility, or changes that
     depend on past compatibility-breaking changes. "Not backwards compatible"
     means that a daemon running this version of mina will not connect to
@@ -29,6 +40,11 @@ these:
     backwards-compatibility breaking, and thereby should go into `compatible`
     (unless you are doing something very special and you know what you're
     doing).
+  - The difference between `develop` and `release/mesa` is that
+    `release/mesa` will be the actual hard-fork release, while `develop`
+    is the subsequent soft-fork release candidate (soft-fork after mesa).
+    `develop` is simply not tested as rigorously, but it is soft-fork
+    compatible with `release/mesa`.
 - `o1js-main`: compatible with mainnet, but has latest `proof-systems`
   features so that they can be used in `o1js`.
   - Uses `o1js/main` and `o1js-bindings/main` as explained
@@ -39,44 +55,43 @@ these:
     `proof-systems/develop` a bit.
 
 The relationship between the long-lived branches is:
-`master ⊆ compatible ⊆ develop`.
+`master ⊆ compatible ⊆ release/mesa ⊆ develop`.
 
-- `compatible` includes all the changes in `master`, and `develop` includes
-  all the changes in `compatible`. So `develop` contains all the changes from
-  _all_ the stable branches, but also contains features that do not exist in
-  the "subsets".
+- `compatible` includes all the changes in `master`, `release/mesa` includes
+  all the changes in `compatible`, and `develop` includes all the changes in
+  `release/mesa`. So `develop` contains all the changes from _all_ the
+  upstream branches, but also contains features that do not exist in the
+  "subsets".
 - The back-merging direction is thus left-to-right: whenever a feature lands
   in this chain, it has to be periodically "back-merged" to the right.
 - The branches are merged in the other direction (upstream) only when
   released.
 - When merely a new feature is introduced, it should aim at the exact target
   branch. This place depends on the feature, e.g. `compatible` for soft-fork
-  features and `develop` for breaking / hard-fork-scoped / experimental work.
+  features, `release/mesa` for the upcoming hard fork, and `develop` for
+  post-mesa / experimental work.
 
 ![Illustration of the branching strategy](https://github.com/MinaProtocol/mina-resources/blob/main/docs/res/branching_flow_david_wong.png)
 
 ## Short-lived release branches
 
-`release/<name>` branches are **not** development targets — they are
-short-lived branches cut from a long-lived branch when it is time to actually
-ship a release. Examples:
+`release/<version>` branches (e.g. `release/3.4.0`) are **not** development
+targets — they are short-lived branches cut from `compatible` when it is
+time to ship a soft-fork release. They are tagged with alpha and beta tags
+until the code is deemed stable, then merged into `master` and given a
+stable tag.
 
-- `release/<version>` (e.g. `release/3.4.0`) — soft-fork release candidates,
-  cut from `compatible`. Tagged with alpha and beta tags until the code is
-  deemed stable, then merged into `master` and given a stable tag.
-- `release/<hardfork-name>` (e.g. `release/mesa`) — hard-fork release
-  candidate, cut when a hard fork is ready to ship.
+Whenever a `release/<version>` is tagged, if anything is missing in the
+downstream long-lived branches (`compatible`, `release/mesa`, `develop`)
+then the tagged branch is also merged back to those branches for
+consistency.
 
-Whenever code is tagged, if anything is missing in the downstream long-lived
-branches (`compatible`, `develop`) then the tagged branch is also merged back
-for consistency.
+Contributors should **not** open PRs against `release/<version>` branches
+as part of normal feature work. The release manager will pick changes into
+a release branch when ready. Hard-fork-scoped work should instead target
+the long-lived `release/mesa` branch described above.
 
-Contributors should **not** open PRs against `release/*` branches as part of
-normal feature work. If a feature is hard-fork-scoped, target `develop`; if
-it's soft-fork-scoped, target `compatible`. The release manager will pick the
-work into a release branch when ready.
-
-### Hard forks
+### Hard fork transition
 
 Whenever a hard fork happens, the code in the corresponding hard-fork release
 branch (e.g. `release/mesa`) is released to become the new `master`.
@@ -100,20 +115,28 @@ branches above to decide. Here's a quick rule:
   mainnet, then base it off of `compatible`. If you're not sure whether or
   not your changes are breaking, they probably are not and should build upon
   `compatible`.
-- If the change is breaking — for example, scoped for the next hard fork, or
-  otherwise incompatible with running public mainnet — base it off of
-  `develop`.
-- Do not target `release/*` branches; those are managed by the release
-  process.
+- If the feature is scoped for the next hard fork and is not compatible
+  with running public mainnet, base it off of the hard-fork branch
+  (currently `release/mesa`).
+- If a change is post-hard-fork (depends on mesa shipping, or is otherwise
+  cutting-edge / not yet release-scoped), base it off of `develop`.
+- Do not target `release/<version>` branches (e.g. `release/3.4.0`); those
+  are managed by the release process.
 
 ### Handling back-merging conflicts
 
 We have CI jobs named `check-merges-cleanly-into-BRANCH` that fail if a PR
 introduces changes conflicting with changes in a downstream branch `BRANCH`.
-E.g. `check-merges-cleanly-into-develop` will check that a PR aimed at
+The jobs currently cover `master`, `compatible`, and `develop`. E.g.
+`check-merges-cleanly-into-develop` will check that a PR aimed at
 `compatible` is easily back-mergable downstream up to `develop`. PR authors
 must create new PRs against those branches to resolve conflicts before
 merging the original PR.
+
+Note: `release/mesa` is **not** covered by the back-merge CI. If a PR
+against `compatible` needs to also land on `release/mesa` for the upcoming
+hard fork, the release manager will pick or back-merge it manually — there
+is no automated gate for it.
 
 If that CI job passes, then you can proceed and no further action is needed.
 


### PR DESCRIPTION
## Summary
Quick win from #18825: \`README-branching.md\` still described mainnet 1.X, the \`rampup\` testnet, and the \`berkeley\`/\`izmir\` hardfork branches — all retired after berkeley shipped.

- Drop the \`rampup\` section (branch retired)
- Replace \`berkeley\`/\`izmir\` hardfork branch with \`release/mesa\` (the currently active hard-fork branch)
- Update the chain diagram \`master ⊆ compatible ⊆ rampup ⊆ berkeley ⊆ develop\` → \`master ⊆ compatible ⊆ release/mesa ⊆ develop\`
- Refresh the "which branch should I use" rules and the merge-conflict workflow example to use \`compatible\`/\`release/mesa\`/\`develop\`
- Generalize release tagging text from \`release/1.X.X\` to \`release/<version>\` with \`release/3.4.0\` as the current example
- Refresh \`o1js-main\` paragraph (drop dead reference to \`rampup\` as upstream)

## Test plan
- [ ] Render the page on GitHub and confirm formatting (markdown was reflowed to ~80 cols, matching the prettier convention introduced in commit \`edd3d9e6b7\`)
- [ ] Sanity-check the branch references against current remote state (\`master\`, \`compatible\`, \`release/mesa\`, \`develop\` all exist; \`rampup\`/\`berkeley\` no longer referenced)

Refs #18825

🤖 Generated with [Claude Code](https://claude.com/claude-code)