### PR TITLE
ci: namespace apps cache by build variant

### DIFF
--- a/buildkite/scripts/apps/write_to_cache.sh
+++ b/buildkite/scripts/apps/write_to_cache.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
+# Writes the freshly-built application binaries to the CI cache under
+#   apps/<codename>/<variant>/
+# where <variant> identifies the build (network-profile[-instrumented][-arm64]).
+#
+# The variant depth is required: several builds share a codename and produce
+# identically-named binaries (e.g. mina_testnet_signatures.exe is emitted by the
+# devnet, mesa and instrumented builds alike). Without the variant they would
+# overwrite each other in apps/<codename>/, leaving whichever build finished last
+# -- a non-deterministic, wrong artifact for any consumer.
+
 CODENAME=$1
+VARIANT=$2
+
+if [[ -z "$CODENAME" || -z "$VARIANT" ]]; then
+  echo "Usage: $0 <codename> <variant>" >&2
+  exit 1
+fi
 
 find _build -type f -name "*.exe" | while read -r entry; do
   # Exclude files ending with ppx.exe
@@ -8,5 +24,5 @@ find _build -type f -name "*.exe" | while read -r entry; do
     continue
   fi
 
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$entry" "apps/${CODENAME}"
+  ./buildkite/scripts/cache/manager.sh write-to-dir "$entry" "apps/${CODENAME}/${VARIANT}"
 done

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -150,7 +150,11 @@ let build_artifacts
                                                                         spec.debVersion}"
                   , Cmd.run
                       "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                      spec.debVersion}"
+                                                                      spec.debVersion} ${Network.lowerName
+                                                                                           spec.network}-${Profiles.toSuffixLowercase
+                                                                                                             spec.profile}${BuildFlags.toLabelSegment
+                                                                                                                              spec.buildFlags}${Arch.toSuffixLowercase
+                                                                                                                                                  spec.arch}"
                   ]
             , label = "Debian: Build ${labelSuffix spec}"
             , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"


### PR DESCRIPTION
## Problem

`apps/write_to_cache.sh` wrote every build's binaries into `apps/<codename>/`. Builds that share a codename but differ in network/profile/buildflag — e.g. devnet, mesa and devnet-instrumented all emit `mina_testnet_signatures.exe` — overwrote each other with `cp -f`, leaving whichever build finished **last**. Any consumer of the cache got a non-deterministic, possibly wrong binary.

(The cache has had no real consumer until now, so this was latent — but it blocks using the apps cache as a deterministic artifact source.)

## Fix

Add a required `<variant>` depth so each build writes to
`apps/<codename>/<network>-<profile>[-instrumented][-arm64]/`, derived in `MinaArtifact.dhall` from the build spec. Consumers can now address a specific build variant deterministically.

Renders verified, e.g.:
- `apps/write_to_cache.sh bullseye devnet-devnet`
- `apps/write_to_cache.sh bullseye mesa-devnet`
- `apps/write_to_cache.sh bullseye devnet-devnet-instrumented`

`make all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)