### PR TITLE
Run Rosetta integration tests outside docker via bare binaries

### DIFF
--- a/buildkite/scripts/tests/rosetta/install-debs.sh
+++ b/buildkite/scripts/tests/rosetta/install-debs.sh
@@ -35,4 +35,10 @@ DEBS_CSV="$(IFS=,; echo "${DEBS[*]}")"
 # Run the installer in a child process (not `source`d) so its strict-mode
 # flags (`set -u`, custom `PS4`) don't leak back into the calling shell. Use
 # sudo (toolchain image runs as opam user with NOPASSWD sudo).
-bash ./buildkite/scripts/debian/install.sh "${DEBS_CSV}" 1
+#
+# restore-or-install.sh is a drop-in for debian/install.sh: when
+# APPS_BARE_BINARIES is set it restores the freshly dune-built executables from
+# the apps cache (skipping the deb install, so no prebuilt mina-rosetta docker
+# image / published debs are needed); when it is unset (or a cache miss occurs)
+# it falls back to installing the debs above, preserving the previous behaviour.
+bash ./buildkite/scripts/debian/restore-or-install.sh "${DEBS_CSV}" 1

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -78,7 +78,13 @@ export PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:54
 
 # Mina Archive variables
 export MINA_ARCHIVE_PORT=${MINA_ARCHIVE_PORT:=3086}
-export MINA_ARCHIVE_SQL_SCHEMA_PATH=${MINA_ARCHIVE_SQL_SCHEMA_PATH:=/etc/mina/archive/create_schema.sql}
+# Prefer the deb-installed schema; fall back to the in-repo copy when running
+# from bare binaries (no mina-archive deb present).
+DEB_ARCHIVE_SQL_SCHEMA_PATH=/etc/mina/archive/create_schema.sql
+if [ ! -f "$DEB_ARCHIVE_SQL_SCHEMA_PATH" ]; then
+  DEB_ARCHIVE_SQL_SCHEMA_PATH=./src/app/archive/create_schema.sql
+fi
+export MINA_ARCHIVE_SQL_SCHEMA_PATH=${MINA_ARCHIVE_SQL_SCHEMA_PATH:=$DEB_ARCHIVE_SQL_SCHEMA_PATH}
 
 # Mina Rosetta variables
 export MINA_ROSETTA_ONLINE_PORT=${MINA_ROSETTA_ONLINE_PORT:=3087}
@@ -100,7 +106,13 @@ export MINA_GRAPHQL_PORT=${MINA_GRAPHQL_PORT:=3085}
 # Files from ROSETTA_CLI_CONFIG_FILES will be read from
 # ROSETTA_CONFIGURATION_INPUT_DIR and some placeholders will be
 # substituted.
-ROSETTA_CONFIGURATION_INPUT_DIR=${ROSETTA_CONFIGURATION_INPUT_DIR:=/etc/mina/rosetta/rosetta-cli-config}
+# Prefer the deb-installed rosetta-cli-config templates; fall back to the
+# in-repo copies when running from bare binaries (no mina-rosetta deb present).
+DEB_ROSETTA_CONFIGURATION_INPUT_DIR=/etc/mina/rosetta/rosetta-cli-config
+if [ ! -d "$DEB_ROSETTA_CONFIGURATION_INPUT_DIR" ]; then
+  DEB_ROSETTA_CONFIGURATION_INPUT_DIR=./src/app/rosetta/rosetta-cli-config
+fi
+ROSETTA_CONFIGURATION_INPUT_DIR=${ROSETTA_CONFIGURATION_INPUT_DIR:=$DEB_ROSETTA_CONFIGURATION_INPUT_DIR}
 ROSETTA_CLI_CONFIG_FILES=${ROSETTA_CLI_CONFIG_FILES:="config.json mina.ros"}
 ROSETTA_CLI_MAIN_CONFIG_FILE=${ROSETTA_CLI_MAIN_CONFIG_FILE:="config.json"}
 
@@ -211,7 +223,13 @@ sudo pg_ctlcluster ${POSTGRES_VERSION} main start || true
 sudo pg_dropcluster --stop ${POSTGRES_VERSION} main || true
 sudo mkdir -p ${POSTGRES_DATA_DIR}
 sudo chown postgres:postgres ${POSTGRES_DATA_DIR}
-sudo pg_createcluster --start -d ${POSTGRES_DATA_DIR} --createclusterconf /etc/mina/rosetta/scripts/postgresql.conf ${POSTGRES_VERSION} main
+# Prefer the deb-installed postgres cluster config; fall back to the in-repo
+# copy when running from bare binaries (no mina-rosetta deb present).
+POSTGRES_CLUSTER_CONF=${POSTGRES_CLUSTER_CONF:=/etc/mina/rosetta/scripts/postgresql.conf}
+if [ ! -f "$POSTGRES_CLUSTER_CONF" ]; then
+  POSTGRES_CLUSTER_CONF=./src/app/rosetta/scripts/postgresql.conf
+fi
+sudo pg_createcluster --start -d ${POSTGRES_DATA_DIR} --createclusterconf "${POSTGRES_CLUSTER_CONF}" ${POSTGRES_VERSION} main
 sudo -u postgres psql --command "CREATE USER ${POSTGRES_USERNAME} WITH SUPERUSER PASSWORD '${POSTGRES_USERNAME}';"
 sudo -u postgres createdb -O ${POSTGRES_USERNAME} ${POSTGRES_DBNAME}
 psql -f "${MINA_ARCHIVE_SQL_SCHEMA_PATH}" "${PG_CONN}"

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -18,6 +18,8 @@ let RunInToolchain = ../../Command/RunInToolchain.dhall
 
 let Network = ../../Constants/Network.dhall
 
+let Profiles = ../../Constants/Profiles.dhall
+
 let network = Network.Type.Devnet
 
 let dirtyWhen =
@@ -25,12 +27,25 @@ let dirtyWhen =
       , S.exactly "buildkite/src/Jobs/Test/RosettaIntegrationTests" "dhall"
       , S.strictlyStart (S.contains "buildkite/scripts/tests/rosetta")
       , S.exactly "buildkite/scripts/debian/install" "sh"
+      , S.exactly "buildkite/scripts/debian/restore-or-install" "sh"
+      , S.strictlyStart (S.contains "buildkite/scripts/apps")
       , S.strictlyStart (S.contains "scripts/debian")
       ]
+
+let bareBinaries =
+          "mina_testnet_signatures.exe:mina"
+      ++  ",archive.exe:mina-archive"
+      ++  ",rosetta_testnet_signatures.exe:mina-rosetta"
+      ++  ",signer_testnet_signatures.exe:mina-ocaml-signer"
+      ++  ",zkapp_test_transaction.exe:mina-zkapp-test-transaction"
+      ++  ",indexer_test.exe:mina-rosetta-indexer-test"
+      ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =
       [ "MINA_NETWORK_DEB=${Network.lowerName network}"
       , "MINA_DEB_CODENAME=bullseye"
+      , "APPS_NETWORK=${Network.lowerName network}"
+      , "APPS_BARE_BINARIES=${bareBinaries}"
       ]
 
 in  Pipeline.build
@@ -60,7 +75,12 @@ in  Pipeline.build
             , key = "rosetta-integration-tests-bullseye"
             , target = Size.Small
             , artifact_paths = [ S.contains "test_output/artifacts/*" ]
-            , depends_on = DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+            , depends_on =
+                DebianVersions.dependsOn
+                  DebianVersions.DepsSpec::{
+                  , network = network
+                  , profile = Profiles.Type.Devnet
+                  }
             }
         ]
       }


### PR DESCRIPTION
## Motivation

`RosettaIntegrationTests` previously ran its daemon + archive + rosetta stack by
installing the `mina-${NETWORK}-generic`, `mina-archive-${NETWORK}`,
`mina-rosetta-${NETWORK}` and `mina-zkapp-test-transaction` debian packages,
which tied the job to the prebuilt Debian/docker artifacts. This converts it to
the repo's "bare binaries" pattern so it runs against the freshly dune-built
executables restored from the apps cache, dropping the dependency on the
prebuilt mina-rosetta docker image / published debs.

## What changed

- **`buildkite/scripts/tests/rosetta/install-debs.sh`** — calls
  `debian/restore-or-install.sh` instead of `debian/install.sh`. When
  `APPS_BARE_BINARIES` is set it restores the binaries from the apps cache and
  skips the deb install; when unset (or on any cache miss) it falls back to the
  identical deb install, so the non-bare path is behaviour-preserving.

- **`buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall`** — adds
  `APPS_NETWORK=devnet` and an `APPS_BARE_BINARIES` mapping covering every binary
  the test invokes:

  | cached `.exe` | install-as | source (deb mapping) |
  | --- | --- | --- |
  | `mina_testnet_signatures.exe` | `mina` | daemon generic deb |
  | `archive.exe` | `mina-archive` | mina-archive deb |
  | `rosetta_testnet_signatures.exe` | `mina-rosetta` | mina-rosetta deb |
  | `signer_testnet_signatures.exe` | `mina-ocaml-signer` | mina-rosetta deb |
  | `zkapp_test_transaction.exe` | `mina-zkapp-test-transaction` | zkapp deb |
  | `indexer_test.exe` | `mina-rosetta-indexer-test` | mina-rosetta deb |
  | `libp2p_helper` | `libp2p_helper` | daemon generic deb |

  `depends_on` is made explicit on the Devnet/Devnet Bullseye build that
  populates that cache (and supplies the deb fallback). `dirtyWhen` gains the
  `restore-or-install` script and `buildkite/scripts/apps` cache scripts.

- **`buildkite/scripts/tests/rosetta/integration-tests.sh`** — sources the
  NON-binary deb payloads from their in-repo copies when the deb-installed paths
  are absent:
  - archive schema: `/etc/mina/archive/create_schema.sql` → `./src/app/archive/create_schema.sql`
  - rosetta-cli-config: `/etc/mina/rosetta/rosetta-cli-config` → `./src/app/rosetta/rosetta-cli-config`
  - postgres cluster conf: `/etc/mina/rosetta/scripts/postgresql.conf` → `./src/app/rosetta/scripts/postgresql.conf`

## Fallback

Every change degrades cleanly: if `APPS_BARE_BINARIES` is unset or a cache read
misses, `restore-or-install.sh` installs the same debs as before, and the
integration script keeps using the deb-installed `/etc/mina/...` payloads
whenever they are present. The bare path only kicks in inside Buildkite with a
populated apps cache.

## Checks

- `dhall --file src/Jobs/Test/RosettaIntegrationTests.dhall` — typechecks
- `dhall format --check` / `dhall lint --check` — clean
- `cd buildkite && make test_monorepo` — 37/37 pass
- `shellcheck` on `install-debs.sh` — clean; on `integration-tests.sh` — only
  pre-existing warnings (no new ones from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
