### PR TITLE
Fix nodes stuck in bootstrap / catchup

### DIFF
--- a/changes/18984.md
+++ b/changes/18984.md
@@ -1,0 +1,2 @@
+Bootstrap/catchup: fixed a bug where a node could silently stall when it had tried every known peer for every pending download job. The downloader now wakes on peer-usefulness changes (such as a temporary ignore expiring or a peer completing another job), so retries happen promptly instead of waiting for a brand-new peer to connect. Previously the node could remain stuck for minutes or indefinitely.
+

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -80,7 +80,11 @@ end) : sig
   val cancel : t -> Key.t -> unit
 
   val create :
-       max_batch_size:int
+       ?ignore_period:Time.Span.t
+    -> ?post_stall_retry_delay:Time.Span.t
+    -> ?no_progress_recheck_delay:Time.Span.t
+    -> ?peer_refresh_interval:Time.Span.t
+    -> max_batch_size:int
     -> stop:unit Deferred.t
     -> logger:Logger.t
     -> trust_system:Trust_system.t
@@ -90,6 +94,7 @@ end) : sig
          (Knowledge_context.t -> Peer.t -> Key.t Claimed_knowledge.t Deferred.t)
     -> peers:(unit -> Peer.t list Deferred.t)
     -> preferred:Peer.t list
+    -> unit
     -> t Deferred.t
 
   val download : t -> key:Key.t -> attempts:Attempt.t Peer.Map.t -> Job.t
@@ -265,6 +270,7 @@ end = struct
       ; knowledge_requesting_peers : Peer.Hash_set.t
       ; temporary_ignores :
           ((unit, unit) Clock.Event.t[@sexp.opaque]) Peer.Table.t
+      ; ignore_period : Time.Span.t
       ; mutable all_preferred : Preferred_heap.t
       ; knowledge : Knowledge.t Peer.Table.t
             (* Written to when something changes. *)
@@ -294,6 +300,7 @@ end = struct
         ; all_preferred
         ; knowledge_requesting_peers
         ; temporary_ignores
+        ; ignore_period = _
         ; downloading_peers
         ; r = _
         ; w = _
@@ -324,7 +331,7 @@ end = struct
                  (Hash_set.to_list knowledge_requesting_peers) ) )
         ]
 
-    let create ~preferred ~all_peers =
+    let create ~ignore_period ~preferred ~all_peers =
       let knowledge =
         Peer.Table.of_alist_exn
           (List.map (List.dedup_and_sort ~compare:Peer.compare all_peers)
@@ -337,6 +344,7 @@ end = struct
       { downloading_peers = Peer.Hash_set.create ()
       ; knowledge_requesting_peers = Peer.Hash_set.create ()
       ; temporary_ignores = Peer.Table.create ()
+      ; ignore_period
       ; knowledge
       ; r
       ; w
@@ -346,6 +354,7 @@ end = struct
     let tear_down
         { downloading_peers
         ; temporary_ignores
+        ; ignore_period = _
         ; knowledge_requesting_peers
         ; knowledge
         ; r = _
@@ -500,8 +509,6 @@ end = struct
       Hashtbl.iter t.knowledge ~f:(fun s ->
           List.iter ks ~f:(Hash_set.remove s.tried_and_failed) )
 
-    let ignore_period = Time.Span.of_min 2.
-
     let update t u =
       O1trace.sync_thread "update_downloader" (fun () ->
           match u with
@@ -567,7 +574,7 @@ end = struct
                if List.is_empty succs then
                  Hashtbl.update t.temporary_ignores peer0 ~f:(fun x ->
                      cancel x ;
-                     Clock.Event.run_after ignore_period
+                     Clock.Event.run_after t.ignore_period
                        (fun () ->
                          Hashtbl.remove t.temporary_ignores peer0 ;
                          if not (Strict_pipe.Writer.is_closed t.w) then
@@ -627,6 +634,8 @@ end = struct
     ; logger : Logger.t
     ; trust_system : Trust_system.t
     ; stop : unit Deferred.t
+    ; post_stall_retry_delay : Time.Span.t
+    ; no_progress_recheck_delay : Time.Span.t
     }
 
   let logger t = t.logger
@@ -734,6 +743,8 @@ end = struct
         ; logger = _
         ; trust_system = _
         ; stop = _
+        ; post_stall_retry_delay = _
+        ; no_progress_recheck_delay = _
         } as t ) =
     let rec clear_queue q =
       match Q.dequeue q with
@@ -882,8 +893,6 @@ end = struct
                    ] ) ) )
       ]
 
-  let post_stall_retry_delay = Time.Span.of_min 1.
-
   let rec step t =
     if Q.length t.pending = 0 then (
       [%log' debug t.logger] "Downloader: no jobs. waiting" ;
@@ -924,9 +933,9 @@ end = struct
           [%log' debug t.logger]
             "Downloader: all stalled. Resetting knowledge, waiting %s and then \
              retrying."
-            (Time.Span.to_string_hum post_stall_retry_delay) ;
+            (Time.Span.to_string_hum t.post_stall_retry_delay) ;
           Useful_peers.reset_knowledge t.useful_peers ~all_peers:t.all_peers ;
-          let%bind () = after post_stall_retry_delay in
+          let%bind () = after t.post_stall_retry_delay in
           [%log' debug t.logger] "Downloader: continuing after reset" ;
           step t
       | `Useful (peer, might_know) -> (
@@ -956,8 +965,12 @@ end = struct
   let mark_preferred t peer ~now =
     Useful_peers.Preferred_heap.add t.useful_peers.all_preferred (peer, now)
 
-  let create ~max_batch_size ~stop ~logger ~trust_system ~get ~knowledge_context
-      ~knowledge ~peers ~preferred =
+  let create ?(ignore_period = Time.Span.of_min 2.)
+      ?(post_stall_retry_delay = Time.Span.of_min 1.)
+      ?(no_progress_recheck_delay = Time.Span.of_min 1.)
+      ?(peer_refresh_interval = Time.Span.of_min 1.) ~max_batch_size ~stop
+      ~logger ~trust_system ~get ~knowledge_context ~knowledge ~peers ~preferred
+      () =
     let%map all_peers = peers () in
     let pipe ~name c =
       Strict_pipe.create ~warn_on_drop:false ~name
@@ -974,19 +987,21 @@ end = struct
       ; jobs_added_bvar = Bvar.create ()
       ; got_new_peers_r
       ; got_new_peers_w
-      ; useful_peers = Useful_peers.create ~all_peers ~preferred
+      ; useful_peers = Useful_peers.create ~ignore_period ~all_peers ~preferred
       ; get
       ; max_batch_size
       ; logger
       ; trust_system
       ; downloading = Key.Table.create ()
       ; stop
+      ; post_stall_retry_delay
+      ; no_progress_recheck_delay
       }
     in
     let peers =
       let r, w = Broadcast_pipe.create [] in
       upon stop (fun () -> Broadcast_pipe.Writer.close w) ;
-      Clock.every' ~stop (Time.Span.of_min 1.) (fun () ->
+      Clock.every' ~stop peer_refresh_interval (fun () ->
           peers ()
           >>= fun ps ->
           try Broadcast_pipe.Writer.write w ps

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -903,12 +903,37 @@ end = struct
       | `Ok () ->
           step t )
     else
+      let read p =
+        Pipe.read_choice_single_consumer_exn
+          (Strict_pipe.Reader.to_linear_pipe p).pipe [%here]
+      in
+      (* The [useful_peers] and [got_new_peers] signals are best-effort
+         (capacity-0, drop-head): a wakeup is lost if it fires before we are
+         parked on the read. Racing the signals against a timeout ensures that a
+         dropped wakeup cannot leave the loop parked indefinitely after the peer
+         set has in fact recovered. *)
+      let wait_for_change pipes =
+        Deferred.choose
+          ( Deferred.choice (after t.no_progress_recheck_delay) (fun () ->
+                `Ok () )
+          :: List.map pipes ~f:read )
+      in
       match
         Useful_peers.useful_peer t.useful_peers
           ~pending_jobs:(Q.to_list t.pending)
       with
       | `No_peers -> (
-          match%bind Strict_pipe.Reader.read t.got_new_peers_r with
+          [%log' debug t.logger]
+            "Downloader: Waiting. No known peer has the remaining jobs" ;
+          (* Wake on new peers, on any change in peer usefulness (e.g. a
+             temporary-ignore expiring), or on the fallback timeout. The
+             [useful_peers] wake matters here in particular: once every job has
+             been tried against every peer no peer has positive knowledge, so it
+             is the only signal by which the loop learns that an ignored peer has
+             become usable again. *)
+          match%bind
+            wait_for_change [ t.got_new_peers_r; t.useful_peers.r ]
+          with
           | `Eof ->
               [%log' debug t.logger] "Downloader: new peers eof" ;
               Deferred.unit
@@ -916,13 +941,7 @@ end = struct
               step t )
       | `Useful_but_busy -> (
           [%log' debug t.logger] "Downloader: Waiting. All useful peers busy" ;
-          let read p =
-            Pipe.read_choice_single_consumer_exn
-              (Strict_pipe.Reader.to_linear_pipe p).pipe [%here]
-          in
-          match%bind
-            Deferred.choose [ read t.flush_r; read t.useful_peers.r ]
-          with
+          match%bind wait_for_change [ t.flush_r; t.useful_peers.r ] with
           | `Eof ->
               [%log' debug t.logger] "Downloader: flush eof" ;
               Deferred.unit

--- a/src/lib/downloader/test/dune
+++ b/src/lib/downloader/test/dune
@@ -1,0 +1,22 @@
+(library
+ (name downloader_test)
+ (libraries
+  ;; opam libraries
+  async
+  async_kernel
+  async_unix
+  core
+  core_kernel
+  ppx_inline_test.config
+  ;; local libraries
+  logger
+  network_peer
+  pipe_lib
+  trust_system
+  downloader)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_jane)))

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -1,0 +1,91 @@
+open Core
+open Async
+open Pipe_lib
+open Network_peer
+
+(* Regression test for the downloader [`No_peers] wedge.
+
+   The downloader step loop reaches the [`No_peers] state when no known peer has
+   any of the pending jobs. Before the fix, that branch waited only on the
+   [got_new_peers] signal and ignored the [useful_peers] signal that fires
+   whenever a peer's usefulness changes (a download finishing, a knowledge
+   update, a temporary-ignore expiring). Once parked, the loop could therefore
+   only be woken by a brand-new peer connecting; every other recovery signal was
+   dropped, leaving the node silently stuck in bootstrap or catchup.
+
+   This test drives the loop into [`No_peers] by starting it with no peers, then
+   advertises -- via [add_knowledge] -- that an existing peer has the job. That
+   writes only the [useful_peers] signal. The fixed loop wakes and downloads the
+   job; the unfixed loop stays parked and the job never resolves, which the
+   timeout below turns into a failure.
+
+   [peers] returns the empty list throughout, so the [got_new_peers] signal is
+   never fired and cannot mask the bug, and the timeout is well under the loop's
+   one-minute fallback re-check so a pass requires the signal-driven wake
+   specifically. *)
+
+module Key = struct
+  include Int
+
+  let to_yojson i = `Int i
+end
+
+module Attempt = struct
+  type t = unit
+
+  let to_yojson () = `Null
+
+  let download = ()
+
+  let worth_retrying _ = true
+end
+
+module Result = struct
+  type t = Key.t
+
+  let key = Fn.id
+end
+
+module Knowledge_context = struct
+  type t = unit
+end
+
+module D = Downloader.Make (Key) (Attempt) (Result) (Knowledge_context)
+
+let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
+  Thread_safe.block_on_async_exn (fun () ->
+      let logger = Logger.null () in
+      let trust_system = Trust_system.null () in
+      let stop = Ivar.create () in
+      let peer =
+        Peer.create
+          (Core.Unix.Inet_addr.of_string "1.2.3.4")
+          ~libp2p_port:8302
+          ~peer_id:(Peer.Id.unsafe_of_string "regression-test-peer")
+      in
+      let knowledge_context, _knowledge_w = Broadcast_pipe.create () in
+      let%bind downloader =
+        D.create ~max_batch_size:1 ~stop:(Ivar.read stop) ~logger ~trust_system
+          ~get:(fun _peer keys -> Deferred.Or_error.return keys)
+          ~knowledge_context
+          ~knowledge:(fun () _peer -> Deferred.return (`Some []))
+          ~peers:(fun () -> Deferred.return [])
+          ~preferred:[]
+      in
+      let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
+      (* Let the loop settle into [`No_peers] (the flush delay is 100ms). *)
+      let%bind () = after (Time.Span.of_ms 500.) in
+      (* Advertise that [peer] has the job. This fires only the [useful_peers]
+         signal -- not [got_new_peers] -- which the unfixed loop ignores. *)
+      D.add_knowledge downloader peer [ 1 ] ;
+      let%map result = with_timeout (Time.Span.of_sec 15.) (D.Job.result job) in
+      Ivar.fill_if_empty stop () ;
+      match result with
+      | `Timeout ->
+          failwith
+            "downloader stayed wedged in [`No_peers]: did not wake on the \
+             useful_peers signal"
+      | `Result (Ok _) ->
+          ()
+      | `Result (Error `Finished) ->
+          failwith "job was cancelled/stopped unexpectedly" )

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -89,3 +89,61 @@ let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
           ()
       | `Result (Error `Finished) ->
           failwith "job was cancelled/stopped unexpectedly" )
+
+(* End-to-end regression test for the full self-heal path.
+
+   Unlike the test above (which injects a [useful_peers] signal directly), this
+   one exercises the production recovery chain: a download fails, which marks the
+   job [tried_and_failed] against the peer and temporarily ignores it; the loop
+   parks in [`No_peers]; the temporary-ignore expires; the loop wakes,
+   re-evaluates to [`Stalled], resets the peer's knowledge (clearing
+   [tried_and_failed]); and the subsequent retry succeeds.
+
+   The recovery delays are set to small values via [create]'s optional
+   parameters so the whole chain runs in well under a second. [get] fails the
+   first attempt and succeeds thereafter. [peers] returns a single stable peer so
+   that [reset_knowledge] (which drops peers not in the peer set) keeps it, and
+   [peer_refresh_interval] is small so the peer is delivered promptly after the
+   initial empty broadcast value. *)
+
+let%test_unit "[`No_peers] self-heals through `Stalled`/reset_knowledge" =
+  Thread_safe.block_on_async_exn (fun () ->
+      let logger = Logger.null () in
+      let trust_system = Trust_system.null () in
+      let stop = Ivar.create () in
+      let peer =
+        Peer.create
+          (Core.Unix.Inet_addr.of_string "1.2.3.4")
+          ~libp2p_port:8302
+          ~peer_id:(Peer.Id.unsafe_of_string "regression-test-peer")
+      in
+      let knowledge_context, _knowledge_w = Broadcast_pipe.create () in
+      let download_attempts = ref 0 in
+      let%bind downloader =
+        D.create ~ignore_period:(Time.Span.of_ms 200.)
+          ~post_stall_retry_delay:(Time.Span.of_ms 200.)
+          ~peer_refresh_interval:(Time.Span.of_ms 100.) ~max_batch_size:1
+          ~stop:(Ivar.read stop) ~logger ~trust_system
+          ~get:(fun _peer keys ->
+            incr download_attempts ;
+            if !download_attempts = 1 then
+              Deferred.return
+                (Or_error.error_string "simulated download failure")
+            else Deferred.Or_error.return keys )
+          ~knowledge_context
+          ~knowledge:(fun () _peer -> Deferred.return `All)
+          ~peers:(fun () -> Deferred.return [ peer ])
+          ~preferred:[] ()
+      in
+      let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
+      let%map result = with_timeout (Time.Span.of_sec 15.) (D.Job.result job) in
+      Ivar.fill_if_empty stop () ;
+      match result with
+      | `Timeout ->
+          failwith
+            "downloader did not self-heal: the failed job was not retried \
+             after the temporary ignore expired"
+      | `Result (Ok _) ->
+          [%test_eq: bool] (!download_attempts >= 2) true
+      | `Result (Error `Finished) ->
+          failwith "job was cancelled/stopped unexpectedly" )

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -70,7 +70,7 @@ let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
           ~knowledge_context
           ~knowledge:(fun () _peer -> Deferred.return (`Some []))
           ~peers:(fun () -> Deferred.return [])
-          ~preferred:[]
+          ~preferred:[] ()
       in
       let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
       (* Let the loop settle into [`No_peers] (the flush delay is 100ms). *)

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1207,7 +1207,7 @@ let run_catchup ~context:(module Context : CONTEXT) ~trust_system ~verifier
                   ( State_hash.With_state_hashes.state_hash x
                   , Mina_state.Protocol_state.consensus_state x.data
                     |> Consensus.Data.Consensus_state.blockchain_length ) ) ) )
-      ~knowledge
+      ~knowledge ()
   in
   check_invariant ~downloader t ;
   let () =

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -462,6 +462,7 @@ let glue_sync_ledger :
                       (List.filter_map ps ~f:(fun (q, r) ->
                            match r with Ok r -> Some (q, r) | Error _ -> None )
                       ) ) ) )
+      ()
   in
   don't_wait_for
     (let%bind downloader = downloader in


### PR DESCRIPTION
## Summary

Nodes intermittently become **stuck in bootstrap or catchup**, where they usually remain stuck until operators restart the node. I was able to reproduce this state on a `--proof-level none` network with a low slot time, which pointed to the root cause: the `Downloader` loop (`src/lib/downloader/downloader.ml`) parks forever after every pending job has been tried against every known peer.

The same `Downloader` module backs **both** stuck states, so one fix addresses both:

- **Catchup** (`super_catchup`) uses it to to download blocks.
- **Bootstrap** (`Sl_downloader` / `Mina_networking.glue_sync_ledger`) uses it to sync the snarked ledger.

## Root cause

The downloader tracks, per peer, which jobs that peer has been "tried and failed" on. When a download fails, the job is recorded as `tried_and_failed` for that peer (and the peer is put in a 2-minute `temporary_ignores` cooldown). Once **every** pending job has failed against **every** peer, `useful_peer` returns `` `No_peers ``.

The bug is in how that state waits:

```ocaml
| `No_peers ->
    match%bind Strict_pipe.Reader.read t.got_new_peers_r with   (* <-- only this *)
    ...
```

`` `No_peers `` woke **only** on `got_new_peers_r`, which fires solely when a *brand-new* peer connects. The signals that actually represent recovery -- a `temporary_ignores` entry expiring, a knowledge update, a completed download -- all write to a *different* pipe, `useful_peers.r`, which this branch did not read. Importantly, this doesn't reflect the evolving state of the network either: even if a peer didn't have the data we needed at the moment we asked, it likely will have it later.

So after the 2-minute cooldowns expire (at which point a re-evaluation would have returned `` `Stalled ``, triggering `reset_knowledge` to clear `tried_and_failed` and retry), the loop never woke to re-evaluate. The self-healing path was structurally unreachable. On a node with a stable peer set, the loop parked indefinitely (silent, ~0 CPU) until a new peer happened to connect or the node was restarted (which rebuilds the downloader from scratch).

This matches every observed symptom: stable, silent, long-lived, cleared by restart, and **correlated with heavy network load**. Load is exactly what causes downloads to time out across all peers at once and fill `tried_and_failed` everywhere.

## The fix

1. **`` `No_peers `` now also waits on `useful_peers.r`** (the same signal the `` `Useful_but_busy `` branch already used), so peer-usefulness changes -- notably a cooldown expiring -- wake the loop and let it reach the self-healing `` `Stalled `` -> `reset_knowledge` path.

2. **Both wait sites race the signals against a fallback timeout.** The signal pipes are capacity-0 / drop-head, so a wakeup is silently lost if it fires before the loop is parked on the read. The timeout guarantees the loop re-evaluates regardless and cannot be wedged by a dropped wakeup. (This also adds a fallback to `` `Useful_but_busy ``, which was subject to the same drop-head hazard.)

3. A debug log on entry to `` `No_peers `` so the condition is observable in production logs.

To make this efficiently testable, I've made the downloader's recovery delays
(`ignore_period`, `post_stall_retry_delay`, `no_progress_recheck_delay`, `peer_refresh_interval`) **injectable** via optional parameters to `create`. This is purely to let the regression tests drive the real recovery path in milliseconds rather than minutes.

## Why retrying the same peers is productive (recovery semantics)

A fair question is *why re-attempting the same peers after a delay helps, when the only thing that changed is the clock.* The timeout/wake is **not** the material change -- it only lets the loop re-evaluate. Two real state changes drive recovery, and the existing `` `Stalled `` machinery (which this fix simply makes reachable again) relies on both:

1. **The cooldown expires.** A failed download puts the peer in a 2-minute `temporary_ignores` cooldown that excludes it from selection. While any peer is excluded, re-evaluation yields `` `No_peers ``. Once the cooldowns lapse the peers are eligible again, so re-evaluation now yields `` `Stalled `` (eligible peers, but all currently at zero knowledge) instead of `` `No_peers ``.
2. **`reset_knowledge` forgets the failures.** The `` `Stalled `` branch calls `reset_knowledge`, which **clears every peer's `tried_and_failed` set and resets their `claimed` knowledge to "unknown"**:

   ```ocaml
   Hashtbl.filter_mapi_inplace t.knowledge ~f:(fun ~key:p ~data:k ->
       Hash_set.clear k.tried_and_failed ;
       if Set.mem all_peers p then Some { k with claimed = None } else None ) ;
   ```

   That is the material change: the downloader deliberately discards its record of past failures. After the reset a peer is `No_information` (positive score), so it is selected and the job is retried, no re-probe of peer knowledge is required first.

The design premise -- already baked into the downloader, **not introduced here** -- is that download failures are typically **transient**: a peer that timed out, was rate-limited, or was momentarily busy is not thereby proven to lack the block. Forgetting the failure after a backoff and re-asking is the correct policy, and it succeeds once the transient condition clears (load subsides, the responder's rate-limit budget recovers, the peer is no longer busy).

The consequence of this PR is therefore a change in **failure mode**, not the invention of a retry policy. Without the fix, exhausting all peers is a *terminal, silent stall*. With it, the same situation becomes a backoff-and-retry loop (≈ cooldown + stall-delay per cycle) that is visibly trying and resolves as soon as any peer can serve the data, or as soon as a new peer connects. The bug was simply that this recovery path was **unreachable** from `` `No_peers ``, because that branch never re-evaluated after the cooldowns expired.

## Interaction with the RPC rate limiter

The RPC rate limiter (`Network_pool.Rate_limiter`) is enforced **by the responder**, per-peer and per-RPC, over a rolling 5-minute window. Under heavy load the expensive catchup/bootstrap RPCs (`Get_staged_ledger_aux_and_pending_coinbases_at_hash` [4/min], `Get_transition_chain_proof` [3/min], `Get_ancestry` [5/min]) are slow to serve, so a requester times out and retries, burning the responder's small per-peer budget and getting back `peer exceeded capacity` errors.

The rate limiter is therefore a significant trigger, where those transient failures are what fill the downloader's `tried_and_failed` set; the downloader wedge then turns them into a permanent stall.

Originally I had planned to bundle client-side outgoing rate-limiting to reduce this as a possible surface, but making the downloader self-heal is sufficient to fix the bug. As such, I've left the rate limiter / per-peer backoff / RPC budget increases as follow-up.

## Testing

A new test library (`src/lib/downloader/test`) adds two regression tests:

- **`` `No_peers `` wakes on a `useful_peers` signal**
  * drives the loop into `` `No_peers `` and fires a `useful_peers`-only signal; the fixed loop wakes and completes, the unfixed loop hangs.
- **`` `No_peers `` self-heals through `` `Stalled `` / `` `reset_knowledge``** 
  * drives the full production recovery chain (download fails -> `tried_and_failed` + cooldown -> `` `No_peers `` -> cooldown expires -> `` `Stalled `` -> `reset_knowledge` -> retry succeeds), using the injectable ms-scale timings.

Both pass in ~0.5s and **fail (time out) when the `useful_peers.r` wait is removed** from `` `No_peers ``, confirming they guard the fix rather than passing vacuously.

## Follow-up: surfacing downloader progress in daemon status / GraphQL

This stall was hard to diagnose because the downloader's state is effectively invisible to operators. Catchup already reports *catchup-tree* node-state counts via `Daemon_status.t` (`catchup_status`, computed in `mina_lib` from `Full_catchup_tree.to_node_status_report`) and exposed through the GraphQL `daemonStatus` field. But the **downloader's own state** (`total_jobs` pending job count, in-flight downloads, per-peer usefulness, active cooldowns, and crucially whether it is parked in `` `No_peers `` / `` `Stalled ``) is only emitted to debug logs via the downloader's `to_yojson`, not surfaced anywhere queryable. Bootstrap's ledger-sync progress is even less visible (no per-phase indicator at all).

A natural follow-up not in this PR is to plumb a compact downloader status (e.g. total / pending / in-flight jobs and usable-peer count, plus the loop's wait state) into `Daemon_status.t` and the `daemonStatus` resolver for both the catchup and bootstrap downloaders. That would turn a parked-in-`` `No_peers `` condition into a directly observable signal (e.g. "N jobs pending, 0 usable peers") and give operators real progress indication for bootstrap and catchup, instead of a node that merely reports `Bootstrap` / `Catchup` with no sense of whether it is advancing.

## Notes for reviewers

- The `` `Useful_but_busy `` branch is changed only to share the new `wait_for_change` helper (gaining the fallback timeout); its signal set is otherwise unchanged.
- The injectable-timings commit changes `Downloader.create`'s signature (trailing `unit`); the only two callers in-tree are updated. Defaults are identical to the previous hard-coded constants, so runtime behaviour is unchanged.
- The recovery tests are timing-based but use generous margins (~0.5s work vs a 15s assertion timeout) and signal-driven recovery, so they are not expected to be flaky.
