### PR TITLE
docker(archive): bundle mina-<network>-config for in-place hardfork genesis repair

### DIFF
--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -23,6 +23,13 @@ ENV SUFFIX=${deb_suffix:+-${deb_suffix}}
 # - mina-archive-devnet-lightnet etc.
 ENV MINA_DEB=mina-archive-${network}${SUFFIX}
 
+# The per-network config package ships the runtime config JSON and, for hardfork
+# networks, the genesis ledger tarball(s) into /var/lib/coda. Bundling it lets
+# `mina-archive-hardfork-toolbox populate-genesis-accounts` (and `mina-archive
+# run --config-file`) resolve the fork genesis ledger locally -- no S3/network --
+# to backfill accounts_accessed for the fork genesis block.
+ENV MINA_CONFIG_DEB=mina-${network}-config
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
@@ -86,10 +93,11 @@ ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 
-# archive-node package
+# archive-node package (+ per-network config so the hardfork toolbox can
+# resolve the fork genesis ledger from /var/lib/coda)
 RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
   && apt-get update --quiet --yes \
-  && apt-get install --no-install-recommends --quiet --yes "${MINA_DEB}=$deb_version" \
+  && apt-get install --no-install-recommends --quiet --yes "${MINA_DEB}=$deb_version" "${MINA_CONFIG_DEB}=$deb_version" \
   && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Bundle the per-network config package (`mina-<network>-config`) into the archive
docker image so an operator can repair a hardfork archive **in-place** with the
new `mina-archive-hardfork-toolbox populate-genesis-accounts` command (see #19058
/ #19059) — no manual ledger fetch, no S3.

## Why

`populate-genesis-accounts` runs `add_genesis_accounts` → `init_from_config_file`,
which for a hardfork network resolves the genesis ledger **by hash**. That
requires two files on disk: the runtime config JSON and the matching
`genesis_ledger_<hash>.tar.gz`. The loader searches `/var/lib/coda` (among other
cache dirs) **before** falling back to S3.

Today the archive image installs only `mina-archive-<network>` (+ generic +
profile); none of those carry the config JSON or the ledger tarball, so the
command fails with *"Could not find a ledger tar file for hash …"* unless the
operator hand-copies files or has S3 egress.

The **hardfork** `mina-<network>-config` deb
(`build_daemon_hardfork_config_deb`) already ships **both** the runtime config
JSON and the `genesis_ledger_*.tar.gz` into `/var/lib/coda` — exactly where the
loader looks. The daemon image already pulls this package in (it's a dependency
of `mina-<network>`); this change gives the archive image the same content.

## Change

`dockerfiles/Dockerfile-mina-archive`: add `MINA_CONFIG_DEB=mina-${network}-config`
and install it (version-pinned to `$deb_version`) alongside `${MINA_DEB}` in the
archive-package `apt-get install`.

After this, an operator on the stock archive image just runs:

```
mina-archive-hardfork-toolbox populate-genesis-accounts \
  --config-file /var/lib/coda/<network>.json \
  --postgres-uri postgres://user:pw@host:5432/archive
```

## Notes / for reviewers

- Config deb is unsuffixed (`mina-${network}-config`), matching the name the
  daemon package depends on (`builder-helpers.sh:578`); it is `Architecture: all`
  and version-pinned to `$deb_version`.
- **Image size:** for mainnet/devnet this adds the genesis ledger tarball to the
  archive image. If we'd rather not carry it on non-hardfork archive images, we
  can gate the install to hardfork networks — happy to do that if preferred.
- hadolint: no new warnings (the install line is version-pinned).
