### PR TITLE
Add mina_caqti postgres memory-usage benchmark + CI perf job

### DIFF
--- a/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
+++ b/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
@@ -7,14 +7,14 @@
 # buildkite/scripts/bench/send.sh uploads it.
 #
 # The PostgreSQL instance is provided by RunWithPostgres (see the Buildkite job),
-# which exports POSTGRES_URI; the benchmark creates its own scratch tables, so no
+# which exports PG_CONN; the benchmark creates its own scratch tables, so no
 # schema is loaded here.
 #
 # USAGE:
 #   ./mina-caqti-pg-memory-bench.sh [iterations]
 #
 # Must be run from the repository root (where dune-project exists), inside the
-# mina-toolchain image with $POSTGRES_URI set.
+# mina-toolchain image with $PG_CONN set.
 
 set -euo pipefail
 
@@ -25,7 +25,11 @@ fi
 
 iterations="${1:-4000}"
 perf_file="${PERF_OUTPUT_FILE:-/workdir/mina_caqti_pg_memory.perf}"
-: "${POSTGRES_URI:?POSTGRES_URI must be set (provided by RunWithPostgres)}"
+pg_uri="${PG_CONN:-${POSTGRES_URI:-}}"
+: "${pg_uri:?PG_CONN or POSTGRES_URI must be set (provided by RunWithPostgres)}"
+
+# mina_caqti pulls in mina_base, whose kimchi bindings need the Rust toolchain.
+export PATH="/home/opam/.cargo/bin:$PATH"
 
 eval "$(opam config env)"
 
@@ -34,7 +38,7 @@ dune build src/lib/mina_caqti/test/pg_memory/main.exe
 
 echo "Running the micro-benchmark (${iterations} iterations/scenario)..."
 ./_build/default/src/lib/mina_caqti/test/pg_memory/main.exe \
-    --uri "${POSTGRES_URI}" \
+    --uri "${pg_uri}" \
     --iterations "${iterations}" \
     --variant "${MINA_BENCH_VARIANT:-ci}" \
     --git-branch "${BUILDKITE_BRANCH:-unknown}" \

--- a/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
+++ b/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
@@ -7,14 +7,14 @@
 # buildkite/scripts/bench/send.sh uploads it.
 #
 # The PostgreSQL instance is provided by RunWithPostgres (see the Buildkite job),
-# which exports PG_CONN; the benchmark creates its own scratch tables, so no
+# which exports POSTGRES_URI; the benchmark creates its own scratch tables, so no
 # schema is loaded here.
 #
 # USAGE:
 #   ./mina-caqti-pg-memory-bench.sh [iterations]
 #
 # Must be run from the repository root (where dune-project exists), inside the
-# mina-toolchain image with $PG_CONN set.
+# mina-toolchain image with $POSTGRES_URI set.
 
 set -euo pipefail
 
@@ -25,8 +25,7 @@ fi
 
 iterations="${1:-4000}"
 perf_file="${PERF_OUTPUT_FILE:-/workdir/mina_caqti_pg_memory.perf}"
-pg_uri="${PG_CONN:-${POSTGRES_URI:-}}"
-: "${pg_uri:?PG_CONN or POSTGRES_URI must be set (provided by RunWithPostgres)}"
+: "${POSTGRES_URI:?POSTGRES_URI must be set (provided by RunWithPostgres)}"
 
 # mina_caqti pulls in mina_base, whose kimchi bindings need the Rust toolchain.
 export PATH="/home/opam/.cargo/bin:$PATH"
@@ -38,7 +37,7 @@ dune build src/lib/mina_caqti/test/pg_memory/main.exe
 
 echo "Running the micro-benchmark (${iterations} iterations/scenario)..."
 ./_build/default/src/lib/mina_caqti/test/pg_memory/main.exe \
-    --uri "${pg_uri}" \
+    --uri "${POSTGRES_URI}" \
     --iterations "${iterations}" \
     --variant "${MINA_BENCH_VARIANT:-ci}" \
     --git-branch "${BUILDKITE_BRANCH:-unknown}" \

--- a/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
+++ b/buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Mina_caqti postgres memory-usage benchmark (CI runner)
+#
+# Builds and runs the pg_memory micro-benchmark (src/lib/mina_caqti/test/pg_memory)
+# and writes an InfluxDB line-protocol perf file to /workdir so that
+# buildkite/scripts/bench/send.sh uploads it.
+#
+# The PostgreSQL instance is provided by RunWithPostgres (see the Buildkite job),
+# which exports POSTGRES_URI; the benchmark creates its own scratch tables, so no
+# schema is loaded here.
+#
+# USAGE:
+#   ./mina-caqti-pg-memory-bench.sh [iterations]
+#
+# Must be run from the repository root (where dune-project exists), inside the
+# mina-toolchain image with $POSTGRES_URI set.
+
+set -euo pipefail
+
+if [[ ! -f dune-project ]]; then
+    echo "Error: run from the repository root (where 'dune-project' exists)."
+    exit 1
+fi
+
+iterations="${1:-4000}"
+perf_file="${PERF_OUTPUT_FILE:-/workdir/mina_caqti_pg_memory.perf}"
+: "${POSTGRES_URI:?POSTGRES_URI must be set (provided by RunWithPostgres)}"
+
+eval "$(opam config env)"
+
+echo "Building the micro-benchmark..."
+dune build src/lib/mina_caqti/test/pg_memory/main.exe
+
+echo "Running the micro-benchmark (${iterations} iterations/scenario)..."
+./_build/default/src/lib/mina_caqti/test/pg_memory/main.exe \
+    --uri "${POSTGRES_URI}" \
+    --iterations "${iterations}" \
+    --variant "${MINA_BENCH_VARIANT:-ci}" \
+    --git-branch "${BUILDKITE_BRANCH:-unknown}" \
+    --git-commit "${BUILDKITE_COMMIT:-unknown}" \
+    --influxdb-file "${perf_file}"
+
+echo "Wrote perf metrics to ${perf_file}:"
+cat "${perf_file}"

--- a/buildkite/src/Command/RunPerformanceTest.dhall
+++ b/buildkite/src/Command/RunPerformanceTest.dhall
@@ -73,10 +73,10 @@ let command
       ->  Command.build
             Command.Config::{
             , commands =
-                    spec.runCommands
-                  # RunInToolchain.runInDefaultToolchain
-                      (Benchmarks.toEnvList Benchmarks.Type::{=})
-                      spec.uploadScript
+                  spec.runCommands
+                # RunInToolchain.runInDefaultToolchain
+                    (Benchmarks.toEnvList Benchmarks.Type::{=})
+                    spec.uploadScript
             , label = spec.label
             , key = spec.key
             , target = spec.size

--- a/buildkite/src/Command/RunPerformanceTest.dhall
+++ b/buildkite/src/Command/RunPerformanceTest.dhall
@@ -1,0 +1,89 @@
+{-|
+## RunPerformanceTest Module
+
+A reusable Buildkite command for performance/benchmark jobs that publish their
+results to InfluxDB.
+
+The benchmark itself is expressed as `runCommands` — arbitrary command(s) that
+produce one or more `*.perf` files (InfluxDB line protocol) under `/workdir`.
+This command appends the standard upload teardown (`uploadScript`, run in the
+default toolchain with the InfluxDB credentials from `Benchmarks`), so every
+perf job uploads the same way instead of open-coding the teardown.
+
+`runCommands` is intentionally open: a job can run its benchmark however it needs
+(plain toolchain, `RunWithPostgres`, a Docker container, several steps, …) and
+still get the InfluxDB upload for free. Everything else (label, key, size,
+artifacts, dependencies, docker, soft-fail, upload script) is a `Spec` field with
+a sensible default.
+
+### Example
+
+    RunPerformanceTest.command
+      RunPerformanceTest.Spec::{
+      , key = "my-bench"
+      , label = "My benchmark"
+      , runCommands =
+        [ RunWithPostgres.runInDockerWithPostgresConn env init image "./my-bench.sh" ]
+      }
+-}
+
+let Command = ./Base.dhall
+
+let Cmd = ../Lib/Cmds.dhall
+
+let RunInToolchain = ./RunInToolchain.dhall
+
+let Benchmarks = ../Constants/Benchmarks.dhall
+
+let Docker = ./Docker/Type.dhall
+
+let Size = ./Size.dhall
+
+let SelectFiles = ../Lib/SelectFiles.dhall
+
+let B = ../External/Buildkite.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
+let Spec =
+      { Type =
+          { key : Text
+          , label : Text
+          , runCommands : List Cmd.Type
+          , uploadScript : Text
+          , size : Size
+          , artifactPaths : List SelectFiles.Type
+          , dependsOn : List Command.TaggedKey.Type
+          , docker : Optional Docker.Type
+          , softFail : Optional B/SoftFail
+          }
+      , default =
+          { uploadScript = "./buildkite/scripts/bench/send.sh"
+          , size = Size.Large
+          , artifactPaths = [ SelectFiles.contains "*.perf" ]
+          , dependsOn = [] : List Command.TaggedKey.Type
+          , docker = None Docker.Type
+          , softFail = None B/SoftFail
+          }
+      }
+
+let command
+    : Spec.Type -> Command.Type
+    =     \(spec : Spec.Type)
+      ->  Command.build
+            Command.Config::{
+            , commands =
+                    spec.runCommands
+                  # RunInToolchain.runInDefaultToolchain
+                      (Benchmarks.toEnvList Benchmarks.Type::{=})
+                      spec.uploadScript
+            , label = spec.label
+            , key = spec.key
+            , target = spec.size
+            , docker = spec.docker
+            , soft_fail = spec.softFail
+            , artifact_paths = spec.artifactPaths
+            , depends_on = spec.dependsOn
+            }
+
+in  { Spec = Spec, command = command }

--- a/buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall
+++ b/buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall
@@ -1,0 +1,51 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let RunWithPostgres = ../../Command/RunWithPostgres.dhall
+
+let RunPerformanceTest = ../../Command/RunPerformanceTest.dhall
+
+let WithCargo = ../../Command/WithCargo.dhall
+
+let ContainerImages = ../../Constants/ContainerImages.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "src/lib/mina_caqti")
+          , S.strictlyStart
+              (S.contains "buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench")
+          , S.exactly "buildkite/scripts/tests/mina-caqti-pg-memory-bench" "sh"
+          ]
+        , path = "Test"
+        , name = "MinaCaqtiPgMemoryBench"
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          , PipelineTag.Type.Archive
+          ]
+        }
+      , steps =
+        [ RunPerformanceTest.command
+            RunPerformanceTest.Spec::{
+            , key = "mina-caqti-pg-memory-bench"
+            , label = "Mina caqti postgres memory-usage bench"
+            , runCommands =
+              [ RunWithPostgres.runInDockerWithPostgresConn
+                  [ "BUILDKITE_BRANCH", "BUILDKITE_COMMIT" ]
+                  (None RunWithPostgres.ScriptOrArchive)
+                  ContainerImages.minaToolchain
+                  ( WithCargo.withCargo
+                      "./buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh"
+                  )
+              ]
+            }
+        ]
+      }

--- a/buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall
+++ b/buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall
@@ -10,9 +10,11 @@ let RunWithPostgres = ../../Command/RunWithPostgres.dhall
 
 let RunPerformanceTest = ../../Command/RunPerformanceTest.dhall
 
-let WithCargo = ../../Command/WithCargo.dhall
-
 let ContainerImages = ../../Constants/ContainerImages.dhall
+
+let FixPermissions = ../../Command/FixPermissions.dhall
+
+let Arch = ../../Constants/Arch.dhall
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -38,13 +40,12 @@ in  Pipeline.build
             , key = "mina-caqti-pg-memory-bench"
             , label = "Mina caqti postgres memory-usage bench"
             , runCommands =
-              [ RunWithPostgres.runInDockerWithPostgresConn
+              [ FixPermissions.command Arch.Type.Amd64
+              , RunWithPostgres.runInDockerWithPostgresConn
                   [ "BUILDKITE_BRANCH", "BUILDKITE_COMMIT" ]
                   (None RunWithPostgres.ScriptOrArchive)
                   ContainerImages.minaToolchain
-                  ( WithCargo.withCargo
-                      "./buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh"
-                  )
+                  "./buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh"
               ]
             }
         ]

--- a/changes/19110.md
+++ b/changes/19110.md
@@ -1,0 +1,3 @@
+Add a PostgreSQL memory-usage benchmark for the archive node's database helpers
+
+Long-running archive nodes could grow their PostgreSQL backend memory over time because each database call registered a new server-side prepared statement that lived for the lifetime of the connection. A new benchmark measures that growth and runs in CI, so regressions in archive database memory usage are caught before a release rather than after a node runs out of memory.

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -512,12 +512,19 @@ let insert_multi_into_col_no_dedup ~(table_name : string) ~(col : string)
         Caqti_request.Infix.((Caqti_type.unit ->* Caqti_type.int) insert)
         ()
 
-let query ~f pool =
-  match%bind Pool.use f pool with
+(** Unwrap a Caqti result, raising on error. [ctx] names the operation being
+    performed and is prepended to the message. *)
+let ok_exn ?ctx = function
   | Ok v ->
-      return v
+      v
   | Error msg ->
-      failwithf "Error querying db, error: %s" (Caqti_error.show msg) ()
+      failwithf "%sError querying db, error: %s"
+        (Option.value_map ctx ~default:"" ~f:(sprintf "%s: "))
+        (Caqti_error.show msg) ()
+
+let query ~f pool =
+  let%map res = Pool.use f pool in
+  ok_exn res
 
 (** functions to retrieve an item from the db, where the input has
     option type; the resulting option is converted to a suitable type
@@ -525,11 +532,8 @@ let query ~f pool =
 let make_get_opt ~of_option ~f item_opt =
   let%map res_opt =
     Option.value_map item_opt ~default:(return None) ~f:(fun item ->
-        match%map f item with
-        | Ok v ->
-            Some v
-        | Error msg ->
-            failwithf "Error querying db, error: %s" (Caqti_error.show msg) () )
+        let%map res = f item in
+        Some (ok_exn res) )
   in
   of_option res_opt
 

--- a/src/lib/mina_caqti/test/pg_memory/README.md
+++ b/src/lib/mina_caqti/test/pg_memory/README.md
@@ -1,0 +1,102 @@
+# mina_caqti postgres memory-usage benchmark
+
+A small, deterministic benchmark of PostgreSQL backend memory used by
+`Mina_caqti`'s DB helpers. It was written to reproduce and measure the leak in
+[MinaProtocol/mina#18857][18857], and stays useful afterwards as a standard
+memory-usage / regression check. Root cause it targets: several `Mina_caqti`
+helpers build a **fresh `Caqti_request.t` on every call**. Caqti keys its per-connection
+prepared-statement cache by request-object *identity*, so each call makes the
+backend register a new server-side prepared statement (`PREPARE _caqtiN`) that
+lives for the connection's lifetime. On the archive's long-lived pooled
+connections these accumulate without bound and OOM the postgres backend
+(observed: 1.5–2 GB RSS per idle backend, ~1 OOMKill / 2 h on ITN).
+
+The benchmark drives one helper `N` times on a single long-lived connection and,
+**on that same connection**, samples two deterministic signals:
+
+- `pg_prepared_statements` — exact server-side prepared-statement count;
+- `pg_backend_memory_contexts` — backend cache/plan memory (PostgreSQL 14+).
+
+On unfixed code the prepared-statement count grows linearly with the number of
+calls; once the offending requests are marked `~oneshot:true` (or hoisted to a
+module-level constant) it stays flat.
+
+## Scenarios
+
+| helper | requests built per call | fixed by |
+| --- | --- | --- |
+| `select_insert_into_cols` | 2 (SELECT + INSERT) | [#18858][18858pr] (`~oneshot:true`) |
+| `insert_multi_into_col` | 2 (INSERT + SELECT) | [#18860][18860pr] (parameter binding) / [#18858][18858pr] |
+| `upsert_into_cols_returning` | 1 | **neither PR** — included to show the residual leak (runs on every block) |
+
+Every scenario uses a `text` column so the exact same source compiles against
+`develop`, #18858 and #18860 (the latter changed `insert_multi_into_col`'s
+`values` from `string list` to `'col list`; with `'col = string` the call is
+unchanged).
+
+## Usage
+
+Needs a live PostgreSQL. Point it at a throwaway database (the tool creates and
+drops its own `mb_*` tables):
+
+```sh
+dune build src/lib/mina_caqti/test/pg_memory/main.exe
+
+./_build/default/src/lib/mina_caqti/test/pg_memory/main.exe \
+  --uri postgresql://user@localhost:5432/scratch \
+  --iterations 2000 --sample-every 1000
+```
+
+The URI may also be supplied via `MINA_CAQTI_TEST_PG_URI`. With neither, the
+tool prints a skip notice and exits 0 (no-op where no database is available).
+
+`--assert-max-prepared K` makes it exit non-zero if any scenario's final
+prepared-statement count exceeds `K`, so it can double as a CI regression guard
+on the fixed code.
+
+### Perf metrics (InfluxDB)
+
+`--influxdb-file PATH` writes one InfluxDB line-protocol point per scenario,
+using the same measurement/tag convention as `scripts/tests/rosetta-load.sh`
+so runs land in the perf time-series database:
+
+```
+mina_caqti_pg_memory_bench,branch=<b>,commit=<c>,variant=<v>,scenario=<name> \
+  prepared_final=<n>i,prepared_per_call=<f>,backend_kib_final=<n>i,iterations=<n>i <ns>
+```
+
+Tags are taken from `--variant`/`--network`/`--git-branch`/`--git-commit`
+(falling back to `$MINA_BENCH_VARIANT` / `$GIT_BRANCH` / `$GIT_COMMIT`). Run the
+tool once per build variant (e.g. `variant=baseline` on develop and
+`variant=pr18858` on the fixed build) to chart the before/after on the perf
+infra.
+
+## Example (develop, unfixed)
+
+```
+== scenario: select_insert_into_cols ==
+   calls      prepared     backend_KiB
+   0          0            1380
+   1000       2000         ...
+   2000       4000         34418          <- 2 leaked prepared stmts / call
+```
+
+With #18858 applied, `select_insert_into_cols` and `insert_multi_into_col` hold
+at `prepared=0`, while `upsert_into_cols_returning` still climbs — demonstrating
+that the two PRs fully neutralise the helpers they touch but do not eliminate
+the leak class.
+
+## Running in CI
+
+The Buildkite job `Test/MinaCaqtiPgMemoryBench`
+(`buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall`, runner
+`buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh`) provisions PostgreSQL in
+the toolchain image, builds and runs this benchmark, and uploads the
+`--influxdb-file` output to the perf InfluxDB via
+`buildkite/scripts/bench/send.sh`. It is triggered by `dirtyWhen` on
+`src/lib/mina_caqti`, so a change that adds `~oneshot:true` (or otherwise
+touches the helpers) re-measures the leak automatically.
+
+[18857]: https://github.com/MinaProtocol/mina/issues/18857
+[18858pr]: https://github.com/MinaProtocol/mina/pull/18858
+[18860pr]: https://github.com/MinaProtocol/mina/pull/18860

--- a/src/lib/mina_caqti/test/pg_memory/README.md
+++ b/src/lib/mina_caqti/test/pg_memory/README.md
@@ -62,8 +62,14 @@ so runs land in the perf time-series database:
 
 ```
 mina_caqti_pg_memory_bench,branch=<b>,commit=<c>,variant=<v>,scenario=<name> \
-  prepared_final=<n>i,prepared_per_call=<f>,backend_kib_final=<n>i,iterations=<n>i <ns>
+  prepared_final=<n>i,prepared_per_call=<f>,iterations=<n>i,backend_kib_final=<n>i <ns>
 ```
+
+`backend_kib_final` is present only where the server exposes
+`pg_backend_memory_contexts` (PostgreSQL 14+); on older servers — including the
+PostgreSQL 12 the CI job provisions — the field is left out of the point rather
+than written as a zero, so the series is visibly absent instead of looking like a
+flat measurement.
 
 Tags are taken from `--variant`/`--network`/`--git-branch`/`--git-commit`
 (falling back to `$MINA_BENCH_VARIANT` / `$GIT_BRANCH` / `$GIT_COMMIT`). Run the

--- a/src/lib/mina_caqti/test/pg_memory/README.md
+++ b/src/lib/mina_caqti/test/pg_memory/README.md
@@ -12,7 +12,7 @@ connections these accumulate without bound and OOM the postgres backend
 (observed: 1.5–2 GB RSS per idle backend, ~1 OOMKill / 2 h on ITN).
 
 The benchmark drives one helper `N` times on a single long-lived connection and,
-**on that same connection**, samples two deterministic signals:
+**on that same connection**, samples two deterministic signals in a single query:
 
 - `pg_prepared_statements` — exact server-side prepared-statement count;
 - `pg_backend_memory_contexts` — backend cache/plan memory (PostgreSQL 14+).
@@ -20,6 +20,10 @@ The benchmark drives one helper `N` times on a single long-lived connection and,
 On unfixed code the prepared-statement count grows linearly with the number of
 calls; once the offending requests are marked `~oneshot:true` (or hoisted to a
 module-level constant) it stays flat.
+
+Whether the second signal is available is discovered by querying it rather than
+by comparing version numbers: on a server without the view the sample query
+fails once, and the run continues reporting the prepared-statement count alone.
 
 ## Scenarios
 
@@ -29,15 +33,29 @@ module-level constant) it stays flat.
 | `insert_multi_into_col` | 2 (INSERT + SELECT) | [#18860][18860pr] (parameter binding) / [#18858][18858pr] |
 | `upsert_into_cols_returning` | 1 | **neither PR** — included to show the residual leak (runs on every block) |
 
-Every scenario uses a `text` column so the exact same source compiles against
+Every scenario uses `text` columns so the exact same source compiles against
 `develop`, #18858 and #18860 (the latter changed `insert_multi_into_col`'s
 `values` from `string list` to `'col list`; with `'col = string` the call is
 unchanged).
 
+The shapes are deliberately not uniform — `select_insert_into_cols` runs against
+a three-column unique key, `upsert_into_cols_returning` against a two-column one
+with a payload column (and reuses every second key, so the `ON CONFLICT DO
+UPDATE` branch is exercised too), and `insert_multi_into_col` inserts a list
+whose length varies per call.
+
+Column values come from Quickcheck generators seeded per (scenario, iteration):
+payload lengths and contents vary from call to call, while two runs of the
+benchmark still see the identical sequence, which is what keeps the numbers
+comparable across builds. Values that must not collide carry the iteration index
+as a prefix — a duplicate would silently turn an INSERT into a SELECT hit and
+change what is being measured.
+
 ## Usage
 
-Needs a live PostgreSQL. Point it at a throwaway database (the tool creates and
-drops its own `mb_*` tables):
+Needs a live PostgreSQL. Each scenario creates one table named
+`pg_memory_<uuid>`, and drops that table when it finishes; nothing else in the
+database is touched, and the tool never drops a table it did not create:
 
 ```sh
 dune build src/lib/mina_caqti/test/pg_memory/main.exe
@@ -80,12 +98,14 @@ infra.
 ## Example (develop, unfixed)
 
 ```
-== scenario: select_insert_into_cols ==
+== scenario: select_insert_into_cols (table pg_memory_1a5d2fc119c535f3) ==
    calls      prepared     backend_KiB
    0          0            1380
    1000       2000         ...
    2000       4000         34418          <- 2 leaked prepared stmts / call
 ```
+
+On a server older than PostgreSQL 14 the `backend_KiB` column reads `n/a`.
 
 With #18858 applied, `select_insert_into_cols` and `insert_multi_into_col` hold
 at `prepared=0`, while `upsert_into_cols_returning` still climbs — demonstrating

--- a/src/lib/mina_caqti/test/pg_memory/README.md
+++ b/src/lib/mina_caqti/test/pg_memory/README.md
@@ -1,15 +1,15 @@
 # mina_caqti postgres memory-usage benchmark
 
-A small, deterministic benchmark of PostgreSQL backend memory used by
-`Mina_caqti`'s DB helpers. It was written to reproduce and measure the leak in
-[MinaProtocol/mina#18857][18857], and stays useful afterwards as a standard
-memory-usage / regression check. Root cause it targets: several `Mina_caqti`
-helpers build a **fresh `Caqti_request.t` on every call**. Caqti keys its per-connection
-prepared-statement cache by request-object *identity*, so each call makes the
-backend register a new server-side prepared statement (`PREPARE _caqtiN`) that
-lives for the connection's lifetime. On the archive's long-lived pooled
-connections these accumulate without bound and OOM the postgres backend
-(observed: 1.5–2 GB RSS per idle backend, ~1 OOMKill / 2 h on ITN).
+A small, deterministic benchmark of the PostgreSQL backend memory used by
+`Mina_caqti`'s DB helpers, useful as a standard memory-usage / regression check
+for them.
+
+What it measures: Caqti keys its per-connection prepared-statement cache by
+request-object *identity*. A helper that builds a fresh `Caqti_request.t` on
+every call therefore makes the backend register a new server-side prepared
+statement (`PREPARE _caqtiN`) per call, which lives for the connection's
+lifetime. On long-lived pooled connections those accumulate without bound and
+grow the backend's memory.
 
 The benchmark drives one helper `N` times on a single long-lived connection and,
 **on that same connection**, samples two deterministic signals in a single query:
@@ -17,9 +17,9 @@ The benchmark drives one helper `N` times on a single long-lived connection and,
 - `pg_prepared_statements` — exact server-side prepared-statement count;
 - `pg_backend_memory_contexts` — backend cache/plan memory (PostgreSQL 14+).
 
-On unfixed code the prepared-statement count grows linearly with the number of
-calls; once the offending requests are marked `~oneshot:true` (or hoisted to a
-module-level constant) it stays flat.
+A helper that builds a request per call makes the count grow linearly with the
+number of calls; one that reuses its request — or marks it `~oneshot:true` so it
+is never cached — keeps it flat.
 
 Whether the second signal is available is discovered by querying it rather than
 by comparing version numbers: on a server without the view the sample query
@@ -27,16 +27,16 @@ fails once, and the run continues reporting the prepared-statement count alone.
 
 ## Scenarios
 
-| helper | requests built per call | fixed by |
-| --- | --- | --- |
-| `select_insert_into_cols` | 2 (SELECT + INSERT) | [#18858][18858pr] (`~oneshot:true`) |
-| `insert_multi_into_col` | 2 (INSERT + SELECT) | [#18860][18860pr] (parameter binding) / [#18858][18858pr] |
-| `upsert_into_cols_returning` | 1 | **neither PR** — included to show the residual leak (runs on every block) |
+| helper | requests built per call |
+| --- | --- |
+| `select_insert_into_cols` | 2 (SELECT + INSERT) |
+| `insert_multi_into_col` | 2 (INSERT + SELECT) |
+| `upsert_into_cols_returning` | 1 |
 
-Every scenario uses `text` columns so the exact same source compiles against
-`develop`, #18858 and #18860 (the latter changed `insert_multi_into_col`'s
-`values` from `string list` to `'col list`; with `'col = string` the call is
-unchanged).
+Every scenario uses `text` columns, which keeps the call sites valid across
+signature variants of these helpers (`insert_multi_into_col` has taken both a
+`string list` and a `'col list` of values; with `'col = string` the call is
+identical either way).
 
 The shapes are deliberately not uniform — `select_insert_into_cols` runs against
 a three-column unique key, `upsert_into_cols_returning` against a two-column one
@@ -69,8 +69,7 @@ The URI may also be supplied via `MINA_CAQTI_TEST_PG_URI`. With neither, the
 tool prints a skip notice and exits 0 (no-op where no database is available).
 
 `--assert-max-prepared K` makes it exit non-zero if any scenario's final
-prepared-statement count exceeds `K`, so it can double as a CI regression guard
-on the fixed code.
+prepared-statement count exceeds `K`, so it can double as a CI regression guard.
 
 ### Perf metrics (InfluxDB)
 
@@ -84,45 +83,22 @@ mina_caqti_pg_memory_bench,branch=<b>,commit=<c>,variant=<v>,scenario=<name> \
 ```
 
 `backend_kib_final` is present only where the server exposes
-`pg_backend_memory_contexts` (PostgreSQL 14+); on older servers — including the
-PostgreSQL 12 the CI job provisions — the field is left out of the point rather
-than written as a zero, so the series is visibly absent instead of looking like a
-flat measurement.
+`pg_backend_memory_contexts` (PostgreSQL 14+); on older servers the field is left
+out of the point rather than written as a zero, so the series is visibly absent
+instead of looking like a flat measurement.
 
 Tags are taken from `--variant`/`--network`/`--git-branch`/`--git-commit`
 (falling back to `$MINA_BENCH_VARIANT` / `$GIT_BRANCH` / `$GIT_COMMIT`). Run the
-tool once per build variant (e.g. `variant=baseline` on develop and
-`variant=pr18858` on the fixed build) to chart the before/after on the perf
-infra.
+tool once per build variant to chart one against another on the perf infra.
 
-## Example (develop, unfixed)
+## Example
 
 ```
 == scenario: select_insert_into_cols (table pg_memory_1a5d2fc119c535f3) ==
    calls      prepared     backend_KiB
    0          0            1380
    1000       2000         ...
-   2000       4000         34418          <- 2 leaked prepared stmts / call
+   2000       4000         34418          <- 2 prepared statements per call
 ```
 
 On a server older than PostgreSQL 14 the `backend_KiB` column reads `n/a`.
-
-With #18858 applied, `select_insert_into_cols` and `insert_multi_into_col` hold
-at `prepared=0`, while `upsert_into_cols_returning` still climbs — demonstrating
-that the two PRs fully neutralise the helpers they touch but do not eliminate
-the leak class.
-
-## Running in CI
-
-The Buildkite job `Test/MinaCaqtiPgMemoryBench`
-(`buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall`, runner
-`buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh`) provisions PostgreSQL in
-the toolchain image, builds and runs this benchmark, and uploads the
-`--influxdb-file` output to the perf InfluxDB via
-`buildkite/scripts/bench/send.sh`. It is triggered by `dirtyWhen` on
-`src/lib/mina_caqti`, so a change that adds `~oneshot:true` (or otherwise
-touches the helpers) re-measures the leak automatically.
-
-[18857]: https://github.com/MinaProtocol/mina/issues/18857
-[18858pr]: https://github.com/MinaProtocol/mina/pull/18858
-[18860pr]: https://github.com/MinaProtocol/mina/pull/18860

--- a/src/lib/mina_caqti/test/pg_memory/dune
+++ b/src/lib/mina_caqti/test/pg_memory/dune
@@ -1,0 +1,15 @@
+(executable
+ (name main)
+ (libraries
+  ;; opam libraries
+  core
+  async
+  core_unix.command_unix
+  uri
+  caqti
+  caqti-async
+  caqti-driver-postgresql
+  ;; local libraries
+  mina_caqti)
+ (preprocess
+  (pps ppx_jane)))

--- a/src/lib/mina_caqti/test/pg_memory/dune
+++ b/src/lib/mina_caqti/test/pg_memory/dune
@@ -9,6 +9,8 @@
   caqti
   caqti-async
   caqti-driver-postgresql
+  core.uuid
+  core_kernel.uuid
   ;; local libraries
   mina_caqti)
  (preprocess

--- a/src/lib/mina_caqti/test/pg_memory/dune
+++ b/src/lib/mina_caqti/test/pg_memory/dune
@@ -12,4 +12,6 @@
   ;; local libraries
   mina_caqti)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_version ppx_jane))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -17,12 +17,17 @@
    so it is never cached, keeps it flat. [--assert-max-prepared] turns that into
    a regression guard.
 
+   The tables themselves are generated, not hand-written: each helper is
+   instantiated over [--shapes] Quickcheck-generated table shapes (column
+   count, column names, text/int column types all drawn from generators), and
+   the per-call values are drawn per (scenario, iteration). Everything is
+   seeded deterministically, so the shapes and payloads vary within a run but
+   two runs still see the identical sequence — a benchmark whose inputs drift
+   is not comparable across builds.
+
    Each scenario works on its own table, named with a UUID and created fresh:
-   the benchmark never drops a table it did not create, and drops the one it did
-   on the way out. Column values come from Quickcheck generators seeded per
-   (scenario, iteration), so the payloads vary in length and shape from call to
-   call while two runs still see the identical sequence — a benchmark whose
-   inputs drift is not comparable across builds.
+   the benchmark never drops a table it did not create, and drops the one it
+   did on the way out.
 
    Results can additionally be emitted as InfluxDB line protocol
    ([--influxdb-file]) using the same measurement/tag convention as
@@ -96,6 +101,7 @@ type result =
 
 type scenario =
   { name : string
+  ; describe : string (* human-readable generated table shape *)
   ; setup : table:string -> string
         (* ONE statement, so the table either exists complete or not at all *)
   ; teardown : table:string -> string
@@ -104,13 +110,26 @@ type scenario =
         (* one unit of work exercising a single helper, using a fresh request *)
   }
 
-(* --- generated payloads ----------------------------------------------------
+(* --- generated table shapes and payloads -----------------------------------
 
-   [insert_multi_into_col] renders its values into the SQL text as single-quoted
-   literals without escaping, so generated tokens stay alphanumeric. The
-   iteration index is prefixed to every value that must be unique: a collision
-   would silently turn an INSERT into a SELECT hit and change what is being
-   measured. *)
+   A shape is a list of columns, each with a generated name and a generated
+   type (text or int). The heterogeneous row value is packed into a nested
+   [Caqti_type.t2] product built at runtime and hidden behind an existential,
+   so the same code drives helpers over tables of any generated width.
+
+   [insert_multi_into_col] renders its values into the SQL text as
+   single-quoted literals without escaping, so generated tokens stay
+   alphanumeric. The iteration index is prefixed to every value that must be
+   unique: a collision would silently turn an INSERT into a SELECT hit and
+   change what is being measured. *)
+
+type col_ty = Text | Int
+
+type col = { col_name : string; col_ty : col_ty }
+
+type cell = Cell_text of string | Cell_int of int
+
+type packed_row = Pack : 'a Caqti_type.t * 'a -> packed_row
 
 let gen_token =
   let open Quickcheck.Generator.Let_syntax in
@@ -123,10 +142,79 @@ let gen_tokens =
   let%bind n = Int.gen_incl 1 8 in
   List.gen_with_length n gen_token
 
+(* the [ci_] prefix guarantees a valid lowercase identifier whatever the token
+   starts with, and makes the names unique per position *)
+let gen_cols ~min_cols ~max_cols =
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind n = Int.gen_incl min_cols max_cols in
+  let%map named =
+    List.gen_with_length n
+      (Quickcheck.Generator.both gen_token
+         (Quickcheck.Generator.of_list [ Text; Int ]) )
+  in
+  List.mapi named ~f:(fun i (tok, ty) ->
+      { col_name = sprintf "c%d_%s" i (String.lowercase tok); col_ty = ty } )
+
+let gen_cell = function
+  | Text ->
+      Quickcheck.Generator.map gen_token ~f:(fun s -> Cell_text s)
+  | Int ->
+      Quickcheck.Generator.map (Int.gen_incl 0 1_000_000) ~f:(fun i ->
+          Cell_int i )
+
+let gen_row cols =
+  List.map cols ~f:(fun c -> gen_cell c.col_ty) |> Quickcheck.Generator.all
+
 let generate ~scenario ~iteration gen =
   Quickcheck.random_value
     ~seed:(`Deterministic (sprintf "%s:%d" scenario iteration))
     gen
+
+(* helpers under test take typed params, so ints go through as ints *)
+let pack_cell = function
+  | Cell_text s ->
+      Pack (Caqti_type.string, s)
+  | Cell_int i ->
+      Pack (Caqti_type.int, i)
+
+let rec pack_row = function
+  | [] ->
+      failwith "pack_row: empty row"
+  | [ cell ] ->
+      pack_cell cell
+  | cell :: rest ->
+      let (Pack (t, v)) = pack_cell cell in
+      let (Pack (t', v')) = pack_row rest in
+      Pack (Caqti_type.t2 t t', (v, v'))
+
+(* calls that must never collide with an earlier call's row get the iteration
+   index stamped into their first cell; shapes generate the first column as
+   text so there is always somewhere to stamp it *)
+let stamp_first ~tag cells =
+  match cells with
+  | Cell_text s :: rest ->
+      Cell_text (sprintf "%s-%s" tag s) :: rest
+  | _ ->
+      failwith "stamp_first: first generated column must be text"
+
+let force_first_text = function
+  | [] ->
+      []
+  | c :: rest ->
+      { c with col_ty = Text } :: rest
+
+let sql_ty = function Text -> "text" | Int -> "int"
+
+let col_defs cols =
+  List.map cols ~f:(fun c ->
+      sprintf "%s %s NOT NULL" c.col_name (sql_ty c.col_ty) )
+  |> String.concat ~sep:", "
+
+let col_names cols = List.map cols ~f:(fun c -> c.col_name)
+
+let describe_cols cols =
+  List.map cols ~f:(fun c -> sprintf "%s %s" c.col_name (sql_ty c.col_ty))
+  |> String.concat ~sep:", "
 
 (* --- the helpers under test ------------------------------------------------
 
@@ -134,84 +222,136 @@ let generate ~scenario ~iteration gen =
    register an unbounded number of server-side prepared statements — the count
    must stay bounded regardless of N (achieved by request reuse / [~oneshot]).
 
-   The columns are text so the same source stays valid across signature variants
-   of these helpers (e.g. [insert_multi_into_col] has taken both a [string list]
-   and a ['col list] of values; with a string column ['col = string] the call
-   site is identical either way). *)
+   Each helper is instantiated over [shapes] generated table shapes; the shape
+   index is part of every seed, so different shapes also see different value
+   sequences. *)
 
-let scenarios : scenario list =
-  [ { name = "select_insert_into_cols"
-    ; setup =
-        (fun ~table ->
-          sprintf
-            "CREATE TABLE %s (id serial PRIMARY KEY, k1 text NOT NULL, k2 text \
-             NOT NULL, k3 text NOT NULL, UNIQUE (k1, k2, k3))"
-            table )
-    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
-    ; step =
-        (fun ~table conn i ->
-          (* distinct key each call -> SELECT miss then INSERT: exercises BOTH
-             of the requests this helper builds per call *)
-          let k2, k3 =
-            generate ~scenario:"select_insert_into_cols" ~iteration:i
-              (Quickcheck.Generator.both gen_token gen_token)
-          in
-          Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
-            ~table_name:table
-            ~cols:([ "k1"; "k2"; "k3" ], Caqti_type.(t3 string string string))
-            conn
-            (sprintf "k-%d" i, k2, k3)
-          >>| Mina_caqti.ok_exn ~ctx:"select_insert_into_cols"
-          >>| ignore )
-    }
-  ; { name = "insert_multi_into_col"
-    ; setup =
-        (fun ~table ->
-          sprintf
-            "CREATE TABLE %s (id serial PRIMARY KEY, v text UNIQUE NOT NULL)"
-            table )
-    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
-    ; step =
-        (fun ~table conn i ->
-          (* a varying number of values per call: the rendered VALUES list is a
-             different length every time, which is the realistic shape and keeps
-             the SQL text varying independently of request identity *)
-          let values =
-            generate ~scenario:"insert_multi_into_col" ~iteration:i gen_tokens
-            |> List.mapi ~f:(fun j v -> sprintf "v-%d-%d-%s" i j v)
-          in
-          Mina_caqti.insert_multi_into_col ~table_name:table
-            ~col:("v", Caqti_type.string) conn values
-          >>| Mina_caqti.ok_exn ~ctx:"insert_multi_into_col"
-          >>| ignore )
-    }
-  ; { name = "upsert_into_cols_returning"
-    ; setup =
-        (fun ~table ->
-          sprintf
-            "CREATE TABLE %s (id serial PRIMARY KEY, k1 text NOT NULL, k2 text \
-             NOT NULL, payload text NOT NULL, UNIQUE (k1, k2))"
-            table )
-    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
-    ; step =
-        (fun ~table conn i ->
-          (* every second call reuses the previous key, so the ON CONFLICT DO
-             UPDATE branch is exercised as well as the plain insert *)
-          let key_index = if i % 2 = 0 then i - 1 else i in
-          let payload =
-            generate ~scenario:"upsert_into_cols_returning" ~iteration:i
-              gen_token
-          in
-          Mina_caqti.upsert_into_cols_returning ~on_conflict:"k1,k2"
-            ~returning:("id", Caqti_type.int) ~table_name:table
-            ~cols:
-              ([ "k1"; "k2"; "payload" ], Caqti_type.(t3 string string string))
-            conn
-            (sprintf "k-%d" key_index, sprintf "j-%d" key_index, payload)
-          >>| Mina_caqti.ok_exn ~ctx:"upsert_into_cols_returning"
-          >>| ignore )
-    }
-  ]
+let select_insert_scenario ~shape_idx =
+  let name = sprintf "select_insert_into_cols_s%d" shape_idx in
+  let cols =
+    generate ~scenario:"shape:select_insert_into_cols" ~iteration:shape_idx
+      (gen_cols ~min_cols:2 ~max_cols:6)
+    |> force_first_text
+  in
+  { name
+  ; describe = describe_cols cols
+  ; setup =
+      (fun ~table ->
+        sprintf "CREATE TABLE %s (id serial PRIMARY KEY, %s, UNIQUE (%s))" table
+          (col_defs cols)
+          (String.concat ~sep:", " (col_names cols)) )
+  ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
+  ; step =
+      (fun ~table conn i ->
+        (* distinct key each call -> SELECT miss then INSERT: exercises BOTH
+           of the requests this helper builds per call *)
+        let (Pack (typ, value)) =
+          generate ~scenario:name ~iteration:i (gen_row cols)
+          |> stamp_first ~tag:(sprintf "k-%d" i)
+          |> pack_row
+        in
+        Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+          ~table_name:table
+          ~cols:(col_names cols, typ)
+          conn value
+        >>| Mina_caqti.ok_exn ~ctx:name
+        >>| ignore )
+  }
+
+let insert_multi_scenario ~shape_idx =
+  let name = sprintf "insert_multi_into_col_s%d" shape_idx in
+  (* the helper only ever writes its one column, so the generated columns are
+     distractors with defaults: the table shape still varies while the call
+     site stays the same *)
+  let distractors =
+    generate ~scenario:"shape:insert_multi_into_col" ~iteration:shape_idx
+      (gen_cols ~min_cols:0 ~max_cols:4)
+  in
+  let distractor_defs =
+    List.map distractors ~f:(fun c ->
+        sprintf ", %s %s NOT NULL DEFAULT %s" c.col_name (sql_ty c.col_ty)
+          (match c.col_ty with Text -> "''" | Int -> "0") )
+    |> String.concat ~sep:""
+  in
+  { name
+  ; describe =
+      ( if List.is_empty distractors then "v text (no distractor columns)"
+      else sprintf "v text; distractors: %s" (describe_cols distractors) )
+  ; setup =
+      (fun ~table ->
+        sprintf
+          "CREATE TABLE %s (id serial PRIMARY KEY, v text UNIQUE NOT NULL%s)"
+          table distractor_defs )
+  ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
+  ; step =
+      (fun ~table conn i ->
+        (* a varying number of values per call: the rendered VALUES list is a
+           different length every time, which is the realistic shape and keeps
+           the SQL text varying independently of request identity *)
+        let values =
+          generate ~scenario:name ~iteration:i gen_tokens
+          |> List.mapi ~f:(fun j v -> sprintf "v-%d-%d-%s" i j v)
+        in
+        Mina_caqti.insert_multi_into_col ~table_name:table
+          ~col:("v", Caqti_type.string) conn values
+        >>| Mina_caqti.ok_exn ~ctx:name
+        >>| ignore )
+  }
+
+let upsert_scenario ~shape_idx =
+  let name = sprintf "upsert_into_cols_returning_s%d" shape_idx in
+  let keys =
+    generate ~scenario:"shape:upsert_keys" ~iteration:shape_idx
+      (gen_cols ~min_cols:2 ~max_cols:4)
+    |> force_first_text
+  in
+  (* payload columns share the key namespace, so offset their positions *)
+  let payload =
+    generate ~scenario:"shape:upsert_payload" ~iteration:shape_idx
+      (gen_cols ~min_cols:1 ~max_cols:3)
+    |> List.map ~f:(fun c -> { c with col_name = sprintf "p_%s" c.col_name })
+  in
+  let cols = keys @ payload in
+  { name
+  ; describe =
+      sprintf "keys: %s; payload: %s" (describe_cols keys)
+        (describe_cols payload)
+  ; setup =
+      (fun ~table ->
+        sprintf "CREATE TABLE %s (id serial PRIMARY KEY, %s, UNIQUE (%s))" table
+          (col_defs cols)
+          (String.concat ~sep:", " (col_names keys)) )
+  ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
+  ; step =
+      (fun ~table conn i ->
+        (* every second call reuses the previous key, so the ON CONFLICT DO
+           UPDATE branch is exercised as well as the plain insert *)
+        let key_index = if i % 2 = 0 then i - 1 else i in
+        let key_cells =
+          generate ~scenario:(name ^ ":key") ~iteration:key_index (gen_row keys)
+          |> stamp_first ~tag:(sprintf "k-%d" key_index)
+        in
+        let payload_cells =
+          generate ~scenario:(name ^ ":payload") ~iteration:i (gen_row payload)
+        in
+        let (Pack (typ, value)) = pack_row (key_cells @ payload_cells) in
+        Mina_caqti.upsert_into_cols_returning
+          ~on_conflict:(String.concat ~sep:"," (col_names keys))
+          ~returning:("id", Caqti_type.int) ~table_name:table
+          ~cols:(col_names cols, typ)
+          conn value
+        >>| Mina_caqti.ok_exn ~ctx:name
+        >>| ignore )
+  }
+
+let scenarios ~shapes : scenario list =
+  List.concat_map
+    (List.range 0 (Int.max 1 shapes))
+    ~f:(fun shape_idx ->
+      [ select_insert_scenario ~shape_idx
+      ; insert_multi_scenario ~shape_idx
+      ; upsert_scenario ~shape_idx
+      ] )
 
 (* A UUID table name per run: the benchmark only ever drops what it created in
    this process, and a collision surfaces as a failed CREATE rather than as
@@ -235,6 +375,7 @@ let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
   in
   let sampler = Sampler.create conn in
   printf "\n== scenario: %s (table %s) ==\n" s.name table ;
+  printf "   shape: %s\n" s.describe ;
   printf "   %-10s %-12s %-14s\n" "calls" "prepared" "backend_KiB" ;
   let sample_and_print calls =
     let%map prepared, bytes = Sampler.sample sampler in
@@ -302,17 +443,18 @@ let influx_lines ~measurement ~tags (results : result list) =
         (String.concat ~sep:"," fields)
         ts_ns )
 
-let main ~uri ~iterations ~sample_every ~assert_max_prepared ~influxdb_file
-    ~measurement ~tags () =
+let main ~uri ~iterations ~sample_every ~shapes ~assert_max_prepared
+    ~influxdb_file ~measurement ~tags () =
   printf "mina_caqti postgres memory-usage benchmark\n" ;
-  printf "uri=%s iterations=%d sample_every=%d\n" (Uri.to_string uri) iterations
-    sample_every ;
+  printf "uri=%s iterations=%d sample_every=%d shapes=%d\n" (Uri.to_string uri)
+    iterations sample_every shapes ;
   let%bind results =
-    Deferred.List.map scenarios ~f:(run_scenario ~uri ~iterations ~sample_every)
+    Deferred.List.map (scenarios ~shapes)
+      ~f:(run_scenario ~uri ~iterations ~sample_every)
   in
   printf "\n== summary ==\n" ;
   List.iter results ~f:(fun r ->
-      printf "   %-28s prepared_final=%-8d per_call=%.3f\n" r.name
+      printf "   %-32s prepared_final=%-8d per_call=%.3f\n" r.name
         r.prepared_final r.per_call ) ;
   let lines = influx_lines ~measurement ~tags results in
   ( match influxdb_file with
@@ -356,6 +498,10 @@ let () =
      and sample_every =
        flag "--sample-every" (optional int)
          ~doc:"M sample cadence (default iterations/10)"
+     and shapes =
+       flag "--shapes"
+         (optional_with_default 2 int)
+         ~doc:"S generated table shapes per helper (default 2)"
      and assert_max_prepared =
        flag "--assert-max-prepared" (optional int)
          ~doc:"K fail if any scenario's final prepared count exceeds K"
@@ -419,6 +565,6 @@ let () =
                     (Some "unknown") )
              @ opt_tag "network" network
            in
-           main ~uri:(Uri.of_string u) ~iterations ~sample_every
+           main ~uri:(Uri.of_string u) ~iterations ~sample_every ~shapes
              ~assert_max_prepared ~influxdb_file ~measurement ~tags () )
   |> Command_unix.run

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -1,0 +1,345 @@
+(* pg_memory/main.ml -- postgres memory-usage benchmark for Mina_caqti.
+
+   Several helpers in {!Mina_caqti} build a fresh [Caqti_request.t] on every
+   call (the SQL text is derived from runtime [~table_name]/[~cols] arguments).
+   Caqti keys its per-connection prepared-statement cache by request-object
+   identity, so a fresh request per call makes the PostgreSQL backend register
+   a new server-side prepared statement (PREPARE _caqtiN) that lives for the
+   lifetime of the connection. On the archive's long-lived pooled connections
+   these accumulate without bound and OOM the postgres backend.
+
+   This tool drives a chosen helper N times on a single long-lived connection
+   and, on that same connection, samples:
+     - [pg_prepared_statements]        -> exact server-side prepared-stmt count
+     - [pg_backend_memory_contexts]    -> backend cache/plan memory (PG14+)
+   On unfixed code the prepared-statement count grows ~linearly with the number
+   of calls; once the offending requests are marked [~oneshot:true] (or hoisted
+   to module level) it stays flat. The tool is therefore both a reproduction of
+   the leak and a regression guard (see [--assert-max-prepared]).
+
+   Results can additionally be emitted as InfluxDB line protocol
+   ([--influxdb-file]) using the same measurement/tag convention as
+   scripts/tests/rosetta-load.sh, so runs can be tracked on the perf infra.
+
+   It needs a live PostgreSQL. Pass [--uri] or set [MINA_CAQTI_TEST_PG_URI];
+   with neither, it prints a skip notice and exits 0 so it is a no-op in
+   environments without a database. *)
+
+open Core
+open Async
+
+let ok_exn ~ctx = function
+  | Ok x ->
+      x
+  | Error e ->
+      failwithf "%s: %s" ctx (Caqti_error.show e) ()
+
+(* Instrumentation / DDL requests are marked [~oneshot:true] so that running
+   them does NOT itself add to the prepared-statement count we are measuring. *)
+let exec_oneshot sql =
+  Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) ~oneshot:true sql
+
+let count_prepared_req =
+  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
+    ~oneshot:true "SELECT count(*)::int FROM pg_prepared_statements"
+
+let server_version_num_req =
+  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
+    ~oneshot:true "SELECT current_setting('server_version_num')::int"
+
+(* Whole-backend private memory. Cached query plans live under CacheMemoryContext
+   as child contexts (CachedPlanSource / CachedPlan), so the total tracks the
+   leak; we report it in KiB as a secondary, corroborating signal to the
+   deterministic prepared-statement count. [pg_backend_memory_contexts] only
+   exists on PostgreSQL 14+, so callers must gate on the server version and
+   report 0 where it is unavailable (the prepared-statement count remains the
+   primary, version-independent signal). *)
+let backend_bytes_req =
+  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
+    ~oneshot:true
+    "SELECT coalesce(sum(total_bytes), 0)::bigint FROM \
+     pg_backend_memory_contexts"
+
+module Conn_ops = struct
+  (* small helpers over a first-class CONNECTION module *)
+  let exec (module C : Mina_caqti.CONNECTION) req arg =
+    C.exec req arg >>| ok_exn ~ctx:"exec"
+
+  let get_int (module C : Mina_caqti.CONNECTION) req =
+    C.find req () >>| ok_exn ~ctx:"find"
+
+  let ddl conn sql = exec conn (exec_oneshot sql) ()
+
+  (* PG14+ only; report 0 on older servers (pg_backend_memory_contexts absent) *)
+  let has_backend_memory_contexts conn =
+    get_int conn server_version_num_req >>| fun v -> v >= 140000
+
+  let sample ~has_memctx conn =
+    let%bind prepared = get_int conn count_prepared_req in
+    let%map bytes =
+      if has_memctx then get_int conn backend_bytes_req else return 0
+    in
+    (prepared, bytes)
+
+  let disconnect (module C : Mina_caqti.CONNECTION) = C.disconnect ()
+end
+
+type result =
+  { name : string
+  ; prepared_final : int
+  ; per_call : float
+  ; backend_kib_final : int
+  ; iterations : int
+  }
+
+type scenario =
+  { name : string
+  ; ddl : string list (* DROP/CREATE statements run before the loop *)
+  ; step : (module Mina_caqti.CONNECTION) -> int -> unit Deferred.t
+        (* one unit of work exercising a single helper, using a fresh request *)
+  }
+
+(* --- the helpers under test ------------------------------------------------
+
+   The invariant under test: a helper driven N times on one connection must NOT
+   register an unbounded number of server-side prepared statements — the count
+   must stay bounded regardless of N (achieved by request reuse / [~oneshot]).
+
+   Every scenario uses a text column so the same source stays valid across
+   signature variants of these helpers (e.g. [insert_multi_into_col] has taken
+   both a [string list] and a ['col list] of values; with a string column
+   ['col = string] the call site is identical either way). *)
+
+let scenarios : scenario list =
+  [ { name = "select_insert_into_cols"
+    ; ddl =
+        [ "DROP TABLE IF EXISTS mb_sic"
+        ; "CREATE TABLE mb_sic (id serial PRIMARY KEY, k text UNIQUE)"
+        ]
+    ; step =
+        (fun conn i ->
+          (* distinct key each call -> SELECT miss then INSERT: exercises BOTH
+             of the requests this helper builds per call *)
+          Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+            ~table_name:"mb_sic"
+            ~cols:([ "k" ], Caqti_type.string)
+            conn (sprintf "k-%d" i)
+          >>| ok_exn ~ctx:"select_insert_into_cols"
+          >>| ignore )
+    }
+  ; { name = "insert_multi_into_col"
+    ; ddl =
+        [ "DROP TABLE IF EXISTS mb_imc"
+        ; "CREATE TABLE mb_imc (id serial PRIMARY KEY, v text UNIQUE)"
+        ]
+    ; step =
+        (fun conn i ->
+          (* single-element list keeps the VALUES/IN list length constant so we
+             isolate the request-identity effect from SQL-text variation *)
+          Mina_caqti.insert_multi_into_col ~table_name:"mb_imc"
+            ~col:("v", Caqti_type.string) conn
+            [ sprintf "v-%d" i ]
+          >>| ok_exn ~ctx:"insert_multi_into_col"
+          >>| ignore )
+    }
+  ; { name = "upsert_into_cols_returning"
+    ; ddl =
+        [ "DROP TABLE IF EXISTS mb_upsert"
+        ; "CREATE TABLE mb_upsert (id serial PRIMARY KEY, k text UNIQUE)"
+        ]
+    ; step =
+        (fun conn i ->
+          Mina_caqti.upsert_into_cols_returning ~on_conflict:"k"
+            ~returning:("id", Caqti_type.int) ~table_name:"mb_upsert"
+            ~cols:([ "k" ], Caqti_type.string)
+            conn (sprintf "k-%d" i)
+          >>| ok_exn ~ctx:"upsert_into_cols_returning"
+          >>| ignore )
+    }
+  ]
+
+let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
+  let%bind conn =
+    Mina_caqti.connect uri >>| ok_exn ~ctx:(sprintf "connect[%s]" s.name)
+  in
+  let%bind () =
+    Deferred.List.iter s.ddl ~f:(fun sql -> Conn_ops.ddl conn sql)
+  in
+  let%bind has_memctx = Conn_ops.has_backend_memory_contexts conn in
+  printf "\n== scenario: %s ==\n" s.name ;
+  if not has_memctx then
+    printf
+      "   (note: pg_backend_memory_contexts unavailable on this server \
+       (<PG14); backend_KiB reported as 0)\n" ;
+  printf "   %-10s %-12s %-14s\n" "calls" "prepared" "backend_KiB" ;
+  let sample_and_print calls =
+    let%map prepared, bytes = Conn_ops.sample ~has_memctx conn in
+    printf "   %-10d %-12d %-14d\n" calls prepared (bytes / 1024) ;
+    (prepared, bytes)
+  in
+  let%bind prepared0, _ = sample_and_print 0 in
+  let%bind final_prepared, final_bytes =
+    Deferred.List.fold
+      (List.range 1 (iterations + 1))
+      ~init:(prepared0, 0)
+      ~f:(fun acc i ->
+        let%bind () = s.step conn i in
+        if i % sample_every = 0 || i = iterations then sample_and_print i
+        else return acc )
+  in
+  let%bind () = Conn_ops.disconnect conn in
+  let per_call = Float.of_int final_prepared /. Float.of_int iterations in
+  let backend_kib_final = final_bytes / 1024 in
+  printf
+    "   RESULT scenario=%s iterations=%d prepared_final=%d \
+     prepared_per_call=%.3f backend_KiB_final=%d\n"
+    s.name iterations final_prepared per_call backend_kib_final ;
+  return
+    { name = s.name
+    ; prepared_final = final_prepared
+    ; per_call
+    ; backend_kib_final
+    ; iterations
+    }
+
+(* --- InfluxDB line protocol (matches scripts/tests/rosetta-load.sh) --------- *)
+
+(* line-protocol tag/measurement values must not contain unescaped spaces or
+   commas; keep it simple and sanitise to underscores *)
+let sanitize s =
+  String.map s ~f:(fun c -> match c with ' ' | ',' | '=' -> '_' | c -> c)
+
+let influx_lines ~measurement ~tags (results : result list) =
+  let ts_ns = Time_ns.now () |> Time_ns.to_int_ns_since_epoch in
+  let tag_str =
+    List.map tags ~f:(fun (k, v) -> sprintf "%s=%s" k (sanitize v))
+    |> String.concat ~sep:","
+  in
+  List.map results ~f:(fun r ->
+      sprintf
+        "%s,%s,scenario=%s \
+         prepared_final=%di,prepared_per_call=%.6f,backend_kib_final=%di,iterations=%di \
+         %d"
+        (sanitize measurement) tag_str (sanitize r.name) r.prepared_final
+        r.per_call r.backend_kib_final r.iterations ts_ns )
+
+let main ~uri ~iterations ~sample_every ~assert_max_prepared ~influxdb_file
+    ~measurement ~tags () =
+  printf "mina_caqti postgres memory-usage benchmark\n" ;
+  printf "uri=%s iterations=%d sample_every=%d\n" (Uri.to_string uri) iterations
+    sample_every ;
+  let%bind results =
+    Deferred.List.map scenarios ~f:(run_scenario ~uri ~iterations ~sample_every)
+  in
+  printf "\n== summary ==\n" ;
+  List.iter results ~f:(fun r ->
+      printf "   %-28s prepared_final=%-8d per_call=%.3f\n" r.name
+        r.prepared_final r.per_call ) ;
+  let lines = influx_lines ~measurement ~tags results in
+  ( match influxdb_file with
+  | None ->
+      ()
+  | Some path ->
+      Out_channel.write_lines path lines ;
+      printf "\n== influxdb line protocol -> %s ==\n" path ;
+      List.iter lines ~f:(fun l -> printf "   %s\n" l) ) ;
+  ( match assert_max_prepared with
+  | None ->
+      ()
+  | Some limit ->
+      let offenders =
+        List.filter results ~f:(fun r -> r.prepared_final > limit)
+      in
+      if not (List.is_empty offenders) then (
+        eprintf
+          "\n\
+           FAIL: %d scenario(s) exceeded --assert-max-prepared=%d (memory \
+           regression):\n"
+          (List.length offenders) limit ;
+        List.iter offenders ~f:(fun r ->
+            eprintf "   %s: prepared_final=%d\n" r.name r.prepared_final ) ;
+        Core.exit 1 )
+      else printf "\nOK: all scenarios <= --assert-max-prepared=%d\n" limit ) ;
+  return ()
+
+let () =
+  Command.async
+    ~summary:
+      "Measure Mina_caqti per-connection prepared-statement count and postgres \
+       backend memory"
+    (let%map_open.Command uri =
+       flag "--uri" (optional string)
+         ~doc:"URI postgres connection (else $MINA_CAQTI_TEST_PG_URI)"
+     and iterations =
+       flag "--iterations"
+         (optional_with_default 2000 int)
+         ~doc:"N calls per scenario (default 2000)"
+     and sample_every =
+       flag "--sample-every" (optional int)
+         ~doc:"M sample cadence (default iterations/10)"
+     and assert_max_prepared =
+       flag "--assert-max-prepared" (optional int)
+         ~doc:"K fail if any scenario's final prepared count exceeds K"
+     and influxdb_file =
+       flag "--influxdb-file" (optional string)
+         ~doc:"PATH write InfluxDB line protocol (one point per scenario) here"
+     and measurement =
+       flag "--measurement"
+         (optional_with_default "mina_caqti_pg_memory_bench" string)
+         ~doc:"NAME InfluxDB measurement name"
+     and variant =
+       flag "--variant" (optional string)
+         ~doc:"V tag runs (e.g. baseline/pr18858); else $MINA_BENCH_VARIANT"
+     and network =
+       flag "--network" (optional string) ~doc:"NET optional network tag"
+     and git_branch =
+       flag "--git-branch" (optional string)
+         ~doc:"B branch tag (else $GIT_BRANCH, else git)"
+     and git_commit =
+       flag "--git-commit" (optional string)
+         ~doc:"C commit tag (else $GIT_COMMIT, else git)"
+     in
+     fun () ->
+       let uri_str =
+         match uri with
+         | Some u ->
+             Some u
+         | None ->
+             Sys.getenv "MINA_CAQTI_TEST_PG_URI"
+       in
+       match uri_str with
+       | None ->
+           printf
+             "SKIP: no --uri and $MINA_CAQTI_TEST_PG_URI unset; nothing to do.\n" ;
+           return ()
+       | Some u ->
+           let iterations = Int.max 1 iterations in
+           let sample_every =
+             match sample_every with
+             | Some m when m > 0 ->
+                 m
+             | _ ->
+                 Int.max 1 (iterations / 10)
+           in
+           let env_or v key =
+             match v with Some _ -> v | None -> Sys.getenv key
+           in
+           let opt_tag k = function None -> [] | Some v -> [ (k, v) ] in
+           let tags =
+             opt_tag "branch"
+               (Option.first_some
+                  (env_or git_branch "GIT_BRANCH")
+                  (Some "unknown") )
+             @ opt_tag "commit"
+                 (Option.first_some
+                    (env_or git_commit "GIT_COMMIT")
+                    (Some "unknown") )
+             @ opt_tag "variant"
+                 (Option.first_some
+                    (env_or variant "MINA_BENCH_VARIANT")
+                    (Some "unknown") )
+             @ opt_tag "network" network
+           in
+           main ~uri:(Uri.of_string u) ~iterations ~sample_every
+             ~assert_max_prepared ~influxdb_file ~measurement ~tags () )
+  |> Command_unix.run

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -5,17 +5,17 @@
    Caqti keys its per-connection prepared-statement cache by request-object
    identity, so a fresh request per call makes the PostgreSQL backend register
    a new server-side prepared statement (PREPARE _caqtiN) that lives for the
-   lifetime of the connection. On the archive's long-lived pooled connections
-   these accumulate without bound and OOM the postgres backend.
+   lifetime of the connection. On long-lived pooled connections these accumulate
+   without bound and grow the backend's memory.
 
    This tool drives a chosen helper N times on a single long-lived connection
    and, on that same connection, samples:
      - [pg_prepared_statements]        -> exact server-side prepared-stmt count
      - [pg_backend_memory_contexts]    -> backend cache/plan memory (PG14+)
-   On unfixed code the prepared-statement count grows ~linearly with the number
-   of calls; once the offending requests are marked [~oneshot:true] (or hoisted
-   to module level) it stays flat. The tool is therefore both a reproduction of
-   the leak and a regression guard (see [--assert-max-prepared]).
+   A helper that builds a request per call makes the count grow ~linearly with
+   the number of calls; one that reuses its request, or marks it [~oneshot:true]
+   so it is never cached, keeps it flat. [--assert-max-prepared] turns that into
+   a regression guard.
 
    Each scenario works on its own table, named with a UUID and created fresh:
    the benchmark never drops a table it did not create, and drops the one it did
@@ -43,8 +43,8 @@ let exec_oneshot sql =
 (* Both signals in one round trip. [sum] is deliberately NOT coalesced: a NULL
    means "nothing to measure" and stays distinguishable from a genuine zero.
    Cached query plans live under CacheMemoryContext as child contexts
-   (CachedPlanSource / CachedPlan), so the backend total tracks the leak as a
-   secondary, corroborating signal to the deterministic prepared-statement
+   (CachedPlanSource / CachedPlan), so the backend total tracks the same growth
+   as a secondary, corroborating signal to the deterministic prepared-statement
    count. *)
 let sample_req =
   Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.(t2 int (option int)))
@@ -368,7 +368,7 @@ let () =
          ~doc:"NAME InfluxDB measurement name"
      and variant =
        flag "--variant" (optional string)
-         ~doc:"V tag runs (e.g. baseline/pr18858); else $MINA_BENCH_VARIANT"
+         ~doc:"V tag runs (e.g. baseline); else $MINA_BENCH_VARIANT"
      and network =
        flag "--network" (optional string) ~doc:"NET optional network tag"
      and git_branch =

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -88,7 +88,8 @@ type result =
   { name : string
   ; prepared_final : int
   ; per_call : float
-  ; backend_kib_final : int
+  ; backend_kib_final : int option
+        (* [None] on servers without [pg_backend_memory_contexts] (<PG14) *)
   ; iterations : int
   }
 
@@ -170,11 +171,13 @@ let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
   if not has_memctx then
     printf
       "   (note: pg_backend_memory_contexts unavailable on this server \
-       (<PG14); backend_KiB reported as 0)\n" ;
-  printf "   %-10s %-12s %-14s\n" "calls" "prepared" "backend_KiB" ;
+       (<PG14); backend_KiB not measured)\n" ;
+  printf "   %-10s %-12s %-14s\n" "calls" "prepared"
+    (if has_memctx then "backend_KiB" else "") ;
   let sample_and_print calls =
     let%map prepared, bytes = Conn_ops.sample ~has_memctx conn in
-    printf "   %-10d %-12d %-14d\n" calls prepared (bytes / 1024) ;
+    printf "   %-10d %-12d %-14s\n" calls prepared
+      (if has_memctx then Int.to_string (bytes / 1024) else "n/a") ;
     (prepared, bytes)
   in
   let%bind prepared0, _ = sample_and_print 0 in
@@ -189,11 +192,14 @@ let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
   in
   let%bind () = Conn_ops.disconnect conn in
   let per_call = Float.of_int final_prepared /. Float.of_int iterations in
-  let backend_kib_final = final_bytes / 1024 in
+  let backend_kib_final =
+    if has_memctx then Some (final_bytes / 1024) else None
+  in
   printf
     "   RESULT scenario=%s iterations=%d prepared_final=%d \
-     prepared_per_call=%.3f backend_KiB_final=%d\n"
-    s.name iterations final_prepared per_call backend_kib_final ;
+     prepared_per_call=%.3f backend_KiB_final=%s\n"
+    s.name iterations final_prepared per_call
+    (Option.value_map backend_kib_final ~default:"n/a" ~f:Int.to_string) ;
   return
     { name = s.name
     ; prepared_final = final_prepared
@@ -215,13 +221,22 @@ let influx_lines ~measurement ~tags (results : result list) =
     List.map tags ~f:(fun (k, v) -> sprintf "%s=%s" k (sanitize v))
     |> String.concat ~sep:","
   in
+  (* [backend_kib_final] is omitted rather than sent as 0 where the server has no
+     [pg_backend_memory_contexts]: a constant-zero series charts as a real
+     measurement, whereas a missing one is visibly missing. *)
   List.map results ~f:(fun r ->
-      sprintf
-        "%s,%s,scenario=%s \
-         prepared_final=%di,prepared_per_call=%.6f,backend_kib_final=%di,iterations=%di \
-         %d"
-        (sanitize measurement) tag_str (sanitize r.name) r.prepared_final
-        r.per_call r.backend_kib_final r.iterations ts_ns )
+      let fields =
+        [ sprintf "prepared_final=%di" r.prepared_final
+        ; sprintf "prepared_per_call=%.6f" r.per_call
+        ; sprintf "iterations=%di" r.iterations
+        ]
+        @ Option.value_map r.backend_kib_final ~default:[] ~f:(fun kib ->
+              [ sprintf "backend_kib_final=%di" kib ] )
+      in
+      sprintf "%s,%s,scenario=%s %s %d" (sanitize measurement) tag_str
+        (sanitize r.name)
+        (String.concat ~sep:"," fields)
+        ts_ns )
 
 let main ~uri ~iterations ~sample_every ~assert_max_prepared ~influxdb_file
     ~measurement ~tags () =

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -17,6 +17,13 @@
    to module level) it stays flat. The tool is therefore both a reproduction of
    the leak and a regression guard (see [--assert-max-prepared]).
 
+   Each scenario works on its own table, named with a UUID and created fresh:
+   the benchmark never drops a table it did not create, and drops the one it did
+   on the way out. Column values come from Quickcheck generators seeded per
+   (scenario, iteration), so the payloads vary in length and shape from call to
+   call while two runs still see the identical sequence — a benchmark whose
+   inputs drift is not comparable across builds.
+
    Results can additionally be emitted as InfluxDB line protocol
    ([--influxdb-file]) using the same measurement/tag convention as
    scripts/tests/rosetta-load.sh, so runs can be tracked on the perf infra.
@@ -33,49 +40,49 @@ open Async
 let exec_oneshot sql =
   Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) ~oneshot:true sql
 
-let count_prepared_req =
+(* Both signals in one round trip. [sum] is deliberately NOT coalesced: a NULL
+   means "nothing to measure" and stays distinguishable from a genuine zero.
+   Cached query plans live under CacheMemoryContext as child contexts
+   (CachedPlanSource / CachedPlan), so the backend total tracks the leak as a
+   secondary, corroborating signal to the deterministic prepared-statement
+   count. *)
+let sample_req =
+  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.(t2 int (option int)))
+    ~oneshot:true
+    "SELECT (SELECT count(*)::int FROM pg_prepared_statements), (SELECT \
+     sum(total_bytes)::bigint FROM pg_backend_memory_contexts)"
+
+(* [pg_backend_memory_contexts] only exists on PostgreSQL 14+; on older servers
+   the query above fails to parse, and this is all we can measure. *)
+let prepared_only_req =
   Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
     ~oneshot:true "SELECT count(*)::int FROM pg_prepared_statements"
 
-let server_version_num_req =
-  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
-    ~oneshot:true "SELECT current_setting('server_version_num')::int"
+module Sampler = struct
+  (* Whether the backend-memory view exists is discovered by using it, not by
+     comparing version numbers: the first failure downgrades the sampler for the
+     rest of the run. *)
+  type t =
+    { conn : (module Mina_caqti.CONNECTION); mutable backend_memory : bool }
 
-(* Whole-backend private memory. Cached query plans live under CacheMemoryContext
-   as child contexts (CachedPlanSource / CachedPlan), so the total tracks the
-   leak; we report it in KiB as a secondary, corroborating signal to the
-   deterministic prepared-statement count. [pg_backend_memory_contexts] only
-   exists on PostgreSQL 14+, so callers must gate on the server version and
-   report nothing where it is unavailable (the prepared-statement count remains
-   the primary, version-independent signal). *)
-let backend_bytes_req =
-  Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
-    ~oneshot:true
-    "SELECT coalesce(sum(total_bytes), 0)::bigint FROM \
-     pg_backend_memory_contexts"
+  let create conn = { conn; backend_memory = true }
 
-module Conn_ops = struct
-  (* small helpers over a first-class CONNECTION module *)
-  let exec (module C : Mina_caqti.CONNECTION) req arg =
-    C.exec req arg >>| Mina_caqti.ok_exn ~ctx:"exec"
+  let prepared_only (module C : Mina_caqti.CONNECTION) =
+    C.find prepared_only_req () >>| Mina_caqti.ok_exn ~ctx:"sample"
 
-  let get_int (module C : Mina_caqti.CONNECTION) req =
-    C.find req () >>| Mina_caqti.ok_exn ~ctx:"find"
-
-  let ddl conn sql = exec conn (exec_oneshot sql) ()
-
-  (* PG14+ only; pg_backend_memory_contexts is absent on older servers *)
-  let has_backend_memory_contexts conn =
-    get_int conn server_version_num_req >>| fun v -> v >= 140000
-
-  let sample ~has_memctx conn =
-    let%bind prepared = get_int conn count_prepared_req in
-    let%map bytes =
-      if has_memctx then get_int conn backend_bytes_req else return 0
-    in
-    (prepared, bytes)
-
-  let disconnect (module C : Mina_caqti.CONNECTION) = C.disconnect ()
+  let sample t =
+    let (module C : Mina_caqti.CONNECTION) = t.conn in
+    if t.backend_memory then (
+      match%bind C.find sample_req () with
+      | Ok (prepared, bytes) ->
+          return (prepared, bytes)
+      | Error _ ->
+          t.backend_memory <- false ;
+          printf
+            "   (note: pg_backend_memory_contexts unavailable on this server \
+             (<PG14); backend_KiB not measured)\n" ;
+          prepared_only t.conn >>| fun prepared -> (prepared, None) )
+    else prepared_only t.conn >>| fun prepared -> (prepared, None)
 end
 
 type result =
@@ -89,10 +96,37 @@ type result =
 
 type scenario =
   { name : string
-  ; ddl : string list (* DROP/CREATE statements run before the loop *)
-  ; step : (module Mina_caqti.CONNECTION) -> int -> unit Deferred.t
+  ; setup : table:string -> string
+        (* ONE statement, so the table either exists complete or not at all *)
+  ; teardown : table:string -> string
+  ; step :
+      table:string -> (module Mina_caqti.CONNECTION) -> int -> unit Deferred.t
         (* one unit of work exercising a single helper, using a fresh request *)
   }
+
+(* --- generated payloads ----------------------------------------------------
+
+   [insert_multi_into_col] renders its values into the SQL text as single-quoted
+   literals without escaping, so generated tokens stay alphanumeric. The
+   iteration index is prefixed to every value that must be unique: a collision
+   would silently turn an INSERT into a SELECT hit and change what is being
+   measured. *)
+
+let gen_token =
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind len = Int.gen_incl 3 24 in
+  let%map chars = List.gen_with_length len Char.gen_alphanum in
+  String.of_char_list chars
+
+let gen_tokens =
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind n = Int.gen_incl 1 8 in
+  List.gen_with_length n gen_token
+
+let generate ~scenario ~iteration gen =
+  Quickcheck.random_value
+    ~seed:(`Deterministic (sprintf "%s:%d" scenario iteration))
+    gen
 
 (* --- the helpers under test ------------------------------------------------
 
@@ -100,108 +134,143 @@ type scenario =
    register an unbounded number of server-side prepared statements — the count
    must stay bounded regardless of N (achieved by request reuse / [~oneshot]).
 
-   Every scenario uses a text column so the same source stays valid across
-   signature variants of these helpers (e.g. [insert_multi_into_col] has taken
-   both a [string list] and a ['col list] of values; with a string column
-   ['col = string] the call site is identical either way). *)
+   The columns are text so the same source stays valid across signature variants
+   of these helpers (e.g. [insert_multi_into_col] has taken both a [string list]
+   and a ['col list] of values; with a string column ['col = string] the call
+   site is identical either way). *)
 
 let scenarios : scenario list =
   [ { name = "select_insert_into_cols"
-    ; ddl =
-        [ "DROP TABLE IF EXISTS mb_sic"
-        ; "CREATE TABLE mb_sic (id serial PRIMARY KEY, k text UNIQUE)"
-        ]
+    ; setup =
+        (fun ~table ->
+          sprintf
+            "CREATE TABLE %s (id serial PRIMARY KEY, k1 text NOT NULL, k2 text \
+             NOT NULL, k3 text NOT NULL, UNIQUE (k1, k2, k3))"
+            table )
+    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
     ; step =
-        (fun conn i ->
+        (fun ~table conn i ->
           (* distinct key each call -> SELECT miss then INSERT: exercises BOTH
              of the requests this helper builds per call *)
+          let k2, k3 =
+            generate ~scenario:"select_insert_into_cols" ~iteration:i
+              (Quickcheck.Generator.both gen_token gen_token)
+          in
           Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
-            ~table_name:"mb_sic"
-            ~cols:([ "k" ], Caqti_type.string)
-            conn (sprintf "k-%d" i)
+            ~table_name:table
+            ~cols:([ "k1"; "k2"; "k3" ], Caqti_type.(t3 string string string))
+            conn
+            (sprintf "k-%d" i, k2, k3)
           >>| Mina_caqti.ok_exn ~ctx:"select_insert_into_cols"
           >>| ignore )
     }
   ; { name = "insert_multi_into_col"
-    ; ddl =
-        [ "DROP TABLE IF EXISTS mb_imc"
-        ; "CREATE TABLE mb_imc (id serial PRIMARY KEY, v text UNIQUE)"
-        ]
+    ; setup =
+        (fun ~table ->
+          sprintf
+            "CREATE TABLE %s (id serial PRIMARY KEY, v text UNIQUE NOT NULL)"
+            table )
+    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
     ; step =
-        (fun conn i ->
-          (* single-element list keeps the VALUES/IN list length constant so we
-             isolate the request-identity effect from SQL-text variation *)
-          Mina_caqti.insert_multi_into_col ~table_name:"mb_imc"
-            ~col:("v", Caqti_type.string) conn
-            [ sprintf "v-%d" i ]
+        (fun ~table conn i ->
+          (* a varying number of values per call: the rendered VALUES list is a
+             different length every time, which is the realistic shape and keeps
+             the SQL text varying independently of request identity *)
+          let values =
+            generate ~scenario:"insert_multi_into_col" ~iteration:i gen_tokens
+            |> List.mapi ~f:(fun j v -> sprintf "v-%d-%d-%s" i j v)
+          in
+          Mina_caqti.insert_multi_into_col ~table_name:table
+            ~col:("v", Caqti_type.string) conn values
           >>| Mina_caqti.ok_exn ~ctx:"insert_multi_into_col"
           >>| ignore )
     }
   ; { name = "upsert_into_cols_returning"
-    ; ddl =
-        [ "DROP TABLE IF EXISTS mb_upsert"
-        ; "CREATE TABLE mb_upsert (id serial PRIMARY KEY, k text UNIQUE)"
-        ]
+    ; setup =
+        (fun ~table ->
+          sprintf
+            "CREATE TABLE %s (id serial PRIMARY KEY, k1 text NOT NULL, k2 text \
+             NOT NULL, payload text NOT NULL, UNIQUE (k1, k2))"
+            table )
+    ; teardown = (fun ~table -> sprintf "DROP TABLE %s" table)
     ; step =
-        (fun conn i ->
-          Mina_caqti.upsert_into_cols_returning ~on_conflict:"k"
-            ~returning:("id", Caqti_type.int) ~table_name:"mb_upsert"
-            ~cols:([ "k" ], Caqti_type.string)
-            conn (sprintf "k-%d" i)
+        (fun ~table conn i ->
+          (* every second call reuses the previous key, so the ON CONFLICT DO
+             UPDATE branch is exercised as well as the plain insert *)
+          let key_index = if i % 2 = 0 then i - 1 else i in
+          let payload =
+            generate ~scenario:"upsert_into_cols_returning" ~iteration:i
+              gen_token
+          in
+          Mina_caqti.upsert_into_cols_returning ~on_conflict:"k1,k2"
+            ~returning:("id", Caqti_type.int) ~table_name:table
+            ~cols:
+              ([ "k1"; "k2"; "payload" ], Caqti_type.(t3 string string string))
+            conn
+            (sprintf "k-%d" key_index, sprintf "j-%d" key_index, payload)
           >>| Mina_caqti.ok_exn ~ctx:"upsert_into_cols_returning"
           >>| ignore )
     }
   ]
 
+(* A UUID table name per run: the benchmark only ever drops what it created in
+   this process, and a collision surfaces as a failed CREATE rather than as
+   somebody else's data disappearing. *)
+let fresh_table_name () =
+  Uuid_unix.create () |> Uuid.to_string
+  |> String.filter ~f:Char.is_alphanum
+  |> (fun s -> String.prefix s 16)
+  |> sprintf "pg_memory_%s"
+
 let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
+  let table = fresh_table_name () in
   let%bind conn =
     Mina_caqti.connect uri
     >>| Mina_caqti.ok_exn ~ctx:(sprintf "connect[%s]" s.name)
   in
+  let (module C : Mina_caqti.CONNECTION) = conn in
   let%bind () =
-    Deferred.List.iter s.ddl ~f:(fun sql -> Conn_ops.ddl conn sql)
+    C.exec (exec_oneshot (s.setup ~table)) ()
+    >>| Mina_caqti.ok_exn ~ctx:(sprintf "setup[%s]" s.name)
   in
-  let%bind has_memctx = Conn_ops.has_backend_memory_contexts conn in
-  printf "\n== scenario: %s ==\n" s.name ;
-  if not has_memctx then
-    printf
-      "   (note: pg_backend_memory_contexts unavailable on this server \
-       (<PG14); backend_KiB not measured)\n" ;
-  printf "   %-10s %-12s %-14s\n" "calls" "prepared"
-    (if has_memctx then "backend_KiB" else "") ;
+  let sampler = Sampler.create conn in
+  printf "\n== scenario: %s (table %s) ==\n" s.name table ;
+  printf "   %-10s %-12s %-14s\n" "calls" "prepared" "backend_KiB" ;
   let sample_and_print calls =
-    let%map prepared, bytes = Conn_ops.sample ~has_memctx conn in
+    let%map prepared, bytes = Sampler.sample sampler in
     printf "   %-10d %-12d %-14s\n" calls prepared
-      (if has_memctx then Int.to_string (bytes / 1024) else "n/a") ;
+      (Option.value_map bytes ~default:"n/a" ~f:(fun b ->
+           Int.to_string (b / 1024) ) ) ;
     (prepared, bytes)
   in
   let%bind prepared0, _ = sample_and_print 0 in
   let%bind final_prepared, final_bytes =
     Deferred.List.fold
       (List.range 1 (iterations + 1))
-      ~init:(prepared0, 0)
+      ~init:(prepared0, None)
       ~f:(fun acc i ->
-        let%bind () = s.step conn i in
+        let%bind () = s.step ~table conn i in
         if i % sample_every = 0 || i = iterations then sample_and_print i
         else return acc )
   in
-  let%bind () = Conn_ops.disconnect conn in
-  let per_call = Float.of_int final_prepared /. Float.of_int iterations in
-  let backend_kib_final =
-    if has_memctx then Some (final_bytes / 1024) else None
+  let%bind () =
+    C.exec (exec_oneshot (s.teardown ~table)) ()
+    >>| Mina_caqti.ok_exn ~ctx:(sprintf "teardown[%s]" s.name)
   in
+  let per_call = Float.of_int final_prepared /. Float.of_int iterations in
+  let backend_kib_final = Option.map final_bytes ~f:(fun b -> b / 1024) in
   printf
     "   RESULT scenario=%s iterations=%d prepared_final=%d \
      prepared_per_call=%.3f backend_KiB_final=%s\n"
     s.name iterations final_prepared per_call
     (Option.value_map backend_kib_final ~default:"n/a" ~f:Int.to_string) ;
-  return
-    { name = s.name
-    ; prepared_final = final_prepared
-    ; per_call
-    ; backend_kib_final
-    ; iterations
-    }
+  let%map () = C.disconnect () in
+  { name = s.name
+  ; prepared_final = final_prepared
+  ; per_call
+  ; backend_kib_final
+  ; iterations
+  }
 
 (* --- InfluxDB line protocol (matches scripts/tests/rosetta-load.sh) --------- *)
 

--- a/src/lib/mina_caqti/test/pg_memory/main.ml
+++ b/src/lib/mina_caqti/test/pg_memory/main.ml
@@ -28,12 +28,6 @@
 open Core
 open Async
 
-let ok_exn ~ctx = function
-  | Ok x ->
-      x
-  | Error e ->
-      failwithf "%s: %s" ctx (Caqti_error.show e) ()
-
 (* Instrumentation / DDL requests are marked [~oneshot:true] so that running
    them does NOT itself add to the prepared-statement count we are measuring. *)
 let exec_oneshot sql =
@@ -52,8 +46,8 @@ let server_version_num_req =
    leak; we report it in KiB as a secondary, corroborating signal to the
    deterministic prepared-statement count. [pg_backend_memory_contexts] only
    exists on PostgreSQL 14+, so callers must gate on the server version and
-   report 0 where it is unavailable (the prepared-statement count remains the
-   primary, version-independent signal). *)
+   report nothing where it is unavailable (the prepared-statement count remains
+   the primary, version-independent signal). *)
 let backend_bytes_req =
   Caqti_request.Infix.(Caqti_type.unit ->! Caqti_type.int)
     ~oneshot:true
@@ -63,14 +57,14 @@ let backend_bytes_req =
 module Conn_ops = struct
   (* small helpers over a first-class CONNECTION module *)
   let exec (module C : Mina_caqti.CONNECTION) req arg =
-    C.exec req arg >>| ok_exn ~ctx:"exec"
+    C.exec req arg >>| Mina_caqti.ok_exn ~ctx:"exec"
 
   let get_int (module C : Mina_caqti.CONNECTION) req =
-    C.find req () >>| ok_exn ~ctx:"find"
+    C.find req () >>| Mina_caqti.ok_exn ~ctx:"find"
 
   let ddl conn sql = exec conn (exec_oneshot sql) ()
 
-  (* PG14+ only; report 0 on older servers (pg_backend_memory_contexts absent) *)
+  (* PG14+ only; pg_backend_memory_contexts is absent on older servers *)
   let has_backend_memory_contexts conn =
     get_int conn server_version_num_req >>| fun v -> v >= 140000
 
@@ -125,7 +119,7 @@ let scenarios : scenario list =
             ~table_name:"mb_sic"
             ~cols:([ "k" ], Caqti_type.string)
             conn (sprintf "k-%d" i)
-          >>| ok_exn ~ctx:"select_insert_into_cols"
+          >>| Mina_caqti.ok_exn ~ctx:"select_insert_into_cols"
           >>| ignore )
     }
   ; { name = "insert_multi_into_col"
@@ -140,7 +134,7 @@ let scenarios : scenario list =
           Mina_caqti.insert_multi_into_col ~table_name:"mb_imc"
             ~col:("v", Caqti_type.string) conn
             [ sprintf "v-%d" i ]
-          >>| ok_exn ~ctx:"insert_multi_into_col"
+          >>| Mina_caqti.ok_exn ~ctx:"insert_multi_into_col"
           >>| ignore )
     }
   ; { name = "upsert_into_cols_returning"
@@ -154,14 +148,15 @@ let scenarios : scenario list =
             ~returning:("id", Caqti_type.int) ~table_name:"mb_upsert"
             ~cols:([ "k" ], Caqti_type.string)
             conn (sprintf "k-%d" i)
-          >>| ok_exn ~ctx:"upsert_into_cols_returning"
+          >>| Mina_caqti.ok_exn ~ctx:"upsert_into_cols_returning"
           >>| ignore )
     }
   ]
 
 let run_scenario ~uri ~iterations ~sample_every (s : scenario) =
   let%bind conn =
-    Mina_caqti.connect uri >>| ok_exn ~ctx:(sprintf "connect[%s]" s.name)
+    Mina_caqti.connect uri
+    >>| Mina_caqti.ok_exn ~ctx:(sprintf "connect[%s]" s.name)
   in
   let%bind () =
     Deferred.List.iter s.ddl ~f:(fun sql -> Conn_ops.ddl conn sql)


### PR DESCRIPTION
## What

Adds a deterministic benchmark of the PostgreSQL backend memory used by
`Mina_caqti`'s DB helpers, plus a Buildkite job that runs it and uploads the
results to the perf InfluxDB.

- `src/lib/mina_caqti/test/pg_memory/` — a small OCaml executable that drives a
  chosen `Mina_caqti` helper N times on a single long-lived connection and, on
  that same connection, samples `pg_prepared_statements` and
  `pg_backend_memory_contexts`.
- `buildkite/src/Jobs/Test/MinaCaqtiPgMemoryBench.dhall` +
  `buildkite/scripts/tests/mina-caqti-pg-memory-bench.sh` — provisions
  PostgreSQL, builds+runs the benchmark, and uploads its InfluxDB line-protocol
  output via `buildkite/scripts/bench/send.sh`. Triggered by `dirtyWhen` on
  `src/lib/mina_caqti`.

It was written to reproduce and measure the memory leak in #18857, and stays
useful afterwards as a **standard memory-usage / regression check** for these
helpers (hence the neutral naming rather than "leak").

## Why

`processor.ml` builds Caqti requests **inline, per call**, and Caqti keys its
per-connection prepared-statement cache by request-object **identity** — so each
call registers a new server-side `PREPARE _caqtiN` that lives for the
connection's lifetime, growing unbounded on the archive's long-lived pooled
connections (the OOM in #18857). This benchmark makes that measurable and gives
#18858 / #18860 a reproducible before/after signal.

## Results (local PostgreSQL 16, 2000 calls/scenario)

| helper | prepared stmts / call — develop | with #18858 |
| --- | --- | --- |
| `select_insert_into_cols` | 2.0 (→ 4000) | **0** |
| `insert_multi_into_col` | 2.0 (→ 4000) | **0** |
| `upsert_into_cols_returning` | 1.0 (→ 2000) | **still 2000** (untouched by either PR) |

So #18858/#18860 fully neutralise the helpers they target, while other helpers
(`upsert_into_cols_returning`, run on every block; `insert_into_cols_returning`;
`insert_multi_into_col_no_dedup`; inline `find/collect/exec`) still grow — useful
context for a follow-up.

## Notes

- The same source compiles against `develop`, #18858 and #18860 (text columns
  keep `insert_multi_into_col`'s call identical across its signature change), so
  it can be run per build variant and charted by `variant`/`branch`/`commit`.
- The CI job **measures and uploads** (it does not `--assert-max-prepared`),
  since `develop` currently grows; the assert flag is for guarding a fixed build.
- Complements a full end-to-end archive-ingestion memory test (to run on the
  perf infra), which lands separately.

Related: #18857, #18858, #18859, #18860.
