### PR TITLE
O1js backwards compatible helper for serde of proof with chunking support

### DIFF
--- a/changes/18883.md
+++ b/changes/18883.md
@@ -1,0 +1,3 @@
+Add o1js-only Pickles proof serialization helpers for chunked proofs.
+
+The default Pickles proof serialization remains unchanged. The new chunk-aware helper preserves chunked public input evaluations for o1js JSON proof roundtrips while keeping single-chunk proofs compatible with the existing base64 representation.

--- a/src/lib/crypto/pickles/pickles_intf.mli
+++ b/src/lib/crypto/pickles/pickles_intf.mli
@@ -89,6 +89,10 @@ module type S = sig
       val to_base64 : t -> string
 
       val of_base64 : string -> (t, string) Result.t
+
+      val to_base64_chunked : t -> string
+
+      val of_base64_chunked : string -> (t, string) Result.t
     end
 
     module Proofs_verified_2 : sig

--- a/src/lib/crypto/pickles/proof.ml
+++ b/src/lib/crypto/pickles/proof.ml
@@ -228,6 +228,21 @@ module Make (MLMB : Nat.Intf) = struct
     [@@deriving compare, sexp, yojson, hash, equal]
   end
 
+  (* This representation exists for bindings that need to serialize proofs
+     without losing chunked public evaluations.
+
+     The stable [Repr] above intentionally mirrors the proof shape used by the
+     node's existing sexp/json serializers. Those serializers predate chunked
+     proofs and only round-trip the single public-evaluation pair that was
+     sufficient for unchunked proofs. For proofs whose public input is split
+     across multiple chunks, that representation is lossy: deserializing it
+     cannot reconstruct the full set of chunked public evaluations.
+
+     We cannot change the node-facing stable serialization format here without
+     making a hard-fork-level data format change. [Chunked_repr] therefore keeps
+     the non-stable [Base.Wrap.t] shape, which preserves chunked proof data, and
+     is exposed for o1js bindings that need a lossless serialization path for
+     chunked proofs. *)
   module Chunked_repr = struct
     type t =
       ( ( Tock.Inner_curve.Affine.t

--- a/src/lib/crypto/pickles/proof.ml
+++ b/src/lib/crypto/pickles/proof.ml
@@ -228,7 +228,74 @@ module Make (MLMB : Nat.Intf) = struct
     [@@deriving compare, sexp, yojson, hash, equal]
   end
 
+  module Chunked_repr = struct
+    type t =
+      ( ( Tock.Inner_curve.Affine.t
+        , Reduced_messages_for_next_proof_over_same_field.Wrap.Challenges_vector
+          .t
+          MLMB_vec.t )
+        Types.Wrap.Proof_state.Messages_for_next_wrap_proof.t
+      , ( unit
+        , Tock.Curve.Affine.t Max_proofs_verified_at_most.t
+        , Challenge.Constant.t Scalar_challenge.t Bulletproof_challenge.t
+          Step_bp_vec.t
+          Max_proofs_verified_at_most.t )
+        Base.Messages_for_next_proof_over_same_field.Step.t )
+      Base.Wrap.t
+    [@@deriving sexp]
+  end
+
   type nonrec t = MLMB.n t
+
+  let to_chunked_repr (T { statement; prev_evals; proof }) : Chunked_repr.t =
+    let lte =
+      Nat.lte_exn
+        (Vector.length
+           statement.messages_for_next_step_proof
+             .challenge_polynomial_commitments )
+        MLMB.n
+    in
+    let statement =
+      { statement with
+        messages_for_next_step_proof =
+          { statement.messages_for_next_step_proof with
+            challenge_polynomial_commitments =
+              At_most.of_vector
+                statement.messages_for_next_step_proof
+                  .challenge_polynomial_commitments lte
+          ; old_bulletproof_challenges =
+              At_most.of_vector
+                statement.messages_for_next_step_proof
+                  .old_bulletproof_challenges lte
+          }
+      }
+    in
+    { statement; prev_evals; proof }
+
+  let of_chunked_repr ({ statement; prev_evals; proof } : Chunked_repr.t) : t =
+    let (Vector.T challenge_polynomial_commitments) =
+      At_most.to_vector
+        statement.messages_for_next_step_proof.challenge_polynomial_commitments
+    in
+    let (Vector.T old_bulletproof_challenges) =
+      At_most.to_vector
+        statement.messages_for_next_step_proof.old_bulletproof_challenges
+    in
+    let T =
+      Nat.eq_exn
+        (Vector.length challenge_polynomial_commitments)
+        (Vector.length old_bulletproof_challenges)
+    in
+    let statement =
+      { statement with
+        messages_for_next_step_proof =
+          { statement.messages_for_next_step_proof with
+            challenge_polynomial_commitments
+          ; old_bulletproof_challenges
+          }
+      }
+    in
+    T { statement; prev_evals; proof }
 
   let to_repr (T { statement; prev_evals; proof }) : Repr.t =
     let lte =
@@ -330,6 +397,27 @@ module Make (MLMB : Nat.Intf) = struct
     | Ok t -> (
         try Ok (t_of_sexp (Sexp.of_string t))
         with exn -> Error (Exn.to_string exn) )
+    | Error (`Msg s) ->
+        Error s
+
+  let has_single_chunk_public_input (T { prev_evals; _ }) =
+    let x1, x2 = prev_evals.evals.public_input in
+    Array.length x1 = 1 && Array.length x2 = 1
+
+  let to_base64_chunked t =
+    let sexp =
+      if has_single_chunk_public_input t then sexp_of_t t
+      else Chunked_repr.sexp_of_t (to_chunked_repr t)
+    in
+    Base64.encode_exn (Sexp.to_string sexp)
+
+  let of_base64_chunked b64 =
+    match Base64.decode b64 with
+    | Ok t -> (
+        try Ok (t_of_sexp (Sexp.of_string t))
+        with _legacy_repr_exn -> (
+          try Ok (of_chunked_repr (Chunked_repr.t_of_sexp (Sexp.of_string t)))
+          with exn -> Error (Exn.to_string exn) ) )
     | Error (`Msg s) ->
         Error s
 

--- a/src/lib/crypto/pickles/proof.mli
+++ b/src/lib/crypto/pickles/proof.mli
@@ -144,6 +144,10 @@ module Make (MLMB : Pickles_types.Nat.Intf) : sig
 
   val of_base64 : string -> (t, string) result
 
+  val to_base64_chunked : t -> string
+
+  val of_base64_chunked : string -> (t, string) result
+
   val to_yojson : t -> [> `String of string ]
 
   val to_yojson_full : t Plonkish_prelude.Sigs.jsonable


### PR DESCRIPTION
Related to https://github.com/MinaProtocol/mina/pull/18850

o1js side: https://github.com/o1-labs/o1js/pull/2878

This PR does not change the behavior of the current base64 format nor other formats used by nodes. 

What it does is it adds a new helper that is backwards compatible with single-chunk proof serialization, but it is also giving type support for circuits which are chunked. 

In the future, an upcoming hardfork will incorporate these fixes to base64 and other formats, removing this temporary helper. For now, this is the workaround to be able to serialize chunked proofs from O1js.