### PR TITLE
ci: CheckGraphQLSchema consumes app binaries from app-build job

### DIFF
--- a/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
+++ b/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
@@ -10,7 +10,7 @@ let CheckGraphQLSchema = ../../Command/CheckGraphQLSchema.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let dependsOn = DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+let dependsOn = DebianVersions.appDependsOn DebianVersions.DepsSpec::{=}
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
Stacked on #19015. Repoints `CheckGraphQLSchema` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)