### PR TITLE
fix(ci): make check-snarky-submodule explain its failure

### DIFF
--- a/scripts/check-snarky-submodule.sh
+++ b/scripts/check-snarky-submodule.sh
@@ -5,10 +5,8 @@ set -eu
 cd src/lib/snarky
 
 CURR=$(git rev-parse HEAD)
-# temporarily skip SSL verification (for CI)
-git config http.sslVerify false
-git fetch origin
-git config http.sslVerify true
+# skip SSL verification for this fetch only (for CI)
+git -c http.sslVerify=false fetch origin
 
 function in_branch {
   if git merge-base --is-ancestor "${CURR}" origin/"$1"; then

--- a/scripts/check-snarky-submodule.sh
+++ b/scripts/check-snarky-submodule.sh
@@ -12,7 +12,7 @@ git config http.sslVerify true
 
 function in_branch {
   if git rev-list origin/"$1" | grep -q "${CURR}"; then
-    echo "Snarky submodule commit is an ancestor of snarky/$1"
+    echo "Snarky submodule commit ${CURR} is an ancestor of snarky/$1"
     true
   else
     false
@@ -20,6 +20,22 @@ function in_branch {
 }
 
 if (! in_branch "master"); then
+  cat >&2 <<EOF
+ERROR: the snarky submodule is pinned to ${CURR}, which is not an
+ancestor of snarky's origin/master.
+
+This means the pinned snarky commit has not been merged upstream.
+Push the snarky commit to snarky's master (or a branch merged into
+master) before merging the change that updates this submodule.
+
+Branches on snarky's origin that do contain ${CURR}:
+EOF
+  BRANCHES=$(git branch -r --contains "${CURR}" 2>/dev/null || true)
+  if [ -n "${BRANCHES}" ]; then
+    printf '%s\n' "${BRANCHES}" | sed 's/^/  /' >&2
+  else
+    echo "  (none - the commit may not be pushed to snarky's origin at all)" >&2
+  fi
   exit 1
 fi
 

--- a/scripts/check-snarky-submodule.sh
+++ b/scripts/check-snarky-submodule.sh
@@ -11,7 +11,7 @@ git fetch origin
 git config http.sslVerify true
 
 function in_branch {
-  if git rev-list origin/"$1" | grep -q "${CURR}"; then
+  if git merge-base --is-ancestor "${CURR}" origin/"$1"; then
     echo "Snarky submodule commit ${CURR} is an ancestor of snarky/$1"
     true
   else


### PR DESCRIPTION
## Summary
- `check-snarky-submodule.sh` previously failed silently (bare `exit 1`, no diagnostic) when the pinned snarky commit isn't an ancestor of `snarky/master`. It now explains what's wrong, why, how to fix it, and lists snarky origin branches (if any) that contain the commit.
- Swapped `git rev-list | grep -q` for `git merge-base --is-ancestor`, the purpose-built ancestry check.
- Scoped the `sslVerify` override to just the fetch (`git -c http.sslVerify=false fetch`) instead of mutating and restoring the submodule's repo config.

## Motivating failure
[Build 41849, "Fast lint steps" job](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/41849#019fa207-fd18-4e59-8133-6a110f38fc72) hit this with the snarky submodule pinned to `517a716e2` ("relax snarky to accept core.v0.16 series"). The entire diagnostic the developer got was:

```
-- Running: make check-snarky-submodule --
--
./scripts/check-snarky-submodule.sh
make: *** [Makefile:414: check-snarky-submodule] Error 1
```

No mention of snarky, the offending commit, ancestry, or how to resolve it — just `Error 1`. That is precisely the experience this PR fixes.

## Test plan
- [x] `shellcheck scripts/check-snarky-submodule.sh` passes
- [x] Manually verified the script's tree is unchanged in net effect versus the working version, only diagnostics/robustness improved