### PR TITLE
tighten test executive replayer check

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -54,6 +54,8 @@ end
 
 let error_count = ref 0
 
+let blocks_replayed = ref 0
+
 let json_ledger_hash_of_ledger ledger =
   Ledger_hash.to_yojson @@ Ledger.merkle_root ledger
 
@@ -1368,29 +1370,33 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           (user_cmds : Sql.User_command.t list)
           (zkapp_cmds : Sql.Zkapp_command.t list) =
         let check_ledger_hash_at_slot state_hash ledger_hash =
-          if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then
+          if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then (
+            incr blocks_replayed ;
             [%log info]
               "Applied all commands at global slot since genesis %Ld, got \
                expected ledger hash"
               ~metadata:
-                [ ("ledger_hash", json_ledger_hash_of_ledger ledger)
+                [ ("replayer_event", `String "block_applied")
+                ; ("ledger_hash", json_ledger_hash_of_ledger ledger)
                 ; ("state_hash", State_hash.to_yojson state_hash)
                 ; ( "global_slot_since_genesis"
                   , `String (Int64.to_string last_global_slot_since_genesis) )
                 ; ("block_id", `Int last_block_id)
                 ]
-              last_global_slot_since_genesis
+              last_global_slot_since_genesis )
           else if
             List.mem state_hashes_to_avoid
               (State_hash.to_base58_check state_hash)
               ~equal:String.equal
-          then
+          then (
+            incr blocks_replayed ;
             [%log info]
               ~metadata:
-                [ ("state_hash", `String (State_hash.to_base58_check state_hash))
+                [ ("replayer_event", `String "block_applied")
+                ; ("state_hash", `String (State_hash.to_base58_check state_hash))
                 ]
               "This block has an inconsistent ledger hash due to a known \
-               historical issue."
+               historical issue." )
           else (
             [%log error]
               "Applied all commands at global slot since genesis %Ld, ledger \
@@ -1975,6 +1981,13 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error
           ~last_block_id:oldest_block_id sorted_internal_cmds sorted_user_cmds
           sorted_zkapp_cmds
       in
+      [%log info] "Replay complete"
+        ~metadata:
+          [ ("replayer_event", `String "replay_done")
+          ; ("blocks_replayed", `Int !blocks_replayed)
+          ; ( "start_slot"
+            , `String (Int64.to_string input.start_slot_since_genesis) )
+          ] ;
       let%bind () =
         match hard_fork_params_opt with
         | Some

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -568,5 +568,20 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Network.Node.run_replayer ~target_state_hash:proof_state_hash ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       let ns = network_state t in
+       let expected = ns.blocks_generated in
+       if n < expected - 3 || n > expected + 3 then
+         Malleable_error.hard_error_string
+           (sprintf
+              "Replayer replayed %d blocks, expected %d (network \
+               blocks_generated ±3)"
+              n expected )
+       else (
+         if n <> expected then
+           [%log warn]
+             "Replayer block count %d differs from network blocks_generated %d \
+              (diff: %d)"
+             n expected (n - expected) ;
+         Malleable_error.return () ) )
 end

--- a/src/app/test_executive/post_hard_fork.ml
+++ b/src/app/test_executive/post_hard_fork.ml
@@ -799,5 +799,20 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       let ns = network_state t in
+       let expected = ns.blocks_generated in
+       if n < expected - 3 || n > expected + 3 then
+         Malleable_error.hard_error_string
+           (sprintf
+              "Replayer replayed %d blocks, expected %d (network \
+               blocks_generated ±3)"
+              n expected )
+       else (
+         if n <> expected then
+           [%log warn]
+             "Replayer block count %d differs from network blocks_generated %d \
+              (diff: %d)"
+             n expected (n - expected) ;
+         Malleable_error.return () ) )
 end

--- a/src/app/test_executive/test_common.ml
+++ b/src/app/test_executive/test_common.ml
@@ -415,33 +415,69 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       ]
       ~f:Fn.id
 
-  (* [logs] is a string containing the entire replayer output *)
+  (* [logs] is a string containing the entire replayer --log-json output *)
   let check_replayer_logs ~logger logs =
-    let error_log_substring = "Error" in
-    let fatal_log_substring = "Fatal" in
-    let info_log_substring = "Info" in
-    let split_logs = String.split logs ~on:'\n' in
-    let error_logs =
-      split_logs
-      |> List.filter ~f:(fun log ->
-             String.is_substring log ~substring:error_log_substring
-             || String.is_substring log ~substring:fatal_log_substring )
+    let open Yojson.Safe.Util in
+    let replay_errors, block_applieds, replay_done_blocks =
+      String.split logs ~on:'\n'
+      |> List.filter ~f:(Fn.non String.is_empty)
+      |> List.fold ~init:([], 0, None)
+           ~f:(fun (errors, n_applied, done_blocks) line ->
+             let json = Yojson.Safe.from_string line in
+             let level = member "level" json |> to_string in
+             let errors' =
+               if String.equal level "Error" || String.equal level "Fatal" then
+                 line :: errors
+               else errors
+             in
+             let metadata_kv =
+               match member "metadata" json with
+               | `Assoc kvs ->
+                   kvs
+               | _ ->
+                   []
+               | exception _ ->
+                   []
+             in
+             let find = List.Assoc.find metadata_kv ~equal:String.equal in
+             let n_applied' =
+               match find "replayer_event" with
+               | Some (`String "block_applied") ->
+                   n_applied + 1
+               | _ ->
+                   n_applied
+             in
+             let done_blocks' =
+               match find "replayer_event" with
+               | Some (`String "replay_done") -> (
+                   match find "blocks_replayed" with
+                   | Some (`Int n) ->
+                       Some n
+                   | _ ->
+                       None )
+               | _ ->
+                   done_blocks
+             in
+             (errors', n_applied', done_blocks') )
     in
-    let info_logs =
-      split_logs
-      |> List.filter ~f:(fun log ->
-             String.is_substring log ~substring:info_log_substring )
-    in
-    if Mina_stdlib.List.Length.Compare.(info_logs < 25) then
-      Malleable_error.hard_error_string
-        (sprintf "Replayer output contains suspiciously few (%d) Info logs"
-           (List.length info_logs) )
-    else if List.is_empty error_logs then (
-      [%log info] "The replayer encountered no errors" ;
-      Malleable_error.return () )
-    else
-      let error = String.concat error_logs ~sep:"\n  " in
+    if not (List.is_empty replay_errors) then
+      let error = String.concat (List.rev replay_errors) ~sep:"\n  " in
       Malleable_error.hard_error_string ("Replayer errors:\n  " ^ error)
+    else
+      match replay_done_blocks with
+      | None ->
+          Malleable_error.hard_error_string
+            "No replay_done event found in replayer output"
+      | Some expected ->
+          if block_applieds <> expected then
+            Malleable_error.hard_error_string
+              (sprintf
+                 "Replayer block_applied count %d does not match expected %d \
+                  from replay_done event"
+                 block_applieds expected )
+          else (
+            [%log info] "The replayer encountered no errors" ;
+            Malleable_error.return expected )
 
   let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
       ~vesting_increment : Mina_base.Account_timing.t =

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -977,7 +977,22 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            Network.Node.run_replayer ~target_state_hash:proof_state_hash ~logger
              archive_node
          in
-         check_replayer_logs ~logger logs )
+         let%bind n = check_replayer_logs ~logger logs in
+         let ns = network_state t in
+         let expected = ns.blocks_generated in
+         if n < expected - 3 || n > expected + 3 then
+           Malleable_error.hard_error_string
+             (sprintf
+                "Replayer replayed %d blocks, expected %d (network \
+                 blocks_generated ±3)"
+                n expected )
+         else (
+           if n <> expected then
+             [%log warn]
+               "Replayer block count %d differs from network blocks_generated \
+                %d (diff: %d)"
+               n expected (n - expected) ;
+           Malleable_error.return () ) )
     in
     let open Deferred.Let_syntax in
     match%bind replayer_result with

--- a/src/app/test_executive/zkapps_nonce_test.ml
+++ b/src/app/test_executive/zkapps_nonce_test.ml
@@ -391,5 +391,20 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
            ( List.hd_exn
            @@ (Network.archive_nodes network |> Core.String.Map.data) )
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       let ns = network_state t in
+       let expected = ns.blocks_generated in
+       if n < expected - 3 || n > expected + 3 then
+         Malleable_error.hard_error_string
+           (sprintf
+              "Replayer replayed %d blocks, expected %d (network \
+               blocks_generated ±3)"
+              n expected )
+       else (
+         if n <> expected then
+           [%log warn]
+             "Replayer block count %d differs from network blocks_generated %d \
+              (diff: %d)"
+             n expected (n - expected) ;
+         Malleable_error.return () ) )
 end

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -740,5 +740,20 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          Network.Node.run_replayer ~target_state_hash ~logger
            (List.hd_exn @@ (Network.archive_nodes network |> Core.Map.data))
        in
-       check_replayer_logs ~logger logs )
+       let%bind n = check_replayer_logs ~logger logs in
+       let ns = network_state t in
+       let expected = ns.blocks_generated in
+       if n < expected - 3 || n > expected + 3 then
+         Malleable_error.hard_error_string
+           (sprintf
+              "Replayer replayed %d blocks, expected %d (network \
+               blocks_generated ±3)"
+              n expected )
+       else (
+         if n <> expected then
+           [%log warn]
+             "Replayer block count %d differs from network blocks_generated %d \
+              (diff: %d)"
+             n expected (n - expected) ;
+         Malleable_error.return () ) )
 end


### PR DESCRIPTION
This PR make test executive check the replayer has correctly applied the replay process with correct number of blocks instead of checking the number of log entries as a heuristic.