### PR TITLE
ci(release): add no Rust target feature optimisation job

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -60,6 +60,7 @@ let ReleaseSpec =
           , deb_repo : DebianRepo.Type
           , build_flags : BuildFlags.Type
           , step_key_suffix : Text
+          , label_suffix : Text
           , docker_publish : DockerPublish.Type
           , docker_repo : DockerRepo.Type
           , save_to_ci_cache : Bool
@@ -92,6 +93,7 @@ let ReleaseSpec =
           , save_to_ci_cache = False
           , docker_repo = DockerRepo.Type.InternalEurope
           , step_key_suffix = "-docker-image"
+          , label_suffix = ""
           , verify = False
           , deb_suffix = None Text
           , image_name = None Text
@@ -112,7 +114,7 @@ let stepLabel =
                                                            spec.deb_codename} ${Profiles.toSuffixUppercase
                                                                                   spec.deb_profile} ${BuildFlags.toSuffixUppercase
                                                                                                         spec.build_flags} ${Arch.capitalName
-                                                                                                                              spec.arch}"
+                                                                                                                              spec.arch}${spec.label_suffix}"
 
 let generateStep =
           \(spec : ReleaseSpec.Type)

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -117,6 +117,10 @@ let nameSuffix
                                                                      spec.buildFlags}${Arch.nameSuffix
                                                                                          spec.arch}"
 
+let stepKeySuffix
+    : MinaBuildSpec.Type -> Text
+    = \(spec : MinaBuildSpec.Type) -> Optional/default Text "" spec.suffix
+
 let build_artifacts
     : MinaBuildSpec.Type -> Command.Type
     =     \(spec : MinaBuildSpec.Type)
@@ -152,8 +156,8 @@ let build_artifacts
                       "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
                                                                       spec.debVersion}"
                   ]
-            , label = "Debian: Build ${labelSuffix spec}"
-            , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
+            , label = "Debian: Build ${labelSuffix spec}${stepKeySuffix spec}"
+            , key = "build-deb-pkg${stepKeySuffix spec}"
             , target = Size.Multi
             , if_ = spec.if_
             , retries =
@@ -180,6 +184,7 @@ let docker_step
                   , step = step_dep_name
                   , prefix = spec.prefix
                   , arch = spec.arch
+                  , suffix = stepKeySuffix spec
                   }
 
           let size = Size.XLarge
@@ -191,6 +196,8 @@ let docker_step
                     , service = Artifacts.Type.Daemon
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -211,13 +218,17 @@ let docker_step
                         # DockerVersion.dependsOn
                             DockerVersion.DepsSpec::{
                             , codename = DockerVersion.ofDebian spec.debVersion
+                            , prefix = spec.prefix
                             , network = spec.network
                             , profile = spec.profile
                             , artifact = Artifacts.Type.Daemon
+                            , suffix = "docker-image${stepKeySuffix spec}"
                             }
                     , service = Artifacts.Type.DaemonAutoHardfork
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -233,13 +244,17 @@ let docker_step
                         # DockerVersion.dependsOn
                             DockerVersion.DepsSpec::{
                             , codename = DockerVersion.ofDebian spec.debVersion
+                            , prefix = spec.prefix
                             , network = spec.network
                             , profile = spec.profile
                             , artifact = Artifacts.Type.DaemonLegacyHardfork
+                            , suffix = "docker-image${stepKeySuffix spec}"
                             }
                     , service = Artifacts.Type.DaemonLegacyHardfork
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -255,6 +270,8 @@ let docker_step
                     , service = Artifacts.Type.DaemonAppsOnly
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -275,15 +292,19 @@ let docker_step
                         # DockerVersion.dependsOn
                             DockerVersion.DepsSpec::{
                             , codename = DockerVersion.ofDebian spec.debVersion
+                            , prefix = spec.prefix
                             , network = spec.network
                             , profile = spec.profile
                             , artifact = Artifacts.Type.DaemonAppsOnly
                             , arch = spec.arch
                             , buildFlags = spec.buildFlags
+                            , suffix = "docker-image${stepKeySuffix spec}"
                             }
                     , service = Artifacts.Type.DaemonConfig
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , docker_publish = spec.docker_publish
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
@@ -304,6 +325,8 @@ let docker_step
                     , service = Artifacts.Type.BatchTxn
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -320,6 +343,8 @@ let docker_step
                     , service = Artifacts.Type.DelegationVerifier
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -337,6 +362,8 @@ let docker_step
                     , service = Artifacts.Type.Archive
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -354,6 +381,8 @@ let docker_step
                     , service = Artifacts.Type.Rosetta
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -371,6 +400,8 @@ let docker_step
                     , service = Artifacts.Type.RosettaAppsOnly
                     , network = spec.network
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_profile = spec.profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
@@ -390,15 +421,19 @@ let docker_step
                         # DockerVersion.dependsOn
                             DockerVersion.DepsSpec::{
                             , codename = DockerVersion.ofDebian spec.debVersion
+                            , prefix = spec.prefix
                             , network = spec.network
                             , profile = spec.profile
                             , artifact = Artifacts.Type.RosettaAppsOnly
+                            , suffix = "docker-image${stepKeySuffix spec}"
                             }
                     , service = Artifacts.Type.RosettaConfig
                     , network = spec.network
                     , image_name = Some
                         (Artifacts.dockerName Artifacts.Type.Rosetta)
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , docker_publish = spec.docker_publish
                     , deb_install_mode =
                         DockerImage.DebianInstallMode.DownloadOnly
@@ -415,6 +450,8 @@ let docker_step
                     , deb_repo = DebianRepo.Type.Local
                     , deb_profile = spec.profile
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , deb_legacy_version = spec.deb_legacy_version
                     , arch = spec.arch
                     , if_ = spec.if_
@@ -427,6 +464,8 @@ let docker_step
                     , service = Artifacts.Type.FunctionalTestSuite
                     , network = Network.Type.Devnet
                     , deb_codename = spec.debVersion
+                    , step_key_suffix = "-docker-image${stepKeySuffix spec}"
+                    , label_suffix = stepKeySuffix spec
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
                     , deb_repo = DebianRepo.Type.Local

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -41,6 +41,7 @@ let DepsSpec =
           , step : Text
           , prefix : Text
           , arch : Arch.Type
+          , suffix : Text
           }
       , default =
           { deb_version = DebVersion.Bullseye
@@ -50,6 +51,7 @@ let DepsSpec =
           , step = "build"
           , prefix = "MinaArtifact"
           , arch = Arch.Type.Amd64
+          , suffix = ""
           }
       }
 
@@ -64,7 +66,7 @@ let dependsOn =
                                                                                          spec.build_flag}${Arch.nameSuffix
                                                                                                              spec.arch}"
 
-          in  [ { name = name, key = "${spec.step}-deb-pkg" } ]
+          in  [ { name = name, key = "${spec.step}-deb-pkg${spec.suffix}" } ]
 
 let minimalDirtyWhen =
       [ S.exactly "buildkite/src/Constants/DebianVersions" "dhall"

--- a/buildkite/src/Jobs/Release/MinaArtifactCompatBookwormDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactCompatBookwormDevnetDevnet.dhall
@@ -1,0 +1,50 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.pipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , prefix = "MinaArtifactCompat"
+          , artifacts =
+            [ Artifacts.Type.Daemon
+            , Artifacts.Type.DaemonAppsOnly
+            , Artifacts.Type.DaemonConfig
+            , Artifacts.Type.DaemonPrefork
+            , Artifacts.Type.DaemonAutoHardfork
+            , Artifacts.Type.DaemonAutomode
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.Archive
+            , Artifacts.Type.Rosetta
+            , Artifacts.Type.RosettaAppsOnly
+            , Artifacts.Type.ZkappTestTransaction
+            , Artifacts.Type.CreatePreforkGenesis
+            , Artifacts.Type.DelegationVerifier
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , network = Network.Type.Devnet
+          , suffix = Some "-compat"
+          , extraBuildEnvs = [ "RUST_TARGET_FEATURE_OPTIMISATIONS=n" ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope =
+            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          }
+      )


### PR DESCRIPTION


- Add a new Bookworm Devnet release job that builds the standard Mina artifact set with `RUST_TARGET_FEATURE_OPTIMISATIONS=n`.
- Give the job a distinct `MinaArtifactCompat...` prefix so it can coexist with the existing Bookworm Devnet release job.
- Keep the same Release/Docker/Devnet/Amd64/Bookworm tags and release scopes as the existing Bookworm Devnet artifact job.
