### PR TITLE
ci: align verify-schema-upgrade.sh with compatible to unblock the forward merge

### DIFF
--- a/buildkite/scripts/archive/verify-schema-upgrade.sh
+++ b/buildkite/scripts/archive/verify-schema-upgrade.sh
@@ -134,11 +134,27 @@ dump_and_normalize() {
     > "$output_file"
 }
 
-# --- Normalize documented lossy downgrade deltas ---
-# The downgrade intentionally does not restore Berkeley's element_ids btree
-# UNIQUE/indexes or events_id/actions_id NOT NULL constraints. Post-Mesa data may
-# contain duplicates, oversized arrays, or NULL values that Berkeley rejected.
-normalize_known_downgrade_deltas() {
+# --- Normalize documented Berkeley/Mesa schema deltas ---
+# A btree key over the unbounded zkapp_{events,field_array}.element_ids int[]
+# overflows Postgres' 2704-byte limit for max-cost zkApps, so Mesa drops those
+# UNIQUE constraints/indexes and makes events_id/actions_id nullable. On the
+# compatible branch this delta shows up in two places and is intentionally
+# tolerated here rather than by retroactively editing the released migration
+# scripts:
+#   * upgrade:   compatible's create_schema + upgrade still carries Berkeley's
+#                element_ids UNIQUE/index + NOT NULL that develop's create_schema
+#                has dropped.
+#   * downgrade: the downgrade does not restore them (lossy) — post-Mesa data may
+#                hold duplicates, oversized arrays, or NULLs Berkeley rejected.
+# Strip that documented delta from both sides before comparing.
+#
+# TODO: the upgrade arm of this tolerance is only needed because compatible's
+# released upgrade_to_mesa.sql never dropped the element_ids UNIQUE/index and the
+# events_id/actions_id NOT NULL, while develop's does. Once compatible's migration
+# carries those DROPs, stop normalizing the upgrade comparison (Test 1) and let it
+# assert the constraints are gone; the downgrade arm (Test 2) stays either way,
+# since the downgrade is deliberately lossy.
+normalize_known_schema_deltas() {
     local schema_file="$1"
     local tmp_file="${schema_file}.known_downgrade_deltas"
 
@@ -209,6 +225,7 @@ main() {
     echo ""
     echo "=== Test 1: Upgrade path verification ==="
     echo "  Expected: ${SOURCE_BRANCH} schema + upgrade_to_mesa.sql == ${TARGET_BRANCH} schema"
+    echo "            except documented Berkeley/Mesa element_ids constraint deltas"
 
     create_db "archive_fresh"
     create_db "archive_upgraded"
@@ -227,6 +244,8 @@ main() {
 
     dump_and_normalize "archive_fresh" "$schema_fresh"
     dump_and_normalize "archive_upgraded" "$schema_upgraded"
+    normalize_known_schema_deltas "$schema_fresh"
+    normalize_known_schema_deltas "$schema_upgraded"
 
     echo "Comparing schemas..."
     if diff -u "$schema_fresh" "$schema_upgraded"; then
@@ -261,8 +280,8 @@ main() {
 
     dump_and_normalize "archive_source_ref" "$schema_source_ref"
     dump_and_normalize "archive_downgraded" "$schema_downgraded"
-    normalize_known_downgrade_deltas "$schema_source_ref"
-    normalize_known_downgrade_deltas "$schema_downgraded"
+    normalize_known_schema_deltas "$schema_source_ref"
+    normalize_known_schema_deltas "$schema_downgraded"
 
     echo "Comparing schemas..."
     if diff -u "$schema_source_ref" "$schema_downgraded"; then


### PR DESCRIPTION
Pre-resolves the `compatible` -> `develop` merge conflict in `buildkite/scripts/archive/verify-schema-upgrade.sh` that #19063 would otherwise introduce. No other file changes.

### Problem
Both branches grew the same element_ids normalizer independently, in the same place in the file, under different names:

* **develop** has `normalize_known_downgrade_deltas`, applied to the downgrade comparison (Test 2) only. develop's `upgrade_to_mesa.sql` already drops the `zkapp_{events,field_array}.element_ids` UNIQUE/index and the `events_id`/`actions_id` NOT NULL, so its Test 1 passes on its own; only the deliberately-lossy downgrade needs tolerating.
* **compatible** (#19063) adds `normalize_known_schema_deltas` — same awk body, renamed, and applied to the upgrade comparison (Test 1) as well, because compatible's *released* `upgrade_to_mesa.sql` never dropped those constraints and is intentionally left untouched.

Two function blocks inserted at the same offset with different names, plus both touching the Test 2 call site, is an add/add conflict the moment compatible is merged forward:
```
$ git merge <compatible-with-19063>
CONFLICT (content): buildkite/scripts/archive/verify-schema-upgrade.sh
```

### Approach
Make develop's copy of the script byte-identical to the post-#19063 compatible copy: adopt the `normalize_known_schema_deltas` name, the expanded comment covering both the upgrade and downgrade rationale, and the Test 1 call sites. The forward merge then has nothing to reconcile in this file.

### Verification
Re-ran the merge against the same compatible tip, before and after this commit:
```
before (plain develop):  CONFLICT  buildkite/scripts/archive/verify-schema-upgrade.sh
after  (this branch):    no conflicts
```
`shellcheck -S warning` clean; `bash -n` clean.

### Tradeoff, stated plainly
On develop the new Test 1 normalization is a **no-op today** — develop's `create_schema.sql` carries no element_ids UNIQUE/index and no `events_id`/`actions_id` NOT NULL, and its upgrade drops them, so both sides of the comparison already lack the constraints and the normalizer strips nothing.

What it does cost is coverage: develop's Test 1 will no longer *assert* that `upgrade_to_mesa.sql` performs those DROPs, so a regression that silently removed them would go unnoticed by this job. That is the same tolerance #19063 accepts on compatible. The TODO added in that PR marks the upgrade arm for removal once compatible's migration carries the DROPs, at which point Test 1 can go back to asserting on both branches.