### PR TITLE
Switch VRF denominator from total_currency to total_stake

### DIFF
--- a/src/lib/consensus/genesis_data.ml
+++ b/src/lib/consensus/genesis_data.ml
@@ -10,6 +10,18 @@ let genesis_ledger_total_currency ~ledger =
              ~message:"failed to calculate total currency in genesis ledger"
       else sum )
 
+let genesis_ledger_total_stake ~ledger =
+  Mina_ledger.Ledger.foldi ~init:Currency.Amount.zero (Lazy.force ledger)
+    ~f:(fun _addr sum (account : Mina_base.Account.t) ->
+      if
+        Mina_base.(Token_id.equal account.token_id Token_id.default)
+        && Option.is_some account.delegate
+      then
+        Currency.Amount.add sum (Currency.Balance.to_amount @@ account.balance)
+        |> Base.Option.value_exn ?here:None ?error:None
+             ~message:"failed to calculate total stake in genesis ledger"
+      else sum )
+
 let genesis_ledger_hash ~ledger =
   Mina_ledger.Ledger.merkle_root (Lazy.force ledger)
   |> Mina_base.Frozen_ledger_hash.of_ledger_hash
@@ -36,7 +48,7 @@ module Epoch = struct
     let to_hashed (t : Genesis_ledger.Packed.t t) : Hashed.t t =
       let ledger = Genesis_ledger.Packed.t t.ledger in
       let total_currency = genesis_ledger_total_currency ~ledger in
-      let total_stake = Currency.Amount.zero in
+      let total_stake = genesis_ledger_total_stake ~ledger in
       let hash = genesis_ledger_hash ~ledger in
       { ledger = { hash; total_currency; total_stake }; seed = t.seed }
   end
@@ -73,6 +85,6 @@ module Ledger = struct
     let ledger = Genesis_ledger.Packed.t t in
     { hash = genesis_ledger_hash ~ledger
     ; total_currency = genesis_ledger_total_currency ~ledger
-    ; total_stake = Currency.Amount.zero
+    ; total_stake = genesis_ledger_total_stake ~ledger
     }
 end

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -680,7 +680,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       include Mina_base.Epoch_ledger
 
       let genesis ~(ledger : Genesis_data.Hashed.t) =
-        { Poly.hash = ledger.hash; total_currency = ledger.total_currency }
+        { Poly.hash = ledger.hash; total_currency = ledger.total_stake }
     end
 
     module Vrf = struct
@@ -1937,7 +1937,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             previous_consensus_state.epoch_count ~prev_epoch ~next_epoch
             ~next_slot ~prev_protocol_state_hash:previous_protocol_state_hash
             ~producer_vrf_result ~snarked_ledger_hash ~genesis_ledger_hash
-            ~total_currency
+            ~total_currency:total_stake
         in
         let min_window_density, sub_window_densities =
           Min_window_density.update_min_window_density ~constants
@@ -3402,7 +3402,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   (Mina_base.State_hash.With_state_hashes.state_hash
                      previous_protocol_state )
                 ~producer_vrf_result ~snarked_ledger_hash ~genesis_ledger_hash
-                ~total_currency
+                ~total_currency:prev.total_stake
             in
             let min_window_density, sub_window_densities =
               Min_window_density.update_min_window_density ~constants


### PR DESCRIPTION
## Summary

- Repurpose the existing `Epoch_ledger.total_currency` field to hold `total_stake` values so the VRF threshold uses staked supply as its denominator (MIP-0010)
- No type changes, no version bumps, no cascade through archive/GraphQL/wire types — the field name stays `total_currency` downstream; only the value that populates it changes
- Add `genesis_ledger_total_stake` in `genesis_data.ml` (fold over default-token accounts with `delegate ≠ None`) to populate the genesis epoch ledger correctly

## Test plan

- [ ] `dune build @check` passes locally
- [ ] CI integration tests (consensus, staking, block production) validate the VRF fires correctly with the new denominator
- [ ] Verify no regressions in existing staged_ledger unit tests (`dune runtest src/lib/staged_ledger`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)