### PR TITLE
Unstaking hardfork test: lazy whales dilute pre-fork fill rate, unstaked at fork

### DIFF
--- a/buildkite/src/Jobs/Test/HardForkTestGoUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestGoUnitTest.dhall
@@ -1,0 +1,51 @@
+let ContainerImages = ../../Constants/ContainerImages.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "src/app/hardfork_test")
+          , S.exactly "buildkite/src/Jobs/Test/HardForkTestGoUnitTest" "dhall"
+          ]
+        , path = "Test"
+        , name = "HardForkTestGoUnitTest"
+        , tags =
+          [ PipelineTag.Type.Fast
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+              [ Cmd.runInDocker
+                  Cmd.Docker::{
+                  , image = ContainerImages.minaToolchain
+                  , extraEnv = [ "GO=/usr/lib/go/bin/go" ]
+                  }
+                  "make -C src/app/hardfork_test test"
+              ]
+            , label = "hardfork_test Go unit tests"
+            , key = "hardfork-test-go-unit-test"
+            , target = Size.Small
+            , docker = None Docker.Type
+            }
+        ]
+      }

--- a/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
+++ b/buildkite/src/Jobs/Test/HardForkTestUnstaking.dhall
@@ -1,0 +1,7 @@
+let HardforkTest = ../../Command/HardForkTest.dhall
+
+in  HardforkTest.pipeline
+      "HardForkTestUnstaking"
+      "hard fork test - unstaking (legacy mode)"
+      "hard-fork-test-unstaking"
+      "--fork-from origin/release/mesa --fork-to origin/martyall/unstaking_consensus_v2_hf --slot-tx-end 30 --slot-chain-end 38 --allow-fork-method legacy --unstaking-test --num-lazy-whales 5 --best-chain-query-from 30"

--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -16,7 +16,7 @@ PREFORK=""
 FORKTO="develop"
 EXTRA_ARGS=()
 
-USAGE="Usage: $0 --fork-from <PREFORK> [--fork-to <FORKTO>] [ADDITONAL ARGS TO HF TEST...]"
+USAGE="Usage: $0 --fork-from <PREFORK> [--fork-to <FORKTO>] [--slot-tx-end <SLOT>] [--slot-chain-end <SLOT>] [ADDITONAL ARGS TO HF TEST...]"
 usage() {
   if (( $# > 0 )); then
     echo "$1" >&2
@@ -44,6 +44,20 @@ while [[ $# -gt 0 ]]; do
         usage "Error: $1 requires an argument."
       fi
       FORKTO="$2"
+      shift 2
+      ;;
+    --slot-tx-end)
+      if [[ $# -lt 2 ]]; then
+        usage "Error: $1 requires an argument."
+      fi
+      SLOT_TX_END="$2"
+      shift 2
+      ;;
+    --slot-chain-end)
+      if [[ $# -lt 2 ]]; then
+        usage "Error: $1 requires an argument."
+      fi
+      SLOT_CHAIN_END="$2"
       shift 2
       ;;
     --help|-h)

--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -14,6 +14,10 @@ set -eux -o pipefail
 
 PREFORK=""
 FORKTO="develop"
+# Set only via --slot-tx-end / --slot-chain-end; started empty here so an
+# inherited environment variable of the same name cannot influence the run.
+SLOT_TX_END=""
+SLOT_CHAIN_END=""
 EXTRA_ARGS=()
 
 USAGE="Usage: $0 --fork-from <PREFORK> [--fork-to <FORKTO>] [--slot-tx-end <SLOT>] [--slot-chain-end <SLOT>] [ADDITONAL ARGS TO HF TEST...]"
@@ -173,9 +177,27 @@ nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#hardfork_test" --out-link "hardfor
 
 # 5. Execute hardfork_test on them.
 
-SLOT_TX_END=${SLOT_TX_END:-$((RANDOM%120+30))}      
-# WARN: ensure SLOT_CHAIN_END - SLOT_TX_END > k is always true!
-SLOT_CHAIN_END=${SLOT_CHAIN_END:-$((SLOT_TX_END+8))}
+# Pinning --slot-chain-end while letting --slot-tx-end randomize would pair a
+# fixed chain-end with a random tx-end (30-149), giving an unpredictable or even
+# inverted (chain-end below tx-end) wind-down gap. Refuse that combo.
+if [[ -z "$SLOT_TX_END" && -n "$SLOT_CHAIN_END" ]]; then
+  usage "Error: --slot-chain-end requires --slot-tx-end (a fixed chain-end with a randomized tx-end would give an unpredictable or inverted wind-down window)."
+fi
+
+# Fall back to defaults only when the flag was not given. Computed explicitly
+# (not via ${VAR:-...}) so the environment is never consulted as input.
+if [[ -z "$SLOT_TX_END" ]]; then
+  SLOT_TX_END=$((RANDOM % 120 + 30))
+fi
+# SLOT_CHAIN_END - SLOT_TX_END is the wind-down window (in slots) after
+# transactions stop, letting the last pre-tx-end block (the fork base) settle
+# before the chain halts. The daemon treats that block as finalized to build the
+# fork config, so the fork proceeds regardless; this gap is NOT strictly > k
+# (default 8 < k=10) but is kept close to k so the fork base is very unlikely to
+# be reorged before chain end.
+if [[ -z "$SLOT_CHAIN_END" ]]; then
+  SLOT_CHAIN_END=$((SLOT_TX_END + 8))
+fi
 
 NETWORK_ROOT=$(mktemp -d --tmpdir hardfork-network.XXXXXXX)
 

--- a/scripts/hardfork/build-and-test.sh
+++ b/scripts/hardfork/build-and-test.sh
@@ -13,9 +13,10 @@
 set -eux -o pipefail
 
 PREFORK=""
+FORKTO="develop"
 EXTRA_ARGS=()
 
-USAGE="Usage: $0 --fork-from <PREFORK> [ADDITONAL ARGS TO HF TEST...]"
+USAGE="Usage: $0 --fork-from <PREFORK> [--fork-to <FORKTO>] [ADDITONAL ARGS TO HF TEST...]"
 usage() {
   if (( $# > 0 )); then
     echo "$1" >&2
@@ -36,6 +37,13 @@ while [[ $# -gt 0 ]]; do
         usage "Error: $1 requires an argument."
       fi
       PREFORK="$2"
+      shift 2
+      ;;
+    --fork-to)
+      if [[ $# -lt 2 ]]; then
+        usage "Error: $1 requires an argument."
+      fi
+      FORKTO="$2"
       shift 2
       ;;
     --help|-h)
@@ -124,8 +132,8 @@ git checkout $PREFORK
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "prefork-devnet"
 
-# 2. Build "develop" branch as a postfork build
-git checkout develop
+# 2. Build postfork branch as a postfork build
+git checkout $FORKTO
 git submodule update --init --recursive --depth 1
 nix "${NIX_OPTS[@]}" build "$PWD?submodules=1#devnet" --out-link "postfork-devnet"
 

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -22,6 +22,7 @@ SNARK_COORDINATOR_PEER_KEY="CAESQFjWdR18zKuCssN+Fi33fah9f5QGebOCc9xTITR8cdoyC+bk
 # Inputs (set to default values)
 
 WHALES=2
+LAZY_WHALES=0
 FISH=1
 NODES=1
 LOG_LEVEL="Trace"
@@ -94,6 +95,9 @@ help() {
 
 -w   |--whales <#>                       | Number of BP Whale Nodes (bigger stake) to spin-up
                                          |   Default: ${WHALES}
+--lazy-whales <#>                        | Number of extra whale accounts to create in the genesis ledger
+                                         |   without launching a block producer for them (dormant stake)
+                                         |   Default: ${LAZY_WHALES}
 -f   |--fish <#>                         | Number of BP Fish Nodes (less stake) to spin-up
                                          |   Default: ${FISH}
 -n   |--nodes <#>                        | Number of non block-producing nodes to spin-up
@@ -523,6 +527,10 @@ while [[ "$#" -gt 0 ]]; do
     WHALES="${2}"
     shift
     ;;
+  --lazy-whales)
+    LAZY_WHALES="${2}"
+    shift
+    ;;
   -f | --fish)
     FISH="${2}"
     shift
@@ -729,6 +737,13 @@ if [ "${ZKAPP_TRANSACTIONS}" = "true" ] && [ "${WHALES}" -lt 2 ]; then
     exit 1
 fi
 
+# Lazy whales are extra whale accounts without block producers; they only make
+# sense alongside at least one active whale
+if [ "${LAZY_WHALES}" -gt 0 ] && [ "${WHALES}" -lt 1 ]; then
+    echo "Error: --lazy-whales requires at least 1 active Whale node."
+    exit 1
+fi
+
 # ================================================
 # Create the Genesis Ledger
 
@@ -763,9 +778,13 @@ if [ ! -d "${ROOT}" ]; then
     generate-keypair "${ROOT}"/online_fish_keys/online_fish_account_${i}
     generate-libp2p-keypair "${ROOT}"/libp2p_keys/fish_${i}
   done
-  for ((i = 0; i < WHALES; i++)); do
+  # Account keypairs are generated for lazy whales too, but no libp2p keypair:
+  # no daemon is ever launched for them, leaving their stake dormant
+  for ((i = 0; i < WHALES + LAZY_WHALES; i++)); do
     generate-keypair "${ROOT}"/offline_whale_keys/offline_whale_account_${i}
     generate-keypair "${ROOT}"/online_whale_keys/online_whale_account_${i}
+  done
+  for ((i = 0; i < WHALES; i++)); do
     generate-libp2p-keypair "${ROOT}"/libp2p_keys/whale_${i}
   done
   for ((i = 0; i < NODES; i++)); do
@@ -821,6 +840,7 @@ if ${DEMO_MODE}; then
   # Set the default values for demo mode
   SNARK_WORKERS_COUNT=0
   WHALES=0
+  LAZY_WHALES=0
   FISH=0
   NODES=0
 
@@ -876,7 +896,7 @@ load_config() {
     reset)
       echo "Making the Ledger..." 
       python3 scripts/mina-local-network/generate-mina-local-network-ledger.py \
-        --num-whale-accounts "${WHALES}" \
+        --num-whale-accounts "$((WHALES + LAZY_WHALES))" \
         --num-fish-accounts "${FISH}" \
         --offline-whale-accounts-directory "${ROOT}"/offline_whale_keys \
         --offline-fish-accounts-directory "${ROOT}"/offline_fish_keys \

--- a/src/app/hardfork_test/Makefile
+++ b/src/app/hardfork_test/Makefile
@@ -2,11 +2,21 @@
 
 APP_NAME := hardfork_test
 BUILD_DIR := bin
+GO ?= go
 
+# -buildvcs=false: the CI toolchain checks out the repo under a different owner,
+# so Go's VCS stamping fails ("error obtaining VCS status: exit status 128");
+# these builds don't need the stamp.
 build:
 	@echo "Building $(APP_NAME)..."
 	@mkdir -p $(BUILD_DIR)
-	@( cd src && go build -o ../$(BUILD_DIR)/$(APP_NAME) ./cmd )
+	@( cd src && $(GO) build -buildvcs=false -o ../$(BUILD_DIR)/$(APP_NAME) ./cmd )
+
+# Build every package first so a compile break is a distinct, fast failure,
+# then run the Go unit tests. Run from the module root (src/, where go.mod is).
+test:
+	@echo "Testing $(APP_NAME)..."
+	@( cd src && $(GO) build -buildvcs=false ./... && $(GO) test -buildvcs=false ./... )
 
 clean:
 	@echo "Cleaning..."

--- a/src/app/hardfork_test/src/internal/app/root.go
+++ b/src/app/hardfork_test/src/internal/app/root.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/hardfork"
 	"github.com/spf13/cobra"
@@ -32,6 +34,10 @@ Example:
     --fork-mina-exe /path/to/mina-fork --fork-runtime-genesis-ledger /path/to/runtime_genesis_ledger-fork
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !cfg.UnstakingTest && cmd.Flags().Changed("num-lazy-whales") {
+			return fmt.Errorf("--num-lazy-whales requires --unstaking-test")
+		}
+
 		// Validate required arguments
 		if err := cfg.Validate(); err != nil {
 			return err
@@ -87,6 +93,10 @@ func init() {
 	rootCmd.Flags().IntVar(&cfg.ClientMaxRetries, "client-max-retries", cfg.ClientMaxRetries, "Maximum number of retries for client requests")
 
 	rootCmd.Flags().Var(&cfg.ForkMethods, "allow-fork-method", "Implementation of fork to use")
+
+	// Unstaking test mode
+	rootCmd.Flags().BoolVar(&cfg.UnstakingTest, "unstaking-test", cfg.UnstakingTest, "Enable unstaking test mode: dilute the pre-fork VRF denominator with lazy whales and unstake them at the fork")
+	rootCmd.Flags().IntVar(&cfg.NumLazyWhales, "num-lazy-whales", cfg.NumLazyWhales, "Number of lazy whale accounts (whales without a block producer); requires --unstaking-test")
 
 	rootCmd.MarkFlagRequired("main-mina-exe")
 	rootCmd.MarkFlagRequired("main-runtime-genesis-ledger")

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/currency"
 	"github.com/tidwall/gjson"
 )
 
@@ -113,10 +113,12 @@ type BlockData struct {
 	NumUserCommands int    `json:"num_user_commands"`
 	NumFeeTransfers int    `json:"num_fee_transfers"`
 	Coinbase        string `json:"coinbase"`
-	// Raw nanomina amounts as reported by GraphQL. On a post-fork (v2) build
-	// the staking epoch ledger's totalCurrency field carries total_stake.
-	TotalCurrency              string `json:"total_currency"`
-	StakingLedgerTotalCurrency string `json:"staking_ledger_total_currency"`
+	// Currency amounts, read from the GraphQL integer-nanomina string scalars via
+	// gjson .Uint() at construction (NOT the decimal-mina currency.UnmarshalJSON
+	// path — see currency.Nanomina). On a post-fork (v2) build the staking epoch
+	// ledger's totalCurrency field carries total_stake.
+	TotalCurrency              currency.Nanomina `json:"total_currency"`
+	StakingLedgerTotalCurrency currency.Nanomina `json:"staking_ledger_total_currency"`
 }
 
 func (block *BlockData) NonEmpty() bool {
@@ -208,11 +210,18 @@ func parseBlock(value gjson.Result) *BlockData {
 		NumUserCommands:            int(value.Get("commandTransactionCount").Int()),
 		NumFeeTransfers:            len(value.Get("transactions.feeTransfer").Array()),
 		Coinbase:                   value.Get("transactions.coinbase").String(),
-		TotalCurrency:              value.Get("protocolState.consensusState.totalCurrency").String(),
-		StakingLedgerTotalCurrency: value.Get("protocolState.consensusState.stakingEpochData.ledger.totalCurrency").String(),
+		TotalCurrency:              nanominaAt(value, "protocolState.consensusState.totalCurrency"),
+		StakingLedgerTotalCurrency: nanominaAt(value, "protocolState.consensusState.stakingEpochData.ledger.totalCurrency"),
 	}
 
 	return block
+}
+
+// nanominaAt reads a GraphQL amount at path as an integer-nanomina scalar. The
+// daemon serializes amounts as nanomina uint64 strings, so .Uint() is the
+// correct decoder here — NOT the decimal-mina currency.UnmarshalJSON path.
+func nanominaAt(value gjson.Result, path string) currency.Nanomina {
+	return currency.Nanomina(value.Get(path).Uint())
 }
 
 func (c *Client) GenesisBlock(port int) (*BlockData, error) {
@@ -258,26 +267,6 @@ func (c *Client) ForkConfig(port int) (gjson.Result, error) {
 	}
 
 	return result.Get("data.fork_config"), nil
-}
-
-// StakingEpochLedgerTotalCurrency returns the total currency (in nanomina) of
-// the current staking epoch ledger — the denominator of the VRF threshold
-// check.
-func (c *Client) StakingEpochLedgerTotalCurrency(port int) (uint64, error) {
-	result, err := c.query(port, `bestChain (maxLength: 1){ protocolState { consensusState { stakingEpochData { ledger { totalCurrency } } } } }`)
-	if err != nil {
-		return 0, err
-	}
-	blocks := result.Get("data.bestChain").Array()
-	if len(blocks) == 0 {
-		return 0, fmt.Errorf("no best chain block at port %d", port)
-	}
-	raw := blocks[0].Get("protocolState.consensusState.stakingEpochData.ledger.totalCurrency").String()
-	total, err := strconv.ParseUint(raw, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse staking epoch ledger total currency %q: %w", raw, err)
-	}
-	return total, nil
 }
 
 // AccountDelegate returns the delegate of the account with the given public

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -128,7 +128,7 @@ func (block *BlockData) NonEmpty() bool {
 func (block BlockData) String() string {
 	b, err := json.MarshalIndent(block, "", "  ")
 	if err != nil {
-		return fmt.Sprintf("%+v", block)
+		return fmt.Sprintf("BlockData(unmarshalable: %v)", err)
 	}
 	return string(b)
 }

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -113,6 +113,10 @@ type BlockData struct {
 	NumUserCommands int    `json:"num_user_commands"`
 	NumFeeTransfers int    `json:"num_fee_transfers"`
 	Coinbase        string `json:"coinbase"`
+	// Public key of the account that produced this block (creatorAccount).
+	// Empty for the genesis block, which is not VRF-produced and whose query
+	// does not request the field.
+	Creator string `json:"creator"`
 	// Currency amounts, read from the GraphQL integer-nanomina string scalars via
 	// gjson .Uint() at construction (NOT the decimal-mina currency.UnmarshalJSON
 	// path — see currency.Nanomina). On a post-fork (v2) build the staking epoch
@@ -167,6 +171,7 @@ genesisBlock {
 const blocksQueryWithLimit = `
 bestChain (maxLength: %d){
   commandTransactionCount
+  creatorAccount { publicKey }
   protocolState {
     consensusState {
       blockHeight
@@ -195,6 +200,13 @@ bestChain (maxLength: %d){
 }
 `
 
+// nanominaAt reads a GraphQL amount at path as an integer-nanomina scalar. The
+// daemon serializes amounts as nanomina uint64 strings, so .Uint() is the
+// correct decoder here — NOT the decimal-mina currency.UnmarshalJSON path.
+func nanominaAt(value gjson.Result, path string) currency.Nanomina {
+	return currency.Nanomina(value.Get(path).Uint())
+}
+
 func parseBlock(value gjson.Result) *BlockData {
 	block := &BlockData{
 		StateHash:                  value.Get("stateHash").String(),
@@ -210,18 +222,12 @@ func parseBlock(value gjson.Result) *BlockData {
 		NumUserCommands:            int(value.Get("commandTransactionCount").Int()),
 		NumFeeTransfers:            len(value.Get("transactions.feeTransfer").Array()),
 		Coinbase:                   value.Get("transactions.coinbase").String(),
+		Creator:                    value.Get("creatorAccount.publicKey").String(),
 		TotalCurrency:              nanominaAt(value, "protocolState.consensusState.totalCurrency"),
 		StakingLedgerTotalCurrency: nanominaAt(value, "protocolState.consensusState.stakingEpochData.ledger.totalCurrency"),
 	}
 
 	return block
-}
-
-// nanominaAt reads a GraphQL amount at path as an integer-nanomina scalar. The
-// daemon serializes amounts as nanomina uint64 strings, so .Uint() is the
-// correct decoder here — NOT the decimal-mina currency.UnmarshalJSON path.
-func nanominaAt(value gjson.Result, path string) currency.Nanomina {
-	return currency.Nanomina(value.Get(path).Uint())
 }
 
 func (c *Client) GenesisBlock(port int) (*BlockData, error) {

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -113,6 +113,10 @@ type BlockData struct {
 	NumUserCommands int    `json:"num_user_commands"`
 	NumFeeTransfers int    `json:"num_fee_transfers"`
 	Coinbase        string `json:"coinbase"`
+	// Raw nanomina amounts as reported by GraphQL. On a post-fork (v2) build
+	// the staking epoch ledger's totalCurrency field carries total_stake.
+	TotalCurrency              string `json:"total_currency"`
+	StakingLedgerTotalCurrency string `json:"staking_ledger_total_currency"`
 }
 
 func (block *BlockData) NonEmpty() bool {
@@ -135,8 +139,9 @@ genesisBlock {
       blockHeight
       slotSinceGenesis
       epoch
+      totalCurrency
       stakingEpochData {
-        ledger { hash }
+        ledger { hash totalCurrency }
         seed
       }
       nextEpochData {
@@ -165,8 +170,9 @@ bestChain (maxLength: %d){
       blockHeight
       slotSinceGenesis
       epoch
+      totalCurrency
       stakingEpochData {
-        ledger { hash }
+        ledger { hash totalCurrency }
         seed
       }
       nextEpochData {
@@ -189,19 +195,21 @@ bestChain (maxLength: %d){
 
 func parseBlock(value gjson.Result) *BlockData {
 	block := &BlockData{
-		StateHash:       value.Get("stateHash").String(),
-		BlockHeight:     int(value.Get("protocolState.consensusState.blockHeight").Int()),
-		Slot:            int(value.Get("protocolState.consensusState.slotSinceGenesis").Int()),
-		CurEpochHash:    value.Get("protocolState.consensusState.stakingEpochData.ledger.hash").String(),
-		CurEpochSeed:    value.Get("protocolState.consensusState.stakingEpochData.seed").String(),
-		NextEpochHash:   value.Get("protocolState.consensusState.nextEpochData.ledger.hash").String(),
-		NextEpochSeed:   value.Get("protocolState.consensusState.nextEpochData.seed").String(),
-		StagedHash:      value.Get("protocolState.blockchainState.stagedLedgerHash").String(),
-		SnarkedHash:     value.Get("protocolState.blockchainState.snarkedLedgerHash").String(),
-		Epoch:           int(value.Get("protocolState.consensusState.epoch").Int()),
-		NumUserCommands: int(value.Get("commandTransactionCount").Int()),
-		NumFeeTransfers: len(value.Get("transactions.feeTransfer").Array()),
-		Coinbase:        value.Get("transactions.coinbase").String(),
+		StateHash:                  value.Get("stateHash").String(),
+		BlockHeight:                int(value.Get("protocolState.consensusState.blockHeight").Int()),
+		Slot:                       int(value.Get("protocolState.consensusState.slotSinceGenesis").Int()),
+		CurEpochHash:               value.Get("protocolState.consensusState.stakingEpochData.ledger.hash").String(),
+		CurEpochSeed:               value.Get("protocolState.consensusState.stakingEpochData.seed").String(),
+		NextEpochHash:              value.Get("protocolState.consensusState.nextEpochData.ledger.hash").String(),
+		NextEpochSeed:              value.Get("protocolState.consensusState.nextEpochData.seed").String(),
+		StagedHash:                 value.Get("protocolState.blockchainState.stagedLedgerHash").String(),
+		SnarkedHash:                value.Get("protocolState.blockchainState.snarkedLedgerHash").String(),
+		Epoch:                      int(value.Get("protocolState.consensusState.epoch").Int()),
+		NumUserCommands:            int(value.Get("commandTransactionCount").Int()),
+		NumFeeTransfers:            len(value.Get("transactions.feeTransfer").Array()),
+		Coinbase:                   value.Get("transactions.coinbase").String(),
+		TotalCurrency:              value.Get("protocolState.consensusState.totalCurrency").String(),
+		StakingLedgerTotalCurrency: value.Get("protocolState.consensusState.stakingEpochData.ledger.totalCurrency").String(),
 	}
 
 	return block
@@ -270,6 +278,20 @@ func (c *Client) StakingEpochLedgerTotalCurrency(port int) (uint64, error) {
 		return 0, fmt.Errorf("failed to parse staking epoch ledger total currency %q: %w", raw, err)
 	}
 	return total, nil
+}
+
+// AccountDelegate returns the delegate of the account with the given public
+// key, or ("", nil) if the account exists and has no delegate (unstaked).
+func (c *Client) AccountDelegate(port int, pk string) (string, error) {
+	result, err := c.query(port, fmt.Sprintf(`account(publicKey: %q) { delegate }`, pk))
+	if err != nil {
+		return "", err
+	}
+	account := result.Get("data.account")
+	if !account.Exists() || account.Type == gjson.Null {
+		return "", fmt.Errorf("account %s not found at port %d", pk, port)
+	}
+	return account.Get("delegate").String(), nil
 }
 
 func (c *Client) NumUserCommandsInBestChain(port int) (int, error) {

--- a/src/app/hardfork_test/src/internal/client/client.go
+++ b/src/app/hardfork_test/src/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -249,6 +250,26 @@ func (c *Client) ForkConfig(port int) (gjson.Result, error) {
 	}
 
 	return result.Get("data.fork_config"), nil
+}
+
+// StakingEpochLedgerTotalCurrency returns the total currency (in nanomina) of
+// the current staking epoch ledger — the denominator of the VRF threshold
+// check.
+func (c *Client) StakingEpochLedgerTotalCurrency(port int) (uint64, error) {
+	result, err := c.query(port, `bestChain (maxLength: 1){ protocolState { consensusState { stakingEpochData { ledger { totalCurrency } } } } }`)
+	if err != nil {
+		return 0, err
+	}
+	blocks := result.Get("data.bestChain").Array()
+	if len(blocks) == 0 {
+		return 0, fmt.Errorf("no best chain block at port %d", port)
+	}
+	raw := blocks[0].Get("protocolState.consensusState.stakingEpochData.ledger.totalCurrency").String()
+	total, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse staking epoch ledger total currency %q: %w", raw, err)
+	}
+	return total, nil
 }
 
 func (c *Client) NumUserCommandsInBestChain(port int) (int, error) {

--- a/src/app/hardfork_test/src/internal/config/config.go
+++ b/src/app/hardfork_test/src/internal/config/config.go
@@ -71,6 +71,12 @@ type Config struct {
 	ForkMethods ForkMethodSet
 
 	DaemonInfos []DaemonInfo
+
+	// Unstaking test mode: the genesis ledger carries NumLazyWhales extra
+	// whale accounts with no block producer (dormant stake diluting the VRF
+	// denominator); at fork time their delegates are cleared via --unstake-pk
+	UnstakingTest bool
+	NumLazyWhales int
 }
 
 // DefaultConfig returns the default configuration with values
@@ -106,6 +112,9 @@ func DefaultConfig() *Config {
 		NodeStartPort:        6000,
 
 		ForkMethods: make(ForkMethodSet),
+
+		UnstakingTest: false,
+		NumLazyWhales: 5,
 	}
 }
 
@@ -263,6 +272,20 @@ func (c *Config) Validate() error {
 
 	if err := validateScriptDir(c.ScriptDir); err != nil {
 		return FileValidationError(c.ScriptDir, err)
+	}
+
+	if c.UnstakingTest {
+		if c.NumLazyWhales < 1 {
+			return fmt.Errorf("unstaking test requires at least 1 lazy whale, got %d", c.NumLazyWhales)
+		}
+		// The lazy whales' delegates are patched via runtime_genesis_ledger
+		// --unstake-pk, which only the legacy fork path invokes
+		if len(c.ForkMethods) != 1 {
+			return fmt.Errorf("unstaking test requires the legacy fork method only, got %s", c.ForkMethods.String())
+		}
+		if _, ok := c.ForkMethods[Legacy]; !ok {
+			return fmt.Errorf("unstaking test requires the legacy fork method, got %s", c.ForkMethods.String())
+		}
 	}
 
 	return nil

--- a/src/app/hardfork_test/src/internal/config/config_test.go
+++ b/src/app/hardfork_test/src/internal/config/config_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// validTestConfig returns a config whose path checks pass, so Validate()
+// reaches the unstaking-specific checks
+func validTestConfig(t *testing.T) *Config {
+	t.Helper()
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "exe")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.MainMinaExe = exe
+	cfg.MainRuntimeGenesisLedger = exe
+	cfg.ForkMinaExe = exe
+	cfg.ForkRuntimeGenesisLedger = exe
+	cfg.ScriptDir = dir
+	cfg.Root = dir
+	cfg.ForkMethods = ForkMethodSet{Legacy: {}}
+	return cfg
+}
+
+func TestValidateUnstaking(t *testing.T) {
+	t.Parallel()
+
+	// The CI configuration: unstaking, legacy only
+	cfg := validTestConfig(t)
+	cfg.UnstakingTest = true
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected valid unstaking config, got: %v", err)
+	}
+
+	// Unstaking off: fork method mix is unconstrained
+	cfg = validTestConfig(t)
+	cfg.ForkMethods = ForkMethodSet{Legacy: {}, Advanced: {}, Auto: {}}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected valid non-unstaking config, got: %v", err)
+	}
+
+	// Unstaking requires at least one lazy whale
+	cfg = validTestConfig(t)
+	cfg.UnstakingTest = true
+	cfg.NumLazyWhales = 0
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unstaking test with 0 lazy whales")
+	}
+
+	// Unstaking requires the legacy fork method only
+	cfg = validTestConfig(t)
+	cfg.UnstakingTest = true
+	cfg.ForkMethods = ForkMethodSet{Legacy: {}, Advanced: {}}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unstaking test with mixed fork methods")
+	}
+
+	cfg = validTestConfig(t)
+	cfg.UnstakingTest = true
+	cfg.ForkMethods = ForkMethodSet{Advanced: {}}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for unstaking test with the advanced fork method")
+	}
+}

--- a/src/app/hardfork_test/src/internal/currency/currency.go
+++ b/src/app/hardfork_test/src/internal/currency/currency.go
@@ -1,0 +1,67 @@
+// Package currency holds the protocol's currency primitive shared by the
+// GraphQL client and the genesis-ledger parser.
+package currency
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// The protocol's fixed currency scale: 1 MINA = 10^9 nanomina.
+// decimals is the same fact expressed as a fractional-digit count.
+const (
+	nanominasPerMina = 1_000_000_000
+	decimals         = 9
+)
+
+// Mina is one MINA expressed in nanomina, so amounts can be written in mina
+// units as e.g. 5 * currency.Mina — mirroring time.Second.
+const Mina Nanomina = nanominasPerMina
+
+// Nanomina is an integer nanomina amount (1 mina = 1e9 nanomina). Making it a
+// distinct type lets currency values name their unit through the type instead
+// of a field-name suffix.
+//
+// UnmarshalJSON expects the decimal-*mina* text the genesis ledger file uses
+// (e.g. "11550000.000000000"); the daemon's GraphQL integer-nanomina scalars
+// are read via gjson (.Uint()) at construction, not through this method, so the
+// two encodings never collide.
+type Nanomina uint64
+
+func (n *Nanomina) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("currency amount must be a decimal mina string: %w", err)
+	}
+	v, err := parseMinaToNanomina(s)
+	if err != nil {
+		return err
+	}
+	*n = Nanomina(v)
+	return nil
+}
+
+// parseMinaToNanomina parses a decimal *mina* amount as emitted by
+// generate-mina-local-network-ledger.py (e.g. "11550000.000000000") into an
+// integer *nanomina* count, exactly (no float rounding).
+func parseMinaToNanomina(balance string) (uint64, error) {
+	whole, frac, found := strings.Cut(balance, ".")
+	if !found {
+		frac = "0"
+	}
+	wholeN, err := strconv.ParseUint(whole, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
+	}
+	if len(frac) > decimals {
+		return 0, fmt.Errorf("invalid balance %q: more than %d fractional digits", balance, decimals)
+	}
+	frac = frac + strings.Repeat("0", decimals-len(frac))
+	fracN, err := strconv.ParseUint(frac, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
+	}
+	return wholeN*nanominasPerMina + fracN, nil
+}

--- a/src/app/hardfork_test/src/internal/currency/currency_test.go
+++ b/src/app/hardfork_test/src/internal/currency/currency_test.go
@@ -1,0 +1,59 @@
+package currency
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseMinaToNanomina(t *testing.T) {
+	t.Parallel()
+
+	valid := []struct {
+		in   string
+		want uint64
+	}{
+		{"0.000000000", 0},
+		{"11550000.000000000", 11_550_000_000_000_000},
+		{"499.000000000", 499_000_000_000},
+		{"0.000000001", 1},
+		{"1", 1_000_000_000},
+		{"65500.5", 65_500_500_000_000},
+	}
+	for _, tc := range valid {
+		got, err := parseMinaToNanomina(tc.in)
+		if err != nil {
+			t.Errorf("parseMinaToNanomina(%q) errored: %v", tc.in, err)
+		} else if got != tc.want {
+			t.Errorf("parseMinaToNanomina(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	invalid := []string{"", "abc", "1.0000000001", "-1.0", "1.2.3"}
+	for _, in := range invalid {
+		if _, err := parseMinaToNanomina(in); err == nil {
+			t.Errorf("parseMinaToNanomina(%q) should have errored", in)
+		}
+	}
+}
+
+func TestNanominaUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	// A decimal-mina string unmarshals straight into nanomina.
+	var n Nanomina
+	if err := json.Unmarshal([]byte(`"65500.5"`), &n); err != nil {
+		t.Fatalf("unmarshal valid amount errored: %v", err)
+	}
+	if n != 65_500_500_000_000 {
+		t.Errorf("Nanomina = %d, want 65_500_500_000_000", n)
+	}
+
+	// A malformed amount surfaces as an error, not a zero value.
+	if err := json.Unmarshal([]byte(`"1.2.3"`), &n); err == nil {
+		t.Error("expected unmarshal to fail on a malformed amount string")
+	}
+	// A non-string amount is rejected too (the ledger encodes amounts as strings).
+	if err := json.Unmarshal([]byte(`123`), &n); err == nil {
+		t.Error("expected unmarshal to fail on a non-string amount")
+	}
+}

--- a/src/app/hardfork_test/src/internal/hardfork/ledger.go
+++ b/src/app/hardfork_test/src/internal/hardfork/ledger.go
@@ -16,8 +16,10 @@ type LedgerHashes struct {
 	LedgerHash  string
 }
 
-// GenerateForkLedgers generates the hardfork ledgers using the specified executable
-func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile string) error {
+// GenerateForkLedgers generates the hardfork ledgers using the specified
+// executable; extraArgs are appended to the runtime_genesis_ledger invocation
+// (e.g. --unstake-pk, which only the fork-side executable understands)
+func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledgersDir, hashesFile string, extraArgs ...string) error {
 	t.Logger.Info("Generating hardfork ledgers with %s...", executablePath)
 
 	// Create hardfork ledgers directory
@@ -25,15 +27,16 @@ func (t *HardforkTest) GenerateForkLedgers(executablePath, forkConfigPath, ledge
 	os.MkdirAll(ledgersDir, 0755)
 
 	// Generate hardfork ledgers with specified executable
-	cmd := exec.Command(
-		executablePath,
+	args := []string{
 		"--config-file", forkConfigPath,
 		"--genesis-dir", ledgersDir,
 		"--hash-output-file", hashesFile,
 		// Forking to mesa need App State size to be expanded to 32
 		// TODO: Consider design the test so this pad app state size is only applied when forking into Mesa
 		"--pad-app-state",
-	)
+	}
+	args = append(args, extraArgs...)
+	cmd := exec.Command(executablePath, args...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -62,9 +65,9 @@ func (t *HardforkTest) GenerateAndValidateHashesAndLedgers(analysis BlockAnalysi
 // 1. generate fork ledgers with runtime-genesis-ledger
 // 2. patch the genesis time & slot for fork config with create_runtime_config.sh
 // 3. perform some base sanity check on the fork config
-func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64) ([]byte, error) {
+func (t *HardforkTest) PatchForkConfigAndGenerateLedgersLegacy(analysis *BlockAnalysisResult, forkConfigPath, forkLedgersDir, forkHashesFile, configFile, preforkGenesisConfigFile string, forkGenesisTs, mainGenesisTs int64, extraArgs ...string) ([]byte, error) {
 	// Generate fork ledgers using fork network executable
-	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile); err != nil {
+	if err := t.GenerateForkLedgers(t.Config.ForkRuntimeGenesisLedger, forkConfigPath, forkLedgersDir, forkHashesFile, extraArgs...); err != nil {
 		return nil, err
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/network.go
+++ b/src/app/hardfork_test/src/internal/hardfork/network.go
@@ -66,6 +66,10 @@ func (t *HardforkTest) RunMainNetwork(extraFilesRoot string, mainGenesisTs int64
 		"--extra-files-root", extraFilesRoot,
 	}
 
+	if t.Config.UnstakingTest {
+		args = append(args, "--lazy-whales", strconv.Itoa(t.Config.NumLazyWhales))
+	}
+
 	return t.startLocalNetwork(t.Config.MainMinaExe, "main", args)
 }
 

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -74,7 +74,7 @@ func (t *HardforkTest) RunMainNetworkPhase(mainGenesisTs int64, beforeShutdown H
 			return nil, err
 		}
 	} else {
-		if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd); err != nil {
+		if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd, t.Config.SlotTxEnd); err != nil {
 			return nil, err
 		}
 	}
@@ -156,7 +156,7 @@ func (t *HardforkTest) RunForkNetworkPhase(analysis *BlockAnalysisResult, mainGe
 			return err
 		}
 	} else {
-		if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip); err != nil {
+		if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip, bestTip.Slot); err != nil {
 			return err
 		}
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -228,11 +228,7 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 	// executable above.
 	var extraArgs []string
 	if t.Config.UnstakingTest {
-		lazyPks, err := t.LazyWhalePks()
-		if err != nil {
-			return err
-		}
-		for _, pk := range lazyPks {
+		for _, pk := range analysis.LazyWhalePks {
 			extraArgs = append(extraArgs, "--unstake-pk", pk)
 		}
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -69,8 +69,14 @@ func (t *HardforkTest) RunMainNetworkPhase(mainGenesisTs int64, beforeShutdown H
 
 	t.Logger.Info("Network analyze result: %v", analysis)
 
-	if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd); err != nil {
-		return nil, err
+	if t.Config.UnstakingTest {
+		if err := t.validatePreForkOccupancyDiluted(analysis); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := t.ValidateSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := t.ValidateLatestOccupiedSlot(analysis.Consensus.LastOccupiedSlot); err != nil {
@@ -102,7 +108,8 @@ type ForkData struct {
 }
 
 // RunForkNetworkPhase runs the fork network and validates its operation
-func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisTs int64) error {
+func (t *HardforkTest) RunForkNetworkPhase(analysis *BlockAnalysisResult, mainGenesisTs int64) error {
+	latestPreForkHeight := analysis.Consensus.LastBlockBeforeTxEnd.BlockHeight
 	// Start fork network
 	forkCmd, err := t.RunForkNetwork()
 	if err != nil {
@@ -144,8 +151,14 @@ func (t *HardforkTest) RunForkNetworkPhase(latestPreForkHeight int, mainGenesisT
 	t.Logger.Info("Block height is %d at slot %d.", bestTip.BlockHeight, bestTip.Slot)
 
 	// Validate slot occupancy
-	if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip); err != nil {
-		return err
+	if t.Config.UnstakingTest {
+		if err := t.validatePostForkOccupancyRecovered(analysis, *commonGenesisBlock, *bestTip); err != nil {
+			return err
+		}
+	} else {
+		if err := t.ValidateSlotOccupancy(*commonGenesisBlock, *bestTip); err != nil {
+			return err
+		}
 	}
 
 	// Validate user commands in blocks
@@ -208,7 +221,23 @@ func (t *HardforkTest) legacyFork(daemon config.DaemonInfo, analysis BlockAnalys
 	preforkGenesisConfigFile := filepath.Join(t.Config.Root, "daemon.json")
 	forkHashesFile := filepath.Join(forkDataPath, "ledger_hashes.json")
 
-	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs)
+	// In unstaking test mode, clear the lazy whales' delegates in the fork
+	// genesis ledger so their stake is excluded from the post-fork VRF
+	// denominator (total_stake). Only the fork-side runtime_genesis_ledger
+	// understands --unstake-pk, so these args must not reach the prefork
+	// executable above.
+	var extraArgs []string
+	if t.Config.UnstakingTest {
+		lazyPks, err := t.LazyWhalePks()
+		if err != nil {
+			return err
+		}
+		for _, pk := range lazyPks {
+			extraArgs = append(extraArgs, "--unstake-pk", pk)
+		}
+	}
+
+	patchedConfigBytes, err := t.PatchForkConfigAndGenerateLedgersLegacy(&analysis, prepatchConfigFile, patchedLedgersDir, forkHashesFile, patchedConfigFile, preforkGenesisConfigFile, forkGenesisTs, mainGenesisTs, extraArgs...)
 	if err != nil {
 		return err
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/phases.go
+++ b/src/app/hardfork_test/src/internal/hardfork/phases.go
@@ -152,7 +152,7 @@ func (t *HardforkTest) RunForkNetworkPhase(analysis *BlockAnalysisResult, mainGe
 
 	// Validate slot occupancy
 	if t.Config.UnstakingTest {
-		if err := t.validatePostForkOccupancyRecovered(analysis, *commonGenesisBlock, *bestTip); err != nil {
+		if err := t.validatePostForkUnstaking(analysis, *commonGenesisBlock, *bestTip); err != nil {
 			return err
 		}
 	} else {

--- a/src/app/hardfork_test/src/internal/hardfork/test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/test.go
@@ -147,7 +147,7 @@ func (t *HardforkTest) Run() error {
 	}
 
 	t.Logger.Info("Phase 4: Running fork network...")
-	if err := t.RunForkNetworkPhase(analysis.Consensus.LastBlockBeforeTxEnd.BlockHeight, mainGenesisTs); err != nil {
+	if err := t.RunForkNetworkPhase(analysis, mainGenesisTs); err != nil {
 		return err
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -6,11 +6,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/currency"
 )
 
 // Slot fill rate f hardcoded in the daemon (src/lib/consensus/vrf/consensus_vrf.ml),
@@ -37,15 +37,14 @@ const preForkMinOccupancy = 0.05
 // ledger the VRF samples.
 const totalCurrencyTolerance = 0.001
 
-// StakeStats summarizes the genesis ledger from the VRF's point of view, in
-// nanomina
+// StakeStats summarizes the genesis ledger from the VRF's point of view.
 type StakeStats struct {
 	// Sum of all account balances: the pre-fork VRF denominator
-	TotalCurrency uint64
+	TotalCurrency currency.Nanomina
 	// Sum of balances delegated to a producer key with a running daemon
-	ActiveProducerStake uint64
+	ActiveProducerStake currency.Nanomina
 	// Sum of the lazy whale account balances
-	LazyStake uint64
+	LazyStake currency.Nanomina
 }
 
 // LazyWhalePks returns the public keys of the lazy whale offline accounts:
@@ -127,9 +126,9 @@ func readPubkeyFile(path string) (string, error) {
 }
 
 type genesisLedgerAccount struct {
-	Pk       string  `json:"pk"`
-	Balance  string  `json:"balance"`
-	Delegate *string `json:"delegate"`
+	Pk       string            `json:"pk"`
+	Balance  currency.Nanomina `json:"balance"`
+	Delegate *string           `json:"delegate"`
 }
 
 type genesisLedgerFile struct {
@@ -165,10 +164,7 @@ func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map
 	}
 
 	for _, account := range ledger.Accounts {
-		balance, err := parseNanominas(account.Balance)
-		if err != nil {
-			return stats, fmt.Errorf("account %s: %w", account.Pk, err)
-		}
+		balance := account.Balance
 		stats.TotalCurrency += balance
 
 		delegate := account.Pk
@@ -184,29 +180,6 @@ func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map
 	}
 
 	return stats, nil
-}
-
-// parseNanominas parses a decimal mina amount as emitted by
-// generate-mina-local-network-ledger.py (e.g. "11550000.000000000") into
-// nanomina
-func parseNanominas(balance string) (uint64, error) {
-	whole, frac, found := strings.Cut(balance, ".")
-	if !found {
-		frac = "0"
-	}
-	wholeN, err := strconv.ParseUint(whole, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
-	}
-	if len(frac) > 9 {
-		return 0, fmt.Errorf("invalid balance %q: more than 9 fractional digits", balance)
-	}
-	frac = frac + strings.Repeat("0", 9-len(frac))
-	fracN, err := strconv.ParseUint(frac, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
-	}
-	return wholeN*1_000_000_000 + fracN, nil
 }
 
 // validatePreForkOccupancyDiluted asserts that the pre-fork slot occupancy is
@@ -247,10 +220,15 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	// assumption that it is the staking epoch ledger the VRF samples during
 	// the whole measurement window (epoch 0). Cross-check the file-derived
 	// total against what consensus actually reports.
-	consensusTotal, err := t.Client.StakingEpochLedgerTotalCurrency(t.Config.AnyDaemon().Port(config.PORT_REST))
-	if err != nil {
-		return fmt.Errorf("failed to query staking epoch ledger total currency: %w", err)
-	}
+	//
+	// Read that total off the genesis block already in hand
+	// (analysis.GenesisBlock, agreed across the network by
+	// GenesisBlockAcrossNetwork) rather than a live bestChain query. The
+	// genesis block's staking epoch ledger is the epoch-0 snapshot by
+	// construction, so this comparison stays valid regardless of run length;
+	// a live query at chain-end could instead read a later, coinbase-grown
+	// staking-epoch snapshot if the run ever crossed an epoch boundary.
+	consensusTotal := analysis.GenesisBlock.StakingLedgerTotalCurrency
 	t.Logger.Info("Staking epoch ledger total currency per consensus: %d nanomina (genesis ledger file: %d nanomina)", consensusTotal, stats.TotalCurrency)
 	if math.Abs(float64(consensusTotal)-float64(stats.TotalCurrency)) > totalCurrencyTolerance*float64(consensusTotal) {
 		return fmt.Errorf("genesis ledger file total currency (%d nanomina) disagrees with the staking epoch ledger total currency (%d nanomina) by more than %.2f%%; the fill-rate bound would be computed against the wrong ledger", stats.TotalCurrency, consensusTotal, totalCurrencyTolerance*100)
@@ -281,17 +259,9 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 // totalCurrency must NOT be used as the minuend — it describes the staged
 // ledger at the fork block, which additionally contains the pre-fork coinbase
 // supply increase.
-func UnstakedTotal(preForkGenesis, forkGenesis client.BlockData) (uint64, error) {
-	// GraphQL Amount fields are raw nanomina integer strings (unlike the
-	// decimal-mina balances in the genesis ledger file)
-	total, err := strconv.ParseUint(preForkGenesis.TotalCurrency, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("total currency of pre-fork genesis block %s: %w", preForkGenesis.StateHash, err)
-	}
-	staked, err := strconv.ParseUint(forkGenesis.StakingLedgerTotalCurrency, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("staking ledger total currency of fork genesis block %s: %w", forkGenesis.StateHash, err)
-	}
+func UnstakedTotal(preForkGenesis, forkGenesis client.BlockData) (currency.Nanomina, error) {
+	total := preForkGenesis.TotalCurrency
+	staked := forkGenesis.StakingLedgerTotalCurrency
 	if staked > total {
 		return 0, fmt.Errorf("fork staking ledger total (%d nanomina) exceeds pre-fork genesis total currency (%d nanomina)", staked, total)
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
 )
 
 // Slot fill rate f hardcoded in the daemon (src/lib/consensus/vrf/consensus_vrf.ml),
@@ -27,6 +28,14 @@ const preForkFillMargin = 0.15
 // broken rather than diluted, and the comparison against the post-fork
 // occupancy would be meaningless
 const preForkMinOccupancy = 0.05
+
+// Relative tolerance when cross-checking the file-derived total currency
+// against the staking epoch ledger's total currency reported by the daemon.
+// The two may differ by accounts the daemon injects on top of the configured
+// genesis (e.g. the genesis winner, ~1000 MINA against ~80M total); a mismatch
+// beyond this tolerance means the genesis ledger file no longer describes the
+// ledger the VRF samples.
+const totalCurrencyTolerance = 0.001
 
 // StakeStats summarizes the genesis ledger from the VRF's point of view, in
 // nanomina
@@ -231,6 +240,19 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	upperBound, err := ExpectedPreForkFillUpperBound(stats)
 	if err != nil {
 		return err
+	}
+
+	// The fill bound is modeled on the genesis ledger file under the
+	// assumption that it is the staking epoch ledger the VRF samples during
+	// the whole measurement window (epoch 0). Cross-check the file-derived
+	// total against what consensus actually reports.
+	consensusTotal, err := t.Client.StakingEpochLedgerTotalCurrency(t.Config.AnyDaemon().Port(config.PORT_REST))
+	if err != nil {
+		return fmt.Errorf("failed to query staking epoch ledger total currency: %w", err)
+	}
+	t.Logger.Info("Staking epoch ledger total currency per consensus: %d nanomina (genesis ledger file: %d nanomina)", consensusTotal, stats.TotalCurrency)
+	if math.Abs(float64(consensusTotal)-float64(stats.TotalCurrency)) > totalCurrencyTolerance*float64(consensusTotal) {
+		return fmt.Errorf("genesis ledger file total currency (%d nanomina) disagrees with the staking epoch ledger total currency (%d nanomina) by more than %.2f%%; the fill-rate bound would be computed against the wrong ledger", stats.TotalCurrency, consensusTotal, totalCurrencyTolerance*100)
 	}
 
 	t.Logger.Info("Genesis stake: total currency %d, active producer stake %d, lazy stake %d (lazy portion %f)",

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -13,10 +13,22 @@ import (
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/currency"
 )
 
-// Slot fill rate f hardcoded in the daemon (src/lib/consensus/vrf/consensus_vrf.ml),
-// independent of build profile. A producer holding fraction s of the VRF
-// denominator wins a slot with probability 1 - (1-f)^s; VRF evaluations are
-// independent across producers, so P(slot filled) = 1 - (1-f)^(sum of s_i).
+// Slot fill rate f, a compile-time consensus constant in the daemon, not
+// exposed by any daemon query and independent of build profile — so it is
+// mirrored here by hand. Source of truth (grep it if this copy is ever
+// suspect): src/lib/consensus/vrf/consensus_vrf.ml, module Threshold,
+//
+//	let f = Bignum.(of_int 3 / of_int 4)
+//
+// (= 0.75, valid while the sibling constant c stays at 2^0, which the same file
+// documents as production behavior). A producer holding fraction s of the VRF
+// denominator wins a slot with probability 1 - (1-f)^s; VRF
+// evaluations are independent across producers, so
+// P(slot filled) = 1 - (1-f)^(sum of s_i). There is no cheap runtime
+// cross-check for this copy, but the post-fork occupancy is itself an indirect
+// one: with the lazy whales unstaked s_active -> 1, so the modeled fill
+// saturates to f and the post-fork band (centered on ~f) would flag a stale
+// value.
 const vrfFillFraction = 0.75
 
 // occupancyBandZ is the confidence multiplier for the derived occupancy margin:
@@ -32,10 +44,20 @@ const preForkMinOccupancy = 0.05
 
 // Relative tolerance when cross-checking the file-derived total currency
 // against the staking epoch ledger's total currency reported by the daemon.
-// The two may differ by accounts the daemon injects on top of the configured
-// genesis (e.g. the genesis winner, ~1000 MINA against ~80M total); a mismatch
-// beyond this tolerance means the genesis ledger file no longer describes the
-// ledger the VRF samples.
+// At proof_level=full (the local-network default) the daemon injects the
+// genesis-winner account on top of the configured genesis, so its total exceeds
+// the file total by that account's balance. That balance is 1000 *nanomina*
+// (0.000001 MINA) — src/lib/consensus/proof_of_stake.ml, genesis_winner_account,
+//
+//	Currency.Balance.of_nanomina_int_exn 1000
+//
+// injected per src/lib/genesis_ledger_helper/genesis_ledger_helper.ml when
+// proof_level=Full and add_genesis_winner is unset. So the real discrepancy is
+// a fixed, negligible amount and this tolerance is generous slack, not a figure
+// sized to it. A mismatch beyond it means the genesis ledger file no longer
+// describes the ledger the VRF samples. Kept a named constant rather than a
+// config knob: the discrepancy is a fixed protocol artifact, not a per-run
+// tuning parameter.
 const totalCurrencyTolerance = 0.001
 
 // StakeStats summarizes the genesis ledger from the VRF's point of view.

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -1,0 +1,281 @@
+package hardfork
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
+)
+
+// Slot fill rate f hardcoded in the daemon (src/lib/consensus/vrf/consensus_vrf.ml),
+// independent of build profile. A producer holding fraction s of the VRF
+// denominator wins a slot with probability 1 - (1-f)^s; VRF evaluations are
+// independent across producers, so P(slot filled) = 1 - (1-f)^(sum of s_i).
+const vrfFillFraction = 0.75
+
+// Slack added on top of the modeled pre-fork fill rate to absorb VRF variance
+// over the ~30-slot measurement window (~1.7 sigma) and the stake the model
+// ignores (online balances, service accounts)
+const preForkFillMargin = 0.15
+
+// Lower bar for the pre-fork occupancy: below this the network is considered
+// broken rather than diluted, and the comparison against the post-fork
+// occupancy would be meaningless
+const preForkMinOccupancy = 0.05
+
+// StakeStats summarizes the genesis ledger from the VRF's point of view, in
+// nanomina
+type StakeStats struct {
+	// Sum of all account balances: the pre-fork VRF denominator
+	TotalCurrency uint64
+	// Sum of balances delegated to a producer key with a running daemon
+	ActiveProducerStake uint64
+	// Sum of the lazy whale account balances
+	LazyStake uint64
+}
+
+// LazyWhalePks returns the public keys of the lazy whale offline accounts:
+// the accounts in the generated genesis ledger whose stake is delegated to a
+// whale producer key that has no running daemon. The classification is done
+// against the ledger rather than by key-file index because the ledger
+// generator pairs offline and online whale keys in glob order, which is not
+// guaranteed to follow the filename indices.
+func (t *HardforkTest) LazyWhalePks() ([]string, error) {
+	running, err := t.RunningProducerPks()
+	if err != nil {
+		return nil, err
+	}
+
+	allOnlineWhalePks := make(map[string]bool)
+	for i := 0; i < t.Config.NumWhales+t.Config.NumLazyWhales; i++ {
+		path := filepath.Join(t.Config.Root, "online_whale_keys", fmt.Sprintf("online_whale_account_%d.pub", i))
+		pk, err := readPubkeyFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read online whale %d public key: %w", i, err)
+		}
+		allOnlineWhalePks[pk] = true
+	}
+
+	ledger, err := readGenesisLedger(filepath.Join(t.Config.Root, "genesis_ledger.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var pks []string
+	for _, account := range ledger.Accounts {
+		if account.Delegate == nil {
+			continue
+		}
+		if allOnlineWhalePks[*account.Delegate] && !running[*account.Delegate] {
+			pks = append(pks, account.Pk)
+		}
+	}
+	if len(pks) != t.Config.NumLazyWhales {
+		return nil, fmt.Errorf("expected %d lazy whale accounts in the genesis ledger, found %d", t.Config.NumLazyWhales, len(pks))
+	}
+	return pks, nil
+}
+
+// RunningProducerPks returns the public keys of the block producer accounts
+// that actually have a daemon running: online whales 0..NumWhales-1 and online
+// fish 0..NumFish-1
+func (t *HardforkTest) RunningProducerPks() (map[string]bool, error) {
+	pks := make(map[string]bool)
+	for i := 0; i < t.Config.NumWhales; i++ {
+		path := filepath.Join(t.Config.Root, "online_whale_keys", fmt.Sprintf("online_whale_account_%d.pub", i))
+		pk, err := readPubkeyFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read online whale %d public key: %w", i, err)
+		}
+		pks[pk] = true
+	}
+	for i := 0; i < t.Config.NumFish; i++ {
+		path := filepath.Join(t.Config.Root, "online_fish_keys", fmt.Sprintf("online_fish_account_%d.pub", i))
+		pk, err := readPubkeyFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read online fish %d public key: %w", i, err)
+		}
+		pks[pk] = true
+	}
+	return pks, nil
+}
+
+func readPubkeyFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	pk := strings.TrimSpace(string(data))
+	if pk == "" {
+		return "", fmt.Errorf("public key file %s is empty", path)
+	}
+	return pk, nil
+}
+
+type genesisLedgerAccount struct {
+	Pk       string  `json:"pk"`
+	Balance  string  `json:"balance"`
+	Delegate *string `json:"delegate"`
+}
+
+type genesisLedgerFile struct {
+	Accounts []genesisLedgerAccount `json:"accounts"`
+}
+
+func readGenesisLedger(path string) (*genesisLedgerFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read genesis ledger: %w", err)
+	}
+	var ledger genesisLedgerFile
+	if err := json.Unmarshal(data, &ledger); err != nil {
+		return nil, fmt.Errorf("failed to parse genesis ledger %s: %w", path, err)
+	}
+	if len(ledger.Accounts) == 0 {
+		return nil, fmt.Errorf("genesis ledger %s contains no accounts", path)
+	}
+	return &ledger, nil
+}
+
+// ComputeStakeStats reads the generated genesis ledger and classifies every
+// account balance. An account's stake counts as active iff its delegate is a
+// running producer key; a null delegate means self-delegation on the pre-fork
+// (mesa) build, so such an account is active iff its own key is a running
+// producer.
+func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map[string]bool) (StakeStats, error) {
+	var stats StakeStats
+
+	ledger, err := readGenesisLedger(genesisLedgerPath)
+	if err != nil {
+		return stats, err
+	}
+
+	for _, account := range ledger.Accounts {
+		balance, err := parseNanominas(account.Balance)
+		if err != nil {
+			return stats, fmt.Errorf("account %s: %w", account.Pk, err)
+		}
+		stats.TotalCurrency += balance
+
+		delegate := account.Pk
+		if account.Delegate != nil {
+			delegate = *account.Delegate
+		}
+		if runningProducerPks[delegate] {
+			stats.ActiveProducerStake += balance
+		}
+		if lazyPks[account.Pk] {
+			stats.LazyStake += balance
+		}
+	}
+
+	return stats, nil
+}
+
+// parseNanominas parses a decimal mina amount as emitted by
+// generate-mina-local-network-ledger.py (e.g. "11550000.000000000") into
+// nanomina
+func parseNanominas(balance string) (uint64, error) {
+	whole, frac, found := strings.Cut(balance, ".")
+	if !found {
+		frac = "0"
+	}
+	wholeN, err := strconv.ParseUint(whole, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
+	}
+	if len(frac) > 9 {
+		return 0, fmt.Errorf("invalid balance %q: more than 9 fractional digits", balance)
+	}
+	frac = frac + strings.Repeat("0", 9-len(frac))
+	fracN, err := strconv.ParseUint(frac, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance %q: %w", balance, err)
+	}
+	return wholeN*1_000_000_000 + fracN, nil
+}
+
+// validatePreForkOccupancyDiluted asserts that the pre-fork slot occupancy is
+// low because the lazy whales dilute the VRF denominator, while the network is
+// still alive. The measured occupancy is recorded on the analysis result for
+// the post-fork comparison.
+func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisResult) error {
+	occ, err := t.ComputeSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd)
+	if err != nil {
+		return fmt.Errorf("failed to compute pre-fork slot occupancy: %w", err)
+	}
+	analysis.PreForkOccupancy = occ
+
+	producerPks, err := t.RunningProducerPks()
+	if err != nil {
+		return err
+	}
+	lazyList, err := t.LazyWhalePks()
+	if err != nil {
+		return err
+	}
+	lazyPks := make(map[string]bool, len(lazyList))
+	for _, pk := range lazyList {
+		lazyPks[pk] = true
+	}
+
+	stats, err := ComputeStakeStats(filepath.Join(t.Config.Root, "genesis_ledger.json"), producerPks, lazyPks)
+	if err != nil {
+		return err
+	}
+	upperBound, err := ExpectedPreForkFillUpperBound(stats)
+	if err != nil {
+		return err
+	}
+
+	t.Logger.Info("Genesis stake: total currency %d, active producer stake %d, lazy stake %d (lazy portion %f)",
+		stats.TotalCurrency, stats.ActiveProducerStake, stats.LazyStake,
+		float64(stats.LazyStake)/float64(stats.TotalCurrency))
+	t.Logger.Info("Pre-fork slot occupancy: %f (expected below %f due to lazy whales)", occ, upperBound)
+
+	if occ < preForkMinOccupancy {
+		return fmt.Errorf("pre-fork slot occupancy (%f) is below %f, network appears broken rather than diluted", occ, preForkMinOccupancy)
+	}
+	if occ >= upperBound {
+		return fmt.Errorf("pre-fork slot occupancy (%f) is not below the expected upper bound (%f), lazy whales are not diluting the VRF denominator", occ, upperBound)
+	}
+	return nil
+}
+
+// validatePostForkOccupancyRecovered asserts that unstaking the lazy whales at
+// the fork restored the slot occupancy: it must beat the pre-fork occupancy
+// and clear the standard 50% health bar.
+func (t *HardforkTest) validatePostForkOccupancyRecovered(analysis *BlockAnalysisResult, commonGenesisBlock, bestTip client.BlockData) error {
+	postOcc, err := t.ComputeSlotOccupancy(commonGenesisBlock, bestTip)
+	if err != nil {
+		return fmt.Errorf("failed to compute post-fork slot occupancy: %w", err)
+	}
+
+	t.Logger.Info("Post-fork slot occupancy: %f (pre-fork was %f)", postOcc, analysis.PreForkOccupancy)
+
+	if postOcc <= analysis.PreForkOccupancy {
+		return fmt.Errorf("post-fork slot occupancy (%f) did not improve on pre-fork occupancy (%f), unstaking the lazy whales had no effect", postOcc, analysis.PreForkOccupancy)
+	}
+	return t.ValidateSlotOccupancy(commonGenesisBlock, bestTip)
+}
+
+// ExpectedPreForkFillUpperBound bounds the pre-fork slot occupancy expected
+// while the lazy whales dilute the VRF denominator: the modeled fill rate for
+// the active stake share plus a slack margin. Pre-fork occupancy at or above
+// this bound means the dilution did not happen.
+func ExpectedPreForkFillUpperBound(s StakeStats) (float64, error) {
+	if s.TotalCurrency == 0 {
+		return 0, fmt.Errorf("total currency is zero, cannot compute expected fill rate")
+	}
+	sActive := float64(s.ActiveProducerStake) / float64(s.TotalCurrency)
+	bound := 1 - math.Pow(1-vrfFillFraction, sActive) + preForkFillMargin
+	if bound > 1 {
+		bound = 1
+	}
+	return bound, nil
+}

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -188,7 +188,7 @@ func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map
 // still alive. The measured occupancy is recorded on the analysis result for
 // the post-fork comparison.
 func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisResult) error {
-	occ, err := t.ComputeSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd)
+	occ, err := t.ComputeSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd, t.Config.SlotTxEnd)
 	if err != nil {
 		return fmt.Errorf("failed to compute pre-fork slot occupancy: %w", err)
 	}
@@ -218,8 +218,9 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 		return err
 	}
 	// n is the slot span the occupancy was measured over — the same denominator
-	// ComputeSlotOccupancy divides by — so the band margin tracks the window.
-	nPre := analysis.Consensus.LastBlockBeforeTxEnd.Slot - analysis.GenesisBlock.Slot
+	// ComputeSlotOccupancy divides by (the intended tx-end boundary, not the
+	// last observed block) — so the band margin tracks the window.
+	nPre := t.Config.SlotTxEnd - analysis.GenesisBlock.Slot
 	band, err := newOccupancyBand(expectedFillRate(sActive), nPre)
 	if err != nil {
 		return fmt.Errorf("failed to compute pre-fork occupancy band: %w", err)
@@ -323,7 +324,11 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 	}
 	t.Logger.Info("All %d lazy whales are unstaked on the fork network", len(lazyPks))
 
-	postOcc, err := t.ComputeSlotOccupancy(commonGenesisBlock, bestTip)
+	// The post-fork window has no tx-end boundary; it runs genesis → the best
+	// tip we queried, so the boundary is the tip's own slot and the window ends
+	// on a hit (a small residual upward bias, unavoidable without a boundary
+	// past the tip). nPost below matches this same denominator.
+	postOcc, err := t.ComputeSlotOccupancy(commonGenesisBlock, bestTip, bestTip.Slot)
 	if err != nil {
 		return fmt.Errorf("failed to compute post-fork slot occupancy: %w", err)
 	}
@@ -353,7 +358,7 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 		return fmt.Errorf("post-fork slot occupancy (%f) is below the model lower bound (%f); unstaking did not restore occupancy to the level the undiluted active stake predicts (partial-unstaking regression)", postOcc, postBand.Lower)
 	}
 	// Retain the absolute >= 0.5 health bar as an additional coarse guard.
-	return t.ValidateSlotOccupancy(commonGenesisBlock, bestTip)
+	return t.ValidateSlotOccupancy(commonGenesisBlock, bestTip, bestTip.Slot)
 }
 
 // preForkActiveShare is the active producers' share of the pre-fork VRF

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -82,14 +82,14 @@ func (t *HardforkTest) LazyWhalePks() ([]string, error) {
 		return nil, err
 	}
 
-	allOnlineWhalePks := make(map[string]bool)
+	allOnlineWhalePks := make(map[string]struct{})
 	for i := 0; i < t.Config.NumWhales+t.Config.NumLazyWhales; i++ {
 		path := filepath.Join(t.Config.Root, "online_whale_keys", fmt.Sprintf("online_whale_account_%d.pub", i))
 		pk, err := readPubkeyFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read online whale %d public key: %w", i, err)
 		}
-		allOnlineWhalePks[pk] = true
+		allOnlineWhalePks[pk] = struct{}{}
 	}
 
 	ledger, err := readGenesisLedger(filepath.Join(t.Config.Root, "genesis_ledger.json"))
@@ -102,7 +102,9 @@ func (t *HardforkTest) LazyWhalePks() ([]string, error) {
 		if account.Delegate == nil {
 			continue
 		}
-		if allOnlineWhalePks[*account.Delegate] && !running[*account.Delegate] {
+		_, isOnlineWhale := allOnlineWhalePks[*account.Delegate]
+		_, isRunning := running[*account.Delegate]
+		if isOnlineWhale && !isRunning {
 			pks = append(pks, account.Pk)
 		}
 	}
@@ -115,15 +117,15 @@ func (t *HardforkTest) LazyWhalePks() ([]string, error) {
 // RunningProducerPks returns the public keys of the block producer accounts
 // that actually have a daemon running: online whales 0..NumWhales-1 and online
 // fish 0..NumFish-1
-func (t *HardforkTest) RunningProducerPks() (map[string]bool, error) {
-	pks := make(map[string]bool)
+func (t *HardforkTest) RunningProducerPks() (map[string]struct{}, error) {
+	pks := make(map[string]struct{})
 	for i := 0; i < t.Config.NumWhales; i++ {
 		path := filepath.Join(t.Config.Root, "online_whale_keys", fmt.Sprintf("online_whale_account_%d.pub", i))
 		pk, err := readPubkeyFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read online whale %d public key: %w", i, err)
 		}
-		pks[pk] = true
+		pks[pk] = struct{}{}
 	}
 	for i := 0; i < t.Config.NumFish; i++ {
 		path := filepath.Join(t.Config.Root, "online_fish_keys", fmt.Sprintf("online_fish_account_%d.pub", i))
@@ -131,7 +133,7 @@ func (t *HardforkTest) RunningProducerPks() (map[string]bool, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read online fish %d public key: %w", i, err)
 		}
-		pks[pk] = true
+		pks[pk] = struct{}{}
 	}
 	return pks, nil
 }
@@ -178,7 +180,7 @@ func readGenesisLedger(path string) (*genesisLedgerFile, error) {
 // running producer key; a null delegate means self-delegation on the pre-fork
 // (mesa) build, so such an account is active iff its own key is a running
 // producer.
-func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map[string]bool) (StakeStats, error) {
+func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map[string]struct{}) (StakeStats, error) {
 	var stats StakeStats
 
 	ledger, err := readGenesisLedger(genesisLedgerPath)
@@ -194,10 +196,10 @@ func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map
 		if account.Delegate != nil {
 			delegate = *account.Delegate
 		}
-		if runningProducerPks[delegate] {
+		if _, ok := runningProducerPks[delegate]; ok {
 			stats.ActiveProducerStake += balance
 		}
-		if lazyPks[account.Pk] {
+		if _, ok := lazyPks[account.Pk]; ok {
 			stats.LazyStake += balance
 		}
 	}
@@ -225,9 +227,9 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 		return err
 	}
 	analysis.LazyWhalePks = lazyList
-	lazyPks := make(map[string]bool, len(lazyList))
+	lazyPks := make(map[string]struct{}, len(lazyList))
 	for _, pk := range lazyList {
-		lazyPks[pk] = true
+		lazyPks[pk] = struct{}{}
 	}
 
 	stats, err := ComputeStakeStats(filepath.Join(t.Config.Root, "genesis_ledger.json"), producerPks, lazyPks)
@@ -421,14 +423,14 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 // consensus). The two must be equal, and the stake partition must not
 // overcount. This is the independent check on the s_active numerator that the
 // 0.1% total-currency cross-check provides for the denominator.
-func validateActiveProducerLiveness(running, observed map[string]bool, stats StakeStats) error {
+func validateActiveProducerLiveness(running, observed map[string]struct{}, stats StakeStats) error {
 	// Every running producer must have produced at least one block. A running
 	// producer that never appears as a creator is dead or misconfigured while
 	// its stake is still counted as active — occupancy would be suppressed with
 	// no dilution to explain it, which the occupancy lower band cannot reliably
 	// catch at the CI window length.
 	for pk := range running {
-		if !observed[pk] {
+		if _, ok := observed[pk]; !ok {
 			return fmt.Errorf("running producer %s authored no blocks in the pre-fork window; its stake is counted as active but it appears dead or misconfigured", pk)
 		}
 	}
@@ -436,7 +438,7 @@ func validateActiveProducerLiveness(running, observed map[string]bool, stats Sta
 	// block creator means the running-producer set is wrong, so the active-stake
 	// classification built from it cannot be trusted.
 	for pk := range observed {
-		if !running[pk] {
+		if _, ok := running[pk]; !ok {
 			return fmt.Errorf("block creator %s is not in the expected running-producer set; the active-stake classification is unreliable", pk)
 		}
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -224,6 +224,7 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	if err != nil {
 		return err
 	}
+	analysis.LazyWhalePks = lazyList
 	lazyPks := make(map[string]bool, len(lazyList))
 	for _, pk := range lazyList {
 		lazyPks[pk] = true
@@ -364,10 +365,7 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 	}
 
 	port := t.Config.AnyDaemon().Port(config.PORT_REST)
-	lazyPks, err := t.LazyWhalePks()
-	if err != nil {
-		return err
-	}
+	lazyPks := analysis.LazyWhalePks
 	for _, pk := range lazyPks {
 		delegate, err := t.Client.AccountDelegate(port, pk)
 		if err != nil {

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -228,6 +228,18 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	}
 	t.Logger.Info("Active-producer cross-check passed: %d running producers all authored blocks in the pre-fork window", len(producerPks))
 
+	// The whole pre-fork analysis assumes the measurement window stays inside the
+	// genesis-anchored epoch (epoch 0): the VRF samples the genesis staking-epoch
+	// ledger for every slot, the fill model is computed against that ledger, and
+	// the total-currency cross-check below compares it to the genesis ledger
+	// file. If slot_tx_end were pushed past an epoch boundary the staking ledger
+	// would roll to a later, coinbase-grown snapshot and those comparisons would
+	// silently be against the wrong ledger. Assert the invariant rather than only
+	// relying on slot_tx_end < slots_per_epoch holding by configuration.
+	if txEndEpoch := analysis.Consensus.LastBlockBeforeTxEnd.Epoch; txEndEpoch != 0 {
+		return fmt.Errorf("last block before tx-end is in epoch %d, not the genesis epoch 0; the pre-fork occupancy model and total-currency cross-check assume the measurement window stays within epoch 0 (slot_tx_end must be below slots_per_epoch)", txEndEpoch)
+	}
+
 	sActive, err := preForkActiveShare(stats)
 	if err != nil {
 		return err
@@ -253,6 +265,12 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	// construction, so this comparison stays valid regardless of run length;
 	// a live query at chain-end could instead read a later, coinbase-grown
 	// staking-epoch snapshot if the run ever crossed an epoch boundary.
+	//
+	// This is a tolerance comparison, not exact equality or a ledger-hash
+	// identity: the daemon's staking-epoch ledger differs from genesis_ledger.json
+	// by the injected genesis-winner account (see totalCurrencyTolerance for the
+	// provenance), so the two account sets — and their Merkle roots — can never
+	// match exactly.
 	consensusTotal := analysis.GenesisBlock.StakingLedgerTotalCurrency
 	t.Logger.Info("Staking epoch ledger total currency per consensus: %d nanomina (genesis ledger file: %d nanomina)", consensusTotal, stats.TotalCurrency)
 	if math.Abs(float64(consensusTotal)-float64(stats.TotalCurrency)) > totalCurrencyTolerance*float64(consensusTotal) {

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -19,10 +19,11 @@ import (
 // independent across producers, so P(slot filled) = 1 - (1-f)^(sum of s_i).
 const vrfFillFraction = 0.75
 
-// Slack added on top of the modeled pre-fork fill rate to absorb VRF variance
-// over the ~30-slot measurement window (~1.7 sigma) and the stake the model
-// ignores (online balances, service accounts)
-const preForkFillMargin = 0.15
+// occupancyBandZ is the confidence multiplier for the derived occupancy margin:
+// the band is expected +/- z*sigma. z = 3 gives a ~0.27% two-sided single-window
+// false-fail budget, which the wide pre/post occupancy separation (~5 sigma at
+// n=30) easily affords.
+const occupancyBandZ = 3.0
 
 // Lower bar for the pre-fork occupancy: below this the network is considered
 // broken rather than diluted, and the comparison against the post-fork
@@ -211,9 +212,17 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 		return err
 	}
 	analysis.PreForkStakeStats = stats
-	upperBound, err := ExpectedPreForkFillUpperBound(stats)
+
+	sActive, err := preForkActiveShare(stats)
 	if err != nil {
 		return err
+	}
+	// n is the slot span the occupancy was measured over — the same denominator
+	// ComputeSlotOccupancy divides by — so the band margin tracks the window.
+	nPre := analysis.Consensus.LastBlockBeforeTxEnd.Slot - analysis.GenesisBlock.Slot
+	band, err := newOccupancyBand(expectedFillRate(sActive), nPre)
+	if err != nil {
+		return fmt.Errorf("failed to compute pre-fork occupancy band: %w", err)
 	}
 
 	// The fill bound is modeled on the genesis ledger file under the
@@ -237,13 +246,26 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	t.Logger.Info("Genesis stake: total currency %d, active producer stake %d, lazy stake %d (lazy portion %f)",
 		stats.TotalCurrency, stats.ActiveProducerStake, stats.LazyStake,
 		float64(stats.LazyStake)/float64(stats.TotalCurrency))
-	t.Logger.Info("Pre-fork slot occupancy: %f (expected below %f due to lazy whales)", occ, upperBound)
+	t.Logger.Info("Pre-fork slot occupancy: %f (model expects %f, band [%f, %f] over %d slots)",
+		occ, band.Expected, band.Lower, band.Upper, nPre)
 
+	// Liveness floor: a totally dead network is a distinct failure from a model
+	// mismatch, and if stake were grossly misclassified the model band itself
+	// could not be trusted to catch it — so keep an absolute, model-independent
+	// backstop.
 	if occ < preForkMinOccupancy {
-		return fmt.Errorf("pre-fork slot occupancy (%f) is below %f, network appears broken rather than diluted", occ, preForkMinOccupancy)
+		return fmt.Errorf("pre-fork slot occupancy (%f) is below the liveness floor %f; the network appears broken rather than diluted", occ, preForkMinOccupancy)
 	}
-	if occ >= upperBound {
-		return fmt.Errorf("pre-fork slot occupancy (%f) is not below the expected upper bound (%f), lazy whales are not diluting the VRF denominator", occ, upperBound)
+	// Two-sided band: reject "too low" as well as "too high". Too low means
+	// occupancy is more suppressed than dilution alone predicts — an active
+	// producer likely died or stake is misclassified. At the CI window length
+	// this lower edge is only a coarse guard; catching a single dead daemon
+	// reliably needs an independent liveness / active-stake check.
+	if occ < band.Lower {
+		return fmt.Errorf("pre-fork slot occupancy (%f) is below the model band lower edge (%f); occupancy is more suppressed than dilution predicts, so an active producer may have died or stake is misclassified", occ, band.Lower)
+	}
+	if occ > band.Upper {
+		return fmt.Errorf("pre-fork slot occupancy (%f) is above the model band upper edge (%f); the lazy whales are not diluting the VRF denominator as expected", occ, band.Upper)
 	}
 	return nil
 }
@@ -306,26 +328,96 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 		return fmt.Errorf("failed to compute post-fork slot occupancy: %w", err)
 	}
 
-	t.Logger.Info("Post-fork slot occupancy: %f (pre-fork was %f)", postOcc, analysis.PreForkOccupancy)
+	// Model-based lower bound: with the lazy stake unstaked, the active
+	// producers hold nearly the whole VRF denominator, so occupancy should
+	// recover to ExpectedPostForkFill (~0.75). n is the post-fork slot span,
+	// which is not epoch-capped, so a longer run tightens this bound and can
+	// catch a partial-unstaking regression that a flat 0.5 floor would pass.
+	sActivePost, err := postForkActiveShare(analysis.PreForkStakeStats)
+	if err != nil {
+		return err
+	}
+	nPost := bestTip.Slot - commonGenesisBlock.Slot
+	postBand, err := newOccupancyBand(expectedFillRate(sActivePost), nPost)
+	if err != nil {
+		return fmt.Errorf("failed to compute post-fork occupancy band: %w", err)
+	}
+
+	t.Logger.Info("Post-fork slot occupancy: %f (pre-fork was %f; model expects %f, lower bound %f over %d slots)",
+		postOcc, analysis.PreForkOccupancy, postBand.Expected, postBand.Lower, nPost)
 
 	if postOcc <= analysis.PreForkOccupancy {
 		return fmt.Errorf("post-fork slot occupancy (%f) did not improve on pre-fork occupancy (%f), unstaking the lazy whales had no effect", postOcc, analysis.PreForkOccupancy)
 	}
+	if postOcc < postBand.Lower {
+		return fmt.Errorf("post-fork slot occupancy (%f) is below the model lower bound (%f); unstaking did not restore occupancy to the level the undiluted active stake predicts (partial-unstaking regression)", postOcc, postBand.Lower)
+	}
+	// Retain the absolute >= 0.5 health bar as an additional coarse guard.
 	return t.ValidateSlotOccupancy(commonGenesisBlock, bestTip)
 }
 
-// ExpectedPreForkFillUpperBound bounds the pre-fork slot occupancy expected
-// while the lazy whales dilute the VRF denominator: the modeled fill rate for
-// the active stake share plus a slack margin. Pre-fork occupancy at or above
-// this bound means the dilution did not happen.
-func ExpectedPreForkFillUpperBound(s StakeStats) (float64, error) {
+// preForkActiveShare is the active producers' share of the pre-fork VRF
+// denominator: ActiveProducerStake / TotalCurrency.
+func preForkActiveShare(s StakeStats) (float64, error) {
 	if s.TotalCurrency == 0 {
-		return 0, fmt.Errorf("total currency is zero, cannot compute expected fill rate")
+		return 0, fmt.Errorf("total currency is zero, cannot compute active stake share")
 	}
-	sActive := float64(s.ActiveProducerStake) / float64(s.TotalCurrency)
-	bound := 1 - math.Pow(1-vrfFillFraction, sActive) + preForkFillMargin
-	if bound > 1 {
-		bound = 1
+	return float64(s.ActiveProducerStake) / float64(s.TotalCurrency), nil
+}
+
+// postForkActiveShare is the active producers' share of the VRF denominator
+// AFTER --unstake-pk removes the lazy whales' stake:
+// ActiveProducerStake / (TotalCurrency − LazyStake). The removed amount equals
+// LazyStake by the conservation identity, so the shrunken denominator is the
+// fork's staking-ledger total.
+func postForkActiveShare(s StakeStats) (float64, error) {
+	if s.LazyStake >= s.TotalCurrency {
+		return 0, fmt.Errorf("lazy stake (%d nanomina) is not below total currency (%d nanomina); the post-fork VRF denominator would be non-positive", s.LazyStake, s.TotalCurrency)
 	}
-	return bound, nil
+	return float64(s.ActiveProducerStake) / float64(s.TotalCurrency-s.LazyStake), nil
+}
+
+// occupancyBand is the model-derived acceptance band for a slot-occupancy
+// measurement: [Expected − Margin, Expected + Margin], each edge clamped to
+// [0,1]. Expected is the modeled fill rate p and Margin = windowMargin(p, n, z)
+// over the measured slot span.
+type occupancyBand struct {
+	Expected float64
+	Margin   float64
+	Lower    float64
+	Upper    float64
+}
+
+func newOccupancyBand(expected float64, nSlots int) (occupancyBand, error) {
+	margin, err := windowMargin(expected, nSlots, occupancyBandZ)
+	if err != nil {
+		return occupancyBand{}, err
+	}
+	return occupancyBand{
+		Expected: expected,
+		Margin:   margin,
+		Lower:    math.Max(0, expected-margin),
+		Upper:    math.Min(1, expected+margin),
+	}, nil
+}
+
+// expectedFillRate is the modeled probability that a slot is filled when the
+// active producers hold VRF-denominator share sActive: 1 - (1-f)^sActive, with
+// f = vrfFillFraction. This is the mean p of the per-slot Bernoulli(p) fill
+// process; the occupancy over a window is an estimator of it.
+func expectedFillRate(sActive float64) float64 {
+	return 1 - math.Pow(1-vrfFillFraction, sActive)
+}
+
+// windowMargin is the half-width of the occupancy band for a measurement window
+// of nSlots slots at confidence multiplier z: z * sqrt(p(1-p)/n), the z-sigma
+// spread of the window fill fraction under the iid-Bernoulli(p) model.
+// nSlots is the SLOT SPAN (the denominator ComputeSlotOccupancy divides by), not
+// a block count, so the margin is expressed in the same units as the occupancy
+// it bounds. Returns an error for a non-positive window.
+func windowMargin(p float64, nSlots int, z float64) (float64, error) {
+	if nSlots <= 0 {
+		return 0, fmt.Errorf("window length (%d slots) must be positive to compute an occupancy margin", nSlots)
+	}
+	return z * math.Sqrt(p*(1-p)/float64(nSlots)), nil
 }

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -237,6 +237,7 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	if err != nil {
 		return err
 	}
+	analysis.PreForkStakeStats = stats
 	upperBound, err := ExpectedPreForkFillUpperBound(stats)
 	if err != nil {
 		return err
@@ -269,10 +270,67 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	return nil
 }
 
-// validatePostForkOccupancyRecovered asserts that unstaking the lazy whales at
-// the fork restored the slot occupancy: it must beat the pre-fork occupancy
-// and clear the standard 50% health bar.
-func (t *HardforkTest) validatePostForkOccupancyRecovered(analysis *BlockAnalysisResult, commonGenesisBlock, bestTip client.BlockData) error {
+// UnstakedTotal computes the amount of currency the fork removed from the VRF
+// denominator: the pre-fork genesis total currency minus the fork network's
+// staking epoch ledger total. On a post-fork (v2) build the epoch ledger's
+// totalCurrency field carries total_stake, and the fork's staking epoch
+// ledger is exactly the pre-fork genesis ledger with the --unstake-pk patch
+// applied — the same ledger on both sides of the subtraction, so every staked
+// account (including the genesis winner) cancels and the difference is
+// exactly the unstaked balances. Note: the fork genesis block's own
+// totalCurrency must NOT be used as the minuend — it describes the staged
+// ledger at the fork block, which additionally contains the pre-fork coinbase
+// supply increase.
+func UnstakedTotal(preForkGenesis, forkGenesis client.BlockData) (uint64, error) {
+	// GraphQL Amount fields are raw nanomina integer strings (unlike the
+	// decimal-mina balances in the genesis ledger file)
+	total, err := strconv.ParseUint(preForkGenesis.TotalCurrency, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("total currency of pre-fork genesis block %s: %w", preForkGenesis.StateHash, err)
+	}
+	staked, err := strconv.ParseUint(forkGenesis.StakingLedgerTotalCurrency, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("staking ledger total currency of fork genesis block %s: %w", forkGenesis.StateHash, err)
+	}
+	if staked > total {
+		return 0, fmt.Errorf("fork staking ledger total (%d nanomina) exceeds pre-fork genesis total currency (%d nanomina)", staked, total)
+	}
+	return total - staked, nil
+}
+
+// validatePostForkUnstaking asserts that the fork actually removed the lazy
+// whales from the VRF denominator, then that slot occupancy recovered
+// accordingly. The deterministic checks come first: the conservation identity
+// (unstaked amount at fork genesis == the lazy whales' balances, exact) and
+// per-account delegate clearing; the occupancy comparisons then confirm the
+// behavioral consequence.
+func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, commonGenesisBlock, bestTip client.BlockData) error {
+	unstaked, err := UnstakedTotal(analysis.GenesisBlock, commonGenesisBlock)
+	if err != nil {
+		return fmt.Errorf("failed to compute unstaked total at fork genesis: %w", err)
+	}
+	lazy := analysis.PreForkStakeStats.LazyStake
+	t.Logger.Info("Fork genesis: unstaked amount %d nanomina, pre-fork lazy stake %d nanomina", unstaked, lazy)
+	if unstaked != lazy {
+		return fmt.Errorf("unstaked amount at fork genesis (%d nanomina) does not equal the lazy whales' stake (%d nanomina); the fork did not remove exactly the lazy stake from the VRF denominator", unstaked, lazy)
+	}
+
+	port := t.Config.AnyDaemon().Port(config.PORT_REST)
+	lazyPks, err := t.LazyWhalePks()
+	if err != nil {
+		return err
+	}
+	for _, pk := range lazyPks {
+		delegate, err := t.Client.AccountDelegate(port, pk)
+		if err != nil {
+			return fmt.Errorf("failed to query post-fork delegate of lazy whale %s: %w", pk, err)
+		}
+		if delegate != "" {
+			return fmt.Errorf("lazy whale %s still has delegate %s on the fork network, expected none", pk, delegate)
+		}
+	}
+	t.Logger.Info("All %d lazy whales are unstaked on the fork network", len(lazyPks))
+
 	postOcc, err := t.ComputeSlotOccupancy(commonGenesisBlock, bestTip)
 	if err != nil {
 		return fmt.Errorf("failed to compute post-fork slot occupancy: %w", err)

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -213,6 +213,21 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	}
 	analysis.PreForkStakeStats = stats
 
+	// The occupancy band is only as trustworthy as s_active, whose numerator
+	// (ActiveProducerStake) is derived entirely from the genesis ledger file and
+	// the running-producer key files. Cross-check that classification against
+	// on-chain evidence before trusting the band: the running-producer set must
+	// have the expected size, and every running producer must have actually
+	// produced a block (a static file cannot witness runtime liveness, and the
+	// occupancy lower band is too weak to catch a single dead active producer).
+	if len(producerPks) != t.Config.NumWhales+t.Config.NumFish {
+		return fmt.Errorf("running-producer set has %d keys, expected %d (NumWhales %d + NumFish %d); producer keys are duplicated or missing", len(producerPks), t.Config.NumWhales+t.Config.NumFish, t.Config.NumWhales, t.Config.NumFish)
+	}
+	if err := validateActiveProducerLiveness(producerPks, analysis.Consensus.ObservedProducerPks, stats); err != nil {
+		return err
+	}
+	t.Logger.Info("Active-producer cross-check passed: %d running producers all authored blocks in the pre-fork window", len(producerPks))
+
 	sActive, err := preForkActiveShare(stats)
 	if err != nil {
 		return err
@@ -359,6 +374,41 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 	}
 	// Retain the absolute >= 0.5 health bar as an additional coarse guard.
 	return t.ValidateSlotOccupancy(commonGenesisBlock, bestTip, bestTip.Slot)
+}
+
+// validateActiveProducerLiveness cross-checks the file-derived active-producer
+// classification against on-chain evidence. running is the set of producers the
+// harness expects to be live (from key files); observed is the set that
+// actually authored a block in the pre-fork window (block creators reported by
+// consensus). The two must be equal, and the stake partition must not
+// overcount. This is the independent check on the s_active numerator that the
+// 0.1% total-currency cross-check provides for the denominator.
+func validateActiveProducerLiveness(running, observed map[string]bool, stats StakeStats) error {
+	// Every running producer must have produced at least one block. A running
+	// producer that never appears as a creator is dead or misconfigured while
+	// its stake is still counted as active — occupancy would be suppressed with
+	// no dilution to explain it, which the occupancy lower band cannot reliably
+	// catch at the CI window length.
+	for pk := range running {
+		if !observed[pk] {
+			return fmt.Errorf("running producer %s authored no blocks in the pre-fork window; its stake is counted as active but it appears dead or misconfigured", pk)
+		}
+	}
+	// Every observed producer must be a known running producer. An unexpected
+	// block creator means the running-producer set is wrong, so the active-stake
+	// classification built from it cannot be trusted.
+	for pk := range observed {
+		if !running[pk] {
+			return fmt.Errorf("block creator %s is not in the expected running-producer set; the active-stake classification is unreliable", pk)
+		}
+	}
+	// Partition sanity: the active and lazy stake are disjoint subsets of the
+	// total, so their sum cannot exceed it. A violation means the classification
+	// double-counts stake.
+	if stats.ActiveProducerStake+stats.LazyStake > stats.TotalCurrency {
+		return fmt.Errorf("active producer stake (%d nanomina) + lazy stake (%d nanomina) exceeds total currency (%d nanomina); the stake classification overcounts", stats.ActiveProducerStake, stats.LazyStake, stats.TotalCurrency)
+	}
+	return nil
 }
 
 // preForkActiveShare is the active producers' share of the pre-fork VRF

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking.go
@@ -209,8 +209,14 @@ func ComputeStakeStats(genesisLedgerPath string, runningProducerPks, lazyPks map
 
 // validatePreForkOccupancyDiluted asserts that the pre-fork slot occupancy is
 // low because the lazy whales dilute the VRF denominator, while the network is
-// still alive. The measured occupancy is recorded on the analysis result for
-// the post-fork comparison.
+// still alive. This is *behavioral corroboration* that the dilution took
+// effect, not the primary proof — the exact conservation identity checked in
+// validatePostForkUnstaking is the proof. Occupancy is a probabilistic
+// measurement over a single window, so if these bounds ever flake the fix is to
+// widen the measurement window or sample more (the band already tracks the
+// window length), never to loosen them toward the deterministic identity. The
+// measured occupancy is recorded on the analysis result for the post-fork
+// comparison.
 func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisResult) error {
 	occ, err := t.ComputeSlotOccupancy(analysis.GenesisBlock, analysis.Consensus.LastBlockBeforeTxEnd, t.Config.SlotTxEnd)
 	if err != nil {
@@ -305,7 +311,7 @@ func (t *HardforkTest) validatePreForkOccupancyDiluted(analysis *BlockAnalysisRe
 	t.Logger.Info("Genesis stake: total currency %d, active producer stake %d, lazy stake %d (lazy portion %f)",
 		stats.TotalCurrency, stats.ActiveProducerStake, stats.LazyStake,
 		float64(stats.LazyStake)/float64(stats.TotalCurrency))
-	t.Logger.Info("Pre-fork slot occupancy: %f (model expects %f, band [%f, %f] over %d slots)",
+	t.Logger.Info("Pre-fork slot occupancy: %f (corroborating dilution; model expects %f, band [%f, %f] over %d slots)",
 		occ, band.Expected, band.Lower, band.Upper, nPre)
 
 	// Liveness floor: a totally dead network is a distinct failure from a model
@@ -351,10 +357,12 @@ func UnstakedTotal(preForkGenesis, forkGenesis client.BlockData) (currency.Nanom
 
 // validatePostForkUnstaking asserts that the fork actually removed the lazy
 // whales from the VRF denominator, then that slot occupancy recovered
-// accordingly. The deterministic checks come first: the conservation identity
-// (unstaked amount at fork genesis == the lazy whales' balances, exact) and
-// per-account delegate clearing; the occupancy comparisons then confirm the
-// behavioral consequence.
+// accordingly. The deterministic checks come first and ARE the proof: the
+// conservation identity (unstaked amount at fork genesis == the lazy whales'
+// balances, exact) and per-account delegate clearing. The occupancy
+// comparisons that follow only corroborate the behavioral consequence; being a
+// probabilistic measurement, a flaky occupancy check is a signal to widen the
+// window or add sampling, not a licence to relax the exact identity above.
 func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, commonGenesisBlock, bestTip client.BlockData) error {
 	unstaked, err := UnstakedTotal(analysis.GenesisBlock, commonGenesisBlock)
 	if err != nil {
@@ -403,7 +411,7 @@ func (t *HardforkTest) validatePostForkUnstaking(analysis *BlockAnalysisResult, 
 		return fmt.Errorf("failed to compute post-fork occupancy band: %w", err)
 	}
 
-	t.Logger.Info("Post-fork slot occupancy: %f (pre-fork was %f; model expects %f, lower bound %f over %d slots)",
+	t.Logger.Info("Post-fork slot occupancy: %f (corroborating the conservation identity; pre-fork was %f; model expects %f, lower bound %f over %d slots)",
 		postOcc, analysis.PreForkOccupancy, postBand.Expected, postBand.Lower, nPost)
 
 	if postOcc <= analysis.PreForkOccupancy {

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -137,6 +137,42 @@ func TestActiveShares(t *testing.T) {
 	}
 }
 
+func TestValidateActiveProducerLiveness(t *testing.T) {
+	t.Parallel()
+
+	// CI-shaped partition: active + lazy = total.
+	stats := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 285, LazyStake: 715}
+	running := map[string]bool{"A": true, "B": true}
+
+	// Both running producers produced blocks (plus an empty-slot signature is
+	// irrelevant): passes.
+	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, stats); err != nil {
+		t.Errorf("expected pass when every running producer authored a block, got %v", err)
+	}
+
+	// A running producer that never produced a block (B died): must fail.
+	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true}, stats); err == nil {
+		t.Error("expected failure when a running producer authored no blocks (dead producer)")
+	}
+
+	// A block creator that is not a known running producer: must fail.
+	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true, "C": true}, stats); err == nil {
+		t.Error("expected failure when an unexpected key produced a block (rogue producer)")
+	}
+
+	// Partition overcount: active + lazy exceeds total, even with liveness OK.
+	overcount := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 600, LazyStake: 500}
+	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, overcount); err == nil {
+		t.Error("expected failure when active + lazy stake exceeds total currency")
+	}
+
+	// Exact partition (active + lazy == total) is allowed.
+	exact := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 300, LazyStake: 700}
+	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, exact); err != nil {
+		t.Errorf("expected pass when active + lazy == total, got %v", err)
+	}
+}
+
 func TestNewOccupancyBand(t *testing.T) {
 	t.Parallel()
 

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -254,17 +254,27 @@ func TestOccupancyBandDecisions(t *testing.T) {
 func TestExpectedFillRate(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		sActive float64
-		want    float64
-	}{
-		{0.0, 0.0},                         // no active stake: no slot can be won
-		{1.0, vrfFillFraction},             // full stake active: saturates at f = 0.75
-		{0.285, 1 - math.Pow(0.25, 0.285)}, // CI config (2 active + 5 lazy whales)
+	// Boundary properties, expressed through the named constant rather than a
+	// recomputed copy of the fill formula:
+	//   sActive = 0 -> no slot can be won            -> 0
+	//   sActive = 1 -> saturates at the daemon's f   -> vrfFillFraction
+	if got := expectedFillRate(0); got != 0 {
+		t.Errorf("expectedFillRate(0) = %f, want 0", got)
 	}
-	for _, tc := range cases {
-		if got := expectedFillRate(tc.sActive); math.Abs(got-tc.want) > 1e-9 {
-			t.Errorf("expectedFillRate(%f) = %f, want %f", tc.sActive, got, tc.want)
+	if got := expectedFillRate(1); math.Abs(got-vrfFillFraction) > 1e-9 {
+		t.Errorf("expectedFillRate(1) = %f, want vrfFillFraction %f", got, vrfFillFraction)
+	}
+
+	// For interior shares (incl. the CI config's ~0.285), cross-check by
+	// INVERTING the model instead of re-evaluating it: the per-slot miss
+	// probability (1 - fill) raised to the 1/sActive power must recover the
+	// daemon's (1 - f). This references vrfFillFraction and is independent of how
+	// expectedFillRate computes the forward direction, so it is not a
+	// f(x) == f(x) tautology.
+	for _, s := range []float64{0.1, 0.285, 0.6} {
+		miss := 1 - expectedFillRate(s)
+		if got := math.Pow(miss, 1/s); math.Abs(got-(1-vrfFillFraction)) > 1e-9 {
+			t.Errorf("inverting expectedFillRate(%f): (1-fill)^(1/s) = %f, want 1-f = %f", s, got, 1-vrfFillFraction)
 		}
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -127,6 +127,35 @@ func TestExpectedPreForkFillUpperBound(t *testing.T) {
 	}
 }
 
+func TestUnstakedTotal(t *testing.T) {
+	t.Parallel()
+
+	// GraphQL Amounts are raw nanomina integer strings. The minuend is the
+	// PRE-FORK genesis total (the fork genesis block's own totalCurrency
+	// additionally contains pre-fork coinbases and must not be used).
+	preFork := client.BlockData{TotalCurrency: "80853498000000000"}
+	forkGenesis := client.BlockData{StakingLedgerTotalCurrency: "23103498000000000"}
+	got, err := UnstakedTotal(preFork, forkGenesis)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := uint64(57_750_000_000_000_000); got != want {
+		t.Errorf("UnstakedTotal = %d, want %d", got, want)
+	}
+
+	// Missing fields (e.g. build that doesn't serve them) must error
+	if _, err := UnstakedTotal(client.BlockData{}, client.BlockData{}); err == nil {
+		t.Error("expected error for empty amounts")
+	}
+	// Fork staking total above the pre-fork genesis total is nonsense
+	if _, err := UnstakedTotal(
+		client.BlockData{TotalCurrency: "100"},
+		client.BlockData{StakingLedgerTotalCurrency: "101"},
+	); err == nil {
+		t.Error("expected error when staked exceeds total")
+	}
+}
+
 func writePubkey(t *testing.T, dir, name, pk string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -1,0 +1,212 @@
+package hardfork
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/utils"
+)
+
+func testHarness(cfg *config.Config) *HardforkTest {
+	return &HardforkTest{Config: cfg, Logger: utils.NewLogger()}
+}
+
+func TestParseNanominas(t *testing.T) {
+	t.Parallel()
+
+	valid := []struct {
+		in   string
+		want uint64
+	}{
+		{"0.000000000", 0},
+		{"11550000.000000000", 11_550_000_000_000_000},
+		{"499.000000000", 499_000_000_000},
+		{"0.000000001", 1},
+		{"1", 1_000_000_000},
+		{"65500.5", 65_500_500_000_000},
+	}
+	for _, tc := range valid {
+		got, err := parseNanominas(tc.in)
+		if err != nil {
+			t.Errorf("parseNanominas(%q) errored: %v", tc.in, err)
+		} else if got != tc.want {
+			t.Errorf("parseNanominas(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	invalid := []string{"", "abc", "1.0000000001", "-1.0", "1.2.3"}
+	for _, in := range invalid {
+		if _, err := parseNanominas(in); err == nil {
+			t.Errorf("parseNanominas(%q) should have errored", in)
+		}
+	}
+}
+
+func TestComputeSlotOccupancy(t *testing.T) {
+	t.Parallel()
+	ht := testHarness(config.DefaultConfig())
+
+	occ, err := ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 1, Slot: 0},
+		client.BlockData{BlockHeight: 16, Slot: 30},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if occ != 0.5 {
+		t.Errorf("occupancy = %f, want 0.5", occ)
+	}
+
+	if _, err := ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 5, Slot: 0},
+		client.BlockData{BlockHeight: 5, Slot: 30},
+	); err == nil {
+		t.Error("expected error when start and last block have the same height")
+	}
+}
+
+func TestExpectedPreForkFillUpperBound(t *testing.T) {
+	t.Parallel()
+
+	// Full stake active: bound saturates at 1 - 0.25^1 + margin = 0.9
+	bound, err := ExpectedPreForkFillUpperBound(StakeStats{TotalCurrency: 100, ActiveProducerStake: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(bound-0.9) > 1e-9 {
+		t.Errorf("bound = %f, want 0.9", bound)
+	}
+
+	// ~28.5% active (the CI configuration: 2 active + 5 lazy whales):
+	// 1 - 0.25^0.285 + 0.15
+	stats := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 285, LazyStake: 715}
+	bound, err = ExpectedPreForkFillUpperBound(stats)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := 1 - math.Pow(0.25, 0.285) + 0.15
+	if math.Abs(bound-want) > 1e-9 {
+		t.Errorf("bound = %f, want %f", bound, want)
+	}
+	if bound < 0 || bound > 1 || math.IsNaN(bound) {
+		t.Errorf("bound = %f, want a non-NaN value in [0,1]", bound)
+	}
+
+	// No active stake: bound = margin
+	bound, err = ExpectedPreForkFillUpperBound(StakeStats{TotalCurrency: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(bound-preForkFillMargin) > 1e-9 {
+		t.Errorf("bound = %f, want %f", bound, preForkFillMargin)
+	}
+
+	// Zero total currency must error, not return NaN
+	if _, err := ExpectedPreForkFillUpperBound(StakeStats{}); err == nil {
+		t.Error("expected error for zero total currency")
+	}
+}
+
+func writePubkey(t *testing.T, dir, name, pk string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(pk+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLazyWhalePksAndComputeStakeStats(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg := config.DefaultConfig()
+	cfg.Root = root
+	cfg.NumWhales = 1
+	cfg.NumLazyWhales = 2
+	cfg.NumFish = 0
+	ht := testHarness(cfg)
+
+	// Whale 0 is active, whales 1 and 2 are lazy
+	for i, pk := range []string{"B62qoffline0", "B62qoffline1", "B62qoffline2"} {
+		writePubkey(t, filepath.Join(root, "offline_whale_keys"), strings.Replace("offline_whale_account_X.pub", "X", string(rune('0'+i)), 1), pk)
+	}
+	for i, pk := range []string{"B62qonline0", "B62qonline1", "B62qonline2"} {
+		writePubkey(t, filepath.Join(root, "online_whale_keys"), strings.Replace("online_whale_account_X.pub", "X", string(rune('0'+i)), 1), pk)
+	}
+
+	producerPks, err := ht.RunningProducerPks()
+	if err != nil {
+		t.Fatalf("RunningProducerPks: %v", err)
+	}
+	if len(producerPks) != 1 || !producerPks["B62qonline0"] {
+		t.Fatalf("RunningProducerPks = %v, want {B62qonline0}", producerPks)
+	}
+
+	online := func(pk string) *string { return &pk }
+	ledger := genesisLedgerFile{Accounts: []genesisLedgerAccount{
+		// The generator pairs offline/online keys in glob order, so the
+		// pairing may not follow the filename indices: here offline1 (not
+		// offline0) happens to be the account delegated to the running
+		// producer. Lazy classification must follow the ledger, not indices.
+		{Pk: "B62qoffline1", Balance: "11550000.000000000", Delegate: online("B62qonline0")},
+		{Pk: "B62qonline0", Balance: "499.000000000", Delegate: nil}, // self-delegates to a running producer
+		// Lazy whale pairs: delegated to producers that never run
+		{Pk: "B62qoffline0", Balance: "11550000.000000000", Delegate: online("B62qonline1")},
+		{Pk: "B62qonline1", Balance: "499.000000000", Delegate: nil},
+		{Pk: "B62qoffline2", Balance: "11550000.000000000", Delegate: online("B62qonline2")},
+		{Pk: "B62qonline2", Balance: "499.000000000", Delegate: nil},
+		// Service account, delegate to nobody relevant
+		{Pk: "B62qfaucet", Balance: "100000.000000000", Delegate: nil},
+	}}
+	data, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerPath := filepath.Join(root, "genesis_ledger.json")
+	if err := os.WriteFile(ledgerPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lazyPks, err := ht.LazyWhalePks()
+	if err != nil {
+		t.Fatalf("LazyWhalePks: %v", err)
+	}
+	if len(lazyPks) != 2 || lazyPks[0] != "B62qoffline0" || lazyPks[1] != "B62qoffline2" {
+		t.Fatalf("LazyWhalePks = %v, want [B62qoffline0 B62qoffline2]", lazyPks)
+	}
+
+	// A count mismatch (e.g. a missing lazy whale account) must error
+	cfg.NumLazyWhales = 3
+	if _, err := ht.LazyWhalePks(); err == nil {
+		t.Error("expected error when the ledger contains fewer lazy whales than configured")
+	}
+	cfg.NumLazyWhales = 2
+
+	lazySet := map[string]bool{"B62qoffline0": true, "B62qoffline2": true}
+	stats, err := ComputeStakeStats(ledgerPath, producerPks, lazySet)
+	if err != nil {
+		t.Fatalf("ComputeStakeStats: %v", err)
+	}
+
+	const mina = uint64(1_000_000_000)
+	wantTotal := (3*11_550_000 + 3*499 + 100_000) * mina
+	wantActive := (11_550_000 + 499) * mina
+	wantLazy := 2 * 11_550_000 * mina
+	if stats.TotalCurrency != wantTotal {
+		t.Errorf("TotalCurrency = %d, want %d", stats.TotalCurrency, wantTotal)
+	}
+	if stats.ActiveProducerStake != wantActive {
+		t.Errorf("ActiveProducerStake = %d, want %d", stats.ActiveProducerStake, wantActive)
+	}
+	if stats.LazyStake != wantLazy {
+		t.Errorf("LazyStake = %d, want %d", stats.LazyStake, wantLazy)
+	}
+}

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -55,45 +55,196 @@ func TestComputeSlotOccupancy(t *testing.T) {
 	}
 }
 
-func TestExpectedPreForkFillUpperBound(t *testing.T) {
+func TestActiveShares(t *testing.T) {
 	t.Parallel()
 
-	// Full stake active: bound saturates at 1 - 0.25^1 + margin = 0.9
-	bound, err := ExpectedPreForkFillUpperBound(StakeStats{TotalCurrency: 100, ActiveProducerStake: 100})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if math.Abs(bound-0.9) > 1e-9 {
-		t.Errorf("bound = %f, want 0.9", bound)
-	}
-
-	// ~28.5% active (the CI configuration: 2 active + 5 lazy whales):
-	// 1 - 0.25^0.285 + 0.15
+	// CI-shaped config: 28.5% active pre-fork; after unstaking the 71.5% lazy
+	// stake the active share is nearly the whole remaining denominator.
 	stats := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 285, LazyStake: 715}
-	bound, err = ExpectedPreForkFillUpperBound(stats)
+
+	pre, err := preForkActiveShare(stats)
+	if err != nil {
+		t.Fatalf("preForkActiveShare: %v", err)
+	}
+	if math.Abs(pre-0.285) > 1e-9 {
+		t.Errorf("preForkActiveShare = %f, want 0.285", pre)
+	}
+
+	post, err := postForkActiveShare(stats)
+	if err != nil {
+		t.Fatalf("postForkActiveShare: %v", err)
+	}
+	if want := 285.0 / (1000.0 - 715.0); math.Abs(post-want) > 1e-9 {
+		t.Errorf("postForkActiveShare = %f, want %f", post, want)
+	}
+	// Post-fork share must exceed pre-fork share (denominator shrank).
+	if post <= pre {
+		t.Errorf("post-fork active share %f should exceed pre-fork %f", post, pre)
+	}
+
+	// Zero total currency must error, not divide by zero.
+	if _, err := preForkActiveShare(StakeStats{}); err == nil {
+		t.Error("expected error for zero total currency (pre)")
+	}
+	// Lazy stake >= total would make the post-fork denominator non-positive.
+	if _, err := postForkActiveShare(StakeStats{TotalCurrency: 100, LazyStake: 100}); err == nil {
+		t.Error("expected error when lazy stake is not below total currency")
+	}
+}
+
+func TestNewOccupancyBand(t *testing.T) {
+	t.Parallel()
+
+	// Band is centered on Expected with half-width windowMargin, clamped to [0,1].
+	band, err := newOccupancyBand(0.324, 30)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := 1 - math.Pow(0.25, 0.285) + 0.15
-	if math.Abs(bound-want) > 1e-9 {
-		t.Errorf("bound = %f, want %f", bound, want)
+	wantMargin, _ := windowMargin(0.324, 30, occupancyBandZ)
+	if math.Abs(band.Margin-wantMargin) > 1e-9 {
+		t.Errorf("Margin = %f, want %f", band.Margin, wantMargin)
 	}
-	if bound < 0 || bound > 1 || math.IsNaN(bound) {
-		t.Errorf("bound = %f, want a non-NaN value in [0,1]", bound)
+	if math.Abs(band.Lower-(0.324-wantMargin)) > 1e-9 || math.Abs(band.Upper-(0.324+wantMargin)) > 1e-9 {
+		t.Errorf("band = [%f, %f], want [%f, %f]", band.Lower, band.Upper, 0.324-wantMargin, 0.324+wantMargin)
 	}
 
-	// No active stake: bound = margin
-	bound, err = ExpectedPreForkFillUpperBound(StakeStats{TotalCurrency: 100})
+	// Edges clamp to [0,1]: a huge margin cannot push Lower below 0 or Upper above 1.
+	wide, err := newOccupancyBand(0.75, 1) // margin = 3*sqrt(0.1875) ~= 1.3 > 0.75
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if math.Abs(bound-preForkFillMargin) > 1e-9 {
-		t.Errorf("bound = %f, want %f", bound, preForkFillMargin)
+	if wide.Lower < 0 || wide.Upper > 1 {
+		t.Errorf("band edges not clamped: [%f, %f]", wide.Lower, wide.Upper)
 	}
 
-	// Zero total currency must error, not return NaN
-	if _, err := ExpectedPreForkFillUpperBound(StakeStats{}); err == nil {
-		t.Error("expected error for zero total currency")
+	// Non-positive window propagates the windowMargin error.
+	if _, err := newOccupancyBand(0.324, 0); err == nil {
+		t.Error("expected error for a zero-slot window")
+	}
+}
+
+// TestOccupancyBandDecisions exercises the assembled pre/post-fork bounds
+// against representative occupancy values: in-band pass, too-high / too-low
+// fail, and the partial-recovery case whose detection depends on window length.
+func TestOccupancyBandDecisions(t *testing.T) {
+	t.Parallel()
+
+	stats := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 285, LazyStake: 715}
+
+	// Pre-fork band (~0.324 expected) over a 30-slot window.
+	sPre, _ := preForkActiveShare(stats)
+	pre, err := newOccupancyBand(expectedFillRate(sPre), 30)
+	if err != nil {
+		t.Fatalf("pre band: %v", err)
+	}
+	if !(pre.Lower < 0.33 && 0.33 < pre.Upper) {
+		t.Errorf("expected 0.33 in pre band [%f, %f]", pre.Lower, pre.Upper)
+	}
+	if 0.62 <= pre.Upper {
+		t.Errorf("expected 0.62 above pre band upper %f (dilution-didn't-take)", pre.Upper)
+	}
+	if 0.05 >= pre.Lower {
+		t.Errorf("expected 0.05 below pre band lower %f (over-suppressed)", pre.Lower)
+	}
+
+	// Post-fork lower bound (~0.75 expected). At n=30 the bound is ~0.51, so a
+	// 0.55 partial recovery still passes; a longer n=60 window tightens the
+	// bound above 0.55 and catches it.
+	sPost, _ := postForkActiveShare(stats)
+	post30, err := newOccupancyBand(expectedFillRate(sPost), 30)
+	if err != nil {
+		t.Fatalf("post band n=30: %v", err)
+	}
+	if !(0.55 >= post30.Lower) {
+		t.Errorf("at n=30 the 0.55 partial recovery should pass (lower %f)", post30.Lower)
+	}
+	post60, err := newOccupancyBand(expectedFillRate(sPost), 60)
+	if err != nil {
+		t.Fatalf("post band n=60: %v", err)
+	}
+	if !(0.55 < post60.Lower) {
+		t.Errorf("at n=60 the 0.55 partial recovery should fail (lower %f)", post60.Lower)
+	}
+	if post60.Lower >= post60.Expected {
+		t.Errorf("post lower bound %f should be below expected %f", post60.Lower, post60.Expected)
+	}
+}
+
+func TestExpectedFillRate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		sActive float64
+		want    float64
+	}{
+		{0.0, 0.0},                         // no active stake: no slot can be won
+		{1.0, vrfFillFraction},             // full stake active: saturates at f = 0.75
+		{0.285, 1 - math.Pow(0.25, 0.285)}, // CI config (2 active + 5 lazy whales)
+	}
+	for _, tc := range cases {
+		if got := expectedFillRate(tc.sActive); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("expectedFillRate(%f) = %f, want %f", tc.sActive, got, tc.want)
+		}
+	}
+
+	// Monotonic increasing in the active share
+	prev := expectedFillRate(0)
+	for _, s := range []float64{0.1, 0.3, 0.5, 0.9, 1.0} {
+		cur := expectedFillRate(s)
+		if cur <= prev {
+			t.Errorf("expectedFillRate not increasing: f(%f)=%f <= previous %f", s, cur, prev)
+		}
+		prev = cur
+	}
+}
+
+func TestWindowMargin(t *testing.T) {
+	t.Parallel()
+
+	// CI config sanity check: sActive ~= 0.285, n = 30, z = 3.
+	// p ~= 0.324, sigma = sqrt(p(1-p)/30) ~= 0.0855, margin ~= 0.256.
+	p := expectedFillRate(0.285)
+	margin, err := windowMargin(p, 30, occupancyBandZ)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := occupancyBandZ * math.Sqrt(p*(1-p)/30)
+	if math.Abs(margin-want) > 1e-9 {
+		t.Errorf("windowMargin(%f, 30, %f) = %f, want %f", p, occupancyBandZ, margin, want)
+	}
+	if margin < 0.24 || margin > 0.27 {
+		t.Errorf("CI-config margin = %f, expected ~0.256", margin)
+	}
+
+	// Monotonic decreasing in n: a longer window gives a tighter band.
+	var last float64 = math.Inf(1)
+	for _, n := range []int{5, 10, 30, 90, 200} {
+		m, err := windowMargin(p, n, occupancyBandZ)
+		if err != nil {
+			t.Fatalf("unexpected error at n=%d: %v", n, err)
+		}
+		if m >= last {
+			t.Errorf("margin not decreasing in n: margin(n=%d)=%f >= previous %f", n, m, last)
+		}
+		last = m
+	}
+
+	// Edge: p = 0 (sActive = 0) and p = 1 both give zero variance, zero margin.
+	for _, edge := range []float64{0.0, 1.0} {
+		m, err := windowMargin(edge, 30, occupancyBandZ)
+		if err != nil {
+			t.Fatalf("unexpected error for p=%f: %v", edge, err)
+		}
+		if math.Abs(m) > 1e-9 {
+			t.Errorf("windowMargin(%f, 30, z) = %f, want 0", edge, m)
+		}
+	}
+
+	// Non-positive window must error, not divide by zero or return NaN.
+	for _, n := range []int{0, -1} {
+		if _, err := windowMargin(p, n, occupancyBandZ); err == nil {
+			t.Errorf("windowMargin(p, %d, z) should have errored", n)
+		}
 	}
 }
 

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -69,6 +69,20 @@ func TestComputeSlotOccupancy(t *testing.T) {
 	); err == nil {
 		t.Error("expected error when start and last block have the same height")
 	}
+
+	// Swapped arguments must error, not return a negative or infinite value
+	if _, err := ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 16, Slot: 30},
+		client.BlockData{BlockHeight: 1, Slot: 0},
+	); err == nil {
+		t.Error("expected error when last block is not after starting block")
+	}
+	if _, err := ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 1, Slot: 10},
+		client.BlockData{BlockHeight: 5, Slot: 10},
+	); err == nil {
+		t.Error("expected error when both blocks are at the same slot")
+	}
 }
 
 func TestExpectedPreForkFillUpperBound(t *testing.T) {

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -22,9 +22,12 @@ func TestComputeSlotOccupancy(t *testing.T) {
 	t.Parallel()
 	ht := testHarness(config.DefaultConfig())
 
+	// Genesis anchor at height 1 / slot 0 excluded from the denominator; 15
+	// blocks over the (0, 30] window = 0.5.
 	occ, err := ht.ComputeSlotOccupancy(
 		client.BlockData{BlockHeight: 1, Slot: 0},
 		client.BlockData{BlockHeight: 16, Slot: 30},
+		30,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -33,9 +36,39 @@ func TestComputeSlotOccupancy(t *testing.T) {
 		t.Errorf("occupancy = %f, want 0.5", occ)
 	}
 
+	// The boundary, not the last block, sets the denominator. The last block
+	// sits at slot 28 but the window runs to slot 30, so the two empty trailing
+	// slots must lower occupancy (15/30 = 0.5), not be dropped (15/28 ≈ 0.536).
+	occ, err = ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 1, Slot: 0},
+		client.BlockData{BlockHeight: 16, Slot: 28},
+		30,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if occ != 0.5 {
+		t.Errorf("occupancy with trailing empty slots = %f, want 0.5 (empty slots must not be dropped)", occ)
+	}
+
+	// A fully filled window is 1.0: every slot after the genesis anchor produced
+	// a block, and the last block coincides with the boundary.
+	occ, err = ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 1, Slot: 0},
+		client.BlockData{BlockHeight: 31, Slot: 30},
+		30,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if occ != 1.0 {
+		t.Errorf("fully filled window occupancy = %f, want 1.0", occ)
+	}
+
 	if _, err := ht.ComputeSlotOccupancy(
 		client.BlockData{BlockHeight: 5, Slot: 0},
 		client.BlockData{BlockHeight: 5, Slot: 30},
+		30,
 	); err == nil {
 		t.Error("expected error when start and last block have the same height")
 	}
@@ -44,14 +77,26 @@ func TestComputeSlotOccupancy(t *testing.T) {
 	if _, err := ht.ComputeSlotOccupancy(
 		client.BlockData{BlockHeight: 16, Slot: 30},
 		client.BlockData{BlockHeight: 1, Slot: 0},
+		30,
 	); err == nil {
 		t.Error("expected error when last block is not after starting block")
 	}
 	if _, err := ht.ComputeSlotOccupancy(
 		client.BlockData{BlockHeight: 1, Slot: 10},
 		client.BlockData{BlockHeight: 5, Slot: 10},
+		30,
 	); err == nil {
 		t.Error("expected error when both blocks are at the same slot")
+	}
+
+	// A boundary before the last observed block is a caller error: blocks would
+	// live past the window boundary and the numerator would over-count.
+	if _, err := ht.ComputeSlotOccupancy(
+		client.BlockData{BlockHeight: 1, Slot: 0},
+		client.BlockData{BlockHeight: 16, Slot: 30},
+		28,
+	); err == nil {
+		t.Error("expected error when boundary slot is before the last block's slot")
 	}
 }
 

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -10,42 +10,12 @@ import (
 
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/client"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/config"
+	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/currency"
 	"github.com/MinaProtocol/mina/src/app/hardfork_test/src/internal/utils"
 )
 
 func testHarness(cfg *config.Config) *HardforkTest {
 	return &HardforkTest{Config: cfg, Logger: utils.NewLogger()}
-}
-
-func TestParseNanominas(t *testing.T) {
-	t.Parallel()
-
-	valid := []struct {
-		in   string
-		want uint64
-	}{
-		{"0.000000000", 0},
-		{"11550000.000000000", 11_550_000_000_000_000},
-		{"499.000000000", 499_000_000_000},
-		{"0.000000001", 1},
-		{"1", 1_000_000_000},
-		{"65500.5", 65_500_500_000_000},
-	}
-	for _, tc := range valid {
-		got, err := parseNanominas(tc.in)
-		if err != nil {
-			t.Errorf("parseNanominas(%q) errored: %v", tc.in, err)
-		} else if got != tc.want {
-			t.Errorf("parseNanominas(%q) = %d, want %d", tc.in, got, tc.want)
-		}
-	}
-
-	invalid := []string{"", "abc", "1.0000000001", "-1.0", "1.2.3"}
-	for _, in := range invalid {
-		if _, err := parseNanominas(in); err == nil {
-			t.Errorf("parseNanominas(%q) should have errored", in)
-		}
-	}
 }
 
 func TestComputeSlotOccupancy(t *testing.T) {
@@ -130,27 +100,24 @@ func TestExpectedPreForkFillUpperBound(t *testing.T) {
 func TestUnstakedTotal(t *testing.T) {
 	t.Parallel()
 
-	// GraphQL Amounts are raw nanomina integer strings. The minuend is the
-	// PRE-FORK genesis total (the fork genesis block's own totalCurrency
-	// additionally contains pre-fork coinbases and must not be used).
-	preFork := client.BlockData{TotalCurrency: "80853498000000000"}
-	forkGenesis := client.BlockData{StakingLedgerTotalCurrency: "23103498000000000"}
+	// BlockData amounts are nanomina uint64s, parsed from the GraphQL string
+	// scalars at construction. The minuend is the PRE-FORK genesis total (the
+	// fork genesis block's own totalCurrency additionally contains pre-fork
+	// coinbases and must not be used).
+	preFork := client.BlockData{TotalCurrency: 80853498000000000}
+	forkGenesis := client.BlockData{StakingLedgerTotalCurrency: 23103498000000000}
 	got, err := UnstakedTotal(preFork, forkGenesis)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if want := uint64(57_750_000_000_000_000); got != want {
+	if want := currency.Nanomina(57_750_000_000_000_000); got != want {
 		t.Errorf("UnstakedTotal = %d, want %d", got, want)
 	}
 
-	// Missing fields (e.g. build that doesn't serve them) must error
-	if _, err := UnstakedTotal(client.BlockData{}, client.BlockData{}); err == nil {
-		t.Error("expected error for empty amounts")
-	}
 	// Fork staking total above the pre-fork genesis total is nonsense
 	if _, err := UnstakedTotal(
-		client.BlockData{TotalCurrency: "100"},
-		client.BlockData{StakingLedgerTotalCurrency: "101"},
+		client.BlockData{TotalCurrency: 100},
+		client.BlockData{StakingLedgerTotalCurrency: 101},
 	); err == nil {
 		t.Error("expected error when staked exceeds total")
 	}
@@ -194,7 +161,16 @@ func TestLazyWhalePksAndComputeStakeStats(t *testing.T) {
 	}
 
 	online := func(pk string) *string { return &pk }
-	ledger := genesisLedgerFile{Accounts: []genesisLedgerAccount{
+	// Build the ledger file with its real on-disk shape: balances are decimal
+	// *mina* strings (ComputeStakeStats parses them to nanomina on read).
+	type rawAccount struct {
+		Pk       string  `json:"pk"`
+		Balance  string  `json:"balance"`
+		Delegate *string `json:"delegate"`
+	}
+	ledger := struct {
+		Accounts []rawAccount `json:"accounts"`
+	}{Accounts: []rawAccount{
 		// The generator pairs offline/online keys in glob order, so the
 		// pairing may not follow the filename indices: here offline1 (not
 		// offline0) happens to be the account delegated to the running
@@ -239,10 +215,9 @@ func TestLazyWhalePksAndComputeStakeStats(t *testing.T) {
 		t.Fatalf("ComputeStakeStats: %v", err)
 	}
 
-	const mina = uint64(1_000_000_000)
-	wantTotal := (3*11_550_000 + 3*499 + 100_000) * mina
-	wantActive := (11_550_000 + 499) * mina
-	wantLazy := 2 * 11_550_000 * mina
+	wantTotal := (3*11_550_000 + 3*499 + 100_000) * currency.Mina
+	wantActive := (11_550_000 + 499) * currency.Mina
+	wantLazy := 2 * 11_550_000 * currency.Mina
 	if stats.TotalCurrency != wantTotal {
 		t.Errorf("TotalCurrency = %d, want %d", stats.TotalCurrency, wantTotal)
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
+++ b/src/app/hardfork_test/src/internal/hardfork/unstaking_test.go
@@ -142,33 +142,33 @@ func TestValidateActiveProducerLiveness(t *testing.T) {
 
 	// CI-shaped partition: active + lazy = total.
 	stats := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 285, LazyStake: 715}
-	running := map[string]bool{"A": true, "B": true}
+	running := map[string]struct{}{"A": {}, "B": {}}
 
 	// Both running producers produced blocks (plus an empty-slot signature is
 	// irrelevant): passes.
-	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, stats); err != nil {
+	if err := validateActiveProducerLiveness(running, map[string]struct{}{"A": {}, "B": {}}, stats); err != nil {
 		t.Errorf("expected pass when every running producer authored a block, got %v", err)
 	}
 
 	// A running producer that never produced a block (B died): must fail.
-	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true}, stats); err == nil {
+	if err := validateActiveProducerLiveness(running, map[string]struct{}{"A": {}}, stats); err == nil {
 		t.Error("expected failure when a running producer authored no blocks (dead producer)")
 	}
 
 	// A block creator that is not a known running producer: must fail.
-	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true, "C": true}, stats); err == nil {
+	if err := validateActiveProducerLiveness(running, map[string]struct{}{"A": {}, "B": {}, "C": {}}, stats); err == nil {
 		t.Error("expected failure when an unexpected key produced a block (rogue producer)")
 	}
 
 	// Partition overcount: active + lazy exceeds total, even with liveness OK.
 	overcount := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 600, LazyStake: 500}
-	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, overcount); err == nil {
+	if err := validateActiveProducerLiveness(running, map[string]struct{}{"A": {}, "B": {}}, overcount); err == nil {
 		t.Error("expected failure when active + lazy stake exceeds total currency")
 	}
 
 	// Exact partition (active + lazy == total) is allowed.
 	exact := StakeStats{TotalCurrency: 1000, ActiveProducerStake: 300, LazyStake: 700}
-	if err := validateActiveProducerLiveness(running, map[string]bool{"A": true, "B": true}, exact); err != nil {
+	if err := validateActiveProducerLiveness(running, map[string]struct{}{"A": {}, "B": {}}, exact); err != nil {
 		t.Errorf("expected pass when active + lazy == total, got %v", err)
 	}
 }
@@ -388,7 +388,7 @@ func TestLazyWhalePksAndComputeStakeStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunningProducerPks: %v", err)
 	}
-	if len(producerPks) != 1 || !producerPks["B62qonline0"] {
+	if _, ok := producerPks["B62qonline0"]; len(producerPks) != 1 || !ok {
 		t.Fatalf("RunningProducerPks = %v, want {B62qonline0}", producerPks)
 	}
 
@@ -441,7 +441,7 @@ func TestLazyWhalePksAndComputeStakeStats(t *testing.T) {
 	}
 	cfg.NumLazyWhales = 2
 
-	lazySet := map[string]bool{"B62qoffline0": true, "B62qoffline2": true}
+	lazySet := map[string]struct{}{"B62qoffline0": {}, "B62qoffline2": {}}
 	stats, err := ComputeStakeStats(ledgerPath, producerPks, lazySet)
 	if err != nil {
 		t.Fatalf("ComputeStakeStats: %v", err)

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -281,6 +281,17 @@ func (t *HardforkTest) ConsensusAcrossNodesAfterSlotChainEnd() (*ConsensusState,
 		state := states[i]
 		last_state := states[i-1]
 
+		// Cross-node agreement on LastBlockBeforeTxEnd is the fork base's
+		// canonicality guarantee for this test. The daemon anchors the fork on
+		// that block (mina_lib.ml best_chain_block_before_stop_slot) and builds
+		// the fork config treating it as finalized regardless of how deeply it is
+		// buried ("We pretend that the block is finalized ... for redundancy",
+		// mina_lib.ml). So the fork does NOT require the tx-end block to reach
+		// k-depth in the (tx-end, chain-end] wind-down; at the CI gap (8 slots,
+		// p ~= 0.33) that window often produces fewer than k = 10 blocks anyway,
+		// so a ">= k deep" burial assertion would be both unwarranted and flaky.
+		// All nodes converging on the same block after chain-end is what makes it
+		// effectively canonical here.
 		if state.LastBlockBeforeTxEnd != last_state.LastBlockBeforeTxEnd {
 			return nil, fmt.Errorf(
 				"Node %s and node %s doesn't agree on last block seen before tx end! The previous has %v while the later has %v",

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -29,6 +29,12 @@ type BlockAnalysisResult struct {
 	// them (only populated in unstaking test mode)
 	PreForkOccupancy  float64
 	PreForkStakeStats StakeStats
+	// Lazy whale public keys, classified once against the genesis ledger during
+	// the main network phase and reused by the fork phases (fork-config
+	// --unstake-pk args and the post-fork delegate check) rather than
+	// re-reading the key files and ledger each time. Only populated in
+	// unstaking test mode.
+	LazyWhalePks []string
 }
 
 func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool, predDescription string, timeout time.Duration) error {

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -49,12 +49,17 @@ func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool
 }
 
 // ComputeSlotOccupancy computes the fraction of slots between two blocks that
-// are occupied by a block
+// are occupied by a block. startBlock must be an ancestor of lastBlock: block
+// heights are dense along a chain, so the height delta counts exactly the
+// blocks after startBlock, while the slot delta counts the slot opportunities.
 func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockData) (float64, error) {
 	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
 
-	if startBlock.BlockHeight == lastBlock.BlockHeight {
-		return 0, fmt.Errorf("starting block has same height as last block, can't calculate slot occupancy!")
+	if lastBlock.Slot <= startBlock.Slot {
+		return 0, fmt.Errorf("last block (slot %d) is not after starting block (slot %d), can't calculate slot occupancy!", lastBlock.Slot, startBlock.Slot)
+	}
+	if lastBlock.BlockHeight <= startBlock.BlockHeight {
+		return 0, fmt.Errorf("last block height (%d) is not above starting block height (%d), can't calculate slot occupancy!", lastBlock.BlockHeight, startBlock.BlockHeight)
 	}
 
 	return float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot), nil

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -20,10 +20,11 @@ type BlockAnalysisResult struct {
 	GenesisBlock       client.BlockData
 	SnarkedHashByEpoch SnarkedHashByEpoch
 
-	// Pre-fork slot occupancy, recorded during the main network phase so the
-	// fork network phase can assert the post-fork occupancy improved on it
-	// (only populated in unstaking test mode)
-	PreForkOccupancy float64
+	// Pre-fork slot occupancy and genesis stake breakdown, recorded during
+	// the main network phase so the fork network phase can assert against
+	// them (only populated in unstaking test mode)
+	PreForkOccupancy  float64
+	PreForkStakeStats StakeStats
 }
 
 func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool, predDescription string, timeout time.Duration) error {

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -49,12 +49,26 @@ func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool
 	return fmt.Errorf("timed out waiting for condition: %s at port %d", predDescription, port)
 }
 
-// ComputeSlotOccupancy computes the fraction of slots between two blocks that
-// are occupied by a block. startBlock must be an ancestor of lastBlock: block
-// heights are dense along a chain, so the height delta counts exactly the
-// blocks after startBlock, while the slot delta counts the slot opportunities.
-func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockData) (float64, error) {
-	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
+// ComputeSlotOccupancy computes the slot fill rate over the half-open window
+// (startBlock.Slot, boundarySlot]: the fraction of those slots that produced a
+// block. startBlock is the window's lower anchor and its own slot is excluded —
+// it is genesis, not a VRF-produced slot. Block heights are dense along a
+// chain, so the height delta counts exactly the blocks produced after
+// startBlock up to lastBlock; startBlock must therefore be an ancestor of
+// lastBlock.
+//
+// The denominator is boundarySlot − startBlock.Slot, NOT lastBlock.Slot −
+// startBlock.Slot. The window runs to an intended boundary (e.g. slot_tx_end),
+// not to the last observed block: anchoring the denominator on lastBlock would
+// end the window on a guaranteed hit and silently drop the empty slots between
+// the last block and the boundary, biasing the fill rate upward. boundarySlot
+// must be at or beyond lastBlock.Slot; callers pass the last block that falls
+// before the boundary, so no block lives in (lastBlock.Slot, boundarySlot] and
+// the height-delta numerator still counts every block in the window. When the
+// boundary coincides with lastBlock.Slot the window ends on a hit — the
+// residual upward bias callers accept when no boundary past the tip exists.
+func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockData, boundarySlot int) (float64, error) {
+	t.Logger.Info("Calculating slot occupancy between block %v and %v over a window ending at slot %d", startBlock, lastBlock, boundarySlot)
 
 	if lastBlock.Slot <= startBlock.Slot {
 		return 0, fmt.Errorf("last block (slot %d) is not after starting block (slot %d), can't calculate slot occupancy!", lastBlock.Slot, startBlock.Slot)
@@ -62,15 +76,20 @@ func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockDa
 	if lastBlock.BlockHeight <= startBlock.BlockHeight {
 		return 0, fmt.Errorf("last block height (%d) is not above starting block height (%d), can't calculate slot occupancy!", lastBlock.BlockHeight, startBlock.BlockHeight)
 	}
+	if boundarySlot < lastBlock.Slot {
+		return 0, fmt.Errorf("window boundary slot (%d) is before the last block's slot (%d); the boundary must be at or beyond the last observed block", boundarySlot, lastBlock.Slot)
+	}
 
-	return float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot), nil
+	return float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(boundarySlot-startBlock.Slot), nil
 }
 
-// ValidateSlotOccupancy checks if block occupancy is above 50%
-func (t *HardforkTest) ValidateSlotOccupancy(startBlock, lastBlock client.BlockData) error {
+// ValidateSlotOccupancy checks if block occupancy is above 50% over the window
+// (startBlock.Slot, boundarySlot]; see ComputeSlotOccupancy for the window
+// convention.
+func (t *HardforkTest) ValidateSlotOccupancy(startBlock, lastBlock client.BlockData, boundarySlot int) error {
 	expectedOccupancy := 0.5
 
-	actualOccupancy, err := t.ComputeSlotOccupancy(startBlock, lastBlock)
+	actualOccupancy, err := t.ComputeSlotOccupancy(startBlock, lastBlock, boundarySlot)
 	if err != nil {
 		return err
 	}

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -13,6 +13,10 @@ import (
 type ConsensusState struct {
 	LastOccupiedSlot     int              `json:"last_occupied_slot"`
 	LastBlockBeforeTxEnd client.BlockData `json:"last_block_before_tx_end"`
+	// Set of public keys that actually produced a block in the observed window
+	// (block creators reported by consensus). This is the on-chain evidence of
+	// which producers were live, independent of the key files the harness reads.
+	ObservedProducerPks map[string]bool `json:"observed_producer_pks"`
 }
 
 type BlockAnalysisResult struct {
@@ -154,6 +158,7 @@ func (t *HardforkTest) ReportBlocksInfo(port int, blocks []client.BlockData) {
 func (t *HardforkTest) ConsensusStateOnNode(port int) (*ConsensusState, error) {
 
 	state := new(ConsensusState)
+	state.ObservedProducerPks = make(map[string]bool)
 
 	recentBlocks, err := t.Client.RecentBlocks(port, config.ProtocolK)
 
@@ -177,6 +182,13 @@ func (t *HardforkTest) ConsensusStateOnNode(port int) (*ConsensusState, error) {
 		// Track latest non-empty block
 		if block.Slot > state.LastBlockBeforeTxEnd.Slot && block.Slot < t.Config.SlotTxEnd {
 			state.LastBlockBeforeTxEnd = block
+		}
+
+		// Record the producer of every VRF-produced (non-genesis) block, so the
+		// active-stake classification can be cross-checked against which
+		// producers were actually live.
+		if block.Slot > 0 && block.Creator != "" {
+			state.ObservedProducerPks[block.Creator] = true
 		}
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -16,7 +16,7 @@ type ConsensusState struct {
 	// Set of public keys that actually produced a block in the observed window
 	// (block creators reported by consensus). This is the on-chain evidence of
 	// which producers were live, independent of the key files the harness reads.
-	ObservedProducerPks map[string]bool `json:"observed_producer_pks"`
+	ObservedProducerPks map[string]struct{} `json:"observed_producer_pks"`
 }
 
 type BlockAnalysisResult struct {
@@ -164,7 +164,7 @@ func (t *HardforkTest) ReportBlocksInfo(port int, blocks []client.BlockData) {
 func (t *HardforkTest) ConsensusStateOnNode(port int) (*ConsensusState, error) {
 
 	state := new(ConsensusState)
-	state.ObservedProducerPks = make(map[string]bool)
+	state.ObservedProducerPks = make(map[string]struct{})
 
 	recentBlocks, err := t.Client.RecentBlocks(port, config.ProtocolK)
 
@@ -194,7 +194,7 @@ func (t *HardforkTest) ConsensusStateOnNode(port int) (*ConsensusState, error) {
 		// active-stake classification can be cross-checked against which
 		// producers were actually live.
 		if block.Slot > 0 && block.Creator != "" {
-			state.ObservedProducerPks[block.Creator] = true
+			state.ObservedProducerPks[block.Creator] = struct{}{}
 		}
 	}
 

--- a/src/app/hardfork_test/src/internal/hardfork/validation.go
+++ b/src/app/hardfork_test/src/internal/hardfork/validation.go
@@ -19,6 +19,11 @@ type BlockAnalysisResult struct {
 	Consensus          ConsensusState
 	GenesisBlock       client.BlockData
 	SnarkedHashByEpoch SnarkedHashByEpoch
+
+	// Pre-fork slot occupancy, recorded during the main network phase so the
+	// fork network phase can assert the post-fork occupancy improved on it
+	// (only populated in unstaking test mode)
+	PreForkOccupancy float64
 }
 
 func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool, predDescription string, timeout time.Duration) error {
@@ -43,17 +48,26 @@ func (t *HardforkTest) WaitForBestTip(port int, pred func(client.BlockData) bool
 	return fmt.Errorf("timed out waiting for condition: %s at port %d", predDescription, port)
 }
 
+// ComputeSlotOccupancy computes the fraction of slots between two blocks that
+// are occupied by a block
+func (t *HardforkTest) ComputeSlotOccupancy(startBlock, lastBlock client.BlockData) (float64, error) {
+	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
+
+	if startBlock.BlockHeight == lastBlock.BlockHeight {
+		return 0, fmt.Errorf("starting block has same height as last block, can't calculate slot occupancy!")
+	}
+
+	return float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot), nil
+}
+
 // ValidateSlotOccupancy checks if block occupancy is above 50%
 func (t *HardforkTest) ValidateSlotOccupancy(startBlock, lastBlock client.BlockData) error {
 	expectedOccupancy := 0.5
 
-	t.Logger.Info("Calculating slot occupancy between block %v and %v", startBlock, lastBlock)
-
-	if startBlock.BlockHeight == lastBlock.BlockHeight {
-		return fmt.Errorf("starting block has same height as last block, can't calculate slot occupancy!")
+	actualOccupancy, err := t.ComputeSlotOccupancy(startBlock, lastBlock)
+	if err != nil {
+		return err
 	}
-
-	actualOccupancy := float64(lastBlock.BlockHeight-startBlock.BlockHeight) / float64(lastBlock.Slot-startBlock.Slot)
 
 	if actualOccupancy < expectedOccupancy {
 		return fmt.Errorf("slot occupancy (%f) is below expected (%f)", actualOccupancy, expectedOccupancy)


### PR DESCRIPTION
## Summary

Adds an unstaking test mode to the hardfork test harness, validating that the unstaking consensus feature (`martyall/unstaking_consensus_v2`, per [MIP: allow for unstaking](https://github.com/MinaProtocol/MIPs/pull/35)) remedies low slot fill rates caused by dormant stake. Supersedes #18996.

### Test design

1. The pre-fork genesis ledger carries **lazy whales**: ordinary whale accounts for which no block producer is ever launched. Laziness is behavioral, not an account property — `mina-local-network.sh --lazy-whales M` simply generates `N+M` whale pairs and only launches daemons for the first `N`.
2. Pre-fork slot occupancy is measured over ~30 slots and asserted to sit **below** a modeled upper bound (`1 − 0.25^s_active + 0.15`, with `s_active` computed from the actual generated `genesis_ledger.json`), proving the lazy stake dilutes the VRF denominator, while staying above a liveness floor. The file-derived total is cross-checked against `stakingEpochData.ledger.totalCurrency` from a live daemon (0.1% tolerance), validating that the file is the ledger the VRF actually samples.
3. At fork time the harness passes `--unstake-pk <pk>` per lazy whale to the fork-side `runtime_genesis_ledger` (#18995), clearing their delegates so `total_stake` excludes them post-fork.
4. Post-fork occupancy is measured over a comparable window (`--best-chain-query-from 30`).
5. Asserts success, deterministic checks first:
   - **Conservation identity (exact):** `preForkGenesis.totalCurrency − forkGenesis.stakingEpochData.ledger.totalCurrency == Σ lazy whale balances`, to the nanomina. On the post-fork build the epoch ledger's `totalCurrency` field carries `total_stake`, and the fork's staking epoch ledger is the pre-fork genesis ledger modulo the `--unstake-pk` patch — same ledger on both sides, so staked accounts (incl. the genesis winner) cancel and pre-fork coinbases never enter. A missed pk, a wrong account, or a fork build without the `total_stake` consensus change each produce a distinct mismatch.
   - **Per-account:** each lazy whale's `delegate` is null on the fork network.
   - **Behavioral corroboration:** post-fork occupancy > pre-fork, plus the standard ≥ 0.5 health bar.

With 2 active + 5 lazy whales (lazy share ≈ 0.714): expected pre-fork fill ≈ 0.33 (bound ≈ 0.48), post-fork ≈ 0.75 — ~3.5σ separation over 30-slot windows.

### Notable implementation points

- Lazy whale accounts are classified from the generated ledger (accounts delegated to a whale producer key with no daemon), **not** by key-file index: the ledger generator pairs offline/online keys in glob order, which does not follow filename indices (verified empirically).
- `--fork-to` on `build-and-test.sh` generalizes the postfork build target (previously hardcoded `develop`); `--slot-tx-end`/`--slot-chain-end` pin the measurement window in CI.
- The fork-to branch `martyall/unstaking_consensus_v2_hf` pins `lyh/restake-postfork-feat` = `unstaking_consensus_v2` + the `zero_totals` chain-id fix + repeatable `--unstake-pk` — all three required for the post-fork network to boot and exclude the lazy stake.
- New CI job `HardForkTestUnstaking` (scope excludes PR pipelines; validate via nightly/manual trigger).

### Testing

- `go build ./... && go test ./...` on the harness: new unit tests for occupancy computation, nanomina parsing, stake-stats classification (including scrambled offline/online pairing), fill-bound math (incl. zero-currency edge case), and config validation.
- Ledger generator smoke-tested with 7 fake whale pairs: lazy share 0.714, scrambled pairing handled.
- End-to-end validated on Buildkite via `!ci-single-me HardForkTestUnstaking` ([build #234](https://buildkite.com/o-1-labs-2/mina-single-job/builds/234), passed in 2h42m); re-run pending for the deterministic-assertion commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P5k4m4SxQHRPfjz25M8Ps
