### PR TITLE
ci: tolerate git short-hash widening in config filename checks

### DIFF
--- a/buildkite/scripts/tests/debian-upgrade-test.sh
+++ b/buildkite/scripts/tests/debian-upgrade-test.sh
@@ -152,15 +152,19 @@ log_info "Pre-upgrade mina version: ${PRE_COMMIT}"
 PRE_COMMIT_SHORT=$(get_short_commit "${PRE_COMMIT}")
 log_info "Pre-upgrade mina short commit: ${PRE_COMMIT_SHORT}"
 
-# List config files before upgrade
+# List config files before upgrade.
+# The config filename hash is produced by `git rev-parse --short=8`, whose
+# width is a MINIMUM: git widens it (to 9+) when the 8-char prefix is
+# ambiguous in the repo. get_short_commit truncates to exactly 8, so glob
+# on the 8-char prefix instead of an exact name to tolerate the widening.
 log_info "Config file before upgrade:"
-PRE_CONFIG_FILE=${CONFIG_DIR}/config_${PRE_COMMIT_SHORT}.json
+PRE_CONFIG_FILE=$(ls "${CONFIG_DIR}"/config_"${PRE_COMMIT_SHORT}"*.json 2>/dev/null | head -1)
 
-if [[ -f "${PRE_CONFIG_FILE}" ]]; then
+if [[ -n "${PRE_CONFIG_FILE}" && -f "${PRE_CONFIG_FILE}" ]]; then
     log_info "Found config file: ${PRE_CONFIG_FILE}"
     log_info "  - $(basename "$PRE_CONFIG_FILE"): $(stat -c %s "$PRE_CONFIG_FILE") bytes"
 else
-    log_error "No config_${PRE_COMMIT_SHORT}.json file found before upgrade"
+    log_error "No config_${PRE_COMMIT_SHORT}*.json file found before upgrade"
     exit 1
 fi
 
@@ -205,12 +209,13 @@ POST_COMMIT_SHORT=$(get_short_commit "${POST_COMMIT}")
 log_info "Post-upgrade commit: ${POST_COMMIT_SHORT}"
 
 
-POST_CONFIG_FILE="${CONFIG_DIR}"/config_${POST_COMMIT_SHORT}.json
-if [[ -f "${POST_CONFIG_FILE}" ]]; then
+# Glob on the 8-char prefix (see note above): `--short=8` may widen to 9+.
+POST_CONFIG_FILE=$(ls "${CONFIG_DIR}"/config_"${POST_COMMIT_SHORT}"*.json 2>/dev/null | head -1)
+if [[ -n "${POST_CONFIG_FILE}" && -f "${POST_CONFIG_FILE}" ]]; then
     log_info "Found config file: ${POST_CONFIG_FILE}"
     log_info "  - $(basename "$POST_CONFIG_FILE"): $(stat -c %s "$POST_CONFIG_FILE") bytes"
 else
-    log_error "No config_${POST_COMMIT_SHORT}.json file found after upgrade"
+    log_error "No config_${POST_COMMIT_SHORT}*.json file found after upgrade"
     exit 1
 fi
 

--- a/scripts/verify/check-daemon.sh
+++ b/scripts/verify/check-daemon.sh
@@ -29,8 +29,13 @@ fi
 
 echo "Found genesis config: $CONFIG_FILE"
 
-# Extract the commit hash from the config filename (config_<hash>.json)
-CONFIG_COMMIT=$(basename "$CONFIG_FILE" | grep -oP 'config_\K[a-f0-9]+')
+# Extract the commit hash from the config filename (config_<hash>.json).
+# The filename hash is produced by `git rev-parse --short=8`, which is a
+# MINIMUM width: git widens it (to 9+) when the 8-char prefix is ambiguous
+# across any object in the repo. The binary hash above is truncated to a
+# fixed 8 chars, so normalize the config hash to the same 8-char prefix
+# before comparing — otherwise an ambiguous commit fails a valid package.
+CONFIG_COMMIT=$(basename "$CONFIG_FILE" | grep -oP 'config_\K[a-f0-9]+' | head -c 8)
 echo "Config file commit hash: $CONFIG_COMMIT"
 
 if [ "$MINA_COMMIT" = "$CONFIG_COMMIT" ]; then


### PR DESCRIPTION
On compatible, HEAD `078b5d2cf662` has an 8-char prefix (`078b5d2c`) that is **ambiguous** — it collides with a tree object `078b5d2c8383…`. `git rev-parse --short=8` is a *minimum* width, so it widens the abbreviation to 9 chars (`078b5d2cf`), and the daemon package ships its genesis config as `config_078b5d2cf.json`.

Two verification steps assume the config filename hash is exactly 8 chars and fail:

- `scripts/verify/check-daemon.sh` compares the binary hash (`head -c 8` → `078b5d2c`) against the full filename hash (`078b5d2cf`) → `FAIL: mina binary commit does not match genesis config commit`.
- `buildkite/scripts/tests/debian-upgrade-test.sh` reconstructs `config_<8-char>.json` and cannot find the 9-char file → `No config_078b5d2c.json file found after upgrade`.

This is a latent bug (present since the shared check scripts landed in March); it only triggers when the 8-char prefix is ambiguous, which is why develop is currently unaffected.

### Fix (consumer-side, zero artifact-name change)
- `check-daemon.sh`: normalize the config hash to an 8-char prefix (`| head -c 8`) before comparing, matching the binary hash.
- `debian-upgrade-test.sh`: glob `config_${SHORT}*.json` instead of reconstructing an exact name — the 8-char prefix anchor still excludes `config_devnet.json`/`config_mainnet.json` but tolerates the widening.

The producer (`git rev-parse --short=8`) is intentionally left as-is so the shipped filename does not change and the apps-cache restore path stays self-consistent.

### Verification
- Logic simulated against the real hashes: daemon check matches (`078b5d2c` == `078b5d2c`); glob resolves `config_078b5d2cf.json` and ignores the network configs.
- `shellcheck -S warning` (what `make check-bash` enforces) is clean on both files.