### PR TITLE
Fix VRF evaluator epoch transition races

### DIFF
--- a/changes/18894.md
+++ b/changes/18894.md
@@ -1,0 +1,1 @@
+Block producers now handle VRF evaluator epoch transitions more safely. The evaluator stops stale VRF scans when epoch data or producer keys change while preserving valid final-slot wins during epoch lookahead, and block production skips expired won slots before constructing block data from the current ledger snapshot.

--- a/src/app/cli/src/init/test_submit_to_archive.ml
+++ b/src/app/cli/src/init/test_submit_to_archive.ml
@@ -241,15 +241,15 @@ let find_winning_slots ~context:(module Context : Consensus.Intf.CONTEXT)
         ~producer_private_key:keypair.private_key
         ~producer_public_key:public_key_compressed
         ~total_stake:epoch_ledger.total_currency
-      |> Interruptible.force
+        ~should_abort:(fun () -> false)
     with
-    | Error _ ->
+    | `Stale ->
         [%log fatal] "VRF check failed" ;
         failwith "VRF check failed"
-    | Ok None ->
+    | `Finished None ->
         (* Not a winning slot, try next one *)
         `Repeat (current_slot + 1, found_slots, attempts_left - 1)
-    | Ok
+    | `Finished
         (Some
           (`Vrf_eval _vrf_eval, `Vrf_output vrf_result, `Delegator delegator) )
       ->

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1146,15 +1146,15 @@ let iteration ~schedule_next_vrf_check ~produce_block_now
         Consensus.Data.Consensus_time.(
           of_time_exn ~constants:consensus_constants now |> to_global_slot)
       in
-      let winner_pk = fst slot_won.delegator in
-      let data =
-        Consensus.Hooks.get_block_data ~slot_won ~ledger_snapshot
-          ~coinbase_receiver:!coinbase_receiver
-      in
       if
         Mina_numbers.Global_slot_since_hard_fork.(
           curr_global_slot = winning_global_slot)
       then (
+        let winner_pk = fst slot_won.delegator in
+        let data =
+          Consensus.Hooks.get_block_data ~slot_won ~ledger_snapshot
+            ~coinbase_receiver:!coinbase_receiver
+        in
         (*produce now*)
         [%log info] "Producing a block now" ;
         set_next_producer_timing
@@ -1185,6 +1185,11 @@ let iteration ~schedule_next_vrf_check ~produce_block_now
                 ] ;
             next_vrf_check_now ()
         | Some slot_diff ->
+            let winner_pk = fst slot_won.delegator in
+            let data =
+              Consensus.Hooks.get_block_data ~slot_won ~ledger_snapshot
+                ~coinbase_receiver:!coinbase_receiver
+            in
             [%log info] "Producing a block in $slots slots"
               ~metadata:
                 [ ("slots", Mina_numbers.Global_slot_span.to_yojson slot_diff) ] ;

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -67,7 +67,6 @@
   currency
   mina_stdlib_unix
   coda_genesis_ledger
-  interruptible
   network_peer
   pickles
   snark_bits
@@ -114,5 +113,5 @@
   (backend bisect_ppx))
  (preprocess
   (pps ppx_version ppx_jane))
- (enabled_if false) ;; Compilation is disabled until this executable has been fixed.
- )
+ (enabled_if false)) ;; Compilation is disabled until this executable has been fixed.
+ 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -416,14 +416,16 @@ module type S = sig
         -> get_delegators:
              (   Public_key.Compressed.t
               -> Mina_base.Account.t Mina_base.Account.Index.Table.t option )
-        -> ( ( [ `Vrf_eval of string ]
+        -> should_abort:(unit -> bool)
+        -> [ `Finished of
+             ( [ `Vrf_eval of string ]
              * [> `Vrf_output of Consensus_vrf.Output_hash.t ]
              * [> `Delegator of
                   Signature_lib.Public_key.Compressed.t
                   * Mina_base.Account.Index.t ] )
              option
-           , unit )
-           Interruptible.t
+           | `Stale ]
+           Deferred.t
     end
 
     module Prover_state : sig

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -842,67 +842,79 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~producer_private_key ~producer_public_key ~total_stake
           ~(get_delegators :
                 Public_key.Compressed.t
-             -> Mina_base.Account.t Mina_base.Account.Index.Table.t option ) =
+             -> Mina_base.Account.t Mina_base.Account.Index.Table.t option )
+          ~should_abort :
+          [ `Finished of
+            ( [ `Vrf_eval of string ]
+            * [> `Vrf_output of Consensus_vrf.Output_hash.t ]
+            * [> `Delegator of
+                 Public_key.Compressed.t * Mina_base.Account.Index.t ] )
+            option
+          | `Stale ]
+          Deferred.t =
         let open Context in
         let open Message in
-        let open Interruptible.Let_syntax in
+        let open Deferred.Let_syntax in
+        let yield = Staged.unstage (Async.Scheduler.yield_every ~n:50) in
         let delegators =
           get_delegators producer_public_key
           |> Option.value_map ~f:Hashtbl.to_alist ~default:[]
         in
         let rec go acc = function
           | [] ->
-              Interruptible.return acc
+              Deferred.return (`Finished acc)
           | (delegator, (account : Mina_base.Account.t)) :: delegators ->
-              let%bind () = Interruptible.return () in
-              let vrf_result =
-                T.eval ~constraint_constants ~private_key:producer_private_key
-                  { global_slot; seed; delegator }
-              in
-              let truncated_vrf_result = Output.truncate vrf_result in
-              [%log debug]
-                "VRF result for delegator: $delegator, balance: $balance, \
-                 amount: $amount, result: $result"
-                ~metadata:
-                  [ ( "delegator"
-                    , `Int (Mina_base.Account.Index.to_int delegator) )
-                  ; ( "delegator_pk"
-                    , Public_key.Compressed.to_yojson account.public_key )
-                  ; ("balance", `Int (Balance.to_nanomina_int account.balance))
-                  ; ("amount", `Int (Amount.to_nanomina_int total_stake))
-                  ; ( "result"
-                    , `String
-                        (* use sexp representation; int might be too small *)
-                        ( Fold.string_bits truncated_vrf_result
-                        |> Bignum_bigint.of_bit_fold_lsb
-                        |> Bignum_bigint.sexp_of_t |> Sexp.to_string ) )
-                  ] ;
-              Mina_metrics.Counter.inc_one
-                Mina_metrics.Consensus.vrf_evaluations ;
-              if
-                Threshold.is_satisfied ~my_stake:account.balance ~total_stake
-                  truncated_vrf_result
-              then
-                let string_of_blake2 =
-                  Blake2.(Fn.compose to_raw_string digest_string)
+              let%bind () = yield () in
+              if should_abort () then Deferred.return `Stale
+              else
+                let vrf_result =
+                  T.eval ~constraint_constants ~private_key:producer_private_key
+                    { global_slot; seed; delegator }
                 in
-                let vrf_eval = string_of_blake2 truncated_vrf_result in
-                let this_vrf () =
-                  go
-                    (Some
-                       ( `Vrf_eval vrf_eval
-                       , `Vrf_output vrf_result
-                       , `Delegator (account.public_key, delegator) ) )
-                    delegators
-                in
-                match acc with
-                | Some (`Vrf_eval prev_best_vrf_eval, _, _) ->
-                    if String.compare prev_best_vrf_eval vrf_eval < 0 then
+                let truncated_vrf_result = Output.truncate vrf_result in
+                [%log debug]
+                  "VRF result for delegator: $delegator, balance: $balance, \
+                   amount: $amount, result: $result"
+                  ~metadata:
+                    [ ( "delegator"
+                      , `Int (Mina_base.Account.Index.to_int delegator) )
+                    ; ( "delegator_pk"
+                      , Public_key.Compressed.to_yojson account.public_key )
+                    ; ("balance", `Int (Balance.to_nanomina_int account.balance))
+                    ; ("amount", `Int (Amount.to_nanomina_int total_stake))
+                    ; ( "result"
+                      , `String
+                          (* use sexp representation; int might be too small *)
+                          ( Fold.string_bits truncated_vrf_result
+                          |> Bignum_bigint.of_bit_fold_lsb
+                          |> Bignum_bigint.sexp_of_t |> Sexp.to_string ) )
+                    ] ;
+                Mina_metrics.Counter.inc_one
+                  Mina_metrics.Consensus.vrf_evaluations ;
+                if
+                  Threshold.is_satisfied ~my_stake:account.balance ~total_stake
+                    truncated_vrf_result
+                then
+                  let string_of_blake2 =
+                    Blake2.(Fn.compose to_raw_string digest_string)
+                  in
+                  let vrf_eval = string_of_blake2 truncated_vrf_result in
+                  let this_vrf () =
+                    go
+                      (Some
+                         ( `Vrf_eval vrf_eval
+                         , `Vrf_output vrf_result
+                         , `Delegator (account.public_key, delegator) ) )
+                      delegators
+                  in
+                  match acc with
+                  | Some (`Vrf_eval prev_best_vrf_eval, _, _) ->
+                      if String.compare prev_best_vrf_eval vrf_eval < 0 then
+                        this_vrf ()
+                      else go acc delegators
+                  | None ->
                       this_vrf ()
-                    else go acc delegators
-                | None ->
-                    this_vrf ()
-              else go acc delegators
+                else go acc delegators
         in
         go None delegators
     end
@@ -3692,15 +3704,20 @@ module Make_str (A : Wire_types.Concrete) = struct
         let check i =
           let global_slot = Mina_numbers.Global_slot_since_hard_fork.of_int i in
           let%map result =
-            Interruptible.force
-              (Vrf.check
-                 ~context:(module Context)
-                 ~global_slot ~seed ~producer_private_key:private_key
-                 ~producer_public_key:public_key_compressed ~total_stake
-                 ~get_delegators:
-                   (Local_state.Snapshot.delegators epoch_snapshot) )
+            Vrf.check
+              ~context:(module Context)
+              ~global_slot ~seed ~producer_private_key:private_key
+              ~producer_public_key:public_key_compressed ~total_stake
+              ~get_delegators:(Local_state.Snapshot.delegators epoch_snapshot)
+              ~should_abort:(fun () -> false)
           in
-          match Result.ok_exn result with Some _ -> 1 | None -> 0
+          match result with
+          | `Finished (Some _) ->
+              1
+          | `Finished None ->
+              0
+          | `Stale ->
+              failwith "Unexpected stale VRF check"
         in
         let rec loop acc_count i =
           match i < samples with

--- a/src/lib/vrf_evaluator/dune
+++ b/src/lib/vrf_evaluator/dune
@@ -18,7 +18,6 @@
   error_json
   currency
   unsigned_extended
-  interruptible
   signature_lib
   consensus
   mina_base

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -72,6 +72,8 @@ module Vrf_evaluation_result = struct
 end
 
 module Worker_state = struct
+  let max_slots_won_queue_length = 100
+
   type init_arg =
     { constraint_constants : Genesis_constants.Constraint_constants.t
     ; consensus_constants : Consensus.Constants.Stable.Latest.t
@@ -97,193 +99,379 @@ module Worker_state = struct
       let logger = logger
     end )
 
-  type t =
-    { config : init_arg
-    ; mutable last_checked_slot_and_epoch :
-        (Epoch.t * Slot.t) Public_key.Compressed.Table.t
-    ; slots_won : Consensus.Data.Slot_won.t Queue.t
-          (*possibly multiple producers per slot*)
-    ; mutable current_slot : Global_slot_since_hard_fork.t option
-    ; mutable epoch_data :
-        unit Ivar.t * Consensus.Data.Epoch_data_for_vrf.t option
-    ; mutable block_producer_keys : Block_producer_keys.t
+  type progress =
+    | Idle
+    | Scanning of Global_slot_since_hard_fork.t
+    | Completed of { epoch_generation : int; state_version : int }
+
+  type vrf_eval_result = Lost | Won of Consensus.Data.Slot_won.t | Stale
+
+  (* Immutable snapshot of the worker state used by one slot evaluation.
+     The scan compares these generations with the mutable worker state at
+     cooperative yield points. This keeps stale-scan cancellation pull-based:
+     the active scan decides whether to stop, instead of a long-lived canceler
+     retaining references into completed keypair/delegator evaluations.
+
+     [epoch_generation] changes when epoch data changes. A scan may continue
+     across an epoch generation change only for the final-slot lookahead case.
+     [keys_generation] changes when block producer keys change and always makes
+     the scan stale. [state_version] tracks the exact worker state seen by the
+     scan for status bookkeeping after evaluation returns. *)
+  type scan_context =
+    { epoch_generation : int
+    ; keys_generation : int
+    ; state_version : int
+    ; global_slot : Global_slot_since_hard_fork.t
     }
 
-  let make_last_checked_slot_and_epoch_table old_table new_keys ~default =
-    let module Set = Public_key.Compressed.Set in
-    let module Table = Public_key.Compressed.Table in
-    let last_checked_slot_and_epoch = Table.create () in
-    List.iter new_keys ~f:(fun (_, pk) ->
-        let data = Option.value (Table.find old_table pk) ~default in
-        Table.add_exn last_checked_slot_and_epoch ~key:pk ~data ) ;
-    last_checked_slot_and_epoch
+  (* Long-lived state owned by the VRF evaluator worker process.
 
-  let seen_slot last_checked_slot_and_epoch epoch slot =
-    let module Table = Public_key.Compressed.Table in
-    let unseens =
-      Table.to_alist last_checked_slot_and_epoch
-      |> List.filter_map ~f:(fun (pk, last_checked_epoch_and_slot) ->
-             let i =
-               Tuple2.compare ~cmp1:Epoch.compare ~cmp2:Slot.compare
-                 last_checked_epoch_and_slot (epoch, slot)
-             in
-             if i > 0 then None
-             else if i = 0 then
-               (*vrf evaluation was stopped at this point because it was either the end of the epoch or the key won this slot; re-check this slot when staking keys are reset so that we don't skip producing block. This will not occur in the normal flow because [slot] will be greater than the last-checked-slot*)
-               Some pk
-             else (
-               Table.set last_checked_slot_and_epoch ~key:pk ~data:(epoch, slot) ;
-               Some pk ) )
-    in
-    match unseens with
-    | [] ->
-        `All_seen
-    | nel ->
-        `Unseen (Public_key.Compressed.Set.of_list nel)
+     [run_loop] mutates this state as RPCs update epoch data or producer keys,
+     and scans slots in the background. Per-slot evaluation should not retain
+     mutable worker state through cancellation callbacks; it snapshots the
+     relevant generations into [scan_context] and polls [scan_is_obsolete]
+     instead.
 
-  let evaluate
-      ( { config
-        ; slots_won
-        ; block_producer_keys
-        ; epoch_data = interrupt_ivar, epoch_data
-        ; _
-        } as t ) : (unit, unit) Interruptible.t =
-    let (module Context) = context_of_config config in
-    let open Context in
-    match epoch_data with
+     [epoch_generation] and [keys_generation] separate the two reasons a scan
+     can become stale. This matters because epoch lookahead may preserve a valid
+     final-slot win, while a producer-key update must invalidate the scan even
+     during that lookahead window. [state_version] is still used for progress and
+     status invalidation visible to the block producer. *)
+  type t =
+    { config : init_arg
+    ; slots_won : Consensus.Data.Slot_won.t Queue.t
+          (*possibly multiple producers per slot*)
+    ; mutable enqueued_wins :
+        (Global_slot_since_hard_fork.t * Public_key.Compressed.t) list
+    ; mutable progress : progress
+    ; mutable epoch_data : Consensus.Data.Epoch_data_for_vrf.t option
+    ; mutable block_producer_keys : Block_producer_keys.t
+    ; mutable state_changed : unit Ivar.t
+    ; mutable slots_won_capacity_available : unit Ivar.t
+    ; mutable epoch_generation : int
+    ; mutable keys_generation : int
+    ; mutable state_version : int
+    }
+
+  let slots_won_queue_full t =
+    Queue.length t.slots_won >= max_slots_won_queue_length
+
+  (* These generations are only compared for equality against recent scan
+     snapshots. Wrap explicitly before integer overflow rather than relying on
+     OCaml integer overflow behavior. *)
+  let next_generation generation =
+    if Int.equal generation Int.max_value then 0 else generation + 1
+
+  let notify slots_changed_ivar_ref =
+    Ivar.fill_if_empty !slots_changed_ivar_ref () ;
+    slots_changed_ivar_ref := Ivar.create ()
+
+  let notify_state_changed t =
+    t.state_version <- next_generation t.state_version ;
+    let state_changed = ref t.state_changed in
+    notify state_changed ;
+    t.state_changed <- !state_changed
+
+  let notify_slots_won_capacity_available t =
+    let slots_won_capacity_available = ref t.slots_won_capacity_available in
+    notify slots_won_capacity_available ;
+    t.slots_won_capacity_available <- !slots_won_capacity_available
+
+  let wait_for_update t =
+    Deferred.choose
+      [ Deferred.choice (Ivar.read t.state_changed) Fn.id
+      ; Deferred.choice (Ivar.read t.slots_won_capacity_available) Fn.id
+      ]
+
+  let mark_progress t progress = t.progress <- progress
+
+  let already_enqueued t slot producer =
+    List.exists t.enqueued_wins ~f:(fun (slot', producer') ->
+        Global_slot_since_hard_fork.equal slot slot'
+        && Public_key.Compressed.equal producer producer' )
+
+  let enqueue_slot_won t (slot_won : Consensus.Data.Slot_won.t)
+      ~producer_public_key =
+    if not (already_enqueued t slot_won.global_slot producer_public_key) then (
+      Queue.enqueue t.slots_won slot_won ;
+      t.enqueued_wins <-
+        (slot_won.global_slot, producer_public_key) :: t.enqueued_wins )
+
+  let evaluator_status t =
+    match t.progress with
+    | Scanning slot ->
+        Evaluator_status.At slot
+    | Completed { epoch_generation; state_version }
+      when epoch_generation = t.epoch_generation
+           && state_version = t.state_version ->
+        Completed
+    | Idle | Completed _ -> (
+        match t.epoch_data with
+        | Some epoch_data ->
+            Evaluator_status.At epoch_data.global_slot
+        | None ->
+            Completed )
+
+  let valid_final_slot_lookahead t (scan : scan_context) =
+    Int.equal t.keys_generation scan.keys_generation
+    && (not (Int.equal t.epoch_generation scan.epoch_generation))
+    &&
+    match t.epoch_data with
+    | Some epoch_data -> (
+        match
+          Global_slot_since_hard_fork.diff epoch_data.global_slot
+            scan.global_slot
+        with
+        | Some slot_diff ->
+            Mina_numbers.Global_slot_span.equal slot_diff
+              Mina_numbers.Global_slot_span.one
+        | None ->
+            false )
     | None ->
-        Interruptible.return ()
-    | Some epoch_data ->
-        let open Interruptible.Let_syntax in
-        let%bind () =
-          Interruptible.lift Deferred.unit (Ivar.read interrupt_ivar)
-        in
-        let epoch = epoch_data.epoch in
-        [%log info] "Starting VRF evaluation for epoch: $epoch"
-          ~metadata:[ ("epoch", Epoch.to_yojson epoch) ] ;
-        let keypairs = block_producer_keys in
-        let start_global_slot = epoch_data.global_slot in
-        let start_global_slot_since_genesis =
-          epoch_data.global_slot_since_genesis
-        in
-        let delegatee_table = epoch_data.delegatee_table in
-        (*slot in the epoch*)
-        let start_consensus_time =
-          Consensus.Data.Consensus_time.(
-            of_global_slot ~constants:consensus_constants start_global_slot)
-        in
-        let total_stake = epoch_data.epoch_ledger.total_currency in
-        let evaluate_vrf ~consensus_time =
-          (* Try vrfs for all keypairs that are unseen within this slot until one wins or all lose *)
-          (* TODO: Don't do this, and instead pick the one that has the highest chance of winning. See #2573 *)
-          let slot : Slot.t =
-            Slot.of_uint32 @@ Consensus_time.slot consensus_time
-          in
-          let global_slot = Consensus_time.to_global_slot consensus_time in
-          [%log info] "Checking VRF evaluations for epoch: $epoch, slot: $slot"
-            ~metadata:
-              [ ("epoch", `Int (Epoch.to_int epoch))
-              ; ("slot", `Int (Slot.to_int slot))
-              ] ;
-          let rec go = function
-            | [] ->
-                Interruptible.return None
-            | ((keypair : Keypair.t), public_key_compressed) :: keypairs -> (
-                let global_slot_since_genesis =
-                  let slot_diff : Mina_numbers.Global_slot_span.t =
-                    match
-                      Global_slot_since_hard_fork.diff global_slot
-                        start_global_slot
-                    with
-                    | None ->
-                        failwith
-                          "Checking slot-winner for a slot which is older than \
-                           the slot in the latest consensus state. System time \
-                           might be out-of-sync"
-                    | Some diff ->
-                        diff
-                  in
-                  Mina_numbers.Global_slot_since_genesis.add
-                    start_global_slot_since_genesis slot_diff
-                in
-                [%log info]
-                  "Checking VRF evaluations at epoch: $epoch, slot: $slot"
-                  ~metadata:
-                    [ ("epoch", `Int (Epoch.to_int epoch))
-                    ; ("slot", `Int (Slot.to_int slot))
-                    ] ;
-                match%bind
-                  Consensus.Data.Vrf.check
-                    ~context:(module Context)
-                    ~global_slot ~seed:epoch_data.epoch_seed
-                    ~get_delegators:
-                      (Public_key.Compressed.Table.find delegatee_table)
-                    ~producer_private_key:keypair.private_key
-                    ~producer_public_key:public_key_compressed ~total_stake
+        false
+
+  (* These predicates intentionally answer different questions. A final-slot
+     epoch lookahead scan is not obsolete: it may still produce a valid win for
+     [scan.global_slot]. But it is also not current: after it returns, the loop
+     must not advance the old scan and should restart from the latest worker
+     state after preserving any valid win. *)
+  let scan_is_obsolete t (scan : scan_context) =
+    if not (Int.equal t.keys_generation scan.keys_generation) then true
+    else if Int.equal t.epoch_generation scan.epoch_generation then false
+    else not (valid_final_slot_lookahead t scan)
+
+  let scan_is_current t (scan : scan_context) =
+    Int.equal t.epoch_generation scan.epoch_generation
+    && Int.equal t.keys_generation scan.keys_generation
+    && Int.equal t.state_version scan.state_version
+
+  let evaluate_vrf ~context:(module Context : CONTEXT)
+      ~(epoch_data : Consensus.Data.Epoch_data_for_vrf.t) ~keypairs
+      ~consensus_time ~should_abort =
+    let open Context in
+    let open Deferred.Let_syntax in
+    let epoch = epoch_data.epoch in
+    let start_global_slot = epoch_data.global_slot in
+    let start_global_slot_since_genesis =
+      epoch_data.global_slot_since_genesis
+    in
+    let delegatee_table = epoch_data.delegatee_table in
+    let total_stake = epoch_data.epoch_ledger.total_currency in
+    (* Try vrfs for all keypairs that are unseen within this slot until one wins or all lose *)
+    (* TODO: Don't do this, and instead pick the one that has the highest chance of winning. See #2573 *)
+    let slot : Slot.t = Slot.of_uint32 @@ Consensus_time.slot consensus_time in
+    let global_slot = Consensus_time.to_global_slot consensus_time in
+    [%log info] "Checking VRF evaluations for epoch: $epoch, slot: $slot"
+      ~metadata:
+        [ ("epoch", `Int (Epoch.to_int epoch))
+        ; ("slot", `Int (Slot.to_int slot))
+        ] ;
+    let yield = Staged.unstage (Async.Scheduler.yield_every ~n:50) in
+    let rec go = function
+      | [] ->
+          Deferred.return Lost
+      | ((keypair : Keypair.t), public_key_compressed) :: keypairs -> (
+          let%bind () = yield () in
+          if should_abort () then Deferred.return Stale
+          else
+            let global_slot_since_genesis =
+              let slot_diff : Mina_numbers.Global_slot_span.t =
+                match
+                  Global_slot_since_hard_fork.diff global_slot start_global_slot
                 with
                 | None ->
-                    go keypairs
+                    failwith
+                      "Checking slot-winner for a slot which is older than the \
+                       slot in the latest consensus state. System time might \
+                       be out-of-sync"
+                | Some diff ->
+                    diff
+              in
+              Mina_numbers.Global_slot_since_genesis.add
+                start_global_slot_since_genesis slot_diff
+            in
+            [%log info] "Checking VRF evaluations at epoch: $epoch, slot: $slot"
+              ~metadata:
+                [ ("epoch", `Int (Epoch.to_int epoch))
+                ; ("slot", `Int (Slot.to_int slot))
+                ] ;
+            let%bind result =
+              Consensus.Data.Vrf.check
+                ~context:(module Context)
+                ~global_slot ~seed:epoch_data.epoch_seed
+                ~get_delegators:
+                  (Public_key.Compressed.Table.find delegatee_table)
+                ~producer_private_key:keypair.private_key
+                ~producer_public_key:public_key_compressed ~total_stake
+                ~should_abort
+            in
+            match result with
+            | `Stale ->
+                Deferred.return Stale
+            | `Finished None ->
+                go keypairs
+            | `Finished
+                (Some
+                  ( `Vrf_eval _vrf_string
+                  , `Vrf_output vrf_result
+                  , `Delegator delegator ) ) ->
+                [%log info] "Won slot %d in epoch %d" (Slot.to_int slot)
+                  (Epoch.to_int epoch) ;
+                let slot_won =
+                  Consensus.Data.Slot_won.
+                    { delegator
+                    ; producer = keypair
+                    ; global_slot
+                    ; global_slot_since_genesis
+                    ; vrf_result
+                    }
+                in
+                Deferred.return (Won slot_won) )
+    in
+    go keypairs
+
+  let run_loop t =
+    let (module Context) = context_of_config t.config in
+    let open Context in
+    let start_consensus_time (epoch_data : Consensus.Data.Epoch_data_for_vrf.t)
+        =
+      Consensus.Data.Consensus_time.(
+        of_global_slot ~constants:consensus_constants epoch_data.global_slot)
+    in
+    let wait_for_state_change () = Ivar.read t.state_changed in
+    let scanning generation state_version consensus_time =
+      Some (`Scanning (generation, state_version, consensus_time))
+    in
+    let completed generation state_version =
+      Some (`Completed (generation, state_version))
+    in
+    let next_slot generation state_version consensus_time =
+      scanning generation state_version (Consensus_time.succ consensus_time)
+    in
+    let rec loop current =
+      match t.epoch_data with
+      | None ->
+          mark_progress t Idle ;
+          let%bind () = wait_for_state_change () in
+          loop None
+      | Some epoch_data -> (
+          let generation = t.epoch_generation in
+          let state_version = t.state_version in
+          match current with
+          | Some (`Completed (completed_generation, completed_state_version))
+            when completed_generation = generation
+                 && completed_state_version = state_version ->
+              mark_progress t
+                (Completed { epoch_generation = generation; state_version }) ;
+              let%bind () = wait_for_state_change () in
+              loop current
+          | _ ->
+              let consensus_time =
+                match current with
                 | Some
-                    ( `Vrf_eval _vrf_string
-                    , `Vrf_output vrf_result
-                    , `Delegator delegator ) ->
-                    [%log info] "Won slot %d in epoch %d" (Slot.to_int slot)
-                      (Epoch.to_int epoch) ;
-                    let slot_won =
-                      Consensus.Data.Slot_won.
-                        { delegator
-                        ; producer = keypair
-                        ; global_slot
-                        ; global_slot_since_genesis
-                        ; vrf_result
-                        }
-                    in
-                    Interruptible.return (Some slot_won) )
-          in
-          go keypairs
-        in
-        let rec find_winning_slot (consensus_time : Consensus_time.t) =
-          let slot = Slot.of_uint32 @@ Consensus_time.slot consensus_time in
-          t.current_slot <-
-            Some
-              ( Consensus_time.to_uint32 consensus_time
-              |> Global_slot_since_hard_fork.of_uint32 ) ;
-          let epoch' = Consensus_time.epoch consensus_time in
-          if Epoch.(epoch' > epoch) then (
-            t.current_slot <- None ;
-            Interruptible.return () )
-          else
-            let start = Time.now () in
-            match%bind evaluate_vrf ~consensus_time with
-            | None ->
-                [%log info] "Did not win slot $slot, took $time ms"
+                    (`Scanning
+                      ( scanning_generation
+                      , scanning_state_version
+                      , consensus_time ) )
+                  when scanning_generation = generation
+                       && scanning_state_version = state_version ->
+                    consensus_time
+                | _ ->
+                    [%log info] "Starting VRF evaluation for epoch: $epoch"
+                      ~metadata:[ ("epoch", Epoch.to_yojson epoch_data.epoch) ] ;
+                    start_consensus_time epoch_data
+              in
+              let slot = Slot.of_uint32 @@ Consensus_time.slot consensus_time in
+              let global_slot =
+                Consensus_time.to_uint32 consensus_time
+                |> Global_slot_since_hard_fork.of_uint32
+              in
+              let epoch' = Consensus_time.epoch consensus_time in
+              if Epoch.(epoch' > epoch_data.epoch) then (
+                if
+                  t.epoch_generation = generation
+                  && t.state_version = state_version
+                then
+                  mark_progress t
+                    (Completed { epoch_generation = generation; state_version }) ;
+                loop (completed generation state_version) )
+              else if slots_won_queue_full t then (
+                mark_progress t (Scanning global_slot) ;
+                [%log' warn t.config.logger]
+                  "Pausing VRF evaluation because $num_slots_won slots are \
+                   waiting to be polled"
                   ~metadata:
-                    [ ("time", `Float Time.(Span.to_ms (diff (now ()) start)))
-                    ; ("slot", Slot.to_yojson slot)
-                    ] ;
-                find_winning_slot (Consensus_time.succ consensus_time)
-            | Some slot_won ->
-                [%log info] "Won a slot $slot, took $time ms"
-                  ~metadata:
-                    [ ("time", `Float Time.(Span.to_ms (diff (now ()) start)))
-                    ; ("slot", Slot.to_yojson slot)
-                    ] ;
-                Queue.enqueue slots_won slot_won ;
-                find_winning_slot (Consensus_time.succ consensus_time)
-        in
-        find_winning_slot start_consensus_time
+                    [ ("num_slots_won", `Int (Queue.length t.slots_won)) ] ;
+                let%bind () = wait_for_update t in
+                loop current )
+              else (
+                mark_progress t (Scanning global_slot) ;
+                let start = Time.now () in
+                let keypairs = t.block_producer_keys in
+                let scan =
+                  { epoch_generation = generation
+                  ; keys_generation = t.keys_generation
+                  ; state_version
+                  ; global_slot
+                  }
+                in
+                let%bind slot_won =
+                  evaluate_vrf
+                    ~context:(module Context)
+                    ~epoch_data ~keypairs ~consensus_time
+                    ~should_abort:(fun () -> scan_is_obsolete t scan)
+                in
+                if not (scan_is_current t scan) then
+                  match slot_won with
+                  | Won slot_won
+                    when valid_final_slot_lookahead t scan
+                         && Global_slot_since_hard_fork.equal
+                              slot_won.global_slot global_slot ->
+                      enqueue_slot_won t slot_won
+                        ~producer_public_key:
+                          (Public_key.compress slot_won.producer.public_key) ;
+                      loop None
+                  | Stale | Lost | Won _ ->
+                      loop None
+                else
+                  match slot_won with
+                  | Stale ->
+                      loop None
+                  | Lost ->
+                      [%log info] "Did not win slot $slot, took $time ms"
+                        ~metadata:
+                          [ ( "time"
+                            , `Float Time.(Span.to_ms (diff (now ()) start)) )
+                          ; ("slot", Slot.to_yojson slot)
+                          ] ;
+                      loop (next_slot generation state_version consensus_time)
+                  | Won slot_won ->
+                      [%log info] "Won a slot $slot, took $time ms"
+                        ~metadata:
+                          [ ( "time"
+                            , `Float Time.(Span.to_ms (diff (now ()) start)) )
+                          ; ("slot", Slot.to_yojson slot)
+                          ] ;
+                      enqueue_slot_won t slot_won
+                        ~producer_public_key:
+                          (Public_key.compress slot_won.producer.public_key) ;
+                      loop (next_slot generation state_version consensus_time) )
+          )
+    in
+    loop None
 
   let create config =
     { config
-    ; last_checked_slot_and_epoch = Public_key.Compressed.Table.create ()
-    ; slots_won =
-        Queue.create
-          ~capacity:
-            (Unsigned.UInt32.to_int config.consensus_constants.slots_per_epoch)
-          ()
-    ; current_slot = None
-    ; epoch_data = (Ivar.create (), None)
+    ; slots_won = Queue.create ~capacity:max_slots_won_queue_length ()
+    ; enqueued_wins = []
+    ; progress = Idle
+    ; epoch_data = None
     ; block_producer_keys = []
+    ; state_changed = Ivar.create ()
+    ; slots_won_capacity_available = Ivar.create ()
+    ; epoch_generation = 0
+    ; keys_generation = 0
+    ; state_version = 0
     }
 end
 
@@ -303,18 +491,24 @@ module Functions = struct
           [%log info]
             "Updating epoch data for the VRF evaluation for epoch $epoch"
             ~metadata:[ ("epoch", Epoch.to_yojson e.epoch) ] ;
-          let interrupt_ivar, _ = w.epoch_data in
-          Ivar.fill_if_empty interrupt_ivar () ;
-          Queue.clear w.slots_won ;
-          w.current_slot <- None ;
-          w.epoch_data <- (Ivar.create (), Some e) ;
-          Interruptible.don't_wait_for (Worker_state.evaluate w) ;
+          let reset_enqueued_wins =
+            match w.epoch_data with
+            | Some current ->
+                Epoch.(e.epoch > current.epoch)
+            | None ->
+                true
+          in
+          w.epoch_data <- Some e ;
+          w.epoch_generation <- Worker_state.next_generation w.epoch_generation ;
+          if reset_enqueued_wins then w.enqueued_wins <- [] ;
+          w.progress <- Worker_state.Idle ;
+          Worker_state.notify_state_changed w ;
           Deferred.unit
         in
         match w.epoch_data with
-        | _, None ->
+        | None ->
             update ()
-        | _, Some current ->
+        | Some current ->
             if Epoch.(succ e.epoch > current.epoch) then update ()
             else (
               [%log info]
@@ -329,13 +523,8 @@ module Functions = struct
           !"Slots won evaluator: %{sexp: Consensus.Data.Slot_won.t list}"
           slots_won ;
         Queue.clear w.slots_won ;
-        let evaluator_status =
-          match w.current_slot with
-          | Some slot ->
-              Evaluator_status.At slot
-          | None ->
-              Completed
-        in
+        Worker_state.notify_slots_won_capacity_available w ;
+        let evaluator_status = Worker_state.evaluator_status w in
         return Vrf_evaluation_result.{ slots_won; evaluator_status } )
 
   let update_block_producer_keys =
@@ -343,7 +532,8 @@ module Functions = struct
         let logger = w.config.logger in
         [%log info] "Updating block producer keys" ;
         w.block_producer_keys <- e ;
-        (*TODO: Interrupt the evaluation here when we handle key updated*)
+        w.keys_generation <- Worker_state.next_generation w.keys_generation ;
+        Worker_state.notify_state_changed w ;
         Deferred.unit )
 end
 
@@ -397,7 +587,9 @@ module Worker = struct
                ~log_filename:"mina-vrf-evaluator.log" ~max_size ~num_rotate )
           () ;
         [%log info] "Vrf_evaluator started" ;
-        return (Worker_state.create init_arg)
+        let worker_state = Worker_state.create init_arg in
+        don't_wait_for (Worker_state.run_loop worker_state) ;
+        return worker_state
 
       let init_connection_state ~connection:_ ~worker_state:_ = return
     end


### PR DESCRIPTION
* Fix VRF evaluator epoch-transition races by making stale scan handling explicit and pull-based.
* Preserve valid final-slot wins during epoch lookahead while invalidating scans when producer keys change.
* Remove `Interruptible` from the VRF evaluation path so long-lived cancelers cannot retain completed keypair/delegator evaluation state.
* Skip expired won slots before constructing block data from the current ledger snapshot.
* Add a release-note entry in `changes/18894.md`.
