### PR TITLE
Use mina-graphql-client in connect-to-network CI script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ build: ocaml_checks reformat-diff libp2p_helper ## Build the main project execut
 		src/app/validate_keypair/validate_keypair.exe \
 		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
 		src/lib/snark_worker/standalone/run_snark_worker.exe \
+		src/app/mina_graphql_client/mina_graphql_client_app.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 
@@ -182,6 +183,7 @@ build-daemon-utils: ocaml_checks reformat-diff libp2p_helper ## Build daemon uti
 		src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe \
 		src/lib/snark_worker/standalone/run_snark_worker.exe \
 		src/app/rocksdb-scanner/rocksdb_scanner.exe \
+		src/app/mina_graphql_client/mina_graphql_client_app.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -78,6 +78,14 @@ source buildkite/scripts/debian/update.sh --verbose
 source buildkite/scripts/export-git-env-vars.sh
 source buildkite/scripts/debian/install.sh "mina-${MINA_DEBIAN_NETWORK},mina-daemon-storage-toolbox" 1
 
+# Stash mina-graphql-client so it survives the legacy downgrade below.
+# The official 3.3.0 mina-${MINA_DEBIAN_NETWORK} package does not ship this
+# binary; without stashing, the post-downgrade sync check would fail because
+# the helper would have been removed. The binary is self-contained except
+# for libc/libssl/libgmp which remain present across the downgrade.
+MINA_GRAPHQL_CLIENT=/tmp/mina-graphql-client.stashed
+cp "$(command -v mina-graphql-client)" "$MINA_GRAPHQL_CLIENT"
+
 # Legacy scanner installs to a separate versioned path under /usr/lib/mina/
 FORCE_VERSION="*" ROOT="legacy" ./buildkite/scripts/debian/install.sh "mina-daemon-recovery-storage-toolbox" 1
 
@@ -108,7 +116,7 @@ start_daemon_and_wait_for_sync() {
 
     local sync_status=""
     while [ "$(date +%s)" -lt $deadline ]; do
-        sync_status=$(timeout 5 mina-graphql-client sync-status \
+        sync_status=$(timeout 5 "$MINA_GRAPHQL_CLIENT" sync-status \
             --graphql-uri http://localhost:3085/graphql --raw \
             2>/dev/null || echo "CONNECT_ERROR")
 
@@ -124,8 +132,10 @@ start_daemon_and_wait_for_sync() {
         exit 1
     fi
 
-    # Check network id via GraphQL
-    NETWORK_ID=$(mina-graphql-client network-id \
+    # Check network id via GraphQL.
+    # Wrap in timeout so a hung GraphQL endpoint doesn't stall the script for
+    # the ~5 minute default retry budget inside exec_graphql_request.
+    NETWORK_ID=$(timeout 10 "$MINA_GRAPHQL_CLIENT" network-id \
         --graphql-uri http://localhost:3085/graphql --raw)
 
     EXPECTED_NETWORK="mina:$NETWORK_NAME"

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -108,11 +108,9 @@ start_daemon_and_wait_for_sync() {
 
     local sync_status=""
     while [ "$(date +%s)" -lt $deadline ]; do
-        sync_status=$( { curl -s -m 5 'http://localhost:3085/graphql' \
-            -H 'accept: application/json' \
-            -H 'content-type: application/json' \
-            --data-raw '{"query":"query { syncStatus }"}' \
-            | jq -r .data.syncStatus ; } 2>/dev/null || echo "CONNECT_ERROR" )
+        sync_status=$(timeout 5 mina-graphql-client sync-status \
+            --graphql-uri http://localhost:3085/graphql --raw \
+            2>/dev/null || echo "CONNECT_ERROR")
 
         if [[ "$sync_status" == "SYNCED" ]]; then
             break
@@ -127,11 +125,8 @@ start_daemon_and_wait_for_sync() {
     fi
 
     # Check network id via GraphQL
-    NETWORK_ID=$(curl -s 'http://localhost:3085/graphql' \
-        -H 'accept: application/json' \
-        -H 'content-type: application/json' \
-        --data-raw '{"query":"query MyQuery {\n  networkID\n}\n","variables":null,"operationName":"MyQuery"}' \
-        | jq -r .data.networkID)
+    NETWORK_ID=$(mina-graphql-client network-id \
+        --graphql-uri http://localhost:3085/graphql --raw)
 
     EXPECTED_NETWORK="mina:$NETWORK_NAME"
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -277,6 +277,10 @@ copy_common_daemon_apps() {
   cp ./default/src/app/cli/src/mina_"${signature}"_signatures.exe \
     "${TARGET_ROOT_DIR}/mina"
 
+  # GraphQL client utility (used by CI scripts; replaces ad-hoc curl invocations)
+  cp ./default/src/app/mina_graphql_client/mina_graphql_client_app.exe \
+    "${TARGET_ROOT_DIR}/mina-graphql-client"
+
 }
 
 # Function to DRY copying config files into daemon packages

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -366,6 +366,7 @@ MOCKEXE
     create_mock_exe "default/src/app/zkapp_test_transaction/zkapp_test_transaction.exe"
     create_mock_exe "default/src/app/delegation_verify/delegation_verify.exe"
     create_mock_exe "default/src/app/dump_slot_ledger/dump_slot_ledger.exe"
+    create_mock_exe "default/src/app/mina_graphql_client/mina_graphql_client_app.exe"
 
     #---------------------------------------------------------------------------
     # Source files under PROJECT_ROOT (referenced via ../ from BUILD_DIR)

--- a/src/app/mina_graphql_client/mina_graphql_client_app.ml
+++ b/src/app/mina_graphql_client/mina_graphql_client_app.ml
@@ -297,6 +297,60 @@ let set_snark_fee_command =
          | Error e ->
              `Assoc [ ("error", Error_json.error_to_yojson e) ] ) )
 
+let sync_status_command =
+  Command.async ~summary:"Query daemon sync status"
+    (let%map_open.Command uri_str = graphql_uri_flag
+     and raw =
+       flag "--raw" no_arg
+         ~doc:"Print just the bare status string (e.g. SYNCED) instead of JSON"
+     in
+     fun () ->
+       let logger = if raw then Logger.null () else Logger.create () in
+       let node_uri = Uri.of_string uri_str in
+       let%map result =
+         Mina_graphql_client.Client.get_sync_status ~logger node_uri
+       in
+       match (result, raw) with
+       | Ok status, true ->
+           print_endline status
+       | Error e, true ->
+           prerr_endline (Yojson.Safe.to_string (Error_json.error_to_yojson e)) ;
+           Core.exit 1
+       | Ok status, false ->
+           Yojson.Safe.pretty_to_channel Out_channel.stdout
+             (`Assoc [ ("sync_status", `String status) ])
+       | Error e, false ->
+           Yojson.Safe.pretty_to_channel Out_channel.stdout
+             (`Assoc [ ("error", Error_json.error_to_yojson e) ]) )
+
+let network_id_command =
+  Command.async ~summary:"Query daemon network ID"
+    (let%map_open.Command uri_str = graphql_uri_flag
+     and raw =
+       flag "--raw" no_arg
+         ~doc:
+           "Print just the bare network id string (e.g. mina:devnet) instead \
+            of JSON"
+     in
+     fun () ->
+       let logger = if raw then Logger.null () else Logger.create () in
+       let node_uri = Uri.of_string uri_str in
+       let%map result =
+         Mina_graphql_client.Client.get_network_id ~logger node_uri
+       in
+       match (result, raw) with
+       | Ok network_id, true ->
+           print_endline network_id
+       | Error e, true ->
+           prerr_endline (Yojson.Safe.to_string (Error_json.error_to_yojson e)) ;
+           Core.exit 1
+       | Ok network_id, false ->
+           Yojson.Safe.pretty_to_channel Out_channel.stdout
+             (`Assoc [ ("network_id", `String network_id) ])
+       | Error e, false ->
+           Yojson.Safe.pretty_to_channel Out_channel.stdout
+             (`Assoc [ ("error", Error_json.error_to_yojson e) ]) )
+
 let () =
   Command.run
     (Command.group ~summary:"Mina GraphQL client utility"
@@ -309,4 +363,6 @@ let () =
        ; ("delegation", delegation_command)
        ; ("set-snark-worker", set_snark_worker_command)
        ; ("set-snark-fee", set_snark_fee_command)
+       ; ("sync-status", sync_status_command)
+       ; ("network-id", network_id_command)
        ] )

--- a/src/lib/mina_graphql_client/client.ml
+++ b/src/lib/mina_graphql_client/client.ml
@@ -77,6 +77,46 @@ let get_peer_id ~logger node_uri =
     (String.concat ~sep:" " peer_ids) ;
   (self_id, peer_ids)
 
+let sync_status_to_string = function
+  | `BOOTSTRAP ->
+      "BOOTSTRAP"
+  | `CATCHUP ->
+      "CATCHUP"
+  | `CONNECTING ->
+      "CONNECTING"
+  | `LISTENING ->
+      "LISTENING"
+  | `OFFLINE ->
+      "OFFLINE"
+  | `SYNCED ->
+      "SYNCED"
+
+let get_sync_status ~logger node_uri =
+  let open Deferred.Or_error.Let_syntax in
+  [%log info] "Getting sync status from daemon"
+    ~metadata:[ ("node_uri", `String (Uri.to_string node_uri)) ] ;
+  let query_obj = Queries.Query_sync_status.(make @@ makeVariables ()) in
+  let%map query_result_obj =
+    exec_graphql_request ~logger ~node_uri ~query_name:"query_sync_status"
+      query_obj
+  in
+  let res = sync_status_to_string query_result_obj.syncStatus in
+  [%log info] "sync_status, result of graphql query = %s" res ;
+  res
+
+let get_network_id ~logger node_uri =
+  let open Deferred.Or_error.Let_syntax in
+  [%log info] "Getting network ID from daemon"
+    ~metadata:[ ("node_uri", `String (Uri.to_string node_uri)) ] ;
+  let query_obj = Queries.Query_network_id.(make @@ makeVariables ()) in
+  let%map query_result_obj =
+    exec_graphql_request ~logger ~node_uri ~query_name:"query_network_id"
+      query_obj
+  in
+  let res = query_result_obj.networkID in
+  [%log info] "network_id, result of graphql query = %s" res ;
+  res
+
 let get_global_slot_since_hard_fork ~logger node_uri =
   let open Deferred.Or_error.Let_syntax in
   [%log info] "Getting global slot since hard fork from daemon status"

--- a/src/lib/mina_graphql_client/queries.ml
+++ b/src/lib/mina_graphql_client/queries.ml
@@ -201,6 +201,18 @@ module Query_metrics =
   }
 |}]
 
+module Query_sync_status = [%graphql {|
+  query {
+    syncStatus
+  }
+|}]
+
+module Query_network_id = [%graphql {|
+  query {
+    networkID
+  }
+|}]
+
 module Genesis_ledger_export = [%graphql {|
   query {
     fork_config


### PR DESCRIPTION
## Summary
- Adds two new subcommands to `mina-graphql-client`: `sync-status` and `network-id` (both support a `--raw` flag for bare string output suitable for bash).
- Replaces the two ad-hoc `curl ... /graphql` calls in `buildkite/scripts/connect/connect-to-network.sh` (used by `ConnectToDevnet`, `ConnectToMainnet`, `ConnectToMesa` Dhall test jobs) with the typed CLI.
- Ships the `mina-graphql-client` binary in the daemon debian package via `copy_common_daemon_apps`, so it's available wherever `mina` is installed.

Rosetta integration scripts intentionally left untouched — they will get their own dedicated rosetta GraphQL client in a follow-up.

## Test plan
- [x] `dune build` of `src/lib/mina_graphql_client/` and `src/app/mina_graphql_client/` clean
- [x] `mina-graphql-client --help` lists `sync-status` and `network-id`
- [x] `mina-graphql-client sync-status --help` / `network-id --help` show `--raw` flag
- [x] `cd buildkite && make all` passes (Dhall + monorepo tests)
- [x] `bash -n` + `shellcheck` on the modified script
- [ ] CI `ConnectToDevnet` / `ConnectToMainnet` / `ConnectToMesa` jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)