### PR TITLE
Add a Debian trixie (glibc 2.41) mina-toolchain build image

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -1,63 +1,43 @@
 -- TODO: Automatically push, tag, and update images #4862
--- NOTE: minaToolchain is the default image for various jobs, set to minaToolchainBullseye
--- NOTE: minaToolchainBullseye is also used for building Ubuntu Focal packages in CI
--- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
--- NOTE: minaToolchainTrixie is FORWARD-REFERENCED: the trixie toolchain image
---       does not exist in the registry yet. The tag below is the one the
---       MinaToolchainArtifactTrixie build will itself produce once it lands;
---       update the git-hash prefix to a real published tag after the first
---       trixie toolchain build completes.
--- NOTE: minaReleaseToolkit bundles the deb-toolkit binary and is published by
---       MinaProtocol/mina-release-toolkit. Pinned to a released version tag
---       (not a moving tag like :latest) for reproducible CI; bump it
---       deliberately when a newer toolkit is wanted.
--- NOTE: minaToolchain* pin the v0.16 opam stack, so they must stay on a sha
---       built from THIS branch: develop's pins carry v0.14 and will not build
---       here. Rebuild with !ci-toolchain-me, then bump the sha below to the one
---       it produced (all five images land on one sha). Do not reach for an
---       older toolchain sha instead: 3-toolchain curls mina-bench-upload by
---       version string with no checksum, so an image's behaviour depends on the
---       date it was built, and rebuilding is the only fix.
--- NOTE: mina-toolchain and mina-base are published by DIFFERENT pipelines and
---       their hashes move independently. mina-toolchain comes from
---       mina-toolchains-build; mina-base from mina-docker-base-build
---       (!ci-docker-base-me). Bumping one is never a reason to bump the other.
--- NOTE: minaBase* are the published common base-deps images on docker.io. The tag
---       format matches build.sh's HASHTAG for service=mina-base: <githash>-<codename>-<network>.
---       These are frozen references, like minaToolchain*: the daemon/archive/hardfork
---       builds load them from the CI cache and build FROM them instead of re-running the
---       base-deps stage. Re-publish with !ci-docker-base-me (pipeline
---       mina-docker-base-build), then bump the short hash here to the one it produced.
---       A stale or unpublished hash is not fatal -- scripts/docker/build.sh falls back to
---       inlining the base-deps fragment when the image is not available locally -- so the
---       only cost of forgetting the bump is losing the reuse.
+-- NOTE: minaToolchain defaults to minaToolchainBullseye. Bullseye also builds
+--       Ubuntu Focal debs in CI; bookworm builds Jammy debs.
+-- NOTE: minaToolchain* and minaBase* are frozen tags, <githash>-<codename>-<network>,
+--       kept on one sha. Republish with !ci-toolchain-me / !ci-docker-base-me,
+--       then bump the sha here to the one that build produced. A stale minaBase*
+--       only costs layer reuse (build.sh re-inlines the base-deps stage), but do
+--       not reach for an OLDER minaToolchain* sha: 3-toolchain curls
+--       mina-bench-upload by version with no checksum, so rebuilding is the fix.
+-- NOTE: minaReleaseToolkit is pinned to a release tag, not :latest, for
+--       reproducible CI; bump it deliberately.
 { toolchainBase =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ci-toolchain-base:v4"
 , minaToolchainBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-toolchain:44e9e82-bookworm-devnet"
+    { amd64 = "docker.io/minaprotocol/mina-toolchain:157199e-bookworm-devnet"
     , arm64 =
-        "docker.io/minaprotocol/mina-toolchain:44e9e82-bookworm-devnet-arm64"
+        "docker.io/minaprotocol/mina-toolchain:157199e-bookworm-devnet-arm64"
     }
 , minaToolchainBullseye.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:44e9e82-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:157199e-bullseye-devnet"
 , minaToolchainNoble.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:44e9e82-noble-devnet"
+    "docker.io/minaprotocol/mina-toolchain:157199e-noble-devnet"
 , minaToolchainJammy.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:44e9e82-jammy-devnet"
-, minaToolchainTrixie.amd64 = "PLACEHOLDER"
+    "docker.io/minaprotocol/mina-toolchain:157199e-jammy-devnet"
+, minaToolchainTrixie.amd64 =
+    "docker.io/minaprotocol/mina-toolchain:157199e-trixie-devnet"
 , minaToolchain =
-    "docker.io/minaprotocol/mina-toolchain:44e9e82-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:157199e-bullseye-devnet"
 , minaBaseBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet"
-    , arm64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet-arm64"
+    { amd64 = "docker.io/minaprotocol/mina-base:157199e-bookworm-devnet"
+    , arm64 = "docker.io/minaprotocol/mina-base:157199e-bookworm-devnet-arm64"
     }
 , minaBaseBullseye.amd64 =
-    "docker.io/minaprotocol/mina-base:86b89d0-bullseye-devnet"
-, minaBaseFocal.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-focal-devnet"
-, minaBaseJammy.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-jammy-devnet"
-, minaBaseNoble.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-noble-devnet"
-, minaBaseTrixie.amd64 = "PLACEHOLDER"
-, minaBase = "docker.io/minaprotocol/mina-base:86b89d0-bullseye-devnet"
+    "docker.io/minaprotocol/mina-base:157199e-bullseye-devnet"
+, minaBaseFocal.amd64 = "docker.io/minaprotocol/mina-base:157199e-focal-devnet"
+, minaBaseJammy.amd64 = "docker.io/minaprotocol/mina-base:157199e-jammy-devnet"
+, minaBaseNoble.amd64 = "docker.io/minaprotocol/mina-base:157199e-noble-devnet"
+, minaBaseTrixie.amd64 =
+    "docker.io/minaprotocol/mina-base:157199e-trixie-devnet"
+, minaBase = "docker.io/minaprotocol/mina-base:157199e-bullseye-devnet"
 , postgres =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/postgres:12.4-alpine"
 , xrefcheck =

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,6 +2,11 @@
 -- NOTE: minaToolchain is the default image for various jobs, set to minaToolchainBullseye
 -- NOTE: minaToolchainBullseye is also used for building Ubuntu Focal packages in CI
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
+-- NOTE: minaToolchainTrixie is FORWARD-REFERENCED: the trixie toolchain image
+--       does not exist in the registry yet. The tag below is the one the
+--       MinaToolchainArtifactTrixie build will itself produce once it lands;
+--       update the git-hash prefix to a real published tag after the first
+--       trixie toolchain build completes.
 -- NOTE: minaReleaseToolkit bundles the deb-toolkit binary and is published by
 --       MinaProtocol/mina-release-toolkit. Pinned to a released version tag
 --       (not a moving tag like :latest) for reproducible CI; bump it
@@ -39,6 +44,7 @@
     "docker.io/minaprotocol/mina-toolchain:44e9e82-noble-devnet"
 , minaToolchainJammy.amd64 =
     "docker.io/minaprotocol/mina-toolchain:44e9e82-jammy-devnet"
+, minaToolchainTrixie.amd64 = "PLACEHOLDER"
 , minaToolchain =
     "docker.io/minaprotocol/mina-toolchain:44e9e82-bullseye-devnet"
 , minaBaseBookworm =
@@ -50,6 +56,7 @@
 , minaBaseFocal.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-focal-devnet"
 , minaBaseJammy.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-jammy-devnet"
 , minaBaseNoble.amd64 = "docker.io/minaprotocol/mina-base:86b89d0-noble-devnet"
+, minaBaseTrixie.amd64 = "PLACEHOLDER"
 , minaBase = "docker.io/minaprotocol/mina-base:86b89d0-bullseye-devnet"
 , postgres =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/postgres:12.4-alpine"

--- a/buildkite/src/Constants/Debian/Versions.dhall
+++ b/buildkite/src/Constants/Debian/Versions.dhall
@@ -8,7 +8,7 @@ let Arch = ../Artifact/Arch.dhall
 
 let S = ../../Lib/SelectFiles.dhall
 
-let DebVersion = < Bookworm | Bullseye | Jammy | Focal | Noble >
+let DebVersion = < Bookworm | Bullseye | Jammy | Focal | Noble | Trixie >
 
 let capitalName =
           \(debVersion : DebVersion)
@@ -18,6 +18,7 @@ let capitalName =
             , Jammy = "Jammy"
             , Focal = "Focal"
             , Noble = "Noble"
+            , Trixie = "Trixie"
             }
             debVersion
 
@@ -29,6 +30,7 @@ let lowerName =
             , Jammy = "jammy"
             , Focal = "focal"
             , Noble = "noble"
+            , Trixie = "trixie"
             }
             debVersion
 
@@ -110,6 +112,7 @@ let dirtyWhen =
             , Jammy = minimalDirtyWhen
             , Focal = minimalDirtyWhen
             , Noble = minimalDirtyWhen
+            , Trixie = minimalDirtyWhen
             }
             debVersion
 

--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -8,7 +8,7 @@ let Arch = ./Arch.dhall
 
 let S = ../Lib/SelectFiles.dhall
 
-let DebVersion = < Bookworm | Bullseye | Jammy | Focal | Noble >
+let DebVersion = < Bookworm | Bullseye | Jammy | Focal | Noble | Trixie >
 
 let capitalName =
           \(debVersion : DebVersion)
@@ -18,6 +18,7 @@ let capitalName =
             , Jammy = "Jammy"
             , Focal = "Focal"
             , Noble = "Noble"
+            , Trixie = "Trixie"
             }
             debVersion
 
@@ -29,6 +30,7 @@ let lowerName =
             , Jammy = "jammy"
             , Focal = "focal"
             , Noble = "noble"
+            , Trixie = "trixie"
             }
             debVersion
 
@@ -110,6 +112,7 @@ let dirtyWhen =
             , Jammy = minimalDirtyWhen
             , Focal = minimalDirtyWhen
             , Noble = minimalDirtyWhen
+            , Trixie = minimalDirtyWhen
             }
             debVersion
 

--- a/buildkite/src/Constants/Docker/BaseImage.dhall
+++ b/buildkite/src/Constants/Docker/BaseImage.dhall
@@ -33,6 +33,7 @@ let imageFor
             , Jammy = ContainerImages.minaBaseJammy.amd64
             , Focal = ContainerImages.minaBaseFocal.amd64
             , Noble = ContainerImages.minaBaseNoble.amd64
+            , Trixie = ContainerImages.minaBaseTrixie.amd64
             }
             debVersion
 

--- a/buildkite/src/Constants/Docker/Versions.dhall
+++ b/buildkite/src/Constants/Docker/Versions.dhall
@@ -12,7 +12,7 @@ let Arch = ../Artifact/Arch.dhall
 
 let Docker
     : Type
-    = < Bookworm | Bullseye | Jammy | Focal | Noble >
+    = < Bookworm | Bullseye | Jammy | Focal | Noble | Trixie >
 
 let capitalName =
           \(docker : Docker)
@@ -22,6 +22,7 @@ let capitalName =
             , Jammy = "Jammy"
             , Focal = "Focal"
             , Noble = "Noble"
+            , Trixie = "Trixie"
             }
             docker
 
@@ -33,6 +34,7 @@ let lowerName =
             , Jammy = "jammy"
             , Focal = "focal"
             , Noble = "noble"
+            , Trixie = "trixie"
             }
             docker
 
@@ -92,6 +94,7 @@ let ofDebian =
             , Jammy = Docker.Jammy
             , Focal = Docker.Focal
             , Noble = Docker.Noble
+            , Trixie = Docker.Trixie
             }
             debian
 

--- a/buildkite/src/Constants/Toolchain.dhall
+++ b/buildkite/src/Constants/Toolchain.dhall
@@ -41,6 +41,7 @@ let imageFor
             , Jammy = ContainerImages.minaToolchainJammy.amd64
             , Focal = ContainerImages.minaToolchain
             , Noble = ContainerImages.minaToolchainNoble.amd64
+            , Trixie = ContainerImages.minaToolchainTrixie.amd64
             }
             debVersion
 

--- a/buildkite/src/Jobs/Release/MinaBaseArtifactTrixie.dhall
+++ b/buildkite/src/Jobs/Release/MinaBaseArtifactTrixie.dhall
@@ -1,0 +1,22 @@
+let MinaArtifactBase = ../../Command/MinaArtifactBase.dhall
+
+let Docker = ../../Constants/Docker/Package.dhall
+
+let DockerImage = ../../Command/DockerImage.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let DockerRepo = ../../Constants/DockerRepo.dhall
+
+let Size = ../../Command/Size.dhall
+
+in  MinaArtifactBase.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Docker.Type.Base
+      , deb_codename = DebianVersions.DebVersion.Trixie
+      , no_cache = True
+      , deb_install_mode = DockerImage.DebianInstallMode.NoInstall
+      , docker_repo = DockerRepo.Type.Public
+      , save_to_ci_cache = True
+      , size = Size.XLarge
+      }

--- a/buildkite/src/Jobs/Release/MinaToolchainArtifactTrixie.dhall
+++ b/buildkite/src/Jobs/Release/MinaToolchainArtifactTrixie.dhall
@@ -1,0 +1,22 @@
+let MinaArtifactToolchain = ../../Command/MinaArtifactToolchain.dhall
+
+let Docker = ../../Constants/Docker/Package.dhall
+
+let DockerImage = ../../Command/DockerImage.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let DockerRepo = ../../Constants/DockerRepo.dhall
+
+let Size = ../../Command/Size.dhall
+
+in  MinaArtifactToolchain.pipeline
+      DockerImage.ReleaseSpec::{
+      , service = Docker.Type.Toolchain
+      , deb_codename = DebianVersions.DebVersion.Trixie
+      , no_cache = True
+      , deb_install_mode = DockerImage.DebianInstallMode.NoInstall
+      , docker_repo = DockerRepo.Type.Public
+      , save_to_ci_cache = True
+      , size = Size.XLarge
+      }

--- a/dockerfiles/toolchain/1-build-deps
+++ b/dockerfiles/toolchain/1-build-deps
@@ -3,6 +3,9 @@
 # - Installs all compilers/interpreters, tools, and OS packages on the given debian or ubuntu image
 #################################################################################################
 # Supports europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/debian:bullseye-slim, and europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ubuntu:focal
+# Also supports debian:bookworm and debian:trixie-slim (trixie = Debian 13, glibc 2.41+,
+# used by the portability effort). UNVALIDATED for trixie: OCaml 4.14.2 + C stubs must be
+# confirmed to compile against trixie's toolchain and glibc 2.41 on real infra.
 ARG image=europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ubuntu:focal
 ARG deb_codename
 ARG apt_cache_url=""
@@ -57,9 +60,17 @@ COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
 RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
   && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
+# Per-codename package-name drift for the SSL and procps runtime libs.
+# trixie (Debian 13, glibc 2.41+) verified against debian:trixie-slim:
+#   - "libssl-dev" resolves (OpenSSL 3.5.x; the runtime lib is libssl3t64
+#     under the 64-bit time_t transition, but we install the -dev metapackage
+#     as for bookworm/bullseye, so no t64 suffix is needed here).
+#   - "libproc2-0" resolves (procps 4.x), same choice as bookworm/noble.
+# All other packages in the list below were confirmed present in trixie.
 RUN CODENAME=$(grep "VERSION_CODENAME" /etc/os-release | cut -d= -f2); \
   case "${CODENAME}" in \
     bookworm) LIBSSL="libssl-dev"; LIBPROCPS="libproc2-0" ;; \
+    trixie) LIBSSL="libssl-dev"; LIBPROCPS="libproc2-0" ;; \
     bullseye) LIBSSL="libssl-dev"; LIBPROCPS="libprocps-dev" ;; \
     focal) LIBSSL="libssl-dev"; LIBPROCPS="libprocps-dev" ;; \
     jammy) LIBSSL="libssl3"; LIBPROCPS="libprocps8";; \
@@ -95,6 +106,7 @@ RUN CODENAME=$(grep "VERSION_CODENAME" /etc/os-release | cut -d= -f2); \
   git \
   git-lfs \
   lld \
+  locales \
   m4 \
   pkg-config \
   rocksdb-tools \

--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -22,6 +22,12 @@ function export_base_image () {
     bookworm)
         IMAGE="europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/debian:bookworm"
     ;;
+    trixie)
+        # Debian 13 (glibc 2.41+). Portability effort: build glibc == bundled glibc.
+        # Draft uses the public debian:trixie-slim; a gar-cache mirror tag
+        # (euro-docker-repo/debian:trixie[-slim]) should be seeded before CI use.
+        IMAGE="debian:trixie-slim"
+    ;;
     esac
     export IMAGE
 }


### PR DESCRIPTION
## Summary

Adds a Debian **trixie** (Debian 13, glibc 2.41) variant of the `mina-toolchain` and `mina-base` build images, plus the Dhall wiring to build them, alongside the existing bookworm/noble/bullseye/focal/jammy targets.

This is the first building block of an effort to ship a single **portable** mina build (bundled libraries, no per-distro coupling). That approach builds mina *on* trixie so the build-time glibc equals the glibc bundled into the artifact, keeping `libnss` / `gconv` / locale versions consistent. A fixed glibc 2.41 also sidesteps the `pthread_cond_signal` deadlock (glibc bug 25847, affecting 2.27–2.40) — see the reproducer in #18654.

## Scope: images only, not mina itself

This PR adds the two image-producing jobs for trixie and nothing else:

| Job | Produces | Status |
| --- | --- | --- |
| `MinaToolchainArtifactTrixie` | `mina-toolchain:<sha>-trixie-devnet` | added, green |
| `MinaBaseArtifactTrixie` | `mina-base:<sha>-trixie-devnet` | added, green |
| `MinaArtifactTrixie` | daemon / archive / rosetta debs + docker | **not added — follow-up** |

So there is **no trixie deb/docker package matrix**: nothing here builds mina itself on trixie. The existing per-codename jobs are untouched. Adding `MinaArtifactTrixie` also needs a `PipelineTag.Type.Trixie` member, so it is not a single-file change. arm64 for trixie is likewise a follow-up.

Consequently the C stubs (rocksdb, libp2p_helper, kimchi/crypto) linking against glibc 2.41 are **not** yet exercised — that is what the follow-up artifact job will validate.

## Changes

**Images**

- `dockerfiles/toolchain/1-build-deps`: trixie branch in the per-codename SSL/procps case (`libssl-dev` + `libproc2-0`); add `locales` for locale source data (absent from `-slim` images). glibc 2.41, the `ld-linux` loader, `libnss_*`, and gconv modules already ship in the base image.
- `scripts/docker/helper.sh`: map the `trixie` codename to `debian:trixie-slim` (a gar-cache mirror should be seeded before broader rollout).

**Dhall wiring** — adds a `DebVersion.Trixie` member and the two image jobs above:

- `Constants/DebianVersions.dhall`, `Constants/Debian/Versions.dhall`, `Constants/Docker/Versions.dhall`: `Trixie` added to the unions.
- `Constants/Toolchain.dhall`, `Constants/Docker/BaseImage.dhall`: select the trixie toolchain / base image.
- `Jobs/Release/MinaToolchainArtifactTrixie.dhall`, `Jobs/Release/MinaBaseArtifactTrixie.dhall`: new amd64-only jobs.
- `Constants/ContainerImages.dhall`: all `minaToolchain*` / `minaBase*` pins moved onto one sha (`157199e`), trixie included; header notes condensed.

## Validation

Both images build and are published from this branch:

- `mina-toolchain:157199e-trixie-devnet` — [mina-toolchains-build #432](https://buildkite.com/o-1-labs-2/mina-toolchains-build/builds/432)
- `mina-base:157199e-trixie-devnet` — [mina-docker-base-build #7](https://buildkite.com/o-1-labs-2/mina-docker-base-build/builds/7)

This clears the earlier block: the toolchain now compiles OCaml 4.14.2 and the opam switch under trixie's **gcc-14** and **OpenSSL 3.5**, which the previous `async_ssl v0.14.0-o1labs` stack could not (its ctypes-generated BN/SSL stubs failed `-Wincompatible-pointer-types`, promoted to an error by gcc-14). The core v0.16 bump (#19119) resolved that.

Dhall `make lint format` is zero-diff.
