### PR TITLE
test(archive): repro update_chain_status fork-canonical-block bug

### DIFF
--- a/buildkite/scripts/tests/archive-fork-canonical-bug-test.sh
+++ b/buildkite/scripts/tests/archive-fork-canonical-bug-test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# archive-fork-canonical-bug-test.sh
+#
+# Reproduces the archive-side bug from the Bundle 5 dry-run hardfork:
+# update_chain_status branch 2 mis-classifies post-fork (chain B) blocks
+# as `orphaned` when they land at heights below the prefork archive's
+# greatest_canonical_height.
+#
+# The test alcotest case lives at src/test/archive/archive_node_tests/
+# archive_fork_canonical_bug_test.ml; this script just pulls the fixture,
+# sets the env vars, and invokes dune.
+#
+# USAGE:
+#   ./archive-fork-canonical-bug-test.sh <user> <password> <postgres_host_port>
+#
+#     user                  postgres superuser (must own CREATE DATABASE)
+#     password              postgres password
+#     postgres_host_port    e.g. "localhost:5432"
+#
+# ENV VARS:
+#   FORK_BUG_FIXTURE_DIR  Local path to a pre-staged fixture folder.
+#                         If unset, the fixture is fetched from the storage
+#                         box (mounted at $STORAGEBOX_BASE in CI, or via
+#                         rsync over ssh for local dev).
+#   STORAGEBOX_BASE       Local mount of the Hetzner storage box on the CI
+#                         agent. Defaults to /var/storagebox (the mount point
+#                         used by buildkite/scripts/cache/manager.sh).
+#   HETZNER_KEY           SSH key path for the Hetzner storage box (used when
+#                         the mount isn't available, e.g. local dev).
+#                         Defaults to ~/work/secrets/storagebox.key.
+#   HETZNER_USER          Hetzner user. Defaults to u434410.
+#   HETZNER_HOST          Hetzner host. Defaults to
+#                         u434410-sub2.your-storagebox.de.
+#   STORAGEBOX_FIXTURE_PATH  Path under the storage box root. Defaults to
+#                         test_data/archive_fork_canonical_bug.
+#
+# FIXTURE LAYOUT (after staging):
+#   $FORK_BUG_FIXTURE_DIR/
+#     prefork_archive_dump.sql.tar.gz   (gzipped tar of pg_dump plain SQL)
+#     genesis.json                       (post-fork runtime config)
+#     precomputed_blocks.tar.xz          (chain B extensional blocks 6816-6819)
+#
+# PREREQUISITES:
+#   - Run from the repo root (where dune-project lives).
+#   - OPAM env available; mina_fresh switch selected by `opam config env`.
+#   - postgres reachable as superuser at <postgres_host_port>.
+
+set -euo pipefail
+
+if [[ ! -f dune-project ]]; then
+  echo "Error: must be run from repo root (where dune-project lives)." >&2
+  exit 1
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <user> <password> <postgres_host_port>" >&2
+  exit 1
+fi
+
+user="$1"
+password="$2"
+host_port="$3"
+
+# Bring up postgres + provision the superuser on the CI agent. Mirrors the
+# setup that ArchiveNodeUnitTest uses. The third arg is a placeholder db
+# name; the test creates its own DB from the dump so the value is unused
+# afterwards, but the setup script still requires it.
+if [[ -x ./buildkite/scripts/setup-database-for-archive-node.sh ]]; then
+  echo "Provisioning postgres via setup-database-for-archive-node.sh..."
+  # shellcheck disable=SC1091
+  source ./buildkite/scripts/setup-database-for-archive-node.sh \
+    "$user" "$password" "fork_canonical_bug_placeholder"
+fi
+
+STORAGEBOX_BASE="${STORAGEBOX_BASE:-/var/storagebox}"
+STORAGEBOX_FIXTURE_PATH="${STORAGEBOX_FIXTURE_PATH:-test_data/archive_fork_canonical_bug}"
+HETZNER_KEY="${HETZNER_KEY:-$HOME/work/secrets/storagebox.key}"
+HETZNER_USER="${HETZNER_USER:-u434410}"
+HETZNER_HOST="${HETZNER_HOST:-u434410-sub2.your-storagebox.de}"
+
+if [[ -n "${FORK_BUG_FIXTURE_DIR:-}" ]]; then
+  fixture_dir="$FORK_BUG_FIXTURE_DIR"
+  echo "Using pre-staged fixture at $fixture_dir"
+elif [[ -d "$STORAGEBOX_BASE/$STORAGEBOX_FIXTURE_PATH" ]]; then
+  fixture_dir="$STORAGEBOX_BASE/$STORAGEBOX_FIXTURE_PATH"
+  echo "Using storage-box-mounted fixture at $fixture_dir"
+else
+  fixture_dir="$(mktemp -d -t fork-bug-fixture-XXXXXX)"
+  echo "Pulling fixture from Hetzner into $fixture_dir (no local mount found)"
+  rsync -avz --progress \
+    -e "ssh -p 23 -i $HETZNER_KEY -o StrictHostKeyChecking=no" \
+    "$HETZNER_USER@$HETZNER_HOST:/home/o1labs-generic/pvc-4d294645-6466-4260-b933-1b909ff9c3a1/$STORAGEBOX_FIXTURE_PATH/" \
+    "$fixture_dir/"
+fi
+
+for required in prefork_archive_dump.sql.tar.gz genesis.json precomputed_blocks.tar.xz; do
+  if [[ ! -f "$fixture_dir/$required" ]]; then
+    echo "Error: fixture missing $required at $fixture_dir/$required" >&2
+    exit 1
+  fi
+done
+
+eval "$(opam config env)"
+
+export MINA_TEST_POSTGRES_URI="postgres://${user}:${password}@${host_port}"
+export MINA_TEST_NETWORK_DATA="$fixture_dir"
+
+echo "Running archive fork-canonical-bug test..."
+dune build src/test/archive/archive_node_tests/archive_node_tests.exe
+dune exec src/test/archive/archive_node_tests/archive_node_tests.exe -- \
+  test 'fork_canonical_bug'

--- a/buildkite/scripts/tests/archive-fork-canonical-bug-test.sh
+++ b/buildkite/scripts/tests/archive-fork-canonical-bug-test.sh
@@ -105,6 +105,10 @@ eval "$(opam config env)"
 
 export MINA_TEST_POSTGRES_URI="postgres://${user}:${password}@${host_port}"
 export MINA_TEST_NETWORK_DATA="$fixture_dir"
+# Opt the fork-canonical-bug case into the registration; without this the
+# test exe omits it (so the generic archive-node-test runner that uses
+# sample_db doesn't try to run it against the wrong fixture).
+export MINA_TEST_RUN_FORK_CANONICAL_BUG=1
 
 echo "Running archive fork-canonical-bug test..."
 dune build src/test/archive/archive_node_tests/archive_node_tests.exe

--- a/buildkite/src/Jobs/Test/ArchiveForkCanonicalBugTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveForkCanonicalBugTest.dhall
@@ -1,0 +1,68 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+
+let WithCargo = ../../Command/WithCargo.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+let user = "admin"
+
+let password = "codarules"
+
+let host_port = "localhost:5432"
+
+let command_key = "archive-fork-canonical-bug-test"
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "src/app/archive")
+          , S.strictlyStart (S.contains "src/test/archive")
+          , S.strictlyStart
+              (S.contains "buildkite/src/Jobs/Test/ArchiveForkCanonicalBugTest")
+          , S.exactly
+              "buildkite/scripts/tests/archive-fork-canonical-bug-test"
+              "sh"
+          ]
+        , path = "Test"
+        , name = "ArchiveForkCanonicalBugTest"
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
+          ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+                RunInToolchain.runInToolchain
+                  [ "POSTGRES_PASSWORD=${password}"
+                  , "POSTGRES_USER=${user}"
+                  , "GO=/usr/lib/go/bin/go"
+                  ]
+                  ( WithCargo.withCargo
+                      "./buildkite/scripts/tests/archive-fork-canonical-bug-test.sh ${user} ${password} ${host_port}"
+                  )
+            , label =
+                "Archive fork-canonical-block bug repro (update_chain_status branch 2)"
+            , key = command_key
+            , target = Size.Large
+            , docker = None Docker.Type
+            , artifact_paths = [ S.contains "test_output/artifacts/*" ]
+            }
+        ]
+      }

--- a/scripts/archive/stage-fork-canonical-bug-fixtures.sh
+++ b/scripts/archive/stage-fork-canonical-bug-fixtures.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# stage-fork-canonical-bug-fixtures.sh
+#
+# One-time fixture builder for the archive fork-canonical bug repro test
+# (src/test/archive/archive_node_tests/archive_fork_canonical_bug_test.ml).
+#
+# What it does:
+#   1. Restores a POST-fork archive dump locally into a scratch postgres db
+#      (the post-fork dump is needed because it contains chain B's first
+#      few blocks; the pre-fork dump does not).
+#   2. Runs mina-extract-blocks to dump chain B 6816-6819 in extensional
+#      format.
+#   3. Bundles those JSONs as precomputed_blocks.tar.xz.
+#   4. Copies the supplied prefork dump, post-fork runtime config, and
+#      chain B blocks bundle into one fixture folder.
+#   5. (Optional) rsyncs the staged folder to Hetzner test_data.
+#
+# This script is intended to be run ONCE; the artifacts it produces are
+# checked into the Hetzner test_data folder for downstream CI runs.
+#
+# USAGE:
+#   ./stage-fork-canonical-bug-fixtures.sh \
+#       --prefork-dump <path-to-prefork.sql.tar> \
+#       --postfork-dump <path-to-postfork.sql.tar> \
+#       --runtime-config <path-to-new_config.json> \
+#       --output <staging-dir> \
+#       [--upload-to-hetzner]
+#
+# CHAIN B BLOCKS extracted:
+#   6816 3NL5YRUKggVqZaGazgNhbWMydcSJnPQtcu5PBfyEwbsHboynPMP1
+#   6817 3NK3NxCrwhkRQbC2dg7XFQkCxhgzzugcxwD2wtfq8dZXPuty78wQ
+#   6818 3NLhNwiyZtJK7ov2JevZUB34W9NnmpiRZBzNvvR3yzVh5TRdGcWn
+#   6819 3NL8kKqzWdEXUg2q4G6Qy7ir4A1PDNW5xFa5xE6hcKW7tQZVwUg8
+#
+# PREREQUISITES:
+#   - mina-extract-blocks built (dune build src/app/extract_blocks)
+#   - postgres reachable at localhost:5432 as superuser `postgres`/`postgres`
+#   - rsync + ssh available if --upload-to-hetzner is set
+#
+# HETZNER UPLOAD TARGET:
+#   /home/o1labs-generic/pvc-4d294645-6466-4260-b933-1b909ff9c3a1/test_data/archive_fork_canonical_bug
+
+set -euo pipefail
+
+PREFORK_DUMP=""
+POSTFORK_DUMP=""
+RUNTIME_CONFIG=""
+OUTPUT_DIR=""
+UPLOAD_TO_HETZNER=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefork-dump)    PREFORK_DUMP="$2"; shift 2 ;;
+    --postfork-dump)   POSTFORK_DUMP="$2"; shift 2 ;;
+    --runtime-config)  RUNTIME_CONFIG="$2"; shift 2 ;;
+    --output)          OUTPUT_DIR="$2"; shift 2 ;;
+    --upload-to-hetzner) UPLOAD_TO_HETZNER=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+for arg in PREFORK_DUMP POSTFORK_DUMP RUNTIME_CONFIG OUTPUT_DIR; do
+  if [[ -z "${!arg}" ]]; then
+    echo "missing --${arg,,/_/-}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$OUTPUT_DIR"
+scratch="$(mktemp -d -t stage-fork-bug-XXXXXX)"
+trap 'rm -rf "$scratch"' EXIT
+
+PGURI="postgres://postgres:postgres@localhost:5432"
+EXTRACT_DB="archive_postfork_extract"
+
+echo "[1/5] Restoring post-fork dump into $EXTRACT_DB"
+psql "$PGURI/postgres" -c "DROP DATABASE IF EXISTS $EXTRACT_DB;"
+psql "$PGURI/postgres" -c "DROP DATABASE IF EXISTS archive;"
+mkdir -p "$scratch/postfork"
+tar -xf "$POSTFORK_DUMP" -C "$scratch/postfork"
+postfork_sql="$(ls "$scratch/postfork"/*.sql | head -1)"
+# The dump hardcodes "archive" as its target db name. Apply it, then rename.
+psql "$PGURI/postgres" -f "$postfork_sql"
+psql "$PGURI/postgres" -c "ALTER DATABASE archive RENAME TO $EXTRACT_DB;"
+
+echo "[2/5] Extracting chain B blocks 6816-6819 via mina-extract-blocks"
+mkdir -p "$scratch/chain_b"
+extract_bin="_build/default/src/app/extract_blocks/extract_blocks.exe"
+if [[ ! -x "$extract_bin" ]]; then
+  extract_bin="$(command -v mina-extract-blocks || true)"
+fi
+if [[ -z "$extract_bin" ]]; then
+  echo "Error: mina-extract-blocks binary not found. Build with 'dune build src/app/extract_blocks' or install the package." >&2
+  exit 1
+fi
+
+# Walk the subchain 6816 -> 6819 on chain B. start_from_specified follows
+# parent links from end back to start, so this gives us 4 extensional JSONs
+# in one shot.
+chain_b_6816="3NL5YRUKggVqZaGazgNhbWMydcSJnPQtcu5PBfyEwbsHboynPMP1"
+chain_b_6819="3NL8kKqzWdEXUg2q4G6Qy7ir4A1PDNW5xFa5xE6hcKW7tQZVwUg8"
+
+"$extract_bin" \
+  --archive-uri "$PGURI/$EXTRACT_DB" \
+  --start-state-hash "$chain_b_6816" \
+  --end-state-hash "$chain_b_6819" \
+  --output-folder "$scratch/chain_b" \
+  --include-block-height-in-name
+
+echo "[3/5] Bundling chain B blocks into precomputed_blocks.tar.xz"
+tar -cJf "$OUTPUT_DIR/precomputed_blocks.tar.xz" -C "$scratch/chain_b" .
+
+echo "[4/5] Copying prefork dump + runtime config into $OUTPUT_DIR"
+# Ensure the prefork dump is gzip-compressed (the test expects .sql.tar.gz).
+if file --brief "$PREFORK_DUMP" | grep -q "gzip compressed"; then
+  cp "$PREFORK_DUMP" "$OUTPUT_DIR/prefork_archive_dump.sql.tar.gz"
+else
+  gzip -c "$PREFORK_DUMP" > "$OUTPUT_DIR/prefork_archive_dump.sql.tar.gz"
+fi
+cp "$RUNTIME_CONFIG" "$OUTPUT_DIR/genesis.json"
+
+# Cleanup scratch postgres db.
+psql "$PGURI/postgres" -c "DROP DATABASE IF EXISTS $EXTRACT_DB;"
+
+echo "[5/5] Fixture staged at $OUTPUT_DIR"
+ls -la "$OUTPUT_DIR"
+
+if [[ "$UPLOAD_TO_HETZNER" -eq 1 ]]; then
+  HETZNER_KEY="${HETZNER_KEY:-$HOME/work/secrets/storagebox.key}"
+  HETZNER_USER="${HETZNER_USER:-u434410}"
+  HETZNER_HOST="${HETZNER_HOST:-u434410-sub2.your-storagebox.de}"
+  HETZNER_FIXTURE_PATH="${HETZNER_FIXTURE_PATH:-/home/o1labs-generic/pvc-4d294645-6466-4260-b933-1b909ff9c3a1/test_data/archive_fork_canonical_bug}"
+  echo "Uploading to Hetzner $HETZNER_FIXTURE_PATH"
+  rsync -avz --progress \
+    -e "ssh -p 23 -i $HETZNER_KEY -o StrictHostKeyChecking=no" \
+    "$OUTPUT_DIR/" "$HETZNER_USER@$HETZNER_HOST:$HETZNER_FIXTURE_PATH/"
+fi

--- a/src/test/archive/archive_node_tests/archive_fork_canonical_bug_test.ml
+++ b/src/test/archive/archive_node_tests/archive_fork_canonical_bug_test.ml
@@ -1,0 +1,174 @@
+open Async
+open Core
+open Mina_automation
+open Mina_automation_fixture.Archive
+
+(** Reproduces the archive-side bug surfaced during the Bundle 5 dry-run
+    hardfork (May 2026, pre-mesa network). When the fork point coincides with
+    the prefork archive's last canonical block, post-fork (chain B) blocks
+    land at heights below the archive's [greatest_canonical_height] and
+    branch 2 of [Processor.update_chain_status] (processor.ml lines 4415-4446)
+    walks chain A's parent links via [get_subchain] and silently re-canonicalizes
+    chain A while orphaning chain B at the same heights.
+
+    The test loads a prefork archive dump (chain A canonical up through 6818,
+    pending tip ~7108), starts an archive process against the new HF runtime
+    config, then feeds chain B's first four post-fork blocks (heights
+    6816-6819, extensional format) and asserts that chain B is left in
+    [pending] status rather than incorrectly orphaned.
+
+    Expected behavior: today this test FAILS — the bug is live, chain B
+    blocks come out [orphaned]. Once branch 2 of [update_chain_status] is
+    made fork-aware, the test will start passing. *)
+
+type t = before_bootstrap
+
+(* State hashes from the live archive DB at the moment the bug fired —
+   see the slack analysis in the Bundle 5 thread. *)
+module Chain_a = struct
+  let h_6816 = "3NL9pw82zro5zdQM4TSi26VzgoY8xCo29AGtZBBsNNbsgmMXU2p7"
+
+  let h_6817 = "3NLsJegtqi16R5nMunHTBYx3siz8PCDmegD7wP7BnJgzY2wp8qNL"
+end
+
+module Chain_b = struct
+  let h_6816 = "3NL5YRUKggVqZaGazgNhbWMydcSJnPQtcu5PBfyEwbsHboynPMP1"
+
+  let h_6817 = "3NK3NxCrwhkRQbC2dg7XFQkCxhgzzugcxwD2wtfq8dZXPuty78wQ"
+end
+
+(* Filename inside [network_data.folder] for the prefork archive dump.
+   Format: gzipped tar containing a single .sql file (pg_dump plain output). *)
+let prefork_dump_archive = "prefork_archive_dump.sql.tar.gz"
+
+(* The dump hardcodes the target db name to "archive" via [CREATE DATABASE
+   archive] + [\connect archive]. We honor that rather than rewriting the
+   dump. *)
+let dump_target_db = "archive"
+
+(* The dump applies its DDL inside a transaction-less psql session, so we
+   need a connection to a db that already exists (postgres' default admin
+   db) before [\connect archive] kicks in. *)
+let admin_db = "postgres"
+
+let strip_db_from_uri uri =
+  match String.rsplit2 ~on:'/' uri with
+  | Some (prefix, _db) when not (String.is_suffix prefix ~suffix:"/") ->
+      prefix
+  | _ ->
+      uri
+
+let restore_prefork_dump ~server_uri ~dump_archive_path ~dump_dir =
+  let open Deferred.Let_syntax in
+  let connection = Psql.Conn_str server_uri in
+  Core.Unix.mkdir_p dump_dir ;
+  let%bind _ = Utils.untar ~archive:dump_archive_path ~output:dump_dir in
+  let files = Core.Sys.readdir dump_dir in
+  let sql_file =
+    Array.find files ~f:(String.is_suffix ~suffix:".sql")
+    |> Option.value_exn ~here:[%here]
+         ~message:
+           (sprintf "no .sql file found after untarring %s" dump_archive_path)
+  in
+  let sql_path = dump_dir ^/ sql_file in
+  let%bind _ =
+    Psql.run_command ~connection
+      (sprintf "DROP DATABASE IF EXISTS %s" dump_target_db)
+  in
+  let%map _ = Psql.run_script ~connection ~db:admin_db sql_path in
+  ()
+
+let query_chain_status ~archive_uri ~state_hash =
+  let connection = Psql.Conn_str archive_uri in
+  let query =
+    sprintf "SELECT chain_status FROM blocks WHERE state_hash = '%s'"
+      state_hash
+  in
+  match%map Psql.run_command ~connection query with
+  | Ok s ->
+      let s = String.strip s in
+      if String.is_empty s then None else Some s
+  | Error _ ->
+      None
+
+let assert_chain_b_not_orphaned ~archive_uri =
+  let open Deferred.Let_syntax in
+  let%bind chain_b_6816_status =
+    query_chain_status ~archive_uri ~state_hash:Chain_b.h_6816
+  in
+  let%bind chain_b_6817_status =
+    query_chain_status ~archive_uri ~state_hash:Chain_b.h_6817
+  in
+  let%bind chain_a_6816_status =
+    query_chain_status ~archive_uri ~state_hash:Chain_a.h_6816
+  in
+  let%bind chain_a_6817_status =
+    query_chain_status ~archive_uri ~state_hash:Chain_a.h_6817
+  in
+  let errors = ref [] in
+  let check name actual expected =
+    match actual with
+    | Some s when String.equal (String.lowercase s) expected ->
+        ()
+    | Some s ->
+        errors := sprintf "%s: expected %s, got %s" name expected s :: !errors
+    | None ->
+        errors := sprintf "%s: row missing in DB" name :: !errors
+  in
+  (* Chain B blocks were inserted by archive_blocks just now. The prefork
+     dump's [greatest_canonical_height] is 6818 (branch 1 had legitimately
+     canonicalized chain A out to 6818 because chain A's pending tip was at
+     ~7108, k=290 hops above). When chain B 6816/6817 land below that
+     threshold, branch 2 of [update_chain_status] fires and orphans them via
+     a get_subchain walk that follows chain A's parent links. After the fix,
+     chain B should be left as [pending]. *)
+  check "chain_b_6816" chain_b_6816_status "pending" ;
+  check "chain_b_6817" chain_b_6817_status "pending" ;
+  (* Chain A's status from the dump should be untouched by the chain B
+     inserts. *)
+  check "chain_a_6816" chain_a_6816_status "canonical" ;
+  check "chain_a_6817" chain_a_6817_status "canonical" ;
+  if List.is_empty !errors then Deferred.return ()
+  else
+    failwithf
+      "update_chain_status branch 2 mis-classified chain B after the \
+       hardfork. Status snapshot:\n\
+      \  %s"
+      (String.concat ~sep:"\n  " !errors) ()
+
+let test_case (test_data : t) =
+  let open Deferred.Let_syntax in
+  let server_uri = strip_db_from_uri test_data.config.postgres_uri in
+  let archive_uri = server_uri ^ "/" ^ dump_target_db in
+  let temp_dir = test_data.temp_dir in
+  let dump_dir = temp_dir ^/ "dump" in
+  let blocks_dir = temp_dir ^/ "chain_b_blocks" in
+  let dump_archive_path =
+    test_data.network_data.folder ^/ prefork_dump_archive
+  in
+  let%bind () =
+    restore_prefork_dump ~server_uri ~dump_archive_path ~dump_dir
+  in
+  (* mina-archive-blocks writes directly to postgres and runs the same
+     [update_chain_status] code path as the archive process, so we don't
+     need to spawn an archive process to surface the bug. *)
+  let%bind chain_b_blocks =
+    let%map files =
+      Network_data.untar_precomputed_blocks test_data.network_data
+        blocks_dir
+    in
+    List.map files ~f:(fun f -> blocks_dir ^/ f)
+    |> List.filter ~f:(String.is_suffix ~suffix:".json")
+  in
+  let%bind _ =
+    Archive_blocks.run Archive_blocks.default ~blocks:chain_b_blocks
+      ~archive_uri ~format:Archive_blocks.Extensional
+  in
+  match%map
+    Monitor.try_with (fun () -> assert_chain_b_not_orphaned ~archive_uri)
+  with
+  | Ok () ->
+      Mina_automation_fixture.Intf.Passed
+  | Error exn ->
+      Mina_automation_fixture.Intf.Failed
+        (Error.of_exn ~backtrace:`Get exn)

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -13,50 +13,68 @@ let () =
     ~metadata:[ ("seed", `Int random_seed) ] ;
   Random.init random_seed
 
+let common_tests =
+  let open Alcotest in
+  [ ( "precomputed_blocks"
+    , [ test_case
+          "Recreate database from precomputed blocks sent from mock daemon"
+          `Quick
+          (Runner.run_blocking
+             ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
+                        (Archive_precomputed_blocks_test) ) )
+      ] )
+  ; ( "genesis_load"
+    , [ test_case "Load mainnet genesis ledger without memory leak" `Quick
+          (Runner.run_blocking
+             ( module Mina_automation_fixture.Archive
+                      .Make_FixtureWithoutBootstrap
+                        (Load_genesis_ledger) ) )
+      ] )
+  ; ( "upgrade_archive"
+    , [ test_case
+          "Recreate database from precomputed blocks after upgrade script is \
+           applied"
+          `Quick
+          (Runner.run_blocking
+             ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
+                        (Upgrade_archive) ) )
+      ] )
+  ; ( "live_upgrade_archive"
+    , [ test_case
+          "Recreate database from precomputed blocks. Meanwhile run upgrade \
+           script randomly at some time"
+          `Quick
+          (Runner.run_blocking
+             ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
+                        (Live_upgrade_archive) ) )
+      ] )
+  ]
+
+(* The fork-canonical-bug repro needs a specific prefork archive dump and
+   chain B extensional block fixtures (see
+   buildkite/scripts/tests/archive-fork-canonical-bug-test.sh). It is
+   registered only when [MINA_TEST_RUN_FORK_CANONICAL_BUG=1] is set, so the
+   generic [scripts/tests/archive-node-test.sh] runner that uses the
+   [sample_db] fixture leaves it alone. The dedicated [ArchiveForkCanonicalBugTest]
+   buildkite job sets the env var. *)
+let fork_canonical_bug_tests =
+  let open Alcotest in
+  match Sys.getenv "MINA_TEST_RUN_FORK_CANONICAL_BUG" with
+  | Some v when String.equal v "1" ->
+      [ ( "fork_canonical_bug"
+        , [ test_case
+              "Reproduce update_chain_status branch-2 mis-classification when \
+               fork point equals last canonical block"
+              `Quick
+              (Runner.run_blocking
+                 ( module Mina_automation_fixture.Archive
+                          .Make_FixtureWithoutBootstrap
+                            (Archive_fork_canonical_bug_test) ) )
+          ] )
+      ]
+  | _ ->
+      []
+
 let () =
   let open Alcotest in
-  run "Test archive node."
-    [ ( "precomputed_blocks"
-      , [ test_case
-            "Recreate database from precomputed blocks sent from mock daemon"
-            `Quick
-            (Runner.run_blocking
-               ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
-                          (Archive_precomputed_blocks_test) ) )
-        ] )
-    ; ( "genesis_load"
-      , [ test_case "Load mainnet genesis ledger without memory leak" `Quick
-            (Runner.run_blocking
-               ( module Mina_automation_fixture.Archive
-                        .Make_FixtureWithoutBootstrap
-                          (Load_genesis_ledger) ) )
-        ] )
-    ; ( "upgrade_archive"
-      , [ test_case
-            "Recreate database from precomputed blocks after upgrade script is \
-             applied"
-            `Quick
-            (Runner.run_blocking
-               ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
-                          (Upgrade_archive) ) )
-        ] )
-    ; ( "live_upgrade_archive"
-      , [ test_case
-            "Recreate database from precomputed blocks. Meanwhile run upgrade \
-             script randomly at some time"
-            `Quick
-            (Runner.run_blocking
-               ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
-                          (Live_upgrade_archive) ) )
-        ] )
-    ; ( "fork_canonical_bug"
-      , [ test_case
-            "Reproduce update_chain_status branch-2 mis-classification when \
-             fork point equals last canonical block"
-            `Quick
-            (Runner.run_blocking
-               ( module Mina_automation_fixture.Archive
-                        .Make_FixtureWithoutBootstrap
-                          (Archive_fork_canonical_bug_test) ) )
-        ] )
-    ]
+  run "Test archive node." (common_tests @ fork_canonical_bug_tests)

--- a/src/test/archive/archive_node_tests/archive_node_tests.ml
+++ b/src/test/archive/archive_node_tests/archive_node_tests.ml
@@ -49,4 +49,14 @@ let () =
                ( module Mina_automation_fixture.Archive.Make_FixtureWithBootstrap
                           (Live_upgrade_archive) ) )
         ] )
+    ; ( "fork_canonical_bug"
+      , [ test_case
+            "Reproduce update_chain_status branch-2 mis-classification when \
+             fork point equals last canonical block"
+            `Quick
+            (Runner.run_blocking
+               ( module Mina_automation_fixture.Archive
+                        .Make_FixtureWithoutBootstrap
+                          (Archive_fork_canonical_bug_test) ) )
+        ] )
     ]


### PR DESCRIPTION
## Summary
- Adds a characterization test that reproduces the dry-run-10 / Bundle 5 hardfork incident: post-fork (chain B) blocks landing at heights below the prefork archive's `greatest_canonical_height` get incorrectly orphaned by branch 2 of `Processor.update_chain_status` (`src/app/archive/lib/processor.ml:4415-4446`).
- The branch walks chain A's parent links via `get_subchain` and assumes a single ancestry between two canonical anchors. After a hardfork that reuses heights, that assumption breaks and chain B is silently orphaned even though it is the chain consensus actually adopted.
- The test loads the prefork archive dump (1700 UTC, just before the dry-run fork), feeds the first two chain B post-fork blocks via `mina-archive-blocks --extensional`, and asserts they land as `pending`. Today the assertion fails with `orphaned` — exactly the symptom captured in `archive=> SELECT id, height, chain_status, parent_id, state_hash FROM blocks WHERE height BETWEEN 6815 AND 6819 …` from the slack thread.
- **Expected to FAIL on this PR.** Once branch 2 is made fork-aware (proper subchain selection or a check that the inserted block actually shares parent ancestry with the canonical anchor below), the test starts passing and becomes a permanent regression guard.

### Files
- `src/test/archive/archive_node_tests/archive_fork_canonical_bug_test.ml` — the test
- `src/test/archive/archive_node_tests/archive_node_tests.ml` — alcotest registration
- `buildkite/scripts/tests/archive-fork-canonical-bug-test.sh` — CI runner; fetches fixture from `/var/storagebox/test_data/archive_fork_canonical_bug/`
- `buildkite/src/Jobs/Test/ArchiveForkCanonicalBugTest.dhall` — pipeline definition
- `scripts/archive/stage-fork-canonical-bug-fixtures.sh` — one-time fixture builder (postfork dump → `mina-extract-blocks` for chain B → tar + upload)

### Fixture
Already staged at `hetzner:/home/o1labs-generic/pvc-4d294645-…/test_data/archive_fork_canonical_bug/`:
- `prefork_archive_dump.sql.tar.gz` — May 7 17:00 UTC `hetzner-pre-mesa-1` archive dump (PG-12 patched: stripped `LOCALE_PROVIDER` and `transaction_timeout` SET so it restores on older postgres)
- `genesis.json` — post-fork runtime config (`new_config.json` from the build cache, fork @ block 6815)
- `precomputed_blocks.tar.xz` — chain B 6816/6817 as extensional JSON, extracted from the 1708 postfork dump

## Test plan
- [ ] CI's new `ArchiveForkCanonicalBugTest` step runs, restores the fixture, and reports the assertion failure (`chain_b_6816: expected pending, got orphaned`, same for 6817)
- [ ] Verify the failure is the assertion, not a setup/fixture error
- [ ] Once `update_chain_status` is patched in a follow-up, the test should flip green

🤖 Generated with [Claude Code](https://claude.com/claude-code)