### PR TITLE
itn: custom (non-default) owned-token zkApp load (nonDefaultToken)

### DIFF
--- a/src/lib/graphql/mina_graphql/itn_zkapps.ml
+++ b/src/lib/graphql/mina_graphql/itn_zkapps.ml
@@ -316,3 +316,358 @@ let send_zkapps ~(genesis_constants : Genesis_constants.t)
                 ~metadata:[ ("error", `String e) ]
         in
         repeat tm_next counter
+
+(* ----------------------------------------------------------------------------
+   Non-default (custom) token load.
+
+   When [nonDefaultToken] is requested we don't generate arbitrary default-token
+   zkApp commands. Instead we stand up a single custom token once (an [owner]
+   account that owns the token plus a fixed pool of [holders] minted an initial
+   balance) and then, for the duration of the run, send commands that transfer
+   that token between the holders, periodically re-minting so no holder runs dry.
+
+   The command shapes mirror the (ledger-validated) zkapp_tokens unit test:
+   a token op nests the holder account updates under the owner account update,
+   with [may_use_token = Parents_own_token], so the owner authorizes use of its
+   token. All updates use signature authorization, filled in afterwards by
+   [Zkapp_command_builder.replace_authorizations]. A transfer nets to zero in the
+   custom token (and in MINA), so it conserves balances; a mint is authorized by
+   the owner. Account-creation fees (paid in MINA) are covered by an explicit
+   negative MINA balance change on the funder/owner. *)
+
+type custom_token =
+  { owner : Signature_lib.Keypair.t
+  ; token_id : Token_id.t
+  ; holders : Signature_lib.Keypair.t array
+  ; balances : int array
+        (** tracked custom-token balance per holder, nanomina *)
+  ; initial_mint : int
+  ; transfer_cap : int
+  ; mint_period : int
+  }
+
+let num_token_holders = 8
+
+(* a large initial balance with small transfers means holders practically never
+   run dry within a run; the periodic re-mint covers arbitrarily long runs *)
+let initial_token_mint = 1_000_000_000_000
+
+let token_transfer_cap = 1_000_000
+
+let token_mint_period = 50
+
+let create_custom_token ~(owner : Signature_lib.Keypair.t) : custom_token =
+  let holders =
+    Array.init num_token_holders ~f:(fun _ -> Signature_lib.Keypair.create ())
+  in
+  let owner_pk = Signature_lib.Public_key.compress owner.public_key in
+  let token_id =
+    Account_id.derive_token_id
+      ~owner:(Account_id.create owner_pk Token_id.default)
+  in
+  { owner
+  ; token_id
+  ; holders
+  ; balances = Array.create ~len:num_token_holders 0
+  ; initial_mint = initial_token_mint
+  ; transfer_cap = token_transfer_cap
+  ; mint_period = token_mint_period
+  }
+
+(* owner + holder private keys must be in the keymap so signatures can be filled *)
+let token_keypairs (ct : custom_token) = ct.owner :: Array.to_list ct.holders
+
+let gen_fee ~(zkapp_command_details : Types.Input.Itn.ZkappCommandsDetails.input)
+    =
+  let lo = Currency.Fee.to_nanomina_int zkapp_command_details.min_fee in
+  let hi = Currency.Fee.to_nanomina_int zkapp_command_details.max_fee in
+  if hi <= lo then lo else lo + Random.int (hi - lo + 1)
+
+let account_creation_fee
+    (constraint_constants : Genesis_constants.Constraint_constants.t) =
+  Currency.Fee.to_nanomina_int constraint_constants.account_creation_fee
+
+(* fund + create the token owner (the create-token step of the unit test):
+   [funder] supplies the MINA, [owner] is created and seeded with enough MINA to
+   later pay the holders' account-creation fees *)
+let build_owner_command ~constraint_constants ~fee ~fee_payer_pk
+    ~fee_payer_nonce ~(funder : Signature_lib.Keypair.t)
+    ~(owner : Signature_lib.Keypair.t) ~owner_seed =
+  let open Zkapp_command_builder in
+  let creation_fee = account_creation_fee constraint_constants in
+  mk_forest
+    [ mk_node
+        (mk_account_update_body Signature No funder Token_id.default
+           (-(owner_seed + creation_fee)) )
+        []
+    ; mk_node
+        (mk_account_update_body Signature No owner Token_id.default owner_seed)
+        []
+    ]
+  |> mk_zkapp_command ~fee ~fee_payer_pk ~fee_payer_nonce
+
+(* the owner mints [initial_mint] of its token to each (new) holder, paying their
+   account-creation fees out of the seed funded above *)
+let build_mint_all_command ~constraint_constants ~fee ~fee_payer_pk
+    ~fee_payer_nonce ~(ct : custom_token) =
+  let open Zkapp_command_builder in
+  let creation_fee = account_creation_fee constraint_constants in
+  let k = Array.length ct.holders in
+  let children =
+    Array.to_list ct.holders
+    |> List.map ~f:(fun h ->
+           mk_node
+             (mk_account_update_body Signature Parents_own_token h ct.token_id
+                ct.initial_mint )
+             [] )
+  in
+  mk_forest
+    [ mk_node
+        (mk_account_update_body Signature No ct.owner Token_id.default
+           (-(k * creation_fee)) )
+        children
+    ]
+  |> mk_zkapp_command ~fee ~fee_payer_pk ~fee_payer_nonce
+
+(* one load command: usually a balanced transfer between two holders,
+   periodically a re-mint to the holder with the smallest balance *)
+let build_load_command ~fee ~fee_payer_pk ~fee_payer_nonce ~memo ~counter
+    ~(ct : custom_token) =
+  let open Zkapp_command_builder in
+  let k = Array.length ct.holders in
+  let extremum cmp =
+    let idx = ref 0 in
+    Array.iteri ct.balances ~f:(fun i b ->
+        if cmp b ct.balances.(!idx) then idx := i ) ;
+    !idx
+  in
+  let owner_node children =
+    mk_node
+      (mk_account_update_body Signature No ct.owner Token_id.default 0)
+      children
+  in
+  let holder_node i amt =
+    mk_node
+      (mk_account_update_body Signature Parents_own_token ct.holders.(i)
+         ct.token_id amt )
+      []
+  in
+  let forest =
+    if counter mod ct.mint_period = 0 then (
+      let i = extremum ( < ) in
+      ct.balances.(i) <- ct.balances.(i) + ct.initial_mint ;
+      mk_forest [ owner_node [ holder_node i ct.initial_mint ] ] )
+    else
+      let sender = extremum ( > ) in
+      let receiver =
+        let r = (sender + 1 + (counter mod (k - 1))) mod k in
+        if r = sender then (sender + 1) mod k else r
+      in
+      let max_amt = Int.min ct.balances.(sender) ct.transfer_cap in
+      let amt = if max_amt <= 1 then 1 else 1 + Random.int max_amt in
+      ct.balances.(sender) <- ct.balances.(sender) - amt ;
+      ct.balances.(receiver) <- ct.balances.(receiver) + amt ;
+      mk_forest
+        [ owner_node [ holder_node sender (-amt); holder_node receiver amt ] ]
+  in
+  forest |> mk_zkapp_command ~memo ~fee ~fee_payer_pk ~fee_payer_nonce
+
+(* create the owner, mint to all holders, and wait for both to appear in the
+   best-tip ledger. Returns [true] once the token and its holders exist. *)
+let setup_custom_token
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~mina
+    ~logger ~(fee_payer_array : Signature_lib.Keypair.t Array.t) ~keymap
+    ~(zkapp_command_details : Types.Input.Itn.ZkappCommandsDetails.input)
+    ~stop_signal ~stop_time ~uuid ~(ct : custom_token) =
+  O1trace.thread "itn_setup_custom_token"
+  @@ fun () ->
+  let num_fee_payers = Array.length fee_payer_array in
+  let k = Array.length ct.holders in
+  let creation_fee = account_creation_fee constraint_constants in
+  let owner_seed = (k + 2) * creation_fee in
+  let expired () =
+    Time.( >= ) (Time.now ()) stop_time || Ivar.is_full stop_signal
+  in
+  let get_ledger () =
+    Option.map (Utils.get_ledger_and_breadcrumb mina) ~f:fst
+  in
+  let account_exists ledger acct_id =
+    Option.is_some (Mina_ledger.Ledger.location_of_account ledger acct_id)
+  in
+  let wait_until predicate =
+    Deferred.repeat_until_finished ()
+    @@ fun () ->
+    if expired () then Deferred.return (`Finished false)
+    else
+      match get_ledger () with
+      | Some ledger when predicate ledger ->
+          Deferred.return (`Finished true)
+      | _ ->
+          let%map () =
+            Async.after
+              (Time.Span.of_ms
+                 ( Float.of_int constraint_constants.block_window_duration_ms
+                 /. 3.0 ) )
+          in
+          `Repeat ()
+  in
+  let send_cmd ~(fee_payer : Signature_lib.Keypair.t) ~build =
+    match get_ledger () with
+    | None ->
+        Deferred.return (Error "no best tip ledger available")
+    | Some ledger ->
+        let fee_payer_nonce = (Utils.account_of_kp fee_payer ledger).nonce in
+        let fee_payer_pk =
+          Signature_lib.Public_key.compress fee_payer.public_key
+        in
+        let cmd = build ~fee_payer_pk ~fee_payer_nonce in
+        let%bind authed =
+          Zkapp_command_builder.replace_authorizations ~keymap cmd
+        in
+        Zkapps.send_zkapp_command mina
+          (Zkapp_command.read_all_proofs_from_disk authed)
+  in
+  let fee_payer0 = fee_payer_array.(0) in
+  let funder = fee_payer_array.(1 mod num_fee_payers) in
+  let owner_id =
+    Account_id.create
+      (Signature_lib.Public_key.compress ct.owner.public_key)
+      Token_id.default
+  in
+  [%log info] "Initializing custom token for handle %s" (Uuid.to_string uuid) ;
+  let%bind () =
+    match%map
+      send_cmd ~fee_payer:fee_payer0
+        ~build:(fun ~fee_payer_pk ~fee_payer_nonce ->
+          build_owner_command ~constraint_constants
+            ~fee:(gen_fee ~zkapp_command_details)
+            ~fee_payer_pk ~fee_payer_nonce ~funder ~owner:ct.owner ~owner_seed )
+    with
+    | Ok _ ->
+        [%log info] "Submitted custom-token owner creation"
+    | Error e ->
+        [%log error] "Failed to submit custom-token owner creation: $error"
+          ~metadata:[ ("error", `String e) ]
+  in
+  match%bind wait_until (fun ledger -> account_exists ledger owner_id) with
+  | false ->
+      Deferred.return false
+  | true ->
+      let%bind () =
+        match%map
+          send_cmd ~fee_payer:fee_payer0
+            ~build:(fun ~fee_payer_pk ~fee_payer_nonce ->
+              build_mint_all_command ~constraint_constants
+                ~fee:(gen_fee ~zkapp_command_details)
+                ~fee_payer_pk ~fee_payer_nonce ~ct )
+        with
+        | Ok _ ->
+            [%log info] "Submitted custom-token mint to %d holders" k
+        | Error e ->
+            [%log error] "Failed to submit custom-token mint: $error"
+              ~metadata:[ ("error", `String e) ]
+      in
+      let%map all_present =
+        wait_until (fun ledger ->
+            Array.for_all ct.holders ~f:(fun h ->
+                account_exists ledger
+                  (Account_id.create
+                     (Signature_lib.Public_key.compress h.public_key)
+                     ct.token_id ) ) )
+      in
+      if all_present then (
+        Array.fill ct.balances ~pos:0 ~len:(Array.length ct.balances)
+          ct.initial_mint ;
+        [%log info] "Custom token initialized with %d holders for handle %s" k
+          (Uuid.to_string uuid) ;
+        true )
+      else false
+
+(* the custom-token load loop: send a transfer (or periodic re-mint) each tick *)
+let send_custom_token_zkapps
+    ~(fee_payer_array : Signature_lib.Keypair.t Array.t) ~tm_end ~scheduler_tbl
+    ~uuid ~keymap ~stop_signal ~mina
+    ~(zkapp_command_details : Types.Input.Itn.ZkappCommandsDetails.input)
+    ~wait_span ~logger ~(ct : custom_token) init_tm_next init_counter =
+  O1trace.thread "itn_send_custom_token_zkapps"
+  @@ fun () ->
+  let wait_span_ms = Time.Span.to_ms wait_span |> int_of_float in
+  let repeat tm_next counter =
+    let%map () = Async_unix.at tm_next in
+    let open Time in
+    let next_tm_next = add tm_next wait_span in
+    let now = now () in
+    let next_tm_next =
+      if next_tm_next <= now then
+        let span = diff now next_tm_next |> Span.to_ms in
+        let additive =
+          wait_span_ms - (int_of_float span % wait_span_ms)
+          |> float_of_int |> Span.of_ms
+        in
+        add now additive
+      else next_tm_next
+    in
+    `Repeat (next_tm_next, counter + 1)
+  in
+  let num_fee_payers = Array.length fee_payer_array in
+  let fee_payer_nonces =
+    match Utils.get_ledger_and_breadcrumb mina with
+    | Some (ledger, _) ->
+        Array.map fee_payer_array ~f:(fun kp ->
+            ref (Utils.account_of_kp kp ledger).nonce )
+    | None ->
+        Array.map fee_payer_array ~f:(fun _ -> ref Account.Nonce.zero)
+  in
+  Deferred.repeat_until_finished (init_tm_next, init_counter)
+  @@ fun (tm_next, counter) ->
+  if Time.( >= ) (Time.now ()) tm_end then (
+    [%log info] "Scheduled zkApp commands with handle %s has expired"
+      (Uuid.to_string uuid) ;
+    Uuid.Table.remove scheduler_tbl uuid ;
+    Deferred.return (`Finished ()) )
+  else if Ivar.is_full stop_signal then (
+    [%log info] "Stopping scheduled zkApp commands with handle %s"
+      (Uuid.to_string uuid) ;
+    Uuid.Table.remove scheduler_tbl uuid ;
+    Deferred.return (`Finished ()) )
+  else
+    let ndx = counter mod num_fee_payers in
+    let fee_payer = fee_payer_array.(ndx) in
+    let fee_payer_pk = Signature_lib.Public_key.compress fee_payer.public_key in
+    let fee_payer_nonce = !(fee_payer_nonces.(ndx)) in
+    let fee = gen_fee ~zkapp_command_details in
+    let memo =
+      String.prefix
+        (sprintf "%s-%d" zkapp_command_details.memo_prefix counter)
+        Signed_command_memo.max_input_length
+    in
+    let zkapp_command =
+      build_load_command ~fee ~fee_payer_pk ~fee_payer_nonce ~memo ~counter ~ct
+    in
+    let%bind zkapp_command =
+      O1trace.thread "itn_replace_custom_token_auth"
+      @@ fun () ->
+      Zkapp_command_builder.replace_authorizations ~keymap zkapp_command
+    in
+    let%bind () =
+      O1trace.thread "itn_send_custom_token_zkapp"
+      @@ fun () ->
+      match%map
+        Zkapps.send_zkapp_command mina
+          (Zkapp_command.read_all_proofs_from_disk zkapp_command)
+      with
+      | Ok _ ->
+          fee_payer_nonces.(ndx) := Account.Nonce.succ fee_payer_nonce ;
+          [%log info]
+            "Sent out custom-token zkApp with fee payer's summary $summary"
+            ~metadata:
+              [ ( "summary"
+                , User_command.fee_payer_summary_json
+                    (Zkapp_command zkapp_command) )
+              ]
+      | Error e ->
+          [%log info]
+            "Failed to send out custom-token zkApp command, see $error"
+            ~metadata:[ ("error", `String e) ]
+    in
+    repeat tm_next counter

--- a/src/lib/graphql/mina_graphql/itn_zkapps.ml
+++ b/src/lib/graphql/mina_graphql/itn_zkapps.ml
@@ -671,3 +671,28 @@ let send_custom_token_zkapps
             ~metadata:[ ("error", `String e) ]
     in
     repeat tm_next counter
+
+(* stand up the custom token, then run the transfer/re-mint load against it.
+   The default-token counterpart is [send_zkapps]; keeping the setup+load
+   sequencing here (rather than inline in the GraphQL resolver) keeps the two
+   entry points symmetric. *)
+let run_custom_token_load
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~mina
+    ~logger ~(fee_payer_array : Signature_lib.Keypair.t Array.t) ~scheduler_tbl
+    ~keymap
+    ~(zkapp_command_details : Types.Input.Itn.ZkappCommandsDetails.input)
+    ~stop_signal ~tm_end ~wait_span ~uuid ~(ct : custom_token) =
+  let%bind setup_ok =
+    setup_custom_token ~constraint_constants ~mina ~logger ~fee_payer_array
+      ~keymap ~zkapp_command_details ~stop_signal ~stop_time:tm_end ~uuid ~ct
+  in
+  if setup_ok then
+    let tm_next = Time.add (Time.now ()) wait_span in
+    send_custom_token_zkapps ~fee_payer_array ~tm_end ~scheduler_tbl ~uuid
+      ~keymap ~stop_signal ~mina ~zkapp_command_details ~wait_span ~logger ~ct
+      tm_next 0
+  else (
+    [%log error] "Custom token setup did not complete, stopping handle %s"
+      (Uuid.to_string uuid) ;
+    Uuid.Table.remove scheduler_tbl uuid ;
+    Deferred.unit )

--- a/src/lib/graphql/mina_graphql/mina_graphql.ml
+++ b/src/lib/graphql/mina_graphql/mina_graphql.ml
@@ -1337,9 +1337,21 @@ module Mutations = struct
                       Utils.account_of_kp fee_payer_keypair ledger ) )
               |> Result.map_error ~f:(const "fee payer not in the ledger")
             in
+            let custom_token_opt =
+              if zkapp_command_details.non_default_token then
+                Some
+                  (Itn_zkapps.create_custom_token
+                     ~owner:(Signature_lib.Keypair.create ()) )
+              else None
+            in
+            let token_keypairs =
+              Option.value_map custom_token_opt ~default:[]
+                ~f:Itn_zkapps.token_keypairs
+            in
             let keymap =
               List.map
-                (zkapp_account_keypairs @ fee_payer_keypairs @ unused_keypairs)
+                ( zkapp_account_keypairs @ fee_payer_keypairs @ unused_keypairs
+                @ token_keypairs )
                 ~f:(fun { public_key; private_key } ->
                   (Public_key.compress public_key, private_key) )
               |> Public_key.Compressed.Map.of_alist_exn
@@ -1361,24 +1373,50 @@ module Mutations = struct
             upon (deploy_zkapps_do ()) (function
               | None ->
                   ()
-              | Some ledger ->
-                  let account_state_tbl =
-                    let get_account ids role =
-                      List.map ids ~f:(fun id ->
-                          (id, (Utils.account_of_id id ledger, role)) )
-                    in
-                    Account_id.Table.of_alist_exn
-                      ( get_account fee_payer_ids `Fee_payer
-                      @ get_account zkapp_account_ids `Ordinary_participant )
-                  in
-                  let tm_next = Time.add (Time.now ()) wait_span in
-                  don't_wait_for
-                  @@ Itn_zkapps.send_zkapps ~genesis_constants
-                       ~constraint_constants ~fee_payer_array ~scheduler_tbl
-                       ~uuid ~keymap ~unused_pks ~stop_signal ~mina
-                       ~zkapp_command_details ~wait_span ~logger ~tm_end
-                       ~account_state_tbl tm_next
-                       (List.length zkapp_account_keypairs) ) ;
+              | Some ledger -> (
+                  match custom_token_opt with
+                  | Some ct ->
+                      (* Stand up the single custom token, then run the
+                         transfer/re-mint load against it. *)
+                      don't_wait_for
+                        (let%bind setup_ok =
+                           Itn_zkapps.setup_custom_token ~constraint_constants
+                             ~mina ~logger ~fee_payer_array ~keymap
+                             ~zkapp_command_details ~stop_signal
+                             ~stop_time:tm_end ~uuid ~ct
+                         in
+                         if setup_ok then
+                           let tm_next = Time.add (Time.now ()) wait_span in
+                           Itn_zkapps.send_custom_token_zkapps ~fee_payer_array
+                             ~tm_end ~scheduler_tbl ~uuid ~keymap ~stop_signal
+                             ~mina ~zkapp_command_details ~wait_span ~logger ~ct
+                             tm_next 0
+                         else (
+                           [%log error]
+                             "Custom token setup did not complete, stopping \
+                              handle %s"
+                             (Uuid.to_string uuid) ;
+                           Uuid.Table.remove scheduler_tbl uuid ;
+                           Deferred.unit ) )
+                  | None ->
+                      let account_state_tbl =
+                        let get_account ids role =
+                          List.map ids ~f:(fun id ->
+                              (id, (Utils.account_of_id id ledger, role)) )
+                        in
+                        Account_id.Table.of_alist_exn
+                          ( get_account fee_payer_ids `Fee_payer
+                          @ get_account zkapp_account_ids `Ordinary_participant
+                          )
+                      in
+                      let tm_next = Time.add (Time.now ()) wait_span in
+                      don't_wait_for
+                      @@ Itn_zkapps.send_zkapps ~genesis_constants
+                           ~constraint_constants ~fee_payer_array ~scheduler_tbl
+                           ~uuid ~keymap ~unused_pks ~stop_signal ~mina
+                           ~zkapp_command_details ~wait_span ~logger ~tm_end
+                           ~account_state_tbl tm_next
+                           (List.length zkapp_account_keypairs) ) ) ;
             Ok (Uuid.to_string uuid) )
 
     let stop_scheduled_transactions =

--- a/src/lib/graphql/mina_graphql/mina_graphql.ml
+++ b/src/lib/graphql/mina_graphql/mina_graphql.ml
@@ -1376,28 +1376,11 @@ module Mutations = struct
               | Some ledger -> (
                   match custom_token_opt with
                   | Some ct ->
-                      (* Stand up the single custom token, then run the
-                         transfer/re-mint load against it. *)
                       don't_wait_for
-                        (let%bind setup_ok =
-                           Itn_zkapps.setup_custom_token ~constraint_constants
-                             ~mina ~logger ~fee_payer_array ~keymap
-                             ~zkapp_command_details ~stop_signal
-                             ~stop_time:tm_end ~uuid ~ct
-                         in
-                         if setup_ok then
-                           let tm_next = Time.add (Time.now ()) wait_span in
-                           Itn_zkapps.send_custom_token_zkapps ~fee_payer_array
-                             ~tm_end ~scheduler_tbl ~uuid ~keymap ~stop_signal
-                             ~mina ~zkapp_command_details ~wait_span ~logger ~ct
-                             tm_next 0
-                         else (
-                           [%log error]
-                             "Custom token setup did not complete, stopping \
-                              handle %s"
-                             (Uuid.to_string uuid) ;
-                           Uuid.Table.remove scheduler_tbl uuid ;
-                           Deferred.unit ) )
+                      @@ Itn_zkapps.run_custom_token_load ~constraint_constants
+                           ~mina ~logger ~fee_payer_array ~scheduler_tbl ~keymap
+                           ~zkapp_command_details ~stop_signal ~tm_end
+                           ~wait_span ~uuid ~ct
                   | None ->
                       let account_state_tbl =
                         let get_account ids role =

--- a/src/lib/graphql/mina_graphql/types.ml
+++ b/src/lib/graphql/mina_graphql/types.ml
@@ -3349,6 +3349,7 @@ module Input = struct
         ; balance_change_range :
             Mina_generators.Zkapp_command_generators.balance_change_range_t
         ; max_account_updates : int option
+        ; non_default_token : bool
         }
 
       let arg_typ : ((input, string) result option, input option) arg_typ =
@@ -3359,7 +3360,7 @@ module Input = struct
                        min_balance_change max_balance_change
                        min_new_zkapp_balance max_new_zkapp_balance init_balance
                        min_fee max_fee deployment_fee account_queue_size
-                       max_cost max_account_updates ->
+                       max_cost max_account_updates non_default_token ->
             Result.return
               { fee_payers
               ; num_zkapps_to_deploy
@@ -3375,6 +3376,7 @@ module Input = struct
               ; account_queue_size
               ; max_cost
               ; max_account_updates
+              ; non_default_token
               ; balance_change_range =
                   { min_balance_change
                   ; max_balance_change
@@ -3390,7 +3392,7 @@ module Input = struct
               t.balance_change_range.min_new_zkapp_balance
               t.balance_change_range.max_new_zkapp_balance t.init_balance
               t.min_fee t.max_fee t.deployment_fee t.account_queue_size
-              t.max_cost t.max_account_updates )
+              t.max_cost t.max_account_updates (Some t.non_default_token) )
           ~fields:
             Arg.
               [ arg "feePayers"
@@ -3443,6 +3445,14 @@ module Input = struct
                      will have (2*maxAccountUpdates+2) account updates \
                      (including balancing and fee payer)"
                   ~typ:int
+              ; arg' "nonDefaultToken"
+                  ~doc:
+                    "When true, generated (non-max-cost) zkApp commands \
+                     initialize a custom, non-default token and transact in it \
+                     instead of the default MINA token. Defaults to false, in \
+                     which case the default token is used. Has no effect when \
+                     maxCost is set."
+                  ~typ:bool ~default:false
               ]
     end
 


### PR DESCRIPTION
# Reproduce archive bug #18941 (`tokens_value_key`) against a real network

**Branch:** `repro/compatible-custom-token` — based on **`compatible`**
**Patch:** `branch1-compatible-custom-token.mbox` (1 commit, 3 files, +424/−21)
**Companion:** the mina-perf-testing orchestrator extension (`orchestrator-non-default-token.mbox`) — needed to drive the load.

## Summary

Adds a `nonDefaultToken` mode to the ITN scheduled-zkApp load (`scheduleZkappCommands`). When enabled, the daemon does **not** generate ordinary default-token zkApp commands. Instead it stands up a single **custom, owned token** once and, for the run's duration, transacts that token between a fixed pool of holders (periodically re-minting so no holder runs dry).

The point is to put an **OWNED custom-token account** (a token whose owner is a real account in the ledger, not the default MINA token) into the pre-fork ledger. When the Berkeley→Mesa hardfork snapshots that ledger into the fork **genesis config**, the post-fork (Mesa) archive's `add_genesis_accounts` materializes those accounts and exercises the `tokens` table's `tokens_value_key UNIQUE(value)` path — which is exactly where issue **#18941** lives. Against a buggy archive processor this collides; against the fixed one it is clean.

This is a standalone extraction of the load logic from the `hardfork_test` `--repro-archive-bugs` reproduction (PR #19000); it is **not** the hardfork test itself. It is a tool you point at a live pre-fork network.

## What the patch changes

| File | Change |
|---|---|
| `src/lib/graphql/mina_graphql/itn_zkapps.ml` | The custom-token load: `create_custom_token`, `setup_custom_token` (create owner + mint to holders, wait for them in the best-tip ledger), `send_custom_token_zkapps` (per-tick transfer / periodic re-mint). Command shapes mirror the ledger-validated `zkapp_tokens` unit test — holder updates nested under the owner update with `may_use_token = Parents_own_token`, signature auth filled by `replace_authorizations`. |
| `src/lib/graphql/mina_graphql/mina_graphql.ml` | In `scheduleZkappCommands`: if `nonDefaultToken` is set, run the custom-token setup + load path instead of the default `send_zkapps`. |
| `src/lib/graphql/mina_graphql/types.ml` | Adds the `nonDefaultToken` input field to `ZkappCommandsDetails` (default `false`; no effect when `maxCost` is set). |

Load parameters (constants in `itn_zkapps.ml`): 8 holders, initial mint `1_000_000_000_000`, transfer cap `1_000_000`, re-mint every 50 commands. The owner is seeded `(holders + 2) × account_creation_fee` MINA (≈ 10 MINA) out of fee-payer 0 so it can pay the holders' account-creation fees.

## How to reproduce, step by step (node side)

### 1. Build the node from this branch

```bash
git checkout compatible            # c1d966758 or later compatible
git am branch1-compatible-custom-token.mbox
# build the devnet/mainnet daemon however you normally build for the target network, e.g.:
DUNE_PROFILE=devnet dune build src/app/cli/src/mina.exe
```

Only `mina.exe` (the daemon) changes — the archive/genesis binaries are unchanged.

### 2. Launch the node on the pre-fork network with the ITN endpoint enabled

The custom-token load is driven over the ITN internal GraphQL server, which is only compiled/served when `ITN_FEATURES` is set **and** `--itn-graphql-port` is given. Authorize the **orchestrator's** ITN public key with `--itn-keys`:

```bash
export ITN_FEATURES=1
mina daemon \
  <your usual flags to join the pre-fork network: --config-file / --peer-list-url / --archive-address ...> \
  --itn-graphql-port 3086 \
  --itn-keys "<ORCHESTRATOR_ITN_PUBKEY_BASE64>"
```

* `--itn-keys` takes a comma-delimited list of **base64-encoded Ed25519 public keys**. It must contain the public key matching the orchestrator's signing key (the orchestrator config `"key"` is the base64 Ed25519 **private** seed). Derive the public key from that seed, e.g.:

  ```python
  import base64
  from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
  seed = base64.b64decode("<orchestrator config \"key\">")
  pub  = Ed25519PrivateKey.from_private_bytes(seed).public_key().public_bytes_raw()
  print(base64.b64encode(pub).decode())
  ```

* The ITN server binds to localhost by default; add `--insecure-rest-server` (or tunnel) if the orchestrator runs on another host. Auth is pure Ed25519 over the request body (and `2-byte-BE seqno ‖ serverUuid ‖ body` for sequenced mutations) — the orchestrator already speaks this.
* The fee-payer keys the orchestrator funds must hold enough MINA to cover the token owner's ≈10 MINA seed plus fees; the orchestrator's zkApp funding path already over-provisions for account creation.

### 3. Fire the load via the orchestrator generator config

Run an experiment with `non_default_token` set (requires the orchestrator patch). Keep `max_cost` off and `zkapp_ratio` > 0 (the option only affects the zkApp load):

```json
{
  "base_tps": 0.02,
  "stress_tps": 0.03,
  "zkapp_ratio": 0.5,
  "rounds": 1,
  "round_duration_min": 30,
  "pause_min": 0,
  "max_cost": false,
  "non_default_token": true
}
```

Equivalently, the standalone `generator` CLI gains `-non-default-token`.

This makes the node: create the owner account, mint the token to 8 holders, wait for them in the best tip, then transfer the token between holders for the round. Confirm in the daemon log:

```
Initializing custom token for handle <uuid>
Submitted custom-token owner creation
Submitted custom-token mint to 8 holders
Custom token initialized with 8 holders for handle <uuid>
Sent out custom-token zkApp with fee payer's summary ...
```

### 4. What you've produced

After the round, the pre-fork ledger holds an account that **owns a non-default token** plus 8 holder accounts of that token. Run the experiment with enough lead time before the hardfork so those accounts are finalized in the ledger that becomes the fork genesis.

When the hardfork happens, that owned-token account is written into the fork genesis config; starting a **Mesa** archive over that genesis runs `add_genesis_accounts`, which is where #18941 (`tokens_value_key`) reproduces on the buggy processor. (Archive-side verification is out of scope for this branch, per the task; this branch's job is to put the triggering account on-chain.)

## Notes

* `nonDefaultToken` is a nullable input field defaulting to `false`. Daemons that predate this change ignore an unknown input field (ocaml-graphql-server drops undeclared input fields), so an orchestrator that always sends `nonDefaultToken: false` is harmless against stock nodes.
* Has **no effect** together with `maxCost` (max-cost commands always use the default token); the orchestrator rejects that combination up front.
