### PR TITLE
Archive: mark the remaining dynamic Caqti requests ~oneshot:true (completes the memory-leak fix)

### DIFF
--- a/changes/19117.md
+++ b/changes/19117.md
@@ -1,0 +1,8 @@
+Reduce archive node memory growth from remaining database query paths
+
+Long-running archive nodes slowly accumulate PostgreSQL backend memory as they
+ingest blocks, because some database queries are re-registered on every call and
+never released. This change closes the last such query paths — including the
+ones exercised by zkApp events and actions — so that memory stays flat instead
+of growing with the number of blocks processed. It complements the larger fix in
+#18858.

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -462,8 +462,11 @@ let insert_multi_into_col ~(table_name : string)
 let insert_into_cols_returning ~(returning : string * 'r Caqti_type.t)
     ~(table_name : string) ?tannot ~(cols : string list * 'cols Caqti_type.t)
     (module Conn : CONNECTION) (value : 'cols) =
+  (* The request is built freshly on every call (its SQL depends on
+     [table_name]/[cols]); pass [~oneshot:true] so it is not registered as a
+     prepared statement that accumulates in the backend plan cache. *)
   Conn.find
-    ( Caqti_request.Infix.(snd cols ->! snd returning)
+    ( Caqti_request.Infix.(snd cols ->! snd returning) ~oneshot:true
     @@ insert_into_cols ~returning:(fst returning) ~table_name ?tannot
          ~cols:(fst cols) () )
     value
@@ -485,8 +488,10 @@ let upsert_into_cols_returning ~(on_conflict : string)
     ~(returning : string * 'r Caqti_type.t) ~(table_name : string) ?tannot
     ~(cols : string list * 'cols Caqti_type.t) (module Conn : CONNECTION)
     (value : 'cols) =
+  (* Built per call; ~oneshot:true keeps it out of the backend plan cache. This
+     upsert runs for every block, so without it the cache grows unbounded. *)
   Conn.find
-    ( Caqti_request.Infix.(snd cols ->! snd returning)
+    ( Caqti_request.Infix.(snd cols ->! snd returning) ~oneshot:true
     @@ upsert_into_cols ~on_conflict ~returning:(fst returning) ~table_name
          ?tannot ~cols:(fst cols) () )
     value
@@ -504,12 +509,17 @@ let insert_multi_into_col_no_dedup ~(table_name : string) ~(col : string)
   | [] ->
       return []
   | _ ->
+      (* The values are sprintf-interpolated into the SQL, so every batch is a
+         distinct query string; ~oneshot:true stops each one from being cached
+         as a prepared statement. This is the zkApp field-array insert path, so
+         the interpolation makes the leak grow with zkApp event/action volume. *)
       let insert =
         sprintf "INSERT INTO %s (%s) VALUES %s RETURNING id" table_name col
           (sep_by_comma ~parenthesis:true values)
       in
       Conn.collect_list
-        Caqti_request.Infix.((Caqti_type.unit ->* Caqti_type.int) insert)
+        (Caqti_request.Infix.(Caqti_type.unit ->* Caqti_type.int)
+           ~oneshot:true insert )
         ()
 
 let query ~f pool =


### PR DESCRIPTION
## Summary

Completes the archive per-backend PostgreSQL memory-leak fix by marking the
three dynamically-built `Mina_caqti` request helpers that #18858 and #18860 do
**not** cover with `~oneshot:true`:

- `insert_into_cols_returning` — zkApp event / state-array inserts
- `upsert_into_cols_returning` — runs for every block
- `insert_multi_into_col_no_dedup` — the zkApp field-array insert path (still
  `sprintf`-interpolates its values, so every batch is a unique query string)

Each is built per call (SQL depends on `table_name`/`cols`, or interpolates the
values), so each call is registered as a distinct prepared statement that is
cached for the lifetime of the backend connection and never evicted.
`~oneshot:true` uses the unnamed/simple-query protocol: no `PREPARE`, nothing
cached server-side.

This is a **completeness fix, not the main event** — #18858 already removes the
bulk of the leak. See the numbers below. It's worth landing because it closes
the last uncovered request sites, including the only remaining
`sprintf`-of-values path (`insert_multi_into_col_no_dedup`), so the archive's
dynamic requests are fully covered once #18858 + #18860 + this land.

## Evidence (end-to-end, per-variant)

Replaying a zkApp-heavy corpus (1273 precomputed blocks; 89 zkApp commands /
~13.6k event + ~13.6k action fields) through the real archive insert path into
PostgreSQL and sampling the serving backend's RSS. Two runs per variant:

| build | PG backend RSS peak (run1 / run2) |
|---|---:|
| `develop` (baseline) | 155.7 / 161.6 MiB |
| #18858 only | 66.7 / 68.4 MiB  (**−58%**) |
| **this PR only** (3 helpers) | 141.5 / 141.3 MiB  (−10%) |
| #18858 + this PR (all dynamic requests) | 56.8 / 55.9 MiB  (**−65%**) |

So `select_insert_into_cols` (a lookup per public key / token — the highest call
volume) dominates, and #18858 captures most of the leak on its own. These three
helpers add roughly a further ~7% on top of #18858 (~11 MiB on this corpus). The
baseline backend keeps climbing at end-of-ingest (the leak is unbounded in block
count), which is what makes even the smaller contribution worth closing.

## Notes

- No schema, API, or behaviour change — only how requests are submitted to
  Postgres.
- #18860's value-binding rewrite of `insert_multi_into_col` is complementary
  (SQL-injection / correctness hardening); this PR is the minimal memory fix for
  the uncovered helpers.
- The e2e benchmark in #19116 tracks this on the perf dashboards.

Relates to: epic #19115, #18858, #18860, #19110, #19116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
