### PR TITLE
docker: drop mina-daemon-recovery-storage-toolbox from daemon image

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -54,7 +54,6 @@ let ReleaseSpec =
           , deb_version : Text
           , deb_root_folder : Text
           , deb_legacy_version : Text
-          , deb_storage_repair_version : Optional Text
           , deb_suffix : Optional Text
           , deb_profile : Profiles.Type
           , deb_repo : DebianRepo.Type
@@ -83,7 +82,6 @@ let ReleaseSpec =
           , deb_release = "unstable"
           , deb_version = "\\\${MINA_DEB_VERSION}"
           , deb_legacy_version = "3.1.1-alpha1-compatible-14a8b92"
-          , deb_storage_repair_version = None Text
           , deb_profile = Profiles.Type.Devnet
           , build_flags = BuildFlags.Type.None
           , deb_repo = DebianRepo.Type.Local
@@ -184,13 +182,6 @@ let generateStep =
                   }
                   spec.service
 
-          let storageRepairVersionSuffix =
-                merge
-                  { None = ""
-                  , Some = \(v : Text) -> " --deb-storage-repair-version ${v} "
-                  }
-                  spec.deb_storage_repair_version
-
           let maybeVerify =
                       if     spec.verify
                          &&  DockerPublish.shouldPublish
@@ -256,7 +247,6 @@ let generateStep =
                                             spec.build_flags}"
                 ++  " --deb-legacy-version ${spec.deb_legacy_version}"
                 ++  debSuffix
-                ++  storageRepairVersionSuffix
                 ++  " --repo ${spec.repo}"
                 ++  " --platform ${Arch.platform spec.arch}"
                 ++  " --docker-registry ${DockerRepo.show spec.docker_repo}"

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -67,7 +67,6 @@ let MinaBuildSpec =
           , buildScript : Text
           , arch : Arch.Type
           , deb_legacy_version : Text
-          , deb_storage_repair_version : Text
           , docker_publish : DockerPublish.Type
           , suffix : Optional Text
           , if_ : Optional B/If
@@ -88,7 +87,6 @@ let MinaBuildSpec =
           , extraBuildEnvs = [] : List Text
           , suffix = None Text
           , deb_legacy_version = "3.4.0-alpha1-compatible-ad13ff4"
-          , deb_storage_repair_version = "3.3.0-master-35445f7"
           , arch = Arch.Type.Amd64
           , docker_publish = DockerPublish.Type.Essential
           , if_ = None B/If
@@ -332,8 +330,6 @@ let docker_step
                     , docker_publish = spec.docker_publish
                     , deb_repo = DebianRepo.Type.Local
                     , deb_legacy_version = spec.deb_legacy_version
-                    , deb_storage_repair_version = Some
-                        spec.deb_storage_repair_version
                     , generic = True
                     , verify = True
                     , arch = spec.arch

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -62,7 +62,6 @@ let Spec =
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
-          , deb_storage_repair_version : Text
           }
       , default =
           { codenames =
@@ -81,8 +80,6 @@ let Spec =
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
-          , deb_storage_repair_version =
-              defaultMinaArtifactSpec.deb_storage_repair_version
           }
       }
 
@@ -300,8 +297,6 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
-                      , deb_storage_repair_version = Some
-                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , generic = True
@@ -332,8 +327,6 @@ let generateDockerForCodename =
                       , deb_codename = codename.DebVersion
                       , deb_profile = profile
                       , deb_legacy_version = spec.deb_legacy_version
-                      , deb_storage_repair_version = Some
-                          spec.deb_storage_repair_version
                       , size = spec.size
                       , deb_version = spec.version
                       , step_key_suffix =

--- a/changes/19014.md
+++ b/changes/19014.md
@@ -1,0 +1,6 @@
+### Changed
+
+- The `mina-daemon` docker image no longer bundles `mina-daemon-recovery-storage-toolbox`.
+  - This was a legacy artifact (pinned to `3.3.0-master-35445f7`) that is never built from the tree and was pulled from the `legacy/debians/<codename>` CI cache, tying the daemon image build to internal infra and blocking local builds.
+  - Removed the now-dead `deb_storage_repair_version` plumbing from `scripts/docker/build.sh` (the `--deb-storage-repair-version` flag) and from the buildkite dhall (`DockerImage.dhall`, `MinaArtifact.dhall`, `GenerateHardforkPackage.dhall`).
+  - The legacy recovery toolbox is still installed at runtime by `connect-to-network.sh` for the hardfork storage downgrade/recovery test; that path is unchanged.

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -12,7 +12,6 @@ ARG deb_repo="http://packages.o1test.net"
 ARG deb_profile
 ARG deb_suffix
 ARG deb_legacy_version
-ARG deb_storage_repair_version
 ARG apt_cache_url=""
 
 ARG GCLOUD_VERSION=476.0.0
@@ -34,9 +33,6 @@ ENV MINA_CREATE_GENESIS_DEB=mina-create-${network}-prefork-genesis-ledger
 
 # Storage toolbox for fixing daemon storage
 ENV MINA_STORAGE_DEB=mina-daemon-storage-toolbox
-
-# Storage recovery toolbox for fixing daemon storage
-ENV MINA_STORAGE_REPAIR_DEB=mina-daemon-recovery-storage-toolbox
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -109,8 +105,8 @@ ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 # to its concrete .deb file and installs them with a single apt-get call (no apt
 # repo / no apt index). Since there is no repo to resolve the mina dependency
 # closure, every mina dependency is requested explicitly here: mina-logproc is a
-# dependency of the daemon (and of the storage / create-genesis / recovery
-# toolboxes) and must be present as a local file too. The network config package
+# dependency of the daemon (and of the storage / create-genesis toolboxes) and
+# must be present as a local file too. The network config package
 # (mina-${network}-config) is intentionally NOT installed here -- see the note on
 # the install RUN below.
 COPY scripts/install-mina-debs.sh /usr/local/bin/install-mina-debs.sh
@@ -130,7 +126,6 @@ RUN echo "Building image with version $deb_version from repo $deb_release $deb_c
        "mina-logproc=$deb_version" \
        "${MINA_STORAGE_DEB}=${deb_version}" \
        "${MINA_CREATE_GENESIS_DEB}=${deb_legacy_version}" \
-       "${MINA_STORAGE_REPAIR_DEB}=${deb_storage_repair_version}" \
      ) \
   && /usr/local/bin/install-mina-debs.sh "${mina_debs[@]}"
 

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -79,7 +79,6 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --deb-release) INPUT_RELEASE="$2"; shift;;
   --deb-version) DEB_VERSION="$2"; shift;;
   --deb-legacy-version) INPUT_LEGACY_VERSION="$2"; shift;;
-  --deb-storage-repair-version) INPUT_STORAGE_REPAIR_VERSION="$2"; shift;;
   --deb-profile) DEB_PROFILE="$2"; shift;;
   --deb-repo) INPUT_REPO="$2"; shift;;
   --deb-arch) DEB_ARCH="$2"; shift;;
@@ -118,13 +117,6 @@ if [[ -z "${INPUT_BRANCH:-}" ]]; then
   BRANCH="--build-arg MINA_BRANCH=compatible"
 else
   BRANCH="--build-arg MINA_BRANCH=$INPUT_BRANCH"
-fi
-
-if [[ -z "${INPUT_STORAGE_REPAIR_VERSION:-}" ]]; then
-  echo "Debian storage repair version is not set. Using the default (unset)"
-  DEB_STORAGE_REPAIR_VERSION=""
-else
-  DEB_STORAGE_REPAIR_VERSION="--build-arg deb_storage_repair_version=$INPUT_STORAGE_REPAIR_VERSION"
 fi
 
 if [[ -z "${MINA_REPO:-}" ]]; then
@@ -382,7 +374,7 @@ fi
 
 BUILD_NETWORK="--allow=network.host"
 
-docker buildx build --load --network=host --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION --build-arg deb_profile="$DEB_PROFILE" --build-arg generic_network="$GENERIC_NETWORK_SEG" $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $DEB_STORAGE_REPAIR_VERSION $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
+docker buildx build --load --network=host --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION --build-arg deb_profile="$DEB_PROFILE" --build-arg generic_network="$GENERIC_NETWORK_SEG" $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
 
 if [[ -n "${SAVE_TO_CI_CACHE_ROOT:-}" ]]; then
 


### PR DESCRIPTION
## Summary

The `mina-daemon-recovery-storage-toolbox` package (an old rocksdb scanner, pinned to `3.3.0-master-35445f7`) is a **legacy artifact** — no function in `builder-helpers.sh` produces it from the current tree. The daemon docker build installed it unconditionally, sourcing the `.deb` from the `legacy/debians/<codename>` CI cache (`read_all_from_cache.sh`).

This tied the daemon image build to internal infra and made it impossible to build the daemon image locally without pulling the legacy cache. Since the recovery toolbox is only needed for the 3.4.0 hardfork storage-migration path, drop it from the daemon image entirely.

## Changes

- `dockerfiles/Dockerfile-mina-daemon`: remove the `MINA_STORAGE_REPAIR_DEB` ENV, the `deb_storage_repair_version` ARG, and the recovery-toolbox install entry.
- `scripts/docker/build.sh`: remove the now-dead `--deb-storage-repair-version` flag and its build-arg plumbing.
- `buildkite/src/Command/DockerImage.dhall`, `buildkite/src/Command/MinaArtifact.dhall` (dropped the pinned `3.3.0-master-35445f7`), `buildkite/src/Entrypoints/GenerateHardforkPackage.dhall`: remove the `deb_storage_repair_version` field and all pass-throughs.

## Out of scope

`buildkite/scripts/connect/connect-to-network.sh` still installs the legacy recovery toolbox at **runtime** — that step *is* the storage downgrade/recovery test across the hardfork, not a docker-build dependency, so it is intentionally left untouched.

## Verification

- `make all` in `buildkite/` passes (37/37); all three edited dhall files `dhall type` clean.
- `shellcheck` clean on `scripts/docker/build.sh`.
- Repo-wide grep confirms no remaining references to the flag/field/package outside the intentionally-kept connect test.