### PR TITLE
ci: run Archive Node Test from bare cached binaries

### DIFF
--- a/buildkite/scripts/debian/restore-or-install.sh
+++ b/buildkite/scripts/debian/restore-or-install.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Drop-in alternative to debian/install.sh for tests that can run from bare
+# cached binaries instead of installing the package.
+#
+# Usage: restore-or-install.sh <comma-separated-debs> <retries>
+#
+# Opt-in via APPS_BARE_BINARIES: a comma-separated list of <cached-exe>:<install-as>
+# pairs (e.g. "archive.exe:mina-archive,replayer.exe:mina-replayer"). When set,
+# each binary is restored from the namespaced apps cache (mirroring the binary a
+# deb would install) via restore_app.sh, and the package install is skipped. The
+# cache variant is derived by restore_app.sh from MINA_DEB_CODENAME / APPS_PROFILE
+# / APPS_BUILD_FLAG / APPS_ARCH -- so callers set those to match the build they
+# depend on (e.g. APPS_BUILD_FLAG=instrumented).
+#
+# If APPS_BARE_BINARIES is unset, or any restore fails (cache miss, not in
+# Buildkite, ...), this falls back to `debian/install.sh <debs> <retries>` -- so
+# it is a behaviour-preserving no-op for any caller that has not opted in.
+#
+# Note: this only provisions the binaries. Non-binary payload a deb would supply
+# (genesis config, fixtures, SQL) must be reproduced by the test from in-repo
+# data; converted tests are expected to point at the in-repo copies.
+
+set -eo pipefail
+
+DEBS=$1
+RETRIES=${2:-1}
+NETWORK="${APPS_NETWORK:-devnet}"
+
+if [[ -z "$DEBS" ]]; then
+  echo "Usage: $0 <comma-separated-debs> <retries>" >&2
+  exit 1
+fi
+
+install_debs() {
+  ./buildkite/scripts/debian/install.sh "$DEBS" "$RETRIES"
+}
+
+if [[ -z "${APPS_BARE_BINARIES:-}" ]]; then
+  install_debs
+  exit $?
+fi
+
+ok=true
+IFS=',' read -ra pairs <<< "$APPS_BARE_BINARIES"
+for pair in "${pairs[@]}"; do
+  exe="${pair%%:*}"
+  install_as="${pair##*:}"
+  if [[ -z "$exe" || -z "$install_as" || "$exe" == "$pair" ]]; then
+    echo "restore-or-install: malformed APPS_BARE_BINARIES entry '$pair'" >&2
+    ok=false
+    break
+  fi
+  if ! ./buildkite/scripts/apps/restore_app.sh "$NETWORK" "$exe" "$install_as"; then
+    ok=false
+    break
+  fi
+done
+
+if $ok; then
+  echo "restore-or-install: restored [${APPS_BARE_BINARIES}] from apps cache; skipping deb install" >&2
+else
+  echo "restore-or-install: bare restore incomplete, falling back to debian install of [${DEBS}]" >&2
+  install_debs
+fi

--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -17,7 +17,9 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
-                    , "MINA_TEST_NETWORK_DATA=/etc/mina/test/archive/sample_db"
+                    , "MINA_TEST_NETWORK_DATA=src/test/archive/sample_db"
+                    , "APPS_BUILD_FLAG=instrumented"
+                    , "APPS_BARE_BINARIES=archive_node_tests.exe:mina-archive-node-test,archive.exe:mina-archive,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina_testnet_signatures.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
                     ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script

--- a/buildkite/src/Command/RunWithPostgres.dhall
+++ b/buildkite/src/Command/RunWithPostgres.dhall
@@ -227,7 +227,7 @@ let runInToolchainWithPostgresAndDebs
                   initScript
 
           let installAndRun =
-                "sudo chown -R opam . && ./buildkite/scripts/debian/install.sh ${debs} 1 && ${innerScript}"
+                "sudo chown -R opam . && ./buildkite/scripts/debian/restore-or-install.sh ${debs} 1 && ${innerScript}"
 
           in  Cmd.chain
                 (   [ "( docker stop ${postgresDockerName} && docker rm ${postgresDockerName} ) || true"


### PR DESCRIPTION
## What

Converts **Archive: Node Test** to run from the freshly-built bare binaries in the apps cache instead of installing `mina-test-suite,mina-devnet-generic-instrumented,mina-archive-devnet-instrumented`. Part of the bare-binary effort (#18910/#18911, #18956, #18958).

> **Stacked on #18956** (base branch `dkijania/ledger-apply-bare-binary`) for `restore_app.sh`. Rebase onto develop once #18956 merges.

## Why it's bare-able

- The test invokes only `mina-archive`, `mina-archive-blocks`, `mina-replayer` (+ the `mina-archive-node-test` driver). The `mina_automation` apps resolve binaries from `_build/default/...` then `$PATH` under the deb name — so cached exes installed under their deb names are found with zero extra wiring.
- All non-binary inputs are **in-repo**: `sample_db` fixtures (`src/test/archive/sample_db`) and `create_schema.sql` (resolved in-repo-first by the test). The deb only staged a *copy* of these.
- The instrumented devnet build (which this test depends on) compiles `Archive` + `FunctionalTestSuite` + `DaemonAppsOnly`, so all needed exes are cached at `apps/<codename>/devnet-devnet-instrumented/`.

## How (opt-in, safe for other callers)

- **New `buildkite/scripts/debian/restore-or-install.sh`** — drop-in for `install.sh`. When `APPS_BARE_BINARIES` (comma-separated `<cached-exe>:<install-as>` pairs) is set, restores each from the apps cache via `restore_app.sh` and skips the deb install; otherwise — or on any cache miss / non-Buildkite — falls back to `install.sh`. Behaviour-preserving no-op for callers that don't opt in.
- **`RunWithPostgres.dhall`** — routes the in-toolchain deb install through it (one line). The other 5 callers (Patch/HardforkToolbox/Replayer×2/RosettaBlockRace) don't set `APPS_BARE_BINARIES`, so they're unchanged.
- **`ArchiveNodeTest.dhall`** — opts in: declares its bare binaries, selects the instrumented variant, points `MINA_TEST_NETWORK_DATA` at the in-repo fixtures.

Runs on **PullRequest** scope → real CI signal. `make all` green (37/37), `shellcheck -S warning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)