### PR TITLE
Fix path comparison in dispatcher script. 

### DIFF
--- a/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
+++ b/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
@@ -450,6 +450,91 @@ fi
 echo "PASSED: user-provided hardfork-handling left untouched"
 
 # =============================================================================
+# Test 12: Config Directory Path Comparison (equivalent spellings accepted)
+# =============================================================================
+
+echo ""
+echo "=== Test 12: Config Directory Path Comparison ==="
+echo "Verifying that --config-directory equal to the hardfork state dir is accepted"
+echo "even when written with a trailing slash or '.'/'..' segments"
+
+# The hardfork state directory in the image (MINA_HARDFORK_STATE_DIR).
+HARDFORK_STATE_DIR="/root/.mina-config"
+
+# Each of these refers to the same directory as $HARDFORK_STATE_DIR and must
+# therefore be accepted (no discrepancy error, dispatcher proceeds normally).
+EQUIVALENT_DIRS=(
+  "${HARDFORK_STATE_DIR}/"
+  "${HARDFORK_STATE_DIR}/."
+  "/root/../root/.mina-config"
+)
+
+for equivalent_dir in "${EQUIVALENT_DIRS[@]}"; do
+  echo "--- Checking equivalent path: ${equivalent_dir}"
+
+  set +e
+  MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
+    -c "$(create_activation_marker) && mina daemon --config-directory ${equivalent_dir}" 2>&1)
+  STATUS=$?
+  set -e
+
+  if [[ "$MINA_EXEC_COMMAND" == *"mina-dispatch ERROR: Discrepancy between provided --config-directory"* ]]; then
+    echo "FAILED: Equivalent path was incorrectly rejected as a discrepancy"
+    echo "  Provided: ${equivalent_dir}"
+    echo "  Expected (normalized): ${HARDFORK_STATE_DIR}"
+    echo "  Actual output: $MINA_EXEC_COMMAND"
+    exit 1
+  fi
+
+  if [[ "$STATUS" -ne 0 ]]; then
+    echo "FAILED: Dispatcher exited non-zero for an equivalent --config-directory"
+    echo "  Provided: ${equivalent_dir}"
+    echo "  Actual output: $MINA_EXEC_COMMAND"
+    exit 1
+  fi
+
+  # The original (un-normalized) argument should be passed through untouched.
+  if [[ "$MINA_EXEC_COMMAND" != *"--config-directory ${equivalent_dir}"* ]]; then
+    echo "FAILED: --config-directory argument was not passed through unchanged"
+    echo "  Expected substring: --config-directory ${equivalent_dir}"
+    echo "  Actual output: $MINA_EXEC_COMMAND"
+    exit 1
+  fi
+done
+
+echo "PASSED: Equivalent --config-directory spellings are accepted via path comparison"
+
+# =============================================================================
+# Test 13: Config Directory Path Comparison (genuine mismatch still rejected)
+# =============================================================================
+
+echo ""
+echo "=== Test 13: Config Directory Genuine Mismatch ==="
+echo "Verifying that a path resolving to a different directory is still rejected"
+
+# This contains '..' but normalizes to a different directory, so it must error.
+set +e
+MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
+  -c "$(create_activation_marker) && mina daemon --config-directory /root/.mina-config/../other" 2>&1)
+STATUS=$?
+set -e
+
+EXPECTED_ERROR="mina-dispatch ERROR: Discrepancy between provided --config-directory"
+if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_ERROR"* ]]; then
+  echo "FAILED: Expected discrepancy error for a path resolving elsewhere"
+  echo "  Expected substring: $EXPECTED_ERROR"
+  echo "  Actual output: $MINA_EXEC_COMMAND"
+  exit 1
+fi
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo "FAILED: Expected non-zero exit for a genuinely mismatched --config-directory"
+  exit 1
+fi
+
+echo "PASSED: Genuine path mismatch is still rejected"
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
+++ b/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
@@ -78,6 +78,70 @@ validate_git_commit_format() {
   fi
 }
 
+# Run mina-dispatch inside the image in JSON mode and capture the emitted JSON
+# object into DISPATCH_JSON and the exit status into DISPATCH_STATUS. Stderr
+# (INFO/DEBUG noise) is discarded so DISPATCH_JSON is a clean, parseable object.
+#
+# This lifts the repetitive `docker run --env ... --entrypoint bash ... ; STATUS=$?`
+# block that every dispatch assertion below would otherwise duplicate.
+#
+# Args:
+#   $1     - command line to run inside the container (e.g. "mina daemon --config-directory /x")
+#   $2     - (optional) "marker" (default) to create the activation marker first
+#            (mesa runtime), or "no-marker" to leave it absent (berkeley runtime)
+#   $3..   - (optional) extra arguments inserted into `docker run` (e.g. --env KEY=VAL)
+DISPATCH_JSON=""
+DISPATCH_STATUS=0
+run_dispatch_json() {
+  local inner_cmd="$1"
+  local marker_mode="${2:-marker}"
+  # Drop the consumed positional args; the remainder are extra docker run args.
+  if [[ $# -ge 2 ]]; then shift 2; else shift $#; fi
+
+  local setup=""
+  if [[ "$marker_mode" == "marker" ]]; then
+    setup="$(create_activation_marker) && "
+  fi
+
+  set +e
+  DISPATCH_JSON=$(docker run --env MINA_DISPATCHER_JSON=1 "$@" --entrypoint bash "$DOCKER_IMAGE" \
+    -c "${setup}${inner_cmd}" 2>/dev/null)
+  DISPATCH_STATUS=$?
+  set -e
+}
+
+# Assert that jq filter $1 over DISPATCH_JSON produces a value containing $2.
+assert_json_contains() {
+  local filter="$1" needle="$2" actual
+  actual=$(jq -r "$filter" <<< "$DISPATCH_JSON")
+  if [[ "$actual" != *"$needle"* ]]; then
+    echo "FAILED: expected '${filter}' to contain '${needle}'"
+    echo "  Actual:    $actual"
+    echo "  Full JSON: $DISPATCH_JSON"
+    exit 1
+  fi
+}
+
+# Assert that jq filter $1 over DISPATCH_JSON equals $2 exactly.
+assert_json_eq() {
+  local filter="$1" expected="$2" actual
+  actual=$(jq -r "$filter" <<< "$DISPATCH_JSON")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAILED: expected '${filter}' == '${expected}', got '${actual}'"
+    echo "  Full JSON: $DISPATCH_JSON"
+    exit 1
+  fi
+}
+
+# Assert that the dispatcher exited non-zero (used for the error-path tests).
+assert_dispatch_failed() {
+  if [[ "$DISPATCH_STATUS" -eq 0 ]]; then
+    echo "FAILED: expected non-zero exit, got 0"
+    echo "  Full JSON: $DISPATCH_JSON"
+    exit 1
+  fi
+}
+
 # =============================================================================
 # Argument Parsing
 # =============================================================================
@@ -114,6 +178,12 @@ done
 
 if [[ -z "$DOCKER_IMAGE" ]]; then
   echo "Error: --docker argument is required"
+  exit 1
+fi
+
+# The JSON-mode assertions parse mina-dispatch output with jq.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required to run these tests"
   exit 1
 fi
 
@@ -181,42 +251,26 @@ echo ""
 echo "=== Test 3: Config Append ==="
 echo "Verifying that user-provided config is kept and hardfork config is appended as last -config-file"
 
-# Modify mina-dispatch to echo the command instead of executing it
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "$(create_activation_marker) && mina daemon -config-file /var/lib/coda/fake_config.json" 2>&1)
+run_dispatch_json "mina daemon -config-file /var/lib/coda/fake_config.json"
 
-# Check user's config file is still present
+COMMAND=$(jq -r '.command' <<< "$DISPATCH_JSON")
+
+# User's config file is still present, and the hardfork config is appended.
 USER_CONFIG="-config-file /var/lib/coda/fake_config.json"
-if [[ "$MINA_EXEC_COMMAND" != *"$USER_CONFIG"* ]]; then
-  echo "FAILED: User-provided config file was removed"
-  echo "  Expected substring: $USER_CONFIG"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
-  exit 1
-fi
+HARDFORK_CONFIG="-config-file $(activation_marker_dir)/daemon.json"
+assert_json_contains '.command' "$USER_CONFIG"
+assert_json_contains '.command' "$HARDFORK_CONFIG"
 
-# Check hardfork config is appended
-EXPECTED_CONFIG="-config-file $(activation_marker_dir)/daemon.json"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_CONFIG"* ]]; then
-  echo "FAILED: Hardfork config not appended"
-  echo "  Expected substring: $EXPECTED_CONFIG"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-# Verify hardfork config appears AFTER user config (is last -config-file)
-USER_CONFIG_POS="${MINA_EXEC_COMMAND%%$USER_CONFIG*}"
-HARDFORK_CONFIG_POS="${MINA_EXEC_COMMAND%%$EXPECTED_CONFIG*}"
+# Verify hardfork config appears AFTER user config (is the last -config-file).
+USER_CONFIG_POS="${COMMAND%%"$USER_CONFIG"*}"
+HARDFORK_CONFIG_POS="${COMMAND%%"$HARDFORK_CONFIG"*}"
 if [[ ${#USER_CONFIG_POS} -ge ${#HARDFORK_CONFIG_POS} ]]; then
   echo "FAILED: Hardfork config should appear after user config"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
+  echo "  Command: $COMMAND"
   exit 1
 fi
 
-if [[ "$MINA_EXEC_COMMAND" != *"--genesis-ledger-dir $(activation_marker_dir)/genesis"* ]]; then
-  echo "FAILED: Genesis ledger directory not overridden to mesa-ledgers"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
-  exit 1
-fi
+assert_json_contains '.command' "--genesis-ledger-dir $(activation_marker_dir)/genesis"
 
 echo "PASSED: User config kept and hardfork config appended as last -config-file"
 
@@ -228,25 +282,12 @@ echo ""
 echo "=== Test 4: Genesis Ledger Override ==="
 echo "Verifying that user-provided genesis ledger directory is overridden with hardfork ones"
 
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "$(create_activation_marker) && mina daemon --genesis-ledger-dir /var/lib/coda/fake/ledger" 2>&1)
+run_dispatch_json "mina daemon --genesis-ledger-dir /var/lib/coda/fake/ledger"
 
-EXPECTED_CONFIG="--genesis-ledger-dir $(activation_marker_dir)/genesis"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_CONFIG"* ]]; then
-  echo "FAILED: Genesis ledger override not applied"
-  echo "  Expected substring: $EXPECTED_CONFIG"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-# Hardfork config should also be appended even without user-provided --config-file
-EXPECTED_HF_CONFIG="-config-file $(activation_marker_dir)/daemon.json"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_HF_CONFIG"* ]]; then
-  echo "FAILED: Hardfork daemon config not appended"
-  echo "  Expected substring: $EXPECTED_HF_CONFIG"
-  echo "  Actual command: $MINA_EXEC_COMMAND"
-  exit 1
-fi
+# Genesis ledger dir overridden to mesa ledgers, and hardfork config appended
+# even without a user-provided --config-file.
+assert_json_contains '.command' "--genesis-ledger-dir $(activation_marker_dir)/genesis"
+assert_json_contains '.command' "-config-file $(activation_marker_dir)/daemon.json"
 
 echo "PASSED: Genesis ledger overridden and hardfork config appended"
 
@@ -258,24 +299,10 @@ echo ""
 echo "=== Test 5: Unsupported Subcommand ==="
 echo "Verifying that dispatcher reports an error for non-daemon subcommands"
 
-set +e
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "mina accounts list" 2>&1)
-STATUS=$?
-set -e
+run_dispatch_json "mina accounts list" no-marker
 
-EXPECTED_ERROR="mina-dispatch ERROR: unsupported subcommand 'accounts'"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_ERROR"* ]]; then
-  echo "FAILED: Expected unsupported subcommand error"
-  echo "  Expected substring: $EXPECTED_ERROR"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-if [[ "$STATUS" -eq 0 ]]; then
-  echo "FAILED: Expected non-zero exit for unsupported subcommand"
-  exit 1
-fi
+assert_json_eq '.error' "unsupported_subcommand"
+assert_dispatch_failed
 
 echo "PASSED: Unsupported subcommand error is emitted"
 
@@ -287,24 +314,10 @@ echo ""
 echo "=== Test 6: MINA_HARDFORK_STATE_DIR Required ==="
 echo "Verifying that missing MINA_HARDFORK_STATE_DIR returns an error"
 
-set +e
-MINA_EXEC_COMMAND=$(docker run --env MINA_HARDFORK_STATE_DIR= --entrypoint bash "$DOCKER_IMAGE" \
-  -c "mina --version" 2>&1)
-STATUS=$?
-set -e
+run_dispatch_json "mina --version" no-marker --env MINA_HARDFORK_STATE_DIR=
 
-EXPECTED_ERROR="mina-dispatch ERROR: MINA_HARDFORK_STATE_DIR is not defined"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_ERROR"* ]]; then
-  echo "FAILED: Expected missing MINA_HARDFORK_STATE_DIR error"
-  echo "  Expected substring: $EXPECTED_ERROR"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-if [[ "$STATUS" -eq 0 ]]; then
-  echo "FAILED: Expected non-zero exit when MINA_HARDFORK_STATE_DIR is missing"
-  exit 1
-fi
+assert_json_eq '.error' "missing_hardfork_state_dir"
+assert_dispatch_failed
 
 echo "PASSED: Missing MINA_HARDFORK_STATE_DIR error is emitted"
 
@@ -316,32 +329,12 @@ echo ""
 echo "=== Test 7: Config Directory Validation ==="
 echo "Verifying that --config-directory must match hardfork state directory"
 
-set +e
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "$(create_activation_marker) && mina daemon --config-directory /var/lib/coda/fake" 2>&1)
-STATUS=$?
-set -e
+run_dispatch_json "mina daemon --config-directory /var/lib/coda/fake"
 
-EXPECTED_ERROR="mina-dispatch ERROR: Discrepancy between provided --config-directory"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_ERROR"* ]]; then
-  echo "FAILED: Expected config directory validation error"
-  echo "  Expected substring: $EXPECTED_ERROR"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-EXPECTED_DIR="/root/.mina-config"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_DIR"* ]]; then
-  echo "FAILED: Expected error to mention required hardfork config directory"
-  echo "  Expected substring: $EXPECTED_DIR"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-if [[ "$STATUS" -eq 0 ]]; then
-  echo "FAILED: Expected non-zero exit for mismatched --config-directory"
-  exit 1
-fi
+assert_json_eq '.error' "config_directory_discrepancy"
+# Error message should mention the required hardfork config directory.
+assert_json_contains '.message' "/root/.mina-config"
+assert_dispatch_failed
 
 echo "PASSED: Mismatched --config-directory is rejected"
 
@@ -353,16 +346,11 @@ echo ""
 echo "=== Test 8: Client Subcommand Uses Mesa ==="
 echo "Verifying that 'client status' always dispatches to mesa runtime"
 
-# Without activation marker - client should still use mesa
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "mina client status" 2>&1)
+# Without activation marker - client should still use mesa.
+run_dispatch_json "mina client status" no-marker
 
-if [[ "$MINA_EXEC_COMMAND" != *"/mesa/mina client status"* ]]; then
-  echo "FAILED: client subcommand should use mesa runtime even without activation marker"
-  echo "  Expected substring: /mesa/mina client status"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
+assert_json_eq '.runtime' "mesa"
+assert_json_contains '.command' "/mesa/mina client status"
 
 echo "PASSED: client subcommand uses mesa runtime"
 
@@ -472,34 +460,18 @@ EQUIVALENT_DIRS=(
 for equivalent_dir in "${EQUIVALENT_DIRS[@]}"; do
   echo "--- Checking equivalent path: ${equivalent_dir}"
 
-  set +e
-  MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-    -c "$(create_activation_marker) && mina daemon --config-directory ${equivalent_dir}" 2>&1)
-  STATUS=$?
-  set -e
+  run_dispatch_json "mina daemon --config-directory ${equivalent_dir}"
 
-  if [[ "$MINA_EXEC_COMMAND" == *"mina-dispatch ERROR: Discrepancy between provided --config-directory"* ]]; then
-    echo "FAILED: Equivalent path was incorrectly rejected as a discrepancy"
-    echo "  Provided: ${equivalent_dir}"
-    echo "  Expected (normalized): ${HARDFORK_STATE_DIR}"
-    echo "  Actual output: $MINA_EXEC_COMMAND"
-    exit 1
-  fi
-
-  if [[ "$STATUS" -ne 0 ]]; then
+  # Equivalent path is accepted: the dispatcher succeeds (no error object) ...
+  if [[ "$DISPATCH_STATUS" -ne 0 ]]; then
     echo "FAILED: Dispatcher exited non-zero for an equivalent --config-directory"
-    echo "  Provided: ${equivalent_dir}"
-    echo "  Actual output: $MINA_EXEC_COMMAND"
+    echo "  Provided:  ${equivalent_dir}"
+    echo "  Full JSON: $DISPATCH_JSON"
     exit 1
   fi
-
-  # The original (un-normalized) argument should be passed through untouched.
-  if [[ "$MINA_EXEC_COMMAND" != *"--config-directory ${equivalent_dir}"* ]]; then
-    echo "FAILED: --config-directory argument was not passed through unchanged"
-    echo "  Expected substring: --config-directory ${equivalent_dir}"
-    echo "  Actual output: $MINA_EXEC_COMMAND"
-    exit 1
-  fi
+  assert_json_eq '.error // "none"' "none"
+  # ... and the original (un-normalized) argument is passed through untouched.
+  assert_json_contains '.command' "--config-directory ${equivalent_dir}"
 done
 
 echo "PASSED: Equivalent --config-directory spellings are accepted via path comparison"
@@ -513,24 +485,10 @@ echo "=== Test 13: Config Directory Genuine Mismatch ==="
 echo "Verifying that a path resolving to a different directory is still rejected"
 
 # This contains '..' but normalizes to a different directory, so it must error.
-set +e
-MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
-  -c "$(create_activation_marker) && mina daemon --config-directory /root/.mina-config/../other" 2>&1)
-STATUS=$?
-set -e
+run_dispatch_json "mina daemon --config-directory /root/.mina-config/../other"
 
-EXPECTED_ERROR="mina-dispatch ERROR: Discrepancy between provided --config-directory"
-if [[ "$MINA_EXEC_COMMAND" != *"$EXPECTED_ERROR"* ]]; then
-  echo "FAILED: Expected discrepancy error for a path resolving elsewhere"
-  echo "  Expected substring: $EXPECTED_ERROR"
-  echo "  Actual output: $MINA_EXEC_COMMAND"
-  exit 1
-fi
-
-if [[ "$STATUS" -eq 0 ]]; then
-  echo "FAILED: Expected non-zero exit for a genuinely mismatched --config-directory"
-  exit 1
-fi
+assert_json_eq '.error' "config_directory_discrepancy"
+assert_dispatch_failed
 
 echo "PASSED: Genuine path mismatch is still rejected"
 

--- a/scripts/hardfork/dispatcher.sh
+++ b/scripts/hardfork/dispatcher.sh
@@ -240,6 +240,25 @@ fi
 # Argument Processing
 # =============================================================================
 
+# Normalize a filesystem path for comparison purposes.
+# Collapses trailing slashes, "." / ".." segments and (for any existing
+# prefix) symlinks, so that paths that point to the same location compare
+# equal even when written differently (e.g. "/a/b", "/a/b/", "/a/./b").
+# The path does NOT need to exist (realpath -m is purely lexical for the
+# non-existent tail). Falls back to the raw value if realpath is unavailable.
+function normalize_path() {
+  local path="$1"
+  realpath -m -- "$path" 2>/dev/null || echo "$path"
+}
+
+# Detailed explanation of the argument processing logic
+function print_argument_warning() {
+  echo "  Automatic argument adjustments are only implemented for the 'daemon' subcommand." >&2
+  echo "  Please ensure you are invoking the correct runtime binary directly if needed." >&2
+  echo "  For example, use 'mina-berkeley' or 'mina-mesa' instead of relying on the dispatcher (mina)." >&2
+  echo "  If you want to call others utility daemon apps using specific version need to be called by full path /usr/lib/mina/berkeley/... or /usr/lib/mina/mesa/..." >&2
+}
+
 first_arg=""
 
 # Copy arguments to a new array for processing
@@ -345,7 +364,9 @@ if [[ "$runtime" == "mesa" ]]; then
         # Check config directory provided as next arg is equal to MINA_HARDFORK_STATE_PARENT_FOLDER
         if [[ "$has_next_arg" == true ]]; then
           provided_dir="${args[$next_i]}"
-          if [[ "$provided_dir" != "$MINA_HARDFORK_STATE_DIR" ]]; then
+          # Compare as normalized paths, not raw strings, so that equivalent
+          # spellings (trailing slash, "." / ".." segments) are accepted.
+          if [[ "$(normalize_path "$provided_dir")" != "$(normalize_path "$MINA_HARDFORK_STATE_DIR")" ]]; then
             echo "mina-dispatch ERROR: Discrepancy between provided --config-directory ($provided_dir) and expected ($MINA_HARDFORK_STATE_DIR)" >&2
             echo " Those must match for auto hardfork mode correct behavior." >&2
             echo " Please adjust your invocation accordingly." >&2

--- a/scripts/hardfork/dispatcher.sh
+++ b/scripts/hardfork/dispatcher.sh
@@ -85,12 +85,24 @@
 #   127 - Binary not found or not executable
 #
 # DRYRUN MODE:
-#   Set DRYRUN=1 in environment to print the exec command instead of executing it.
-#   Useful for debugging argument processing and runtime selection.
+#   Set MINA_DISPATCHER_DRYRUN=1 in environment to print the exec command instead
+#   of executing it. Useful for debugging argument processing and runtime
+#   selection.
 #   Example:
-#     DRYRUN=1 mina daemon --peer-list-url ...
-#   Output:
+#     MINA_DISPATCHER_DRYRUN=1 mina daemon --peer-list-url ...
+#   Output (to stderr):
 #     mina-dispatch DRYRUN: exec /path/to/binary arg1 arg2 ...
+#
+# JSON MODE:
+#   Set MINA_DISPATCHER_JSON=1 to emit a single machine-readable JSON object on
+#   stdout instead of human-readable text, so callers can parse the dispatch
+#   decision/errors with jq rather than scraping stderr. Implies dry-run (the
+#   command is described, not exec'd). Examples:
+#     resolved command:
+#       {"runtime":"mesa","binary":"/usr/lib/mina/mesa/mina",
+#        "args":["daemon","-config-file","..."],"command":"/usr/lib/mina/mesa/mina daemon ..."}
+#     error:
+#       {"error":"config_directory_discrepancy","exit_code":1,"message":"..."}
 # SECURITY CONSIDERATIONS:
 #   - SOURCE_FILE must be owned by root and not world-writable
 #   - Binary paths are constructed from trusted configuration only
@@ -108,13 +120,99 @@ set -euo pipefail
 SOURCE_FILE=${SOURCE_FILE:-"/etc/default/mina-dispatch"}
 MINA_DISPATCHER_DEBUG=${MINA_DISPATCHER_DEBUG:-0}
 MINA_DISPATCHER_DRYRUN=${MINA_DISPATCHER_DRYRUN:-0}
+# JSON mode: emit machine-readable output instead of human-readable text, so
+# callers (e.g. the dispatcher tests) can parse decisions/errors with jq rather
+# than substring-matching. Implies dry-run for the success path (we describe the
+# command instead of exec'ing it). Off by default; production behaviour is
+# unchanged when MINA_DISPATCHER_JSON=0.
+MINA_DISPATCHER_JSON=${MINA_DISPATCHER_JSON:-0}
+
+# =============================================================================
+# Output Helpers (human-readable vs JSON)
+# =============================================================================
+
+# Escape a string for embedding in a JSON double-quoted value.
+json_escape() {
+  local s="$1" out="" i c
+  for (( i = 0; i < ${#s}; i++ )); do
+    c="${s:i:1}"
+    case "$c" in
+      '"') out+=$'\\"' ;;
+      \\) out+=$'\\\\' ;;
+      $'\n') out+='\n' ;;
+      $'\t') out+='\t' ;;
+      $'\r') out+='\r' ;;
+      *) out+="$c" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# Emit a JSON array of the given strings: ["a","b",...]
+json_array() {
+  local first=1 elem
+  printf '['
+  for elem in "$@"; do
+    if [[ $first -eq 1 ]]; then first=0; else printf ','; fi
+    printf '"%s"' "$(json_escape "$elem")"
+  done
+  printf ']'
+}
+
+# True when the dispatcher should describe (not execute) the command: either an
+# explicit dry-run, or JSON mode (which always describes rather than exec's).
+dryrun_active() {
+  [[ "${MINA_DISPATCHER_DRYRUN:-0}" -ne 0 || "${MINA_DISPATCHER_JSON:-0}" -ne 0 ]]
+}
+
+# Report an error and exit. In JSON mode a single object is printed to stdout:
+#   {"error":"<key>","exit_code":<n>,"message":"<joined message>"}
+# Otherwise the provided lines are printed to stderr verbatim (preserving the
+# original human-readable output) and the same exit code is used.
+# Usage: dispatch_fail <exit_code> <error_key> <line> [line...]
+dispatch_fail() {
+  local code="$1" key="$2"
+  shift 2
+  if [[ "$MINA_DISPATCHER_JSON" -ne 0 ]]; then
+    printf '{"error":"%s","exit_code":%s,"message":"%s"}\n' \
+      "$(json_escape "$key")" "$code" "$(json_escape "$*")"
+  else
+    printf '%s\n' "$@" >&2
+  fi
+  exit "$code"
+}
+
+# Emit the resolved dry-run command. In JSON mode a single object is printed to
+# stdout describing the runtime, binary and final argument vector:
+#   {"runtime":"<rt>","binary":"<bin>","args":[...],"command":"<bin args>"}
+# Otherwise the original human-readable line is printed to stderr.
+# Usage: emit_dryrun <runtime> <binary> [arg...]
+emit_dryrun() {
+  local rt="$1" bin="$2"
+  shift 2
+  if [[ "$MINA_DISPATCHER_JSON" -ne 0 ]]; then
+    local command="$bin"
+    if [[ $# -gt 0 ]]; then
+      command="$bin $*"
+    fi
+    printf '{"runtime":"%s","binary":"%s","args":%s,"command":"%s"}\n' \
+      "$(json_escape "$rt")" \
+      "$(json_escape "$bin")" \
+      "$(json_array "$@")" \
+      "$(json_escape "$command")"
+  elif [[ $# -gt 0 ]]; then
+    echo "mina-dispatch DRYRUN: exec $bin $*" >&2
+  else
+    echo "mina-dispatch DRYRUN: exec $bin" >&2
+  fi
+}
 
 # Validate source file exists before sourcing
 if [[ ! -f "$SOURCE_FILE" ]]; then
-  echo "mina-dispatch ERROR: source file not found: $SOURCE_FILE" >&2
-  echo "  Installation is incomplete or corrupted." >&2
-  echo "  Expected configuration at: $SOURCE_FILE" >&2
-  exit 1
+  dispatch_fail 1 source_file_not_found \
+    "mina-dispatch ERROR: source file not found: $SOURCE_FILE" \
+    "  Installation is incomplete or corrupted." \
+    "  Expected configuration at: $SOURCE_FILE"
 fi
 
 # Security check: warn if source file has problematic permissions
@@ -145,18 +243,17 @@ declare -a required_vars=(
 
 for var in "${required_vars[@]}"; do
   if [[ -z "${!var:-}" ]]; then
-    echo "mina-dispatch ERROR: $var is not defined" >&2
-    echo "  This variable should be set in: $SOURCE_FILE" >&2
-    exit 1
+    dispatch_fail 1 required_var_undefined \
+      "mina-dispatch ERROR: $var is not defined" \
+      "  This variable should be set in: $SOURCE_FILE"
   fi
 done
 
 if [[ -z "${MINA_HARDFORK_STATE_DIR:-}" ]]; then
-  echo "mina-dispatch ERROR: MINA_HARDFORK_STATE_DIR is not defined" >&2
-  echo "  This variable should be set in your environment and point" >&2
-  echo "  to the mina config directory (usually ${HOME}/.mina-config)." >&2
-
-  exit 1
+  dispatch_fail 1 missing_hardfork_state_dir \
+    "mina-dispatch ERROR: MINA_HARDFORK_STATE_DIR is not defined" \
+    "  This variable should be set in your environment and point" \
+    "  to the mina config directory (usually ${HOME}/.mina-config)."
 fi
 
 # =============================================================================
@@ -192,10 +289,10 @@ cmd="$(basename "$0")"
 # Handle direct invocation for debugging: mina-dispatch mina --help
 if [[ "$cmd" == "mina-dispatch" ]]; then
   if [[ $# -lt 1 ]]; then
-    echo "mina-dispatch ERROR: no command provided" >&2
-    echo "  Usage: mina-dispatch <command> [arguments...]" >&2
-    echo "  Example: mina-dispatch mina daemon --help" >&2
-    exit 1
+    dispatch_fail 1 no_command \
+      "mina-dispatch ERROR: no command provided" \
+      "  Usage: mina-dispatch <command> [arguments...]" \
+      "  Example: mina-dispatch mina daemon --help"
   fi
   cmd="$1"
   shift
@@ -203,8 +300,8 @@ fi
 
 # Validate command name contains only safe characters
 if [[ ! "$cmd" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-  echo "mina-dispatch ERROR: invalid command name: $cmd" >&2
-  exit 1
+  dispatch_fail 1 invalid_command_name \
+    "mina-dispatch ERROR: invalid command name: $cmd"
 fi
 
 # =============================================================================
@@ -214,13 +311,13 @@ fi
 bin="${RUNTIMES_BASE_PATH}/${runtime}/${cmd}"
 
 if [[ ! -f "$bin" ]]; then
-  echo "mina-dispatch ERROR: binary not found: $bin" >&2
-  exit 127
+  dispatch_fail 127 binary_not_found \
+    "mina-dispatch ERROR: binary not found: $bin"
 fi
 
 if [[ ! -x "$bin" ]]; then
-  echo "mina-dispatch ERROR: binary not executable: $bin" >&2
-  exit 127
+  dispatch_fail 127 binary_not_executable \
+    "mina-dispatch ERROR: binary not executable: $bin"
 fi
 
 # =============================================================================
@@ -230,8 +327,8 @@ fi
 if [[ "$cmd" == "mina" ]]; then
   helper="${RUNTIMES_BASE_PATH}/${runtime}/coda-libp2p_helper"
   if [[ ! -x "$helper" ]]; then
-    echo "mina-dispatch ERROR: coda-libp2p_helper not found or not executable: $helper" >&2
-    exit 127
+    dispatch_fail 127 libp2p_helper_not_found \
+      "mina-dispatch ERROR: coda-libp2p_helper not found or not executable: $helper"
   fi
   export "${MINA_LIBP2P_ENVVAR_NAME}=${helper}"
 fi
@@ -270,10 +367,20 @@ else
   args=()
 fi
 
+if [[ -z "$first_arg" ]]; then
+  if [[ "$MINA_DISPATCHER_JSON" -ne 0 ]]; then
+    dispatch_fail 1 no_subcommand \
+      "mina-dispatch ERROR: no subcommand provided for automatic hardfork handling"
+  fi
+  echo "mina-dispatch ERROR: no subcommand provided for automatic hardfork handling" >&2
+  print_argument_warning
+  exit 1
+fi
+
 if [[ "$first_arg" == "--version" || "$first_arg" == "-version" ]]; then
   # Pass --version directly to the binary without argument processing
-  if [[ "${MINA_DISPATCHER_DRYRUN:-0}" -ne 0 ]]; then
-    echo "mina-dispatch DRYRUN: exec $bin $first_arg" >&2
+  if dryrun_active; then
+    emit_dryrun "$runtime" "$bin" "$first_arg"
     exit 0
   fi
   exec "$bin" "$first_arg"
@@ -287,8 +394,8 @@ if [[ "$first_arg" == "client" ]]; then
   # correct runtime binary instead of unconditionally using mesa.
   runtime="mesa"
   bin="${RUNTIMES_BASE_PATH}/${runtime}/${cmd}"
-  if [[ "${MINA_DISPATCHER_DRYRUN:-0}" -ne 0 ]]; then
-    echo "mina-dispatch DRYRUN: exec $bin ${args[*]}" >&2
+  if dryrun_active; then
+    emit_dryrun "$runtime" "$bin" "${args[@]}"
     exit 0
   fi
   exec "$bin" "${args[@]}"
@@ -309,6 +416,10 @@ if [[ "$first_arg" == "libp2p" ]]; then
 fi
 
 if [[ "$first_arg" != "daemon" ]]; then
+  if [[ "$MINA_DISPATCHER_JSON" -ne 0 ]]; then
+    dispatch_fail 1 unsupported_subcommand \
+      "mina-dispatch ERROR: unsupported subcommand '$first_arg' for automatic hardfork handling"
+  fi
   echo "mina-dispatch ERROR: unsupported subcommand '${first_arg:-<none>}' for automatic hardfork handling" >&2
   echo "  Only 'daemon' is rewritten; 'libp2p', 'client' and '--version' are passed through." >&2
   echo "  To run any other subcommand against a specific runtime, call the binary directly:" >&2
@@ -367,10 +478,10 @@ if [[ "$runtime" == "mesa" ]]; then
           # Compare as normalized paths, not raw strings, so that equivalent
           # spellings (trailing slash, "." / ".." segments) are accepted.
           if [[ "$(normalize_path "$provided_dir")" != "$(normalize_path "$MINA_HARDFORK_STATE_DIR")" ]]; then
-            echo "mina-dispatch ERROR: Discrepancy between provided --config-directory ($provided_dir) and expected ($MINA_HARDFORK_STATE_DIR)" >&2
-            echo " Those must match for auto hardfork mode correct behavior." >&2
-            echo " Please adjust your invocation accordingly." >&2
-            exit 1
+            dispatch_fail 1 config_directory_discrepancy \
+              "mina-dispatch ERROR: Discrepancy between provided --config-directory ($provided_dir) and expected ($MINA_HARDFORK_STATE_DIR)" \
+              " Those must match for auto hardfork mode correct behavior." \
+              " Please adjust your invocation accordingly."
           fi
         fi
         new_args+=("$arg")
@@ -453,13 +564,9 @@ fi
 # =============================================================================
 
 
-# DRYRUN: If set, print the exec command and exit
-if [[ "${MINA_DISPATCHER_DRYRUN:-0}" -ne 0 ]]; then
-  if [[ ${#args[@]} -gt 0 ]]; then
-    echo "mina-dispatch DRYRUN: exec $bin ${args[*]}" >&2
-  else
-    echo "mina-dispatch DRYRUN: exec $bin" >&2
-  fi
+# DRYRUN / JSON: describe the command instead of executing it, then exit.
+if dryrun_active; then
+  emit_dryrun "$runtime" "$bin" "${args[@]}"
   exit 0
 fi
 
@@ -469,18 +576,10 @@ if [[ ${#args[@]} -gt 0 ]]; then
   if [[ "$MINA_DISPATCHER_DEBUG" -ne 0 ]]; then
     echo "DEBUG: Executing $bin with arguments: ${args[*]}" >&2
   fi
-  if [[ "${MINA_DISPATCHER_DRYRUN}" -ne 0 ]]; then
-    echo "$bin ${args[*]}"
-  else
-    exec "$bin" "${args[@]}"
-  fi
+  exec "$bin" "${args[@]}"
 else
   if [[ "$MINA_DISPATCHER_DEBUG" -ne 0 ]]; then
     echo "DEBUG: Executing $bin with no arguments" >&2
   fi
-  if [[ "${MINA_DISPATCHER_DRYRUN}" -ne 0 ]]; then
-    echo "$bin"
-  else
-    exec "$bin"
-  fi
+  exec "$bin"
 fi


### PR DESCRIPTION
PR Normalizes a filesystem path for comparison purposes. Collapses trailing slashes, "." / ".." segments and (for any existing prefix) symlinks, so that paths that point to the same location compare equal even when written differently (e.g. "/a/b", "/a/b/", "/a/./b").

added new `normalize_path`function which prepares input path before comparison:

`if [[ "$(normalize_path "$provided_dir")" != "$(normalize_path "$MINA_HARDFORK_STATE_DIR")" ]]; then`

Added tests for coverage