### PR TITLE
ci: restore_binary.sh restores mina.exe (not the never-built mina_*_signatures.exe)

### DIFF
--- a/buildkite/scripts/apps/restore_binary.sh
+++ b/buildkite/scripts/apps/restore_binary.sh
@@ -7,11 +7,14 @@
 #
 # Usage: restore_binary.sh <network>      (network: devnet | mainnet | mesa)
 #
-# This is a thin convenience wrapper over restore_app.sh: it maps the network to
-# the signature-specific binary name and installs it as the plain `mina`, so
-# client scripts never deal with the variant or the signature name. The cache
-# location (codename/profile/flag/arch) is derived from the build identity by
-# restore_app.sh -- see its header for the env knobs.
+# This is a thin convenience wrapper over restore_app.sh: it installs the daemon
+# binary as the plain `mina`, so client scripts never deal with the variant. The
+# app-build (and the .deb, see scripts/debian/builder-helpers.sh) ships
+# src/app/cli/src/mina.exe as `mina`; the network's signatures are baked in at
+# build time via the profile and encoded in the cache variant that restore_app.sh
+# derives from the network -- there is no separate mina_<sig>_signatures.exe in
+# the cache. The cache location (codename/profile/flag/arch) is derived from the
+# build identity by restore_app.sh -- see its header for the env knobs.
 #
 # Exits non-zero without side effects if not in Buildkite context or the binary
 # is not cached, so callers can fall back to installing the .deb.
@@ -26,12 +29,11 @@ if [[ -z "$NETWORK" ]]; then
 fi
 
 case "$NETWORK" in
-  devnet | mesa) sig=testnet ;;
-  mainnet) sig=mainnet ;;
+  devnet | mesa | mainnet) ;;
   *)
     echo "restore_binary: unknown network '$NETWORK'" >&2
     exit 1
     ;;
 esac
 
-exec ./buildkite/scripts/apps/restore_app.sh "$NETWORK" "mina_${sig}_signatures.exe" mina
+exec ./buildkite/scripts/apps/restore_app.sh "$NETWORK" mina.exe mina

--- a/buildkite/scripts/apps/write_to_cache.sh
+++ b/buildkite/scripts/apps/write_to_cache.sh
@@ -5,10 +5,10 @@
 # where <variant> identifies the build (network-profile[-instrumented][-arm64]).
 #
 # The variant depth is required: several builds share a codename and produce
-# identically-named binaries (e.g. mina_testnet_signatures.exe is emitted by the
-# devnet, mesa and instrumented builds alike). Without the variant they would
-# overwrite each other in apps/<codename>/, leaving whichever build finished last
-# -- a non-deterministic, wrong artifact for any consumer.
+# identically-named binaries (e.g. mina.exe is emitted by the devnet, mesa and
+# instrumented builds alike, differing only by build profile). Without the
+# variant they would overwrite each other in apps/<codename>/, leaving whichever
+# build finished last -- a non-deterministic, wrong artifact for any consumer.
 
 CODENAME=$1
 VARIANT=$2


### PR DESCRIPTION
## Problem

`restore_binary.sh` restores `mina_<sig>_signatures.exe` and installs it as `mina`, but no make target builds that executable. `make build` produces `src/app/cli/src/mina.exe`, and the .deb ships exactly that as `/usr/local/bin/mina` (builder-helpers.sh). The signature kind is selected at runtime, not by a separate binary — so the restore always missed.

This blocks every bare-cache consumer of the shared helper (single-node tests, ledger-apply bench, …).

## Fix
- `restore_binary.sh`: `mina_${sig}_signatures.exe` → `mina.exe`.
- `write_to_cache.sh`: corrected the misleading comment.

Shared helper fix only. The per-consumer profile/binary tweaks live in their own conversion PRs (bench-base #19025, ledger-apply #19026); single-node already sets MINA_PROFILE in its script.