### PR TITLE
feat(scripts): propagate -r flag into prepare-test-ledger-hf-dryrun.sh

### DIFF
--- a/scripts/generate-ledger-hf-dryrun.sh
+++ b/scripts/generate-ledger-hf-dryrun.sh
@@ -89,6 +89,7 @@ MINA_BINARY=""
 RUNTIME_GENESIS_LEDGER_BINARY=""
 PAD_APP_STATE=""
 PER_KEY_PASSWORD=false
+REPLACE_TOP=false
 
 export MINA_PRIVKEY_PASS="${MINA_PRIVKEY_PASS:-}"
 
@@ -152,6 +153,10 @@ OPTIONS:
 
   --pad-app-state             Pad app state when generating ledger hashes
                                (passed to runtime_genesis_ledger)
+
+  -r, --replace-top           Replace top N delegate keys with the specified
+                               keys instead of distributing evenly
+                               (passed to prepare-test-ledger-hf-dryrun.sh)
 
   -h, --help                  Show this help message
 
@@ -329,6 +334,10 @@ while [[ $# -gt 0 ]]; do
             PAD_APP_STATE="--pad-app-state"
             shift
             ;;
+        -r|--replace-top)
+            REPLACE_TOP=true
+            shift
+            ;;
         --per-key-password)
             PER_KEY_PASSWORD=true
             shift
@@ -380,6 +389,7 @@ echo "  Output Directory: $OUTPUT_DIR"
 echo "  Mina Binary: ${MINA_BINARY:-"(will build if needed)"}"
 echo "  Runtime Genesis Ledger Binary: ${RUNTIME_GENESIS_LEDGER_BINARY:-"(will build if needed)"}"
 echo "  Per-Key Password: $PER_KEY_PASSWORD"
+echo "  Replace Top: $REPLACE_TOP"
 echo "  Pad App State: ${PAD_APP_STATE:-"disabled"}"
 echo
 
@@ -505,7 +515,11 @@ if [[ ${#KEY_ARGS[@]} -gt 0 ]]; then
     echo "  Target stake ownership by inactive stake (plain keys): $PERCENTAGE_EXTRA_KEYS_DISPLAY%"
 fi
 
-"$SCRIPT_DIR/prepare-test-ledger-hf-dryrun.sh" -e "$EXTRA_KEYS" -b "$EXTRA_BALANCE" "${KEY_ARGS[@]}"
+PREPARE_ARGS=(-e "$EXTRA_KEYS" -b "$EXTRA_BALANCE")
+if [[ "$REPLACE_TOP" == "true" ]]; then
+    PREPARE_ARGS+=(-r)
+fi
+"$SCRIPT_DIR/prepare-test-ledger-hf-dryrun.sh" "${PREPARE_ARGS[@]}" "${KEY_ARGS[@]}"
 
 # Verify expected output files were generated
 if [[ ! -f "genesis.json" ]]; then

--- a/scripts/generate-ledger-hf-dryrun.sh
+++ b/scripts/generate-ledger-hf-dryrun.sh
@@ -118,11 +118,11 @@ OPTIONS:
 
   -p, --bp-keys NUM           Number of block producer keys to generate
                                Default: $DEFAULT_BP_KEYS
-                               Range: 1-50 (recommended: 2-10)
+                               Range: 1-200 (recommended: 2-10)
 
   -k, --plain-keys NUM        Number of plain keys to generate
                                Default: $DEFAULT_PLAIN_KEYS
-                               Range: 1-100 (recommended: 4-20)
+                               Range: 1-500 (recommended: 4-20)
 
   -b, --balance AMOUNT        Balance in MINA for each of extra keys
                                Default: $DEFAULT_EXTRA_BALANCE ($((DEFAULT_EXTRA_BALANCE / 1000000)) million MINA)
@@ -283,12 +283,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         -p|--bp-keys)
             BP_KEYS="$2"
-            validate_positive_integer "$BP_KEYS" "BP keys" 50
+            validate_positive_integer "$BP_KEYS" "BP keys" 200
             shift 2
             ;;
         -k|--plain-keys)
             PLAIN_KEYS="$2"
-            validate_positive_integer "$PLAIN_KEYS" "Plain keys" 100
+            validate_positive_integer "$PLAIN_KEYS" "Plain keys" 500
             shift 2
             ;;
         -b|--balance)
@@ -298,7 +298,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -e|--extra-keys)
             EXTRA_KEYS="$2"
-            validate_non_negative_integer "$EXTRA_KEYS" "Extra keys" 50
+            validate_non_negative_integer "$EXTRA_KEYS" "Extra keys" 200
             shift 2
             ;;
         --plain-balance)

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -34,6 +34,9 @@ NORM=${NORM:-}
 # Replace top N delegate keys with the specified keys
 REPLACE_TOP=${REPLACE_TOP:-}
 
+# Native MINA token identifier (non-native custom token accounts are excluded)
+NATIVE_TOKEN_ID='wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf'
+
 # Mainnet configuration constants
 MAINNET_START='2024-06-05T00:00:00Z'
 SLOTS_PER_EPOCH=7140
@@ -158,8 +161,8 @@ keys_="${keys_:0:-1}"
 
 tmpfile=$(mktemp)
 
-# jq filter to exclude PKs from the ledger
-if ! <"$ledger_file" jq "[.[] | select(.pk | IN($keys_) | not)]" >"$tmpfile"; then
+# jq filter to native MINA token accounts only, excluding our new PKs
+if ! <"$ledger_file" jq "[.[] | select(.token == \"$NATIVE_TOKEN_ID\") | select(.pk | IN($keys_) | not)]" >"$tmpfile"; then
   echo "Error: Failed to filter ledger with jq" >&2
   rm "$tmpfile"
   exit 1

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -206,6 +206,31 @@ expr=$(for i in "${!KEYS[@]}"; do make_expr $i; done | tr "\n" "|" | head -c -1)
 expr="$expr | [.[] | select(.delegate | IN($keys_)) |= del(.receipt_chain_hash)]"
 
 
+##########################################################
+# Print old keys stake distribution (before transformation)
+##########################################################
+
+old_total_balance=$(<"$tmpfile" jq "[.[].balance | tonumber] | add | round")
+
+if [[ "$REPLACE_TOP" != "" ]] && [[ ${#TOP_KEYS[@]} -gt 0 ]]; then
+  echo "Old keys stake distribution (before replacement):" >&2
+  old_bal_exprs=()
+  for i in "${!TOP_KEYS[@]}"; do
+    old_bal_exprs+=("\"${TOP_KEYS[$i]}\": ([.[] | select(.delegate == \"${TOP_KEYS[$i]}\") | .balance | tonumber] | add // 0)")
+  done
+  old_bal_expr=$(IFS=,; echo "${old_bal_exprs[*]}")
+  if ! <"$tmpfile" jq --argjson total "$old_total_balance" \
+    "{$old_bal_expr} | to_entries | sort_by(.value) | reverse | from_entries | map_values((. / \$total * 10000 | round / 100 | tostring) + \"%\")" 1>&2; then
+    echo "Error: Failed to display old stake distribution with jq" >&2
+    rm "$tmpfile"
+    exit 1
+  fi
+  echo "Key mapping (old -> new):" >&2
+  for i in "${!TOP_KEYS[@]}"; do
+    echo "  ${TOP_KEYS[$i]} -> ${KEYS[$i]}" >&2
+  done
+fi
+
 tmpfile2=$(mktemp)
 if ! <"$tmpfile" jq "$expr" >"$tmpfile2"; then
   echo "Error: Failed to apply ledger transformations with jq" >&2

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -220,7 +220,9 @@ if [[ "$REPLACE_TOP" != "" ]] && [[ ${#TOP_KEYS[@]} -gt 0 ]]; then
   done
   old_bal_expr=$(IFS=,; echo "${old_bal_exprs[*]}")
   if ! <"$tmpfile" jq --argjson total "$old_total_balance" \
-    "{$old_bal_expr} | to_entries | sort_by(.value) | reverse | from_entries | map_values((. / \$total * 10000 | round / 100 | tostring) + \"%\")" 1>&2; then
+    "{$old_bal_expr} | to_entries | sort_by(.value) | reverse |
+     map({key, value: (.value | tostring) + \" MINA (\" + (.value / \$total * 10000 | round / 100 | tostring) + \"%)\"}) |
+     from_entries + {\"__total\": (\$total | tostring) + \" MINA\"}" 1>&2; then
     echo "Error: Failed to display old stake distribution with jq" >&2
     rm "$tmpfile"
     exit 1

--- a/scripts/prepare-test-ledger.sh
+++ b/scripts/prepare-test-ledger.sh
@@ -220,9 +220,7 @@ if [[ "$REPLACE_TOP" != "" ]] && [[ ${#TOP_KEYS[@]} -gt 0 ]]; then
   done
   old_bal_expr=$(IFS=,; echo "${old_bal_exprs[*]}")
   if ! <"$tmpfile" jq --argjson total "$old_total_balance" \
-    "{$old_bal_expr} | to_entries | sort_by(.value) | reverse |
-     map({key, value: (.value | tostring) + \" MINA (\" + (.value / \$total * 10000 | round / 100 | tostring) + \"%)\"}) |
-     from_entries + {\"__total\": (\$total | tostring) + \" MINA\"}" 1>&2; then
+    "{$old_bal_expr} | to_entries | sort_by(.value) | reverse | map({key: .key, value: ((.value | tostring) + \" MINA (\" + (.value / \$total * 10000 | round / 100 | tostring) + \"%)\")} ) | from_entries + {\"__total\": ((\$total | tostring) + \" MINA\")}" 1>&2; then
     echo "Error: Failed to display old stake distribution with jq" >&2
     rm "$tmpfile"
     exit 1


### PR DESCRIPTION
## Summary

- Adds `-r`/`--replace-top` flag to `generate-ledger-hf-dryrun.sh`
- Forwards the flag to `prepare-test-ledger-hf-dryrun.sh`, which already supports it and passes it through to `prepare-test-ledger.sh`
- Updates help text and configuration display to document the new flag

## Test plan

- [ ] Run `generate-ledger-hf-dryrun.sh --help` and verify `-r`/`--replace-top` appears in the output
- [ ] Run with `-r` flag and confirm it propagates to `prepare-test-ledger.sh` (observe "replace top" behaviour in stake distribution)
- [ ] Run without `-r` flag and confirm default behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)