### PR TITLE
ci: port verify-schema-upgrade element_ids tolerance to release/mesa

### DIFF
--- a/buildkite/scripts/archive/verify-schema-upgrade.sh
+++ b/buildkite/scripts/archive/verify-schema-upgrade.sh
@@ -134,11 +134,27 @@ dump_and_normalize() {
     > "$output_file"
 }
 
-# --- Normalize documented lossy downgrade deltas ---
-# The downgrade intentionally does not restore Berkeley's element_ids btree
-# UNIQUE/indexes or events_id/actions_id NOT NULL constraints. Post-Mesa data may
-# contain duplicates, oversized arrays, or NULL values that Berkeley rejected.
-normalize_known_downgrade_deltas() {
+# --- Normalize documented Berkeley/Mesa schema deltas ---
+# A btree key over the unbounded zkapp_{events,field_array}.element_ids int[]
+# overflows Postgres' 2704-byte limit for max-cost zkApps, so Mesa drops those
+# UNIQUE constraints/indexes and makes events_id/actions_id nullable. On the
+# compatible branch this delta shows up in two places and is intentionally
+# tolerated here rather than by retroactively editing the released migration
+# scripts:
+#   * upgrade:   compatible's create_schema + upgrade still carries Berkeley's
+#                element_ids UNIQUE/index + NOT NULL that develop's create_schema
+#                has dropped.
+#   * downgrade: the downgrade does not restore them (lossy) — post-Mesa data may
+#                hold duplicates, oversized arrays, or NULLs Berkeley rejected.
+# Strip that documented delta from both sides before comparing.
+#
+# TODO: the upgrade arm of this tolerance is only needed because compatible's
+# released upgrade_to_mesa.sql never dropped the element_ids UNIQUE/index and the
+# events_id/actions_id NOT NULL, while develop's does. Once compatible's migration
+# carries those DROPs, stop normalizing the upgrade comparison (Test 1) and let it
+# assert the constraints are gone; the downgrade arm (Test 2) stays either way,
+# since the downgrade is deliberately lossy.
+normalize_known_schema_deltas() {
     local schema_file="$1"
     local tmp_file="${schema_file}.known_downgrade_deltas"
 
@@ -209,6 +225,7 @@ main() {
     echo ""
     echo "=== Test 1: Upgrade path verification ==="
     echo "  Expected: ${SOURCE_BRANCH} schema + upgrade_to_mesa.sql == ${TARGET_BRANCH} schema"
+    echo "            except documented Berkeley/Mesa element_ids constraint deltas"
 
     create_db "archive_fresh"
     create_db "archive_upgraded"
@@ -227,6 +244,8 @@ main() {
 
     dump_and_normalize "archive_fresh" "$schema_fresh"
     dump_and_normalize "archive_upgraded" "$schema_upgraded"
+    normalize_known_schema_deltas "$schema_fresh"
+    normalize_known_schema_deltas "$schema_upgraded"
 
     echo "Comparing schemas..."
     if diff -u "$schema_fresh" "$schema_upgraded"; then
@@ -261,8 +280,8 @@ main() {
 
     dump_and_normalize "archive_source_ref" "$schema_source_ref"
     dump_and_normalize "archive_downgraded" "$schema_downgraded"
-    normalize_known_downgrade_deltas "$schema_source_ref"
-    normalize_known_downgrade_deltas "$schema_downgraded"
+    normalize_known_schema_deltas "$schema_source_ref"
+    normalize_known_schema_deltas "$schema_downgraded"
 
     echo "Comparing schemas..."
     if diff -u "$schema_source_ref" "$schema_downgraded"; then

--- a/buildkite/scripts/archive/verify-schema-upgrade.sh
+++ b/buildkite/scripts/archive/verify-schema-upgrade.sh
@@ -134,6 +134,41 @@ dump_and_normalize() {
     > "$output_file"
 }
 
+# --- Normalize documented lossy downgrade deltas ---
+# The downgrade intentionally does not restore Berkeley's element_ids btree
+# UNIQUE/indexes or events_id/actions_id NOT NULL constraints. Post-Mesa data may
+# contain duplicates, oversized arrays, or NULL values that Berkeley rejected.
+normalize_known_downgrade_deltas() {
+    local schema_file="$1"
+    local tmp_file="${schema_file}.known_downgrade_deltas"
+
+    awk '
+        /^ALTER TABLE ONLY public\.zkapp_(events|field_array)$/ {
+            alter_line = $0
+            if ((getline constraint_line) <= 0) {
+                print alter_line
+                next
+            }
+            if (constraint_line ~ /^    ADD CONSTRAINT zkapp_(events|field_array)_element_ids_key UNIQUE \(element_ids\);$/) {
+                next
+            }
+            print alter_line
+            print constraint_line
+            next
+        }
+        /^CREATE INDEX idx_zkapp_(events|field_array)_element_ids ON public\.zkapp_(events|field_array) USING btree \(element_ids\);$/ {
+            next
+        }
+        {
+            sub(/^    events_id integer NOT NULL,/, "    events_id integer,")
+            sub(/^    actions_id integer NOT NULL,/, "    actions_id integer,")
+            print
+        }
+    ' "$schema_file" > "$tmp_file"
+
+    mv "$tmp_file" "$schema_file"
+}
+
 # --- Main ---
 main() {
     parse_args "$@"
@@ -208,6 +243,7 @@ main() {
     echo ""
     echo "=== Test 2: Downgrade path verification ==="
     echo "  Expected: ${SOURCE_BRANCH} schema + upgrade + downgrade == ${SOURCE_BRANCH} schema"
+    echo "            except documented lossy Berkeley constraint restorations"
 
     create_db "archive_downgraded"
     create_db "archive_source_ref"
@@ -225,6 +261,8 @@ main() {
 
     dump_and_normalize "archive_source_ref" "$schema_source_ref"
     dump_and_normalize "archive_downgraded" "$schema_downgraded"
+    normalize_known_downgrade_deltas "$schema_source_ref"
+    normalize_known_downgrade_deltas "$schema_downgraded"
 
     echo "Comparing schemas..."
     if diff -u "$schema_source_ref" "$schema_downgraded"; then


### PR DESCRIPTION
Explain your changes:

* Ports the two `verify-schema-upgrade.sh` tolerance commits from `develop` to `release/mesa` (cherry-picks of 8801489833 and 863d6c2413). No functional/product code changes — CI script only, no Dhall.
* **`ArchiveSchemaUpgradeTest` is currently red on `release/mesa`** (scope `AllButPullRequest`, so it only surfaces in nightly, never on PRs). Test 2 (downgrade path) fails because `downgrade_to_berkeley.sql` is deliberately lossy: it never restores Berkeley's `zkapp_{events,field_array}.element_ids` UNIQUE/index or the `events_id`/`actions_id NOT NULL`, since post-Mesa data may hold duplicates, oversized arrays, or NULLs that Berkeley rejected. The comparison against `compatible`'s fresh schema therefore shows 6 expected deltas.
* The two commits are not the same fix, which the shared subject lines obscure:
  * **8801489833 (downgrade arm)** is what actually turns `release/mesa` green. Test 2 fails on *every* Mesa-carrying branch for the lossy-downgrade reason above.
  * **863d6c2413 (upgrade arm)** is a no-op here — `release/mesa`'s `upgrade_to_mesa.sql` already carries the element_ids DROPs (byte-identical to `develop`'s), so Test 1 already passes. It's included so the shared script stops drifting between branches. Its TODO stays accurate: only `compatible`'s released `upgrade_to_mesa.sql` still lacks the DROPs, and once it carries them the upgrade-arm tolerance can go.
* Result: `buildkite/scripts/archive/verify-schema-upgrade.sh` is now byte-identical to `develop`'s (both blob `a4523d90e4`).

Explain how you tested your changes:

* Ran the script locally against real Postgres (`postgres:12.4-alpine`, the same image CI uses), `--source-branch compatible --target-branch develop`:
  * **Pre-fix** (`origin/release/mesa`): Test 1 PASS, **Test 2 FAIL** — mismatch on exactly the 4 element_ids UNIQUE constraints/indexes plus `events_id`/`actions_id NOT NULL`. Exit 1.
  * **Post-fix** (this branch): Test 1 PASS, Test 2 PASS, "All schema verification tests passed". Exit 0.
* `shellcheck` clean and `bash -n` OK on the modified script.
* No Dhall touched, so no `buildkite` regeneration needed.

Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
  - N/A — CI-only change, no user-facing behavior
- [x] Document code purpose, how to use it
  - The ported comments document why each tolerance exists and when the upgrade arm can be removed
- [x] Tests were added for the new behavior
  - N/A — this *is* the test; it repairs an existing nightly job
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
  - N/A
- [ ] Does this close issues? List them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
