### PR TITLE
Fix double arm64 suffix on Docker tags breaking self-verify

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -159,6 +159,34 @@ let generateStep =
                   { Arm64 = " --custom-suffix arm64 ", Amd64 = "" }
                   spec.arch
 
+          -- Only Daemon/Rosetta ("*-config" images) need an arch marker
+          -- baked into the *custom* suffix build-arg on top of --platform.
+          -- Every other service already gets its arch suffix for free from
+          -- --platform (scripts/docker/helper.sh get_platform_suffix), which
+          -- is also the only arch suffix manager.sh verify's tag ever
+          -- expects (buildkite/scripts/release/manager.sh get_arch_suffix) -
+          -- so applying archCustomSuffix unconditionally double-suffixes
+          -- (e.g. mina-archive:...-arm64-arm64) and self-verify 404s.
+          let customSuffix =
+                merge
+                  { DaemonGeneric = ""
+                  , DaemonProfiled = \(args : { profile : Profiles.Type }) -> ""
+                  , Daemon =
+                      \(args : { network : Network.Type }) -> archCustomSuffix
+                  , DaemonLegacyHardfork =
+                      \(args : { network : Network.Type }) -> ""
+                  , DaemonAutoHardfork =
+                      \(args : { network : Network.Type }) -> ""
+                  , Archive = \(args : { network : Network.Type }) -> ""
+                  , RosettaGeneric = ""
+                  , Rosetta =
+                      \(args : { network : Network.Type }) -> archCustomSuffix
+                  , TxTools = ""
+                  , DelegationVerifier = ""
+                  , Toolchain = ""
+                  }
+                  spec.service
+
           let storageRepairVersionSuffix =
                 merge
                   { None = ""
@@ -236,7 +264,7 @@ let generateStep =
                 ++  " --platform ${Arch.platform spec.arch}"
                 ++  " --docker-registry ${DockerRepo.show spec.docker_repo}"
                 ++  loadOnlyArg
-                ++  archCustomSuffix
+                ++  customSuffix
                 ++  imageNameArg
                 ++  maybeSaveToCacheArg
 

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -159,15 +159,12 @@ let generateStep =
                   { Arm64 = " --custom-suffix arm64 ", Amd64 = "" }
                   spec.arch
 
-          -- Only Daemon/Rosetta ("*-config" images) need an arch marker
-          -- baked into the *custom* suffix build-arg on top of --platform.
-          -- Every other service already gets its arch suffix for free from
-          -- --platform (scripts/docker/helper.sh get_platform_suffix), which
-          -- is also the only arch suffix manager.sh verify's tag ever
-          -- expects (buildkite/scripts/release/manager.sh get_arch_suffix) -
-          -- so applying archCustomSuffix unconditionally double-suffixes
-          -- (e.g. mina-archive:...-arm64-arm64) and self-verify 404s.
           let customSuffix =
+              -- Only Daemon/Rosetta ("*-config" images) need an arch marker
+              -- baked into the custom suffix build-arg on top of --platform;
+              -- --platform alone already derives -arm64 for everyone else
+              -- (scripts/docker/helper.sh get_platform_suffix), which is the
+              -- only arch suffix manager.sh verify's tag ever expects.
                 merge
                   { DaemonGeneric = ""
                   , DaemonProfiled = \(args : { profile : Profiles.Type }) -> ""


### PR DESCRIPTION
## Root cause: 5947086ccd8d1f0d8d0af09602ebca1c13406c30

**["Model Buildkite release artifacts by package dimensions"](https://github.com/MinaProtocol/mina/commit/5947086ccd8d1f0d8d0af09602ebca1c13406c30) (2026-06-23) is the commit that broke this.** As part of a large Dhall refactor (`Artifacts.dhall` → namespaced `Artifact`/`Debian`/`Docker` modules), it deleted `DockerImage.dhall`'s per-service `customSuffix` allowlist and replaced it with an unconditional `archCustomSuffix`:

```diff
-          let customSuffix =
-                merge
-                  { DaemonConfig = archCustomSuffix
-                  , Archive = ""
-                  , RosettaConfig = archCustomSuffix
-                  , ... (every other service = "")
-                  }
-                  spec.service
 ...
-                ++  customSuffix
+                ++  archCustomSuffix
```

Before that commit, only `DaemonConfig`/`RosettaConfig` got `--custom-suffix arm64` passed to `build.sh`; every other service (`Archive`, `TxTools`, `DelegationVerifier`, `Toolchain`, the generic/hardfork `Daemon*` variants, `RosettaGeneric`) got `""`. After it, **every** service gets `--custom-suffix arm64` unconditionally on arm64 builds.

`--platform linux/arm64` already independently derives `-arm64` on its own (`scripts/docker/helper.sh`'s `get_platform_suffix`), and that's the *only* arch suffix `buildkite/scripts/release/manager.sh verify`'s tag formula (`get_arch_suffix`) ever expects. So since 5947086ccd, every non-Daemon/Rosetta arm64 docker build+push has landed under a double-suffixed tag (e.g. `mina-archive:...-bookworm-devnet-arm64-arm64`) that the self-verify step immediately after never looks for — it 404s even though the build+push succeeded.

Confirmed in production: `mina-mainline-branches-nightlies` build 1489 (`docker-archive-devnet-bookworm-devnet-arm64`) failed this way on 2026-07-02; the same run shows the identical failure for `mina-rosetta` and generic `mina-daemon` arm64 builds too — all three are services this commit accidentally moved out of the `""` bucket.

## Fix

Restore the per-service split, ported to the `Docker.Type` ADT this commit introduced (a payload-carrying union, not the old flat enum — which is presumably why the table got dropped rather than translated). The `DaemonConfig`→`Daemon` / `RosettaConfig`→`Rosetta` mapping is confirmed by two independent signals in the codebase: this same commit's `ReleaseSpec.default` directly renames `Artifacts.Type.DaemonConfig` to `Docker.Type.Daemon { network = ... }`, and `Docker.lowerName` maps `Daemon`/`Rosetta` to `"daemon_config"`/`"rosetta_config"` — an unambiguous naming echo of the old variants.

Explain your changes:
* Reintroduce a per-service `customSuffix` in `buildkite/src/Command/DockerImage.dhall` (only `Daemon`/`Rosetta` get `archCustomSuffix`, everything else `""`), and use it in place of the unconditional `archCustomSuffix` in the final `build.sh` command assembly.

Explain how you tested your changes:
* `dhall --file` (syntax + type-check) passes.
* Evaluated `generateStep` directly for the exact failing scenario (`Archive`, `Devnet`, `Bookworm`, `Arm64`) — confirmed the generated `build.sh` command no longer contains `--custom-suffix arm64`.
* Evaluated the same for `Daemon`/`Arm64` — confirmed `--custom-suffix arm64` is still present, so the one case that legitimately needs it is unaffected.
* Change is isolated to `buildkite/src/Command/DockerImage.dhall`: 29 insertions / 1 deletion.

Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it — inline comment explains why Daemon/Rosetta differ from every other service
- [ ] Tests were added for the new behavior — no dhall test harness exists for this file; verified via direct `generateStep` evaluation (see above)
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules — n/a, CI pipeline-generation only
- [ ] Does this close issues? List them

* No tracked issue — found via CI-log/git-archaeology investigation of build 1489's arm64 verify failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)