### PR TITLE
Fix some dev unit test race

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -45,10 +45,11 @@ fi
 
 # Note: By attempting a re-run on failure here, we can avoid rebuilding and
 # skip running all of the tests that have already succeeded, since dune will
-# only retry those tests that failed.
+# only retry those tests that failed. Do not pass --force to the retry: it
+# forces Dune to rerun the whole test suite, including tests that already passed.
 echo "--- Run unit tests"
 time dune runtest ${FORCE_FLAG} "${path}" || \
 (./scripts/link-coredumps.sh && \
  echo "--- Retrying failed unit tests" && \
- time dune runtest ${FORCE_FLAG} "${path}" || \
+ time dune runtest "${path}" || \
  (./scripts/link-coredumps.sh && false))

--- a/src/lib/allocation_functor/table.ml
+++ b/src/lib/allocation_functor/table.ml
@@ -52,8 +52,8 @@ module Allocation_data = struct
   let unregister_allocation data id =
     Queue.filter_inplace data.allocation_times ~f:(fun (id', _) -> id = id')
 
-  let compute_statistics { allocation_times; _ } =
-    let now = Time.now () in
+  let compute_statistics ?now { allocation_times; _ } =
+    let now = Option.value now ~default:(Time.now ()) in
     let count = Queue.length allocation_times in
     let lifetime_ms_of_time time = Time.Span.to_ms (Time.diff now time) in
     let get_lifetime_ms i =
@@ -89,8 +89,8 @@ module Allocation_data = struct
     in
     Allocation_statistics.{ count; lifetimes }
 
-  let compute_statistics t =
-    try compute_statistics t
+  let compute_statistics ?now t =
+    try compute_statistics ?now t
     with _ ->
       Allocation_statistics.
         { count = 0; lifetimes = Allocation_statistics.make_quartiles 0. }
@@ -119,7 +119,7 @@ module Allocation_data = struct
           ; next_allocation_id = 0
           }
         in
-        let stats = compute_statistics data in
+        let stats = compute_statistics ~now data in
         [%test_eq: int] stats.count (List.length time_offsets) ;
         [%test_eq: robust_float] stats.lifetimes.q1 expected_quartiles.q1 ;
         [%test_eq: robust_float] stats.lifetimes.q2 expected_quartiles.q2 ;


### PR DESCRIPTION
## Summary

- Avoid passing `--force` when retrying failed unit tests in Buildkite, so Dune can retry only failed test rules instead of rerunning the full suite.
- Stabilize `allocation_functor` lifetime-statistics inline tests by using the same reference time for fixture construction and statistics computation.

## Motivation

The nightly dev unit-test log showed multiple flaky failures. The CI retry script intended to rerun only failed tests, but coverage nightlies set `FORCE_FLAG=--force` and reused it on retry. That forced Dune to rerun already-passing tests and exposed unrelated slow/flaky tests during the retry.

The same log also showed a deterministic test bug in `src/lib/allocation_functor/table.ml`, where expected allocation lifetimes were derived from one `Time.now ()` while `compute_statistics` sampled another. Under CI load, the elapsed time between those calls exceeded the test tolerance and caused false failures.
