### PR TITLE
fix: clear stale catchup jobs

### DIFF
--- a/changes/18906.md
+++ b/changes/18906.md
@@ -1,0 +1,1 @@
+Daemon: reduce memory growth during catchup when transition frontier updates invalidate stale catchup jobs.

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1026,9 +1026,10 @@ let setup_state_machine_runner ~context:(module Context : CONTEXT) ~t ~verifier
                  Option.value_map valid_cb ~default:ignore
                    ~f:Mina_net2.Validation_callback.fire_if_not_already_fired
                    `Ignore ;
-                 ignore
-                   ( Cached.invalidate_with_failure av
-                     : Mina_block.almost_valid_block Envelope.Incoming.t ) ;
+                 if not (Cached.was_consumed av) then
+                   ignore
+                     ( Cached.invalidate_with_failure av
+                       : Mina_block.almost_valid_block Envelope.Incoming.t ) ;
                  finish t node ~is_error:true ;
                  Error `Finished )
         in

--- a/src/lib/transition_frontier/full_catchup_tree.ml
+++ b/src/lib/transition_frontier/full_catchup_tree.ml
@@ -316,9 +316,13 @@ let remove_node' t (node : Node.t) =
   match node.state with
   | Root _ | Failed | Finished ->
       ()
-  | Wait_for_parent _ ->
-      (* cache invalidation for this case is handled explicitly in the super catchup fstm *)
-      ()
+  | Wait_for_parent (c, vc) ->
+      Option.value_map ~default:ignore
+        ~f:Mina_net2.Validation_callback.fire_if_not_already_fired vc `Ignore ;
+      if not (Cached.was_consumed c) then
+        ignore
+          ( Cached.invalidate_with_failure c
+            : Mina_block.almost_valid_block Envelope.Incoming.t )
   | To_download _job ->
       (* TODO: Cancel job somehow *)
       ()
@@ -362,6 +366,8 @@ let prune t ~root_hash =
   in
   List.iter to_remove ~f:(remove_node' t)
 
+let clear t = Hashtbl.data t.nodes |> List.iter ~f:(remove_node' t)
+
 let apply_diffs (t : t) (ds : Diff.Full.E.t list) =
   List.iter ds ~f:(function
     | E (New_node (Full b)) ->
@@ -375,9 +381,9 @@ let apply_diffs (t : t) (ds : Diff.Full.E.t list) =
             ~metadata:
               [ ("hash", State_hash.to_yojson h); ("tree", to_yojson t) ]
             "catchup $tree invariant broken: new root $hash not present. Diffs \
-             may have been applied out of order. This may lead to a memory \
-             leak" ;
-          () )
+             may have been applied out of order. Clearing catchup state to \
+             avoid retaining stale jobs" ;
+          clear t )
     | E (Best_tip_changed _) ->
         () )
 


### PR DESCRIPTION
## Summary

Fix a catchup-state memory retention path when the transition frontier moves its root to a block that is not present in the full catchup tree.

The daemon now clears stale full-catchup jobs in that broken-root case and explicitly releases cached blocks held by `Wait_for_parent` catchup nodes.

## Bug

`Full_catchup_tree.apply_diffs` handles `Root_transitioned` diffs by pruning catchup jobs relative to the new transition-frontier root. That pruning assumes the new root hash is already present in the catchup tree.

When the new root was missing, the old behavior logged the invariant violation and then returned without modifying the catchup tree.

At that point the catchup tree no longer has a reliable root anchor. Since pruning depends on walking parent links back to the root, stale detached catchup jobs can remain reachable through `t.nodes` and `t.states`. Those jobs may retain cached transition data, validation callbacks, downloader jobs, and async state-machine closures.

There was also a cleanup gap for `Wait_for_parent` nodes. `remove_node'` did not invalidate the cached almost-valid block in that state because it relied on the super-catchup state machine to handle parent-failure cleanup. Full-tree removal can bypass that path, so a removed `Wait_for_parent` node could keep its cached block alive until GC/finalization instead of releasing it immediately.

## How It Can Be Triggered

The normal in-memory path is ordered so the catchup tree sees `New_node` before the corresponding `Root_transitioned` diff. In that case the invariant holds.

A realistic broken case can happen after loading a persisted frontier from disk:

1. The daemon loads a full transition frontier from disk, for example containing `R -> A -> B -> C`.
2. The catchup state is created only from the current frontier root, so it starts with `R` but not necessarily the already-loaded descendants `A`, `B`, or `C`.
3. A new block `D` is added, extending the full frontier to `R -> A -> B -> C -> D`.
4. Adding `D` pushes the full frontier past its max length, so the full frontier emits `Root_transitioned(new_root = A)`.
5. `A` exists in the full frontier, but it was never inserted into the catchup tree because it came from persisted frontier loading.
6. `Full_catchup_tree.apply_diffs` receives the root-transition diff and cannot find `A` in `t.nodes`.

The same invariant can also break if a future path applies or replays diffs out of order, for example applying `Root_transitioned(new_root = A)` before `New_node(A)`, or if catchup state otherwise diverges from the full frontier.

## Fix

When `Root_transitioned` references a missing root, `Full_catchup_tree.apply_diffs` now clears the catchup tree instead of leaving stale jobs retained.

The cleanup goes through `remove_node'`, so pending node results are failed/cancelled consistently with existing removal logic.

`remove_node'` now also handles `Wait_for_parent` nodes by:

- firing the validation callback with `Ignore`
- invalidating the cached almost-valid block if it has not already been consumed

The super-catchup parent-failure path now checks `Cached.was_consumed` before invalidating the same cached block. This prevents double-finalization if a node was cancelled/removed while a parent-result callback is still pending.

