### PR TITLE
Remove test-only tooling from the production rosetta image

### DIFF
--- a/changes/18973.md
+++ b/changes/18973.md
@@ -1,0 +1,6 @@
+- The production `mina-rosetta` Docker image no longer bundles test-only tooling.
+  The Go toolchain and `rosetta-cli` (previously built from source), the baked
+  sample/demo wallet, and the `mina-zkapp-test-transaction` package have been
+  removed. They are used only by the Rosetta integration tests — which now
+  provision them at test time — and have no role in the production runtime, so
+  dropping them noticeably slims the shipped image.

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -5,18 +5,11 @@ ARG deb_version
 ARG deb_release=unstable
 ARG network=mainnet
 ARG deb_repo="http://packages.o1test.net"
-ARG TARGETARCH
 
 ARG psql_version=15
-# Golang version number used to detemine tarball name
-ARG GO_VERSION=1.19.11
 
 ARG MINA_DAEMON_PORT=8302
 ARG MINA_CONFIG_DIR=/data/.mina-config
-# Sample public key for use in dev profile / demo mode genesis block
-ARG PK=B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p
-
-ARG ROSETTA_CLI_VERSION=v0.10.1
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -105,37 +98,15 @@ RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     postgresql-client-"$psql_version" \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Golang install of a given GO_VERSION (add -v for spam output of each file from the go dist)
+# rosetta-cli and the Go toolchain that builds it are intentionally NOT installed
+# in the production image: they are test-only (the rosetta integration test builds
+# its own copy via buildkite/scripts/tests/rosetta/install-cli.sh) and have no
+# role in the production runtime. Keeping them out slims the shipped image.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -xz -C /usr/lib/
-
-# --- Install rosetta-cli
-# The following commands install rosetta-cli with an updated rosetta-sdk-go dependency, which supports delegation transactions.
-# Upstream PR to rosetta-sdk-go: https://github.com/coinbase/rosetta-sdk-go/pull/457
-# They can be replaced once there is a new release of rosetta-cli containing the above change by:
-#RUN curl -sSfL https://raw.githubusercontent.com/coinbase/mesh-cli/${ROSETTA_CLI_VERSION}/scripts/install.sh | sh -s
-RUN curl -L "https://github.com/coinbase/mesh-cli/archive/refs/tags/v0.10.1.tar.gz" -o "/tmp/v0.10.1.tar.gz" \
-    && tar xzf "/tmp/v0.10.1.tar.gz" -C "/tmp"
-
-WORKDIR /tmp/mesh-cli-0.10.1
-RUN GOBIN="/bin" \
-    export GOBIN \
-    && /usr/lib/go/bin/go mod edit -replace github.com/coinbase/rosetta-sdk-go@v0.8.1=github.com/MinaProtocol/rosetta-sdk-go@stake-delegation-v1 \
-    && /usr/lib/go/bin/go mod tidy \
-    && /usr/lib/go/bin/go install
 
 # --- Generate en_US.UTF-8 locale to allow use of O(1) Labs DB dumps
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && locale-gen
-
-# --- Set up sample/demo wallets and configuration
-RUN mkdir -p ${MINA_CONFIG_DIR}/wallets/store/ \
-    && chmod 700 ${MINA_CONFIG_DIR}/wallets/store/ \
-    && echo "$PK" >  ${MINA_CONFIG_DIR}/wallets/store/$PK.pub \
-    && echo '{"box_primitive":"xsalsa20poly1305","pw_primitive":"argon2i","nonce":"6pcvpWSLkMi393dT5VSLR6ft56AWKkCYRqJoYia","pwsalt":"ASoBkV3NsY7ZRuxztyPJdmJCiz3R","pwdiff":[134217728,6],"ciphertext":"Dmq1Qd8uNbZRT1NT7zVbn3eubpn9Myx9Je9ZQGTKDxUv4BoPNmZAGox18qVfbbEUSuhT4ZGDt"}' \
-    > ${MINA_CONFIG_DIR}/wallets/store/${PK} \
-    && chmod go-rwx ${MINA_CONFIG_DIR}/wallets/store/${PK}
-
 
 # Mina daemon package
 # jemalloc is also installed automatically here to match the package dependencies for this $deb_codename.
@@ -154,16 +125,14 @@ RUN echo "Building image with version $deb_version from repo $deb_release $deb_c
            "mina-${network}${SUFFIX}=$deb_version" \
            "mina-logproc=$deb_version" \
            "${MINA_ARCHIVE_DEB}=$deb_version" \
-           "${MINA_ROSETTA_DEB}=$deb_version" \
-           "mina-zkapp-test-transaction=$deb_version" ; \
+           "${MINA_ROSETTA_DEB}=$deb_version" ; \
        else \
          /usr/local/bin/install-mina-debs.sh \
            "mina-${network}-generic${SUFFIX}=$deb_version" \
            "mina-logproc=$deb_version" \
            "${MINA_CONFIG_DEB}=$deb_version" \
            "${MINA_ARCHIVE_DEB}=$deb_version" \
-           "${MINA_ROSETTA_DEB}=$deb_version" \
-           "mina-zkapp-test-transaction=$deb_version" ; \
+           "${MINA_ROSETTA_DEB}=$deb_version" ; \
        fi
 
 # --- Set up postgres


### PR DESCRIPTION
## Summary

First step toward running the rosetta tests off the apps cache (no production docker image). This PR strips **test-only** baggage out of the production `mina-rosetta` image so the shipped image is slimmer and no longer doubles as a test harness.

Removed from `dockerfiles/Dockerfile-mina-rosetta`:
- **Go toolchain + `rosetta-cli` built from source** — the biggest size win (Go distribution + build).
- **Hardcoded demo wallet** (`$PK` + `wallets/store` entry).
- **`mina-zkapp-test-transaction`** deb from both install branches.
- The now-orphaned `GO_VERSION`, `PK`, `ROSETTA_CLI_VERSION`, `TARGETARCH` ARGs.

Net: **+6 / −37 lines**.

## Why this is safe

| Removed | Who actually needs it |
|---|---|
| rosetta-cli / Go | Production entrypoint `docker-start.sh` never calls it; the connectivity load test (`rosetta-load.sh`) uses psql only. The integration test builds its **own** rosetta-cli via `buildkite/scripts/tests/rosetta/install-cli.sh` (whose header says it mirrors these very Dockerfile steps). |
| demo wallet | Demo scripts generate their own keys; the integration test generates its own accounts. |
| `mina-zkapp-test-transaction` | Used only by the rosetta integration test, which runs in the toolchain and installs the deb itself via `install-debs.sh`. |

Verified there is **no** consumer that `docker exec`s the baked rosetta-cli / zkapp-test-transaction inside the `mina-rosetta` image, and demo mode does not exec rosetta-cli. `rosetta-cli-config` stays (it ships via the `mina-rosetta` deb). No new hadolint warnings.

## Follow-ups (not in this PR)
- Flip `RosettaIntegrationTests` to the apps-cache pattern (`APPS_BARE_BINARIES` for mina / archive / rosetta / zkapp_test_transaction), then drop the deb fallback + `dependsOn` — same "flip" the archive family is set up for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)