### PR TITLE
Fix some libp2p helper memleaks

### DIFF
--- a/changes/18945.md
+++ b/changes/18945.md
@@ -1,0 +1,50 @@
+# PR #18945 Fix libp2p_helper out-of-memory crashes under heavy load
+
+The daemon's internal `libp2p_helper` Go process could grow unbounded in memory
+and eventually OOM under sustained load. This was caused by several leaks:
+
+- **Cap'n Proto arena retention:** Every incoming message allocated a new arena.
+  The `SetNodeStatus` handler stored a `[]byte` slice pointing into that arena,
+  keeping the entire arena (56MB+) alive until the next GC cycle. Node status
+  bytes are now copied to decouple them from the arena.
+
+- **Unbounded goroutine spawning:** When the OCaml daemon's stdout pipe was
+  slow, incoming message handlers piled up as unbounded goroutines, each
+  holding its own arena. Concurrent handlers are now capped at 256; when the
+  pool is full, reading from the daemon pipe blocks (backpressure) so no
+  messages are lost.
+
+- **Unbounded `_addedPeers` growth:** Repeated `AddPeer` calls for the same
+  peer (e.g. reconnect loops) accumulated duplicate entries indefinitely. The
+  list is now deduplicated by peer ID, keeping the freshest addresses, so it
+  is bounded by the number of distinct added peers. Gating semantics
+  (`cleanAddedPeers`) are unchanged.
+
+- **Validator leak:** Timed-out pubsub validators were never cleaned up if the
+  daemon failed to send a validation response. A periodic sweep now removes
+  validators that have been timed out for over one hour. Validation responses
+  arriving after the timeout no longer leak a permanently blocked goroutine.
+
+- **Unbounded stream writes:** Writes to a peer's stream had no deadline, so a
+  peer that stopped reading blocked the write indefinitely, pinning a stream
+  and a handler slot. Stream writes now time out after 60 seconds and the
+  stream is closed, as with any other write failure.
+
+- **Resource leak monitoring:** The helper now records stream, subscription,
+  and validator counts as they change, and periodically warns when any of them
+  exceeds a safe threshold, making OCaml-side leaks easier to detect before
+  they cause OOM.
+
+The following environment variables control the new behavior (all have sensible
+defaults for production use):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LIBP2P_WORKER_POOL_SIZE` | `256` | Maximum concurrent incoming message handlers |
+| `LIBP2P_STREAM_WRITE_TIMEOUT_DURATION` | `60s` | Deadline for a single write to a peer stream |
+| `LIBP2P_VALIDATOR_CLEANUP_INTERVAL_DURATION` | `30s` | How often to sweep for stale validators |
+| `LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION` | `1h` | How long after timeout before removing a validator |
+| `LIBP2P_LEAK_MONITOR_INTERVAL_DURATION` | `5m` | How often to check collection sizes |
+| `LIBP2P_LEAK_WARN_STREAMS` | `500` | Stream count warning threshold |
+| `LIBP2P_LEAK_WARN_SUBS` | `500` | Subscription count warning threshold |
+| `LIBP2P_LEAK_WARN_VALIDATORS` | `5000` | Validator count warning threshold |

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -646,6 +646,13 @@ func (h *Helper) handleNodeStatusStreams(s network.Stream) {
 	h.NodeStatusMutex.RLock()
 	status := h.NodeStatus
 	h.NodeStatusMutex.RUnlock()
+	// Bound the write: without a deadline a peer that stops reading blocks
+	// this goroutine (and the stream it holds) indefinitely on muxer flow
+	// control. NodeStatusTimeout is already how long we are willing to spend
+	// on one of these streams.
+	if err := s.SetWriteDeadline(time.Now().Add(NodeStatusTimeout)); err != nil {
+		logger.Debugf("failed to set write deadline on node status stream: %s", err)
+	}
 	n, err := s.Write(status)
 	if err != nil {
 		logger.Error("failed to write to stream", err)

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -244,6 +244,7 @@ type Helper struct {
 	BandwidthCounter  *metrics.BandwidthCounter
 	MsgStats          *MessageStats
 	NodeStatus        []byte
+	NodeStatusMutex   sync.RWMutex // protects NodeStatus: written by SetNodeStatus handler, read by handleNodeStatusStreams
 	HeartbeatPeer     func(peer.ID)
 }
 
@@ -638,11 +639,18 @@ func (h *Helper) handleNodeStatusStreams(s network.Stream) {
 		}
 	}()
 
-	n, err := s.Write(h.NodeStatus)
+	// Snapshot under the read lock: these goroutines race with the
+	// SetNodeStatus handler replacing NodeStatus. The slice itself is never
+	// mutated after publication, so using the snapshot without the lock is
+	// safe and avoids holding it across a slow network write.
+	h.NodeStatusMutex.RLock()
+	status := h.NodeStatus
+	h.NodeStatusMutex.RUnlock()
+	n, err := s.Write(status)
 	if err != nil {
 		logger.Error("failed to write to stream", err)
 		return
-	} else if n != len(h.NodeStatus) {
+	} else if n != len(status) {
 		// TODO repeat writing, not log error
 		logger.Error("failed to write all data to stream")
 		return

--- a/src/app/libp2p_helper/src/libp2p_helper/added_peers_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/added_peers_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+
+	capnp "capnproto.org/go/capnp/v3"
+	ipc "libp2p_ipc"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test: repeated AddPeers calls for the same peer ID (e.g.
+// reconnect loops) must not grow _addedPeers unboundedly.
+func TestAddPeersDedupesByID(t *testing.T) {
+	testApp := &app{}
+	addr1 := ma.StringCast("/ip4/127.0.0.1/tcp/7000")
+	addr2 := ma.StringCast("/ip4/127.0.0.1/tcp/7001")
+
+	for i := 0; i < 100; i++ {
+		testApp.AddPeers(peer.AddrInfo{ID: peer.ID("peer-a"), Addrs: []ma.Multiaddr{addr1}})
+	}
+	testApp.AddPeers(peer.AddrInfo{ID: peer.ID("peer-b"), Addrs: []ma.Multiaddr{addr1}})
+	// Re-adding peer-a with a new address updates in place.
+	testApp.AddPeers(peer.AddrInfo{ID: peer.ID("peer-a"), Addrs: []ma.Multiaddr{addr2}})
+
+	added := testApp.GetAddedPeers()
+	require.Len(t, added, 2)
+	require.Equal(t, peer.ID("peer-a"), added[0].ID)
+	require.Equal(t, []ma.Multiaddr{addr2}, added[0].Addrs, "latest AddrInfo must win")
+	require.Equal(t, peer.ID("peer-b"), added[1].ID)
+}
+
+func TestGetAddedPeersReturnsCopy(t *testing.T) {
+	testApp := &app{}
+	testApp.AddPeers(peer.AddrInfo{ID: peer.ID("peer-a")})
+
+	snapshot := testApp.GetAddedPeers()
+	testApp.AddPeers(peer.AddrInfo{ID: peer.ID("peer-a"), Addrs: []ma.Multiaddr{ma.StringCast("/ip4/127.0.0.1/tcp/7000")}})
+
+	require.Empty(t, snapshot[0].Addrs, "snapshot must not observe later in-place updates")
+}
+
+// Regression test: readGatingConfig must honor the cleanAddedPeers flag from
+// the daemon. Added peers are trusted only while the flag is unset — the
+// daemon's gating pushes (e.g. on ban expiry) do not re-send runtime-added
+// peers, so the helper must keep merging them itself.
+func TestReadGatingConfigRespectsCleanAddedPeers(t *testing.T) {
+	mkGatingConfig := func(clean bool) ipc.GatingConfig {
+		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		require.NoError(t, err)
+		m, err := ipc.NewRootLibp2pHelperInterface_SetGatingConfig_Request(seg)
+		require.NoError(t, err)
+		gc, err := m.NewGatingConfig()
+		require.NoError(t, err)
+		_, err = gc.NewBannedIps(0)
+		require.NoError(t, err)
+		_, err = gc.NewBannedPeerIds(0)
+		require.NoError(t, err)
+		_, err = gc.NewTrustedIps(0)
+		require.NoError(t, err)
+		_, err = gc.NewTrustedPeerIds(0)
+		require.NoError(t, err)
+		gc.SetIsolate(false)
+		gc.SetCleanAddedPeers(clean)
+		return gc
+	}
+
+	addedPeers := []peer.AddrInfo{{ID: peer.ID("added-peer")}}
+
+	cfg, err := readGatingConfig(mkGatingConfig(false), addedPeers)
+	require.NoError(t, err)
+	_, trusted := cfg.TrustedPeers[peer.ID("added-peer")]
+	require.True(t, trusted, "added peers must stay trusted when cleanAddedPeers=false")
+
+	cfg, err = readGatingConfig(mkGatingConfig(true), addedPeers)
+	require.NoError(t, err)
+	_, trusted = cfg.TrustedPeers[peer.ID("added-peer")]
+	require.False(t, trusted, "added peers must be excluded when cleanAddedPeers=true")
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -65,16 +65,30 @@ func (app *app) NextId() uint64 {
 func (app *app) AddPeers(infos ...peer.AddrInfo) {
 	app.addedPeersMutex.Lock()
 	defer app.addedPeersMutex.Unlock()
-	app._addedPeers = append(app._addedPeers, infos...)
+	// Deduplicate by peer ID so repeated AddPeer calls for the same peers
+	// (e.g. reconnect loops) don't grow the slice unboundedly. The latest
+	// AddrInfo wins, keeping the freshest addresses.
+	for _, info := range infos {
+		replaced := false
+		for i, existing := range app._addedPeers {
+			if existing.ID == info.ID {
+				app._addedPeers[i] = info
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			app._addedPeers = append(app._addedPeers, info)
+		}
+	}
 }
 
-// GetAddedPeers returns list of peers
-//
-// Elements of returned slice should never be modified!
+// GetAddedPeers returns a snapshot of the added peers. A copy is returned
+// because AddPeers may overwrite elements in place after the lock is released.
 func (app *app) GetAddedPeers() []peer.AddrInfo {
 	app.addedPeersMutex.RLock()
 	defer app.addedPeersMutex.RUnlock()
-	return app._addedPeers
+	return append([]peer.AddrInfo(nil), app._addedPeers...)
 }
 
 func (app *app) ResetAddedPeers() {

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -25,6 +25,7 @@ import (
 
 var ValidatorCleanupInterval = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_INTERVAL_DURATION", 30*time.Second)
 var ValidatorCleanupGrace = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION", 1*time.Hour)
+var WorkerPoolSize = initIntEnv("LIBP2P_WORKER_POOL_SIZE", 256)
 var StreamWriteTimeout = initDurationEnv("LIBP2P_STREAM_WRITE_TIMEOUT_DURATION", 60*time.Second)
 
 func initDurationEnv(envVar string, defaultVal time.Duration) time.Duration {
@@ -34,6 +35,17 @@ func initDurationEnv(envVar string, defaultVal time.Duration) time.Duration {
 			return d
 		}
 		fmt.Fprintf(os.Stderr, "WARNING: %s=%q is not a positive duration, using default %s\n", envVar, s, defaultVal)
+	}
+	return defaultVal
+}
+
+func initIntEnv(envVar string, defaultVal int) int {
+	if s := os.Getenv(envVar); s != "" {
+		v, err := strconv.Atoi(s)
+		if err == nil && v > 0 {
+			return v
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: %s=%q is not a positive integer, using default %d\n", envVar, s, defaultVal)
 	}
 	return defaultVal
 }
@@ -55,6 +67,7 @@ func newApp() *app {
 		metricsCollectionStarted: false,
 		metricsServer:            nil,
 		bitswapCtx:               NewBitswapCtx(ctx, outChan),
+		workerSem:                make(chan struct{}, WorkerPoolSize),
 	}
 	return app
 }
@@ -154,10 +167,11 @@ func (app *app) WriteStream(streamId uint64, data []byte) error {
 
 		// Bound the write. libp2p stream writes have no deadline of their
 		// own: a peer that stops reading blocks here indefinitely on muxer
-		// flow control, holding this stream's mutex for as long as it lasts.
-		// A peer that cannot accept a write within the timeout is treated
-		// like any other write failure below: the stream is removed and
-		// closed.
+		// flow control, holding both the stream mutex and a slot in the
+		// bounded worker pool. Enough stalled peers would stop the helper
+		// from processing stdin at all. A peer that cannot accept a write
+		// within the timeout is treated like any other write failure below:
+		// the stream is removed and closed.
 		if err := stream.stream.SetWriteDeadline(time.Now().Add(StreamWriteTimeout)); err != nil {
 			app.P2p.Logger.Debugf("failed to set write deadline on stream %d: %s", streamId, err)
 		}

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -14,6 +14,7 @@ import (
 
 	capnp "capnproto.org/go/capnp/v3"
 	"github.com/go-errors/errors"
+	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	net "github.com/libp2p/go-libp2p/core/network"
 	peer "github.com/libp2p/go-libp2p/core/peer"
@@ -22,10 +23,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var ValidatorCleanupInterval = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_INTERVAL_DURATION", 30*time.Second)
+var ValidatorCleanupGrace = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION", 1*time.Hour)
+
+func initDurationEnv(envVar string, defaultVal time.Duration) time.Duration {
+	if s := os.Getenv(envVar); s != "" {
+		d, err := time.ParseDuration(s)
+		if err == nil && d > 0 {
+			return d
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: %s=%q is not a positive duration, using default %s\n", envVar, s, defaultVal)
+	}
+	return defaultVal
+}
+
 func newApp() *app {
 	outChan := make(chan *capnp.Message, 1<<12) // 4096 messages stacked
 	ctx := context.Background()
-	return &app{
+	app := &app{
 		P2p:                      nil,
 		Ctx:                      ctx,
 		_subs:                    make(map[uint64]subscription),
@@ -40,6 +55,17 @@ func newApp() *app {
 		metricsServer:            nil,
 		bitswapCtx:               NewBitswapCtx(ctx, outChan),
 	}
+	return app
+}
+
+// StartBackgroundTasks launches the helper's periodic maintenance tasks. It is
+// called from the Configure handler rather than newApp so the tasks never read
+// app.P2p before it is assigned; the logger is passed in for the same reason,
+// and sync.Once keeps a repeated Configure from starting a second copy.
+func (app *app) StartBackgroundTasks(logger logging.StandardLogger) {
+	app.backgroundTasksOnce.Do(func() {
+		go app.startValidatorCleanup(logger)
+	})
 }
 
 func (app *app) SetConnectionHandlers() {
@@ -145,7 +171,11 @@ func (app *app) WriteStream(streamId uint64, data []byte) error {
 
 func (app *app) AddValidator() (uint64, chan pubsub.ValidationResult) {
 	seqno := app.NextId()
-	ch := make(chan pubsub.ValidationResult)
+	// Buffered so a late Validation push (arriving after the validate
+	// goroutine timed out and stopped receiving) doesn't block its handler
+	// goroutine forever. Each validator sees exactly one send: the push
+	// handler removes the entry via RemoveValidator before sending.
+	ch := make(chan pubsub.ValidationResult, 1)
 	app.validatorMutex.Lock()
 	defer app.validatorMutex.Unlock()
 	app._validators[seqno] = new(validationStatus)
@@ -158,6 +188,36 @@ func (app *app) TimeoutValidator(seqno uint64) {
 	app.validatorMutex.Lock()
 	defer app.validatorMutex.Unlock()
 	app._validators[seqno].TimedOutAt = &now
+}
+
+// cleanupTimedOutValidators removes validator entries that have been
+// timed out for longer than ValidatorCleanupGrace. Validators time out
+// after 5min from libp2p; this sweep runs after an additional 1-hour
+// grace period to give OCaml time to respond with a Validation push.
+func (app *app) cleanupTimedOutValidators(logger logging.StandardLogger) {
+	app.validatorMutex.Lock()
+	defer app.validatorMutex.Unlock()
+
+	now := time.Now()
+	removed := 0
+	for seqno, st := range app._validators {
+		if st.TimedOutAt != nil && now.Sub(*st.TimedOutAt) > ValidatorCleanupGrace {
+			delete(app._validators, seqno)
+			removed++
+			logger.Debugf("validator cleanup: removed timed-out validator seqno=%d age=%s", seqno, now.Sub(*st.TimedOutAt))
+		}
+	}
+	if removed > 0 {
+		logger.Infof("validator cleanup: removed %d stale validators (timed out >%s), remaining=%d", removed, ValidatorCleanupGrace, len(app._validators))
+	}
+}
+
+func (app *app) startValidatorCleanup(logger logging.StandardLogger) {
+	ticker := time.NewTicker(ValidatorCleanupInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		app.cleanupTimedOutValidators(logger)
+	}
 }
 
 func (app *app) RemoveValidator(seqno uint64) (*validationStatus, bool) {

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -25,6 +25,7 @@ import (
 
 var ValidatorCleanupInterval = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_INTERVAL_DURATION", 30*time.Second)
 var ValidatorCleanupGrace = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION", 1*time.Hour)
+var StreamWriteTimeout = initDurationEnv("LIBP2P_STREAM_WRITE_TIMEOUT_DURATION", 60*time.Second)
 
 func initDurationEnv(envVar string, defaultVal time.Duration) time.Duration {
 	if s := os.Getenv(envVar); s != "" {
@@ -150,6 +151,16 @@ func (app *app) WriteStream(streamId uint64, data []byte) error {
 	if stream, ok := app.getStream(streamId); ok {
 		stream.mutex.Lock()
 		defer stream.mutex.Unlock()
+
+		// Bound the write. libp2p stream writes have no deadline of their
+		// own: a peer that stops reading blocks here indefinitely on muxer
+		// flow control, holding this stream's mutex for as long as it lasts.
+		// A peer that cannot accept a write within the timeout is treated
+		// like any other write failure below: the stream is removed and
+		// closed.
+		if err := stream.stream.SetWriteDeadline(time.Now().Add(StreamWriteTimeout)); err != nil {
+			app.P2p.Logger.Debugf("failed to set write deadline on stream %d: %s", streamId, err)
+		}
 
 		if n, err := stream.stream.Write(data); err != nil {
 			// TODO check that it's correct to error out, not repeat writing

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -27,6 +27,10 @@ var ValidatorCleanupInterval = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_INTERVA
 var ValidatorCleanupGrace = initDurationEnv("LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION", 1*time.Hour)
 var WorkerPoolSize = initIntEnv("LIBP2P_WORKER_POOL_SIZE", 256)
 var StreamWriteTimeout = initDurationEnv("LIBP2P_STREAM_WRITE_TIMEOUT_DURATION", 60*time.Second)
+var LeakMonitorInterval = initDurationEnv("LIBP2P_LEAK_MONITOR_INTERVAL_DURATION", 5*time.Minute)
+var LeakWarnStreams = initIntEnv("LIBP2P_LEAK_WARN_STREAMS", 500)
+var LeakWarnSubs = initIntEnv("LIBP2P_LEAK_WARN_SUBS", 500)
+var LeakWarnValidators = initIntEnv("LIBP2P_LEAK_WARN_VALIDATORS", 5000)
 
 func initDurationEnv(envVar string, defaultVal time.Duration) time.Duration {
 	if s := os.Getenv(envVar); s != "" {
@@ -79,6 +83,7 @@ func newApp() *app {
 func (app *app) StartBackgroundTasks(logger logging.StandardLogger) {
 	app.backgroundTasksOnce.Do(func() {
 		go app.startValidatorCleanup(logger)
+		go app.startLeakMonitor(logger)
 	})
 }
 
@@ -140,8 +145,12 @@ func (app *app) ResetAddedPeers() {
 func (app *app) AddStream(stream_ net.Stream) uint64 {
 	streamIdx := app.NextId()
 	app.streamsMutex.Lock()
-	defer app.streamsMutex.Unlock()
 	app._streams[streamIdx] = &stream{stream: stream_}
+	count := len(app._streams)
+	app.streamsMutex.Unlock()
+	if app.P2p != nil {
+		app.P2p.Logger.Debugf("stream count: %d streams (added stream %d)", count, streamIdx)
+	}
 	return streamIdx
 }
 
@@ -202,9 +211,13 @@ func (app *app) AddValidator() (uint64, chan pubsub.ValidationResult) {
 	// handler removes the entry via RemoveValidator before sending.
 	ch := make(chan pubsub.ValidationResult, 1)
 	app.validatorMutex.Lock()
-	defer app.validatorMutex.Unlock()
 	app._validators[seqno] = new(validationStatus)
 	app._validators[seqno].Completion = ch
+	count := len(app._validators)
+	app.validatorMutex.Unlock()
+	if app.P2p != nil {
+		app.P2p.Logger.Debugf("validator count: %d (added validator %d)", count, seqno)
+	}
 	return seqno, ch
 }
 
@@ -245,6 +258,35 @@ func (app *app) startValidatorCleanup(logger logging.StandardLogger) {
 	}
 }
 
+// startLeakMonitor periodically checks stream/subscription/validator
+// collection sizes and logs a warning if any exceed their threshold.
+// This helps detect OCaml-side leaks where close/unsubscribe RPCs are
+// never sent, causing memory growth in the Go helper.
+func (app *app) startLeakMonitor(logger logging.StandardLogger) {
+	ticker := time.NewTicker(LeakMonitorInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		app.reportCollectionSizes(logger)
+	}
+}
+
+func (app *app) reportCollectionSizes(logger logging.StandardLogger) {
+	app.streamsMutex.RLock()
+	streams := len(app._streams)
+	app.streamsMutex.RUnlock()
+	app.subsMutex.Lock()
+	subs := len(app._subs)
+	app.subsMutex.Unlock()
+	app.validatorMutex.Lock()
+	validators := len(app._validators)
+	app.validatorMutex.Unlock()
+
+	if streams > LeakWarnStreams || subs > LeakWarnSubs || validators > LeakWarnValidators {
+		logger.Warnf("resource leak check: streams=%d (warn>%d), subs=%d (warn>%d), validators=%d (warn>%d)",
+			streams, LeakWarnStreams, subs, LeakWarnSubs, validators, LeakWarnValidators)
+	}
+}
+
 func (app *app) RemoveValidator(seqno uint64) (*validationStatus, bool) {
 	app.validatorMutex.Lock()
 	defer app.validatorMutex.Unlock()
@@ -268,8 +310,12 @@ func (app *app) GetTopic(topicName string) (*pubsub.Topic, bool) {
 
 func (app *app) AddSubscription(subId uint64, sub subscription) {
 	app.subsMutex.Lock()
-	defer app.subsMutex.Unlock()
 	app._subs[subId] = sub
+	count := len(app._subs)
+	app.subsMutex.Unlock()
+	if app.P2p != nil {
+		app.P2p.Logger.Debugf("subscription count: %d (added sub %d)", count, subId)
+	}
 }
 
 func (app *app) RemoveSubscription(subId uint64) (subscription, bool) {

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -225,7 +225,11 @@ func (app *app) TimeoutValidator(seqno uint64) {
 	now := time.Now()
 	app.validatorMutex.Lock()
 	defer app.validatorMutex.Unlock()
-	app._validators[seqno].TimedOutAt = &now
+	// The entry is gone if a Validation push raced this timeout and removed
+	// it first; there is nothing left to mark in that case.
+	if st, found := app._validators[seqno]; found {
+		st.TimedOutAt = &now
+	}
 }
 
 // cleanupTimedOutValidators removes validator entries that have been

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -622,7 +622,10 @@ func (m SetNodeStatusReq) handle(app *app, seqno uint64) (*capnp.Message, func()
 		return mkRpcRespError(seqno, badRPC(err))
 	}
 	app.P2p.NodeStatusMutex.Lock()
-	app.P2p.NodeStatus = status
+	// Copy status bytes to decouple from the capnp message arena.
+	// Otherwise Go GC keeps the entire arena (56MB+) alive as long as
+	// NodeStatus references it, causing OOM under concurrent load.
+	app.P2p.NodeStatus = append([]byte(nil), status...)
 	app.P2p.NodeStatusMutex.Unlock()
 	return mkRpcRespSuccess(seqno, func(m *ipc.Libp2pHelperInterface_RpcResponseSuccess) {
 		_, err := m.NewSetNodeStatus()

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -621,7 +621,9 @@ func (m SetNodeStatusReq) handle(app *app, seqno uint64) (*capnp.Message, func()
 	if err != nil {
 		return mkRpcRespError(seqno, badRPC(err))
 	}
+	app.P2p.NodeStatusMutex.Lock()
 	app.P2p.NodeStatus = status
+	app.P2p.NodeStatusMutex.Unlock()
 	return mkRpcRespSuccess(seqno, func(m *ipc.Libp2pHelperInterface_RpcResponseSuccess) {
 		_, err := m.NewSetNodeStatus()
 		panicOnErr(err)

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -446,6 +446,7 @@ func (msg ConfigureReq) handle(app *app, seqno uint64) (*capnp.Message, func()) 
 	app.P2p = helper
 	app.bitswapCtx.engine = helper.Bitswap
 	app.bitswapCtx.storage = helper.BitswapStorage
+	app.StartBackgroundTasks(helper.Logger)
 
 	opts := []pubsub.Option{
 		pubsub.WithFloodPublish(m.Flood()),

--- a/src/app/libp2p_helper/src/libp2p_helper/data.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/data.go
@@ -72,6 +72,7 @@ type app struct {
 	bitswapCtx                *BitswapCtx
 	setConnectionHandlersOnce sync.Once
 	backgroundTasksOnce       sync.Once
+	workerSem                 chan struct{}
 }
 
 type subscription struct {

--- a/src/app/libp2p_helper/src/libp2p_helper/data.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/data.go
@@ -71,6 +71,7 @@ type app struct {
 
 	bitswapCtx                *BitswapCtx
 	setConnectionHandlersOnce sync.Once
+	backgroundTasksOnce       sync.Once
 }
 
 type subscription struct {

--- a/src/app/libp2p_helper/src/libp2p_helper/leak_monitor_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/leak_monitor_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Smoke test for the periodic leak monitor: exercises the lock/log paths
+// both below and above the warning thresholds.
+func TestReportCollectionSizes(t *testing.T) {
+	testApp, _ := newTestApp(t, nil, true)
+
+	seqno, _ := testApp.AddValidator()
+	testApp.AddSubscription(1, subscription{})
+	require.NotPanics(t, func() { testApp.reportCollectionSizes(logging.Logger("test")) })
+
+	origWarn := LeakWarnValidators
+	LeakWarnValidators = 0 // force the over-threshold warning branch
+	defer func() { LeakWarnValidators = origWarn }()
+	require.NotPanics(t, func() { testApp.reportCollectionSizes(logging.Logger("test")) })
+
+	testApp.RemoveValidator(seqno)
+	testApp.RemoveSubscription(1)
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -199,6 +199,18 @@ func main() {
 			return
 		}
 
-		go app.handleIncomingMsg(&msg)
+		app.dispatchIncoming(&msg)
 	}
+}
+
+// dispatchIncoming runs an incoming message handler on the bounded worker
+// pool. When the pool is full it blocks until a slot frees up: messages are
+// RPC requests and pushes from the daemon, so dropping them would leave the
+// OCaml side waiting forever on a response. Backpressure on stdin is safe.
+func (app *app) dispatchIncoming(msg *ipc.Libp2pHelperInterface_Message) {
+	app.workerSem <- struct{}{}
+	go func() {
+		defer func() { <-app.workerSem }()
+		app.handleIncomingMsg(msg)
+	}()
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/node_status_copy_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/node_status_copy_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	capnp "capnproto.org/go/capnp/v3"
+	ipc "libp2p_ipc"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test: the SetNodeStatus handler must copy the status bytes out
+// of the request's capnp arena. Storing the arena-backed slice directly keeps
+// the whole arena alive (a large memory leak) and aliases memory the arena
+// owner may reuse.
+func TestSetNodeStatusCopiesOutOfArena(t *testing.T) {
+	testApp, _ := newTestApp(t, nil, true)
+
+	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+	require.NoError(t, err)
+	m, err := ipc.NewRootLibp2pHelperInterface_SetNodeStatus_Request(seg)
+	require.NoError(t, err)
+	original := []byte("status_bytes_owned_by_arena")
+	require.NoError(t, m.SetStatus(original))
+
+	resMsg, _ := SetNodeStatusReq(m).handle(testApp, 77)
+	_, respSuccess := checkRpcResponseSuccess(t, resMsg, "setNodeStatus")
+	require.True(t, respSuccess.HasSetNodeStatus())
+	require.Equal(t, original, testApp.P2p.NodeStatus)
+
+	// Corrupt the arena-backed bytes; a stored alias would see the change.
+	arenaBytes, err := m.Status()
+	require.NoError(t, err)
+	for i := range arenaBytes {
+		arenaBytes[i] = 'X'
+	}
+	require.Equal(t, original, testApp.P2p.NodeStatus,
+		"NodeStatus must not alias the capnp arena")
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/node_status_race_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/node_status_race_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"codanet"
+
+	capnp "capnproto.org/go/capnp/v3"
+	ipc "libp2p_ipc"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setNodeStatusImpl(t *testing.T, testApp *app, status []byte) {
+	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+	require.NoError(t, err)
+	m, err := ipc.NewRootLibp2pHelperInterface_SetNodeStatus_Request(seg)
+	require.NoError(t, err)
+	require.NoError(t, m.SetStatus(status))
+	resMsg, _ := SetNodeStatusReq(m).handle(testApp, 1)
+	_, respSuccess := checkRpcResponseSuccess(t, resMsg, "setNodeStatus")
+	require.True(t, respSuccess.HasSetNodeStatus())
+}
+
+// Regression test: NodeStatus is written by the SetNodeStatus RPC handler
+// while node-status streams concurrently read it to serve remote peers.
+// Without synchronization this is a data race (run with -race).
+func TestNodeStatusConcurrentSetAndServe(t *testing.T) {
+	codanet.NoDHT = true
+	defer func() {
+		codanet.NoDHT = false
+	}()
+
+	maxCount := 2
+	port := nextPort()
+	appA := newTestAppWithMaxConns(t, nil, true, maxCount, maxCount, port)
+	appAInfos, err := addrInfos(appA.P2p.Host)
+	require.NoError(t, err)
+	setNodeStatusImpl(t, appA, []byte("initial status"))
+
+	appB, _ := newTestApp(t, nil, true)
+	err = appB.P2p.Host.Connect(appB.Ctx, appAInfos[0])
+	require.NoError(t, err)
+
+	addr := multiaddrs(appA.P2p.Host)[0].String()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			setNodeStatusImpl(t, appA, []byte{byte(i), byte(i >> 8)})
+			i++
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		require.NoError(t, err)
+		m, err := ipc.NewRootLibp2pHelperInterface_GetPeerNodeStatus_Request(seg)
+		require.NoError(t, err)
+		ma, err := m.NewPeer()
+		require.NoError(t, err)
+		require.NoError(t, ma.SetRepresentation(addr))
+		resMsg, _ := GetPeerNodeStatusReq(m).handle(appB, uint64(100+i))
+		_, respSuccess := checkRpcResponseSuccess(t, resMsg, "getPeerNodeStatus")
+		require.True(t, respSuccess.HasGetPeerNodeStatus())
+	}
+
+	close(done)
+	wg.Wait()
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/stream_write_deadline_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/stream_write_deadline_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	net "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// stallingStream stands in for a peer that has stopped reading: every write
+// runs out the deadline the caller set and fails, the way a libp2p stream
+// does once the muxer's flow control window is exhausted.
+type stallingStream struct {
+	net.Stream
+	writeDeadline time.Time
+	closed        bool
+}
+
+func (s *stallingStream) SetWriteDeadline(t time.Time) error {
+	s.writeDeadline = t
+	return nil
+}
+
+func (s *stallingStream) Write(p []byte) (int, error) {
+	if s.writeDeadline.IsZero() {
+		// No deadline: a real stream would block here forever.
+		select {}
+	}
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (s *stallingStream) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *stallingStream) Reset() error                  { return nil }
+func (s *stallingStream) ID() string                    { return "stalling" }
+func (s *stallingStream) Protocol() protocol.ID         { return "" }
+func (s *stallingStream) Conn() net.Conn                { return nil }
+func (s *stallingStream) Stat() net.Stats               { return net.Stats{} }
+func (s *stallingStream) Scope() net.StreamScope        { return nil }
+func (s *stallingStream) SetProtocol(protocol.ID) error { return nil }
+func (s *stallingStream) RemotePeer() peer.ID           { return "" }
+
+// Regression test: WriteStream must bound its write with a deadline. Without
+// one a peer that stops reading blocks the caller indefinitely, holding both
+// the stream mutex and a slot in the bounded worker pool.
+func TestWriteStreamSetsWriteDeadline(t *testing.T) {
+	testApp, _ := newTestApp(t, nil, true)
+
+	peerStream := &stallingStream{}
+	streamId := testApp.NextId()
+	testApp.streamsMutex.Lock()
+	testApp._streams[streamId] = &stream{stream: peerStream}
+	testApp.streamsMutex.Unlock()
+
+	before := time.Now()
+	err := testApp.WriteStream(streamId, []byte("payload"))
+	require.Error(t, err, "a stalled write must fail rather than block")
+
+	require.False(t, peerStream.writeDeadline.IsZero(), "no write deadline was set")
+	require.WithinDuration(t, before.Add(StreamWriteTimeout), peerStream.writeDeadline, time.Minute)
+
+	// A failed write retires the stream.
+	_, stillThere := testApp.getStream(streamId)
+	require.False(t, stillThere, "stream must be removed after a write failure")
+	require.True(t, peerStream.closed, "stream must be closed after a write failure")
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/util_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/util_test.go
@@ -100,6 +100,7 @@ func newTestAppWithMaxConnsAndCtxAndGrace(t *testing.T, privkey crypto.PrivKey, 
 		metricsServer:            nil,
 		metricsCollectionStarted: false,
 		bitswapCtx:               bitswapCtx,
+		workerSem:                make(chan struct{}, WorkerPoolSize),
 	}
 }
 

--- a/src/app/libp2p_helper/src/libp2p_helper/validator_cleanup_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/validator_cleanup_test.go
@@ -61,6 +61,19 @@ func TestLateValidationPushSendDoesNotBlock(t *testing.T) {
 	}
 }
 
+// Regression test: a Validation push can remove a validator entry in the
+// window between the validate goroutine observing ctx.Done() and calling
+// TimeoutValidator. Marking a missing entry must not panic.
+func TestTimeoutValidatorAfterRemovalDoesNotPanic(t *testing.T) {
+	testApp := newValidatorTestApp()
+
+	seqno, _ := testApp.AddValidator()
+	_, found := testApp.RemoveValidator(seqno)
+	require.True(t, found)
+
+	require.NotPanics(t, func() { testApp.TimeoutValidator(seqno) })
+}
+
 func TestInitDurationEnvRejectsInvalid(t *testing.T) {
 	def := 42 * time.Second
 	t.Setenv("LIBP2P_TEST_DURATION_ENV", "bogus")

--- a/src/app/libp2p_helper/src/libp2p_helper/validator_cleanup_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/validator_cleanup_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/require"
+)
+
+func newValidatorTestApp() *app {
+	return &app{_validators: make(map[uint64]*validationStatus)}
+}
+
+// Regression test: validators whose grace period elapsed after timing out
+// must be swept; ones inside the grace period must be kept.
+func TestCleanupTimedOutValidatorsAfterGrace(t *testing.T) {
+	testApp := newValidatorTestApp()
+
+	staleSeqno, _ := testApp.AddValidator()
+	freshSeqno, _ := testApp.AddValidator()
+	pendingSeqno, _ := testApp.AddValidator()
+
+	stale := time.Now().Add(-ValidatorCleanupGrace - time.Minute)
+	testApp._validators[staleSeqno].TimedOutAt = &stale
+	testApp.TimeoutValidator(freshSeqno)
+
+	testApp.cleanupTimedOutValidators(logging.Logger("test"))
+
+	_, staleFound := testApp._validators[staleSeqno]
+	require.False(t, staleFound, "validator past its grace period must be removed")
+	_, freshFound := testApp._validators[freshSeqno]
+	require.True(t, freshFound, "recently timed-out validator must be kept")
+	_, pendingFound := testApp._validators[pendingSeqno]
+	require.True(t, pendingFound, "pending validator must be kept")
+}
+
+// Regression test: a Validation push arriving after the validate goroutine
+// timed out (and stopped receiving) must not block the sender forever. A
+// permanently blocked sender leaks the goroutine handling the push.
+func TestLateValidationPushSendDoesNotBlock(t *testing.T) {
+	testApp := newValidatorTestApp()
+
+	seqno, _ := testApp.AddValidator()
+	// The validate goroutine timed out and returned: nobody receives.
+	testApp.TimeoutValidator(seqno)
+
+	// A late Validation push arrives from the daemon.
+	st, found := testApp.RemoveValidator(seqno)
+	require.True(t, found)
+	sent := make(chan struct{})
+	go func() {
+		st.Completion <- pubsub.ValidationAccept
+		close(sent)
+	}()
+	select {
+	case <-sent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("late validation send blocked; Completion channel must be buffered")
+	}
+}
+
+func TestInitDurationEnvRejectsInvalid(t *testing.T) {
+	def := 42 * time.Second
+	t.Setenv("LIBP2P_TEST_DURATION_ENV", "bogus")
+	require.Equal(t, def, initDurationEnv("LIBP2P_TEST_DURATION_ENV", def))
+	t.Setenv("LIBP2P_TEST_DURATION_ENV", "-5s")
+	require.Equal(t, def, initDurationEnv("LIBP2P_TEST_DURATION_ENV", def))
+	t.Setenv("LIBP2P_TEST_DURATION_ENV", "0s")
+	require.Equal(t, def, initDurationEnv("LIBP2P_TEST_DURATION_ENV", def))
+	t.Setenv("LIBP2P_TEST_DURATION_ENV", "90s")
+	require.Equal(t, 90*time.Second, initDurationEnv("LIBP2P_TEST_DURATION_ENV", def))
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/worker_pool_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/worker_pool_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	capnp "capnproto.org/go/capnp/v3"
+	ipc "libp2p_ipc"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mkSetNodeStatusMsg(t *testing.T, seqno uint64, status []byte) *ipc.Libp2pHelperInterface_Message {
+	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+	require.NoError(t, err)
+	msg, err := ipc.NewRootLibp2pHelperInterface_Message(seg)
+	require.NoError(t, err)
+	req, err := msg.NewRpcRequest()
+	require.NoError(t, err)
+	h, err := req.NewHeader()
+	require.NoError(t, err)
+	sn, err := h.NewSequenceNumber()
+	require.NoError(t, err)
+	sn.SetSeqno(seqno)
+	sns, err := req.NewSetNodeStatus()
+	require.NoError(t, err)
+	require.NoError(t, sns.SetStatus(status))
+	return &msg
+}
+
+// Regression test: when the worker pool is full, incoming messages must be
+// queued via backpressure, never dropped. Every message is an RPC request or
+// push from the daemon; a dropped RPC request leaves the daemon waiting
+// forever on a response that will never arrive.
+func TestDispatchBackpressureDoesNotDropMessages(t *testing.T) {
+	testApp, _ := newTestApp(t, nil, true)
+	testApp.NoUpcalls = false
+	// Unbuffered out channel: handlers block in writeMsg until the test
+	// reads, keeping the pool saturated while further messages arrive.
+	testApp.OutChan = make(chan *capnp.Message)
+	testApp.workerSem = make(chan struct{}, 2)
+
+	const total = 10
+	msgs := make([]*ipc.Libp2pHelperInterface_Message, total)
+	for i := 0; i < total; i++ {
+		msgs[i] = mkSetNodeStatusMsg(t, uint64(i), []byte("status"))
+	}
+
+	go func() {
+		for _, m := range msgs {
+			testApp.dispatchIncoming(m)
+		}
+	}()
+
+	deadline := time.After(15 * time.Second)
+	for i := 0; i < total; i++ {
+		select {
+		case <-testApp.OutChan:
+		case <-deadline:
+			t.Fatalf("received only %d of %d responses; messages were dropped", i, total)
+		}
+	}
+}
+
+func TestInitIntEnvRejectsInvalid(t *testing.T) {
+	t.Setenv("LIBP2P_TEST_INT_ENV", "bogus")
+	require.Equal(t, 256, initIntEnv("LIBP2P_TEST_INT_ENV", 256))
+	t.Setenv("LIBP2P_TEST_INT_ENV", "-1")
+	require.Equal(t, 256, initIntEnv("LIBP2P_TEST_INT_ENV", 256))
+	t.Setenv("LIBP2P_TEST_INT_ENV", "0")
+	require.Equal(t, 256, initIntEnv("LIBP2P_TEST_INT_ENV", 256))
+	t.Setenv("LIBP2P_TEST_INT_ENV", "512")
+	require.Equal(t, 512, initIntEnv("LIBP2P_TEST_INT_ENV", 256))
+}


### PR DESCRIPTION
## Problem

The daemon's internal `libp2p_helper` Go process OOMs under sustained load due to
three root-cause leaks:

1. **Cap'n Proto arena retention:** Every incoming message allocates a new
   arena (56MB+). `SetNodeStatus` stores a `[]byte` sub-slice into that arena,
   keeping it alive until GC. With a blocked stdout pipe, goroutines pile up —
   each holding a 56MB arena. (~1 GB per 18 blocked handlers)

2. **`_addedPeers` never trimmed:** `AddPeer` is re-sent on reconnects, and each
   call appended unconditionally. Unbounded growth on testnets where nodes are
   created/destroyed frequently.

3. **Timed-out validators never cleaned up:** If OCaml never sends a
   `Validation` push (dropped upcall), the validator entry leaks forever. A
   *late* `Validation` push additionally left its handler goroutine blocked
   forever on the unbuffered completion channel.

Secondary: unbounded `go app.handleIncomingMsg(&msg)` goroutine spawning, data
race on `NodeStatus`, and peer stream writes with no deadline — a peer that
stops reading pins the stream and the goroutine driving it indefinitely.

## Changes

Each commit carries its fix together with regression tests that fail on the
pre-fix code (verified per-commit; the race test detects 3 data races on bare
develop).

| # | Commit | File(s) | Description |
|---|--------|---------|-------------|
| 1 | `56dc5cb` | `codanet.go` | Add `NodeStatusMutex sync.RWMutex` to `Helper`; reads snapshot under the lock and write outside it, so a slow peer cannot stall writers |
| 2 | `557cbb0` | `config_msg.go` | Copy NodeStatus bytes with `append([]byte(nil), status...)` to decouple from capnp arena |
| 3 | `57a225b` | `app.go` | Dedupe `_addedPeers` by peer ID (latest `AddrInfo` wins), bounding it by distinct peers; `GetAddedPeers` returns a copy. Gating semantics (`cleanAddedPeers`) unchanged |
| 4 | `bf73db6` | `app.go`, `data.go`, `config_msg.go` | Periodic sweep of timed-out validators (30s cycle, 1h grace period); buffer the validator completion channel so late `Validation` pushes cannot block their handler goroutine forever. The sweep is started from `Configure`, not `newApp`, so it never reads `app.P2p` before it is assigned |
| 5 | `b3be2ea` | `app.go`, `codanet.go` | Bound peer stream writes with a deadline (default 60s). libp2p stream writes have no deadline of their own, so a peer that stops reading blocks on muxer flow control forever; a timed-out write is handled like any other write failure (stream removed and closed) |
| 6 | `cff250a` | `app.go`, `main.go`, `data.go` | Cap incoming message handlers at 256 via semaphore pool; on overflow the stdin read loop **blocks (backpressure)** rather than dropping — every message is an RPC request or push, and a dropped request would hang the daemon's response wait |
| 7 | `85bf015` | `app.go` | Debug log on AddStream/AddSub/AddValidator, periodic Warn if thresholds exceeded. The monitor joins the background tasks started from `Configure` |
| 8 | `2781511` | `app.go` | `TimeoutValidator` no longer dereferences a validator entry unconditionally: a `Validation` push can remove it in the window between the validate goroutine seeing `ctx.Done()` and the timeout being recorded, which panicked the helper (pre-existing bug) |
| 9 | `f3e063e` | `changes/18945.md` | Changelog entry |

Commit 5 is ordered before the worker pool deliberately: with a bounded pool a
stalled write also pins a pool slot, so the deadline lands first and the pool
commit never introduces head-of-line blocking.

## Not addressed in this PR

These came out of the root-cause analysis but are outside this PR's scope. Each
is tracked in its own issue so it is not lost here:

| Issue | Item | Why not fixed here |
|---|---|---|
| #19315 | `/mina/node-status` server sleeps a fixed 10s instead of ACKing, racing the client's identical 10s read deadline and pinning a goroutine and stream per request | Replacing the sleep with an ACK is a breaking change to the protocol; old and new peers would not interoperate. This PR bounds the *write* with a deadline but leaves the protocol alone. `GetPeerNodeStatus` backs only the diagnostic `mina advanced node-status` CLI, not steady-state operation |
| #18195 | `GetPeerNodeStatus` reads the response with a single `s.Read` into a fixed 1MB buffer, so long statuses come back truncated | Already filed, with a reproduction. Same protocol constraint as above |
| #18361 | `ban_statuses` grows without bound — `Trust_system.Peer_trust.peer_statuses` returns the whole trust DB via `Db.to_alist`, and it is serialized to the helper every ~30s | Already filed. Root cause is addressed by #19241 (removes the trust system), currently open against `develop`. The Go-side fixes here stop an oversized `SetNodeStatus` from OOMing the helper but do not bound the message itself |
| #19316 | `TestUpcalls` is flaky on clean `develop` — a port assertion races connection teardown after `bob.Close()` | Pre-existing and unrelated to this branch |

## Backward compatibility

All changes are fully backward-compatible — no protocol changes, no schema
changes, and `cleanAddedPeers` keeps its documented semantics (runtime-added
peers stay trusted across gating pushes unless the daemon explicitly requests
cleaning — the daemon's ban/unban pushes do not re-send runtime-added peers, so
the helper must keep merging them).

The one behavior change visible to operators is the stream write deadline: a
peer that cannot accept a write within 60s now has its stream closed, where
previously the write blocked indefinitely.

## Configuration

All new behavior is configurable via environment variables with production-safe
defaults (non-positive values are rejected in favor of the default):

| Variable | Default | Purpose |
|---|---|---|
| `LIBP2P_WORKER_POOL_SIZE` | `256` | Max concurrent incoming message handlers |
| `LIBP2P_STREAM_WRITE_TIMEOUT_DURATION` | `60s` | Deadline for a single write to a peer stream |
| `LIBP2P_VALIDATOR_CLEANUP_INTERVAL_DURATION` | `30s` | Stale validator sweep frequency |
| `LIBP2P_VALIDATOR_CLEANUP_GRACE_DURATION` | `1h` | Age after timeout before removal |
| `LIBP2P_LEAK_MONITOR_INTERVAL_DURATION` | `5m` | Collection size check frequency |
| `LIBP2P_LEAK_WARN_STREAMS` | `500` | Stream count warning threshold |
| `LIBP2P_LEAK_WARN_SUBS` | `500` | Subscription count warning threshold |
| `LIBP2P_LEAK_WARN_VALIDATORS` | `5000` | Validator count warning threshold |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
