### PR TITLE
test_executive: deepen zkapps-timing replayer span to clear log check

### DIFF
--- a/changes/18997.md
+++ b/changes/18997.md
@@ -1,0 +1,3 @@
+test_executive: deepen the zkapps-timing replayer span so its log check passes.
+
+After #18992 the `zkapps-timing` `-local` test still tripped `check_replayer_logs` ("suspiciously few (24) Info logs"): the replayer emits a fixed startup base of "Info" lines plus one per replayed block, and targeting a block two below the best tip put no lower bound on the replay span, so a short-lived 2-minute-block network left the count just under the required 25. The test now waits for the chain to grow by a safe margin (`block_height_growth ~height_growth:10`) before choosing the target, keeping the tip-2 offset (archive-ingestion safety) and not waiting for a ledger proof (fast path).

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -716,13 +716,20 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
              (Error.of_string "Ledger update contains a timing update") ) )
     in
     section_hard "Running replayer"
-      (* Without an explicit target the replayer only replays up to the highest
-         canonical block, which in a short-lived test network is genesis, so it
-         emits too few logs. This test does not wait for a ledger proof, so
-         target a recent best-chain block instead. Pick one a couple below the
-         best tip so it is already persisted in the archive (avoiding a race
-         with archive ingestion of the very latest block). *)
-      (let%bind best_chain =
+      (* The replayer replays from genesis up to an explicit target block, and
+         check_replayer_logs requires at least 25 "Info" log lines: it emits a
+         fixed startup base plus one Info line per replayed block, so the count
+         grows with the target block's height. This test deliberately does not
+         wait for a ledger proof (to stay fast), and a short-lived network with
+         a 2-minute block window may only have a handful of blocks; without a
+         lower bound on the replay span the count can land just under 25. So
+         first grow the chain by a safe margin, then target a block a couple
+         below the best tip so it is already persisted in the archive (avoiding
+         a race with archive ingestion of the very latest block). *)
+      (let%bind () =
+         wait_for t (Wait_condition.block_height_growth ~height_growth:10)
+       in
+       let%bind best_chain =
          Graphql_requests.must_get_best_chain ~logger
            (Network.Node.get_ingress_uri node)
        in


### PR DESCRIPTION
## Problem

The `zkapps-timing-integration-test-local` nightly still fails at its final **Running replayer** section, *after* #18992 was merged:

```
× Running replayer
    Replayer output contains suspiciously few (24) Info logs
```

(nightly build 1483, on HEAD `28b7f4a09f` which already includes #18992.)

## Root cause

`check_replayer_logs` (`src/app/test_executive/test_common.ml:435`) hard-errors when the replayer emits fewer than **25** `"Info"` log lines. The replayer emits a *fixed startup base* of Info lines **plus one Info line per replayed block** (`replayer.ml:1372`, `"Applied all commands at global slot … got expected ledger hash"`, fired once per slot-change; empty blocks log at `spam` level but every block carries a coinbase, so effectively one Info per produced block). So:

```
info_count ≈ fixed_base + target_block_height
```

#18992 fixed the four replayer tests by passing an explicit `~target_state_hash`. For `zkapps-timing` (which deliberately does **not** wait for a ledger proof, to stay fast) it targets a block **two below the best tip** (`_tip :: _prev :: deep :: _`). That offset is archive-safe but puts **no lower bound** on the replay span: on a short-lived network with a 2-minute block window (`block_window_duration_ms = 120000`), this ~24-minute run only reached ~11–12 blocks, so the `tip-2` target was only ~9–10 deep → exactly **24** Info logs, one short.

## Fix

Grow the chain by a safe margin before choosing the target, then keep the existing `tip-2` selection:

```ocaml
let%bind () =
  wait_for t (Wait_condition.block_height_growth ~height_growth:10)
in
let%bind best_chain = Graphql_requests.must_get_best_chain ~logger … in
(* unchanged: target _tip :: _prev :: deep :: _, run_replayer, check_replayer_logs *)
```

`block_height_growth` (`wait_condition.ml:173`) waits until the objective chain **block height** grows by 10 since the call. This puts a hard lower bound on the replay span: from the observed 24 at target height ~9–10, +10 height yields a target ~17–20 deep → **~29–34 Info logs**, comfortably clearing 25 with margin (a flake would now require the section-start height to fall below ~3, which the test's ~7 sequential `wait_for_zkapp` inclusion waits make impossible).

### Why this approach
- **Root cause, not a band-aid:** establishes the missing "minimum replay span" invariant instead of nudging the offset or weakening the threshold.
- **`block_height_growth` over `blocks_to_be_produced`:** the former keys off canonical `block_height`; the latter counts every produced block including forks. We need canonical depth.
- **`tip-2` kept** to avoid racing archive ingestion of the very latest block.
- **No ledger-proof wait added.** Copying the proof-wait pattern from the other four tests would require sending padding transactions to fill the scan state and plumbing the full `config` record — invasive, and against #18992's deliberate choice to keep this test fast. Growing N blocks is strictly cheaper.

### Rejected alternatives
- **Target tip / tip-1:** gains only 1–2 blocks (≈25–26), still boundary-flaky, and re-introduces the archive-ingestion race.
- **Wait for a ledger proof + padding (like the 4 other tests):** most invasive and slowest; contradicts the fast-path intent.
- **Lower the 25 threshold:** weakens the "replayer did real work" check for all five tests — the exact regression #18884 introduced.

## Cost
At a 2-minute block window the wait adds ~20 min (it passes as soon as 10 blocks land; soft timeout 21 slots, hard 42 slots). Total runtime is in line with the sibling proof-wait tests. No per-job timeout is configured in-repo for `test_executive`.

## Verification
- Type/scope checked against the surrounding `run` body (`wait_for`, `t`, `Wait_condition` already in scope at `zkapps_timing.ml:41–43`); the `let open Mina_base in` and the `tip-2` match are unchanged.
- All edited lines ≤ 80 cols; `wrap-comments=false` in `src/.ocamlformat`, so the comment will not reflow.
- Full local-engine run should be confirmed by CI (counts ≥ ~29 Info lines in the replayer section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)