### PR TITLE
ci: run Patch Archive + Hardfork Toolbox tests from bare cached binaries

### DIFF
--- a/buildkite/scripts/debian/restore-or-install.sh
+++ b/buildkite/scripts/debian/restore-or-install.sh
@@ -17,9 +17,14 @@
 # Buildkite, ...), this falls back to `debian/install.sh <debs> <retries>` -- so
 # it is a behaviour-preserving no-op for any caller that has not opted in.
 #
-# Note: this only provisions the binaries. Non-binary payload a deb would supply
-# (genesis config, fixtures, SQL) must be reproduced by the test from in-repo
-# data; converted tests are expected to point at the in-repo copies.
+# Some debs ship "binaries" that are actually in-repo shell scripts (e.g. the
+# missing-blocks guardian). For those, set APPS_BARE_SCRIPTS: a comma-separated
+# list of <repo-path>:<install-as> pairs. When the bare restore is taken, each
+# script is installed onto PATH as /usr/local/bin/<install-as>, mirroring the deb.
+#
+# Note: this only provisions the binaries/scripts. Non-binary payload a deb would
+# supply (genesis config, fixtures, SQL) must be reproduced by the test from
+# in-repo data; converted tests are expected to point at the in-repo copies.
 
 set -eo pipefail
 
@@ -41,6 +46,12 @@ if [[ -z "${APPS_BARE_BINARIES:-}" ]]; then
   exit $?
 fi
 
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+BIN_DIR="${MINA_BIN_DIR:-/usr/local/bin}"
+
 ok=true
 IFS=',' read -ra pairs <<< "$APPS_BARE_BINARIES"
 for pair in "${pairs[@]}"; do
@@ -56,6 +67,22 @@ for pair in "${pairs[@]}"; do
     break
   fi
 done
+
+# In-repo scripts the deb would install as binaries (e.g. the guardian).
+if $ok && [[ -n "${APPS_BARE_SCRIPTS:-}" ]]; then
+  IFS=',' read -ra scripts <<< "$APPS_BARE_SCRIPTS"
+  for s in "${scripts[@]}"; do
+    src="${s%%:*}"
+    install_as="${s##*:}"
+    if [[ -z "$src" || -z "$install_as" || "$src" == "$s" || ! -f "$src" ]]; then
+      echo "restore-or-install: missing/malformed APPS_BARE_SCRIPTS entry '$s'" >&2
+      ok=false
+      break
+    fi
+    $SUDO install -D -m 0755 "$src" "${BIN_DIR}/${install_as}"
+    echo "restore-or-install: installed script ${src} as ${BIN_DIR}/${install_as}" >&2
+  done
+fi
 
 if $ok; then
   echo "restore-or-install: restored [${APPS_BARE_BINARIES}] from apps cache; skipping deb install" >&2

--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -20,7 +20,10 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
                     [ "PATCH_ARCHIVE_TEST_APP=mina-patch-archive-test"
-                    , "NETWORK_DATA_FOLDER=/etc/mina/test/archive/sample_db"
+                    , "NETWORK_DATA_FOLDER=src/test/archive/sample_db"
+                    , "APPS_BUILD_FLAG=instrumented"
+                    , "APPS_BARE_BINARIES=patch_archive_test.exe:mina-patch-archive-test,extract_blocks.exe:mina-extract-blocks,missing_blocks_auditor.exe:mina-missing-blocks-auditor,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina_testnet_signatures.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
+                    , "APPS_BARE_SCRIPTS=scripts/archive/missing-blocks-guardian.sh:mina-missing-blocks-guardian"
                     ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script

--- a/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
@@ -55,7 +55,9 @@ in  Pipeline.build
             Command.Config::{
             , commands =
               [ RunWithPostgres.runInToolchainWithPostgresAndDebs
-                  ([] : List Text)
+                  [ "APPS_BUILD_FLAG=instrumented"
+                  , "APPS_BARE_BINARIES=archive_hardfork_toolbox.exe:mina-archive-hardfork-toolbox"
+                  ]
                   ( Some
                       ( RunWithPostgres.ScriptOrArchive.Archive
                           { Script = "post_upgrade_archive.sql"
@@ -72,7 +74,9 @@ in  Pipeline.build
               , Cmd.run
                   "buildkite/scripts/upload-partial-coverage-data.sh ${key}"
               , RunWithPostgres.runInToolchainWithPostgresAndDebs
-                  ([] : List Text)
+                  [ "APPS_BUILD_FLAG=instrumented"
+                  , "APPS_BARE_BINARIES=archive_hardfork_toolbox.exe:mina-archive-hardfork-toolbox"
+                  ]
                   ( Some
                       ( RunWithPostgres.ScriptOrArchive.Archive
                           { Script = "hf_archive.sql"


### PR DESCRIPTION
## What

Extends the bare-binary path to two more **PullRequest-scoped** archive tests, reusing the opt-in `restore-or-install` seam from #18959.

> **Stacked on #18959** (base `dkijania/archive-node-bare`). Chain: #18956 → #18959 → this. Rebase down as they merge.

## PatchArchiveTest
- Restores `patch_archive_test` / `extract_blocks` / `missing_blocks_auditor` / `archive_blocks` / `replayer` (+ `mina`, `mina-create-genesis`) from the instrumented cache.
- Its guardian "binary" is actually the **in-repo script** `scripts/archive/missing-blocks-guardian.sh`. `restore-or-install.sh` gains **`APPS_BARE_SCRIPTS`** to install in-repo scripts onto PATH (as `mina-missing-blocks-guardian`) — AutoDetect then finds it via PATH `official_name`.
- The driver already reads the in-repo `src/test/archive/sample_db`.

## ArchiveHardforkToolboxTest
- Restores `archive_hardfork_toolbox` as `mina-archive-hardfork-toolbox` on PATH (as `runner.sh`'s `TOOLBOX_PATH` expects), in **both** the pre/upgrade and post-fork phases.
- Dump-tarball fixtures (`hf_archive.tar.gz`, `post_upgrade_archive.tar.gz`) are already in-repo.

Both fall back to the debs on any cache miss. `make all` green (37/37), `shellcheck -S warning` clean.

## ⚠️ Polish next week
These are wired for correctness but not yet CI-verified end-to-end — watch the "restored … from apps cache" vs fallback log line. The guardian/auditor/archive_blocks set for Patch is from static analysis; worth confirming the test doesn't reach for another binary at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)