### PR TITLE
[Pkg] Copy prefork config even if commit does not exist (port of #19092 to develop)

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -67,6 +67,7 @@ let MinaBuildSpec =
           , buildScript : Text
           , arch : Arch.Type
           , deb_legacy_version : Text
+          , deb_legacy_githash_config : Text
           , docker_publish : DockerPublish.Type
           , suffix : Optional Text
           , if_ : Optional B/If
@@ -87,6 +88,7 @@ let MinaBuildSpec =
           , extraBuildEnvs = [] : List Text
           , suffix = None Text
           , deb_legacy_version = "3.4.0-alpha1-compatible-ad13ff4"
+          , deb_legacy_githash_config = ""
           , arch = Arch.Type.Amd64
           , docker_publish = DockerPublish.Type.Essential
           , if_ = None B/If
@@ -239,6 +241,7 @@ let build_artifacts
                             , "ARCHITECTURE=${Arch.lowerName spec.arch}"
                             , Network.foldMinaBuildMainnetEnv nets
                             , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
+                            , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
                             ]
                           # BuildFlags.buildEnvs spec.buildFlags
                           # spec.extraBuildEnvs
@@ -275,6 +278,7 @@ let commonBuildEnvs =
                 , "ARCHITECTURE=${Arch.lowerName spec.arch}"
                 , Network.foldMinaBuildMainnetEnv nets
                 , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
+                , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
                 ]
               # BuildFlags.buildEnvs spec.buildFlags
               # spec.extraBuildEnvs

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -62,6 +62,7 @@ let Spec =
           , use_generic_dockers_from_version : Optional Text
           , size : Size
           , deb_legacy_version : Text
+          , deb_legacy_githash_config : Text
           }
       , default =
           { codenames =
@@ -80,6 +81,8 @@ let Spec =
           , use_generic_dockers_from_version = None Text
           , size = Size.XLarge
           , deb_legacy_version = defaultMinaArtifactSpec.deb_legacy_version
+          , deb_legacy_githash_config =
+              defaultMinaArtifactSpec.deb_legacy_githash_config
           }
       }
 
@@ -239,6 +242,8 @@ let generateDockerForCodename =
                         , debVersion = codename.DebVersion
                         , prefix = pipelineName
                         , suffix = Some "-${lowerNameCodename}"
+                        , deb_legacy_githash_config =
+                            spec.deb_legacy_githash_config
                         }
                     ]
                   }

--- a/changes/19114.md
+++ b/changes/19114.md
@@ -1,0 +1,3 @@
+Ship the prefork daemon configuration in automode packages even when the prefork commit is missing from the build checkout
+
+Automode packages bundle both the prefork and postfork runtimes, and the prefork runtime looks for its configuration under a filename derived from the prefork commit hash. When that commit was not present in the build checkout, the configuration was silently left out and the prefork daemon started without it. The build can now be given the configuration hash directly, so the file is always shipped.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -769,6 +769,49 @@ EOF
 
 }
 
+# Resolves the hash for the prefork daemon's auto-loaded config_<hash>.json.
+#
+# The prefork daemon auto-loads config_<GITHASH_CONFIG>.json where
+# GITHASH_CONFIG is the full 8-char short hash of the prefork commit.  The hash
+# embedded in PREFORK_LEGACY_VERSION is only the 7-char GITHASH (see
+# scripts/export-git-env-vars.sh), so we must recover the missing 8th char.  We
+# do that by resolving the short hash against this repo with
+# `git rev-parse --short=8`.  When the prefork commit is NOT present in this
+# checkout git cannot resolve it, so the pipeline can supply the full 8-char
+# hash directly via the PREFORK_GITHASH_CONFIG override.
+#
+# PREFORK_GITHASH_CONFIG is injected into the build container from the Dhall
+# pipeline (buildkite/src/Command/MinaArtifact.dhall and
+# buildkite/src/Entrypoints/GenerateHardforkPackage.dhall, field
+# deb_legacy_githash_config); leave it empty to fall back to git resolution.
+#
+# Echoes the 8-char config hash to ship on stdout, or nothing when no prefork
+# config should be shipped (unresolvable hash, or identical to postfork).
+# Diagnostics go to stderr so they never contaminate the returned value.
+resolve_prefork_config_hash() {
+  local prefork_short_hash="$1"
+  local config_hash
+
+  if [[ -n "${PREFORK_GITHASH_CONFIG:-}" ]]; then
+    echo "Using PREFORK_GITHASH_CONFIG override (${PREFORK_GITHASH_CONFIG}) for prefork config filename." >&2
+    config_hash="$PREFORK_GITHASH_CONFIG"
+  else
+    config_hash=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$config_hash" ]]; then
+    echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}' in mina repo, and PREFORK_GITHASH_CONFIG override is not set; prefork config not shipped." >&2
+    return 0
+  fi
+
+  if [[ "$config_hash" == "$GITHASH_CONFIG" ]]; then
+    echo "Prefork githash (${config_hash}) is the same as postfork; skipping config copy." >&2
+    return 0
+  fi
+
+  echo "$config_hash"
+}
+
 # Copies common binaries and configuration for postfork automode packages
 # Includes only binaries without configuration files or genesisledgers
 # Places binaries in /usr/lib/mina/<network_name> directory
@@ -792,22 +835,18 @@ copy_common_daemon_post_automode_apps_and_configs() {
   # Config files (config_<hash>.json, <network>.json) are provided by the
   # mina-<network>-config package, so we do NOT ship them here to avoid
   # dpkg file conflicts.  Only ship the prefork config when it differs from
-  # the postfork hash, since the config package won't contain it.
+  # the postfork hash, since the config package won't contain it.  See
+  # resolve_prefork_config_hash for how the config hash is derived.
   if [[ -n "${PREFORK_LEGACY_VERSION:-}" ]]; then
     local prefork_short_hash="${PREFORK_LEGACY_VERSION##*-}"
-    local prefork_githash_config
-    prefork_githash_config=$(git rev-parse --short=8 "$prefork_short_hash" 2>/dev/null || echo "")
-    if [[ -n "$prefork_githash_config" ]]; then
-      if [[ "$prefork_githash_config" == "$GITHASH_CONFIG" ]]; then
-        echo "Prefork githash (${prefork_githash_config}) is the same as postfork; skipping config copy."
-      else
-        echo "Copying config for prefork daemon as config_${prefork_githash_config}.json"
-        mkdir -p "${BUILDDIR}/var/lib/coda"
-        cp "../genesis_ledgers/${prefork_network}.json" \
-           "${BUILDDIR}/var/lib/coda/config_${prefork_githash_config}.json"
-      fi
-    else
-      echo "WARNING: Could not resolve prefork commit hash from '${prefork_short_hash}'. Prefork config not shipped."
+    local config_hash
+    config_hash=$(resolve_prefork_config_hash "$prefork_short_hash")
+
+    if [[ -n "$config_hash" ]]; then
+      echo "Copying config for prefork daemon as config_${config_hash}.json"
+      mkdir -p "${BUILDDIR}/var/lib/coda"
+      cp "../genesis_ledgers/${prefork_network}.json" \
+         "${BUILDDIR}/var/lib/coda/config_${config_hash}.json"
     fi
   fi
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -776,23 +776,64 @@ test_build_daemon_postfork_deb_without_prefork_version() {
 }
 
 test_build_daemon_postfork_deb_unresolvable_prefork_hash() {
-    # When the prefork hash can't be resolved by git, warn but don't fail
+    # When the prefork commit does not exist in this repo, git cannot resolve
+    # the 7-char version hash back to the 8-char config hash, and no
+    # PREFORK_GITHASH_CONFIG override is set. We must warn but not fail, and
+    # ship no config (we can't guess the missing 8th char of the hash).
     export PREFORK_LEGACY_VERSION="3.3.0-compatible-badhash"
+    unset PREFORK_GITHASH_CONFIG 2>/dev/null || true
 
     safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
 
     load_captured_state
 
     # No config files — postfork config comes from config package,
-    # and prefork config can't be shipped because hash is unresolvable
+    # and prefork config can't be shipped because the hash is unresolvable
     local config_count
     config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
     if [[ "$config_count" -eq 0 ]]; then
         log_pass
     else
-        log_fail "Expected 0 config_*.json (unresolvable prefork hash), got ${config_count}"
+        log_fail "Expected 0 config_*.json (unresolvable prefork hash, no override), got ${config_count}"
     fi
 
+    unset PREFORK_LEGACY_VERSION
+}
+
+test_build_daemon_postfork_deb_prefork_githash_override() {
+    # When the prefork commit is not in this repo (git can't resolve the short
+    # hash), the pipeline supplies the full 8-char config hash directly via the
+    # PREFORK_GITHASH_CONFIG override. The prefork config must then ship under
+    # that exact filename, bypassing git resolution entirely.
+    export PREFORK_LEGACY_VERSION="3.3.0-compatible-badhash"
+    export PREFORK_GITHASH_CONFIG="abadcafe"
+
+    safe_build build_daemon_postfork_deb devnet || { log_fail "build exited non-zero"; return; }
+
+    load_captured_state
+
+    # Postfork config still comes from the config package, not here
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_${EXPECTED_GITHASH_CONFIG}.json"
+
+    # Prefork config shipped under the override hash (full 8-char), and no
+    # attempt made to ship the unresolvable version hash
+    assert_file_captured "$CAPTURED_FILES" "var/lib/coda/config_abadcafe.json"
+    assert_file_not_captured "$CAPTURED_FILES" "var/lib/coda/config_badhash.json"
+
+    # Exactly one config file (the prefork override), nothing else
+    local config_count
+    config_count=$(echo "$CAPTURED_FILES" | grep -c "config_" || true)
+    if [[ "$config_count" -eq 1 ]]; then
+        log_pass
+    else
+        log_fail "Expected 1 config_*.json (prefork githash override), got ${config_count}"
+    fi
+
+    # Prefork config should have the correct network content
+    assert_captured_file_contains "$CAPTURED_LAST_BUILD_DIR" \
+        "var/lib/coda/config_abadcafe.json" "devnet"
+
+    unset PREFORK_GITHASH_CONFIG
     unset PREFORK_LEGACY_VERSION
 }
 
@@ -1265,6 +1306,7 @@ main() {
     run_test test_build_daemon_mainnet_postfork_deb
     run_test test_build_daemon_postfork_deb_without_prefork_version
     run_test test_build_daemon_postfork_deb_unresolvable_prefork_hash
+    run_test test_build_daemon_postfork_deb_prefork_githash_override
 
     # Automode metapackages
     run_test test_build_daemon_devnet_automode_deb


### PR DESCRIPTION
Port of #19092 (release/mesa) to `develop`.

When building the automode package (prefork + postfork components) we ship the postfork debian's magic config under the prefork config filename, because the prefork runtime is chosen first. The filename is `config_<8-char hash>.json`, but `PREFORK_LEGACY_VERSION` only carries the 7-char `GITHASH`, so `builder-helpers.sh` recovered the 8th char with `git rev-parse --short=8`. If the prefork commit is not present in the checkout (e.g. lost to a rebase), that resolution fails and the copy was silently skipped.

This adds a `PREFORK_GITHASH_CONFIG` override so the pipeline can supply the full 8-char config hash directly, bypassing git resolution. It is plumbed through Dhall as `deb_legacy_githash_config` (`MinaArtifact.dhall`, `GenerateHardforkPackage.dhall`); empty (the default) keeps the existing git-resolution behaviour.

Differences from the mesa PR, due to develop's split-artifact refactor:
- `PREFORK_GITHASH_CONFIG` is exported in both env lists that already carry `PREFORK_LEGACY_VERSION` (the debian build command and `commonBuildEnvs`), rather than the single `build_artifacts` site on release/mesa.

Verified locally:
- `scripts/debian/tests/test_builder_helpers.sh`: 36 tests, 279 assertions, 0 failures (includes the new `test_build_daemon_postfork_deb_prefork_githash_override`).
- `cd buildkite && make all`: exit 0 (Dhall compiles, monorepo tests 45/45).