### PR TITLE
hardfork_test: end-to-end vesting slot-reduction test

### DIFF
--- a/buildkite/src/Jobs/Test/HardForkTestLegacy.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestLegacy.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestLegacy"
       "hard fork test - legacy mode"
       "hard-fork-test-legacy"
-      "--fork-from origin/master --allow-fork-method legacy"
+      "--fork-from origin/master --fork-into origin/release/mesa --allow-fork-method legacy"

--- a/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestMixed"
       "hard fork test - mixed mode"
       "hard-fork-test-mixed"
-      "--fork-from origin/compatible --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"
+      "--fork-from origin/compatible --fork-into origin/release/mesa --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"

--- a/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestMixed"
       "hard fork test - mixed mode"
       "hard-fork-test-mixed"
-      "--fork-from origin/compatible --fork-into origin/release/mesa --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"
+      "--fork-from origin/compatible --fork-into origin/release/mesa --num-nodes 1 --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"

--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -3,8 +3,8 @@
 # This scripts builds a designated PREFORK branch and current branch with nix
 # 0. Prepare environment if needed
 # 1. Build PREFORK as a prefork build;
-# 2. Build "develop" branch as a postfork build
-# 3. Upload to nix cache, the reason for not uploading cache for following 2 
+# 2. Build the current (test) branch as a postfork build
+# 3. Upload to nix cache, the reason for not uploading cache for following 2
 # steps is that they change for each PR. 
 # 4. Build hardfork_test on current branch;
 # 5. Execute hardfork_test on them.
@@ -13,9 +13,10 @@
 set -eux -o pipefail
 
 PREFORK=""
+POSTFORK=""
 EXTRA_ARGS=()
 
-USAGE="Usage: $0 --fork-from <PREFORK> [ADDITONAL ARGS TO HF TEST...]"
+USAGE="Usage: $0 --fork-from <PREFORK> [--fork-into <POSTFORK>] [ADDITIONAL ARGS TO HF TEST...]"
 usage() {
   if (( $# > 0 )); then
     echo "$1" >&2
@@ -36,6 +37,14 @@ while [[ $# -gt 0 ]]; do
         usage "Error: $1 requires an argument."
       fi
       PREFORK="$2"
+      shift 2
+      ;;
+    --fork-into)
+      # ensure value exists
+      if [[ $# -lt 2 ]]; then
+        usage "Error: $1 requires an argument."
+      fi
+      POSTFORK="$2"
       shift 2
       ;;
     --help|-h)
@@ -91,7 +100,11 @@ if [ -n "${BUILDKITE:-}" ]; then
   git config --global --add safe.directory /workdir
 fi
 
-TEST_COMMIT="$(git rev-parse HEAD)"
+# Prefer the symbolic branch name so checkouts below leave the working tree on a
+# named branch; a detached HEAD (plain `git checkout <sha>`) can confuse nix
+# flake evaluation. Fall back to the commit SHA when already detached (e.g. CI).
+TEST_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+POSTFORK="${POSTFORK:-origin/develop}"
 
 
 if [ -n "${BUILDKITE:-}" ]; then
@@ -120,12 +133,12 @@ if [ -n "${BUILDKITE:-}" ]; then
 fi
 
 # 1. Build PREFORK as a prefork build;
-git checkout $PREFORK
+git checkout "$PREFORK"
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "prefork-devnet"
 
-# 2. Build "develop" branch as a postfork build
-git checkout develop
+# 2. Build the postfork branch.
+git checkout "$POSTFORK"
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "postfork-devnet"
 
@@ -145,7 +158,7 @@ EOF
 fi
 
 # 4. Build hardfork_test on current branch;
-git checkout "$TEST_COMMIT"
+git checkout "$TEST_REF"
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#hardfork_test" --out-link "hardfork_test"
 

--- a/scripts/mina-local-network/README.md
+++ b/scripts/mina-local-network/README.md
@@ -118,6 +118,17 @@ You can now spawn networks without certain components:
 ./scripts/mina-local-network/mina-local-network.sh --seed "at:SEED_PEER_ID"
 ```
 
+**Combine block-producer roles** (fewer daemons): with `--seed-is-whale` and/or
+`--snark-coordinator-is-whale`, the seed and/or snark coordinator additionally
+run as whale block producers, consuming the leading whale accounts instead of
+spawning them as standalone whale daemons. For example, the following runs the
+network as just two daemons (seed+whale and snark-coordinator+whale) plus two
+snark workers:
+```shell
+./scripts/mina-local-network/mina-local-network.sh \
+  -w 2 -f 0 -n 0 --seed-is-whale --snark-coordinator-is-whale
+```
+
 ### Config Inheritance Modes
 
 The `--config` parameter supports three modes:

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -59,6 +59,7 @@ SLOT_TX_END=
 SLOT_CHAIN_END=
 HARDFORK_GENESIS_SLOT_DELTA=
 EXTRA_FILES_ROOT=
+EXTRA_GENESIS_ACCOUNT_FILE=
 SEED_IS_WHALE=false
 SNARK_COORDINATOR_IS_WHALE=false
 
@@ -182,7 +183,9 @@ help() {
                                          |   Default: ${ON_EXIT}
 --node-status-url <url>                  | Url of the node status collection service 
                                          |   Default: not set
---extra-files-root <path>                | Directory of file tree need to be overlayed on a prepared network folder, useful when initializing from fresh but need some files set. 
+--extra-files-root <path>                | Directory of file tree need to be overlayed on a prepared network folder, useful when initializing from fresh but need some files set.
+                                         |   Default: None
+--extra-genesis-account-file <path>      | Path to a JSON file holding an array of extra genesis-ledger accounts to merge into the freshly generated ledger (only used with '--config reset'). Useful for seeding e.g. timed/vesting accounts.
                                          |   Default: None
 --seed-is-whale                          | When set, the seed node also runs as a whale block producer (presence of argument), consuming the first whale account instead of spawning it as a standalone whale daemon.
                                          |   Default: ${SEED_IS_WHALE}
@@ -693,6 +696,10 @@ while [[ "$#" -gt 0 ]]; do
     EXTRA_FILES_ROOT="${2}"
     shift
     ;;
+  --extra-genesis-account-file)
+    EXTRA_GENESIS_ACCOUNT_FILE="${2}"
+    shift
+    ;;
   --seed-is-whale)
     SEED_IS_WHALE=true
     ;;
@@ -923,6 +930,30 @@ load_config() {
         --online-fish-accounts-directory "${ROOT}"/online_fish_keys \
         --snark-coordinator-accounts-directory "${ROOT}"/snark_coordinator_keys \
         --out-genesis-ledger-file "${ROOT}"/genesis_ledger.json
+
+      if [[ -n "${EXTRA_GENESIS_ACCOUNT_FILE}" ]]; then
+        if [[ ! -f "${EXTRA_GENESIS_ACCOUNT_FILE}" ]]; then
+          echo "Error: extra genesis account file '${EXTRA_GENESIS_ACCOUNT_FILE}' does not exist." >&2
+          exit 1
+        fi
+        echo "Merging extra genesis accounts from ${EXTRA_GENESIS_ACCOUNT_FILE} into the ledger..."
+        if ! merged_ledger=$(mktemp); then
+          echo "Error: failed to create temporary ledger file." >&2
+          exit 1
+        fi
+        if ! jq --slurpfile extra "${EXTRA_GENESIS_ACCOUNT_FILE}" \
+          '.accounts += $extra[0]' \
+          "${ROOT}"/genesis_ledger.json > "${merged_ledger}"; then
+          echo "Error: failed to merge extra genesis accounts from '${EXTRA_GENESIS_ACCOUNT_FILE}'." >&2
+          rm -f "${merged_ledger}"
+          exit 1
+        fi
+        if ! mv -f "${merged_ledger}" "${ROOT}"/genesis_ledger.json; then
+          echo "Error: failed to replace genesis ledger with merged ledger." >&2
+          rm -f "${merged_ledger}"
+          exit 1
+        fi
+      fi
 
       reset-genesis-ledger "${ROOT}" "${config_file}"
       echo "Using freshly generated config file ${config_file}:"

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -261,7 +261,7 @@ on-exit() {
 
       for ((i=0; i<NODES; i++)); do
         port=$((NODE_START_PORT + i*6))
-        stop-node "node_${i}" "$port" &
+        stop-node "plain_${i}" "$port" &
         job_pids+=("$!")
       done
 
@@ -810,7 +810,7 @@ if [ ! -d "${ROOT}" ]; then
   for ((i = 0; i < NODES; i++)); do
     generate-keypair "${ROOT}"/offline_whale_keys/offline_whale_account_${i}
     generate-keypair "${ROOT}"/online_whale_keys/online_whale_account_${i}
-    generate-libp2p-keypair "${ROOT}"/libp2p_keys/node_${i}
+    generate-libp2p-keypair "${ROOT}"/libp2p_keys/plain_${i}
   done
 
   if [ "$(uname)" != "Darwin" ] && [ ${FISH} -gt 0 ]; then
@@ -1166,10 +1166,10 @@ done
 # ----------
 
 for ((i = 0; i < NODES; i++)); do
-  FOLDER=${NODES_FOLDER}/node_${i}
+  FOLDER=${NODES_FOLDER}/plain_${i}
   mkdir -p "${FOLDER}"
   spawn-daemon "plain_${i}" "${FOLDER}" $((NODE_START_PORT + i * 6)) -peer ${SEED_PEER_ID} \
-    -libp2p-keypair "${ROOT}"/libp2p_keys/node_${i} "${ARCHIVE_ADDRESS_CLI_ARG}"
+    -libp2p-keypair "${ROOT}"/libp2p_keys/plain_${i} "${ARCHIVE_ADDRESS_CLI_ARG}"
   NODE_PIDS[${i}]=$!
 done
 
@@ -1285,7 +1285,7 @@ EOF
 		Instance #${i}:
 		  pid ${NODE_PIDS[${i}]}
 		  status: ${MINA_EXE} client status -daemon-port $((NODE_START_PORT + i * 6))
-		  data dir: ${NODES_FOLDER}/node_${i}
+		  data dir: ${NODES_FOLDER}/plain_${i}
 EOF
   done
 fi

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -59,6 +59,8 @@ SLOT_TX_END=
 SLOT_CHAIN_END=
 HARDFORK_GENESIS_SLOT_DELTA=
 EXTRA_FILES_ROOT=
+SEED_IS_WHALE=false
+SNARK_COORDINATOR_IS_WHALE=false
 
 # ================================================
 # Globals (assigned during execution of script)
@@ -71,7 +73,22 @@ CONFIG=""
 SNARK_COORDINATOR_PID=""
 SEED_PID=""
 ARCHIVE_PID=""
+# Index of the first whale account spawned as a *standalone* whale daemon. When
+# the seed and/or snark coordinator double as whale block producers (see
+# --seed-is-whale / --snark-coordinator-is-whale) they consume the leading whale
+# accounts, and the standalone whale loop starts past them.
+WHALE_STANDALONE_START=0
+SEED_WHALE_KEY=""
+SNARK_COORDINATOR_WHALE_KEY=""
 WHALE_PIDS=()
+# Candidate daemons (port base, pid, online key file, label) that can originate
+# value-transfer / zkApp transactions. Built up as block-producing daemons are
+# spawned so selection always targets a daemon that is actually running,
+# including when the seed / snark coordinator double as whales.
+TRANSFER_NODE_PORTS=()
+TRANSFER_NODE_PIDS=()
+TRANSFER_NODE_KEYS=()
+TRANSFER_NODE_LABELS=()
 SNARK_WORKERS_PIDS=()
 FISH_PIDS=()
 NODE_PIDS=()
@@ -167,6 +184,10 @@ help() {
                                          |   Default: not set
 --extra-files-root <path>                | Directory of file tree need to be overlayed on a prepared network folder, useful when initializing from fresh but need some files set. 
                                          |   Default: None
+--seed-is-whale                          | When set, the seed node also runs as a whale block producer (presence of argument), consuming the first whale account instead of spawning it as a standalone whale daemon.
+                                         |   Default: ${SEED_IS_WHALE}
+--snark-coordinator-is-whale             | When set, the snark coordinator node also runs as a whale block producer (presence of argument), consuming the next whale account instead of spawning it as a standalone whale daemon.
+                                         |   Default: ${SNARK_COORDINATOR_IS_WHALE}
 -h   |--help                             | Displays this help message
 
 Available logging levels:
@@ -189,6 +210,18 @@ stop-node() {
     if ! "$MINA_EXE" client stop-daemon --daemon-port "$port"; then
         echo "Failed to stop $tag on port $port, maybe it has already exited?" >&2
     fi
+}
+
+register-transfer-node() {
+    local label="$1"
+    local port_base="$2"
+    local pid="$3"
+    local key_file="$4"
+
+    TRANSFER_NODE_PORTS+=("${port_base}")
+    TRANSFER_NODE_PIDS+=("${pid}")
+    TRANSFER_NODE_KEYS+=("${key_file}")
+    TRANSFER_NODE_LABELS+=("${label}")
 }
 
 # Kill all processes when script exits
@@ -232,7 +265,7 @@ on-exit() {
         job_pids+=("$!")
       done
 
-      for ((i=0; i<WHALES; i++)); do
+      for ((i=WHALE_STANDALONE_START; i<WHALES; i++)); do
         port=$((WHALE_START_PORT + i*6))
         stop-node "whale_${i}" "$port" &
         job_pids+=("$!")
@@ -660,6 +693,12 @@ while [[ "$#" -gt 0 ]]; do
     EXTRA_FILES_ROOT="${2}"
     shift
     ;;
+  --seed-is-whale)
+    SEED_IS_WHALE=true
+    ;;
+  --snark-coordinator-is-whale)
+    SNARK_COORDINATOR_IS_WHALE=true
+    ;;
   *)
     echo "Unknown parameter passed: ${1}"
 
@@ -1004,6 +1043,20 @@ fi
 
 # ----------
 
+# Optionally let the seed node double as a whale block producer, consuming the
+# first whale account so it is not also spawned as a standalone whale daemon.
+SEED_BLOCK_PRODUCER_ARGS=()
+if [[ "${SEED_IS_WHALE}" == "true" ]] && ! ${DEMO_MODE}; then
+  if [ "${WHALE_STANDALONE_START}" -ge "${WHALES}" ]; then
+    echo "Error: --seed-is-whale requires at least $((WHALE_STANDALONE_START + 1)) whale account(s), but WHALES=${WHALES}." >&2
+    exit 1
+  fi
+  SEED_WHALE_KEY="${ROOT}/online_whale_keys/online_whale_account_${WHALE_STANDALONE_START}"
+  SEED_BLOCK_PRODUCER_ARGS=(-block-producer-key "${SEED_WHALE_KEY}")
+  echo "Seed node will also act as whale block producer (online_whale_account_${WHALE_STANDALONE_START})"
+  WHALE_STANDALONE_START=$((WHALE_STANDALONE_START + 1))
+fi
+
 SEED_PEER_ID=
 case "${SEED}" in
   spawn:*)
@@ -1021,7 +1074,7 @@ case "${SEED}" in
         --seed \
         ${ARCHIVE_ADDRESS_CLI_ARG}
     else
-      spawn-daemon seed "${NODES_FOLDER}"/seed "${SEED_START_PORT}" -seed -libp2p-keypair ${SEED_PEER_KEY} "${ARCHIVE_ADDRESS_CLI_ARG}"
+      spawn-daemon seed "${NODES_FOLDER}"/seed "${SEED_START_PORT}" -seed -libp2p-keypair ${SEED_PEER_KEY} "${SEED_BLOCK_PRODUCER_ARGS[@]}" "${ARCHIVE_ADDRESS_CLI_ARG}"
     fi
     SEED_PID=$!
 
@@ -1046,6 +1099,11 @@ case "${SEED}" in
 esac
 printf "$SEED_PEER_ID" > "${ROOT}/seed_peer_id.txt"
 
+# Register the seed as a transaction origin when it doubles as a whale.
+if [[ -n "${SEED_PID}" && -n "${SEED_WHALE_KEY}" ]]; then
+  register-transfer-node "seed" "${SEED_START_PORT}" "${SEED_PID}" "${SEED_WHALE_KEY}"
+fi
+
 #---------- Starting snark coordinator
 
 
@@ -1056,21 +1114,41 @@ elif [ "${SNARK_WORKERS_COUNT}" -eq "0" ]; then
   SNARK_COORDINATOR_PORT=""
 fi
 
+# Optionally let the snark coordinator double as a whale block producer,
+# consuming the next whale account so it is not spawned as a standalone whale.
+SNARK_COORDINATOR_BLOCK_PRODUCER_ARGS=()
+if [[ -n "${SNARK_COORDINATOR_PORT}" && "${SNARK_COORDINATOR_IS_WHALE}" == "true" ]]; then
+  if [ "${WHALE_STANDALONE_START}" -ge "${WHALES}" ]; then
+    echo "Error: --snark-coordinator-is-whale requires at least $((WHALE_STANDALONE_START + 1)) whale account(s), but WHALES=${WHALES}." >&2
+    exit 1
+  fi
+  SNARK_COORDINATOR_WHALE_KEY="${ROOT}/online_whale_keys/online_whale_account_${WHALE_STANDALONE_START}"
+  SNARK_COORDINATOR_BLOCK_PRODUCER_ARGS=(-block-producer-key "${SNARK_COORDINATOR_WHALE_KEY}")
+  echo "Snark coordinator node will also act as whale block producer (online_whale_account_${WHALE_STANDALONE_START})"
+  WHALE_STANDALONE_START=$((WHALE_STANDALONE_START + 1))
+fi
+
 if [[ -n "${SNARK_COORDINATOR_PORT}" ]]; then
   SNARK_COORDINATOR_FLAGS="-snark-worker-fee ${SNARK_WORKER_FEE} -run-snark-coordinator ${SNARK_COORDINATOR_PUBKEY} -work-selection seq"
-  spawn-daemon snark_coordinator "${NODES_FOLDER}"/snark_coordinator "${SNARK_COORDINATOR_PORT}" -peer ${SEED_PEER_ID} -libp2p-keypair ${SNARK_COORDINATOR_PEER_KEY} ${SNARK_COORDINATOR_FLAGS}
+  spawn-daemon snark_coordinator "${NODES_FOLDER}"/snark_coordinator "${SNARK_COORDINATOR_PORT}" -peer ${SEED_PEER_ID} -libp2p-keypair ${SNARK_COORDINATOR_PEER_KEY} "${SNARK_COORDINATOR_BLOCK_PRODUCER_ARGS[@]}" ${SNARK_COORDINATOR_FLAGS}
   SNARK_COORDINATOR_PID=$!
+
+  # Register the snark coordinator as a transaction origin when it doubles as a whale.
+  if [[ -n "${SNARK_COORDINATOR_WHALE_KEY}" ]]; then
+    register-transfer-node "snark_coordinator" "${SNARK_COORDINATOR_PORT}" "${SNARK_COORDINATOR_PID}" "${SNARK_COORDINATOR_WHALE_KEY}"
+  fi
 fi
 
 # ----------
 
-for ((i = 0; i < WHALES; i++)); do
+for ((i = WHALE_STANDALONE_START; i < WHALES; i++)); do
   FOLDER=${NODES_FOLDER}/whale_${i}
   KEY_FILE=${ROOT}/online_whale_keys/online_whale_account_${i}
   mkdir -p "${FOLDER}"
   spawn-daemon "whale_${i}" "${FOLDER}" $((WHALE_START_PORT + i * 6)) -peer ${SEED_PEER_ID} -block-producer-key ${KEY_FILE} \
     -libp2p-keypair "${ROOT}"/libp2p_keys/whale_${i} "${ARCHIVE_ADDRESS_CLI_ARG}"
   WHALE_PIDS[${i}]=$!
+  register-transfer-node "whale_${i}" "$((WHALE_START_PORT + i * 6))" "${WHALE_PIDS[${i}]}" "${KEY_FILE}"
 done
 
 # ----------
@@ -1082,6 +1160,7 @@ for ((i = 0; i < FISH; i++)); do
   spawn-daemon "fish_${i}" "${FOLDER}" $((FISH_START_PORT + i * 6)) -peer ${SEED_PEER_ID} -block-producer-key "${KEY_FILE}" \
     -libp2p-keypair "${ROOT}"/libp2p_keys/fish_${i} "${ARCHIVE_ADDRESS_CLI_ARG}"
   FISH_PIDS[${i}]=$!
+  register-transfer-node "fish_${i}" "$((FISH_START_PORT + i * 6))" "${FISH_PIDS[${i}]}" "${KEY_FILE}"
 done
 
 # ----------
@@ -1169,11 +1248,11 @@ if [[ -n "${ROSETTA_PORT}" ]]; then
 EOF
 fi
 
-if [ "${WHALES}" -gt 0 ]; then
+if [ "${WHALE_STANDALONE_START}" -lt "${WHALES}" ]; then
   cat <<EOF
 	Whales:
 EOF
-  for ((i = 0; i < WHALES; i++)); do
+  for ((i = WHALE_STANDALONE_START; i < WHALES; i++)); do
     cat <<EOF
 		Instance #${i}:
 		  pid ${WHALE_PIDS[${i}]}
@@ -1219,31 +1298,23 @@ printf "\n"
 
 if ${VALUE_TRANSFERS} || ${ZKAPP_TRANSACTIONS}; then
 
-  VALID_TRANSFER_NODES=$((WHALES + FISH))
+  VALID_TRANSFER_NODES=${#TRANSFER_NODE_PORTS[@]}
 
   if [ "$VALID_TRANSFER_NODES" -eq 0 ]; then
       echo "Error: No nodes available to send transactions."
       exit 1
   fi
 
+  # Pick a random block-producing daemon that is actually running. This list
+  # covers standalone whales/fish as well as the seed / snark coordinator when
+  # they double as whale block producers.
   RANDOM_INDEX=$(( RANDOM % VALID_TRANSFER_NODES ))
+  TRANSFER_NODE_LABEL="${TRANSFER_NODE_LABELS[$RANDOM_INDEX]}"
+  TRANSFER_PORT_BASE="${TRANSFER_NODE_PORTS[$RANDOM_INDEX]}"
+  TRANFER_NODE_PID="${TRANSFER_NODE_PIDS[$RANDOM_INDEX]}"
+  KEY_FILE="${TRANSFER_NODE_KEYS[$RANDOM_INDEX]}"
 
-  # Determine if the index falls into the Whale or Fish range
-  if [ "$RANDOM_INDEX" -lt "$WHALES" ]; then
-      TRANSFER_NODE_TYPE="whale"
-      # For whales, the relative index is just the RANDOM_INDEX
-      TRANSFER_NODE_INDEX="$RANDOM_INDEX"
-      TRANSFER_PORT_BASE=$(( WHALE_START_PORT + TRANSFER_NODE_INDEX * 6 ))
-      TRANFER_NODE_PID="${WHALE_PIDS[TRANSFER_NODE_INDEX]}"
-  else
-      TRANSFER_NODE_TYPE="fish" # Fixed variable name here
-      TRANSFER_NODE_INDEX=$((RANDOM_INDEX - WHALES))
-      # For fish, we subtract the whale count to get the 0-based fish index
-      TRANSFER_PORT_BASE=$(( FISH_START_PORT + TRANSFER_NODE_INDEX * 6 ))
-      TRANFER_NODE_PID="${FISH_PIDS[TRANSFER_NODE_INDEX]}"
-  fi
-
-  echo "Using ${TRANSFER_NODE_TYPE} at base port ${TRANSFER_PORT_BASE} to send transactions"
+  echo "Using ${TRANSFER_NODE_LABEL} at base port ${TRANSFER_PORT_BASE} to send transactions"
 
 
   FEE_PAYER_KEY_FILE=${ROOT}/offline_whale_keys/offline_whale_account_0
@@ -1253,7 +1324,6 @@ if ${VALUE_TRANSFERS} || ${ZKAPP_TRANSACTIONS}; then
     ZKAPP_ACCOUNT_PUB_KEY=$(cat "${ROOT}/zkapp_keys/zkapp_account.pub")
   fi
 
-  KEY_FILE="${ROOT}/online_${TRANSFER_NODE_TYPE}_keys/online_${TRANSFER_NODE_TYPE}_account_${TRANSFER_NODE_INDEX}"
   PUB_KEY=$(cat "${KEY_FILE}.pub")
   REST_SERVER="http://127.0.0.1:$((TRANSFER_PORT_BASE + 1))/graphql"
 
@@ -1314,7 +1384,7 @@ if ${VALUE_TRANSFERS} || ${ZKAPP_TRANSACTIONS}; then
   value_txn_id=0
   while is_process_running "${TRANFER_NODE_PID}"; do
     sleep ${TRANSACTION_INTERVAL}
-    echo "${TRANSFER_NODE_TYPE} ${TRANSFER_NODE_INDEX} at ${TRANFER_NODE_PID} is alive, sending txns"
+    echo "${TRANSFER_NODE_LABEL} at ${TRANFER_NODE_PID} is alive, sending txns"
 
     if ${VALUE_TRANSFERS} && \
       ${MINA_EXE} client send-payment \

--- a/src/app/hardfork_test/README.md
+++ b/src/app/hardfork_test/README.md
@@ -36,6 +36,29 @@ This validates the critical hardfork mechanism:
 - **Network Functionality**: Both pre-fork and post-fork networks operate correctly (block production, transaction processing)
 - **Hardfork Tooling**: The `runtime_genesis_ledger` tool correctly generates hardfork genesis ledgers from the extracted state
 
+### Fork methods
+
+One or more fork methods are requested via `--allow-fork-method` (repeatable);
+valid values are `legacy`, `advanced`, and `auto`:
+
+- **legacy** — migrates the ledger via `runtime_genesis_ledger` (applies the
+  slot-reduction update correctly).
+- **advanced** — `mina advanced generate-hardfork-config` against the live
+  daemon; uses the converting ledger / `migrate_to_mesa`.
+- **auto** — daemon self-generates its hardfork config at slot-chain-end under
+  `--hardfork-handling migrate-exit`; also uses `migrate_to_mesa`. Auto daemons
+  **exit** at slot-chain-end.
+
+Each requested method is assigned to **at least one** daemon (remaining daemons
+get a random method from the set), so:
+
+- Requesting more methods than there are daemons fails with an error — request
+  fewer methods or grow the network with `--num-whales` / `--num-fish` /
+  `--num-nodes`.
+- At least one **non-auto** method is required, because auto daemons exit at
+  slot-chain-end and the post-fork checks need a still-running daemon. Use
+  `advanced` for an auto-equivalent migration path that keeps the daemon alive.
+
 ## Usage
 
 ```
@@ -53,6 +76,16 @@ This validates the critical hardfork mechanism:
 - `--fork-runtime-genesis-ledger`: Path to the fork runtime genesis ledger executable
 
 ### Optional Arguments
+
+#### Network Size
+- `--num-whales`: Number of whale (block-producer) accounts (default: 2). Whales
+  beyond those absorbed by the seed/snark-coordinator run as standalone daemons.
+- `--num-fish`: Number of fish (smaller block-producer) daemons (default: 0)
+- `--num-nodes`: Number of plain (non-block-producing) daemons (default: 0)
+
+The number of daemons bounds how many fork methods can be requested: every
+`--allow-fork-method` value is assigned to at least one daemon (see "Fork
+methods" below), so requesting more methods than there are daemons is an error.
 
 #### Test Configuration
 - `--slot-tx-end`: Slot at which transactions should end (default: 30)

--- a/src/app/hardfork_test/README.md
+++ b/src/app/hardfork_test/README.md
@@ -35,6 +35,29 @@ This validates the critical hardfork mechanism:
 - **Protocol Compatibility**: The fork configuration and ledger format are compatible between versions
 - **Network Functionality**: Both pre-fork and post-fork networks operate correctly (block production, transaction processing)
 - **Hardfork Tooling**: The `runtime_genesis_ledger` tool correctly generates hardfork genesis ledgers from the extracted state
+- **Vesting Slot-Reduction Update**: A timed (vesting) account is seeded into the pre-fork genesis ledger, and after the fork its timing is checked to confirm the Mesa slot-reduction update was applied (vesting period doubled, cliff advanced) — see "Vesting account test" below
+
+### Vesting account test
+
+Before the fork, the harness injects a timed account into the pre-fork genesis
+ledger (via the `--extra-genesis-account-file` option of
+`mina-local-network.sh`). The account is "not yet vesting" at the hardfork slot
+and fully unlocks at its cliff, which is placed `2 * offset` slots after the
+hardfork under correct migration (`offset` slots without it).
+
+After the fork the harness:
+1. Asserts the migrated `timingInfo` (queried via GraphQL) equals the expected
+   slot-reduction-updated values — i.e. `vesting_period` doubled and
+   `cliff_time` advanced to `hardfork_slot + 2*(cliff_time - hardfork_slot)`.
+2. Watches the account's `liquid` balance and fails if it unlocks before the
+   correct (migrated) cliff slot.
+
+This specifically targets the `Account.Hardfork.migrate_to_mesa` migration path
+(`src/lib/mina_base/account.ml`). That path is exercised by the live daemon
+during migration, so to test the bug end-to-end run with the `auto` (or
+`advanced`) fork method; with `legacy` the account is migrated via
+`runtime_genesis_ledger` instead, and the same assertions validate that path.
+The test is always on and requires no extra flags.
 
 ### Fork methods
 
@@ -58,6 +81,16 @@ get a random method from the set), so:
 - At least one **non-auto** method is required, because auto daemons exit at
   slot-chain-end and the post-fork checks need a still-running daemon. Use
   `advanced` for an auto-equivalent migration path that keeps the daemon alive.
+
+**Caveat — do not mix `legacy` with `auto`/`advanced` while the vesting test is
+on.** Because of the `migrate_to_mesa` bug, `legacy` (correct) and
+`auto`/`advanced` (buggy) migrate the injected timed account differently,
+producing different post-fork genesis ledger hashes; the nodes then compute
+different chain IDs and cannot peer, so the network fails to form instead of the
+vesting assertion firing. For a clean single-path signal use **`--allow-fork-method advanced`**
+(all daemons hit the buggy `migrate_to_mesa` path, the network forms, and
+`ValidateVestingAfterFork` fails as designed); use `--allow-fork-method legacy`
+as the green control.
 
 ## Usage
 

--- a/src/app/hardfork_test/README.md
+++ b/src/app/hardfork_test/README.md
@@ -4,6 +4,14 @@ A Go application for testing hardfork functionality in the Mina Protocol. This t
 
 ## Overview
 
+### Network Topology
+
+By default the test runs a compact network of **2 Mina nodes and 2 snark
+workers**: the seed node and the snark coordinator each double as a whale block
+producer (via the `--seed-is-whale` / `--snark-coordinator-is-whale` options of
+`mina-local-network.sh`), so no standalone whale daemons are spawned. This keeps
+two block producers (for healthy slot occupancy) while halving the daemon count.
+
 ### High-Level Test Sequence
 
 The hardfork test simulates a complete protocol upgrade by running two sequential networks:

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -38,7 +38,11 @@ Example:
 		}
 
 		// Create and run the hardfork test
-		return hardfork.NewHardforkTest(cfg).Run()
+		test, err := hardfork.NewHardforkTest(cfg)
+		if err != nil {
+			return err
+		}
+		return test.Run()
 	},
 }
 
@@ -53,6 +57,12 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.MainRuntimeGenesisLedger, "main-runtime-genesis-ledger", "", "Path to the main runtime genesis ledger executable (required)")
 	rootCmd.Flags().StringVar(&cfg.ForkMinaExe, "fork-mina-exe", "", "Path to the fork Mina executable (required)")
 	rootCmd.Flags().StringVar(&cfg.ForkRuntimeGenesisLedger, "fork-runtime-genesis-ledger", "", "Path to the fork runtime genesis ledger executable (required)")
+
+	// Network size. These also bound how many fork methods can be requested at
+	// once, since every --allow-fork-method needs at least one daemon.
+	rootCmd.Flags().IntVar(&cfg.NumWhales, "num-whales", cfg.NumWhales, "Number of whale (block-producer) accounts; whales beyond those absorbed by the seed/snark-coordinator run as standalone daemons")
+	rootCmd.Flags().IntVar(&cfg.NumFish, "num-fish", cfg.NumFish, "Number of fish (smaller block-producer) daemons")
+	rootCmd.Flags().IntVar(&cfg.NumNodes, "num-nodes", cfg.NumNodes, "Number of plain (non-block-producing) daemons")
 
 	// Test configuration
 	rootCmd.Flags().IntVar(&cfg.SlotTxEnd, "slot-tx-end", cfg.SlotTxEnd, "Slot at which transactions should end")

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -121,7 +121,8 @@ func (block *BlockData) NonEmpty() bool {
 func (block BlockData) String() string {
 	b, err := json.MarshalIndent(block, "", "  ")
 	if err != nil {
-		return fmt.Sprintf("%+v", block)
+		type blockData BlockData
+		return fmt.Sprintf("%+v", blockData(block))
 	}
 	return string(b)
 }
@@ -249,6 +250,63 @@ func (c *Client) ForkConfig(port int) (gjson.Result, error) {
 	}
 
 	return result.Get("data.fork_config"), nil
+}
+
+// accountTiming mirrors the GraphQL account timing/balance response. All
+// numeric fields are decoded from the stringified integers GraphQL returns:
+// amounts/balances are in nanomina and times are global-slot numbers.
+type accountTiming struct {
+	Timing *struct {
+		InitialMinimumBalance int64 `json:"initialMinimumBalance,string"`
+		CliffTime             int64 `json:"cliffTime,string"`
+		CliffAmount           int64 `json:"cliffAmount,string"`
+		VestingPeriod         int64 `json:"vestingPeriod,string"`
+		VestingIncrement      int64 `json:"vestingIncrement,string"`
+	} `json:"timing"`
+	Balance struct {
+		Total  int64 `json:"total,string"`
+		Liquid int64 `json:"liquid,string"`
+	} `json:"balance"`
+}
+
+const accountTimingQuery = `
+account(publicKey: "%s") {
+  timing {
+    initialMinimumBalance
+    cliffTime
+    cliffAmount
+    vestingPeriod
+    vestingIncrement
+  }
+  balance {
+    total
+    liquid
+  }
+}
+`
+
+// AccountTiming queries the timing parameters and balances of the account with
+// the given public key.
+func (c *Client) AccountTiming(port int, pubKey string) (*accountTiming, error) {
+	result, err := c.query(port, fmt.Sprintf(accountTimingQuery, pubKey))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Data struct {
+			Account *accountTiming `json:"account"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result.Raw), &response); err != nil {
+		return nil, fmt.Errorf("failed to decode account timing response: %w", err)
+	}
+
+	if response.Data.Account == nil {
+		return nil, fmt.Errorf("account %s not found at port %d", pubKey, port)
+	}
+
+	return response.Data.Account, nil
 }
 
 func (c *Client) NumUserCommandsInBestChain(port int) (int, error) {

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -145,17 +145,17 @@ func (d *DaemonInfo) NodeDirRel(root string) string {
 	return filepath.Join(root, "nodes", d.Name)
 }
 
-func (c *Config) InitDaemonInfos() {
+func (c *Config) InitDaemonInfos() error {
+	// Build the daemon slots first (without fork methods); methods are assigned
+	// below so that every requested method is guaranteed at least one daemon.
 	result := []DaemonInfo{
 		{
-			StartPort:  c.SeedStartPort,
-			Name:       "seed",
-			ForkMethod: c.ForkMethods.RandomChoose(),
+			StartPort: c.SeedStartPort,
+			Name:      "seed",
 		},
 		{
-			StartPort:  c.SnarkCoordinatorPort,
-			Name:       "snark_coordinator",
-			ForkMethod: c.ForkMethods.RandomChoose(),
+			StartPort: c.SnarkCoordinatorPort,
+			Name:      "snark_coordinator",
 		},
 	}
 
@@ -172,42 +172,77 @@ func (c *Config) InitDaemonInfos() {
 
 	for whale_id := standaloneWhaleStart; whale_id < c.NumWhales; whale_id++ {
 		result = append(result, DaemonInfo{
-			StartPort:  c.WhaleStartPort + whale_id*PORT_PER_NODE,
-			Name:       fmt.Sprintf("whale_%d", whale_id),
-			ForkMethod: c.ForkMethods.RandomChoose(),
+			StartPort: c.WhaleStartPort + whale_id*PORT_PER_NODE,
+			Name:      fmt.Sprintf("whale_%d", whale_id),
 		})
 	}
 
 	for fish_id := 0; fish_id < c.NumFish; fish_id++ {
 		result = append(result, DaemonInfo{
-			StartPort:  c.FishStartPort + fish_id*PORT_PER_NODE,
-			Name:       fmt.Sprintf("fish_%d", fish_id),
-			ForkMethod: c.ForkMethods.RandomChoose(),
+			StartPort: c.FishStartPort + fish_id*PORT_PER_NODE,
+			Name:      fmt.Sprintf("fish_%d", fish_id),
 		})
 	}
 
 	for node_id := 0; node_id < c.NumNodes; node_id++ {
 		result = append(result, DaemonInfo{
-			StartPort:  c.NodeStartPort + node_id*PORT_PER_NODE,
-			Name:       fmt.Sprintf("plain_%d", node_id),
-			ForkMethod: c.ForkMethods.RandomChoose(),
+			StartPort: c.NodeStartPort + node_id*PORT_PER_NODE,
+			Name:      fmt.Sprintf("plain_%d", node_id),
 		})
 	}
 
-	// NOTE: ensure there's at least one daemon not running in auto mode, o.w. we
-	// can't check on anything after slot-chain-end
-	allAuto := true
-	for _, info := range result {
-		if info.ForkMethod != Auto {
-			allAuto = false
+	// Assign fork methods so that every method passed via --allow-fork-method is
+	// used by at least one daemon. Mixing migration paths that disagree on a given
+	// ledger (e.g. legacy via runtime_genesis_ledger vs auto/advanced via
+	// migrate_to_mesa) makes the post-fork nodes compute different genesis ledger
+	// hashes and fail to peer, so coverage must be explicit and bounded by the
+	// number of daemons rather than left to chance.
+	methods := c.ForkMethods.Methods()
+	if len(methods) == 0 {
+		return fmt.Errorf("no fork method supplied; pass at least one --allow-fork-method")
+	}
+	if len(methods) > len(result) {
+		return fmt.Errorf(
+			"requested %d fork method(s) %s but the network only has %d daemon(s); "+
+				"each requested method needs its own daemon. Either request fewer methods "+
+				"(drop some --allow-fork-method flags) or grow the network with "+
+				"--num-whales / --num-fish / --num-nodes.",
+			len(methods), c.ForkMethods.String(), len(result))
+	}
+
+	// Auto daemons exit at slot-chain-end (migrate-exit), so an all-auto network
+	// leaves nothing alive for the post-chain-end checks. Require a non-auto
+	// method; `advanced` exercises the same migrate_to_mesa path as auto.
+	hasNonAuto := false
+	for _, m := range methods {
+		if m != Auto {
+			hasNonAuto = true
 		}
 	}
-	if allAuto {
-		nonAutoForkMethods := []ForkMethod{Legacy, Advanced}
-		result[rand.Intn(len(result))].ForkMethod = nonAutoForkMethods[rand.Intn(len(nonAutoForkMethods))]
+	if !hasNonAuto {
+		return fmt.Errorf(
+			"only the 'auto' fork method was requested, but auto daemons exit at " +
+				"slot-chain-end and the post-fork checks need a still-running daemon. Add a " +
+				"non-auto method, e.g. --allow-fork-method advanced (which exercises the same " +
+				"migration path as auto).")
+	}
+
+	// Give the first len(methods) slots one distinct method each, fill the rest
+	// randomly, then shuffle so the assignment isn't tied to daemon position.
+	assignment := make([]ForkMethod, len(result))
+	copy(assignment, methods)
+	for i := len(methods); i < len(assignment); i++ {
+		assignment[i] = methods[rand.Intn(len(methods))]
+	}
+	rand.Shuffle(len(assignment), func(i, j int) {
+		assignment[i], assignment[j] = assignment[j], assignment[i]
+	})
+	for i := range result {
+		result[i].ForkMethod = assignment[i]
 	}
 
 	c.DaemonInfos = result
+	return nil
 }
 
 func (c *Config) AllDaemonSatisfying(tag string, pred func(*DaemonInfo) bool) []*DaemonInfo {

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -78,6 +78,19 @@ type Config struct {
 	ForkMethods ForkMethodSet
 
 	DaemonInfos []DaemonInfo
+
+	// Vesting-account test (see vesting.go). When enabled, the hardfork test
+	// injects a timed account into the pre-fork genesis ledger, and checks its
+	// timing after the fork to ensure the Mesa slot-reduction update was applied
+	// correctly.
+	VestingTestEnabled bool
+}
+
+// HardforkSlot is the global slot since genesis at which the fork network's
+// genesis is set; this is the slot used by the migration to adjust vesting
+// parameters. It matches expectedGenesisSlot computed in RunForkNetworkPhase.
+func (c *Config) HardforkSlot() int {
+	return c.SlotChainEnd + c.HfSlotDelta
 }
 
 // DefaultConfig returns the default configuration with values
@@ -115,6 +128,8 @@ func DefaultConfig() *Config {
 		NodeStartPort:        6000,
 
 		ForkMethods: make(ForkMethodSet),
+
+		VestingTestEnabled: true,
 	}
 }
 

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -49,6 +49,13 @@ type Config struct {
 	NumFish   int
 	NumNodes  int
 
+	// When set, the seed and/or snark coordinator daemons also run as whale block
+	// producers (consuming the leading whale accounts) instead of those whales
+	// being spawned as standalone daemons. With both enabled and NumWhales=2 this
+	// collapses the topology to 2 Mina nodes (seed+whale, snark-coordinator+whale).
+	SeedIsWhale             bool
+	SnarkCoordinatorIsWhale bool
+
 	// Interval of sending payments in second
 	PaymentInterval int
 
@@ -87,6 +94,8 @@ func DefaultConfig() *Config {
 		NumWhales:                     2,
 		NumFish:                       0,
 		NumNodes:                      0,
+		SeedIsWhale:                   true,
+		SnarkCoordinatorIsWhale:       true,
 		PaymentInterval:               20,
 		ShutdownTimeoutMinutes:        10,
 		PollingIntervalSeconds:        8,
@@ -150,7 +159,18 @@ func (c *Config) InitDaemonInfos() {
 		},
 	}
 
-	for whale_id := 0; whale_id < c.NumWhales; whale_id++ {
+	// Whale accounts consumed by the seed / snark coordinator (when they double as
+	// block producers) are not spawned as standalone whale daemons; mirror the
+	// WHALE_STANDALONE_START logic in mina-local-network.sh.
+	standaloneWhaleStart := 0
+	if c.SeedIsWhale && standaloneWhaleStart < c.NumWhales {
+		standaloneWhaleStart++
+	}
+	if c.SnarkCoordinatorIsWhale && standaloneWhaleStart < c.NumWhales {
+		standaloneWhaleStart++
+	}
+
+	for whale_id := standaloneWhaleStart; whale_id < c.NumWhales; whale_id++ {
 		result = append(result, DaemonInfo{
 			StartPort:  c.WhaleStartPort + whale_id*PORT_PER_NODE,
 			Name:       fmt.Sprintf("whale_%d", whale_id),

--- a/src/app/hardfork_test/src/internal/config/config_test.go
+++ b/src/app/hardfork_test/src/internal/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestPlainDaemonUsesMinaLocalNetworkPlainNaming(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumNodes = 1
+	if err := cfg.ForkMethods.Set("legacy"); err != nil {
+		t.Fatalf("failed to set fork method: %v", err)
+	}
+	if err := cfg.InitDaemonInfos(); err != nil {
+		t.Fatalf("failed to initialize daemon infos: %v", err)
+	}
+
+	for _, daemon := range cfg.DaemonInfos {
+		if daemon.Name == "plain_0" {
+			if got, want := daemon.NodeDirRel("/root"), "/root/nodes/plain_0"; got != want {
+				t.Fatalf("plain daemon dir = %q, want %q", got, want)
+			}
+			return
+		}
+	}
+	t.Fatal("plain_0 daemon was not initialized")
+}

--- a/src/app/hardfork_test/src/internal/config/fork_method.go
+++ b/src/app/hardfork_test/src/internal/config/fork_method.go
@@ -63,6 +63,20 @@ func (s *ForkMethodSet) String() string {
 	return fmt.Sprintf("[%s]", result)
 }
 
+// Methods returns the fork methods in the set as a slice. The order is
+// non-deterministic (Go map iteration), which is fine for callers that assign
+// methods to daemons and shuffle afterwards.
+func (s *ForkMethodSet) Methods() []ForkMethod {
+	if s == nil {
+		return nil
+	}
+	methods := make([]ForkMethod, 0, len(*s))
+	for m := range *s {
+		methods = append(methods, m)
+	}
+	return methods
+}
+
 func (s *ForkMethodSet) RandomChoose() ForkMethod {
 	if s == nil || len(*s) == 0 {
 		panic("choosing fork method from empty set")

--- a/src/app/hardfork_test/src/internal/hardfork/ledger.go
+++ b/src/app/hardfork_test/src/internal/hardfork/ledger.go
@@ -16,8 +16,19 @@ type LedgerHashes struct {
 	LedgerHash  string
 }
 
-// GenerateForkLedgers generates the hardfork ledgers using the specified executable
-func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile string) error {
+// GenerateForkLedgers generates the hardfork ledgers using the specified
+// executable. When preforkGenesisConfig is non-empty it is passed as
+// --prefork-genesis-config, which makes runtime_genesis_ledger derive the
+// hardfork slot (slot_chain_end + hard_fork_genesis_slot_delta) from it and
+// apply the Mesa vesting slot-reduction update to timed accounts. The legacy
+// path MUST supply it for the final fork ledgers: without it the generated
+// ledger keeps un-migrated vesting timing, which both diverges from the
+// auto/advanced (daemon-side) migration — splitting the network on chain id —
+// and from the real release flow
+// (scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh). It is
+// left empty when (re)generating the pre-fork ledgers, whose hashes must match
+// the still-un-migrated live network state.
+func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile, preforkGenesisConfig string) error {
 	t.Logger.Info("Generating hardfork ledgers with %s...", executablePath)
 
 	// Create hardfork ledgers directory
@@ -25,15 +36,19 @@ func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledge
 	os.MkdirAll(ledgersDir, 0755)
 
 	// Generate hardfork ledgers with specified executable
-	cmd := exec.Command(
-		executablePath,
+	args := []string{
 		"--config-file", forkConfigPath,
 		"--genesis-dir", ledgersDir,
 		"--hash-output-file", hashesFile,
 		// Forking to mesa need App State size to be expanded to 32
 		// TODO: Consider design the test so this pad app state size is only applied when forking into Mesa
 		"--pad-app-state",
-	)
+	}
+	if preforkGenesisConfig != "" {
+		args = append(args, "--prefork-genesis-config", preforkGenesisConfig)
+	}
+
+	cmd := exec.Command(executablePath, args...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -47,8 +62,10 @@ func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledge
 }
 
 func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysisResult, forkConfigPath, preforkLedgersDir, prepatchForkConfig string) error {
-	// Generate prefork ledgers using main network executable
-	if err := t.GenerateForkLedgers(t.Config.MainRuntimeGenesisLedger, forkConfigPath, preforkLedgersDir, prepatchForkConfig); err != nil {
+	// Generate prefork ledgers using main network executable. No prefork genesis
+	// config here: these hashes are validated against the still-un-migrated live
+	// prefork network state, so the slot-reduction update must NOT be applied.
+	if err := t.GenerateForkLedgers(t.Config.MainRuntimeGenesisLedger, forkConfigPath, preforkLedgersDir, prepatchForkConfig, ""); err != nil {
 		return err
 	}
 
@@ -63,8 +80,11 @@ func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysi
 // 2. patch the genesis time & slot for fork config with create_runtime_config.sh
 // 3. perform some base sanity check on the fork config
 func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64) ([]byte, error) {
-	// Generate fork ledgers using fork network executable
-	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile); err != nil {
+	// Generate fork ledgers using fork network executable. Pass the prefork
+	// genesis config so runtime_genesis_ledger applies the Mesa vesting
+	// slot-reduction update (mirrors the release flow); otherwise the legacy
+	// ledger would keep un-migrated timing and diverge from auto/advanced.
+	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile, preforkGenesisConfigFile); err != nil {
 		return nil, err
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/ledger.go
+++ b/src/app/hardfork_test/src/internal/hardfork/ledger.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-
-	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
 )
 
 // LedgerHashes holds the expected ledger hashes for validation
@@ -16,7 +14,7 @@ type LedgerHashes struct {
 	LedgerHash  string
 }
 
-// GenerateForkLedgers generates the hardfork ledgers using the specified
+// GenerateGenesisLedgersFromRuntimeConfig generates the hardfork ledgers using the specified
 // executable. When preforkGenesisConfig is non-empty it is passed as
 // --prefork-genesis-config, which makes runtime_genesis_ledger derive the
 // hardfork slot (slot_chain_end + hard_fork_genesis_slot_delta) from it and
@@ -28,7 +26,7 @@ type LedgerHashes struct {
 // (scripts/hardfork/release/generate-fork-config-with-ledger-tarballs.sh). It is
 // left empty when (re)generating the pre-fork ledgers, whose hashes must match
 // the still-un-migrated live network state.
-func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile, preforkGenesisConfig string) error {
+func (t *HardforkTest) GenerateGenesisLedgersFromRuntimeConfig(executablePath, forkConfigPath, ledgersDir, hashesFile, preforkGenesisConfig string) error {
 	t.Logger.Info("Generating hardfork ledgers with %s...", executablePath)
 
 	// Create hardfork ledgers directory
@@ -61,11 +59,11 @@ func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledge
 	return nil
 }
 
-func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysisResult, forkConfigPath, preforkLedgersDir, prepatchForkConfig string) error {
+func (t *HardforkTest) RegenerateAndValidatePrepatchLedgerHashes(analysis BlockAnalysisResult, forkConfigPath, preforkLedgersDir, prepatchForkConfig string) error {
 	// Generate prefork ledgers using main network executable. No prefork genesis
 	// config here: these hashes are validated against the still-un-migrated live
 	// prefork network state, so the slot-reduction update must NOT be applied.
-	if err := t.GenerateForkLedgers(t.Config.MainRuntimeGenesisLedger, forkConfigPath, preforkLedgersDir, prepatchForkConfig, ""); err != nil {
+	if err := t.GenerateGenesisLedgersFromRuntimeConfig(t.Config.MainRuntimeGenesisLedger, forkConfigPath, preforkLedgersDir, prepatchForkConfig, ""); err != nil {
 		return err
 	}
 
@@ -75,22 +73,15 @@ func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysi
 	)
 }
 
-// PatchForkConfigAndGenerateLedgersLegacy does the following:
-// 1. generate fork ledgers with runtime-genesis-ledger
-// 2. patch the genesis time & slot for fork config with create_runtime_config.sh
-// 3. perform some base sanity check on the fork config
-func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64) ([]byte, error) {
-	// Generate fork ledgers using fork network executable. Pass the prefork
-	// genesis config so runtime_genesis_ledger applies the Mesa vesting
-	// slot-reduction update (mirrors the release flow); otherwise the legacy
-	// ledger would keep un-migrated timing and diverge from auto/advanced.
-	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile, preforkGenesisConfigFile); err != nil {
-		return nil, err
-	}
-
-	// Create runtime config
-	forkGenesisTimestamp := config.FormatTimestamp(forkGenesisTs)
-	return t.PatchRuntimeConfigLegacy(forkGenesisTimestamp, forkConfigPath, configFile, preforkGenesisConfigFile, forkHashesFile)
+// GenerateLegacyPostforkGenesisLedgers generates postfork genesis ledgers
+// from the prepatch fork config using the fork-network runtime_genesis_ledger binary.
+func (t *HardforkTest) GenerateLegacyPostforkGenesisLedgers(
+	forkConfigPath, forkLedgersDir, forkHashesFile, preforkGenesisConfigFile string,
+) error {
+	return t.GenerateGenesisLedgersFromRuntimeConfig(
+		t.Config.ForkRuntimeGenesisLedger,
+		forkConfigPath, forkLedgersDir, forkHashesFile, preforkGenesisConfigFile,
+	)
 }
 
 func (t *HardforkTest) AdvancedGenerateHardForkConfig(configDir string, clientPort int) error {

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -76,6 +76,12 @@ func (t *HardforkTest) RunMainNetwork(extraFilesRoot string, mainGenesisTs int64
 		"--extra-files-root", extraFilesRoot,
 	}
 
+	// Seed the timed/vesting account into the freshly generated genesis ledger so
+	// it flows through fork-config extraction and migration (see vesting.go).
+	if t.Config.VestingTestEnabled && t.vestingAccount != nil {
+		args = append(args, "--extra-genesis-account-file", t.vestingAccount.extraAccountFile)
+	}
+
 	return t.startLocalNetwork(t.Config.MainMinaExe, "main", args)
 }
 

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -33,6 +33,16 @@ func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, 
 		"--root", t.Config.Root,
 	)
 
+	// Combine block-producer roles onto the seed and snark coordinator so the
+	// network runs as 2 daemons instead of 4. These flags apply to both the main
+	// and fork networks (both must keep producing blocks).
+	if t.Config.SeedIsWhale {
+		cmd.Args = append(cmd.Args, "--seed-is-whale")
+	}
+	if t.Config.SnarkCoordinatorIsWhale {
+		cmd.Args = append(cmd.Args, "--snark-coordinator-is-whale")
+	}
+
 	cmd.Args = append(cmd.Args, extraArgs...)
 	cmd.Env = append(os.Environ(), "MINA_EXE="+minaExecutable)
 

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -204,7 +204,7 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 
 	prepatchLedgersDir := filepath.Join(forkDataPrepatchPath, "ledgers")
 	prepatchHashesFile := filepath.Join(forkDataPrepatchPath, "ledger_hashes.json")
-	if err := t.GenerateAndValidateHashesAndLedgers(analysis, prepatchConfigFile, prepatchLedgersDir, prepatchHashesFile); err != nil {
+	if err := t.RegenerateAndValidatePrepatchLedgerHashes(analysis, prepatchConfigFile, prepatchLedgersDir, prepatchHashesFile); err != nil {
 		return err
 	}
 
@@ -217,7 +217,17 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 	preforkGenesisConfigFile := filepath.Join(t.Config.Root, "daemon.json")
 	forkHashesFile := filepath.Join(forkDataPath, "ledger_hashes.json")
 
-	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs)
+	if err := t.GenerateLegacyPostforkGenesisLedgers(
+		prepatchConfigFile, patchedLedgersDir, forkHashesFile, preforkGenesisConfigFile,
+	); err != nil {
+		return err
+	}
+
+	forkGenesisTimestamp := config.FormatTimestamp(forkGenesisTs)
+	patchedConfigBytes, err := t.PatchRuntimeConfigLegacy(
+		forkGenesisTimestamp, prepatchConfigFile, patchedConfigFile,
+		preforkGenesisConfigFile, forkHashesFile,
+	)
 	if err != nil {
 		return err
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -148,6 +148,15 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 		return err
 	}
 
+	// Validate the injected vesting account had its timing correctly adjusted by
+	// the Mesa slot-reduction update on every fork-network daemon. The
+	// timing-parameter assertion is run first on all daemons (deterministic), then
+	// the liquid-balance watch runs across all daemons before the slots past the
+	// cliff have elapsed, so it can observe the account still locked.
+	if err := t.ValidateVestingOnForkNetwork(int(expectedGenesisSlot)); err != nil {
+		return err
+	}
+
 	// Validate user commands in blocks
 	if err := t.ValidateBlockWithUserCommandCreatedForkNetwork(t.Config.AnyDaemon().Port(config.PORT_REST)); err != nil {
 		return err

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -20,6 +20,7 @@ type HardforkTest struct {
 	Client         *client.Client
 	Logger         *utils.Logger
 	ScriptDir      string
+	vestingAccount *vestingAccount
 	runningCmds    []*exec.Cmd
 	runningCmdsMux sync.Mutex
 	ctx            context.Context
@@ -122,6 +123,13 @@ func (t *HardforkTest) Run() error {
 	defer t.cleanupAllProcesses()
 
 	t.Logger.Info("===== Starting Hardfork Test =====")
+
+	// Seed a timed/vesting account into the pre-fork genesis ledger so we can
+	// verify the Mesa slot-reduction vesting update after the fork (see vesting.go).
+	if err := t.SetupVestingAccount(); err != nil {
+		return err
+	}
+	defer t.CleanupVestingAccount()
 
 	// Calculate main network genesis timestamp
 	mainGenesisTs := time.Now().Unix() + int64(t.Config.MainDelayMin*60)

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -27,9 +27,12 @@ type HardforkTest struct {
 }
 
 // NewHardforkTest creates a new instance of the hardfork test
-func NewHardforkTest(cfg *config.Config) *HardforkTest {
+func NewHardforkTest(cfg *config.Config) (*HardforkTest, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cfg.InitDaemonInfos()
+	if err := cfg.InitDaemonInfos(); err != nil {
+		cancel()
+		return nil, err
+	}
 	return &HardforkTest{
 		Config:      cfg,
 		Client:      client.NewClient(cfg.HTTPClientTimeoutSeconds, cfg.ClientMaxRetries),
@@ -38,7 +41,7 @@ func NewHardforkTest(cfg *config.Config) *HardforkTest {
 		runningCmds: make([]*exec.Cmd, 0),
 		ctx:         ctx,
 		cancel:      cancel,
-	}
+	}, nil
 }
 
 // gracefulShutdown attempts to gracefully shutdown a process with timeout

--- a/src/app/hardfork_test/src/internal/hardfork/vesting.go
+++ b/src/app/hardfork_test/src/internal/hardfork/vesting.go
@@ -1,0 +1,407 @@
+package hardfork
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
+)
+
+// This file implements an end-to-end test for the Mesa hardfork "slot reduction"
+// vesting update (MIP-0006). A timed account that only *starts* vesting after the
+// hardfork slot is injected into the pre-fork genesis ledger. After the fork, its
+// timing must have been adjusted by Account.slot_reduction_update so that it still
+// unlocks funds at the same wall-clock time despite slots becoming 2x faster:
+// the vesting period is doubled and the cliff is pushed from
+// hardfork_slot + offset to hardfork_slot + 2*offset.
+//
+// The bug described in 3_mesa-hardfork-vesting-schedule-not-adjusted.txt is that
+// Account.Hardfork.migrate_to_mesa discards its hardfork_slot argument and never
+// applies this update, so the account vests ~2x too fast. This test catches that
+// both by asserting the migrated timing parameters and by observing that liquid
+// funds do not unlock before the correct slot.
+
+// formatMina renders a nanomina amount as the decimal-mina string used in genesis
+// ledger JSON (mirrors encode_nanominas in
+// scripts/mina-local-network/generate-mina-local-network-ledger.py).
+func formatMina(nanomina int64) string {
+	return fmt.Sprintf("%d.%09d", nanomina/1_000_000_000, nanomina%1_000_000_000)
+}
+
+type genesisMinaAmount int64
+
+func (a genesisMinaAmount) MarshalJSON() ([]byte, error) {
+	return json.Marshal(formatMina(int64(a)))
+}
+
+type genesisSlot int64
+
+func (s genesisSlot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatInt(int64(s), 10))
+}
+
+// generateKeypair generates a Mina keypair at privPath and returns its public
+// key, mirroring the generate-keypair helper in mina-local-network.sh.
+func generateKeypair(minaExe, privPath string) (string, error) {
+	cmd := exec.Command(minaExe, "advanced", "generate-keypair", "-privkey-path", privPath)
+	cmd.Env = append(os.Environ(), "MINA_PRIVKEY_PASS=")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to generate keypair: %w", err)
+	}
+
+	pubBytes, err := os.ReadFile(privPath + ".pub")
+	if err != nil {
+		return "", fmt.Errorf("failed to read generated public key: %w", err)
+	}
+	pubKey := strings.TrimSpace(string(pubBytes))
+	if pubKey == "" {
+		return "", fmt.Errorf("generated public key is empty")
+	}
+	return pubKey, nil
+}
+
+// Vesting-account test parameters. All amounts are in nanomina.
+//
+// The account is "not yet vesting" at the hardfork slot (its cliff is
+// vestingCliffOffsetSlots slots *after* the hardfork slot) and fully unlocks at
+// its cliff (cliff_amount == initial_minimum_balance). The Mesa slot-reduction
+// update therefore must double the vesting period and push the cliff out to
+// hardfork_slot + 2*vestingCliffOffsetSlots. See
+// src/lib/mina_base/account_timing.ml:actively_vesting_hardfork_adjustment.
+//
+// vestingCliffOffsetSlots is chosen so that the *buggy* (un-migrated) cliff
+// (hardfork_slot + offset) falls before, and the *correct* migrated cliff
+// (hardfork_slot + 2*offset) falls after, the slot at which the fork network
+// becomes queryable (BestChainQueryFrom + genesisSlot, default 25 + 68 = 93).
+// This lets the liquid-balance check observe the account still locked under
+// correct migration while it would already be unlocked under the bug.
+const (
+	vestingBalanceNanomina  = 100 * 1_000_000_000
+	vestingCliffOffsetSlots = 15
+	vestingPreForkPeriod    = 1
+)
+
+type vestingAccount struct {
+	PK       string               `json:"pk"`
+	Balance  genesisMinaAmount    `json:"balance"`
+	Delegate *string              `json:"delegate"`
+	Timing   vestingAccountTiming `json:"timing"`
+
+	extraAccountFile string
+}
+
+type vestingAccountTiming struct {
+	InitialMinimumBalance genesisMinaAmount `json:"initial_minimum_balance"`
+	CliffTime             genesisSlot       `json:"cliff_time"`
+	CliffAmount           genesisMinaAmount `json:"cliff_amount"`
+	VestingPeriod         genesisSlot       `json:"vesting_period"`
+	VestingIncrement      genesisMinaAmount `json:"vesting_increment"`
+}
+
+func newFullyLockedVestingAccountTiming(balance genesisMinaAmount, cliffTime, vestingPeriod genesisSlot) vestingAccountTiming {
+	// Fully locked at genesis, fully unlocking at the cliff.
+	return vestingAccountTiming{
+		InitialMinimumBalance: balance,
+		CliffTime:             cliffTime,
+		CliffAmount:           balance,
+		VestingPeriod:         vestingPeriod,
+		VestingIncrement:      balance,
+	}
+}
+
+func newVestingAccount(pubKey, extraAccountFile string, hardforkSlot int) *vestingAccount {
+	balance := genesisMinaAmount(vestingBalanceNanomina)
+	cliffTime := genesisSlot(hardforkSlot + vestingCliffOffsetSlots)
+	vestingPeriod := genesisSlot(vestingPreForkPeriod)
+
+	return &vestingAccount{
+		PK:               pubKey,
+		Balance:          balance,
+		Timing:           newFullyLockedVestingAccountTiming(balance, cliffTime, vestingPeriod),
+		extraAccountFile: extraAccountFile,
+	}
+}
+
+// ExpectedTiming holds the timing parameters expected after migration. Amounts
+// are in nanomina; times are global-slot numbers.
+type ExpectedTiming struct {
+	InitialMinimumBalance int64
+	CliffTime             int64
+	CliffAmount           int64
+	VestingPeriod         int64
+	VestingIncrement      int64
+}
+
+// ExpectedMigratedTiming computes the timing parameters this account should
+// have *after* the Mesa slot-reduction update. It is a direct port of the "not
+// yet vesting" branch of actively_vesting_hardfork_adjustment in
+// src/lib/mina_base/account_timing.ml: the cliff time is pushed out to
+// hardfork_slot + 2*(cliff_time - hardfork_slot) and the vesting period is
+// doubled, while the amounts are unchanged.
+func (a *vestingAccount) ExpectedMigratedTiming(hardforkSlot int) ExpectedTiming {
+	hf := int64(hardforkSlot)
+	preCliff := int64(a.Timing.CliffTime)
+	return ExpectedTiming{
+		InitialMinimumBalance: int64(a.Timing.InitialMinimumBalance),
+		CliffTime:             hf + 2*(preCliff-hf),
+		CliffAmount:           int64(a.Timing.CliffAmount),
+		VestingPeriod:         2 * int64(a.Timing.VestingPeriod),
+		VestingIncrement:      int64(a.Timing.VestingIncrement),
+	}
+}
+
+// SetupVestingAccount generates a fresh keypair and writes a one-element genesis
+// account array (a timed/vesting account) to a temporary file, recording the
+// public key and file path on the test so they can be used when launching the
+// main network and when validating after the fork.
+func (t *HardforkTest) SetupVestingAccount() error {
+	if !t.Config.VestingTestEnabled {
+		return nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "hf-vesting-account")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir for vesting account: %w", err)
+	}
+
+	privPath := filepath.Join(tmpDir, "vesting_account")
+	pubKey, err := generateKeypair(t.Config.MainMinaExe, privPath)
+	if err != nil {
+		return fmt.Errorf("failed to generate vesting account keypair: %w", err)
+	}
+
+	account := newVestingAccount(pubKey, filepath.Join(tmpDir, "extra_account.json"), t.Config.HardforkSlot())
+	data, err := json.MarshalIndent([]*vestingAccount{account}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal vesting account: %w", err)
+	}
+
+	if err := os.WriteFile(account.extraAccountFile, data, 0644); err != nil {
+		return fmt.Errorf("failed to write vesting account file: %w", err)
+	}
+	t.vestingAccount = account
+	expected := account.ExpectedMigratedTiming(t.Config.HardforkSlot())
+
+	t.Logger.Info(
+		"Vesting test: injecting timed account %s (pre-fork cliff_time=%d, hardfork_slot=%d, expected migrated cliff_time=%d)",
+		account.PK, account.Timing.CliffTime, t.Config.HardforkSlot(), expected.CliffTime,
+	)
+
+	return nil
+}
+
+// CleanupVestingAccount removes the temporary files created by SetupVestingAccount.
+func (t *HardforkTest) CleanupVestingAccount() {
+	if t.vestingAccount == nil || t.vestingAccount.extraAccountFile == "" {
+		return
+	}
+	if err := os.RemoveAll(filepath.Dir(t.vestingAccount.extraAccountFile)); err != nil {
+		t.Logger.Error("Failed to remove vesting account temp dir: %v", err)
+	}
+}
+
+// ValidateVestingAfterFork queries the injected account on the fork network and
+// asserts that its timing parameters match the expected slot-reduction-updated
+// values. A mismatch (in particular an unchanged cliff time / vesting period) is
+// the signature of the migrate_to_mesa bug.
+func (t *HardforkTest) ValidateVestingAfterFork(port, hardforkSlot int) error {
+	if !t.Config.VestingTestEnabled {
+		return nil
+	}
+	account := t.vestingAccount
+	if account == nil {
+		return fmt.Errorf("vesting test is enabled but no vesting account was set up")
+	}
+
+	expected := account.ExpectedMigratedTiming(hardforkSlot)
+
+	actual, err := t.Client.AccountTiming(port, account.PK)
+	if err != nil {
+		return fmt.Errorf("failed to query vesting account timing on fork network: %w", err)
+	}
+	if actual.Timing == nil {
+		return fmt.Errorf("vesting account %s lost its timing after the fork (became untimed)", account.PK)
+	}
+
+	var mismatches []string
+	checkField := func(name string, exp, act int64) {
+		if exp != act {
+			mismatches = append(mismatches, fmt.Sprintf("%s: expected %d, got %d", name, exp, act))
+		}
+	}
+	checkField("initialMinimumBalance", expected.InitialMinimumBalance, actual.Timing.InitialMinimumBalance)
+	checkField("cliffTime", expected.CliffTime, actual.Timing.CliffTime)
+	checkField("cliffAmount", expected.CliffAmount, actual.Timing.CliffAmount)
+	checkField("vestingPeriod", expected.VestingPeriod, actual.Timing.VestingPeriod)
+	checkField("vestingIncrement", expected.VestingIncrement, actual.Timing.VestingIncrement)
+
+	if len(mismatches) > 0 {
+		return fmt.Errorf(
+			"vesting account timing was not correctly slot-reduction-updated during Mesa migration "+
+				"(hardfork_slot=%d); this is the migrate_to_mesa bug. Mismatches: %s",
+			hardforkSlot, strings.Join(mismatches, "; "),
+		)
+	}
+
+	t.Logger.Info(
+		"Vesting test: account %s timing correctly migrated (cliff_time=%d, vesting_period=%d)",
+		account.PK, actual.Timing.CliffTime, actual.Timing.VestingPeriod,
+	)
+	return nil
+}
+
+func (t *HardforkTest) ValidateVestingOnForkNetwork(hardforkSlot int) error {
+	if !t.Config.VestingTestEnabled {
+		return nil
+	}
+	if t.vestingAccount == nil {
+		return fmt.Errorf("vesting test is enabled but no vesting account was set up")
+	}
+
+	type validationResult struct {
+		daemon config.DaemonInfo
+		err    error
+	}
+
+	var timingErrors []string
+	for _, daemon := range t.Config.DaemonInfos {
+		port := daemon.Port(config.PORT_REST)
+		t.Logger.Info(
+			"Vesting test: validating migrated timing on daemon %s using fork method %s (REST port %d)",
+			daemon.Name, daemon.ForkMethod, port,
+		)
+		if err := t.ValidateVestingAfterFork(port, hardforkSlot); err != nil {
+			timingErrors = append(timingErrors, fmt.Sprintf(
+				"%s using fork method %s: %v",
+				daemon.Name, daemon.ForkMethod, err,
+			))
+		}
+	}
+	if len(timingErrors) > 0 {
+		return fmt.Errorf("vesting timing validation failed: %s", strings.Join(timingErrors, "; "))
+	}
+
+	results := make(chan validationResult, len(t.Config.DaemonInfos))
+	var wg sync.WaitGroup
+	for _, daemon := range t.Config.DaemonInfos {
+		daemon := daemon
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			port := daemon.Port(config.PORT_REST)
+			t.Logger.Info(
+				"Vesting test: watching liquid balance on daemon %s using fork method %s (REST port %d)",
+				daemon.Name, daemon.ForkMethod, port,
+			)
+			err := t.ValidateVestingLiquidUnlock(port, hardforkSlot)
+			results <- validationResult{daemon: daemon, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var errors []string
+	for result := range results {
+		if result.err != nil {
+			errors = append(errors, fmt.Sprintf(
+				"%s using fork method %s: %v",
+				result.daemon.Name, result.daemon.ForkMethod, result.err,
+			))
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("vesting liquid-balance validation failed: %s", strings.Join(errors, "; "))
+	}
+
+	return nil
+}
+
+// ValidateVestingLiquidUnlock polls the injected account's liquid balance and
+// asserts it does not become fully liquid before the correct (migrated) cliff
+// slot. Under the migrate_to_mesa bug the cliff is never advanced, so the funds
+// unlock at hardfork_slot + offset instead of hardfork_slot + 2*offset, which
+// this check observes as the account being fully liquid while the best tip slot
+// is still below the expected cliff.
+//
+// The check only *fails* on a definitive early unlock; if the network does not
+// reach the expected cliff within the polling window it logs a warning and
+// returns nil, leaving ValidateVestingAfterFork as the authoritative gate.
+func (t *HardforkTest) ValidateVestingLiquidUnlock(port, hardforkSlot int) error {
+	if !t.Config.VestingTestEnabled {
+		return nil
+	}
+	account := t.vestingAccount
+	if account == nil {
+		return fmt.Errorf("vesting test is enabled but no vesting account was set up")
+	}
+
+	expected := account.ExpectedMigratedTiming(hardforkSlot)
+	expectedCliff := int(expected.CliffTime)
+
+	// Poll for a generous number of slots past the expected cliff.
+	maxWait := time.Duration((expectedCliff-hardforkSlot+10)*t.Config.ForkSlot) * time.Second
+	deadline := time.Now().Add(maxWait)
+
+	t.Logger.Info(
+		"Vesting test: watching liquid balance of %s; it must stay locked until slot %d",
+		account.PK, expectedCliff,
+	)
+
+	for time.Now().Before(deadline) {
+		// Query the account first, then the best tip, so the slot we compare
+		// against is never *earlier* than the slot the liquid balance was
+		// computed at. This makes an "unlocked too early" verdict reliable.
+		acct, err := t.Client.AccountTiming(port, account.PK)
+		if err != nil {
+			t.Logger.Debug("Vesting test: failed to query account liquid balance: %v", err)
+			time.Sleep(time.Duration(t.Config.PollingIntervalSeconds) * time.Second)
+			continue
+		}
+		tip, err := t.Client.BestTip(port)
+		if err != nil {
+			t.Logger.Debug("Vesting test: failed to query best tip: %v", err)
+			time.Sleep(time.Duration(t.Config.PollingIntervalSeconds) * time.Second)
+			continue
+		}
+
+		fullyLiquid := acct.Balance.Total > 0 && acct.Balance.Liquid >= acct.Balance.Total
+
+		if fullyLiquid && tip.Slot < expectedCliff {
+			return fmt.Errorf(
+				"vesting account %s unlocked too early: fully liquid (liquid=%d total=%d) at slot %d, "+
+					"but the correct migrated cliff is slot %d. This is the migrate_to_mesa slot-reduction bug.",
+				account.PK, acct.Balance.Liquid, acct.Balance.Total, tip.Slot, expectedCliff,
+			)
+		}
+
+		if tip.Slot >= expectedCliff {
+			if fullyLiquid {
+				t.Logger.Info(
+					"Vesting test: account %s became fully liquid at/after slot %d as expected",
+					account.PK, expectedCliff,
+				)
+				return nil
+			}
+			// Reached the cliff but funds not yet liquid; the unlock happens at
+			// the cliff, so give it one more slot to settle.
+		}
+
+		time.Sleep(time.Duration(t.Config.PollingIntervalSeconds) * time.Second)
+	}
+
+	t.Logger.Info(
+		"Vesting test: fork network did not reach the expected cliff slot %d within the polling window; "+
+			"relying on the timing-parameter assertion for correctness",
+		expectedCliff,
+	)
+	return nil
+}


### PR DESCRIPTION
## Summary

Bottom PR of a two-PR train (stacked on `release/mesa`).

Adds an end-to-end hardfork test that verifies vesting schedules are correctly
slot-reduced across a fork, plus the supporting infrastructure it needs:

- `hardfork_test`: new `vesting.go` end-to-end test, one daemon per requested
  fork method, and vesting slot-reduction applied in the legacy fork path.
- `scripts/hardfork/build-and-test.sh`: build/checkout the postfork from the
  current branch name rather than a bare commit.
- `mina-local-network.sh`: allow the seed / snark-coordinator to double as a
  whale block producer (`--seed-is-whale`, `--seed-is-coordinator`), and
  `--extra-genesis-account-file` to seed timed/vesting accounts.
- Carries the VRF-evaluator memory-leak fixes and the runtime-fork ledger
  backing fix the test depends on.

## Notes

This is the dependency branch for the single-node localnet load-testing work,
which is the top PR of the train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)