### PR TITLE
Archive: bind values via Caqti instead of sprintf-interpolating them into SQL

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -1553,11 +1553,8 @@ module Zkapp_events = struct
             (* if there's no fields, then we must have some list of empty lists *)
             return @@ List.map field_list_list ~f:(fun _ -> [])
         in
-        (* this conversion should be done by caqti using `typ`, FIX this in the future *)
         let field_array_list =
-          List.map field_id_list_list ~f:(fun id_list ->
-              List.map id_list ~f:Int.to_string
-              |> String.concat ~sep:", " |> sprintf "{%s}" )
+          List.map field_id_list_list ~f:Array.of_list
         in
         let%map field_array_map =
           Mina_caqti.insert_multi_into_col ~table_name:"zkapp_field_array"

--- a/src/lib/mina_caqti/dune
+++ b/src/lib/mina_caqti/dune
@@ -11,7 +11,8 @@
   caqti
   async_kernel
   ;; local libraries
-  mina_base)
+  mina_base
+  mina_stdlib)
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_custom_printf h_list.ppx))
  (instrumentation

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -409,38 +409,54 @@ let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
              ~cols:(fst cols) () )
         value
 
-let sep_by_comma ?(parenthesis = false) xs =
-  List.map xs ~f:(if parenthesis then sprintf "('%s')" else sprintf "'%s'")
-  |> String.concat ~sep:", "
+(* Insert each value in [values] into [table_name] under [col], ignoring
+   conflicts, and return the (col, id) pairs for whatever ended up in the
+   table afterwards.
 
+   Values are bound via the Caqti parameter encoding for [(snd col)], so the
+   SQL string is independent of [values]. This:
+     - eliminates the sprintf-of-values pattern that previously interpolated
+       string-quoted user values directly into the query text (SQL-injection
+       shaped, and trivially broken by any value containing a single quote);
+     - lets [(snd col)]'s Caqti encoder handle textual representation
+       (e.g. Postgres array literals for [array_int_typ]) instead of asking
+       the caller to pre-format values into strings;
+     - keeps the SQL strings stable per (table_name, col_name) pair so that
+       per-batch SQL no longer pollutes the postgres backend plan cache.
+
+   We mark the requests [~oneshot:true] because the SQL strings still depend
+   on [table_name]/[col_name] arguments (i.e. they're built per call rather
+   than once at module-init time); hoisting these to module-level constants
+   would be a further follow-up.
+
+   N.B. this issues one INSERT and one SELECT per value, which is fine for
+   the small batches the archive currently produces. If batch sizes grow,
+   switch to a single ["unnest($1::...[])"] form bound as an array. *)
 let insert_multi_into_col ~(table_name : string)
     ~(col : string * 'col Caqti_type.t) (module Conn : CONNECTION)
-    (values : string list) =
+    (values : 'col list) =
   let open Deferred.Result.Let_syntax in
-  let insert =
-    sprintf
-      {sql| INSERT INTO %s (%s) VALUES %s
-            ON CONFLICT (%s)
-            DO NOTHING |sql}
-      table_name (fst col)
-      (sep_by_comma ~parenthesis:true values)
-      (fst col)
+  let col_name = fst col in
+  let col_typ = snd col in
+  let insert_req =
+    Caqti_request.Infix.(col_typ ->. Caqti_type.unit) ~oneshot:true
+      (sprintf "INSERT INTO %s (%s) VALUES (?) ON CONFLICT (%s) DO NOTHING"
+         table_name col_name col_name )
+  in
+  let select_req =
+    Caqti_request.Infix.(col_typ ->? Caqti_type.(t2 col_typ int)) ~oneshot:true
+      (sprintf "SELECT %s, id FROM %s WHERE %s = ?" col_name table_name
+         col_name )
   in
   let%bind () =
-    Conn.exec
-      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) insert)
-      ()
+    Mina_stdlib.Deferred.Result.List.iter values ~f:(fun v ->
+        Conn.exec insert_req v )
   in
-  let search =
-    sprintf
-      {sql| SELECT %s, id FROM %s
-            WHERE %s in (%s) |sql}
-      (fst col) table_name (fst col) (sep_by_comma values)
+  let%map row_opts =
+    Mina_stdlib.Deferred.Result.List.map values ~f:(fun v ->
+        Conn.find_opt select_req v )
   in
-  Conn.collect_list
-    Caqti_request.Infix.(
-      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int)) search)
-    ()
+  List.filter_opt row_opts
 
 let query ~f pool =
   match%bind Pool.use f pool with


### PR DESCRIPTION
## Summary

- Rewrites `Mina_caqti.insert_multi_into_col` to bind values via Caqti's parameter encoders instead of `sprintf`-interpolating them into the SQL text. The SQL strings are now independent of the values; nothing user-supplied lands in the query text.
- Changes the helper's value-list type from `string list` to `'col list`, so the caller passes values typed by `(snd col)` and the corresponding `Caqti_type` encoder handles textual representation (e.g. Postgres array literals for `array_int_typ`).
- Drops the per-call sprintf-of-int-arrays in `processor.ml` (the path that had a "FIX this in the future" TODO).
- Removes `sep_by_comma` (no remaining callers after this rewrite).

Fixes #18859.

## Why

The previous implementation built every batch's SQL by `sprintf`'ing values into the query text via `sep_by_comma ~parenthesis:true`, producing strings like `INSERT INTO foo (col) VALUES ('val1'), ('val2'), … ON CONFLICT …`. This:

- defeats parameter binding (postgres-side plan cache gets a new entry per batch — compounds with the leak fixed in #18858);
- is SQL-injection shaped (single quotes inside any value would terminate the string literal — today's call sites are safe by accident, not by construction);
- forces the caller to pre-format typed values like `int array` back into Postgres-textual form, duplicating what Caqti's encoders already do (and the code carried a TODO admitting this).

`unnest($1::TYPE[])`-style single-round-trip parameterized batch insert would be even faster, but introduces complications for the `int[]`-column case (no native variable-length `int[][]`). This PR keeps the helper general and accepts a slight throughput regression (1 round trip per value rather than 1 per batch) for correctness/security. The archive's batch sizes are small (~50 values per ingested block at ~5 ops/sec on ITN) so this is well within budget. A future PR can adopt `unnest` for the homogeneous-scalar case if profiling demands it.

## Diff scope

- `src/lib/mina_caqti/mina_caqti.ml` — rewrite `insert_multi_into_col`, remove `sep_by_comma`.
- `src/lib/mina_caqti/dune` — add `mina_stdlib` dep for `Deferred.Result.List.{iter,map}`.
- `src/app/archive/lib/processor.ml` — drop the manual `int list -> Postgres array literal string` pre-formatting at the `zkapp_field_array` insert site; pass `int array list` directly.

Both existing callers (`zkapp_field`, `zkapp_field_array`) keep their semantics.

## Relationship to #18858

Both PRs touch the same file. #18858 is the minimal, urgent fix that adds `~oneshot:true` to the existing dynamically-built Caqti requests, including the old (sprintf-based) body of `insert_multi_into_col`. This PR replaces that body entirely while keeping `~oneshot:true` on the new requests. If #18858 lands first this PR will need a trivial rebase; if this PR lands first, #18858 's changes to `insert_multi_into_col` become moot but its changes to `select_insert_into_cols` remain valuable and should still ship.

## Test plan

- [ ] CI passes (archive lint / dune build / unit tests in `src/app/archive/lib/test.ml`).
- [ ] Functional smoke: ingest a few blocks containing zkApp events on a devnet/ITN archive, verify `SELECT count(*) FROM zkapp_field`, `zkapp_field_array` advances and no rows are duplicated.
- [ ] No regressions in archive consistency checks (the existing block-replay invariants).
- [ ] Watch `pg_stat_database.tup_inserted` for `zkapp_field_array` over a sustained ingestion window to confirm the per-row pattern doesn't cause queueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
