### PR TITLE
ci: run bare-able benches from apps-cache binaries (drop .deb)

### DIFF
--- a/buildkite/scripts/apps/restore_app.sh
+++ b/buildkite/scripts/apps/restore_app.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Restore a single freshly-built application binary from the namespaced apps CI
+# cache (written by buildkite/scripts/apps/write_to_cache.sh) and install it on
+# PATH under a chosen name -- mirroring the layout a .deb would provide, so
+# callers invoke the tool identically whether it came from the cache or a
+# package.
+#
+# Usage: restore_app.sh <network> <exe> <install-as>
+#   network    : devnet | mainnet | mesa  (selects the default build profile)
+#   exe        : the .exe filename in the cache, e.g. runtime_genesis_ledger.exe
+#   install-as : the name to install it under on PATH, e.g. mina-create-genesis
+#
+# The cache location is derived from the build identity, so callers don't repeat
+# the variant string:
+#   apps/<codename>/<network>-<profile>[-instrumented][-arm64]/<exe>
+# with
+#   codename : $MINA_DEB_CODENAME (default bullseye)
+#   profile  : $APPS_PROFILE      (default: devnet/mesa -> devnet, mainnet -> mainnet)
+#   flag     : $APPS_BUILD_FLAG   ("instrumented" appends -instrumented; default none)
+#   arch     : $APPS_ARCH         ("arm64" appends -arm64; default amd64)
+#
+# Installs to ${MINA_BIN_DIR:-/usr/local/bin}/<install-as> (using sudo when not
+# root). Exits non-zero without side effects if not in Buildkite context or the
+# binary is not cached, so callers can fall back to installing the .deb.
+
+set -eo pipefail
+
+NETWORK=$1
+EXE=$2
+INSTALL_AS=$3
+
+if [[ -z "$NETWORK" || -z "$EXE" || -z "$INSTALL_AS" ]]; then
+  echo "Usage: $0 <network> <exe> <install-as>" >&2
+  exit 1
+fi
+
+if [[ ! -v BUILDKITE_BUILD_ID ]]; then
+  echo "restore_app: not in Buildkite context" >&2
+  exit 1
+fi
+
+case "$NETWORK" in
+  devnet | mesa) default_profile=devnet ;;
+  mainnet) default_profile=mainnet ;;
+  *)
+    echo "restore_app: unknown network '$NETWORK'" >&2
+    exit 1
+    ;;
+esac
+
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
+PROFILE="${APPS_PROFILE:-$default_profile}"
+
+flag_seg=""
+[[ "${APPS_BUILD_FLAG:-}" == "instrumented" ]] && flag_seg="-instrumented"
+arch_seg=""
+[[ "${APPS_ARCH:-amd64}" == "arm64" ]] && arch_seg="-arm64"
+
+VARIANT="${NETWORK}-${PROFILE}${flag_seg}${arch_seg}"
+BIN_DIR="${MINA_BIN_DIR:-/usr/local/bin}"
+
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$TMP_DIR" >&2; then
+  echo "restore_app: apps/${CODENAME}/${VARIANT}/${EXE} not found in cache" >&2
+  exit 1
+fi
+
+$SUDO install -D -m 0755 "${TMP_DIR}/${EXE}" "${BIN_DIR}/${INSTALL_AS}"
+echo "restore_app: installed ${EXE} as ${BIN_DIR}/${INSTALL_AS}" >&2

--- a/buildkite/scripts/apps/restore_binary.sh
+++ b/buildkite/scripts/apps/restore_binary.sh
@@ -7,19 +7,12 @@
 #
 # Usage: restore_binary.sh <network>      (network: devnet | mainnet | mesa)
 #
-# The cache location is derived from the build identity, so callers don't repeat
-# the variant string:
-#   apps/<codename>/<network>-<profile>[-instrumented][-arm64]/mina_<sig>_signatures.exe
-# with
-#   codename : $MINA_DEB_CODENAME (default bullseye)
-#   profile  : $APPS_PROFILE      (default: devnet/mesa -> devnet, mainnet -> mainnet)
-#   flag     : $APPS_BUILD_FLAG   ("instrumented" appends -instrumented; default none)
-#   arch     : $APPS_ARCH         ("arm64" appends -arm64; default amd64)
-#   sig      : devnet/mesa -> testnet, mainnet -> mainnet
-# The signature-specific binary is installed as plain `mina`, so client scripts
-# never deal with the variant or the signature name.
+# This is a thin convenience wrapper over restore_app.sh: it maps the network to
+# the signature-specific binary name and installs it as the plain `mina`, so
+# client scripts never deal with the variant or the signature name. The cache
+# location (codename/profile/flag/arch) is derived from the build identity by
+# restore_app.sh -- see its header for the env knobs.
 #
-# Installs to ${MINA_BIN_DIR:-/usr/local/bin}/mina (using sudo when not root).
 # Exits non-zero without side effects if not in Buildkite context or the binary
 # is not cached, so callers can fall back to installing the .deb.
 
@@ -32,44 +25,13 @@ if [[ -z "$NETWORK" ]]; then
   exit 1
 fi
 
-if [[ ! -v BUILDKITE_BUILD_ID ]]; then
-  echo "restore_binary: not in Buildkite context" >&2
-  exit 1
-fi
-
 case "$NETWORK" in
-  devnet | mesa) sig=testnet ; default_profile=devnet ;;
-  mainnet) sig=mainnet ; default_profile=mainnet ;;
+  devnet | mesa) sig=testnet ;;
+  mainnet) sig=mainnet ;;
   *)
     echo "restore_binary: unknown network '$NETWORK'" >&2
     exit 1
     ;;
 esac
 
-CODENAME="${MINA_DEB_CODENAME:-bullseye}"
-PROFILE="${APPS_PROFILE:-$default_profile}"
-
-flag_seg=""
-[[ "${APPS_BUILD_FLAG:-}" == "instrumented" ]] && flag_seg="-instrumented"
-arch_seg=""
-[[ "${APPS_ARCH:-amd64}" == "arm64" ]] && arch_seg="-arm64"
-
-VARIANT="${NETWORK}-${PROFILE}${flag_seg}${arch_seg}"
-EXE="mina_${sig}_signatures.exe"
-BIN_DIR="${MINA_BIN_DIR:-/usr/local/bin}"
-
-SUDO=""
-if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
-  SUDO="sudo"
-fi
-
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$TMP_DIR" >&2; then
-  echo "restore_binary: apps/${CODENAME}/${VARIANT}/${EXE} not found in cache" >&2
-  exit 1
-fi
-
-$SUDO install -D -m 0755 "${TMP_DIR}/${EXE}" "${BIN_DIR}/mina"
-echo "restore_binary: installed ${EXE} as ${BIN_DIR}/mina" >&2
+exec ./buildkite/scripts/apps/restore_app.sh "$NETWORK" "mina_${sig}_signatures.exe" mina

--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -7,25 +7,23 @@ RED_THRESHOLD="0.3"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 BRANCH="${BRANCH:-BUILDKITE_BRANCH}"
 
-source buildkite/scripts/bench/install.sh
-
 MAINLINE_BRANCHES="-m develop -m compatible -m master -m dkijania/bench_for_ledger_test"
 while [[ "$#" -gt 0 ]]; do case $1 in
   heap-usage) BENCHMARK="heap-usage"; ;;
   mina-base) BENCHMARK="mina-base"; ;;
-  archive) 
-    BENCHMARK="archive"; 
-    EXTRA_ARGS="--no-run ${EXTRA_ARGS}" 
+  archive)
+    BENCHMARK="archive";
+    EXTRA_ARGS="--no-run ${EXTRA_ARGS}"
 
   ;;
-  ledger-export) 
+  ledger-export)
     BENCHMARK="ledger-export"
     EXTRA_ARGS="--genesis-ledger-path ./genesis_ledgers/devnet.json"
   ;;
-  ledger-apply) 
+  ledger-apply)
     BENCHMARK="ledger-apply"
   ;;
-  snark) 
+  snark)
     BENCHMARK="snark";
     K=1
     MAX_NUM_UPDATES=4
@@ -37,5 +35,35 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --red-threshold) RED_THRESHOLD="$2"; shift;;
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
+
+# The mina-base, heap-usage and zkapp micro-benchmarks each invoke a single
+# self-contained test-suite executable with no genesis ledger, /etc/mina config
+# or network -- so the freshly-built bare binary from the apps cache is enough,
+# no .deb required. Map each to its cached exe and the name the python harness
+# expects on PATH (mirroring what mina-test-suite installs). The other benches
+# (archive: postgres DB; ledger-export/snark: genesis payload) still need the
+# package, and any cache miss falls back to it too.
+case "$BENCHMARK" in
+  mina-base)  BARE_EXE=benchmarks.exe;   BARE_AS=mina-benchmarks ;;
+  heap-usage) BARE_EXE=heap_usage.exe;   BARE_AS=mina-heap-usage ;;
+  zkapp)      BARE_EXE=zkapp_limits.exe; BARE_AS=mina-zkapp-limits ;;
+  *)          BARE_EXE="" ;;
+esac
+
+INSTALLED_BARE=false
+if [[ -n "$BARE_EXE" ]]; then
+  git config --global --add safe.directory /workdir
+  source buildkite/scripts/export-git-env-vars.sh
+
+  if ./buildkite/scripts/apps/restore_app.sh devnet "$BARE_EXE" "$BARE_AS"; then
+    echo "Using bare $BARE_AS from apps cache (no .deb needed)"
+    pip3 install -r scripts/benchmarks/requirements.txt
+    INSTALLED_BARE=true
+  fi
+fi
+
+if [[ "$INSTALLED_BARE" == false ]]; then
+  source buildkite/scripts/bench/install.sh
+fi
 
 python3 ./scripts/benchmarks test --benchmark ${BENCHMARK}  --branch ${BRANCH} --tmpfile ${BENCHMARK}.csv --yellow-threshold $YELLOW_THRESHOLD --red-threshold $RED_THRESHOLD $MAINLINE_BRANCHES $EXTRA_ARGS

--- a/buildkite/scripts/tests/ledger_test_apply.sh
+++ b/buildkite/scripts/tests/ledger_test_apply.sh
@@ -6,10 +6,27 @@ git config --global --add safe.directory /workdir
 
 source buildkite/scripts/export-git-env-vars.sh
 
-source buildkite/scripts/debian/install.sh "mina-devnet-generic-instrumented" 1
+# `ledger test apply` builds its own throwaway genesis ledger from generated
+# accounts (mina ledger test generate-accounts -> mina-create-genesis ->
+# mina ledger test apply) and never touches the .deb's genesis payload or
+# /etc/mina config -- the deb-based path even deletes those config files below.
+# So the freshly-built bare binaries from the apps cache are sufficient. This
+# job depends on the instrumented build, so restore from that variant (and the
+# instrumented binaries still emit bisect_ppx coverage). Restore both the daemon
+# (`mina`) and the genesis tool (`mina-create-genesis`); fall back to the .deb if
+# either is unavailable.
+export APPS_BUILD_FLAG=instrumented
 
-echo "removing magic config files"
-sudo rm -f /var/lib/coda/config_*
+if ./buildkite/scripts/apps/restore_binary.sh devnet \
+  && ./buildkite/scripts/apps/restore_app.sh devnet runtime_genesis_ledger.exe mina-create-genesis; then
+  echo "Using bare mina + mina-create-genesis from apps cache"
+else
+  echo "Falling back to debian-installed mina"
+  source buildkite/scripts/debian/install.sh "mina-devnet-generic-instrumented" 1
+
+  echo "removing magic config files"
+  sudo rm -f /var/lib/coda/config_*
+fi
 
 ./scripts/tests/ledger_test_apply.sh \
     --mina-app mina \


### PR DESCRIPTION
## What

Converts the **bench jobs that only need a binary** to run from the freshly-built bare executables in the apps CI cache, instead of installing debian packages. Continues the effort from #18910 / #18911 (VersionLint).

Benches converted:
- **LedgerApply** — builds its own throwaway genesis (`generate-accounts` → `mina-create-genesis` → `ledger test apply`), needs `mina` + `mina-create-genesis`.
- **mina-base / heap-usage / zkapp** — each invokes a single self-contained `mina-test-suite` exe (`benchmarks.exe` / `heap_usage.exe` / `zkapp_limits.exe`) with no genesis/config/network.

Left on the deb (genuinely need the package payload): **archive** (postgres DB), **ledger-export** / **snark** (genesis).

## How

- **New `buildkite/scripts/apps/restore_app.sh <network> <exe> <install-as>`** — generalized single-binary restore from the namespaced apps cache; holds the variant-derivation logic.
- **`restore_binary.sh`** becomes a thin `exec` wrapper over it (network→sig→`mina_<sig>_signatures.exe`, installed as `mina`). Existing callers (`version-linter.sh`, `dump-mina-type-shapes.sh`) behaviorally unchanged.
- **`ledger_test_apply.sh`** restores `mina` + `mina-create-genesis` from the **instrumented** variant (`APPS_BUILD_FLAG=instrumented`, so `bisect_ppx` coverage still works), `.deb` fallback on miss.
- **`bench/run.sh`** maps the three pure micro-benches to their single cached exe, restores it bare (deb fallback on miss), and leaves the other benches on `bench/install.sh`.

No Dhall change. `shellcheck -S warning` clean on all changed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)