### PR TITLE
fix(archive): detect failed block adds in missing-blocks-guardian (stop silent infinite loop)

### DIFF
--- a/scripts/archive/missing-blocks-guardian.sh
+++ b/scripts/archive/missing-blocks-guardian.sh
@@ -109,10 +109,20 @@ populate_db() {
   tempfile=$(mktemp)
   echo  "${ARCHIVE_BLOCKS} --${BLOCKS_FORMAT} --archive-uri ${1} ${2}"
   ${ARCHIVE_BLOCKS} "--${BLOCKS_FORMAT}" --archive-uri "${1}" "${2}" > "$tempfile"
-  
-  if [ $? -ne 0 ]; then
-    echo $'[ERROR] mina-archive-blocks failed. The database remains unhealthy.\n Make sure the environment variables are set correctly and the database is accessible.'
-    rm "${2}" "$tempfile"
+  archive_blocks_exit=$?
+
+  # NOTE: mina-archive-blocks exits 0 even when it fails to add a block. After
+  # exhausting its internal retries it logs an "Error"-level entry ("Error when
+  # adding block") and rolls back the transaction, yet still returns exit code 0.
+  # Trusting the exit code alone makes bootstrap() re-download and re-attempt the
+  # very same un-addable block forever -- a silent infinite loop. So treat an
+  # Error-level log line as a failure too, and surface the underlying cause so the
+  # operator can act on it instead of the run spinning unnoticed.
+  if [ "$archive_blocks_exit" -ne 0 ] || grep -Eq '"level"[[:space:]]*:[[:space:]]*"Error"' "$tempfile"; then
+    echo $'[ERROR] mina-archive-blocks failed to add the block. The database remains unhealthy.'
+    echo "[ERROR] Diagnostics from ${ARCHIVE_BLOCKS} (exit code ${archive_blocks_exit}):"
+    jq -rs '.[] | select(.level == "Error" or .level == "Warn") | "  [\(.level)] \(.message): \(.metadata.error // "")"' "$tempfile" 2>/dev/null | tail -n 5
+    rm -f "${2}" "$tempfile"
     exit 1
   fi
   jq -rs '"[BOOTSTRAP] Populated database with block: \(.[-1].message)"' < "$tempfile"


### PR DESCRIPTION
## Problem

`scripts/archive/missing-blocks-guardian.sh` can get stuck in a silent infinite loop. Observed live on an archive-backfill CronJob: a single pod ran for **4+ days** repeating this every few seconds and never exiting:

```
[BOOTSTRAP] Downloading <network>-303310-<hash>.json block
mina-archive-blocks --precomputed --archive-uri postgres://...  <block>.json
[BOOTSTRAP] Populated database with block: Error when adding block
```

## Root cause

`populate_db()` checked only the process exit code:

```bash
${ARCHIVE_BLOCKS} ... > "$tempfile"
if [ $? -ne 0 ]; then ... exit 1; fi
```

But `mina-archive-blocks` **exits 0 even when it fails to add a block**. After exhausting its internal retries it logs a final `"level":"Error"` / `"Error when adding block"` and rolls back the transaction, yet returns 0. So the guard never fired, the script printed `Populated database with block: Error when adding block` (it just echoes the tool's last `.message`), and `bootstrap()`'s `until [[ "$PARENT" == "null" ]]` loop kept re-downloading and re-attempting the same block because the auditor still reported it missing.

In `single-run` mode the run therefore never terminates. Because the deploying CronJob uses `concurrencyPolicy: Forbid`, the stuck run also blocks every later scheduled run.

## Fix

Detect an `Error`-level log line as a failure (in addition to a non-zero exit code), surface the underlying diagnostics, and `exit 1` so the run fails loudly instead of looping:

```bash
${ARCHIVE_BLOCKS} ... > "$tempfile"
archive_blocks_exit=$?
if [ "$archive_blocks_exit" -ne 0 ] || grep -Eq '"level"[[:space:]]*:[[:space:]]*"Error"' "$tempfile"; then
  echo '[ERROR] mina-archive-blocks failed to add the block. The database remains unhealthy.'
  echo "[ERROR] Diagnostics from ${ARCHIVE_BLOCKS} (exit code ${archive_blocks_exit}):"
  jq -rs '.[] | select(.level=="Error" or .level=="Warn") | "  [\(.level)] \(.message): \(.metadata.error // "")"' "$tempfile" 2>/dev/null | tail -n 5
  rm -f "${2}" "$tempfile"; exit 1
fi
```

Transient `Warn`-level retries (which the binary recovers from) are intentionally **not** treated as failures — only a terminal `Error`.

## Out of scope

In the case that surfaced this, the underlying reason the block could not be added is a **separate archive issue**: `Unexpected result ... Received 21360 tuples, expected at most one. Query: "SELECT id FROM zkapp_events WHERE (element_ids = $1::int[] OR (element_ids IS NULL AND $1 IS NULL))"`. This PR does not fix that — it makes the guardian fail loudly and actionably instead of hiding it forever.

## Testing

- `bash -n` clean.
- Verified the detection lets a success / `Warn`-only log through, fails a log containing a terminal `Error` line, and that the diagnostics render the underlying error message.
