### PR TITLE
[test bundle] Archive postgres OOM fixes — cherry-pick of #18858 + #18860

### DIFF
--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -1553,11 +1553,8 @@ module Zkapp_events = struct
             (* if there's no fields, then we must have some list of empty lists *)
             return @@ List.map field_list_list ~f:(fun _ -> [])
         in
-        (* this conversion should be done by caqti using `typ`, FIX this in the future *)
         let field_array_list =
-          List.map field_id_list_list ~f:(fun id_list ->
-              List.map id_list ~f:Int.to_string
-              |> String.concat ~sep:", " |> sprintf "{%s}" )
+          List.map field_id_list_list ~f:Array.of_list
         in
         let%map field_array_map =
           Mina_caqti.insert_multi_into_col ~table_name:"zkapp_field_array"

--- a/src/lib/mina_caqti/dune
+++ b/src/lib/mina_caqti/dune
@@ -11,7 +11,8 @@
   caqti
   async_kernel
   ;; local libraries
-  mina_base)
+  mina_base
+  mina_stdlib)
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_custom_printf h_list.ppx))
  (instrumentation

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -416,40 +416,54 @@ let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
              ~cols:(fst cols) () )
         value
 
-let sep_by_comma ?(parenthesis = false) xs =
-  List.map xs ~f:(if parenthesis then sprintf "('%s')" else sprintf "'%s'")
-  |> String.concat ~sep:", "
+(* Insert each value in [values] into [table_name] under [col], ignoring
+   conflicts, and return the (col, id) pairs for whatever ended up in the
+   table afterwards.
 
+   Values are bound via the Caqti parameter encoding for [(snd col)], so the
+   SQL string is independent of [values]. This:
+     - eliminates the sprintf-of-values pattern that previously interpolated
+       string-quoted user values directly into the query text (SQL-injection
+       shaped, and trivially broken by any value containing a single quote);
+     - lets [(snd col)]'s Caqti encoder handle textual representation
+       (e.g. Postgres array literals for [array_int_typ]) instead of asking
+       the caller to pre-format values into strings;
+     - keeps the SQL strings stable per (table_name, col_name) pair so that
+       per-batch SQL no longer pollutes the postgres backend plan cache.
+
+   We mark the requests [~oneshot:true] because the SQL strings still depend
+   on [table_name]/[col_name] arguments (i.e. they're built per call rather
+   than once at module-init time); hoisting these to module-level constants
+   would be a further follow-up.
+
+   N.B. this issues one INSERT and one SELECT per value, which is fine for
+   the small batches the archive currently produces. If batch sizes grow,
+   switch to a single ["unnest($1::...[])"] form bound as an array. *)
 let insert_multi_into_col ~(table_name : string)
     ~(col : string * 'col Caqti_type.t) (module Conn : CONNECTION)
-    (values : string list) =
+    (values : 'col list) =
   let open Deferred.Result.Let_syntax in
-  let insert =
-    sprintf
-      {sql| INSERT INTO %s (%s) VALUES %s
-            ON CONFLICT (%s)
-            DO NOTHING |sql}
-      table_name (fst col)
-      (sep_by_comma ~parenthesis:true values)
-      (fst col)
+  let col_name = fst col in
+  let col_typ = snd col in
+  let insert_req =
+    Caqti_request.Infix.(col_typ ->. Caqti_type.unit) ~oneshot:true
+      (sprintf "INSERT INTO %s (%s) VALUES (?) ON CONFLICT (%s) DO NOTHING"
+         table_name col_name col_name )
+  in
+  let select_req =
+    Caqti_request.Infix.(col_typ ->? Caqti_type.(t2 col_typ int)) ~oneshot:true
+      (sprintf "SELECT %s, id FROM %s WHERE %s = ?" col_name table_name
+         col_name )
   in
   let%bind () =
-    Conn.exec
-      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) ~oneshot:true
-         insert )
-      ()
+    Mina_stdlib.Deferred.Result.List.iter values ~f:(fun v ->
+        Conn.exec insert_req v )
   in
-  let search =
-    sprintf
-      {sql| SELECT %s, id FROM %s
-            WHERE %s in (%s) |sql}
-      (fst col) table_name (fst col) (sep_by_comma values)
+  let%map row_opts =
+    Mina_stdlib.Deferred.Result.List.map values ~f:(fun v ->
+        Conn.find_opt select_req v )
   in
-  Conn.collect_list
-    Caqti_request.Infix.(
-      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int))
-        ~oneshot:true search )
-    ()
+  List.filter_opt row_opts
 
 let query ~f pool =
   match%bind Pool.use f pool with

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -389,13 +389,20 @@ let insert_into_cols ~(returning : string) ~(table_name : string)
 
 (* run `select_cols` and return the result, if found
    if not found, run `insert_into_cols` and return the result
-*)
+
+   The Caqti requests below are built freshly on every call (their SQL
+   strings depend on the [table_name]/[cols] arguments), so each one would
+   otherwise be registered as a distinct prepared statement on the server
+   and accumulate in the backend's plan cache for the lifetime of the
+   connection. Pass [~oneshot:true] to keep per-backend memory bounded; see
+   Caqti_request docs: "dynamically constructed requests should have
+   ~oneshot:true". *)
 let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
     ~(table_name : string) ?tannot ~(cols : string list * 'cols Caqti_type.t)
     (module Conn : CONNECTION) (value : 'cols) =
   let open Deferred.Result.Let_syntax in
   Conn.find_opt
-    ( Caqti_request.Infix.(snd cols ->? snd select)
+    ( Caqti_request.Infix.(snd cols ->? snd select) ~oneshot:true
     @@ select_cols ~select:(fst select) ~table_name ?tannot ~cols:(fst cols) ()
     )
     value
@@ -404,7 +411,7 @@ let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
       return id
   | None ->
       Conn.find
-        ( Caqti_request.Infix.(snd cols ->! snd select)
+        ( Caqti_request.Infix.(snd cols ->! snd select) ~oneshot:true
         @@ insert_into_cols ~returning:(fst select) ~table_name ?tannot
              ~cols:(fst cols) () )
         value
@@ -428,7 +435,8 @@ let insert_multi_into_col ~(table_name : string)
   in
   let%bind () =
     Conn.exec
-      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) insert)
+      (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) ~oneshot:true
+         insert )
       ()
   in
   let search =
@@ -439,7 +447,8 @@ let insert_multi_into_col ~(table_name : string)
   in
   Conn.collect_list
     Caqti_request.Infix.(
-      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int)) search)
+      (Caqti_type.unit ->* Caqti_type.(t2 (snd col) int))
+        ~oneshot:true search )
     ()
 
 let query ~f pool =


### PR DESCRIPTION
## Summary

Test bundle that cherry-picks **#18858** and **#18860** onto `develop` so the two archive-postgres fixes can be exercised end-to-end on a deployable build before they land independently. **Not intended to merge** — the two source PRs should be reviewed and merged on their own; this branch exists so QA can run a single artifact that contains both changes.

- Cherry-picked from #18858: mark dynamically-built Caqti requests in `Mina_caqti.select_insert_into_cols` as `~oneshot:true` so the postgres backend's plan cache stops accumulating one entry per call.
- Cherry-picked from #18860: rewrite `Mina_caqti.insert_multi_into_col` to bind values via Caqti instead of `sprintf`-interpolating them into SQL; drop `sep_by_comma` and the manual `int list → "{1,2,3}"` pre-formatting at the `zkapp_field_array` insert site.

The two source commits overlap in `insert_multi_into_col` (#18858 adds `~oneshot:true` to its old sprintf-based body; #18860 replaces that body entirely). The overlap was resolved in favor of #18860's rewrite; #18860's new requests carry their own `~oneshot:true`, so the leak fix is preserved.

## What to test

This branch addresses the postgres-OOM cycle observed on `itn-archive-postgresql-0` (26 OOMKills in 46 h prior to the fix). The signal that matters:

- [ ] Deploy this build to an archive whose postgres is on a tight memory budget (e.g. the ITN archive pod). Run for ≥24 h with normal block ingestion.
- [ ] `kubectl exec itn-archive-postgresql-0 -c postgresql -- ps -eo pid,rss,comm,args --sort=-rss | head` — long-lived archive backends should plateau in RSS instead of climbing into the 1.5–2 GB range. Pre-fix baseline: three idle backends holding ~5 GB combined.
- [ ] Cgroup `memory.current` on the postgres pod no longer trends toward the 10 GiB ceiling. No new `OOMKilled` events on the pod.
- [ ] Archive consistency: counts of `zkapp_field`, `zkapp_field_array`, etc. advance at the expected rate; no duplicate rows; replayer (or whatever invariant check you run) is green.
- [ ] CI passes (archive lint / dune build / unit tests in `src/app/archive/lib/test.ml`).

Local verification done before pushing: `dune build src/lib/mina_caqti` and `dune build src/app/archive` both exit 0 against the cherry-picked tree.

## Background

Issue #18857 has the full live-cluster evidence (RSS of idle backends, cgroup numbers, the offending code at `src/lib/mina_caqti/mina_caqti.ml:393-410` and `:416-443`, and the Caqti documentation that calls out this exact case). Issue #18859 covers the sprintf/binding correctness side. This branch contains the union of the fixes for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
