### PR TITLE
ci: run Replayer + ReplayerMesaHf tests from bare cached binaries

### DIFF
--- a/buildkite/src/Command/ReplayerMesaHfTest.dhall
+++ b/buildkite/src/Command/ReplayerMesaHfTest.dhall
@@ -24,7 +24,9 @@ in  { step =
                 [ Cmd.run
                     "cp /var/storagebox/test_data/develop/replayer_mesa/mina-devnet-config_*.deb ./src/test/archive/sample_mesa_hf_db/"
                 , RunWithPostgres.runInToolchainWithPostgresAndDebs
-                    ([] : List Text)
+                    [ "APPS_BUILD_FLAG=instrumented"
+                    , "APPS_BARE_BINARIES=replayer.exe:mina-replayer"
+                    ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Archive
                             { Script = "mesa_hf_dry_run_db.sql"

--- a/buildkite/src/Command/ReplayerTest.dhall
+++ b/buildkite/src/Command/ReplayerTest.dhall
@@ -18,7 +18,9 @@ in  { step =
               Command.Config::{
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
-                    ([] : List Text)
+                    [ "APPS_BUILD_FLAG=instrumented"
+                    , "APPS_BARE_BINARIES=replayer.exe:mina-replayer"
+                    ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script
                             "./src/test/archive/sample_db/archive_db.sql"


### PR DESCRIPTION
## What

Migrates the two replayer tests to run from the apps cache instead of installing `mina-devnet-generic-instrumented,mina-archive-devnet-instrumented`. Uses the `restore-or-install` seam (merged in #18959).

Both tests:
- invoke **only `mina-replayer`** (`replayer.exe`), never start a networked daemon (no libp2p),
- read **in-repo** inputs: `src/test/archive/sample_db/{archive_db.sql,replayer_input_file.json}` (ReplayerTest) and the in-repo mesa-hf dump tarball (ReplayerMesaHf).

So each opts in with `APPS_BARE_BINARIES=replayer.exe:mina-replayer` + `APPS_BUILD_FLAG=instrumented`, falling back to the debs on a cache miss.

Note: `ReplayerMesaHfTest`'s driver separately `dpkg -i`s a `mina-devnet-config` deb (from the Hetzner cache) for the mesa-hf genesis — that's orthogonal to the binary and left unchanged.

`make all` green (37/37). Both run on PullRequest scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)