### PR TITLE
ci: run RosettaBlockRace test from bare cached binaries

### DIFF
--- a/buildkite/src/Command/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Command/RosettaBlockRaceTest.dhall
@@ -1,5 +1,3 @@
-let Cmd = ../Lib/Cmds.dhall
-
 let Command = ./Base.dhall
 
 let Size = ./Size.dhall
@@ -11,7 +9,7 @@ let ContainerImages = ../Constants/ContainerImages.dhall
 let key = "rosetta-block-race-test"
 
 let debs =
-      "mina-mainnet-generic-instrumented,mina-archive-mainnet-instrumented,mina-rosetta-mainnet-generic"
+      "mina-mainnet-generic,mina-archive-mainnet,mina-rosetta-mainnet-generic"
 
 in  { step =
             \(dependsOn : List Command.TaggedKey.Type)
@@ -19,7 +17,9 @@ in  { step =
               Command.Config::{
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
-                    ([] : List Text)
+                    [ "APPS_NETWORK=mainnet"
+                    , "APPS_BARE_BINARIES=mina_mainnet_signatures.exe:mina,archive.exe:mina-archive,rosetta_mainnet_signatures.exe:mina-rosetta"
+                    ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.OnlineTarGzDump
                             "https://storage.googleapis.com/mina-archive-dumps/mainnet-archive-dump-2025-11-11_0000.sql.tar.gz"
@@ -28,8 +28,6 @@ in  { step =
                     ContainerImages.minaToolchainBullseye.amd64
                     debs
                     "./buildkite/scripts/tests/rosetta/block-race-test.sh"
-                , Cmd.run
-                    "./buildkite/scripts/upload-partial-coverage-data.sh ${key}"
                 ]
               , label = "Rosetta: Rosetta Block Race test"
               , key = key

--- a/buildkite/src/Jobs/Test/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaBlockRaceTest.dhall
@@ -8,7 +8,11 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let BuildFlags = ../../Constants/BuildFlags.dhall
+let Network = ../../Constants/Network.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
 
 let RosettaBlockRaceTest = ../../Command/RosettaBlockRaceTest.dhall
 
@@ -18,7 +22,10 @@ let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
 
 let dependsOn =
       DebianVersions.dependsOn
-        DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
+        DebianVersions.DepsSpec::{
+        , network = Network.Type.Mainnet
+        , profile = Profiles.Type.Mainnet
+        }
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -33,6 +40,8 @@ in  Pipeline.build
           ]
         , path = "Test"
         , name = "RosettaBlockRaceTest"
+        , scope =
+          [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
         , excludeIf =
           [ Expr.Type.DescendantOf
               { ancestor = MainlineBranch.Type.Mesa


### PR DESCRIPTION
## What

Converts **RosettaBlockRaceTest** to bare apps — the last per-test conversion in the bare-binary effort.

The test runs `mina advanced test submit-to-archive` + `mina-archive` + `mina-rosetta` against a downloaded mainnet archive dump. It does **not** start a networked daemon (no libp2p — `submit-to-archive` builds blocks locally and pushes over the archive RPC port).

## How (drop coverage → single variant)

- Restore `mina` / `mina-archive` / `mina-rosetta` from the **`mainnet-mainnet`** apps cache (`APPS_NETWORK=mainnet`, non-instrumented). Dropping coverage means no instrumented build is needed, so all three share one variant.
- `.deb` fallback switched to the non-instrumented mainnet packages.
- Job `dependsOn` repointed from the **mismatched** devnet-instrumented build → the **mainnet build** (`MinaArtifactBullseyeMainnetMainnet`), which actually populates `mainnet-mainnet` + the fallback debs. Scope set to **MainlineNightly+Release** to match when that build runs (you OK'd nightly).
- Removed the coverage upload (no instrumentation).

This also **fixes a pre-existing inconsistency**: the test depended on a *devnet* build but installed *mainnet* debs sourced from the published apt repo (no mainnet-instrumented build exists in-pipeline).

`make all` green (37/37). Needs the libp2p-independent mainnet cache, which the nightly mainnet build provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)