### PR TITLE
ci: ArchiveHardforkToolboxTest consumes app binaries from app-build job

### DIFF
--- a/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveHardforkToolboxTest.dhall
@@ -21,7 +21,7 @@ let Size = ../../Command/Size.dhall
 let RunWithPostgres = ../../Command/RunWithPostgres.dhall
 
 let dependsOn =
-      DebianVersions.dependsOn
+      DebianVersions.appDependsOn
         DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 let key = "archive-hardfork-toolbox-test"


### PR DESCRIPTION
Stacked on #19015. Repoints `ArchiveHardforkToolboxTest` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)