### PR TITLE
ci: don't pull job dependencies that triage already selects (fix multi-phase duplicate step keys)

### DIFF
--- a/buildkite/scripts/monorepo.sh
+++ b/buildkite/scripts/monorepo.sh
@@ -221,10 +221,18 @@ while IFS= read -r file; do
   SELECTED_FILES["$file"]=1
 done < <(find "$JOBS" -type f -name "*.yml")
 
-# Phase 2: dependency resolution. A selected job may depend on build jobs whose
-# own dirty-when did not match; pull every transitive prerequisite into the run
-# set. TO_UPLOAD is a set, so each job -- whether selected directly or required
-# as a dependency -- is uploaded exactly once (duplicates are ignored).
+# Phase 2: dependency resolution. A selected job may depend on a build job whose
+# own dirty-when did not match, so triage would not upload it. Pull only such
+# "would not be selected" prerequisites into the run set.
+#
+# A dependency is pulled ONLY when select_job would reject it on its own. If it
+# would be selected, its own triage step already uploads it -- and re-uploading
+# it here would duplicate the step key. That matters for full/multi-phase runs
+# (e.g. nightly): every job is selected in full mode, so nothing is ever pulled,
+# and cross-phase duplicates (a build selected in one phase, depended on from
+# another) are avoided. select_job is phase-independent (it only looks at the
+# selection mode and the job's own dirty-when), so the decision is consistent
+# regardless of which phase's tag/scope filter is running.
 build_step_index "$JOBS"
 
 declare -A TO_UPLOAD=()
@@ -235,12 +243,21 @@ done
 for file in "${!SELECTED_FILES[@]}"; do
   while IFS= read -r dep_file; do
     [[ -z "$dep_file" ]] && continue
-    if [[ -z "${TO_UPLOAD[$dep_file]-}" ]]; then
-      TO_UPLOAD["$dep_file"]=1
-      dep_name=$(yq -r .spec.name "$dep_file")
-      sel_name=$(yq -r .spec.name "$file")
-      echo "➕ Including dependency job $dep_name (required by $sel_name)"
+    [[ -n "${TO_UPLOAD[$dep_file]-}" ]] && continue
+
+    dep_name=$(yq -r .spec.name "$dep_file")
+
+    # Skip dependencies that triage would select on their own; their dedicated
+    # step already uploads them (pulling would duplicate the step key).
+    dep_selected=$(select_job "$SELECTION_FULL" "$SELECTION_TRIAGED" "$dep_file" "$dep_name" "$GIT_DIFF_FILE")
+    if [[ "$dep_selected" -eq 1 ]]; then
+      echo "↩️  Skipping dependency $dep_name: already selected by its own triage step" >&2
+      continue
     fi
+
+    TO_UPLOAD["$dep_file"]=1
+    sel_name=$(yq -r .spec.name "$file")
+    echo "➕ Including dependency job $dep_name (required by $sel_name)"
   done < <(resolve_transitive_deps "$file")
 done
 

--- a/buildkite/scripts/test_monorepo.sh
+++ b/buildkite/scripts/test_monorepo.sh
@@ -731,6 +731,61 @@ EOF
   assert_equals "1" "$build_uploads" "Shared dependency DepBuild uploaded exactly once"
 }
 
+# Test: Integration test - dependency NOT pulled when it is selectable on its own.
+# In full mode (and in multi-phase runs generally) a dependency is uploaded by
+# its own triage step, so pulling it here would duplicate the step key. Only
+# dependencies that triage would reject (e.g. dirty-when miss) should be pulled.
+test_integration_dependency_skip_when_selectable() {
+  echo -e "\n${YELLOW}Testing: Integration - dependency not pulled when selectable${NC}"
+
+  # A test that depends on a build carrying a different tag (its own "phase").
+  cat > "$TEST_DIR/jobs/FullDepTest.yml" << 'EOF'
+spec:
+  name: FullDepTest
+  path: Test
+  tags:
+    - FullDep
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: full-dep-test-run
+      depends_on:
+        - step: _FullDepBuild-build-deb-pkg
+EOF
+  echo "^.*$" > "$TEST_DIR/jobs/FullDepTest.dirtywhen"
+
+  cat > "$TEST_DIR/jobs/FullDepBuild.yml" << 'EOF'
+spec:
+  name: FullDepBuild
+  path: Release
+  tags:
+    - BuildOnly
+  scope:
+    - PullRequest
+pipeline:
+  steps:
+    - key: _FullDepBuild-build-deb-pkg
+EOF
+  echo "^.*$" > "$TEST_DIR/jobs/FullDepBuild.dirtywhen"
+
+  # Full selection: every job is selected on its own, so the build is uploaded
+  # by its own step and must NOT be pulled as a dependency.
+  local output
+  output=$(FORCE_CLOSEST_ANCESTOR="$TEST_CLOSEST_ANCESTOR" "$MONOREPO_SCRIPT" \
+    --scopes pullrequest \
+    --tags fulldep \
+    --filter-mode any \
+    --selection-mode full \
+    --jobs "$TEST_DIR/jobs" \
+    --git-diff-file "$TEST_DIR/git_diff.txt" \
+    --mainline-branches "$MAINLINE_BRANCHES_COMMA_SEPARATED" \
+    --dry-run 2>&1 || true)
+
+  assert_contains "$output" "Including job FullDepTest" "Dependent test is selected"
+  assert_not_contains "$output" "Including dependency job FullDepBuild" "Selectable build is NOT pulled as a dependency"
+}
+
 # Test: Integration test - both excludeIf and includeIf (includeIf matches, excludeIf doesn't)
 test_integration_both_include_exclude_include_wins() {
   echo -e "\n${YELLOW}Testing: Integration - includeIf matches, excludeIf doesn't${NC}"
@@ -855,6 +910,7 @@ main() {
   test_integration_include_if_not_matching
   test_integration_dependency_resolution
   test_integration_dependency_dedup
+  test_integration_dependency_skip_when_selectable
 
   teardown
 


### PR DESCRIPTION
## Problem

The monorepo triage pipeline runs `monorepo.sh` once per phase (each with its own tags/scope/mode) into the **same** Buildkite build. The dependency-pulling added in #19043 pulls a job's prerequisites in whichever phase sees the dependent — but that build job is *also* uploaded by its own triage step in another phase, so the step key collides:

```
Pipeline upload rejected: The key "_MinaArtifactBullseye-build-deb-pkg" has already been used by another step in this build
```

Seen on the nightly (`mina-mainline-branches-nightlies`) develop build.

## Fix

Pull a dependency **only when triage would not select it on its own** — gate the pull on `select_job`:

- **Full / nightly mode**: `select_job` is always 1 (every job runs in its home phase), so nothing is pulled → no cross-phase duplicates.
- **Triaged (PR) mode**: pull only dependencies whose own dirty-when did **not** match (the real gap the feature was for). A dependency whose dirty-when *did* match is uploaded by its own step, so it's skipped here.

`select_job` only looks at the selection mode and the job's own dirty-when, so the decision is phase-independent and consistent across the multi-phase run.

## Tests
`test_monorepo.sh` (45/45): existing dep-resolution/dedup tests still pass (triaged dirty-when miss → pulled), plus a new case asserting a selectable build is **not** pulled as a dependency in full mode.
