### PR TITLE
ci: run DumpSlotLedger test from bare binary (drop archive Docker image)

### DIFF
--- a/buildkite/scripts/dump-slot-test.sh
+++ b/buildkite/scripts/dump-slot-test.sh
@@ -2,7 +2,9 @@
 
 set -eox pipefail
 
-# PG_CONN is set by RunWithPostgres Dhall module
-# This script runs inside the mina-archive Docker container
+# PG_CONN is set by RunWithPostgres Dhall module.
+# Runs in the toolchain image with mina-dump-slot-ledger restored bare from the
+# apps cache (falling back to the mina-archive deb on a cache miss); both put it
+# on PATH, so this is invoked by name regardless.
 
 ./scripts/dump-slot-test.sh -a mina-dump-slot-ledger -p "$PG_CONN"

--- a/buildkite/src/Command/DumpSlotLedgerTest.dhall
+++ b/buildkite/src/Command/DumpSlotLedgerTest.dhall
@@ -1,33 +1,31 @@
-let Artifacts = ../Constants/Artifacts.dhall
-
-let BuildFlags = ../Constants/BuildFlags.dhall
-
 let Command = ./Base.dhall
 
 let Size = ./Size.dhall
 
 let RunWithPostgres = ./RunWithPostgres.dhall
 
+let ContainerImages = ../Constants/ContainerImages.dhall
+
 let key = "dump-slot-ledger-test"
+
+let debs = "mina-archive-devnet-instrumented"
 
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)
         ->  Command.build
               Command.Config::{
               , commands =
-                [ RunWithPostgres.runInDockerWithPostgresConn
-                    ([] : List Text)
+                [ RunWithPostgres.runInToolchainWithPostgresAndDebs
+                    [ "APPS_BUILD_FLAG=instrumented"
+                    , "APPS_BARE_BINARIES=dump_slot_ledger.exe:mina-dump-slot-ledger"
+                    ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script
                             "src/test/archive/sample_db/archive_db.sql"
                         )
                     )
-                    ( Artifacts.fullDockerTag
-                        Artifacts.Tag::{
-                        , artifact = Artifacts.Type.Archive
-                        , buildFlags = BuildFlags.Type.Instrumented
-                        }
-                    )
+                    ContainerImages.minaToolchainBullseye.amd64
+                    debs
                     "./buildkite/scripts/dump-slot-test.sh"
                 ]
               , label = "Archive: Dump Slot test"

--- a/buildkite/src/Jobs/Test/DumpSlotLedgerTest.dhall
+++ b/buildkite/src/Jobs/Test/DumpSlotLedgerTest.dhall
@@ -8,18 +8,13 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let DumpSlotLedgerTest = ../../Command/DumpSlotLedgerTest.dhall
 
-let Artifacts = ../../Constants/Artifacts.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let BuildFlags = ../../Constants/BuildFlags.dhall
 
-let Dockers = ../../Constants/DockerVersions.dhall
-
 let dependsOn =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{
-        , artifact = Artifacts.Type.Archive
-        , buildFlags = BuildFlags.Type.Instrumented
-        }
+      DebianVersions.dependsOn
+        DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
## What

Migrates **DumpSlotLedgerTest** off the prebuilt `mina-archive` **Docker image** to the toolchain + a bare cached binary — so this is a **docker dependency removal**, not just a deb one.

## How

- The test ran inside the archive Docker image (`runInDockerWithPostgresConn` + `Artifacts.fullDockerTag Archive Instrumented`) and only invoked `mina-dump-slot-ledger` against the in-repo `src/test/archive/sample_db`.
- Switched to `runInToolchainWithPostgresAndDebs` (toolchain image + postgres sidecar), restoring the binary bare: `APPS_BARE_BINARIES=dump_slot_ledger.exe:mina-dump-slot-ledger` + `APPS_BUILD_FLAG=instrumented`, with a `.deb` fallback (`mina-archive-devnet-instrumented`) on a cache miss.
- Job `dependsOn` moves from `Dockers.dependsOn(Archive)` → `DebianVersions.dependsOn(Instrumented)` (the build that populates the apps cache + provides the fallback deb).

`make all` green (37/37), `shellcheck` clean. Runs on PullRequest scope.

⚠️ This is the most behavior-changing of the bare-migration set (it changes the test's *execution environment* from the archive image to the toolchain), so it deserves a close CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)