### PR TITLE
Archive: stop per-backend pg memory leak by marking dynamic Caqti requests ~oneshot:true

### DIFF
--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -389,13 +389,20 @@ let insert_into_cols ~(returning : string) ~(table_name : string)
 
 (* run `select_cols` and return the result, if found
    if not found, run `insert_into_cols` and return the result
-*)
+
+   The Caqti requests below are built freshly on every call (their SQL
+   strings depend on the [table_name]/[cols] arguments), so each one would
+   otherwise be registered as a distinct prepared statement on the server
+   and accumulate in the backend's plan cache for the lifetime of the
+   connection. Pass [~oneshot:true] to keep per-backend memory bounded; see
+   Caqti_request docs: "dynamically constructed requests should have
+   ~oneshot:true". *)
 let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
     ~(table_name : string) ?tannot ~(cols : string list * 'cols Caqti_type.t)
     (module Conn : CONNECTION) (value : 'cols) =
   let open Deferred.Result.Let_syntax in
   Conn.find_opt
-    ( Caqti_request.Infix.(snd cols ->? snd select)
+    ( Caqti_request.Infix.(snd cols ->? snd select) ~oneshot:true
     @@ select_cols ~select:(fst select) ~table_name ?tannot ~cols:(fst cols) ()
     )
     value
@@ -404,7 +411,7 @@ let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
       return id
   | None ->
       Conn.find
-        ( Caqti_request.Infix.(snd cols ->! snd select)
+        ( Caqti_request.Infix.(snd cols ->! snd select) ~oneshot:true
         @@ insert_into_cols ~returning:(fst select) ~table_name ?tannot
              ~cols:(fst cols) () )
         value
@@ -428,7 +435,8 @@ let insert_multi_into_col ~(table_name : string)
   in
   let%bind () =
     Conn.exec
-      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) insert)
+      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) ~oneshot:true
+         insert )
       ()
   in
   let search =
@@ -439,7 +447,8 @@ let insert_multi_into_col ~(table_name : string)
   in
   Conn.collect_list
     Caqti_request.Infix.(
-      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int)) search)
+      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int))
+        ~oneshot:true search )
     ()
 
 let query ~f pool =


### PR DESCRIPTION
## Summary

- Marks the dynamically-built Caqti requests inside `Mina_caqti.select_insert_into_cols` and `Mina_caqti.insert_multi_into_col` as `~oneshot:true` so they're not registered as named prepared statements on the postgres backend.
- This stops a per-backend prepared-statement-cache leak that grows long-lived archive→postgres connections to 1.5–2 GB RSS each and OOMs the archive postgres pod (observed: 26 OOMKills in 46 h on `itn-archive-postgresql-0`).
- Caqti's own documentation calls this out explicitly: *"dynamically constructed requests should have `~oneshot:true`"* (`caqti_request.mli`).

Fixes #18857.

## Why this works

Both helpers allocate a fresh `Caqti_request.t` on every call (their SQL strings depend on `~table_name`/`~cols`/`~tannot` arguments, and in `insert_multi_into_col` the SQL is `sprintf`-built per batch). With the default `~oneshot:false`, Caqti's PG driver issues a server-side `PREPARE _caqtiN AS …` keyed by the request id and keeps the entry alive on the postgres backend until the connection closes. Because the archive's Caqti pool (`Mina_caqti.connect_pool ~max_size:30` in `src/app/archive/lib/processor.ml`) keeps idle connections forever and `idle_session_timeout = 0` on the server, the backend's `CacheMemoryContext` grows monotonically. With ~41 helper call sites in `processor.ml` and many calls per ingested block, the cache reaches GB-scale within hours.

`~oneshot:true` makes the driver execute via the unnamed/simple protocol, so nothing accumulates on the backend.

## Diff scope

Single file: `src/lib/mina_caqti/mina_caqti.ml`. Four `Caqti_request.Infix` constructor sites get `~oneshot:true`. Behavior is otherwise unchanged.

## Out of scope (follow-ups)

- `insert_multi_into_col` builds its SQL via `sprintf` and inlines values into the query text via `sep_by_comma ~parenthesis:true`. That defeats parameter binding and is SQL-injection-shaped if a value can contain a single quote. Tracked in a separate issue/PR.
- Hoisting `Caqti_request.t` values out of the helpers into module-level constants so the *good* statement-preparation path can be used. Larger refactor; not required to stop the bleeding.
- DB-side mitigations (idle_session_timeout, Caqti pool max_idle_age, pgbouncer) — not part of this PR; configuration-side.

## Test plan

- [ ] CI: archive unit tests / integration tests pass (the helpers are behaviorally unchanged — `~oneshot:true` only changes the driver's caching strategy).
- [ ] Deploy to a long-running archive (ITN works) and verify per-backend `RSS` plateaus instead of growing monotonically; cgroup `memory.current` on the postgres pod no longer trends toward 10 Gi.
- [ ] No new OOMKills on the postgres pod over a 24 h window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
