### PR TITLE
dispatcher: imply --hardfork-handling migrate-exit in automode package

### DIFF
--- a/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
+++ b/buildkite/scripts/tests/hardfork/dispatcher-tests.sh
@@ -367,6 +367,57 @@ fi
 echo "PASSED: client subcommand uses mesa runtime"
 
 # =============================================================================
+# Test 9: Berkeley Daemon Always Runs In migrate-exit Mode
+# =============================================================================
+
+echo ""
+echo "=== Test 9: Berkeley Daemon migrate-exit Injection ==="
+echo "Verifying that the pre-fork (berkeley) daemon always gets --hardfork-handling migrate-exit"
+
+# Without activation marker -> berkeley runtime
+MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
+  -c "mina daemon" 2>&1)
+
+if [[ "$MINA_EXEC_COMMAND" != *"/berkeley/mina daemon"* ]]; then
+  echo "FAILED: Expected berkeley runtime for daemon without activation marker"
+  echo "  Actual command: $MINA_EXEC_COMMAND"
+  exit 1
+fi
+
+if [[ "$MINA_EXEC_COMMAND" != *"--hardfork-handling migrate-exit"* ]]; then
+  echo "FAILED: berkeley daemon should have --hardfork-handling migrate-exit injected"
+  echo "  Actual command: $MINA_EXEC_COMMAND"
+  exit 1
+fi
+
+echo "PASSED: berkeley daemon runs in migrate-exit mode"
+
+# =============================================================================
+# Test 10: Berkeley Daemon Respects User-Provided hardfork-handling
+# =============================================================================
+
+echo ""
+echo "=== Test 10: Berkeley Daemon hardfork-handling Respected ==="
+echo "Verifying that a user-provided --hardfork-handling value is left untouched"
+
+MINA_EXEC_COMMAND=$(docker run --env MINA_DISPATCHER_DRYRUN=1 --entrypoint bash "$DOCKER_IMAGE" \
+  -c "mina daemon --hardfork-handling keep-running" 2>&1)
+
+if [[ "$MINA_EXEC_COMMAND" != *"--hardfork-handling keep-running"* ]]; then
+  echo "FAILED: user-provided --hardfork-handling keep-running should be preserved"
+  echo "  Actual command: $MINA_EXEC_COMMAND"
+  exit 1
+fi
+
+if [[ "$MINA_EXEC_COMMAND" == *"--hardfork-handling migrate-exit"* ]]; then
+  echo "FAILED: migrate-exit must not be injected when user provided their own value"
+  echo "  Actual command: $MINA_EXEC_COMMAND"
+  exit 1
+fi
+
+echo "PASSED: user-provided hardfork-handling left untouched"
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/scripts/hardfork/dispatcher.sh
+++ b/scripts/hardfork/dispatcher.sh
@@ -28,12 +28,17 @@
 #   - MINA_HARDFORK_STATE_DIR absent  -> berkeley runtime (pre-hardfork)
 #   - MINA_HARDFORK_STATE_DIR present -> mesa runtime (post-hardfork)
 #
-# ARGUMENT PROCESSING (mesa runtime only):
+# ARGUMENT PROCESSING (mesa runtime, daemon only):
 #   - "-config-file <path>" is KEPT and MESA_CONFIG is appended as the last -config-file
 #   - "--genesis-ledger-dir <path>" is rewritten to use MESA_LEDGERS_DIR
 #   - "--hardfork-handling <value>" is REMOVED (not supported in mesa)
 #   - If --genesis-ledger-dir is not provided, it is appended with MESA_LEDGERS_DIR
 #   - Auto-hardfork daemon config (-config-file MESA_CONFIG) is always appended last
+#
+# ARGUMENT PROCESSING (berkeley runtime, daemon only):
+#   - If "--hardfork-handling" is not provided, "--hardfork-handling migrate-exit"
+#     is appended (installing the automode package implies automode). If the user
+#     provides their own "--hardfork-handling", arguments are left untouched.
 #
 # REQUIRED ENVIRONMENT (via SOURCE_FILE):
 #   MINA_NETWORK          - Network identifier (e.g., mainnet, devnet)
@@ -395,6 +400,27 @@ if [[ "$runtime" == "mesa" ]]; then
   fi
   # Replace args with the processed continuous array
   args=("${new_args[@]}")
+elif [[ "$first_arg" == "daemon" ]]; then
+  # Berkeley (pre-fork) runtime. The automode package runs the pre-fork daemon
+  # in migrate-exit mode by default: installing the automode package implies
+  # automode, so there is no reason to make users pass --hardfork-handling
+  # themselves (see https://github.com/MinaProtocol/MIPs/pull/32).
+  #
+  # If the user explicitly passes --hardfork-handling we assume they know what
+  # they are doing and leave the arguments untouched.
+  has_hardfork_handling=false
+  for arg in "${args[@]}"; do
+    if [[ "$arg" == "--hardfork-handling" || "$arg" == "-hardfork-handling" ]]; then
+      has_hardfork_handling=true
+      break
+    fi
+  done
+
+  if [[ "$has_hardfork_handling" == false ]]; then
+    args+=("--hardfork-handling" "migrate-exit")
+  elif [[ "$MINA_DISPATCHER_DEBUG" -ne 0 ]]; then
+    echo "mina-dispatch INFO: User-provided --hardfork-handling detected; leaving it untouched" >&2
+  fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Installing the automode package implies you intend to run in automode — so the dispatcher should not require users to pass `--hardfork-handling migrate-exit` themselves (per discussion with George).

The dispatcher now, for the **berkeley (pre-fork) `daemon`** path:
- appends `--hardfork-handling migrate-exit` when the user did **not** provide `--hardfork-handling`;
- leaves the arguments **untouched** when the user provided their own `--hardfork-handling` value (we assume they know what they're doing).

The mesa (post-fork) path is unchanged — it still strips `--hardfork-handling` since the post-fork binary does not support it.

## Changes
- `scripts/hardfork/dispatcher.sh`: berkeley `daemon` branch injects `migrate-exit` only when absent; header doc updated with the berkeley argument-processing rule. An informational note is logged only under `MINA_DISPATCHER_DEBUG`.
- `buildkite/scripts/tests/hardfork/dispatcher-tests.sh`:
  - Test 9 — berkeley daemon with no flag gets `--hardfork-handling migrate-exit` injected.
  - Test 10 — user-provided `--hardfork-handling keep-running` is preserved (no override, no duplicate).

## Testing
- `bash -n` and `shellcheck` clean (only the pre-existing annotated SC1091 on the `source` line).
- Local DRYRUN smoke test confirms: no-flag → injected; `keep-running` → preserved; `migrate-exit` → preserved, no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)