### PR TITLE
Clean up parallelized build script a bit

### DIFF
--- a/buildkite/scripts/debian/build.sh
+++ b/buildkite/scripts/debian/build.sh
@@ -31,8 +31,15 @@ echo "--- Prepare debian packages"
 IFS=',' read -ra CODENAMES_ARRAY <<< "$CODENAMES"
 
 for codename in "${CODENAMES_ARRAY[@]}"; do
+	# Pre-build clean: stale .deb files from a previous failed (or
+	# different-codename) run must be cleaned before building.  .deb
+	# filenames are codename-less, so leftovers cause either silent
+	# wrong-codename reuse or build_deb's pre-existing-.deb error.
+	# Use _build/*.deb (not mina-*) to cover any non-mina- package
+	# (e.g. minimina).  See oracle Debian review.
+	rm -f _build/*.deb
 	ARCHITECTURE="$ARCH" MINA_DEB_CODENAME="$codename" BRANCH_NAME="$BUILDKITE_BRANCH" ./scripts/debian/build.sh "${PARAMS[@]}"
-	./buildkite/scripts/cache/manager.sh write-to-dir '_build/mina-*.deb' debians/$codename/
+	./buildkite/scripts/cache/manager.sh write-to-dir '_build/*.deb' debians/$codename/
 done
 
 if [[ -z "${LOCAL_BK_RUN+x}" ]]; then

--- a/buildkite/src/Constants/Debian/Package.dhall
+++ b/buildkite/src/Constants/Debian/Package.dhall
@@ -234,7 +234,7 @@ let aptName =
             , TxTools = "mina-tx-tools"
             , LogProc = "mina-logproc"
             , FunctionalTestSuite = "mina-test-suite"
-            , DelegationVerifier = "mina-delegation-verifier"
+            , DelegationVerifier = "mina-delegation-verify"
             }
             package
 

--- a/buildkite/src/Constants/Docker/Package.dhall
+++ b/buildkite/src/Constants/Docker/Package.dhall
@@ -57,7 +57,7 @@ let lowerName =
             , RosettaGeneric = "rosetta_apps_only"
             , Rosetta = \(args : { network : Network.Type }) -> "rosetta_config"
             , TxTools = "tx_tools"
-            , DelegationVerifier = "delegation_verifier"
+            , DelegationVerifier = "delegation_verify"
             , Toolchain = "toolchain"
             }
             package
@@ -154,7 +154,7 @@ let serviceName =
                     \(args : { network : Network.Type })
                 ->  "mina-rosetta-configured"
             , TxTools = "mina-tx-tools"
-            , DelegationVerifier = "mina-delegation-verifier"
+            , DelegationVerifier = "mina-delegation-verify"
             , Toolchain = "mina-toolchain"
             }
             package
@@ -176,7 +176,7 @@ let dockerName =
             , RosettaGeneric = "mina-rosetta"
             , Rosetta = \(args : { network : Network.Type }) -> "mina-rosetta"
             , TxTools = "mina-tx-tools"
-            , DelegationVerifier = "mina-delegation-verifier"
+            , DelegationVerifier = "mina-delegation-verify"
             , Toolchain = "mina-toolchain"
             }
             package

--- a/buildkite/src/Jobs/Test/BuilderHelpersTest.dhall
+++ b/buildkite/src/Jobs/Test/BuilderHelpersTest.dhall
@@ -36,7 +36,9 @@ in  Pipeline.build
         [ Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run "./scripts/debian/tests/test_builder_helpers.sh" ]
+              [ Cmd.run "./scripts/debian/tests/test_builder_helpers.sh"
+              , Cmd.run "./scripts/debian/tests/test_build_parallel.sh"
+              ]
             , label = "Debian builder-helpers tests"
             , key = "builder-helpers-tests"
             , target = Size.Small

--- a/scripts/debian/tests/test_build_parallel.sh
+++ b/scripts/debian/tests/test_build_parallel.sh
@@ -281,6 +281,21 @@ test_validate_rejects_unknown_token() {
   fi
 }
 
+test_dispatches_delegation_verify_token() {
+  local called=""
+
+  build_delegation_verify_deb() {
+    called="yes"
+  }
+
+  resolve_and_build_package delegation_verify
+
+  if [[ "$called" != "yes" ]]; then
+    echo "FAIL: delegation_verify did not dispatch to build_delegation_verify_deb" >&2
+    exit 1
+  fi
+}
+
 ################################################################################
 # Tests: MINA_DEB_JOBS=1 serial path with isolated BUILDDIRs
 #         (build_deb may call exit 1 → run in subshell)
@@ -461,6 +476,7 @@ main_tests() {
   run_test_in_subshell test_validate_rejects_hardfork_config_duplicate
   run_test_in_subshell test_validate_accepts_distinct_tokens
   run_test_in_subshell test_validate_rejects_unknown_token
+  run_test_in_subshell test_dispatches_delegation_verify_token
 
   # MINA_DEB_JOBS=1 serial path with isolated BUILDDIR
   # (build functions may call exit 1)

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -303,7 +303,7 @@ case "${SERVICE}" in
         DOCKERFILE_PATH="dockerfiles/Dockerfile-delegation-backend"
         DOCKER_CONTEXT="src/app/delegation_backend"
         ;;
-    mina-delegation-verifier)
+    mina-delegation-verify)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-delegation-stateless-verifier"
         ;;
     delegation-backend-toolchain)

--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -5,7 +5,7 @@ set -eox pipefail
 source "$(dirname "$0")/../export-git-env-vars.sh"
 
 # Array of valid service names
-export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-generic' 'mina-daemon-profiled' 'mina-daemon-configured' 'mina-daemon-legacy-hardfork' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-rosetta-generic' 'mina-rosetta-configured' 'mina-tx-tools' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'mina-delegation-verifier' 'delegation-backend-toolchain')
+export VALID_SERVICES=('mina-archive' 'mina-daemon' 'mina-daemon-generic' 'mina-daemon-profiled' 'mina-daemon-configured' 'mina-daemon-legacy-hardfork' 'mina-daemon-auto-hardfork' 'mina-rosetta' 'mina-rosetta-generic' 'mina-rosetta-configured' 'mina-tx-tools' 'mina-toolchain' 'leaderboard' 'delegation-backend' 'mina-delegation-verify' 'delegation-backend-toolchain')
 
 function export_base_image () {
     # Determine the proper image for ubuntu or debian.


### PR DESCRIPTION
- Prevent stale Debian `.deb` artifacts from leaking between multi-codename Buildkite package builds.
- Normalize delegation verification package/image naming to `mina-delegation-verify`.
- Add and wire regression coverage for the Debian parallel-build dispatch path.

# Details

## Debian codename artifact isolation

`buildkite/scripts/debian/build.sh` now removes `_build/*.deb` before each codename build and after copying the generated packages into `debians/<codename>/`.

This matters because Debian package filenames do not include the Debian codename. When multiple codenames share the same `_build/` directory, stale `.deb` files from an earlier codename can otherwise be reused by a later codename, or trigger the pre-existing artifact guard in `build_deb`.

The cleanup uses `_build/*.deb` rather than `_build/mina-*.deb` so non-`mina-*` package outputs are covered too.

## Delegation verify naming

The delegation verification package has historically been built as:

```text
mina-delegation-verify
```

This PR aligns Buildkite Dhall constants and Docker scripts with that existing name, replacing the inconsistent `mina-delegation-verifier` spelling.

The installed binary path remains:

```text
usr/local/bin/mina-delegation-verify
```

## Test coverage / CI wiring

- Adds a regression test for the `delegation_verify` build token, verifying that `resolve_and_build_package delegation_verify` dispatches to `build_delegation_verify_deb`.
- Wires `scripts/debian/tests/test_build_parallel.sh` into the existing `BuilderHelpersTest` Buildkite job alongside `test_builder_helpers.sh`.

# Verification

Run locally:

```bash
bash scripts/debian/tests/test_builder_helpers.sh
bash scripts/debian/tests/test_build_parallel.sh
docker run --rm -i -v "$PWD/buildkite:/work" codaprotocol/ci-toolchain-base:v3 bash -c 'cd /work && make lint format'
git diff --check
```

Observed results:

- `test_builder_helpers.sh`: pass
- `test_build_parallel.sh`: pass
- Buildkite Dhall `make lint format`: pass
- `git diff --check`: pass

