### PR TITLE
archive: drop element_ids UNIQUE/index (btree overflow) from compatible schema

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -128,12 +128,13 @@ CREATE TABLE zkapp_field
    The elements of the array are NOT NULL (not enforced by Postgresql)
 
 */
+/* No UNIQUE/index on element_ids: a btree key over the unbounded int[] overflows
+   Postgres' 2704-byte limit for max-cost zkApps. Rows are not content-deduplicated;
+   identical arrays simply yield distinct rows. */
 CREATE TABLE zkapp_field_array
 ( id                       serial  PRIMARY KEY
-, element_ids              int[]   NOT NULL UNIQUE
+, element_ids              int[]   NOT NULL
 );
-
-CREATE INDEX idx_zkapp_field_array_element_ids ON zkapp_field_array(element_ids);
 
 /* Fixed-width arrays of algebraic fields, given as id's from
    zkapp_field
@@ -178,12 +179,11 @@ CREATE TABLE zkapp_action_states
 /* the element_ids are non-NULL, and refer to zkapp_field_array
    they represent a list of arrays of field elements
 */
+/* No UNIQUE/index on element_ids (see zkapp_field_array): not content-deduplicated. */
 CREATE TABLE zkapp_events
 ( id                       serial           PRIMARY KEY
-, element_ids              int[]            NOT NULL UNIQUE
+, element_ids              int[]            NOT NULL
 );
-
-CREATE INDEX idx_zkapp_events_element_ids ON zkapp_events(element_ids);
 
 /* field elements derived from verification keys */
 CREATE TABLE zkapp_verification_key_hashes


### PR DESCRIPTION
## Motivation

The **Archive: Schema upgrade verification** nightly job (`verify-schema-upgrade.sh --source-branch compatible --target-branch develop`) is red on the downgrade round-trip check:

```
FAIL: Schema mismatch between downgrade path and fresh source schema
  Left:  compatible's create_schema.sql applied directly
  Right: compatible's create_schema.sql + upgrade + downgrade
```

`compatible`'s `create_schema.sql` still declares `element_ids int[] NOT NULL UNIQUE` (plus a btree index) on `zkapp_events` and `zkapp_field_array`. `develop`/`mesa` already **removed** these: a btree key over the unbounded `element_ids` array overflows Postgres' 2704-byte page limit for max-cost zkApps. `upgrade_to_mesa.sql` drops them (`DROP ... IF EXISTS`), and `downgrade_to_berkeley.sql` intentionally does **not** restore them (post-fix data has duplicate `element_ids`, so `ADD UNIQUE` would fail). The round-trip is therefore lossy and can never reproduce compatible's constrained schema.

## Change

Backport the removal to `compatible`'s `create_schema.sql` — drop `UNIQUE` on the two `element_ids` columns and delete the two `CREATE INDEX` lines. The blocks now match `develop` verbatim.

Effect:
- `compatible-fresh == compatible + upgrade + downgrade` → round-trip check passes
- `compatible + upgrade == develop` still passes (upgrade already `DROP ... IF EXISTS`, now a clean no-op)
- flows into `develop` through the normal `compatible → develop` merge; no develop-side change needed

This also removes the latent btree-overflow bug on `compatible` itself. Relaxing a `UNIQUE` only affects freshly created DBs, so it is backward-compatible; existing archive DBs are unaffected.

## Note

Unrelated to the mesa-network removal PR (#19010) — that touches no schema/SQL. This is the correct home for the schema-upgrade nightly fix.