### PR TITLE
chore: track .claude/skills in git

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,6 @@ Pipfile.lock
 _coverage/
 
 CLAUDE.local.md
-/.claude/
+/.claude/*
+!/.claude/skills
 /.opencode/


### PR DESCRIPTION
## Summary
- Un-ignore `.claude/skills` so it can be tracked in git, while the rest of `.claude/` (e.g. `settings.local.json`, `worktrees`) stays ignored.
- Add `.claude/skills` as a symlink to `../.agents/skills`, making the shared agent skills available under the Claude Code skills path.

## Changes
- `.gitignore`: replaced the blanket `/.claude/` ignore with `/.claude/*` + `!/.claude/skills` (git cannot re-include a path under a fully-ignored directory).
- `.claude/skills` → `../.agents/skills` symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)