### PR TITLE
Create a quickcheck generator for valid runtime configs

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1379,6 +1379,15 @@ module Epoch_data = struct
       let%bind ledger = Ledger.gen in
       let%map seed = String.gen_nonempty in
       { ledger; seed }
+
+    (** Like [gen] but generates a base58-encoded seed: the daemon parses
+        [seed] via [Epoch_seed.of_base58_check_exn], which rejects arbitrary
+        non-empty strings. *)
+    let gen_valid =
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind ledger = Ledger.gen in
+      let%map seed = Mina_base.Epoch_seed.gen in
+      { ledger; seed = Mina_base.Epoch_seed.to_base58_check seed }
   end
 
   type t =
@@ -1458,6 +1467,14 @@ module Epoch_data = struct
     let open Quickcheck.Generator.Let_syntax in
     let%bind staking = Data.gen in
     let%map next = Option.quickcheck_generator Data.gen in
+    { staking; next }
+
+  (** Like [gen] but uses [Data.gen_valid] for the staking and (optional)
+      next epoch data, generating base58-encoded seeds. *)
+  let gen_valid =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind staking = Data.gen_valid in
+    let%map next = Option.quickcheck_generator Data.gen_valid in
     { staking; next }
 end
 
@@ -1573,7 +1590,7 @@ let gen_valid =
   and genesis = Genesis.gen
   and proof = Proof_keys.gen_valid
   and ledger = Ledger.gen
-  and epoch_data = Epoch_data.gen in
+  and epoch_data = Epoch_data.gen_valid in
   { daemon = Some daemon
   ; genesis = Some genesis
   ; proof = Some proof

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1298,6 +1298,13 @@ module Genesis = struct
     ; grace_period_slots
     ; genesis_state_timestamp = Some genesis_state_timestamp
     }
+
+  (** Like [gen] but ensures [slots_per_epoch mod 3 = 0]: the daemon's
+      [Slot.in_seed_update_range] asserts this divisibility. *)
+  let gen_valid =
+    let open Quickcheck.Generator.Let_syntax in
+    let%map t = gen and slots_per_epoch_div_3 = Int.gen_incl 1 333_333 in
+    { t with slots_per_epoch = Some (slots_per_epoch_div_3 * 3) }
 end
 
 module Daemon = struct
@@ -1610,7 +1617,7 @@ let gen =
 let gen_valid =
   let open Quickcheck.Generator.Let_syntax in
   let%map daemon = Daemon.gen
-  and genesis = Genesis.gen
+  and genesis = Genesis.gen_valid
   and proof = Proof_keys.gen_valid
   and ledger = Ledger.gen_valid
   and epoch_data = Epoch_data.gen_valid in

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1199,6 +1199,20 @@ module Proof_keys = struct
     ; account_creation_fee = Some account_creation_fee
     ; fork
     }
+
+  (** Like [gen] but only produces [block_window_duration_ms] values that
+      satisfy the daemon's [slots_per_year mod 12 = 0] assertion, where
+      [slots_per_year = (365 * 86_400_000) / block_window_duration_ms]
+      (integer division). Roughly 1 in 12 candidates pass, so rejection
+      sample. *)
+  let gen_valid =
+    let open Quickcheck.Generator.Let_syntax in
+    let%map t = gen
+    and block_window_duration_ms =
+      Quickcheck.Generator.filter (Int.gen_incl 1_000 360_000) ~f:(fun d ->
+          365 * 86_400_000 / d mod 12 = 0 )
+    in
+    { t with block_window_duration_ms = Some block_window_duration_ms }
 end
 
 (** Parameters for protocol constants that specify slot spans, and relate slot
@@ -1557,7 +1571,7 @@ let gen_valid =
   let open Quickcheck.Generator.Let_syntax in
   let%map daemon = Daemon.gen
   and genesis = Genesis.gen
-  and proof = Proof_keys.gen
+  and proof = Proof_keys.gen_valid
   and ledger = Ledger.gen
   and epoch_data = Epoch_data.gen in
   { daemon = Some daemon

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -968,6 +968,29 @@ module Ledger = struct
     ; name = Some name
     ; add_genesis_winner = Some add_genesis_winner
     }
+
+  (** Like [gen] but caps each account balance to keep the ledger total in
+      range. The daemon's [genesis_ledger_total_currency] sums balances via
+      [Currency.Amount.add] and raises if the total overflows uint64
+      nanomina; [Accounts.Single.gen] produces balances spanning the full
+      uint64 range, so any non-trivial ledger overflows. *)
+  let gen_valid =
+    let open Quickcheck.Generator.Let_syntax in
+    let max_per_account = Currency.Balance.of_mina_int_exn 1_000_000 in
+    let cap b =
+      if Currency.Balance.compare b max_per_account > 0 then max_per_account
+      else b
+    in
+    let%map t = gen in
+    match t.base with
+    | Accounts accs ->
+        let accs =
+          List.map accs ~f:(fun a -> { a with balance = cap a.balance })
+        in
+        let balances = List.mapi accs ~f:(fun i a -> (i, a.balance)) in
+        { t with base = Accounts accs; balances }
+    | Named _ | Hash ->
+        t
 end
 
 module Proof_keys = struct
@@ -1380,12 +1403,12 @@ module Epoch_data = struct
       let%map seed = String.gen_nonempty in
       { ledger; seed }
 
-    (** Like [gen] but generates a base58-encoded seed: the daemon parses
-        [seed] via [Epoch_seed.of_base58_check_exn], which rejects arbitrary
-        non-empty strings. *)
+    (** Like [gen] but uses [Ledger.gen_valid] and generates a base58-encoded
+        seed: the daemon parses [seed] via [Epoch_seed.of_base58_check_exn],
+        which rejects arbitrary non-empty strings. *)
     let gen_valid =
       let open Quickcheck.Generator.Let_syntax in
-      let%bind ledger = Ledger.gen in
+      let%bind ledger = Ledger.gen_valid in
       let%map seed = Mina_base.Epoch_seed.gen in
       { ledger; seed = Mina_base.Epoch_seed.to_base58_check seed }
   end
@@ -1589,7 +1612,7 @@ let gen_valid =
   let%map daemon = Daemon.gen
   and genesis = Genesis.gen
   and proof = Proof_keys.gen_valid
-  and ledger = Ledger.gen
+  and ledger = Ledger.gen_valid
   and epoch_data = Epoch_data.gen_valid in
   { daemon = Some daemon
   ; genesis = Some genesis

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1550,6 +1550,23 @@ let gen =
   ; epoch_data = Some epoch_data
   }
 
+(** A random runtime config the daemon should accept at startup. Composes
+    per-section [gen_valid]s where they exist and falls back to [gen]
+    otherwise. *)
+let gen_valid =
+  let open Quickcheck.Generator.Let_syntax in
+  let%map daemon = Daemon.gen
+  and genesis = Genesis.gen
+  and proof = Proof_keys.gen
+  and ledger = Ledger.gen
+  and epoch_data = Epoch_data.gen in
+  { daemon = Some daemon
+  ; genesis = Some genesis
+  ; proof = Some proof
+  ; ledger = Some ledger
+  ; epoch_data = Some epoch_data
+  }
+
 let ledger_accounts (ledger : Mina_ledger.Ledger.Any_ledger.witness) =
   let open Async.Deferred.Or_error.Let_syntax in
   let yield = Async_unix.Scheduler.yield_every ~n:100 |> Staged.unstage in

--- a/src/test/command_line_tests/command_line_tests.ml
+++ b/src/test/command_line_tests/command_line_tests.ml
@@ -993,6 +993,61 @@ module NodeStatusReport = struct
             Node_status_mock_server.stop mock )
 end
 
+(** Smoke test for [Runtime_config.gen_valid]: start a daemon on a random
+    config produced by the generator and wait for init. *)
+module RandomConfigStartup = struct
+  type t = Mina_automation_fixture.Daemon.before_bootstrap
+
+  let test_case (test : t) =
+    let daemon = Daemon.of_config test.config in
+    let%bind () = Daemon.Config.generate_keys test.config in
+    let ledger_file = test.config.dirs.conf ^/ "daemon.json" in
+    let runtime_config = Quickcheck.random_value Runtime_config.gen_valid in
+    let runtime_config =
+      let genesis_timestamp =
+        let now_unix_ts = Unix.time () |> Float.to_int in
+        let genesis_unix_ts = now_unix_ts - (now_unix_ts mod 60) + 120 in
+        Time.of_span_since_epoch (Time.Span.of_int_sec genesis_unix_ts)
+        |> Time.to_string_iso8601_basic ~zone:Time.Zone.utc
+      in
+      let genesis =
+        match runtime_config.genesis with
+        | Some g ->
+            Some { g with genesis_state_timestamp = Some genesis_timestamp }
+        | None ->
+            Some
+              { k = None
+              ; delta = None
+              ; slots_per_epoch = None
+              ; slots_per_sub_window = None
+              ; grace_period_slots = None
+              ; genesis_state_timestamp = Some genesis_timestamp
+              }
+      in
+      { runtime_config with genesis }
+    in
+    Runtime_config.to_yojson runtime_config |> Yojson.Safe.to_file ledger_file ;
+    let%bind process = Daemon.start daemon in
+    match%bind Daemon.wait_for_node_init process with
+    | Ok () ->
+        let%map () = Daemon.Client.stop_daemon process.client in
+        Mina_automation_fixture.Intf.Passed
+    | Error e ->
+        let log_file = Daemon.Config.ConfigDirs.mina_log test.config.dirs in
+        let%bind logs =
+          match%bind Sys.file_exists log_file with
+          | `Yes ->
+              Reader.file_contents log_file
+          | `No | `Unknown ->
+              Deferred.return ""
+        in
+        let%map _ = Daemon.Process.force_kill process in
+        Mina_automation_fixture.Intf.Failed
+          (Error.tag e
+             ~tag:
+               (sprintf "Daemon failed to initialise.\nDaemon logs:\n%s" logs) )
+end
+
 let () =
   let open Alcotest in
   run "Test commadline."
@@ -1131,5 +1186,15 @@ let () =
                ( module Mina_automation_fixture.Daemon
                         .Make_FixtureWithoutBootstrap
                           (NodeStatusReport) ) )
+        ] )
+    ; ( "random-config-startup"
+      , [ test_case
+            "The mina daemon initialises on a random Runtime_config.gen_valid \
+             config"
+            `Slow
+            (Mina_automation_runner.Runner.run_blocking
+               ( module Mina_automation_fixture.Daemon
+                        .Make_FixtureWithoutBootstrap
+                          (RandomConfigStartup) ) )
         ] )
     ]


### PR DESCRIPTION
The new `Runtime_config.gen_valid` generator will generate a random valid protocol config; it is valid in the sense that a single daemon in seed mode will successfully start up given this config. A test has been added to confirm this property. The existing `Runtime_config.gen` does not have this property, notably. I've kept that generator around, but we could conceivably delete it, since it isn't actually used anywhere.

There is no guarantee that the resulting config will be at all sensible. If we ever need runtime configs that are random but more reasonable then we can always add (optional or mandatory) bounds to the ranges of the generators, or something like that.

For context: I want to use this generator in a new test, but the change was isolated enough that I thought I'd put this up now for review. The test in this PR is just to confirm that the generator actually works the way I want it to.