### PR TITLE
mina-graphql-client: send logs to stderr so stdout is clean JSON

### DIFF
--- a/changes/19118.md
+++ b/changes/19118.md
@@ -1,0 +1,6 @@
+Send mina-graphql-client logs to stderr so its stdout is clean JSON
+
+The `mina-graphql-client` utility previously printed its log lines to stdout
+alongside the JSON result of each command, so piping the output to `jq` or
+another JSON parser failed. Logs now go to stderr and stdout carries only the
+command's JSON result.

--- a/src/app/mina_graphql_client/mina_graphql_client_app.ml
+++ b/src/app/mina_graphql_client/mina_graphql_client_app.ml
@@ -408,6 +408,14 @@ let send_raw_command =
            Core.exit 1 )
 
 let () =
+  (* Route logs to stderr so stdout carries only the JSON result. Without this
+     the default logger consumer writes structured log lines to stdout, mixing
+     them with the result and breaking consumers that pipe the output to `jq`
+     or otherwise parse stdout as JSON. *)
+  Logger.Consumer_registry.register ~id:"default"
+    ~processor:(Logger.Processor.raw ())
+    ~transport:(Logger.Transport.raw (fun s -> Core.prerr_endline s))
+    () ;
   Command.run
     (Command.group ~summary:"Mina GraphQL client utility"
        [ ("peer", peer_command)


### PR DESCRIPTION
## Summary

`mina-graphql-client` wrote its structured log lines to **stdout**, interleaved
with the JSON result of each command. Any caller that pipes the output to `jq`
(or otherwise parses stdout as JSON) got several log objects ahead of the actual
result and failed to parse it.

This routes the logger to **stderr**, so stdout carries only the command's JSON
result. Logs are still emitted (unchanged content, now on stderr) for
diagnostics — the standard stdout=data / stderr=diagnostics split.

## Before

```
$ mina-graphql-client account --public-key B62... 2>/dev/null
{"timestamp":"...","level":"Info","message":"Getting account data ...", ...}
{"timestamp":"...","level":"Info","message":"Getting account", ...}
{"timestamp":"...","level":"Info","message":"Attempting to send GraphQL request ...", ...}
{
  "nonce": "124",
  ...
}
```

`... | jq '.nonce'` fails — stdout is several JSON objects, not one.

## After

```
$ mina-graphql-client account --public-key B62... 2>/dev/null
{
  "nonce": "124",
  ...
}
```

Logs go to stderr; `... | jq '.nonce'` works.

## Change

One consumer registration at startup routes the default logger to stderr
instead of the built-in stdout fallback. No change to the log content, log
level, or any command's result formatting.

Found while scripting local networks for the archive memory-leak work (epic
#19115), where the mixed stdout broke nonce lookups and forced a `jq -rs`
workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
