### PR TITLE
nat: constrain div_mod remainder and divisor

### DIFF
--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -78,7 +78,16 @@ struct
 
        q * y = x - r
     *)
-    let%map () = assert_r1cs q y (Field.Var.sub x r) in
+    let%bind () = assert_r1cs q y (Field.Var.sub x r) in
+    (* Enforce canonical Euclidean division: x = q * y + r, y != 0, r < y *)
+    let%bind y_nonzero =
+      Checked.map
+        (Field.Checked.equal y (Field.Var.constant Field.zero))
+        ~f:Boolean.not
+    in
+    let%bind () = Boolean.Assert.is_true y_nonzero in
+    let%bind r_lt_y = r < y in
+    let%map () = Boolean.Assert.is_true r_lt_y in
     (q, r)
 
   type t = var


### PR DESCRIPTION
Fixed an underspecified divmod gadget in src/lib/minanumbers/nat.Fixed an underspecified div_mod gadget in src/lib/mina_numbers/nat.ml that only enforced q * y = x - r without constraining the remainder to r < y or the divisor to y != 0, allowing a prover to substitute non-canonical witnesses such as q=0, r=x for any input, added explicit constraints for both conditions to enforce unique Euclidean decomposition, which affects downstream checked arithmetic including epoch and slot derivation in consensus logic.