### PR TITLE
Change debian deps descriptor. Require more strict version dependency

### DIFF
--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -148,13 +148,7 @@ ORIG_AUTOMODE_DEB=$(ls "${DEB_DIR}"/${PKG_AUTOMODE}_*.deb | head -1)
 ORIG_CONFIG_DEB=$(ls "${DEB_DIR}"/${PKG_CONFIG}_*.deb | head -1)
 ORIG_POSTFORK_DEB=$(ls "${DEB_DIR}"/${PKG_POSTFORK}_*.deb | head -1)
 ORIG_LOGPROC_DEB=$(ls "${DEB_DIR}"/mina-logproc_*.deb | head -1)
-
-# The prefork debs come from the legacy cache at their original versions.
-# Copy all of them into the repo — no reversioning needed since the automode
-# metapackage already references the legacy version in its dependency.
-# We must include all variants so the correct one satisfying the dependency
-# constraint (>= PREFORK_LEGACY_VERSION) is available.
-cp "${DEB_DIR}"/${PKG_PREFORK}_*.deb "${REPO_DIR}/"
+ORIG_PREFORK_DEB=$(ls "${DEB_DIR}"/${PKG_PREFORK}_*.deb | head -1)
 
 reversion_deb() {
     local input_deb="$1"
@@ -178,8 +172,26 @@ reversion_deb "${ORIG_DAEMON_DEB}"  "${V1}" "${REPO_DIR}/${PKG_DAEMON}_${V1}_amd
 reversion_deb "${ORIG_CONFIG_DEB}"  "${V1}" "${REPO_DIR}/${PKG_CONFIG}_${V1}_all.deb"
 reversion_deb "${ORIG_LOGPROC_DEB}" "${V1}" "${REPO_DIR}/mina-logproc_${V1}_amd64.deb"
 
+# The automode metapackage pins prefork to an EXACT version — the legacy
+# PREFORK_LEGACY_VERSION baked in at build time, which is NOT rewritten when the
+# metapackage is reversioned (deb-session-reversion only rewrites deps that
+# reference the package's own old version, i.e. postfork). The prefork deb in
+# the legacy cache may carry a different (newer) version, so we reversion it to
+# exactly the version the metapackage depends on, otherwise the '=' pin can't be
+# satisfied. Derive that version straight from the metapackage's Depends field.
+EXPECTED_PREFORK_VERSION=$(dpkg-deb -f "${ORIG_AUTOMODE_DEB}" Depends \
+    | tr ',' '\n' \
+    | sed -n "s/.*${PKG_PREFORK} *(= *\([^)]*\)).*/\1/p" \
+    | tr -d ' ')
+if [[ -z "${EXPECTED_PREFORK_VERSION}" ]]; then
+    log_error "Could not determine pinned prefork version from ${ORIG_AUTOMODE_DEB} Depends"
+    exit 1
+fi
+log_info "Automode pins ${PKG_PREFORK} to exact version: ${EXPECTED_PREFORK_VERSION}"
+reversion_deb "${ORIG_PREFORK_DEB}" "${EXPECTED_PREFORK_VERSION}" \
+    "${REPO_DIR}/${PKG_PREFORK}_${EXPECTED_PREFORK_VERSION}_amd64.deb"
+
 # V2: automode + postfork + config + logproc (hardfork)
-# Note: prefork is already in REPO_DIR from the legacy cache (not reversioned)
 reversion_deb "${ORIG_AUTOMODE_DEB}" "${V2}" "${REPO_DIR}/${PKG_AUTOMODE}_${V2}_all.deb"
 reversion_deb "${ORIG_POSTFORK_DEB}" "${V2}" "${REPO_DIR}/${PKG_POSTFORK}_${V2}_amd64.deb"
 reversion_deb "${ORIG_CONFIG_DEB}"   "${V2}" "${REPO_DIR}/${PKG_CONFIG}_${V2}_all.deb"

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -163,6 +163,18 @@ reversion_deb() {
     rm -rf "${session_dir}"
 }
 
+# Extract the exact ('=') version a deb pins a given dependency to.
+# dpkg exposes whole control fields (dpkg-deb -f Depends) but has no built-in
+# way to pull out the version constraint of a single dependency, so we split the
+# comma-separated Depends list and read the "pkg (= version)" entry ourselves.
+dep_pinned_version() {
+    local deb="$1" pkg="$2"
+    dpkg-deb -f "${deb}" Depends \
+        | tr ',' '\n' \
+        | sed -n "s/.*${pkg} *(= *\([^)]*\)).*/\1/p" \
+        | tr -d ' '
+}
+
 V1="1.0.0-transition-test"
 V2="2.0.0-transition-test"
 V3="3.0.0-transition-test"
@@ -179,15 +191,11 @@ reversion_deb "${ORIG_LOGPROC_DEB}" "${V1}" "${REPO_DIR}/mina-logproc_${V1}_amd6
 # the legacy cache may carry a different (newer) version, so we reversion it to
 # exactly the version the metapackage depends on, otherwise the '=' pin can't be
 # satisfied. Derive that version straight from the metapackage's Depends field.
-EXPECTED_PREFORK_VERSION=$(dpkg-deb -f "${ORIG_AUTOMODE_DEB}" Depends \
-    | tr ',' '\n' \
-    | sed -n "s/.*${PKG_PREFORK} *(= *\([^)]*\)).*/\1/p" \
-    | tr -d ' ')
+EXPECTED_PREFORK_VERSION=$(dep_pinned_version "${ORIG_AUTOMODE_DEB}" "${PKG_PREFORK}")
 if [[ -z "${EXPECTED_PREFORK_VERSION}" ]]; then
     log_error "Could not determine pinned prefork version from ${ORIG_AUTOMODE_DEB} Depends"
     exit 1
 fi
-log_info "Automode pins ${PKG_PREFORK} to exact version: ${EXPECTED_PREFORK_VERSION}"
 reversion_deb "${ORIG_PREFORK_DEB}" "${EXPECTED_PREFORK_VERSION}" \
     "${REPO_DIR}/${PKG_PREFORK}_${EXPECTED_PREFORK_VERSION}_amd64.deb"
 

--- a/buildkite/scripts/tests/debian-automode-transition-test.sh
+++ b/buildkite/scripts/tests/debian-automode-transition-test.sh
@@ -196,6 +196,12 @@ if [[ -z "${EXPECTED_PREFORK_VERSION}" ]]; then
     log_error "Could not determine pinned prefork version from ${ORIG_AUTOMODE_DEB} Depends"
     exit 1
 fi
+
+# Report exactly which version we pin to, alongside the legacy cache deb's own
+# version, so the reversion is auditable. When the two already match the
+# reversion is a no-op; otherwise it aligns the legacy deb with the '=' pin.
+LEGACY_PREFORK_VERSION=$(dpkg-deb -f "${ORIG_PREFORK_DEB}" Version)
+log_info "Automode pins ${PKG_PREFORK} to exact version: ${EXPECTED_PREFORK_VERSION} (legacy cache deb is ${LEGACY_PREFORK_VERSION})"
 reversion_deb "${ORIG_PREFORK_DEB}" "${EXPECTED_PREFORK_VERSION}" \
     "${REPO_DIR}/${PKG_PREFORK}_${EXPECTED_PREFORK_VERSION}_amd64.deb"
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -575,7 +575,7 @@ build_daemon_deb() {
       ;;
   esac
 
-  create_control_file "${package_name}" "${SHARED_DEPS}${DAEMON_DEPS}, mina-${network}-config (>=${MINA_DEB_VERSION})" \
+  create_control_file "${package_name}" "${SHARED_DEPS}${DAEMON_DEPS}, mina-${network}-config (=${MINA_DEB_VERSION})" \
     'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}" "mina-${network} (<< ${MINA_DEB_VERSION}), mina-${network}-postfork-${POSTFORK_CODENAME}"
 
   copy_common_daemon_apps "${network}"
@@ -781,7 +781,7 @@ build_daemon_automode_deb() {
   local prefork_pkg="mina-${network}-prefork-${POSTFORK_CODENAME}"
   local postfork_pkg="mina-${network}-postfork-${POSTFORK_CODENAME}"
   local prefork_version="${PREFORK_LEGACY_VERSION:-${MINA_DEB_VERSION}}"
-  local depends="${postfork_pkg} (>= ${MINA_DEB_VERSION}), ${prefork_pkg} (>= ${prefork_version})"
+  local depends="${postfork_pkg} (=${MINA_DEB_VERSION}), ${prefork_pkg} (=${prefork_version})"
 
   create_control_file "${package_name}" "${depends}" \
     "Transitional metapackage for Mina ${network} automode (installs both prefork and postfork runtimes)" \

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -590,7 +590,6 @@ test_build_daemon_mainnet_deb() {
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "libffi7"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "libjemalloc2"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-logproc"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-config"
     # Config dependency is pinned to the exact build version
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-config (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Suggests" "jq"
@@ -642,7 +641,6 @@ test_build_daemon_devnet_deb() {
     load_captured_state
     assert_eq "deb name" "mina-devnet" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-config"
     # Config dependency is pinned to the exact build version
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-config (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-logproc"
@@ -817,8 +815,6 @@ test_build_daemon_devnet_automode_deb() {
     assert_eq "deb name" "mina-devnet-automode" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet-automode"
     assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa"
     # Prefork/postfork runtimes are pinned to the exact build version
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa (=${EXPECTED_VERSION})"
@@ -838,8 +834,6 @@ test_build_daemon_mainnet_automode_deb() {
     assert_eq "deb name" "mina-mainnet-automode" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-mainnet-automode"
     assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa"
-    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa"
     # Prefork/postfork runtimes are pinned to the exact build version
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa (=${EXPECTED_VERSION})"

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -591,6 +591,8 @@ test_build_daemon_mainnet_deb() {
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "libjemalloc2"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-logproc"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-config"
+    # Config dependency is pinned to the exact build version
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-config (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Suggests" "jq"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-mainnet"
     assert_control_has_field "$CAPTURED_CONTROL" "Breaks"
@@ -641,6 +643,8 @@ test_build_daemon_devnet_deb() {
     assert_eq "deb name" "mina-devnet" "$CAPTURED_DEB_NAME"
     assert_control_field "$CAPTURED_CONTROL" "Package" "mina-devnet"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-config"
+    # Config dependency is pinned to the exact build version
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-config (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-logproc"
     assert_control_contains "$CAPTURED_CONTROL" "Suggests" "jq"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-devnet"
@@ -815,6 +819,9 @@ test_build_daemon_devnet_automode_deb() {
     assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa"
+    # Prefork/postfork runtimes are pinned to the exact build version
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-postfork-mesa (=${EXPECTED_VERSION})"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-devnet-prefork-mesa (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-devnet"
     assert_control_contains "$CAPTURED_CONTROL" "Breaks" "mina-devnet"
     assert_control_contains "$CAPTURED_CONTROL" "Provides" "mina-devnet"
@@ -833,6 +840,9 @@ test_build_daemon_mainnet_automode_deb() {
     assert_control_field "$CAPTURED_CONTROL" "Architecture" "amd64"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa"
     assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa"
+    # Prefork/postfork runtimes are pinned to the exact build version
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-postfork-mesa (=${EXPECTED_VERSION})"
+    assert_control_contains "$CAPTURED_CONTROL" "Depends" "mina-mainnet-prefork-mesa (=${EXPECTED_VERSION})"
     assert_control_contains "$CAPTURED_CONTROL" "Replaces" "mina-mainnet"
     assert_control_contains "$CAPTURED_CONTROL" "Breaks" "mina-mainnet"
     assert_control_contains "$CAPTURED_CONTROL" "Provides" "mina-mainnet"


### PR DESCRIPTION
Changing how debians are resolving dependency for daemon and automode. Before dependency was relaxed, using >=. That cause problem since we are abusing semver syntax for our debians. There were cases that older version of dep was pulled instead of expected (with the same version as caller).

PR fixes this ambiguity and introduce strict dependency resolution. Version with the very same version would be pulled.

FIxing gaps in testing for this behavior