### PR TITLE
ci: ChainIdTestDevnet consumes app binaries from app-build job

### DIFF
--- a/buildkite/src/Jobs/Test/ChainIdTestDevnet.dhall
+++ b/buildkite/src/Jobs/Test/ChainIdTestDevnet.dhall
@@ -1,8 +1,6 @@
-let Dockers = ../../Constants/Docker/Versions.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
 
 let ChainIdTest = ../../Command/ChainIdTest.dhall
 
@@ -12,9 +10,7 @@ let scopes = [ PipelineScope.Type.PullRequest ]
 
 let network = Network.Type.Devnet
 
-let deps =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Devnet }
+let deps = DebianVersions.appDependsOn DebianVersions.DepsSpec::{=}
 
 let expectedChainId =
       "8c6312664c60ecc4c0c695e69f6301692c0b20f354b55e08e69a289f3d373e50"


### PR DESCRIPTION
Stacked on #19015. Repoints `ChainIdTestDevnet` from a per-network docker image to the app-build job's `build-apps` step (`DebianVersions.appDependsOn`). `test-chain-id.sh` already restores the daemon binary and its packaged genesis config from the apps cache, so no docker image is needed. Part of the per-test migration so packages can be skipped on source PRs in the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)