### PR TITLE
ci: RosettaIntegrationTests consumes app binaries from app-build job

### DIFF
--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -77,7 +77,7 @@ in  Pipeline.build
             , target = Size.Small
             , artifact_paths = [ S.contains "test_output/artifacts/*" ]
             , depends_on =
-                DebianVersions.dependsOn
+                DebianVersions.appDependsOn
                   DebianVersions.DepsSpec::{
                   , network = network
                   , profile = Profiles.Type.Devnet


### PR DESCRIPTION
Stacked on #19015. Repoints `RosettaIntegrationTests` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)