### PR TITLE
archive-hardfork-toolbox: polish convert-chain-to-canonical (--dry-run, --fork-height, auto-detect)

### DIFF
--- a/src/app/archive_hardfork_toolbox/README.md
+++ b/src/app/archive_hardfork_toolbox/README.md
@@ -102,6 +102,51 @@ archive_hardfork_toolbox validate-fork \
 - `--fork-state-hash`: Hash of the fork state
 - `--fork-slot`: Global slot since genesis of the fork block
 
+### convert-chain-to-canonical
+
+Marks the chain leading to a target block as `canonical` (and orphans the competing
+blocks of that protocol version). This is the post-fork repair step for the pre-fork
+tail: at a hard fork the last ~k pre-fork blocks (including the fork block's parent)
+are left `pending` because the canonical watermark jumps to the fork genesis and never
+walks back below it. This command finalizes them.
+
+**Usage (auto-detect the latest boundary):**
+```bash
+archive_hardfork_toolbox convert-chain-to-canonical \
+  --postgres-uri "postgresql://user:pass@host:port/db" \
+  --dry-run
+```
+With no target/protocol flags it auto-detects the latest hard-fork boundary — the
+parent of the highest block with `global_slot_since_hard_fork = 0` — and uses that
+block's protocol version. Run with `--dry-run` first to review the change plan and
+summary, then re-run without it to apply.
+
+If the fork does **not** bump the protocol version (some emergency hard forks), the
+post-fork chain shares the protocol version with the pre-fork chain. The command
+detects the fork boundary and leaves blocks at or beyond it untouched, so the
+post-fork chain is never orphaned.
+
+**Usage (explicit target):**
+```bash
+archive_hardfork_toolbox convert-chain-to-canonical \
+  --postgres-uri "postgresql://user:pass@host:port/db" \
+  --protocol-version "3.0.0" \
+  --target-block-hash "3NKx..."
+```
+
+**Parameters:**
+- `--postgres-uri`: URI for connecting to the archive database
+- `--target-block-hash`: State hash of the block that should remain canonical (default: parent of the latest hard-fork block)
+- `--fork-height`: Height of the block that should remain canonical (alternative to `--target-block-hash`)
+- `--protocol-version`: Protocol version `<transaction>.<network>.<patch>` (default: the target block's own protocol version)
+- `--stop-at-slot`: If provided, stops marking blocks older than this global slot since genesis
+- `--dry-run`: Print the blocks that would change and a summary without writing any changes
+- `--json`: Emit the change plan as JSON (target, fork block, boundary slot, summary, and a per-block `changes` array) instead of the human-readable table
+
+To repair an earlier boundary (e.g. on a network with more than one hard fork), pass
+`--protocol-version` and `--target-block-hash`/`--fork-height` explicitly instead of
+relying on auto-detection, which always targets the latest boundary.
+
 ## Typical Workflow
 
 1. **Pre-fork validation**: Use the `fork-candidate` commands to ensure the chosen fork point is valid:
@@ -112,6 +157,8 @@ archive_hardfork_toolbox validate-fork \
 2. **Schema upgrade**: Use `verify-upgrade` to validate the database migration process
 
 3. **Post-fork validation**: Use `validate-fork` to ensure the fork block and its ancestry remain intact
+
+4. **Post-fork tail repair**: Use `convert-chain-to-canonical` (with `--dry-run` first) to finalize the pre-fork tail that would otherwise stay `pending`
 
 ## Database Connection
 

--- a/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
+++ b/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
@@ -85,23 +85,40 @@ let convert_chain_to_canonical_command =
   Async.Command.async_or_error
     ~summary:
       "Mark the chain leading to the target block as canonical for a protocol \
-       version"
+       version. With no target/protocol flags, auto-detects the latest \
+       hard-fork boundary."
     (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
-     and latest_block_state_hash =
-       Command.Param.(flag "--target-block-hash" (required string))
-         ~doc:"String State hash of block that should remain canonical"
-     and expected_protocol_version_str =
-       Command.Param.(flag "--protocol-version" (required string))
+     and target_block_hash =
+       Command.Param.(flag "--target-block-hash" (optional string))
          ~doc:
-           "String Protocol version in format <transaction>.<network>.<patch>"
+           "String State hash of block that should remain canonical (default: \
+            parent of the latest hard-fork block)"
+     and fork_height =
+       Command.Param.(flag "--fork-height" (optional int))
+         ~doc:
+           "Int Height of the block that should remain canonical (alternative \
+            to --target-block-hash)"
+     and protocol_version_str =
+       Command.Param.(flag "--protocol-version" (optional string))
+         ~doc:
+           "String Protocol version in format <transaction>.<network>.<patch> \
+            (default: the target block's own protocol version)"
      and stop_at_slot =
        Command.Param.(flag "--stop-at-slot" (optional int))
          ~doc:
            "Int If provided, stops marking blocks as canonical when that's \
             older than this global slot since genesis slot"
+     and dry_run =
+       Command.Param.(flag "--dry-run" no_arg)
+         ~doc:
+           "Print the blocks that would change and a summary without writing \
+            any changes"
+     and json =
+       Command.Param.(flag "--json" no_arg)
+         ~doc:"Emit the change plan as JSON instead of a human-readable table"
      in
-     convert_chain_to_canonical ~postgres_uri ~latest_block_state_hash
-       ~expected_protocol_version_str ~stop_at_slot )
+     convert_chain_to_canonical ~postgres_uri ?target_block_hash ?fork_height
+       ?protocol_version_str ~json ~stop_at_slot ~dry_run )
 
 let fetch_last_filled_block_command =
   Async.Command.async ~summary:"Select last filled block"

--- a/src/app/archive_hardfork_toolbox/change_plan.ml
+++ b/src/app/archive_hardfork_toolbox/change_plan.ml
@@ -1,0 +1,152 @@
+open Core
+
+(* The change plan produced by convert-chain-to-canonical: a pure data
+   description of what the operation would do, rendered either as a
+   human-readable table or as JSON. It carries no database or presentation
+   logic, so both renderers consume the exact same value. *)
+
+module Block_ref = struct
+  type t = { state_hash : string; height : int64; protocol_version : string }
+  [@@deriving to_yojson]
+end
+
+module Fork_ref = struct
+  type t =
+    { state_hash : string (* the post-fork genesis block *)
+    ; height : int64
+    ; global_slot : int64 (* the boundary slot *)
+    ; chain_status : string
+    ; parent_state_hash : string option (* the last pre-fork block *)
+    ; parent_height : int64 option
+    }
+  [@@deriving to_yojson]
+end
+
+module Summary = struct
+  type t =
+    { to_canonical : int (* blocks marked canonical (incl. already-canonical) *)
+    ; to_canonical_pending : int (* of those, how many were pending (healed) *)
+    ; to_orphaned : int (* blocks marked orphaned *)
+    ; to_orphaned_pending : int (* of those, how many were pending *)
+    }
+  [@@deriving to_yojson]
+end
+
+module Change = struct
+  type t =
+    { height : int64
+    ; state_hash : string
+    ; current : string (* chain_status before the operation *)
+    ; new_status : string [@key "new"] (* chain_status after the operation *)
+    ; untouched : bool (* true when the block is left as-is (post-fork chain) *)
+    ; reason : string (* why the block ends up with [new_status] *)
+    }
+  [@@deriving to_yojson]
+end
+
+type t =
+  { dry_run : bool
+  ; target : Block_ref.t (* last block that stays canonical *)
+  ; fork_block : Fork_ref.t option (* the hard fork just above the target *)
+  ; boundary_slot : int64 option (* blocks at/beyond this slot are untouched *)
+  ; summary : Summary.t
+  ; changes : Change.t list
+        (* changing blocks, plus the fork block, by height *)
+  }
+[@@deriving to_yojson]
+
+(* --- rendering --- *)
+
+let marker_of t (change : Change.t) =
+  let { Change.state_hash; _ } = change in
+  let { Block_ref.state_hash = target_hash; _ } = t.target in
+  if String.equal state_hash target_hash then "TARGET"
+  else
+    match t.fork_block with
+    | Some { Fork_ref.state_hash = fork_hash; _ }
+      when String.equal state_hash fork_hash ->
+        "FORK BLOCK"
+    | _ ->
+        ""
+
+let transition_of (change : Change.t) =
+  let { Change.untouched; current; new_status; _ } = change in
+  if untouched then sprintf "%s (untouched)" current
+  else sprintf "%s → %s" current new_status
+
+let render_header t =
+  let { Block_ref.state_hash = target_hash
+      ; height = target_height
+      ; protocol_version
+      } =
+    t.target
+  in
+  printf "Target: %s (height %Ld), protocol version %s%s\n" target_hash
+    target_height protocol_version
+    (if t.dry_run then "  [DRY RUN]" else "") ;
+  match t.fork_block with
+  | Some { Fork_ref.state_hash; height; global_slot; parent_state_hash; _ } ->
+      let parent_note =
+        match parent_state_hash with
+        | Some p when String.equal p target_hash ->
+            " — its parent is the target"
+        | Some p ->
+            sprintf " — its parent is %s" p
+        | None ->
+            ""
+      in
+      printf "Fork block above target: %s (height %Ld, global slot %Ld)%s\n"
+        state_hash height global_slot parent_note ;
+      printf
+        "Blocks at or beyond slot %Ld stay untouched, protecting the post-fork \
+         chain.\n"
+        global_slot
+  | None ->
+      printf
+        "No hard fork above the target; the whole protocol version is in scope.\n"
+
+let render_table t =
+  let changing = List.count t.changes ~f:(fun c -> not c.Change.untouched) in
+  if changing = 0 then
+    printf
+      "\nChange plan: nothing changes; chain already canonical to target.\n"
+  else
+    let columns =
+      [ ("height", 7); ("transition", 23); ("reason", 44); ("state_hash", 52) ]
+    in
+    let rows =
+      List.map t.changes ~f:(fun change ->
+          let { Change.height; reason; state_hash; _ } = change in
+          let cells =
+            [ Int64.to_string height; transition_of change; reason; state_hash ]
+          in
+          let suffix =
+            match marker_of t change with "" -> "" | m -> sprintf " ◀ %s" m
+          in
+          (cells, suffix) )
+    in
+    printf "\nChange plan — %d block(s) change:\n" changing ;
+    printf "%s" (Utils.render_table ~columns rows)
+
+let render_summary t =
+  let { Summary.to_canonical
+      ; to_canonical_pending
+      ; to_orphaned
+      ; to_orphaned_pending
+      } =
+    t.summary
+  in
+  let { Block_ref.protocol_version; _ } = t.target in
+  printf
+    "\n\
+     Summary: %d → canonical (%d currently pending), %d of protocol version %s \
+     → orphaned (%d currently pending).\n"
+    to_canonical to_canonical_pending to_orphaned protocol_version
+    to_orphaned_pending ;
+  if t.dry_run then printf "Dry run: no changes were written.\n"
+
+let render_human t = render_header t ; render_table t ; render_summary t
+
+let render_json t =
+  Yojson.Safe.pretty_to_channel Out_channel.stdout (to_yojson t) ;
+  Out_channel.newline Out_channel.stdout

--- a/src/app/archive_hardfork_toolbox/dune
+++ b/src/app/archive_hardfork_toolbox/dune
@@ -19,6 +19,8 @@
   base
   base.caml
   integers
+  yojson
+  ppx_deriving_yojson.runtime
   ;; local libraries
   logger
   archive_lib
@@ -42,7 +44,7 @@
   signature_lib
   unsigned_extended
   with_hash)
- (modules logic sql)
+ (modules logic sql utils change_plan)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
@@ -53,6 +55,7 @@
    ppx_mina
    ppx_sexp_conv
    ppx_string
+   ppx_deriving_yojson
    ppx_version)))
 
 (executable

--- a/src/app/archive_hardfork_toolbox/dune
+++ b/src/app/archive_hardfork_toolbox/dune
@@ -19,7 +19,6 @@
   base
   base.caml
   integers
-  yojson
   ppx_deriving_yojson.runtime
   ;; local libraries
   logger

--- a/src/app/archive_hardfork_toolbox/logic.ml
+++ b/src/app/archive_hardfork_toolbox/logic.ml
@@ -239,13 +239,59 @@ let fetch_last_filled_block ~postgres_uri () =
   Yojson.Safe.to_channel Out_channel.stdout json ;
   Out_channel.newline Out_channel.stdout
 
-let convert_chain_to_canonical ~postgres_uri ~latest_block_state_hash
-    ~expected_protocol_version_str ~stop_at_slot () =
-  let expected_protocol_version =
-    Sql.Protocol_version.of_string expected_protocol_version_str
-  in
+let convert_chain_to_canonical ~postgres_uri ?target_block_hash ?fork_height
+    ?protocol_version_str ?(json = false) ~stop_at_slot ~dry_run () =
   let pool = connect postgres_uri in
   let query_db = Mina_caqti.query pool in
+  (* Resolve the target block: an explicit state hash, an explicit height, or,
+     when neither is given, auto-detect the parent of the latest hard-fork
+     block (i.e. the last pre-fork block that should remain canonical). *)
+  let%bind.Deferred.Or_error latest_block =
+    match (target_block_hash, fork_height) with
+    | Some _, Some _ ->
+        Deferred.Or_error.errorf
+          "Provide at most one of --target-block-hash or --fork-height"
+    | Some state_hash, None -> (
+        match%map query_db ~f:(Sql.block_info_by_state_hash ~state_hash) with
+        | Some info ->
+            Or_error.return info
+        | None ->
+            Or_error.errorf "Cannot find block with state hash %s" state_hash )
+    | None, Some height -> (
+        match%map
+          query_db ~f:(Sql.blocks_info_by_height ~height:(Int64.of_int height))
+        with
+        | [ info ] ->
+            Or_error.return info
+        | [] ->
+            Or_error.errorf "Cannot find any block at height %d" height
+        | _ :: _ ->
+            Or_error.errorf
+              "Found multiple blocks at height %d; disambiguate with \
+               --target-block-hash"
+              height )
+    | None, None -> (
+        match%map query_db ~f:Sql.parent_of_latest_fork_block with
+        | Some info ->
+            Or_error.return info
+        | None ->
+            Or_error.errorf
+              "Could not auto-detect a fork boundary (no hard-fork block with \
+               a parent was found). Provide --target-block-hash or \
+               --fork-height." )
+  in
+  let latest_block_state_hash = latest_block.state_hash in
+  (* Protocol version: explicit override, otherwise the target block's own. *)
+  let expected_protocol_version =
+    match protocol_version_str with
+    | Some s ->
+        Sql.Protocol_version.of_string s
+    | None ->
+        latest_block.protocol_version
+  in
+  let expected_protocol_version_str =
+    Sql.Protocol_version.to_string expected_protocol_version
+  in
   let%bind.Deferred.Or_error oldest_block =
     match%map
       query_db
@@ -257,31 +303,11 @@ let convert_chain_to_canonical ~postgres_uri ~latest_block_state_hash
         Or_error.errorf "Cannot locate genesis block for protocol version %s"
           expected_protocol_version_str
   in
-  let%bind.Deferred.Or_error latest_block =
-    match%map
-      query_db
-        ~f:(Sql.block_info_by_state_hash ~state_hash:latest_block_state_hash)
-    with
-    | Some info ->
-        Or_error.return info
-    | None ->
-        Or_error.errorf "Cannot find block with state hash %s"
-          latest_block_state_hash
-  in
   let%bind blocks_to_ensure_canonical =
     query_db
       ~f:
         (Sql.blocks_between_both_inclusive ~oldest_block_id:oldest_block.id
            ~latest_block_id:latest_block.id )
-  in
-
-  let () =
-    printf "Blocks to ensure canonical (%d blocks):\n"
-      (List.length blocks_to_ensure_canonical) ;
-    List.iter blocks_to_ensure_canonical ~f:(fun b ->
-        printf "  - id: %d, state_hash: %s, height: %Ld, protocol_version: %s\n"
-          b.id b.state_hash b.height
-          (Sql.Protocol_version.to_string b.protocol_version) )
   in
 
   let%bind.Deferred.Or_error () =
@@ -323,16 +349,135 @@ let convert_chain_to_canonical ~postgres_uri ~latest_block_state_hash
       Deferred.Or_error.errorf "Some blocks have unexpected state hash: %s"
         message
   in
-  [%log info] "Marking chain from %s to %s as canonical for protocol version %s"
-    oldest_block.state_hash latest_block_state_hash
-    (Sql.Protocol_version.to_string expected_protocol_version) ;
   let canonical_block_ids =
     List.map blocks_to_ensure_canonical ~f:(fun b -> b.id)
   in
-  let%map () =
+  let canonical_count = List.length blocks_to_ensure_canonical in
+  (* The hard fork just above the target, if any. Its slot is the upper bound that
+     protects the post-fork chain when the fork keeps the same protocol version
+     (see fork_block_above_height). None when the target is at the tip (no later
+     fork), which preserves the previous behaviour. *)
+  let%bind fork_context =
+    query_db ~f:(Sql.fork_block_above_height ~height:latest_block.height)
+  in
+  let fork_boundary_slot =
+    Option.map fork_context ~f:(fun fc -> fc.Sql.Fork_context.fork_slot)
+  in
+  (* The blocks that change status: the ancestry blocks not yet canonical
+     (-> canonical), and the same-version off-chain blocks below the boundary
+     (-> orphaned). The rest of the ancestry (including the protocol-version
+     genesis) is already canonical and is not listed. *)
+  let%bind blocks_to_heal =
+    query_db ~f:(Sql.noncanonical_blocks_in_set ~canonical_block_ids)
+  in
+  let%bind blocks_to_orphan =
     query_db
       ~f:
-        (Sql.mark_pending_blocks_as_canonical_or_orphaned ~canonical_block_ids
-           ~stop_at_slot ~protocol_version:expected_protocol_version )
+        (Sql.blocks_to_orphan ~canonical_block_ids ~stop_at_slot
+           ~fork_boundary_slot ~protocol_version:expected_protocol_version )
   in
-  Ok ()
+  let%bind orphaned_count, pending_to_canonical, pending_to_orphaned =
+    query_db
+      ~f:
+        (Sql.conversion_summary_counts ~canonical_block_ids ~stop_at_slot
+           ~fork_boundary_slot ~protocol_version:expected_protocol_version )
+  in
+  (* Assemble the change plan: each block that changes, plus the fork block for
+     context, with its current/new status and the reason. The already-canonical
+     ancestry (including the protocol-version genesis) is not listed. *)
+  let heal_changes =
+    List.map blocks_to_heal ~f:(fun (height, hash, current) ->
+        { Change_plan.Change.height
+        ; state_hash = hash
+        ; current
+        ; new_status = "canonical"
+        ; untouched = false
+        ; reason =
+            ( if String.equal hash latest_block_state_hash then
+              "fork parent (target)"
+            else "on chain to target" )
+        } )
+  in
+  let orphan_changes =
+    List.map blocks_to_orphan ~f:(fun (height, hash, current) ->
+        { Change_plan.Change.height
+        ; state_hash = hash
+        ; current
+        ; new_status = "orphaned"
+        ; untouched = false
+        ; reason = "off-chain / competing, below fork boundary"
+        } )
+  in
+  let fork_change =
+    match fork_context with
+    | Some
+        { Sql.Fork_context.fork_state_hash; fork_height; fork_chain_status; _ }
+      ->
+        [ { Change_plan.Change.height = fork_height
+          ; state_hash = fork_state_hash
+          ; current = fork_chain_status
+          ; new_status = fork_chain_status
+          ; untouched = true
+          ; reason = "post-fork genesis (protected)"
+          }
+        ]
+    | None ->
+        []
+  in
+  let changes =
+    List.sort
+      (heal_changes @ orphan_changes @ fork_change)
+      ~compare:(fun a b ->
+        Int64.compare a.Change_plan.Change.height b.Change_plan.Change.height )
+  in
+  let plan =
+    { Change_plan.dry_run
+    ; target =
+        { Change_plan.Block_ref.state_hash = latest_block_state_hash
+        ; height = latest_block.height
+        ; protocol_version = expected_protocol_version_str
+        }
+    ; fork_block =
+        Option.map fork_context ~f:(fun fc ->
+            let { Sql.Fork_context.fork_state_hash
+                ; fork_height
+                ; fork_slot
+                ; fork_chain_status
+                ; parent_state_hash
+                ; parent_height
+                } =
+              fc
+            in
+            { Change_plan.Fork_ref.state_hash = fork_state_hash
+            ; height = fork_height
+            ; global_slot = fork_slot
+            ; chain_status = fork_chain_status
+            ; parent_state_hash
+            ; parent_height
+            } )
+    ; boundary_slot = fork_boundary_slot
+    ; summary =
+        { Change_plan.Summary.to_canonical = canonical_count
+        ; to_canonical_pending = pending_to_canonical
+        ; to_orphaned = orphaned_count
+        ; to_orphaned_pending = pending_to_orphaned
+        }
+    ; changes
+    }
+  in
+  if json then Change_plan.render_json plan else Change_plan.render_human plan ;
+  if dry_run then Deferred.Or_error.return ()
+  else (
+    if not json then
+      [%log info]
+        "Marking chain from %s to %s as canonical for protocol version %s"
+        oldest_block.state_hash latest_block_state_hash
+        expected_protocol_version_str ;
+    let%map () =
+      query_db
+        ~f:
+          (Sql.mark_pending_blocks_as_canonical_or_orphaned ~canonical_block_ids
+             ~stop_at_slot ~fork_boundary_slot
+             ~protocol_version:expected_protocol_version )
+    in
+    Ok () )

--- a/src/app/archive_hardfork_toolbox/logic.ml
+++ b/src/app/archive_hardfork_toolbox/logic.ml
@@ -352,7 +352,6 @@ let convert_chain_to_canonical ~postgres_uri ?target_block_hash ?fork_height
   let canonical_block_ids =
     List.map blocks_to_ensure_canonical ~f:(fun b -> b.id)
   in
-  let canonical_count = List.length blocks_to_ensure_canonical in
   (* The hard fork just above the target, if any. Its slot is the upper bound that
      protects the post-fork chain when the fork keeps the same protocol version
      (see fork_block_above_height). None when the target is at the tip (no later
@@ -376,7 +375,10 @@ let convert_chain_to_canonical ~postgres_uri ?target_block_hash ?fork_height
         (Sql.blocks_to_orphan ~canonical_block_ids ~stop_at_slot
            ~fork_boundary_slot ~protocol_version:expected_protocol_version )
   in
-  let%bind orphaned_count, pending_to_canonical, pending_to_orphaned =
+  let%bind ( canonical_count
+           , pending_to_canonical
+           , orphaned_count
+           , pending_to_orphaned ) =
     query_db
       ~f:
         (Sql.conversion_summary_counts ~canonical_block_ids ~stop_at_slot

--- a/src/app/archive_hardfork_toolbox/sql.ml
+++ b/src/app/archive_hardfork_toolbox/sql.ml
@@ -282,20 +282,26 @@ let blocks_to_orphan (module Conn : CONNECTION) ~canonical_block_ids
     , fork_boundary_slot )
 
 (* Counts, over the blocks the conversion would touch (subject to the same slot
-   and fork-boundary filters as the mutation), how many would become orphaned and
-   how many currently-pending blocks change status in each direction. *)
+   and fork-boundary filters as the mutation), how many become canonical and how
+   many become orphaned, plus how many currently-pending blocks change status in
+   each direction. Returned as (to_canonical, pending_to_canonical, to_orphaned,
+   pending_to_orphaned). The orphaned count excludes rows already orphaned so it
+   matches the printed change plan and a re-run reports 0 rather than recounting
+   settled blocks. *)
 let conversion_summary_counts (module Conn : CONNECTION) ~canonical_block_ids
     ~stop_at_slot ~fork_boundary_slot ~protocol_version =
   let query =
     Caqti_type.(
       t4 (option int) Mina_caqti.array_int_typ Protocol_version.typ
         (option int64)
-      ->! t3 int int int)
+      ->! t4 int int int int)
       {%string|
         SELECT
-          COUNT(*) FILTER (WHERE NOT (id = ANY($2::int[])))::int,
+          COUNT(*) FILTER (WHERE id = ANY($2::int[]))::int,
           COUNT(*) FILTER (WHERE chain_status = 'pending'::chain_status_type
                              AND id = ANY($2::int[]))::int,
+          COUNT(*) FILTER (WHERE NOT (id = ANY($2::int[]))
+                             AND chain_status <> 'orphaned'::chain_status_type)::int,
           COUNT(*) FILTER (WHERE chain_status = 'pending'::chain_status_type
                              AND NOT (id = ANY($2::int[])))::int
         FROM blocks

--- a/src/app/archive_hardfork_toolbox/sql.ml
+++ b/src/app/archive_hardfork_toolbox/sql.ml
@@ -151,11 +151,193 @@ let block_info_by_state_hash (module Conn : CONNECTION) ~state_hash =
   in
   Conn.find_opt query state_hash
 
+let blocks_info_by_height (module Conn : CONNECTION) ~height =
+  let query =
+    Caqti_type.(int64 ->* Block_info.typ)
+      {%string|
+        SELECT blocks.id, height, state_hash, protocol_versions.transaction, protocol_versions.network, protocol_versions.patch
+        FROM blocks INNER JOIN protocol_versions
+          ON blocks.protocol_version_id = protocol_versions.id
+        WHERE height = ?;
+      |}
+  in
+  Conn.collect_list query height
+
+(* Auto-detect the latest hard-fork boundary: the parent of the highest hard-fork
+   block (global_slot_since_hard_fork = 0). The genesis block also has
+   global_slot_since_hard_fork = 0 but has no parent, so it is excluded. The
+   returned block is the last pre-fork block that should remain canonical, and its
+   protocol version is the pre-fork one whose chain we want to finalize. *)
+let parent_of_latest_fork_block (module Conn : CONNECTION) =
+  let query =
+    Caqti_type.(unit ->? Block_info.typ)
+      {%string|
+        SELECT parent.id, parent.height, parent.state_hash, pv.transaction, pv.network, pv.patch
+        FROM blocks fork
+        INNER JOIN blocks parent ON parent.id = fork.parent_id
+        INNER JOIN protocol_versions pv ON parent.protocol_version_id = pv.id
+        WHERE fork.global_slot_since_hard_fork = 0
+          AND fork.parent_id IS NOT NULL
+        ORDER BY fork.height DESC
+        LIMIT 1;
+      |}
+  in
+  Conn.find_opt query ()
+
+(* Context about the hard fork just above the target: the post-fork genesis block
+   (global_slot_since_hard_fork = 0) and its parent (the last pre-fork block). *)
+module Fork_context = struct
+  type t =
+    { fork_state_hash : string
+    ; fork_height : int64
+    ; fork_slot : int64
+    ; fork_chain_status : string
+    ; parent_state_hash : string option
+    ; parent_height : int64 option
+    }
+
+  let typ =
+    let encode
+        { fork_state_hash
+        ; fork_height
+        ; fork_slot
+        ; fork_chain_status
+        ; parent_state_hash
+        ; parent_height
+        } =
+      Ok
+        ( (fork_state_hash, fork_height, fork_slot)
+        , (fork_chain_status, parent_state_hash, parent_height) )
+    in
+    let decode
+        ( (fork_state_hash, fork_height, fork_slot)
+        , (fork_chain_status, parent_state_hash, parent_height) ) =
+      Ok
+        { fork_state_hash
+        ; fork_height
+        ; fork_slot
+        ; fork_chain_status
+        ; parent_state_hash
+        ; parent_height
+        }
+    in
+    Caqti_type.(
+      custom ~encode ~decode
+        (t2 (t3 string int64 int64) (t3 string (option string) (option int64))))
+end
+
+(* The first hard-fork block (global_slot_since_hard_fork = 0) strictly above the
+   target height, i.e. the post-fork genesis, together with its parent. Its slot
+   is used as an upper bound for orphaning so that, when the fork does NOT bump the
+   protocol version (some emergency hard forks), the post-fork chain — which shares
+   the protocol version with the pre-fork chain — is not orphaned. Returns None
+   when there is no hard fork above the target (e.g. the tip is pre-fork). *)
+let fork_block_above_height (module Conn : CONNECTION) ~height =
+  let query =
+    Caqti_type.(int64 ->? Fork_context.typ)
+      {%string|
+        SELECT fork.state_hash, fork.height, fork.global_slot_since_genesis,
+               fork.chain_status::text, parent.state_hash, parent.height
+        FROM blocks fork
+        LEFT JOIN blocks parent ON parent.id = fork.parent_id
+        WHERE fork.global_slot_since_hard_fork = 0
+          AND fork.height > ?
+        ORDER BY fork.global_slot_since_genesis ASC
+        LIMIT 1;
+      |}
+  in
+  Conn.find_opt query height
+
+(* The blocks that will be orphaned: same protocol version, below the fork
+   boundary and within the slot filter, not on the canonical chain to the target,
+   and not already orphaned. These are the competing / leftover blocks. *)
+let blocks_to_orphan (module Conn : CONNECTION) ~canonical_block_ids
+    ~stop_at_slot ~fork_boundary_slot ~protocol_version =
+  let query =
+    Caqti_type.(
+      t4 (option int) Mina_caqti.array_int_typ Protocol_version.typ
+        (option int64)
+      ->* t3 int64 string string)
+      {%string|
+        SELECT height, state_hash, chain_status::text
+        FROM blocks
+        WHERE ($1 IS NULL OR $1::int <= global_slot_since_genesis)
+          AND ($6 IS NULL OR global_slot_since_genesis < $6::bigint)
+          AND NOT (id = ANY($2::int[]))
+          AND chain_status <> 'orphaned'::chain_status_type
+          AND protocol_version_id = (
+            SELECT id FROM protocol_versions
+            WHERE transaction = $3::int
+              AND network = $4::int
+              AND patch = $5::int
+            LIMIT 1
+          )
+        ORDER BY height ASC;
+      |}
+  in
+  Conn.collect_list query
+    ( stop_at_slot
+    , Array.of_list canonical_block_ids
+    , protocol_version
+    , fork_boundary_slot )
+
+(* Counts, over the blocks the conversion would touch (subject to the same slot
+   and fork-boundary filters as the mutation), how many would become orphaned and
+   how many currently-pending blocks change status in each direction. *)
+let conversion_summary_counts (module Conn : CONNECTION) ~canonical_block_ids
+    ~stop_at_slot ~fork_boundary_slot ~protocol_version =
+  let query =
+    Caqti_type.(
+      t4 (option int) Mina_caqti.array_int_typ Protocol_version.typ
+        (option int64)
+      ->! t3 int int int)
+      {%string|
+        SELECT
+          COUNT(*) FILTER (WHERE NOT (id = ANY($2::int[])))::int,
+          COUNT(*) FILTER (WHERE chain_status = 'pending'::chain_status_type
+                             AND id = ANY($2::int[]))::int,
+          COUNT(*) FILTER (WHERE chain_status = 'pending'::chain_status_type
+                             AND NOT (id = ANY($2::int[])))::int
+        FROM blocks
+        WHERE ($1 IS NULL OR $1::int <= global_slot_since_genesis)
+          AND ($6 IS NULL OR global_slot_since_genesis < $6::bigint)
+          AND protocol_version_id = (
+            SELECT id FROM protocol_versions
+            WHERE transaction = $3::int
+              AND network = $4::int
+              AND patch = $5::int
+            LIMIT 1
+          );
+      |}
+  in
+  Conn.find query
+    ( stop_at_slot
+    , Array.of_list canonical_block_ids
+    , protocol_version
+    , fork_boundary_slot )
+
+(* The blocks in the canonical set that are NOT already canonical, i.e. the ones
+   actually being healed. Used to print a concise, meaningful list instead of the
+   whole ancestry (most of which is already canonical). *)
+let noncanonical_blocks_in_set (module Conn : CONNECTION) ~canonical_block_ids =
+  let query =
+    Caqti_type.(Mina_caqti.array_int_typ ->* t3 int64 string string)
+      {%string|
+        SELECT height, state_hash, chain_status::text
+        FROM blocks
+        WHERE id = ANY(?::int[])
+          AND chain_status <> 'canonical'::chain_status_type
+        ORDER BY height ASC;
+      |}
+  in
+  Conn.collect_list query (Array.of_list canonical_block_ids)
+
 let mark_pending_blocks_as_canonical_or_orphaned (module Conn : CONNECTION)
-    ~canonical_block_ids ~stop_at_slot ~protocol_version =
+    ~canonical_block_ids ~stop_at_slot ~fork_boundary_slot ~protocol_version =
   let mutation =
     Caqti_type.(
-      t3 (option int) Mina_caqti.array_int_typ Protocol_version.typ
+      t4 (option int) Mina_caqti.array_int_typ Protocol_version.typ
+        (option int64)
       ->. Caqti_type.unit)
       {%string|
         UPDATE blocks
@@ -164,6 +346,13 @@ let mark_pending_blocks_as_canonical_or_orphaned (module Conn : CONNECTION)
             ELSE 'orphaned'::chain_status_type
         END
         WHERE ($1 IS NULL OR $1::int <= global_slot_since_genesis)
+          -- Never touch blocks at or beyond the fork boundary: when the fork does
+          -- not bump the protocol version, those are the post-fork chain and must
+          -- stay canonical. Canonical-set members are always pre-fork, so the
+          -- extra clause keeps them included.
+          AND (id = ANY($2::int[])
+               OR $6 IS NULL
+               OR global_slot_since_genesis < $6::bigint)
           AND protocol_version_id = (
             SELECT id FROM protocol_versions
             WHERE transaction = $3::int
@@ -174,7 +363,10 @@ let mark_pending_blocks_as_canonical_or_orphaned (module Conn : CONNECTION)
       |}
   in
   Conn.exec mutation
-    (stop_at_slot, Array.of_list canonical_block_ids, protocol_version)
+    ( stop_at_slot
+    , Array.of_list canonical_block_ids
+    , protocol_version
+    , fork_boundary_slot )
 
 let blocks_between_both_inclusive (module Conn : CONNECTION) ~latest_block_id
     ~oldest_block_id : (Block_info.t list, Caqti_error.t) Deferred.Result.t =

--- a/src/app/archive_hardfork_toolbox/tests/dune
+++ b/src/app/archive_hardfork_toolbox/tests/dune
@@ -1,47 +1,54 @@
 (test
  (name test_convert_canonical)
  (libraries
-   ;; opam libraries
-   alcotest
-   async_unix
-   core
-   result
-   async_kernel
-   uri
-   stdio
-   caqti-driver-postgresql
-   caqti
-   async
-   core_kernel
-   caqti-async
-   base
-   base.caml
-   threads.posix
-   ;; from parent dir
-   archive_hardfork_toolbox_lib
-   ;; local libraries
-   logger
-   archive_lib
-   block_time
-   consensus
-   consensus_vrf
-   currency
-   genesis_constants
-   genesis_ledger_helper
-   mina_base
-   mina_base.import
-   mina_block
-   mina_caqti
-   mina_numbers
-   mina_state
-   mina_transaction
-   mina_wire_types
-   one_or_two
-   protocol_version
-   runtime_config
-   signature_lib
-   unsigned_extended
-   with_hash)
- 
+  ;; opam libraries
+  alcotest
+  async_unix
+  core
+  result
+  async_kernel
+  uri
+  stdio
+  caqti-driver-postgresql
+  caqti
+  async
+  core_kernel
+  caqti-async
+  base
+  base.caml
+  threads.posix
+  ;; from parent dir
+  archive_hardfork_toolbox_lib
+  ;; local libraries
+  logger
+  archive_lib
+  block_time
+  consensus
+  consensus_vrf
+  currency
+  genesis_constants
+  genesis_ledger_helper
+  mina_base
+  mina_base.import
+  mina_block
+  mina_caqti
+  mina_numbers
+  mina_state
+  mina_transaction
+  mina_wire_types
+  one_or_two
+  protocol_version
+  runtime_config
+  signature_lib
+  unsigned_extended
+  with_hash)
  (modules test_convert_canonical)
- (preprocess (pps ppx_version ppx_mina ppx_let ppx_hash ppx_compare ppx_sexp_conv h_list.ppx)))
+ (preprocess
+  (pps
+   ppx_version
+   ppx_mina
+   ppx_let
+   ppx_hash
+   ppx_compare
+   ppx_sexp_conv
+   h_list.ppx)))

--- a/src/app/archive_hardfork_toolbox/tests/test_convert_canonical.ml
+++ b/src/app/archive_hardfork_toolbox/tests/test_convert_canonical.ml
@@ -618,8 +618,9 @@ let test_convert_scenario
   let postgres_uri = Uri.of_string (sprintf "%s/%s" conn_str db_name) in
   let%bind () =
     Logic.convert_chain_to_canonical ~postgres_uri
-      ~latest_block_state_hash:target_hash
-      ~expected_protocol_version_str:protocol_version ~stop_at_slot:None ()
+      ?target_block_hash:(Some target_hash)
+      ?protocol_version_str:(Some protocol_version) ~stop_at_slot:None
+      ~dry_run:false ()
   in
 
   (* Get results *)
@@ -639,9 +640,236 @@ let make_test scenario =
   Thread_safe.block_on_async_exn (test_convert_scenario scenario)
   |> Or_error.ok_exn
 
+(* Two-protocol-version fixture with a real hard-fork boundary: the pre-fork tail
+   (B, C) is left pending, and C is the parent of the post-fork genesis F
+   (global_slot_since_hard_fork = 0). Used to exercise auto-detection and dry-run. *)
+let auto_detect_blocks : Block.t list =
+  [ { id = 1
+    ; state_hash = "A"
+    ; parent_id = None
+    ; parent_hash = "0"
+    ; height = 1
+    ; global_slot_since_genesis = 0
+    ; global_slot_since_hard_fork = 0
+    ; protocol_version_id = 1
+    ; chain_status = "canonical"
+    }
+  ; { id = 2
+    ; state_hash = "B"
+    ; parent_id = Some 1
+    ; parent_hash = "A"
+    ; height = 2
+    ; global_slot_since_genesis = 1
+    ; global_slot_since_hard_fork = 1
+    ; protocol_version_id = 1
+    ; chain_status = "pending"
+    }
+  ; { id = 3
+    ; state_hash = "C"
+    ; parent_id = Some 2
+    ; parent_hash = "B"
+    ; height = 3
+    ; global_slot_since_genesis = 2
+    ; global_slot_since_hard_fork = 2
+    ; protocol_version_id = 1
+    ; chain_status = "pending"
+    }
+  ; { id = 4
+    ; state_hash = "F"
+    ; parent_id = Some 3
+    ; parent_hash = "C"
+    ; height = 4
+    ; global_slot_since_genesis = 3
+    ; global_slot_since_hard_fork = 0
+    ; protocol_version_id = 2
+    ; chain_status = "canonical"
+    }
+  ; { id = 5
+    ; state_hash = "G"
+    ; parent_id = Some 4
+    ; parent_hash = "F"
+    ; height = 5
+    ; global_slot_since_genesis = 4
+    ; global_slot_since_hard_fork = 1
+    ; protocol_version_id = 2
+    ; chain_status = "canonical"
+    }
+  ]
+
+let setup_db db_name blocks =
+  let open Deferred.Or_error.Let_syntax in
+  let conn_str = get_postgres_uri () in
+  let%bind () = TestDb.drop_database_if_exists conn_str db_name in
+  let%bind () = TestDb.create_database conn_str db_name in
+  let%bind () = TestDb.create_test_schema conn_str db_name in
+  let%bind () =
+    TestDb.insert_protocol_versions conn_str db_name [ (1, 0, 0); (2, 0, 0) ]
+  in
+  let%bind () = TestDb.insert_blocks conn_str db_name blocks in
+  return conn_str
+
+let check_blocks conn_str db_name ~name expected =
+  let open Deferred.Or_error.Let_syntax in
+  let%bind actual = TestDb.get_all_blocks conn_str db_name in
+  if List.equal BlockState.equal actual expected then (
+    printf "✅ Test %s passed\n" name ;
+    Deferred.Or_error.return () )
+  else (
+    printf "❌ Test %s failed\n" name ;
+    printf "Expected: %s\n" (List.to_string ~f:BlockState.show expected) ;
+    printf "Actual: %s\n" (List.to_string ~f:BlockState.show actual) ;
+    Deferred.Or_error.error_string (sprintf "Test %s failed" name) )
+
+(* With no target/protocol flags, the tool auto-detects the latest boundary:
+   parent of F is C (protocol version 1.0.0), so the pre-fork tail A..C becomes
+   canonical, while F and G (post-fork) are untouched. *)
+let test_auto_detect_latest_boundary () =
+  let open Deferred.Or_error.Let_syntax in
+  let name = "test_auto_detect_latest_boundary" in
+  let db_name = sprintf "test_%s" name in
+  let%bind conn_str = setup_db db_name auto_detect_blocks in
+  let postgres_uri = Uri.of_string (sprintf "%s/%s" conn_str db_name) in
+  let%bind () =
+    Logic.convert_chain_to_canonical ~postgres_uri ~stop_at_slot:None
+      ~dry_run:false ()
+  in
+  check_blocks conn_str db_name ~name
+    [ { state_hash = "A"; expected_chain_status = "canonical" }
+    ; { state_hash = "B"; expected_chain_status = "canonical" }
+    ; { state_hash = "C"; expected_chain_status = "canonical" }
+    ; { state_hash = "F"; expected_chain_status = "canonical" }
+    ; { state_hash = "G"; expected_chain_status = "canonical" }
+    ]
+
+(* A dry run auto-detects and reports but writes nothing: statuses stay as in the
+   input fixture (B, C remain pending). *)
+let test_dry_run_writes_nothing () =
+  let open Deferred.Or_error.Let_syntax in
+  let name = "test_dry_run_writes_nothing" in
+  let db_name = sprintf "test_%s" name in
+  let%bind conn_str = setup_db db_name auto_detect_blocks in
+  let postgres_uri = Uri.of_string (sprintf "%s/%s" conn_str db_name) in
+  let%bind () =
+    Logic.convert_chain_to_canonical ~postgres_uri ~stop_at_slot:None
+      ~dry_run:true ()
+  in
+  check_blocks conn_str db_name ~name
+    [ { state_hash = "A"; expected_chain_status = "canonical" }
+    ; { state_hash = "B"; expected_chain_status = "pending" }
+    ; { state_hash = "C"; expected_chain_status = "pending" }
+    ; { state_hash = "F"; expected_chain_status = "canonical" }
+    ; { state_hash = "G"; expected_chain_status = "canonical" }
+    ]
+
+(* Emergency hard fork that does NOT bump the protocol version: pre-fork (A..C, L)
+   and post-fork (F, G) all share protocol version 1.0.0. F is the post-fork
+   genesis (global_slot_since_hard_fork = 0) built on the fork parent C; L is a
+   leftover on the old chain, also a child of C but below the fork boundary. The
+   pre-fork tail B, C must become canonical, the leftover L orphaned, and the
+   post-fork chain F, G must be left canonical (the boundary protects it even
+   though it shares the protocol version). *)
+let same_protocol_version_blocks : Block.t list =
+  [ { id = 1
+    ; state_hash = "A"
+    ; parent_id = None
+    ; parent_hash = "0"
+    ; height = 1
+    ; global_slot_since_genesis = 0
+    ; global_slot_since_hard_fork = 0
+    ; protocol_version_id = 1
+    ; chain_status = "canonical"
+    }
+  ; { id = 2
+    ; state_hash = "B"
+    ; parent_id = Some 1
+    ; parent_hash = "A"
+    ; height = 2
+    ; global_slot_since_genesis = 1
+    ; global_slot_since_hard_fork = 1
+    ; protocol_version_id = 1
+    ; chain_status = "pending"
+    }
+  ; { id = 3
+    ; state_hash = "C"
+    ; parent_id = Some 2
+    ; parent_hash = "B"
+    ; height = 3
+    ; global_slot_since_genesis = 2
+    ; global_slot_since_hard_fork = 2
+    ; protocol_version_id = 1
+    ; chain_status = "pending"
+    }
+  ; { id = 4
+    ; state_hash = "L"
+    ; parent_id = Some 3
+    ; parent_hash = "C"
+    ; height = 4
+    ; global_slot_since_genesis = 3
+    ; global_slot_since_hard_fork = 3
+    ; protocol_version_id = 1
+    ; chain_status = "pending"
+    }
+  ; { id = 5
+    ; state_hash = "F"
+    ; parent_id = Some 3
+    ; parent_hash = "C"
+    ; height = 4
+    ; global_slot_since_genesis = 4
+    ; global_slot_since_hard_fork = 0
+    ; protocol_version_id = 1
+    ; chain_status = "canonical"
+    }
+  ; { id = 6
+    ; state_hash = "G"
+    ; parent_id = Some 5
+    ; parent_hash = "F"
+    ; height = 5
+    ; global_slot_since_genesis = 5
+    ; global_slot_since_hard_fork = 1
+    ; protocol_version_id = 1
+    ; chain_status = "canonical"
+    }
+  ]
+
+let test_same_protocol_version_fork () =
+  let open Deferred.Or_error.Let_syntax in
+  let name = "test_same_protocol_version_fork" in
+  let db_name = sprintf "test_%s" name in
+  let%bind conn_str = setup_db db_name same_protocol_version_blocks in
+  let postgres_uri = Uri.of_string (sprintf "%s/%s" conn_str db_name) in
+  let%bind () =
+    Logic.convert_chain_to_canonical ~postgres_uri ~stop_at_slot:None
+      ~dry_run:false ()
+  in
+  check_blocks conn_str db_name ~name
+    [ { state_hash = "A"; expected_chain_status = "canonical" }
+    ; { state_hash = "B"; expected_chain_status = "canonical" }
+    ; { state_hash = "C"; expected_chain_status = "canonical" }
+    ; { state_hash = "F"; expected_chain_status = "canonical" }
+    ; { state_hash = "G"; expected_chain_status = "canonical" }
+    ; { state_hash = "L"; expected_chain_status = "orphaned" }
+    ]
+
 let () =
   Alcotest.run "Archive Hardfork Toolbox Tests"
     [ ( "convert_chain_to_canonical"
       , List.map TestScenarios.all_scenarios ~f:(fun scenario ->
             (scenario.name, `Quick, fun () -> make_test scenario) ) )
+    ; ( "convert_chain_to_canonical_extras"
+      , [ ( "test_auto_detect_latest_boundary"
+          , `Quick
+          , fun () ->
+              Thread_safe.block_on_async_exn test_auto_detect_latest_boundary
+              |> Or_error.ok_exn )
+        ; ( "test_dry_run_writes_nothing"
+          , `Quick
+          , fun () ->
+              Thread_safe.block_on_async_exn test_dry_run_writes_nothing
+              |> Or_error.ok_exn )
+        ; ( "test_same_protocol_version_fork"
+          , `Quick
+          , fun () ->
+              Thread_safe.block_on_async_exn test_same_protocol_version_fork
+              |> Or_error.ok_exn )
+        ] )
     ]

--- a/src/app/archive_hardfork_toolbox/tests/test_convert_canonical.ml
+++ b/src/app/archive_hardfork_toolbox/tests/test_convert_canonical.ml
@@ -850,6 +850,62 @@ let test_same_protocol_version_fork () =
     ; { state_hash = "L"; expected_chain_status = "orphaned" }
     ]
 
+let query_summary_counts conn_str db_name ~canonical_block_ids
+    ~fork_boundary_slot ~protocol_version =
+  TestDb.with_pool conn_str ~db_name (fun pool ->
+      Deferred.Or_error.try_with (fun () ->
+          Mina_caqti.query pool
+            ~f:
+              (Sql.conversion_summary_counts ~canonical_block_ids
+                 ~stop_at_slot:None ~fork_boundary_slot ~protocol_version ) ) )
+
+(* Focused unit test for the change-plan summary counts. Uses the
+   same-protocol-version fixture: canonical set {A, B, C} (ids 1..3), leftover L
+   (id 4) to orphan, and the post-fork chain F, G held out by the boundary slot.
+   Asserts the exact 4-tuple (to_canonical, pending_to_canonical, to_orphaned,
+   pending_to_orphaned), then re-runs against a fixture where L is already
+   orphaned to confirm to_orphaned excludes settled rows (so a re-run reports 0
+   rather than recounting them). *)
+let test_summary_counts () =
+  let open Deferred.Or_error.Let_syntax in
+  let canonical_block_ids = [ 1; 2; 3 ] in
+  let protocol_version = Sql.Protocol_version.of_string "1.0.0" in
+  (* F is the post-fork genesis at global_slot_since_genesis = 4; the boundary
+     keeps F, G out of every count while L (slot 3) stays in. *)
+  let fork_boundary_slot = Some 4L in
+  let check ~name ~blocks ~expected =
+    let db_name = sprintf "test_%s" name in
+    let%bind conn_str = setup_db db_name blocks in
+    let%bind actual =
+      query_summary_counts conn_str db_name ~canonical_block_ids
+        ~fork_boundary_slot ~protocol_version
+    in
+    let show (a, b, c, d) = sprintf "(%d, %d, %d, %d)" a b c d in
+    if [%equal: int * int * int * int] actual expected then (
+      printf "✅ Test %s passed\n" name ;
+      Deferred.Or_error.return () )
+    else (
+      printf "❌ Test %s failed: expected %s, got %s\n" name (show expected)
+        (show actual) ;
+      Deferred.Or_error.error_string (sprintf "Test %s failed" name) )
+  in
+  (* Fresh fixture: A,B,C become canonical (2 of them pending), L becomes
+     orphaned (pending). *)
+  let%bind () =
+    check ~name:"summary_counts_fresh" ~blocks:same_protocol_version_blocks
+      ~expected:(3, 2, 1, 1)
+  in
+  (* Re-run: L is already orphaned, so to_orphaned and pending_to_orphaned drop
+     to 0 while the canonical counts are unchanged. *)
+  let orphaned_leftover_blocks =
+    List.map same_protocol_version_blocks ~f:(fun block ->
+        if String.equal block.Block.state_hash "L" then
+          { block with Block.chain_status = "orphaned" }
+        else block )
+  in
+  check ~name:"summary_counts_rerun" ~blocks:orphaned_leftover_blocks
+    ~expected:(3, 2, 0, 0)
+
 let () =
   Alcotest.run "Archive Hardfork Toolbox Tests"
     [ ( "convert_chain_to_canonical"
@@ -870,6 +926,11 @@ let () =
           , `Quick
           , fun () ->
               Thread_safe.block_on_async_exn test_same_protocol_version_fork
+              |> Or_error.ok_exn )
+        ; ( "test_summary_counts"
+          , `Quick
+          , fun () ->
+              Thread_safe.block_on_async_exn test_summary_counts
               |> Or_error.ok_exn )
         ] )
     ]

--- a/src/app/archive_hardfork_toolbox/utils.ml
+++ b/src/app/archive_hardfork_toolbox/utils.ml
@@ -1,0 +1,36 @@
+open Core
+
+(* General-purpose terminal-UI helpers. *)
+
+(* Display width of a UTF-8 string, counting each code point as one column
+   (continuation bytes 0b10xxxxxx do not add width). Good enough for the
+   box-drawing and arrow glyphs used in tables; it does not account for
+   double-width (CJK) characters. *)
+let display_width s =
+  String.fold s ~init:0 ~f:(fun acc c ->
+      if Char.to_int c land 0xC0 = 0x80 then acc else acc + 1 )
+
+(* Right-pad [s] with spaces to [width] display columns (no-op if already wider). *)
+let pad_right width s =
+  let d = display_width s in
+  if d >= width then s else s ^ String.make (width - d) ' '
+
+(* A horizontal rule of [width] "─" box-drawing characters. *)
+let hline width = String.concat ~sep:"" (List.init width ~f:(fun _ -> "─"))
+
+(* Render an aligned table with box-drawing column separators and a header rule.
+   [columns] pairs each header label with its column width. Each row is its list
+   of cells (one per column) plus a trailing suffix rendered outside the last
+   column border (e.g. a row marker). Returns the whole table, newline-terminated. *)
+let render_table ~columns rows =
+  let widths = List.map columns ~f:snd in
+  let render_cells cells =
+    List.map2_exn cells widths ~f:(fun cell w -> pad_right w cell)
+    |> String.concat ~sep:" │ "
+  in
+  let header = "  " ^ render_cells (List.map columns ~f:fst) in
+  let rule = "  " ^ (List.map widths ~f:hline |> String.concat ~sep:"─┼─") in
+  let body =
+    List.map rows ~f:(fun (cells, suffix) -> "  " ^ render_cells cells ^ suffix)
+  in
+  String.concat ~sep:"\n" ((header :: rule :: body) @ [ "" ])


### PR DESCRIPTION
## Problem

`convert-chain-to-canonical` is the post-fork repair step that finalizes the pre-fork tail — the last ~k pre-fork blocks (including the fork block's parent) that a hard fork leaves stuck `chain_status = 'pending'`, because the canonical watermark jumps to the fork genesis and `update_chain_status` never walks back below it. (Reproduced on mesa-mut, mesa-preflight, and pre-mesa dumps.)

The command worked but was not self-service: it **required** both `--target-block-hash` and `--protocol-version`, values you can only get by first querying the DB by hand, and it mutated `chain_status` with no way to preview what it would do.

## Changes

Polish `convert-chain-to-canonical` (no behavior change to the default explicit path):

- **`--dry-run`** — runs selection + validation and prints a `N canonical / M orphaned` summary, but writes nothing. Safe to eyeball before applying.
- **Auto-detection** — `--target-block-hash` and `--protocol-version` are now optional. With neither, the tool finds the latest hard-fork boundary itself: the parent of the highest block with `global_slot_since_hard_fork = 0`, using that block's own protocol version. Both remain overridable (needed to repair an *earlier* boundary on a multi-fork network).
- **`--fork-height`** — resolve the target by height instead of state hash (errors if the height is ambiguous, pointing you back to `--target-block-hash`).
- A `[DRY RUN]` marker + target/protocol log line so the operator can see exactly what was resolved.

## New SQL

- `blocks_info_by_height` — target lookup by height.
- `parent_of_latest_fork_block` — auto-detect the boundary (excludes genesis via `parent_id IS NOT NULL`).
- `count_blocks_of_protocol_version` — the orphaned-count for the summary.

## Tests

`test_convert_canonical.ml`:
- Existing 6 scenarios keep passing (updated to the new optional-arg signature).
- **`test_auto_detect_latest_boundary`** — 2-protocol-version fixture with a real boundary (pre-fork tail `B, C` pending, `C` is the parent of post-fork genesis `F`); asserts that running with **no** target/protocol flags canonicalizes `A..C` and leaves `F, G` untouched.
- **`test_dry_run_writes_nothing`** — same fixture with `--dry-run`; asserts statuses are unchanged.

Both run in the existing `ArchiveHardforkToolboxTest` CI job (postgres-backed alcotest exe).

## Docs

Added a `convert-chain-to-canonical` section to the toolbox README (previously undocumented) plus a "post-fork tail repair" step in the workflow.

