### PR TITLE
Fix snark worker: don't wait for 0.5s before starting proving

### DIFF
--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -108,8 +108,6 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
           "SNARK work $work_ids received from $address. Starting proof \
            generation"
           ~metadata:[ address_json; work_ids_json ] ;
-        let%bind () = wait () in
-        (* Pause to wait for stdout to flush *)
         let id = Spec.Partitioned.Poly.get_id partitioned_spec in
         match%bind
           Prod.Impl.perform_partitioned ~state ~spec:partitioned_spec


### PR DESCRIPTION
This PR fixes a very old issue: when a snark worker receives work, it sleeps for 0.5s before starting it. This was wholly unnecessary, and defended by a comment describing a fake defence.

Extrapolating the blockchain snark proving time (~6s) blindly to snark worker performance, this represents an ~8% performance improvement.

**Edit:** I discovered this while testing a `--proof-level none` network, where I was seeing transaction volume heavily restricted by snark worker performance. By removing this wait, a single snark worker can happily support full saturation (128 txns) at 7s slot time.