### PR TITLE
Add worktree-safe nix support via direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake "git+file://$PWD?submodules=1#with-lsp"

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ target
 
 ### Direnv ###
 .env
-.envrc
 .direnv/
 
 ### Python ###

--- a/nix/README.md
+++ b/nix/README.md
@@ -19,6 +19,10 @@ mina`, etc. You can discover all the available packages as usual, by using tab
 completion or `nix eval mina#packages.x86_64-linux --apply __attrNames` or your
 favourite way.
 
+**Multi-worktree**: Use direnv with `use flake "git+file://$PWD?submodules=1"`
+in each worktree's `.envrc`, or pin each with a custom name:
+`nix/pin.sh my-branch` then `nix develop my-branch#with-lsp`.
+
 </details>
 
 ## 1. Install Nix
@@ -76,6 +80,23 @@ For the curious, `mina` registry entry will resolve to
 `git+file:///path/to/your/mina/checkout?submodules=1`. Should you want to hack
 on a different mina checkout, try e.g. `nix develop
 "git+file://$PWD?submodules=1"` from that checkout.
+
+**Working with multiple worktrees**: The registry entry `mina` is global and can
+only point to one checkout. For parallel development across multiple worktrees,
+you have two options:
+
+1. **Use direnv** (recommended) with `use flake "git+file://$PWD?submodules=1"`
+   in each worktree's `.envrc`. This auto-enters the correct environment per
+   directory — no registry needed.
+
+2. **Register each worktree with a unique name**:
+   ```bash
+   cd /path/to/worktree1 && nix/pin.sh my-feature
+   cd /path/to/worktree2 && nix/pin.sh bugfix
+   nix develop my-feature#with-lsp
+   nix develop bugfix#with-lsp
+   ```
+   ```
 
 ## 4. Use it
 
@@ -271,6 +292,12 @@ sudo nixos-container start mina
 TL;DR
 ```
 printf './nix/pin.sh\nuse flake mina\n' > .envrc
+direnv allow
+```
+
+For worktree-safe direnv (no global registry needed):
+```
+echo 'use flake "git+file://$PWD?submodules=1"' > .envrc
 direnv allow
 ```
 

--- a/nix/pin.sh
+++ b/nix/pin.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Set up flake registry to get Mina with all the submodules
+#
+# Usage:
+#   nix/pin.sh           # registers as 'mina' (default)
+#   nix/pin.sh mybranch  # registers as 'mybranch' for multi-worktree use
 
 # Find the root of the Mina repo
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )
 # Update the submodules
 pushd "$ROOT" && git submodule sync && git submodule update --init --recursive --depth 1 && popd
-# Add the flake registry entry
-nix registry add mina "git+file://$ROOT?submodules=1"
+# Add the flake registry entry (accept optional name for worktree-specific registrations)
+NAME="${1:-mina}"
+nix registry add "$NAME" "git+file://$ROOT?submodules=1"


### PR DESCRIPTION
- .envrc: use flake via git+file:// so it auto-resolves per worktree
- .gitignore: unignore .envrc so each checkout gets direnv support
- nix/pin.sh: accept optional name for per-worktree registry entries
- nix/README.md: document multi-worktree workflows