### PR TITLE
test(itn): integration test for ITN GraphQL Ed25519 auth

### DIFF
--- a/src/dune-project
+++ b/src/dune-project
@@ -62,6 +62,7 @@
 (package (name interpolator_lib))
 (package (name interruptible))
 (package (name itn_crypto))
+(package (name itn_graphql_client))
 (package (name itn_logger))
 (package (name key_cache))
 (package (name key_gen))

--- a/src/lib/graphql/itn_graphql_client/dune
+++ b/src/lib/graphql/itn_graphql_client/dune
@@ -1,0 +1,19 @@
+(library
+ (name itn_graphql_client)
+ (public_name itn_graphql_client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  async
+  async_kernel
+  cohttp
+  cohttp-async
+  uri
+  yojson
+  ;; local libraries
+  itn_crypto)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane ppx_version)))

--- a/src/lib/graphql/itn_graphql_client/itn_graphql_client.ml
+++ b/src/lib/graphql/itn_graphql_client/itn_graphql_client.ml
@@ -1,0 +1,203 @@
+(** Minimal client for the daemon's ITN GraphQL server.
+
+    The ITN endpoint requires every request to carry an [Authorization] header
+    of the form
+
+      [Signature <pubkey-b64> <sig-b64>]                       (unsequenced)
+      [Signature <pubkey-b64> <sig-b64> ; Sequencing <uuid> <n>] (sequenced)
+
+    where the Ed25519 signature is over a message whose layout matches
+    [src/app/cli/src/init/graphql_internal.ml]:
+
+      unsequenced:  body                                       (used by [auth])
+      sequenced:    seq_no_hi :: seq_no_lo :: uuid :: body
+
+    The unsequenced form is only valid for the [auth] query — every other
+    request must be sequenced and the [n] must match the daemon's expected
+    sequence number for the signer.
+
+    This module wraps signing and posting so test code (and any future
+    automation tooling that talks to the ITN endpoint) doesn't have to
+    reinvent the wire format each time. *)
+
+open Core
+open Async
+
+let default_path = "/graphql"
+
+let default_timeout = Time.Span.of_sec 30.
+
+let make_uri ?(host = "localhost") ?(scheme = "http") ?(path = default_path)
+    ~port () =
+  Uri.make ~scheme ~host ~port ~path ()
+
+(** [unsequenced_auth_header ~privkey ~pubkey_b64 ~body] signs [body] verbatim
+    with [privkey] and returns the value to put in the [Authorization]
+    header.  Use for the initial [auth] query. *)
+let unsequenced_auth_header ~privkey ~pubkey_b64 ~body =
+  let signature = Itn_crypto.sign ~key:privkey body in
+  sprintf "Signature %s %s" pubkey_b64 signature
+
+(** [sequenced_auth_header ~privkey ~pubkey_b64 ~uuid ~seq_no ~body] builds the
+    [Authorization] header for a sequenced request.  The signed message is
+    [<seq_no_hi><seq_no_lo><uuid><body>] to match the daemon's verifier.
+
+    Raises [Invalid_argument] if [seq_no] is outside the UInt16 range — the
+    daemon's sequence-number type is [Unsigned.UInt16], so anything else is
+    necessarily a client bug. *)
+let sequenced_auth_header ~privkey ~pubkey_b64 ~uuid ~seq_no ~body =
+  if seq_no < 0 || seq_no > 0xffff then
+    invalid_argf "Itn_graphql_client: seq_no %d out of UInt16 range" seq_no () ;
+  let seq_no_lo = seq_no land 0xff |> Char.of_int_exn in
+  let seq_no_hi = (seq_no lsr 8) land 0xff |> Char.of_int_exn in
+  let msg = sprintf "%c%c%s%s" seq_no_hi seq_no_lo uuid body in
+  let signature = Itn_crypto.sign ~key:privkey msg in
+  sprintf "Signature %s %s ; Sequencing %s %d" pubkey_b64 signature uuid seq_no
+
+let auth_query =
+  {|{"query":"{ auth { serverUuid signerSequenceNumber } }","variables":null}|}
+
+(** [post ~uri ~auth_header ~body] POSTs [body] to [uri] with the supplied
+    [Authorization] header.  Cohttp exceptions and a missing response within
+    [?timeout] are converted to [Or_error.t]. *)
+let post ?(timeout = default_timeout) ~uri ~auth_header ~body () =
+  let headers =
+    Cohttp.Header.of_list
+      [ ("Accept", "application/json")
+      ; ("Content-Type", "application/json")
+      ; ("Authorization", auth_header)
+      ]
+  in
+  let do_post () =
+    let%bind response, body_in =
+      Cohttp_async.Client.post ~headers
+        ~body:(Cohttp_async.Body.of_string body)
+        uri
+    in
+    let%map body_str = Cohttp_async.Body.to_string body_in in
+    let status =
+      Cohttp.Code.code_of_status (Cohttp_async.Response.status response)
+    in
+    (status, body_str)
+  in
+  match%bind
+    Async.Clock.with_timeout timeout
+      (Monitor.try_with ~extract_exn:true do_post)
+  with
+  | `Timeout ->
+      Deferred.Or_error.errorf "Itn_graphql_client: POST %s timed out"
+        (Uri.to_string uri)
+  | `Result (Ok r) ->
+      Deferred.Or_error.return r
+  | `Result (Error exn) ->
+      Deferred.Or_error.errorf "Itn_graphql_client: POST %s failed: %s"
+        (Uri.to_string uri) (Exn.to_string exn)
+
+(** [probe ?timeout ~uri ()] sends a no-auth POST to [uri] just to confirm the
+    ITN listener is bound — the daemon's [Authorization]-required check will
+    reject the body, but a 401 means a real ITN server is on the wire.  Returns
+    [`Ready] once *any* HTTP response comes back, [`Timeout] otherwise.
+
+    Note: this only proves the port is bound and speaking HTTP.  Callers should
+    follow up with a real [send_auth] handshake to confirm identity. *)
+let probe ?(timeout = Time.Span.of_sec 60.) ~uri () =
+  let deadline = Time.add (Time.now ()) timeout in
+  let rec loop () =
+    let attempt =
+      Monitor.try_with ~extract_exn:true (fun () ->
+          Cohttp_async.Client.post
+            ~body:(Cohttp_async.Body.of_string auth_query)
+            uri )
+    in
+    match%bind attempt with
+    | Ok (_, body) ->
+        let%map _ = Cohttp_async.Body.to_string body in
+        `Ready
+    | Error _ ->
+        if Time.( >= ) (Time.now ()) deadline then Deferred.return `Timeout
+        else
+          let%bind () = after (Time.Span.of_sec 1.) in
+          loop ()
+  in
+  loop ()
+
+(** GraphQL custom scalars like [UInt16] serialise as a JSON string even
+    though they hold an integer.  Accept either form so we don't get
+    [Type_error] surprises if the encoding changes. *)
+let json_int_or_string json =
+  match json with
+  | `Int n ->
+      n
+  | `String s ->
+      Int.of_string s
+  | other ->
+      failwithf "expected int or stringified int, got %s"
+        (Yojson.Safe.to_string other)
+        ()
+
+(** Parse a GraphQL response body into the [data] sub-tree, surfacing any
+    server-side [errors] field as an [Or_error.t] failure.  GraphQL servers
+    emit application-level errors with HTTP 200 + an [errors] key, so a status
+    check is not enough to call the request a success. *)
+let parse_graphql_data body =
+  Or_error.try_with (fun () ->
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string body in
+      ( match member "errors" json with
+      | `Null ->
+          ()
+      | errors ->
+          failwithf "GraphQL errors in response: %s"
+            (Yojson.Safe.to_string errors)
+            () ) ;
+      member "data" json )
+
+(** [send_auth ~uri ~privkey ~pubkey_b64] performs the [auth] handshake against
+    [uri], returning the daemon's UUID + the next expected sequence number for
+    this signer on success. *)
+let send_auth ~uri ~privkey ~pubkey_b64 =
+  let auth_header =
+    unsequenced_auth_header ~privkey ~pubkey_b64 ~body:auth_query
+  in
+  match%map post ~uri ~auth_header ~body:auth_query () with
+  | Error _ as e ->
+      e
+  | Ok (status, body) ->
+      if status <> 200 then
+        Or_error.errorf "ITN auth expected 200, got %d.  Body: %s" status body
+      else
+        let open Or_error.Let_syntax in
+        let%bind data = parse_graphql_data body in
+        Or_error.try_with (fun () ->
+            let open Yojson.Safe.Util in
+            let auth = data |> member "auth" in
+            let uuid = auth |> member "serverUuid" |> to_string in
+            let seq_no =
+              auth |> member "signerSequenceNumber" |> json_int_or_string
+            in
+            (uuid, seq_no) )
+
+(** [send_sequenced ~uri ~privkey ~pubkey_b64 ~uuid ~seq_no ~body] posts a
+    sequenced GraphQL [body] against [uri] using the supplied identity and
+    daemon-issued sequencing tokens.  Returns ([status_code], [response_body])
+    on a successful HTTP exchange, or an error if the network call fails, the
+    HTTP status is non-2xx, or the GraphQL body contains an [errors] field.
+
+    Note: the daemon increments its internal counter on every successful
+    sequenced request, so callers should bump their local [seq_no] after a
+    success before sending the next query. *)
+let send_sequenced ~uri ~privkey ~pubkey_b64 ~uuid ~seq_no ~body =
+  let auth_header =
+    sequenced_auth_header ~privkey ~pubkey_b64 ~uuid ~seq_no ~body
+  in
+  match%map post ~uri ~auth_header ~body () with
+  | Error _ as e ->
+      e
+  | Ok (status, body) ->
+      if status < 200 || status >= 300 then
+        Or_error.errorf "ITN sequenced request expected 2xx, got %d.  Body: %s"
+          status body
+      else
+        let open Or_error.Let_syntax in
+        let%map _data = parse_graphql_data body in
+        (status, body)

--- a/src/test/command_line_tests/command_line_tests.ml
+++ b/src/test/command_line_tests/command_line_tests.ml
@@ -1110,6 +1110,174 @@ module HealthcheckUnreachable = struct
         Mina_automation_fixture.Intf.Passed
 end
 
+(** Verify that the daemon's ITN GraphQL server enforces Ed25519-signed auth.
+
+    Boots a single daemon with [--itn-keys <permitted-pubkey>] and
+    [--itn-graphql-port <port>] (ITN_FEATURES=1 is injected by Daemon.start).
+    Then:
+    1. Posts the [auth] query to the ITN port signed with the permitted key,
+       parses the returned UUID + sequence number.
+    2. Posts a sequenced [internalLogs] query using that UUID/seq-no.
+    3. Posts the [auth] query signed with a DIFFERENT Ed25519 key and asserts
+       the daemon rejects the request with a 4xx.
+    4. Posts a sequenced [internalLogs] signed with the foreign key and asserts
+       the daemon rejects it too (the sequenced rejection path is distinct from
+       the unsequenced one inside [graphql_internal.ml]).
+
+    Wire-level signing and posting live in [Itn_graphql_client] so the same
+    helpers can be reused by other automation. *)
+module ItnGraphqlAuth = struct
+  type t = Mina_automation_fixture.Daemon.before_bootstrap
+
+  (* All ports are non-default so the test can run alongside other mina
+     daemons on the same host (CI runners and local dev boxes often have one
+     running on 8031/3085/8302). *)
+  let client_port = 18031
+
+  let rest_port = 13085
+
+  let itn_port = 13086
+
+  let libp2p_port = 18302
+
+  let itn_uri = Itn_graphql_client.make_uri ~port:itn_port ()
+
+  (* Use [internalLogs] for the sequenced query: it works on any node (no
+     block-producer requirement, unlike [internalLogs]) and only reads daemon
+     state. *)
+  let sequenced_query =
+    {|{"query":"{ internalLogs(startLogId: 0) { id } }","variables":null}|}
+
+  let or_error_result_of d =
+    match%map d with
+    | Ok _ ->
+        Mina_automation_fixture.Intf.Passed
+    | Error err ->
+        Mina_automation_fixture.Intf.Failed err
+
+  let happy_path ~permitted_priv ~permitted_pub_b64 =
+    let open Deferred.Or_error.Let_syntax in
+    (* Step 1: auth handshake with the permitted key. *)
+    let%bind uuid, seq_no =
+      Itn_graphql_client.send_auth ~uri:itn_uri ~privkey:permitted_priv
+        ~pubkey_b64:permitted_pub_b64
+    in
+    (* Step 2: sequenced internalLogs query using the daemon-issued seq_no.  The
+       client checks status code AND graphql `errors` body for us. *)
+    let%map _ =
+      Itn_graphql_client.send_sequenced ~uri:itn_uri ~privkey:permitted_priv
+        ~pubkey_b64:permitted_pub_b64 ~uuid ~seq_no ~body:sequenced_query
+    in
+    ()
+
+  let expect_rejection ~description response =
+    match response with
+    | Ok (status, _body) when status >= 400 && status < 500 ->
+        Ok ()
+    | Ok (status, body) ->
+        Or_error.errorf "%s: expected 4xx, got %d.  Body: %s" description status
+          body
+    | Error err ->
+        (* Network/timeout failures are not what we're asserting here. *)
+        Error (Error.tag err ~tag:description)
+
+  let negative_path ~foreign_priv ~foreign_pub_b64 =
+    let open Deferred.Or_error.Let_syntax in
+    (* Step 3: unsequenced auth signed with a foreign key. *)
+    let foreign_unseq_header =
+      Itn_graphql_client.unsequenced_auth_header ~privkey:foreign_priv
+        ~pubkey_b64:foreign_pub_b64 ~body:Itn_graphql_client.auth_query
+    in
+    let%bind () =
+      Itn_graphql_client.post ~uri:itn_uri ~auth_header:foreign_unseq_header
+        ~body:Itn_graphql_client.auth_query ()
+      |> Deferred.map
+           ~f:(expect_rejection ~description:"unsequenced foreign auth")
+    in
+    (* Step 4: sequenced internalLogs signed with the foreign key.  UUID and seq_no
+       are arbitrary — the daemon must reject before validating them. *)
+    let foreign_seq_header =
+      Itn_graphql_client.sequenced_auth_header ~privkey:foreign_priv
+        ~pubkey_b64:foreign_pub_b64 ~uuid:"deadbeef" ~seq_no:0
+        ~body:sequenced_query
+    in
+    Itn_graphql_client.post ~uri:itn_uri ~auth_header:foreign_seq_header
+      ~body:sequenced_query ()
+    |> Deferred.map
+         ~f:(expect_rejection ~description:"sequenced foreign internalLogs")
+
+  let cleanup ~process =
+    let%bind _ =
+      Monitor.try_with (fun () ->
+          Daemon.Client.stop_daemon process.Daemon.Process.client )
+    in
+    (* `stop-daemon` returns exit code 0 whether or not the daemon was actually
+       reachable, so wait for the OS process to exit and SIGKILL if it doesn't.
+       This is what closes the ports for the next test. *)
+    match%bind
+      Async.Clock.with_timeout (Time.Span.of_sec 10.)
+        (Process.wait process.Daemon.Process.process)
+    with
+    | `Result _ ->
+        Deferred.unit
+    | `Timeout ->
+        let%bind kill_result =
+          Monitor.try_with (fun () -> Daemon.Process.force_kill process)
+        in
+        ( match kill_result with
+        | Ok _ ->
+            ()
+        | Error exn ->
+            eprintf "ITN test cleanup: force_kill failed: %s\n"
+              (Exn.to_string exn) ) ;
+        Deferred.unit
+
+  let test_case (test : t) =
+    let config = { test.config with client_port; rest_port } in
+    let daemon = Daemon.of_config config in
+    let%bind () = Daemon.Config.generate_keys config in
+    let ledger_file = config.dirs.conf ^/ "daemon.json" in
+    let%bind () =
+      Mina_automation_fixture.Daemon.generate_random_config daemon ledger_file
+    in
+    let permitted_priv, permitted_pub = Itn_crypto.generate_keypair () in
+    let foreign_priv, foreign_pub = Itn_crypto.generate_keypair () in
+    let permitted_pub_b64 = Itn_crypto.pubkey_to_base64 permitted_pub in
+    let foreign_pub_b64 = Itn_crypto.pubkey_to_base64 foreign_pub in
+    let%bind process =
+      Daemon.start ~itn_keys:permitted_pub_b64 ~itn_graphql_port:itn_port
+        ~libp2p_port daemon
+    in
+    Monitor.protect
+      ~finally:(fun () -> cleanup ~process)
+      (fun () ->
+        let%bind bootstrap_result = Daemon.wait_for_node_init process in
+        match bootstrap_result with
+        | Error e ->
+            let log_file = Daemon.Config.ConfigDirs.mina_log config.dirs in
+            let%bind logs = Reader.file_contents log_file in
+            printf "Bootstrap error: %s\nDaemon logs:\n%s\n"
+              (Error.to_string_hum e) logs ;
+            Deferred.return
+              (Mina_automation_fixture.Intf.Failed
+                 (Error.tag e ~tag:"Bootstrap failed") )
+        | Ok () -> (
+            match%bind Itn_graphql_client.probe ~uri:itn_uri () with
+            | `Timeout ->
+                Deferred.return
+                  (Mina_automation_fixture.Intf.Failed
+                     (Error.of_string
+                        "ITN graphql port did not start accepting connections" )
+                  )
+            | `Ready ->
+                let run =
+                  let open Deferred.Or_error.Let_syntax in
+                  let%bind () = happy_path ~permitted_priv ~permitted_pub_b64 in
+                  negative_path ~foreign_priv ~foreign_pub_b64
+                in
+                or_error_result_of run ) )
+end
+
 let () =
   let open Alcotest in
   run "Test commadline."
@@ -1263,5 +1431,15 @@ let () =
                ( module Mina_automation_fixture.Daemon
                         .Make_FixtureWithoutBootstrap
                           (HealthcheckUnreachable) ) )
+        ] )
+    ; ( "itn-graphql-auth"
+      , [ test_case
+            "The mina daemon authenticates ITN GraphQL requests with Ed25519 \
+             signatures"
+            `Slow
+            (Mina_automation_runner.Runner.run_blocking
+               ( module Mina_automation_fixture.Daemon
+                        .Make_FixtureWithoutBootstrap
+                          (ItnGraphqlAuth) ) )
         ] )
     ]

--- a/src/test/command_line_tests/dune
+++ b/src/test/command_line_tests/dune
@@ -19,6 +19,8 @@
   yojson
   ;; mina libraries
   init
+  itn_crypto
+  itn_graphql_client
   logger
   mina_automation
   mina_automation.fixture

--- a/src/test/mina_automation/daemon.ml
+++ b/src/test/mina_automation/daemon.ml
@@ -261,7 +261,8 @@ let client t = Client.create ~port:t.config.client_port ~executor:t.executor ()
 
 let start ?hardfork_handling ?block_producer_key ?config_files ?env
     ?peer_list_url ?node_status_url ?node_error_url ?simplified_node_stats
-    ?(start_filtered_logs = default_init_log_filters) t =
+    ?(start_filtered_logs = default_init_log_filters) ?itn_keys
+    ?itn_graphql_port ?libp2p_port t =
   let open Deferred.Let_syntax in
   let base_args =
     [ "daemon"
@@ -286,6 +287,9 @@ let start ?hardfork_handling ?block_producer_key ?config_files ?env
   in
   let opt_arg key value_opt =
     match value_opt with None -> [] | Some value -> [ key; value ]
+  in
+  let int_opt_arg key value_opt =
+    opt_arg key (Option.map value_opt ~f:string_of_int)
   in
   let bool_flag key value_opt =
     match value_opt with
@@ -317,6 +321,29 @@ let start ?hardfork_handling ?block_producer_key ?config_files ?env
     @ config_file_args
     @ opt_arg "--peer-list-url" peer_list_url
     @ start_filtered_log_args
+    @ opt_arg "--itn-keys" itn_keys
+    @ int_opt_arg "--itn-graphql-port" itn_graphql_port
+    @ int_opt_arg "--external-port" libp2p_port
+  in
+  (* The --itn-keys / --itn-graphql-port flags are only recognised by the daemon
+     when ITN_FEATURES is set in the environment.  Inject it transparently for
+     every env-shape so callers don't need to thread the env var through. *)
+  let env =
+    if Option.is_none itn_keys && Option.is_none itn_graphql_port then env
+    else
+      let itn_kv = ("ITN_FEATURES", "1") in
+      let itn_raw = "ITN_FEATURES=1" in
+      match env with
+      | None ->
+          Some (`Extend [ itn_kv ])
+      | Some (`Extend xs) ->
+          Some (`Extend (itn_kv :: xs))
+      | Some (`Replace xs) ->
+          Some (`Replace (itn_kv :: xs))
+      | Some (`Replace_raw xs) ->
+          Some (`Replace_raw (itn_raw :: xs))
+      | Some (`Override xs) ->
+          Some (`Override ((fst itn_kv, Some (snd itn_kv)) :: xs))
   in
   [%log debug] "Starting daemon" ;
 


### PR DESCRIPTION
## Summary

- Adds a single-daemon command_line_test (`itn-graphql-auth`) that exercises the ITN GraphQL authentication surface end-to-end: auth handshake → sequenced query → unsequenced foreign-key rejection → sequenced foreign-key rejection.
- Extracts the Ed25519 signing + Authorization-header construction into a new reusable `itn_graphql_client` library under `src/lib/graphql/`, so any future automation that needs to talk to the ITN endpoint can reuse it instead of re-deriving the wire format.
- Extends `Daemon.start` with `?itn_keys` / `?itn_graphql_port` / `?libp2p_port` parameters and transparently injects `ITN_FEATURES=1` into the daemon env (covers all four async env variants), so callers don't need to thread the env var through.

## Test plan

- [x] `dune build @check src/lib/graphql/itn_graphql_client/ src/test/command_line_tests/ src/test/mina_automation/` — clean.
- [x] `dune build src/test/command_line_tests/command_line_tests.exe` — clean.
- [x] Manual run: `command_line_tests test itn-graphql-auth -e` → `[OK]` in ~38s on a host running other mina daemons concurrently (uses non-default ports 18031/13085/13086/18302 to avoid collision).
- [ ] CI runs the test alongside other command_line_tests via `make test_command_line_tests` (or whatever the existing alcotest harness invokes).

## Wire format reference

The Authorization header layout is documented in `itn_graphql_client.ml` and mirrors the daemon's verifier in `src/app/cli/src/init/graphql_internal.ml`:

```
Unsequenced (only valid for the `auth` query):
  Authorization: Signature <pubkey-b64> <sig-b64>
  signed message = body

Sequenced (everything else):
  Authorization: Signature <pubkey-b64> <sig-b64> ; Sequencing <uuid> <n>
  signed message = seq_no_hi :: seq_no_lo :: uuid :: body
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)