### PR TITLE
hardfork_test: integrated archive-bug repro (#18941 + element_ids overflow) with in-process Go ITN client

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -1104,13 +1104,21 @@ fi
 # ----------
 
 if [[ -n "${ARCHIVE_SERVER_PORT}" ]]; then
-  echo 'Starting the Archive Node...'
-  printf "\n"
+  if [[ "${HARDFORK_ARCHIVE_EXTERNAL:-0}" == "1" ]] && config_mode_is_inherit "${CONFIG_MODE}"; then
+    # The hardfork archive-repro drives the post-fork (inherit-mode) archive itself so
+    # it can run add_genesis_accounts at startup (#18941). The daemons still get
+    # -archive-address ${ARCHIVE_SERVER_PORT}; the externally-managed archive binds it.
+    echo 'Post-fork archive node is managed externally (archive-repro); not spawning here.'
+    printf "\n"
+  else
+    echo 'Starting the Archive Node...'
+    printf "\n"
 
-  mkdir -p "${NODES_FOLDER}"/archive
+    mkdir -p "${NODES_FOLDER}"/archive
 
-  spawn-archive-node "${NODES_FOLDER}"/archive
-  ARCHIVE_PID=$!
+    spawn-archive-node "${NODES_FOLDER}"/archive
+    ARCHIVE_PID=$!
+  fi
 fi
 
 if [[ -n "${ROSETTA_PORT}" ]]; then

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -420,20 +420,41 @@ exec-snark-worker() {
 
 # Executes the Archive node
 exec-archive-node() {
-  # In inherit (fork) mode the post-fork genesis config has its ledger section
-  # stripped (see CleanUpNetworkForForkPhase in the hardfork test), so passing it
-  # as --config-file makes the archive fail to compute precomputed_values:
-  #   "No ledger was provided in the runtime configuration".
-  # So this inherit-mode path omits --config-file, which makes the archive skip
-  # add_genesis_accounts and simply archive incoming blocks via RPC.
-  # CAVEAT: this is a limitation, not a no-op. The FORK genesis ledger is NOT identical
-  # to the inherited pre-fork DB: runtime_genesis_ledger applies slot_reduction_update,
-  # which ROTATES actively-vesting accounts' timing (cliff/period). A no-config archive
-  # therefore keeps only the STALE pre-fork timing and never records the rotated
-  # fork-genesis schedule. The hardfork archive-repro flow (HARDFORK_ARCHIVE_EXTERNAL=1,
-  # handled at the spawn site above) instead drives the fork archive itself WITH the
-  # (ledger-staged) fork genesis config so add_genesis_accounts runs and the rotated
-  # genesis accounts are archived; ValidateVestingInArchive asserts that.
+  # ---------------------------------------------------------------------------
+  # Archive node --config-file management across a hardfork run.
+  #
+  # The archive is given --config-file exactly when it should (re)load a genesis
+  # ledger and run add_genesis_accounts (which materializes the genesis accounts —
+  # incl. timed/vesting accounts — into the DB). WHO supplies that config differs by
+  # phase, and this function only owns the pre-fork half:
+  #
+  #   * Pre-fork  (--config reset, main network): spawned HERE with
+  #     --config-file "${CONFIG}" (= ${ROOT}/daemon.json), which at reset time still
+  #     carries its inline genesis ledger. The archive runs add_genesis_accounts over
+  #     the PRE-FORK genesis and loads the pre-fork genesis accounts (with pre-fork
+  #     vesting timing) into the DB.
+  #
+  #   * Post-fork (--config inherit, fork network): "${CONFIG}" (= ${ROOT}/daemon.json)
+  #     has had its ledger section stripped by CleanUpNetworkForForkPhase — the fork
+  #     daemons run from the PER-NODE config nodes/<name>/daemon.json via
+  #     --config-directory, not from ${CONFIG} — so passing ${CONFIG} here would fail
+  #     with "No ledger was provided in the runtime configuration". Hence this path
+  #     omits --config-file. That is correct: the post-fork archive's config is
+  #     supplied out-of-band, depending on the caller:
+  #       - Hardfork archive-repro test (HARDFORK_ARCHIVE_EXTERNAL=1): this script does
+  #         NOT spawn the fork archive at all (see the spawn site). The Go hardfork test
+  #         (StartForkArchive) owns it and starts it WITH the per-node fork genesis
+  #         config (nodes/seed/daemon.json) plus the fork genesis ledger tar staged into
+  #         the archive's ledger search path, so add_genesis_accounts runs over the FORK
+  #         genesis and loads the fork genesis accounts — with the
+  #         slot_reduction_update-rotated vesting timing. This is where #18941 and the
+  #         archived vesting rotation are exercised (ValidateVestingInArchive asserts the
+  #         latter).
+  #       - Standalone (flag unset): the archive is spawned here without a config and
+  #         archives incoming post-fork blocks via RPC only, linking to the pre-fork
+  #         parent already in the DB. The fork genesis accounts are not re-materialized —
+  #         acceptable for a plain dev net that only needs post-fork blocks archived.
+  # ---------------------------------------------------------------------------
   local archive_config_arg=()
   if ! config_mode_is_inherit "$CONFIG_MODE"; then
     archive_config_arg=(--config-file "${CONFIG}")

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -424,10 +424,16 @@ exec-archive-node() {
   # stripped (see CleanUpNetworkForForkPhase in the hardfork test), so passing it
   # as --config-file makes the archive fail to compute precomputed_values:
   #   "No ledger was provided in the runtime configuration".
-  # The genesis accounts are already present in the inherited DB, and post-fork
-  # blocks link to the pre-fork parent that is already archived, so the archive
-  # needs no runtime config at all in inherit mode: omitting --config-file makes
-  # it skip genesis-account loading and simply archive incoming blocks via RPC.
+  # So this inherit-mode path omits --config-file, which makes the archive skip
+  # add_genesis_accounts and simply archive incoming blocks via RPC.
+  # CAVEAT: this is a limitation, not a no-op. The FORK genesis ledger is NOT identical
+  # to the inherited pre-fork DB: runtime_genesis_ledger applies slot_reduction_update,
+  # which ROTATES actively-vesting accounts' timing (cliff/period). A no-config archive
+  # therefore keeps only the STALE pre-fork timing and never records the rotated
+  # fork-genesis schedule. The hardfork archive-repro flow (HARDFORK_ARCHIVE_EXTERNAL=1,
+  # handled at the spawn site above) instead drives the fork archive itself WITH the
+  # (ledger-staged) fork genesis config so add_genesis_accounts runs and the rotated
+  # genesis accounts are archived; ValidateVestingInArchive asserts that.
   local archive_config_arg=()
   if ! config_mode_is_inherit "$CONFIG_MODE"; then
     archive_config_arg=(--config-file "${CONFIG}")

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -296,6 +296,16 @@ on-exit() {
         wait "$ROSETTA_PID"
       fi
 
+      # 2b. stop the archive node. It is spawned with '&' and is otherwise never
+      # reaped, so without this it survives the network teardown as an orphan,
+      # keeps holding the archive server port, and (across a hardfork) the next
+      # network's archive node cannot bind that port. Kill it explicitly here.
+      if [[ -n "${ARCHIVE_PID:-}" ]]; then
+        echo "Killing archive node at ${ARCHIVE_PID}"
+        kill "$ARCHIVE_PID" 2>/dev/null || true
+        wait "$ARCHIVE_PID" 2>/dev/null || true
+      fi
+
       # 3. stop the seed node, if we've spawned it.
       if [[ -n "${SEED_PID}" ]]; then
         stop-node "seed" "$SEED_START_PORT"
@@ -410,9 +420,21 @@ exec-snark-worker() {
 
 # Executes the Archive node
 exec-archive-node() {
+  # In inherit (fork) mode the post-fork genesis config has its ledger section
+  # stripped (see CleanUpNetworkForForkPhase in the hardfork test), so passing it
+  # as --config-file makes the archive fail to compute precomputed_values:
+  #   "No ledger was provided in the runtime configuration".
+  # The genesis accounts are already present in the inherited DB, and post-fork
+  # blocks link to the pre-fork parent that is already archived, so the archive
+  # needs no runtime config at all in inherit mode: omitting --config-file makes
+  # it skip genesis-account loading and simply archive incoming blocks via RPC.
+  local archive_config_arg=()
+  if ! config_mode_is_inherit "$CONFIG_MODE"; then
+    archive_config_arg=(--config-file "${CONFIG}")
+  fi
   # shellcheck disable=SC2068
   exec ${ARCHIVE_EXE} run \
-    --config-file "${CONFIG}" \
+    "${archive_config_arg[@]}" \
     --log-level "${LOG_LEVEL}" \
     --postgres-uri postgresql://"${PG_USER}":"${PG_PASSWD}"@"${PG_HOST}":"${PG_PORT}"/"${PG_DB}" \
     --server-port "${ARCHIVE_SERVER_PORT}" \
@@ -534,11 +556,13 @@ recreate-schema() {
 
   PGPASSWORD="${PG_PASSWD}" psql postgresql://"${PG_USER}":"${PG_PASSWD}"@"${PG_HOST}":"${PG_PORT}" -c "CREATE DATABASE ${PG_DB};"
 
-  # We need to change our working directory as script has relation to others subscripts
-  # and calling them from local folder
-  pushd ./src/app/archive
-  psql postgresql://"${PG_USER}":"${PG_PASSWD}"@"${PG_HOST}":"${PG_PORT}"/"${PG_DB}" < create_schema.sql
-  popd
+  # Allow overriding the schema file via CREATE_SCHEMA_FILE (absolute path). This is
+  # used by the hardfork test to load a Berkeley-compatible schema for the pre-fork
+  # network; it then applies upgrade_to_mesa.sql before the fork. Defaults to the
+  # in-tree schema.
+  local schema_file="${CREATE_SCHEMA_FILE:-$(pwd)/src/app/archive/create_schema.sql}"
+  echo "Loading archive schema from ${schema_file}"
+  psql postgresql://"${PG_USER}":"${PG_PASSWD}"@"${PG_HOST}":"${PG_PORT}"/"${PG_DB}" < "${schema_file}"
 
   echo "Schema '${PG_DB}' created successfully."
   printf "\n"

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -102,7 +102,6 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.ReproArchiveBugs, "repro-archive-bugs", cfg.ReproArchiveBugs, "Drive a custom-token + max-cost ITN load across the fork and assert the archive node is free of #18941 (tokens_value_key) and the element_ids btree overflow; reproduces (and FAILS, non-zero) against the buggy archive/migration, passes against the fixed ones")
 	rootCmd.Flags().StringVar(&cfg.MainArchiveExe, "main-archive-exe", cfg.MainArchiveExe, "Compatible (pre-fork) mina-archive binary for the live main-network archive node")
 	rootCmd.Flags().StringVar(&cfg.ForkArchiveExe, "fork-archive-exe", cfg.ForkArchiveExe, "Mesa (post-fork) mina-archive binary for the live fork-network archive node")
-	rootCmd.Flags().StringVar(&cfg.ProbeArchiveExe, "probe-archive-exe", cfg.ProbeArchiveExe, "Mesa mina-archive binary used for the add_genesis_accounts (#18941) probe (defaults to --fork-archive-exe)")
 	rootCmd.Flags().StringVar(&cfg.CreateSchemaFile, "create-schema-file", cfg.CreateSchemaFile, "Berkeley (pre-fork) archive create_schema.sql used to initialize the shared archive DB")
 	rootCmd.Flags().StringVar(&cfg.MigrationSql, "migration-sql", cfg.MigrationSql, "Berkeley->Mesa upgrade_to_mesa.sql applied at the fork transition (v0.0.5 keeps the element_ids UNIQUE = buggy; v0.0.6 drops it = fixed)")
 	rootCmd.Flags().StringVar(&cfg.ItnKeyPath, "itn-key", cfg.ItnKeyPath, "Path the in-process ITN ed25519 auth key PEM is written to (a sibling of --root if empty; debug only)")

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -98,6 +98,20 @@ func init() {
 
 	rootCmd.Flags().Var(&cfg.ForkMethods, "allow-fork-method", "Implementation of fork to use")
 
+	// Archive bug reproduction (#18941 tokens_value_key + element_ids btree overflow).
+	rootCmd.Flags().BoolVar(&cfg.ReproArchiveBugs, "repro-archive-bugs", cfg.ReproArchiveBugs, "Drive a custom-token + max-cost ITN load across the fork and assert the archive node is free of #18941 (tokens_value_key) and the element_ids btree overflow; reproduces (and FAILS, non-zero) against the buggy archive/migration, passes against the fixed ones")
+	rootCmd.Flags().StringVar(&cfg.MainArchiveExe, "main-archive-exe", cfg.MainArchiveExe, "Compatible (pre-fork) mina-archive binary for the live main-network archive node")
+	rootCmd.Flags().StringVar(&cfg.ForkArchiveExe, "fork-archive-exe", cfg.ForkArchiveExe, "Mesa (post-fork) mina-archive binary for the live fork-network archive node")
+	rootCmd.Flags().StringVar(&cfg.ProbeArchiveExe, "probe-archive-exe", cfg.ProbeArchiveExe, "Mesa mina-archive binary used for the add_genesis_accounts (#18941) probe (defaults to --fork-archive-exe)")
+	rootCmd.Flags().StringVar(&cfg.CreateSchemaFile, "create-schema-file", cfg.CreateSchemaFile, "Berkeley (pre-fork) archive create_schema.sql used to initialize the shared archive DB")
+	rootCmd.Flags().StringVar(&cfg.MigrationSql, "migration-sql", cfg.MigrationSql, "Berkeley->Mesa upgrade_to_mesa.sql applied at the fork transition (v0.0.5 keeps the element_ids UNIQUE = buggy; v0.0.6 drops it = fixed)")
+	rootCmd.Flags().StringVar(&cfg.ItnKeyPath, "itn-key", cfg.ItnKeyPath, "Path the in-process ITN ed25519 auth key PEM is written to (a sibling of --root if empty; debug only)")
+	rootCmd.Flags().IntVar(&cfg.ArchivePort, "archive-port", cfg.ArchivePort, "Archive server port for the live archive node")
+	rootCmd.Flags().StringVar(&cfg.ArchivePgHost, "archive-pg-host", cfg.ArchivePgHost, "Archive Postgres host")
+	rootCmd.Flags().IntVar(&cfg.ArchivePgPort, "archive-pg-port", cfg.ArchivePgPort, "Archive Postgres port")
+	rootCmd.Flags().StringVar(&cfg.ArchivePgUser, "archive-pg-user", cfg.ArchivePgUser, "Archive Postgres user")
+	rootCmd.Flags().StringVar(&cfg.ArchivePgDb, "archive-pg-db", cfg.ArchivePgDb, "Archive Postgres database name")
+
 	rootCmd.MarkFlagRequired("main-mina-exe")
 	rootCmd.MarkFlagRequired("main-runtime-genesis-ledger")
 	rootCmd.MarkFlagRequired("fork-mina-exe")

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -117,9 +117,6 @@ type Config struct {
 	MainArchiveExe   string
 	ForkArchiveExe   string
 	CreateSchemaFile string
-	// Bug A probe: the Mesa mina-archive binary started with the fork genesis config
-	// to trigger add_genesis_accounts (defaults to ForkArchiveExe).
-	ProbeArchiveExe string
 	// Berkeley->Mesa migration SQL applied at the fork transition. The file choice
 	// (v0.0.5 keeps the element_ids UNIQUE = buggy; v0.0.6 drops it = fixed) is what
 	// makes Bug B reproduce or not.

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -90,6 +90,45 @@ type Config struct {
 	// Path to the temporary JSON file holding the extra genesis account that is
 	// passed to mina-local-network.sh (filled in at runtime).
 	VestingExtraAccountFile string
+
+	// ---- Archive bug reproduction (#18941 tokens_value_key + element_ids btree
+	// overflow) ----
+	//
+	// When ReproArchiveBugs is set, the test drives a custom-token ITN load on the
+	// pre-fork (compatible) network so a real OWNED custom token is archived, then
+	// (at the fork transition) migrates the shared archive DB to the Mesa schema,
+	// and on the post-fork (Mesa) network drives a max-cost zkApp load and probes
+	// the archive for both bugs. With the buggy archive binary + the migration that
+	// keeps the element_ids UNIQUE both bugs reproduce and the test FAILS (non-zero
+	// exit); with the fixed archive binary + the element_ids-dropping migration
+	// neither reproduces and the test passes.
+	ReproArchiveBugs bool
+	// Postgres connection for the shared archive DB. ArchivePgUri is the full URI
+	// used by detection/probes; the host/port/user/db parts are what
+	// mina-local-network.sh consumes to wire the live archive node.
+	ArchivePgUri  string
+	ArchivePgHost string
+	ArchivePgPort int
+	ArchivePgUser string
+	ArchivePgDb   string
+	// Archive node wiring: port for the live archive in each phase, and the
+	// protocol-appropriate archive binaries (compatible pre-fork, Mesa post-fork).
+	ArchivePort      int
+	MainArchiveExe   string
+	ForkArchiveExe   string
+	CreateSchemaFile string
+	// Bug A probe: the Mesa mina-archive binary started with the fork genesis config
+	// to trigger add_genesis_accounts (defaults to ForkArchiveExe).
+	ProbeArchiveExe string
+	// Berkeley->Mesa migration SQL applied at the fork transition. The file choice
+	// (v0.0.5 keeps the element_ids UNIQUE = buggy; v0.0.6 drops it = fixed) is what
+	// makes Bug B reproduce or not.
+	MigrationSql string
+	// ITN auth: path the ed25519 key PEM is written to (a sibling of Root if empty;
+	// the test signs in-process, so the file is for debugging only). ItnPubKey is the
+	// base64 public key, filled in at runtime and passed to the daemon via --itn-keys.
+	ItnKeyPath string
+	ItnPubKey  string
 }
 
 // Vesting-account test parameters. All amounts are in nanomina.
@@ -153,6 +192,13 @@ func DefaultConfig() *Config {
 		HTTPClientTimeoutSeconds:      600,
 		// ^ fork config take really long time to complete (2-3 minutes)
 		ClientMaxRetries: 5,
+
+		// Archive bug reproduction defaults.
+		ArchivePgHost: "localhost",
+		ArchivePgPort: 5432,
+		ArchivePgUser: "agent",
+		ArchivePgDb:   "archive",
+		ArchivePort:   3086,
 
 		SeedStartPort:        3000,
 		SnarkCoordinatorPort: 7000,

--- a/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
+++ b/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
@@ -1,0 +1,595 @@
+package hardfork
+
+// Archive-node bug reproduction integrated into the hardfork test.
+//
+// When --repro-archive-bugs is set, the test drives real transaction load across
+// the fork and asserts the archive node is free of two known bugs:
+//
+//   - #18941 "tokens_value_key": at post-fork archive startup, add_genesis_accounts
+//     re-inserts an already-owned custom token as ownerless and collides on the
+//     tokens_value_key UNIQUE(value) constraint.
+//   - "element_ids btree overflow": the Mesa archive cannot insert a max-cost
+//     zkApp's 1024-element field array into the UNIQUE btree on
+//     zkapp_field_array.element_ids (index row exceeds the btree page maximum).
+//
+// To produce real triggering data: a custom-token ITN load on the pre-fork
+// (compatible) network mints an OWNED custom token that the compatible archive
+// records; at the fork transition the shared archive DB is migrated to the Mesa
+// schema; a max-cost ITN load on the post-fork (Mesa) network makes the Mesa
+// archive ingest the overflowing field array; and finally a probe starts the Mesa
+// archive over the fork genesis config to exercise add_genesis_accounts.
+//
+// Buggy binaries + the migration that keeps the element_ids UNIQUE reproduce both
+// bugs and AssertArchiveBugsAbsent returns an error (the test exits non-zero);
+// the fixed archive + the element_ids-dropping migration reproduce neither and the
+// test passes.
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// itnPort returns the seed daemon's ITN GraphQL port (daemon base port + 5).
+func (t *HardforkTest) itnPort() int { return t.Config.SeedStartPort + 5 }
+
+// forkGenesisConfigPath returns the post-fork seed daemon.json (moved into place
+// by CleanUpNetworkForForkPhase), used as the genesis config for the #18941 probe.
+func (t *HardforkTest) forkGenesisConfigPath() string {
+	for _, info := range t.Config.DaemonInfos {
+		if info.Name == "seed" {
+			return filepath.Join(info.NodeDirRel(t.Config.Root), "daemon.json")
+		}
+	}
+	if len(t.Config.DaemonInfos) > 0 {
+		return filepath.Join(t.Config.DaemonInfos[0].NodeDirRel(t.Config.Root), "daemon.json")
+	}
+	return ""
+}
+
+// firstLine returns the first line of s (for compact logging).
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// lineContaining returns the first line of s containing sub (trimmed), or "".
+// Used to echo a spawned archive's decisive raw log line into the main test log,
+// so each run is self-contained — the raw DB-side error (e.g. the tokens_value_key
+// violation) otherwise lands only in the shared Postgres log, not the test output.
+func lineContaining(s, sub string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
+// InitArchiveRepro prepares the environment for the archive-bug reproduction:
+// fills in derived config, generates the ITN auth key, resets the shared archive
+// DB, and exports the env vars that network.go / mina-local-network.sh read to
+// wire the live archive node and the ITN endpoints. No-op unless enabled.
+func (t *HardforkTest) InitArchiveRepro() error {
+	if !t.Config.ReproArchiveBugs {
+		return nil
+	}
+	c := t.Config
+
+	if c.ProbeArchiveExe == "" {
+		c.ProbeArchiveExe = c.ForkArchiveExe
+	}
+	if c.ItnKeyPath == "" {
+		// The ITN auth key MUST live outside Root: mina-local-network.sh does
+		// `rm -rf $ROOT` when it (re)initializes the main network (config=reset),
+		// which would delete a key placed inside Root. The daemon would still hold
+		// its pubkey (passed via --itn-keys before the wipe), but the client would
+		// then have no matching private key and ITN auth would fail for the whole
+		// run. A sibling path survives the wipe and keeps the keypair consistent
+		// across both the pre-fork (reset) and post-fork (inherit) networks.
+		// Clean first: a trailing slash on --root would otherwise yield
+		// "<root>/.itn_key.pem" (inside Root), which the wipe would delete.
+		root := filepath.Clean(c.Root)
+		c.ItnKeyPath = filepath.Join(filepath.Dir(root), filepath.Base(root)+".itn_key.pem")
+	}
+	c.ArchivePgUri = fmt.Sprintf("postgresql://%s@%s:%d/%s",
+		c.ArchivePgUser, c.ArchivePgHost, c.ArchivePgPort, c.ArchivePgDb)
+
+	for _, p := range []struct{ name, val string }{
+		{"--main-archive-exe", c.MainArchiveExe},
+		{"--fork-archive-exe", c.ForkArchiveExe},
+		{"--create-schema-file", c.CreateSchemaFile},
+		{"--migration-sql", c.MigrationSql},
+	} {
+		if p.val == "" {
+			return fmt.Errorf("--repro-archive-bugs requires %s", p.name)
+		}
+		if _, err := os.Stat(p.val); err != nil {
+			return fmt.Errorf("%s: %s: %w", p.name, p.val, err)
+		}
+	}
+
+	if err := os.MkdirAll(c.Root, 0755); err != nil {
+		return err
+	}
+	// Generate the ITN ed25519 auth keypair in-process (crypto/ed25519). The base64
+	// of the 32-byte public key is the value the daemon receives via --itn-keys; the
+	// matching private key stays in memory and signs ITN requests directly, so the
+	// main-network root wipe can no longer strand the client (it never reads a file).
+	itn, err := newItnAuth()
+	if err != nil {
+		return err
+	}
+	t.itn = itn
+	c.ItnPubKey = itn.pubB64
+	if err := itn.writePEM(c.ItnKeyPath); err != nil {
+		t.Logger.Info("Archive repro: could not write ITN key PEM %s (non-fatal): %v", c.ItnKeyPath, err)
+	}
+	t.Logger.Info("Archive repro: ITN key %s pub=%s", c.ItnKeyPath, itn.pubB64)
+
+	// Reset the shared archive DB; mina-local-network.sh recreates+schemas it.
+	maint := fmt.Sprintf("postgresql://%s@%s:%d/%s",
+		c.ArchivePgUser, c.ArchivePgHost, c.ArchivePgPort, c.ArchivePgUser)
+	if out, err := exec.Command("psql", maint, "-c",
+		"DROP DATABASE IF EXISTS "+c.ArchivePgDb+";").CombinedOutput(); err != nil {
+		t.Logger.Info("Archive repro: drop DB warning: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	// Env consumed by network.go (archive + ITN wiring) and mina-local-network.sh
+	// (Postgres connection + schema). The pre-fork archive is compatible-lineage,
+	// the post-fork archive is Mesa-lineage (bin_io must match the phase daemon).
+	os.Setenv("HARDFORK_ARCHIVE_PORT", strconv.Itoa(c.ArchivePort))
+	os.Setenv("MAIN_ARCHIVE_EXE", c.MainArchiveExe)
+	os.Setenv("FORK_ARCHIVE_EXE", c.ForkArchiveExe)
+	os.Setenv("CREATE_SCHEMA_FILE", c.CreateSchemaFile)
+	os.Setenv("HARDFORK_ITN_KEYS_MAIN", c.ItnPubKey)
+	os.Setenv("HARDFORK_ITN_KEYS_FORK", c.ItnPubKey)
+	os.Setenv("PG_HOST", c.ArchivePgHost)
+	os.Setenv("PG_PORT", strconv.Itoa(c.ArchivePgPort))
+	os.Setenv("PG_USER", c.ArchivePgUser)
+	os.Setenv("PG_PW", "")
+	os.Setenv("PG_DB", c.ArchivePgDb)
+	// Keep BOTH networks quiet apart from their ITN loads. Post-fork: the only zkApp
+	// traffic the Mesa archive sees is the max-cost overflow trigger. Pre-fork: the
+	// custom-token ITN load (driven in-daemon over GraphQL) is the only traffic, and
+	// it alone produces Bug A's owned-token data. Disabling the built-in value-transfer
+	// loop here is also essential for resource reasons: it spawns a `mina client
+	// send-payment` subprocess (each forking a `brew --prefix` shell) per payment,
+	// which — concurrently with 2 daemons, snark workers, the archive and Postgres —
+	// exhausts the cgroup pid limit (pids.max=512) and crashes the run with
+	// "fork: Resource temporarily unavailable". The chain still produces blocks (the
+	// pre-fork validations check slot occupancy, not user commands), so this is safe.
+	os.Setenv("HARDFORK_VALUE_TRANSFERS_MAIN", "0")
+	os.Setenv("HARDFORK_VALUE_TRANSFERS_FORK", "0")
+	return nil
+}
+
+// psqlQuery runs a single-value query against the archive DB.
+func (t *HardforkTest) psqlQuery(query string) (string, error) {
+	out, err := exec.Command("psql", t.Config.ArchivePgUri, "-tAc", query).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("psql query failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (t *HardforkTest) psqlCount(query string) int {
+	out, err := t.psqlQuery(query)
+	if err != nil {
+		return -1
+	}
+	n, err := strconv.Atoi(out)
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+func (t *HardforkTest) ownedTokenCount() int {
+	return t.psqlCount("select count(*) from tokens where owner_public_key_id is not null;")
+}
+
+// feePayerKeys discovers the offline whale private keys to use as ITN fee payers.
+func (t *HardforkTest) feePayerKeys() []string {
+	dir := filepath.Join(t.Config.Root, "offline_whale_keys")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var keys []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, ".pub") || !strings.HasPrefix(name, "offline_whale_account_") {
+			continue
+		}
+		cmd := exec.Command(t.Config.MainMinaExe, "advanced", "dump-keypair",
+			"--privkey-path", filepath.Join(dir, name))
+		cmd.Env = append(os.Environ(), "MINA_PRIVKEY_PASS=naughty blue worm")
+		out, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(line, "Private key: ") {
+				keys = append(keys, strings.TrimSpace(strings.TrimPrefix(line, "Private key: ")))
+			}
+		}
+	}
+	return keys
+}
+
+func (t *HardforkTest) waitItnAuth(port, attempts int) bool {
+	url := itnURL(port)
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if _, _, err := t.itn.auth(url); err == nil {
+			t.Logger.Info("Archive repro: ITN authenticated on :%d after %d attempt(s)", port, i+1)
+			return true
+		} else {
+			lastErr = err
+		}
+		// Surface the real client error (connection refused / 401 / GraphQL) instead
+		// of silently retrying — the swallowed error previously hid auth failures.
+		if i == 0 || (i+1)%6 == 0 {
+			t.Logger.Info("Archive repro: ITN auth :%d attempt %d/%d not ready (err=%v)",
+				port, i+1, attempts, lastErr)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Logger.Error("Archive repro: ITN auth never succeeded on :%d after %d attempts; last err=%v",
+		port, attempts, lastErr)
+	return false
+}
+
+// scheduleWithBestTipRetry runs an ITN schedule mutation, retrying until the daemon
+// has a best-tip ledger (the scheduler rejects the request otherwise).
+func (t *HardforkTest) scheduleWithBestTipRetry(schedule func() (string, error), attempts int) error {
+	for i := 0; i < attempts; i++ {
+		handle, err := schedule()
+		if err == nil {
+			t.Logger.Info("Archive repro: ITN scheduled (handle %s)", firstLine(handle))
+			return nil
+		}
+		t.Logger.Info("Archive repro: ITN schedule attempt %d not ready: %v", i+1, err)
+		time.Sleep(8 * time.Second)
+	}
+	return fmt.Errorf("ITN schedule did not succeed after %d attempts", attempts)
+}
+
+// DriveTokenLoadPreFork schedules the persistent custom-token ITN load on the
+// pre-fork network and blocks until an owned custom token is recorded in the
+// archive DB (so it carries into the fork genesis ledger).
+func (t *HardforkTest) DriveTokenLoadPreFork() error {
+	port := t.itnPort()
+	url := itnURL(port)
+	t.Logger.Info("Archive repro: driving pre-fork custom-token load on ITN :%d", port)
+	if !t.waitItnAuth(port, 120) {
+		return fmt.Errorf("pre-fork ITN endpoint did not authenticate on :%d", port)
+	}
+	keys := t.feePayerKeys()
+	if len(keys) == 0 {
+		return fmt.Errorf("no fee payer (offline whale) keys found under %s", t.Config.Root)
+	}
+	load := zkappLoadParams{
+		feePayers: keys, numZkapps: 0, numNewAccounts: 0,
+		durationMin: 6, tps: 0.5, memoPrefix: "tokload", nonDefaultToken: true,
+	}
+	if err := t.scheduleWithBestTipRetry(func() (string, error) {
+		return t.itn.scheduleZkappCommands(url, load)
+	}, 60); err != nil {
+		return err
+	}
+	t.Logger.Info("Archive repro: waiting for the owned custom token in the archive DB...")
+	for i := 0; i < 150; i++ {
+		if n := t.ownedTokenCount(); n >= 1 {
+			t.Logger.Info("Archive repro: owned custom token recorded in archive DB (count=%d)", n)
+			return nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+	return fmt.Errorf("owned custom token never appeared in the archive DB (pre-fork load failed)")
+}
+
+// ApplyMigration runs the Berkeley->Mesa migration on the shared archive DB at the
+// fork transition (pre-fork archive stopped, post-fork archive not yet started).
+func (t *HardforkTest) ApplyMigration() error {
+	if !t.Config.ReproArchiveBugs {
+		return nil
+	}
+	t.Logger.Info("Archive repro: applying migration %s", t.Config.MigrationSql)
+	out, err := exec.Command("psql", t.Config.ArchivePgUri, "-v", "ON_ERROR_STOP=1",
+		"-q", "-f", t.Config.MigrationSql).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("migration failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	ver, _ := t.psqlQuery("select max(migration_version) from migration_history;")
+	t.Logger.Info("Archive repro: migration applied (version=%s)", ver)
+	return nil
+}
+
+// DriveMaxCostLoadPostFork schedules the max-cost zkApp load on the post-fork
+// (Mesa) network so the Mesa archive ingests a Shape-B 1024-element field array,
+// the element_ids btree overflow trigger.
+func (t *HardforkTest) DriveMaxCostLoadPostFork() error {
+	port := t.itnPort()
+	url := itnURL(port)
+	t.Logger.Info("Archive repro: driving post-fork max-cost load on ITN :%d", port)
+	if !t.waitItnAuth(port, 60) {
+		return fmt.Errorf("post-fork ITN endpoint did not authenticate on :%d", port)
+	}
+	keys := t.feePayerKeys()
+	if len(keys) == 0 {
+		return fmt.Errorf("no fee payer keys for the post-fork max-cost load")
+	}
+	load := zkappLoadParams{
+		feePayers: []string{keys[0]}, numZkapps: 2, numUpdates: 15,
+		durationMin: 5, tps: 0.3, memoPrefix: "maxcost", maxCost: true,
+	}
+	return t.scheduleWithBestTipRetry(func() (string, error) {
+		return t.itn.scheduleZkappCommands(url, load)
+	}, 60)
+}
+
+// bugStatus is the three-valued result of a bug check. The detection is
+// fail-closed: only bugClean lets the test pass, so an indeterminate check
+// (bugInconclusive) fails the run rather than masquerading as either a clean
+// fix (false exit 0) or a reproduced bug (false exit 1).
+type bugStatus int
+
+const (
+	bugReproduced  bugStatus = iota // the bug definitively reproduced
+	bugClean                        // the bug is definitively absent (fix verified)
+	bugInconclusive                 // neither could be established (setup/timing issue)
+)
+
+// DetectElementIdsOverflow reports whether the element_ids btree overflow
+// reproduced on the Mesa archive.
+//   - bugReproduced: the live Mesa archive logged the btree-overflow error.
+//   - bugClean: a large (Shape-B, >=100-element) element_ids array was archived
+//     successfully — only possible once the UNIQUE index is dropped (the fix).
+//   - bugInconclusive: neither signal is present, i.e. the max-cost load delivered
+//     no Shape-B 1024-element command to the archive, so the overflow could be
+//     neither triggered nor shown fixed. (We must NOT treat "only small Shape-A
+//     arrays archived" as reproduced — that false-positives the fixed run.)
+func (t *HardforkTest) DetectElementIdsOverflow() (bugStatus, string) {
+	logPath := filepath.Join(t.Config.Root, "fork-network.log")
+	if data, err := os.ReadFile(logPath); err == nil {
+		s := string(data)
+		if strings.Contains(s, "exceeds btree") ||
+			strings.Contains(s, "zkapp_field_array_element_ids_key") ||
+			strings.Contains(s, "zkapp_events_element_ids_key") {
+			if raw := lineContaining(s, "exceeds btree"); raw != "" {
+				t.Logger.Info("Archive repro: element_ids raw signal: %s", raw)
+			}
+			return bugReproduced, "Mesa archive logged the element_ids btree-overflow error"
+		}
+	}
+	large := t.psqlCount("select count(*) from zkapp_field_array where coalesce(array_length(element_ids,1),0) >= 100;")
+	total := t.psqlCount("select count(*) from zkapp_field_array;")
+	t.Logger.Info("Archive repro: element_ids check: total field-array rows=%d, large(>=100)=%d", total, large)
+	if large >= 1 {
+		return bugClean, fmt.Sprintf("a large (>=100) element_ids array was archived (count=%d): btree overflow fixed", large)
+	}
+	return bugInconclusive, fmt.Sprintf(
+		"no btree-overflow error was logged and no large element_ids array was archived (total field-array rows=%d); "+
+			"the max-cost load delivered no Shape-B 1024-element command to the archive, so the overflow is undetermined", total)
+}
+
+// ProbeAddGenesisAccounts starts the Mesa probe archive over the shared DB with
+// the fork genesis config and reports whether #18941 (tokens_value_key) reproduced
+// in add_genesis_accounts:
+//   - bugReproduced: add_genesis_accounts hit tokens_value_key (buggy archive).
+//   - bugClean: the archive logged "Archive process ready" (genesis accounts added
+//     without collision — the fix).
+//   - bugInconclusive: the probe could not even reach add_genesis_accounts (no
+//     ledger tars staged, or it failed to load the hash-referenced fork genesis
+//     ledger), or it timed out / exited without a decisive signal. These must NOT
+//     be read as "fixed": a probe that never ran the collision path proves nothing.
+func (t *HardforkTest) ProbeAddGenesisAccounts(genesisConfig string) (bugStatus, string) {
+	t.Logger.Info("Archive repro: probing add_genesis_accounts (%s over %s)",
+		t.Config.ProbeArchiveExe, t.Config.ArchivePgUri)
+	// The fork genesis config references its ledger by hash (not inline accounts),
+	// so the probe archive must load the ledger tarball to materialize the genesis
+	// accounts. Those tars live under the fork node's chain-state dir, which is NOT
+	// in the archive's ledger search path — without staging them the probe dies with
+	// "Could not find a ledger tar file for hash ..." before add_genesis_accounts
+	// runs, masking #18941. Stage them into the autogen cache the archive searches.
+	if n := t.stageGenesisLedgerTars(); n == 0 {
+		return bugInconclusive, "no genesis/epoch ledger tars were staged; the probe cannot load the fork " +
+			"genesis ledger and would never reach add_genesis_accounts (would mask #18941)"
+	}
+	cmd := exec.Command(t.Config.ProbeArchiveExe, "run",
+		"--postgres-uri", t.Config.ArchivePgUri,
+		"--server-port", strconv.Itoa(t.Config.ArchivePort+10),
+		"--config-file", genesisConfig)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Start(); err != nil {
+		return bugInconclusive, fmt.Sprintf("failed to start probe archive: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { cmd.Wait(); close(done) }()
+	kill := func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+	}
+	// scan returns (decided, status). A genesis-ledger load failure is treated as
+	// inconclusive (the probe never reached add_genesis_accounts), NOT as clean.
+	scan := func() (bool, bugStatus) {
+		s := buf.String()
+		if strings.Contains(s, "tokens_value_key") || strings.Contains(s, "Failed to add genesis accounts") {
+			return true, bugReproduced
+		}
+		if strings.Contains(s, "Could not find a ledger tar file") ||
+			strings.Contains(s, "Could not get precomputed values") ||
+			strings.Contains(s, "Could not find or generate") {
+			return true, bugInconclusive
+		}
+		if strings.Contains(s, "Archive process ready") {
+			return true, bugClean
+		}
+		// Not yet decided. The bugStatus here is a sentinel only — every caller gates
+		// on the bool (decided) first, so this value is never consumed while
+		// decided==false; bugInconclusive makes the "undetermined" intent explicit.
+		return false, bugInconclusive
+	}
+	// Loading the hash-referenced genesis ledger and inserting accounts in chunks of
+	// 100 before the collision can take minutes on a loaded box, so allow ample time;
+	// a timeout is inconclusive, never "fixed".
+	timeout := time.After(600 * time.Second)
+	decide := func(st bugStatus) (bugStatus, string) {
+		s := buf.String()
+		switch st {
+		case bugReproduced:
+			// Echo the raw DB-side collision so it lands in the main test log; it
+			// otherwise appears only in the shared Postgres log.
+			if raw := lineContaining(s, "tokens_value_key"); raw != "" {
+				t.Logger.Info("Archive repro: probe raw signal: %s", raw)
+			}
+			return bugReproduced, "add_genesis_accounts hit tokens_value_key (#18941 reproduced)"
+		case bugClean:
+			if raw := lineContaining(s, "Archive process ready"); raw != "" {
+				t.Logger.Info("Archive repro: probe raw signal: %s", raw)
+			}
+			return bugClean, "probe archive started cleanly (add_genesis_accounts succeeded; #18941 fixed)"
+		default:
+			return bugInconclusive, "probe could not load the fork genesis ledger / no decisive signal: " +
+				firstLine(tail(buf.String(), 400))
+		}
+	}
+	for {
+		if decided, st := scan(); decided {
+			kill()
+			return decide(st)
+		}
+		select {
+		case <-done:
+			if _, st := scan(); st == bugReproduced {
+				return decide(bugReproduced)
+			}
+			// The fixed archive stays running (decided clean above before exit), so a
+			// process exit here means a crash without the collision — inconclusive.
+			return bugInconclusive, "probe archive exited without a decisive signal: " +
+				firstLine(tail(buf.String(), 400))
+		case <-timeout:
+			kill()
+			return bugInconclusive, "probe timed out without a decisive signal: " + firstLine(tail(buf.String(), 400))
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// tail returns the last n bytes of s.
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+
+// ledgerCacheDir returns the autogen ledger cache the archive searches
+// (Cache_dir.autogen_path = $TMPDIR/coda_cache_dir, defaulting TMPDIR to /tmp).
+func ledgerCacheDir() string {
+	tmp := os.Getenv("TMPDIR")
+	if tmp == "" {
+		tmp = "/tmp"
+	}
+	return filepath.Join(tmp, "coda_cache_dir")
+}
+
+// stageGenesisLedgerTars copies the fork node's genesis + epoch ledger tarballs
+// from the per-node chain-state dirs (where the fork daemon wrote them) into the
+// archive's autogen ledger cache, so the #18941 probe can resolve the fork genesis
+// config's hash-referenced ledger and run add_genesis_accounts. No-op-safe: missing
+// dirs / already-present tars are skipped. The archive selects the right tar by
+// hash, so staging every matching tar (incl. the pre-fork ones) is harmless.
+func (t *HardforkTest) stageGenesisLedgerTars() int {
+	cacheDir := ledgerCacheDir()
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Logger.Error("Archive repro: could not create ledger cache %s: %v", cacheDir, err)
+		return 0
+	}
+	nodesDir := filepath.Join(t.Config.Root, "nodes")
+	staged := 0
+	_ = filepath.Walk(nodesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		name := info.Name()
+		if !strings.HasSuffix(name, ".tar.gz") ||
+			!(strings.HasPrefix(name, "genesis_ledger_") || strings.HasPrefix(name, "epoch_ledger_")) {
+			return nil
+		}
+		dst := filepath.Join(cacheDir, name)
+		if _, err := os.Stat(dst); err == nil {
+			return nil // already staged
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Logger.Error("Archive repro: could not read ledger tar %s: %v", path, err)
+			return nil
+		}
+		if err := os.WriteFile(dst, data, 0644); err != nil {
+			t.Logger.Error("Archive repro: could not stage ledger tar %s: %v", dst, err)
+			return nil
+		}
+		staged++
+		return nil
+	})
+	t.Logger.Info("Archive repro: staged %d genesis/epoch ledger tar(s) into %s for the #18941 probe", staged, cacheDir)
+	return staged
+}
+
+// AssertArchiveBugsAbsent runs the post-fork bug probes and detection. Returns nil
+// when the archive is healthy (fixes applied) and a non-nil error enumerating the
+// reproduced bugs otherwise, so the hardfork test exits non-zero against the buggy
+// archive/migration and passes against the fixed ones.
+func (t *HardforkTest) AssertArchiveBugsAbsent(genesisConfig string) error {
+	t.Logger.Info("===== Archive bug assertion: checking #18941 + element_ids overflow =====")
+	var reproduced, inconclusive []string
+
+	record := func(name string, st bugStatus, detail string) {
+		switch st {
+		case bugReproduced:
+			t.Logger.Error("REPRODUCED %s: %s", name, detail)
+			reproduced = append(reproduced, name+" ("+detail+")")
+		case bugInconclusive:
+			t.Logger.Error("INCONCLUSIVE %s: %s", name, detail)
+			inconclusive = append(inconclusive, name+" ("+detail+")")
+		default:
+			t.Logger.Info("%s NOT reproduced: %s", name, detail)
+		}
+	}
+
+	st, detail := t.DetectElementIdsOverflow()
+	record("element_ids btree overflow", st, detail)
+
+	if genesisConfig == "" {
+		record("#18941 tokens_value_key", bugInconclusive, "no fork genesis config available for the probe")
+	} else {
+		st, detail := t.ProbeAddGenesisAccounts(genesisConfig)
+		record("#18941 tokens_value_key", st, detail)
+	}
+
+	// Fail-closed: a reproduced bug OR an indeterminate check both fail the run, so
+	// the test only passes (exit 0) when BOTH checks definitively show the bug absent.
+	if len(reproduced) > 0 {
+		return fmt.Errorf("archive-node bug(s) reproduced: %s", strings.Join(reproduced, "; "))
+	}
+	if len(inconclusive) > 0 {
+		return fmt.Errorf("archive-bug check inconclusive (failing closed — neither confirmed present nor "+
+			"definitively absent): %s", strings.Join(inconclusive, "; "))
+	}
+	t.Logger.Info("===== Archive healthy: neither #18941 nor the element_ids overflow reproduced =====")
+	return nil
+}

--- a/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
+++ b/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
@@ -655,6 +655,17 @@ func (t *HardforkTest) AssertArchiveBugsAbsent() error {
 	// #18941 was decided at the live archive's startup (add_genesis_accounts).
 	record("#18941 tokens_value_key", t.bug18941, t.bug18941Detail)
 
+	// Archive-side vesting rotation: when the live archive ran add_genesis_accounts
+	// (#18941 absent), assert it PERSISTED the fork genesis's rotated vesting schedule —
+	// the reason the post-fork config is fed to the archive at all. This complements the
+	// daemon-side ValidateVestingAfterFork (which only checks the live ledger). When
+	// #18941 reproduced, the fallback archive skipped add_genesis_accounts, so there is
+	// no rotated row to validate and the run is already failing on #18941.
+	if t.bug18941 == bugClean {
+		vst, vdetail := t.ValidateVestingInArchive()
+		record("archive vesting rotation", vst, vdetail)
+	}
+
 	// Fail-closed: a reproduced bug OR an indeterminate check both fail the run, so
 	// the test only passes (exit 0) when BOTH checks definitively show the bug absent.
 	if len(reproduced) > 0 {

--- a/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
+++ b/src/app/hardfork_test/src/internal/hardfork/archive_repro.go
@@ -16,8 +16,9 @@ package hardfork
 // (compatible) network mints an OWNED custom token that the compatible archive
 // records; at the fork transition the shared archive DB is migrated to the Mesa
 // schema; a max-cost ITN load on the post-fork (Mesa) network makes the Mesa
-// archive ingest the overflowing field array; and finally a probe starts the Mesa
-// archive over the fork genesis config to exercise add_genesis_accounts.
+// archive ingest the overflowing field array; and the post-fork archive node runs
+// add_genesis_accounts at its own startup over the fork genesis config (the #18941
+// path), exercised on the real live node rather than a synthetic probe.
 //
 // Buggy binaries + the migration that keeps the element_ids UNIQUE reproduce both
 // bugs and AssertArchiveBugsAbsent returns an error (the test exits non-zero);
@@ -25,21 +26,22 @@ package hardfork
 // test passes.
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
 // itnPort returns the seed daemon's ITN GraphQL port (daemon base port + 5).
 func (t *HardforkTest) itnPort() int { return t.Config.SeedStartPort + 5 }
 
-// forkGenesisConfigPath returns the post-fork seed daemon.json (moved into place
-// by CleanUpNetworkForForkPhase), used as the genesis config for the #18941 probe.
+// forkGenesisConfigPath returns the post-fork seed daemon.json (moved into place by
+// CleanUpNetworkForForkPhase), the genesis config the live archive node loads at
+// startup to run add_genesis_accounts (the #18941 path).
 func (t *HardforkTest) forkGenesisConfigPath() string {
 	for _, info := range t.Config.DaemonInfos {
 		if info.Name == "seed" {
@@ -83,10 +85,11 @@ func (t *HardforkTest) InitArchiveRepro() error {
 		return nil
 	}
 	c := t.Config
+	// Default the #18941 verdict to inconclusive; StartForkArchive overwrites it at the
+	// live archive's startup. If that never runs, the assertion fails closed.
+	t.bug18941 = bugInconclusive
+	t.bug18941Detail = "the live post-fork archive was never started"
 
-	if c.ProbeArchiveExe == "" {
-		c.ProbeArchiveExe = c.ForkArchiveExe
-	}
 	if c.ItnKeyPath == "" {
 		// The ITN auth key MUST live outside Root: mina-local-network.sh does
 		// `rm -rf $ROOT` when it (re)initializes the main network (config=reset),
@@ -147,6 +150,10 @@ func (t *HardforkTest) InitArchiveRepro() error {
 	// (Postgres connection + schema). The pre-fork archive is compatible-lineage,
 	// the post-fork archive is Mesa-lineage (bin_io must match the phase daemon).
 	os.Setenv("HARDFORK_ARCHIVE_PORT", strconv.Itoa(c.ArchivePort))
+	// The post-fork (inherit-mode) archive is started by Go (StartForkArchive), not by
+	// mina-local-network.sh, so it can run add_genesis_accounts at startup and exercise
+	// #18941 on the real node. The pre-fork (reset-mode) archive is still script-spawned.
+	os.Setenv("HARDFORK_ARCHIVE_EXTERNAL", "1")
 	os.Setenv("MAIN_ARCHIVE_EXE", c.MainArchiveExe)
 	os.Setenv("FORK_ARCHIVE_EXE", c.ForkArchiveExe)
 	os.Setenv("CREATE_SCHEMA_FILE", c.CreateSchemaFile)
@@ -345,9 +352,9 @@ func (t *HardforkTest) DriveMaxCostLoadPostFork() error {
 type bugStatus int
 
 const (
-	bugReproduced  bugStatus = iota // the bug definitively reproduced
-	bugClean                        // the bug is definitively absent (fix verified)
-	bugInconclusive                 // neither could be established (setup/timing issue)
+	bugReproduced   bugStatus = iota // the bug definitively reproduced
+	bugClean                         // the bug is definitively absent (fix verified)
+	bugInconclusive                  // neither could be established (setup/timing issue)
 )
 
 // DetectElementIdsOverflow reports whether the element_ids btree overflow
@@ -360,17 +367,24 @@ const (
 //     neither triggered nor shown fixed. (We must NOT treat "only small Shape-A
 //     arrays archived" as reproduced — that false-positives the fixed run.)
 func (t *HardforkTest) DetectElementIdsOverflow() (bugStatus, string) {
-	logPath := filepath.Join(t.Config.Root, "fork-network.log")
-	if data, err := os.ReadFile(logPath); err == nil {
-		s := string(data)
-		if strings.Contains(s, "exceeds btree") ||
-			strings.Contains(s, "zkapp_field_array_element_ids_key") ||
-			strings.Contains(s, "zkapp_events_element_ids_key") {
-			if raw := lineContaining(s, "exceeds btree"); raw != "" {
-				t.Logger.Info("Archive repro: element_ids raw signal: %s", raw)
-			}
-			return bugReproduced, "Mesa archive logged the element_ids btree-overflow error"
+	// The btree-overflow error surfaces in the live archive's log (now Go-owned,
+	// t.forkArchiveLog) and — for older/script-spawned setups — in fork-network.log.
+	var s string
+	for _, logPath := range []string{t.forkArchiveLog, filepath.Join(t.Config.Root, "fork-network.log")} {
+		if logPath == "" {
+			continue
 		}
+		if data, err := os.ReadFile(logPath); err == nil {
+			s += string(data)
+		}
+	}
+	if strings.Contains(s, "exceeds btree") ||
+		strings.Contains(s, "zkapp_field_array_element_ids_key") ||
+		strings.Contains(s, "zkapp_events_element_ids_key") {
+		if raw := lineContaining(s, "exceeds btree"); raw != "" {
+			t.Logger.Info("Archive repro: element_ids raw signal: %s", raw)
+		}
+		return bugReproduced, "Mesa archive logged the element_ids btree-overflow error"
 	}
 	large := t.psqlCount("select count(*) from zkapp_field_array where coalesce(array_length(element_ids,1),0) >= 100;")
 	total := t.psqlCount("select count(*) from zkapp_field_array;")
@@ -383,109 +397,171 @@ func (t *HardforkTest) DetectElementIdsOverflow() (bugStatus, string) {
 			"the max-cost load delivered no Shape-B 1024-element command to the archive, so the overflow is undetermined", total)
 }
 
-// ProbeAddGenesisAccounts starts the Mesa probe archive over the shared DB with
-// the fork genesis config and reports whether #18941 (tokens_value_key) reproduced
-// in add_genesis_accounts:
-//   - bugReproduced: add_genesis_accounts hit tokens_value_key (buggy archive).
-//   - bugClean: the archive logged "Archive process ready" (genesis accounts added
-//     without collision — the fix).
-//   - bugInconclusive: the probe could not even reach add_genesis_accounts (no
-//     ledger tars staged, or it failed to load the hash-referenced fork genesis
-//     ledger), or it timed out / exited without a decisive signal. These must NOT
-//     be read as "fixed": a probe that never ran the collision path proves nothing.
-func (t *HardforkTest) ProbeAddGenesisAccounts(genesisConfig string) (bugStatus, string) {
-	t.Logger.Info("Archive repro: probing add_genesis_accounts (%s over %s)",
-		t.Config.ProbeArchiveExe, t.Config.ArchivePgUri)
-	// The fork genesis config references its ledger by hash (not inline accounts),
-	// so the probe archive must load the ledger tarball to materialize the genesis
-	// accounts. Those tars live under the fork node's chain-state dir, which is NOT
-	// in the archive's ledger search path — without staging them the probe dies with
-	// "Could not find a ledger tar file for hash ..." before add_genesis_accounts
-	// runs, masking #18941. Stage them into the autogen cache the archive searches.
+// StartForkArchive starts the post-fork (Mesa) archive node the way production does —
+// with the fork genesis config, so it runs add_genesis_accounts at startup, the code
+// path where #18941 lives. This is the live archive node the fork daemons stream blocks
+// to (it binds the archive server port), so #18941 is exercised on the REAL node
+// startup rather than a synthetic post-teardown probe. The verdict is recorded in
+// t.bug18941 for AssertArchiveBugsAbsent. Called after ApplyMigration, before the fork
+// daemons start, so the node is listening before any fork block is produced.
+//
+//   - fixed archive: add_genesis_accounts succeeds ("Archive process ready"); the node
+//     stays up and ingests the fork blocks, incl. the max-cost element_ids array.
+//   - buggy archive: add_genesis_accounts collides on tokens_value_key and the node
+//     exits (#18941 reproduced at real startup). The collision happens before the fork
+//     network's first block, so we then start a FALLBACK archive WITHOUT the genesis
+//     config (skipping add_genesis_accounts) on the same port, so the fork blocks are
+//     still archived and the element_ids check has its data.
+func (t *HardforkTest) StartForkArchive(genesisConfig string) error {
+	t.forkArchiveLog = filepath.Join(t.Config.Root, "fork-archive.log")
+	// The fork genesis config references its ledger by hash (not inline accounts), so
+	// the archive must load the ledger tarball to materialize the genesis accounts.
+	// Those tars live under the fork node's chain-state dir, NOT in the archive's search
+	// path — without staging them add_genesis_accounts dies with "Could not find a
+	// ledger tar file ..." before the collision, masking #18941.
 	if n := t.stageGenesisLedgerTars(); n == 0 {
-		return bugInconclusive, "no genesis/epoch ledger tars were staged; the probe cannot load the fork " +
-			"genesis ledger and would never reach add_genesis_accounts (would mask #18941)"
+		t.bug18941 = bugInconclusive
+		t.bug18941Detail = "no genesis/epoch ledger tars were staged; the live archive could not run " +
+			"add_genesis_accounts (would mask #18941)"
+		t.Logger.Error("Archive repro: %s", t.bug18941Detail)
+		// Still bring up a plain archive so the element_ids path remains testable.
+		cmd, err := t.spawnForkArchive(genesisConfig, false)
+		if err != nil {
+			return err
+		}
+		t.forkArchiveCmd = cmd
+		return nil
 	}
-	cmd := exec.Command(t.Config.ProbeArchiveExe, "run",
+	t.Logger.Info("Archive repro: starting post-fork archive with add_genesis_accounts "+
+		"(fork genesis %s over %s)", genesisConfig, t.Config.ArchivePgUri)
+	cmd, err := t.spawnForkArchive(genesisConfig, true) // WITH --config-file -> add_genesis_accounts
+	if err != nil {
+		return err
+	}
+	st, detail := t.watchForkArchiveStartup(cmd)
+	t.bug18941, t.bug18941Detail = st, detail
+	switch st {
+	case bugClean:
+		t.Logger.Info("Archive repro: #18941 absent at live archive startup: %s", detail)
+		t.forkArchiveCmd = cmd // healthy live archive; keep it running to ingest blocks
+		return nil
+	case bugReproduced:
+		t.Logger.Error("Archive repro: REPRODUCED #18941 at live archive startup: %s", detail)
+	default:
+		t.Logger.Error("Archive repro: #18941 inconclusive at live archive startup: %s", detail)
+	}
+	// #18941 reproduced or inconclusive: the add_genesis_accounts archive is gone.
+	// Start a fallback archive WITHOUT the genesis config so the fork blocks (and the
+	// element_ids max-cost array) are still archived for the element_ids check.
+	t.stopProc(cmd)
+	fb, err := t.spawnForkArchive(genesisConfig, false)
+	if err != nil {
+		return fmt.Errorf("failed to start fallback fork archive: %w", err)
+	}
+	t.forkArchiveCmd = fb
+	t.Logger.Info("Archive repro: fallback fork archive started (no add_genesis_accounts) for the element_ids check")
+	return nil
+}
+
+// spawnForkArchive starts a Mesa archive node on the archive server port, appending its
+// output to t.forkArchiveLog. With withConfig it passes --config-file (running
+// add_genesis_accounts at startup); without it, the archive skips genesis loading and
+// simply archives incoming blocks via RPC.
+func (t *HardforkTest) spawnForkArchive(genesisConfig string, withConfig bool) (*exec.Cmd, error) {
+	args := []string{"run",
 		"--postgres-uri", t.Config.ArchivePgUri,
-		"--server-port", strconv.Itoa(t.Config.ArchivePort+10),
-		"--config-file", genesisConfig)
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	if err := cmd.Start(); err != nil {
-		return bugInconclusive, fmt.Sprintf("failed to start probe archive: %v", err)
+		"--server-port", strconv.Itoa(t.Config.ArchivePort)}
+	if withConfig {
+		args = append(args, "--config-file", genesisConfig)
 	}
+	cmd := exec.Command(t.Config.ForkArchiveExe, args...)
+	f, err := os.OpenFile(t.forkArchiveLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open fork archive log: %w", err)
+	}
+	cmd.Stdout = f
+	cmd.Stderr = f
+	if err := cmd.Start(); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("start fork archive: %w", err)
+	}
+	return cmd, nil
+}
+
+// watchForkArchiveStartup watches a just-started add_genesis_accounts archive for its
+// decisive signal, reading t.forkArchiveLog. It does NOT kill the process: on bugClean
+// the caller keeps it running as the live archive. Ledger-load failures / exit-without-
+// signal / timeout are inconclusive (never "fixed"): an archive that never ran the
+// collision path proves nothing.
+func (t *HardforkTest) watchForkArchiveStartup(cmd *exec.Cmd) (bugStatus, string) {
 	done := make(chan struct{})
 	go func() { cmd.Wait(); close(done) }()
-	kill := func() {
-		if cmd.Process != nil {
-			cmd.Process.Kill()
-		}
+	read := func() string {
+		data, _ := os.ReadFile(t.forkArchiveLog)
+		return string(data)
 	}
-	// scan returns (decided, status). A genesis-ledger load failure is treated as
-	// inconclusive (the probe never reached add_genesis_accounts), NOT as clean.
-	scan := func() (bool, bugStatus) {
-		s := buf.String()
+	classify := func(s string) (bool, bugStatus, string) {
 		if strings.Contains(s, "tokens_value_key") || strings.Contains(s, "Failed to add genesis accounts") {
-			return true, bugReproduced
+			if raw := lineContaining(s, "tokens_value_key"); raw != "" {
+				t.Logger.Info("Archive repro: archive raw signal: %s", raw)
+			}
+			return true, bugReproduced, "add_genesis_accounts hit tokens_value_key at live archive startup (#18941 reproduced)"
 		}
 		if strings.Contains(s, "Could not find a ledger tar file") ||
 			strings.Contains(s, "Could not get precomputed values") ||
 			strings.Contains(s, "Could not find or generate") {
-			return true, bugInconclusive
+			return true, bugInconclusive, "live archive could not load the fork genesis ledger: " + firstLine(tail(s, 400))
 		}
 		if strings.Contains(s, "Archive process ready") {
-			return true, bugClean
-		}
-		// Not yet decided. The bugStatus here is a sentinel only — every caller gates
-		// on the bool (decided) first, so this value is never consumed while
-		// decided==false; bugInconclusive makes the "undetermined" intent explicit.
-		return false, bugInconclusive
-	}
-	// Loading the hash-referenced genesis ledger and inserting accounts in chunks of
-	// 100 before the collision can take minutes on a loaded box, so allow ample time;
-	// a timeout is inconclusive, never "fixed".
-	timeout := time.After(600 * time.Second)
-	decide := func(st bugStatus) (bugStatus, string) {
-		s := buf.String()
-		switch st {
-		case bugReproduced:
-			// Echo the raw DB-side collision so it lands in the main test log; it
-			// otherwise appears only in the shared Postgres log.
-			if raw := lineContaining(s, "tokens_value_key"); raw != "" {
-				t.Logger.Info("Archive repro: probe raw signal: %s", raw)
-			}
-			return bugReproduced, "add_genesis_accounts hit tokens_value_key (#18941 reproduced)"
-		case bugClean:
 			if raw := lineContaining(s, "Archive process ready"); raw != "" {
-				t.Logger.Info("Archive repro: probe raw signal: %s", raw)
+				t.Logger.Info("Archive repro: archive raw signal: %s", raw)
 			}
-			return bugClean, "probe archive started cleanly (add_genesis_accounts succeeded; #18941 fixed)"
-		default:
-			return bugInconclusive, "probe could not load the fork genesis ledger / no decisive signal: " +
-				firstLine(tail(buf.String(), 400))
+			return true, bugClean, "live archive ran add_genesis_accounts and reported ready (#18941 absent)"
 		}
+		return false, bugInconclusive, ""
 	}
+	// add_genesis_accounts loads the hash-referenced genesis ledger and inserts accounts
+	// in chunks before the collision, which can take minutes on a loaded box.
+	timeout := time.After(600 * time.Second)
 	for {
-		if decided, st := scan(); decided {
-			kill()
-			return decide(st)
+		if decided, st, detail := classify(read()); decided {
+			return st, detail
 		}
 		select {
 		case <-done:
-			if _, st := scan(); st == bugReproduced {
-				return decide(bugReproduced)
+			if decided, st, detail := classify(read()); decided {
+				return st, detail
 			}
-			// The fixed archive stays running (decided clean above before exit), so a
-			// process exit here means a crash without the collision — inconclusive.
-			return bugInconclusive, "probe archive exited without a decisive signal: " +
-				firstLine(tail(buf.String(), 400))
+			return bugInconclusive, "live archive exited during startup without a decisive signal: " +
+				firstLine(tail(read(), 400))
 		case <-timeout:
-			kill()
-			return bugInconclusive, "probe timed out without a decisive signal: " + firstLine(tail(buf.String(), 400))
+			return bugInconclusive, "live archive did not reach a decisive add_genesis_accounts signal within timeout"
 		case <-time.After(2 * time.Second):
 		}
+	}
+}
+
+// StopForkArchive stops the Go-owned fork archive node (live or fallback), if any.
+func (t *HardforkTest) StopForkArchive() {
+	if t.forkArchiveCmd != nil {
+		t.Logger.Info("Archive repro: stopping the post-fork archive node")
+		t.stopProc(t.forkArchiveCmd)
+		t.forkArchiveCmd = nil
+	}
+}
+
+// stopProc terminates a process (SIGTERM, then wait) started by the archive-repro code.
+func (t *HardforkTest) stopProc(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() { cmd.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
 	}
 }
 
@@ -546,15 +622,17 @@ func (t *HardforkTest) stageGenesisLedgerTars() int {
 		staged++
 		return nil
 	})
-	t.Logger.Info("Archive repro: staged %d genesis/epoch ledger tar(s) into %s for the #18941 probe", staged, cacheDir)
+	t.Logger.Info("Archive repro: staged %d genesis/epoch ledger tar(s) into %s for add_genesis_accounts", staged, cacheDir)
 	return staged
 }
 
-// AssertArchiveBugsAbsent runs the post-fork bug probes and detection. Returns nil
-// when the archive is healthy (fixes applied) and a non-nil error enumerating the
-// reproduced bugs otherwise, so the hardfork test exits non-zero against the buggy
-// archive/migration and passes against the fixed ones.
-func (t *HardforkTest) AssertArchiveBugsAbsent(genesisConfig string) error {
+// AssertArchiveBugsAbsent evaluates the two archive-bug checks and returns nil when the
+// archive is healthy (fixes applied), or a non-nil error enumerating the reproduced bugs
+// otherwise, so the hardfork test exits non-zero against the buggy archive/migration and
+// passes against the fixed ones. The #18941 verdict was recorded earlier at the live
+// archive node's add_genesis_accounts startup (StartForkArchive); element_ids is detected
+// here from the (now-ingested) archive log + DB.
+func (t *HardforkTest) AssertArchiveBugsAbsent() error {
 	t.Logger.Info("===== Archive bug assertion: checking #18941 + element_ids overflow =====")
 	var reproduced, inconclusive []string
 
@@ -574,12 +652,8 @@ func (t *HardforkTest) AssertArchiveBugsAbsent(genesisConfig string) error {
 	st, detail := t.DetectElementIdsOverflow()
 	record("element_ids btree overflow", st, detail)
 
-	if genesisConfig == "" {
-		record("#18941 tokens_value_key", bugInconclusive, "no fork genesis config available for the probe")
-	} else {
-		st, detail := t.ProbeAddGenesisAccounts(genesisConfig)
-		record("#18941 tokens_value_key", st, detail)
-	}
+	// #18941 was decided at the live archive's startup (add_genesis_accounts).
+	record("#18941 tokens_value_key", t.bug18941, t.bug18941Detail)
 
 	// Fail-closed: a reproduced bug OR an indeterminate check both fail the run, so
 	// the test only passes (exit 0) when BOTH checks definitively show the bug absent.

--- a/src/app/hardfork_test/src/internal/hardfork/itn_client.go
+++ b/src/app/hardfork_test/src/internal/hardfork/itn_client.go
@@ -1,0 +1,229 @@
+package hardfork
+
+// In-process ITN GraphQL client: the hardfork test signs ITN auth and
+// scheduled-transaction mutations in-process with crypto/ed25519, so it depends
+// only on Go (no external keygen/signing subprocesses).
+//
+// Auth protocol — mirrors the node's src/app/cli/src/init/graphql_internal.ml and
+// the mina-perf-testing orchestrator (src/graphql.go):
+//   - auth query:        Authorization: "Signature <b64 pub> <b64 sig(body)>"
+//   - sequenced mutation: Authorization: "Signature <b64 pub> <b64 sig(msg)> ;
+//     Sequencing <uuid> <seqno>", where msg = 2-byte big-endian seqno ++ uuid ++ body.
+// The signature is pure Ed25519 over the exact transmitted body bytes; the public
+// key is the 32 raw key bytes, base64'd, which is exactly what the daemon receives
+// via --itn-keys.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// itnAuth holds the ed25519 keypair used to authenticate to a daemon's ITN GraphQL
+// endpoint.
+type itnAuth struct {
+	priv   ed25519.PrivateKey
+	pubB64 string // base64 of the 32-byte raw public key (the daemon --itn-keys value)
+}
+
+// newItnAuth generates a fresh ed25519 ITN keypair.
+func newItnAuth() (*itnAuth, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ITN ed25519 key: %w", err)
+	}
+	return &itnAuth{priv: priv, pubB64: base64.StdEncoding.EncodeToString(pub)}, nil
+}
+
+// writePEM writes the private key as a PKCS#8 PEM, for debugging / manual reuse of
+// the same identity with an external client. Signing always uses the in-memory key,
+// so deleting this file (e.g. the main-network root wipe) cannot break the run.
+func (a *itnAuth) writePEM(path string) error {
+	der, err := x509.MarshalPKCS8PrivateKey(a.priv)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600)
+}
+
+// sigB64 returns base64(ed25519 signature over msg).
+func (a *itnAuth) sigB64(msg []byte) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(a.priv, msg))
+}
+
+// itnURL is the ITN GraphQL endpoint for a daemon listening on the given port.
+func itnURL(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d/graphql", port)
+}
+
+// itnPost issues a GraphQL POST with the given Authorization header and returns the
+// "data" object, erroring if the response carries GraphQL "errors".
+func itnPost(url string, body []byte, authHeader string) (map[string]json.RawMessage, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader)
+	resp, err := (&http.Client{Timeout: 60 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Data   map[string]json.RawMessage `json:"data"`
+		Errors json.RawMessage            `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode ITN response: %w", err)
+	}
+	if len(out.Errors) > 0 && string(out.Errors) != "null" {
+		return nil, fmt.Errorf("GraphQL errors: %s", out.Errors)
+	}
+	return out.Data, nil
+}
+
+// marshalNoEscape JSON-encodes v without HTML escaping, trimming the trailing
+// newline Encoder appends. The returned bytes are used both to sign and to send, so
+// the signature always covers the exact transmitted body.
+func marshalNoEscape(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// auth performs the ITN auth handshake and returns the server UUID + the signer's
+// current sequence number.
+func (a *itnAuth) auth(url string) (string, int, error) {
+	body := []byte(`{"query":"query { auth { serverUuid signerSequenceNumber } }"}`)
+	hdr := "Signature " + a.pubB64 + " " + a.sigB64(body)
+	data, err := itnPost(url, body, hdr)
+	if err != nil {
+		return "", 0, err
+	}
+	var auth struct {
+		ServerUUID           string          `json:"serverUuid"`
+		SignerSequenceNumber json.RawMessage `json:"signerSequenceNumber"`
+	}
+	if err := json.Unmarshal(data["auth"], &auth); err != nil {
+		return "", 0, fmt.Errorf("decode auth: %w", err)
+	}
+	// signerSequenceNumber may arrive as a JSON string or number; accept both.
+	seqno, err := strconv.Atoi(strings.Trim(string(auth.SignerSequenceNumber), `"`))
+	if err != nil {
+		return "", 0, fmt.Errorf("parse signerSequenceNumber %s: %w", auth.SignerSequenceNumber, err)
+	}
+	return auth.ServerUUID, seqno, nil
+}
+
+// sequencedMutation signs and sends a sequenced ITN mutation: it authenticates to
+// obtain the current (uuid, seqno), signs 2-byte BE seqno ++ uuid ++ body, and
+// returns the named field of the "data" object as a string.
+func (a *itnAuth) sequencedMutation(url string, body []byte, field string) (string, error) {
+	uuid, seqno, err := a.auth(url)
+	if err != nil {
+		return "", err
+	}
+	msg := make([]byte, 2, 2+len(uuid)+len(body))
+	binary.BigEndian.PutUint16(msg, uint16(seqno))
+	msg = append(msg, []byte(uuid)...)
+	msg = append(msg, body...)
+	hdr := fmt.Sprintf("Signature %s %s ; Sequencing %s %d", a.pubB64, a.sigB64(msg), uuid, seqno)
+	data, err := itnPost(url, body, hdr)
+	if err != nil {
+		return "", err
+	}
+	var s string
+	if err := json.Unmarshal(data[field], &s); err != nil {
+		return "", fmt.Errorf("decode %s: %w", field, err)
+	}
+	return s, nil
+}
+
+// zkappLoadParams are the caller-supplied knobs for a scheduled zkApp load.
+type zkappLoadParams struct {
+	feePayers       []string
+	numZkapps       int
+	numNewAccounts  int
+	numUpdates      int
+	durationMin     int
+	tps             float64
+	memoPrefix      string
+	maxCost         bool
+	nonDefaultToken bool
+}
+
+// zkappCommandsInput mirrors the GraphQL ZkappCommandsDetails input the ITN
+// scheduler expects.
+type zkappCommandsInput struct {
+	FeePayers          []string `json:"feePayers"`
+	NumZkappsToDeploy  int      `json:"numZkappsToDeploy"`
+	NumNewAccounts     int      `json:"numNewAccounts"`
+	Tps                float64  `json:"tps"`
+	DurationMin        int      `json:"durationMin"`
+	MemoPrefix         string   `json:"memoPrefix"`
+	NoPrecondition     bool     `json:"noPrecondition"`
+	MinBalanceChange   string   `json:"minBalanceChange"`
+	MaxBalanceChange   string   `json:"maxBalanceChange"`
+	MinNewZkappBalance string   `json:"minNewZkappBalance"`
+	MaxNewZkappBalance string   `json:"maxNewZkappBalance"`
+	InitBalance        string   `json:"initBalance"`
+	MinFee             string   `json:"minFee"`
+	MaxFee             string   `json:"maxFee"`
+	DeploymentFee      string   `json:"deploymentFee"`
+	AccountQueueSize   int      `json:"accountQueueSize"`
+	MaxCost            bool     `json:"maxCost"`
+	MaxCostNumUpdates  int      `json:"maxCostNumUpdates"`
+	NonDefaultToken    bool     `json:"nonDefaultToken"`
+}
+
+// scheduleZkappCommands schedules a zkApp load (max-cost or persistent custom-token,
+// per params) and returns the scheduler handle. Balance-change bounds are required by
+// the schema but unused by the max-cost generator; accountQueueSize 0 returns accounts
+// to the pool immediately, keeping the per-public-key proof cache hot.
+func (a *itnAuth) scheduleZkappCommands(url string, p zkappLoadParams) (string, error) {
+	in := zkappCommandsInput{
+		FeePayers:          p.feePayers,
+		NumZkappsToDeploy:  p.numZkapps,
+		NumNewAccounts:     p.numNewAccounts,
+		Tps:                p.tps,
+		DurationMin:        p.durationMin,
+		MemoPrefix:         p.memoPrefix,
+		NoPrecondition:     false,
+		MinBalanceChange:   "0",
+		MaxBalanceChange:   "1000000000",
+		MinNewZkappBalance: "1000000000",
+		MaxNewZkappBalance: "2000000000",
+		InitBalance:        "5000000000",
+		MinFee:             "1000000000",
+		MaxFee:             "2000000000",
+		DeploymentFee:      "1000000000",
+		AccountQueueSize:   0,
+		MaxCost:            p.maxCost,
+		MaxCostNumUpdates:  p.numUpdates,
+		NonDefaultToken:    p.nonDefaultToken,
+	}
+	body, err := marshalNoEscape(map[string]interface{}{
+		"query":     "mutation($input: ZkappCommandsDetails!) { scheduleZkappCommands(input: $input) }",
+		"variables": map[string]interface{}{"input": in},
+	})
+	if err != nil {
+		return "", err
+	}
+	return a.sequencedMutation(url, body, "scheduleZkappCommands")
+}

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -28,10 +28,29 @@ func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, 
 		"--nodes", strconv.Itoa(t.Config.NumNodes),
 		"--log-level", "Info",
 		"--file-log-level", "Trace",
-		"--value-transfer-txns",
 		"--transaction-interval", strconv.Itoa(t.Config.PaymentInterval),
 		"--root", t.Config.Root,
 	)
+
+	// Built-in value-transfer load (mina-local-network's per-payment `mina client
+	// send-payment` loop), selected per phase. Both networks default to OFF: the
+	// transaction load is instead driven in-process over ITN (custom-token payments
+	// on the pre-fork network, max-cost zkApps on the post-fork network), which the
+	// daemon schedules internally and so avoids spawning a client subprocess per
+	// payment (which otherwise churns PIDs against the cgroup limit). The old
+	// subprocess loop can still be re-enabled per phase with
+	// HARDFORK_VALUE_TRANSFERS_MAIN / HARDFORK_VALUE_TRANSFERS_FORK ("0"/"1").
+	valueTransfers := false
+	vtVar := "HARDFORK_VALUE_TRANSFERS_MAIN"
+	if profile == "fork" {
+		vtVar = "HARDFORK_VALUE_TRANSFERS_FORK"
+	}
+	if v := os.Getenv(vtVar); v != "" {
+		valueTransfers = v != "0"
+	}
+	if valueTransfers {
+		cmd.Args = append(cmd.Args, "--value-transfer-txns")
+	}
 
 	// Combine block-producer roles onto the seed and snark coordinator so the
 	// network runs as 2 daemons instead of 4. These flags apply to both the main
@@ -45,6 +64,40 @@ func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, 
 
 	cmd.Args = append(cmd.Args, extraArgs...)
 	cmd.Env = append(os.Environ(), "MINA_EXE="+minaExecutable)
+
+	// Optional archive node: when HARDFORK_ARCHIVE_PORT is set, enable the archive
+	// node in the local network and select the protocol-appropriate archive binary
+	// (Berkeley for the main/pre-fork network, Mesa for the fork/post-fork network)
+	// so the archive binary stays compatible with the (migrated) schema across the
+	// hardfork. The Postgres connection and the pre-fork schema file are taken from
+	// the PG_* / CREATE_SCHEMA_FILE environment, which mina-local-network.sh reads.
+	if archivePort := os.Getenv("HARDFORK_ARCHIVE_PORT"); archivePort != "" {
+		cmd.Args = append(cmd.Args, "--archive-server-port", archivePort)
+		archiveExe := os.Getenv("MAIN_ARCHIVE_EXE")
+		if profile == "fork" {
+			archiveExe = os.Getenv("FORK_ARCHIVE_EXE")
+		}
+		if archiveExe != "" {
+			cmd.Env = append(cmd.Env, "ARCHIVE_EXE="+archiveExe)
+		}
+	}
+
+	// Optional ITN GraphQL endpoint (each daemon's base port + 5), used to drive
+	// transaction load externally after a quiet, archive-verified warm-up: payments
+	// on the pre-fork (main) network and max-cost zkApp commands on the post-fork
+	// (Mesa) network. Selected per phase so ITN can be enabled only where the binary
+	// supports it (the Berkeley pre-fork binary may differ from the Mesa one). The
+	// daemons additionally need ITN_FEATURES=1 in their environment (caller-provided).
+	itnEnv := "HARDFORK_ITN_KEYS_MAIN"
+	if profile == "fork" {
+		itnEnv = "HARDFORK_ITN_KEYS_FORK"
+	}
+	if itnKeys := os.Getenv(itnEnv); itnKeys != "" {
+		cmd.Args = append(cmd.Args, "--itn-keys", itnKeys)
+		// mina-local-network.sh only wires up the ITN GraphQL endpoint when the
+		// daemons see ITN_FEATURES=1 in their environment, so propagate it here.
+		cmd.Env = append(cmd.Env, "ITN_FEATURES=1")
+	}
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -2,6 +2,7 @@ package hardfork
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,6 +102,18 @@ func (t *HardforkTest) startLocalNetwork(minaExecutable string, profile string, 
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	// For the archive-bug reproduction, also tee this phase's combined output
+	// (which includes the live archive node's logs) to a file so the element_ids
+	// btree-overflow signal can be detected after the post-fork max-cost load.
+	if t.Config.ReproArchiveBugs {
+		if f, err := os.Create(filepath.Join(t.Config.Root, profile+"-network.log")); err == nil {
+			cmd.Stdout = io.MultiWriter(os.Stdout, f)
+			cmd.Stderr = io.MultiWriter(os.Stderr, f)
+		} else {
+			t.Logger.Error("Archive repro: could not open %s-network.log: %v", profile, err)
+		}
+	}
 
 	// Start command
 	if err := cmd.Start(); err != nil {

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -123,6 +123,8 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 	// Calculate expected genesis slot
 	forkGenesisTs := t.Config.ForkGenesisTsGivenMainGenesisTs(mainGenesisTs)
 	expectedGenesisSlot := (forkGenesisTs - mainGenesisTs) / int64(t.Config.MainSlot)
+	// Stash for the post-fork archive-side vesting-rotation check (ValidateVestingInArchive).
+	t.expectedGenesisSlot = int(expectedGenesisSlot)
 
 	t.Logger.Info("Fork network genesis slot: %d", expectedGenesisSlot)
 

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -63,6 +63,14 @@ func (t *HardforkTest) RunMainNetworkPhase(mainGenesisTs int64, beforeShutdown H
 				Add(time.Duration(2*t.Config.MainSlot)*time.Second)),
 	)
 
+	// Archive bug reproduction: drive the custom-token ITN load on the pre-fork
+	// (compatible) network so a real OWNED custom token is archived before the fork.
+	if t.Config.ReproArchiveBugs {
+		if err := t.DriveTokenLoadPreFork(); err != nil {
+			return nil, fmt.Errorf("pre-fork custom-token load failed: %w", err)
+		}
+	}
+
 	analysis, err := t.AnalyzeBlocksOnMainNetwork(mainGenesisTs)
 	if err != nil {
 		return nil, err
@@ -175,6 +183,22 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 		}
 	} else {
 		t.Logger.Info("Fork network is quiet (no built-in value transfers); skipping user-command-in-block validation. Post-fork traffic is driven externally during the hold.")
+	}
+
+	// Archive bug reproduction: drive the max-cost zkApp load on the post-fork
+	// (Mesa) network so the Mesa archive ingests the overflowing 1024-element field
+	// array, then let it settle so the element_ids overflow (if any) is recorded
+	// before the network is torn down and the bug assertion runs.
+	if t.Config.ReproArchiveBugs {
+		if err := t.DriveMaxCostLoadPostFork(); err != nil {
+			return fmt.Errorf("post-fork max-cost load failed: %w", err)
+		}
+		settle := 7 * time.Minute
+		t.Logger.Info("Archive repro: letting the max-cost load archive for %s", settle)
+		select {
+		case <-time.After(settle):
+		case <-t.ctx.Done():
+		}
 	}
 
 	// Optional post-fork hold: keep the Mesa network (and its archive node) alive

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -160,9 +161,37 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 		return err
 	}
 
-	// Validate user commands in blocks
-	if err := t.ValidateBlockWithUserCommandCreatedForkNetwork(t.Config.AnyDaemon().Port(config.PORT_REST)); err != nil {
-		return err
+	// Validate user commands in blocks. This requires the fork network to carry
+	// user transactions; when the post-fork network is intentionally quiet (the
+	// max-cost experiment drives traffic externally during the hold below), there
+	// are no built-in payments to observe, so skip this check.
+	forkValueTransfers := false
+	if v := os.Getenv("HARDFORK_VALUE_TRANSFERS_FORK"); v != "" {
+		forkValueTransfers = v != "0"
+	}
+	if forkValueTransfers {
+		if err := t.ValidateBlockWithUserCommandCreatedForkNetwork(t.Config.AnyDaemon().Port(config.PORT_REST)); err != nil {
+			return err
+		}
+	} else {
+		t.Logger.Info("Fork network is quiet (no built-in value transfers); skipping user-command-in-block validation. Post-fork traffic is driven externally during the hold.")
+	}
+
+	// Optional post-fork hold: keep the Mesa network (and its archive node) alive
+	// after validation so an external driver can (1) verify the migrated archive on
+	// a few clean post-fork blocks and (2) run the max-cost ITN zkApp load while
+	// watching the archive/postgres for the expected error. Without this the phase
+	// returns immediately and the deferred gracefulShutdown tears the network down.
+	if holdStr := os.Getenv("HARDFORK_POSTFORK_HOLD_MIN"); holdStr != "" {
+		if holdMin, err := strconv.Atoi(holdStr); err == nil && holdMin > 0 {
+			t.Logger.Info("Post-fork hold: keeping fork network alive for %d minute(s) for external load/observation", holdMin)
+			select {
+			case <-time.After(time.Duration(holdMin) * time.Minute):
+				t.Logger.Info("Post-fork hold elapsed; proceeding to shutdown")
+			case <-t.ctx.Done():
+				t.Logger.Info("Post-fork hold interrupted; proceeding to shutdown")
+			}
+		}
 	}
 
 	return nil

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -24,14 +24,15 @@ type HardforkTest struct {
 	// Fork-network archive node owned by the archive-repro logic (see StartForkArchive):
 	// the live post-fork archive is started by Go — not mina-local-network.sh — so its
 	// add_genesis_accounts startup exercises #18941 on the real node.
-	forkArchiveCmd *exec.Cmd
-	forkArchiveLog string
-	bug18941       bugStatus // recorded at the live archive's startup
-	bug18941Detail string
-	runningCmds    []*exec.Cmd
-	runningCmdsMux sync.Mutex
-	ctx            context.Context
-	cancel         context.CancelFunc
+	forkArchiveCmd      *exec.Cmd
+	forkArchiveLog      string
+	bug18941            bugStatus // recorded at the live archive's startup
+	bug18941Detail      string
+	expectedGenesisSlot int // fork genesis global slot (stashed by RunForkNetworkPhase)
+	runningCmds         []*exec.Cmd
+	runningCmdsMux      sync.Mutex
+	ctx                 context.Context
+	cancel              context.CancelFunc
 }
 
 // NewHardforkTest creates a new instance of the hardfork test

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -20,6 +20,7 @@ type HardforkTest struct {
 	Client         *client.Client
 	Logger         *utils.Logger
 	ScriptDir      string
+	itn            *itnAuth // in-process ITN GraphQL client (archive-repro mode)
 	runningCmds    []*exec.Cmd
 	runningCmdsMux sync.Mutex
 	ctx            context.Context
@@ -130,6 +131,12 @@ func (t *HardforkTest) Run() error {
 	}
 	defer t.CleanupVestingAccount()
 
+	// Archive bug reproduction: generate the ITN key, reset the archive DB, and
+	// export the archive/ITN wiring the network phases read (no-op unless enabled).
+	if err := t.InitArchiveRepro(); err != nil {
+		return err
+	}
+
 	// Calculate main network genesis timestamp
 	mainGenesisTs := time.Now().Unix() + int64(t.Config.MainDelayMin*60)
 
@@ -156,9 +163,26 @@ func (t *HardforkTest) Run() error {
 		return err
 	}
 
+	// Archive bug reproduction: migrate the shared archive DB Berkeley->Mesa at the
+	// fork transition (pre-fork archive stopped, post-fork archive not yet started).
+	if t.Config.ReproArchiveBugs {
+		if err := t.ApplyMigration(); err != nil {
+			return err
+		}
+	}
+
 	t.Logger.Info("Phase 4: Running fork network...")
 	if err := t.RunForkNetworkPhase(analysis.Consensus.LastBlockBeforeTxEnd.BlockHeight, mainGenesisTs); err != nil {
 		return err
+	}
+
+	// Archive bug reproduction: the fork network (and its Mesa archive) is now shut
+	// down. Assert the archive is free of #18941 and the element_ids overflow; a
+	// reproduction returns a non-nil error so the test exits non-zero.
+	if t.Config.ReproArchiveBugs {
+		if err := t.AssertArchiveBugsAbsent(t.forkGenesisConfigPath()); err != nil {
+			return err
+		}
 	}
 
 	t.Logger.Info("===== Hardfork test completed successfully! =====")

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -16,11 +16,18 @@ import (
 
 // HardforkTest represents the main hardfork test logic
 type HardforkTest struct {
-	Config         *config.Config
-	Client         *client.Client
-	Logger         *utils.Logger
-	ScriptDir      string
-	itn            *itnAuth // in-process ITN GraphQL client (archive-repro mode)
+	Config    *config.Config
+	Client    *client.Client
+	Logger    *utils.Logger
+	ScriptDir string
+	itn       *itnAuth // in-process ITN GraphQL client (archive-repro mode)
+	// Fork-network archive node owned by the archive-repro logic (see StartForkArchive):
+	// the live post-fork archive is started by Go — not mina-local-network.sh — so its
+	// add_genesis_accounts startup exercises #18941 on the real node.
+	forkArchiveCmd *exec.Cmd
+	forkArchiveLog string
+	bug18941       bugStatus // recorded at the live archive's startup
+	bug18941Detail string
 	runningCmds    []*exec.Cmd
 	runningCmdsMux sync.Mutex
 	ctx            context.Context
@@ -169,6 +176,15 @@ func (t *HardforkTest) Run() error {
 		if err := t.ApplyMigration(); err != nil {
 			return err
 		}
+		// Start the post-fork archive node the production way — running
+		// add_genesis_accounts at startup — BEFORE the fork daemons, so the node is
+		// listening before any fork block and #18941 is exercised on the real node.
+		// (A buggy archive fails here; StartForkArchive brings up a fallback so the
+		// element_ids check still gets its data.)
+		if err := t.StartForkArchive(t.forkGenesisConfigPath()); err != nil {
+			return err
+		}
+		defer t.StopForkArchive()
 	}
 
 	t.Logger.Info("Phase 4: Running fork network...")
@@ -176,11 +192,12 @@ func (t *HardforkTest) Run() error {
 		return err
 	}
 
-	// Archive bug reproduction: the fork network (and its Mesa archive) is now shut
-	// down. Assert the archive is free of #18941 and the element_ids overflow; a
-	// reproduction returns a non-nil error so the test exits non-zero.
+	// Archive bug reproduction: assert the archive is free of #18941 (verdict recorded
+	// at the live archive's startup above) and the element_ids overflow (detected from
+	// the now-ingested archive log + DB). A reproduction returns a non-nil error so the
+	// test exits non-zero.
 	if t.Config.ReproArchiveBugs {
-		if err := t.AssertArchiveBugsAbsent(t.forkGenesisConfigPath()); err != nil {
+		if err := t.AssertArchiveBugsAbsent(); err != nil {
 			return err
 		}
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/vesting.go
+++ b/src/app/hardfork_test/src/internal/hardfork/vesting.go
@@ -188,6 +188,87 @@ func (t *HardforkTest) ValidateVestingAfterFork(port, hardforkSlot int) error {
 	return nil
 }
 
+// ValidateVestingInArchive asserts the ARCHIVE DB recorded the seeded vesting
+// account's ROTATED (slot-reduction-updated) timing on the fork genesis block. This
+// only happens when the post-fork archive ran add_genesis_accounts over the fork
+// genesis ledger (i.e. was started with --config-file). It complements the daemon-side
+// ValidateVestingAfterFork, which proves the live fork ledger rotated the schedule but
+// says nothing about what the archive persisted: an archive started WITHOUT the fork
+// config (add_genesis_accounts skipped) keeps only the STALE pre-fork timing and never
+// records the rotated fork-genesis schedule.
+//
+//   - bugClean: the fork-genesis timing row exists and matches ExpectedMigratedTiming.
+//   - bugReproduced: the row exists but the timing is un-rotated (e.g. stale cliff/period)
+//     — the archived fork genesis was not slot-reduction-updated.
+//   - bugInconclusive: no fork-genesis timing row for the account — add_genesis_accounts
+//     never ran over the fork genesis (e.g. a no-config / #18941-fallback archive), so
+//     the archived rotation cannot be validated. Fail-closed (never read as clean).
+//
+// The query is scoped to the FORK GENESIS block (global_slot_since_hard_fork = 0 at the
+// fork genesis slot) so it reads the add_genesis_accounts row and never the stale
+// pre-fork chain-genesis row (which lives at global_slot_since_genesis = 0).
+func (t *HardforkTest) ValidateVestingInArchive() (bugStatus, string) {
+	if !t.Config.VestingTestEnabled {
+		return bugClean, "vesting test disabled; archive vesting-rotation check skipped"
+	}
+	pk := t.Config.VestingAccountPubKey
+	if pk == "" {
+		return bugInconclusive, "no vesting account public key was recorded"
+	}
+	slot := t.expectedGenesisSlot
+	expected := ExpectedMigratedTiming(slot)
+	query := fmt.Sprintf(`select ti.initial_minimum_balance, ti.cliff_time, ti.cliff_amount, ti.vesting_period, ti.vesting_increment
+from timing_info ti
+join account_identifiers ai on ti.account_identifier_id = ai.id
+join public_keys pk on ai.public_key_id = pk.id
+join accounts_accessed aa on aa.timing_id = ti.id
+join blocks b on aa.block_id = b.id
+where pk.value = '%s' and b.global_slot_since_hard_fork = 0 and b.global_slot_since_genesis = %d
+order by b.height limit 1;`, pk, slot)
+	out, err := t.psqlQuery(query)
+	if err != nil {
+		return bugInconclusive, fmt.Sprintf("archive vesting-timing query failed: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return bugInconclusive, fmt.Sprintf(
+			"no add_genesis_accounts timing row for vesting account %s on the fork genesis block (slot %d); "+
+				"the live --config-file archive did not run add_genesis_accounts (e.g. #18941 fallback) — "+
+				"archived vesting rotation is unverifiable", pk, slot)
+	}
+	fields := strings.Split(strings.TrimSpace(out), "|")
+	if len(fields) != 5 {
+		return bugInconclusive, fmt.Sprintf("unexpected archive timing row %q for vesting account %s", out, pk)
+	}
+	parse := func(s string) int64 { n, _ := strconv.ParseInt(strings.TrimSpace(s), 10, 64); return n }
+	actual := ExpectedTiming{
+		InitialMinimumBalance: parse(fields[0]),
+		CliffTime:             parse(fields[1]),
+		CliffAmount:           parse(fields[2]),
+		VestingPeriod:         parse(fields[3]),
+		VestingIncrement:      parse(fields[4]),
+	}
+	var mismatches []string
+	checkField := func(name string, exp, act int64) {
+		if exp != act {
+			mismatches = append(mismatches, fmt.Sprintf("%s: expected %d, got %d", name, exp, act))
+		}
+	}
+	checkField("initialMinimumBalance", expected.InitialMinimumBalance, actual.InitialMinimumBalance)
+	checkField("cliffTime", expected.CliffTime, actual.CliffTime)
+	checkField("cliffAmount", expected.CliffAmount, actual.CliffAmount)
+	checkField("vestingPeriod", expected.VestingPeriod, actual.VestingPeriod)
+	checkField("vestingIncrement", expected.VestingIncrement, actual.VestingIncrement)
+	if len(mismatches) > 0 {
+		return bugReproduced, fmt.Sprintf(
+			"archive recorded an un-rotated vesting schedule for %s on the fork genesis block (hardfork_slot=%d) — "+
+				"the archived fork genesis was not slot-reduction-updated. Mismatches: %s",
+			pk, slot, strings.Join(mismatches, "; "))
+	}
+	return bugClean, fmt.Sprintf(
+		"archive recorded the rotated vesting schedule for %s on the fork genesis block (cliff_time=%d, vesting_period=%d)",
+		pk, actual.CliffTime, actual.VestingPeriod)
+}
+
 // ValidateVestingLiquidUnlock polls the injected account's liquid balance and
 // asserts it does not become fully liquid before the correct (migrated) cliff
 // slot. Under the migrate_to_mesa bug the cliff is never advanced, so the funds

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1676,7 +1676,7 @@ let mk_fee_payer ~fee ~pk ~nonce : Account_update.Fee_payer.t =
     ~body:{ public_key = pk; fee; valid_until = None; nonce }
     ~authorization:Signature.dummy
 
-let gen_max_cost_zkapp_command_from ?memo ?fee_range ?pk ?(n_updates : int = 15)
+let gen_max_cost_zkapp_command_from ?memo ?fee_range ?pk ?(n_updates : int = 1)
     ~(fee_payer_pk : Signature_lib.Public_key.Compressed.t)
     ~(account_state_tbl : (Account.t * role) Account_id.Table.t) ~vk
     ~(genesis_constants : Genesis_constants.t) () =
@@ -1708,20 +1708,29 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range ?pk ?(n_updates : int = 15)
   let[@warning "-8"] (head :: tail) =
     List.map pks ~f:(fun pk -> mk_account_update ~pk ~vk)
   in
-  let events =
-    List.init genesis_constants.max_event_elements ~f:(fun i ->
-        [| Snark_params.Tick.Field.of_int i |] )
-  in
-  let actions =
-    List.init genesis_constants.max_action_elements ~f:(fun i ->
-        [| Snark_params.Tick.Field.of_int i |] )
-  in
-  let account_updates =
-    { head with body = { head.body with events; actions } } :: tail
-  in
   let fee_payer_id = Account_id.create fee_payer_pk Token_id.default in
   let fee_payer_account, _ =
     Account_id.Table.find_exn account_state_tbl fee_payer_id
+  in
+  (* Keep events and actions maxed out (max_event_elements / max_action_elements
+     total field elements), but alternate their on-wire encoding per generated
+     transaction so both valid shapes are exercised across a load run. The
+     fee-payer nonce increments once per generated command (see the
+     [Account_id.Table.change] below), giving a deterministic A/B/A/B alternation
+     applied to both events and actions.
+       Shape A: a list of N single-element field arrays      [ [|f0|]; [|f1|]; ... ]
+       Shape B: a singleton list of one N-element field array [ [|f0; f1; ...; f_{N-1}|] ]
+     Both encode N field elements and pass [Zkapp_command.valid_size]. *)
+  let use_shape_b = Account.Nonce.to_int fee_payer_account.nonce mod 2 = 1 in
+  let mk_maxed n =
+    if use_shape_b then
+      [ Array.init n ~f:(fun i -> Snark_params.Tick.Field.of_int i) ]
+    else List.init n ~f:(fun i -> [| Snark_params.Tick.Field.of_int i |])
+  in
+  let events = mk_maxed genesis_constants.max_event_elements in
+  let actions = mk_maxed genesis_constants.max_action_elements in
+  let account_updates =
+    { head with body = { head.body with events; actions } } :: tail
   in
   let%map fee =
     Option.value_map fee_range
@@ -1926,8 +1935,14 @@ let%test_module _ =
       let events = first_update.body.events in
       let actions = first_update.body.actions in
 
-      assert (List.length events = genesis_constants.max_event_elements) ;
-      assert (List.length actions = genesis_constants.max_action_elements) ;
+      (* events/actions may be encoded as either Shape A (a list of single-element
+         arrays) or Shape B (a singleton list of one all-elements array); assert
+         on the total number of field elements, which is shape-independent. *)
+      let total_elements l =
+        List.fold l ~init:0 ~f:(fun acc arr -> acc + Array.length arr)
+      in
+      assert (total_elements events = genesis_constants.max_event_elements) ;
+      assert (total_elements actions = genesis_constants.max_action_elements) ;
       let _ =
         Zkapp_command.Call_forest.mapi_with_trees command.account_updates
           ~f:(fun _ndx acc tree ->


### PR DESCRIPTION
## Summary

Adds an integrated **archive-bug reproduction** to `hardfork_test`: a `--repro-archive-bugs` mode that drives real ITN transaction load across a hardfork with a live archive node and asserts the migrated Mesa archive is free of two known bugs — exiting **non-zero** against the buggy archive binary + migration and **zero** against the fixed ones (a fixed-vs-buggy A/B control that varies only the post-fork artifacts).

- **#18941 `tokens_value_key`** — a pre-fork custom-token ITN load mints an OWNED token; after the fork the probe runs the Mesa archive over the fork genesis config, exercising `add_genesis_accounts` → `tokens_value_key UNIQUE(value)` (collision on the buggy processor, clean on the fixed one).
- **`element_ids` btree overflow** — a post-fork max-cost zkApp load makes the Mesa archive ingest a Shape-B 1024-element field array; the buggy migration keeps the `element_ids` UNIQUE btree (index row 4128 > 2704 max → overflow), the fixed one drops it.

Detection is fail-closed three-state (reproduced / clean / inconclusive): the run passes only when **both** bugs are definitively absent; an indeterminate check fails closed rather than masquerading as fixed.

Also included:
- **In-process Go ITN client** (`internal/hardfork/itn_client.go`) — ITN auth and the sequenced-mutation protocol are signed in-process with `crypto/ed25519` (pure Ed25519 over the exact transmitted body, matching the node's `graphql_internal` verifier). No external signing/keygen subprocesses; the keypair is generated in-process and the private key stays in memory, so the main-network root wipe can't strand the driver.
- **Archive node + ITN-driven load orchestration** — enable a live archive node per phase with the protocol-appropriate binary, and drive the load over ITN.
- **Live post-fork archive startup** exercise of #18941 and archived **vesting-rotation** validation on the fork genesis.
- `mina_generators`: alternate max-cost zkApp events/actions encoding.

### Pre-fork network now defaults to ITN sending

Both networks now default to **no** built-in `--value-transfer-txns` load. The pre-fork (main) network previously drove payments through mina-local-network's per-payment `mina client send-payment` subprocess loop, which churns PIDs against the cgroup limit. The load is now driven in-process over ITN (same mechanism already used for the post-fork max-cost load), consistent across both phases. The old subprocess loop remains available per phase via `HARDFORK_VALUE_TRANSFERS_MAIN` / `HARDFORK_VALUE_TRANSFERS_FORK`.

## Base branch / dependencies

> ⚠️ **This PR targets `georgeee/hardfork-archive-bug-repro-base`, not `release/mesa`.**

The base branch holds work that is already up for review in the stacked chain below; it is not new to this PR. Every commit in the base branch is covered by:

- #18937 — hardfork_test: end-to-end vesting slot-reduction test (→ `release/mesa`)
- #18938 — mina-local-network: single-node max-cost zkApp load network (→ #18937)
- #18940 — mina-local-network: no-proofs preset, configurable epoch, payments load (→ #18938)

Related (provides the archive fix this repro asserts):
- #18990 — archive: fix `element_ids` btree overflow for max-cost zkApps (→ `release/mesa`)

**TODO before merge:** once #18937 / #18938 / #18940 land in `release/mesa`, retarget this PR's base from `georgeee/hardfork-archive-bug-repro-base` to `release/mesa` (or `develop`), then delete the throwaway base branch. Only the six commits on top of the base branch are the actual contribution of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVrrrCWsh6chb5H9m4pXo2
