### PR TITLE
archive-hardfork-toolbox: format tests dune

### DIFF
--- a/changes/19077.md
+++ b/changes/19077.md
@@ -1,0 +1,1 @@
+Format archive-hardfork-toolbox tests/dune (follow-up to #19072).

--- a/src/app/archive_hardfork_toolbox/tests/dune
+++ b/src/app/archive_hardfork_toolbox/tests/dune
@@ -1,47 +1,54 @@
 (test
  (name test_convert_canonical)
  (libraries
-   ;; opam libraries
-   alcotest
-   async_unix
-   core
-   result
-   async_kernel
-   uri
-   stdio
-   caqti-driver-postgresql
-   caqti
-   async
-   core_kernel
-   caqti-async
-   base
-   base.caml
-   threads.posix
-   ;; from parent dir
-   archive_hardfork_toolbox_lib
-   ;; local libraries
-   logger
-   archive_lib
-   block_time
-   consensus
-   consensus_vrf
-   currency
-   genesis_constants
-   genesis_ledger_helper
-   mina_base
-   mina_base.import
-   mina_block
-   mina_caqti
-   mina_numbers
-   mina_state
-   mina_transaction
-   mina_wire_types
-   one_or_two
-   protocol_version
-   runtime_config
-   signature_lib
-   unsigned_extended
-   with_hash)
- 
+  ;; opam libraries
+  alcotest
+  async_unix
+  core
+  result
+  async_kernel
+  uri
+  stdio
+  caqti-driver-postgresql
+  caqti
+  async
+  core_kernel
+  caqti-async
+  base
+  base.caml
+  threads.posix
+  ;; from parent dir
+  archive_hardfork_toolbox_lib
+  ;; local libraries
+  logger
+  archive_lib
+  block_time
+  consensus
+  consensus_vrf
+  currency
+  genesis_constants
+  genesis_ledger_helper
+  mina_base
+  mina_base.import
+  mina_block
+  mina_caqti
+  mina_numbers
+  mina_state
+  mina_transaction
+  mina_wire_types
+  one_or_two
+  protocol_version
+  runtime_config
+  signature_lib
+  unsigned_extended
+  with_hash)
  (modules test_convert_canonical)
- (preprocess (pps ppx_version ppx_mina ppx_let ppx_hash ppx_compare ppx_sexp_conv h_list.ppx)))
+ (preprocess
+  (pps
+   ppx_version
+   ppx_mina
+   ppx_let
+   ppx_hash
+   ppx_compare
+   ppx_sexp_conv
+   h_list.ppx)))


### PR DESCRIPTION
Follow-up to #19072, which ported the `convert-chain-to-canonical` polish work to develop but brought an unformatted `tests/dune` with it. `dune build @fmt` fails on develop as a result; this applies the auto-format.

Formatting only — no functional change.

Note: the duplicate-`yojson` dependency fixed on the mesa branch (#19056) does **not** exist on develop, so nothing else needed porting here.