### PR TITLE
fix hf test on master

### DIFF
--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -52,6 +52,8 @@ if [[ -z "$PREFORK" ]]; then
   usage "Error: --fork-from must be provided."
 fi
 
+export MINA_PROFILE="devnet"
+
 NIX_OPTS=( --accept-flake-config --experimental-features 'nix-command flakes' )
 
 if [[ -n "${NIX_CACHE_NAR_SECRET:-}" ]]; then


### PR DESCRIPTION
We've refactor mina to dispatch profile on runtime in `develop`. this affects master/compatible HF test because those depends on develop artifacts.

Need to port to compatible later.