### PR TITLE
ci: run ledger-export / snark / archive benches from bare binaries

### DIFF
--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -40,18 +40,34 @@ esac; shift; done
 # self-contained test-suite executable with no genesis ledger, /etc/mina config
 # or network -- so the freshly-built bare binary from the apps cache is enough,
 # no .deb required. Map each to its cached exe and the name the python harness
-# expects on PATH (mirroring what mina-test-suite installs). The other benches
-# (archive: postgres DB; ledger-export/snark: genesis payload) still need the
-# package, and any cache miss falls back to it too.
+# expects on PATH (mirroring what the deb installs):
+#   - mina-base/heap-usage/zkapp/ledger-export: a self-contained micro-bench exe.
+#     ledger-export reads only ./genesis_ledgers/devnet.json (in-repo, passed via
+#     --genesis-ledger-path), not a deb payload.
+#   - snark: `mina transaction-snark-profiler`, a self-contained mina subcommand
+#     (it generates its own transactions), restored as plain `mina`.
+#   - archive: runs with --no-run; it only parses a pre-generated JSON into CSV
+#     and executes no binary, so neither a .deb nor a cached exe is needed.
+# Any cache miss falls back to the .deb.
+BARE_NONE=false
 case "$BENCHMARK" in
-  mina-base)  BARE_EXE=benchmarks.exe;   BARE_AS=mina-benchmarks ;;
-  heap-usage) BARE_EXE=heap_usage.exe;   BARE_AS=mina-heap-usage ;;
-  zkapp)      BARE_EXE=zkapp_limits.exe; BARE_AS=mina-zkapp-limits ;;
-  *)          BARE_EXE="" ;;
+  mina-base)     BARE_EXE=benchmarks.exe;              BARE_AS=mina-benchmarks ;;
+  heap-usage)    BARE_EXE=heap_usage.exe;              BARE_AS=mina-heap-usage ;;
+  zkapp)         BARE_EXE=zkapp_limits.exe;            BARE_AS=mina-zkapp-limits ;;
+  ledger-export) BARE_EXE=ledger_export_benchmark.exe; BARE_AS=mina-ledger-export-benchmark ;;
+  snark)         BARE_EXE=mina_testnet_signatures.exe; BARE_AS=mina ;;
+  archive)       BARE_NONE=true ;;
+  *)             BARE_EXE="" ;;
 esac
 
 INSTALLED_BARE=false
-if [[ -n "$BARE_EXE" ]]; then
+if [[ "$BARE_NONE" == true ]]; then
+  git config --global --add safe.directory /workdir
+  source buildkite/scripts/export-git-env-vars.sh
+  echo "archive bench is parse-only (--no-run); skipping binary and .deb install"
+  pip3 install -r scripts/benchmarks/requirements.txt
+  INSTALLED_BARE=true
+elif [[ -n "$BARE_EXE" ]]; then
   git config --global --add safe.directory /workdir
   source buildkite/scripts/export-git-env-vars.sh
 


### PR DESCRIPTION
## What

Completes the bench bare-binary migration (follows #18956, now merged). The remaining `bench/run.sh` benchmarks run from the apps cache instead of installing `mina-test-suite,mina-devnet-generic`.

| bench | bare source | notes |
|-------|-------------|-------|
| **ledger-export** | `ledger_export_benchmark.exe` → `mina-ledger-export-benchmark` | only input is `./genesis_ledgers/devnet.json` (in-repo, passed via `--genesis-ledger-path`) |
| **snark** | `mina_testnet_signatures.exe` → `mina` | `mina transaction-snark-profiler` is self-contained (generates its own txns) |
| **archive** | *none* | runs `--no-run`: parses a pre-generated JSON into CSV, executes no binary → skip install entirely, pip only |

All fall back to `bench/install.sh` on a cache miss. With #18956, **every** bench (mina-base, heap-usage, zkapp, ledger-apply, ledger-export, snark, archive) is now bare. `shellcheck -S warning` clean, no Dhall change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)