### PR TITLE
ci: PatchArchiveTest consumes app binaries from app-build job

### DIFF
--- a/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
+++ b/buildkite/src/Jobs/Test/PatchArchiveTest.dhall
@@ -13,7 +13,7 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 let BuildFlags = ../../Constants/BuildFlags.dhall
 
 let dependsOn =
-      DebianVersions.dependsOn
+      DebianVersions.appDependsOn
         DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 in  Pipeline.build


### PR DESCRIPTION
Stacked on #19015. Repoints `PatchArchiveTest` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)