### PR TITLE
ci: trim nightly to bullseye, run full distro matrix weekly

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnet.dhall
@@ -40,7 +40,6 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetDevnetArm64.dhall
@@ -40,7 +40,6 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnet.dhall
@@ -30,7 +30,6 @@ in  Pipeline.build
             , PipelineTag.Type.Docker
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDevnetLightnetArm64.dhall
@@ -33,7 +33,6 @@ in  Pipeline.build
             , PipelineTag.Type.Docker
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMainnetMainnet.dhall
@@ -42,7 +42,6 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , profile = Profiles.Type.Mainnet
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormMesaDevnet.dhall
@@ -40,8 +40,7 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , includeIf =
             [ Expr.Type.DescendantOf
                 { ancestor = MainlineBranch.Type.Mesa

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDevnetDevnet.dhall
@@ -30,8 +30,7 @@ in  Pipeline.build
             , Artifacts.Type.DaemonStorageToolbox
             ]
           , network = Network.Type.Devnet
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMainnetMainnet.dhall
@@ -42,7 +42,6 @@ in  Pipeline.build
             , PipelineTag.Type.Focal
             ]
           , profile = Profiles.Type.Mainnet
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalMesaDevnet.dhall
@@ -32,8 +32,7 @@ in  Pipeline.build
             , Artifacts.Type.CreatePreforkGenesis
             ]
           , network = Network.Type.Mesa
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyDevnetDevnet.dhall
@@ -39,7 +39,6 @@ in  Pipeline.build
             , PipelineTag.Type.Jammy
             ]
           , debVersion = DebianVersions.DebVersion.Jammy
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyMainnetMainnet.dhall
@@ -42,7 +42,6 @@ in  Pipeline.build
             , PipelineTag.Type.Jammy
             ]
           , profile = Profiles.Type.Mainnet
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyMesaDevnet.dhall
@@ -40,8 +40,7 @@ in  Pipeline.build
             , PipelineTag.Type.Jammy
             ]
           , debVersion = DebianVersions.DebVersion.Jammy
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , includeIf =
             [ Expr.Type.DescendantOf
                 { ancestor = MainlineBranch.Type.Mesa

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetDevnet.dhall
@@ -39,7 +39,6 @@ in  Pipeline.build
             , PipelineTag.Type.Noble
             ]
           , debVersion = DebianVersions.DebVersion.Noble
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDevnetLightnet.dhall
@@ -30,7 +30,6 @@ in  Pipeline.build
             , PipelineTag.Type.Docker
             ]
           , debVersion = DebianVersions.DebVersion.Noble
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMainnetMainnet.dhall
@@ -42,7 +42,6 @@ in  Pipeline.build
             ]
           , debVersion = DebianVersions.DebVersion.Noble
           , profile = Profiles.Type.Mainnet
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleMesaDevnet.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleMesaDevnet.dhall
@@ -39,8 +39,7 @@ in  Pipeline.build
             , PipelineTag.Type.Noble
             ]
           , debVersion = DebianVersions.DebVersion.Noble
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , includeIf =
             [ Expr.Type.DescendantOf
                 { ancestor = MainlineBranch.Type.Mesa

--- a/buildkite/src/Pipeline/Scope.dhall
+++ b/buildkite/src/Pipeline/Scope.dhall
@@ -1,9 +1,10 @@
 -- Scope defines pipeline run scope
 --
--- Scope of the pipeline can be either PullRequest, Nightly, MainlineNightly or Release.
+-- Scope of the pipeline can be either PullRequest, Nightly, MainlineNightly, Weekly or Release.
 -- PullRequest - run pipeline for pull request
 -- Nightly - run pipeline for nightly changes
 -- MainlineNightly - run pipeline for mainline nightly changes
+-- Weekly - run pipeline for the weekly full-matrix sweep (all distros/dockers/debians)
 -- Release - run pipeline for release changes
 --
 -- Scope is used to determine which jobs should be run in the pipeline.
@@ -14,7 +15,7 @@ let Prelude = ../External/Prelude.dhall
 
 let Extensions = ../Lib/Extensions.dhall
 
-let Scope = < PullRequest | Nightly | MainlineNightly | Release >
+let Scope = < PullRequest | Nightly | MainlineNightly | Weekly | Release >
 
 let capitalName =
           \(scope : Scope)
@@ -22,6 +23,7 @@ let capitalName =
             { PullRequest = "PullRequest"
             , Nightly = "Nightly"
             , MainlineNightly = "MainlineNightly"
+            , Weekly = "Weekly"
             , Release = "Release"
             }
             scope
@@ -32,6 +34,7 @@ let lowerName =
             { PullRequest = "pullrequest"
             , Nightly = "nightly"
             , MainlineNightly = "mainlinenightly"
+            , Weekly = "weekly"
             , Release = "release"
             }
             scope
@@ -41,11 +44,17 @@ let join =
       ->  Extensions.join "," (Prelude.List.map Scope Text lowerName scopes)
 
 let Full =
-      [ Scope.PullRequest, Scope.Nightly, Scope.MainlineNightly, Scope.Release ]
+      [ Scope.PullRequest
+      , Scope.Nightly
+      , Scope.MainlineNightly
+      , Scope.Weekly
+      , Scope.Release
+      ]
 
 let PullRequestOnly = [ Scope.PullRequest ]
 
-let AllButPullRequest = [ Scope.Nightly, Scope.MainlineNightly, Scope.Release ]
+let AllButPullRequest =
+      [ Scope.Nightly, Scope.MainlineNightly, Scope.Weekly, Scope.Release ]
 
 in  { Type = Scope
     , Full = Full

--- a/buildkite/src/Pipeline/ScopeFilter.dhall
+++ b/buildkite/src/Pipeline/ScopeFilter.dhall
@@ -6,7 +6,13 @@ let Scope = ./Scope.dhall
 
 let Filter
     : Type
-    = < PullRequestOnly | StableOnly | Nightly | MainlineNightly | All >
+    = < PullRequestOnly
+      | StableOnly
+      | Nightly
+      | MainlineNightly
+      | Weekly
+      | All
+      >
 
 let scopes
     : Filter -> List Scope.Type
@@ -16,10 +22,12 @@ let scopes
             , StableOnly = [ Scope.Type.MainlineNightly, Scope.Type.Release ]
             , Nightly = [ Scope.Type.Nightly ]
             , MainlineNightly = [ Scope.Type.MainlineNightly ]
+            , Weekly = [ Scope.Type.Weekly ]
             , All =
               [ Scope.Type.PullRequest
               , Scope.Type.Nightly
               , Scope.Type.MainlineNightly
+              , Scope.Type.Weekly
               , Scope.Type.Release
               ]
             }
@@ -33,6 +41,7 @@ let show
             , StableOnly = "stableonly"
             , Nightly = "nightly"
             , MainlineNightly = "mainlinenightly"
+            , Weekly = "weekly"
             , All = "all"
             }
             filter


### PR DESCRIPTION
## What

Nightly currently rebuilds the **entire** debian/docker matrix across every distro (bookworm / focal / jammy / noble) on top of bullseye. With the build cache in place there's no degradation risk that justifies that nightly cadence — so this trims **nightly to bullseye only** and sweeps the rest **weekly**.

## How

- **New `Weekly` pipeline scope** (`Scope.dhall` + `ScopeFilter.dhall`). It's included in `Full` and `AllButPullRequest`, so bullseye / default-scoped jobs also run in the weekly sweep — i.e. **Weekly is the full-matrix superset** (all distros, all dockers, all debians).
- **Retag the 16 non-bullseye `MinaArtifact` jobs** from `[MainlineNightly, Release]` → `[Weekly, Release]`:
  - Bookworm ×6 (incl. arm64 + lightnet), Focal ×3, Jammy ×3, Noble ×4.
  - They no longer run nightly; they run weekly and on release (unchanged).
  - **Bullseye stays nightly** (`MinaArtifactBullseyeMainnetMainnet` keeps `MainlineNightly`; bullseye devnet uses the default `Full` scope).
- Only build jobs move. All other currently-nightly jobs (ChainId/Connect/Rosetta mainnet tests, automode-transition, toolchain-cache-validation) are unchanged — they run on bullseye.

## Verification

- `make all` in `buildkite/` passes (37/37 monorepo-checker tests).
- `dhall type` clean on `Scope.dhall`, `ScopeFilter.dhall`, `Prepare.dhall`, `JobSpec.dhall`, and a converted job. Only `Scope.dhall`/`ScopeFilter.dhall` `merge` over the scope union, both updated exhaustively.

## ⚠️ Follow-up (not in this PR — Buildkite UI)

A **scheduled build (cron)** must be created in the Buildkite pipeline settings with `BUILDKITE_PIPELINE_SCOPE=Weekly` (e.g. weekly, `BUILDKITE_PIPELINE_FILTER=LongOnly`) to actually drive the weekly sweep. Until that schedule exists, the non-bullseye matrix runs only on release. The nightly schedule needs no change — it already targets `MainlineNightly`, which is now bullseye-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)