### PR TITLE
fix: clean up transition processing waiters

### DIFF
--- a/changes/18903.md
+++ b/changes/18903.md
@@ -1,0 +1,1 @@
+Daemon: reduce memory growth during block production and transition processing, especially when the node is overloaded or drops delayed transitions.

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -987,10 +987,13 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
               [%log internal] "Wait_for_confirmation" ;
               [%log debug] ~metadata
                 "Waiting for block $state_hash to be inserted into frontier" ;
+              let registration =
+                Transition_registry.register transition_registry
+                  protocol_state_hashes.state_hash
+              in
               Deferred.choose
                 [ Deferred.choice
-                    (Transition_registry.register transition_registry
-                       protocol_state_hashes.state_hash )
+                    (Transition_registry.wait registration)
                     (Fn.const (Ok `Transition_accepted))
                 ; Deferred.choice
                     ( Block_time.Timeout.create time_controller
@@ -1010,6 +1013,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                 ]
               >>= function
               | `Transition_accepted ->
+                  Transition_registry.unregister registration ;
                   [%log internal] "Transition_accepted" ;
                   [%log info] ~metadata
                     "Generated transition $state_hash was accepted into \
@@ -1023,6 +1027,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                   (* FIXME #3167: this should be fatal, and more
                      importantly, shouldn't happen.
                   *)
+                  Transition_registry.unregister registration ;
                   [%log internal] "Transition_accept_timeout" ;
                   let msg : (_, unit, string, unit) format4 =
                     "Timed out waiting for generated transition $state_hash to \
@@ -1534,10 +1539,13 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
           in
           [%log debug] ~metadata
             "Waiting for block $state_hash to be inserted into frontier" ;
+          let registration =
+            Transition_registry.register transition_registry
+              protocol_state_hashes.state_hash
+          in
           Deferred.choose
             [ Deferred.choice
-                (Transition_registry.register transition_registry
-                   protocol_state_hashes.state_hash )
+                (Transition_registry.wait registration)
                 (Fn.const (Ok `Transition_accepted))
             ; Deferred.choice
                 ( Block_time.Timeout.create time_controller
@@ -1548,6 +1556,7 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
             ]
           >>= function
           | `Transition_accepted ->
+              Transition_registry.unregister registration ;
               [%log info] ~metadata
                 "Generated transition $state_hash was accepted into transition \
                  frontier" ;
@@ -1556,6 +1565,7 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
               (* FIXME #3167: this should be fatal, and more importantly,
                  shouldn't happen.
               *)
+              Transition_registry.unregister registration ;
               [%log fatal] ~metadata
                 "Timed out waiting for generated transition $state_hash to \
                  enter transition frontier. Continuing to produce new blocks \

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -4,18 +4,36 @@ open Mina_base
 open Frontier_base
 
 module T = struct
-  type t = unit Ivar.t list State_hash.Table.t
+  type waiters = unit Ivar.t Int.Table.t
+
+  type t = { mutable next_id : int; waiters : waiters State_hash.Table.t }
+
+  type registration = { wait : unit Deferred.t; unregister : unit -> unit }
 
   type view = unit
 
   let name = "transition_registry"
 
-  let create ~logger:_ _frontier = (State_hash.Table.create (), ())
+  let create ~logger:_ _frontier =
+    ({ next_id = 0; waiters = State_hash.Table.create () }, ())
+
+  let advance_next_id t =
+    let id = t.next_id in
+    t.next_id <- (if Int.equal id Int.max_value then 0 else id + 1) ;
+    id
+
+  let rec fresh_id t waiters =
+    let id = advance_next_id t in
+    if Hashtbl.mem waiters id then fresh_id t waiters else id
+
+  let find_or_add_waiters t state_hash =
+    State_hash.Table.find_or_add t.waiters state_hash ~default:(fun () ->
+        Int.Table.create () )
 
   let notify t state_hash =
-    State_hash.Table.change t state_hash ~f:(function
-      | Some ls ->
-          List.iter ls ~f:(fun ivar ->
+    State_hash.Table.change t.waiters state_hash ~f:(function
+      | Some waiters ->
+          Hashtbl.iter waiters ~f:(fun ivar ->
               if Ivar.is_full ivar then
                 [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
               Ivar.fill ivar () ) ;
@@ -23,13 +41,30 @@ module T = struct
       | None ->
           None )
 
+  let unregister_id t state_hash id =
+    State_hash.Table.change t.waiters state_hash ~f:(function
+      | Some waiters ->
+          Hashtbl.remove waiters id ;
+          if Hashtbl.is_empty waiters then None else Some waiters
+      | None ->
+          None )
+
   let register t state_hash =
-    Deferred.create (fun ivar ->
-        State_hash.Table.update t state_hash ~f:(function
-          | Some ls ->
-              ivar :: ls
-          | None ->
-              [ ivar ] ) )
+    let ivar = Ivar.create () in
+    let waiters = find_or_add_waiters t state_hash in
+    let id = fresh_id t waiters in
+    Hashtbl.add_exn waiters ~key:id ~data:ivar ;
+    let unregistered = ref false in
+    let unregister () =
+      if not !unregistered then (
+        unregistered := true ;
+        if not (Ivar.is_full ivar) then unregister_id t state_hash id )
+    in
+    { wait = Ivar.read ivar; unregister }
+
+  let wait { wait; _ } = wait
+
+  let unregister { unregister; _ } = unregister ()
 
   let handle_diffs transition_registry _ diffs_with_mutants =
     List.iter diffs_with_mutants ~f:(function

--- a/src/lib/transition_frontier/extensions/transition_registry.mli
+++ b/src/lib/transition_frontier/extensions/transition_registry.mli
@@ -3,4 +3,10 @@ open Mina_base
 
 include Intf.Extension_intf with type view = unit
 
-val register : t -> State_hash.t -> unit Deferred.t
+type registration
+
+val register : t -> State_hash.t -> registration
+
+val wait : registration -> unit Deferred.t
+
+val unregister : registration -> unit

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -35,7 +35,16 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
           @@ Network_peer.Envelope.Incoming.data h
     in
     Mina_block.handle_dropped_transition hashes ?valid_cb ~pipe_name:name
-      ~logger
+      ~logger ;
+    match head with
+    | `Block b ->
+        let (_ : Mina_block.initial_valid_block Network_peer.Envelope.Incoming.t)
+            =
+          Cache_lib.Cached.invalidate_with_failure b
+        in
+        ()
+    | `Header _ ->
+        ()
   in
   let valid_transition_reader, valid_transition_writer =
     let name = "valid transitions" in


### PR DESCRIPTION
## Summary

This fixes two OCaml-side retention paths in transition processing:

- Cleans up `Transition_registry` waiters when produced-block frontier insertion waits time out.
- Explicitly invalidates cached block transitions when bounded transition pipes drop them.

## Problem

`Transition_registry.register` previously returned only a deferred backed by an `Ivar.t` stored in a `State_hash.Table`. The block producer races that deferred against a timeout while waiting for a generated block to enter the transition frontier. If the timeout won and the block was never later notified through the registry, the ivar stayed registered indefinitely under that state hash.

The transition frontier controller also dropped cached block transitions from bounded pipes without explicitly finalizing the cache entry. That left cleanup to GC finalizers instead of removing the block from `Unprocessed_transition_cache` at the point where the transition was known to be dropped.

Both paths can keep OCaml heap objects reachable longer than intended and match the kind of post-GC baseline growth seen in runtime memory graphs.

## Solution

- Introduce an abstract `Transition_registry.registration` handle with:
  - `wait : registration -> unit Deferred.t`
  - `unregister : registration -> unit`
- Store transition-registry waiters by generated registration id instead of list position/object identity.
- Use a per-state-hash id-to-ivar table so unregister can remove an exact waiter without `phys_equal`.
- Use the registration handle in normal and precomputed block production.
- Call `Transition_registry.unregister` after both accepted and timed-out frontier insertion waits.
- Invalidate dropped cached block transitions with `Cache_lib.Cached.invalidate_with_failure` in the transition frontier controller drop-head handler.
- Leave header drops unchanged because headers are not stored in `Unprocessed_transition_cache`.
