### PR TITLE
Improve nix submodule building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,10 @@ check-format: ocaml_checks ## Check formatting of OCaml code
 check-snarky-submodule: ## Check the snarky submodule
 	./scripts/check-snarky-submodule.sh
 
+.PHONY: check-flake-submodule-sync
+check-flake-submodule-sync: ## Check flake input revs match git submodule SHAs
+	./scripts/check-flake-submodule-sync.sh
+
 #######################################
 ## Bash checks
 

--- a/buildkite/scripts/test-nix.sh
+++ b/buildkite/scripts/test-nix.sh
@@ -65,9 +65,9 @@ git checkout -b $BUILDKITE_BRANCH
 git reset --hard $BUILDKITE_COMMIT
 
 # Test developer terminal with lsp server
-nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "echo tested"
-nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "dune build src" &
-  nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --no-link
+nix "${NIX_OPTS[@]}" develop "$PWD#with-lsp" --command bash -c "echo tested"
+nix "${NIX_OPTS[@]}" develop "$PWD#with-lsp" --command bash -c "dune build src" &
+  nix "${NIX_OPTS[@]}" build "$PWD#devnet" --no-link
 wait
 
 if [[ "$NIX_CACHE_GCP_ID" != "" ]] && [[ "$NIX_CACHE_GCP_SECRET" != "" ]]; then

--- a/buildkite/src/Jobs/Lint/FlakeSubmoduleSync.dhall
+++ b/buildkite/src/Jobs/Lint/FlakeSubmoduleSync.dhall
@@ -1,0 +1,48 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.exactly "flake" "nix"
+          , S.exactly "flake" "lock"
+          , S.exactly ".gitmodules" ""
+          , S.exactly "scripts/check-flake-submodule-sync" "sh"
+          , S.exactly "buildkite/src/Jobs/Lint/FlakeSubmoduleSync" "dhall"
+          ]
+        , path = "Lint"
+        , name = "FlakeSubmoduleSync"
+        , tags =
+          [ PipelineTag.Type.Fast
+          , PipelineTag.Type.Lint
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+                RunInToolchain.runInToolchain
+                  ([] : List Text)
+                  "make check-flake-submodule-sync"
+            , label = "Lint: flake input revs match submodule SHAs"
+            , key = "check-flake-submodule-sync"
+            , target = Size.Multi
+            , docker = None Docker.Type
+            }
+        ]
+      }

--- a/flake.lock
+++ b/flake.lock
@@ -179,6 +179,23 @@
         "type": "github"
       }
     },
+    "kimchi-stubs-vendors": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775558323,
+        "narHash": "sha256-0dQghqUhYl3MBzwvmlqoJ0fBpsXLfUVNyvxIZj34Jrw=",
+        "owner": "MinaProtocol",
+        "repo": "kimchi-stubs-vendors",
+        "rev": "818fbf6fa38f20f976657ea1d9705b7a29bd3a38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MinaProtocol",
+        "repo": "kimchi-stubs-vendors",
+        "rev": "818fbf6fa38f20f976657ea1d9705b7a29bd3a38",
+        "type": "github"
+      }
+    },
     "mirage-opam-overlays": {
       "flake": false,
       "locked": {
@@ -443,6 +460,23 @@
         "type": "github"
       }
     },
+    "proof-systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776252774,
+        "narHash": "sha256-wG/03dwrV2kD+TQDbYY7biJ/l1fJq9btbGOgsx/ICv0=",
+        "owner": "o1-labs",
+        "repo": "proof-systems",
+        "rev": "ab84160fa2c22290a8506a7742ac1378879fc386",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "proof-systems",
+        "rev": "ab84160fa2c22290a8506a7742ac1378879fc386",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "describe-dune": "describe-dune",
@@ -451,6 +485,7 @@
         "flake-compat": "flake-compat",
         "flockenzeit": "flockenzeit",
         "gitignore-nix": "gitignore-nix",
+        "kimchi-stubs-vendors": "kimchi-stubs-vendors",
         "nix-filter": "nix-filter",
         "nix-npm-buildPackage": "nix-npm-buildPackage",
         "nix-utils": "nix-utils",
@@ -461,7 +496,26 @@
         "o1-opam-repository": "o1-opam-repository",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository",
+        "proof-systems": "proof-systems",
+        "snarky": "snarky",
         "utils": "utils"
+      }
+    },
+    "snarky": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767824453,
+        "narHash": "sha256-+vZBEyun21AqGFDJW+QQ1qUTZrZsPYEyHQ5et1C1KDA=",
+        "owner": "o1-labs",
+        "repo": "snarky",
+        "rev": "9f55ef7c2f2570365aeb24b6ddfc713f48be3117",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "snarky",
+        "rev": "9f55ef7c2f2570365aeb24b6ddfc713f48be3117",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -84,33 +84,6 @@
     , nix-utils, flockenzeit, nixpkgs-old, nixpkgs-unstable, ... }:
     let
       inherit (nixpkgs) lib;
-
-      # All the submodules required by .gitmodules
-      submodules = map builtins.head (builtins.filter lib.isList
-        (map (builtins.match "	path = (.*)")
-          (lib.splitString "\n" (builtins.readFile ./.gitmodules))));
-
-      # Warn about missing submodules
-      requireSubmodules = let
-        ref = r: "[34;1m${r}[31;1m";
-        command = c: "[37;1m${c}[31;1m";
-      in lib.warnIf (!builtins.all (x: x)
-        (map (x: builtins.pathExists ./${x} && builtins.readDir ./${x} != { })
-          submodules)) ''
-            Some submodules are missing, you may get errors. Consider one of the following:
-            - run ${command "nix/pin.sh"} and use "${
-              ref "mina"
-            }" flake ref, e.g. ${command "nix develop mina"} or ${
-              command "nix build mina"
-            };
-            - use "${ref "git+file://$PWD?submodules=1"}";
-            - use "${
-              ref "git+https://github.com/minaprotocol/mina?submodules=1"
-            }";
-            - use non-flake commands like ${command "nix-build"} and ${
-              command "nix-shell"
-            }.
-          '';
     in {
       overlays = {
         misc = import ./nix/misc.nix;
@@ -121,8 +94,7 @@
         go = import ./nix/go.nix;
         javascript = import ./nix/javascript.nix;
         ocaml = pkgs: prev: {
-          ocamlPackages_mina =
-            requireSubmodules (import ./nix/ocaml.nix { inherit inputs pkgs; });
+          ocamlPackages_mina = import ./nix/ocaml.nix { inherit inputs pkgs; };
         };
         # Skip tests on nodejs dep due to known issue with nixpkgs 24.11 https://github.com/NixOS/nixpkgs/issues/402079
         # this can be removed after upgrading

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,26 @@
 
   inputs.nix-filter.url = "github:numtide/nix-filter";
 
+  inputs.proof-systems = {
+    # Pinned to the same commit used in the proof systems git submodule
+    # If you want to hack locally with an overriden proof systems, add the
+    # argument `--override-input proof-systems "github:o1-labs/proof-systems/<commit>"`
+    # to your `nix develop` or `nix build` command. Use the URI "path:/path/to/my/proof-systems"
+    # if you want to use a local proof systems repo.
+    url = "github:o1-labs/proof-systems/ab84160fa2c22290a8506a7742ac1378879fc386";
+    flake = false;
+  };
+
+  inputs.kimchi-stubs-vendors = {
+    url = "github:MinaProtocol/kimchi-stubs-vendors/818fbf6fa38f20f976657ea1d9705b7a29bd3a38";
+    flake = false;
+  };
+
+  inputs.snarky = {
+    url = "github:o1-labs/snarky/9f55ef7c2f2570365aeb24b6ddfc713f48be3117";
+    flake = false;
+  };
+
   inputs.flake-buildkite-pipeline.url = "github:tweag/flake-buildkite-pipeline";
 
   inputs.nix-utils.url = "github:juliosueiras-nix/nix-utils";
@@ -94,7 +114,10 @@
     in {
       overlays = {
         misc = import ./nix/misc.nix;
-        rust = import ./nix/rust.nix;
+        rust = import ./nix/rust.nix {
+          proof-systems-src = inputs.proof-systems;
+          kimchi-stubs-vendors-src = inputs.kimchi-stubs-vendors;
+        };
         go = import ./nix/go.nix;
         javascript = import ./nix/javascript.nix;
         ocaml = pkgs: prev: {

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,13 +11,14 @@ encounter any problem.
 <details>
 <summary>TL;DR for those who know Nix</summary>
 
-This is a flake. It provides a lot of different packages from the monorepo. Most
-of those packages require submodules to build. To simplify your life, there's
-`nix/pin.sh` script which creates the relevant registry entry with
-`?submodules=1`, so that you can then use it like `nix build mina`, `nix develop
-mina`, etc. You can discover all the available packages as usual, by using tab
-completion or `nix eval mina#packages.x86_64-linux --apply __attrNames` or your
-favourite way.
+This is a flake. It provides a lot of different packages from the monorepo.
+Build them with `nix build .#<package>` (e.g. `nix build .` for the default
+mina derivation) or enter a dev shell with `nix develop`. Discover the
+available packages with `nix eval .#packages.x86_64-linux --apply __attrNames`.
+
+The rest of this README uses the `mina#<package>` shorthand. Run `./nix/pin.sh`
+once to register it as a flake-registry alias, or just replace `mina` with `.`
+in the commands below.
 
 </details>
 
@@ -64,18 +65,14 @@ echo 'experimental-features = nix-command flakes' > "${XDG_CONFIG_HOME-${HOME}/.
 You can check that your flake support is working by running `nix flake metadata
 github:nixos/nixpkgs` for example.
 
-## 3. Add a nix registry entry
+## 3. (Optional) Register the `mina` flake alias
 
-If you're using flakes (see previous section), **you have to run the
-`./nix/pin.sh` script** to get the `mina` registry entry, since that's the
-easiest way to enable submodules to be available to the build. This is needed
-because by default Nix will not include submodules in the source tree it builds
-dependencies from, resulting in errors.
-
-For the curious, `mina` registry entry will resolve to
-`git+file:///path/to/your/mina/checkout?submodules=1`. Should you want to hack
-on a different mina checkout, try e.g. `nix develop
-"git+file://$PWD?submodules=1"` from that checkout.
+Every command in the rest of this README can be invoked directly as
+`nix <cmd> .#<package>` from the repo root. If you prefer the shorter
+`mina#<package>` form, run `./nix/pin.sh` once to register a flake-registry
+entry pointing at your checkout. `pin.sh` also initialises the git submodules,
+which is needed if you want to run `dune build` directly (outside of any Nix
+invocation).
 
 ## 4. Use it
 
@@ -270,7 +267,7 @@ sudo nixos-container start mina
 
 TL;DR
 ```
-printf './nix/pin.sh\nuse flake mina\n' > .envrc
+echo 'use flake' > .envrc
 direnv allow
 ```
 
@@ -289,10 +286,10 @@ time you enter the Mina repo directory. One way to do this is by using
 - Configure the [`nix-direnv`](https://github.com/nix-community/nix-direnv)
   - The `Via home-manager (Recommended)` section
 - Create the `.envrc` file under the Mina repo root path with the following
-  content: `use flake mina`:
+  content: `use flake`:
   ```
   cd mina
-  touch .envrc && echo "use flake mina" >> .envrc
+  echo 'use flake' > .envrc
   ```
 - Execute the following command within the Mina repo root path, in order to
   activate the `direnv` for current directory (it will read and apply previously
@@ -348,9 +345,20 @@ expressions from `nix/`, `flake.lock` which locks the input versions, and
 
 ### Updating inputs
 
-If you wish to update all the inputs of this flake, run `nix flake update` . If
-you want to update a particular input, run `nix flake lock --update-input
-<input>` .
+If you wish to update all the inputs of this flake, run `nix flake update`. To
+update a particular input, run `nix flake update <input>`.
+
+Three of the inputs — `proof-systems`, `kimchi-stubs-vendors`, and `snarky` —
+shadow the corresponding git submodules under `src/lib/`. They must be kept in
+lock-step with the submodule SHAs in `HEAD`. To bump one of them:
+
+1. Bump the submodule in the worktree
+   (`cd <submodule path> && git checkout <new-rev> && cd -; git add <path>`).
+2. Update the rev in the corresponding `url = "github:.../<rev>";` line in
+   `flake.nix`.
+3. Run `nix flake update <input>` to refresh `flake.lock`.
+4. Run `make check-flake-submodule-sync` to verify the flake input rev and the
+   submodule SHA agree. The same check runs in the Buildkite Lint pipeline.
 
 ### Notes on the "pure" build
 
@@ -468,9 +476,8 @@ nix-repl> :u legacyPackages.x86_64-linux.regular.ocamlPackages_mina.mina-dev.ove
 ### Evaluation takes too long
 
 Evaluating any output of this flake for the first time can take a substantial
-amount of time. This is because Nix wants to ensure purity, and thus copies all
-submodules to the store and checks them out individually, even if you already
-have them checked out in your work tree.
+amount of time, because Nix copies your work tree into the store to ensure
+purity. Subsequent evaluations are much faster as the inputs are cached.
 
 This is good for reproducibility, but can be inconvenient. Here are some steps
 you can take to circumvent this:
@@ -574,21 +581,22 @@ running it with `result/bin/mina` instead.
 
 ### Submodules
 
-Nix will **not** fetch submodules for you. You have to make sure that
-you have the entire mina source code, including submodules, before you
-run any nix commands. This should make sure you have the right
-versions checked out (in most cases):
+The Nix build pulls in the `proof-systems`, `kimchi-stubs-vendors`, and
+`snarky` components as dedicated flake inputs pinned in `flake.lock`. `nix
+build .` and `nix develop` work on a fresh checkout without any explicit
+submodule setup.
+
+If you want to run `dune build` directly (outside of any Nix invocation),
+you still need the submodules initialised in your work tree:
 
 ```
 git submodule sync
 git submodule update --init --recursive
 ```
 
-If you don't do this, Nix may not always yell at you right away
-(especially if all the submodule directories are present in the tree
-somehow, but not correctly filled in). It will however fail with a
-strange error during the build, when it fails to find a
-dependency. Make sure you do this!
+Bumping a submodule also requires bumping its matching flake input — see
+[Updating inputs](#updating-inputs). The `make check-flake-submodule-sync`
+target (also enforced in the Buildkite Lint pipeline) catches drift.
 
 ### `Warning: ignoring untrusted substituter`
 
@@ -647,7 +655,7 @@ For compilation units that have no package defined, a synthetic package name is 
 
 ## Examples
 
-CLI commands below assume to be executed from a directory with Mina repository checked out and `./nix/pin.sh` executed.
+CLI commands below assume execution from the root of the Mina repository checkout, and use the `mina#` flake-alias shorthand registered by `./nix/pin.sh`. Replace `mina` with `.` to invoke them without the alias.
 
 | Description | Command |
 |--------------|-------------|

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -114,6 +114,9 @@ let
     ];
     phases = [ "unpackPhase" "buildPhase" ];
     buildPhase = ''
+      cp -r ${pkgs.lib.sources.sourceFilesBySuffices inputs.snarky [
+        "dune" "dune-project" ".inc" ".opam"
+      ]} lib/snarky
       files=$(ls)
       mkdir src
       mv $files src
@@ -310,6 +313,12 @@ let
               "opam.export"
             ];
           };
+
+        # Also add the snarky submodule from the dedicated flake input.
+        postUnpack = ''
+          chmod u+w source/src/lib
+          cp -r ${inputs.snarky} source/src/lib/snarky
+        '';
 
         withFakeOpam = false;
 

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,4 +1,5 @@
 # An overlay defining Rust parts&dependencies of Mina
+{ proof-systems-src, kimchi-stubs-vendors-src }:
 final: prev:
 let
   rustPlatformFor = rust:
@@ -69,6 +70,10 @@ let
         allRefs = true;
       }).narHash;
     }) package;
+  proofSystemsVersion =
+    (fromTOML (builtins.readFile
+      "${proof-systems-src}/Cargo.toml")).workspace.package.version;
+
 in {
   kimchi_bindings_stubs = let
     toolchain = rustChannelFromToolchainFileOf
@@ -76,19 +81,22 @@ in {
     rust_platform = rustPlatformFor toolchain.rust;
   in rust_platform.buildRustPackage {
     pname = "kimchi_bindings_stubs";
-    version = "0.1.0";
+    version = proofSystemsVersion;
     src = final.lib.sourceByRegex ../src [
-      "^lib(/crypto(/kimchi_bindings(/stubs(/.*)?)?)?)?$"
-      "^lib(/crypto(/proof-systems(/.*)?)?)?$"
+      "^lib(/crypto(/kimchi_bindings(/stubs(/(Cargo\\.(toml|lock)|rust-toolchain\\.toml|\\.cargo(/.*)?|src(/.*)?|build\\.rs))?)?)?)?$"
     ];
     sourceRoot = "source/lib/crypto/kimchi_bindings/stubs";
+    # Add proof-systems and kimchi-stubs-vendors from dedicated flake inputs,
+    # preserving the relative path layout that Cargo.toml and
+    # .cargo/config.toml expect.
+    postUnpack = ''
+      chmod u+w source/lib/crypto source/lib/crypto/kimchi_bindings/stubs
+      cp -r ${proof-systems-src} source/lib/crypto/proof-systems
+      cp -r ${kimchi-stubs-vendors-src} source/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors
+    '';
+    cargoVendorDir = "kimchi-stubs-vendors";
     nativeBuildInputs = [ final.ocamlPackages_mina.ocaml ];
     buildInputs = with final; lib.optional stdenv.isDarwin libiconv;
-    cargoLock = let fixupLockFile = path: builtins.readFile path;
-    in {
-      lockFileContents =
-        fixupLockFile ../src/lib/crypto/kimchi_bindings/stubs/Cargo.lock;
-    };
     # FIXME: tests fail
     doCheck = false;
     dontUpdateAutotoolsGnuConfigScripts = true;
@@ -99,13 +107,11 @@ in {
       # Using the same toolchain which is used by the local stubs crate
       ../src/lib/crypto/kimchi_bindings/stubs/rust-toolchain.toml;
     rust_platform = rustPlatformFor toolchain.rust;
-    lock = ../src/lib/crypto/proof-systems/Cargo.lock;
+    lock = "${proof-systems-src}/Cargo.lock";
   in rust_platform.buildRustPackage {
     pname = "kimchi_stubs_static_lib";
-    version = "0.1.0";
-    src = final.lib.sourceByRegex ../src
-      [ "^lib(/crypto(/proof-systems(/.*)?)?)?$" ];
-    sourceRoot = "source/lib/crypto/proof-systems";
+    version = proofSystemsVersion;
+    src = proof-systems-src;
     nativeBuildInputs = [ final.ocamlPackages_mina.ocaml ];
     buildInputs = with final; lib.optional stdenv.isDarwin libiconv;
     cargoLock = let fixupLockFile = path: builtins.readFile path;
@@ -146,7 +152,7 @@ in {
   };
 
   plonk_wasm = let
-    lock = ../src/lib/crypto/proof-systems/Cargo.lock;
+    lock = "${proof-systems-src}/Cargo.lock";
 
     deps = builtins.listToAttrs (map (pkg: {
       inherit (pkg) name;
@@ -188,15 +194,11 @@ in {
     };
   in rustPlatform.buildRustPackage {
     pname = "plonk_wasm";
-    version = "0.1.0";
-    src = final.lib.sourceByRegex ../src [
-      "^lib(/crypto(/kimchi_bindings(/wasm(/.*)?)?)?)?$"
-      "^lib(/crypto(/proof-systems(/.*)?)?)?$"
-    ];
-    sourceRoot = "source/lib/crypto/proof-systems";
+    version = proofSystemsVersion;
+    src = proof-systems-src;
     nativeBuildInputs = [ final.wasm-pack wasm-bindgen-cli ];
     buildInputs = with final; lib.optional stdenv.isDarwin libiconv;
-    cargoLock.lockFile = lock;
+    cargoLock.lockFileContents = builtins.readFile lock;
     cargoLock.outputHashes = narHashesFromCargoLock lock;
 
     # Without this env variable, wasm pack attempts to create cache dir in root

--- a/scripts/check-flake-submodule-sync.sh
+++ b/scripts/check-flake-submodule-sync.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Verify that the revs pinned in flake.lock for the rust and snarky
+# flake inputs match the SHAs of their corresponding git submodules.
+# Fails if they drift, so a submodule bump that forgets to update the
+# flake input is caught before it can hide a build divergence between
+# `nix build` and `dune build`.
+
+set -euo pipefail
+
+# Map of submodule path -> flake input name. Keep in sync with flake.nix.
+SUBMODULES=(
+  "src/lib/snarky:snarky"
+  "src/lib/crypto/proof-systems:proof-systems"
+  "src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors:kimchi-stubs-vendors"
+)
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+failed=0
+for entry in "${SUBMODULES[@]}"; do
+  path="${entry%%:*}"
+  input="${entry##*:}"
+
+  submodule_sha="$(git ls-tree HEAD "$path" | awk '{print $3}')"
+  if [[ -z "$submodule_sha" ]]; then
+    echo "error: no submodule entry for $path in HEAD" >&2
+    failed=1
+    continue
+  fi
+
+  flake_rev="$(jq -r --arg name "$input" '.nodes[$name].locked.rev // empty' flake.lock)"
+  if [[ -z "$flake_rev" ]]; then
+    echo "error: no flake.lock entry for input '$input'" >&2
+    failed=1
+    continue
+  fi
+
+  if [[ "$submodule_sha" != "$flake_rev" ]]; then
+    echo "drift: $path / flake input '$input'" >&2
+    echo "  git submodule SHA: $submodule_sha" >&2
+    echo "  flake.lock rev:    $flake_rev" >&2
+    failed=1
+  fi
+done
+
+if (( failed != 0 )); then
+  echo >&2
+  echo "To fix: update the corresponding URL in flake.nix and run" >&2
+  echo "  nix flake update <input> [<input>...]" >&2
+  exit 1
+fi
+
+echo "flake inputs are in sync with git submodules."

--- a/scripts/generate-ledger-hf-dryrun.sh
+++ b/scripts/generate-ledger-hf-dryrun.sh
@@ -400,7 +400,7 @@ ensure_binary() {
     
     echo "Building $binary_name..."
     local nix_result
-    nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")?submodules=1"#"$nix_target")
+    nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")"#"$nix_target")
     local new_binary_path="$nix_result/bin/$binary_name"
     
     if [[ ! -x "$new_binary_path" ]]; then

--- a/scripts/generate-local-genesis.sh
+++ b/scripts/generate-local-genesis.sh
@@ -77,7 +77,7 @@ elif [[ -n "$MINA_BINARY" ]]; then
   echo "Error: mina binary not found or not executable: $MINA_BINARY" >&2; exit 1
 else
   echo "Building mina via nix..."
-  nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")?submodules=1#devnet")
+  nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")#devnet")
   MINA_BINARY="$nix_result/bin/mina"
   echo "Built mina: $MINA_BINARY"
 fi
@@ -89,7 +89,7 @@ elif [[ -n "$RUNTIME_GENESIS_LEDGER_BINARY" ]]; then
   echo "Error: runtime_genesis_ledger binary not found or not executable: $RUNTIME_GENESIS_LEDGER_BINARY" >&2; exit 1
 else
   echo "Building runtime_genesis_ledger via nix..."
-  nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")?submodules=1#devnet.genesis")
+  nix_result=$(nix build --no-link --print-out-paths "$(dirname "$SCRIPT_DIR")#devnet.genesis")
   RUNTIME_GENESIS_LEDGER_BINARY="$nix_result/bin/runtime_genesis_ledger"
   echo "Built runtime_genesis_ledger: $RUNTIME_GENESIS_LEDGER_BINARY"
 fi


### PR DESCRIPTION
This PR improves the submodule-related aspects of the nix flake in a few ways:

1. Explicit flake inputs are now defined for the `snark`, `proof-systems`, and `kimchi-stubs-vendors` submodules. These flake inputs are sourced from their corresponding github repositories and pinned to specific git commits, and a new CI lint ensures that the commits in the flake are kept in sync with the corresponding git submodule commits.
2. The file copying for each of the submodules has been cleaned up as part of adding the flake inputs.
3. The `version` metadata of the `kimchi_stubs_static_lib` nix package defined in the flake is now set to the actual proof systems version.

The result of all of this is that `?submodules=1` is no longer required when building with nix. Also, nix can now more easily detect changes to these inputs that require a rebuild, so we should get less stale cache hits than before. The `./nix/pin.sh` script is no longer necessary to run before doing a nix build as well; I've kept it because it still adds a `mina` flake to the flake registry and updates submodules, which might still be convenient for people.

If you want to override these inputs for local development, you can use something like this in a `.envrc` file (if using direnv)

```
use flake .#with-lsp \
    --override-input proof-systems        "path:$PWD/src/lib/crypto/proof-systems" \
    --override-input kimchi-stubs-vendors "path:$PWD/src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors" \
    --override-input snarky               "path:$PWD/src/lib/snarky
```

or this at the git root, for a development shell

```
nix develop .#with-lsp \
    --override-input proof-systems        "path:$PWD/src/lib/crypto/proof-systems" \
    --override-input kimchi-stubs-vendors "path:$PWD/src/lib/crypto/kimchi_bindings/stubs/kimchi-stubs-vendors" \
    --override-input snarky               "path:$PWD/src/lib/snarky"
```

These commands will use whatever is on disk at the given `path:` as an input, so you still need to `git submodule update --init --recursive` or edit the path so it points to an already-existing repo. You can also use `git:file:/path/to/submodule/repo`, which will cache things better, but does require you to check things in.

This doesn't change building with `dune`, even inside of a nix develop shell; you'll still need to make sure that the `src/lib/snarky` submodule is present and up to date when you `dune build`, for instance. It also doesn't affect non-nix builds in any way. It only affects the rust build inputs for the flake (build or dev shell) and the full nix builds of the ocaml code.

------

I have not isolated the three submodules as external packaged dependencies yet, because I wanted to fix the nix builds without disrupting existing non-nix workflows for now. This isolation could be done as a follow-up, which would allow us to get rid of the submodules entirely.