### PR TITLE
Propagate number of chunks for standalone verify

### DIFF
--- a/changes/18928.md
+++ b/changes/18928.md
@@ -1,0 +1,1 @@
+Propagate number of circuit chunks through the side-loaded verification path.

--- a/src/lib/crypto/pickles/common.ml
+++ b/src/lib/crypto/pickles/common.ml
@@ -9,6 +9,9 @@ module Max_degree = struct
   let step = 1 lsl step_log2
 
   let wrap_log2 = Nat.to_int Backend.Tock.Rounds.n
+
+  let step_domain_log2_for_num_chunks num_chunks =
+    step_log2 + Int.ceil_log2 num_chunks
 end
 
 let tick_shifts, tock_shifts =

--- a/src/lib/crypto/pickles/common.mli
+++ b/src/lib/crypto/pickles/common.mli
@@ -123,6 +123,9 @@ module Max_degree : sig
 
   (** Log base 2 of the maximum degree for step circuits. *)
   val step_log2 : int
+
+  (** Maximum supported step domain log size for a chunked proof. *)
+  val step_domain_log2_for_num_chunks : int -> int
 end
 
 (** {2 Field Shifts} *)

--- a/src/lib/crypto/pickles/compile.ml
+++ b/src/lib/crypto/pickles/compile.ml
@@ -866,13 +866,7 @@ struct
       ; step_domains
       ; feature_flags
       ; num_chunks
-      ; zk_rows =
-          ( match num_chunks with
-          | 1 (* cannot match with Plonk_checks.num_chunks_by_default *) ->
-              Plonk_checks.zk_rows_by_default
-          | num_chunks ->
-              let permuts = 7 in
-              ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts )
+      ; zk_rows = Plonk_checks.zk_rows_for_num_chunks num_chunks
       }
     in
     Timer.clock __LOC__ ;
@@ -932,7 +926,18 @@ module Side_loaded = struct
     let of_proof : _ Proof.t -> t = Wrap_hack.pad_proof
   end
 
-  let verify_promise (type t) ~(typ : (_, t) Impls.Step.Typ.t)
+  let chunking_data_of_num_chunks num_chunks =
+    Option.map num_chunks ~f:(fun num_chunks ->
+        if num_chunks < 1 then
+          failwith "Pickles.Side_loaded.verify: num_chunks must be a positive integer" ;
+        ( { Verify.Instance.num_chunks
+          ; domain_size =
+              Common.Max_degree.step_domain_log2_for_num_chunks num_chunks
+          ; zk_rows = Plonk_checks.zk_rows_for_num_chunks num_chunks
+          }
+          : Verify.Instance.chunking_data ) )
+
+  let verify_promise (type t) ?num_chunks ~(typ : (_, t) Impls.Step.Typ.t)
       (ts : (Verification_key.t * t * Proof.t) list) =
     let m =
       ( module struct
@@ -949,6 +954,7 @@ module Side_loaded = struct
       (module Verification_key.Max_width : Nat.Intf
         with type n = Verification_key.Max_width.n )
     in
+    let chunking_data = chunking_data_of_num_chunks num_chunks in
     with_return (fun { return } ->
         List.map ts ~f:(fun (vk, x, p) ->
             let vk : V.t =
@@ -966,10 +972,12 @@ module Side_loaded = struct
                   { constraints = 0 }
               }
             in
-            Verify.Instance.T (max_proofs_verified, m, None, vk, x, p) )
+            Verify.Instance.T
+              (max_proofs_verified, m, chunking_data, vk, x, p) )
         |> Verify.verify_heterogenous )
 
-  let verify ~typ ts = verify_promise ~typ ts |> Promise.to_deferred
+  let verify ?num_chunks ~typ ts =
+    verify_promise ?num_chunks ~typ ts |> Promise.to_deferred
 
   let srs_precomputation () : unit =
     let srs = Tock.Keypair.load_urs () in

--- a/src/lib/crypto/pickles/compile.mli
+++ b/src/lib/crypto/pickles/compile.mli
@@ -129,12 +129,14 @@ module Side_loaded : sig
     -> ('var, 'value, 'n1, Nat.N8.n) Tag.t
 
   val verify_promise :
-       typ:('var, 'value) Impls.Step.Typ.t
+       ?num_chunks:int
+    -> typ:('var, 'value) Impls.Step.Typ.t
     -> (Verification_key.t * 'value * Proof.t) list
     -> unit Or_error.t Promise.t
 
   val verify :
-       typ:('var, 'value) Impls.Step.Typ.t
+       ?num_chunks:int
+    -> typ:('var, 'value) Impls.Step.Typ.t
     -> (Verification_key.t * 'value * Proof.t) list
     -> unit Or_error.t Deferred.t
 

--- a/src/lib/crypto/pickles/pickles.ml
+++ b/src/lib/crypto/pickles/pickles.ml
@@ -264,7 +264,19 @@ module Make_str (_ : Wire_types.Concrete) = struct
       let of_proof : _ Proof.t -> t = Wrap_hack.pad_proof
     end
 
-    let verify_promise (type t) ~(typ : (_, t) Impls.Step.Typ.t)
+    let chunking_data_of_num_chunks num_chunks =
+      Option.map num_chunks ~f:(fun num_chunks ->
+          if num_chunks < 1 then
+            failwith
+              "Pickles.Side_loaded.verify: num_chunks must be a positive integer" ;
+          ( { Verify.Instance.num_chunks
+            ; domain_size =
+                Common.Max_degree.step_domain_log2_for_num_chunks num_chunks
+            ; zk_rows = Plonk_checks.zk_rows_for_num_chunks num_chunks
+            }
+            : Verify.Instance.chunking_data ) )
+
+    let verify_promise (type t) ?num_chunks ~(typ : (_, t) Impls.Step.Typ.t)
         (ts : (Verification_key.t * t * Proof.t) list) =
       let m =
         ( module struct
@@ -281,6 +293,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         (module Verification_key.Max_width : Nat.Intf
           with type n = Verification_key.Max_width.n )
       in
+      let chunking_data = chunking_data_of_num_chunks num_chunks in
       with_return (fun { return } ->
           List.map ts ~f:(fun (vk, x, p) ->
               let vk : V.t =
@@ -299,10 +312,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
                     { constraints = 0 }
                 }
               in
-              Verify.Instance.T (max_proofs_verified, m, None, vk, x, p) )
+              Verify.Instance.T
+                (max_proofs_verified, m, chunking_data, vk, x, p) )
           |> Verify.verify_heterogenous )
 
-    let verify ~typ ts = verify_promise ~typ ts |> Promise.to_deferred
+    let verify ?num_chunks ~typ ts =
+      verify_promise ?num_chunks ~typ ts |> Promise.to_deferred
 
     let srs_precomputation () : unit =
       let srs = Tock.Keypair.load_urs () in

--- a/src/lib/crypto/pickles/pickles_intf.mli
+++ b/src/lib/crypto/pickles/pickles_intf.mli
@@ -370,12 +370,14 @@ module type S = sig
       -> ('var, 'value, 'n1, Nat.N8.n) Tag.t
 
     val verify_promise :
-         typ:('var, 'value) Impls.Step.Typ.t
+         ?num_chunks:int
+      -> typ:('var, 'value) Impls.Step.Typ.t
       -> (Verification_key.t * 'value * Proof.t) list
       -> unit Or_error.t Promise.t
 
     val verify :
-         typ:('var, 'value) Impls.Step.Typ.t
+         ?num_chunks:int
+      -> typ:('var, 'value) Impls.Step.Typ.t
       -> (Verification_key.t * 'value * Proof.t) list
       -> unit Or_error.t Deferred.t
 

--- a/src/lib/crypto/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/crypto/pickles/plonk_checks/plonk_checks.ml
@@ -9,6 +9,13 @@ let num_chunks_by_default = 1
 
 let zk_rows_by_default = 3
 
+let zk_rows_for_num_chunks = function
+  | 1 ->
+      zk_rows_by_default
+  | num_chunks ->
+      let permuts = 7 in
+      ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts
+
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Plonk_types.Shifts.t

--- a/src/lib/crypto/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/crypto/pickles/plonk_checks/plonk_checks.mli
@@ -6,6 +6,10 @@ val num_chunks_by_default : int
 (** The number of rows required for zero knowledge in circuits with one single chunk *)
 val zk_rows_by_default : int
 
+(** [zk_rows_for_num_chunks num_chunks] computes the number of rows required
+    for zero knowledge in circuits with [num_chunks] chunks. *)
+val zk_rows_for_num_chunks : int -> int
+
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Pickles_types.Plonk_types.Shifts.t

--- a/src/lib/crypto/pickles/step_branch_data.ml
+++ b/src/lib/crypto/pickles/step_branch_data.ml
@@ -195,13 +195,7 @@ module Make (Inductive_rule : Inductive_rule.Intf) = struct
           ; step_domains
           ; feature_flags
           ; num_chunks
-          ; zk_rows =
-              ( match num_chunks with
-              | 1 (* cannot match with Plonk_checks.num_chunks_by_default *) ->
-                  Plonk_checks.zk_rows_by_default
-              | num_chunks ->
-                  let permuts = 7 in
-                  ((2 * (permuts + 1) * num_chunks) - 2 + permuts) / permuts )
+          ; zk_rows = Plonk_checks.zk_rows_for_num_chunks num_chunks
           }
         ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
         ~local_signature:widths ~local_signature_length ~local_branches_length


### PR DESCRIPTION
This PR enables o1js standalone verification of chunked proofs without requiring to recompile the ZkProgram when you already have access to the proof artifact and verification keys. This is achieved by passing around the chunks count, which was not being propagated correctly across the standalone verify function.

o1js side: https://github.com/o1-labs/o1js/pull/2886