### PR TITLE
Fix mina-local-network genesis ledger padding breaking block production

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -466,7 +466,7 @@ reset-genesis-ledger() {
         "2_to_the": 2 
       },
     },
-    ledger: .
+    ledger: { accounts: .accounts }
   }
   ' < "${GENESIS_LEDGER_FOLDER}/genesis_ledger.json" > "${DAEMON_CONFIG}"
 }


### PR DESCRIPTION
## Problem

Running `scripts/mina-local-network/mina-local-network.sh -c reset ...` never produces blocks. Every block-production attempt aborts with:

```
Aborting block production: cannot generate a genesis proof
  error: Sparse_ledger.get: Bad index 0. Expected a node, but got a hash at depth 4 ... 243
```

`blockchain_length` stays at 1 (genesis only).

## Root cause

`reset-genesis-ledger` builds the runtime config with `ledger: .`, embedding the **entire** ledger file produced by `generate-mina-local-network-ledger.py` — including its hard-coded `"num_accounts": 250`. The daemon honours `num_accounts` and **pads the genesis ledger to 250 accounts**: the 7 real accounts plus ~243 deterministically generated filler accounts. Building the genesis proof over that padded ledger then fails in the sparse-ledger witness — the block producer's account ends up at index **243 = 250 − 7**, exactly the index in the error.

## Fix

Emit only the `accounts` array in the runtime ledger config:

```diff
-    ledger: .
+    ledger: { accounts: .accounts }
```

This matches the two configs that *do* produce blocks — `scripts/hardfork/run-localnet.sh` (`"ledger": {"accounts": ...}`) and the integration-test local engine (`num_accounts = None`) — so the daemon proves against the real 7-account ledger. Verified: with the padding removed the network produces blocks (with a dev build, `-pl none -st 20000` for a sane slot time/epoch length).

No `src/` changes, so no changelog entry is required.
