### PR TITLE
docker(archive): bundle mina-<network>-config for in-place hardfork genesis repair

### DIFF
--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -25,6 +25,22 @@ ENV BUILD_FLAGS_SUFFIX=${build_flags_suffix}
 # - mina-archive-devnet-lightnet etc.
 ENV MINA_DEB=mina-archive-${network}${SUFFIX}
 
+# The per-network config package ships the runtime config JSON and, for hardfork
+# networks, the genesis ledger tarball(s) into /var/lib/coda. Bundling it lets
+# `mina-archive-hardfork-toolbox populate-genesis-accounts` (and `mina-archive
+# run --config-file`) resolve the fork genesis ledger locally -- no S3, no
+# network -- to backfill accounts_accessed for the fork genesis block.
+#
+# Unlike the daemon (see Dockerfile-mina-daemon), the archive image can carry a
+# config safely: its entrypoint never picks up /var/lib/coda/* implicitly, so
+# these files stay inert unless a command names them via --config-file. The
+# archive image is also already per-network, so there is no network-free generic
+# base for the -configured pattern to layer onto.
+#
+# Architecture: all, and no profile/build-flag suffix -- the package is named
+# mina-<network>-config for every variant.
+ENV MINA_CONFIG_DEB=mina-${network}-config
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
@@ -88,7 +104,8 @@ ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 
-# archive-node package
+# archive-node package (+ the per-network config so the hardfork toolbox can
+# resolve the fork genesis ledger from /var/lib/coda)
 # Installed DIRECTLY from the local build context: scripts/docker/build.sh stages
 # the freshly-built .deb files under _debs, which we COPY to /opt/mina-local-debs,
 # and install-mina-debs.sh installs the resolved .deb file with a single apt-get
@@ -104,6 +121,7 @@ RUN chmod +x /usr/local/bin/install-mina-debs.sh \
      /usr/local/bin/install-mina-debs.sh \
        "${MINA_DEB}=$deb_version" \
        "${MINA_ARCHIVE_GENERIC_DEB}=$deb_version" \
-       "${PROFILE_DEB}=$deb_version"
+       "${PROFILE_DEB}=$deb_version" \
+       "${MINA_CONFIG_DEB}=$deb_version"
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]


### PR DESCRIPTION
Port of #19060 (`release/mesa`) to `develop`. Same goal, different mechanism — develop's archive image installs debs from the local build context rather than from an apt repo, so this is a re-implementation rather than a cherry-pick.

### Why
The archive image ships `mina-archive-hardfork-toolbox` but not the network config. `populate-genesis-accounts` (and `mina-archive run --config-file`) need the fork's runtime config JSON and genesis ledger tarball to backfill `accounts_accessed` for the fork genesis block. Without them the toolbox has nothing local to resolve and the operator has to fetch the ledger out of band.

`mina-<network>-config` ships exactly those into `/var/lib/coda`, so installing it in the archive image makes the repair work in-place, with no S3 and no network access.

### What changed vs the mesa version
On `release/mesa` the archive image installs from an apt repo, so the port there was one extra package name on the `apt-get install` line. On `develop` the image installs the resolved `.deb` files directly from the build context via `install-mina-debs.sh`, which takes **no** apt repo and therefore requires the full mina dependency closure to be listed explicitly. So the config package is added as a fourth explicit entry alongside `${MINA_DEB}`, `${MINA_ARCHIVE_GENERIC_DEB}` and `${PROFILE_DEB}`.

### Why install the config directly instead of using the `-configured` pattern
`Dockerfile-mina-daemon` deliberately does *not* install `mina-<network>-config`, and layers it separately via `Dockerfile-install-config` (`mina-daemon-configured` / `mina-rosetta-configured`). That does not apply here, for two independent reasons:

1. The daemon's objection is that a baked `/var/lib/coda/*` config would silently override a runtime config injected later (e.g. by `test_executive`). The archive entrypoint never reads `/var/lib/coda` implicitly — it just `exec`s its argv — so the config files stay inert unless a command names them via `--config-file`. Nothing about existing archive usage changes.
2. `Dockerfile-install-config` does `FROM …:<version>-generic…`, and the archive image is not published with a `-generic` base tag (nor is `mina-archive-configured` in `VALID_SERVICES`). The archive image is already per-network, so there is no network-free base for the pattern to layer onto. Adopting it would mean introducing a generic archive base — a far bigger change than this fix warrants.

### Availability of the deb
`install-mina-debs.sh` hard-fails if a requested package is not staged, so this only works if the config deb is always in the context. It is:
- `scripts/debian/build.sh` `default_targets` builds `daemon_devnet_config` and `daemon_mainnet_config` in the same job as `archive_devnet` / `archive_mainnet`.
- `read_all_from_cache.sh` pulls `debians/$MINA_DEB_CODENAME/*` — every deb for the codename — flat into the `dockerfiles/` build context, which `build.sh` then stages into `_debs`.
- `build_daemon_config_deb` builds it as `Architecture: all` with no profile/build-flag suffix, so the name is `mina-<network>-config` for every variant and resolves against `install-mina-debs.sh`'s `${pkg}_${version}_all.deb` candidate.

`hadolint` reports no new warnings (the three it emits on this file are pre-existing and on untouched lines).