### PR TITLE
Refactor: introducing backoff library

### DIFF
--- a/changes/18969.md
+++ b/changes/18969.md
@@ -1,0 +1,1 @@
+Archive: breadcrumbs are now dispatched concurrently from the daemon to the archive process. Previously, breadcrumbs were sent one at a time, so a stalled dispatch (for example, due to retry backoff) would block later ones. Now they proceed independently in parallel, improving throughput and resilience of archive data delivery.

--- a/src/dune-project
+++ b/src/dune-project
@@ -6,6 +6,7 @@
 (package (name archive_hardfork_toolbox))
 (package (name archive_blocks))
 (package (name archive_lib))
+(package (name backoff) (synopsis "Exponential backoff with jitter for retry loops"))
 (package (name base58_check))
 (package (name best_tip_merger))
 (package (name best_tip_prover))

--- a/src/lib/backoff/backoff.ml
+++ b/src/lib/backoff/backoff.ml
@@ -1,0 +1,86 @@
+open Core_kernel
+open Async_kernel
+
+module Strategy = struct
+  type t =
+    { base : Time_ns.Span.t
+    ; max_delay : Time_ns.Span.t
+    ; max_attempts : int option
+    ; rng : Random.State.t
+    }
+
+  let create ~base ~max_delay ~max_attempts
+      ?(random_state = Random.State.default) () =
+    { base; max_delay; max_attempts; rng = Random.State.copy random_state }
+end
+
+module type Monad = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val bind : 'a t -> f:('a -> 'b t) -> 'b t
+
+  val sleep : Time_ns.Span.t -> unit t
+end
+
+let full_jitter ~base ~max_delay ~attempt ~rng =
+  let max_multiplier = Time_ns.Span.( // ) max_delay base in
+  let multiplier = 2. ** Float.of_int attempt in
+  let capped =
+    if Float.( >= ) multiplier max_multiplier then max_delay
+    else Time_ns.Span.scale base multiplier
+  in
+  Time_ns.Span.scale capped (Random.State.float rng 1.0)
+
+let exhausted ~max_attempts ~attempts =
+  match max_attempts with Some max -> attempts >= max - 1 | None -> false
+
+module Make (M : Monad) = struct
+  let retry ?(log_errors = false) (strategy : Strategy.t) ~logger ~f =
+    let rng = strategy.rng in
+    let attempts = ref 0 in
+    let rec go () =
+      M.bind (f ()) ~f:(function
+        | Ok ok ->
+            M.return (Ok ok)
+        | Error e ->
+            let attempt = !attempts in
+            if exhausted ~max_attempts:strategy.max_attempts ~attempts:attempt
+            then M.return (Error e)
+            else (
+              attempts := attempt + 1 ;
+              let delay =
+                full_jitter ~base:strategy.base ~max_delay:strategy.max_delay
+                  ~attempt ~rng
+              in
+              if log_errors then
+                [%log warn]
+                  "Backoff: attempt %d failed, retrying after %s" attempt
+                  (Time_ns.Span.to_string_hum delay)
+                  ~metadata:[ ("error", Error_json.error_to_yojson e) ]
+              else
+                [%log debug] "Backoff: retrying after %s (attempt %d)"
+                  (Time_ns.Span.to_string_hum delay)
+                  attempt ;
+              M.bind (M.sleep delay) ~f:(fun () ->
+                  (* Trampoline via M.return () to keep the call stack
+                     bounded. Without this, synchronous monads (e.g. the
+                     Identity monad used in tests) would tail-recurse
+                     inside the bind closure and overflow the stack.
+                     For Deferred.t the bind already schedules
+                     asynchronously, so this is a no-op. *)
+                  M.bind (M.return ()) ~f:go ) ) )
+    in
+    go ()
+end
+
+module Deferred = Make (struct
+  type 'a t = 'a Deferred.t
+
+  let return = Deferred.return
+
+  let bind = Deferred.bind
+
+  let sleep span = after span
+end)

--- a/src/lib/backoff/backoff.ml
+++ b/src/lib/backoff/backoff.ml
@@ -9,7 +9,7 @@ module Strategy = struct
     ; rng : Random.State.t
     }
 
-  let create ~base ~max_delay ~max_attempts
+  let create ~base ~max_delay ?max_attempts
       ?(random_state = Random.State.default) () =
     { base; max_delay; max_attempts; rng = Random.State.copy random_state }
 end
@@ -55,8 +55,8 @@ module Make (M : Monad) = struct
                   ~attempt ~rng
               in
               if log_errors then
-                [%log warn]
-                  "Backoff: attempt %d failed, retrying after %s" attempt
+                [%log warn] "Backoff: attempt %d failed, retrying after %s"
+                  attempt
                   (Time_ns.Span.to_string_hum delay)
                   ~metadata:[ ("error", Error_json.error_to_yojson e) ]
               else

--- a/src/lib/backoff/backoff.mli
+++ b/src/lib/backoff/backoff.mli
@@ -12,7 +12,7 @@ module Strategy : sig
   val create :
        base:Time_ns.Span.t
     -> max_delay:Time_ns.Span.t
-    -> max_attempts:int option
+    -> ?max_attempts:int
     -> ?random_state:Random.State.t
     -> unit
     -> t

--- a/src/lib/backoff/backoff.mli
+++ b/src/lib/backoff/backoff.mli
@@ -1,0 +1,52 @@
+open Core_kernel
+open Async_kernel
+
+(** A strategy for computing exponential backoff delays with full jitter.
+
+    [Strategy.t] is an opaque configuration object. Create one with
+    {!create}, then pass it to one of the [retry] functions. The same
+    strategy can be reused across multiple retry operations. *)
+module Strategy : sig
+  type t
+
+  val create :
+       base:Time_ns.Span.t
+    -> max_delay:Time_ns.Span.t
+    -> max_attempts:int option
+    -> ?random_state:Random.State.t
+    -> unit
+    -> t
+end
+
+(** The signature required by {!Make} to instantiate the retry loop over
+    a particular monad. *)
+module type Monad = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val bind : 'a t -> f:('a -> 'b t) -> 'b t
+
+  val sleep : Time_ns.Span.t -> unit t
+end
+
+(** [Make(M)] returns a module with a [retry] function that runs in the
+    monad [M]. *)
+module Make (M : Monad) : sig
+  val retry :
+       ?log_errors:bool
+    -> Strategy.t
+    -> logger:Logger.t
+    -> f:(unit -> 'a Or_error.t M.t)
+    -> 'a Or_error.t M.t
+end
+
+(** Pre-built instance of {!Make} for [Deferred.t]. *)
+module Deferred : sig
+  val retry :
+       ?log_errors:bool
+    -> Strategy.t
+    -> logger:Logger.t
+    -> f:(unit -> 'a Or_error.t Deferred.t)
+    -> 'a Or_error.t Deferred.t
+end

--- a/src/lib/backoff/dune
+++ b/src/lib/backoff/dune
@@ -1,0 +1,15 @@
+(library
+ (name backoff)
+ (public_name backoff)
+ (libraries
+  ;; opam libraries
+  async_kernel
+  core_kernel
+  ;; local libraries
+  error_json
+  logger)
+ (preprocess
+  (pps ppx_jane ppx_mina))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Exponential backoff with jitter for retry loops"))

--- a/src/lib/backoff/dune
+++ b/src/lib/backoff/dune
@@ -9,7 +9,7 @@
   error_json
   logger)
  (preprocess
-  (pps ppx_jane ppx_mina))
+  (pps ppx_jane ppx_mina ppx_version))
  (instrumentation
   (backend bisect_ppx))
  (synopsis "Exponential backoff with jitter for retry loops"))

--- a/src/lib/backoff/test/dune
+++ b/src/lib/backoff/test/dune
@@ -1,0 +1,15 @@
+(test
+ (name test_backoff)
+ (package backoff)
+ (libraries
+  alcotest
+  async
+  async_kernel
+  core
+  core_kernel
+  backoff
+  logger)
+ (preprocess
+  (pps ppx_jane))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/lib/backoff/test/test_backoff.ml
+++ b/src/lib/backoff/test/test_backoff.ml
@@ -15,7 +15,7 @@ module B = Make (Identity)
 
 let test_strategy ?max_attempts () =
   Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
-    ~max_delay:(Time_ns.Span.of_sec 60.0) ~max_attempts
+    ~max_delay:(Time_ns.Span.of_sec 60.0) ?max_attempts
     ~random_state:(Random.State.make [| 0 |])
     ()
 
@@ -43,7 +43,10 @@ let test_succeeds_after_failures () =
 let test_exhausts_max_attempts () =
   let strategy = test_strategy ~max_attempts:3 () in
   let called = ref 0 in
-  let f () = Int.incr called ; Error (Error.of_string "always fails") in
+  let f () =
+    Int.incr called ;
+    Error (Error.of_string "always fails")
+  in
   let result = B.retry strategy ~logger ~f in
   Alcotest.(check bool) "result is error" true (Result.is_error result) ;
   Alcotest.(check int) "f called 3 times" 3 !called
@@ -51,7 +54,10 @@ let test_exhausts_max_attempts () =
 let test_max_attempts_one_means_no_retries () =
   let strategy = test_strategy ~max_attempts:1 () in
   let called = ref 0 in
-  let f () = Int.incr called ; Error (Error.of_string "fail") in
+  let f () =
+    Int.incr called ;
+    Error (Error.of_string "fail")
+  in
   let result = B.retry strategy ~logger ~f in
   Alcotest.(check bool) "result is error" true (Result.is_error result) ;
   Alcotest.(check int) "f called 1 time" 1 !called
@@ -59,7 +65,7 @@ let test_max_attempts_one_means_no_retries () =
 let test_none_retries_indefinitely () =
   let strategy =
     Strategy.create ~base:(Time_ns.Span.of_ms 1.0)
-      ~max_delay:(Time_ns.Span.of_sec 1.0) ~max_attempts:None
+      ~max_delay:(Time_ns.Span.of_sec 1.0)
       ~random_state:(Random.State.make [| 0 |])
       ()
   in
@@ -67,7 +73,8 @@ let test_none_retries_indefinitely () =
   let succeed_after = 10 in
   let f () =
     Int.incr called ;
-    if Int.equal !called succeed_after then Ok "success" else Error (Error.of_string "fail")
+    if Int.equal !called succeed_after then Ok "success"
+    else Error (Error.of_string "fail")
   in
   let result = B.retry strategy ~logger ~f in
   Alcotest.(check bool) "result is ok" true (Result.is_ok result) ;

--- a/src/lib/backoff/test/test_backoff.ml
+++ b/src/lib/backoff/test/test_backoff.ml
@@ -1,0 +1,90 @@
+open Core_kernel
+open Backoff
+
+module Identity = struct
+  type 'a t = 'a
+
+  let return x = x
+
+  let bind x ~f = f x
+
+  let sleep _ = ()
+end
+
+module B = Make (Identity)
+
+let test_strategy ?max_attempts () =
+  Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
+    ~max_delay:(Time_ns.Span.of_sec 60.0) ~max_attempts
+    ~random_state:(Random.State.make [| 0 |])
+    ()
+
+let logger = Logger.null ()
+
+let test_succeeds_on_first_attempt () =
+  let strategy = test_strategy ~max_attempts:3 () in
+  let called = ref 0 in
+  let f () = Int.incr called ; Ok "success" in
+  let result = B.retry strategy ~logger ~f in
+  Alcotest.(check bool) "result is ok" true (Result.is_ok result) ;
+  Alcotest.(check int) "f called once" 1 !called
+
+let test_succeeds_after_failures () =
+  let strategy = test_strategy ~max_attempts:5 () in
+  let called = ref 0 in
+  let f () =
+    Int.incr called ;
+    if Int.equal !called 3 then Ok "success" else Error (Error.of_string "fail")
+  in
+  let result = B.retry strategy ~logger ~f in
+  Alcotest.(check bool) "result is ok" true (Result.is_ok result) ;
+  Alcotest.(check int) "f called 3 times" 3 !called
+
+let test_exhausts_max_attempts () =
+  let strategy = test_strategy ~max_attempts:3 () in
+  let called = ref 0 in
+  let f () = Int.incr called ; Error (Error.of_string "always fails") in
+  let result = B.retry strategy ~logger ~f in
+  Alcotest.(check bool) "result is error" true (Result.is_error result) ;
+  Alcotest.(check int) "f called 3 times" 3 !called
+
+let test_max_attempts_one_means_no_retries () =
+  let strategy = test_strategy ~max_attempts:1 () in
+  let called = ref 0 in
+  let f () = Int.incr called ; Error (Error.of_string "fail") in
+  let result = B.retry strategy ~logger ~f in
+  Alcotest.(check bool) "result is error" true (Result.is_error result) ;
+  Alcotest.(check int) "f called 1 time" 1 !called
+
+let test_none_retries_indefinitely () =
+  let strategy =
+    Strategy.create ~base:(Time_ns.Span.of_ms 1.0)
+      ~max_delay:(Time_ns.Span.of_sec 1.0) ~max_attempts:None
+      ~random_state:(Random.State.make [| 0 |])
+      ()
+  in
+  let called = ref 0 in
+  let succeed_after = 10 in
+  let f () =
+    Int.incr called ;
+    if Int.equal !called succeed_after then Ok "success" else Error (Error.of_string "fail")
+  in
+  let result = B.retry strategy ~logger ~f in
+  Alcotest.(check bool) "result is ok" true (Result.is_ok result) ;
+  Alcotest.(check int) "f called 10 times" 10 !called
+
+let () =
+  Alcotest.run "Backoff"
+    [ ( "retry"
+      , [ Alcotest.test_case "succeeds on first attempt" `Quick
+            test_succeeds_on_first_attempt
+        ; Alcotest.test_case "succeeds after failures" `Quick
+            test_succeeds_after_failures
+        ; Alcotest.test_case "exhausts max_attempts" `Quick
+            test_exhausts_max_attempts
+        ; Alcotest.test_case "max_attempts=1 means no retries" `Quick
+            test_max_attempts_one_means_no_retries
+        ; Alcotest.test_case "None retries indefinitely" `Quick
+            test_none_retries_indefinitely
+        ] )
+    ]

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -733,20 +733,6 @@ let time ~logger ~time_controller label f =
     !"%s: $time %!" label ;
   x
 
-let retry ?(max = 3) ~logger ~error_message f =
-  let rec go n =
-    if n >= max then failwith error_message
-    else
-      match%bind f () with
-      | Error e ->
-          [%log error] "%s : $error. Trying again" error_message
-            ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
-          go (n + 1)
-      | Ok res ->
-          return res
-  in
-  go 0
-
 module Vrf_evaluation_state = struct
   type status =
     | At of Mina_numbers.Global_slot_since_hard_fork.t
@@ -758,12 +744,20 @@ module Vrf_evaluation_state = struct
     ; mutable vrf_evaluator_status : status
     }
 
+  let vrf_retry_strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some 3) ()
+
   let poll_vrf_evaluator ~logger vrf_evaluator =
     let f () =
       O1trace.thread "query_vrf_evaluator" (fun () ->
           Vrf_evaluator.slots_won_so_far vrf_evaluator )
     in
-    retry ~logger ~error_message:"Error fetching slots from the VRF evaluator" f
+    match%map Backoff.Deferred.retry vrf_retry_strategy ~logger ~f with
+    | Ok res ->
+        res
+    | Error _ ->
+        failwith "Error fetching slots from the VRF evaluator"
 
   let create () = { queue = Core.Queue.create (); vrf_evaluator_status = Start }
 
@@ -810,8 +804,11 @@ module Vrf_evaluation_state = struct
         O1trace.thread "set_vrf_evaluator_epoch_state" (fun () ->
             Vrf_evaluator.set_new_epoch_state vrf_evaluator ~epoch_data_for_vrf )
       in
-      retry ~logger
-        ~error_message:"Error setting epoch state of the VRF evaluator" f
+      match%map Backoff.Deferred.retry vrf_retry_strategy ~logger ~f with
+      | Ok res ->
+          res
+      | Error _ ->
+          failwith "Error setting epoch state of the VRF evaluator"
     in
     [%log info] "Sending data for VRF evaluations for epoch $epoch"
       ~metadata:

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -746,7 +746,7 @@ module Vrf_evaluation_state = struct
 
   let vrf_retry_strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
-      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some 3) ()
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:3 ()
 
   let poll_vrf_evaluator ~logger vrf_evaluator =
     let f () =

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -12,8 +12,9 @@
   core_kernel
   integers
   sexplib0
-  ;; local libraries
-  block_time
+   ;; local libraries
+   backoff
+   block_time
   blockchain_snark
   coda_genesis_proof
   consensus

--- a/src/lib/mina_graphql_client/client.ml
+++ b/src/lib/mina_graphql_client/client.ml
@@ -34,69 +34,48 @@ let exec_graphql_request ?(num_tries = 10) ?(retry_delay_sec = 30.0)
   let past_deadline () =
     match deadline with None -> false | Some d -> Time.( >= ) (Time.now ()) d
   in
-  let bounded_sleep span =
-    match deadline with
-    | None ->
-        span
-    | Some d ->
-        let remaining = Time.diff d (Time.now ()) in
-        if Time.Span.( <= ) remaining Time.Span.zero then Time.Span.zero
-        else Time.Span.min span remaining
-  in
   let deadline_failure_msg () =
     sprintf
       "GraphQL \"%s\" to \"%s\" request hit caller's deadline before succeeding"
       query_name (Uri.to_string node_uri)
   in
-  let rec retry n =
-    if past_deadline () then (
-      [%log error] "$query to $uri exhausted caller's deadline" ~metadata ;
-      Deferred.Or_error.error_string (deadline_failure_msg ()) )
-    else if n <= 0 then (
-      [%log error]
-        "GraphQL request \"$query\" to \"$uri\" failed too many times" ~metadata ;
-      Deferred.Or_error.errorf
-        "GraphQL \"%s\" to \"%s\" request failed too many times" query_name
-        (Uri.to_string node_uri) )
-    else
-      match%bind Queries.Client.query query_obj node_uri with
-      | Ok result ->
-          [%log info] "GraphQL request \"$query\" to \"$uri\" succeeded"
-            ~metadata ;
-          Deferred.Or_error.return result
-      | Error (`Failed_request err_string) ->
-          [%log warn]
-            "GraphQL request \"$query\" to \"$uri\" failed: \"$error\" \
-             ($num_tries attempts left)"
-            ~metadata:
-              ( metadata
-              @ [ ("error", `String err_string); ("num_tries", `Int (n - 1)) ]
-              ) ;
-          (* Skip the retry sleep when this was the last attempt — otherwise
-             a [num_tries=1] caller burns [retry_delay_sec] (~30s by default)
-             waiting for a retry that will never happen.  This matters for
-             the one-shot CLI subcommands, which set [num_tries:1] precisely
-             to fail fast against an unreachable daemon. *)
-          if n - 1 <= 0 then
-            Deferred.Or_error.errorf
-              "GraphQL \"%s\" to \"%s\" request failed too many times: %s"
-              query_name (Uri.to_string node_uri) err_string
-          else if past_deadline () then
-            Deferred.Or_error.error_string (deadline_failure_msg ())
-          else
-            let%bind () =
-              after (bounded_sleep (Time.Span.of_sec retry_delay_sec))
-            in
-            retry (n - 1)
-      | Error (`Graphql_error err_string) ->
-          [%log error]
-            "GraphQL request \"$query\" to \"$uri\" returned an error: \
-             \"$error\" (this is a graphql error so not retrying)"
-            ~metadata:(metadata @ [ ("error", `String err_string) ]) ;
-          Deferred.Or_error.error_string err_string
+  let%bind () = after (Time.Span.of_sec initial_delay_sec) in
+  let strategy =
+    Backoff.Strategy.create
+      ~base:(Time_ns.Span.of_sec retry_delay_sec)
+      ~max_delay:(Time_ns.Span.of_sec retry_delay_sec)
+      ~max_attempts:(Some num_tries) ()
   in
-  let%bind () = after (bounded_sleep (Time.Span.of_sec initial_delay_sec)) in
-  retry num_tries
+  let retry () =
+    Backoff.Deferred.retry ~log_errors:true strategy ~logger ~f:(fun () ->
+        match%bind Queries.Client.query query_obj node_uri with
+        | Ok result ->
+            return (Ok (Ok result))
+        | Error (`Failed_request err) ->
+            return (Error (Error.of_string err))
+        | Error (`Graphql_error err) ->
+            return (Ok (Error (Error.of_string err))) )
+  in
+  let result =
+    match deadline with
+    | None ->
+        retry ()
+    | Some d -> (
+        if past_deadline () then
+          Deferred.return (Error (Error.of_string (deadline_failure_msg ())))
+        else
+          let remaining = Time.diff d (Time.now ()) in
+          match%map Clock.with_timeout remaining (retry ()) with
+          | `Timeout ->
+              Error (Error.of_string (deadline_failure_msg ()))
+          | `Result r ->
+              r )
+  in
+  match%map result with
+  | Ok (Ok r) ->
+      Ok r
+  | Ok (Error err) | Error err ->
+      Error err
 
 let get_peer_id ~logger node_uri =
   let open Deferred.Or_error.Let_syntax in

--- a/src/lib/mina_graphql_client/client.ml
+++ b/src/lib/mina_graphql_client/client.ml
@@ -44,7 +44,7 @@ let exec_graphql_request ?(num_tries = 10) ?(retry_delay_sec = 30.0)
     Backoff.Strategy.create
       ~base:(Time_ns.Span.of_sec retry_delay_sec)
       ~max_delay:(Time_ns.Span.of_sec retry_delay_sec)
-      ~max_attempts:(Some num_tries) ()
+      ~max_attempts:num_tries ()
   in
   let retry () =
     Backoff.Deferred.retry ~log_errors:true strategy ~logger ~f:(fun () ->

--- a/src/lib/mina_graphql_client/dune
+++ b/src/lib/mina_graphql_client/dune
@@ -14,6 +14,7 @@
   async async_kernel core_kernel core uri integers result
   cohttp cohttp-async yojson ppx_deriving_yojson.runtime
   ;; local libraries
+  backoff
   graphql_lib generated_graphql_queries mina_graphql mina_base mina_base.import
   mina_transaction mina_numbers currency signature_lib logger with_hash
   data_hash_lib sync_status))

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -83,45 +83,46 @@ let run ~logger ~precomputed_values
                transfer breadcrumb_reader writer ) ) ) ;
   O1trace.background_thread "send_diffs_to_archiver" (fun () ->
       Async.Pipe.iter reader ~f:(fun breadcrumbs ->
-          Deferred.List.iter breadcrumbs ~f:(fun breadcrumb ->
-              let start = Time.now () in
-              let diff =
-                Archive_lib.Diff.Builder.breadcrumb_added ~precomputed_values
-                  ~logger breadcrumb
-              in
-              let diff_time = Time.now () in
-              [%log debug]
-                "Archive data generation for $state_hash took $time ms"
-                ~metadata:
-                  [ ( "state_hash"
-                    , Mina_base.State_hash.to_yojson
-                        (Transition_frontier.Breadcrumb.state_hash breadcrumb)
-                    )
-                  ; ( "time"
-                    , `Float (Time.Span.to_ms (Time.diff diff_time start)) )
-                  ] ;
-              match%map
-                dispatch archive_location ~logger (Transition_frontier diff)
-              with
-              | Ok () ->
-                  [%log debug]
-                    "Dispatched archive data for $state_hash, took $time ms"
-                    ~metadata:
-                      [ ( "state_hash"
-                        , Mina_base.State_hash.to_yojson
-                            (Transition_frontier.Breadcrumb.state_hash
-                               breadcrumb ) )
-                      ; ( "time"
-                        , `Float
-                            (Time.Span.to_ms
-                               (Time.diff (Time.now ()) diff_time) ) )
-                      ] ;
-                  ()
-              | Error e ->
-                  [%log warn]
-                    ~metadata:
-                      [ ("error", Error_json.error_to_yojson e)
-                      ; ( "breadcrumb"
-                        , Transition_frontier.Breadcrumb.to_yojson breadcrumb )
-                      ]
-                    "Could not send breadcrumb to archive: $error" ) ) )
+          breadcrumbs
+          |> List.map ~f:(fun breadcrumb ->
+                 let start = Time.now () in
+                 let diff =
+                   Archive_lib.Diff.Builder.breadcrumb_added ~precomputed_values
+                     ~logger breadcrumb
+                 in
+                 let diff_time = Time.now () in
+                 [%log debug]
+                   "Archive data generation for $state_hash took $time ms"
+                   ~metadata:
+                     [ ( "state_hash"
+                       , Mina_base.State_hash.to_yojson
+                           (Transition_frontier.Breadcrumb.state_hash breadcrumb)
+                       )
+                     ; ( "time"
+                       , `Float (Time.Span.to_ms (Time.diff diff_time start)) )
+                     ] ;
+                 dispatch archive_location ~logger (Transition_frontier diff)
+                 >>| function
+                 | Ok () ->
+                     [%log debug]
+                       "Dispatched archive data for $state_hash, took $time ms"
+                       ~metadata:
+                         [ ( "state_hash"
+                           , Mina_base.State_hash.to_yojson
+                               (Transition_frontier.Breadcrumb.state_hash
+                                  breadcrumb ) )
+                         ; ( "time"
+                           , `Float
+                               (Time.Span.to_ms
+                                  (Time.diff (Time.now ()) diff_time) ) )
+                         ]
+                 | Error e ->
+                     [%log warn]
+                       ~metadata:
+                         [ ("error", Error_json.error_to_yojson e)
+                         ; ( "breadcrumb"
+                           , Transition_frontier.Breadcrumb.to_yojson breadcrumb
+                           )
+                         ]
+                       "Could not send breadcrumb to archive: $error" )
+          |> Deferred.all_unit ) )

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -4,61 +4,52 @@ open Pipe_lib
 
 let dispatch ?(max_tries = 5) ~logger
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) diff =
-  let rec go tries_left errs =
-    if Int.( <= ) tries_left 0 then
-      let e = Error.of_list (List.rev errs) in
-      return
-        (Error
-           (Error.tag_arg e
-              (sprintf
-                 "Could not send archive diff data to archive process after %d \
-                  tries. The process may not be running, please check the \
-                  daemon-argument"
-                 max_tries )
-              ( ("host_and_port", archive_location.value)
-              , ("daemon-argument", archive_location.name) )
-              [%sexp_of: (string * Host_and_port.t) * (string * string)] ) )
-    else
-      match%bind
-        Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
-          archive_location.value
-      with
-      | Ok () ->
-          return (Ok ())
-      | Error e ->
-          [%log error]
-            "Error sending data to the archive process $error. Retrying..."
-            ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
-          go (tries_left - 1) (e :: errs)
+  let strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some max_tries) ()
   in
-  go max_tries []
+  Backoff.Deferred.retry ~log_errors:true strategy ~logger ~f:(fun () ->
+      Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
+        archive_location.value )
+  >>| function
+  | Ok () ->
+      Ok ()
+  | Error e ->
+      Error
+        (Error.tag_arg e
+           (sprintf
+              "Could not send archive diff data to archive process after %d \
+               tries. The process may not be running, please check the \
+               daemon-argument"
+              max_tries )
+           ( ("host_and_port", archive_location.value)
+           , ("daemon-argument", archive_location.name) )
+           [%sexp_of: (string * Host_and_port.t) * (string * string)] )
+
+let _null_logger = Logger.null ()
 
 let make_dispatch_block rpc ?(max_tries = 5)
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) block =
-  let rec go tries_left errs =
-    if Int.( <= ) tries_left 0 then
-      let e = Error.of_list (List.rev errs) in
-      return
-        (Error
-           (Error.tag_arg e
-              (sprintf
-                 "Could not send block data to archive process after %d tries. \
-                  The process may not be running, please check the \
-                  daemon-argument"
-                 max_tries )
-              ( ("host_and_port", archive_location.value)
-              , ("daemon-argument", archive_location.name) )
-              [%sexp_of: (string * Host_and_port.t) * (string * string)] ) )
-    else
-      match%bind
-        Daemon_rpcs.Client.dispatch rpc block archive_location.value
-      with
-      | Ok () ->
-          return (Ok ())
-      | Error e ->
-          go (tries_left - 1) (e :: errs)
+  let strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some max_tries) ()
   in
-  go max_tries []
+  Backoff.Deferred.retry strategy ~logger:_null_logger ~f:(fun () ->
+      Daemon_rpcs.Client.dispatch rpc block archive_location.value )
+  >>| function
+  | Ok () ->
+      Ok ()
+  | Error e ->
+      Error
+        (Error.tag_arg e
+           (sprintf
+              "Could not send block data to archive process after %d tries. \
+               The process may not be running, please check the \
+               daemon-argument"
+              max_tries )
+           ( ("host_and_port", archive_location.value)
+           , ("daemon-argument", archive_location.name) )
+           [%sexp_of: (string * Host_and_port.t) * (string * string)] )
 
 let dispatch_precomputed_block =
   make_dispatch_block Archive_lib.Rpc.precomputed_block

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -6,11 +6,10 @@ let dispatch ?(max_tries = 5) ~logger
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) diff =
   let strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
-      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some max_tries) ()
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:max_tries ()
   in
   Backoff.Deferred.retry ~log_errors:true strategy ~logger ~f:(fun () ->
-      Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
-        archive_location.value )
+      Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff archive_location.value )
   >>| function
   | Ok () ->
       Ok ()
@@ -32,7 +31,7 @@ let make_dispatch_block rpc ?(max_tries = 5)
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) block =
   let strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 1.0)
-      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:(Some max_tries) ()
+      ~max_delay:(Time_ns.Span.of_sec 10.0) ~max_attempts:max_tries ()
   in
   Backoff.Deferred.retry strategy ~logger:_null_logger ~f:(fun () ->
       Daemon_rpcs.Client.dispatch rpc block archive_location.value )

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -22,7 +22,8 @@
   result
   bin_prot.shape
   ;; local libraries
-  mina_stdlib
+   backoff
+   mina_stdlib
   transition_chain_prover
   best_tip_prover
   proof_carrying_data

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -21,8 +21,9 @@
   ppx_version.runtime
   result
   sexplib0
-  ;; local libraries
-  mina_stdlib
+   ;; local libraries
+   backoff
+   mina_stdlib
   cli_lib
   currency
   error_json

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -42,24 +42,12 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
     Prod.Impl.Worker_state.create ~constraint_constants ~proof_level
       ~signature_kind ()
   in
-  let wait ?(sec = 0.5) () = after (Time.Span.of_sec sec) in
-  (* retry interval with jitter *)
-  let retry_pause sec = Random.float_range (sec -. 2.0) (sec +. 2.0) in
-  let log_and_retry label error sec k =
-    let error_str = Error.to_string_hum error in
-    (* HACK: the bind before the call to go () produces an evergrowing
-         backtrace history which takes forever to print and fills our disks.
-         If the string becomes too long, chop off the first 10 lines and include
-         only that *)
-    ( if String.length error_str < 4096 then
-      [%log error] !"Error %s: %{sexp:Error.t}" label error
-    else
-      let lines = String.split ~on:'\n' error_str in
-      [%log error] !"Error %s: %s" label
-        (String.concat ~sep:"\\n" (List.take lines 10)) ) ;
-    let%bind () = wait ~sec () in
-    (* FIXME: Use a backoff algo here *)
-    k ()
+  let retry_strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 10.0)
+      ~max_delay:(Time_ns.Span.of_sec 120.0) ~max_attempts:None ()
+  in
+  let retry_forever ~f =
+    Backoff.Deferred.retry ~log_errors:true retry_strategy ~logger ~f
   in
   let rec go () =
     let%bind daemon_address =
@@ -80,20 +68,20 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
       !"Snark worker using daemon $addr"
       ~metadata:[ ("addr", `String (Host_and_port.to_string daemon_address)) ] ;
     match%bind
-      dispatch Rpc_get_work.Stable.Latest.rpc shutdown_on_disconnect ()
-        daemon_address
+      retry_forever ~f:(fun () ->
+          dispatch Rpc_get_work.Stable.Latest.rpc shutdown_on_disconnect ()
+            daemon_address )
     with
-    | Error e ->
-        log_and_retry "getting work" e (retry_pause 10.) go
+    | Error _ ->
+        go ()
     | Ok None ->
         let random_delay =
           Prod.Impl.Worker_state.worker_wait_time
           +. (0.5 *. Random.float Prod.Impl.Worker_state.worker_wait_time)
         in
-        (* No work to be done -- quietly take a brief nap *)
         [%log info] "No jobs available. Napping for $time seconds"
           ~metadata:[ ("time", `Float random_delay) ] ;
-        let%bind () = wait ~sec:random_delay () in
+        let%bind () = after (Time.Span.of_sec random_delay) in
         go ()
     | Ok (Some partitioned_spec) -> (
         let address_json =
@@ -108,43 +96,54 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
           "SNARK work $work_ids received from $address. Starting proof \
            generation"
           ~metadata:[ address_json; work_ids_json ] ;
-        let%bind () = wait () in
-        (* Pause to wait for stdout to flush *)
+        let%bind () = after (Time.Span.of_sec 0.5) in
         let id = Spec.Partitioned.Poly.get_id partitioned_spec in
         match%bind
-          Prod.Impl.perform_partitioned ~state ~spec:partitioned_spec
-        with
-        | Error e ->
-            let%bind () =
-              match%map
-                dispatch Rpc_failed_to_generate_snark.Stable.Latest.rpc
-                  shutdown_on_disconnect (e, id) daemon_address
+          retry_forever ~f:(fun () ->
+              match%bind
+                Prod.Impl.perform_partitioned ~state ~spec:partitioned_spec
               with
               | Error e ->
-                  [%log error]
-                    "Couldn't inform the daemon about the snark work failure"
-                    ~metadata:[ ("error", Error_json.error_to_yojson e) ]
-              | Ok () ->
-                  ()
-            in
-            log_and_retry "performing work" e (retry_pause 10.) go
+                  let%bind () =
+                    match%map
+                      dispatch Rpc_failed_to_generate_snark.Stable.Latest.rpc
+                        shutdown_on_disconnect (e, id) daemon_address
+                    with
+                    | Error e ->
+                        [%log error]
+                          "Couldn't inform the daemon about the snark work \
+                           failure"
+                          ~metadata:
+                            [ ("error", Error_json.error_to_yojson e) ]
+                    | Ok () ->
+                        ()
+                  in
+                  return (Error e)
+              | Ok data ->
+                  return (Ok data) )
+        with
+        | Error _ ->
+            go ()
         | Ok ({ data = elapsed; _ } as data) ->
-            let wire_result = Result.Partitioned.Stable.Latest.{ id; data } in
+            let wire_result =
+              Result.Partitioned.Stable.Latest.{ id; data }
+            in
             ( match partitioned_spec with
             | Spec.Partitioned.Poly.Single { spec = single_spec; _ } ->
-                Metrics.emit_single_metrics_stable ~logger ~single_spec ~elapsed
+                Metrics.emit_single_metrics_stable ~logger ~single_spec
+                  ~elapsed
             | Spec.Partitioned.Poly.Sub_zkapp_command
                 { spec = sub_zkapp_spec; _ } ->
-                Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec ~elapsed
-            ) ;
-            let rec submit_work () =
+                Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec
+                  ~elapsed ) ;
+            let submit_work () =
               match%bind
-                dispatch Rpc_submit_work.Stable.Latest.rpc
-                  shutdown_on_disconnect wire_result daemon_address
+                retry_forever ~f:(fun () ->
+                    dispatch Rpc_submit_work.Stable.Latest.rpc
+                      shutdown_on_disconnect wire_result daemon_address )
               with
-              | Error e ->
-                  log_and_retry "submitting work" e (retry_pause 10.)
-                    submit_work
+              | Error _ ->
+                  go ()
               | Ok `Ok ->
                   [%log info]
                     "Submitted completed SNARK work $work_ids to $address"
@@ -156,8 +155,8 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
                   go ()
               | Ok `SpecUnmatched ->
                   [%log info]
-                    "Result $work_ids rejected by $address since it has wrong \
-                     shape"
+                    "Result $work_ids rejected by $address since it has \
+                     wrong shape"
                     ~metadata:[ address_json; work_ids_json ] ;
                   go ()
             in

--- a/src/lib/snark_worker/entry.ml
+++ b/src/lib/snark_worker/entry.ml
@@ -44,7 +44,8 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
   in
   let retry_strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 10.0)
-      ~max_delay:(Time_ns.Span.of_sec 120.0) ~max_attempts:None ()
+      ~max_delay:(Time_ns.Span.of_sec 120.0)
+      ()
   in
   let retry_forever ~f =
     Backoff.Deferred.retry ~log_errors:true retry_strategy ~logger ~f
@@ -113,8 +114,7 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
                         [%log error]
                           "Couldn't inform the daemon about the snark work \
                            failure"
-                          ~metadata:
-                            [ ("error", Error_json.error_to_yojson e) ]
+                          ~metadata:[ ("error", Error_json.error_to_yojson e) ]
                     | Ok () ->
                         ()
                   in
@@ -125,17 +125,14 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
         | Error _ ->
             go ()
         | Ok ({ data = elapsed; _ } as data) ->
-            let wire_result =
-              Result.Partitioned.Stable.Latest.{ id; data }
-            in
+            let wire_result = Result.Partitioned.Stable.Latest.{ id; data } in
             ( match partitioned_spec with
             | Spec.Partitioned.Poly.Single { spec = single_spec; _ } ->
-                Metrics.emit_single_metrics_stable ~logger ~single_spec
-                  ~elapsed
+                Metrics.emit_single_metrics_stable ~logger ~single_spec ~elapsed
             | Spec.Partitioned.Poly.Sub_zkapp_command
                 { spec = sub_zkapp_spec; _ } ->
-                Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec
-                  ~elapsed ) ;
+                Metrics.emit_subzkapp_metrics ~logger ~sub_zkapp_spec ~elapsed
+            ) ;
             let submit_work () =
               match%bind
                 retry_forever ~f:(fun () ->
@@ -155,8 +152,8 @@ let main ~logger ~proof_level ~constraint_constants ~signature_kind
                   go ()
               | Ok `SpecUnmatched ->
                   [%log info]
-                    "Result $work_ids rejected by $address since it has \
-                     wrong shape"
+                    "Result $work_ids rejected by $address since it has wrong \
+                     shape"
                     ~metadata:[ address_json; work_ids_json ] ;
                   go ()
             in

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -19,8 +19,9 @@
   base.caml
   cohttp
   uri
-  ;; local libraries
-  kimchi_bindings
+   ;; local libraries
+   backoff
+   kimchi_bindings
   kimchi_types
   pasta_bindings
   network_peer

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -31,21 +31,14 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
   let headers =
     Cohttp.Header.of_list [ ("Content-Type", "application/json") ]
   in
-  let metadata_of_body = function
-    | `String s ->
-        [ ("error", `String s) ]
-    | `Strings ss ->
-        [ ("error", `List (List.map ss ~f:(fun s -> `String s))) ]
-    | `Empty | `Pipe _ ->
-        []
-  in
   let max_attempts = 8 in
-  let attempt_pause_sec = 4.0 in
-  (* see https://github.com/MinaProtocol/mina/blob/compatible/src/app/delegation_backend/README.md
-     for significance of these status codes
-  *)
   let unrecoverable_status_codes = [ 400; 401; 411; 413 ] in
-  let run_attempt attempt =
+  let strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 4.0)
+      ~max_delay:(Time_ns.Span.of_sec 4.0) ~max_attempts:(Some max_attempts)
+      ()
+  in
+  let run_attempt () =
     let interruptible =
       match%map
         make_interruptible
@@ -55,7 +48,7 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
                    (Yojson.Safe.to_string json |> Cohttp_async.Body.of_string)
                  url ) )
       with
-      | Ok ({ status; _ }, body) ->
+      | Ok ({ status; _ }, _body) ->
           let status_code = Cohttp.Code.code_of_status status in
           let status_string = Cohttp.Code.string_of_status status in
           let unretriable =
@@ -83,35 +76,17 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
                 ; ("http_code", `Int status_code)
                 ; ("http_error", `String status_string)
                 ]
-          else if attempt >= max_attempts then
-            let base_metadata =
-              [ ("state_hash", State_hash.to_yojson state_hash)
-              ; ("url", `String (Uri.to_string url))
-              ; ("http_code", `Int status_code)
-              ; ("http_error", `String status_string)
-              ]
-            in
-            let extra_metadata = metadata_of_body body in
-            let metadata = base_metadata @ extra_metadata in
-            [%log error]
-              "After %d attempts, failed to send block with state hash \
-               $state_hash to uptime service at URL $url, no more retries"
-              max_attempts ~metadata
           else
-            let base_metadata =
-              [ ("state_hash", State_hash.to_yojson state_hash)
-              ; ("url", `String (Uri.to_string url))
-              ; ("http_code", `Int status_code)
-              ; ("http_error", `String status_string)
-              ]
-            in
-            let extra_metadata = metadata_of_body body in
-            let metadata = base_metadata @ extra_metadata in
             [%log info]
               "Failure when sending block with state hash $state_hash to \
-               uptime service at URL $url, attempt %d of %d, retrying"
-              attempt max_attempts ~metadata ) ;
-          succeeded || unretriable
+               uptime service at URL $url, retrying"
+              ~metadata:
+                [ ("state_hash", State_hash.to_yojson state_hash)
+                ; ("url", `String (Uri.to_string url))
+                ; ("http_code", `Int status_code)
+                ; ("http_error", `String status_string)
+                ] ) ;
+          if succeeded || unretriable then Ok () else Error (Error.of_string "uptime post failed")
       | Error exn ->
           [%log warn]
             "Error when sending block with state hash $state_hash to uptime \
@@ -121,34 +96,26 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
               ; ("url", `String (Uri.to_string url))
               ; ("error", `String (Exn.to_string exn))
               ] ;
-          (* retry *)
-          false
+          Error (Error.of_string "uptime post exception")
     in
     match%map.Deferred Interruptible.force interruptible with
-    | Ok succeeded ->
-        succeeded
+    | Ok (Ok ()) ->
+        Ok ()
+    | Ok (Error _) ->
+        Error (Error.of_string "uptime post failed")
     | Error _ ->
         [%log error]
           "In uptime service, POST of block with state hash $state_hash was \
            interrupted"
           ~metadata:[ ("state_hash", State_hash.to_yojson state_hash) ] ;
-        (* interrupted, don't want to retry, claim success *)
-        true
+        Ok ()
   in
-  let rec go attempt =
-    let open Deferred.Let_syntax in
-    let%bind succeeded = run_attempt attempt in
-    if succeeded then Deferred.return ()
-    else if attempt < max_attempts then (
-      let%bind () = Async.after (Time.Span.of_sec attempt_pause_sec) in
-      [%log info]
-        "In uptime service, retrying to send block, attempt %d of %d attempts \
-         allowed"
-        attempt max_attempts ;
-      go (attempt + 1) )
-    else Deferred.unit
-  in
-  make_interruptible (go 1)
+  make_interruptible
+    (let%map.Deferred _ =
+       Backoff.Deferred.retry ~log_errors:true strategy ~logger
+         ~f:(fun () -> run_attempt ())
+     in
+     () )
 
 let block_base64_of_breadcrumb breadcrumb =
   let external_transition =

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -35,8 +35,7 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
   let unrecoverable_status_codes = [ 400; 401; 411; 413 ] in
   let strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 4.0)
-      ~max_delay:(Time_ns.Span.of_sec 4.0) ~max_attempts:(Some max_attempts)
-      ()
+      ~max_delay:(Time_ns.Span.of_sec 4.0) ~max_attempts ()
   in
   let run_attempt () =
     let interruptible =
@@ -55,7 +54,7 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
             List.mem unrecoverable_status_codes status_code ~equal:Int.equal
           in
           let succeeded = status_code = 200 in
-          ( if succeeded then
+          if succeeded then
             [%log info]
               "Sent block with state hash $state_hash to uptime service at URL \
                $url"
@@ -85,8 +84,9 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
                 ; ("url", `String (Uri.to_string url))
                 ; ("http_code", `Int status_code)
                 ; ("http_error", `String status_string)
-                ] ) ;
-          if succeeded || unretriable then Ok () else Error (Error.of_string "uptime post failed")
+                ] ;
+          if succeeded || unretriable then Ok ()
+          else Error (Error.of_string "uptime post failed")
       | Error exn ->
           [%log warn]
             "Error when sending block with state hash $state_hash to uptime \
@@ -112,8 +112,8 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
   in
   make_interruptible
     (let%map.Deferred _ =
-       Backoff.Deferred.retry ~log_errors:true strategy ~logger
-         ~f:(fun () -> run_attempt ())
+       Backoff.Deferred.retry ~log_errors:true strategy ~logger ~f:(fun () ->
+           run_attempt () )
      in
      () )
 

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -13,8 +13,9 @@
   core_kernel
   rpc_parallel
   sexplib0
-  ;; local libraries
-  blockchain_snark
+   ;; local libraries
+   backoff
+   blockchain_snark
   child_processes
   error_json
   genesis_constants

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -536,7 +536,7 @@ let create ~logger ?(enable_internal_tracing = false) ?internal_trace_filename
 let with_retry ~logger f =
   let strategy =
     Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 5.0)
-      ~max_delay:(Time_ns.Span.of_sec 5.0) ~max_attempts:(Some 5) ()
+      ~max_delay:(Time_ns.Span.of_sec 5.0) ~max_attempts:5 ()
   in
   Backoff.Deferred.retry strategy ~logger ~f:(fun () ->
       match%bind f () with

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -534,22 +534,18 @@ let create ~logger ?(enable_internal_tracing = false) ?internal_trace_filename
   { worker = worker_ref; logger }
 
 let with_retry ~logger f =
-  let pause = Time.Span.of_sec 5. in
-  let rec go attempts_remaining =
-    [%log trace] "Verifier trying with $attempts_remaining"
-      ~metadata:[ ("attempts_remaining", `Int attempts_remaining) ] ;
-    match%bind f () with
-    | Ok (`Continue x) ->
-        return (Ok x)
-    | Ok (`Stop e) ->
-        return (Error e)
-    | Error e ->
-        if attempts_remaining = 0 then return (Error e)
-        else
-          let%bind () = after pause in
-          go (attempts_remaining - 1)
+  let strategy =
+    Backoff.Strategy.create ~base:(Time_ns.Span.of_sec 5.0)
+      ~max_delay:(Time_ns.Span.of_sec 5.0) ~max_attempts:(Some 5) ()
   in
-  go 4
+  Backoff.Deferred.retry strategy ~logger ~f:(fun () ->
+      match%bind f () with
+      | Ok (`Continue x) ->
+          return (Ok x)
+      | Ok (`Stop e) ->
+          return (Error e)
+      | Error e ->
+          return (Error e) )
 
 let verify_blockchain_snarks { worker; logger } chains =
   O1trace.thread "dispatch_blockchain_snark_verification" (fun () ->


### PR DESCRIPTION
## Summary

Add a reusable `backoff` library and wire it into 7 retry sites across the codebase, eliminating ~260 lines of ad-hoc retry boilerplate.

## New library: `src/lib/backoff/`

A monad-agnostic exponential backoff library for retry loops with full jitter:

- **`Strategy.create ~base ~max_delay ?max_attempts ?random_state ()`** — opaque config. Exponential backoff with full jitter (`delay = random(0, min(max_delay, base × 2^attempt))`). Overflow-safe via multiplier clamping and `Float.pow`. `?max_attempts` defaults to unlimited retry.

- **`Backoff.Make(M : Monad).retry strategy ~logger ~f`** — functor for any monad implementing `bind`/`return`/`sleep`. Trampolined via `M.return() >>= go` to keep the call stack bounded.

- **`Backoff.Deferred.retry`** — pre-built `Deferred.t` instance covering the 90% case. Supports `~log_errors:bool` with structured `error_json` metadata on each retry.

- Error type is `Core.Error.t` (matches all existing call sites).

- External Alcotest tests with `Identity` monad for pure verification.

Dependencies: `async_kernel`, `core_kernel`, `error_json`, `logger`.

## Wired sites

| File | Change | Before | After |
|------|--------|--------|-------|
| `verifier/prod.ml` | `with_retry` → `Backoff.Deferred.retry` | Manual `go 4` loop, 5s fixed pause | 5 attempts, 5s delay, `Continue`/`Stop` preserved |
| `block_producer/block_producer.ml` | Removed `retry` wrapper | Ad-hoc `go n` loop, no delay, `failwith` on exhaustion | Shared `vrf_retry_strategy` (1s base, 10s cap, 3 attempts) |
| `snark_worker/entry.ml` | Removed `wait`/`retry_pause`/`log_and_retry` + FIXME | Fixed 10s ± 2s jitter, indefinite loop | `retry_forever ~f` (10s base, 120s cap, unlimited, `~log_errors:true`) |
| `mina_graphql_client/client.ml` | `exec_graphql_request` retry loop → backoff | Hand-rolled `retry n`, `bounded_sleep`, deadline logic | `Backoff.Deferred.retry` with `Clock.with_timeout` for deadline; `Graphql_error` escapes via double-wrapped `Ok (Error ...)` |
| `uptime_service/uptime_service.ml` | `go attempt` loop → backoff | 8 attempts, 4s fixed delay, custom logging | `Backoff.Deferred.retry` with `make_interruptible` preserved; custom per-attempt logging kept |
| `mina_lib/archive_client.ml` | Two `go tries_left errs` loops → backoff | Immediate retry, 5 attempts, error accumulation | 1s base / 10s cap, `log_errors:true`; tagged error on exhaustion preserved |

## Not wired (and why)

- **`archive/processor.ml`** — polymorphic variant error types (`Caqiti_error.t`) throughout; replacing with `Error.t` requires deep refactor.
- **`ledger_catchup/super_catchup.ml`** — uses `Deferred.Result` (not `Or_error`), `step` bail-out wrapper, and retry is a state-machine restart (not an operation retry).
- **`network_pool/network_pool_base.ml`** — periodic broadcast loop, not a retry-on-failure pattern.
- **`mina_networking/mina_networking.ml`** — one-shot peer fallback, no delay, no retry loop.
