### PR TITLE
ci: VersionLint runs from bare binary instead of .deb (pilot)

### DIFF
--- a/buildkite/scripts/apps/restore_binary.sh
+++ b/buildkite/scripts/apps/restore_binary.sh
@@ -1,40 +1,75 @@
 #!/bin/bash
 
-# Restore a single freshly-built executable from the namespaced apps CI cache
-# (written by buildkite/scripts/apps/write_to_cache.sh) into a local directory.
+# Restore the freshly-built mina daemon binary for a network from the namespaced
+# apps CI cache (written by buildkite/scripts/apps/write_to_cache.sh) and install
+# it as `mina` on PATH -- mirroring the .deb -- so callers invoke `mina`
+# identically whether it came from the cache or a package.
 #
-# Usage: restore_binary.sh <codename> <variant> <exe_name> <dest_dir>
-#   <variant> is the build identity: network-profile[-instrumented][-arm64].
+# Usage: restore_binary.sh <network>      (network: devnet | mainnet | mesa)
 #
-# On success prints the path to the restored, executable binary on stdout and
-# exits 0. Exits non-zero if not in Buildkite context or the binary is absent,
-# so callers can fall back to installing the debian package.
+# The cache location is derived from the build identity, so callers don't repeat
+# the variant string:
+#   apps/<codename>/<network>-<profile>[-instrumented][-arm64]/mina_<sig>_signatures.exe
+# with
+#   codename : $MINA_DEB_CODENAME (default bullseye)
+#   profile  : $APPS_PROFILE      (default: devnet/mesa -> devnet, mainnet -> mainnet)
+#   flag     : $APPS_BUILD_FLAG   ("instrumented" appends -instrumented; default none)
+#   arch     : $APPS_ARCH         ("arm64" appends -arm64; default amd64)
+#   sig      : devnet/mesa -> testnet, mainnet -> mainnet
+# The signature-specific binary is installed as plain `mina`, so client scripts
+# never deal with the variant or the signature name.
+#
+# Installs to ${MINA_BIN_DIR:-/usr/local/bin}/mina (using sudo when not root).
+# Exits non-zero without side effects if not in Buildkite context or the binary
+# is not cached, so callers can fall back to installing the .deb.
 
 set -eo pipefail
 
-if [[ $# -ne 4 ]]; then
-  echo "Usage: $0 <codename> <variant> <exe_name> <dest_dir>" >&2
+NETWORK=$1
+
+if [[ -z "$NETWORK" ]]; then
+  echo "Usage: $0 <network>" >&2
   exit 1
 fi
-
-CODENAME=$1
-VARIANT=$2
-EXE=$3
-DEST=$4
 
 if [[ ! -v BUILDKITE_BUILD_ID ]]; then
   echo "restore_binary: not in Buildkite context" >&2
   exit 1
 fi
 
-mkdir -p "$DEST"
+case "$NETWORK" in
+  devnet | mesa) sig=testnet ; default_profile=devnet ;;
+  mainnet) sig=mainnet ; default_profile=mainnet ;;
+  *)
+    echo "restore_binary: unknown network '$NETWORK'" >&2
+    exit 1
+    ;;
+esac
 
-# Send the cache manager's own stdout to stderr so the only thing on our stdout
-# is the resolved binary path.
-if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$DEST" >&2; then
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
+PROFILE="${APPS_PROFILE:-$default_profile}"
+
+flag_seg=""
+[[ "${APPS_BUILD_FLAG:-}" == "instrumented" ]] && flag_seg="-instrumented"
+arch_seg=""
+[[ "${APPS_ARCH:-amd64}" == "arm64" ]] && arch_seg="-arm64"
+
+VARIANT="${NETWORK}-${PROFILE}${flag_seg}${arch_seg}"
+EXE="mina_${sig}_signatures.exe"
+BIN_DIR="${MINA_BIN_DIR:-/usr/local/bin}"
+
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$TMP_DIR" >&2; then
   echo "restore_binary: apps/${CODENAME}/${VARIANT}/${EXE} not found in cache" >&2
   exit 1
 fi
 
-chmod +x "${DEST}/${EXE}" 2>/dev/null || true
-echo "${DEST}/${EXE}"
+$SUDO install -D -m 0755 "${TMP_DIR}/${EXE}" "${BIN_DIR}/mina"
+echo "restore_binary: installed ${EXE} as ${BIN_DIR}/mina" >&2

--- a/buildkite/scripts/apps/restore_binary.sh
+++ b/buildkite/scripts/apps/restore_binary.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Restore a single freshly-built executable from the namespaced apps CI cache
+# (written by buildkite/scripts/apps/write_to_cache.sh) into a local directory.
+#
+# Usage: restore_binary.sh <codename> <variant> <exe_name> <dest_dir>
+#   <variant> is the build identity: network-profile[-instrumented][-arm64].
+#
+# On success prints the path to the restored, executable binary on stdout and
+# exits 0. Exits non-zero if not in Buildkite context or the binary is absent,
+# so callers can fall back to installing the debian package.
+
+set -eo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <codename> <variant> <exe_name> <dest_dir>" >&2
+  exit 1
+fi
+
+CODENAME=$1
+VARIANT=$2
+EXE=$3
+DEST=$4
+
+if [[ ! -v BUILDKITE_BUILD_ID ]]; then
+  echo "restore_binary: not in Buildkite context" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+
+# Send the cache manager's own stdout to stderr so the only thing on our stdout
+# is the resolved binary path.
+if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$DEST" >&2; then
+  echo "restore_binary: apps/${CODENAME}/${VARIANT}/${EXE} not found in cache" >&2
+  exit 1
+fi
+
+chmod +x "${DEST}/${EXE}" 2>/dev/null || true
+echo "${DEST}/${EXE}"

--- a/buildkite/scripts/dump-mina-type-shapes.sh
+++ b/buildkite/scripts/dump-mina-type-shapes.sh
@@ -6,32 +6,24 @@ buildkite/scripts/debian/update.sh --verbose
 
 TESTNET_NAME="devnet-generic"
 
-# Build variant whose binaries this job consumes from the apps cache. Matches
-# the VersionLint dependsOn default (Bullseye / Devnet network / Devnet profile).
-CODENAME="${MINA_DEB_CODENAME:-bullseye}"
-APPS_VARIANT="devnet-devnet"
-MINA_EXE="mina_testnet_signatures.exe"
-
 git config --global --add safe.directory /workdir
 source buildkite/scripts/export-git-env-vars.sh
 
 # dump-type-shapes only reads the binary's compiled-in type registry, so the
 # freshly-built bare binary from the apps cache is sufficient; no debian package
 # (and its config/genesis payload) is required. Fall back to the .deb when the
-# bare binary is unavailable (e.g. branch without the namespaced apps cache).
-if MINA_BIN=$(./buildkite/scripts/apps/restore_binary.sh "$CODENAME" "$APPS_VARIANT" "$MINA_EXE" ./_apps_bin); then
-  MINA_CMD=("$MINA_BIN")
-  echo "Using bare binary from apps cache: $MINA_BIN"
+# bare binary is unavailable. Either way `mina` ends up on PATH.
+if ./buildkite/scripts/apps/restore_binary.sh devnet; then
+  echo "Using bare mina from apps cache"
 else
-  source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
-  MINA_CMD=(mina)
   echo "Using debian-installed mina"
+  source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
 fi
 
 MINA_COMMIT_SHA1=$(git log -n 1 --format=%h --abbrev=7)
 export TYPE_SHAPE_FILE=${MINA_COMMIT_SHA1}-type_shape.txt
 
 echo "--- Create type shapes git note for commit: ${MINA_COMMIT_SHA1}"
-"${MINA_CMD[@]}" internal dump-type-shapes > ${TYPE_SHAPE_FILE}
+mina internal dump-type-shapes > "${TYPE_SHAPE_FILE}"
 
-source buildkite/scripts/gsutil-upload.sh ${TYPE_SHAPE_FILE} gs://mina-type-shapes
+source buildkite/scripts/gsutil-upload.sh "${TYPE_SHAPE_FILE}" gs://mina-type-shapes

--- a/buildkite/scripts/dump-mina-type-shapes.sh
+++ b/buildkite/scripts/dump-mina-type-shapes.sh
@@ -6,15 +6,32 @@ buildkite/scripts/debian/update.sh --verbose
 
 TESTNET_NAME="devnet-generic"
 
+# Build variant whose binaries this job consumes from the apps cache. Matches
+# the VersionLint dependsOn default (Bullseye / Devnet network / Devnet profile).
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
+APPS_VARIANT="devnet-devnet"
+MINA_EXE="mina_testnet_signatures.exe"
+
 git config --global --add safe.directory /workdir
 source buildkite/scripts/export-git-env-vars.sh
 
-source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
+# dump-type-shapes only reads the binary's compiled-in type registry, so the
+# freshly-built bare binary from the apps cache is sufficient; no debian package
+# (and its config/genesis payload) is required. Fall back to the .deb when the
+# bare binary is unavailable (e.g. branch without the namespaced apps cache).
+if MINA_BIN=$(./buildkite/scripts/apps/restore_binary.sh "$CODENAME" "$APPS_VARIANT" "$MINA_EXE" ./_apps_bin); then
+  MINA_CMD=("$MINA_BIN")
+  echo "Using bare binary from apps cache: $MINA_BIN"
+else
+  source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
+  MINA_CMD=(mina)
+  echo "Using debian-installed mina"
+fi
 
 MINA_COMMIT_SHA1=$(git log -n 1 --format=%h --abbrev=7)
 export TYPE_SHAPE_FILE=${MINA_COMMIT_SHA1}-type_shape.txt
 
 echo "--- Create type shapes git note for commit: ${MINA_COMMIT_SHA1}"
-mina internal dump-type-shapes > ${TYPE_SHAPE_FILE}
+"${MINA_CMD[@]}" internal dump-type-shapes > ${TYPE_SHAPE_FILE}
 
 source buildkite/scripts/gsutil-upload.sh ${TYPE_SHAPE_FILE} gs://mina-type-shapes

--- a/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
+++ b/buildkite/scripts/version-linter-patch-missing-type-shapes.sh
@@ -42,7 +42,7 @@ if [[ $FORK == 1 ]]; then
     exit 0
 fi
 
-if ! $(source buildkite/scripts/cache/manager.sh read mina-type-shapes/"$RELEASE_BRANCH_COMMIT"* . 2>/dev/null); then
+if ! gsutil ls "gs://mina-type-shapes/${RELEASE_BRANCH_COMMIT}*" >/dev/null 2>&1; then
     checkout_and_dump $RELEASE_BRANCH_COMMIT
 fi
 

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -27,10 +27,18 @@ release_branch=origin/$1
 echo "--- Run Python version linter with branches: ${pr_branch} ${base_branch} ${release_branch}"
 ./scripts/version-linter.py ${pr_branch} ${base_branch} ${release_branch}
 
-echo "--- Install Mina"
+echo "--- Audit type shapes"
 source buildkite/scripts/export-git-env-vars.sh
 
-source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
-
-echo "--- Audit type shapes"
-mina internal audit-type-shapes
+# audit-type-shapes only inspects the binary's compiled-in type registry, so the
+# freshly-built bare binary from the apps cache is sufficient; no debian package
+# is required. Fall back to the .deb when the bare binary is unavailable.
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
+if MINA_BIN=$(./buildkite/scripts/apps/restore_binary.sh "$CODENAME" devnet-devnet mina_testnet_signatures.exe ./_apps_bin); then
+  echo "Using bare binary from apps cache: $MINA_BIN"
+  "$MINA_BIN" internal audit-type-shapes
+else
+  echo "Falling back to debian-installed mina"
+  source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
+  mina internal audit-type-shapes
+fi

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -32,13 +32,13 @@ source buildkite/scripts/export-git-env-vars.sh
 
 # audit-type-shapes only inspects the binary's compiled-in type registry, so the
 # freshly-built bare binary from the apps cache is sufficient; no debian package
-# is required. Fall back to the .deb when the bare binary is unavailable.
-CODENAME="${MINA_DEB_CODENAME:-bullseye}"
-if MINA_BIN=$(./buildkite/scripts/apps/restore_binary.sh "$CODENAME" devnet-devnet mina_testnet_signatures.exe ./_apps_bin); then
-  echo "Using bare binary from apps cache: $MINA_BIN"
-  "$MINA_BIN" internal audit-type-shapes
+# is required. Fall back to the .deb when the bare binary is unavailable. Either
+# way `mina` ends up on PATH.
+if ./buildkite/scripts/apps/restore_binary.sh devnet; then
+  echo "Using bare mina from apps cache"
 else
   echo "Falling back to debian-installed mina"
   source buildkite/scripts/debian/install.sh "mina-${TESTNET_NAME}" 1
-  mina internal audit-type-shapes
 fi
+
+mina internal audit-type-shapes


### PR DESCRIPTION
## Pilot: consume the namespaced apps cache instead of installing a .deb

**Stacked on #18910** (apps-cache namespacing) — includes that commit; merge order is namespacing first.

`mina internal audit-type-shapes` / `dump-type-shapes` only inspect the binary's compiled-in `Ppx_version_runtime.Shapes` registry — **no genesis ledger, config, postgres or network**. So `VersionLint` installs a `.deb` purely to get a runnable `mina` binary.

This restores the freshly-built binary from the namespaced apps cache (`apps/<codename>/devnet-devnet/mina_testnet_signatures.exe`) and runs it directly, falling back to the `.deb` when the bare binary is unavailable. A small `restore_binary.sh` helper encapsulates the cache-read + fallback.

### Why this candidate (vs the earlier chain-id attempt)
chain-id failed because its real computation needs the **materialized genesis ledger** (deb payload). `audit-type-shapes` reads only the binary's intrinsic compiled type registry — there is no external data and no config-mismatch failure mode. It also already runs on `develop` (no exclude surgery).

### Validation
A green run with `Using bare binary from apps cache: …/mina_testnet_signatures.exe` in the log proves the bare path works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)