### PR TITLE
ci: SingleNodeTest consumes app binaries from app-build job

### DIFF
--- a/buildkite/scripts/single-node-tests.sh
+++ b/buildkite/scripts/single-node-tests.sh
@@ -9,14 +9,17 @@ source buildkite/scripts/export-git-env-vars.sh
 # mina-command-line-tests spins up a real lightnet daemon but generates its own
 # random genesis/config, so it needs no deb config -- only binaries. Restore them
 # bare from the apps cache, each from the build variant that produced it:
-#   - mina (lightnet daemon) + libp2p_helper  <- the lightnet build (devnet-lightnet)
+#   - mina (daemon) + libp2p_helper  <- the generic devnet build (devnet-devnet).
+#     The apps build only compiles one profile; the lightnet behaviour is selected
+#     at runtime via MINA_PROFILE=lightnet (set below), which node_config_profiled
+#     resolves at startup -- there is no separate lightnet binary in the cache.
 #   - mina-command-line-tests (the driver) + mina-node-status-mock-server (a
 #     subprocess the suite spawns)  <- the instrumented build's test-suite
 #     (devnet-devnet-instrumented), so bisect_ppx coverage still works.
 # The daemon finds the helper as coda-libp2p_helper on PATH, exactly like the deb.
 # Fall back to the debs on any cache miss (e.g. outside Buildkite).
-if APPS_PROFILE=lightnet ./buildkite/scripts/apps/restore_binary.sh devnet \
-  && APPS_PROFILE=lightnet ./buildkite/scripts/apps/restore_app.sh devnet libp2p_helper coda-libp2p_helper \
+if ./buildkite/scripts/apps/restore_binary.sh devnet \
+  && ./buildkite/scripts/apps/restore_app.sh devnet libp2p_helper coda-libp2p_helper \
   && APPS_PROFILE=devnet APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh devnet command_line_tests.exe mina-command-line-tests \
   && APPS_PROFILE=devnet APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh devnet node_status_mock_server.exe mina-node-status-mock-server; then
   echo "Using bare mina + libp2p_helper + mina-command-line-tests + mina-node-status-mock-server from apps cache"

--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -14,15 +14,12 @@ let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let BuildFlags = ../../Constants/BuildFlags.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
-
 let Docker = ../../Command/Docker/Type.dhall
 
 let Size = ../../Command/Size.dhall
 
 let dependsOn =
-        DebianVersions.appDependsOn
-          DebianVersions.DepsSpec::{ profile = Profiles.Type.Lightnet }
+        DebianVersions.appDependsOn DebianVersions.DepsSpec::{=}
       # DebianVersions.appDependsOn
           DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 

--- a/buildkite/src/Jobs/Test/SingleNodeTest.dhall
+++ b/buildkite/src/Jobs/Test/SingleNodeTest.dhall
@@ -21,9 +21,9 @@ let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
 let dependsOn =
-        DebianVersions.dependsOn
+        DebianVersions.appDependsOn
           DebianVersions.DepsSpec::{ profile = Profiles.Type.Lightnet }
-      # DebianVersions.dependsOn
+      # DebianVersions.appDependsOn
           DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 let buildTestCmd


### PR DESCRIPTION
Stacked on #19015. Repoints `SingleNodeTest` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)