### PR TITLE
feat(minimina): archive support on the supervisor (ephemeral postgres)

### DIFF
--- a/src/app/minimina/src/archive.rs
+++ b/src/app/minimina/src/archive.rs
@@ -1,0 +1,108 @@
+//! Shared archive **contract**: the cross-backend constants and command helpers
+//! both plan builders must agree on so an archive-node daemon can reach its
+//! archive service regardless of backend — the postgres connection params, the
+//! `mina-archive` service command line, the archive-service unit name (which is
+//! the service's DNS host under docker), and the default server port.
+//!
+//! Backend-*internal* postgres details do NOT belong here: the native socket
+//! dir / server args / unit name live in [`crate::native::archive`]; the docker
+//! image + container env in [`crate::docker::archive`]. Only what the two
+//! backends must keep in lockstep is shared.
+//!
+//! Archive is three units: **postgres** (ephemeral DB), **archive-service**
+//! (`mina-archive run …`), and **archive-node** (a mina daemon with
+//! `-archive-address`).
+
+/// Default archive-service server port when the topology doesn't specify one.
+pub const DEFAULT_ARCHIVE_PORT: u16 = 3086;
+
+/// The (fixed, local-only) postgres configuration shared by both backends — one
+/// source of truth for the connection params. The shapes different consumers
+/// need (the connection URI here; the docker image env in [`crate::docker::archive`])
+/// are *derived* from these fields, so we never re-parse a connection string
+/// back into parts.
+pub struct PgConfig {
+    pub user: &'static str,
+    pub password: &'static str,
+    pub db: &'static str,
+    pub port: u16,
+}
+
+impl Default for PgConfig {
+    /// The standard local-only settings. Override individual fields with struct
+    /// update syntax, e.g. `PgConfig { port: free, ..Default::default() }`.
+    fn default() -> Self {
+        PgConfig {
+            user: "postgres",
+            password: "postgres",
+            db: "archive",
+            port: 5432,
+        }
+    }
+}
+
+impl PgConfig {
+    /// Connection URI for the archive-service's `--postgres-uri`.
+    fn uri(&self, host: &str) -> String {
+        format!(
+            "postgres://{}:{}@{host}:{}/{}",
+            self.user, self.password, self.port, self.db
+        )
+    }
+}
+
+/// Args to `mina-archive` for the archive-service (i.e. everything after the
+/// `mina-archive` program itself). `pg_host` is where the service finds
+/// postgres: `localhost` (native) or the postgres container's DNS name (docker).
+pub fn archive_service_args(pg_host: &str, archive_port: u16) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        "--postgres-uri".to_string(),
+        PgConfig::default().uri(pg_host),
+        "--server-port".to_string(),
+        archive_port.to_string(),
+    ]
+}
+
+/// Supervisor unit name for the archive-service unit of archive node `name`.
+/// Under docker this doubles as the container name and DNS alias the
+/// archive-node daemon dials, so both backends must derive it identically.
+pub fn archive_service_unit_name(archive_node_name: &str) -> String {
+    format!("{archive_node_name}-archive-service")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::{ServiceConfig, ServiceType};
+
+    /// With no `archive_port` in the topology, the archive-service's
+    /// `--server-port` and the daemon's `-archive-address` must land on the
+    /// same (default) port.
+    #[test]
+    fn daemon_and_service_agree_on_unset_archive_port() {
+        let node = ServiceConfig {
+            service_type: ServiceType::ArchiveNode,
+            service_name: "archive".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(node.archive_port, None);
+
+        let port = node.resolved_archive_port();
+        assert_eq!(port, DEFAULT_ARCHIVE_PORT);
+
+        let svc_args = archive_service_args("localhost", port);
+        let server_port = svc_args
+            .iter()
+            .position(|a| a == "--server-port")
+            .map(|i| svc_args[i + 1].clone())
+            .expect("--server-port missing from archive-service args");
+        assert_eq!(server_port, port.to_string());
+
+        let daemon_cmd = node.generate_archive_command("svc-host".to_string());
+        assert!(
+            daemon_cmd.contains(&format!("-archive-address svc-host:{port}")),
+            "daemon command must dial the archive-service port: {daemon_cmd}"
+        );
+    }
+}

--- a/src/app/minimina/src/docker/archive.rs
+++ b/src/app/minimina/src/docker/archive.rs
@@ -1,0 +1,43 @@
+//! Docker archive provisioning (create-time): stage the archive schema SQLs
+//! into the network dir so the postgres container's `/docker-entrypoint-initdb.d`
+//! applies them on first boot. Kept beside the docker plan builder so all docker
+//! backend specifics live under `docker/`; `main.rs` only decides *when* to call
+//! this, not *how* it works.
+
+use crate::archive::PgConfig;
+use crate::service::ServiceConfig;
+use crate::utils::fetch_schema;
+use std::io::Result;
+use std::path::Path;
+
+/// Docker image for the ephemeral postgres container.
+pub const PG_IMAGE: &str = "postgres:16";
+
+/// Env for the docker `postgres` image: `POSTGRES_DB` creates the database and,
+/// on first boot, the entrypoint applies `/docker-entrypoint-initdb.d`. Derived
+/// from the shared [`PgConfig`] so the container's credentials match the URI the
+/// archive-service is given.
+pub fn postgres_container_env(pg: &PgConfig) -> Vec<(String, String)> {
+    vec![
+        ("POSTGRES_USER".to_string(), pg.user.to_string()),
+        ("POSTGRES_PASSWORD".to_string(), pg.password.to_string()),
+        ("POSTGRES_DB".to_string(), pg.db.to_string()),
+    ]
+}
+
+/// Stage the schema SQLs where the postgres container's
+/// `/docker-entrypoint-initdb.d` picks them up — auto-applied on first boot,
+/// after `POSTGRES_DB` creates the `archive` database. Number-prefixed to
+/// preserve apply order (initdb.d runs its scripts alphabetically).
+pub fn stage_schema(network_path: &Path, archive_node: &ServiceConfig) -> Result<()> {
+    let initdb_dir = network_path.join("postgres-initdb");
+    std::fs::create_dir_all(&initdb_dir)?;
+    if let Some(scripts) = &archive_node.archive_schema_files {
+        for (i, script) in scripts.iter().enumerate() {
+            let fetched = fetch_schema(script, network_path.to_path_buf()).unwrap();
+            let fname = fetched.file_name().unwrap().to_str().unwrap();
+            std::fs::copy(&fetched, initdb_dir.join(format!("{:02}_{fname}", i + 1)))?;
+        }
+    }
+    Ok(())
+}

--- a/src/app/minimina/src/docker/mod.rs
+++ b/src/app/minimina/src/docker/mod.rs
@@ -1,2 +1,3 @@
+pub mod archive;
 pub mod manager;
 pub mod plan_builder;

--- a/src/app/minimina/src/docker/plan_builder.rs
+++ b/src/app/minimina/src/docker/plan_builder.rs
@@ -3,7 +3,9 @@
 //! no lifecycle — creating, starting, and removing containers is the
 //! supervisor's job.
 
+use crate::archive::{self, PgConfig};
 use crate::directory_manager::CONFIG_DIRECTORY;
+use crate::docker::archive as docker_archive;
 use crate::service::{daemon_env, ServiceConfig, ServiceType};
 use crate::supervisor::plan::{DockerBackendSpec, DockerNodeSpec, Mount, SupervisorPlan};
 use std::io::Result;
@@ -27,7 +29,8 @@ impl DockerPlanBuilder {
     /// host network dir is bind-mounted at `/local-network` and a per-service
     /// config dir at `/config-directory` (both paths the commands expect).
     ///
-    /// Archive and uptime-service backends are not yet ported to bollard.
+    /// Archive is expanded to postgres + archive-service + archive-node units;
+    /// the uptime-service backend is not yet ported to bollard.
     pub fn build_supervisor_plan(
         &self,
         services: &[ServiceConfig],
@@ -35,6 +38,66 @@ impl DockerPlanBuilder {
     ) -> Result<SupervisorPlan> {
         let network_path_str = self.network_path.to_str().unwrap().to_string();
         let mut nodes = Vec::new();
+
+        // Archive infra first (so postgres/archive-service launch before daemons):
+        // an ephemeral postgres container (POSTGRES_DB + initdb.d schema applied on
+        // first boot) and the mina-archive service. Both reachable by daemons via
+        // docker DNS on their `<name>-<network>` container name / alias. In the new
+        // spec a unit's `name` *is* the container name and network alias, so the
+        // peer/archive hostnames the commands bake in resolve directly.
+        if let Some(archive_node) = ServiceConfig::get_archive_node(services) {
+            let archive_port = archive_node.resolved_archive_port();
+            let pg_container = format!("postgres-{network_id}");
+            let svc_container = format!(
+                "{}-{network_id}",
+                archive::archive_service_unit_name(&archive_node.service_name)
+            );
+
+            nodes.push(DockerNodeSpec {
+                name: pg_container.clone(),
+                image: docker_archive::PG_IMAGE.to_string(),
+                entrypoint: None,
+                cmd: vec![],
+                env: docker_archive::postgres_container_env(&PgConfig::default()),
+                ports: vec![], // internal-only; reached via DNS
+                mounts: vec![Mount {
+                    host: self
+                        .network_path
+                        .join("postgres-initdb")
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                    container: "/docker-entrypoint-initdb.d".into(),
+                    read_only: true,
+                }],
+                aliases: vec![pg_container.clone()],
+            });
+
+            let mut svc_cmd = vec!["mina-archive".to_string()];
+            svc_cmd.extend(archive::archive_service_args(&pg_container, archive_port));
+            nodes.push(DockerNodeSpec {
+                name: svc_container.clone(),
+                image: archive_node.archive_docker_image.clone().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "missing archive docker image for '{}'",
+                            archive_node.service_name
+                        ),
+                    )
+                })?,
+                entrypoint: None,
+                cmd: svc_cmd,
+                env: vec![],
+                ports: vec![],
+                mounts: vec![Mount {
+                    host: network_path_str.clone(),
+                    container: "/local-network".into(),
+                    read_only: false,
+                }],
+                aliases: vec![svc_container],
+            });
+        }
 
         for config in services {
             let cmd_str = match config.service_type {
@@ -44,7 +107,16 @@ impl DockerPlanBuilder {
                 ServiceType::SnarkWorker => {
                     config.generate_snark_worker_command(network_id.to_string())
                 }
-                ServiceType::ArchiveNode | ServiceType::UptimeServiceBackend => {
+                ServiceType::ArchiveNode => {
+                    // The archive-node daemon forwards blocks to the archive-service
+                    // container via docker DNS.
+                    let svc_host = format!(
+                        "{}-{network_id}",
+                        archive::archive_service_unit_name(&config.service_name)
+                    );
+                    config.generate_archive_command(svc_host)
+                }
+                ServiceType::UptimeServiceBackend => {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::Unsupported,
                         format!(

--- a/src/app/minimina/src/docker/plan_builder.rs
+++ b/src/app/minimina/src/docker/plan_builder.rs
@@ -7,7 +7,7 @@ use crate::archive::{self, PgConfig};
 use crate::directory_manager::CONFIG_DIRECTORY;
 use crate::docker::archive as docker_archive;
 use crate::service::{daemon_env, ServiceConfig, ServiceType};
-use crate::supervisor::plan::{DockerBackendSpec, DockerNodeSpec, Mount, SupervisorPlan};
+use crate::supervisor::plan::{DockerBackendSpec, DockerNodeSpec, SupervisorPlan};
 use std::io::Result;
 use std::path::{Path, PathBuf};
 
@@ -53,50 +53,32 @@ impl DockerPlanBuilder {
                 archive::archive_service_unit_name(&archive_node.service_name)
             );
 
-            nodes.push(DockerNodeSpec {
-                name: pg_container.clone(),
-                image: docker_archive::PG_IMAGE.to_string(),
-                entrypoint: None,
-                cmd: vec![],
-                env: docker_archive::postgres_container_env(&PgConfig::default()),
-                ports: vec![], // internal-only; reached via DNS
-                mounts: vec![Mount {
-                    host: self
-                        .network_path
-                        .join("postgres-initdb")
-                        .to_str()
-                        .unwrap()
-                        .to_string(),
-                    container: "/docker-entrypoint-initdb.d".into(),
-                    read_only: true,
-                }],
-                aliases: vec![pg_container.clone()],
-            });
+            // No published ports: internal-only, reached via DNS.
+            nodes.push(
+                DockerNodeSpec::new(pg_container.clone(), docker_archive::PG_IMAGE)
+                    .env(docker_archive::postgres_container_env(&PgConfig::default()))
+                    .mount_ro(
+                        self.network_path.join("postgres-initdb").to_str().unwrap(),
+                        "/docker-entrypoint-initdb.d",
+                    ),
+            );
 
+            let svc_image = archive_node.archive_docker_image.clone().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "missing archive docker image for '{}'",
+                        archive_node.service_name
+                    ),
+                )
+            })?;
             let mut svc_cmd = vec!["mina-archive".to_string()];
             svc_cmd.extend(archive::archive_service_args(&pg_container, archive_port));
-            nodes.push(DockerNodeSpec {
-                name: svc_container.clone(),
-                image: archive_node.archive_docker_image.clone().ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!(
-                            "missing archive docker image for '{}'",
-                            archive_node.service_name
-                        ),
-                    )
-                })?,
-                entrypoint: None,
-                cmd: svc_cmd,
-                env: vec![],
-                ports: vec![],
-                mounts: vec![Mount {
-                    host: network_path_str.clone(),
-                    container: "/local-network".into(),
-                    read_only: false,
-                }],
-                aliases: vec![svc_container],
-            });
+            nodes.push(
+                DockerNodeSpec::new(svc_container, svc_image)
+                    .cmd(svc_cmd)
+                    .mount_rw(network_path_str.clone(), "/local-network"),
+            );
         }
 
         for config in services {
@@ -150,27 +132,18 @@ impl DockerPlanBuilder {
                 )
             })?;
 
-            nodes.push(DockerNodeSpec {
-                name: container_name.clone(),
-                image,
-                entrypoint: Some(vec!["mina".to_string()]),
-                cmd: cmd_str.split_whitespace().map(str::to_string).collect(),
-                env: daemon_env(),
-                ports,
-                mounts: vec![
-                    Mount {
-                        host: network_path_str.clone(),
-                        container: "/local-network".into(),
-                        read_only: false,
-                    },
-                    Mount {
-                        host: config_dir_host.to_str().unwrap().to_string(),
-                        container: format!("/{CONFIG_DIRECTORY}"),
-                        read_only: false,
-                    },
-                ],
-                aliases: vec![container_name],
-            });
+            nodes.push(
+                DockerNodeSpec::new(container_name, image)
+                    .entrypoint(vec!["mina".to_string()])
+                    .cmd(cmd_str.split_whitespace().map(str::to_string).collect())
+                    .env(daemon_env())
+                    .ports(ports)
+                    .mount_rw(network_path_str.clone(), "/local-network")
+                    .mount_rw(
+                        config_dir_host.to_str().unwrap(),
+                        format!("/{CONFIG_DIRECTORY}"),
+                    ),
+            );
         }
 
         Ok(SupervisorPlan {

--- a/src/app/minimina/src/main.rs
+++ b/src/app/minimina/src/main.rs
@@ -1,3 +1,4 @@
+mod archive;
 mod cli;
 mod directory_manager;
 mod docker;
@@ -17,7 +18,6 @@ use crate::{
     native::{keys::NativeKeysManager, mina_locator, plan_builder::NativePlanBuilder},
     output::{network, node},
     service::{ServiceConfig, ServiceType},
-    utils::fetch_schema,
 };
 use clap::Parser;
 use cli::{
@@ -806,7 +806,6 @@ fn generate_default_topology(
             format!("https://raw.githubusercontent.com/MinaProtocol/mina/{IMAGE_COMMIT_HASH}/src/app/archive/zkapp_tables.sql"),
             format!("https://raw.githubusercontent.com/MinaProtocol/mina/{IMAGE_COMMIT_HASH}/src/app/archive/create_schema.sql"),
         ]),
-        archive_port: Some(3086),
         ..Default::default()
     };
     vec![
@@ -1033,11 +1032,10 @@ fn create_network_docker(
     network_id: &str,
     services: &[ServiceConfig],
 ) -> Result<()> {
-    if ServiceConfig::get_archive_node(services).is_some() {
-        warn!(
-            "Archive nodes are not yet supported on the bollard docker backend; \
-             the archive node will be skipped when the network starts."
-        );
+    // Archive: stage the schema SQLs for the postgres container's initdb.d.
+    if let Some(archive_node) = ServiceConfig::get_archive_node(services) {
+        let network_path = directory_manager.network_path(network_id);
+        docker::archive::stage_schema(&network_path, archive_node)?;
     }
     if let Err(e) = directory_manager.save_network_info(network_id, services) {
         error!("Error generating network.json: {e}");
@@ -1058,43 +1056,14 @@ fn create_network_native(
     // create only prepares plan artifacts and any archive database.
     info!("Successfully prepared native network '{network_id}'!");
 
-    // Handle archive node setup with local postgres
+    // Archive: initialize an ephemeral postgres cluster under the network dir and
+    // apply the schema now, so at `network start` the supervisor just runs
+    // `postgres` on a ready datadir (no dependency on a system postgres server).
     if let Some(archive_node) = ServiceConfig::get_archive_node(services) {
-        default::LedgerGenerator::generate_replayer_input(
-            &directory_manager.network_path(network_id),
-        )?;
-
-        // Create database using local psql
-        info!("Creating archive database using local postgres...");
-        let createdb_out = std::process::Command::new("createdb")
-            .args(["-U", "postgres", "archive"])
-            .output()?;
-
-        if !createdb_out.status.success() {
-            warn!(
-                "createdb may have failed (database might already exist): {}",
-                String::from_utf8_lossy(&createdb_out.stderr)
-            );
-        }
-
-        // Apply schema scripts directly via psql
-        if let Some(scripts) = &archive_node.archive_schema_files {
-            let network_path = directory_manager.network_path(network_id);
-            for script in scripts {
-                let file_path = fetch_schema(script, network_path.clone()).unwrap();
-                info!("Applying schema script: {}", file_path.display());
-                let psql_out = std::process::Command::new("psql")
-                    .args(["-U", "postgres", "-d", "archive", "-f"])
-                    .arg(&file_path)
-                    .output()?;
-
-                if !psql_out.status.success() {
-                    warn!(
-                        "psql schema application may have failed: {}",
-                        String::from_utf8_lossy(&psql_out.stderr)
-                    );
-                }
-            }
+        let network_path = directory_manager.network_path(network_id);
+        default::LedgerGenerator::generate_replayer_input(&network_path)?;
+        if let Err(e) = native::archive::provision(&network_path, network_id, archive_node) {
+            return exit_with(format!("Failed to provision native archive postgres: {e}"));
         }
     }
 

--- a/src/app/minimina/src/native/archive.rs
+++ b/src/app/minimina/src/native/archive.rs
@@ -1,0 +1,158 @@
+//! Native archive provisioning (create-time): stand up the ephemeral postgres
+//! cluster the supervisor later runs as a `postgres` unit. Kept beside the
+//! native plan builder so all native backend specifics live under `native/`;
+//! `main.rs` only decides *when* to call this, not *how* it works.
+
+use crate::archive::PgConfig;
+use crate::service::ServiceConfig;
+use crate::utils::fetch_schema;
+use log::{info, warn};
+use std::io::{Error, Result};
+use std::path::{Path, PathBuf};
+
+/// Supervisor unit name for the native postgres process.
+pub const POSTGRES_UNIT_NAME: &str = "postgres";
+
+/// Short unix-socket directory for the native postgres. Network dirs are often
+/// deeper than the ~107-char unix-socket path limit, so the socket lives under
+/// `/tmp` (per-network); all real connections use TCP on `127.0.0.1:<port>`.
+/// Shared between `provision` (which starts postgres briefly) and the native
+/// plan builder (which runs it as a unit), so both agree on the socket path.
+pub fn postgres_socket_dir(network_id: &str) -> PathBuf {
+    PathBuf::from(format!("/tmp/mmn-{network_id}"))
+}
+
+/// Args for running the native postgres server on `pgdata` (TCP + a short unix
+/// socket dir). Used by the native plan builder to run postgres as a unit.
+pub fn postgres_server_args(pgdata: &str, socket_dir: &str) -> Vec<String> {
+    vec![
+        "-D".to_string(),
+        pgdata.to_string(),
+        "-p".to_string(),
+        PgConfig::default().port.to_string(),
+        "-k".to_string(),
+        socket_dir.to_string(),
+        "-c".to_string(),
+        "listen_addresses=127.0.0.1".to_string(),
+    ]
+}
+
+/// Initialize an ephemeral postgres cluster for native archive: `initdb` a
+/// datadir under the network path, briefly start it, `createdb` + apply the
+/// archive schema, then stop it. At `network start` the supervisor runs
+/// `postgres` on this ready datadir. Requires the postgres client/server
+/// binaries on PATH (`initdb`/`pg_ctl`/`createdb`/`psql`) — no running system
+/// postgres server needed.
+pub fn provision(
+    network_path: &Path,
+    network_id: &str,
+    archive_node: &ServiceConfig,
+) -> Result<()> {
+    let pg = PgConfig::default();
+    let pgdata = network_path.join("pgdata");
+    let pgdata_str = pgdata.to_str().unwrap();
+    let port = pg.port.to_string();
+    // Short unix-socket dir (network dirs can exceed the ~107-char limit).
+    let socket_dir = postgres_socket_dir(network_id);
+    std::fs::create_dir_all(&socket_dir)?;
+    let sockdir = socket_dir.to_str().unwrap();
+
+    info!(
+        "Initializing ephemeral postgres cluster at '{}'",
+        pgdata.display()
+    );
+    // `--locale=C` so initdb doesn't depend on the ambient LANG/LC_* being valid.
+    let initdb = std::process::Command::new("initdb")
+        .args([
+            "-D",
+            pgdata_str,
+            "-U",
+            pg.user,
+            "-A",
+            "trust",
+            "--locale=C",
+            "-E",
+            "UTF8",
+        ])
+        .output()
+        .map_err(|e| {
+            Error::other(format!(
+                "failed to run 'initdb' (is postgres on PATH?): {e}"
+            ))
+        })?;
+    if !initdb.status.success() {
+        return Err(Error::other(format!(
+            "initdb failed: {}",
+            String::from_utf8_lossy(&initdb.stderr)
+        )));
+    }
+
+    let start = std::process::Command::new("pg_ctl")
+        .args([
+            "-D",
+            pgdata_str,
+            "-o",
+            &format!("-p {port} -k {sockdir} -c listen_addresses=127.0.0.1"),
+            "-w",
+            "start",
+        ])
+        .output()?;
+    if !start.status.success() {
+        return Err(Error::other(format!(
+            "pg_ctl start failed: {}",
+            String::from_utf8_lossy(&start.stderr)
+        )));
+    }
+
+    // createdb + schema against the temp server; always stop it afterwards.
+    let init = init_archive_db(network_path, archive_node, &port);
+    let _ = std::process::Command::new("pg_ctl")
+        .args(["-D", pgdata_str, "-w", "stop"])
+        .output();
+    init
+}
+
+/// Create the `archive` database and apply its schema against a running
+/// postgres on `127.0.0.1:<port>`.
+fn init_archive_db(network_path: &Path, archive_node: &ServiceConfig, port: &str) -> Result<()> {
+    let pg = PgConfig::default();
+    let createdb = std::process::Command::new("createdb")
+        .args(["-h", "127.0.0.1", "-p", port, "-U", pg.user, pg.db])
+        .output()?;
+    if !createdb.status.success() {
+        warn!(
+            "createdb may have failed (database might already exist): {}",
+            String::from_utf8_lossy(&createdb.stderr)
+        );
+    }
+
+    if let Some(scripts) = &archive_node.archive_schema_files {
+        for script in scripts {
+            let file_path = fetch_schema(script, network_path.to_path_buf()).unwrap();
+            info!("Applying archive schema: {}", file_path.display());
+            let psql = std::process::Command::new("psql")
+                .args([
+                    "-h",
+                    "127.0.0.1",
+                    "-p",
+                    port,
+                    "-U",
+                    pg.user,
+                    "-d",
+                    pg.db,
+                    "-v",
+                    "ON_ERROR_STOP=1",
+                    "-f",
+                ])
+                .arg(&file_path)
+                .output()?;
+            if !psql.status.success() {
+                warn!(
+                    "psql schema application may have failed: {}",
+                    String::from_utf8_lossy(&psql.stderr)
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/app/minimina/src/native/archive.rs
+++ b/src/app/minimina/src/native/archive.rs
@@ -13,6 +13,13 @@ use std::path::{Path, PathBuf};
 /// Supervisor unit name for the native postgres process.
 pub const POSTGRES_UNIT_NAME: &str = "postgres";
 
+/// Data directory of the ephemeral postgres cluster. Shared between `provision`
+/// (which `initdb`s it) and the native plan builder (which runs `postgres` on
+/// it), so both agree on the location.
+pub fn pgdata_dir(network_path: &Path) -> PathBuf {
+    network_path.join("pgdata")
+}
+
 /// Short unix-socket directory for the native postgres. Network dirs are often
 /// deeper than the ~107-char unix-socket path limit, so the socket lives under
 /// `/tmp` (per-network); all real connections use TCP on `127.0.0.1:<port>`.
@@ -49,7 +56,7 @@ pub fn provision(
     archive_node: &ServiceConfig,
 ) -> Result<()> {
     let pg = PgConfig::default();
-    let pgdata = network_path.join("pgdata");
+    let pgdata = pgdata_dir(network_path);
     let pgdata_str = pgdata.to_str().unwrap();
     let port = pg.port.to_string();
     // Short unix-socket dir (network dirs can exceed the ~107-char limit).

--- a/src/app/minimina/src/native/mod.rs
+++ b/src/app/minimina/src/native/mod.rs
@@ -1,3 +1,4 @@
+pub mod archive;
 pub mod keys;
 pub mod mina_locator;
 pub mod plan_builder;

--- a/src/app/minimina/src/native/plan_builder.rs
+++ b/src/app/minimina/src/native/plan_builder.rs
@@ -6,7 +6,7 @@ use crate::archive;
 use crate::directory_manager::{CONFIG_DIRECTORY, LOGS_DIRECTORY};
 use crate::native::archive as native_archive;
 use crate::native::port_manager;
-use crate::service::{daemon_env, ServiceConfig, ServiceType};
+use crate::service::{daemon_env, keypair_pass_env, ServiceConfig, ServiceType};
 use crate::supervisor::plan::{NativeBackendSpec, NativeNodeSpec, SupervisorPlan};
 use log::warn;
 use std::fs;
@@ -65,7 +65,7 @@ impl NativePlanBuilder {
         // by the loop below (build_command adds `-archive-address 127.0.0.1:PORT`).
         if let Some(archive) = ServiceConfig::get_archive_node(services) {
             let archive_port = archive.resolved_archive_port();
-            let pgdata = self.network_path.join("pgdata");
+            let pgdata = native_archive::pgdata_dir(&self.network_path);
             let socket_dir = native_archive::postgres_socket_dir(network_id);
             fs::create_dir_all(&socket_dir)?;
             nodes.push(NativeNodeSpec {
@@ -84,10 +84,7 @@ impl NativePlanBuilder {
                 name: svc_name.clone(),
                 binary: self.bin_path.join("mina-archive"),
                 args: archive::archive_service_args("localhost", archive_port),
-                env: vec![
-                    ("MINA_PRIVKEY_PASS".into(), "naughty blue worm".into()),
-                    ("MINA_LIBP2P_PASS".into(), "naughty blue worm".into()),
-                ],
+                env: keypair_pass_env(),
                 log_file: self.logs_dir().join(format!("{svc_name}.log")),
             });
         }

--- a/src/app/minimina/src/native/plan_builder.rs
+++ b/src/app/minimina/src/native/plan_builder.rs
@@ -2,7 +2,9 @@
 //! supervisor runs (one child-process unit per service). Pure "describe", no
 //! lifecycle — running, stopping, and reaping are the supervisor's job.
 
+use crate::archive;
 use crate::directory_manager::{CONFIG_DIRECTORY, LOGS_DIRECTORY};
+use crate::native::archive as native_archive;
 use crate::native::port_manager;
 use crate::service::{daemon_env, ServiceConfig, ServiceType};
 use crate::supervisor::plan::{NativeBackendSpec, NativeNodeSpec, SupervisorPlan};
@@ -56,6 +58,40 @@ impl NativePlanBuilder {
 
         let network_path_str = self.network_path.to_str().unwrap();
         let mut nodes = Vec::new();
+
+        // Archive: an ephemeral postgres process (its cluster is `initdb`'d and
+        // schema-applied at `network create`) + the mina-archive service, both
+        // launched before the daemons. The archive-node daemon itself is emitted
+        // by the loop below (build_command adds `-archive-address 127.0.0.1:PORT`).
+        if let Some(archive) = ServiceConfig::get_archive_node(services) {
+            let archive_port = archive.resolved_archive_port();
+            let pgdata = self.network_path.join("pgdata");
+            let socket_dir = native_archive::postgres_socket_dir(network_id);
+            fs::create_dir_all(&socket_dir)?;
+            nodes.push(NativeNodeSpec {
+                name: native_archive::POSTGRES_UNIT_NAME.to_string(),
+                binary: PathBuf::from("postgres"),
+                args: native_archive::postgres_server_args(
+                    pgdata.to_str().unwrap(),
+                    socket_dir.to_str().unwrap(),
+                ),
+                env: vec![],
+                log_file: self.logs_dir().join("postgres.log"),
+            });
+
+            let svc_name = archive::archive_service_unit_name(&archive.service_name);
+            nodes.push(NativeNodeSpec {
+                name: svc_name.clone(),
+                binary: self.bin_path.join("mina-archive"),
+                args: archive::archive_service_args("localhost", archive_port),
+                env: vec![
+                    ("MINA_PRIVKEY_PASS".into(), "naughty blue worm".into()),
+                    ("MINA_LIBP2P_PASS".into(), "naughty blue worm".into()),
+                ],
+                log_file: self.logs_dir().join(format!("{svc_name}.log")),
+            });
+        }
+
         for service in services {
             if service.service_type == ServiceType::UptimeServiceBackend {
                 warn!(
@@ -221,10 +257,8 @@ impl NativePlanBuilder {
             }
             ServiceType::ArchiveNode => {
                 self.add_peers_args(service, network_path, &mut args);
-                if let Some(archive_port) = service.archive_port {
-                    args.push("-archive-address".to_string());
-                    args.push(format!("127.0.0.1:{}", archive_port));
-                }
+                args.push("-archive-address".to_string());
+                args.push(format!("127.0.0.1:{}", service.resolved_archive_port()));
                 self.add_libp2p_args(service, network_path, &mut args);
             }
             _ => {}

--- a/src/app/minimina/src/native/port_manager.rs
+++ b/src/app/minimina/src/native/port_manager.rs
@@ -24,11 +24,9 @@ pub fn collect_all_ports(services: &[ServiceConfig]) -> Vec<u16> {
             ports.push(client_port + 3);
             ports.push(client_port + 4);
         }
-        if let Some(archive_port) = service.archive_port {
-            ports.push(archive_port);
-        }
         if service.service_type == ServiceType::ArchiveNode {
-            ports.push(5432);
+            ports.push(service.resolved_archive_port());
+            ports.push(crate::archive::PgConfig::default().port);
         }
     }
     ports

--- a/src/app/minimina/src/service.rs
+++ b/src/app/minimina/src/service.rs
@@ -148,6 +148,35 @@ impl ServiceConfig {
         base_command.join(" ")
     }
 
+    /// The archive-service port for this archive node. Single resolution point
+    /// so the archive-service unit and the daemon's `-archive-address` can never
+    /// disagree when the topology leaves the port unset.
+    pub fn resolved_archive_port(&self) -> u16 {
+        self.archive_port
+            .unwrap_or(crate::archive::DEFAULT_ARCHIVE_PORT)
+    }
+
+    /// Generate the command for the archive-node **daemon** — a normal mina
+    /// daemon that forwards blocks to the archive-service at
+    /// `<archive_service_host>:<archive_port>`.
+    pub fn generate_archive_command(&self, archive_service_host: String) -> String {
+        assert_eq!(self.service_type, ServiceType::ArchiveNode);
+        let mut base_command = self.generate_base_command();
+
+        // Handling multiple peers
+        self.add_peers_command(&mut base_command);
+
+        base_command.push("-archive-address".to_string());
+        base_command.push(format!(
+            "{}:{}",
+            archive_service_host,
+            self.resolved_archive_port()
+        ));
+
+        self.add_libp2p_command(&mut base_command);
+        base_command.join(" ")
+    }
+
     /// Generate command for block producer node
     pub fn generate_block_producer_command(
         &self,

--- a/src/app/minimina/src/service.rs
+++ b/src/app/minimina/src/service.rs
@@ -28,15 +28,24 @@ pub enum ServiceType {
     UptimeServiceBackend,
 }
 
-/// Environment shared by every daemon unit, whichever backend runs it. Both
-/// plan builders bake this into their node specs.
-pub fn daemon_env() -> Vec<(String, String)> {
+/// Passphrases for the throwaway local-network keypairs, needed by any unit
+/// that reads them (daemons, mina-archive).
+pub fn keypair_pass_env() -> Vec<(String, String)> {
     vec![
         ("MINA_PRIVKEY_PASS".into(), "naughty blue worm".into()),
         ("MINA_LIBP2P_PASS".into(), "naughty blue worm".into()),
+    ]
+}
+
+/// Environment shared by every daemon unit, whichever backend runs it. Both
+/// plan builders bake this into their node specs.
+pub fn daemon_env() -> Vec<(String, String)> {
+    let mut env = keypair_pass_env();
+    env.extend([
         ("MINA_CLIENT_TRUSTLIST".into(), "0.0.0.0/0".into()),
         ("RAYON_NUM_THREADS".into(), "2".into()),
-    ]
+    ]);
+    env
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/app/minimina/src/supervisor/plan.rs
+++ b/src/app/minimina/src/supervisor/plan.rs
@@ -49,6 +49,63 @@ pub struct DockerNodeSpec {
     pub aliases: Vec<String>,
 }
 
+impl DockerNodeSpec {
+    /// A minimal container spec: everything else defaults to empty and is
+    /// filled fluently. The name doubles as the container's DNS alias on the
+    /// docker network — that identity is what lets peers dial it by unit name.
+    pub fn new(name: impl Into<String>, image: impl Into<String>) -> Self {
+        let name = name.into();
+        DockerNodeSpec {
+            aliases: vec![name.clone()],
+            name,
+            image: image.into(),
+            entrypoint: None,
+            cmd: vec![],
+            env: vec![],
+            ports: vec![],
+            mounts: vec![],
+        }
+    }
+
+    pub fn entrypoint(mut self, entrypoint: Vec<String>) -> Self {
+        self.entrypoint = Some(entrypoint);
+        self
+    }
+
+    pub fn cmd(mut self, cmd: Vec<String>) -> Self {
+        self.cmd = cmd;
+        self
+    }
+
+    pub fn env(mut self, env: Vec<(String, String)>) -> Self {
+        self.env = env;
+        self
+    }
+
+    pub fn ports(mut self, ports: Vec<(u16, u16)>) -> Self {
+        self.ports = ports;
+        self
+    }
+
+    pub fn mount_rw(mut self, host: impl Into<String>, container: impl Into<String>) -> Self {
+        self.mounts.push(Mount {
+            host: host.into(),
+            container: container.into(),
+            read_only: false,
+        });
+        self
+    }
+
+    pub fn mount_ro(mut self, host: impl Into<String>, container: impl Into<String>) -> Self {
+        self.mounts.push(Mount {
+            host: host.into(),
+            container: container.into(),
+            read_only: true,
+        });
+        self
+    }
+}
+
 /// The native backend's share of the plan.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NativeBackendSpec {

--- a/src/app/minimina/src/topology.rs
+++ b/src/app/minimina/src/topology.rs
@@ -95,7 +95,6 @@ impl TopologyInfo {
         service_name: String,
         peer_list_file: &Path,
         client_port: u16,
-        archive_port: u16,
     ) -> ServiceConfig {
         match self {
             TopologyInfo::UptimeServiceBackend(uptime_service_info) => ServiceConfig {
@@ -128,7 +127,10 @@ impl TopologyInfo {
                         .map(|path| path.to_str().unwrap().to_string())
                         .collect(),
                 ),
-                archive_port: Some(archive_port),
+                // Left unset: resolved everywhere via
+                // `ServiceConfig::resolved_archive_port` (in-code default, not
+                // yet a user-facing topology knob).
+                archive_port: None,
                 archive_docker_image: archive_info.archive_image.clone(),
                 libp2p_keypair_path: Some(archive_info.libp2p_keyfile.clone()),
                 libp2p_peerid: Some(archive_info.libp2p_peerid.clone()),
@@ -176,19 +178,13 @@ impl Topology {
 
     pub fn services(&self, peer_list_file: &Path) -> Vec<ServiceConfig> {
         let mut client_port = 7070;
-        let archive_port = 3086;
 
         let mut services: Vec<ServiceConfig> = self
             .topology
             .iter()
             .map(|(service_name, service_info)| {
                 client_port += 5;
-                service_info.to_service_config(
-                    service_name.clone(),
-                    peer_list_file,
-                    client_port,
-                    archive_port,
-                )
+                service_info.to_service_config(service_name.clone(), peer_list_file, client_port)
             })
             .collect();
 


### PR DESCRIPTION
## Summary

Adds archive support to the supervisor-based minimina, on both the native and docker backends, with an **ephemeral, self-contained postgres** — no dependency on a system postgres server.

An archive node expands to three uniformly-named supervisor units on either backend:

| Unit | Role |
|---|---|
| `postgres` / `postgres-<network>` | ephemeral DB, provisioned at `network create` |
| `<name>-archive-service` | `mina-archive run --postgres-uri … --server-port …` |
| `<name>` | the mina daemon, dialing the service via `-archive-address` |

Shared cross-backend logic (postgres connection params, `mina-archive` args, unit naming, default port) lives in a new `archive` module — the contract both plan builders must agree on — while backend-internal details stay under `native/archive.rs` and `docker/archive.rs`.

## Postgres provisioning (at `network create`)

- **native**: `initdb` an on-disk cluster under the network dir, briefly start it, `createdb` + apply the archive schema, stop. At `network start` the supervisor just runs `postgres` on the ready datadir. Uses `--locale=C` (independent of ambient `LANG`) and a short `/tmp` socket dir (network dirs exceed the ~107-char unix-socket path limit); all real connections are TCP on `127.0.0.1`.
- **docker**: a `postgres:16` container with `POSTGRES_DB=archive`; the schema SQLs are staged (number-prefixed for order) into `/docker-entrypoint-initdb.d` and auto-applied on first boot.

## Archive port resolution

The archive-service port resolves at a single point — `ServiceConfig::resolved_archive_port`, falling back to `archive::DEFAULT_ARCHIVE_PORT` — used by the service unit's `--server-port`, the daemon's `-archive-address` on both backends, and the native port-availability check, so the two sides cannot disagree when the topology omits the port. The default lives only in `archive.rs` as an in-code knob (not yet a user-facing topology field), and a contract test locks the agreement in.

## Testing

- Both DB-init paths validated against real postgres 16 (native initdb sequence; docker initdb.d auto-schema).
- The mina-archive/daemon wiring is compile+review only (no mina image available locally).
- Full suite passes: 71 tests (incl. the new port-contract test), clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)