### PR TITLE
fix: correct daemon log typo

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1242,7 +1242,7 @@ let stop_long_running_daemon t =
       Time_ns.(diff (now ()) daemon_start_time |> Span.to_min |> Int.of_float)
     in
     [%log' info t.config.logger]
-      "Deamon has been running for $uptime mins. Stopping now..."
+      "Daemon has been running for $uptime mins. Stopping now..."
       ~metadata:[ ("uptime", `Int uptime_mins) ] ;
     Scheduler.yield ()
     >>= (fun () -> return (Async.shutdown 1))


### PR DESCRIPTION
Fixes MinaProtocol/mina#18932.

## Summary
- Correct the daemon shutdown log message from `Deamon` to `Daemon`.

## Testing
- `git diff --check`
- `rg -n 'Deamon has been running|Daemon has been running' src/lib/mina_lib/mina_lib.ml`