### PR TITLE
ci: BenchBase consumes app binaries from app-build job

### DIFF
--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -57,11 +57,17 @@ case "$BENCHMARK" in
   heap-usage)    BARE_EXE=heap_usage.exe;              BARE_AS=mina-heap-usage ;;
   zkapp)         BARE_EXE=zkapp_limits.exe;            BARE_AS=mina-zkapp-limits ;;
   ledger-export) BARE_EXE=ledger_export_benchmark.exe; BARE_AS=mina-ledger-export-benchmark ;;
-  snark)         BARE_EXE=mina_testnet_signatures.exe; BARE_AS=mina ;;
+  snark)         BARE_EXE=mina.exe;                    BARE_AS=mina ;;
   archive)       BARE_NONE=true ;;
   ledger-apply)  BARE_NONE=true ;;
   *)             BARE_EXE="" ;;
 esac
+
+# The daemon binary resolves its node profile from MINA_PROFILE, defaulting to
+# "dev" (ledger_depth 10) when unset. Benches run against devnet-sized data, so
+# pin the profile to devnet (ledger_depth 35) -- the .deb path gets this from
+# /etc/coda/build_config/PROFILE, the bare-cache binary needs it set explicitly.
+export MINA_PROFILE=devnet
 
 INSTALLED_BARE=false
 if [[ "$BARE_NONE" == true ]]; then

--- a/buildkite/src/Command/Bench/Base.dhall
+++ b/buildkite/src/Command/Bench/Base.dhall
@@ -10,8 +10,6 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let BuildFlags = ../../Constants/BuildFlags.dhall
-
 let RunInToolchain = ../../Command/RunInToolchain.dhall
 
 let Command = ../../Command/Base.dhall
@@ -25,8 +23,6 @@ let Size = ../Size.dhall
 let Benchmarks = ../../Constants/Benchmarks.dhall
 
 let SelectFiles = ../../Lib/SelectFiles.dhall
-
-let Network = ../../Constants/Network.dhall
 
 let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
@@ -48,13 +44,7 @@ let Spec =
           }
       , default =
           { size = Size.Perf
-          , dependsOn =
-                DebianVersions.dependsOn
-                  DebianVersions.DepsSpec::{
-                  , build_flag = BuildFlags.Type.Instrumented
-                  }
-              # DebianVersions.dependsOn
-                  DebianVersions.DepsSpec::{ network = Network.Type.Devnet }
+          , dependsOn = DebianVersions.appDependsOn DebianVersions.DepsSpec::{=}
           , additionalDirtyWhen = [] : List SelectFiles.Type
           , yellowThreshold = 0.1
           , redThreshold = 0.2


### PR DESCRIPTION
Stacked on #19015. Repoints `BenchBase` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)