### PR TITLE
fix(syncable-ledger): clean up sync lifecycle

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -201,8 +201,10 @@ let sync_ledger ({ context = (module Context); _ } as t) ~preferred
   let open Context in
   let query_reader = Sync_ledger.Root.query_reader root_sync_ledger in
   let response_writer = Sync_ledger.Root.answer_writer root_sync_ledger in
-  Mina_networking.glue_sync_ledger ~preferred t.network query_reader
-    response_writer ;
+  don't_wait_for
+    (Mina_networking.glue_sync_ledger ~preferred t.network
+       (Sync_ledger.Root.target_state root_sync_ledger)
+       query_reader response_writer ) ;
   Pipe_lib.Choosable_synchronous_pipe.iter sync_ledger_reader
     ~f:(fun (b_or_h, `Valid_cb vc) ->
       let header_with_hash, sender, transition_cache_element =
@@ -275,9 +277,13 @@ let download_snarked_ledger ~trust_system ~preferred_peers ~transition_graph
      (* We ignore the resulting ledger returned here since it will always
         * be the same as the ledger we started with because we are syncing
         * a db ledger. *)
-     let%map _, data = Sync_ledger.Root.valid_tree root_sync_ledger in
-     Sync_ledger.Root.destroy root_sync_ledger ;
-     data )
+     let%bind result = Sync_ledger.Root.valid_tree root_sync_ledger in
+     let%map () = Sync_ledger.Root.destroy root_sync_ledger in
+     match result with
+     | `Ok (_, data) ->
+         data
+     | `Destroyed ->
+         failwith "root sync ledger was destroyed before becoming valid" )
 
 let handle_scan_state_and_aux ~logger ~expected_staged_ledger_hash
     ~temp_snarked_ledger ~verifier ~constraint_constants ~signature_kind

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -810,6 +810,7 @@ module type S = sig
       -> local_state:Local_state.t
       -> glue_sync_ledger:
            (   preferred:Network_peer.Peer.t list
+            -> Mina_ledger.Sync_ledger.Root.Target_state.t
             -> (Frozen_ledger_hash.t * Mina_ledger.Sync_ledger.Query.t)
                Pipe_lib.Linear_pipe.Reader.t
             -> ( Frozen_ledger_hash.t
@@ -817,7 +818,7 @@ module type S = sig
                * Mina_ledger.Sync_ledger.Answer.t
                  Network_peer.Envelope.Incoming.t )
                Pipe.Writer.t
-            -> unit )
+            -> unit Deferred.t )
       -> local_state_sync
       -> unit Deferred.Or_error.t
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2687,11 +2687,23 @@ module Make_str (A : Wire_types.Concrete) = struct
               let response_writer =
                 Mina_ledger.Sync_ledger.Root.answer_writer sync_ledger
               in
-              glue_sync_ledger ~preferred:[] query_reader response_writer ;
-              match%bind
-                Mina_ledger.Sync_ledger.Root.fetch sync_ledger
-                  target_ledger_hash ~data:() ~equal:(fun () () -> true)
-              with
+              let glue_stopped =
+                glue_sync_ledger ~preferred:[]
+                  (Mina_ledger.Sync_ledger.Root.target_state sync_ledger)
+                  query_reader response_writer
+              in
+              let%bind result =
+                Monitor.protect
+                  ~finally:(fun () ->
+                    let%bind () =
+                      Mina_ledger.Sync_ledger.Root.destroy sync_ledger
+                    in
+                    glue_stopped )
+                  (fun () ->
+                    Mina_ledger.Sync_ledger.Root.fetch sync_ledger
+                      target_ledger_hash ~data:() ~equal:(fun () () -> true) )
+              in
+              match result with
               | `Ok ledger ->
                   [%log info]
                     "Succeeded in syncing epoch ledger with hash \
@@ -2705,6 +2717,10 @@ module Make_str (A : Wire_types.Concrete) = struct
               | `Target_changed _ ->
                   [%log error] "Target changed when syncing epoch ledger" ;
                   return (Or_error.error_string "Epoch ledger target changed")
+              | `Destroyed ->
+                  [%log error] "Sync ledger destroyed when syncing epoch ledger" ;
+                  return
+                    (Or_error.error_string "Epoch ledger sync ledger destroyed")
           in
           match requested_syncs with
           | One required_sync ->

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -79,12 +79,20 @@ end) : sig
 
   val cancel : t -> Key.t -> unit
 
+  val cancel_if : t -> f:(Key.t -> bool) -> unit
+
+  val closed : t -> unit Deferred.t
+
   val create :
        max_batch_size:int
     -> stop:unit Deferred.t
     -> logger:Logger.t
     -> trust_system:Trust_system.t
-    -> get:(Peer.t -> Key.t list -> Result.t list Deferred.Or_error.t)
+    -> get:
+         (   stop:unit Deferred.t
+          -> Peer.t
+          -> Key.t list
+          -> Result.t list Deferred.Or_error.t )
     -> knowledge_context:Knowledge_context.t Broadcast_pipe.Reader.t
     -> knowledge:
          (Knowledge_context.t -> Peer.t -> Key.t Claimed_knowledge.t Deferred.t)
@@ -599,11 +607,21 @@ end = struct
         Strict_pipe.Writer.write t.w ()
   end
 
+  type active_download =
+    { peer : Peer.t
+    ; job : Job.t
+    ; started_at : Time.t
+    ; batch_id : int
+    ; batch_stop : unit Ivar.t
+    }
+
   type t =
     { mutable next_flush : (unit, unit) Clock.Event.t option
+    ; mutable next_batch_id : int
+    ; mutable torn_down : bool
     ; mutable all_peers : Peer.Set.t
     ; pending : Job.t Q.t
-    ; downloading : (Peer.t * Job.t * Time.t) Key.Table.t
+    ; downloading : active_download Key.Table.t
     ; useful_peers : Useful_peers.t
     ; flush_r : unit Strict_pipe.Reader.t (* Single reader *)
     ; flush_w :
@@ -613,7 +631,11 @@ end = struct
         Strict_pipe.Writer.t
           (* buffer of length 0 *)
     ; jobs_added_bvar : (unit, read_write) Bvar.t
-    ; get : Peer.t -> Key.t list -> Result.t list Deferred.Or_error.t
+    ; get :
+           stop:unit Deferred.t
+        -> Peer.t
+        -> Key.t list
+        -> Result.t list Deferred.Or_error.t
     ; max_batch_size : int
           (* A peer is useful if there is a job in the pending queue which has not
              been attempted with that peer. *)
@@ -627,9 +649,12 @@ end = struct
     ; logger : Logger.t
     ; trust_system : Trust_system.t
     ; stop : unit Deferred.t
+    ; closed : unit Ivar.t
     }
 
   let logger t = t.logger
+
+  let closed t = Ivar.read t.closed
 
   let jobs_added t = Bvar.broadcast t.jobs_added_bvar ()
 
@@ -676,8 +701,7 @@ end = struct
     let job =
       List.find_map ~f:Lazy.force
         [ lazy (Q.lookup t.pending h)
-        ; lazy
-            (Option.map ~f:(fun (_, j, _) -> j) (Hashtbl.find t.downloading h))
+        ; lazy (Option.map ~f:(fun d -> d.job) (Hashtbl.find t.downloading h))
         ]
     in
     Q.remove t.pending h ;
@@ -688,6 +712,34 @@ end = struct
     | Some j ->
         kill_job t j ;
         Useful_peers.update t.useful_peers (Job_cancelled h)
+
+  let cancel_if t ~f =
+    let cancelled_batches = Int.Table.create () in
+    let cancel_key key =
+      if f key then
+        match Q.lookup t.pending key with
+        | Some j ->
+            Q.remove t.pending key ;
+            kill_job t j ;
+            Useful_peers.update t.useful_peers (Job_cancelled key)
+        | None -> (
+            match Hashtbl.find t.downloading key with
+            | None ->
+                ()
+            | Some d ->
+                Hashtbl.remove t.downloading key ;
+                Hashtbl.set cancelled_batches ~key:d.batch_id ~data:d.batch_stop ;
+                kill_job t d.job ;
+                Useful_peers.update t.useful_peers (Job_cancelled key) )
+    in
+    Q.to_list t.pending |> List.iter ~f:(fun j -> cancel_key j.key) ;
+    Hashtbl.keys t.downloading |> List.iter ~f:cancel_key ;
+    Hashtbl.iteri cancelled_batches ~f:(fun ~key:batch_id ~data:batch_stop ->
+        let batch_still_live =
+          Hashtbl.exists t.downloading ~f:(fun d -> d.batch_id = batch_id)
+        in
+        if not batch_still_live then Ivar.fill_if_empty batch_stop () ) ;
+    jobs_added t
 
   let enqueue t e =
     match Q.enqueue t.pending e with
@@ -701,7 +753,7 @@ end = struct
 
   let active_jobs t =
     Q.to_list t.pending
-    @ List.map (Hashtbl.data t.downloading) ~f:(fun (_, j, _) -> j)
+    @ List.map (Hashtbl.data t.downloading) ~f:(fun d -> d.job)
 
   let refresh_peers t peers =
     Broadcast_pipe.Reader.iter peers ~f:(fun peers ->
@@ -720,6 +772,8 @@ end = struct
 
   let tear_down
       ( { next_flush
+        ; next_batch_id = _
+        ; torn_down = _
         ; all_peers = _
         ; flush_w
         ; get = _
@@ -734,21 +788,27 @@ end = struct
         ; logger = _
         ; trust_system = _
         ; stop = _
+        ; closed
         } as t ) =
-    let rec clear_queue q =
-      match Q.dequeue q with
-      | None ->
-          ()
-      | Some j ->
-          kill_job t j ; clear_queue q
-    in
-    Option.iter next_flush ~f:(fun e -> Clock.Event.abort_if_possible e ()) ;
-    Strict_pipe.Writer.close flush_w ;
-    Useful_peers.tear_down useful_peers ;
-    Strict_pipe.Writer.close got_new_peers_w ;
-    Hashtbl.iter downloading ~f:(fun (_, j, _) -> kill_job t j) ;
-    Hashtbl.clear downloading ;
-    clear_queue pending
+    if not t.torn_down then (
+      t.torn_down <- true ;
+      let rec clear_queue q =
+        match Q.dequeue q with
+        | None ->
+            ()
+        | Some j ->
+            kill_job t j ; clear_queue q
+      in
+      Option.iter next_flush ~f:(fun e -> Clock.Event.abort_if_possible e ()) ;
+      Strict_pipe.Writer.close flush_w ;
+      Useful_peers.tear_down useful_peers ;
+      Strict_pipe.Writer.close got_new_peers_w ;
+      Hashtbl.iter downloading ~f:(fun d ->
+          Ivar.fill_if_empty d.batch_stop () ;
+          kill_job t d.job ) ;
+      Hashtbl.clear downloading ;
+      clear_queue pending ;
+      Ivar.fill_if_empty closed () )
 
   let download t peer xs =
     O1trace.thread "download" (fun () ->
@@ -763,7 +823,10 @@ end = struct
               ] ) )
         in
         let keys = List.map xs ~f:(fun x -> x.J.key) in
-        let fail (e : Error.t) =
+        let live_jobs () =
+          List.filter xs ~f:(fun x -> Hashtbl.mem t.downloading x.key)
+        in
+        let fail xs (e : Error.t) =
           let e = Error.to_string_hum e in
           [%log' debug t.logger]
             "Downloading from $peer failed ($error) on $keys"
@@ -779,11 +842,16 @@ end = struct
                 } ) ;
           flush_soon t
         in
+        let batch_stop = Ivar.create () in
+        let batch_id = t.next_batch_id in
+        t.next_batch_id <- t.next_batch_id + 1 ;
+        let started_at = Time.now () in
         List.iter xs ~f:(fun x ->
-            Hashtbl.set t.downloading ~key:x.key ~data:(peer, x, Time.now ()) ) ;
+            Hashtbl.set t.downloading ~key:x.key
+              ~data:{ peer; job = x; started_at; batch_id; batch_stop } ) ;
         jobs_added t ;
         Useful_peers.update t.useful_peers (Download_starting peer) ;
-        let download_deferred = t.get peer keys in
+        let download_deferred = t.get ~stop:(Ivar.read batch_stop) peer keys in
         upon download_deferred (fun res ->
             let succs, unsuccs =
               match res with
@@ -806,12 +874,14 @@ end = struct
           Deferred.choose
             [ Deferred.choice download_deferred (fun x -> `Not_stopped x)
             ; Deferred.choice t.stop (fun () -> `Stopped)
+            ; Deferred.choice (Ivar.read batch_stop) (fun () -> `Stopped)
             ; Deferred.choice
                 (* This happens if all the jobs are cancelled. *)
                 (Deferred.List.map xs ~f:(fun x -> Ivar.read x.res))
                 (fun _ -> `Stopped)
             ]
         in
+        let live_xs = live_jobs () in
         List.iter xs ~f:(fun j -> Hashtbl.remove t.downloading j.key) ;
         match res with
         | `Stopped ->
@@ -819,7 +889,7 @@ end = struct
         | `Not_stopped r -> (
             match r with
             | Error e ->
-                fail e
+                fail live_xs e
             | Ok rs ->
                 [%log' debug t.logger] "result is $result"
                   ~metadata:
@@ -828,7 +898,8 @@ end = struct
                     ] ;
                 let received_at = Time.now () in
                 let jobs =
-                  Key.Table.of_alist_exn (List.map xs ~f:(fun x -> (x.key, x)))
+                  Key.Table.of_alist_exn
+                    (List.map live_xs ~f:(fun x -> (x.key, x)))
                 in
                 List.iter rs ~f:(fun r ->
                     match Hashtbl.find jobs (Result.key r) with
@@ -870,15 +941,15 @@ end = struct
       ; ("pending", f t.pending)
       ; ( "downloading"
         , list
-            (List.map (Hashtbl.to_alist t.downloading)
-               ~f:(fun (h, (p, _, start)) ->
+            (List.map (Hashtbl.to_alist t.downloading) ~f:(fun (h, d) ->
                  `Assoc
                    [ ("hash", Key.to_yojson h)
-                   ; ("start", `String (Time.to_string start))
+                   ; ("start", `String (Time.to_string d.started_at))
                    ; ( "time_since_start"
-                     , `String (Time.Span.to_string_hum (Time.diff now start))
+                     , `String
+                         (Time.Span.to_string_hum (Time.diff now d.started_at))
                      )
-                   ; ("peer", `String (Peer.to_multiaddr_string p))
+                   ; ("peer", `String (Peer.to_multiaddr_string d.peer))
                    ] ) ) )
       ]
 
@@ -967,6 +1038,8 @@ end = struct
     let got_new_peers_r, got_new_peers_w = pipe ~name:"got_new_peers" 0 in
     let t =
       { all_peers = Peer.Set.of_list all_peers
+      ; next_batch_id = 0
+      ; torn_down = false
       ; pending = Q.create ()
       ; next_flush = None
       ; flush_r
@@ -981,6 +1054,7 @@ end = struct
       ; trust_system
       ; downloading = Key.Table.create ()
       ; stop
+      ; closed = Ivar.create ()
       }
     in
     let peers =
@@ -1087,8 +1161,10 @@ end = struct
     match (Q.lookup t.pending key, Hashtbl.find t.downloading key) with
     | Some _, Some _ ->
         assert false
-    | Some x, None | None, Some (_, x, _) ->
+    | Some x, None ->
         x
+    | None, Some d ->
+        d.job
     | None, None ->
         flush_soon t ;
         let e = { J.key; attempts; res = Ivar.create () } in

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -53,11 +53,11 @@ module Make (Rpc_interface : RPC_INTERFACE) :
 
   let random_peers_except (Any ((module M), t)) = M.random_peers_except t
 
-  let query_peer ?heartbeat_timeout ?timeout (Any ((module M), t)) =
-    M.query_peer ?heartbeat_timeout ?timeout t
+  let query_peer ?stop ?heartbeat_timeout ?timeout (Any ((module M), t)) =
+    M.query_peer ?stop ?heartbeat_timeout ?timeout t
 
-  let query_peer' ?how ?heartbeat_timeout ?timeout (Any ((module M), t)) =
-    M.query_peer' ?how ?heartbeat_timeout ?timeout t
+  let query_peer' ?how ?stop ?heartbeat_timeout ?timeout (Any ((module M), t)) =
+    M.query_peer' ?how ?stop ?heartbeat_timeout ?timeout t
 
   let query_random_peers (Any ((module M), t)) = M.query_random_peers t
 

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -241,14 +241,14 @@ module Make (Rpc_interface : RPC_INTERFACE) :
     let ban_notification_reader { ban_notification_reader; _ } =
       ban_notification_reader
 
-    let query_peer ?heartbeat_timeout:_ ?timeout:_ t peer rpc query =
+    let query_peer ?stop:_ ?heartbeat_timeout:_ ?timeout:_ t peer rpc query =
       Network.call_rpc t.network t.peer_table ~sender_id:t.local_ip.peer_id
         ~responder_id:peer rpc query
 
-    let query_peer' ?how ?heartbeat_timeout ?timeout t peer rpc qs =
+    let query_peer' ?how ?stop ?heartbeat_timeout ?timeout t peer rpc qs =
       let%map rs =
         Deferred.List.map ?how qs
-          ~f:(query_peer ?timeout ?heartbeat_timeout t peer rpc)
+          ~f:(query_peer ?stop ?timeout ?heartbeat_timeout t peer rpc)
       in
       with_return (fun { return } ->
           let data =

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -115,6 +115,7 @@ module type GOSSIP_NET = sig
 
   val query_peer' :
        ?how:Monad_sequence.how
+    -> ?stop:unit Deferred.t
     -> ?heartbeat_timeout:Time_ns.Span.t
     -> ?timeout:Time.Span.t
     -> t
@@ -124,7 +125,8 @@ module type GOSSIP_NET = sig
     -> 'r list rpc_response Deferred.t
 
   val query_peer :
-       ?heartbeat_timeout:Time_ns.Span.t
+       ?stop:unit Deferred.t
+    -> ?heartbeat_timeout:Time_ns.Span.t
     -> ?timeout:Time.Span.t
     -> t
     -> Peer.Id.t

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -891,7 +891,7 @@ module Make (Rpc_interface : RPC_INTERFACE) :
         ~rpc_failed_counter:Impl.failed_request_counter ~rpc_name:Impl.name t
         peer transport Impl.dispatch_multi query
 
-    let query_peer ?heartbeat_timeout ?timeout t (peer_id : Peer.Id.t) rpc
+    let query_peer ?stop ?heartbeat_timeout ?timeout t (peer_id : Peer.Id.t) rpc
         rpc_input =
       let%bind net2 = !(t.net2) in
       match%bind
@@ -900,15 +900,29 @@ module Make (Rpc_interface : RPC_INTERFACE) :
       | Ok stream ->
           let peer = Mina_net2.Libp2p_stream.remote_peer stream in
           let transport = prepare_stream_transport stream in
-          try_call_rpc ?heartbeat_timeout ?timeout t peer transport rpc
-            rpc_input
-          >>| fun data ->
+          let call =
+            try_call_rpc ?heartbeat_timeout ?timeout t peer transport rpc
+              rpc_input
+          in
+          let%map data =
+            match stop with
+            | None ->
+                call
+            | Some stop ->
+                Deferred.choose
+                  [ Deferred.choice call Fn.id
+                  ; Deferred.choice stop (fun () ->
+                        don't_wait_for
+                          (Mina_net2.reset_stream net2 stream >>| ignore) ;
+                        Or_error.error_string "rpc aborted" )
+                  ]
+          in
           Connected (Envelope.Incoming.wrap_peer ~data ~sender:peer)
       | Error e ->
           Mina_metrics.(Counter.inc_one Network.rpc_connections_failed) ;
           return (Failed_to_connect e)
 
-    let query_peer' (type q r) ?how ?heartbeat_timeout ?timeout t
+    let query_peer' (type q r) ?how ?stop ?heartbeat_timeout ?timeout t
         (peer_id : Peer.Id.t) (rpc : (q, r) Rpc_interface.rpc) (qs : q list) =
       let%bind net2 = !(t.net2) in
       match%bind
@@ -918,15 +932,29 @@ module Make (Rpc_interface : RPC_INTERFACE) :
           let peer = Mina_net2.Libp2p_stream.remote_peer stream in
           let transport = prepare_stream_transport stream in
           let (module Impl) = Rpc_interface.implementation rpc in
-          try_call_rpc_with_dispatch ?heartbeat_timeout ?timeout
-            ~rpc_counter:Impl.sent_counter
-            ~rpc_failed_counter:Impl.failed_request_counter ~rpc_name:Impl.name
-            t peer transport
-            (fun conn qs ->
-              Deferred.Or_error.List.map ?how qs ~f:(fun q ->
-                  Impl.dispatch_multi conn q ) )
-            qs
-          >>| fun data ->
+          let call =
+            try_call_rpc_with_dispatch ?heartbeat_timeout ?timeout
+              ~rpc_counter:Impl.sent_counter
+              ~rpc_failed_counter:Impl.failed_request_counter
+              ~rpc_name:Impl.name t peer transport
+              (fun conn qs ->
+                Deferred.Or_error.List.map ?how qs ~f:(fun q ->
+                    Impl.dispatch_multi conn q ) )
+              qs
+          in
+          let%map data =
+            match stop with
+            | None ->
+                call
+            | Some stop ->
+                Deferred.choose
+                  [ Deferred.choice call Fn.id
+                  ; Deferred.choice stop (fun () ->
+                        don't_wait_for
+                          (Mina_net2.reset_stream net2 stream >>| ignore) ;
+                        Or_error.error_string "rpc aborted" )
+                  ]
+          in
           Connected (Envelope.Incoming.wrap_peer ~data ~sender:peer)
       | Error e ->
           Mina_metrics.(Counter.inc_one Network.rpc_connections_failed) ;

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1181,7 +1181,7 @@ let run_catchup ~context:(module Context : CONTEXT) ~trust_system ~verifier
     in
     Downloader.create ~stop ~trust_system ~logger ~preferred:[]
       ~max_batch_size:5
-      ~get:(fun peer hs ->
+      ~get:(fun ~stop:_ peer hs ->
         let sec =
           let sec_per_block =
             Option.value_map

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -483,9 +483,11 @@ let%test_module "Epoch ledger sync tests" =
             )
             Linear_pipe.write proxy_response_writer response)
         *)
-        Mina_networking.glue_sync_ledger test.network_info2.networking
-          ~preferred:[ test.network_info1.network_peer ]
-          query_reader answer_writer ;
+        don't_wait_for
+          (Mina_networking.glue_sync_ledger test.network_info2.networking
+             ~preferred:[ test.network_info1.network_peer ]
+             (Mina_ledger.Sync_ledger.Root.target_state sync_ledger)
+             query_reader answer_writer ) ;
         sync_ledger
       in
       let staking_ledger_root =
@@ -513,6 +515,8 @@ let%test_module "Epoch ledger sync tests" =
             [%log debug] "Synced current epoch ledger successfully"
         | `Target_changed _ ->
             failwith "Target changed when getting staking ledger"
+        | `Destroyed ->
+            failwith "Sync ledger destroyed when getting staking ledger"
       in
       (* sync next staking ledger *)
       let sync_ledger2_tm0 = Unix.gettimeofday () in
@@ -533,6 +537,9 @@ let%test_module "Epoch ledger sync tests" =
       | `Target_changed _ ->
           test.cleanup () ;
           failwith "Target changed when getting next epoch ledger"
+      | `Destroyed ->
+          test.cleanup () ;
+          failwith "Sync ledger destroyed when getting next epoch ledger"
 
     let cannot_sync_staking_ledger (test : test_state) =
       let staking_ledger_root =

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -167,11 +167,11 @@ include struct
 
   let random_peers = lift random_peers
 
-  let query_peer ?heartbeat_timeout ?timeout { gossip_net; _ } =
-    query_peer ?heartbeat_timeout ?timeout gossip_net
+  let query_peer ?stop ?heartbeat_timeout ?timeout { gossip_net; _ } =
+    query_peer ?stop ?heartbeat_timeout ?timeout gossip_net
 
-  let query_peer' ?how ?heartbeat_timeout ?timeout { gossip_net; _ } =
-    query_peer' ?how ?heartbeat_timeout ?timeout gossip_net
+  let query_peer' ?how ?stop ?heartbeat_timeout ?timeout { gossip_net; _ } =
+    query_peer' ?how ?stop ?heartbeat_timeout ?timeout gossip_net
 
   let restart_helper { gossip_net; _ } = restart_helper gossip_net
 
@@ -406,72 +406,122 @@ end
 let glue_sync_ledger :
        t
     -> preferred:Peer.t list
+    -> Mina_ledger.Sync_ledger.Root.Target_state.t
     -> (Mina_base.Ledger_hash.t * Sync_ledger.Query.t)
        Pipe_lib.Linear_pipe.Reader.t
     -> ( Mina_base.Ledger_hash.t
        * Sync_ledger.Query.t
        * Sync_ledger.Answer.t Network_peer.Envelope.Incoming.t )
        Pipe_lib.Linear_pipe.Writer.t
-    -> unit =
- fun t ~preferred query_reader response_writer ->
-  let downloader =
-    let heartbeat_timeout = Time_ns.Span.of_sec 20. in
-    let global_stop = Pipe_lib.Linear_pipe.closed query_reader in
-    let knowledge h peer =
-      match%map
-        query_peer ~heartbeat_timeout ~timeout:(Time.Span.of_sec 10.) t
-          peer.Peer.peer_id Rpcs.Answer_sync_ledger_query (h, Num_accounts)
-      with
-      | Connected { data = Ok _; _ } ->
-          `Call (fun (h', _) -> Ledger_hash.equal h' h)
-      | Failed_to_connect _ | Connected { data = Error _; _ } ->
-          `Some []
-    in
-    let%bind _ = Linear_pipe.values_available query_reader in
-    let root_hash_r, root_hash_w =
-      Broadcast_pipe.create
-        (Option.value_exn (Linear_pipe.peek query_reader) |> fst)
-    in
-    Sl_downloader.create ~preferred ~max_batch_size:100
-      ~peers:(fun () -> peers t)
-      ~knowledge_context:root_hash_r ~knowledge ~stop:global_stop
-      ~logger:t.logger ~trust_system:t.trust_system
-      ~get:(fun (peer : Peer.t) qs ->
-        List.iter qs ~f:(fun (h, _) ->
-            if
-              not (Ledger_hash.equal h (Broadcast_pipe.Reader.peek root_hash_r))
-            then don't_wait_for (Broadcast_pipe.Writer.write root_hash_w h) ) ;
-        let%map rs =
-          query_peer' ~how:`Parallel ~heartbeat_timeout
-            ~timeout:(Time.Span.of_sec (Float.of_int (List.length qs) *. 2.))
-            t peer.peer_id Rpcs.Answer_sync_ledger_query qs
-        in
-        match rs with
-        | Failed_to_connect e ->
-            Error e
-        | Connected res -> (
-            match res.data with
-            | Error e ->
-                Error e
-            | Ok rs -> (
-                match List.zip qs rs with
-                | Unequal_lengths ->
-                    Or_error.error_string "mismatched lengths"
-                | Ok ps ->
-                    Ok
-                      (List.filter_map ps ~f:(fun (q, r) ->
-                           match r with Ok r -> Some (q, r) | Error _ -> None )
-                      ) ) ) )
+    -> unit Deferred.t =
+ fun t ~preferred target_state query_reader response_writer ->
+  let heartbeat_timeout = Time_ns.Span.of_sec 20. in
+  let global_stop =
+    Deferred.any
+      [ Pipe_lib.Linear_pipe.closed query_reader
+      ; Mina_ledger.Sync_ledger.Root.Target_state.closed target_state
+      ]
   in
-  don't_wait_for
-    (let%bind downloader = downloader in
-     Linear_pipe.iter_unordered ~max_concurrency:400 query_reader ~f:(fun q ->
-         match%bind
-           Sl_downloader.Job.result
-             (Sl_downloader.download downloader ~key:q ~attempts:Peer.Map.empty)
-         with
-         | Error _ ->
-             Deferred.unit
-         | Ok (a, _) ->
-             Linear_pipe.write_if_open response_writer
-               (fst q, snd q, { a with data = snd a.data }) ) )
+  match%bind Linear_pipe.values_available query_reader with
+  | `Eof ->
+      Deferred.unit
+  | `Ok ->
+      let current_root () =
+        Mina_ledger.Sync_ledger.Root.Target_state.current target_state
+      in
+      let initial_root =
+        Option.value (current_root ())
+          ~default:(Option.value_exn (Linear_pipe.peek query_reader) |> fst)
+      in
+      let root_hash_r, root_hash_w = Broadcast_pipe.create initial_root in
+      let knowledge h peer =
+        match%map
+          query_peer ~heartbeat_timeout ~timeout:(Time.Span.of_sec 10.) t
+            peer.Peer.peer_id Rpcs.Answer_sync_ledger_query (h, Num_accounts)
+        with
+        | Connected { data = Ok _; _ } ->
+            `Call (fun (h', _) -> Ledger_hash.equal h' h)
+        | Failed_to_connect _ | Connected { data = Error _; _ } ->
+            `Some []
+      in
+      let%bind downloader =
+        Sl_downloader.create ~preferred ~max_batch_size:100
+          ~peers:(fun () -> peers t)
+          ~knowledge_context:root_hash_r ~knowledge ~stop:global_stop
+          ~logger:t.logger ~trust_system:t.trust_system
+          ~get:(fun ~stop (peer : Peer.t) qs ->
+            let%map rs =
+              query_peer' ~how:`Parallel ~stop ~heartbeat_timeout
+                ~timeout:
+                  (Time.Span.of_sec (Float.of_int (List.length qs) *. 2.))
+                t peer.peer_id Rpcs.Answer_sync_ledger_query qs
+            in
+            match rs with
+            | Failed_to_connect e ->
+                Error e
+            | Connected res -> (
+                match res.data with
+                | Error e ->
+                    Error e
+                | Ok rs -> (
+                    match List.zip qs rs with
+                    | Unequal_lengths ->
+                        Or_error.error_string "mismatched lengths"
+                    | Ok ps ->
+                        Ok
+                          (List.filter_map ps ~f:(fun (q, r) ->
+                               match r with
+                               | Ok r ->
+                                   Some (q, r)
+                               | Error _ ->
+                                   None ) ) ) ) )
+      in
+      let cancel_stale_work () =
+        let root = current_root () in
+        Sl_downloader.cancel_if downloader ~f:(fun (h, _) ->
+            not (Option.equal Ledger_hash.equal (Some h) root) ) ;
+        Option.iter root ~f:(fun h ->
+            don't_wait_for (Broadcast_pipe.Writer.write root_hash_w h) )
+      in
+      let rec watch_target_state () =
+        match%bind
+          Deferred.choose
+            [ Deferred.choice
+                (Mina_ledger.Sync_ledger.Root.Target_state.closed target_state)
+                (fun () -> `Closed)
+            ; Deferred.choice
+                (Mina_ledger.Sync_ledger.Root.Target_state.changed target_state)
+                (fun () -> `Changed)
+            ]
+        with
+        | `Closed ->
+            Broadcast_pipe.Writer.close root_hash_w ;
+            Deferred.unit
+        | `Changed ->
+            cancel_stale_work () ; watch_target_state ()
+      in
+      don't_wait_for (watch_target_state ()) ;
+      cancel_stale_work () ;
+      let%bind () =
+        Linear_pipe.iter_unordered ~max_concurrency:400 query_reader
+          ~f:(fun q ->
+            if
+              not
+                (Option.equal Ledger_hash.equal
+                   (Some (fst q))
+                   (current_root ()) )
+            then Deferred.unit
+            else
+              match%bind
+                Sl_downloader.Job.result
+                  (Sl_downloader.download downloader ~key:q
+                     ~attempts:Peer.Map.empty )
+              with
+              | Error _ ->
+                  Deferred.unit
+              | Ok (a, _) ->
+                  Linear_pipe.write_if_open response_writer
+                    (fst q, snd q, { a with data = snd a.data }) )
+      in
+      let%map () = Sl_downloader.closed downloader in
+      Broadcast_pipe.Writer.close root_hash_w

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -256,15 +256,17 @@ val broadcast_transaction_pool_diff :
 val glue_sync_ledger :
      t
   -> preferred:Peer.t list
+  -> Mina_ledger.Sync_ledger.Root.Target_state.t
   -> (Ledger_hash.t * Mina_ledger.Sync_ledger.Query.t) Linear_pipe.Reader.t
   -> ( Ledger_hash.t
      * Mina_ledger.Sync_ledger.Query.t
      * Mina_ledger.Sync_ledger.Answer.t Envelope.Incoming.t )
      Linear_pipe.Writer.t
-  -> unit
+  -> unit Deferred.t
 
 val query_peer :
-     ?heartbeat_timeout:Time_ns.Span.t
+     ?stop:unit Deferred.t
+  -> ?heartbeat_timeout:Time_ns.Span.t
   -> ?timeout:Time.Span.t
   -> t
   -> Network_peer.Peer.Id.t

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -327,11 +327,20 @@ let%test_module "Sync_handler" =
                        [(peer.host, frontier)])
                   ~peers:(Hash_set.of_list (module Network_peer.Peer) [peer])
               in
-              Network.glue_sync_ledger network query_reader answer_writer ;
-              match%map
+              let glue_stopped =
+                Network.glue_sync_ledger network
+                  (Sync_ledger.Mask.target_state sync_ledger)
+                  query_reader answer_writer
+              in
+              let%bind result =
                 Sync_ledger.Mask.fetch sync_ledger desired_root ~data:()
                   ~equal:(fun () () -> true)
-              with
+              in
+              let%map () =
+                let%bind () = Sync_ledger.Mask.destroy sync_ledger in
+                glue_stopped
+              in
+              match result with
               | `Ok synced_ledger ->
                   heartbeat_flag := false ;
                   Ledger_hash.equal
@@ -342,7 +351,10 @@ let%test_module "Sync_handler" =
                        (Ledger.merkle_root source_ledger)
               | `Target_changed _ ->
                   heartbeat_flag := false ;
-                  failwith "target of sync_ledger should not change" ) )
+                  failwith "target of sync_ledger should not change"
+              | `Destroyed ->
+                  heartbeat_flag := false ;
+                  failwith "sync_ledger should not be destroyed" ) )
 
     let to_external_transition breadcrumb =
       Transition_frontier.Breadcrumb.validated_transition breadcrumb

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -140,6 +140,16 @@ module type S = sig
 
   type answer
 
+  module Target_state : sig
+    type t
+
+    val current : t -> root_hash option
+
+    val changed : t -> unit Deferred.t
+
+    val closed : t -> unit Deferred.t
+  end
+
   module Responder : sig
     type t
 
@@ -166,7 +176,9 @@ module type S = sig
 
   val query_reader : 'a t -> (root_hash * query) Linear_pipe.Reader.t
 
-  val destroy : 'a t -> unit
+  val target_state : 'a t -> Target_state.t
+
+  val destroy : 'a t -> unit Deferred.t
 
   val new_goal :
        'a t
@@ -177,12 +189,14 @@ module type S = sig
 
   val peek_valid_tree : 'a t -> merkle_tree option
 
-  val valid_tree : 'a t -> (merkle_tree * 'a) Deferred.t
+  val valid_tree : 'a t -> [ `Ok of merkle_tree * 'a | `Destroyed ] Deferred.t
 
   val wait_until_valid :
        'a t
     -> root_hash
-    -> [ `Ok of merkle_tree | `Target_changed of root_hash option * root_hash ]
+    -> [ `Ok of merkle_tree
+       | `Target_changed of root_hash option * root_hash
+       | `Destroyed ]
        Deferred.t
 
   val fetch :
@@ -190,7 +204,9 @@ module type S = sig
     -> root_hash
     -> data:'a
     -> equal:('a -> 'a -> bool)
-    -> [ `Ok of merkle_tree | `Target_changed of root_hash option * root_hash ]
+    -> [ `Ok of merkle_tree
+       | `Target_changed of root_hash option * root_hash
+       | `Destroyed ]
        Deferred.t
 
   val apply_or_queue_diff : 'a t -> diff -> unit
@@ -418,9 +434,26 @@ end = struct
           Or_error.error_string err
   end
 
+  type target_state =
+    { current_root : Root_hash.t option ref
+    ; changed_bvar : (unit, read_write) Bvar.t
+    ; closed : unit Ivar.t
+    }
+
+  module Target_state = struct
+    type t = target_state
+
+    let current t = !(t.current_root)
+
+    let changed t = Bvar.wait t.changed_bvar
+
+    let closed t = Ivar.read t.closed
+  end
+
   type 'a t =
     { mutable desired_root : Root_hash.t option
     ; mutable auxiliary_data : 'a option
+    ; mutable destroyed : bool
     ; tree : MT.t
     ; trust_system : Trust_system.t
     ; answers :
@@ -434,7 +467,12 @@ end = struct
               hash of the node with the address. *)
     ; waiting_content : Hash.t Addr.Table.t
     ; mutable validity_listener :
-        [ `Ok | `Target_changed of Root_hash.t option * Root_hash.t ] Ivar.t
+        [ `Ok
+        | `Target_changed of Root_hash.t option * Root_hash.t
+        | `Destroyed ]
+        Ivar.t
+    ; stopped : unit Ivar.t
+    ; target_state : target_state
     ; context : (module CONTEXT)
     }
 
@@ -444,9 +482,19 @@ end = struct
 
   let desired_root_exn { desired_root; _ } = desired_root |> Option.value_exn
 
+  let target_state t = t.target_state
+
   let destroy t =
+    if not t.destroyed then (
+      t.destroyed <- true ;
+      Ivar.fill_if_empty t.validity_listener `Destroyed ;
+      Ivar.fill_if_empty t.target_state.closed () ;
+      Bvar.broadcast t.target_state.changed_bvar () ;
+      Linear_pipe.close t.answer_writer ;
+      Linear_pipe.close t.queries ) ;
     Linear_pipe.close_read t.answers ;
-    Linear_pipe.close_read t.query_reader
+    Linear_pipe.close_read t.query_reader ;
+    Ivar.read t.stopped
 
   let answer_writer t = t.answer_writer
 
@@ -461,7 +509,7 @@ end = struct
         ; ("hash", Hash.to_yojson expected)
         ]
       "Expecting children parent $parent_address, expected: $hash" ;
-    Addr.Table.add_exn t.waiting_parents ~key:parent_addr ~data:expected
+    Hashtbl.set t.waiting_parents ~key:parent_addr ~data:expected
 
   let expect_content : 'a t -> Addr.t -> Hash.t -> unit =
    fun t addr expected ->
@@ -470,7 +518,7 @@ end = struct
       ~metadata:
         [ ("address", Addr.to_yojson addr); ("hash", Hash.to_yojson expected) ]
       "Expecting content addr $address, expected: $hash" ;
-    Addr.Table.add_exn t.waiting_content ~key:addr ~data:expected
+    Hashtbl.set t.waiting_content ~key:addr ~data:expected
 
   (** Given an address and the accounts below that address, fill in the tree
       with them. *)
@@ -574,7 +622,15 @@ end = struct
     else (
       if Ivar.is_full t.validity_listener then
         [%log error] "Ivar.fill bug is here!" ;
-      Ivar.fill t.validity_listener `Ok )
+      Ivar.fill_if_empty t.validity_listener `Ok )
+
+  let enqueue_query t root_hash query =
+    if
+      (not t.destroyed)
+      && Option.equal Root_hash.equal
+           !(t.target_state.current_root)
+           (Some root_hash)
+    then Linear_pipe.write_without_pushback_if_open t.queries (root_hash, query)
 
   (** Compute the hash of an empty tree of the specified height. *)
   let empty_hash_at_height h =
@@ -603,13 +659,13 @@ end = struct
     let open (val t.context) in
     if Addr.depth addr >= MT.depth t.tree - account_subtree_height then (
       expect_content t addr exp_hash ;
-      Linear_pipe.write_without_pushback_if_open t.queries
-        (desired_root_exn t, What_contents addr) )
+      let root_hash = desired_root_exn t in
+      enqueue_query t root_hash (What_contents addr) )
     else (
       expect_children t addr exp_hash ;
-      Linear_pipe.write_without_pushback_if_open t.queries
-        ( desired_root_exn t
-        , What_child_hashes (addr, ledger_sync_config.default_subtree_depth) ) )
+      let root_hash = desired_root_exn t in
+      enqueue_query t root_hash
+        (What_child_hashes (addr, ledger_sync_config.default_subtree_depth)) )
 
   (** Handle the initial Num_accounts message, starting the main syncing
       process. *)
@@ -652,10 +708,12 @@ end = struct
           ; ("query", Query.to_yojson Addr.to_yojson query)
           ]
         "Handle answer for $root_hash" ;
-      if not (Root_hash.equal root_hash (desired_root_exn t)) then (
+      if t.destroyed then Deferred.unit
+      else if not (Option.equal Root_hash.equal (Some root_hash) t.desired_root)
+      then (
         [%log trace]
           ~metadata:
-            [ ("desired_hash", Root_hash.to_yojson (desired_root_exn t))
+            [ ("desired_hash", [%to_yojson: Root_hash.t option] t.desired_root)
             ; ("ignored_hash", Root_hash.to_yojson root_hash)
             ]
           "My desired root was $desired_hash, so I'm ignoring $ignored_hash" ;
@@ -669,9 +727,7 @@ end = struct
         let open Trust_system in
         (* If a peer misbehaves we still need the information we asked them for,
            so requeue in that case. *)
-        let requeue_query () =
-          Linear_pipe.write_without_pushback_if_open t.queries (root_hash, query)
-        in
+        let requeue_query () = enqueue_query t root_hash query in
         let credit_fulfilled_request () =
           record_envelope_sender t.trust_system logger sender
             ( Actions.Fulfilled_request
@@ -785,7 +841,8 @@ end = struct
       | Some h' ->
           Root_hash.equal h h'
     in
-    if not should_skip then (
+    if t.destroyed then `Repeat
+    else if not should_skip then (
       Option.iter t.desired_root ~f:(fun root_hash ->
           [%log debug]
             ~metadata:
@@ -797,8 +854,10 @@ end = struct
         (`Target_changed (t.desired_root, h)) ;
       t.validity_listener <- Ivar.create () ;
       t.desired_root <- Some h ;
+      t.target_state.current_root := Some h ;
+      Bvar.broadcast t.target_state.changed_bvar () ;
       t.auxiliary_data <- Some data ;
-      Linear_pipe.write_without_pushback_if_open t.queries (h, Num_accounts) ;
+      enqueue_query t h Num_accounts ;
       `New )
     else if
       Option.fold t.auxiliary_data ~init:false ~f:(fun _ saved_data ->
@@ -813,26 +872,31 @@ end = struct
   let rec valid_tree t =
     match%bind Ivar.read t.validity_listener with
     | `Ok ->
-        return (t.tree, Option.value_exn t.auxiliary_data)
+        return (`Ok (t.tree, Option.value_exn t.auxiliary_data))
     | `Target_changed _ ->
         valid_tree t
+    | `Destroyed ->
+        return `Destroyed
 
   let peek_valid_tree t =
     Option.bind (Ivar.peek t.validity_listener) ~f:(function
       | `Ok ->
           Some t.tree
-      | `Target_changed _ ->
+      | `Target_changed _ | `Destroyed ->
           None )
 
   let wait_until_valid t h =
-    if not (Root_hash.equal h (desired_root_exn t)) then
+    if t.destroyed then return `Destroyed
+    else if not (Option.equal Root_hash.equal (Some h) t.desired_root) then
       return (`Target_changed (t.desired_root, h))
     else
       Deferred.map (Ivar.read t.validity_listener) ~f:(function
         | `Target_changed payload ->
             `Target_changed payload
         | `Ok ->
-            `Ok t.tree )
+            `Ok t.tree
+        | `Destroyed ->
+            `Destroyed )
 
   let fetch t rh ~data ~equal =
     ignore (new_goal t rh ~data ~equal : [ `New | `Repeat | `Update_data ]) ;
@@ -844,6 +908,7 @@ end = struct
     let t =
       { desired_root = None
       ; auxiliary_data = None
+      ; destroyed = false
       ; tree = mt
       ; trust_system
       ; answers = ar
@@ -853,10 +918,18 @@ end = struct
       ; waiting_parents = Addr.Table.create ()
       ; waiting_content = Addr.Table.create ()
       ; validity_listener = Ivar.create ()
+      ; stopped = Ivar.create ()
+      ; target_state =
+          { current_root = ref None
+          ; changed_bvar = Bvar.create ()
+          ; closed = Ivar.create ()
+          }
       ; context
       }
     in
-    don't_wait_for (main_loop t) ;
+    don't_wait_for
+      (let%map () = main_loop t in
+       Ivar.fill_if_empty t.stopped () ) ;
     t
 
   let apply_or_queue_diff _ _ =

--- a/src/lib/syncable_ledger/test/dune
+++ b/src/lib/syncable_ledger/test/dune
@@ -1,10 +1,12 @@
-(library
+(test
  (name test)
- (inline_tests
-  (flags -verbose -show-counts))
+ (flags
+  (:standard -w -32))
  (libraries
   ;; opam libraries
-  result
+   result
+   alcotest
+   alcotest-async
   base.base_internalhash_types
   bin_prot.shape
   async_unix

--- a/src/lib/syncable_ledger/test/test.ml
+++ b/src/lib/syncable_ledger/test/test.ml
@@ -3,6 +3,16 @@ open Async_kernel
 open Pipe_lib
 open Network_peer
 
+let alcotest_suites = ref []
+
+let suite_counter = ref 0
+
+let register suite cases = alcotest_suites := (suite, cases) :: !alcotest_suites
+
+let next_suite_name prefix =
+  incr suite_counter ;
+  sprintf "%s-%d" prefix !suite_counter
+
 module type Ledger_intf = sig
   include Merkle_ledger.Intf.SYNCABLE
 
@@ -111,7 +121,7 @@ struct
     Async.Scheduler.set_record_backtraces true ;
     Core.Backtrace.elide := false
 
-  let%test "full_sync_entirely_different" =
+  let test_full_sync_entirely_different () =
     let l1, _k1 = Ledger.load_ledger 1 1 in
     let l2, _k2 = Ledger.load_ledger num_accts 2 in
     let desired_root = Ledger.merkle_root l2 in
@@ -141,18 +151,20 @@ struct
            in
            Linear_pipe.write aw (root_hash, query, Envelope.Incoming.local answ) )
       ) ;
-    match
-      Async.Thread_safe.block_on_async_exn (fun () ->
-          Sync_ledger.fetch lsync desired_root ~data:() ~equal:(fun () () ->
-              true ) )
+    match%map
+      Sync_ledger.fetch lsync desired_root ~data:() ~equal:(fun () () -> true)
     with
     | `Ok mt ->
         total_queries := Some (List.length !seen_queries) ;
-        Root_hash.equal desired_root (Ledger.merkle_root mt)
+        Alcotest.(check bool)
+          "synced root" true
+          (Root_hash.equal desired_root (Ledger.merkle_root mt))
     | `Target_changed _ ->
-        false
+        Alcotest.fail "target changed"
+    | `Destroyed ->
+        Alcotest.fail "sync ledger destroyed"
 
-  let%test_unit "new_goal_soon" =
+  let test_new_goal_soon () =
     let l1, _k1 = Ledger.load_ledger num_accts 1 in
     let l2, _k2 = Ledger.load_ledger num_accts 2 in
     let l3, _k3 = Ledger.load_ledger num_accts 3 in
@@ -197,23 +209,69 @@ struct
              in
              ctr := !ctr + 1 ;
              res ) ) ;
-    match
-      Async.Thread_safe.block_on_async_exn (fun () ->
-          Sync_ledger.fetch lsync !desired_root ~data:() ~equal:(fun () () ->
-              true ) )
+    match%bind
+      Sync_ledger.fetch lsync !desired_root ~data:() ~equal:(fun () () -> true)
     with
     | `Ok _ ->
         failwith "shouldn't happen"
     | `Target_changed _ -> (
-        match
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              Sync_ledger.wait_until_valid lsync !desired_root )
-        with
+        match%map Sync_ledger.wait_until_valid lsync !desired_root with
         | `Ok mt ->
-            [%test_result: Root_hash.t] ~expect:(Ledger.merkle_root l3)
-              (Ledger.merkle_root mt)
+            Alcotest.(check bool)
+              "synced retargeted root" true
+              (Root_hash.equal (Ledger.merkle_root l3) (Ledger.merkle_root mt))
         | `Target_changed _ ->
-            failwith "the target changed again" )
+            Alcotest.fail "the target changed again"
+        | `Destroyed ->
+            Alcotest.fail "sync ledger destroyed" )
+    | `Destroyed ->
+        Alcotest.fail "sync ledger destroyed"
+
+  let test_destroy_unblocks_fetch () =
+    let l1, _k1 = Ledger.load_ledger 1 1 in
+    let l2, _k2 = Ledger.load_ledger num_accts 2 in
+    let desired_root = Ledger.merkle_root l2 in
+    let lsync = Sync_ledger.create l1 ~context:(module Context) ~trust_system in
+    let result =
+      Sync_ledger.fetch lsync desired_root ~data:() ~equal:(fun () () -> true)
+    in
+    let%bind () = Sync_ledger.destroy lsync in
+    match%map result with
+    | `Destroyed ->
+        ()
+    | `Ok _ | `Target_changed _ ->
+        Alcotest.fail "fetch should resolve as destroyed"
+
+  let test_destroy_unblocks_valid_tree () =
+    let l1, _k1 = Ledger.load_ledger 1 1 in
+    let lsync = Sync_ledger.create l1 ~context:(module Context) ~trust_system in
+    let result = Sync_ledger.valid_tree lsync in
+    let%bind () = Sync_ledger.destroy lsync in
+    match%map result with
+    | `Destroyed ->
+        ()
+    | `Ok _ ->
+        Alcotest.fail "valid_tree should resolve as destroyed"
+
+  let test_destroy_is_idempotent () =
+    let l1, _k1 = Ledger.load_ledger 1 1 in
+    let lsync = Sync_ledger.create l1 ~context:(module Context) ~trust_system in
+    let%bind () = Sync_ledger.destroy lsync in
+    Sync_ledger.destroy lsync
+
+  let () =
+    register
+      (next_suite_name (sprintf "syncable_ledger-%d_accounts" num_accts))
+      [ Alcotest_async.test_case "full sync entirely different" `Quick
+          test_full_sync_entirely_different
+      ; Alcotest_async.test_case "new goal soon" `Quick test_new_goal_soon
+      ; Alcotest_async.test_case "destroy unblocks fetch" `Quick
+          test_destroy_unblocks_fetch
+      ; Alcotest_async.test_case "destroy unblocks valid_tree" `Quick
+          test_destroy_unblocks_valid_tree
+      ; Alcotest_async.test_case "destroy is idempotent" `Quick
+          test_destroy_is_idempotent
+      ]
 end
 
 module Make_test_edge_cases (Input : Input_intf) = struct
@@ -253,7 +311,7 @@ module Make_test_edge_cases (Input : Input_intf) = struct
     | _ ->
         `Answer (Or_error.ok_exn answer)
 
-  let%test "try full_sync_entirely_different with failures" =
+  let test_full_sync_entirely_different_with_failures () =
     let l1, _k1 = Ledger.load_ledger 1 1 in
     let l2, _k2 = Ledger.load_ledger num_accts 2 in
     let desired_root = Ledger.merkle_root l2 in
@@ -285,18 +343,26 @@ module Make_test_edge_cases (Input : Input_intf) = struct
            | `Failure_as_expected ->
                Ivar.fill got_failure_ivar true ;
                Deferred.unit ) ) ;
-    Async.Thread_safe.block_on_async_exn (fun () ->
-        let deferred_res =
-          match%map
-            Sync_ledger.fetch lsync desired_root ~data:() ~equal:(fun () () ->
-                true )
-          with
-          | `Ok mt ->
-              Root_hash.equal desired_root (Ledger.merkle_root mt)
-          | `Target_changed _ ->
-              false
-        in
-        Deferred.any [ deferred_res; Ivar.read got_failure_ivar ] )
+    let deferred_res =
+      match%map
+        Sync_ledger.fetch lsync desired_root ~data:() ~equal:(fun () () -> true)
+      with
+      | `Ok mt ->
+          Root_hash.equal desired_root (Ledger.merkle_root mt)
+      | `Target_changed _ | `Destroyed ->
+          false
+    in
+    let%map result =
+      Deferred.any [ deferred_res; Ivar.read got_failure_ivar ]
+    in
+    Alcotest.(check bool) "sync recovered after failure" true result
+
+  let () =
+    register
+      (next_suite_name "syncable_ledger-edge_cases")
+      [ Alcotest_async.test_case "full sync with invalid-depth failures" `Quick
+          test_full_sync_entirely_different_with_failures
+      ]
 end
 
 module Root_hash = struct
@@ -749,3 +815,7 @@ module Mask = struct
   module TestMask16_Edge_Cases_Depth80 =
     Make_test_edge_cases (Mask16_Layer2_Depth80)
 end
+
+let () =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      Alcotest_async.run "Syncable ledger" (List.rev !alcotest_suites) )


### PR DESCRIPTION
Explain your changes:

* Clean up the syncable-ledger synchronization lifecycle so callers can tear down sync work deterministically.
* Add `Sync_ledger.Target_state` to expose the current target root, target-change notifications, and shutdown notification to networking code.
* Make `Sync_ledger.destroy` asynchronous and idempotent, unblock `fetch`, `valid_tree`, and `wait_until_valid` with `Destroyed`, and close the syncable-ledger pipes during teardown.
* Teach the downloader to cancel matching pending or active jobs, propagate per-batch stop signals to in-flight downloads, and expose a `closed` deferred once teardown completes.
* Update sync-ledger networking glue to cancel stale root work when the target root changes, abort in-flight sync RPCs on cancellation, ignore obsolete queries, and wait for downloader shutdown before returning.
* Wire the new lifecycle through bootstrap, epoch-ledger sync, sync-handler tests, consensus local-state sync, and gossip-net RPC helpers.
* Add changelog entry `changes/18924.md`.

Explain how you tested your changes:

* Converted `src/lib/syncable_ledger/test` from inline tests to an Alcotest-async test executable.
* Preserved existing full-sync, retargeting, and invalid-depth failure coverage.
* Added lifecycle coverage for `destroy` unblocking `fetch`, unblocking `valid_tree`, and being idempotent.
* Suggested local command: `dune runtest src/lib/syncable_ledger/test`.
