### PR TITLE
[Pkg] Copy prefork config even if commit does not exist

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -66,6 +66,7 @@ let MinaBuildSpec =
           , arch : Arch.Type
           , deb_legacy_version : Text
           , deb_storage_repair_version : Text
+          , deb_legacy_githash_config : Text
           , docker_publish : DockerPublish.Type
           , suffix : Optional Text
           , if_ : Optional B/If
@@ -89,6 +90,7 @@ let MinaBuildSpec =
           , suffix = None Text
           , deb_legacy_version = "3.4.0-alpha1-compatible-ad13ff4"
           , deb_storage_repair_version = "3.3.0-master-35445f7"
+          , deb_legacy_githash_config = ""
           , arch = Arch.Type.Amd64
           , docker_publish = DockerPublish.Type.Essential
           , if_ = None B/If
@@ -137,6 +139,7 @@ let build_artifacts
                         , "ARCHITECTURE=${Arch.lowerName spec.arch}"
                         , Network.buildMainnetEnv spec.network
                         , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
+                        , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
                         ]
                       # BuildFlags.buildEnvs spec.buildFlags
                       # spec.extraBuildEnvs

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -61,6 +61,7 @@ let Spec =
           , size : Size
           , deb_legacy_version : Text
           , deb_storage_repair_version : Text
+          , deb_legacy_githash_config : Text
           }
       , default =
           { codenames =
@@ -81,6 +82,8 @@ let Spec =
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
           , deb_storage_repair_version =
               defaultMinaArtifactSpec.deb_storage_repair_version
+          , deb_legacy_githash_config =
+              defaultMinaArtifactSpec.deb_legacy_githash_config
           }
       }
 
@@ -228,6 +231,8 @@ let generateDockerForCodename =
                         , network = spec.network
                         , prefix = pipelineName
                         , suffix = Some "-${lowerNameCodename}"
+                        , deb_legacy_githash_config =
+                            spec.deb_legacy_githash_config
                         }
                     ]
                   }

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -694,21 +694,44 @@ copy_common_daemon_post_automode_apps_and_configs() {
   # mina-<network>-config package, so we do NOT ship them here to avoid
   # dpkg file conflicts.  Only ship the prefork config when it differs from
   # the postfork hash, since the config package won't contain it.
+  #
+  # The prefork daemon auto-loads config_<GITHASH_CONFIG>.json where
+  # GITHASH_CONFIG is the full 8-char short hash of the prefork commit.  The
+  # hash embedded in PREFORK_LEGACY_VERSION is only the 7-char GITHASH (see
+  # scripts/export-git-env-vars.sh), so we must recover the missing 8th char.
+  # We do that by resolving the short hash against this repo with `git
+  # rev-parse --short=8`.  When the prefork commit is NOT present in this
+  # checkout git cannot resolve it, so the pipeline can supply the full 8-char
+  # hash directly via the PREFORK_GITHASH_CONFIG override.
+  #
+  # PREFORK_GITHASH_CONFIG is injected into the build container from the Dhall
+  # pipeline (buildkite/src/Command/MinaArtifact.dhall and
+  # buildkite/src/Entrypoints/GenerateHardforkPackage.dhall, field
+  # deb_legacy_githash_config); leave it empty to fall back to git resolution.
   if [[ -n "${PREFORK_LEGACY_VERSION:-}" ]]; then
     local prefork_short_hash="${PREFORK_LEGACY_VERSION##*-}"
-    local prefork_githash_config
-    prefork_githash_config=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
-    if [[ -n "$prefork_githash_config" ]]; then
-      if [[ "$prefork_githash_config" == "$GITHASH_CONFIG" ]]; then
-        echo "Prefork githash (${prefork_githash_config}) is the same as postfork; skipping config copy."
-      else
-        echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
-        mkdir -p "${BUILDDIR}/var/lib/coda"
-        cp "../genesis_ledgers/${prefork_network}.json" \
-           "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
-      fi
+    local config_hash
+
+    if [[ -n "${PREFORK_GITHASH_CONFIG:-}" ]]; then
+      echo "Using PREFORK_GITHASH_CONFIG override (${PREFORK_GITHASH_CONFIG}) for prefork config filename."
+      config_hash="$PREFORK_GITHASH_CONFIG"
     else
-      echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}'. Prefork config not shipped."
+      config_hash=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
+      if [[ -z "$config_hash" ]]; then
+        echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}' in mina repo, and PREFORK_GITHASH_CONFIG override is not set; prefork config not shipped."
+      fi
+    fi
+
+    if [[ -n "$config_hash" && "$config_hash" == "$GITHASH_CONFIG" ]]; then
+      echo "Prefork githash (${config_hash}) is the same as postfork; skipping config copy."
+      config_hash=""
+    fi
+
+    if [[ -n "$config_hash" ]]; then
+      echo "Copying config for prefork daemon as config_${config_hash}.json"
+      mkdir -p "${BUILDDIR}/var/lib/coda"
+      cp "../genesis_ledgers/${prefork_network}.json" \
+         "${BUILDDIR}/var/lib/coda/config_${config_hash}.json"
     fi
   fi
 

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -668,6 +668,49 @@ EOF
 
 }
 
+# Resolves the hash for the prefork daemon's auto-loaded config_<hash>.json.
+#
+# The prefork daemon auto-loads config_<GITHASH_CONFIG>.json where
+# GITHASH_CONFIG is the full 8-char short hash of the prefork commit.  The hash
+# embedded in PREFORK_LEGACY_VERSION is only the 7-char GITHASH (see
+# scripts/export-git-env-vars.sh), so we must recover the missing 8th char.  We
+# do that by resolving the short hash against this repo with
+# `git rev-parse --short=8`.  When the prefork commit is NOT present in this
+# checkout git cannot resolve it, so the pipeline can supply the full 8-char
+# hash directly via the PREFORK_GITHASH_CONFIG override.
+#
+# PREFORK_GITHASH_CONFIG is injected into the build container from the Dhall
+# pipeline (buildkite/src/Command/MinaArtifact.dhall and
+# buildkite/src/Entrypoints/GenerateHardforkPackage.dhall, field
+# deb_legacy_githash_config); leave it empty to fall back to git resolution.
+#
+# Echoes the 8-char config hash to ship on stdout, or nothing when no prefork
+# config should be shipped (unresolvable hash, or identical to postfork).
+# Diagnostics go to stderr so they never contaminate the returned value.
+resolve_prefork_config_hash() {
+  local prefork_short_hash="$1"
+  local config_hash
+
+  if [[ -n "${PREFORK_GITHASH_CONFIG:-}" ]]; then
+    echo "Using PREFORK_GITHASH_CONFIG override (${PREFORK_GITHASH_CONFIG}) for prefork config filename." >&2
+    config_hash="$PREFORK_GITHASH_CONFIG"
+  else
+    config_hash=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$config_hash" ]]; then
+    echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}' in mina repo, and PREFORK_GITHASH_CONFIG override is not set; prefork config not shipped." >&2
+    return 0
+  fi
+
+  if [[ "$config_hash" == "$GITHASH_CONFIG" ]]; then
+    echo "Prefork githash (${config_hash}) is the same as postfork; skipping config copy." >&2
+    return 0
+  fi
+
+  echo "$config_hash"
+}
+
 # Copies common binaries and configuration for postfork automode packages
 # Includes only binaries without configuration files or genesisledgers
 # Places binaries in /usr/lib/mina/<network_name> directory
@@ -693,39 +736,12 @@ copy_common_daemon_post_automode_apps_and_configs() {
   # Config files (config_<hash>.json, <network>.json) are provided by the
   # mina-<network>-config package, so we do NOT ship them here to avoid
   # dpkg file conflicts.  Only ship the prefork config when it differs from
-  # the postfork hash, since the config package won't contain it.
-  #
-  # The prefork daemon auto-loads config_<GITHASH_CONFIG>.json where
-  # GITHASH_CONFIG is the full 8-char short hash of the prefork commit.  The
-  # hash embedded in PREFORK_LEGACY_VERSION is only the 7-char GITHASH (see
-  # scripts/export-git-env-vars.sh), so we must recover the missing 8th char.
-  # We do that by resolving the short hash against this repo with `git
-  # rev-parse --short=8`.  When the prefork commit is NOT present in this
-  # checkout git cannot resolve it, so the pipeline can supply the full 8-char
-  # hash directly via the PREFORK_GITHASH_CONFIG override.
-  #
-  # PREFORK_GITHASH_CONFIG is injected into the build container from the Dhall
-  # pipeline (buildkite/src/Command/MinaArtifact.dhall and
-  # buildkite/src/Entrypoints/GenerateHardforkPackage.dhall, field
-  # deb_legacy_githash_config); leave it empty to fall back to git resolution.
+  # the postfork hash, since the config package won't contain it.  See
+  # resolve_prefork_config_hash for how the config hash is derived.
   if [[ -n "${PREFORK_LEGACY_VERSION:-}" ]]; then
     local prefork_short_hash="${PREFORK_LEGACY_VERSION##*-}"
     local config_hash
-
-    if [[ -n "${PREFORK_GITHASH_CONFIG:-}" ]]; then
-      echo "Using PREFORK_GITHASH_CONFIG override (${PREFORK_GITHASH_CONFIG}) for prefork config filename."
-      config_hash="$PREFORK_GITHASH_CONFIG"
-    else
-      config_hash=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
-      if [[ -z "$config_hash" ]]; then
-        echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}' in mina repo, and PREFORK_GITHASH_CONFIG override is not set; prefork config not shipped."
-      fi
-    fi
-
-    if [[ -n "$config_hash" && "$config_hash" == "$GITHASH_CONFIG" ]]; then
-      echo "Prefork githash (${config_hash}) is the same as postfork; skipping config copy."
-      config_hash=""
-    fi
+    config_hash=$(resolve_prefork_config_hash "$prefork_short_hash")
 
     if [[ -n "$config_hash" ]]; then
       echo "Copying config for prefork daemon as config_${config_hash}.json"

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -784,23 +784,64 @@ test_build_daemon_postfork_deb_without_prefork_version() {
 }
 
 test_build_daemon_postfork_deb_unresolvable_prefork_hash() {
-    # When the prefork hash can't be resolved by git, warn but don't fail
+    # When the prefork commit does not exist in this repo, git cannot resolve
+    # the 7-char version hash back to the 8-char config hash, and no
+    # PREFORK_GITHASH_CONFIG override is set. We must warn but not fail, and
+    # ship no config (we can't guess the missing 8th char of the hash).
     export PREFORK_LEGACY_VERSION="3.3.0-compatible-badhash"
+    unset PREFORK_GITHASH_CONFIG 2>/dev/null || true
 
     safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
 
     load_captured_state
 
     # No config files — postfork config comes from config package,
-    # and prefork config can't be shipped because hash is unresolvable
+    # and prefork config can't be shipped because the hash is unresolvable
     local config_count
     config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
     if [[ "$config_count" -eq 0 ]]; then
         log_pass
     else
-        log_fail "Expected 0 config_*.json (unresolvable prefork hash), got ${config_count}"
+        log_fail "Expected 0 config_*.json (unresolvable prefork hash, no override), got ${config_count}"
     fi
 
+    unset PREFORK_LEGACY_VERSION
+}
+
+test_build_daemon_postfork_deb_prefork_githash_override() {
+    # When the prefork commit is not in this repo (git can't resolve the short
+    # hash), the pipeline supplies the full 8-char config hash directly via the
+    # PREFORK_GITHASH_CONFIG override. The prefork config must then ship under
+    # that exact filename, bypassing git resolution entirely.
+    export PREFORK_LEGACY_VERSION="3.3.0-compatible-badhash"
+    export PREFORK_GITHASH_CONFIG="abadcafe"
+
+    safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+
+    # Postfork config still comes from the config package, not here
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+
+    # Prefork config shipped under the override hash (full 8-char), and no
+    # attempt made to ship the unresolvable version hash
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_abadcafe.json"
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_badhash.json"
+
+    # Exactly one config file (the prefork override), nothing else
+    local config_count
+    config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
+    if [[ "$config_count" -eq 1 ]]; then
+        log_pass
+    else
+        log_fail "Expected 1 config_*.json (prefork githash override), got ${config_count}"
+    fi
+
+    # Prefork config should have the correct network content
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
+        "var/lib/coda/config_abadcafe.json" "devnet"
+
+    unset PREFORK_GITHASH_CONFIG
     unset PREFORK_LEGACY_VERSION
 }
 
@@ -1252,6 +1293,7 @@ main() {
     run_test test_build_daemon_mainnet_postfork_deb
     run_test test_build_daemon_postfork_deb_without_prefork_version
     run_test test_build_daemon_postfork_deb_unresolvable_prefork_hash
+    run_test test_build_daemon_postfork_deb_prefork_githash_override
 
     # Automode metapackages
     run_test test_build_daemon_devnet_automode_deb


### PR DESCRIPTION
Pr is fixing issue we encounter when creating package for automode (which contains postfork and prefork components). In order to leverage UX we want to push magic configs with postfork debian for prefork (as prefork runtime is chosen first, before postfork).
However, if due to rebase commit for prefork package is lost then logic in builder-herlper.sh skips copy operation. We shouldn't care if commit is lost but just build whatever is given. 

I introduced approach with custom env var as unfortunately we cannot derive 8chars commit hash from 7chars package suffix
 