### PR TITLE
ci: BenchLedgerApply consumes app binaries from app-build job

### DIFF
--- a/buildkite/scripts/tests/ledger_test_apply.sh
+++ b/buildkite/scripts/tests/ledger_test_apply.sh
@@ -17,6 +17,13 @@ source buildkite/scripts/export-git-env-vars.sh
 # either is unavailable.
 export APPS_BUILD_FLAG=instrumented
 
+# The bare cache binary (and the network-free mina-generic-instrumented fallback)
+# resolve the node profile from MINA_PROFILE, defaulting to "dev" (ledger_depth
+# 10) when unset -- too small for the 20k-account test ledger. The .deb daemon
+# gets this from /etc/coda/build_config/PROFILE; set it explicitly here so
+# mina-create-genesis uses the devnet constants (ledger_depth 35).
+export MINA_PROFILE=devnet
+
 if ./buildkite/scripts/apps/restore_binary.sh devnet \
   && ./buildkite/scripts/apps/restore_app.sh devnet runtime_genesis_ledger.exe mina-create-genesis; then
   echo "Using bare mina + mina-create-genesis from apps cache"

--- a/buildkite/src/Command/Bench/LedgerApply.dhall
+++ b/buildkite/src/Command/Bench/LedgerApply.dhall
@@ -19,7 +19,7 @@ let Spec =
       }
 
 let dependsOn =
-      DebianVersions.dependsOn
+      DebianVersions.appDependsOn
         DebianVersions.DepsSpec::{ build_flag = BuildFlags.Type.Instrumented }
 
 let pipeline


### PR DESCRIPTION
Stacked on #19015. Repoints `BenchLedgerApply` from the debian package (`build-deb-pkg`) to the app-build job's `build-apps` step via `DebianVersions.appDependsOn`; the test's runner already restores bare binaries from the apps cache. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)