### PR TITLE
Repro: max-cost zkApp Shape-B encoding for archive element_ids btree overflow (Mesa)

### DIFF
--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1708,20 +1708,29 @@ let gen_max_cost_zkapp_command_from ?memo ?fee_range ?pk ?(n_updates : int = 15)
   let[@warning "-8"] (head :: tail) =
     List.map pks ~f:(fun pk -> mk_account_update ~pk ~vk)
   in
-  let events =
-    List.init genesis_constants.max_event_elements ~f:(fun i ->
-        [| Snark_params.Tick.Field.of_int i |] )
-  in
-  let actions =
-    List.init genesis_constants.max_action_elements ~f:(fun i ->
-        [| Snark_params.Tick.Field.of_int i |] )
-  in
-  let account_updates =
-    { head with body = { head.body with events; actions } } :: tail
-  in
   let fee_payer_id = Account_id.create fee_payer_pk Token_id.default in
   let fee_payer_account, _ =
     Account_id.Table.find_exn account_state_tbl fee_payer_id
+  in
+  (* Keep events and actions maxed out (max_event_elements / max_action_elements
+     total field elements), but alternate their on-wire encoding per generated
+     transaction so both valid shapes are exercised across a load run. The
+     fee-payer nonce increments once per generated command (see the
+     [Account_id.Table.change] below), giving a deterministic A/B/A/B alternation
+     applied to both events and actions.
+       Shape A: a list of N single-element field arrays      [ [|f0|]; [|f1|]; ... ]
+       Shape B: a singleton list of one N-element field array [ [|f0; f1; ...; f_{N-1}|] ]
+     Both encode N field elements and pass [Zkapp_command.valid_size]. *)
+  let use_shape_b = Account.Nonce.to_int fee_payer_account.nonce mod 2 = 1 in
+  let mk_maxed n =
+    if use_shape_b then
+      [ Array.init n ~f:(fun i -> Snark_params.Tick.Field.of_int i) ]
+    else List.init n ~f:(fun i -> [| Snark_params.Tick.Field.of_int i |])
+  in
+  let events = mk_maxed genesis_constants.max_event_elements in
+  let actions = mk_maxed genesis_constants.max_action_elements in
+  let account_updates =
+    { head with body = { head.body with events; actions } } :: tail
   in
   let%map fee =
     Option.value_map fee_range
@@ -1926,8 +1935,14 @@ let%test_module _ =
       let events = first_update.body.events in
       let actions = first_update.body.actions in
 
-      assert (List.length events = genesis_constants.max_event_elements) ;
-      assert (List.length actions = genesis_constants.max_action_elements) ;
+      (* events/actions may be encoded as either Shape A (a list of single-element
+         arrays) or Shape B (a singleton list of one all-elements array); assert
+         on the total number of field elements, which is shape-independent. *)
+      let total_elements l =
+        List.fold l ~init:0 ~f:(fun acc arr -> acc + Array.length arr)
+      in
+      assert (total_elements events = genesis_constants.max_event_elements) ;
+      assert (total_elements actions = genesis_constants.max_action_elements) ;
       let _ =
         Zkapp_command.Call_forest.mapi_with_trees command.account_updates
           ~f:(fun _ndx acc tree ->


### PR DESCRIPTION
# Reproduce the archive `element_ids` btree overflow against a real (Mesa) network

**Branch:** `repro/mesa-maxcost-shapeb` — based on **`release/mesa`** (`edadae0`)
**Patch:** `branch2-mesa-maxcost-shapeb.mbox` (1 commit, 1 file, +28/−13)
**Driver:** the mina-perf-testing orchestrator, **unchanged** — it already exposes `max_cost` in the generator config, which is all this reproduction needs.

## Summary

The max-cost zkApp generator (`gen_max_cost_zkapp_command_from`, used by the ITN `scheduleZkappCommands` `maxCost` load) previously emitted a transaction's events and actions only as a **list of single-element field arrays** (Shape A). This patch alternates the on-wire encoding per generated command so both valid shapes are exercised:

```
Shape A: a list of N single-element field arrays    [ [|f0|]; [|f1|]; ... ]
Shape B: a singleton list of one N-element array     [ [|f0; f1; ...; f_{N-1}|] ]
```

Both encode `N = max_event_elements = max_action_elements = 1024` (on Mesa) field elements and pass `Zkapp_command.valid_size` — which counts total field elements (`events_elements` sums `Array.length` across the list), so the two shapes are cost-equivalent. The shape alternates deterministically by fee-payer nonce parity, so a live load emits a **Shape-B** command every other transaction. The generator's `n_updates` default (15) is unchanged, so the load stays genuinely "max cost."

**Why Shape B matters:** a Shape-B command makes an archive node ingest a single 1024-element field array — a `zkapp_field_array` row whose `element_ids int[]` holds 1024 entries. On an archive whose schema still carries the `element_ids` **UNIQUE btree index**, the index row (**4128 bytes**) exceeds Postgres' **2704-byte** btree-v4 key maximum and the INSERT fails:

```
ERROR: index row size 4128 exceeds btree version 4 maximum 2704 for index "zkapp_field_array_element_ids_key"
```

Shape A never triggers this (each array is a single element, so the index row is tiny), which is why the stock generator misses the bug. This is a standalone extraction of the Shape-B encoding from the `hardfork_test` `--repro-archive-bugs` reproduction (PR #19000); it is a tool you point at a live Mesa network, not the hardfork test itself.

## What the patch changes

One file — `src/lib/mina_generators/zkapp_command_generators.ml`:

* `gen_max_cost_zkapp_command_from`: build events/actions via a `mk_maxed` helper that picks Shape A or Shape B by `fee_payer_account.nonce mod 2`. The `n_updates` default is unchanged.
* The generator's inline test now asserts on the **total element count** (shape-independent) instead of the list length.

No archive, schema, or migration change is in this branch — the bug is a property of the archive schema/migration you point the load at; this branch only makes the daemon **emit** the triggering transaction.

## How to reproduce, step by step (node side)

### 1. Build the node from this branch

```bash
git checkout release/mesa          # edadae0 or later
git am branch2-mesa-maxcost-shapeb.mbox
DUNE_PROFILE=devnet dune build src/app/cli/src/mina.exe
```

Only `mina.exe` (the daemon) changes.

### 2. Launch the node on the Mesa network with the ITN endpoint enabled

Identical to any ITN-driven load: the ITN GraphQL server is served only when `ITN_FEATURES` is set and `--itn-graphql-port` is given, with the orchestrator's public key authorized via `--itn-keys`.

```bash
export ITN_FEATURES=1
mina daemon \
  <your usual flags to join the Mesa network: --config-file / --peer-list-url / --archive-address ...> \
  --itn-graphql-port 3086 \
  --itn-keys "<ORCHESTRATOR_ITN_PUBKEY_BASE64>"
```

`--itn-keys` is a comma-delimited list of base64 Ed25519 **public** keys; use the public key matching the orchestrator's signing key (the orchestrator config `"key"` is the base64 Ed25519 private seed — derive the public key as shown in the branch-1 README). Bind with `--insecure-rest-server` / a tunnel if the orchestrator is remote.

### 3. Fire the max-cost load via the orchestrator generator config

No orchestrator patch is required — just set `max_cost: true`:

```json
{
  "base_tps": 0.02,
  "stress_tps": 0.03,
  "zkapp_ratio": 1.0,
  "rounds": 1,
  "round_duration_min": 30,
  "pause_min": 0,
  "max_cost": true
}
```

(`zkapp_ratio: 1.0` because max-cost is a zkApp-only load; the orchestrator forces the deploy count internally for max-cost.) The node then generates max-cost zkApp commands, and — thanks to this branch — every other one is Shape B.

Confirm in the daemon log that max-cost zkApp commands are being sent (the standard `scheduleZkappCommands` max-cost log lines). Within a handful of transactions you will have emitted at least one Shape-B command.

### 4. What you've produced

Each Shape-B max-cost command carries a single 1024-element events array and a single 1024-element actions array. Any archive node ingesting the block that includes such a command will try to insert a `zkapp_field_array` row with a 1024-entry `element_ids` array. On an archive whose schema/migration still keeps the `element_ids` UNIQUE btree index, the insert fails with the 4128 > 2704 overflow above and the archive falls behind; the fixed archive (which drops that UNIQUE index) ingests it cleanly. (Archive-side verification is out of scope for this branch — this branch's job is to emit the triggering transaction.)

## Notes

* The alternation is deterministic (nonce parity), not random, so the reproduction is reliable: sustained max-cost load = a steady stream of Shape-B commands.
* If you want a purely Shape-B stream, that would be a follow-up knob; this branch intentionally matches the upstream commit used by the hardfork unit test (~50% Shape-B), which is more than enough to trigger the overflow.
