### PR TITLE
fix: warn on high block reward threshold

### DIFF
--- a/changes/18919.md
+++ b/changes/18919.md
@@ -1,0 +1,1 @@
+Added a startup warning for block producers when `--minimum-block-reward` is set above the network coinbase amount, making it clearer that the node may produce empty blocks unless transaction fees or supercharged coinbase raise the block reward above the configured threshold.

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1231,6 +1231,19 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~block_reward_threshold ~block_produced_bvar ~vrf_evaluation_state ~net
     ~zkapp_cmd_limit_hardcap =
   let open Context in
+  Option.iter block_reward_threshold ~f:(fun threshold ->
+      if Currency.Amount.(threshold > constraint_constants.coinbase_amount) then
+        [%log warn]
+          "Minimum block reward threshold $threshold is greater than the \
+           coinbase amount $coinbase_amount. This node may produce empty \
+           blocks unless transaction fees or supercharged coinbase raise the \
+           block reward above the threshold"
+          ~metadata:
+            [ ("threshold", Currency.Amount.to_yojson threshold)
+            ; ( "coinbase_amount"
+              , Currency.Amount.to_yojson constraint_constants.coinbase_amount
+              )
+            ] ) ;
   O1trace.sync_thread "produce_blocks" (fun () ->
       let genesis_breadcrumb =
         genesis_breadcrumb_creator ~context:(module Context) prover


### PR DESCRIPTION
Context: https://discord.com/channels/484437221055922177/1513417678490959872

## Summary

Warn block producers at startup when `--minimum-block-reward` is configured above the network coinbase amount.

This makes a potentially confusing configuration easier to diagnose: with a threshold above coinbase, the node may produce empty blocks unless transaction fees or supercharged coinbase raise the block reward above the configured threshold.
