### PR TITLE
Run rosetta integration tests from bare apps-cache binaries

### DIFF
--- a/buildkite/scripts/tests/rosetta/install-debs.sh
+++ b/buildkite/scripts/tests/rosetta/install-debs.sh
@@ -32,7 +32,23 @@ DEBS=(
 
 DEBS_CSV="$(IFS=,; echo "${DEBS[*]}")"
 
-# Run the installer in a child process (not `source`d) so its strict-mode
-# flags (`set -u`, custom `PS4`) don't leak back into the calling shell. Use
-# sudo (toolchain image runs as opam user with NOPASSWD sudo).
-bash ./buildkite/scripts/debian/install.sh "${DEBS_CSV}" 1
+# Prefer bare binaries from the apps cache (mirroring exactly what the debs
+# above install) and fall back to the .deb install on any cache miss, via
+# restore-or-install.sh. The signature flavor follows the network: devnet uses
+# the testnet signatures, mainnet the mainnet ones. Cached names are the
+# flattened *.exe basenames written by buildkite/scripts/apps/write_to_cache.sh
+# (e.g. ocaml-signer/signer_testnet_signatures.exe is cached as its basename).
+# rosetta-cli is built separately by install-cli.sh; the non-binary payload the
+# rosetta deb ships under /etc/mina/rosetta (rosetta-cli-config, postgresql.conf)
+# is read from the in-repo copies by integration-tests.sh in the bare path.
+case "${NETWORK}" in
+  mainnet) SIG=mainnet ;;
+  *)       SIG=testnet ;;
+esac
+export APPS_NETWORK="${NETWORK}"
+export APPS_BARE_BINARIES="mina_${SIG}_signatures.exe:mina,libp2p_helper:coda-libp2p_helper,archive.exe:mina-archive,rosetta_${SIG}_signatures.exe:mina-rosetta,signer_${SIG}_signatures.exe:mina-ocaml-signer,indexer_test.exe:mina-rosetta-indexer-test,zkapp_test_transaction.exe:mina-zkapp-test-transaction"
+
+# Run in a child process (not `source`d) so its strict-mode flags (`set -u`,
+# custom `PS4`) don't leak back into the calling shell. Use sudo (toolchain
+# image runs as opam user with NOPASSWD sudo).
+bash ./buildkite/scripts/debian/restore-or-install.sh "${DEBS_CSV}" 1

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -100,7 +100,16 @@ export MINA_GRAPHQL_PORT=${MINA_GRAPHQL_PORT:=3085}
 # Files from ROSETTA_CLI_CONFIG_FILES will be read from
 # ROSETTA_CONFIGURATION_INPUT_DIR and some placeholders will be
 # substituted.
-ROSETTA_CONFIGURATION_INPUT_DIR=${ROSETTA_CONFIGURATION_INPUT_DIR:=/etc/mina/rosetta/rosetta-cli-config}
+# In the bare-binary path the mina-rosetta deb is not installed, so the
+# rosetta-cli config it ships under /etc/mina/rosetta is absent; fall back to
+# the in-repo copy (the same files the deb is built from).
+if [[ -z "${ROSETTA_CONFIGURATION_INPUT_DIR:-}" ]]; then
+  if [[ -d /etc/mina/rosetta/rosetta-cli-config ]]; then
+    ROSETTA_CONFIGURATION_INPUT_DIR=/etc/mina/rosetta/rosetta-cli-config
+  else
+    ROSETTA_CONFIGURATION_INPUT_DIR=src/app/rosetta/rosetta-cli-config
+  fi
+fi
 ROSETTA_CLI_CONFIG_FILES=${ROSETTA_CLI_CONFIG_FILES:="config.json mina.ros"}
 ROSETTA_CLI_MAIN_CONFIG_FILE=${ROSETTA_CLI_MAIN_CONFIG_FILE:="config.json"}
 
@@ -211,7 +220,11 @@ sudo pg_ctlcluster ${POSTGRES_VERSION} main start || true
 sudo pg_dropcluster --stop ${POSTGRES_VERSION} main || true
 sudo mkdir -p ${POSTGRES_DATA_DIR}
 sudo chown postgres:postgres ${POSTGRES_DATA_DIR}
-sudo pg_createcluster --start -d ${POSTGRES_DATA_DIR} --createclusterconf /etc/mina/rosetta/scripts/postgresql.conf ${POSTGRES_VERSION} main
+# postgresql.conf is shipped by the mina-rosetta deb under /etc/mina/rosetta;
+# fall back to the in-repo copy when running from bare binaries.
+ROSETTA_PG_CONF=/etc/mina/rosetta/scripts/postgresql.conf
+[[ -f "$ROSETTA_PG_CONF" ]] || ROSETTA_PG_CONF=src/app/rosetta/scripts/postgresql.conf
+sudo pg_createcluster --start -d ${POSTGRES_DATA_DIR} --createclusterconf "$ROSETTA_PG_CONF" ${POSTGRES_VERSION} main
 sudo -u postgres psql --command "CREATE USER ${POSTGRES_USERNAME} WITH SUPERUSER PASSWORD '${POSTGRES_USERNAME}';"
 sudo -u postgres createdb -O ${POSTGRES_USERNAME} ${POSTGRES_DBNAME}
 psql -f "${MINA_ARCHIVE_SQL_SCHEMA_PATH}" "${PG_CONN}"


### PR DESCRIPTION
## Summary

Moves `RosettaIntegrationTests` off Debian-package installs onto the **apps cache** of freshly-built bare binaries — the same pattern the archive/replayer test family already uses (`APPS_BARE_BINARIES` via `restore-or-install.sh`). The test already runs in the toolchain container (not the rosetta docker image) and hand-rolls its own `testnet.json` + accounts, so this is purely a binary-acquisition change.

Follows #18973 (which strips the test-only tooling out of the production rosetta image).

## Changes

**`buildkite/scripts/tests/rosetta/install-debs.sh`** — restore bare binaries first, deb install as fallback:
```
mina_${SIG}_signatures.exe:mina, libp2p_helper:coda-libp2p_helper,
archive.exe:mina-archive, rosetta_${SIG}_signatures.exe:mina-rosetta,
signer_${SIG}_signatures.exe:mina-ocaml-signer,
indexer_test.exe:mina-rosetta-indexer-test,
zkapp_test_transaction.exe:mina-zkapp-test-transaction
```
(`SIG` = `testnet` for devnet, `mainnet` for mainnet.)

**`buildkite/scripts/tests/rosetta/integration-tests.sh`** — the non-binary payload the `mina-rosetta` deb ships under `/etc/mina/rosetta` falls back to the in-repo copies when the deb path is absent:
- `rosetta-cli-config` → `src/app/rosetta/rosetta-cli-config`
- `scripts/postgresql.conf` → `src/app/rosetta/scripts/postgresql.conf`

## Why it's safe

- **Behaviour-preserving:** the deb CSV stays as the `restore-or-install.sh` cache-miss fallback, and `DebianVersions.dependsOn` is kept. If any binary isn't cached, the test transparently reverts to the deb install.
- **No genesis-ledger/S3 trap:** the test hand-rolls `testnet.json` with `base = Accounts`, so the daemon generates genesis locally — no config deb, no S3 download.
- `rosetta-cli` is unchanged (built by `install-cli.sh`).

Validated locally: all dune exe names exist; in-repo `rosetta-cli-config` (`config.json` + `mina.ros`) and `postgresql.conf` present; shellcheck clean; all `/etc/mina/rosetta` reads guarded.

## Follow-up (stage 2, separate PR)

Once this is green in CI, drop the deb fallback + `DebianVersions.dependsOn` so `RosettaIntegrationTests` no longer waits on the Debian build at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)