### PR TITLE
rosetta: drop initialPeers/daemonStatus from GQL in mempool

### DIFF
--- a/changes/18942.md
+++ b/changes/18942.md
@@ -1,0 +1,2 @@
+Rosetta: mempool queries no longer request unused `initialPeers` or `daemonStatus` fields from the daemon, reducing per-request GraphQL overhead.
+

--- a/src/app/rosetta/lib/mempool.ml
+++ b/src/app/rosetta/lib/mempool.ml
@@ -5,10 +5,6 @@ module Get_all_transactions =
 [%graphql
 {|
     query all_transactions {
-      initialPeers
-      daemonStatus {
-        chainId
-      }
       pooledUserCommands(publicKey: null) {
         hash @ppxCustom(module: "Scalars.String_json")
       }
@@ -19,11 +15,6 @@ module Get_transactions_by_hash =
 [%graphql
 {|
     query all_transactions_by_hash($hashes: [String!]) {
-      initialPeers
-      daemonStatus {
-        chainId
-        peers { host }
-      }
       pooledUserCommands(hashes: $hashes) {
         hash @ppxCustom(module: "Scalars.String_json")
         amount @ppxCustom(module: "Scalars.UInt64")
@@ -94,8 +85,6 @@ module All = struct
             Result.return
               { Get_all_transactions.pooledUserCommands =
                   [| { hash = "TXN_1" }; { hash = "TXN_2" } |]
-              ; initialPeers = [||]
-              ; daemonStatus = { chainId = "dummy" }
               } )
       ; validate_network_choice = Network.Validate_choice.Mock.succeed
       }


### PR DESCRIPTION
## Summary

Removes unused `initialPeers` and `daemonStatus` fields from the two GraphQL queries in `mempool.ml` that fetch pooled user commands.

## Problem

The `Get_all_transactions` and `Get_transactions_by_hash` GraphQL queries in `src/app/rosetta/lib/mempool.ml` request `initialPeers` and `daemonStatus` from the Mina daemon, but neither field is consumed by their respective handler functions. This causes unnecessary bandwidth and GraphQL resolver overhead on the daemon side.

## Solution

Removed `initialPeers` and `daemonStatus` from both query definitions, along with the corresponding mock data fields.

