### PR TITLE
fix mina_healthcheck unit test and refactor related code a bit.

### DIFF
--- a/buildkite/src/Jobs/Test/MinaHealthcheckUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/MinaHealthcheckUnitTest.dhall
@@ -19,20 +19,16 @@ let buildTestCmd
     =     \(profile : Text)
       ->  \(path : Text)
       ->  \(cmd_target : Size)
-      ->  let command_key = "unit-test-${profile}"
+      ->  let key = "mina-healthcheck-unit-test-${profile}"
 
           in  Command.build
                 Command.Config::{
                 , commands =
                     RunInToolchain.runInToolchain
                       [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
-                      (     "buildkite/scripts/unit-test.sh ${profile} ${path}"
-                        ++  " && buildkite/scripts/upload-partial-coverage-data.sh ${command_key} dev"
-                        ++  " && buildkite/scripts/profile-dependent-tests.sh devnet"
-                        ++  " && buildkite/scripts/profile-dependent-tests.sh mainnet"
-                      )
-                , label = "${profile} unit-tests"
-                , key = command_key
+                      "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
+                , label = "Mina healthcheck unit tests"
+                , key = key
                 , target = cmd_target
                 , docker = None Docker.Type
                 , artifact_paths = [ S.contains "core_dumps/*" ]
@@ -43,23 +39,22 @@ in  Pipeline.build
       , spec =
           let unitDirtyWhen =
                 [ S.strictlyStart (S.contains "src")
-                , S.strictly (S.contains "Makefile")
-                , S.exactly "buildkite/src/Jobs/Test/DaemonUnitTest" "dhall"
-                , S.exactly "buildkite/src/Constants/ContainerImages" "dhall"
-                , S.exactly "scripts/link-coredumps" "sh"
-                , S.exactly "buildkite/scripts/profile-dependent-tests" "sh"
+                , S.exactly
+                    "buildkite/src/Jobs/Test/MinaHealthcheckUnitTest"
+                    "dhall"
                 , S.exactly "buildkite/scripts/unit-test" "sh"
                 ]
 
           in  JobSpec::{
               , dirtyWhen = unitDirtyWhen
               , path = "Test"
-              , name = "DaemonUnitTest"
+              , name = "MinaHealthcheckUnitTest"
               , tags =
-                [ PipelineTag.Type.VeryLong
+                [ PipelineTag.Type.Fast
                 , PipelineTag.Type.Test
                 , PipelineTag.Type.Stable
                 ]
               }
-      , steps = [ buildTestCmd "dev" "src/lib" Size.XLarge ]
+      , steps =
+        [ buildTestCmd "dev" "src/app/mina_healthcheck" Size.Small ]
       }

--- a/buildkite/src/Jobs/Test/MinaHealthcheckUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/MinaHealthcheckUnitTest.dhall
@@ -1,60 +1,19 @@
-let S = ../../Lib/SelectFiles.dhall
-
-let Pipeline = ../../Pipeline/Dsl.dhall
+let SimpleUnitTestJob = ../../Lib/SimpleUnitTestJob.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let Command = ../../Command/Base.dhall
-
-let RunInToolchain = ../../Command/RunInToolchain.dhall
-
-let Docker = ../../Command/Docker/Type.dhall
-
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd
-    : Text -> Text -> Size -> Command.Type
-    =     \(profile : Text)
-      ->  \(path : Text)
-      ->  \(cmd_target : Size)
-      ->  let key = "mina-healthcheck-unit-test-${profile}"
-
-          in  Command.build
-                Command.Config::{
-                , commands =
-                    RunInToolchain.runInToolchain
-                      [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
-                      "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
-                , label = "Mina healthcheck unit tests"
-                , key = key
-                , target = cmd_target
-                , docker = None Docker.Type
-                , artifact_paths = [ S.contains "core_dumps/*" ]
-                }
-
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec =
-          let unitDirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.exactly
-                    "buildkite/src/Jobs/Test/MinaHealthcheckUnitTest"
-                    "dhall"
-                , S.exactly "buildkite/scripts/unit-test" "sh"
-                ]
-
-          in  JobSpec::{
-              , dirtyWhen = unitDirtyWhen
-              , path = "Test"
-              , name = "MinaHealthcheckUnitTest"
-              , tags =
-                [ PipelineTag.Type.Fast
-                , PipelineTag.Type.Test
-                , PipelineTag.Type.Stable
-                ]
-              }
-      , steps =
-        [ buildTestCmd "dev" "src/app/mina_healthcheck" Size.Small ]
+in  SimpleUnitTestJob.build
+      { name = "MinaHealthcheckUnitTest"
+      , keyPrefix = "mina-healthcheck"
+      , label = "Mina healthcheck unit tests"
+      , testProfile = "dev"
+      , testPath = "src/app/mina_healthcheck"
+      , tags =
+        [ PipelineTag.Type.Fast
+        , PipelineTag.Type.Test
+        , PipelineTag.Type.Stable
+        ]
+      , cmdTarget = Size.Small
       }

--- a/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaUnitTest.dhall
@@ -1,58 +1,20 @@
-let S = ../../Lib/SelectFiles.dhall
-
-let Pipeline = ../../Pipeline/Dsl.dhall
+let SimpleUnitTestJob = ../../Lib/SimpleUnitTestJob.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let Command = ../../Command/Base.dhall
-
-let RunInToolchain = ../../Command/RunInToolchain.dhall
-
-let Docker = ../../Command/Docker/Type.dhall
-
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd
-    : Text -> Text -> Size -> Command.Type
-    =     \(profile : Text)
-      ->  \(path : Text)
-      ->  \(cmd_target : Size)
-      ->  let key = "rosetta-unit-test-${profile}"
-
-          in  Command.build
-                Command.Config::{
-                , commands =
-                    RunInToolchain.runInToolchain
-                      [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
-                      "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
-                , label = "Rosetta unit tests"
-                , key = key
-                , target = cmd_target
-                , docker = None Docker.Type
-                , artifact_paths = [ S.contains "core_dumps/*" ]
-                }
-
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec =
-          let unitDirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.exactly "buildkite/src/Jobs/Test/RosettaUnitTest" "dhall"
-                , S.exactly "buildkite/scripts/unit-test" "sh"
-                ]
-
-          in  JobSpec::{
-              , dirtyWhen = unitDirtyWhen
-              , path = "Test"
-              , name = "RosettaUnitTest"
-              , tags =
-                [ PipelineTag.Type.Long
-                , PipelineTag.Type.Test
-                , PipelineTag.Type.Stable
-                , PipelineTag.Type.Rosetta
-                ]
-              }
-      , steps = [ buildTestCmd "dev" "src/app/rosetta" Size.Small ]
+in  SimpleUnitTestJob.build
+      { name = "RosettaUnitTest"
+      , keyPrefix = "rosetta"
+      , label = "Rosetta unit tests"
+      , testProfile = "dev"
+      , testPath = "src/app/rosetta"
+      , tags =
+        [ PipelineTag.Type.Long
+        , PipelineTag.Type.Test
+        , PipelineTag.Type.Stable
+        , PipelineTag.Type.Rosetta
+        ]
+      , cmdTarget = Size.Small
       }

--- a/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ZkappTestToolUnitTest.dhall
@@ -1,60 +1,19 @@
-let S = ../../Lib/SelectFiles.dhall
-
-let Pipeline = ../../Pipeline/Dsl.dhall
+let SimpleUnitTestJob = ../../Lib/SimpleUnitTestJob.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
-let JobSpec = ../../Pipeline/JobSpec.dhall
-
-let Command = ../../Command/Base.dhall
-
-let RunInToolchain = ../../Command/RunInToolchain.dhall
-
-let Docker = ../../Command/Docker/Type.dhall
-
 let Size = ../../Command/Size.dhall
 
-let buildTestCmd
-    : Text -> Text -> Size -> Command.Type
-    =     \(profile : Text)
-      ->  \(path : Text)
-      ->  \(cmd_target : Size)
-      ->  let key = "zkapp-tool-unit-test-${profile}"
-
-          in  Command.build
-                Command.Config::{
-                , commands =
-                    RunInToolchain.runInToolchain
-                      [ "DUNE_INSTRUMENT_WITH=bisect_ppx", "COVERALLS_TOKEN" ]
-                      "buildkite/scripts/unit-test.sh ${profile} ${path} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
-                , label = "Zkapps test transaction tool unit tests"
-                , key = key
-                , target = cmd_target
-                , docker = None Docker.Type
-                , artifact_paths = [ S.contains "core_dumps/*" ]
-                }
-
-in  Pipeline.build
-      Pipeline.Config::{
-      , spec =
-          let unitDirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.exactly
-                    "buildkite/src/Jobs/Test/ZkappTestToolUnitTest"
-                    "dhall"
-                , S.exactly "buildkite/scripts/unit-test" "sh"
-                ]
-
-          in  JobSpec::{
-              , dirtyWhen = unitDirtyWhen
-              , path = "Test"
-              , name = "ZkappTestToolUnitTest"
-              , tags =
-                [ PipelineTag.Type.Fast
-                , PipelineTag.Type.Test
-                , PipelineTag.Type.Stable
-                ]
-              }
-      , steps =
-        [ buildTestCmd "dev" "src/app/zkapp_test_transaction" Size.Small ]
+in  SimpleUnitTestJob.build
+      { name = "ZkappTestToolUnitTest"
+      , keyPrefix = "zkapp-tool"
+      , label = "Zkapps test transaction tool unit tests"
+      , testProfile = "dev"
+      , testPath = "src/app/zkapp_test_transaction"
+      , tags =
+        [ PipelineTag.Type.Fast
+        , PipelineTag.Type.Test
+        , PipelineTag.Type.Stable
+        ]
+      , cmdTarget = Size.Small
       }

--- a/buildkite/src/Lib/SimpleUnitTestJob.dhall
+++ b/buildkite/src/Lib/SimpleUnitTestJob.dhall
@@ -1,0 +1,66 @@
+let S = ../Lib/SelectFiles.dhall
+
+let Pipeline = ../Pipeline/Dsl.dhall
+
+let PipelineTag = ../Pipeline/Tag.dhall
+
+let JobSpec = ../Pipeline/JobSpec.dhall
+
+let Command = ../Command/Base.dhall
+
+let RunInToolchain = ../Command/RunInToolchain.dhall
+
+let Docker = ../Command/Docker/Type.dhall
+
+let Size = ../Command/Size.dhall
+
+let Config
+    : Type
+    = { name : Text
+      , keyPrefix : Text
+      , label : Text
+      , testProfile : Text
+      , testPath : Text
+      , tags : List PipelineTag.Type
+      , cmdTarget : Size
+      }
+
+let build
+    : Config -> Pipeline.CompoundType
+    =     \(c : Config)
+      ->  let key = "${c.keyPrefix}-unit-test-${c.testProfile}"
+
+          let buildTestCmd
+              : Size -> Command.Type
+              =     \(cmd_target : Size)
+                ->  Command.build
+                      Command.Config::{
+                      , commands =
+                          RunInToolchain.runInToolchain
+                            [ "DUNE_INSTRUMENT_WITH=bisect_ppx"
+                            , "COVERALLS_TOKEN"
+                            ]
+                            "buildkite/scripts/unit-test.sh ${c.testProfile} ${c.testPath} && buildkite/scripts/upload-partial-coverage-data.sh ${key} dev"
+                      , label = c.label
+                      , key = key
+                      , target = cmd_target
+                      , docker = None Docker.Type
+                      , artifact_paths = [ S.contains "core_dumps/*" ]
+                      }
+
+          in  Pipeline.build
+                Pipeline.Config::{
+                , spec = JobSpec::{
+                  , dirtyWhen =
+                    [ S.strictlyStart (S.contains "src")
+                    , S.exactly "buildkite/src/Jobs/Test/${c.name}" "dhall"
+                    , S.exactly "buildkite/scripts/unit-test" "sh"
+                    ]
+                  , path = "Test"
+                  , name = c.name
+                  , tags = c.tags
+                  }
+                , steps = [ buildTestCmd c.cmdTarget ]
+                }
+
+in  { Config = Config, build = build }


### PR DESCRIPTION
## Summary

Fix CI failure in `dev unit-tests` job where `dune runtest src/app/mina_healthcheck` failed with exit 127 (`dune: command not found`), and refactor duplicated CI job definitions into a shared library.

## Problem

In PR #18746, mina-healthcheck tests were wired into the DaemonUnitTest buildkite job by appending ` && dune runtest src/app/mina_healthcheck` to the command chain inside `DaemonUnitTest.dhall`. This broke the job because:

- `unit-test.sh` sources `~/.profile` internally to set up the opam environment (placing `dune` on PATH), but this sourcing does not propagate to subsequent commands in the `&&` chain.
- After `unit-test.sh` exits, the outer `bash -c` process running the remaining `&& dune runtest ...` command cannot find `dune`.

## Changes

### 1. Split mina-healthcheck into its own CI job

Created `buildkite/src/Jobs/Test/MinaHealthcheckUnitTest.dhall` — a standalone CI job inspired by the `RosettaUnitTest` pattern. It runs `unit-test.sh` on `src/app/mina_healthcheck` under `Size.Small` / `Fast`.

Removed the broken `dune runtest src/app/mina_healthcheck` from `DaemonUnitTest.dhall`.

### 2. Extract `SimpleUnitTestJob` library

Factored the common `buildTestCmd` logic shared by `RosettaUnitTest`, `ZkappTestToolUnitTest`, and `MinaHealthcheckUnitTest` into `buildkite/src/Lib/SimpleUnitTestJob.dhall`. Each job is now a ~15‑line configuration record specifying `name`, `keyPrefix`, `label`, `testPath`, `testProfile`, `tags`, and `cmdTarget`.
