### PR TITLE
Fix: don't hang for ~20s waiting for a DNS lookup when running CLI tools

### DIFF
--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -27,7 +27,7 @@ let command_run =
                heights max(1, h-n) and h (default %d)"
               Archive_lib.Metrics.default_missing_blocks_width )
          (optional int)
-     and postgres = Flag.Uri.Archive.postgres
+     and postgres = Lazy.force Flag.Uri.Archive.postgres
      and runtime_config_file =
        flag "--config-file" ~aliases:[ "-config-file" ] (optional string)
          ~doc:"PATH to the configuration file containing the genesis ledger"
@@ -92,7 +92,7 @@ let command_prune =
          ~doc:
            "timestamp Delete blocks that are older than the given timestamp. \
             Format: 2000-00-00 12:00:00+0100"
-     and postgres = Flag.Uri.Archive.postgres in
+     and postgres = Lazy.force Flag.Uri.Archive.postgres in
      fun () ->
        let logger = Logger.create () in
        let timestamp =

--- a/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
+++ b/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
@@ -22,7 +22,8 @@ let fork_slot =
 
 let is_in_best_chain_command =
   Async.Command.async ~summary:"Verify fork block is in best chain"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_height =
        Command.Param.(flag "--fork-height" (required int))
@@ -36,7 +37,8 @@ let is_in_best_chain_command =
 let confirmations_command =
   Async.Command.async
     ~summary:"Verify number of confirmations for the fork block"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and latest_state_hash =
        Command.Param.(flag "--latest-state-hash" (required string))
          ~doc:"String Hash of the latest state"
@@ -52,7 +54,8 @@ let confirmations_command =
 
 let no_commands_after_command =
   Async.Command.async ~summary:"Verify no commands after the fork block"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_slot = fork_slot in
 
@@ -62,7 +65,8 @@ let no_commands_after_command =
 let verify_upgrade_command =
   Async.Command.async
     ~summary:"Verify upgrade from pre-fork to post-fork schema"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and expected_protocol_version =
        Command.Param.(flag "--protocol-version" (required string))
          ~doc:"String Protocol Version to upgrade to (e.g. 3.2.0 etc)"
@@ -76,7 +80,8 @@ let verify_upgrade_command =
 
 let validate_fork_command =
   Async.Command.async ~summary:"Validate fork block and its ancestors"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_slot = fork_slot in
      run_check_and_exit
@@ -87,7 +92,8 @@ let convert_chain_to_canonical_command =
     ~summary:
       "Mark the chain leading to the target block as canonical for a protocol \
        version"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and latest_block_state_hash =
        Command.Param.(flag "--target-block-hash" (required string))
          ~doc:"String State hash of block that should remain canonical"
@@ -106,7 +112,9 @@ let convert_chain_to_canonical_command =
 
 let fetch_last_filled_block_command =
   Async.Command.async ~summary:"Select last filled block"
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres in
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
+     in
      fetch_last_filled_block ~postgres_uri )
 
 let run_all_verifications_command =
@@ -119,7 +127,8 @@ let run_all_verifications_command =
        protocol_version, required_confirmations (default 290), \
        migration_version (default 0.0.5). Individual CLI flags override config \
        values."
-    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } =
+       Lazy.force Uri.Archive.postgres
      and runtime_config_path =
        Command.Param.(flag "--runtime-config" (required string))
          ~doc:

--- a/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
+++ b/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
@@ -22,7 +22,7 @@ let fork_slot =
 
 let is_in_best_chain_command =
   Async.Command.async ~summary:"Verify fork block is in best chain"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_height =
        Command.Param.(flag "--fork-height" (required int))
@@ -36,7 +36,7 @@ let is_in_best_chain_command =
 let confirmations_command =
   Async.Command.async
     ~summary:"Verify number of confirmations for the fork block"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and latest_state_hash =
        Command.Param.(flag "--latest-state-hash" (required string))
          ~doc:"String Hash of the latest state"
@@ -52,7 +52,7 @@ let confirmations_command =
 
 let no_commands_after_command =
   Async.Command.async ~summary:"Verify no commands after the fork block"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_slot = fork_slot in
 
@@ -62,7 +62,7 @@ let no_commands_after_command =
 let verify_upgrade_command =
   Async.Command.async
     ~summary:"Verify upgrade from pre-fork to post-fork schema"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and expected_protocol_version =
        Command.Param.(flag "--protocol-version" (required string))
          ~doc:"String Protocol Version to upgrade to (e.g. 3.2.0 etc)"
@@ -76,7 +76,7 @@ let verify_upgrade_command =
 
 let validate_fork_command =
   Async.Command.async ~summary:"Validate fork block and its ancestors"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and fork_state_hash = fork_state_hash
      and fork_slot = fork_slot in
      run_check_and_exit
@@ -87,7 +87,7 @@ let convert_chain_to_canonical_command =
     ~summary:
       "Mark the chain leading to the target block as canonical for a protocol \
        version"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and latest_block_state_hash =
        Command.Param.(flag "--target-block-hash" (required string))
          ~doc:"String State hash of block that should remain canonical"
@@ -106,7 +106,7 @@ let convert_chain_to_canonical_command =
 
 let fetch_last_filled_block_command =
   Async.Command.async ~summary:"Select last filled block"
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres in
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres in
      fetch_last_filled_block ~postgres_uri )
 
 let run_all_verifications_command =
@@ -119,7 +119,7 @@ let run_all_verifications_command =
        protocol_version, required_confirmations (default 290), \
        migration_version (default 0.0.5). Individual CLI flags override config \
        values."
-    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+    (let%map_open.Command { value = postgres_uri; _ } = Lazy.force Uri.Archive.postgres
      and runtime_config_path =
        Command.Param.(flag "--runtime-config" (required string))
          ~doc:

--- a/src/app/dump_slot_ledger/dump_slot_ledger.ml
+++ b/src/app/dump_slot_ledger/dump_slot_ledger.ml
@@ -152,7 +152,8 @@ let command =
     ~summary:
       "Prints out the ledger for a given slot for debugging purposes. \n\
       \  It requires an archive db url and a slot number"
-    (let%map_open.Command postgres = Lazy.force Cli_lib.Flag.Uri.Archive.postgres
+    (let%map_open.Command postgres =
+       Lazy.force Cli_lib.Flag.Uri.Archive.postgres
      and slot =
        flag "--slot" ~aliases:[ "slot" ]
          ~doc:"the global slot since genesis that you would like to dump"

--- a/src/app/dump_slot_ledger/dump_slot_ledger.ml
+++ b/src/app/dump_slot_ledger/dump_slot_ledger.ml
@@ -152,7 +152,7 @@ let command =
     ~summary:
       "Prints out the ledger for a given slot for debugging purposes. \n\
       \  It requires an archive db url and a slot number"
-    (let%map_open.Command postgres = Cli_lib.Flag.Uri.Archive.postgres
+    (let%map_open.Command postgres = Lazy.force Cli_lib.Flag.Uri.Archive.postgres
      and slot =
        flag "--slot" ~aliases:[ "slot" ]
          ~doc:"the global slot since genesis that you would like to dump"

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -305,8 +305,8 @@ module Uri = struct
              (Command.Arg_type.map Command.Param.string ~f:Uri.of_string)
            doc_builder
            (Resolve_with_default
-              (Uri.of_string
-                 "postgres://admin:codarules@postgres:5432/archiver" ) ) )
+              (Uri.of_string "postgres://admin:codarules@postgres:5432/archiver")
+           ) )
   end
 end
 

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -178,11 +178,13 @@ module Port = struct
 end
 
 module Host = struct
-  let localhost = Core.Unix.Host.getbyname_exn "localhost"
+  (* Lazy so that merely loading this module performs no DNS lookup; resolved
+     the first time [is_localhost] actually runs. *)
+  let localhost = lazy (Core.Unix.Host.getbyname_exn "localhost")
 
   let is_localhost host =
     Option.value_map ~default:false (Unix.Host.getbyname host) ~f:(fun host ->
-        Core.Unix.Host.have_address_in_common host localhost )
+        Core.Unix.Host.have_address_in_common host (Lazy.force localhost) )
 end
 
 let example_host = "154.97.53.97"
@@ -282,20 +284,29 @@ module Uri = struct
   end
 
   module Archive = struct
+    (* Lazy: constructing this flag renders its doc string, which runs the
+       [display] over the example/default URI whose host is "postgres" — an
+       unresolvable name that blocks ~20s on a DNS timeout. Deferring it until a
+       command that actually uses the archive DB forces the flag keeps that cost
+       out of every other Mina executable's startup. Consumers must
+       [Lazy.force] it. *)
     let postgres =
-      let doc_builder =
-        Doc_builder.create ~display:to_string
-          ~examples:
-            [ Uri.of_string "postgres://admin:codarules@postgres:5432/archiver"
-            ]
-          "URI" "URI for postgresql database"
-      in
-      create ~name:"--postgres-uri" ~aliases:[ "postgres-uri" ]
-        ~arg_type:(Command.Arg_type.map Command.Param.string ~f:Uri.of_string)
-        doc_builder
-        (Resolve_with_default
-           (Uri.of_string "postgres://admin:codarules@postgres:5432/archiver")
-        )
+      lazy
+        (let doc_builder =
+           Doc_builder.create ~display:to_string
+             ~examples:
+               [ Uri.of_string
+                   "postgres://admin:codarules@postgres:5432/archiver"
+               ]
+             "URI" "URI for postgresql database"
+         in
+         create ~name:"--postgres-uri" ~aliases:[ "postgres-uri" ]
+           ~arg_type:
+             (Command.Arg_type.map Command.Param.string ~f:Uri.of_string)
+           doc_builder
+           (Resolve_with_default
+              (Uri.of_string
+                 "postgres://admin:codarules@postgres:5432/archiver" ) ) )
   end
 end
 

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -43,7 +43,7 @@ module Uri : sig
   end
 
   module Archive : sig
-    val postgres : Uri.t Types.with_name Command.Param.t
+    val postgres : Uri.t Types.with_name Command.Param.t Lazy.t
   end
 end
 


### PR DESCRIPTION
This PR fixes an oversight in `cli_lib`, where the `--postgres-uri` flag's description runs some code that involves a DNS entry. On my machine, where this entry doesn't resolve, I get a 20s hang waiting for the 5s timeout of 4 attempts.

This PR doesn't take a stance on whether it's good or right to run this code for the entry, but it does make it `lazy` so that it is only triggered on tools that use the flag.