### PR TITLE
[DNM] test prefork branch forking into unstake feature.

### DIFF
--- a/buildkite/src/Jobs/Test/HardForkTestLegacy.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestLegacy.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestLegacy"
       "hard fork test - legacy mode"
       "hard-fork-test-legacy"
-      "--fork-from origin/master --allow-fork-method legacy"
+      "--fork-from origin/master --fork-to develop --allow-fork-method legacy"

--- a/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestMixed.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestMixed"
       "hard fork test - mixed mode"
       "hard-fork-test-mixed"
-      "--fork-from origin/compatible --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"
+      "--fork-from origin/compatible --fork-to develop --allow-fork-method legacy --allow-fork-method advanced --allow-fork-method auto"

--- a/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
@@ -4,4 +4,4 @@ in  HardforkTest.pipeline
       "HardForkTestUnstaking"
       "hard fork test - unstaking (legacy mode)"
       "hard-fork-test-unstaking"
-      "--fork-from origin/restake-prefork-patch --fork-to origin/lyh/restake-postfork-feat --allow-fork-method legacy --unstaking-test"
+      "--fork-from origin/restake-prefork-patch --fork-to origin/lyh/restake-postfork-feat --allow-fork-method legacy --unstaking-test --inactive-stake-portion 0.5 --num-dormant-whales 3"

--- a/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
@@ -1,0 +1,7 @@
+let HardforkTest = ../../Command/HardForkTest.dhall
+
+in  HardforkTest.pipeline
+      "HardForkTestUnstaking"
+      "hard fork test - unstaking (legacy mode)"
+      "hard-fork-test-unstaking"
+      "--fork-from origin/restake-prefork-patch --fork-to origin/lyh/restake-postfork-feat --allow-fork-method legacy --unstaking-test"

--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -13,9 +13,10 @@
 set -eux -o pipefail
 
 PREFORK=""
+FORKTO="develop"
 EXTRA_ARGS=()
 
-USAGE="Usage: $0 --fork-from <PREFORK> [ADDITONAL ARGS TO HF TEST...]"
+USAGE="Usage: $0 --fork-from <PREFORK> [--fork-to <FORKTO>] [ADDITONAL ARGS TO HF TEST...]"
 usage() {
   if (( $# > 0 )); then
     echo "$1" >&2
@@ -36,6 +37,13 @@ while [[ $# -gt 0 ]]; do
         usage "Error: $1 requires an argument."
       fi
       PREFORK="$2"
+      shift 2
+      ;;
+    --fork-to)
+      if [[ $# -lt 2 ]]; then
+        usage "Error: $1 requires an argument."
+      fi
+      FORKTO="$2"
       shift 2
       ;;
     --help|-h)
@@ -122,8 +130,8 @@ git checkout $PREFORK
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "prefork-devnet"
 
-# 2. Build "develop" branch as a postfork build
-git checkout develop
+# 2. Build postfork branch as a postfork build
+git checkout $FORKTO
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "postfork-devnet"
 

--- a/scripts/mina-local-network/generate-mina-local-network-ledger.py
+++ b/scripts/mina-local-network/generate-mina-local-network-ledger.py
@@ -82,6 +82,10 @@ def encode_nanominas(nanominas):
 @click.option('--snark-coordinator-accounts-directory',
               default=DEFAULT_SNARK_COORDINATOR_KEYS_DIR.absolute(),
               help='Directory where Snark Coordinator Account Keys will be stored.')
+@click.option('--active-stake-per-whale',
+              default=11550000,
+              type=int,
+              help='Active stake per whale in nanomina. Default: 11550000')
 @click.option(
     '--out-genesis-ledger-file',
     default=DEFAULT_GENESIS_LEDGER_FILE.absolute(),
@@ -102,6 +106,7 @@ def generate_ledger(generate_remainder,
                     offline_fish_accounts_directory,
                     staker_csv_file,
                     snark_coordinator_accounts_directory,
+                    active_stake_per_whale,
                     out_genesis_ledger_file,
                     out_annotated_ledger_file,
                     ):
@@ -384,7 +389,7 @@ def generate_ledger(generate_remainder,
             .format(num_whale_accounts,
                     len(ledger_public_keys["online_whale_keys"])))
 
-    whale_offline_balance = encode_nanominas(66000 * 175 * (10**9))
+    whale_offline_balance = encode_nanominas(active_stake_per_whale * (10**9))
     whale_online_balance = encode_nanominas(499 * (10**9))
 
     # Whale Accounts

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -59,6 +59,8 @@ SLOT_TX_END=
 SLOT_CHAIN_END=
 HARDFORK_GENESIS_SLOT_DELTA=
 EXTRA_FILES_ROOT=
+ACTIVE_STAKE_PER_WHALE="11550000"
+EXTRA_GENESIS_ACCOUNTS=""
 
 # ================================================
 # Globals (assigned during execution of script)
@@ -167,7 +169,9 @@ help() {
                                          |   Default: not set
 --extra-files-root <path>                | Directory of file tree need to be overlayed on a prepared network folder, useful when initializing from fresh but need some files set. 
                                          |   Default: None
--h   |--help                             | Displays this help message
+--active-stake-per-whale <#>             | Active stake per whale in nanomina. Default: 11550000
+--extra-genesis-accounts <path>          | Path to a JSON file of extra genesis accounts to merge into the generated ledger
+-h   |--help                              | Displays this help message
 
 Available logging levels:
   Spam, Trace, Debug, Info, Warn, Error, Faulty_peer, Fatal
@@ -660,6 +664,14 @@ while [[ "$#" -gt 0 ]]; do
     EXTRA_FILES_ROOT="${2}"
     shift
     ;;
+  --active-stake-per-whale)
+    ACTIVE_STAKE_PER_WHALE="${2}"
+    shift
+    ;;
+  --extra-genesis-accounts)
+    EXTRA_GENESIS_ACCOUNTS="${2}"
+    shift
+    ;;
   *)
     echo "Unknown parameter passed: ${1}"
 
@@ -883,7 +895,15 @@ load_config() {
         --online-whale-accounts-directory "${ROOT}"/online_whale_keys \
         --online-fish-accounts-directory "${ROOT}"/online_fish_keys \
         --snark-coordinator-accounts-directory "${ROOT}"/snark_coordinator_keys \
+        --active-stake-per-whale "${ACTIVE_STAKE_PER_WHALE}" \
         --out-genesis-ledger-file "${ROOT}"/genesis_ledger.json
+
+      if [ -n "${EXTRA_GENESIS_ACCOUNTS}" ]; then
+        jq --slurpfile extra "${EXTRA_GENESIS_ACCOUNTS}" \
+          '.accounts += $extra[0].accounts' \
+          "${ROOT}"/genesis_ledger.json > "${ROOT}"/genesis_ledger_tmp.json
+        mv "${ROOT}"/genesis_ledger_tmp.json "${ROOT}"/genesis_ledger.json
+      fi
 
       reset-genesis-ledger "${ROOT}" "${config_file}"
       echo "Using freshly generated config file ${config_file}:"

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/hardfork"
 	"github.com/spf13/cobra"
@@ -32,12 +34,18 @@ Example:
     --fork-mina-exe /path/to/mina-fork --fork-runtime-genesis-ledger /path/to/runtime_genesis_ledger-fork
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Validate required arguments
+		if !cfg.UnstakingTest {
+			if cmd.Flags().Changed("inactive-stake-portion") {
+				return fmt.Errorf("--inactive-stake-portion requires --unstaking-test")
+			}
+			if cmd.Flags().Changed("num-dormant-whales") {
+				return fmt.Errorf("--num-dormant-whales requires --unstaking-test")
+			}
+		}
 		if err := cfg.Validate(); err != nil {
 			return err
 		}
 
-		// Create and run the hardfork test
 		return hardfork.NewHardforkTest(cfg).Run()
 	},
 }

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -89,7 +89,8 @@ func init() {
 	rootCmd.Flags().Var(&cfg.ForkMethods, "allow-fork-method", "Implementation of fork to use")
 
 	rootCmd.Flags().BoolVar(&cfg.UnstakingTest, "unstaking-test", cfg.UnstakingTest, "Enable unstaking test mode")
-	rootCmd.Flags().Float64Var(&cfg.DormantWhaleBalance, "dormant-whale-balance", cfg.DormantWhaleBalance, "Balance for the dormant whale account")
+	rootCmd.Flags().Float64Var(&cfg.InactiveStakePortion, "inactive-stake-portion", cfg.InactiveStakePortion, "Portion of total stake that is inactive (0-1)")
+	rootCmd.Flags().IntVar(&cfg.NumDormantWhales, "num-dormant-whales", cfg.NumDormantWhales, "Number of dormant whale accounts (>= 1)")
 
 	rootCmd.MarkFlagRequired("main-mina-exe")
 	rootCmd.MarkFlagRequired("main-runtime-genesis-ledger")

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -88,6 +88,9 @@ func init() {
 
 	rootCmd.Flags().Var(&cfg.ForkMethods, "allow-fork-method", "Implementation of fork to use")
 
+	rootCmd.Flags().BoolVar(&cfg.UnstakingTest, "unstaking-test", cfg.UnstakingTest, "Enable unstaking test mode")
+	rootCmd.Flags().Float64Var(&cfg.DormantWhaleBalance, "dormant-whale-balance", cfg.DormantWhaleBalance, "Balance for the dormant whale account")
+
 	rootCmd.MarkFlagRequired("main-mina-exe")
 	rootCmd.MarkFlagRequired("main-runtime-genesis-ledger")
 	rootCmd.MarkFlagRequired("fork-mina-exe")

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -71,6 +71,12 @@ type Config struct {
 	ForkMethods ForkMethodSet
 
 	DaemonInfos []DaemonInfo
+
+	UnstakingTest        bool
+	DormantWhaleBalance  float64
+	ActiveStakePerWhale  float64
+	DormantWhalePk       string
+	DormantWhaleKeyDir   string
 }
 
 // DefaultConfig returns the default configuration with values
@@ -106,6 +112,10 @@ func DefaultConfig() *Config {
 		NodeStartPort:        6000,
 
 		ForkMethods: make(ForkMethodSet),
+
+		UnstakingTest:       false,
+		DormantWhaleBalance: 50000000,
+		ActiveStakePerWhale: 11550000,
 	}
 }
 

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -75,10 +75,11 @@ type Config struct {
 	DaemonInfos []DaemonInfo
 
 	UnstakingTest        bool
-	DormantWhaleBalance  float64
+	InactiveStakePortion float64
+	NumDormantWhales    int
 	ActiveStakePerWhale  float64
-	DormantWhalePk       string
-	DormantWhaleKeyDir   string
+	DormantWhalePks      []string
+	DormantWhaleKeyDirs  []string
 }
 
 // DefaultConfig returns the default configuration with values
@@ -115,8 +116,9 @@ func DefaultConfig() *Config {
 
 		ForkMethods: make(ForkMethodSet),
 
-		UnstakingTest:       false,
-		DormantWhaleBalance: 50000000,
+		UnstakingTest:        false,
+		InactiveStakePortion: 0.684,
+		NumDormantWhales:    1,
 		ActiveStakePerWhale: 11550000,
 	}
 }
@@ -320,6 +322,37 @@ func validateScriptDir(path string) error {
 	}
 
 	return nil
+}
+
+func (c *Config) TotalDormantBalance() float64 {
+	if c.InactiveStakePortion <= 0.0 || c.InactiveStakePortion >= 1.0 {
+		return 0.0
+	}
+	totalActive := float64(c.NumWhales) * c.ActiveStakePerWhale
+	return totalActive * c.InactiveStakePortion / (1.0 - c.InactiveStakePortion)
+}
+
+func (c *Config) DormantBalances() []float64 {
+	n := c.NumDormantWhales
+	if n <= 0 {
+		return nil
+	}
+	total := c.TotalDormantBalance()
+	if total <= 0.0 {
+		return make([]float64, n)
+	}
+	proportions := make([]float64, n)
+	sum := 0.0
+	for j := 0; j < n; j++ {
+		v := rand.Float64()
+		proportions[j] = v
+		sum += v
+	}
+	balances := make([]float64, n)
+	for j := 0; j < n; j++ {
+		balances[j] = total * proportions[j] / sum
+	}
+	return balances
 }
 
 func EncodeNanominas(nanominas uint64) string {

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -318,4 +320,12 @@ func validateScriptDir(path string) error {
 	}
 
 	return nil
+}
+
+func EncodeNanominas(nanominas uint64) string {
+	s := strconv.FormatUint(nanominas, 10)
+	if len(s) > 9 {
+		return s[:len(s)-9] + "." + s[len(s)-9:]
+	}
+	return "0." + strings.Repeat("0", 9-len(s)) + s
 }

--- a/src/app/hardfork_test/src/internal/hardfork/fill_rate_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/fill_rate_test.go
@@ -1,0 +1,65 @@
+package hardfork
+
+import (
+	"testing"
+
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
+)
+
+func TestExpectedPreForkFillUpperBound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		numWhales           int
+		activeStakePerWhale float64
+		dormantWhaleBalance float64
+	}{
+		{
+			name:                "typical values",
+			numWhales:           2,
+			activeStakePerWhale: 11550000,
+			dormantWhaleBalance: 50000000,
+		},
+		{
+			name:                "no whales",
+			numWhales:           0,
+			activeStakePerWhale: 11550000,
+			dormantWhaleBalance: 50000000,
+		},
+		{
+			name:                "single whale",
+			numWhales:           1,
+			activeStakePerWhale: 11550000,
+			dormantWhaleBalance: 50000000,
+		},
+		{
+			name:                "zero balance",
+			numWhales:           2,
+			activeStakePerWhale: 0,
+			dormantWhaleBalance: 0,
+		},
+		{
+			name:                "many whales",
+			numWhales:           10,
+			activeStakePerWhale: 11550000,
+			dormantWhaleBalance: 50000000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ht := &HardforkTest{
+				Config: &config.Config{
+					NumWhales:          tt.numWhales,
+					ActiveStakePerWhale: tt.activeStakePerWhale,
+					DormantWhaleBalance: tt.dormantWhaleBalance,
+				},
+			}
+			result := ht.expectedPreForkFillUpperBound()
+			if result < 0 || result > 1.0 {
+				t.Errorf("expectedPreForkFillUpperBound() = %f, want in [0,1]", result)
+			}
+		})
+	}
+}

--- a/src/app/hardfork_test/src/internal/hardfork/fill_rate_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/fill_rate_test.go
@@ -13,37 +13,43 @@ func TestExpectedPreForkFillUpperBound(t *testing.T) {
 		name                string
 		numWhales           int
 		activeStakePerWhale float64
-		dormantWhaleBalance float64
+		inactiveStakePortion float64
+		numDormantWhales    int
 	}{
 		{
-			name:                "typical values",
-			numWhales:           2,
-			activeStakePerWhale: 11550000,
-			dormantWhaleBalance: 50000000,
+			name:                 "typical values",
+			numWhales:            2,
+			activeStakePerWhale:  11550000,
+			inactiveStakePortion: 0.684,
+			numDormantWhales:     1,
 		},
 		{
-			name:                "no whales",
-			numWhales:           0,
-			activeStakePerWhale: 11550000,
-			dormantWhaleBalance: 50000000,
+			name:                 "no whales",
+			numWhales:            0,
+			activeStakePerWhale:  11550000,
+			inactiveStakePortion: 0.5,
+			numDormantWhales:     1,
 		},
 		{
-			name:                "single whale",
-			numWhales:           1,
-			activeStakePerWhale: 11550000,
-			dormantWhaleBalance: 50000000,
+			name:                 "single whale",
+			numWhales:            1,
+			activeStakePerWhale:  11550000,
+			inactiveStakePortion: 0.3,
+			numDormantWhales:     1,
 		},
 		{
-			name:                "zero balance",
-			numWhales:           2,
-			activeStakePerWhale: 0,
-			dormantWhaleBalance: 0,
+			name:                 "zero balance",
+			numWhales:            2,
+			activeStakePerWhale:  0,
+			inactiveStakePortion: 0.0,
+			numDormantWhales:     1,
 		},
 		{
-			name:                "many whales",
-			numWhales:           10,
-			activeStakePerWhale: 11550000,
-			dormantWhaleBalance: 50000000,
+			name:                 "many whales",
+			numWhales:            10,
+			activeStakePerWhale:  11550000,
+			inactiveStakePortion: 0.9,
+			numDormantWhales:     5,
 		},
 	}
 
@@ -51,9 +57,10 @@ func TestExpectedPreForkFillUpperBound(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ht := &HardforkTest{
 				Config: &config.Config{
-					NumWhales:          tt.numWhales,
+					NumWhales:           tt.numWhales,
 					ActiveStakePerWhale: tt.activeStakePerWhale,
-					DormantWhaleBalance: tt.dormantWhaleBalance,
+					InactiveStakePortion: tt.inactiveStakePortion,
+					NumDormantWhales:    tt.numDormantWhales,
 				},
 			}
 			result := ht.expectedPreForkFillUpperBound()

--- a/src/app/hardfork_test/src/internal/hardfork/ledger.go
+++ b/src/app/hardfork_test/src/internal/hardfork/ledger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
@@ -17,23 +18,23 @@ type LedgerHashes struct {
 }
 
 // GenerateForkLedgers generates the hardfork ledgers using the specified executable
-func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile string) error {
+func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile string, extraArgs ...string) error {
 	t.Logger.Info("Generating hardfork ledgers with %s...", executablePath)
 
-	// Create hardfork ledgers directory
 	os.RemoveAll(ledgersDir)
 	os.MkdirAll(ledgersDir, 0755)
 
-	// Generate hardfork ledgers with specified executable
-	cmd := exec.Command(
-		executablePath,
+	args := []string{
 		"--config-file", forkConfigPath,
 		"--genesis-dir", ledgersDir,
 		"--hash-output-file", hashesFile,
-		// Forking to mesa need App State size to be expanded to 32
-		// TODO: Consider design the test so this pad app state size is only applied when forking into Mesa
 		"--pad-app-state",
-	)
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command(executablePath, args...)
+
+	cmd.Env = append(os.Environ(), "TMPDIR="+filepath.Join(t.Config.Root, "tmp"))
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -62,9 +63,9 @@ func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysi
 // 1. generate fork ledgers with runtime-genesis-ledger
 // 2. patch the genesis time & slot for fork config with create_runtime_config.sh
 // 3. perform some base sanity check on the fork config
-func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64) ([]byte, error) {
+func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64, extraArgs ...string) ([]byte, error) {
 	// Generate fork ledgers using fork network executable
-	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile); err != nil {
+	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile, extraArgs...); err != nil {
 		return nil, err
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -87,14 +87,16 @@ func (t *HardforkTest) RunMainNetwork(extraFilesRoot string, mainGenesisTs int64
 	}
 
 	if t.Config.UnstakingTest {
-		extraAccountsPath, err := t.setupDormantWhaleAccount()
+		extraAccountsPath, err := t.setupDormantWhaleAccounts()
 		if err != nil {
 			return nil, err
 		}
-		args = append(args,
-			"--extra-genesis-accounts", extraAccountsPath,
-			"--active-stake-per-whale", strconv.FormatFloat(t.Config.ActiveStakePerWhale, 'f', 0, 64),
-		)
+		if extraAccountsPath != "" {
+			args = append(args,
+				"--extra-genesis-accounts", extraAccountsPath,
+				"--active-stake-per-whale", strconv.FormatFloat(t.Config.ActiveStakePerWhale, 'f', 0, 64),
+			)
+		}
 	}
 
 	return t.startLocalNetwork(t.Config.MainMinaExe, "main", args)
@@ -117,41 +119,47 @@ func (t *HardforkTest) WaitUntilBestChainQuery(slotDurationSec int, genesisSlot 
 	)
 }
 
-func (t *HardforkTest) setupDormantWhaleAccount() (string, error) {
-	dormantDir, err := os.MkdirTemp("", "dormant-whale-keys")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir for dormant whale keys: %w", err)
+func (t *HardforkTest) setupDormantWhaleAccounts() (string, error) {
+	if t.Config.NumDormantWhales <= 0 || t.Config.TotalDormantBalance() <= 0.0 {
+		return "", nil
 	}
 
-	t.Config.DormantWhaleKeyDir = dormantDir
+	var accounts []extraGenesisAccount
+	balances := t.Config.DormantBalances()
 
-	keyPath := filepath.Join(dormantDir, "dormant_whale_account")
+	for i := 0; i < t.Config.NumDormantWhales; i++ {
+		dormantDir, err := os.MkdirTemp("", fmt.Sprintf("dormant-whale-%d-keys", i))
+		if err != nil {
+			return "", fmt.Errorf("failed to create temp dir for dormant whale %d keys: %w", i, err)
+		}
+		t.Config.DormantWhaleKeyDirs = append(t.Config.DormantWhaleKeyDirs, dormantDir)
 
-	cmd := exec.Command(t.Config.MainMinaExe, "advanced", "generate-keypair", "-privkey-path", keyPath)
-	cmd.Env = append(os.Environ(), "MINA_PRIVKEY_PASS="+os.Getenv("MINA_PRIVKEY_PASS"))
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to generate dormant whale keypair: %w", err)
+		keyPath := filepath.Join(dormantDir, "dormant_whale_account")
+
+		cmd := exec.Command(t.Config.MainMinaExe, "advanced", "generate-keypair", "-privkey-path", keyPath)
+		cmd.Env = append(os.Environ(), "MINA_PRIVKEY_PASS="+os.Getenv("MINA_PRIVKEY_PASS"))
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to generate dormant whale %d keypair: %w", i, err)
+		}
+
+		pubkeyBytes, err := os.ReadFile(keyPath + ".pub")
+		if err != nil {
+			return "", fmt.Errorf("failed to read dormant whale %d public key: %w", i, err)
+		}
+		pubkey := strings.TrimSpace(string(pubkeyBytes))
+
+		t.Config.DormantWhalePks = append(t.Config.DormantWhalePks, pubkey)
+
+		accounts = append(accounts, extraGenesisAccount{
+			Pk:       pubkey,
+			Sk:       nil,
+			Balance:  config.EncodeNanominas(uint64(balances[i] * 1e9)),
+			Delegate: pubkey,
+		})
 	}
-
-	pubkeyBytes, err := os.ReadFile(keyPath + ".pub")
-	if err != nil {
-		return "", fmt.Errorf("failed to read dormant whale public key: %w", err)
-	}
-	pubkey := strings.TrimSpace(string(pubkeyBytes))
-
-	t.Config.DormantWhalePk = pubkey
 
 	extraFile := filepath.Join(os.TempDir(), "extra_genesis_accounts.json")
-	extra := extraGenesisAccounts{
-		Accounts: []extraGenesisAccount{
-			{
-				Pk:       pubkey,
-				Sk:       nil,
-				Balance:  config.EncodeNanominas(uint64(t.Config.DormantWhaleBalance * 1e9)),
-				Delegate: pubkey,
-			},
-		},
-	}
+	extra := extraGenesisAccounts{Accounts: accounts}
 	data, err := json.Marshal(extra)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal extra genesis accounts: %w", err)

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -1,16 +1,29 @@
 package hardfork
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
 )
+
+type extraGenesisAccount struct {
+	Pk       string      `json:"pk"`
+	Sk       interface{} `json:"sk"`
+	Balance  string      `json:"balance"`
+	Delegate interface{} `json:"delegate"`
+}
+
+type extraGenesisAccounts struct {
+	Accounts []extraGenesisAccount `json:"accounts"`
+}
 
 func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, extraArgs []string) (*exec.Cmd, error) {
 
@@ -34,7 +47,14 @@ func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, 
 	)
 
 	cmd.Args = append(cmd.Args, extraArgs...)
-	cmd.Env = append(os.Environ(), "MINA_EXE="+minaExecutable)
+	tmpDir, err := os.MkdirTemp("", "mina-hf-tmp-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	cmd.Env = append(os.Environ(),
+		"MINA_EXE="+minaExecutable,
+		"TMPDIR="+tmpDir,
+	)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -66,6 +86,17 @@ func (t *HardforkTest) RunMainNetwork(extraFilesRoot string, mainGenesisTs int64
 		"--extra-files-root", extraFilesRoot,
 	}
 
+	if t.Config.UnstakingTest {
+		extraAccountsPath, err := t.setupDormantWhaleAccount()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args,
+			"--extra-genesis-accounts", extraAccountsPath,
+			"--active-stake-per-whale", strconv.FormatFloat(t.Config.ActiveStakePerWhale, 'f', 0, 64),
+		)
+	}
+
 	return t.startLocalNetwork(t.Config.MainMinaExe, "main", args)
 }
 
@@ -84,4 +115,50 @@ func (t *HardforkTest) WaitUntilBestChainQuery(slotDurationSec int, genesisSlot 
 	}, fmt.Sprintf("best tip reached slot %d", t.Config.BestChainQueryFrom),
 		time.Duration(2*t.Config.BestChainQueryFrom*slotDurationSec)*time.Second,
 	)
+}
+
+func (t *HardforkTest) setupDormantWhaleAccount() (string, error) {
+	dormantDir, err := os.MkdirTemp("", "dormant-whale-keys")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir for dormant whale keys: %w", err)
+	}
+
+	t.Config.DormantWhaleKeyDir = dormantDir
+
+	keyPath := filepath.Join(dormantDir, "dormant_whale_account")
+
+	cmd := exec.Command(t.Config.MainMinaExe, "advanced", "generate-keypair", "-privkey-path", keyPath)
+	cmd.Env = append(os.Environ(), "MINA_PRIVKEY_PASS="+os.Getenv("MINA_PRIVKEY_PASS"))
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to generate dormant whale keypair: %w", err)
+	}
+
+	pubkeyBytes, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		return "", fmt.Errorf("failed to read dormant whale public key: %w", err)
+	}
+	pubkey := strings.TrimSpace(string(pubkeyBytes))
+
+	t.Config.DormantWhalePk = pubkey
+
+	extraFile := filepath.Join(os.TempDir(), "extra_genesis_accounts.json")
+	extra := extraGenesisAccounts{
+		Accounts: []extraGenesisAccount{
+			{
+				Pk:       pubkey,
+				Sk:       nil,
+				Balance:  config.EncodeNanominas(uint64(t.Config.DormantWhaleBalance * 1e9)),
+				Delegate: pubkey,
+			},
+		},
+	}
+	data, err := json.Marshal(extra)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal extra genesis accounts: %w", err)
+	}
+	if err := os.WriteFile(extraFile, data, 0644); err != nil {
+		return "", fmt.Errorf("failed to write extra genesis accounts: %w", err)
+	}
+
+	return extraFile, nil
 }

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -69,8 +69,21 @@ func (t *HardforkTest) RunMainNetworkPhase(mainGenesisTs int64, beforeShutdown H
 
 	t.Logger.Info("Network analyze result: %v", analysis)
 
-	if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd); err != nil {
-		return nil, err
+	if t.Config.UnstakingTest {
+		occ, err := t.ComputeSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute pre-fork slot occupancy: %w", err)
+		}
+		analysis.PreForkOccupancy = occ
+		t.Logger.Info("Pre-fork slot occupancy (expected low due to dormant whale): %f", occ)
+		upperBound := t.expectedPreForkFillUpperBound()
+		if occ >= upperBound {
+			return nil, fmt.Errorf("pre-fork slot occupancy (%f) exceeds expected upper bound (%f), dormant whale not diluting VRF denominator correctly", occ, upperBound)
+		}
+	} else {
+		if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := t.ValidateLatestOccupiedSlot(analysis.Consensus.LastOccupiedSlot); err != nil {
@@ -144,8 +157,19 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 	t.Logger.Info("Block height is %d at slot %d.", bestTip.BlockHeight, bestTip.Slot)
 
 	// Validate slot occupancy
-	if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip); err != nil {
-		return err
+	if t.Config.UnstakingTest {
+		postForkOcc, err := t.ComputeSlotOccupancy(*commonGenesisBlock, *bestTip)
+		if err != nil {
+			return fmt.Errorf("failed to compute post-fork slot occupancy: %w", err)
+		}
+		t.Logger.Info("Post-fork slot occupancy: %f (pre-fork was %f)", postForkOcc, analysis.PreForkOccupancy)
+		if postForkOcc <= analysis.PreForkOccupancy {
+			return fmt.Errorf("post-fork slot occupancy (%f) did not improve over pre-fork (%f)", postForkOcc, analysis.PreForkOccupancy)
+		}
+	} else {
+		if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip); err != nil {
+			return err
+		}
 	}
 
 	// Validate user commands in blocks
@@ -456,4 +480,21 @@ func (t *HardforkTest) CleanUpNetworkForForkPhase() error {
 		}
 	}
 	return nil
+}
+
+const fillRateThreshold = 0.25
+
+func (t *HardforkTest) expectedPreForkFillUpperBound() float64 {
+	activeStake := t.Config.ActiveStakePerWhale
+	dormantBalance := t.Config.DormantWhaleBalance
+	totalCurrency := float64(t.Config.NumWhales)*activeStake + dormantBalance
+	p := 1.0
+	for i := 0; i < t.Config.NumWhales; i++ {
+		p *= (1.0 - activeStake/totalCurrency)
+	}
+	expectedFill := 1.0 - p + fillRateThreshold
+	if expectedFill > 1.0 {
+		return 1.0
+	}
+	return expectedFill
 }

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -115,7 +115,7 @@ type ForkData struct {
 }
 
 // RunForkNetworkPhase runs the fork network and validates its operation
-func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisTs int64) error {
+func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisTs int64, analysis *BlockAnalysisResult) error {
 	// Start fork network
 	forkCmd, err := t.RunForkNetwork()
 	if err != nil {

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -232,7 +232,12 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 	preforkGenesisConfigFile := filepath.Join(t.Config.Root, "daemon.json")
 	forkHashesFile := filepath.Join(forkDataPath, "ledger_hashes.json")
 
-	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs)
+	var extraArgs []string
+	if t.Config.UnstakingTest {
+		extraArgs = append(extraArgs, "--unstake-pk", t.Config.DormantWhalePk)
+	}
+
+	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs, extraArgs...)
 	if err != nil {
 		return err
 	}
@@ -337,6 +342,14 @@ func (t *HardforkTest) autoFork(daemon config.DaemonInfo, analysis BlockAnalysis
 }
 
 func (t *HardforkTest) ForkPhase(analysis *BlockAnalysisResult, mainGenesisTs int64) error {
+	if t.Config.UnstakingTest {
+		for _, info := range t.Config.DaemonInfos {
+			if info.ForkMethod != config.Legacy {
+				panic(fmt.Sprintf("unstaking test requires all nodes use legacy fork method, but node %s uses %s", info.Name, info.ForkMethod))
+			}
+		}
+	}
+
 	numDaemons := len(t.Config.DaemonInfos)
 	errors := make([]error, numDaemons)
 

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -234,7 +234,9 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 
 	var extraArgs []string
 	if t.Config.UnstakingTest {
-		extraArgs = append(extraArgs, "--unstake-pk", t.Config.DormantWhalePk)
+		for _, pk := range t.Config.DormantWhalePks {
+			extraArgs = append(extraArgs, "--unstake-pk", pk)
+		}
 	}
 
 	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs, extraArgs...)
@@ -499,8 +501,8 @@ const fillRateThreshold = 0.25
 
 func (t *HardforkTest) expectedPreForkFillUpperBound() float64 {
 	activeStake := t.Config.ActiveStakePerWhale
-	dormantBalance := t.Config.DormantWhaleBalance
-	totalCurrency := float64(t.Config.NumWhales)*activeStake + dormantBalance
+	totalDormant := t.Config.TotalDormantBalance()
+	totalCurrency := float64(t.Config.NumWhales)*activeStake + totalDormant
 	p := 1.0
 	for i := 0; i < t.Config.NumWhales; i++ {
 		p *= (1.0 - activeStake/totalCurrency)

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -147,7 +147,7 @@ func (t *HardforkTest) Run() error {
 	}
 
 	t.Logger.Info("Phase 4: Running fork network...")
-	if err := t.RunForkNetworkPhase(analysis.Consensus.LastBlockBeforeTxEnd.BlockHeight, mainGenesisTs); err != nil {
+	if err := t.RunForkNetworkPhase(analysis.Consensus.LastBlockBeforeTxEnd.BlockHeight, mainGenesisTs, analysis); err != nil {
 		return err
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -19,6 +19,7 @@ type BlockAnalysisResult struct {
 	Consensus          ConsensusState
 	GenesisBlock       client.BlockData
 	SnarkedHashByEpoch SnarkedHashByEpoch
+	PreForkOccupancy   float64
 }
 
 func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool, predDescription string, timeout time.Duration) error {
@@ -43,17 +44,24 @@ func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool
 	return fmt.Errorf("timed out waiting for condition: %s at port %d", predDescription, port)
 }
 
+func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockData) (float64, error) {
+	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
+
+	if startBlock.BlockHeight == lastBlock.BlockHeight {
+		return 0, fmt.Errorf("starting block has same height as last block, can't calculate slot occupancy!")
+	}
+
+	return float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot), nil
+}
+
 // ValidateSlotOccupancy checks if block occupancy is above 50%
 func (t *HardforkTest) ValidateSlotOccupancy(startBlock, lastBlock client.BlockData) error {
 	expectedOccupancy := 0.5
 
-	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
-
-	if startBlock.BlockHeight == lastBlock.BlockHeight {
-		return fmt.Errorf("starting block has same height as last block, can't calculate slot occupancy!")
+	actualOccupancy, err := t.ComputeSlotOccupancy(startBlock, lastBlock)
+	if err != nil {
+		return err
 	}
-
-	actualOccupancy := float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot)
 
 	if actualOccupancy < expectedOccupancy {
 		return fmt.Errorf("slot occupancy (%f) is below expected (%f)", actualOccupancy, expectedOccupancy)


### PR DESCRIPTION
## Add unstaking hardfork test

### Summary

Adds an **unstaking test mode** to the hardfork test harness, exercising the scenario where a large "dormant" whale holds stake before the fork (diluting the VRF denominator so pre-fork slot occupancy is low), then gets its delegation patched at fork time so occupancy recovers post-fork. This validates that the restake/unstaking hardfork logic correctly reactivates dormant stake.

Also generalizes the hardfork harness so the post-fork build target is configurable (`--fork-to`) instead of hardcoded to `develop`, and wires up a new CI job for the unstaking scenario.

### What's included

**Unstaking test mode (`--unstaking-test`)**
- New config fields and CLI flags: `--unstaking-test`, `--inactive-stake-portion`, `--num-dormant-whales`. The latter two are guarded so they error unless `--unstaking-test` is set (`app/root.go`).
- `config.go`: dormant-balance math (`TotalDormantBalance`, `DormantBalances` distributes total dormant stake across N whales via random proportions), plus an `EncodeNanominas` helper.
- `network.go`: `setupDormantWhaleAccounts` generates keypairs for each dormant whale, writes an `extra_genesis_accounts.json`, and passes `--extra-genesis-accounts` / `--active-stake-per-whale` into the main network.
- `phases.go`:
  - Pre-fork: computes slot occupancy and asserts it stays **below** an expected upper bound (`expectedPreForkFillUpperBound`, modeling per-whale VRF fill probability against total currency incl. dormant stake) — proving the dormant whale dilutes the VRF denominator.
  - Fork: patches each dormant whale's delegation via `--unstake-pk`.
  - Post-fork: asserts occupancy **improved** over the pre-fork value.
  - Guards that all nodes use the `legacy` fork method in unstaking mode.
- `validation.go`: extracted `ComputeSlotOccupancy` out of `ValidateSlotOccupancy`; added `PreForkOccupancy` to the analysis result so it can be threaded from the pre-fork to the post-fork phase.
- `fill_rate_test.go`: unit tests asserting `expectedPreForkFillUpperBound` stays in `[0,1]` across edge cases (no whales, zero balance, many whales).

**Genesis ledger / local network plumbing**
- `generate-mina-local-network-ledger.py`: new `--active-stake-per-whale` option (replaces the hardcoded `66000 * 175` whale offline balance).
- `mina-local-network.sh`: new `--active-stake-per-whale` and `--extra-genesis-accounts` flags; extra accounts are merged into the generated ledger via `jq`.

**Harness generalization**
- `build-and-test.sh`: new `--fork-to <branch>` (default `develop`) so the post-fork build isn't hardcoded to `develop`.
- `ledger.go`: `GenerateForkLedgers` / `PatchForkConfigAndGenerateLedgersLegacy` now accept variadic extra args (used to pass `--unstake-pk`); sets an explicit `TMPDIR` under the test root.

**CI**
- New `HardForkTestUnstaking.dhall` job: forks from `origin/restake-prefork-patch` to `origin/lyh/restake-postfork-feat`, legacy mode, 50% inactive stake across 3 dormant whales.
- `HardForkTestLegacy` / `HardForkTestMixed` updated to pass `--fork-to develop` explicitly.

### Testing
- Go unit tests: `fill_rate_test.go` covers the fill-rate bound.
- End-to-end validated via the new `HardForkTestUnstaking` Buildkite job.
