### PR TITLE
Fix genesis_ledgers lookup for mesa_mut in hardfork package generation

### DIFF
--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -713,7 +713,8 @@ copy_common_daemon_post_automode_apps_and_configs() {
       else
         echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
         mkdir -p "${BUILDDIR}/var/lib/coda"
-        cp "../genesis_ledgers/${prefork_network}.json" \
+        # Genesis ledger files use hyphens, network names use underscores; convert before lookup.
+        cp "../genesis_ledgers/${prefork_network//_/-}.json" \
            "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
       fi
     else
@@ -849,6 +850,8 @@ build_daemon_generic_deb() {
 
 copy_common_daemon_hardfork_configs() {
   local NETWORK_NAME="${1}"
+  # Genesis ledger files use hyphens, network names use underscores; convert before lookup.
+  local ledger_name="${NETWORK_NAME//_/-}"
 
   # Copy build config and ledgers
   copy_common_daemon_configs ${NETWORK_NAME}
@@ -863,9 +866,9 @@ copy_common_daemon_hardfork_configs() {
   done
 
   # Copy older genesis ledger as .old.json for backwards compatibility
-  cp "../genesis_ledgers/${NETWORK_NAME}.json" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.old.json"
+  cp "../genesis_ledgers/${ledger_name}.json" "${BUILDDIR}/var/lib/coda/${ledger_name}.old.json"
 
-  cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/var/lib/coda/${NETWORK_NAME}.json"
+  cp "${RUNTIME_CONFIG_JSON}" "${BUILDDIR}/var/lib/coda/${ledger_name}.json"
 }
 
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -404,6 +404,8 @@ SVCEOF
     echo '{"genesis": "mainnet"}' > "${PROJECT_ROOT}/genesis_ledgers/mainnet.json"
     echo '{"genesis": "devnet"}' > "${PROJECT_ROOT}/genesis_ledgers/devnet.json"
     echo '{"genesis": "mesa"}' > "${PROJECT_ROOT}/genesis_ledgers/mesa.json"
+    # Genesis ledger filename uses a hyphen while the bash network name uses an underscore (mesa_mut)
+    echo '{"genesis": "mesa-mut"}' > "${PROJECT_ROOT}/genesis_ledgers/mesa-mut.json"
 
     # rosetta scripts and configs
     create_mock_exe "src/app/rosetta/scripts/run.sh" "$PROJECT_ROOT"
@@ -984,6 +986,39 @@ test_build_daemon_mainnet_hardfork_config_deb() {
     unset RUNTIME_CONFIG_JSON LEDGER_TARBALLS
 }
 
+test_build_daemon_mesa_mut_hardfork_config_deb() {
+    # Regression test: the bash network name uses an underscore (mesa_mut) but the
+    # genesis ledger file on disk uses a hyphen (mesa-mut.json). The hardfork config
+    # path must convert before lookup, otherwise it fails with
+    #   cp: cannot stat '../genesis_ledgers/mesa_mut.json'
+    export RUNTIME_CONFIG_JSON="${TEST_TMPDIR}/fork_config.json"
+    export LEDGER_TARBALLS="${TEST_TMPDIR}/ledger1.tar.gz ${TEST_TMPDIR}/ledger2.tar.gz"
+
+    safe_build build_daemon_hardfork_config_deb mesa_mut || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+    assert_eq "deb name" "mina-mesa-mut-config" "$CAPTURED_DEB_NAME"
+    assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mesa-mut-config"
+    assert_control_field "$CAPTURED_CONTROL" "Architecture" "all"
+
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
+        "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json" '{"fork": true}'
+
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/ledger1.tar.gz"
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/ledger2.tar.gz"
+
+    # Old genesis ledger backup resolves the hyphenated source and is written with a hyphen
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/mesa-mut.old.json"
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" "var/lib/coda/mesa-mut.old.json" "mesa-mut"
+
+    # mesa-mut.json replaced with fork config (hyphenated destination)
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/mesa-mut.json"
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" "var/lib/coda/mesa-mut.json" '{"fork": true}'
+
+    unset RUNTIME_CONFIG_JSON LEDGER_TARBALLS
+}
+
 ################################################################################
 # Tests: Architecture restoration after config packages
 ################################################################################
@@ -1264,6 +1299,7 @@ main() {
     # Hardfork config packages
     run_test test_build_daemon_devnet_hardfork_config_deb
     run_test test_build_daemon_mainnet_hardfork_config_deb
+    run_test test_build_daemon_mesa_mut_hardfork_config_deb
 
     # Utility packages
     run_test test_build_zkapp_test_transaction_deb


### PR DESCRIPTION
## Problem

The `hardfork-package-generation-new` pipeline (build 1193 on `mesa-mut`) failed in the "Create hardfork packages" job (target `daemon_mesa-mut_hardfork_config`) with:

```
copy_common_daemon_configs inputs:
Network Name: mesa_mut
cp: cannot stat '../genesis_ledgers/mesa_mut.json': No such file or directory
```

## Root cause

Genesis ledger files on disk use hyphens (`genesis_ledgers/mesa-mut.json`), but bash-side network names use underscores (`mesa_mut`).

A prior commit (`8a637fd3f9`) fixed this underscore/hyphen mismatch in `copy_common_daemon_configs` by converting `_`→`-` (`local ledger_name="${NETWORK_NAME//_/-}"`). However, two sibling call sites that also look up `genesis_ledgers/<network>.json` were never converted and still used the raw underscore name:

1. `copy_common_daemon_hardfork_configs()` — the call site that fails build 1193 (the `.old.json` source/dest and the `.json` dest).
2. The prefork automode path in `copy_common_daemon_post_automode_apps_and_configs()` (the `config_<hash>.json` source).

## Fix

Mirror the prior fix exactly:

- In `copy_common_daemon_hardfork_configs`, add `local ledger_name="${NETWORK_NAME//_/-}"` and use it for the genesis-ledger source as well as the `.old.json` / `.json` destination filenames, so on-disk names stay consistent with what `copy_common_daemon_configs` already writes (`mesa-mut.json`).
- In the prefork automode path, convert `prefork_network` before the `genesis_ledgers` lookup (destination is hash-based and left unchanged).

Behavior is unchanged for networks without underscores (`devnet`/`mainnet`/`mesa`), since `${name//_/-}` is a no-op for them.

Adds a focused `test_build_daemon_mesa_mut_hardfork_config_deb` unit test asserting the hyphenated `mesa-mut.json` source and destination resolve correctly.

## Validation

- `scripts/debian/tests/test_builder_helpers.sh`: 38 tests, 328 assertions, all pass (was 37/317 before).
- `shellcheck scripts/debian/builder-helpers.sh`: no new warnings (3 pre-existing on base: SC1090 line 19, SC1004 line 374, SC2086 line 857).
- `bash -n scripts/debian/builder-helpers.sh`: parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)