### PR TITLE
ci: monorepo triage pulls in transitive job dependencies

### DIFF
--- a/buildkite/scripts/monorepo.sh
+++ b/buildkite/scripts/monorepo.sh
@@ -167,7 +167,12 @@ else
   closest_ancestor=$(find_closest_ancestor)
 fi
 
-find "$JOBS" -type f -name "*.yml" | while read -r file; do
+# Phase 1: triage. Collect every job that passes tags, scope, dirty-when and
+# include/exclude filters into the SELECTED_FILES set. Nothing is uploaded yet:
+# their dependencies must be pulled in first (Phase 2).
+declare -A SELECTED_FILES=()
+
+while IFS= read -r file; do
   tags=$(yq .spec.tags "$file")
   scope=$(yq .spec.scope "$file")
   job_name=$(yq -r .spec.name "$file")
@@ -213,14 +218,42 @@ find "$JOBS" -type f -name "*.yml" | while read -r file; do
   fi
 
   echo "✅ Including job $job_name in build "
+  SELECTED_FILES["$file"]=1
+done < <(find "$JOBS" -type f -name "*.yml")
+
+# Phase 2: dependency resolution. A selected job may depend on build jobs whose
+# own dirty-when did not match; pull every transitive prerequisite into the run
+# set. TO_UPLOAD is a set, so each job -- whether selected directly or required
+# as a dependency -- is uploaded exactly once (duplicates are ignored).
+build_step_index "$JOBS"
+
+declare -A TO_UPLOAD=()
+for file in "${!SELECTED_FILES[@]}"; do
+  TO_UPLOAD["$file"]=1
+done
+
+for file in "${!SELECTED_FILES[@]}"; do
+  while IFS= read -r dep_file; do
+    [[ -z "$dep_file" ]] && continue
+    if [[ -z "${TO_UPLOAD[$dep_file]-}" ]]; then
+      TO_UPLOAD["$dep_file"]=1
+      dep_name=$(yq -r .spec.name "$dep_file")
+      sel_name=$(yq -r .spec.name "$file")
+      echo "➕ Including dependency job $dep_name (required by $sel_name)"
+    fi
+  done < <(resolve_transitive_deps "$file")
+done
+
+# Phase 3: upload every job in the run set exactly once.
+for file in "${!TO_UPLOAD[@]}"; do
+  job_name=$(yq -r .spec.name "$file")
 
   if [[ "$DRY_RUN" == true ]]; then
-      printf " -> 🛑 Dry run enabled, skipping upload for job: %s\n" "$job_name"
-  else
-    job_path=$(yq -r .spec.path "$file")
-
-    ./buildkite/scripts/pipeline/upload.sh "(./buildkite/src/Jobs/$job_path/$job_name.dhall).pipeline"
-    printf " -> ✅ Uploaded job: %s\n" "$job_name"
+    printf " -> 🛑 Dry run enabled, skipping upload for job: %s\n" "$job_name"
+    continue
   fi
 
+  job_path=$(yq -r .spec.path "$file")
+  ./buildkite/scripts/pipeline/upload.sh "(./buildkite/src/Jobs/$job_path/$job_name.dhall).pipeline"
+  printf " -> ✅ Uploaded job: %s\n" "$job_name"
 done

--- a/buildkite/scripts/monorepo_lib.sh
+++ b/buildkite/scripts/monorepo_lib.sh
@@ -207,6 +207,73 @@ select_job() {
   fi
 }
 
+# ------------------------------------------------------------------------------
+# Dependency resolution
+#
+#   A job selected by dirty-when triage may depend (via step depends_on) on other
+#   jobs -- typically build jobs -- whose own dirty-when did NOT match the change
+#   set. Those dependencies must still be uploaded, otherwise the selected job
+#   waits on a step that never gets scheduled. The helpers below reproduce the
+#   dependency walk used by run-single-job-with-deps.sh (the !ci-single-me logic)
+#   so triage can pull every prerequisite job into the run set.
+# ------------------------------------------------------------------------------
+
+# Global: maps a pipeline step key to the job YAML file that defines it.
+declare -A STEP_KEY_TO_FILE
+
+# build_step_index - populate STEP_KEY_TO_FILE from every job YAML in a directory.
+# Args:
+#   $1: jobs directory
+build_step_index() {
+  local jobs_dir="$1"
+  STEP_KEY_TO_FILE=()
+  local file key
+  while IFS= read -r file; do
+    while IFS= read -r key; do
+      [[ -z "$key" || "$key" == "null" ]] && continue
+      STEP_KEY_TO_FILE["$key"]="$file"
+    done < <(yq -r '[.pipeline.steps[]?.key] | .[]' "$file" 2>/dev/null)
+  done < <(find "$jobs_dir" -type f -name "*.yml")
+}
+
+# resolve_transitive_deps - print the set of dependency job files (transitive,
+# excluding the starting file itself) for a given job. Each dependency is emitted
+# at most once. Requires build_step_index to have been called first.
+# Args:
+#   $1: starting job YAML file
+resolve_transitive_deps() {
+  local start="$1"
+  local -A visited=()
+  local -a queue=("$start")
+  visited["$start"]=1
+
+  while [[ ${#queue[@]} -gt 0 ]]; do
+    local cur="${queue[0]}"
+    queue=("${queue[@]:1}")
+
+    local dep_key dep_file
+    while IFS= read -r dep_key; do
+      [[ -z "$dep_key" || "$dep_key" == "null" ]] && continue
+      dep_file="${STEP_KEY_TO_FILE[$dep_key]-}"
+      if [[ -z "$dep_file" ]]; then
+        echo "⚠️  Warning: dependency step '$dep_key' (required by $(basename "$cur")) is not produced by any known job" >&2
+        continue
+      fi
+      # Skip self-references (steps depending on other steps of the same job).
+      [[ "$dep_file" == "$cur" ]] && continue
+      if [[ -z "${visited[$dep_file]-}" ]]; then
+        visited["$dep_file"]=1
+        queue+=("$dep_file")
+      fi
+    done < <(yq -r '[.pipeline.steps[]?.depends_on[]?.step] | .[]' "$cur" 2>/dev/null)
+  done
+
+  local f
+  for f in "${!visited[@]}"; do
+    [[ "$f" != "$start" ]] && echo "$f"
+  done
+}
+
 # find_closest_ancestor - Find the closest mainline branch ancestor
 # Uses global variable MAINLINE_BRANCHES (array of branch names)
 # Returns: name of the closest ancestor branch

--- a/buildkite/scripts/monorepo_lib.sh
+++ b/buildkite/scripts/monorepo_lib.sh
@@ -236,6 +236,31 @@ build_step_index() {
   done < <(find "$jobs_dir" -type f -name "*.yml")
 }
 
+# job_dependency_files - print the immediate dependency job files of a job: the
+# jobs that own the steps this job's steps depend on. Dedupes and skips
+# self-references (steps that depend on other steps of the same job). Requires
+# build_step_index to have been called first.
+# Args:
+#   $1: job YAML file
+job_dependency_files() {
+  local file="$1"
+  local -A seen=()
+  local dep_key dep_file
+  while IFS= read -r dep_key; do
+    [[ -z "$dep_key" || "$dep_key" == "null" ]] && continue
+    dep_file="${STEP_KEY_TO_FILE[$dep_key]-}"
+    if [[ -z "$dep_file" ]]; then
+      echo "⚠️  Warning: dependency step '$dep_key' (required by $(basename "$file")) is not produced by any known job" >&2
+      continue
+    fi
+    [[ "$dep_file" == "$file" ]] && continue
+    if [[ -z "${seen[$dep_file]-}" ]]; then
+      seen["$dep_file"]=1
+      echo "$dep_file"
+    fi
+  done < <(yq -r '[.pipeline.steps[]?.depends_on[]?.step] | .[]' "$file" 2>/dev/null)
+}
+
 # resolve_transitive_deps - print the set of dependency job files (transitive,
 # excluding the starting file itself) for a given job. Each dependency is emitted
 # at most once. Requires build_step_index to have been called first.
@@ -251,21 +276,14 @@ resolve_transitive_deps() {
     local cur="${queue[0]}"
     queue=("${queue[@]:1}")
 
-    local dep_key dep_file
-    while IFS= read -r dep_key; do
-      [[ -z "$dep_key" || "$dep_key" == "null" ]] && continue
-      dep_file="${STEP_KEY_TO_FILE[$dep_key]-}"
-      if [[ -z "$dep_file" ]]; then
-        echo "⚠️  Warning: dependency step '$dep_key' (required by $(basename "$cur")) is not produced by any known job" >&2
-        continue
-      fi
-      # Skip self-references (steps depending on other steps of the same job).
-      [[ "$dep_file" == "$cur" ]] && continue
+    local dep_file
+    while IFS= read -r dep_file; do
+      [[ -z "$dep_file" ]] && continue
       if [[ -z "${visited[$dep_file]-}" ]]; then
         visited["$dep_file"]=1
         queue+=("$dep_file")
       fi
-    done < <(yq -r '[.pipeline.steps[]?.depends_on[]?.step] | .[]' "$cur" 2>/dev/null)
+    done < <(job_dependency_files "$cur")
   done
 
   local f

--- a/buildkite/scripts/run-single-job-with-deps.sh
+++ b/buildkite/scripts/run-single-job-with-deps.sh
@@ -8,10 +8,17 @@
 # Flow:
 # - Reads generated job pipeline YAMLs in --jobs.
 # - Resolves the requested job by name (case-insensitive).
-# - Walks step dependencies to find prerequisite jobs.
+# - Walks step dependencies to find prerequisite jobs (shared with monorepo triage).
 # - Orders jobs topologically and uploads each pipeline.
 
 set -euo pipefail
+
+# Get the directory of this script and source the shared dependency-resolution
+# helpers (build_step_index, job_dependency_files) so the walk logic lives in one
+# place and stays consistent with the monorepo triage.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/monorepo_lib.sh
+source "$SCRIPT_DIR/monorepo_lib.sh"
 
 show_help() {
   cat << EOF
@@ -88,17 +95,17 @@ if ! command -v yq &> /dev/null; then
   fi
 fi
 
-# Index job files by name and map step keys to job names.
-declare -A step_key_to_job
-declare -A job_file_by_name
-declare -A job_display_by_name
-
 mapfile -t job_files < <(find "$JOBS_DIR" -type f -name "*.yml" | sort)
 
 if [[ ${#job_files[@]} -eq 0 ]]; then
   echo "Error: no job pipeline files found in $JOBS_DIR" >&2
   exit 1
 fi
+
+# Index job files by name (for resolving the requested job) and build the shared
+# step-key -> file index used by job_dependency_files.
+declare -A file_by_name_key
+declare -A display_by_name_key
 
 for file in "${job_files[@]}"; do
   job_name=$(yq -r '.spec.name' "$file")
@@ -107,115 +114,75 @@ for file in "${job_files[@]}"; do
     job_name="${job_name%.yml}"
   fi
 
-  job_name_key=$(to_lower "$job_name")
-  if [[ -n "${job_file_by_name[$job_name_key]-}" && "${job_display_by_name[$job_name_key]}" != "$job_name" ]]; then
-    echo "Error: job name collision (case-insensitive): '${job_display_by_name[$job_name_key]}' and '$job_name'." >&2
+  name_key=$(to_lower "$job_name")
+  if [[ -n "${file_by_name_key[$name_key]-}" && "${display_by_name_key[$name_key]}" != "$job_name" ]]; then
+    echo "Error: job name collision (case-insensitive): '${display_by_name_key[$name_key]}' and '$job_name'." >&2
     exit 1
   fi
-  job_file_by_name["$job_name_key"]="$file"
-  job_display_by_name["$job_name_key"]="$job_name"
-
-  while IFS= read -r step_key; do
-    [[ -z "$step_key" || "$step_key" == "null" ]] && continue
-    if [[ -n "${step_key_to_job[$step_key]-}" && "${step_key_to_job[$step_key]}" != "$job_name_key" ]]; then
-      echo "Warning: duplicate step key '$step_key' in $file (already mapped to ${job_display_by_name[${step_key_to_job[$step_key]}]})." >&2
-    fi
-    step_key_to_job["$step_key"]="$job_name_key"
-  done < <(yq -r '.pipeline.steps[].key' "$file")
+  file_by_name_key["$name_key"]="$file"
+  display_by_name_key["$name_key"]="$job_name"
 done
 
-# Resolve the requested job name.
-job_name_key=$(to_lower "$JOB_NAME")
-if [[ -z "${job_file_by_name[$job_name_key]-}" ]]; then
+build_step_index "$JOBS_DIR"
+
+# Resolve the requested job name to a file.
+name_key=$(to_lower "$JOB_NAME")
+if [[ -z "${file_by_name_key[$name_key]-}" ]]; then
   candidate="$JOBS_DIR/$JOB_NAME.yml"
   if [[ -f "$candidate" ]]; then
     resolved_name=$(yq -r '.spec.name' "$candidate")
-    if [[ -n "$resolved_name" && "$resolved_name" != "null" ]]; then
-      job_name_key=$(to_lower "$resolved_name")
-      JOB_NAME="$resolved_name"
-    else
-      base_name=$(basename "$candidate")
-      base_name="${base_name%.yml}"
-      job_name_key=$(to_lower "$base_name")
-      JOB_NAME="$base_name"
+    if [[ -z "$resolved_name" || "$resolved_name" == "null" ]]; then
+      resolved_name=$(basename "$candidate")
+      resolved_name="${resolved_name%.yml}"
     fi
+    name_key=$(to_lower "$resolved_name")
+    JOB_NAME="$resolved_name"
   fi
 fi
 
-if [[ -z "${job_file_by_name[$job_name_key]-}" ]]; then
+if [[ -z "${file_by_name_key[$name_key]-}" ]]; then
   echo "Error: job '$JOB_NAME' not found in $JOBS_DIR" >&2
   exit 1
 fi
 
-# Extract dependency step keys from a pipeline file.
-list_dep_steps() {
-  local file="$1"
-  yq -r '.pipeline.steps[].depends_on[]? | .step' "$file"
-}
+start_file="${file_by_name_key[$name_key]}"
 
-# Map dependency step keys to job names and return unique deps.
-get_job_deps() {
-  local job="$1"
-  local file="${job_file_by_name[$job]}"
-  declare -A seen=()
-
-  while IFS= read -r dep_step; do
-    [[ -z "$dep_step" || "$dep_step" == "null" ]] && continue
-    dep_job="${step_key_to_job[$dep_step]-}"
-    if [[ -z "$dep_job" ]]; then
-      echo "Error: dependency step '$dep_step' referenced by job '${job_display_by_name[$job]}' not found in $JOBS_DIR." >&2
-      exit 1
-    fi
-    if [[ "$dep_job" == "$job" ]]; then
-      continue
-    fi
-    if [[ -z "${seen[$dep_job]-}" ]]; then
-      seen["$dep_job"]=1
-      echo "$dep_job"
-    fi
-  done < <(list_dep_steps "$file")
-}
-
-# Depth-first walk for topological ordering with cycle detection.
+# Depth-first walk for topological ordering with cycle detection, using the
+# shared job_dependency_files helper for immediate dependencies.
 declare -A temp_mark
 declare -A perm_mark
-declare -a ordered_jobs
+declare -a ordered_files
 
-visit_job() {
-  local job="$1"
-  if [[ -n "${perm_mark[$job]-}" ]]; then
+visit_file() {
+  local file="$1"
+  if [[ -n "${perm_mark[$file]-}" ]]; then
     return
   fi
-  if [[ -n "${temp_mark[$job]-}" ]]; then
-    echo "Error: circular dependency detected at job '$job'." >&2
+  if [[ -n "${temp_mark[$file]-}" ]]; then
+    echo "Error: circular dependency detected at job '$(yq -r '.spec.name' "$file")'." >&2
     exit 1
   fi
 
-  temp_mark["$job"]=1
+  temp_mark["$file"]=1
 
-  while IFS= read -r dep; do
-    [[ -z "$dep" ]] && continue
-    if [[ -z "${job_file_by_name[$dep]-}" ]]; then
-      echo "Error: dependency job '${job_display_by_name[$dep]-$dep}' not found in $JOBS_DIR" >&2
-      exit 1
-    fi
-    visit_job "$dep"
-  done < <(get_job_deps "$job")
+  while IFS= read -r dep_file; do
+    [[ -z "$dep_file" ]] && continue
+    visit_file "$dep_file"
+  done < <(job_dependency_files "$file")
 
-  perm_mark["$job"]=1
-  ordered_jobs+=("$job")
+  perm_mark["$file"]=1
+  ordered_files+=("$file")
 }
 
-visit_job "$job_name_key"
+visit_file "$start_file"
 
 if [[ "$DEBUG" == true ]]; then
-  echo "Debug: upload order: ${ordered_jobs[*]}"
+  echo "Debug: upload order: ${ordered_files[*]}"
 fi
 
 # Upload pipelines in dependency order (or print in dry-run).
-for job in "${ordered_jobs[@]}"; do
-  file="${job_file_by_name[$job]}"
-  display_name="${job_display_by_name[$job]}"
+for file in "${ordered_files[@]}"; do
+  display_name=$(yq -r '.spec.name' "$file")
   if [[ "$DRY_RUN" == true ]]; then
     echo "Dry run: would upload job '$display_name' from $file"
     continue

--- a/buildkite/scripts/test_monorepo.sh
+++ b/buildkite/scripts/test_monorepo.sh
@@ -614,6 +614,123 @@ EOF
   assert_not_contains "$output" "Including job IncludeIfNoMatch" "Should not include job when includeIf doesn't match"
 }
 
+# Test: Integration test - dependency resolution
+# A job selected by dirty-when must pull in the build jobs it depends on, even
+# when those builds' own dirty-when did not match the change set. This is the
+# case that used to break: modifying a bench file triggers the bench but not the
+# apps/package build it needs.
+test_integration_dependency_resolution() {
+  echo -e "\n${YELLOW}Testing: Integration - dependency resolution${NC}"
+
+  # Bench job: selected by dirty-when, depends on a build job's package step.
+  cat > "$TEST_DIR/jobs/DepBench.yml" << 'EOF'
+spec:
+  name: DepBench
+  path: Bench
+  tags:
+    - DepTest
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: dep-bench-run
+      depends_on:
+        - step: _DepBuild-build-deb-pkg
+EOF
+  echo "bench" > "$TEST_DIR/jobs/DepBench.dirtywhen"
+
+  # Package build: dirty-when does NOT match the bench change; depends on apps.
+  cat > "$TEST_DIR/jobs/DepBuild.yml" << 'EOF'
+spec:
+  name: DepBuild
+  path: Release
+  tags:
+    - DepTest
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: _DepBuild-build-deb-pkg
+      depends_on:
+        - step: _DepBuildApps-build-apps
+EOF
+  echo "^src/" > "$TEST_DIR/jobs/DepBuild.dirtywhen"
+
+  # Apps build: transitive dependency, also not matched by the change.
+  cat > "$TEST_DIR/jobs/DepBuildApps.yml" << 'EOF'
+spec:
+  name: DepBuildApps
+  path: Release
+  tags:
+    - DepTest
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: _DepBuildApps-build-apps
+EOF
+  echo "^src/" > "$TEST_DIR/jobs/DepBuildApps.dirtywhen"
+
+  # Change set touches only a bench file: matches DepBench, not the builds.
+  echo "buildkite/scripts/bench/run.sh" > "$TEST_DIR/dep_diff.txt"
+
+  local output
+  output=$(FORCE_CLOSEST_ANCESTOR="$TEST_CLOSEST_ANCESTOR" "$MONOREPO_SCRIPT" \
+    --scopes pullrequest \
+    --tags deptest \
+    --filter-mode any \
+    --selection-mode triaged \
+    --jobs "$TEST_DIR/jobs" \
+    --git-diff-file "$TEST_DIR/dep_diff.txt" \
+    --mainline-branches "$MAINLINE_BRANCHES_COMMA_SEPARATED" \
+    --dry-run 2>&1 || true)
+
+  assert_contains "$output" "Including job DepBench" "Bench job selected by dirty-when"
+  assert_contains "$output" "Including dependency job DepBuild" "Package build pulled in as a dependency"
+  assert_contains "$output" "Including dependency job DepBuildApps" "Transitive apps build pulled in"
+  assert_contains "$output" "skipping upload for job: DepBuild" "Dependency build is in the upload set"
+  assert_contains "$output" "skipping upload for job: DepBuildApps" "Transitive dependency is in the upload set"
+}
+
+# Test: Integration test - dependency deduplication
+# When two selected jobs share a dependency, that dependency is uploaded once.
+test_integration_dependency_dedup() {
+  echo -e "\n${YELLOW}Testing: Integration - dependency dedup (no duplicate uploads)${NC}"
+
+  # Second bench that also depends on the same DepBuild package step.
+  cat > "$TEST_DIR/jobs/DepBench2.yml" << 'EOF'
+spec:
+  name: DepBench2
+  path: Bench
+  tags:
+    - DepTest
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: dep-bench2-run
+      depends_on:
+        - step: _DepBuild-build-deb-pkg
+EOF
+  echo "bench" > "$TEST_DIR/jobs/DepBench2.dirtywhen"
+
+  local output
+  output=$(FORCE_CLOSEST_ANCESTOR="$TEST_CLOSEST_ANCESTOR" "$MONOREPO_SCRIPT" \
+    --scopes pullrequest \
+    --tags deptest \
+    --filter-mode any \
+    --selection-mode triaged \
+    --jobs "$TEST_DIR/jobs" \
+    --git-diff-file "$TEST_DIR/dep_diff.txt" \
+    --mainline-branches "$MAINLINE_BRANCHES_COMMA_SEPARATED" \
+    --dry-run 2>&1 || true)
+
+  # DepBuild is a shared dependency of DepBench and DepBench2, uploaded once.
+  local build_uploads
+  build_uploads=$(echo "$output" | grep -c "skipping upload for job: DepBuild$" || true)
+  assert_equals "1" "$build_uploads" "Shared dependency DepBuild uploaded exactly once"
+}
+
 # Test: Integration test - both excludeIf and includeIf (includeIf matches, excludeIf doesn't)
 test_integration_both_include_exclude_include_wins() {
   echo -e "\n${YELLOW}Testing: Integration - includeIf matches, excludeIf doesn't${NC}"
@@ -736,6 +853,8 @@ main() {
   test_integration_tag_filtering
   test_integration_scope_filtering
   test_integration_include_if_not_matching
+  test_integration_dependency_resolution
+  test_integration_dependency_dedup
 
   teardown
 


### PR DESCRIPTION
## Problem

The monorepo triage (`monorepo.sh`) uploads only the jobs whose own `dirtyWhen` matched the change set. But a selected job often **depends** on build jobs (via step `depends_on`) whose `dirtyWhen` did **not** match — so the build never gets scheduled and the selected job waits on a step that never runs.

Concrete case: editing a bench file triggers the bench job, but not the apps/package build it needs → dangling dependency.

## Fix

Reuse the dependency walk from `run-single-job-with-deps.sh` (the `!ci-single-me` logic) and apply it across the whole triaged set:

1. **Triage** — collect every job passing tags/scope/dirtyWhen/include-exclude into a selected set (nothing uploaded yet).
2. **Resolve** — build a `step-key → job` index, then transitively pull each selected job's dependency jobs into a **deduplicated** run set. A job selected directly *or* required as a dependency is included exactly once.
3. **Upload** — upload every job in the run set once.

Dependencies are force-included regardless of their own `dirtyWhen` (that's the point) — a required prerequisite must run.

## Changes
- `monorepo_lib.sh` — new `build_step_index` + `resolve_transitive_deps` (transitive walk with dedupe).
- `monorepo.sh` — main loop split into collect → resolve-deps → upload phases.
- `test_monorepo.sh` — two new integration tests: (1) a bench selected by dirtyWhen pulls in its package + transitive apps build even though their dirtyWhen didn't match; (2) a dependency shared by two jobs is uploaded exactly once.

## Verification
- `make test_monorepo` — 43/43 pass.
- Dependency walk validated against the real 87-job dump (e.g. `RosettaIntegrationTests → MinaArtifactBullseye + Apps`; a bench → package + apps + instrumented builds).
- End-to-end smoke run of `monorepo.sh` over the real dump exits cleanly.
