### PR TITLE
Add CLAUDE.md docs for custom async primitives

### DIFF
--- a/src/lib/concurrency/interruptible/CLAUDE.md
+++ b/src/lib/concurrency/interruptible/CLAUDE.md
@@ -1,0 +1,77 @@
+# Interruptible
+
+## What it solves
+
+A monad for computations that can be **cancelled by an external signal**.
+`('a, 's) t` represents a computation producing `'a` that can be interrupted
+by a signal of type `'s`. Once interrupted, the computation and all dependent
+computations (via `bind`, `map`) resolve as "interrupted" and their results
+are discarded.
+
+## Key semantics
+
+### Internal type
+
+```ocaml
+type ('a, 's) t =
+  { interruption_signal : 's Ivar.t
+  ; d : ('a, 's) Deferred.Result.t
+  }
+```
+
+Two key states:
+- `Ivar` not full → computation not yet interrupted
+- `Ivar` full → interruption signal received; `d` resolves to `Error signal`
+
+### `bind` / `map` interruption propagation
+
+When a signal arrives:
+- If the bound computation has **already resolved**, it is not interrupted
+  (other dependents may still need it), but the *result* of the `bind` becomes
+  interrupted.
+- If bound computation has **not resolved**, its internal `interruption_signal`
+  is filled, interrupting it too.
+
+`map` always prefers the interruption signal over the resolved value: if the
+signal fires after resolution but before the `map` callback runs, the result
+is still `Error signal`.
+
+### `lift d interrupt` vs `uninterruptible d`
+
+- `lift`: the computation becomes interruptible when `interrupt` resolves.
+- `uninterruptible`: creates an interruptible with a **never-filled** Ivar.
+  The computation runs to completion. But if a parent `bind` propagates an
+  interruption, the result is still discarded via the `bind` logic.
+
+### `finally x ~f`
+
+`f ()` runs after `x` finishes, regardless of interruption. The final
+result is unchanged.
+
+### `force`
+
+Returns `('a, 's) Deferred.Result.t`. Prefers interruption even if the
+underlying `d` has already resolved OK — it runs through `map` which
+checks the signal.
+
+### `don't_wait_for`
+
+Ignores both the result and interruption. Equivalent to:
+```ocaml
+don't_wait_for (Deferred.map d ~f:(function Ok () -> () | Error _ -> ()))
+```
+
+## Common pitfalls
+
+1. **`uninterruptible` still discards results**: if a parent bind interrupts,
+   the uninterruptible block's result is discarded even though it ran to
+   completion. Use `force` to retrieve it.
+2. **Interruption is one-shot**: once the `Ivar` is filled, there's no
+   "un-interrupt". All dependent computations immediately see the error.
+3. **`don't_wait_for` ignores errors**: if a computation raises (not
+   interrupted), the exception is swallowed.
+
+## Source files
+
+- `src/lib/concurrency/interruptible/interruptible.ml`
+- `src/lib/concurrency/interruptible/interruptible.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE-broadcast_pipe.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE-broadcast_pipe.md
@@ -1,0 +1,52 @@
+# Broadcast_pipe
+
+## What it solves
+
+A single-writer, **multiple-reader** pipe. Always seeded with an initial value.
+Every new reader sees the **current cached value** immediately, then all
+subsequent writes. Writers block until all downstream consumers have processed
+the value.
+
+## Key semantics
+
+### Internal architecture
+
+Uses a single `root_pipe` + one sub-pipe per reader (created in `prepare_pipe`).
+Writes go to `root_pipe`; a background `don't_wait_for (Pipe.iter ...)` fans out
+each value to all sub-pipes in **parallel** (`Deferred.List.iter ~how:\`Parallel`).
+
+### Write is synchronous (blocks callers)
+
+`Writer.write` blocks until all downstream consumers have called
+`Pipe.Consumer.values_sent_downstream` AND their pipes are `downstream_flushed`.
+This means slow readers block the writer.
+
+### Exception behavior
+
+- **`Reader.iter`** delegates to `Pipe.iter` with a trivial consumer.
+  Default `continue_on_error` is not explicitly set, so exceptions propagate.
+- **`Reader.fold`** same pattern.
+- If a sub-pipe write fails (e.g. closed reader), the fan-out loop's
+  `Deferred.List.iter` may fail and propagate to the monitor (via
+  `don't_wait_for`).
+
+### Close semantics
+
+`Writer.close` closes `root_pipe`, then closes and removes all sub-pipes.
+Writes after close raise `Broadcast_pipe.Already_closed`. Reads after close
+see `Eof`.
+
+## Common pitfalls
+
+1. **Slow readers block writers**: the `Writer.write` blocks on ALL consumers
+   flushing. A stuck reader stalls the entire broadcast.
+2. **`Already_closed`**: writing/peeking after close raises — check `is_closed`
+   or wrap in try/with.
+3. **Initial value seeding**: `create a` seeds the pipe with `a`, which is
+   immediately visible to all new readers via `peek` and as the first `iter`
+   element.
+
+## Source files
+
+- `src/lib/concurrency/pipe_lib/broadcast_pipe.ml`
+- `src/lib/concurrency/pipe_lib/broadcast_pipe.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE-choosable_synchronous_pipe.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE-choosable_synchronous_pipe.md
@@ -1,0 +1,59 @@
+# Choosable_synchronous_pipe
+
+## What it solves
+
+A CSP-style pipe designed to work with `Deferred.choose`. Reading is
+**idempotent** (calling `read` on the same handle returns the same result).
+Writing happens **only after a read is initiated** — no buffering.
+The pipe is synchronous (no background processing).
+
+## Key semantics
+
+### Immutable-handle pattern
+
+Every `read` and `write_choice` returns a **new handle**. The old handle
+remains functional (for reads, it returns the same value; for writes,
+reusing it raises `Pipe_handle_used`).
+
+```ocaml
+val read : 'a reader_t -> [ `Eof | `Ok of 'a * 'a reader_t ] Deferred.t
+val write_choice : on_chosen:('a writer_t -> 'b) -> 'a writer_t -> 'a -> 'b Deferred.Choice.t
+val write : 'a writer_t -> 'a -> 'a writer_t Deferred.t
+```
+
+### `write_choice` semantics
+
+Does NOT block. Returns a `Choice.t` for `Deferred.choose`. The write only
+executes if the choice is selected AND a concurrent `read` has been initiated.
+`on_chosen` receives the new writer handle. If the choice is not selected,
+the write is silently dropped and `on_chosen` is never called.
+
+### Exception behavior
+
+- `write` / `write_choice` / `close` after the pipe is closed: raises
+  `Pipe_closed`.
+- Reusing a writer handle after a completed write/close: raises
+  `Pipe_handle_used`.
+- `read` on a closed pipe returns `` `Eof ``.
+- `iter` uses `Deferred.repeat_until_finished` — if `f` raises, the exception
+  propagates through the `iter` deferred.
+
+### Thread safety
+
+Safe for `iter` and `read` in parallel (same handle returns same value).
+Safe for `write` and `write_choice` in parallel (but only one write completes).
+
+## Common pitfalls
+
+1. **Stale handles**: forgetting to use the new handle returned by `read`
+   or `write_choice` means subsequent reads/writes see the same state (or
+   raise `Pipe_handle_used`).
+2. **`write_choice` silently drops**: if the choice is not selected (by
+   `Deferred.choose`), the write is lost. No error, no warning.
+3. **Deadlock**: `write` blocks until a reader calls `read`. If no reader
+   exists, `write` hangs forever.
+
+## Source files
+
+- `src/lib/concurrency/pipe_lib/choosable_synchronous_pipe.ml`
+- `src/lib/concurrency/pipe_lib/choosable_synchronous_pipe.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE-linear_pipe.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE-linear_pipe.md
@@ -1,0 +1,69 @@
+# Linear_pipe
+
+## What it solves
+
+Wraps Jane Street's `Async_kernel.Pipe` with **single-reader enforcement** (`bracket`
+pattern). Prevents the same `Reader.t` from being consumed concurrently — attempting
+to do so raises `failwith "Linear_pipe.bracket: the same reader has been used
+multiple times"`.
+
+The `Writer` is just `Pipe.Writer.t` (no extra wrapper).
+
+## Key semantics
+
+### Exception behavior: `iter` / `iter_unordered`
+
+`iter` delegates to `Pipe.iter` with `?continue_on_error` passthrough.
+**Default is `continue_on_error=false`**, which means:
+
+- If the callback `f` raises (returns a failed `Deferred.t`), iteration **stops**
+  and the exception **propagates** to whoever awaited the `iter` deferred.
+- The pipe is **not** read further — upstream writers will accumulate pushback.
+
+With `~continue_on_error:true`, the exception is suppressed and iteration continues.
+
+`iter_unordered` has **no** `continue_on_error` option — exceptions always
+propagate (it calls `Deferred.all_unit` which fails on any child failure).
+
+### `don't_wait_for` + `iter`
+
+A common pattern in Mina:
+
+```ocaml
+don't_wait_for (Linear_pipe.iter reader ~f:callback)
+```
+
+The `iter` deferred's error flows to Async's **current monitor**. If nothing
+handles it locally (no `Monitor.try_with`), it propagates to the daemon's
+top-level `Monitor.detach_and_iter_errors` handler in `mina_run.ml`, which
+logs the crash and calls `Stdlib.exit 1`.
+
+### `bracket` and read operations
+
+`read`, `read_now`, `fold`, `scan`, `map`, `filter_map`, `transfer`, etc. all
+enforce the single-reader invariant. `read_now` and `scan`/`map`/`filter_map`
+use `set_has_reader` (sets the flag without clearing on completion — the caller
+owns the read side afterward).
+
+### Close semantics
+
+- `close_read` closes the reader; `close` closes the writer.
+- `force_write_maybe_drop_head ~capacity` drops the oldest element if the pipe
+  exceeds `capacity`.
+- `write_or_exn ~capacity` raises `Linear_pipe.Overflow` if the pipe exceeds
+  `capacity`.
+
+## Common pitfalls
+
+1. **`iter` default `continue_on_error=false`**: an uncaught exception in
+   `f` kills the pipe consumer and propagates. If the `iter` was `don't_wait_for`-ed,
+   the error becomes an unhandled Async monitor exception → daemon crash.
+2. **`scan` / `map` / `filter_map` permanently consume the reader**: they call
+   `set_has_reader` — the source `Reader` can never be used again.
+3. **`write_without_pushback_if_open` returns `unit` immediately** — no deferred
+   to catch write errors.
+
+## Source files
+
+- `src/lib/concurrency/pipe_lib/linear_pipe.ml`
+- `src/lib/concurrency/pipe_lib/linear_pipe.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE-strict_pipe.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE-strict_pipe.md
@@ -1,0 +1,62 @@
+# Strict_pipe
+
+## What it solves
+
+A pipe with **overflow behavior** control and **downstream tracking**. Unlike
+`Linear_pipe`, it has its own `Reader` and `Writer` types (not just a thin
+wrapper over `Pipe`). Provides CSP-style pushback: writers block until
+readers consume.
+
+Supports three modes via GADT `type_`:
+
+| Mode | Behavior on overflow |
+|------|---------------------|
+| `Synchronous` | No buffering; write returns a `unit Deferred.t` (pushback until read) |
+| `Buffered (\`Capacity n, \`Overflow Crash)` | Raises `Strict_pipe.Overflow` |
+| `Buffered (\`Capacity n, \`Overflow (Drop_head f))` | Drops oldest, calls `f` on it |
+| `Buffered (\`Capacity n, \`Overflow (Call f))` | Calls `f data`, returns `Some (f data)` |
+
+## Key semantics
+
+### Exception behavior
+
+- **`fold` / `iter`**: enforce single-reader (like `Linear_pipe.bracket`).
+  Reader's `read` calls `enforce_single_reader`. If callback `f` raises,
+  the exception propagates through the deferred (stops pipe consumption).
+- **`iter_without_pushback`**: delegates to `Pipe.iter_without_pushback`;
+  has optional `?continue_on_error` (default `false` — exceptions propagate).
+- **`Merge.iter`**: same — callback exceptions propagate.
+- No `Monitor.try_with` wrapping in Strict_pipe itself.
+
+### Downstream tracking
+
+When you `map`, `filter_map`, `Fork`, or `partition_map3` a `Reader`,
+the source keeps a linked list `downstreams` of created readers. On `close`
+or `kill`, all downstreams are `close_read` (cascading close).
+
+### Fork semantics (CSP)
+
+`Reader.Fork.n` uses `Pipe.iter` (WITH pushback) internally. The `don't_wait_for`
+background thread blocks writers until all downstream forks take the value.
+
+### `transfer` / `transfer_while_writer_alive`
+
+`transfer` links upstream reader to downstream writer (sets `downstreams` chain).
+`transfer_while_writer_alive` keeps transferring while the destination is open
+(no downstream link — checks `Pipe.is_closed` each iteration).
+
+## Common pitfalls
+
+1. **Synchronous mode deadlock**: if no reader calls `read`, `write` blocks
+   forever (pushback). Use `Buffered` if readers may lag.
+2. **`Drop_head` + `warn_on_drop:true`**: logs a warning on overflow. Set
+   `~warn_on_drop:false` for expected overflow.
+3. **`kill` vs `close`**: `kill` first clears the pipe buffer, then closes
+   writer and downstreams. `close` does not clear the buffer.
+4. **Exception in `fold`/`iter` callback kills the pipe and propagates**
+   (same pattern as `Linear_pipe`).
+
+## Source files
+
+- `src/lib/concurrency/pipe_lib/strict_pipe.ml`
+- `src/lib/concurrency/pipe_lib/strict_pipe.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE-swappable_strict_pipe.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE-swappable_strict_pipe.md
@@ -1,0 +1,55 @@
+# Swappable_strict_pipe
+
+## What it solves
+
+Wraps a `Strict_pipe` with **short-lived reader swapping**. The long-lived
+writer feeds a persistent `Strict_pipe`; a background thread reads from it
+and forwards data to the current "short-lived" `Choosable_synchronous_pipe`.
+Calling `swap_reader` creates a new short-lived reader; the old reader's
+unconsumed data is passed to the new one. Guarantees no data loss or
+duplication across swaps.
+
+## Key semantics
+
+### Background thread (`O1trace.background_thread`)
+
+A single `Deferred.repeat_until_finished` loop processes one event per async
+cycle via `Deferred.choose`:
+1. If `termination_signal` is set → cleanup and exit.
+2. If a new short-lived pipe is available → swap to it.
+3. If no short-lived sink → wait for one.
+4. If data is available from long-lived reader → read it into `data_unconsumed`.
+5. If both unconsumed data and a sink exist → write to short-lived sink.
+
+### `swap_reader` behavior
+
+- Creates a new `Choosable_synchronous_pipe` and signals the background thread
+  to swap via `next_short_lived_pipe` Ivar.
+- Returns immediately closed reader if pipe is terminated or another swap is
+  in-flight (at most one pending swap).
+- The old short-lived reader remains open until the background thread processes
+  the swap signal.
+
+### `write` behavior
+
+Delegates directly to the underlying `Strict_pipe.Writer.write`. Does not
+interact with the short-lived pipes.
+
+### Termination (`kill`)
+
+Fills `termination_signal` Ivar. The background thread then kills the
+long-lived writer, closes remaining short-lived pipes, and exits.
+
+## Common pitfalls
+
+1. **Write is not buffered by the swappable layer**: `write` goes straight
+   to the long-lived `Strict_pipe`. Overflow behavior is determined by the
+   `Strict_pipe.type_` used at creation.
+2. **Concurrent `swap_reader`**: second caller gets immediately closed reader.
+   No error raised.
+3. **`swap_reader` after `kill`**: returns immediately closed reader (no error).
+
+## Source files
+
+- `src/lib/concurrency/pipe_lib/swappable_strict_pipe.ml`
+- `src/lib/concurrency/pipe_lib/swappable_strict_pipe.mli`

--- a/src/lib/concurrency/pipe_lib/CLAUDE.md
+++ b/src/lib/concurrency/pipe_lib/CLAUDE.md
@@ -1,0 +1,14 @@
+# Pipe_lib async primitives
+
+This directory contains Mina's custom pipe primitives built on
+`Async_kernel.Pipe`. Each has its own CLAUDE doc:
+
+| Primitive | File | Summary |
+|-----------|------|---------|
+| [Linear_pipe](./CLAUDE-linear_pipe.md) | `linear_pipe.ml` | Single-reader pipe with `bracket` enforcement |
+| [Strict_pipe](./CLAUDE-strict_pipe.md) | `strict_pipe.ml` | Pipe with overflow behavior (Crash/Drop_head/Call) and downstream tracking |
+| [Broadcast_pipe](./CLAUDE-broadcast_pipe.md) | `broadcast_pipe.ml` | Single-writer, multi-reader with cached value |
+| [Choosable_synchronous_pipe](./CLAUDE-choosable_synchronous_pipe.md) | `choosable_synchronous_pipe.ml` | CSP-style pipe for `Deferred.choose` with idempotent reads |
+| [Swappable_strict_pipe](./CLAUDE-swappable_strict_pipe.md) | `swappable_strict_pipe.ml` | Strict_pipe with swappable short-lived readers |
+
+See also the root `CLAUDE.md` for the repo build system and other conventions.

--- a/src/lib/concurrency/promise/CLAUDE.md
+++ b/src/lib/concurrency/promise/CLAUDE.md
@@ -1,0 +1,49 @@
+# Promise
+
+## What it solves
+
+A platform-abstracted promise type (`'a t`) with native (`Async.Deferred`)
+and JS implementations. Provides a minimal `Monad` interface plus `run_in_thread`,
+`block_on_async_exn`, `upon`, `peek`, `value_exn`, `to_deferred`.
+
+## Key semantics
+
+### `run_in_thread : (unit -> 'a) -> 'a t`
+
+Runs a synchronous function in a thread pool. In the native backend this
+delegates to `In_thread.run`; in JS it runs in a Web Worker.
+
+### `block_on_async_exn : (unit -> 'a t) -> 'a`
+
+Blocks the current (non-async) thread until the promise resolves. On native
+this is `Thread_safe.block_on_async_exn`; on JS this is `Async_js.block`.
+
+### `create : (('a -> unit) -> unit) -> 'a t`
+
+Lower-level: the callback receives a "resolve" function. Mirrors JavaScript's
+`new Promise(resolve => ...)`.
+
+### `to_deferred : 'a t -> 'a Deferred.t`
+
+Converts to an `Async.Deferred`. On native this is identity; on JS it bridges
+the JS promise to Async.
+
+### Monad interface
+
+Includes `return`, `bind` (`>>=`), `map` (`>>|`), `both`, etc. via
+`include Base.Monad.S`.
+
+## Common pitfalls
+
+1. **`block_on_async_exn` must NOT be called inside an Async scheduler**
+   (thread — deadlock risk). Only call from non-async contexts like tests.
+2. **`peek` returns `None` if not yet determined** — not an error.
+   Contrast with `value_exn` which raises if not determined.
+3. **`upon` vs `>>=`**: `upon` is fire-and-forget (returns `unit`); `>>=` is
+   monadic bind (returns new promise). Don't confuse them.
+
+## Source files
+
+- `src/lib/concurrency/promise/promise.mli`
+- `src/lib/concurrency/promise/native/promise.ml`
+- `src/lib/concurrency/promise/js/promise.ml`

--- a/src/lib/concurrency/run_in_thread/CLAUDE.md
+++ b/src/lib/concurrency/run_in_thread/CLAUDE.md
@@ -1,0 +1,51 @@
+# Run_in_thread
+
+## What it solves
+
+Minimal interface providing `run_in_thread` (run blocking OCaml code in a
+thread pool) and `block_on_async_exn` (block until an async computation
+completes).
+
+```ocaml
+val run_in_thread : (unit -> 'a) -> 'a Async_kernel.Deferred.t
+val block_on_async_exn : (unit -> 'a Async_kernel.Deferred.t) -> 'a
+```
+
+## Key semantics
+
+### `run_in_thread`
+
+On native: delegates to `Async.Thread_safe.run_in_thread` (or just
+`In_thread.run` in the "fake" variant). The function runs in a system
+thread managed by Async's thread pool. The returned deferred resolves
+when the function returns or raises (exception is captured).
+
+### `block_on_async_exn`
+
+On native: delegates to `Async.Thread_safe.block_on_async_exn`. **Must NOT
+be called inside the Async scheduler** (deadlock). Used primarily in tests
+and CLI entry points to bridge async and sync code. If the deferred raises,
+the exception propagates to the caller.
+
+### Two implementations
+
+- `native/run_in_thread.ml` — uses Async's `In_thread` module
+- `fake/run_in_thread.ml` — used in non-async contexts; `run_in_thread`
+  calls `In_thread.run` with a fake thread pool
+
+## Common pitfalls
+
+1. **`block_on_async_exn` inside the scheduler** → hard deadlock. Only
+   use from non-async code.
+2. **`run_in_thread` for long-running code**: ties up a thread from the
+   pool. For CPU-intensive work, consider offloading to a separate process.
+3. **GC interaction**: OCaml's GC stops-the-world. Long `run_in_thread`
+   calls that allocate heavily can stall other async threads.
+4. **Exception in `run_in_thread` callback**: captured into the deferred
+   as a failed deferred. Handle with `try_with` or `.Or_error` patterns.
+
+## Source files
+
+- `src/lib/concurrency/run_in_thread/run_in_thread.mli`
+- `src/lib/concurrency/run_in_thread/native/run_in_thread.ml`
+- `src/lib/concurrency/run_in_thread/fake/run_in_thread.ml`

--- a/src/lib/o1trace/CLAUDE-thread.md
+++ b/src/lib/o1trace/CLAUDE-thread.md
@@ -1,0 +1,52 @@
+# O1trace.Thread (and background_thread)
+
+## What it solves
+
+Named threads with fiber tracking for observability (O1trace plugins).
+`O1trace.thread name f` runs `f` inside `Scheduler.within_context`, attaching
+a `Thread.Fiber` to the execution context. If `f` raises synchronously, the
+exception is converted to `failwithf` with the thread name.
+
+`O1trace.background_thread name f` is `don't_wait_for (thread name f)` —
+schedules `f` as a background task, returning immediately.
+
+## Key semantics
+
+### `thread name f`
+
+1. Creates or reuses a `Thread.Fiber` for `name`.
+2. Attaches it to the current `Scheduler.current_execution_context()`.
+3. Runs `f` inside `Scheduler.within_context`.
+4. If `Scheduler.within_context` returns `Error ()` (the scheduler was
+   shut down), calls `failwithf "timing task \`%s\` failed, exception
+   reported to parent monitor" name`.
+5. Returns the result of `f` (which is typically a `Deferred.t`).
+
+### `background_thread name f`
+
+Same as `don't_wait_for (thread name f)`. The returned deferred is ignored.
+If the deferred eventually raises, the error goes to Async's current monitor
+(same as any `don't_wait_for`).
+
+### Recursive thread detection
+
+If `f` calls `thread` with the same `name` while already inside a fiber of
+that name, the existing fiber is reused (avoids duplicate fiber registration).
+
+## Common pitfalls
+
+1. **`background_thread` + deferred exception**: since the deferred is
+   `don't_wait_for`-ed, any async exception propagates to the current
+   monitor. This is the standard Async pattern — the same as any
+   `don't_wait_for (main_loop t)`.
+2. **`failwithf` on scheduler shutdown**: during daemon shutdown,
+   `Scheduler.within_context` may return `Error ()`, causing a `failwithf`.
+   This is expected during normal shutdown and should not be treated as
+   a crash.
+3. **Not an error boundary**: `thread` does NOT set up a `Monitor.try_with`.
+   Exceptions from `f` (synchronous) are caught by `failwithf`; async
+   exceptions from the returned deferred propagate to the parent monitor.
+
+## Source files
+
+- `src/lib/o1trace/o1trace.ml` (lines 58-100)

--- a/src/lib/o1trace/CLAUDE.md
+++ b/src/lib/o1trace/CLAUDE.md
@@ -1,0 +1,7 @@
+# O1trace
+
+Observability library with thread tracing, fiber registration, and plugin dispatch.
+
+| Primitive | File | Summary |
+|-----------|------|---------|
+| [Thread / background_thread](./CLAUDE-thread.md) | `o1trace.ml` (lines 58-100) | Named threads with fiber tracking; `background_thread` = `don't_wait_for (thread name f)` |


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` documentation for all custom async primitives in the codebase, covering exception semantics, architecture details, and common pitfalls.

## Motivation

When investigating code structure, we spent significant time reading async primitive implementations to understand exception behavior. These docs prevent that in the future by documenting each primitive's contract in one place.

## What's documented

| Primitive | Location | Key behaviors documented |
|-----------|----------|--------------------------|
| `Linear_pipe` | `pipe_lib/CLAUDE-linear_pipe.md` | `bracket` single-reader, `iter` default `continue_on_error=false`, `don't_wait_for` → daemon crash chain |
| `Strict_pipe` | `pipe_lib/CLAUDE-strict_pipe.md` | Overflow modes (Crash/Drop_head/Call), downstream tracking, CSP pushback, deadlock risks |
| `Broadcast_pipe` | `pipe_lib/CLAUDE-broadcast_pipe.md` | Multi-reader fan-out, synchronous writes, cached seed value |
| `Choosable_synchronous_pipe` | `pipe_lib/CLAUDE-choosable_synchronous_pipe.md` | `Deferred.choose` integration, immutable handles, `write_choice` silent drops |
| `Swappable_strict_pipe` | `pipe_lib/CLAUDE-swappable_strict_pipe.md` | Background thread loop, reader swapping, no-data-loss guarantee |
| `Interruptible` | `interruptible/CLAUDE.md` | Interruption signal propagation, `bind`/`map` semantics, `force` vs `uninterruptible` |
| `Promise` | `promise/CLAUDE.md` | Sync/async bridge, `block_on_async_exn` restrictions, native/JS backends |
| `Run_in_thread` | `run_in_thread/CLAUDE.md` | Thread pool, `block_on_async_exn` deadlock, GC interaction |
| `O1trace.Thread` | `o1trace/CLAUDE-thread.md` | Named threads, fiber tracking, `background_thread` = `don't_wait_for (thread ...)` |
