### PR TITLE
ci: opt-in git submodule init for jobs that build from source (master)

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -118,9 +118,12 @@ let build_artifacts
             Command.Config::{
             , commands =
                   Toolchain.select
-                    spec.toolchainSelectMode
-                    spec.debVersion
-                    spec.arch
+                    Toolchain.Spec::{
+                    , mode = spec.toolchainSelectMode
+                    , debVersion = spec.debVersion
+                    , arch = spec.arch
+                    , submodules = True
+                    }
                     (   [ "DUNE_PROFILE=${Profiles.duneProfile spec.profile}"
                         , "AWS_ACCESS_KEY_ID"
                         , "AWS_SECRET_ACCESS_KEY"

--- a/buildkite/src/Command/RunInToolchain.dhall
+++ b/buildkite/src/Command/RunInToolchain.dhall
@@ -1,3 +1,18 @@
+-- Helpers for running a command inside the mina toolchain docker image.
+--
+-- Submodules: the Buildkite agents are configured to NOT auto-checkout git
+-- submodules. Most CI jobs (lint, dhall checks, tests that run against prebuilt
+-- artifacts) do not need them, so submodule init is OPT-IN: the default
+-- `runInToolchain*` wrappers do NOT initialize submodules.
+--
+-- Jobs that build code from source (the proof-systems/snarky submodules are
+-- linked into the OCaml build) must opt in. They either:
+--   * use a `*WithSubmodules` wrapper (e.g. runInToolchainWithSubmodules), or
+--   * set `submodules = True` on the `Config` passed to `runInToolchainImage`
+--     (this is how Toolchain.select threads it for artifact builds).
+-- When enabled, `git submodule sync/update --init --recursive` runs on the agent
+-- host before the toolchain container starts (the host tree is bind-mounted in).
+
 let Cmd = ../Lib/Cmds.dhall
 
 let ContainerImages = ../Constants/ContainerImages.dhall
@@ -5,6 +20,21 @@ let ContainerImages = ../Constants/ContainerImages.dhall
 let Arch = ../Constants/Arch.dhall
 
 let FixPermissions = ../Command/FixPermissions.dhall
+
+let Config =
+      { Type =
+          { submodules : Bool
+          , image : Text
+          , arch : Arch.Type
+          , environment : List Text
+          , innerScript : Text
+          }
+      , default =
+          { submodules = False
+          , arch = Arch.Type.Amd64
+          , environment = [] : List Text
+          }
+      }
 
 let binfmtSetup
     : Arch.Type -> List Cmd.Type
@@ -18,78 +48,139 @@ let binfmtSetup
             }
             arch
 
+let submodulesInit
+    : Bool -> List Cmd.Type
+    =     \(submodules : Bool)
+      ->        if submodules
+
+          then  [ Cmd.run
+                    "git submodule sync --recursive && git submodule update --init --recursive"
+                ]
+
+          else  [] : List Cmd.Type
+
 let runInToolchainImage
-    : Text -> Arch.Type -> List Text -> Text -> List Cmd.Type
-    =     \(image : Text)
-      ->  \(arch : Arch.Type)
-      ->  \(environment : List Text)
-      ->  \(innerScript : Text)
-      ->    binfmtSetup arch
-          # [ FixPermissions.command arch ]
+    : Config.Type -> List Cmd.Type
+    =     \(c : Config.Type)
+      ->    submodulesInit c.submodules
+          # binfmtSetup c.arch
+          # [ FixPermissions.command c.arch ]
           # [ Cmd.runInDocker
                 Cmd.Docker::{
-                , image = image
-                , extraEnv = environment
-                , platform = Arch.platform arch
+                , image = c.image
+                , extraEnv = c.environment
+                , platform = Arch.platform c.arch
                 }
-                innerScript
+                c.innerScript
             ]
 
-let runInToolchainNoble
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
-      ->  \(innerScript : Text)
-      ->  runInToolchainImage
-            ContainerImages.minaToolchainNoble.amd64
-            Arch.Type.Amd64
-            environment
-            innerScript
-
-let runInToolchainJammy
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
-      ->  \(innerScript : Text)
-      ->  runInToolchainImage
-            ContainerImages.minaToolchainJammy.amd64
-            Arch.Type.Amd64
-            environment
-            innerScript
-
-let runInToolchainBookworm
-    : Arch.Type -> List Text -> Text -> List Cmd.Type
+let imageFor
+    :     Arch.Type
+      ->  { bookworm : Text
+          , bullseye : Text
+          , jammy : Text
+          , noble : Text
+          , focal : Text
+          }
     =     \(arch : Arch.Type)
-      ->  \(environment : List Text)
-      ->  \(innerScript : Text)
-      ->  let image =
-                merge
-                  { Amd64 = ContainerImages.minaToolchainBookworm.amd64
-                  , Arm64 = ContainerImages.minaToolchainBookworm.arm64
-                  }
-                  arch
-
-          in  runInToolchainImage image arch environment innerScript
-
-let runInToolchainBullseye
-    : List Text -> Text -> List Cmd.Type
-    =     \(environment : List Text)
-      ->  \(innerScript : Text)
-      ->  runInToolchainImage
-            ContainerImages.minaToolchainBullseye.amd64
-            Arch.Type.Amd64
-            environment
-            innerScript
+      ->  { bookworm =
+              merge
+                { Amd64 = ContainerImages.minaToolchainBookworm.amd64
+                , Arm64 = ContainerImages.minaToolchainBookworm.arm64
+                }
+                arch
+          , bullseye = ContainerImages.minaToolchainBullseye.amd64
+          , jammy = ContainerImages.minaToolchainJammy.amd64
+          , noble = ContainerImages.minaToolchainNoble.amd64
+          , focal = ContainerImages.minaToolchain
+          }
 
 let runInToolchain
     : List Text -> Text -> List Cmd.Type
     =     \(environment : List Text)
       ->  \(innerScript : Text)
       ->  runInToolchainImage
-            ContainerImages.minaToolchain
-            Arch.Type.Amd64
-            environment
-            innerScript
+            Config::{
+            , image = ContainerImages.minaToolchain
+            , environment = environment
+            , innerScript = innerScript
+            }
 
-in  { runInToolchain = runInToolchain
+let runInToolchainNoble
+    : List Text -> Text -> List Cmd.Type
+    =     \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , image = ContainerImages.minaToolchainNoble.amd64
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+let runInToolchainJammy
+    : List Text -> Text -> List Cmd.Type
+    =     \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , image = ContainerImages.minaToolchainJammy.amd64
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+let runInToolchainBookworm
+    : Arch.Type -> List Text -> Text -> List Cmd.Type
+    =     \(arch : Arch.Type)
+      ->  \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , image = (imageFor arch).bookworm
+            , arch = arch
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+let runInToolchainBullseye
+    : List Text -> Text -> List Cmd.Type
+    =     \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , image = ContainerImages.minaToolchainBullseye.amd64
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+let runInToolchainWithSubmodules
+    : List Text -> Text -> List Cmd.Type
+    =     \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , submodules = True
+            , image = ContainerImages.minaToolchain
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+let runInToolchainNobleWithSubmodules
+    : List Text -> Text -> List Cmd.Type
+    =     \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  runInToolchainImage
+            Config::{
+            , submodules = True
+            , image = ContainerImages.minaToolchainNoble.amd64
+            , environment = environment
+            , innerScript = innerScript
+            }
+
+in  { Config = Config
+    , imageFor = imageFor
+    , runInToolchain = runInToolchain
+    , runInToolchainWithSubmodules = runInToolchainWithSubmodules
+    , runInToolchainNobleWithSubmodules = runInToolchainNobleWithSubmodules
     , runInToolchainImage = runInToolchainImage
     , runInToolchainNoble = runInToolchainNoble
     , runInToolchainBookworm = runInToolchainBookworm

--- a/buildkite/src/Constants/Toolchain.dhall
+++ b/buildkite/src/Constants/Toolchain.dhall
@@ -4,31 +4,55 @@ let RunInToolchain = ../Command/RunInToolchain.dhall
 
 let Arch = ./Arch.dhall
 
+let Cmd = ../Lib/Cmds.dhall
+
 let SelectionMode
     : Type
     = < ByDebianAndArch | Custom : Text >
 
-let runner =
-          \(debVersion : DebianVersions.DebVersion)
-      ->  \(arch : Arch.Type)
-      ->  merge
-            { Bookworm = RunInToolchain.runInToolchainBookworm arch
-            , Bullseye = RunInToolchain.runInToolchainBullseye
-            , Jammy = RunInToolchain.runInToolchainJammy
-            , Focal = RunInToolchain.runInToolchain
-            , Noble = RunInToolchain.runInToolchainNoble
-            }
-            debVersion
+let Spec =
+      { Type =
+          { mode : SelectionMode
+          , debVersion : DebianVersions.DebVersion
+          , arch : Arch.Type
+          , submodules : Bool
+          }
+      , default =
+          { mode = SelectionMode.ByDebianAndArch
+          , arch = Arch.Type.Amd64
+          , submodules = False
+          }
+      }
 
-let select =
-          \(mode : SelectionMode)
-      ->  \(debVersion : DebianVersions.DebVersion)
-      ->  \(arch : Arch.Type)
-      ->  merge
-            { ByDebianAndArch = runner debVersion arch
-            , Custom =
-                \(image : Text) -> RunInToolchain.runInToolchainImage image arch
-            }
-            mode
+let select
+    : Spec.Type -> List Text -> Text -> List Cmd.Type
+    =     \(spec : Spec.Type)
+      ->  \(environment : List Text)
+      ->  \(innerScript : Text)
+      ->  let images = RunInToolchain.imageFor spec.arch
 
-in  { SelectionMode = SelectionMode, select = select, runner = runner }
+          let image =
+                merge
+                  { ByDebianAndArch =
+                      merge
+                        { Bookworm = images.bookworm
+                        , Bullseye = images.bullseye
+                        , Jammy = images.jammy
+                        , Focal = images.focal
+                        , Noble = images.noble
+                        }
+                        spec.debVersion
+                  , Custom = \(image : Text) -> image
+                  }
+                  spec.mode
+
+          in  RunInToolchain.runInToolchainImage
+                RunInToolchain.Config::{
+                , submodules = spec.submodules
+                , image = image
+                , arch = spec.arch
+                , environment = environment
+                , innerScript = innerScript
+                }
+
+in  { SelectionMode = SelectionMode, Spec = Spec, select = select }

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -103,9 +103,11 @@ let generateReferenceTarballsCommand =
                 Command.Config::{
                 , commands =
                     Toolchain.select
-                      Toolchain.SelectionMode.ByDebianAndArch
-                      codename.DebVersion
-                      codename.Arch
+                      Toolchain.Spec::{
+                      , debVersion = codename.DebVersion
+                      , arch = codename.Arch
+                      , submodules = True
+                      }
                       [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
                       "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs-using-legacy-app.sh --network ${Network.lowerName
                                                                                                                                        spec.network} --version ${spec.deb_legacy_version}  --codename ${DebianVersions.lowerName
@@ -136,9 +138,11 @@ let generateTarballsCommand =
                 Command.Config::{
                 , commands =
                     Toolchain.select
-                      Toolchain.SelectionMode.ByDebianAndArch
-                      codename.DebVersion
-                      codename.Arch
+                      Toolchain.Spec::{
+                      , debVersion = codename.DebVersion
+                      , arch = codename.Arch
+                      , submodules = True
+                      }
                       [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
                       (     "./buildkite/scripts/hardfork/release/generate-fork-config-and-ledger-tarballs.sh "
                         ++  "--network ${Network.lowerName spec.network} "
@@ -176,9 +180,11 @@ let generateDockerForCodename =
                               Command.Config::{
                               , commands =
                                   Toolchain.select
-                                    Toolchain.SelectionMode.ByDebianAndArch
-                                    codename.DebVersion
-                                    codename.Arch
+                                    Toolchain.Spec::{
+                                    , debVersion = codename.DebVersion
+                                    , arch = codename.Arch
+                                    , submodules = True
+                                    }
                                     ([] : List Text)
                                     (     "./buildkite/scripts/release/manager.sh persist "
                                       ++  " --backend local --artifacts mina-logproc,mina-${Network.lowerName
@@ -473,9 +479,11 @@ let generateHfRelatedStepsForCodename =
                     Command.Config::{
                     , commands =
                         Toolchain.select
-                          Toolchain.SelectionMode.ByDebianAndArch
-                          codename.DebVersion
-                          codename.Arch
+                          Toolchain.Spec::{
+                          , debVersion = codename.DebVersion
+                          , arch = codename.Arch
+                          , submodules = True
+                          }
                           (   [ "NETWORK_NAME=${Network.lowerName spec.network}"
                               , "MINA_DEB_CODENAME=${lowerNameCodename}"
                               ]
@@ -532,9 +540,11 @@ let generateHfRelatedStepsForCodename =
                     Command.Config::{
                     , commands =
                           Toolchain.select
-                            Toolchain.SelectionMode.ByDebianAndArch
-                            codename.DebVersion
-                            codename.Arch
+                            Toolchain.Spec::{
+                            , debVersion = codename.DebVersion
+                            , arch = codename.Arch
+                            , submodules = True
+                            }
                             ([] : List Text)
                             "./buildkite/scripts/cache/manager.sh read hardfork . && ls -al ./hardfork"
                         # [ Cmd.run

--- a/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
@@ -46,7 +46,7 @@ in  Pipeline.build
         [ Command.build
             Command.Config::{
             , commands =
-                RunInToolchain.runInToolchain
+                RunInToolchain.runInToolchainWithSubmodules
                   [ "POSTGRES_PASSWORD=${password}"
                   , "POSTGRES_USER=${user}"
                   , "POSTGRES_DB=${db}"

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -24,7 +24,7 @@ let buildTestCmd
           in  Command.build
                 Command.Config::{
                 , commands =
-                    RunInToolchain.runInToolchain
+                    RunInToolchain.runInToolchainWithSubmodules
                       [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
                       (     "buildkite/scripts/unit-test.sh ${profile} ${path}"
                         ++  " && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev"

--- a/buildkite/src/Jobs/Test/HardforkPipelineTest.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPipelineTest.dhall
@@ -42,7 +42,7 @@ in  Pipeline.build
         [ Command.build
             Command.Config::{
             , commands =
-                RunInToolchain.runInToolchain
+                RunInToolchain.runInToolchainWithSubmodules
                   [ "BUILDKITE_AGENT_WRITE_TOKEN" ]
                   "./buildkite/scripts/pipeline/run_for_newest_devnet.sh"
             , label = "Hardfork: pipeline test"

--- a/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
@@ -24,7 +24,7 @@ let buildTestCmd
           in  Command.build
                 Command.Config::{
                 , commands =
-                    RunInToolchain.runInToolchain
+                    RunInToolchain.runInToolchainWithSubmodules
                       [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
                       "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
                 , label = "Rosetta unit tests"

--- a/buildkite/src/Jobs/Test/VersionLint.dhall
+++ b/buildkite/src/Jobs/Test/VersionLint.dhall
@@ -31,13 +31,13 @@ let buildTestCmd
       ->  Command.build
             Command.Config::{
             , commands =
-                  RunInToolchain.runInToolchain
+                  RunInToolchain.runInToolchainWithSubmodules
                     DebianVersions.overrideEnvs
                     "buildkite/scripts/dump-mina-type-shapes.sh"
-                # RunInToolchain.runInToolchain
+                # RunInToolchain.runInToolchainWithSubmodules
                     DebianVersions.overrideEnvs
                     "buildkite/scripts/version-linter-patch-missing-type-shapes.sh ${release_branch}"
-                # RunInToolchain.runInToolchain
+                # RunInToolchain.runInToolchainWithSubmodules
                     DebianVersions.overrideEnvs
                     "buildkite/scripts/version-linter.sh ${release_branch}"
             , label = "Versioned type linter for ${release_branch}"

--- a/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
@@ -24,7 +24,7 @@ let buildTestCmd
           in  Command.build
                 Command.Config::{
                 , commands =
-                    RunInToolchain.runInToolchain
+                    RunInToolchain.runInToolchainWithSubmodules
                       [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
                       "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
                 , label = "Zkapps test transaction tool unit tests"

--- a/buildkite/src/Jobs/Test/ZkappsExamplesTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappsExamplesTest.dhall
@@ -23,7 +23,7 @@ let buildTestCmd
           in  Command.build
                 Command.Config::{
                 , commands =
-                    RunInToolchain.runInToolchain
+                    RunInToolchain.runInToolchainWithSubmodules
                       [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
                       "buildkite/scripts/zkapps-examples-unit-tests.sh ${profile} && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev"
                 , label = "${profile} zkApps examples tests"


### PR DESCRIPTION
## Summary

Port of #18912 to **master**. Inverts git submodule handling in the Buildkite pipeline so submodule init is **opt-in**: only jobs that build from source initialize them, the rest skip the (wasted) recursive checkout once the agents are configured to not auto-checkout submodules.

Same change as the develop PR, adapted to master's pipeline:
- `RunInToolchain.dhall`: `runInToolchainImage` takes a `Config` struct (not positional args); submodule init is opt-in (`submodules` defaults `False`). Adds `runInToolchainWithSubmodules` / `runInToolchainNobleWithSubmodules`; exports `imageFor`. (master keeps its own no-`load_from_cache` body.)
- `Toolchain.dhall`: `select` takes a `Spec` config struct.
- Opt in (build from source): `MinaArtifact`, hardfork pipeline, and OCaml unit/build jobs.
- Default off: linters, standalone Rust builds, prebuilt-artifact tests.

## Rollout

This is part of porting the change to all three mainline branches (develop #18912, master, compatible) so the shared `BUILDKITE_GIT_SUBMODULES=false` agent setting can be flipped without breaking any branch. Safe to merge before the flip (build jobs just init submodules redundantly).

## Validation

- `make all` in `buildkite/` (dhall typecheck + 42 monorepo tests): pass.
- Rendered YAML: opt-in build jobs carry `git submodule update --init`; lint/prebuilt jobs do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)