### PR TITLE
test_executive: give the archive replayer an explicit target block (fix -local nightly replayer check)

### DIFF
--- a/changes/18992.md
+++ b/changes/18992.md
@@ -1,0 +1,3 @@
+test_executive: target an archived block in the local replayer checks.
+
+After 3feb9cca2a the no-target `mina-replayer` only replays up to the highest canonical block, which in a short-lived test network is the genesis block; it then emits fewer than 25 "Info" log lines and trips `check_replayer_logs`, failing the payments, zkapps-timing, zkapps-nonce and post-hard-fork `-local` tests. These tests now pass an explicit `~target_state_hash` (a recent proof block, or a best-chain block for zkapps-timing) so the replayer walks a full span.

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -550,8 +550,22 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               ~txn_hash:hash ~node_included_in:`Any_node ) )
     in
     section_hard "running replayer"
-      (let%bind logs =
-         Network.Node.run_replayer ~logger
+      (* Without an explicit target the replayer only replays up to the highest
+         canonical block, which in a short-lived test network is genesis, so it
+         emits too few logs. Target a recent proof block instead: it is deep in
+         the chain and therefore already persisted in the archive. *)
+      (let proof_state_hash =
+         let ns = network_state t in
+         match ns.proof_block_state_hashes with
+         | hash :: _ ->
+             hash
+         | [] ->
+             failwith "Expected at least one proof block state hash"
+       in
+       [%log info] "Replaying archive up to proof block $state_hash"
+         ~metadata:[ ("state_hash", State_hash.to_yojson proof_state_hash) ] ;
+       let%bind logs =
+         Network.Node.run_replayer ~target_state_hash:proof_state_hash ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
        check_replayer_logs ~logger logs )

--- a/src/app/test_executive/post_hard_fork.ml
+++ b/src/app/test_executive/post_hard_fork.ml
@@ -778,8 +778,23 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       @@ wait_for_zkapp zkapp_command_upgrade_version
     in
     section_hard "running replayer"
-      (let%bind logs =
-         Network.Node.run_replayer
+      (* Without an explicit target the replayer only replays up to the highest
+         canonical block, which in a short-lived test network is the post-fork
+         genesis, so it emits too few logs. Target a recent (post-fork) proof
+         block instead: it is deep in the chain and therefore already persisted
+         in the archive. *)
+      (let proof_state_hash =
+         let ns = network_state t in
+         match ns.proof_block_state_hashes with
+         | hash :: _ ->
+             hash
+         | [] ->
+             failwith "Expected at least one proof block state hash"
+       in
+       [%log info] "Replaying archive up to proof block $state_hash"
+         ~metadata:[ ("state_hash", State_hash.to_yojson proof_state_hash) ] ;
+       let%bind logs =
+         Network.Node.run_replayer ~target_state_hash:proof_state_hash
            ~start_slot_since_genesis:fork_config.global_slot_since_genesis
            ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -372,8 +372,22 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     Event_router.cancel (event_router t) snark_work_event_subscription () ;
     Event_router.cancel (event_router t) snark_work_failure_subscription () ;
     section_hard "Running replayer"
-      (let%bind logs =
-         Network.Node.run_replayer ~logger
+      (* Without an explicit target the replayer only replays up to the highest
+         canonical block, which in a short-lived test network is genesis, so it
+         emits too few logs. Target a recent proof block instead: it is deep in
+         the chain and therefore already persisted in the archive. *)
+      (let proof_state_hash =
+         let ns = network_state t in
+         match ns.proof_block_state_hashes with
+         | hash :: _ ->
+             hash
+         | [] ->
+             failwith "Expected at least one proof block state hash"
+       in
+       [%log info] "Replaying archive up to proof block $state_hash"
+         ~metadata:[ ("state_hash", State_hash.to_yojson proof_state_hash) ] ;
+       let%bind logs =
+         Network.Node.run_replayer ~target_state_hash:proof_state_hash ~logger
            ( List.hd_exn
            @@ (Network.archive_nodes network |> Core.String.Map.data) )
        in

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -716,8 +716,28 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              (Error.of_string "Ledger update contains a timing update") ) )
     in
     section_hard "Running replayer"
-      (let%bind logs =
-         Network.Node.run_replayer ~logger
+      (* Without an explicit target the replayer only replays up to the highest
+         canonical block, which in a short-lived test network is genesis, so it
+         emits too few logs. This test does not wait for a ledger proof, so
+         target a recent best-chain block instead. Pick one a couple below the
+         best tip so it is already persisted in the archive (avoiding a race
+         with archive ingestion of the very latest block). *)
+      (let%bind best_chain =
+         Graphql_requests.must_get_best_chain ~logger
+           (Network.Node.get_ingress_uri node)
+       in
+       let open Mina_base in
+       let target_state_hash =
+         match List.rev best_chain with
+         | _tip :: _prev :: deep :: _ ->
+             State_hash.of_base58_check_exn deep.state_hash
+         | _ ->
+             failwith "best chain too short to pick a replayer target"
+       in
+       [%log info] "Replaying archive up to best-chain block $state_hash"
+         ~metadata:[ ("state_hash", State_hash.to_yojson target_state_hash) ] ;
+       let%bind logs =
+         Network.Node.run_replayer ~target_state_hash ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
        check_replayer_logs ~logger logs )


### PR DESCRIPTION
## Problem

The nightly `payments`, `zkapps-timing`, `zkapps-nonce`, and `post-hard-fork`
`-local` integration tests began failing on 2026-06-26. Each passes **every
functional assertion** and fails only the final `check_replayer_logs` step with
`Replayer output contains suspiciously few (N) Info logs` (observed N = 17–18,
threshold 25).

## Root cause

PR #18884 included commit `3feb9cca2a` ("replayer: choose canonical target
blocks by slot"), which changed `mina-replayer`'s default (no-target) end block
from the chain tip to the highest **canonical** block (`get_max_slot` →
`get_max_canonical_slot`, plus a `chain_status = 'canonical'` filter).

In these short-lived test networks (`k = 20`, ~2-minute blocks, fewer than 21
blocks produced) no non-genesis block has been confirmed canonical yet, so the
canonical tip **is the genesis block**. The replayer therefore replays almost
nothing and emits only the ~18 fixed startup `Info` log lines — below the
hard-coded `< 25` threshold in `src/app/test_executive/test_common.ml`. That
log-count check is unchanged since 2022; only the replayer's target selection
changed.

This affects exactly the tests that call `run_replayer` **without** a target.
`zkapps.ml` is unaffected because it already passes `~target_state_hash`.

## Fix

Give each failing test an explicit `~target_state_hash`, so the replayer walks a
full span via the un-filtered parent query (the same path `zkapps.ml` uses):

- **payments / zkapps-nonce / post-hard-fork** already wait for a ledger proof,
  so they target the latest proof block (`(network_state t).proof_block_state_hashes`
  head) — deep in the chain and therefore already persisted in the archive.
- **zkapps-timing** never waits for a proof, so it targets a best-chain block a
  couple below the tip (already archived, deep enough), failing loudly if the
  chain is implausibly short.

Each call also logs the chosen target hash to aid triage on future replayer
failures.

## Testing / notes

- I could **not** compile locally (the available switch is OCaml 5.1.0; Mina
  needs 4.14.2) — please rely on CI to build `test_executive` and run the four
  `-local` tests. The change was statically reviewed against the `run_replayer`
  signature, `network_state`, and the GraphQL best-chain types.
- `post-hard-fork` has the thinnest log-count margin (it waits `num_proofs:1`
  and, with a non-zero start slot, drops one startup log). If it ever flakes
  near the threshold, bumping its proof wait to `num_proofs:2` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
