### PR TITLE
ci: skip debian+docker build unless packaging (dockerfiles/debian scripts) changed

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -687,7 +687,7 @@ let packagePipeline
     =     \(spec : MinaBuildSpec.Type)
       ->  Pipeline.Config::{
           , spec = JobSpec::{
-            , dirtyWhen = DebianVersions.dirtyWhen spec.debVersion
+            , dirtyWhen = DebianVersions.packageDirtyWhen
             , path = "Release"
             , name = "${spec.prefix}${nameSuffix spec}"
             , tags = spec.tags


### PR DESCRIPTION
## Motivation

Porting each test to bare-apps is slow because every PR still runs the full **debian + docker** build to completion, even when the change is pure source/dhall and the packages aren't needed.

## Change

The split `packagePipeline` (the debian + docker job) used the broad `DebianVersions.dirtyWhen` (matches `src/**`, all test dhall, …), so it ran on essentially every PR. Point it at the already-existing **`DebianVersions.packageDirtyWhen`** instead, which matches only the packaging layer:

- `dockerfiles/**`, `scripts/debian/**`, `scripts/docker/**`, `scripts/hardfork/**`
- `buildkite/scripts/{docker,debian,apps,cache}/**`, `build-artifact.sh`
- `buildkite/src/Command/MinaArtifact.dhall`, `DebianVersions.dhall`, `ContainerImages.dhall`, `Jobs/Release/MinaArtifact*`
- debian/hardfork test jobs

The **apps** build keeps the broad dirty-when, so bare-apps consumers always get fresh binaries.

## Effect (triaged / PR runs)

- **Source-only or test-conversion PR** → package job's dirty-when doesn't match → **debian + docker skipped**. The apps job still runs.
- **Deb-path test selected** → it pulls the package job in via the dependency resolver, so it still builds when actually needed.
- **dockerfiles / debian-scripts PR** → package job matches → builds as before.
- **Full runs (nightly / release)** → dirty-when is ignored in full mode, so packages build regardless. No change there.

Affects the bullseye package jobs (`MinaArtifactBullseye`, `…Instrumented`, `…MainnetBullseye`); non-bullseye use the combined pipeline (Weekly-only).

## Verification
`cd buildkite && make all` passes (dhall checks, deps, dups, names, 45/45 monorepo tests). Confirmed the dumped dirty-when: package job no longer contains `^src`, apps job still does.
