### PR TITLE
Fix discrepancy between standard docker and automode per mina exec

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon-auto-hardfork
+++ b/dockerfiles/Dockerfile-mina-daemon-auto-hardfork
@@ -103,6 +103,10 @@ RUN chmod +x /mina_daemon_puppeteer.py /find_puppeteer.sh /start.sh /stop.sh
 ENV MINA_TIME_OFFSET 0
 
 ENV MINA_HARDFORK_STATE_DIR /root/.mina-config
-ENV MINA_APP /usr/local/bin/mina-dispatch
+
+# MINA_APP is intentionally left unset: daemon-entrypoint.sh defaults to bare
+# `mina`, which PATH-resolves to /usr/local/bin/mina (the mina-dispatch symlink).
+# Invoking via the `mina` symlink keeps the dispatcher out of its direct-invocation
+# (debugging) mode, so `docker run <img> daemon ...` / `--version` work as expected.
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]


### PR DESCRIPTION
Unify mina command run for standard and automode docker. Before: 

Standard mina daemon:
```
@:~/work/minaprotocol/mina$ docker run  gcr.io/o1labs-192920/mina-daemon:3.4.0-alpha1-11401cc-noble-mesa-mut  --version
Commit 11401ccfc661c1c4ca6fc98112bef6cafd696ce5
Mina process exited with status code 0
```

Automode:
```
@:~/work/minaprotocol/mina$ docker run  gcr.io/o1labs-192920/mina-daemon-auto-hardfork:4.0.0-rc1-mesa-mut-c4a5a6b-noble-mesa-mut  --version
Mina process exited with status code 127
```

Workaround is to add `mina` before --version. However, this make BP lives harder as they need to handle different mina exec depending on hardfork style. 

After the change automode docker will behave in a same  manner from command line perspective