### PR TITLE
ci: run chain-id test from bare binary + replicated genesis config

### DIFF
--- a/buildkite/scripts/apps/restore_daemon_config.sh
+++ b/buildkite/scripts/apps/restore_daemon_config.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Reproduce the daemon *config* package's payload for a network from the in-repo
+# genesis ledger, so callers get the same /var/lib/coda layout a .deb provides
+# without installing one. This is the config-side companion to restore_binary.sh
+# (which restores the daemon binary from the apps cache): together they let a
+# test run on the freshly-built binary + repo data instead of the package.
+#
+# Usage: restore_daemon_config.sh <network>      (network: devnet | mainnet | mesa)
+#
+# Mirrors copy_common_daemon_configs in scripts/debian/builder-helpers.sh: the
+# config package does no generation -- it just copies the in-repo
+# genesis_ledgers/<network>.json into /var/lib/coda as both
+#   - config_<GITHASH_CONFIG>.json  (the "magic" config the daemon auto-loads), and
+#   - <network>.json                (the named config passed via --config-file).
+# We copy the very same file to the very same paths, so the daemon resolves the
+# genesis ledger identically to the packaged case.
+#
+# GITHASH_CONFIG comes from buildkite/scripts/export-git-env-vars.sh; if it is
+# unset we still lay down the named config (the magic config is best-effort).
+# Target dir is ${MINA_CONFIG_DIR:-/var/lib/coda}; uses sudo when not root.
+
+set -eo pipefail
+
+NETWORK=$1
+
+if [[ -z "$NETWORK" ]]; then
+  echo "Usage: $0 <network>" >&2
+  exit 1
+fi
+
+case "$NETWORK" in
+  devnet | mainnet | mesa) ;;
+  *)
+    echo "restore_daemon_config: unknown network '$NETWORK'" >&2
+    exit 1
+    ;;
+esac
+
+SRC="genesis_ledgers/${NETWORK}.json"
+if [[ ! -f "$SRC" ]]; then
+  echo "restore_daemon_config: ${SRC} not found" >&2
+  exit 1
+fi
+
+CODA_DIR="${MINA_CONFIG_DIR:-/var/lib/coda}"
+
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+$SUDO mkdir -p "$CODA_DIR"
+$SUDO cp "$SRC" "${CODA_DIR}/${NETWORK}.json"
+
+if [[ -n "${GITHASH_CONFIG:-}" ]]; then
+  $SUDO cp "$SRC" "${CODA_DIR}/config_${GITHASH_CONFIG}.json"
+else
+  echo "restore_daemon_config: GITHASH_CONFIG unset, skipping magic config" >&2
+fi
+
+echo "restore_daemon_config: installed ${NETWORK} genesis config into ${CODA_DIR}" >&2

--- a/buildkite/scripts/apps/restore_daemon_config.sh
+++ b/buildkite/scripts/apps/restore_daemon_config.sh
@@ -16,9 +16,12 @@
 # We copy the very same file to the very same paths, so the daemon resolves the
 # genesis ledger identically to the packaged case.
 #
-# GITHASH_CONFIG comes from buildkite/scripts/export-git-env-vars.sh; if it is
-# unset we still lay down the named config (the magic config is best-effort).
-# Target dir is ${MINA_CONFIG_DIR:-/var/lib/coda}; uses sudo when not root.
+# The magic config is named after the build's git hash. We resolve it the same
+# way the deb build does (scripts/export-git-env-vars.sh): use GITHASH_CONFIG if
+# already exported (callers normally `source export-git-env-vars.sh` first), else
+# an explicit OVERRIDE_GITHASH, else derive it from HEAD -- so the hash is always
+# determined, never skipped. Target dir is ${MINA_CONFIG_DIR:-/var/lib/coda};
+# uses sudo when not root.
 
 set -eo pipefail
 
@@ -50,13 +53,17 @@ if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
-$SUDO mkdir -p "$CODA_DIR"
-$SUDO cp "$SRC" "${CODA_DIR}/${NETWORK}.json"
+# Resolve the build git hash exactly as export-git-env-vars.sh does, falling
+# back to HEAD so it is always defined (not best-effort).
+GITHASH_CONFIG="${GITHASH_CONFIG:-${OVERRIDE_GITHASH:-$(git rev-parse --short=8 --verify HEAD 2>/dev/null || true)}}"
 
-if [[ -n "${GITHASH_CONFIG:-}" ]]; then
-  $SUDO cp "$SRC" "${CODA_DIR}/config_${GITHASH_CONFIG}.json"
-else
-  echo "restore_daemon_config: GITHASH_CONFIG unset, skipping magic config" >&2
+if [[ -z "$GITHASH_CONFIG" ]]; then
+  echo "restore_daemon_config: could not determine GITHASH_CONFIG (set GITHASH_CONFIG/OVERRIDE_GITHASH, or run inside a git checkout)" >&2
+  exit 1
 fi
 
-echo "restore_daemon_config: installed ${NETWORK} genesis config into ${CODA_DIR}" >&2
+$SUDO mkdir -p "$CODA_DIR"
+$SUDO cp "$SRC" "${CODA_DIR}/${NETWORK}.json"
+$SUDO cp "$SRC" "${CODA_DIR}/config_${GITHASH_CONFIG}.json"
+
+echo "restore_daemon_config: installed ${NETWORK} genesis config (incl. config_${GITHASH_CONFIG}.json) into ${CODA_DIR}" >&2

--- a/buildkite/scripts/test-chain-id.sh
+++ b/buildkite/scripts/test-chain-id.sh
@@ -8,9 +8,23 @@ EXPECTED_CHAIN_ID=$2
 echo "--- Testing chain_id command for ${MINA_DEBIAN_NETWORK}"
 
 git config --global --add safe.directory /workdir
-source buildkite/scripts/debian/update.sh --verbose
 source buildkite/scripts/export-git-env-vars.sh
-source buildkite/scripts/debian/install.sh "mina-${MINA_DEBIAN_NETWORK}" 1
+
+# `mina internal chain-id` reads only the daemon binary and the network's genesis
+# config json. The .deb's config package does no generation -- it just copies the
+# in-repo genesis_ledgers/<net>.json into /var/lib/coda -- so we reproduce the
+# exact same state from the apps cache (bare `mina`) + repo (config), with no
+# package. Either way `mina` is on PATH and /var/lib/coda/<net>.json exists, so
+# chain-id resolves the genesis ledger identically. Fall back to the .deb on a
+# cache miss (e.g. outside Buildkite).
+if ./buildkite/scripts/apps/restore_binary.sh "${MINA_DEBIAN_NETWORK}" \
+  && ./buildkite/scripts/apps/restore_daemon_config.sh "${MINA_DEBIAN_NETWORK}"; then
+  echo "Using bare mina + replicated genesis config from apps cache"
+else
+  echo "Falling back to debian-installed mina-${MINA_DEBIAN_NETWORK}"
+  source buildkite/scripts/debian/update.sh --verbose
+  source buildkite/scripts/debian/install.sh "mina-${MINA_DEBIAN_NETWORK}" 1
+fi
 
 echo "--- Running mina chain-id command"
 


### PR DESCRIPTION
## What

Converts the **chain-id** test to run from the freshly-built bare `mina` binary in the apps cache plus a replicated genesis config, instead of installing the `mina-<network>` debian package. Continues the bare-binary effort (#18910/#18911, #18956).

## Why it's bare-able (correcting the earlier negative)

`mina internal chain-id --config-file /var/lib/coda/<net>.json` needs only the daemon binary and the network's genesis config json. The `.deb` config package does **no generation** — `copy_common_daemon_configs` literally copies the in-repo `genesis_ledgers/<net>.json` into `/var/lib/coda`. So we reproduce the exact same on-disk state from the apps cache + repo, and chain-id resolves the genesis ledger identically.

(The previous negative result, PR #18909, was specific to the `--from-config-hashes-only` *shortcut*, which computes a different id. Replicating the config the deb actually ships avoids that.)

## Changes

- **New `buildkite/scripts/apps/restore_daemon_config.sh <network>`** — the config-side companion to `restore_binary.sh`. Mirrors `copy_common_daemon_configs`: copies `genesis_ledgers/<net>.json` to both `/var/lib/coda/<net>.json` (named config) and `/var/lib/coda/config_<GITHASH_CONFIG>.json` (magic auto-loaded config).
- **`test-chain-id.sh`** restores bare `mina` + replicated config, falling back to the `.deb` on a cache miss.

## ⚠️ CI validation note

ChainIdTest is `excludeIf DescendantOf {Mesa, Develop}`, so it does **not** run on develop CI — it's validated once on **compatible** lineage. Full bare-path validation on compatible additionally requires backporting the apps-cache namespacing there (tracked separately); this PR lands the conversion so it's ready.

`shellcheck -S warning` clean on both scripts. No Dhall change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)