### PR TITLE
snark_worker: drop the 0.5s per-work-item flush pause

### DIFF
--- a/changes/18947.md
+++ b/changes/18947.md
@@ -1,0 +1,1 @@
+Removes an artificial 0.5-second delay the snark worker inserted between processing proof-generation work items to wait for stdout to flush. Proof generation now flows continuously from one work item to the next, reducing idle time and improving snark worker throughput.

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -97,7 +97,6 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
           "SNARK work $work_ids received from $address. Starting proof \
            generation"
           ~metadata:[ address_json; work_ids_json ] ;
-        let%bind () = after (Time.Span.of_sec 0.5) in
         let id = Spec.Partitioned.Poly.get_id partitioned_spec in
         match%bind
           retry_forever ~f:(fun () ->


### PR DESCRIPTION
This PR ports https://github.com/MinaProtocol/mina/pull/18929 and attach a changelog.