### PR TITLE
Backport #18984 to compatible: fix downloader silent no-peers wedge (nightly Sync_timeout)

### DIFF
--- a/changes/18993.md
+++ b/changes/18993.md
@@ -1,0 +1,2 @@
+Bootstrap/catchup: fixed a bug where a node could silently stall when it had tried every known peer for every pending download job. The downloader now wakes on peer-usefulness changes (such as a temporary ignore expiring or a peer completing another job), so retries happen promptly instead of waiting for a brand-new peer to connect. Previously the node could remain stuck for minutes or indefinitely.
+

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -1012,7 +1012,8 @@ end = struct
       Strict_pipe.create ~name:"knowledge-requests" Strict_pipe.Synchronous
     in
     upon stop (fun () -> Strict_pipe.Writer.close request_w) ;
-    let refresh_knowledge stop peer =
+    let refresh_knowledge forgot_peer peer =
+      let stop = Deferred.any [ forgot_peer; stop ] in
       Clock.every' (Time.Span.of_min 7.) ~stop (fun () ->
           match%bind jobs_to_download stop with
           | `Finished ->

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -80,7 +80,11 @@ end) : sig
   val cancel : t -> Key.t -> unit
 
   val create :
-       max_batch_size:int
+       ?ignore_period:Time.Span.t
+    -> ?post_stall_retry_delay:Time.Span.t
+    -> ?no_progress_recheck_delay:Time.Span.t
+    -> ?peer_refresh_interval:Time.Span.t
+    -> max_batch_size:int
     -> stop:unit Deferred.t
     -> logger:Logger.t
     -> trust_system:Trust_system.t
@@ -90,6 +94,7 @@ end) : sig
          (Knowledge_context.t -> Peer.t -> Key.t Claimed_knowledge.t Deferred.t)
     -> peers:(unit -> Peer.t list Deferred.t)
     -> preferred:Peer.t list
+    -> unit
     -> t Deferred.t
 
   val download : t -> key:Key.t -> attempts:Attempt.t Peer.Map.t -> Job.t
@@ -265,6 +270,7 @@ end = struct
       ; knowledge_requesting_peers : Peer.Hash_set.t
       ; temporary_ignores :
           ((unit, unit) Clock.Event.t[@sexp.opaque]) Peer.Table.t
+      ; ignore_period : Time.Span.t
       ; mutable all_preferred : Preferred_heap.t
       ; knowledge : Knowledge.t Peer.Table.t
             (* Written to when something changes. *)
@@ -294,6 +300,7 @@ end = struct
         ; all_preferred
         ; knowledge_requesting_peers
         ; temporary_ignores
+        ; ignore_period = _
         ; downloading_peers
         ; r = _
         ; w = _
@@ -324,7 +331,7 @@ end = struct
                  (Hash_set.to_list knowledge_requesting_peers) ) )
         ]
 
-    let create ~preferred ~all_peers =
+    let create ~ignore_period ~preferred ~all_peers =
       let knowledge =
         Peer.Table.of_alist_exn
           (List.map (List.dedup_and_sort ~compare:Peer.compare all_peers)
@@ -337,6 +344,7 @@ end = struct
       { downloading_peers = Peer.Hash_set.create ()
       ; knowledge_requesting_peers = Peer.Hash_set.create ()
       ; temporary_ignores = Peer.Table.create ()
+      ; ignore_period
       ; knowledge
       ; r
       ; w
@@ -346,6 +354,7 @@ end = struct
     let tear_down
         { downloading_peers
         ; temporary_ignores
+        ; ignore_period = _
         ; knowledge_requesting_peers
         ; knowledge
         ; r = _
@@ -500,8 +509,6 @@ end = struct
       Hashtbl.iter t.knowledge ~f:(fun s ->
           List.iter ks ~f:(Hash_set.remove s.tried_and_failed) )
 
-    let ignore_period = Time.Span.of_min 2.
-
     let update t u =
       O1trace.sync_thread "update_downloader" (fun () ->
           match u with
@@ -567,7 +574,7 @@ end = struct
                if List.is_empty succs then
                  Hashtbl.update t.temporary_ignores peer0 ~f:(fun x ->
                      cancel x ;
-                     Clock.Event.run_after ignore_period
+                     Clock.Event.run_after t.ignore_period
                        (fun () ->
                          Hashtbl.remove t.temporary_ignores peer0 ;
                          if not (Strict_pipe.Writer.is_closed t.w) then
@@ -627,6 +634,8 @@ end = struct
     ; logger : Logger.t
     ; trust_system : Trust_system.t
     ; stop : unit Deferred.t
+    ; post_stall_retry_delay : Time.Span.t
+    ; no_progress_recheck_delay : Time.Span.t
     }
 
   let logger t = t.logger
@@ -734,6 +743,8 @@ end = struct
         ; logger = _
         ; trust_system = _
         ; stop = _
+        ; post_stall_retry_delay = _
+        ; no_progress_recheck_delay = _
         } as t ) =
     let rec clear_queue q =
       match Q.dequeue q with
@@ -882,8 +893,6 @@ end = struct
                    ] ) ) )
       ]
 
-  let post_stall_retry_delay = Time.Span.of_min 1.
-
   let rec step t =
     if Q.length t.pending = 0 then (
       [%log' debug t.logger] "Downloader: no jobs. waiting" ;
@@ -924,9 +933,9 @@ end = struct
           [%log' debug t.logger]
             "Downloader: all stalled. Resetting knowledge, waiting %s and then \
              retrying."
-            (Time.Span.to_string_hum post_stall_retry_delay) ;
+            (Time.Span.to_string_hum t.post_stall_retry_delay) ;
           Useful_peers.reset_knowledge t.useful_peers ~all_peers:t.all_peers ;
-          let%bind () = after post_stall_retry_delay in
+          let%bind () = after t.post_stall_retry_delay in
           [%log' debug t.logger] "Downloader: continuing after reset" ;
           step t
       | `Useful (peer, might_know) -> (
@@ -956,8 +965,12 @@ end = struct
   let mark_preferred t peer ~now =
     Useful_peers.Preferred_heap.add t.useful_peers.all_preferred (peer, now)
 
-  let create ~max_batch_size ~stop ~logger ~trust_system ~get ~knowledge_context
-      ~knowledge ~peers ~preferred =
+  let create ?(ignore_period = Time.Span.of_min 2.)
+      ?(post_stall_retry_delay = Time.Span.of_min 1.)
+      ?(no_progress_recheck_delay = Time.Span.of_min 1.)
+      ?(peer_refresh_interval = Time.Span.of_min 1.) ~max_batch_size ~stop
+      ~logger ~trust_system ~get ~knowledge_context ~knowledge ~peers ~preferred
+      () =
     let%map all_peers = peers () in
     let pipe ~name c =
       Strict_pipe.create ~warn_on_drop:false ~name
@@ -974,19 +987,21 @@ end = struct
       ; jobs_added_bvar = Bvar.create ()
       ; got_new_peers_r
       ; got_new_peers_w
-      ; useful_peers = Useful_peers.create ~all_peers ~preferred
+      ; useful_peers = Useful_peers.create ~ignore_period ~all_peers ~preferred
       ; get
       ; max_batch_size
       ; logger
       ; trust_system
       ; downloading = Key.Table.create ()
       ; stop
+      ; post_stall_retry_delay
+      ; no_progress_recheck_delay
       }
     in
     let peers =
       let r, w = Broadcast_pipe.create [] in
       upon stop (fun () -> Broadcast_pipe.Writer.close w) ;
-      Clock.every' ~stop (Time.Span.of_min 1.) (fun () ->
+      Clock.every' ~stop peer_refresh_interval (fun () ->
           peers ()
           >>= fun ps ->
           try Broadcast_pipe.Writer.write w ps

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -903,12 +903,37 @@ end = struct
       | `Ok () ->
           step t )
     else
+      let read p =
+        Pipe.read_choice_single_consumer_exn
+          (Strict_pipe.Reader.to_linear_pipe p).pipe [%here]
+      in
+      (* The [useful_peers] and [got_new_peers] signals are best-effort
+         (capacity-0, drop-head): a wakeup is lost if it fires before we are
+         parked on the read. Racing the signals against a timeout ensures that a
+         dropped wakeup cannot leave the loop parked indefinitely after the peer
+         set has in fact recovered. *)
+      let wait_for_change pipes =
+        Deferred.choose
+          ( Deferred.choice (after t.no_progress_recheck_delay) (fun () ->
+                `Ok () )
+          :: List.map pipes ~f:read )
+      in
       match
         Useful_peers.useful_peer t.useful_peers
           ~pending_jobs:(Q.to_list t.pending)
       with
       | `No_peers -> (
-          match%bind Strict_pipe.Reader.read t.got_new_peers_r with
+          [%log' debug t.logger]
+            "Downloader: Waiting. No known peer has the remaining jobs" ;
+          (* Wake on new peers, on any change in peer usefulness (e.g. a
+             temporary-ignore expiring), or on the fallback timeout. The
+             [useful_peers] wake matters here in particular: once every job has
+             been tried against every peer no peer has positive knowledge, so it
+             is the only signal by which the loop learns that an ignored peer has
+             become usable again. *)
+          match%bind
+            wait_for_change [ t.got_new_peers_r; t.useful_peers.r ]
+          with
           | `Eof ->
               [%log' debug t.logger] "Downloader: new peers eof" ;
               Deferred.unit
@@ -916,13 +941,7 @@ end = struct
               step t )
       | `Useful_but_busy -> (
           [%log' debug t.logger] "Downloader: Waiting. All useful peers busy" ;
-          let read p =
-            Pipe.read_choice_single_consumer_exn
-              (Strict_pipe.Reader.to_linear_pipe p).pipe [%here]
-          in
-          match%bind
-            Deferred.choose [ read t.flush_r; read t.useful_peers.r ]
-          with
+          match%bind wait_for_change [ t.flush_r; t.useful_peers.r ] with
           | `Eof ->
               [%log' debug t.logger] "Downloader: flush eof" ;
               Deferred.unit

--- a/src/lib/downloader/test/dune
+++ b/src/lib/downloader/test/dune
@@ -1,0 +1,22 @@
+(library
+ (name downloader_test)
+ (libraries
+  ;; opam libraries
+  async
+  async_kernel
+  async_unix
+  core
+  core_kernel
+  ppx_inline_test.config
+  ;; local libraries
+  logger
+  network_peer
+  pipe_lib
+  trust_system
+  downloader)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_jane)))

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -1,0 +1,91 @@
+open Core
+open Async
+open Pipe_lib
+open Network_peer
+
+(* Regression test for the downloader [`No_peers] wedge.
+
+   The downloader step loop reaches the [`No_peers] state when no known peer has
+   any of the pending jobs. Before the fix, that branch waited only on the
+   [got_new_peers] signal and ignored the [useful_peers] signal that fires
+   whenever a peer's usefulness changes (a download finishing, a knowledge
+   update, a temporary-ignore expiring). Once parked, the loop could therefore
+   only be woken by a brand-new peer connecting; every other recovery signal was
+   dropped, leaving the node silently stuck in bootstrap or catchup.
+
+   This test drives the loop into [`No_peers] by starting it with no peers, then
+   advertises -- via [add_knowledge] -- that an existing peer has the job. That
+   writes only the [useful_peers] signal. The fixed loop wakes and downloads the
+   job; the unfixed loop stays parked and the job never resolves, which the
+   timeout below turns into a failure.
+
+   [peers] returns the empty list throughout, so the [got_new_peers] signal is
+   never fired and cannot mask the bug, and the timeout is well under the loop's
+   one-minute fallback re-check so a pass requires the signal-driven wake
+   specifically. *)
+
+module Key = struct
+  include Int
+
+  let to_yojson i = `Int i
+end
+
+module Attempt = struct
+  type t = unit
+
+  let to_yojson () = `Null
+
+  let download = ()
+
+  let worth_retrying _ = true
+end
+
+module Result = struct
+  type t = Key.t
+
+  let key = Fn.id
+end
+
+module Knowledge_context = struct
+  type t = unit
+end
+
+module D = Downloader.Make (Key) (Attempt) (Result) (Knowledge_context)
+
+let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
+  Thread_safe.block_on_async_exn (fun () ->
+      let logger = Logger.null () in
+      let trust_system = Trust_system.null () in
+      let stop = Ivar.create () in
+      let peer =
+        Peer.create
+          (Core.Unix.Inet_addr.of_string "1.2.3.4")
+          ~libp2p_port:8302
+          ~peer_id:(Peer.Id.unsafe_of_string "regression-test-peer")
+      in
+      let knowledge_context, _knowledge_w = Broadcast_pipe.create () in
+      let%bind downloader =
+        D.create ~max_batch_size:1 ~stop:(Ivar.read stop) ~logger ~trust_system
+          ~get:(fun _peer keys -> Deferred.Or_error.return keys)
+          ~knowledge_context
+          ~knowledge:(fun () _peer -> Deferred.return (`Some []))
+          ~peers:(fun () -> Deferred.return [])
+          ~preferred:[]
+      in
+      let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
+      (* Let the loop settle into [`No_peers] (the flush delay is 100ms). *)
+      let%bind () = after (Time.Span.of_ms 500.) in
+      (* Advertise that [peer] has the job. This fires only the [useful_peers]
+         signal -- not [got_new_peers] -- which the unfixed loop ignores. *)
+      D.add_knowledge downloader peer [ 1 ] ;
+      let%map result = with_timeout (Time.Span.of_sec 15.) (D.Job.result job) in
+      Ivar.fill_if_empty stop () ;
+      match result with
+      | `Timeout ->
+          failwith
+            "downloader stayed wedged in [`No_peers]: did not wake on the \
+             useful_peers signal"
+      | `Result (Ok _) ->
+          ()
+      | `Result (Error `Finished) ->
+          failwith "job was cancelled/stopped unexpectedly" )

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -89,3 +89,61 @@ let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
           ()
       | `Result (Error `Finished) ->
           failwith "job was cancelled/stopped unexpectedly" )
+
+(* End-to-end regression test for the full self-heal path.
+
+   Unlike the test above (which injects a [useful_peers] signal directly), this
+   one exercises the production recovery chain: a download fails, which marks the
+   job [tried_and_failed] against the peer and temporarily ignores it; the loop
+   parks in [`No_peers]; the temporary-ignore expires; the loop wakes,
+   re-evaluates to [`Stalled], resets the peer's knowledge (clearing
+   [tried_and_failed]); and the subsequent retry succeeds.
+
+   The recovery delays are set to small values via [create]'s optional
+   parameters so the whole chain runs in well under a second. [get] fails the
+   first attempt and succeeds thereafter. [peers] returns a single stable peer so
+   that [reset_knowledge] (which drops peers not in the peer set) keeps it, and
+   [peer_refresh_interval] is small so the peer is delivered promptly after the
+   initial empty broadcast value. *)
+
+let%test_unit "[`No_peers] self-heals through `Stalled`/reset_knowledge" =
+  Thread_safe.block_on_async_exn (fun () ->
+      let logger = Logger.null () in
+      let trust_system = Trust_system.null () in
+      let stop = Ivar.create () in
+      let peer =
+        Peer.create
+          (Core.Unix.Inet_addr.of_string "1.2.3.4")
+          ~libp2p_port:8302
+          ~peer_id:(Peer.Id.unsafe_of_string "regression-test-peer")
+      in
+      let knowledge_context, _knowledge_w = Broadcast_pipe.create () in
+      let download_attempts = ref 0 in
+      let%bind downloader =
+        D.create ~ignore_period:(Time.Span.of_ms 200.)
+          ~post_stall_retry_delay:(Time.Span.of_ms 200.)
+          ~peer_refresh_interval:(Time.Span.of_ms 100.) ~max_batch_size:1
+          ~stop:(Ivar.read stop) ~logger ~trust_system
+          ~get:(fun _peer keys ->
+            incr download_attempts ;
+            if !download_attempts = 1 then
+              Deferred.return
+                (Or_error.error_string "simulated download failure")
+            else Deferred.Or_error.return keys )
+          ~knowledge_context
+          ~knowledge:(fun () _peer -> Deferred.return `All)
+          ~peers:(fun () -> Deferred.return [ peer ])
+          ~preferred:[] ()
+      in
+      let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
+      let%map result = with_timeout (Time.Span.of_sec 15.) (D.Job.result job) in
+      Ivar.fill_if_empty stop () ;
+      match result with
+      | `Timeout ->
+          failwith
+            "downloader did not self-heal: the failed job was not retried \
+             after the temporary ignore expired"
+      | `Result (Ok _) ->
+          [%test_eq: bool] (!download_attempts >= 2) true
+      | `Result (Error `Finished) ->
+          failwith "job was cancelled/stopped unexpectedly" )

--- a/src/lib/downloader/test/test.ml
+++ b/src/lib/downloader/test/test.ml
@@ -70,7 +70,7 @@ let%test_unit "[`No_peers] state wakes on a useful_peers signal" =
           ~knowledge_context
           ~knowledge:(fun () _peer -> Deferred.return (`Some []))
           ~peers:(fun () -> Deferred.return [])
-          ~preferred:[]
+          ~preferred:[] ()
       in
       let job = D.download downloader ~key:1 ~attempts:Peer.Map.empty in
       (* Let the loop settle into [`No_peers] (the flush delay is 100ms). *)

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1189,7 +1189,7 @@ let run_catchup ~context:(module Context : CONTEXT) ~trust_system ~verifier
                   ( State_hash.With_state_hashes.state_hash x
                   , Mina_state.Protocol_state.consensus_state x.data
                     |> Consensus.Data.Consensus_state.blockchain_length ) ) ) )
-      ~knowledge
+      ~knowledge ()
   in
   check_invariant ~downloader t ;
   let () =

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -462,6 +462,7 @@ let glue_sync_ledger :
                       (List.filter_map ps ~f:(fun (q, r) ->
                            match r with Ok r -> Some (q, r) | Error _ -> None )
                       ) ) ) )
+      ()
   in
   don't_wait_for
     (let%bind downloader = downloader in


### PR DESCRIPTION
## Summary

Backports **#18984 (downloader: fix silent wedge when all peers have been tried)** plus its prerequisites from `develop` to `compatible`.

This fixes the intermittent `Sync_timeout` failure in the **`mina_lib` "Epoch ledger sync tests"** that has been failing the `compatible` nightly `dev-unit-tests` (e.g. `mina-mainline-branches-nightlies` build 1478):

```
File "src/lib/mina_lib/tests/tests.ml", line 620: Sync current, next staking ledgers to
empty ledgers, backed with stable db threw (monitor.ml.Error (Sync_timeout) ...)
FAILED 1 / 5 tests
```

## Root cause

The epoch-ledger-sync test spins up two real libp2p nodes and syncs a ledger from node1 to node2. That sync routes through the shared `Downloader` (`Mina_networking.glue_sync_ledger` → `Sl_downloader`), the same path production bootstrap/catchup use.

`compatible` was **missing the downloader no-peers-wedge fix** that already landed on `develop` (#18984). In the old code, once every pending job has been tried-and-failed against every known peer, the `No_peers` branch of the downloader step loop waits **only** on `got_new_peers_r` — a signal fired solely when a brand-new peer connects. The recovery events (a temporary-ignore expiring, a knowledge update) write to a *different* signal (`useful_peers.r`) that branch never read. In a two-node test no new peer ever connects, so once node2's cold-start downloader hits `No_peers` it **parks forever** — even after the connection to node1 is established — and the test's 5-minute watchdog fires `Sync_timeout`.

This matches the evidence exactly: the other 4 sub-tests in the same module **passed** in the failing run (so libp2p connectivity itself works); only the cold-start one wedged. It also explains "used to pass / nothing changed": the wedge is a latent, timing-dependent bug, made more likely by the slow/DHT-starved CI sandbox visible in the run logs (`failed to find any peer in table`).

The fix makes `No_peers` also wait on `useful_peers.r` and races both wait sites against a fallback `no_progress_recheck_delay` timeout, so the loop reaches the self-healing `Stalled` → `reset_knowledge` path instead of stalling indefinitely.

## What's included

Cherry-picked (with `-x` provenance) from `develop`, in order:

| commit | purpose |
|---|---|
| `db8a4e9188` | Downloader: don't leave `refresh_knowledge` thread running after exit |
| `74697ec8c8` | downloader: add `No_peers` wedge regression test |
| `4b6b4efa77` | downloader: make recovery timing constants injectable (prereq — adds `no_progress_recheck_delay`) |
| `607f65a0f9` | downloader: add e2e regression test for the `No_peers` self-heal |
| `998e672f6f` | **downloader: fix silent wedge when all peers have been tried** |
| changelog | `changes/` entry for #18984 |

After this PR, `src/lib/downloader/downloader.ml`, `src/lib/downloader/test/`, and `src/lib/mina_networking/mina_networking.ml` are **byte-identical to `develop`**. The only cross-file touch is a one-token `()` arg added to the `Downloader.create` call sites in `super_catchup.ml` and `mina_networking.ml` (the new optional-timing-param signature).

**Scope:** deliberately excludes the unrelated SNARK commits (`37cc27292a`, `7fd46d9547`) that also happen to touch `super_catchup.ml`.

## Out of scope (separate, pre-existing flakiness)

The same nightly also showed two **environmental** flakes that are *not* a regression and are present on `develop` too — not addressed here:
- `mina_net2` `all_ipc.ml` `UnexpectedState` — a libp2p connection-gating race (Carol transiently observes a gated peer connect before the post-handshake rejection); the test file is identical on `develop`.
- `abstract_test.exe` `Sys_error .../latest` — a known Alcotest 1.1.0 `latest`-symlink TOCTOU race across parallel test binaries; auto-recovered on retry.

## Test plan

- Backported regression tests in `src/lib/downloader/test/` cover the `No_peers` self-heal (fast, deterministic — inject ms-scale timing constants; no real libp2p).
- Full `dev` unit tests via CI.
- `!ci-build-me` required to run PR CI.
