### PR TITLE
block_producer: warn on zero coinbase blocks

### DIFF
--- a/changes/18922.md
+++ b/changes/18922.md
@@ -1,0 +1,1 @@
+Block producers now log a warning when they create a block with zero coinbase, including the specific reason (for example, the block reward fell below the configured minimum threshold, no snark work was available to purchase, or the slot had reached the transaction end limit).

--- a/src/app/cli/src/init/test_submit_to_archive.ml
+++ b/src/app/cli/src/init/test_submit_to_archive.ml
@@ -307,7 +307,7 @@ let build_breadcrumb ~transactions ~context ~precomputed_values ~verifier
   let winner_pk = fst slot_won.delegator in
   (* Copied from block producer, creates inputs for
      generating a new block's proof, header and body. *)
-  let%bind protocol_state, internal_transition, pending_coinbase_witness =
+  let%bind protocol_state, internal_transition, pending_coinbase_witness, _ =
     Block_producer.generate_next_state ~commit_id:"" ~constraint_constants
       ~scheduled_time ~block_data ~previous_protocol_state ~time_controller
       ~staged_ledger:previous.staged_ledger ~transactions

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -95,27 +95,42 @@ module Zero_coinbase_logging = struct
     let end_coinbase_parts =
       sum_partitions diagnostics ~f:(fun p -> p.end_coinbase_parts)
     in
-    if insufficient_work > 0 then "insufficient_work"
-    else if insufficient_fees > 0 then "insufficient_fees"
-    else if insufficient_space > 0 then "insufficient_space"
-    else if
+    let no_resources =
       start_commands = 0 && start_completed_work = 0 && end_commands = 0
       && end_completed_work = 0 && end_coinbase_parts = 0
-    then "empty_diff_no_resources"
-    else "generated_diff_without_coinbase"
+    in
+    let reasons = [] in
+    let reasons =
+      if insufficient_work > 0 then "insufficient_work" :: reasons else reasons
+    in
+    let reasons =
+      if insufficient_fees > 0 then "insufficient_fees" :: reasons else reasons
+    in
+    let reasons =
+      if insufficient_space > 0 then "insufficient_space" :: reasons
+      else reasons
+    in
+    let reasons =
+      if no_resources then "empty_diff_no_resources" :: reasons else reasons
+    in
+    if List.is_empty reasons then [ "generated_diff_without_coinbase" ]
+    else reasons
 
   let zero_reason ~coinbase_amount ~coinbase_parts { source; _ } =
     match source with
     | Slot_tx_end_reached _ ->
-        "slot_tx_end_reached"
+        [ "slot_tx_end_reached" ]
     | Below_min_block_reward _ ->
-        "below_min_block_reward"
+        [ "below_min_block_reward" ]
     | Precomputed ->
-        "precomputed_zero_coinbase"
+        [ "precomputed_zero_coinbase" ]
     | Generated_diff diagnostics ->
-        if Option.is_none coinbase_amount && coinbase_parts > 0 then
-          "coinbase_amount_unavailable"
-        else generated_reason diagnostics
+        let reasons =
+          if Option.is_none coinbase_amount && coinbase_parts > 0 then
+            [ "coinbase_amount_unavailable" ]
+          else []
+        in
+        reasons @ generated_reason diagnostics
 
   let source_diagnostics_json = function
     | Slot_tx_end_reached slot_tx_end ->
@@ -153,7 +168,9 @@ module Zero_coinbase_logging = struct
         , Option.value_map coinbase_amount ~default:(`String "unavailable")
             ~f:Currency.Amount.to_yojson )
       ; ( "zero_coinbase_reason"
-        , `String (zero_reason ~coinbase_amount ~coinbase_parts t) )
+        , `List
+            (List.map (zero_reason ~coinbase_amount ~coinbase_parts t)
+               ~f:(fun r -> `String r) ) )
       ; ("zero_coinbase_diagnostics", source_diagnostics_json source)
       ]
     else []

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -1143,8 +1143,9 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                   ; ("transactions", `List txs)
                   ] ;
               let zero_coinbase_metadata =
-                Zero_coinbase_logging.metadata_if_coinbase_zero ~constraint_constants
-                  ~diff:staged_ledger_diff coinbase_logging
+                Zero_coinbase_logging.metadata_if_coinbase_zero
+                  ~constraint_constants ~diff:staged_ledger_diff
+                  coinbase_logging
               in
               if not (List.is_empty zero_coinbase_metadata) then
                 [%log warn] ~metadata:zero_coinbase_metadata
@@ -1710,8 +1711,9 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
                          err ) )
           in
           let zero_coinbase_metadata =
-            Zero_coinbase_logging.metadata_if_coinbase_zero ~constraint_constants
-              ~diff:staged_ledger_diff_for_block coinbase_logging
+            Zero_coinbase_logging.metadata_if_coinbase_zero
+              ~constraint_constants ~diff:staged_ledger_diff_for_block
+              coinbase_logging
           in
           if not (List.is_empty zero_coinbase_metadata) then
             [%log warn] ~metadata:zero_coinbase_metadata

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -41,14 +41,6 @@ module Zero_coinbase_logging = struct
 
   let amount_is_zero = Currency.Amount.equal Currency.Amount.zero
 
-  let first_coinbase_parts = function
-    | Staged_ledger_diff.At_most_two.Zero ->
-        0
-    | One _ ->
-        1
-    | Two _ ->
-        2
-
   let second_coinbase_parts = function
     | Staged_ledger_diff.At_most_one.Zero ->
         0
@@ -57,7 +49,7 @@ module Zero_coinbase_logging = struct
 
   let n_diff_coinbase_parts (diff : Staged_ledger_diff.t) =
     let first, second_opt = diff.diff in
-    first_coinbase_parts first.coinbase
+    Staged_ledger.Diff_creation_diagnostics.coinbase_parts first.coinbase
     + Option.value_map second_opt ~default:0 ~f:(fun second ->
           second_coinbase_parts second.coinbase )
 
@@ -148,7 +140,7 @@ module Zero_coinbase_logging = struct
     | Precomputed ->
         `Assoc []
 
-  let metadata_if_zero ~constraint_constants ~diff
+  let metadata_if_coinbase_zero ~constraint_constants ~diff
       ({ supercharge_coinbase; source } as t) =
     let coinbase_amount =
       Staged_ledger_diff.Diff.coinbase ~constraint_constants
@@ -1151,7 +1143,7 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                   ; ("transactions", `List txs)
                   ] ;
               let zero_coinbase_metadata =
-                Zero_coinbase_logging.metadata_if_zero ~constraint_constants
+                Zero_coinbase_logging.metadata_if_coinbase_zero ~constraint_constants
                   ~diff:staged_ledger_diff coinbase_logging
               in
               if not (List.is_empty zero_coinbase_metadata) then
@@ -1718,7 +1710,7 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
                          err ) )
           in
           let zero_coinbase_metadata =
-            Zero_coinbase_logging.metadata_if_zero ~constraint_constants
+            Zero_coinbase_logging.metadata_if_coinbase_zero ~constraint_constants
               ~diff:staged_ledger_diff_for_block coinbase_logging
           in
           if not (List.is_empty zero_coinbase_metadata) then

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -29,6 +29,145 @@ end
 type Structured_log_events.t += Block_produced
   [@@deriving register_event { msg = "Successfully produced a new block" }]
 
+module Zero_coinbase_logging = struct
+  type zero_coinbase_source =
+    | Slot_tx_end_reached of Mina_numbers.Global_slot_since_hard_fork.t
+    | Below_min_block_reward of
+        { threshold : Currency.Amount.t; reward : Currency.Amount.t }
+    | Generated_diff of Staged_ledger.Diff_creation_diagnostics.t
+    | Precomputed
+
+  type t = { supercharge_coinbase : bool; source : zero_coinbase_source }
+
+  let amount_is_zero = Currency.Amount.equal Currency.Amount.zero
+
+  let first_coinbase_parts = function
+    | Staged_ledger_diff.At_most_two.Zero ->
+        0
+    | One _ ->
+        1
+    | Two _ ->
+        2
+
+  let second_coinbase_parts = function
+    | Staged_ledger_diff.At_most_one.Zero ->
+        0
+    | One _ ->
+        1
+
+  let diff_coinbase_parts (diff : Staged_ledger_diff.t) =
+    let first, second_opt = diff.diff in
+    first_coinbase_parts first.coinbase
+    + Option.value_map second_opt ~default:0 ~f:(fun second ->
+          second_coinbase_parts second.coinbase )
+
+  let sum_partitions diagnostics ~f =
+    List.sum
+      (module Int)
+      diagnostics.Staged_ledger.Diff_creation_diagnostics.partitions ~f
+
+  let generated_reason diagnostics =
+    let open Staged_ledger.Diff_creation_diagnostics in
+    let insufficient_work =
+      sum_partitions diagnostics ~f:(fun p ->
+          p.discard_counters.insufficient_work )
+    in
+    let insufficient_fees =
+      sum_partitions diagnostics ~f:(fun p ->
+          p.discard_counters.insufficient_fees )
+    in
+    let insufficient_space =
+      sum_partitions diagnostics ~f:(fun p ->
+          p.discard_counters.insufficient_space )
+    in
+    let start_commands =
+      sum_partitions diagnostics ~f:(fun p -> p.start_commands)
+    in
+    let start_completed_work =
+      sum_partitions diagnostics ~f:(fun p -> p.start_completed_work)
+    in
+    let end_commands =
+      sum_partitions diagnostics ~f:(fun p -> p.end_commands)
+    in
+    let end_completed_work =
+      sum_partitions diagnostics ~f:(fun p -> p.end_completed_work)
+    in
+    let end_coinbase_parts =
+      sum_partitions diagnostics ~f:(fun p -> p.end_coinbase_parts)
+    in
+    if insufficient_work > 0 then "insufficient_work"
+    else if insufficient_fees > 0 then "insufficient_fees"
+    else if insufficient_space > 0 then "insufficient_space"
+    else if
+      start_commands = 0 && start_completed_work = 0 && end_commands = 0
+      && end_completed_work = 0 && end_coinbase_parts = 0
+    then "empty_diff_no_resources"
+    else "generated_diff_without_coinbase"
+
+  let zero_reason ~coinbase_amount ~coinbase_parts { source; _ } =
+    match source with
+    | Slot_tx_end_reached _ ->
+        "slot_tx_end_reached"
+    | Below_min_block_reward _ ->
+        "below_min_block_reward"
+    | Precomputed ->
+        "precomputed_zero_coinbase"
+    | Generated_diff diagnostics ->
+        if Option.is_none coinbase_amount && coinbase_parts > 0 then
+          "coinbase_amount_unavailable"
+        else generated_reason diagnostics
+
+  let source_diagnostics_json = function
+    | Slot_tx_end_reached slot_tx_end ->
+        `Assoc
+          [ ( "slot_tx_end"
+            , Mina_numbers.Global_slot_since_hard_fork.to_yojson slot_tx_end )
+          ]
+    | Below_min_block_reward { threshold; reward } ->
+        `Assoc
+          [ ("threshold", Currency.Amount.to_yojson threshold)
+          ; ("reward", Currency.Amount.to_yojson reward)
+          ]
+    | Generated_diff diagnostics ->
+        Staged_ledger.Diff_creation_diagnostics.to_yojson diagnostics
+    | Precomputed ->
+        `Assoc []
+
+  let metadata_if_zero ~constraint_constants ~diff
+      ({ supercharge_coinbase; source } as t) =
+    let coinbase_amount =
+      Staged_ledger_diff.Diff.coinbase ~constraint_constants
+        ~supercharge_coinbase
+        (Staged_ledger_diff.diff diff)
+    in
+    let should_log =
+      match coinbase_amount with
+      | None ->
+          true
+      | Some amount ->
+          amount_is_zero amount
+    in
+    if should_log then
+      let coinbase_parts = diff_coinbase_parts diff in
+      [ ( "coinbase_amount"
+        , Option.value_map coinbase_amount ~default:(`String "unavailable")
+            ~f:Currency.Amount.to_yojson )
+      ; ( "zero_coinbase_reason"
+        , `String (zero_reason ~coinbase_amount ~coinbase_parts t) )
+      ; ("zero_coinbase_diagnostics", source_diagnostics_json source)
+      ]
+    else []
+end
+
+type generated_staged_ledger_diff =
+  { diff : Staged_ledger_diff.With_valid_signatures_and_proofs.t
+  ; next_staged_ledger_hash : Staged_ledger_hash.t
+  ; ledger_proof_opt : Ledger_proof.Cached.t option
+  ; is_new_stack : bool
+  ; pending_coinbase_update : Pending_coinbase.Update.t
+  ; coinbase_logging_source : Zero_coinbase_logging.zero_coinbase_source
+  }
+
 module Singleton_supervisor : sig
   type ('data, 'a) t
 
@@ -217,7 +356,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
           let coinbase_receiver =
             Consensus.Data.Block_data.coinbase_receiver block_data
           in
-          let diff =
+          let diff_with_logging =
             match slot_tx_end with
             | Some slot_tx_end
               when Mina_numbers.Global_slot_since_hard_fork.(
@@ -230,30 +369,35 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                           slot_tx_end )
                     ] ;
                 Result.return
-                  Staged_ledger_diff.With_valid_signatures_and_proofs.empty_diff
+                  ( Staged_ledger_diff.With_valid_signatures_and_proofs
+                    .empty_diff
+                  , Zero_coinbase_logging.Slot_tx_end_reached slot_tx_end )
             | Some _ | None ->
                 O1trace.sync_thread "create_staged_ledger_diff" (fun () ->
                     [%log internal] "Create_staged_ledger_diff" ;
                     (* TODO: handle transaction inclusion failures here *)
                     let diff_result =
-                      Staged_ledger.create_diff ~constraint_constants
-                        ~global_slot staged_ledger ~coinbase_receiver ~logger
+                      Staged_ledger.create_diff_with_diagnostics
+                        ~constraint_constants ~global_slot staged_ledger
+                        ~coinbase_receiver ~logger
                         ~current_state_view:previous_state_view
                         ~transactions_by_fee:transactions ~get_completed_work
                         ~log_block_creation ~supercharge_coinbase
                         ~zkapp_cmd_limit
-                      |> Result.map ~f:(fun (diff, failed_txns) ->
+                      |> Result.map ~f:(fun (diff, failed_txns, diagnostics) ->
                              if not (List.is_empty failed_txns) then
                                don't_wait_for
                                  (report_transaction_inclusion_failures ~logger
                                     ~commit_id failed_txns ) ;
-                             diff )
+                             ( diff
+                             , Zero_coinbase_logging.Generated_diff diagnostics
+                             ) )
                       |> Result.map_error ~f:(fun err ->
                              Staged_ledger.Staged_ledger_error.Pre_diff err )
                     in
                     [%log internal] "Create_staged_ledger_diff_done" ;
                     match (diff_result, block_reward_threshold) with
-                    | Ok diff, Some threshold ->
+                    | Ok (diff, _), Some threshold ->
                         let net_return =
                           Option.value ~default:Currency.Amount.zero
                             (Staged_ledger_diff.net_return ~constraint_constants
@@ -272,28 +416,39 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                               ; ("reward", Currency.Amount.to_yojson net_return)
                               ] ;
                           Ok
-                            Staged_ledger_diff.With_valid_signatures_and_proofs
-                            .empty_diff )
+                            ( Staged_ledger_diff.With_valid_signatures_and_proofs
+                              .empty_diff
+                            , Zero_coinbase_logging.Below_min_block_reward
+                                { threshold; reward = net_return } ) )
                     | _ ->
                         diff_result )
           in
           [%log internal] "Apply_staged_ledger_diff" ;
           match%map
-            let%bind.Deferred.Result diff = return diff in
-            Staged_ledger.apply_diff_unchecked staged_ledger
-              ~constraint_constants ~global_slot diff ~logger
-              ~current_state_view:previous_state_view
-              ~state_and_body_hash:
-                (previous_protocol_state_hash, previous_protocol_state_body_hash)
-              ~coinbase_receiver ~supercharge_coinbase ~zkapp_cmd_limit_hardcap
-              ~signature_kind
+            let%bind.Deferred.Result diff_with_logging =
+              return diff_with_logging
+            in
+            let diff, coinbase_logging_source = diff_with_logging in
+            let%map.Deferred.Result apply_diff_result =
+              Staged_ledger.apply_diff_unchecked staged_ledger
+                ~constraint_constants ~global_slot diff ~logger
+                ~current_state_view:previous_state_view
+                ~state_and_body_hash:
+                  ( previous_protocol_state_hash
+                  , previous_protocol_state_body_hash )
+                ~coinbase_receiver ~supercharge_coinbase
+                ~zkapp_cmd_limit_hardcap ~signature_kind
+            in
+            (diff, coinbase_logging_source, apply_diff_result)
           with
           | Ok
-              ( `Ledger_proof ledger_proof_opt
-              , `Staged_ledger transitioned_staged_ledger
-              , `Accounts_created _
-              , `Pending_coinbase_update (is_new_stack, pending_coinbase_update)
-              ) ->
+              ( diff
+              , coinbase_logging_source
+              , ( `Ledger_proof ledger_proof_opt
+                , `Staged_ledger transitioned_staged_ledger
+                , `Accounts_created _
+                , `Pending_coinbase_update
+                    (is_new_stack, pending_coinbase_update) ) ) ->
               [%log internal] "Hash_new_staged_ledger" ;
               let staged_ledger_hash =
                 Staged_ledger.hash transitioned_staged_ledger
@@ -304,18 +459,20 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
               @@ Mina_ledger.Ledger.unregister_mask_exn ~loc:__LOC__
                    (Staged_ledger.ledger transitioned_staged_ledger) ;
               Some
-                ( (match diff with Ok diff -> diff | Error _ -> assert false)
-                , staged_ledger_hash
-                , ledger_proof_opt
-                , is_new_stack
-                , pending_coinbase_update )
+                { diff
+                ; next_staged_ledger_hash = staged_ledger_hash
+                ; ledger_proof_opt
+                ; is_new_stack
+                ; pending_coinbase_update
+                ; coinbase_logging_source
+                }
           | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
               [%log error] "Failed to apply the diff: $error"
                 ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
               None
           | Error e ->
-              ( match diff with
-              | Ok diff ->
+              ( match diff_with_logging with
+              | Ok (diff, _) ->
                   [%log error]
                     ~metadata:
                       [ ( "error"
@@ -341,11 +498,13 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
       | None ->
           Interruptible.return None
       | Some
-          ( diff
-          , next_staged_ledger_hash
-          , ledger_proof_opt
-          , is_new_stack
-          , pending_coinbase_update ) ->
+          { diff
+          ; next_staged_ledger_hash
+          ; ledger_proof_opt
+          ; is_new_stack
+          ; pending_coinbase_update
+          ; coinbase_logging_source
+          } ->
           let diff_unwrapped =
             Staged_ledger_diff.read_all_proofs_from_disk
             @@ Staged_ledger_diff.forget diff
@@ -433,7 +592,14 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                 ; is_new_stack
                 }
               in
-              Some (protocol_state, internal_transition, witness) ) )
+              let coinbase_logging =
+                { Zero_coinbase_logging.supercharge_coinbase
+                ; source = coinbase_logging_source
+                }
+              in
+              Some
+                (protocol_state, internal_transition, witness, coinbase_logging) )
+      )
 
 let handle_block_production_errors ~logger ~rejected_blocks_logger
     ~time_taken:span ~previous_protocol_state ~protocol_state x =
@@ -802,7 +968,11 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
       match next_state_opt with
       | None ->
           Interruptible.return ()
-      | Some (protocol_state, internal_transition, pending_coinbase_witness) ->
+      | Some
+          ( protocol_state
+          , internal_transition
+          , pending_coinbase_witness
+          , coinbase_logging ) ->
           let diff =
             Internal_transition.staged_ledger_diff internal_transition
           in
@@ -963,6 +1133,13 @@ let produce ~genesis_breadcrumb ~context:(module Context : CONTEXT) ~prover
                       @@ Breadcrumb.block breadcrumb )
                   ; ("transactions", `List txs)
                   ] ;
+              let zero_coinbase_metadata =
+                Zero_coinbase_logging.metadata_if_zero ~constraint_constants
+                  ~diff:staged_ledger_diff coinbase_logging
+              in
+              if not (List.is_empty zero_coinbase_metadata) then
+                [%log warn] ~metadata:zero_coinbase_metadata
+                  "Produced block with zero coinbase: $zero_coinbase_reason" ;
               [%str_log info]
                 ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson breadcrumb) ]
                 Block_produced ;
@@ -1457,15 +1634,24 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
           let previous_protocol_state_hash =
             State_hash.With_state_hashes.state_hash previous_transition
           in
+          let supercharge_coinbase =
+            Protocol_state.consensus_state protocol_state
+            |> Consensus.Data.Consensus_state.supercharge_coinbase
+          in
+          let coinbase_logging =
+            { Zero_coinbase_logging.supercharge_coinbase
+            ; source = Zero_coinbase_logging.Precomputed
+            }
+          in
           let header =
             Header.create ~protocol_state ~protocol_state_proof
               ~delta_block_chain_proof ()
           in
-          let body =
-            Body.create
-              (Staged_ledger_diff.write_all_proofs_to_disk ~signature_kind
-                 ~proof_cache_db staged_ledger_diff )
+          let staged_ledger_diff_for_block =
+            Staged_ledger_diff.write_all_proofs_to_disk ~signature_kind
+              ~proof_cache_db staged_ledger_diff
           in
+          let body = Body.create staged_ledger_diff_for_block in
           let%bind transition =
             let open Result.Let_syntax in
             Validation.wrap_header
@@ -1514,6 +1700,13 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
                        | `Parent_missing_from_frontier ) as err ->
                          err ) )
           in
+          let zero_coinbase_metadata =
+            Zero_coinbase_logging.metadata_if_zero ~constraint_constants
+              ~diff:staged_ledger_diff_for_block coinbase_logging
+          in
+          if not (List.is_empty zero_coinbase_metadata) then
+            [%log warn] ~metadata:zero_coinbase_metadata
+              "Produced block with zero coinbase: $zero_coinbase_reason" ;
           [%str_log trace]
             ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson breadcrumb) ]
             Block_produced ;

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -55,7 +55,7 @@ module Zero_coinbase_logging = struct
     | One _ ->
         1
 
-  let diff_coinbase_parts (diff : Staged_ledger_diff.t) =
+  let n_diff_coinbase_parts (diff : Staged_ledger_diff.t) =
     let first, second_opt = diff.diff in
     first_coinbase_parts first.coinbase
     + Option.value_map second_opt ~default:0 ~f:(fun second ->
@@ -148,7 +148,7 @@ module Zero_coinbase_logging = struct
           amount_is_zero amount
     in
     if should_log then
-      let coinbase_parts = diff_coinbase_parts diff in
+      let coinbase_parts = n_diff_coinbase_parts diff in
       [ ( "coinbase_amount"
         , Option.value_map coinbase_amount ~default:(`String "unavailable")
             ~f:Currency.Amount.to_yojson )

--- a/src/lib/block_producer/test/dune
+++ b/src/lib/block_producer/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_zero_coinbase_logging)
+ (libraries alcotest block_producer currency mina_numbers staged_ledger))

--- a/src/lib/block_producer/test/test_zero_coinbase_logging.ml
+++ b/src/lib/block_producer/test/test_zero_coinbase_logging.ml
@@ -1,0 +1,87 @@
+module Z = Block_producer.Zero_coinbase_logging
+
+let check_reason label expected source
+    ?(coinbase_amount = Some Currency.Amount.zero) ?(coinbase_parts = 0) () =
+  Alcotest.(check string)
+    label expected
+    (Z.zero_reason ~coinbase_amount ~coinbase_parts
+       { Z.supercharge_coinbase = false; source } )
+
+let test_diagnostics ?(insufficient_work = 0) ?(insufficient_space = 0)
+    ?(insufficient_fees = 0) ?(extra_work = 0) ?(start_commands = 0)
+    ?(start_completed_work = 0) ?(end_commands = 0) ?(end_completed_work = 0)
+    ?(end_coinbase_parts = 0) () =
+  let open Staged_ledger.Diff_creation_diagnostics in
+  { proof_count = 0
+  ; valid_user_command_count = start_commands
+  ; partitions =
+      [ { partition = `First
+        ; start_commands
+        ; start_completed_work
+        ; available_slots = 0
+        ; required_work_count = 0
+        ; end_commands
+        ; end_completed_work
+        ; end_coinbase_parts
+        ; discard_counters =
+            { insufficient_work
+            ; insufficient_space
+            ; insufficient_fees
+            ; extra_work
+            }
+        }
+      ]
+  }
+
+let test_explicit_slot_tx_end () =
+  check_reason "slot tx end" "slot_tx_end_reached"
+    (Z.Slot_tx_end_reached Mina_numbers.Global_slot_since_hard_fork.zero) ()
+
+let test_explicit_min_reward_threshold () =
+  check_reason "min reward" "below_min_block_reward"
+    (Z.Below_min_block_reward
+       { threshold = Currency.Amount.zero; reward = Currency.Amount.zero } )
+    ()
+
+let test_unavailable_amount () =
+  check_reason "unavailable amount" "coinbase_amount_unavailable"
+    (Z.Generated_diff (test_diagnostics ()))
+    ~coinbase_amount:None ~coinbase_parts:1 ()
+
+let test_insufficient_work () =
+  check_reason "insufficient work" "insufficient_work"
+    (Z.Generated_diff (test_diagnostics ~insufficient_work:1 ()))
+    ()
+
+let test_insufficient_fees () =
+  check_reason "insufficient fees" "insufficient_fees"
+    (Z.Generated_diff (test_diagnostics ~insufficient_fees:1 ()))
+    ()
+
+let test_insufficient_space () =
+  check_reason "insufficient space" "insufficient_space"
+    (Z.Generated_diff (test_diagnostics ~insufficient_space:1 ()))
+    ()
+
+let test_empty_resources () =
+  check_reason "empty resources" "empty_diff_no_resources"
+    (Z.Generated_diff (test_diagnostics ()))
+    ()
+
+let test_precomputed () =
+  check_reason "precomputed" "precomputed_zero_coinbase" Z.Precomputed ()
+
+let () =
+  Alcotest.run "zero coinbase logging"
+    [ ( "reason priority"
+      , [ Alcotest.test_case "slot_tx_end" `Quick test_explicit_slot_tx_end
+        ; Alcotest.test_case "min_block_reward" `Quick
+            test_explicit_min_reward_threshold
+        ; Alcotest.test_case "amount_unavailable" `Quick test_unavailable_amount
+        ; Alcotest.test_case "insufficient_work" `Quick test_insufficient_work
+        ; Alcotest.test_case "insufficient_fees" `Quick test_insufficient_fees
+        ; Alcotest.test_case "insufficient_space" `Quick test_insufficient_space
+        ; Alcotest.test_case "empty_resources" `Quick test_empty_resources
+        ; Alcotest.test_case "precomputed" `Quick test_precomputed
+        ] )
+    ]

--- a/src/lib/block_producer/test/test_zero_coinbase_logging.ml
+++ b/src/lib/block_producer/test/test_zero_coinbase_logging.ml
@@ -1,7 +1,8 @@
 module Z = Block_producer.Zero_coinbase_logging
 
-let check_reason label expected source
+let check_reason expected source
     ?(coinbase_amount = Some Currency.Amount.zero) ?(coinbase_parts = 0) () =
+  let label = String.concat "," expected in
   Alcotest.(check (list string))
     label expected
     (Z.zero_reason ~coinbase_amount ~coinbase_parts
@@ -34,46 +35,42 @@ let test_diagnostics ?(insufficient_work = 0) ?(insufficient_space = 0)
   }
 
 let test_explicit_slot_tx_end () =
-  check_reason "slot tx end" [ "slot_tx_end_reached" ]
+  check_reason [ "slot_tx_end_reached" ]
     (Z.Slot_tx_end_reached Mina_numbers.Global_slot_since_hard_fork.zero) ()
 
 let test_explicit_min_reward_threshold () =
-  check_reason "min reward" [ "below_min_block_reward" ]
+  check_reason [ "below_min_block_reward" ]
     (Z.Below_min_block_reward
        { threshold = Currency.Amount.zero; reward = Currency.Amount.zero } )
     ()
 
 let test_unavailable_amount () =
-  check_reason "unavailable amount"
-    [ "coinbase_amount_unavailable"; "empty_diff_no_resources" ]
+  check_reason [ "coinbase_amount_unavailable"; "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ~coinbase_amount:None ~coinbase_parts:1 ()
 
 let test_insufficient_work () =
-  check_reason "insufficient work"
-    [ "empty_diff_no_resources"; "insufficient_work" ]
+  check_reason [ "empty_diff_no_resources"; "insufficient_work" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_work:1 ()))
     ()
 
 let test_insufficient_fees () =
-  check_reason "insufficient fees"
-    [ "empty_diff_no_resources"; "insufficient_fees" ]
+  check_reason [ "empty_diff_no_resources"; "insufficient_fees" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_fees:1 ()))
     ()
 
 let test_insufficient_space () =
-  check_reason "insufficient space"
-    [ "empty_diff_no_resources"; "insufficient_space" ]
+  check_reason [ "empty_diff_no_resources"; "insufficient_space" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_space:1 ()))
     ()
 
 let test_empty_resources () =
-  check_reason "empty resources" [ "empty_diff_no_resources" ]
+  check_reason [ "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ()
 
 let test_precomputed () =
-  check_reason "precomputed" [ "precomputed_zero_coinbase" ] Z.Precomputed ()
+  check_reason [ "precomputed_zero_coinbase" ] Z.Precomputed ()
 
 let () =
   Alcotest.run "zero coinbase logging"

--- a/src/lib/block_producer/test/test_zero_coinbase_logging.ml
+++ b/src/lib/block_producer/test/test_zero_coinbase_logging.ml
@@ -1,7 +1,7 @@
 module Z = Block_producer.Zero_coinbase_logging
 
-let check_reason expected source
-    ?(coinbase_amount = Some Currency.Amount.zero) ?(coinbase_parts = 0) () =
+let check_reason expected source ?(coinbase_amount = Some Currency.Amount.zero)
+    ?(coinbase_parts = 0) () =
   let label = String.concat "," expected in
   Alcotest.(check (list string))
     label expected
@@ -39,33 +39,39 @@ let test_explicit_slot_tx_end () =
     (Z.Slot_tx_end_reached Mina_numbers.Global_slot_since_hard_fork.zero) ()
 
 let test_explicit_min_reward_threshold () =
-  check_reason [ "below_min_block_reward" ]
+  check_reason
+    [ "below_min_block_reward" ]
     (Z.Below_min_block_reward
        { threshold = Currency.Amount.zero; reward = Currency.Amount.zero } )
     ()
 
 let test_unavailable_amount () =
-  check_reason [ "coinbase_amount_unavailable"; "empty_diff_no_resources" ]
+  check_reason
+    [ "coinbase_amount_unavailable"; "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ~coinbase_amount:None ~coinbase_parts:1 ()
 
 let test_insufficient_work () =
-  check_reason [ "empty_diff_no_resources"; "insufficient_work" ]
+  check_reason
+    [ "empty_diff_no_resources"; "insufficient_work" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_work:1 ()))
     ()
 
 let test_insufficient_fees () =
-  check_reason [ "empty_diff_no_resources"; "insufficient_fees" ]
+  check_reason
+    [ "empty_diff_no_resources"; "insufficient_fees" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_fees:1 ()))
     ()
 
 let test_insufficient_space () =
-  check_reason [ "empty_diff_no_resources"; "insufficient_space" ]
+  check_reason
+    [ "empty_diff_no_resources"; "insufficient_space" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_space:1 ()))
     ()
 
 let test_empty_resources () =
-  check_reason [ "empty_diff_no_resources" ]
+  check_reason
+    [ "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ()
 

--- a/src/lib/block_producer/test/test_zero_coinbase_logging.ml
+++ b/src/lib/block_producer/test/test_zero_coinbase_logging.ml
@@ -2,7 +2,7 @@ module Z = Block_producer.Zero_coinbase_logging
 
 let check_reason label expected source
     ?(coinbase_amount = Some Currency.Amount.zero) ?(coinbase_parts = 0) () =
-  Alcotest.(check string)
+  Alcotest.(check (list string))
     label expected
     (Z.zero_reason ~coinbase_amount ~coinbase_parts
        { Z.supercharge_coinbase = false; source } )
@@ -34,42 +34,46 @@ let test_diagnostics ?(insufficient_work = 0) ?(insufficient_space = 0)
   }
 
 let test_explicit_slot_tx_end () =
-  check_reason "slot tx end" "slot_tx_end_reached"
+  check_reason "slot tx end" [ "slot_tx_end_reached" ]
     (Z.Slot_tx_end_reached Mina_numbers.Global_slot_since_hard_fork.zero) ()
 
 let test_explicit_min_reward_threshold () =
-  check_reason "min reward" "below_min_block_reward"
+  check_reason "min reward" [ "below_min_block_reward" ]
     (Z.Below_min_block_reward
        { threshold = Currency.Amount.zero; reward = Currency.Amount.zero } )
     ()
 
 let test_unavailable_amount () =
-  check_reason "unavailable amount" "coinbase_amount_unavailable"
+  check_reason "unavailable amount"
+    [ "coinbase_amount_unavailable"; "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ~coinbase_amount:None ~coinbase_parts:1 ()
 
 let test_insufficient_work () =
-  check_reason "insufficient work" "insufficient_work"
+  check_reason "insufficient work"
+    [ "empty_diff_no_resources"; "insufficient_work" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_work:1 ()))
     ()
 
 let test_insufficient_fees () =
-  check_reason "insufficient fees" "insufficient_fees"
+  check_reason "insufficient fees"
+    [ "empty_diff_no_resources"; "insufficient_fees" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_fees:1 ()))
     ()
 
 let test_insufficient_space () =
-  check_reason "insufficient space" "insufficient_space"
+  check_reason "insufficient space"
+    [ "empty_diff_no_resources"; "insufficient_space" ]
     (Z.Generated_diff (test_diagnostics ~insufficient_space:1 ()))
     ()
 
 let test_empty_resources () =
-  check_reason "empty resources" "empty_diff_no_resources"
+  check_reason "empty resources" [ "empty_diff_no_resources" ]
     (Z.Generated_diff (test_diagnostics ()))
     ()
 
 let test_precomputed () =
-  check_reason "precomputed" "precomputed_zero_coinbase" Z.Precomputed ()
+  check_reason "precomputed" [ "precomputed_zero_coinbase" ] Z.Precomputed ()
 
 let () =
   Alcotest.run "zero coinbase logging"

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -39,6 +39,73 @@ module T = struct
   module Scan_state = Transaction_snark_scan_state
   module Pre_diff_info = Pre_diff_info
 
+  module Diff_creation_diagnostics = struct
+    type discard_counters =
+      { insufficient_work : int
+      ; insufficient_space : int
+      ; insufficient_fees : int
+      ; extra_work : int
+      }
+    [@@deriving to_yojson]
+
+    type partition =
+      { partition : [ `First | `Second ]
+      ; start_commands : int
+      ; start_completed_work : int
+      ; available_slots : int
+      ; required_work_count : int
+      ; end_commands : int
+      ; end_completed_work : int
+      ; end_coinbase_parts : int
+      ; discard_counters : discard_counters
+      }
+    [@@deriving to_yojson]
+
+    type t =
+      { proof_count : int
+      ; valid_user_command_count : int
+      ; partitions : partition list
+      }
+    [@@deriving to_yojson]
+
+    let coinbase_parts = function
+      | Staged_ledger_diff.At_most_two.Zero ->
+          0
+      | One _ ->
+          1
+      | Two _ ->
+          2
+
+    let partition_of_summary (summary : Diff_creation_log.Summary.t) =
+      let start_commands, _ = summary.start_resources.commands in
+      let start_completed_work, _ = summary.start_resources.completed_work in
+      let end_commands, _ = summary.end_resources.commands in
+      let end_completed_work, _ = summary.end_resources.completed_work in
+      { partition = summary.partition
+      ; start_commands
+      ; start_completed_work
+      ; available_slots = summary.available_slots
+      ; required_work_count = summary.required_work_count
+      ; end_commands
+      ; end_completed_work
+      ; end_coinbase_parts =
+          coinbase_parts summary.end_resources.coinbase_work_fees
+      ; discard_counters =
+          { insufficient_work = summary.discarded_commands.insufficient_work
+          ; insufficient_space = summary.discarded_commands.insufficient_space
+          ; insufficient_fees =
+              summary.discarded_completed_work.insufficient_fees
+          ; extra_work = summary.discarded_completed_work.extra_work
+          }
+      }
+
+    let create ~proof_count ~valid_user_command_count summaries =
+      { proof_count
+      ; valid_user_command_count
+      ; partitions = List.map summaries ~f:partition_of_summary
+      }
+  end
+
   module Staged_ledger_error = struct
     type t =
       | Non_zero_fee_excess of
@@ -2019,7 +2086,7 @@ module T = struct
         : Ledger.unattached_mask ) ;
     r
 
-  let create_diff
+  let create_diff_with_diagnostics
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~(global_slot : Mina_numbers.Global_slot_since_genesis.t)
       ?(log_block_creation = false) t ~coinbase_receiver ~logger
@@ -2153,10 +2220,17 @@ module T = struct
                     ~is_coinbase_receiver_new ~supercharge_coinbase partitions )
             in
             let summaries = List.map ~f:fst log in
+            let valid_user_command_count =
+              Sequence.length valid_on_this_ledger
+            in
+            let diagnostics =
+              Diff_creation_diagnostics.create ~proof_count
+                ~valid_user_command_count summaries
+            in
             [%log internal] "@block_metadata"
               ~metadata:
                 [ ("proof_count", `Int proof_count)
-                ; ("txn_count", `Int (Sequence.length valid_on_this_ledger))
+                ; ("txn_count", `Int valid_user_command_count)
                 ; ( "diff_log"
                   , Diff_creation_log.summary_list_to_yojson summaries )
                 ] ;
@@ -2179,7 +2253,7 @@ module T = struct
                log: $diff_log"
               ~metadata:
                 [ ("proof_count", `Int proof_count)
-                ; ("txn_count", `Int (Sequence.length valid_on_this_ledger))
+                ; ("txn_count", `Int valid_user_command_count)
                 ; ( "diff_log"
                   , Diff_creation_log.summary_list_to_yojson summaries )
                 ] ;
@@ -2191,7 +2265,17 @@ module T = struct
                         (List.map ~f:List.rev detailed) )
                   ] ;
             ( { Staged_ledger_diff.With_valid_signatures_and_proofs.diff }
-            , invalid_on_this_ledger ) ) )
+            , invalid_on_this_ledger
+            , diagnostics ) ) )
+
+  let create_diff ~constraint_constants ~global_slot ?log_block_creation t
+      ~coinbase_receiver ~logger ~current_state_view ~zkapp_cmd_limit
+      ~transactions_by_fee ~get_completed_work ~supercharge_coinbase =
+    create_diff_with_diagnostics ~constraint_constants ~global_slot
+      ?log_block_creation t ~coinbase_receiver ~logger ~current_state_view
+      ~zkapp_cmd_limit ~transactions_by_fee ~get_completed_work
+      ~supercharge_coinbase
+    |> Result.map ~f:(fun (diff, invalid_txns, _) -> (diff, invalid_txns))
 end
 
 include T

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -163,6 +163,9 @@ module Diff_creation_diagnostics : sig
     ; partitions : partition list
     }
   [@@deriving to_yojson]
+
+  val coinbase_parts :
+    Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t -> int
 end
 
 module Staged_ledger_error : sig

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -135,6 +135,36 @@ end
 
 module Pre_diff_info : Pre_diff_info.S
 
+module Diff_creation_diagnostics : sig
+  type discard_counters =
+    { insufficient_work : int
+    ; insufficient_space : int
+    ; insufficient_fees : int
+    ; extra_work : int
+    }
+  [@@deriving to_yojson]
+
+  type partition =
+    { partition : [ `First | `Second ]
+    ; start_commands : int
+    ; start_completed_work : int
+    ; available_slots : int
+    ; required_work_count : int
+    ; end_commands : int
+    ; end_completed_work : int
+    ; end_coinbase_parts : int
+    ; discard_counters : discard_counters
+    }
+  [@@deriving to_yojson]
+
+  type t =
+    { proof_count : int
+    ; valid_user_command_count : int
+    ; partitions : partition list
+    }
+  [@@deriving to_yojson]
+end
+
 module Staged_ledger_error : sig
   type t =
     | Non_zero_fee_excess of
@@ -236,6 +266,26 @@ val create_diff :
   -> supercharge_coinbase:bool
   -> ( Staged_ledger_diff.With_valid_signatures_and_proofs.t
        * (User_command.Valid.t * Error.t) list
+     , Pre_diff_info.Error.t )
+     Result.t
+
+val create_diff_with_diagnostics :
+     constraint_constants:Genesis_constants.Constraint_constants.t
+  -> global_slot:Mina_numbers.Global_slot_since_genesis.t
+  -> ?log_block_creation:bool
+  -> t
+  -> coinbase_receiver:Public_key.Compressed.t
+  -> logger:Logger.t
+  -> current_state_view:Zkapp_precondition.Protocol_state.View.t
+  -> zkapp_cmd_limit:int option
+  -> transactions_by_fee:User_command.Valid.t Sequence.t
+  -> get_completed_work:
+       (   Transaction_snark_work.Statement.t
+        -> Transaction_snark_work.Checked.t option )
+  -> supercharge_coinbase:bool
+  -> ( Staged_ledger_diff.With_valid_signatures_and_proofs.t
+       * (User_command.Valid.t * Error.t) list
+       * Diff_creation_diagnostics.t
      , Pre_diff_info.Error.t )
      Result.t
 


### PR DESCRIPTION
## Summary

Block producers now emit a warning-level log when they produce a block whose final coinbase amount is zero. The warning includes a stable `zero_coinbase_reason` string and compact diagnostics, computed cheaply and only on the zero-coinbase path.

## Changes

- **`staged_ledger`**: added a public `Diff_creation_diagnostics` module and `create_diff_with_diagnostics` that returns compact diff-creation counters alongside the staged-ledger diff. The existing `create_diff` API is preserved as a wrapper.
- **`block_producer`**: threads zero-coinbase source data through local block production. Explicit empty-block causes (`slot_tx_end_reached`, `below_min_block_reward`, `precomputed_zero_coinbase`) are recorded exactly; for generated diffs with zero coinbase, an inferred reason is derived from staged-ledger diagnostics (`insufficient_work`, `insufficient_fees`, etc.). A warning is emitted only when coinbase is zero; existing `Block_produced` trace/info logs are unchanged.
