### PR TITLE
fix: structured replayer-log validation

### DIFF
--- a/buildkite/scripts/replayer-mesa-hf-test.sh
+++ b/buildkite/scripts/replayer-mesa-hf-test.sh
@@ -29,7 +29,8 @@ export MINA_LEDGER_S3_BUCKET
 
 $REPLAYER_APP \
   --archive-uri "$PG_CONN" \
-  --input-file "$INPUT_FILE"
+  --input-file "$INPUT_FILE" \
+  --canonical-only
 
 RESULT=$?
 

--- a/changes/18989.md
+++ b/changes/18989.md
@@ -1,0 +1,6 @@
+- `mina-replayer` now accepts a `--canonical-only` flag. When set, the
+  replayer only considers blocks whose `chain_status` is `'canonical'` in
+  the archive database, preventing it from accidentally walking a forked
+  chain when orphaned blocks exist at the same global slot as the canonical
+  tip. Without the flag, all blocks are considered — matching the pre-3.0
+  behavior and compatible with archive nodes that store blocks as `'pending'`.

--- a/scripts/regenerate-archive.sh
+++ b/scripts/regenerate-archive.sh
@@ -164,8 +164,9 @@ PGPASSWORD="${PG_PW}" psql \
           -h "${PG_HOST}" \
           -p "${PG_PORT}" \
           "${PG_DB}" < ./src/test/archive/sample_db/archive_db.sql
-dune exec src/app/replayer/replayer.exe -- \
-     --archive-uri "$PG_URI" \
-     --input-file src/test/archive/sample_db/replayer_input_file.json \
-     --log-level Trace \
-     --log-json  | jq
+ dune exec src/app/replayer/replayer.exe -- \
+      --archive-uri "$PG_URI" \
+      --input-file src/test/archive/sample_db/replayer_input_file.json \
+      --canonical-only \
+      --log-level Trace \
+      --log-json  | jq

--- a/scripts/replayer-test.sh
+++ b/scripts/replayer-test.sh
@@ -23,7 +23,7 @@ function report () {
 }
 
 echo "Running replayer"
-$REPLAYER_APP --archive-uri $PG_CONN --input-file $INPUT_FILE
+$REPLAYER_APP --archive-uri $PG_CONN --input-file $INPUT_FILE --canonical-only
 
 RESULT=$?
 

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -54,6 +54,8 @@ end
 
 let error_count = ref 0
 
+let blocks_replayed = ref 0
+
 let json_ledger_hash_of_ledger ledger =
   Ledger_hash.to_yojson @@ Ledger.merkle_root ledger
 
@@ -1368,29 +1370,33 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           (user_cmds : Sql.User_command.t list)
           (zkapp_cmds : Sql.Zkapp_command.t list) =
         let check_ledger_hash_at_slot state_hash ledger_hash =
-          if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then
+          if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then (
+            incr blocks_replayed ;
             [%log info]
               "Applied all commands at global slot since genesis %Ld, got \
                expected ledger hash"
               ~metadata:
-                [ ("ledger_hash", json_ledger_hash_of_ledger ledger)
+                [ ("replayer_event", `String "block_applied")
+                ; ("ledger_hash", json_ledger_hash_of_ledger ledger)
                 ; ("state_hash", State_hash.to_yojson state_hash)
                 ; ( "global_slot_since_genesis"
                   , `String (Int64.to_string last_global_slot_since_genesis) )
                 ; ("block_id", `Int last_block_id)
                 ]
-              last_global_slot_since_genesis
+              last_global_slot_since_genesis )
           else if
             List.mem state_hashes_to_avoid
               (State_hash.to_base58_check state_hash)
               ~equal:String.equal
-          then
+          then (
+            incr blocks_replayed ;
             [%log info]
               ~metadata:
-                [ ("state_hash", `String (State_hash.to_base58_check state_hash))
+                [ ("replayer_event", `String "block_applied")
+                ; ("state_hash", `String (State_hash.to_base58_check state_hash))
                 ]
               "This block has an inconsistent ledger hash due to a known \
-               historical issue."
+               historical issue." )
           else (
             [%log error]
               "Applied all commands at global slot since genesis %Ld, ledger \
@@ -1975,6 +1981,13 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           ~last_block_id:oldest_block_id sorted_internal_cmds sorted_user_cmds
           sorted_zkapp_cmds
       in
+      [%log info] "Replay complete"
+        ~metadata:
+          [ ("replayer_event", `String "replay_done")
+          ; ("blocks_replayed", `Int !blocks_replayed)
+          ; ( "start_slot"
+            , `String (Int64.to_string input.start_slot_since_genesis) )
+          ] ;
       let%bind () =
         match hard_fork_params_opt with
         | Some

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -563,7 +563,7 @@ let zkapp_command_to_transaction ~proof_cache_db ~logger ~pool
   @@ Mina_transaction.Transaction.Command
        (User_command.Zkapp_command zkapp_command)
 
-let find_canonical_chain ~logger pool slot =
+let find_canonical_chain ~canonical_only ~logger pool slot =
   (* find longest canonical chain
      a slot may represent several blocks, only one of which can be on canonical chain
      starting with max slot, look for chain, decrementing slot until chain found
@@ -579,18 +579,19 @@ let find_canonical_chain ~logger pool slot =
         Some state_hash
   in
   let%bind state_hashes =
-    query_db ~f:(fun db -> Sql.Block.get_state_hashes_by_slot db slot)
+    query_db ~f:(fun db ->
+        Sql.Block.get_state_hashes_by_slot ~canonical_only db slot )
   in
   Deferred.List.find_map state_hashes ~f:find_state_hash_chain
 
-let try_slot ~logger pool slot =
+let try_slot ~canonical_only ~logger pool slot =
   let num_tries = 5 in
   let rec go ~slot ~tries_left =
     if tries_left <= 0 then (
       [%log fatal] "Could not find canonical chain after trying %d slots"
         num_tries ;
       Core_kernel.exit 1 ) ;
-    match%bind find_canonical_chain ~logger pool slot with
+    match%bind find_canonical_chain ~canonical_only ~logger pool slot with
     | None ->
         go ~slot:(Int64.pred slot) ~tries_left:(tries_left - 1)
     | Some state_hash ->
@@ -919,10 +920,10 @@ let filter_block_infos_for_hard_fork ~logger ~target_state_hash
       block_infos
 
 let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
-    ~checkpoint_interval ~checkpoint_output_folder_opt ~checkpoint_file_prefix
-    ~genesis_dir_opt ~stop_slot_config_file ~hard_fork_output_file
-    ~hard_fork_target ~log_json ~log_level ~log_filename ~file_log_level
-    ~constraint_constants ~proof_level () =
+    ~canonical_only ~checkpoint_interval ~checkpoint_output_folder_opt
+    ~checkpoint_file_prefix ~genesis_dir_opt ~stop_slot_config_file
+    ~hard_fork_output_file ~hard_fork_target ~log_json ~log_level ~log_filename
+    ~file_log_level ~constraint_constants ~proof_level () =
   Cli_lib.Stdout_log.setup log_json log_level ;
   Option.iter log_filename ~f:(fun log_filename ->
       Logger.Consumer_registry.register ~id:"default"
@@ -1001,11 +1002,13 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
             [%log info]
               "Searching for block with greatest height on canonical chain" ;
             let%bind max_slot =
-              query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
+              if canonical_only then
+                query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
+              else query_db ~f:(fun db -> Sql.Block.get_max_slot db ())
             in
             [%log info] "Maximum global slot since genesis in blocks is %Ld"
               max_slot ;
-            try_slot ~logger pool max_slot
+            try_slot ~canonical_only ~logger pool max_slot
       in
       if not @@ List.is_empty input.first_pass_ledger_hashes then (
         [%log info] "Populating set of first-pass ledger hashes" ;
@@ -1265,7 +1268,9 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
                Int64.(input.start_slot_since_genesis + interval) ) )
       in
       let%bind max_canonical_slot =
-        query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
+        if canonical_only then
+          query_db ~f:(fun db -> Sql.Block.get_max_canonical_slot db ())
+        else query_db ~f:(fun db -> Sql.Block.get_max_slot db ())
       in
       let%bind genesis_snarked_ledger_hash =
         let%map hash_str =
@@ -2063,9 +2068,13 @@ let () =
                "URI URI for connecting to the archive database (e.g., \
                 postgres://$USER@localhost:5432/archiver)"
              Param.(required string)
-         and continue_on_error =
-           Param.flag "--continue-on-error"
-             ~doc:"Continue processing after errors" Param.no_arg
+          and continue_on_error =
+            Param.flag "--continue-on-error"
+              ~doc:"Continue processing after errors" Param.no_arg
+          and canonical_only =
+            Param.flag "--canonical-only"
+              ~doc:"Only consider blocks with chain_status=canonical"
+              Param.no_arg
          and checkpoint_interval =
            Param.flag "--checkpoint-interval"
              ~doc:"NN Write checkpoint file every NN slots"
@@ -2108,7 +2117,7 @@ let () =
          and file_log_level = Cli_lib.Flag.Log.file_log_level
          and log_filename = Cli_lib.Flag.Log.file in
          main ~input_file ~output_file_opt ~archive_uri ~checkpoint_interval
-           ~continue_on_error ~checkpoint_output_folder_opt
-           ~checkpoint_file_prefix ~genesis_dir_opt ~stop_slot_config_file
-           ~hard_fork_output_file ~hard_fork_target ~log_json ~log_level
-           ~file_log_level ~log_filename ~constraint_constants ~proof_level )))
+            ~continue_on_error ~canonical_only ~checkpoint_output_folder_opt
+            ~checkpoint_file_prefix ~genesis_dir_opt ~stop_slot_config_file
+            ~hard_fork_output_file ~hard_fork_target ~log_json ~log_level
+            ~file_log_level ~log_filename ~constraint_constants ~proof_level )))

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -149,8 +149,16 @@ module Block = struct
             AND chain_status = 'canonical'
       |sql}
 
-  let get_state_hashes_by_slot (module Conn : Mina_caqti.CONNECTION) slot =
-    Conn.collect_list state_hashes_by_slot_query slot
+  let state_hashes_by_slot_noncanonical_query =
+    Mina_caqti.collect_req Caqti_type.int64 Caqti_type.string
+      {sql| SELECT state_hash FROM blocks
+            WHERE global_slot_since_genesis = $1
+      |sql}
+
+  let get_state_hashes_by_slot ?(canonical_only = true)
+      (module Conn : Mina_caqti.CONNECTION) slot =
+    if canonical_only then Conn.collect_list state_hashes_by_slot_query slot
+    else Conn.collect_list state_hashes_by_slot_noncanonical_query slot
 
   (* find all blocks, working back from block with given state hash *)
   let chain_query =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -554,5 +554,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Network.Node.run_replayer ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       if n < 8 || n > 30 then
+         Malleable_error.hard_error_string
+           (sprintf "Replayer replayed %d blocks, expected between 8 and 30" n)
+       else Malleable_error.return () )
 end

--- a/src/app/test_executive/post_hard_fork.ml
+++ b/src/app/test_executive/post_hard_fork.ml
@@ -784,5 +784,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       if n < 5 || n > 25 then
+         Malleable_error.hard_error_string
+           (sprintf "Replayer replayed %d blocks, expected between 5 and 25" n)
+       else Malleable_error.return () )
 end

--- a/src/app/test_executive/test_common.ml
+++ b/src/app/test_executive/test_common.ml
@@ -415,33 +415,69 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       ]
       ~f:Fn.id
 
-  (* [logs] is a string containing the entire replayer output *)
+  (* [logs] is a string containing the entire replayer --log-json output *)
   let check_replayer_logs ~logger logs =
-    let error_log_substring = "Error" in
-    let fatal_log_substring = "Fatal" in
-    let info_log_substring = "Info" in
-    let split_logs = String.split logs ~on:'\n' in
-    let error_logs =
-      split_logs
-      |> List.filter ~f:(fun log ->
-             String.is_substring log ~substring:error_log_substring
-             || String.is_substring log ~substring:fatal_log_substring )
+    let open Yojson.Safe.Util in
+    let replay_errors, block_applieds, replay_done_blocks =
+      String.split logs ~on:'\n'
+      |> List.filter ~f:(Fn.non String.is_empty)
+      |> List.fold ~init:([], 0, None)
+           ~f:(fun (errors, n_applied, done_blocks) line ->
+             let json = Yojson.Safe.from_string line in
+             let level = member "level" json |> to_string in
+             let errors' =
+               if String.equal level "Error" || String.equal level "Fatal" then
+                 line :: errors
+               else errors
+             in
+             let metadata_kv =
+               match member "metadata" json with
+               | `Assoc kvs ->
+                   kvs
+               | _ ->
+                   []
+               | exception _ ->
+                   []
+             in
+             let find = List.Assoc.find metadata_kv ~equal:String.equal in
+             let n_applied' =
+               match find "replayer_event" with
+               | Some (`String "block_applied") ->
+                   n_applied + 1
+               | _ ->
+                   n_applied
+             in
+             let done_blocks' =
+               match find "replayer_event" with
+               | Some (`String "replay_done") -> (
+                   match find "blocks_replayed" with
+                   | Some (`Int n) ->
+                       Some n
+                   | _ ->
+                       None )
+               | _ ->
+                   done_blocks
+             in
+             (errors', n_applied', done_blocks') )
     in
-    let info_logs =
-      split_logs
-      |> List.filter ~f:(fun log ->
-             String.is_substring log ~substring:info_log_substring )
-    in
-    if Mina_stdlib.List.Length.Compare.(info_logs < 25) then
-      Malleable_error.hard_error_string
-        (sprintf "Replayer output contains suspiciously few (%d) Info logs"
-           (List.length info_logs) )
-    else if List.is_empty error_logs then (
-      [%log info] "The replayer encountered no errors" ;
-      Malleable_error.return () )
-    else
-      let error = String.concat error_logs ~sep:"\n  " in
+    if not (List.is_empty replay_errors) then
+      let error = String.concat (List.rev replay_errors) ~sep:"\n  " in
       Malleable_error.hard_error_string ("Replayer errors:\n  " ^ error)
+    else
+      match replay_done_blocks with
+      | None ->
+          Malleable_error.hard_error_string
+            "No replay_done event found in replayer output"
+      | Some expected ->
+          if block_applieds <> expected then
+            Malleable_error.hard_error_string
+              (sprintf
+                 "Replayer block_applied count %d does not match expected %d \
+                  from replay_done event"
+                 block_applieds expected )
+          else (
+            [%log info] "The replayer encountered no errors" ;
+            Malleable_error.return expected )
 
   let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
       ~vesting_increment : Mina_base.Account_timing.t =

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -977,7 +977,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            Network.Node.run_replayer ~target_state_hash:proof_state_hash ~logger
              archive_node
          in
-         check_replayer_logs ~logger logs )
+         let%bind n = check_replayer_logs ~logger logs in
+         if n < 5 || n > 25 then
+           Malleable_error.hard_error_string
+             (sprintf "Replayer replayed %d blocks, expected between 5 and 25" n)
+         else Malleable_error.return () )
     in
     let open Deferred.Let_syntax in
     match%bind replayer_result with

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -377,5 +377,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ( List.hd_exn
            @@ (Network.archive_nodes network |> Core.String.Map.data) )
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       if n < 8 || n > 30 then
+         Malleable_error.hard_error_string
+           (sprintf "Replayer replayed %d blocks, expected between 8 and 30" n)
+       else Malleable_error.return () )
 end

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -720,5 +720,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Network.Node.run_replayer ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       if n < 5 || n > 40 then
+         Malleable_error.hard_error_string
+           (sprintf "Replayer replayed %d blocks, expected between 5 and 40" n)
+       else Malleable_error.return () )
 end


### PR DESCRIPTION
## Summary

Add structured replayer-event logging, rewrite replayer-log validation in tests as JSON-based block-count checks, and gate canonical-block filtering behind a `--canonical-only` flag so the replayer works in environments where blocks are stored as `pending` rather than `canonical`.

## Motivation

**Structured log validation.** The existing `check_replayer_logs` matched substrings (`"Info"`, `"Error"`) against log lines, which was brittle — log-format changes, message rephrasing, or `Error` appearing in non-error contexts could produce false positives/negatives. It also enforced a hardcoded floor of 25 `Info` log lines, causing false failures on tests with short chains (e.g. `payments_test.ml` ~13–20 blocks, `zkapps.ml` ~10–15).

**Canonical-only regression.** Commit `3feb9cca2a` replaced `get_max_slot` with `get_max_canonical_slot` to avoid picking orphaned blocks as the chain tip in archive fixtures. However, integration tests store blocks as `pending` (not yet marked `canonical`), so the replayer found 0 blocks and `check_replayer_logs` reported "Replayer replayed 0 blocks" everywhere.

## Changes

### `src/app/replayer/replayer.ml`
- Added `blocks_replayed` counter, incremented on every successful `block_applied`
- Added `replayer_event` metadata (`"block_applied"` / `"replay_done"`) to log entries so tests can count events precisely via structured JSON
- Added `replay_done` structured event with `blocks_replayed` field emitted at replay completion
- Added `--canonical-only` CLI flag (default off):
  - **On**: uses `get_max_canonical_slot` and filters `state_hashes_by_slot` by `chain_status='canonical'` — preserves the `3feb9cca2a` fix for archive fixtures with orphaned blocks
  - **Off (default)**: uses `get_max_slot` (no filter) and unfiltered `state_hashes_by_slot` — matches pre-`3feb9cca2a` behavior for test environments

### `src/app/replayer/sql.ml`
- Made `get_state_hashes_by_slot` accept optional `?(canonical_only = true)` parameter
- Added `state_hashes_by_slot_noncanonical_query` (no chain_status filter) for the non-canonical path

### `src/app/test_executive/test_common.ml`
- Rewrote `check_replayer_logs` as a pure fold over JSONL lines:
  - Parses each line as JSON and inspects the `level` field to detect errors
  - Counts `block_applied` events via `replayer_event` metadata
  - Reads `blocks_replayed` from the `replay_done` event
  - Cross-validates `block_applied` count against `blocks_replayed`
  - Returns the `blocks_replayed` count on success
- Dropped all substring-based detection

### `src/app/test_executive/*.ml` (5 test files)
- Updated all callers to bind the returned block count and assert it falls within a reasonable range per test

### Scripts
- `scripts/replayer-test.sh`, `buildkite/scripts/replayer-mesa-hf-test.sh`, `scripts/regenerate-archive.sh`: pass `--canonical-only` to the replayer (these run against archive fixtures that may contain orphaned blocks)

## Test ranges

| Test | Expected blocks range | Rationale |
|---|---|---|
| `payments_test.ml` | 8–30 | 3 BPs, small txn capacity, 3 ledger proofs |
| `zkapps_timing.ml` | 5–40 | 3 BPs, no explicit proof wait, 7 zkapp commands |
| `zkapps.ml` | 5–25 | 2 BPs, small txn capacity, 1 explicit block + 1 proof |
| `zkapps_nonce_test.ml` | 8–30 | 2 BPs, medium txn capacity, 2 proofs |
| `post_hard_fork.ml` | 5–25 | 2 BPs, small txn capacity, 1 proof after fork |

## Integration tests
The `run_replayer` function in `docker_network.ml` does **not** pass `--canonical-only`, so the replayer defaults to non-canonical mode — compatible with integration test environments where blocks are stored as `pending`.
