### PR TITLE
buildkite/local: verify toolchain + auto-recover perms after runs

### DIFF
--- a/buildkite/local/README.md
+++ b/buildkite/local/README.md
@@ -92,9 +92,44 @@ Local execution differs from CI in several ways:
 **Local behavior:** Containers also run as `opam` (UID 1000). This allows sudo
 to work inside containers for apt operations.
 
-If your host user has a different UID than 1000, you may see permission issues
-with the `_build` directory. The script checks for this at startup and will
-show an error with instructions to fix ownership.
+If your host user has a different UID than 1000, files written by the container
+to the bind-mounted worktree appear on the host owned by UID 1000 — likely
+unreadable/unwritable from your host account.
+
+`run_job.sh` mitigates this with **automatic recovery**:
+
+- **Pre-flight scan:** Before running a job the script scans the worktree
+  (excluding `.git/` and `.claude/worktrees/`) for files not owned by you.
+  If any are found, it prompts to run `sudo chown -R` to recover them.
+  Pass `--auto-fix-perms` to skip the prompt.
+- **Exit trap:** The same scan runs on exit (success, failure, or Ctrl-C),
+  so an interrupted run still leaves the worktree usable for `git`, `dune`,
+  etc.
+
+The recovery is `sudo`-based, so passwordless sudo is the smoothest experience
+for repeated runs. If you cannot use sudo, the only path is to make your host
+user UID 1000 (or run the container as your host UID, which currently breaks
+in-container `apt` flows — tracked as a known limitation).
+
+### Toolchain image verification
+
+Each job pulls one or more pinned Docker images from the
+`europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/` registry — the
+same images CI uses, pinned by tag in
+[`buildkite/src/Constants/ContainerImages.dhall`](../src/Constants/ContainerImages.dhall).
+
+`run_job.sh` checks each image referenced by the job before running anything
+and reports one of:
+
+| State | Meaning |
+|---|---|
+| `local-cached` | Already in your local Docker daemon. No pull needed. |
+| `pull-needed` | Registry has it; first run will pull. Use `--pull-toolchain` to pull up-front. |
+| `unreachable` | Image (or registry) cannot be reached. Most often an auth issue — `gcloud auth configure-docker europe-west3-docker.pkg.dev` usually fixes it. |
+
+If any images are `unreachable` the script exits before running steps so you
+don't burn 30+ minutes only to die at the first `docker run`. Use
+`--skip-toolchain-check` to bypass this check entirely.
 
 ### Environment Variables
 
@@ -221,6 +256,9 @@ Options:
   --env-file FILE    File with KEY=VALUE pairs passed to all commands (including Docker)
   --list             List available job names and exit
   --list-steps       List steps in the job and exit (requires job name)
+  --skip-toolchain-check   Don't verify toolchain images before running
+  --pull-toolchain         docker pull each toolchain image up-front
+  --auto-fix-perms         Auto-recover container-owned files (sudo chown) without prompting
   -h, --help         Show this help
 ```
 
@@ -290,17 +328,37 @@ ERROR: Local storagebox directory is not writable: /var/storagebox
 
 Run the one-time setup commands in Prerequisites above.
 
-### _build owned by different user
+### Files owned by different user
 
 ```
-ERROR: _build directory is owned by UID 0 (you are 1000)
+WARN: Found N file(s) in /home/.../mina not owned by <you> (UID <id>)
 ```
 
-This happens when a previous Docker run created files as root. Fix with:
+This happens because containers run as `opam` (UID 1000) and write into the
+bind-mounted worktree. The script auto-recovers this on the next run (and
+on exit) via `sudo chown -R`. To skip the confirmation prompt, pass
+`--auto-fix-perms`.
+
+If you want to fix it manually:
 
 ```bash
-sudo chown -R $(id -u):$(id -g) _build
+sudo chown -R $(id -u):$(id -g) .
 ```
+
+### Toolchain image unreachable
+
+```
+ERROR: 1 image(s) unreachable.
+```
+
+The registry can't be reached — usually a missing gcloud auth. Run:
+
+```bash
+gcloud auth configure-docker europe-west3-docker.pkg.dev
+```
+
+then re-run. If you intentionally want to bypass the check (e.g. you've
+side-loaded the image), pass `--skip-toolchain-check`.
 
 ### Hetzner key not found
 

--- a/buildkite/local/run_job.sh
+++ b/buildkite/local/run_job.sh
@@ -45,6 +45,10 @@ SYNC_FILTER=""
 OVERRIDE_COMMIT=""
 LIST_JOBS=false
 LIST_STEPS=false
+SKIP_TOOLCHAIN_CHECK=false
+PULL_TOOLCHAIN=false
+AUTO_FIX_PERMS=false
+JOB_FILE=""
 
 # Populated by load_env_file, used by patch_docker_command
 USER_ENV_DOCKER_FLAGS=""
@@ -182,6 +186,10 @@ Options:
   --env-file FILE    File with KEY=VALUE pairs passed to all commands (including Docker)
   --list             List available job names and exit
   --list-steps       List steps in the job and exit (requires job name)
+  --skip-toolchain-check   Don't verify toolchain images before running
+  --pull-toolchain         docker pull each toolchain image up-front
+  --auto-fix-perms         Automatically run \`sudo chown\` to recover from
+                           container-owned files (UID 1000) without prompting
   -h, --help         Show this help
 
 Examples:
@@ -217,6 +225,9 @@ parse_args() {
       --env-file)   ENV_FILE="$2"; shift 2;;
       --list)       LIST_JOBS=true; shift;;
       --list-steps) LIST_STEPS=true; shift;;
+      --skip-toolchain-check) SKIP_TOOLCHAIN_CHECK=true; shift;;
+      --pull-toolchain)       PULL_TOOLCHAIN=true; shift;;
+      --auto-fix-perms)       AUTO_FIX_PERMS=true; shift;;
       -h|--help)    usage; exit 0;;
       -*)           err "Unknown option: $1"; usage; exit 1;;
       *)            JOB_NAME="$1"; shift;;
@@ -260,7 +271,7 @@ load_env_file() {
 
 # Step 1: Source env-file & export all Buildkite environment variables.
 setup_environment() {
-  step_banner "1/5" "Setting up environment"
+  step_banner "1/6" "Setting up environment"
 
   load_env_file
 
@@ -338,7 +349,7 @@ setup_environment() {
 
 # Step 2: Generate pipeline YAMLs from Dhall (or reuse existing ones).
 generate_pipelines() {
-  step_banner "2/5" "Generating pipeline YAMLs"
+  step_banner "2/6" "Generating pipeline YAMLs"
 
   # Auto-enable skip-dump when listing with --jobs-dir provided
   if [[ ( "$LIST_JOBS" == true || "$LIST_STEPS" == true ) && -n "$JOBS_DIR" ]]; then
@@ -378,9 +389,82 @@ rsync_tolerant() {
   fi
 }
 
+# ==============================================================================
+# Permission recovery — Docker containers in this pipeline run as opam (UID
+# 1000) by default (see buildkite/src/Lib/Cmds.dhall). When the host user's
+# UID differs, files written into the bind-mounted worktree end up unwritable
+# from the host. We detect this and recover with sudo chown.
+# ==============================================================================
+
+# Find files in the worktree not owned by the current host user. Runs `find`
+# with prunes for .git and the .claude worktree dir. Outputs nothing on
+# stdout; uses exit code 0 = foreign-owned files exist, 1 = clean.
+foreign_files_present() {
+  local hit
+  hit=$(find "$MINA_ROOT" \
+    \( -path "$MINA_ROOT/.git" -o -path "$MINA_ROOT/.claude/worktrees" \) -prune \
+    -o ! -user "$USER" -print -quit 2>/dev/null) || true
+  [[ -n "$hit" ]]
+}
+
+# Count foreign-owned files (slow — full traversal).
+count_foreign_files() {
+  find "$MINA_ROOT" \
+    \( -path "$MINA_ROOT/.git" -o -path "$MINA_ROOT/.claude/worktrees" \) -prune \
+    -o ! -user "$USER" -print 2>/dev/null | wc -l
+}
+
+# Recover ownership of any files in the worktree not owned by the current
+# user. Uses sudo. Honors $AUTO_FIX_PERMS to skip the confirmation prompt.
+# Safe to call when there's nothing to recover (returns silently).
+recover_perms() {
+  if ! foreign_files_present; then
+    return 0
+  fi
+
+  local count
+  count=$(count_foreign_files)
+  warn "Found $count file(s) in $MINA_ROOT not owned by $USER (UID $(id -u))."
+  warn "These were written by a container running as opam (UID 1000)."
+
+  if [[ "$AUTO_FIX_PERMS" != true ]]; then
+    if ! [ -t 0 ]; then
+      err "Stdin is not a TTY; cannot prompt. Re-run with --auto-fix-perms."
+      return 1
+    fi
+    local ans
+    read -r -p "Run 'sudo chown -R $(id -u):$(id -g)' on those files now? [y/N] " ans
+    if [[ ! "$ans" =~ ^[Yy] ]]; then
+      err "Skipping chown. Subsequent runs may fail until ownership is fixed."
+      return 1
+    fi
+  else
+    echo "Auto-fixing ownership (--auto-fix-perms)..."
+  fi
+
+  sudo find "$MINA_ROOT" \
+    \( -path "$MINA_ROOT/.git" -o -path "$MINA_ROOT/.claude/worktrees" \) -prune \
+    -o ! -user "$USER" -exec chown -h "$(id -u):$(id -g)" {} + 2>/dev/null
+  echo "Ownership recovered."
+}
+
+# Trap handler — runs on script exit (success, error, or signal). Recovers
+# perms so the next run starts clean. Preserves the original exit code.
+cleanup_perms_on_exit() {
+  local rc=$?
+  # Don't fight set -e during cleanup
+  set +e
+  if [[ -n "${MINA_ROOT:-}" && -d "$MINA_ROOT" ]] && foreign_files_present; then
+    echo ""
+    log "Post-run: foreign-owned files detected, recovering permissions"
+    recover_perms || true
+  fi
+  return $rc
+}
+
 # Step 3: Sync cache folders from Hetzner via rsync.
 sync_legacy_cache() {
-  step_banner "3/5" "Syncing cache from Hetzner"
+  step_banner "3/6" "Syncing cache from Hetzner"
 
   if [[ "$SKIP_SYNC" == true ]]; then
     echo "Skipping cache sync"
@@ -435,7 +519,7 @@ sync_legacy_cache() {
 
 # Step 4: Ensure local storagebox and shared directories are usable.
 validate_directories() {
-  step_banner "4/5" "Validating local directories"
+  step_banner "4/6" "Validating local directories"
 
   require_dir_writable "$LOCAL_STORAGEBOX" "Local storagebox directory"
 
@@ -446,22 +530,21 @@ validate_directories() {
 
   require_dir_writable "/var/buildkite/shared" "Shared buildkite state directory"
 
-  # Check ownership of _build if it was created by a previous Docker run as a
-  # different UID (e.g. root). Stale ownership causes permission errors inside
-  # the container which bind-mounts the workdir.
-  if [[ -d "$MINA_ROOT/_build" ]]; then
-    local build_owner
-    build_owner=$(stat -c '%u' "$MINA_ROOT/_build")
-    if [[ "$build_owner" != "$(id -u)" ]]; then
-      err "_build directory is owned by UID $build_owner (you are $(id -u))"
-      err "Fix with:"
-      err "  sudo chown -R \$(id -u):\$(id -g) $MINA_ROOT/_build"
+  # Check for stale ownership across the whole worktree. Containers run as
+  # opam (UID 1000) and write into the bind-mounted /workdir, so files
+  # appear on the host owned by UID 1000 regardless of the host user. If the
+  # host user is also UID 1000 this is a no-op.
+  if foreign_files_present; then
+    if ! recover_perms; then
+      err "Cannot continue with broken file ownership."
       exit 1
     fi
+  fi
 
-    # dune-build-root files cache absolute paths. Stale host paths (instead of
-    # /workdir) cause cargo to fail inside the container. Remove them so dune
-    # regenerates with the correct container paths.
+  # dune-build-root files cache absolute paths. Stale host paths (instead of
+  # /workdir) cause cargo to fail inside the container. Remove them so dune
+  # regenerates with the correct container paths.
+  if [[ -d "$MINA_ROOT/_build" ]]; then
     local stale
     stale=$(find "$MINA_ROOT/_build" -name dune-build-root -exec grep -L '^/workdir' {} + 2>/dev/null || true)
     if [[ -n "$stale" ]]; then
@@ -540,10 +623,77 @@ execute_step() {
   fi
 }
 
+# Extract unique container image references from JOB_FILE's command strings.
+# Looks for the o1labs/anthropic-style fully-qualified image names embedded
+# in `docker run` lines.
+extract_job_images() {
+  yq -r '.pipeline.steps[].commands[]?, .pipeline.steps[].command? // empty' "$JOB_FILE" 2>/dev/null \
+    | grep -oE '(europe-west3-docker\.pkg\.dev|gcr\.io|docker\.io)/[a-zA-Z0-9._/-]+(:[a-zA-Z0-9._-]+)?' \
+    | sort -u
+}
+
+# Verify the toolchain images this job needs are reachable. Reports each as
+# `local-cached`, `pull-needed`, or `unreachable`. Fails fast if anything is
+# unreachable so the user doesn't burn 30 minutes before discovering an auth
+# issue. Honors --skip-toolchain-check and --pull-toolchain.
+verify_toolchain() {
+  step_banner "5/6" "Verifying toolchain images"
+
+  if [[ "$SKIP_TOOLCHAIN_CHECK" == true ]]; then
+    echo "Skipping toolchain verification (--skip-toolchain-check)"
+    return 0
+  fi
+
+  if ! command -v docker &>/dev/null; then
+    warn "docker not in PATH; cannot verify toolchain"
+    return 0
+  fi
+
+  find_job_file
+  local images
+  images=$(extract_job_images)
+  if [[ -z "$images" ]]; then
+    echo "No container images referenced in this job."
+    return 0
+  fi
+
+  local unreachable=0
+  while IFS= read -r img; do
+    [[ -z "$img" ]] && continue
+    printf '  %-80s ' "$img"
+    if docker image inspect "$img" >/dev/null 2>&1; then
+      echo -e "\033[1;32mlocal-cached\033[0m"
+    elif docker manifest inspect "$img" >/dev/null 2>&1; then
+      echo -e "\033[1;33mpull-needed\033[0m"
+      if [[ "$PULL_TOOLCHAIN" == true ]]; then
+        echo "    pulling..."
+        if ! docker pull "$img"; then
+          err "Failed to pull $img"
+          unreachable=$((unreachable + 1))
+        fi
+      fi
+    else
+      echo -e "\033[1;31munreachable\033[0m"
+      unreachable=$((unreachable + 1))
+    fi
+  done <<< "$images"
+
+  if [[ "$unreachable" -gt 0 ]]; then
+    err "$unreachable image(s) unreachable. Possible causes:"
+    err "  - Not authenticated to the registry. Try:"
+    err "      gcloud auth configure-docker europe-west3-docker.pkg.dev"
+    err "  - Network problem reaching the registry."
+    err "  - Image tag in ContainerImages.dhall is stale."
+    err "Re-run with --skip-toolchain-check to bypass this verification."
+    exit 1
+  fi
+}
+
 # Find job YAML file by spec.name (case-insensitive) or filename.
-# Sets the global JOB_FILE variable or exits with an error.
+# Sets the global JOB_FILE variable or exits with an error. Idempotent:
+# returns immediately if JOB_FILE is already set.
 find_job_file() {
-  JOB_FILE=""
+  [[ -n "$JOB_FILE" ]] && return 0
   local job_name_lower
   job_name_lower=$(to_lower "$JOB_NAME")
 
@@ -573,9 +723,9 @@ find_job_file() {
 # Step 5: Locate the job, iterate its steps, and execute them.
 run_job() {
   if [[ "$LIST_STEPS" == true ]]; then
-    step_banner "5/5" "Listing steps for '$JOB_NAME'"
+    step_banner "6/6" "Listing steps for '$JOB_NAME'"
   else
-    step_banner "5/5" "Running job '$JOB_NAME'"
+    step_banner "6/6" "Running job '$JOB_NAME'"
   fi
 
   if ! command -v yq &>/dev/null; then
@@ -672,6 +822,12 @@ run_job() {
 # Main
 # ==============================================================================
 parse_args "$@"
+
+# Register the perms-recovery trap as early as possible so a Ctrl-C between
+# steps still leaves the worktree in a usable state. cleanup_perms_on_exit
+# is a no-op when there's nothing to fix.
+trap cleanup_perms_on_exit EXIT
+
 setup_environment
 generate_pipelines
 
@@ -685,6 +841,7 @@ fi
 if [[ "$LIST_STEPS" != true ]]; then
   sync_legacy_cache
   validate_directories
+  verify_toolchain
 fi
 
 run_job


### PR DESCRIPTION
## Summary

Two long-standing pain points with the local Buildkite runner (\`buildkite/local/run_job.sh\`):

### 1. Toolchain image verification

Pipelines run \`docker run\` against pinned toolchain images from \`europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/\`. If the user isn't authenticated to the registry (or the tag in \`ContainerImages.dhall\` has drifted), the failure surfaced ~30 minutes into the job at the first \`docker run\`. There was no up-front check.

**Fix:** new \`verify_toolchain\` step (5/6, between \`validate_directories\` and \`run_job\`):
- Extracts container images referenced by the job's pipeline YAML.
- Reports each as \`local-cached\` / \`pull-needed\` / \`unreachable\`.
- Fails fast on \`unreachable\` so the auth error surfaces in seconds, not 30 minutes.
- Two new flags: \`--skip-toolchain-check\` (bypass), \`--pull-toolchain\` (\`docker pull\` everything up-front).

### 2. Worktree permission rot

Containers in this pipeline run as the \`opam\` user (UID 1000) per [\`buildkite/src/Lib/Cmds.dhall:80\`](../blob/develop/buildkite/src/Lib/Cmds.dhall#L80). Files written into the bind-mounted \`/workdir\` end up on the host owned by UID 1000 regardless of the host UID. When the host user isn't UID 1000, those files are unreadable from the host, blocking subsequent \`git\`/\`dune\`/etc. operations.

The previous behavior was to detect this for \`_build/\` only and **bail** with a sudo-chown instruction. No auto-fix, no exit-time recovery, and only one of many directories that get written.

**Fix:** three layers of recovery:
- **Pre-flight:** scans the whole worktree (excluding \`.git\` and \`.claude/worktrees\`) for files not owned by the current user. Prompts to run \`sudo chown -R\` and recover them. \`--auto-fix-perms\` skips the prompt.
- **Exit trap:** same scan runs on script exit (success, failure, or Ctrl-C), so an interrupted run still leaves the tree usable for git/dune.
- **\`find_job_file\` made idempotent** so \`verify_toolchain\` and \`run_job\` can both call it cheaply.

### Out of scope

Supporting \`--user $(id -u):$(id -g)\` on \`docker run\` is a structural fix for the same problem but requires container changes (the pipeline relies on in-container \`sudo apt\`). Documented as a known limitation in \`buildkite/local/README.md\`.

### Documentation

- \`buildkite/local/README.md\`:
  - "Docker UID Mapping" section: replaced the "show an error" wording with the new auto-recovery description.
  - New "Toolchain image verification" subsection.
  - Three new flags listed in "Command Reference".
  - Troubleshooting refreshed: drops the obsolete "_build owned by different user" entry; adds "Files owned by different user" and "Toolchain image unreachable" entries (the latter points at \`gcloud auth configure-docker\`).

## Test plan

- [x] \`bash -n buildkite/local/run_job.sh\` — clean
- [x] \`shellcheck buildkite/local/run_job.sh\` — clean
- [x] \`./buildkite/local/run_job.sh --help\` renders new flags
- [x] Image-extraction regex handles \`europe-west3-docker.pkg.dev/...\` and \`gcr.io/...\` tags (verified on a synthetic input)
- [ ] End-to-end: run a real job (\`./run_job.sh --dry-run RosettaDevnetConnect\`) and confirm the new "5/6 Verifying toolchain images" banner shows the expected image set
- [ ] End-to-end: trigger a chown-needed state by running a job that writes to \`_build\`, then re-run to confirm pre-flight recovery and the exit-trap recovery both fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)