### PR TITLE
ci: chain-id test runs from bare binary instead of debian package (pi…

### DIFF
--- a/buildkite/scripts/test-chain-id.sh
+++ b/buildkite/scripts/test-chain-id.sh
@@ -8,15 +8,71 @@ EXPECTED_CHAIN_ID=$2
 echo "--- Testing chain_id command for ${MINA_DEBIAN_NETWORK}"
 
 git config --global --add safe.directory /workdir
-source buildkite/scripts/debian/update.sh --verbose
 source buildkite/scripts/export-git-env-vars.sh
-source buildkite/scripts/debian/install.sh "mina-${MINA_DEBIAN_NETWORK}" 1
 
-echo "--- Running mina chain-id command"
+# Codename of the build whose artifacts we consume. The ChainIdTest jobs depend
+# on the Bullseye build, but honour an override if one is set in the env.
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
 
-MINA_CONFIG_FILE="${MINA_CONFIG_FILE:-/var/lib/coda/${MINA_DEBIAN_NETWORK}.json}"
+# In-repo runtime config carrying the precomputed ledger/epoch hashes. This is
+# all `chain-id --from-config-hashes-only` needs; it never materialises the
+# genesis ledger tarball.
+CONFIG_FILE="genesis_ledgers/${MINA_DEBIAN_NETWORK}.json"
 
-ACTUAL_CHAIN_ID=$(mina internal chain-id --config-file ${MINA_CONFIG_FILE} | tail -n1)
+# Signature variant of the daemon binary for this network. Mirrors
+# signature_of_network() in scripts/debian/builder-helpers.sh.
+case "$MINA_DEBIAN_NETWORK" in
+  mainnet) SIGNATURE=mainnet ;;
+  devnet | mesa) SIGNATURE=testnet ;;
+  *)
+    echo "Unknown network name provided: ${MINA_DEBIAN_NETWORK}" >&2
+    exit 1
+    ;;
+esac
+
+# Try to set up the bare-binary path: restore the freshly-built daemon binary
+# from the apps/<codename> CI cache (populated by
+# buildkite/scripts/apps/write_to_cache.sh) and confirm it supports the
+# hashes-only chain-id mode. Returns non-zero if the binary is unavailable or
+# too old, so the caller can fall back to the .deb.
+BARE_EXE=""
+prepare_bare() {
+  local exe_name="mina_${SIGNATURE}_signatures.exe"
+  local dest="./_chain_id_bare"
+  mkdir -p "$dest"
+
+  if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${exe_name}" "$dest"; then
+    echo "..bare binary apps/${CODENAME}/${exe_name} not found in CI cache" >&2
+    return 1
+  fi
+
+  local exe="${dest}/${exe_name}"
+  chmod +x "$exe" 2>/dev/null || true
+
+  # --from-config-hashes-only lets us compute chain_id without unpacking the
+  # genesis ledger. It is not present on every release branch yet, so probe for
+  # it and fall back to the .deb path when absent.
+  if ! "$exe" internal chain-id --help 2>&1 | grep -q -- '--from-config-hashes-only'; then
+    echo "..binary lacks --from-config-hashes-only; falling back to debian package" >&2
+    return 1
+  fi
+
+  BARE_EXE="$exe"
+}
+
+if [[ -v BUILDKITE_BUILD_ID ]] && prepare_bare; then
+  echo "--- Running mina chain-id command (bare binary, no debian package)"
+  ACTUAL_CHAIN_ID=$("$BARE_EXE" internal chain-id \
+    --config-file "$CONFIG_FILE" \
+    --from-config-hashes-only | tail -n1)
+else
+  echo "--- Running mina chain-id command (debian package fallback)"
+  source buildkite/scripts/debian/update.sh --verbose
+  source buildkite/scripts/debian/install.sh "mina-${MINA_DEBIAN_NETWORK}" 1
+
+  MINA_CONFIG_FILE="${MINA_CONFIG_FILE:-/var/lib/coda/${MINA_DEBIAN_NETWORK}.json}"
+  ACTUAL_CHAIN_ID=$(mina internal chain-id --config-file "${MINA_CONFIG_FILE}" | tail -n1)
+fi
 
 echo "Expected Chain ID: ${EXPECTED_CHAIN_ID}"
 echo "Actual Chain ID: ${ACTUAL_CHAIN_ID}"

--- a/buildkite/src/Command/ChainIdTest.dhall
+++ b/buildkite/src/Command/ChainIdTest.dhall
@@ -69,10 +69,6 @@ let makeTest =
                     { ancestor = MainlineBranch.Type.Mesa
                     , reason = "Mesa does not support this test yet"
                     }
-                , Expr.Type.DescendantOf
-                    { ancestor = MainlineBranch.Type.Develop
-                    , reason = "Develop does not support this test"
-                    }
                 ]
               }
             , steps = [ buildTestStep network expectedChainId deps ]

--- a/buildkite/src/Command/ChainIdTest.dhall
+++ b/buildkite/src/Command/ChainIdTest.dhall
@@ -16,8 +16,6 @@ let Size = ../Command/Size.dhall
 
 let Network = ../Constants/Network.dhall
 
-let MainlineBranch = ../Pipeline/MainlineBranch.dhall
-
 let Expr = ../Pipeline/Expr.dhall
 
 let DebianVersions = ../Constants/DebianVersions.dhall
@@ -64,12 +62,7 @@ let makeTest =
                 , PipelineTag.Type.Stable
                 ]
               , scope = scope
-              , excludeIf =
-                [ Expr.Type.DescendantOf
-                    { ancestor = MainlineBranch.Type.Mesa
-                    , reason = "Mesa does not support this test yet"
-                    }
-                ]
+              , excludeIf = [] : List Expr.Type
               }
             , steps = [ buildTestStep network expectedChainId deps ]
             }

--- a/buildkite/src/Jobs/Test/ChainIdTestDevnet.dhall
+++ b/buildkite/src/Jobs/Test/ChainIdTestDevnet.dhall
@@ -1,4 +1,4 @@
-let Dockers = ../../Constants/DockerVersions.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
@@ -13,8 +13,12 @@ let scopes = [ PipelineScope.Type.PullRequest ]
 let network = Network.Type.Devnet
 
 let deps =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Devnet }
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = network
+        , profile = Profile.Type.Devnet
+        }
 
 let expectedChainId =
       "8c6312664c60ecc4c0c695e69f6301692c0b20f354b55e08e69a289f3d373e50"

--- a/buildkite/src/Jobs/Test/ChainIdTestMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ChainIdTestMainnet.dhall
@@ -1,4 +1,4 @@
-let Dockers = ../../Constants/DockerVersions.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
@@ -13,8 +13,12 @@ let scopes = [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
 let network = Network.Type.Mainnet
 
 let deps =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = network
+        , profile = Profile.Type.Mainnet
+        }
 
 let expectedChainId =
       "6bc1d75e39f3bbe2bd0418160775c6655d5854c1121dc5044c70e4481e4476c0"

--- a/buildkite/src/Jobs/Test/ChainIdTestMesa.dhall
+++ b/buildkite/src/Jobs/Test/ChainIdTestMesa.dhall
@@ -1,4 +1,4 @@
-let Dockers = ../../Constants/DockerVersions.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
@@ -13,8 +13,12 @@ let scopes = [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
 let network = Network.Type.Mesa
 
 let deps =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Devnet }
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{
+        , deb_version = DebianVersions.DebVersion.Bullseye
+        , network = network
+        , profile = Profile.Type.Devnet
+        }
 
 let expectedChainId =
       "c0b179da879e26cfd2aa118282ca148d2eaa0a13041c789bcac5a92c7dccf6ce"


### PR DESCRIPTION
…lot)

Experiment to validate consuming freshly-built bare binaries from the apps/<codename> CI cache instead of installing a .deb, removing the docker/debian round-trip from the test's critical path.

- test-chain-id.sh: restore mina_<sig>_signatures.exe from the apps/<codename> cache and compute chain_id via `internal chain-id --from-config-hashes-only` against the in-repo genesis_ledgers/<network>.json. No .deb, no S3 ledger download, no /var/lib/coda. Falls back to the original .deb path when the binary is absent or predates the flag (e.g. on compatible).
- ChainIdTest{Devnet,Mainnet,Mesa}.dhall: depend on the build-deb-pkg job (which writes the apps cache) instead of the docker image, dropping the docker build from the dependency chain.

TEMPORARY: ChainIdTest's "DescendantOf Develop" exclusion is dropped so the test runs on this develop-based branch to validate the bare path. Restore it before merge.

### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
*

Explain how you tested your changes:
*

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
