### PR TITLE
archive-hardfork-toolbox: populate-genesis-accounts to repair fork genesis accounts_accessed

### DIFF
--- a/changes/19059.md
+++ b/changes/19059.md
@@ -1,0 +1,7 @@
+archive-hardfork-toolbox: add a `populate-genesis-accounts` subcommand to repair a hardfork archive whose fork genesis block is missing its ledger accounts. Fixes #19058.
+
+After a hard fork the chain restarts at a fork genesis block whose `blockchain_length` is `fork.blockchain_length + 1`. Only `add_genesis_accounts` writes the genesis ledger into `accounts_accessed`, and the archive runs it at startup only when it is (re)started with the fork `--config-file`. An archive that ingested the fork blocks without that step — restored from a dump, or started without the config — ends up with no `accounts_accessed` rows at the fork genesis block, so Rosetta reports zero balances there and `rosetta-cli check:data` fails at the first post-fork block.
+
+`mina-archive-hardfork-toolbox populate-genesis-accounts --postgres-uri <uri> --config-file <runtime-config>` runs `add_genesis_accounts` against an existing archive, backfilling the (fork) genesis ledger onto the already-present fork genesis block, so operators can repair an affected archive without a full re-ingest. `--chunks-length` (default 100) bounds how many accounts are inserted per transaction.
+
+Also adds a regression test in `src/app/archive/lib/test.ml` that ingests a fork genesis block with no accounts, asserts `accounts_accessed = 0`, then runs `add_genesis_accounts` and asserts every ledger account is attached.

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -418,6 +418,117 @@ let%test_module "Archive node unit tests" =
       | Error e ->
           failwith @@ Caqti_error.show e
 
+    (* Regression test for the hardfork "fork genesis" bug that breaks Rosetta
+       balance reconciliation at the fork boundary. A hard fork restarts the
+       chain at a genesis block whose [blockchain_length] is [fork.blockchain_length
+       + 1] (not 1). When such a block is present in the archive but was ingested
+       WITHOUT its ledger accounts (e.g. the archive was never (re)started with
+       the fork [--config-file]), [accounts_accessed] is empty for it, so Rosetta
+       reports zero balances at the fork block. [add_genesis_accounts] -- the
+       routine the [populate-genesis-accounts] toolbox command invokes -- must
+       backfill the full fork genesis ledger onto that existing block. *)
+    let%test_unit "Accounts_accessed: add_genesis_accounts backfills the fork \
+                   genesis ledger onto an existing fork genesis block" =
+      let pool = Lazy.force conn_pool_lazy in
+      Thread_safe.block_on_async_exn
+      @@ fun () ->
+      let num_accounts = 3 in
+      let accounts =
+        List.init num_accounts ~f:(fun i ->
+            let pk = Public_key.compress (Keypair.create ()).public_key in
+            { Runtime_config.Accounts.Single.default with
+              pk = Public_key.Compressed.to_base58_check pk
+            ; balance = Currency.Balance.of_mina_int_exn (1000 + i)
+            } )
+      in
+      (* [fork.state_hash] is only parsed (not validated against a real block),
+         so any well-formed state hash works. *)
+      let fork_state_hash =
+        State_hash.to_base58_check
+          (Quickcheck.random_value
+             ~seed:(`Deterministic "fork-genesis-accounts-test") State_hash.gen )
+      in
+      let runtime_config =
+        { Runtime_config.default with
+          proof =
+            Some
+              (Runtime_config.Proof_keys.make
+                 ~fork:
+                   { Runtime_config.Fork_config.state_hash = fork_state_hash
+                   ; blockchain_length = 100 (* genesis block height => 101 *)
+                   ; global_slot_since_genesis = 100
+                   }
+                 () )
+        ; ledger = Some (Runtime_config.ledger_of_accounts accounts)
+        }
+      in
+      (* Derive the precomputed values (and hence the exact fork genesis block)
+         the same way [add_genesis_accounts] does internally, so the block we
+         insert below is the very block it will later look up and backfill. *)
+      let%bind precomputed_values =
+        match%map
+          Genesis_ledger_helper.init_from_config_file ~logger
+            ~proof_level:Genesis_constants.Compiled.proof_level
+            ~genesis_constants ~constraint_constants ~cli_proof_level:None
+            runtime_config
+        with
+        | Ok precomputed_values ->
+            precomputed_values
+        | Error err ->
+            failwithf "init_from_config_file: %s" (Error.to_string_hum err) ()
+      in
+      let genesis_block =
+        let With_hash.{ data = block; hash = the_hash }, _ =
+          Mina_block.genesis ~precomputed_values
+        in
+        With_hash.{ data = block; hash = the_hash }
+      in
+      let count_accounts_accessed block_id =
+        match%map
+          Mina_caqti.Pool.use
+            (fun (module Conn : Mina_caqti.CONNECTION) ->
+              Conn.find
+                (Mina_caqti.find_req Caqti_type.int Caqti_type.int
+                   "SELECT COUNT(*) FROM accounts_accessed WHERE block_id = ?" )
+                block_id )
+            pool
+        with
+        | Ok count ->
+            count
+        | Error e ->
+            failwith @@ Caqti_error.show e
+      in
+      (* Reproduce the production state: the fork genesis block is present in the
+         archive but was ingested with NO ledger accounts attached. *)
+      let%bind genesis_block_id =
+        match%map
+          Mina_caqti.Pool.use
+            (fun (module Conn : Mina_caqti.CONNECTION) ->
+              Processor.Block.add_if_doesn't_exist
+                (module Conn)
+                ~logger
+                ~constraint_constants:precomputed_values.constraint_constants
+                genesis_block ~accounts_accessed:[] ~accounts_created:[] )
+            pool
+        with
+        | Ok genesis_block_id ->
+            genesis_block_id
+        | Error e ->
+            failwith @@ Caqti_error.show e
+      in
+      let%bind before = count_accounts_accessed genesis_block_id in
+      (* The bug: the fork genesis block has no accounts_accessed rows. *)
+      [%test_result: int] ~expect:0 before ;
+      let%bind () =
+        Processor.add_genesis_accounts ~logger
+          ~runtime_config_opt:(Some runtime_config) ~genesis_constants
+          ~chunks_length:100 ~constraint_constants pool
+      in
+      let%map after = count_accounts_accessed genesis_block_id in
+      (* The fix: every fork genesis ledger account is now attached to the
+         fork genesis block. *)
+      [%test_result: int] ~expect:num_accounts after
+
     (*
     let%test_unit "Block: read and write with pruning" =
       let conn = Lazy.force conn_lazy in

--- a/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
+++ b/src/app/archive_hardfork_toolbox/archive_hardfork_toolbox.ml
@@ -108,6 +108,25 @@ let fetch_last_filled_block_command =
     (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres in
      fetch_last_filled_block ~postgres_uri )
 
+let populate_genesis_accounts_command =
+  Async.Command.async
+    ~summary:
+      "Populate accounts_accessed for the genesis block (including a fork \
+       genesis) from the runtime config's genesis ledger. Repairs a hardfork \
+       archive whose fork genesis block is missing its ledger accounts."
+    (let%map_open.Command { value = postgres_uri; _ } = Uri.Archive.postgres
+     and runtime_config_file =
+       Command.Param.(flag "--config-file" (required string))
+         ~doc:"PATH runtime config file containing the (fork) genesis ledger"
+     and chunks_length =
+       Command.Param.(flag "--chunks-length" (optional_with_default 100 int))
+         ~doc:
+           "Int number of accounts to insert per transaction, to avoid \
+            Postgres OOM on large ledgers (default 100)"
+     in
+     populate_genesis_accounts ~postgres_uri ~runtime_config_file ~chunks_length
+    )
+
 (* TODO: consider refactor these commands to reuse queries in the future. *)
 let commands =
   [ ( "fork-candidate"
@@ -121,6 +140,7 @@ let commands =
   ; ("verify-upgrade", verify_upgrade_command)
   ; ("validate-fork", validate_fork_command)
   ; ("convert-chain-to-canonical", convert_chain_to_canonical_command)
+  ; ("populate-genesis-accounts", populate_genesis_accounts_command)
   ]
 
 let () =

--- a/src/app/archive_hardfork_toolbox/dune
+++ b/src/app/archive_hardfork_toolbox/dune
@@ -9,6 +9,7 @@
   async_kernel
   uri
   stdio
+  yojson
   caqti-driver-postgresql
   caqti
   cli_lib
@@ -66,6 +67,7 @@
   async_kernel
   uri
   stdio
+  yojson
   caqti-driver-postgresql
   caqti
   cli_lib

--- a/src/app/archive_hardfork_toolbox/logic.ml
+++ b/src/app/archive_hardfork_toolbox/logic.ml
@@ -50,6 +50,28 @@ let connect postgres_uri =
   | Ok pool ->
       pool
 
+(* Populate accounts_accessed for the genesis block described by the runtime
+   config. When the config has [proof.fork] set, the genesis block is the fork
+   genesis, so this attaches the full fork genesis ledger to the fork block. This
+   is the same routine the archive runs at startup with --config-file; exposing it
+   here lets operators repair an existing hardfork archive whose fork genesis was
+   never populated (e.g. because the archive was not (re)started with the fork
+   config). *)
+let populate_genesis_accounts ~postgres_uri ~runtime_config_file ~chunks_length
+    () =
+  let runtime_config =
+    Yojson.Safe.from_file runtime_config_file
+    |> Runtime_config.of_yojson |> Result.ok_or_failwith
+  in
+  let genesis_constants = Genesis_constants.Compiled.genesis_constants in
+  let constraint_constants = Genesis_constants.Compiled.constraint_constants in
+  let pool = connect postgres_uri in
+  [%log info] "Populating genesis accounts from runtime config %s"
+    runtime_config_file ;
+  Archive_lib.Processor.add_genesis_accounts ~logger
+    ~runtime_config_opt:(Some runtime_config) ~genesis_constants ~chunks_length
+    ~constraint_constants pool
+
 let is_in_best_chain ~postgres_uri ~fork_state_hash ~fork_height ~fork_slot () =
   let pool = connect postgres_uri in
   let query_db = Mina_caqti.query pool in


### PR DESCRIPTION
## Summary

Fixes #19058.

After a hard fork the chain restarts at a **fork genesis block** whose
`blockchain_length` is `fork.blockchain_length + 1` (not 1). Only
`add_genesis_accounts` writes the genesis ledger into `accounts_accessed`, and it
runs at archive startup **only when the archive is (re)started with the fork
`--config-file`**. An archive that ingested the fork blocks without that step
(e.g. restored from a dump, or started without the config) ends up with an empty
`accounts_accessed` at the fork block, so Rosetta reports zero balances there and
`rosetta-cli check:data` fails at the first post-fork block.

This PR:

1. **`populate-genesis-accounts`** — a new `mina-archive-hardfork-toolbox`
   subcommand that runs `add_genesis_accounts` against an existing archive from a
   runtime config, backfilling the (fork) genesis ledger onto the already-present
   fork genesis block. This lets operators repair an affected archive without a
   full re-ingest.

2. **Regression test** (`src/app/archive/lib/test.ml`) — builds a fork runtime
   config (inline ledger + `proof.fork`, so the genesis block is at height 101),
   ingests that fork genesis block with **no** accounts (reproducing the
   production state), asserts `accounts_accessed = 0` for it, then runs
   `add_genesis_accounts` and asserts every ledger account is now attached.

## Test-first (red → green)

Verified locally against a fresh postgres schema:

- **Red** (backfill disabled): the test fails with `(expected 3) (got 0)` — the
  fork genesis block has no `accounts_accessed` rows.
- **Green** (backfill enabled): 8/8 archive unit tests pass.

The test runs in the existing **Archive node unit tests** CI job
(`dune runtest src/app/archive`), which builds the schema from the current
`create_schema.sql`.
