### PR TITLE
Add buildkite-cache-manager parity job (pilot)

### DIFF
--- a/buildkite/scripts/cache/tests/cache-parity-test.sh
+++ b/buildkite/scripts/cache/tests/cache-parity-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# cache-parity-test.sh
+# ------------------------------------------------------------------------------
+# Parity gate for the CI cache manager. Exercises the two verbs mina actually
+# uses — `read` and `write-to-dir` — against one of two interchangeable engines,
+# selected by CACHE_ENGINE:
+#
+#   bash                      (default) — buildkite/scripts/cache/manager.sh
+#   buildkite-cache-manager             — the Rust tool (binary on PATH, or $BCM)
+#
+# Both operate on the same cache layout ($CACHE_BASE_URL/$BUILDKITE_BUILD_ID/...)
+# and honour the same env, so the assertions below are shared. Run once per
+# engine (in CI, bash in the toolchain image and the tool in the release-toolkit
+# image); identical conclusions == parity.
+#
+# The cache root is a throwaway temp dir (CACHE_BASE_URL), so this touches no
+# real Hetzner storage.
+# ------------------------------------------------------------------------------
+
+set -eux -o pipefail
+
+TEST_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+MANAGER_SH="$(realpath "$TEST_DIR/../manager.sh")"
+
+CACHE_ENGINE="${CACHE_ENGINE:-bash}"
+BCM="${BCM:-buildkite-cache-manager}"
+
+log()  { echo "[cache-parity][$CACHE_ENGINE] $*"; }
+fail() { echo "[cache-parity][$CACHE_ENGINE][ERROR] $*" >&2; exit 1; }
+
+assert_file_equals() {
+  local path="$1" expected="$2" actual
+  [[ -f "$path" ]] || fail "expected file $path to exist"
+  actual="$(cat "$path")"
+  [[ "$actual" == "$expected" ]] || fail "file $path: expected '$expected', got '$actual'"
+}
+
+# Dispatch a cache verb to the selected engine. The tool renames write-to-dir to
+# `write` (variadic: INPUT... DEST, same as the bash verb); everything else is a
+# straight pass-through with matching argument order.
+cache_verb() {
+  local verb="$1"; shift
+  case "$CACHE_ENGINE" in
+    bash)
+      "$MANAGER_SH" "$verb" "$@" ;;
+    buildkite-cache-manager)
+      case "$verb" in
+        write-to-dir) "$BCM" write "$@" ;;
+        *)            "$BCM" "$verb" "$@" ;;
+      esac ;;
+    *)
+      fail "unknown CACHE_ENGINE '$CACHE_ENGINE' (expected 'bash' or 'buildkite-cache-manager')" ;;
+  esac
+}
+
+# Both engines require a Buildkite build id (the cache namespace) and read
+# CACHE_BASE_URL. Use throwaway values so nothing touches real storage.
+WORKDIR="$(mktemp -d -t cache-parity-XXXXXX)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+export CACHE_BASE_URL="$WORKDIR/cache"
+export BUILDKITE_BUILD_ID="parity-test-build"
+mkdir -p "$CACHE_BASE_URL"
+
+SRC="$WORKDIR/src"; mkdir -p "$SRC"
+echo "hashes-content"  > "$SRC/hashes.json"
+echo "config-content"  > "$SRC/new_config.json"
+echo "ledger-a"        > "$SRC/ledger_a.tar.gz"
+echo "ledger-b"        > "$SRC/ledger_b.tar.gz"
+
+# ------------------------------------------------------------------------------
+# write-to-dir: multiple explicit inputs into one destination directory
+# ------------------------------------------------------------------------------
+log "write-to-dir (multiple inputs)"
+cache_verb write-to-dir "$SRC/hashes.json" "$SRC/new_config.json" hardfork/
+
+CACHE_HF="$CACHE_BASE_URL/$BUILDKITE_BUILD_ID/hardfork"
+assert_file_equals "$CACHE_HF/hashes.json"     "hashes-content"
+assert_file_equals "$CACHE_HF/new_config.json" "config-content"
+
+# ------------------------------------------------------------------------------
+# write-to-dir: a glob input into a destination directory
+# ------------------------------------------------------------------------------
+log "write-to-dir (glob input)"
+cache_verb write-to-dir "$SRC/ledger_*.tar.gz" hardfork/ledgers/
+
+CACHE_LED="$CACHE_BASE_URL/$BUILDKITE_BUILD_ID/hardfork/ledgers"
+assert_file_equals "$CACHE_LED/ledger_a.tar.gz" "ledger-a"
+assert_file_equals "$CACHE_LED/ledger_b.tar.gz" "ledger-b"
+
+# ------------------------------------------------------------------------------
+# read: copy cached artifacts back to a local directory
+# ------------------------------------------------------------------------------
+log "read (single input) into a local dir"
+OUT="$WORKDIR/out"; mkdir -p "$OUT"
+cache_verb read hardfork/hashes.json "$OUT"
+assert_file_equals "$OUT/hashes.json" "hashes-content"
+
+log "read (glob input) into a local dir"
+OUT2="$WORKDIR/out2"; mkdir -p "$OUT2"
+cache_verb read "hardfork/ledgers/ledger_*.tar.gz" "$OUT2"
+assert_file_equals "$OUT2/ledger_a.tar.gz" "ledger-a"
+assert_file_equals "$OUT2/ledger_b.tar.gz" "ledger-b"
+
+log "All cache operations executed and verified successfully"

--- a/buildkite/src/Command/CacheManagerTest.dhall
+++ b/buildkite/src/Command/CacheManagerTest.dhall
@@ -1,0 +1,40 @@
+let Command = ./Base.dhall
+
+let Cmd = ../Lib/Cmds.dhall
+
+let Size = ./Size.dhall
+
+let Arch = ../Constants/Arch.dhall
+
+let ContainerImages = ../Constants/ContainerImages.dhall
+
+let RunInToolchain = ./RunInToolchain.dhall
+
+let testScript = "./buildkite/scripts/cache/tests/cache-parity-test.sh"
+
+in  { bashStep =
+        Command.build
+          Command.Config::{
+          , commands =
+              RunInToolchain.runInDefaultToolchain ([] : List Text) testScript
+          , label = "Cache manager tests (bash)"
+          , key = "cache-manager-tests-bash"
+          , target = Size.Small
+          }
+    , toolStep =
+        Command.build
+          Command.Config::{
+          , commands =
+            [ Cmd.runInDocker
+                Cmd.Docker::{
+                , image = ContainerImages.minaReleaseToolkit
+                , extraEnv = [ "CACHE_ENGINE=buildkite-cache-manager" ]
+                , platform = Arch.platform Arch.Type.Amd64
+                }
+                testScript
+            ]
+          , label = "Cache manager tests (buildkite-cache-manager)"
+          , key = "cache-manager-tests-tool"
+          , target = Size.Small
+          }
+    }

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -26,5 +26,5 @@
 , xrefcheck =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/dkhamsing/awesome_bot:latest"
 , nixos = "gcr.io/o1labs-192920/nix-unstable:1.0.0"
-, minaReleaseToolkit = "ghcr.io/minaprotocol/mina-release-toolkit:0.0.2"
+, minaReleaseToolkit = "ghcr.io/minaprotocol/mina-release-toolkit:0.0.3"
 }

--- a/buildkite/src/Jobs/Test/CacheManagerTest.dhall
+++ b/buildkite/src/Jobs/Test/CacheManagerTest.dhall
@@ -1,0 +1,28 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let CacheManagerTest = ../../Command/CacheManagerTest.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "buildkite/scripts/cache")
+          , S.exactly "buildkite/src/Jobs/Test/CacheManagerTest" "dhall"
+          , S.exactly "buildkite/src/Command/CacheManagerTest" "dhall"
+          ]
+        , path = "Test"
+        , name = "CacheManagerTest"
+        , tags =
+          [ PipelineTag.Type.Fast
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          ]
+        }
+      , steps = [ CacheManagerTest.bashStep, CacheManagerTest.toolStep ]
+      }


### PR DESCRIPTION
## What

A parity gate before migrating mina's `cache/manager.sh` callers to the `buildkite-cache-manager` tool. The same suite runs once per engine and both must agree: bash `manager.sh` in the toolchain image, and `buildkite-cache-manager` in the release-toolkit image. **No production caller changes** — this only adds a CI gate.

## Changes

- `cache-parity-test.sh` exercises the two verbs mina actually uses — `read` and `write-to-dir` (with multiple inputs and globs) — against a throwaway `CACHE_BASE_URL` temp dir, so it touches **no real Hetzner storage**. Engine selected by `CACHE_ENGINE` (bash default, or `buildkite-cache-manager`); the tool renames `write-to-dir` → `write`.
- `CacheManagerTest` emits two steps, one per engine (same pattern as the deb-toolkit session pilot).
- `ContainerImages` gains `minaReleaseToolkit` at `:0.0.3`.

## Why :0.0.3

This gate depends on two cache-manager fixes shipped in that image:
- **variadic `write`** ([toolkit #21](https://github.com/MinaProtocol/mina-release-toolkit/pull/21)) — so `write` matches `write-to-dir`'s multi-input calls;
- **`read` CLI fix** ([toolkit #22](https://github.com/MinaProtocol/mina-release-toolkit/pull/22)) — building this gate is what **surfaced a pre-existing bug: `read` panicked at the CLI on an arg-id collision and was unusable.** The tests missed it because they bypass the parser. Now fixed, with a `debug_assert` guard against the whole class.

## Verified

- Both engines pass the suite locally.
- The tool engine passes **inside the actual `:0.0.3` image** (`docker run`), read included.
- `make all` green (45/45); `check_format`, `check_lint`, `shellcheck` clean.

## Notes

- Needs `!ci-build-me` to exercise the new job in CI.
- Overlaps the deb-toolkit session pilot (#19102) on one line: both add `ContainerImages.minaReleaseToolkit`. This pins `:0.0.3` (a superset of #19102's `:0.0.2` — same deb-toolkit, plus the cache fixes), so whichever merges second needs a one-line reconcile to `:0.0.3`. Consider bumping #19102 to `:0.0.3` too so they align.