### PR TITLE
fix(docker): scope local .deb install to build's target arch (fix develop nightlies)

### DIFF
--- a/dockerfiles/scripts/install-mina-debs.sh
+++ b/dockerfiles/scripts/install-mina-debs.sh
@@ -16,9 +16,19 @@
 # explicit name (+optional version) glob, so unrelated debs that may also be
 # present in the context (other networks/profiles) are never installed.
 #
+# Resolution is scoped to the build's target architecture (dpkg
+# --print-architecture, which inside a `docker buildx build --platform <p>` RUN
+# returns the target platform's arch) plus arch-independent "all" packages. This
+# prevents the foreign-arch variant of a package (when both _amd64.deb and
+# _arm64.deb of the same version are staged into the context) from being handed
+# to apt, which would otherwise fail with uninstallable foreign-arch
+# dependencies and self-conflicts.
+#
 # Usage: install-mina-debs.sh "pkg1=version" ["pkg2" ...]
-#   - "pkg=version"  resolves to ${LOCAL_DEB_DIR}/pkg_version_*.deb
-#   - "pkg"          resolves to ${LOCAL_DEB_DIR}/pkg_*.deb
+#   - "pkg=version"  resolves to ${LOCAL_DEB_DIR}/pkg_version_${TARGET_ARCH}.deb
+#                    or ${LOCAL_DEB_DIR}/pkg_version_all.deb
+#   - "pkg"          resolves to ${LOCAL_DEB_DIR}/pkg_*_${TARGET_ARCH}.deb
+#                    or ${LOCAL_DEB_DIR}/pkg_*_all.deb
 #
 # Environment:
 #   LOCAL_DEB_DIR    - directory the local debs were COPY'd to.
@@ -34,6 +44,11 @@ fi
 
 LOCAL_DEB_DIR="${LOCAL_DEB_DIR:-/opt/mina-local-debs}"
 
+# Architecture of the build we are running in. Inside a buildx RUN this is the
+# target platform's arch, so we only ever select debs matching this arch (plus
+# arch-independent "all" packages).
+TARGET_ARCH="$(dpkg --print-architecture)"
+
 ALLOW_DOWNGRADES="--allow-downgrades"
 if [[ "${APT_NO_DOWNGRADE:-0}" == "1" ]]; then
   ALLOW_DOWNGRADES=""
@@ -41,21 +56,35 @@ fi
 
 shopt -s nullglob
 
-# Resolve each requested item to a concrete .deb file in the local deb dir.
+# Resolve each requested item to the concrete .deb file(s) in the local deb dir,
+# restricted to the build's own architecture (plus arch-independent "all").
+# Candidate paths are filtered to those that actually exist so the foreign-arch
+# variant (and any non-existent candidate) is never handed to apt.
 deb_files=()
 for item in "$@"; do
   if [[ "$item" == *"="* ]]; then
     pkg="${item%%=*}"
     version="${item#*=}"
-    matches=("${LOCAL_DEB_DIR}/${pkg}_${version}_"*.deb)
+    candidates=(
+      "${LOCAL_DEB_DIR}/${pkg}_${version}_${TARGET_ARCH}.deb"
+      "${LOCAL_DEB_DIR}/${pkg}_${version}_all.deb"
+    )
   else
     pkg="$item"
-    matches=("${LOCAL_DEB_DIR}/${pkg}_"*.deb)
+    candidates=(
+      "${LOCAL_DEB_DIR}/${pkg}_"*"_${TARGET_ARCH}.deb"
+      "${LOCAL_DEB_DIR}/${pkg}_"*"_all.deb"
+    )
   fi
+
+  matches=()
+  for candidate in "${candidates[@]}"; do
+    [[ -e "$candidate" ]] && matches+=("$candidate")
+  done
 
   if [[ "${#matches[@]}" -eq 0 ]]; then
     echo "ERROR: no local .deb file found for '${item}' in ${LOCAL_DEB_DIR}"
-    echo "       (looked for ${LOCAL_DEB_DIR}/${pkg}_*.deb)"
+    echo "       (looked for ${LOCAL_DEB_DIR}/${pkg}_*_${TARGET_ARCH}.deb and ${LOCAL_DEB_DIR}/${pkg}_*_all.deb)"
     echo "Available .deb files in ${LOCAL_DEB_DIR}:"
     ls -1 "${LOCAL_DEB_DIR}"/*.deb 2>/dev/null || echo "  (none)"
     exit 1


### PR DESCRIPTION
## Problem

Scheduled nightlies on \`develop\` fail in the Docker build steps. amd64 docker builds (e.g. *Docker: DaemonAppsOnly Devnet Noble Lightnet Amd64*) fail while installing the mina debs:

\`\`\`
Depends: libgomp1:arm64 but it is not installable
Depends: rocksdb-tools:arm64 but it is not installable
...
Conflicts: mina-daemon-recovery-storage-toolbox but 3.3.0-master-35445f7 is to be installed
E: Unable to correct problems, you have held broken packages.
\`\`\`

Ref: https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1433

## Root cause

The images install debs from local files via \`dockerfiles/scripts/install-mina-debs.sh\`. \`scripts/docker/build.sh\` stages **all** \`*.deb\` from the build context into \`_debs/\`. For cross-arch cached packages (e.g. \`mina-daemon-recovery-storage-toolbox\`, \`mina-create-*-prefork-genesis-ledger\`) **both** \`_amd64.deb\` and \`_arm64.deb\` of the same version are present.

The resolution glob \`${pkg}_${version}_*.deb\` matched **both** arches, so apt was handed the arm64 deb on an amd64 image → uninstallable foreign-arch deps + a self-conflict between the two arch variants.

## Fix

Scope deb resolution in \`install-mina-debs.sh\` to the build's own architecture (\`dpkg --print-architecture\`, which inside a \`docker buildx build --platform <p>\` RUN returns the target platform's arch) plus arch-independent \`all\` packages. Candidates are filtered to files that actually exist, so a foreign-arch variant is never passed to apt.

Single-file, bash-only change; affects all 7 Dockerfiles that consume the script.

## Verification

- \`shellcheck\` clean.
- Sanity-checked resolution for both amd64 and arm64 targets with mixed-arch and \`_all\` fixtures: only the target-arch + \`all\` debs are selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)