### PR TITLE
ci: bare-apps tests restore mina/rosetta/signer.exe + set MINA_PROFILE

### DIFF
--- a/buildkite/src/Command/ArchiveNodeTest.dhall
+++ b/buildkite/src/Command/ArchiveNodeTest.dhall
@@ -21,7 +21,8 @@ in  { step =
                     [ "ARCHIVE_TEST_APP=mina-archive-node-test"
                     , "MINA_TEST_NETWORK_DATA=src/test/archive/sample_db"
                     , "APPS_BUILD_FLAG=instrumented"
-                    , "APPS_BARE_BINARIES=archive_node_tests.exe:mina-archive-node-test,archive.exe:mina-archive,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina_testnet_signatures.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
+                    , "MINA_PROFILE=devnet"
+                    , "APPS_BARE_BINARIES=archive_node_tests.exe:mina-archive-node-test,archive.exe:mina-archive,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
                     ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.Script

--- a/buildkite/src/Command/PatchArchiveTest.dhall
+++ b/buildkite/src/Command/PatchArchiveTest.dhall
@@ -22,7 +22,8 @@ in  { step =
                     [ "PATCH_ARCHIVE_TEST_APP=mina-patch-archive-test"
                     , "NETWORK_DATA_FOLDER=src/test/archive/sample_db"
                     , "APPS_BUILD_FLAG=instrumented"
-                    , "APPS_BARE_BINARIES=patch_archive_test.exe:mina-patch-archive-test,extract_blocks.exe:mina-extract-blocks,missing_blocks_auditor.exe:mina-missing-blocks-auditor,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina_testnet_signatures.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
+                    , "MINA_PROFILE=devnet"
+                    , "APPS_BARE_BINARIES=patch_archive_test.exe:mina-patch-archive-test,extract_blocks.exe:mina-extract-blocks,missing_blocks_auditor.exe:mina-missing-blocks-auditor,archive_blocks.exe:mina-archive-blocks,replayer.exe:mina-replayer,mina.exe:mina,runtime_genesis_ledger.exe:mina-create-genesis"
                     , "APPS_BARE_SCRIPTS=scripts/archive/missing-blocks-guardian.sh:mina-missing-blocks-guardian"
                     ]
                     ( Some

--- a/buildkite/src/Command/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Command/RosettaBlockRaceTest.dhall
@@ -17,7 +17,8 @@ in  { step =
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
                     [ "APPS_NETWORK=mainnet"
-                    , "APPS_BARE_BINARIES=mina_mainnet_signatures.exe:mina,archive.exe:mina-archive,rosetta_mainnet_signatures.exe:mina-rosetta"
+                    , "MINA_PROFILE=mainnet"
+                    , "APPS_BARE_BINARIES=mina.exe:mina,archive.exe:mina-archive,rosetta.exe:mina-rosetta"
                     ]
                     ( Some
                         ( RunWithPostgres.ScriptOrArchive.OnlineTarGzDump

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -33,10 +33,10 @@ let dirtyWhen =
       ]
 
 let bareBinaries =
-          "mina_testnet_signatures.exe:mina"
+          "mina.exe:mina"
       ++  ",archive.exe:mina-archive"
-      ++  ",rosetta_testnet_signatures.exe:mina-rosetta"
-      ++  ",signer_testnet_signatures.exe:mina-ocaml-signer"
+      ++  ",rosetta.exe:mina-rosetta"
+      ++  ",signer.exe:mina-ocaml-signer"
       ++  ",zkapp_test_transaction.exe:mina-zkapp-test-transaction"
       ++  ",indexer_test.exe:mina-rosetta-indexer-test"
       ++  ",libp2p_helper:libp2p_helper"
@@ -45,6 +45,7 @@ let envExports =
       [ "MINA_NETWORK_DEB=${Network.lowerName network}"
       , "MINA_DEB_CODENAME=bullseye"
       , "APPS_NETWORK=${Network.lowerName network}"
+      , "MINA_PROFILE=${Network.lowerName network}"
       , "APPS_BARE_BINARIES=${bareBinaries}"
       ]
 


### PR DESCRIPTION
## Problem

Bare-apps tests that restore binaries via `restore-or-install.sh` list **signature-specific executables** in `APPS_BARE_BINARIES` — `mina_testnet_signatures.exe`, `mina_mainnet_signatures.exe`, `rosetta_*_signatures.exe`, `signer_*_signatures.exe`. None of those are built (`make build` builds `mina.exe`/`rosetta.exe`/`signer.exe`; the signature kind is a separate dune target that isn't compiled), so the restore misses and the test fails:

```
restore_app: apps/bullseye/devnet-devnet-instrumented/mina_testnet_signatures.exe not found in cache
```

(Seen on ArchiveNodeTest and RosettaIntegrationTests, among others.)

Additionally, the bare binary resolves its node profile from `MINA_PROFILE` (default `dev`, ledger_depth 10). The `.deb` path got this from `/etc/coda/build_config/PROFILE`; the bare path didn't set it, so anything that builds a realistic genesis ledger (e.g. `mina-create-genesis`) would overflow with "Index is too large".

## Fix

For the four affected command/test files:
- Replace `<base>_<network>_signatures.exe` → `<base>.exe` (`mina.exe`, `rosetta.exe`, `signer.exe`) — the binaries the app-build actually caches (and the deb ships).
- Set `MINA_PROFILE` to the test's network (`devnet` for ArchiveNode/PatchArchive/Rosetta, `mainnet` for RosettaBlockRace), matching what the deb's `PROFILE` hint provided.

Files: `ArchiveNodeTest.dhall`, `PatchArchiveTest.dhall`, `RosettaBlockRaceTest.dhall`, `RosettaIntegrationTests.dhall`.

This is the same class of fix as #19045 (`restore_binary.sh`) and #19026 (`MINA_PROFILE` for ledger-apply), applied to the `restore-or-install.sh` callers.

## Verification
`cd buildkite && make all` passes (45/45); no `*_signatures.exe` references remain in `buildkite/src`.
