### PR TITLE
ci: nightly builds only bullseye; non-bullseye distros back to Weekly

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBookworm.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookworm.dhall
@@ -56,7 +56,6 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64.dhall
@@ -54,7 +54,6 @@ in  Pipeline.build
             , PipelineTag.Type.Bookworm
             ]
           , debVersion = DebianVersions.DebVersion.Bookworm
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocal.dhall
@@ -46,8 +46,7 @@ in  Pipeline.build
             , Artifacts.Type.TxTools
             , Artifacts.Type.DaemonStorageToolbox
             ]
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Release/MinaArtifactJammy.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammy.dhall
@@ -55,7 +55,6 @@ in  Pipeline.build
             , PipelineTag.Type.Jammy
             ]
           , debVersion = DebianVersions.DebVersion.Jammy
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNoble.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNoble.dhall
@@ -55,7 +55,6 @@ in  Pipeline.build
             , PipelineTag.Type.Noble
             ]
           , debVersion = DebianVersions.DebVersion.Noble
-          , scope =
-            [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )


### PR DESCRIPTION
## Problem

Nightly rebuilds the full debian/docker matrix across every distro (bookworm/focal/jammy/noble + arm64) on top of bullseye. PR #18957 (`6af0e67c2f`) trimmed nightly to bullseye and swept the rest weekly — but the artifact-dimensions refactor (`5947086ccd`, "Model Buildkite release artifacts by package dimensions") consolidated the old per-network files into per-distro files and, in doing so, reverted the non-bullseye scopes from `[Weekly, Release]` back to `[MainlineNightly, Release]`. So they run nightly again.

## Fix

Re-apply #18957's intent on the current per-distro files — retag the non-bullseye MinaArtifact jobs from `[MainlineNightly, Release]` → `[Weekly, Release]`:

- `MinaArtifactBookworm`, `MinaArtifactBookwormArm64`, `MinaArtifactFocal`, `MinaArtifactJammy`, `MinaArtifactNoble`

Bullseye (devnet/mainnet/lightnet + instrumented) stays on nightly. `Weekly` is already part of `Full`/`AllButPullRequest`, so bullseye/default-scoped jobs still run in the weekly sweep — Weekly remains the full-matrix superset. (The weekly cron with `BUILDKITE_PIPELINE_SCOPE=Weekly` already exists from #18957.)

## Verification
- Scopes confirmed `Weekly Release` for all five.
- Dump scan: **no nightly/mainline-nightly job depends on a non-bullseye build**, so nothing dangles.
- `cd buildkite && make all` passes (dhall checks, deps, dups, names, 45/45 monorepo tests).
