### PR TITLE
make HF test work on external PR

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -114,7 +114,7 @@ if [ -n "${BUILDKITE:-}" ]; then
     exit 1
   fi
 
-  git fetch origin
+  git fetch origin ${BUILDKITE_PULL_REQUEST:+"+refs/pull/${BUILDKITE_PULL_REQUEST}/head"}
 fi
 
 # 1. Build PREFORK as a prefork build;


### PR DESCRIPTION
Currently HF test will not work on external PR because it tries to just fetch the PR branch commit which might not exist in the branch. 

A failing instance could be observed here. https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/4288

This PR fixed the issue by feching PR branch ref instead.