### PR TITLE
ci: drop unused mina-test-suite dep from archive/replayer/rosetta tests

### DIFF
--- a/buildkite/src/Command/ReplayerMesaHfTest.dhall
+++ b/buildkite/src/Command/ReplayerMesaHfTest.dhall
@@ -15,7 +15,7 @@ let ContainerImages = ../Constants/ContainerImages.dhall
 let key = "replayer-mesa-hf-test"
 
 let debs =
-      "mina-test-suite,mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
+      "mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
 
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -11,7 +11,7 @@ let ContainerImages = ../Constants/ContainerImages.dhall
 let key = "replayer-test"
 
 let debs =
-      "mina-test-suite,mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
+      "mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
 
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)

--- a/buildkite/src/Command/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Command/RosettaBlockRaceTest.dhall
@@ -11,7 +11,7 @@ let ContainerImages = ../Constants/ContainerImages.dhall
 let key = "rosetta-block-race-test"
 
 let debs =
-      "mina-test-suite,mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
+      "mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
 
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)

--- a/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
@@ -27,7 +27,7 @@ let dependsOn =
 let key = "archive-hardfork-toolbox-test"
 
 let debs =
-      "mina-test-suite,mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
+      "mina-devnet-instrumented,mina-archive-devnet-instrumented,mina-rosetta-devnet"
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
## Phase 1 of removing the `mina-test-suite` ("functional test") debian

Four test jobs install `mina-test-suite` but **never use it** — they run binaries from the daemon/archive/rosetta packages and read their fixtures from the in-tree `src/test/archive/`, not the deb's `/etc/mina/test/archive` payload:

| Job | What it actually uses |
|---|---|
| `ReplayerTest` | `mina-replayer` (mina-archive) + `src/test/archive/sample_db` |
| `ReplayerMesaHfTest` | `mina-replayer` |
| `RosettaBlockRaceTest` | `mina-archive` / `mina-rosetta` exes |
| `ArchiveHardforkToolboxTest` | `mina-archive-hardfork-toolbox` (mina-archive) |

This removes `mina-test-suite` from those four deb lists (faster installs, no behavior change).

Next phases: convert the real consumers (`ArchiveNodeTest`, `PatchArchiveTest`, `SingleNodeTest`, `Bench`) to restore their test binary from the apps cache, then delete the `mina-test-suite` package build entirely.

`make all` green (37/37 monorepo tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)