### PR TITLE
Remove broken cargo-xtask install from toolchain image

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -9,18 +9,18 @@
 { toolchainBase =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ci-toolchain-base:v4"
 , minaToolchainBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-toolchain:169fd52-bookworm-devnet"
+    { amd64 = "docker.io/minaprotocol/mina-toolchain:ffab0f8-bookworm-devnet"
     , arm64 =
-        "docker.io/minaprotocol/mina-toolchain:169fd52-bookworm-devnet-arm64"
+        "docker.io/minaprotocol/mina-toolchain:ffab0f8-bookworm-devnet-arm64"
     }
 , minaToolchainBullseye.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:169fd52-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:ffab0f8-bullseye-devnet"
 , minaToolchainNoble.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:169fd52-noble-devnet"
+    "docker.io/minaprotocol/mina-toolchain:ffab0f8-noble-devnet"
 , minaToolchainJammy.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:169fd52-jammy-devnet"
+    "docker.io/minaprotocol/mina-toolchain:ffab0f8-jammy-devnet"
 , minaToolchain =
-    "docker.io/minaprotocol/mina-toolchain:169fd52-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:ffab0f8-bullseye-devnet"
 , postgres =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/postgres:12.4-alpine"
 , xrefcheck =

--- a/dockerfiles/toolchain/1-build-deps
+++ b/dockerfiles/toolchain/1-build-deps
@@ -136,8 +136,6 @@ RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 # For more about rustup-init see: https://github.com/rust-lang/rustup/blob/master/README.md
 # As opposed to introducing another shell script here (that mostly just determines the platform)
 # we just download the binary for the only platform we care about in this docker environment
-# In addition to that, we also install cargo-xtask as it is used to build the
-# WebAssembly artefacts.
 USER opam
 RUN case "${TARGETARCH}" in \
         "amd64") RUSTUP_ARCH="x86_64" ;; \
@@ -158,7 +156,6 @@ RUN case "${TARGETARCH}" in \
     --component rust-src \
     --target wasm32-unknown-unknown \
     --no-self-update \
-  && "$HOME/.cargo/bin/cargo" install cargo-xtask \
   && rm /tmp/rustup-init
 USER root
 


### PR DESCRIPTION
## Problem

`mina-toolchains-build` fails on develop at Rust provisioning (`dockerfiles/toolchain/1-build-deps`, step 9/23):

```
error: could not find `cargo-xtask` in registry `crates-io` with version `*`
```

Failing run for comparison: https://buildkite.com/o-1-labs-2/mina-toolchains-build/builds/405

The crate `cargo-xtask` does not exist on crates.io — xtask is a project-local cargo pattern (`cargo run --package xtask`), not an installable tool — so this `cargo install` fails 100% of the time. The currently pinned toolchain image predates the line.

## Fix

Delete the `cargo install cargo-xtask` line (and its comment). Nothing consumes a globally installed `cargo-xtask`:

- The kimchi WASM build goes dune → `kimchi_bindings/js/{node_js,web}/build.sh` → `make -C proof-systems build-{nodejs,web}` → `cargo +nightly run --package xtask`, which builds the **workspace-local** `xtask` crate (a proof-systems workspace member, `publish = false`).
- The `cargo xtask` spelling resolves through proof-systems' `.cargo/config.toml` alias (`xtask = "run --package xtask --"`); cargo aliases take precedence over external `cargo-*` binaries.
- No other references in `dockerfiles/`, `scripts/`, or `buildkite/`.
- The xtask binary itself only shells out to `cargo` and `rustup` (both installed in this same Dockerfile stage) and links wasm-pack as a library dependency.

## Validation

Trigger `!ci-toolchain-me` and compare against failing build #405 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)