### PR TITLE
[mesa] zkapp_test_transaction: generate events, actions and multiple account updates

### DIFF
--- a/changes/19130.md
+++ b/changes/19130.md
@@ -1,0 +1,5 @@
+Add flags to generate zkApp transactions carrying events, actions and several account updates
+
+The `update-state` subcommand of the zkApp test transaction tool previously always produced transactions with empty events and actions and a single account update. It now accepts `--num-events`, `--num-actions`, `--event-elements-per` and `--action-elements-per` to fill those arrays, `--repeat-arrays` to emit identical arrays rather than distinct ones, and `--num-account-updates` to repeat the update within one transaction. This makes it possible to generate the heavy zkApp payloads needed to exercise and load-test archive nodes.
+
+The two count flags also accept `max`, which fills up to the network's event and action limit, so the same command line can be reused against networks whose limits differ. Omitting all of the flags leaves the generated transaction unchanged.

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -338,6 +338,30 @@ module Util = struct
      With [repeat] every array holds the same elements, which defeats the
      content-based deduplication that consumers such as the archive node apply
      to event and action arrays. *)
+
+  (* Pick the zkApp state fields to set: either the ones named explicitly, or
+     [count] generated ones. How many fields a zkApp account has is fixed when
+     the tool is built, so asking for [Max] is the only way to set all of them
+     without naming a number that a different protocol version rejects. *)
+  let state_fields ~explicit ~count =
+    match count with
+    | Count 0 ->
+        explicit
+    | _ ->
+        if not (List.is_empty explicit) then
+          failwith
+            "--zkapp-state and --num-state-fields both set the zkApp state; \
+             pass one or the other" ;
+        let n =
+          match count with Count n -> n | Max -> Zkapp_state.max_size_int
+        in
+        if n > Zkapp_state.max_size_int then
+          failwithf
+            "%d zkApp state fields is above the %d this protocol version \
+             defines"
+            n Zkapp_state.max_size_int () ;
+        List.init n ~f:(fun i -> Int.to_string (i + 1))
+
   let gen_field_arrays ~kind ~max_elements ~count ~elements_per ~repeat
       ~account_updates : Snark_params.Tick.Field.t array list =
     if elements_per < 1 then
@@ -544,12 +568,15 @@ let transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer ~fee_payer_nonce
 
 let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
     ~num_events ~num_actions ~event_elements_per ~action_elements_per
-    ~repeat_arrays ~num_account_updates ~genesis_constants ~constraint_constants
-    =
+    ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
+    ~constraint_constants =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.fee_payer_keypair_of_file keyfile in
   let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
-  let app_state = Util.app_state_of_list app_state in
+  let app_state =
+    Util.app_state_of_list
+      (Util.state_fields ~explicit:app_state ~count:num_state_fields)
+  in
   if num_account_updates < 1 then
     failwithf "--num-account-updates must be at least 1, got %d"
       num_account_updates () ;

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -307,6 +307,62 @@ module Util = struct
   let action_state_of_list array_lst : Snark_params.Tick.Field.t array list =
     List.map ~f:Events.of_string_array array_lst
 
+  (* How many events/actions arrays to generate. [Max] saturates the protocol
+     cap instead of naming a number, so that one command line stays valid
+     across protocol versions that cap events and actions differently. *)
+  type array_count = Count of int | Max
+
+  let array_count_of_string s =
+    match String.lowercase (String.strip s) with
+    | "max" ->
+        Max
+    | _ -> (
+        match Option.try_with (fun () -> Int.of_string s) with
+        | Some n when n >= 0 ->
+            Count n
+        | _ ->
+            failwithf "expected a non-negative integer or \"max\", got %s" s ()
+        )
+
+  (* Generate the events or actions of a zkApp command: [count] field-arrays of
+     [elements_per] field elements each.
+
+     [max_elements] is the cap that Zkapp_command.valid_size enforces, and it
+     bounds the *total* number of field elements of one kind across the whole
+     command, not the length of a single array. Going over it builds a command
+     that every daemon rejects, so fail here with a message naming the total.
+
+     With [repeat] every array holds the same elements, which defeats the
+     content-based deduplication that consumers such as the archive node apply
+     to event and action arrays. *)
+  let gen_field_arrays ~kind ~max_elements ~count ~elements_per ~repeat :
+      Snark_params.Tick.Field.t array list =
+    if elements_per < 1 then
+      failwithf "%s arrays need at least 1 field element, got %d" kind
+        elements_per () ;
+    let count =
+      match count with
+      | Count n ->
+          n
+      | Max ->
+          if elements_per > max_elements then
+            failwithf
+              "a single %s array of %d field elements is already above the \
+               maximum of %d (genesis constant max_%s_elements)"
+              kind elements_per max_elements kind () ;
+          max_elements / elements_per
+    in
+    let total = count * elements_per in
+    if total > max_elements then
+      failwithf
+        "%d %s arrays of %d field elements is %d elements, above the maximum \
+         of %d (genesis constant max_%s_elements)"
+        count kind elements_per total max_elements kind () ;
+    List.init count ~f:(fun i ->
+        Array.init elements_per ~f:(fun j ->
+            let ndx = if repeat then j else (i * elements_per) + j in
+            Snark_params.Tick.Field.of_int (ndx + 1) ) )
+
   let auth_of_string s : Permissions.Auth_required.t =
     match String.lowercase s with
     | "none" ->
@@ -481,11 +537,23 @@ let transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer ~fee_payer_nonce
   zkapp_command
 
 let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
-    ~genesis_constants ~constraint_constants =
+    ~num_events ~num_actions ~event_elements_per ~action_elements_per
+    ~repeat_arrays ~genesis_constants ~constraint_constants =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.fee_payer_keypair_of_file keyfile in
   let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let app_state = Util.app_state_of_list app_state in
+  let Genesis_constants.{ max_event_elements; max_action_elements; _ } =
+    genesis_constants
+  in
+  let events =
+    Util.gen_field_arrays ~kind:"event" ~max_elements:max_event_elements
+      ~count:num_events ~elements_per:event_elements_per ~repeat:repeat_arrays
+  in
+  let actions =
+    Util.gen_field_arrays ~kind:"action" ~max_elements:max_action_elements
+      ~count:num_actions ~elements_per:action_elements_per ~repeat:repeat_arrays
+  in
   let spec =
     { Transaction_snark.For_tests.Update_states_spec.sender = (keypair, nonce)
     ; fee
@@ -498,8 +566,8 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
     ; snapp_update = { Account_update.Update.dummy with app_state }
     ; current_auth = Permissions.Auth_required.Signature
     ; call_data = Snark_params.Tick.Field.zero
-    ; events = []
-    ; actions = []
+    ; events
+    ; actions
     ; preconditions = None
     }
   in

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -329,35 +329,41 @@ module Util = struct
 
      [max_elements] is the cap that Zkapp_command.valid_size enforces, and it
      bounds the *total* number of field elements of one kind across the whole
-     command, not the length of a single array. Going over it builds a command
-     that every daemon rejects, so fail here with a message naming the total.
+     command, not the length of a single array. These arrays are attached to
+     every one of the [account_updates] account updates, so the total to check
+     against the cap is [account_updates * count * elements_per]. Going over it
+     builds a command that every daemon rejects, so fail here with a message
+     naming the total.
 
      With [repeat] every array holds the same elements, which defeats the
      content-based deduplication that consumers such as the archive node apply
      to event and action arrays. *)
-  let gen_field_arrays ~kind ~max_elements ~count ~elements_per ~repeat :
-      Snark_params.Tick.Field.t array list =
+  let gen_field_arrays ~kind ~max_elements ~count ~elements_per ~repeat
+      ~account_updates : Snark_params.Tick.Field.t array list =
     if elements_per < 1 then
       failwithf "%s arrays need at least 1 field element, got %d" kind
         elements_per () ;
+    let per_update_cost = elements_per * account_updates in
     let count =
       match count with
       | Count n ->
           n
       | Max ->
-          if elements_per > max_elements then
+          if per_update_cost > max_elements then
             failwithf
-              "a single %s array of %d field elements is already above the \
-               maximum of %d (genesis constant max_%s_elements)"
-              kind elements_per max_elements kind () ;
-          max_elements / elements_per
+              "one %s array of %d field elements across %d account updates is \
+               already %d elements, above the maximum of %d (genesis constant \
+               max_%s_elements)"
+              kind elements_per account_updates per_update_cost max_elements
+              kind () ;
+          max_elements / per_update_cost
     in
-    let total = count * elements_per in
+    let total = count * per_update_cost in
     if total > max_elements then
       failwithf
-        "%d %s arrays of %d field elements is %d elements, above the maximum \
-         of %d (genesis constant max_%s_elements)"
-        count kind elements_per total max_elements kind () ;
+        "%d %s arrays of %d field elements across %d account updates is %d \
+         elements, above the maximum of %d (genesis constant max_%s_elements)"
+        count kind elements_per account_updates total max_elements kind () ;
     List.init count ~f:(fun i ->
         Array.init elements_per ~f:(fun j ->
             let ndx = if repeat then j else (i * elements_per) + j in
@@ -538,29 +544,41 @@ let transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer ~fee_payer_nonce
 
 let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
     ~num_events ~num_actions ~event_elements_per ~action_elements_per
-    ~repeat_arrays ~genesis_constants ~constraint_constants =
+    ~repeat_arrays ~num_account_updates ~genesis_constants ~constraint_constants
+    =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.fee_payer_keypair_of_file keyfile in
   let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let app_state = Util.app_state_of_list app_state in
+  if num_account_updates < 1 then
+    failwithf "--num-account-updates must be at least 1, got %d"
+      num_account_updates () ;
   let Genesis_constants.{ max_event_elements; max_action_elements; _ } =
     genesis_constants
   in
   let events =
     Util.gen_field_arrays ~kind:"event" ~max_elements:max_event_elements
       ~count:num_events ~elements_per:event_elements_per ~repeat:repeat_arrays
+      ~account_updates:num_account_updates
   in
   let actions =
     Util.gen_field_arrays ~kind:"action" ~max_elements:max_action_elements
       ~count:num_actions ~elements_per:action_elements_per ~repeat:repeat_arrays
+      ~account_updates:num_account_updates
   in
   let spec =
     { Transaction_snark.For_tests.Update_states_spec.sender = (keypair, nonce)
     ; fee
     ; fee_payer = None
     ; receivers = []
-    ; amount = Currency.Amount.zero
-    ; zkapp_account_keypairs = [ zkapp_keypair ]
+    ; amount =
+        Currency.Amount.zero
+        (* Repeating the same keypair yields one account update per entry, all
+           against the same zkApp account. This is how the max-cost generator in
+           Mina_generators builds a multi-update command too, and it is what
+           raises the zkApp cost towards max_zkapp_segment_per_transaction. *)
+    ; zkapp_account_keypairs =
+        List.init num_account_updates ~f:(fun _ -> zkapp_keypair)
     ; memo = Util.memo memo
     ; new_zkapp_account = false
     ; snapp_update = { Account_update.Update.dummy with app_state }

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -342,8 +342,10 @@ module Util = struct
   (* Pick the zkApp state fields to set: either the ones named explicitly, or
      [count] generated ones. How many fields a zkApp account has is fixed when
      the tool is built, so asking for [Max] is the only way to set all of them
-     without naming a number that a different protocol version rejects. *)
-  let state_fields ~explicit ~count =
+     without naming a number that a different protocol version rejects.
+     [max_fields] is that limit, read once at the entrypoint and passed down
+     rather than looked up here. *)
+  let state_fields ~explicit ~count ~max_fields =
     match count with
     | Count 0 ->
         explicit
@@ -352,14 +354,12 @@ module Util = struct
           failwith
             "--zkapp-state and --num-state-fields both set the zkApp state; \
              pass one or the other" ;
-        let n =
-          match count with Count n -> n | Max -> Zkapp_state.max_size_int
-        in
-        if n > Zkapp_state.max_size_int then
+        let n = match count with Count n -> n | Max -> max_fields in
+        if n > max_fields then
           failwithf
             "%d zkApp state fields is above the %d this protocol version \
              defines"
-            n Zkapp_state.max_size_int () ;
+            n max_fields () ;
         List.init n ~f:(fun i -> Int.to_string (i + 1))
 
   let gen_field_arrays ~kind ~max_elements ~count ~elements_per ~repeat
@@ -568,14 +568,15 @@ let transfer_funds ~debug ~sender ~sender_nonce ~fee ~fee_payer ~fee_payer_nonce
 
 let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
     ~num_events ~num_actions ~event_elements_per ~action_elements_per
-    ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
-    ~constraint_constants =
+    ~repeat_arrays ~num_state_fields ~num_account_updates ~max_state_fields
+    ~genesis_constants ~constraint_constants =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.fee_payer_keypair_of_file keyfile in
   let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let app_state =
     Util.app_state_of_list
-      (Util.state_fields ~explicit:app_state ~count:num_state_fields)
+      (Util.state_fields ~explicit:app_state ~count:num_state_fields
+         ~max_fields:max_state_fields )
   in
   if num_account_updates < 1 then
     failwithf "--num-account-updates must be at least 1, got %d"

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -280,14 +280,14 @@ let transfer_funds =
 let update_state =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
       ~num_events ~num_actions ~event_elements_per ~action_elements_per
-      ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
-      ~constraint_constants () =
+      ~repeat_arrays ~num_state_fields ~num_account_updates ~max_state_fields
+      ~genesis_constants ~constraint_constants () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
       update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
         ~num_events ~num_actions ~event_elements_per ~action_elements_per
-        ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
-        ~constraint_constants
+        ~repeat_arrays ~num_state_fields ~num_account_updates ~max_state_fields
+        ~genesis_constants ~constraint_constants
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -360,10 +360,17 @@ let update_state =
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
+       (* Read once at the entrypoint and thread down. Kept below the fee check
+          (rather than beside the genesis-constants block) so this mesa-only
+          addition does not adjoin the lines develop rewrote to
+          Genesis_constants.profiled (), which would make the branch fail the
+          "merges cleanly into develop" lint. *)
+       let max_state_fields = Mina_base.Zkapp_state.max_size_int in
        create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
          ~app_state ~num_events ~num_actions ~event_elements_per
          ~action_elements_per ~repeat_arrays ~num_state_fields
-         ~num_account_updates ~genesis_constants ~constraint_constants ))
+         ~num_account_updates ~max_state_fields ~genesis_constants
+         ~constraint_constants ))
 
 let update_zkapp_uri =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -33,6 +33,8 @@ module Flags = struct
     Param.flag "--nonce" ~doc:"NN Nonce of the fee payer account"
       Param.(required txn_nonce)
 
+  let array_count = Arg_type.create Util.array_count_of_string
+
   let common_flags =
     Command.(
       let open Let_syntax in
@@ -277,11 +279,13 @@ let transfer_funds =
 
 let update_state =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
-      ~genesis_constants ~constraint_constants () =
+      ~num_events ~num_actions ~event_elements_per ~action_elements_per
+      ~repeat_arrays ~genesis_constants ~constraint_constants () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
       update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
-        ~genesis_constants ~constraint_constants
+        ~num_events ~num_actions ~event_elements_per ~action_elements_per
+        ~repeat_arrays ~genesis_constants ~constraint_constants
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -303,6 +307,32 @@ let update_state =
                  that represent the zkApp state (Use empty string for no-op)"
                 Mina_base.Zkapp_state.max_size_int )
            Param.(listed string)
+       and num_events =
+         Param.flag "--num-events"
+           ~doc:
+             "NN|max Number of event arrays to put in the account update, or \
+              \"max\" to fill up to the protocol cap (default: 0)"
+           Param.(optional_with_default (Util.Count 0) Flags.array_count)
+       and num_actions =
+         Param.flag "--num-actions"
+           ~doc:
+             "NN|max Number of action arrays to put in the account update, or \
+              \"max\" to fill up to the protocol cap (default: 0)"
+           Param.(optional_with_default (Util.Count 0) Flags.array_count)
+       and event_elements_per =
+         Param.flag "--event-elements-per"
+           ~doc:"NN Field elements in each event array (default: 1)"
+           Param.(optional_with_default 1 int)
+       and action_elements_per =
+         Param.flag "--action-elements-per"
+           ~doc:"NN Field elements in each action array (default: 1)"
+           Param.(optional_with_default 1 int)
+       and repeat_arrays =
+         Param.flag "--repeat-arrays"
+           ~doc:
+             "Emit identical event and action arrays instead of distinct ones, \
+              to exercise consumers that deduplicate them by content"
+           Param.no_arg
        in
        let fee = Option.value ~default:Flags.default_fee fee in
        let constraint_constants =
@@ -314,7 +344,9 @@ let update_state =
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
        create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
-         ~app_state ~genesis_constants ~constraint_constants ))
+         ~app_state ~num_events ~num_actions ~event_elements_per
+         ~action_elements_per ~repeat_arrays ~genesis_constants
+         ~constraint_constants ))
 
 let update_zkapp_uri =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -280,12 +280,14 @@ let transfer_funds =
 let update_state =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
       ~num_events ~num_actions ~event_elements_per ~action_elements_per
-      ~repeat_arrays ~genesis_constants ~constraint_constants () =
+      ~repeat_arrays ~num_account_updates ~genesis_constants
+      ~constraint_constants () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
       update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
         ~num_events ~num_actions ~event_elements_per ~action_elements_per
-        ~repeat_arrays ~genesis_constants ~constraint_constants
+        ~repeat_arrays ~num_account_updates ~genesis_constants
+        ~constraint_constants
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
     ()
@@ -333,6 +335,13 @@ let update_state =
              "Emit identical event and action arrays instead of distinct ones, \
               to exercise consumers that deduplicate them by content"
            Param.no_arg
+       and num_account_updates =
+         Param.flag "--num-account-updates"
+           ~doc:
+             "NN Number of account updates against the zkApp account, which \
+              raises the cost of the transaction towards the protocol's \
+              per-transaction zkApp segment limit (default: 1)"
+           Param.(optional_with_default 1 int)
        in
        let fee = Option.value ~default:Flags.default_fee fee in
        let constraint_constants =
@@ -345,8 +354,8 @@ let update_state =
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
        create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
          ~app_state ~num_events ~num_actions ~event_elements_per
-         ~action_elements_per ~repeat_arrays ~genesis_constants
-         ~constraint_constants ))
+         ~action_elements_per ~repeat_arrays ~num_account_updates
+         ~genesis_constants ~constraint_constants ))
 
 let update_zkapp_uri =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -280,13 +280,13 @@ let transfer_funds =
 let update_state =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
       ~num_events ~num_actions ~event_elements_per ~action_elements_per
-      ~repeat_arrays ~num_account_updates ~genesis_constants
+      ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
       ~constraint_constants () =
     let open Deferred.Let_syntax in
     let%map zkapp_command =
       update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state
         ~num_events ~num_actions ~event_elements_per ~action_elements_per
-        ~repeat_arrays ~num_account_updates ~genesis_constants
+        ~repeat_arrays ~num_state_fields ~num_account_updates ~genesis_constants
         ~constraint_constants
     in
     Util.print_snapp_transaction ~debug zkapp_command ;
@@ -335,6 +335,14 @@ let update_state =
              "Emit identical event and action arrays instead of distinct ones, \
               to exercise consumers that deduplicate them by content"
            Param.no_arg
+       and num_state_fields =
+         Param.flag "--num-state-fields"
+           ~doc:
+             "NN|max Set this many zkApp state fields to generated values, or \
+              \"max\" for every field this protocol version defines. Cannot be \
+              combined with --zkapp-state (default: 0, meaning use \
+              --zkapp-state)"
+           Param.(optional_with_default (Util.Count 0) Flags.array_count)
        and num_account_updates =
          Param.flag "--num-account-updates"
            ~doc:
@@ -354,8 +362,8 @@ let update_state =
               (Currency.Fee.to_mina_string Flags.min_fee) ) ;
        create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
          ~app_state ~num_events ~num_actions ~event_elements_per
-         ~action_elements_per ~repeat_arrays ~num_account_updates
-         ~genesis_constants ~constraint_constants ))
+         ~action_elements_per ~repeat_arrays ~num_state_fields
+         ~num_account_updates ~genesis_constants ~constraint_constants ))
 
 let update_zkapp_uri =
   let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri


### PR DESCRIPTION
Port of #19126 and #19127 onto `release/mesa`. Both cherry-picked without conflict — `src/app/zkapp_test_transaction/` is byte-identical between `compatible` and `release/mesa`.

## What

`update-state` previously hard-coded `events = []; actions = []` and a single account update. It now accepts:

| flag | meaning |
| --- | --- |
| `--num-events` / `--num-actions` | number of arrays, or `max` to fill up to the protocol cap |
| `--event-elements-per` / `--action-elements-per` | field elements per array, per kind |
| `--repeat-arrays` | identical arrays rather than distinct ones |
| `--num-account-updates` | repeat the account update, raising the transaction's zkApp cost |

All default to the previous behaviour.

## Why on this branch

Validating archive ingestion across the fork needs the same payload shapes generated on both sides of it. The caps and the state width are compile-time on this branch, so a mesa-built binary is required to produce anything above the pre-fork limits — the flags themselves carry no version knowledge.

## Verification

Built on this branch and run. The same manifest that produces 100-element payloads from a `compatible` build produces 1024-element ones here, with no change to the command lines:

| variant | compatible build (ev/act) | this branch (ev/act) |
| --- | --- | --- |
| `small` | 6/6 | 6/6 |
| `events-only` | 32/0 | 32/0 |
| `saturate-events-short` | 100/0 | **1024/0** |
| `saturate-events-long` | 96/0 | **1024/0** |
| `saturate-actions-short` | 0/100 | **0/1024** |
| `saturate-actions-long` | 0/96 | **0/1024** |
| `repeated` | 32/32 | 32/32 |
| `multi-update` | 24/0 | 24/0 |

`--num-events max` lands exactly on `max_event_elements` (1024) here. The long-array variants reach 1024 exactly on this branch where they reached only 96 on `compatible`, because 1024 divides by 16 and 100 does not.

`--zkapp-state` help text reports 32 fields here versus 8 on `compatible`, from `Zkapp_state.max_size_int`.

Cap accounting is checked against the total across all arrays and all account updates, matching what `Zkapp_command.valid_size` sums; the caps are read from the `genesis_constants` record rather than a compile-time constant.