### PR TITLE
[mesa] scripts: manifest-driven runner for zkApp test payloads

### DIFF
--- a/scripts/zkapp-payloads/general.manifest
+++ b/scripts/zkapp-payloads/general.manifest
@@ -1,0 +1,47 @@
+# Variants of zkApp transaction to generate, one per line:
+#
+#   <name> <flags passed to zkapp-test-transaction update-state>
+#
+# Blank lines and lines starting with # are ignored. Names must be unique; they
+# label the generated file and the summary line.
+#
+# Nothing here names a protocol version. "max" resolves against whichever event
+# and action limit the tool was built with, so this manifest can be replayed
+# unchanged against networks with different limits, and the payloads scale to
+# match.
+
+# No events and no actions. Exercises the path where a zkApp account update
+# carries neither, which archive nodes store as empty rather than as a list.
+empty
+
+# A small, ordinary payload.
+small --num-events 2 --num-actions 2 --event-elements-per 3 --action-elements-per 3
+
+# Events only, and actions only, so that a failure can be attributed to one
+# path rather than to both at once.
+events-only --num-events 8 --event-elements-per 4
+actions-only --num-actions 8 --action-elements-per 4
+
+# Fill the event and action limits exactly, in two shapes: many short arrays,
+# and fewer long ones. These are the payloads that stress per-element storage.
+saturate-events-short --num-events max
+saturate-events-long --num-events max --event-elements-per 16
+saturate-actions-short --num-actions max
+saturate-actions-long --num-actions max --action-elements-per 16
+
+# Identical arrays, which collide with each other. Consumers that deduplicate
+# events and actions by content take a different path for these.
+repeated --num-events 8 --num-actions 8 --event-elements-per 4 --action-elements-per 4 --repeat-arrays
+
+# Several account updates in one transaction, which raises its zkApp cost.
+# Requires the --num-account-updates flag.
+multi-update --num-account-updates 6 --num-events 2 --event-elements-per 2
+
+# Every zkApp state field set at once. "max" resolves to however many fields
+# the protocol version defines, so this line fills the state completely on
+# either side of a version that widens it. Naming the fields one by one with
+# --zkapp-state would need a value list per version instead.
+state-full --num-state-fields max
+
+# A partially set state, leaving the remaining fields untouched.
+state-partial --num-state-fields 3

--- a/scripts/zkapp-payloads/send-payloads.sh
+++ b/scripts/zkapp-payloads/send-payloads.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# Generate a set of zkApp transactions with the zkApp test transaction tool and
+# optionally submit them to a daemon's GraphQL endpoint.
+#
+# The variants come from a manifest rather than from this script, so the same
+# runner drives different test plans, and the same manifest can be replayed
+# against networks whose zkApp limits differ. Which limits apply is decided by
+# the tool binary, not here: point --tool at a build matching the network.
+
+set -euo pipefail
+
+TOOL=""
+FEE_PAYER_KEY=""
+ZKAPP_KEY=""
+ENDPOINT=""
+MANIFEST="$(dirname "${BASH_SOURCE[0]}")/general.manifest"
+OUT_DIR=""
+NONCE=""
+FEE=""
+DRY_RUN=0
+ONLY=""
+
+usage() {
+  cat <<'EOF'
+Usage: send-payloads.sh --tool PATH --fee-payer-key FILE --zkapp-key FILE
+                        [--endpoint URL] [--manifest FILE] [--out-dir DIR]
+                        [--nonce N] [--fee AMOUNT] [--only NAME] [--dry-run]
+
+  --tool           zkApp test transaction binary (mina-zkapp-test-transaction)
+  --fee-payer-key  private key file of the fee payer
+  --zkapp-key      private key file of the zkApp account being updated
+  --endpoint       daemon GraphQL endpoint; omit, or pass --dry-run, to only
+                   generate the transactions without submitting them
+  --manifest       variants to generate (default: general.manifest beside this
+                   script)
+  --out-dir        where to write the generated transactions
+                   (default: a new directory under the current directory)
+  --nonce          fee payer nonce to start from; queried from --endpoint when
+                   omitted
+  --fee            fee for each transaction, passed through to the tool
+  --only           generate just the named variant
+  --dry-run        generate but do not submit
+
+The fee payer key password is read from MINA_PRIVKEY_PASS, as the tool itself
+does. The key files must live in a directory with 0700 permissions.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tool) TOOL="$2"; shift 2 ;;
+    --fee-payer-key) FEE_PAYER_KEY="$2"; shift 2 ;;
+    --zkapp-key) ZKAPP_KEY="$2"; shift 2 ;;
+    --endpoint) ENDPOINT="$2"; shift 2 ;;
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    --nonce) NONCE="$2"; shift 2 ;;
+    --fee) FEE="$2"; shift 2 ;;
+    --only) ONLY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+for required in TOOL FEE_PAYER_KEY ZKAPP_KEY; do
+  if [[ -z "${!required}" ]]; then
+    echo "missing required argument for ${required}" >&2
+    usage >&2
+    exit 2
+  fi
+done
+
+[[ -x "$TOOL" ]] || { echo "not executable: $TOOL" >&2; exit 2; }
+[[ -r "$MANIFEST" ]] || { echo "cannot read manifest: $MANIFEST" >&2; exit 2; }
+
+if [[ -z "$ENDPOINT" ]]; then
+  DRY_RUN=1
+fi
+
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="zkapp-payloads-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "$OUT_DIR"
+
+# The tool prints the key prompts on stdout ahead of the transaction, so take
+# everything from the opening "mutation" keyword rather than the whole stream.
+extract_mutation() {
+  sed -n '/^[[:space:]]*mutation/,$p' "$1"
+}
+
+# Ask the daemon for the fee payer's next nonce. Only reached when the caller
+# did not pass --nonce and an endpoint is available.
+query_nonce() {
+  local pubkey_file="${FEE_PAYER_KEY}.pub" pubkey response nonce
+  [[ -r "$pubkey_file" ]] || {
+    echo "cannot read ${pubkey_file}; pass --nonce instead" >&2
+    return 1
+  }
+  pubkey="$(tr -d '[:space:]' < "$pubkey_file")"
+  response="$(curl -sS -X POST -H 'Content-Type: application/json' \
+    -d "{\"query\":\"{ account(publicKey: \\\"${pubkey}\\\") { nonce } }\"}" \
+    "$ENDPOINT")" || return 1
+  nonce="$(printf '%s' "$response" |
+    sed -n 's/.*"nonce"[[:space:]]*:[[:space:]]*"\{0,1\}\([0-9]\{1,\}\).*/\1/p')"
+  [[ -n "$nonce" ]] || {
+    echo "could not read a nonce from: ${response}" >&2
+    return 1
+  }
+  printf '%s' "$nonce"
+}
+
+if [[ -z "$NONCE" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    NONCE=0
+    echo "no --nonce and not submitting; generating from nonce 0"
+  else
+    NONCE="$(query_nonce)"
+    echo "fee payer nonce from ${ENDPOINT}: ${NONCE}"
+  fi
+fi
+
+# Submit one generated transaction, echoing whatever the daemon replies. The
+# tool emits a complete GraphQL document, so it is sent as the query verbatim.
+submit() {
+  local file="$1" payload
+  payload="$(python3 -c 'import json,sys; print(json.dumps({"query": open(sys.argv[1]).read()}))' "$file")"
+  curl -sS -X POST -H 'Content-Type: application/json' -d "$payload" "$ENDPOINT"
+}
+
+declare -a NAMES=() RESULTS=()
+generated=0
+submitted=0
+failed=0
+
+while read -r name flags; do
+  [[ -z "$name" || "$name" == \#* ]] && continue
+  if [[ -n "$ONLY" && "$name" != "$ONLY" ]]; then
+    continue
+  fi
+
+  raw="${OUT_DIR}/${name}.raw"
+  out="${OUT_DIR}/${name}.graphql"
+
+  # Deliberately unquoted: the manifest supplies whole flag lists.
+  # shellcheck disable=SC2086
+  set -- $flags
+  if [[ -n "$FEE" ]]; then
+    set -- "$@" --fee "$FEE"
+  fi
+
+  if "$TOOL" update-state \
+    --fee-payer-key "$FEE_PAYER_KEY" \
+    --zkapp-account-key "$ZKAPP_KEY" \
+    --nonce "$NONCE" \
+    "$@" > "$raw" 2>&1
+  then
+    extract_mutation "$raw" > "$out"
+    if [[ ! -s "$out" ]]; then
+      NAMES+=("$name"); RESULTS+=("no transaction in output")
+      failed=$((failed + 1))
+      continue
+    fi
+    generated=$((generated + 1))
+    rm -f "$raw"
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      NAMES+=("$name"); RESULTS+=("generated")
+    else
+      if response="$(submit "$out")" && [[ "$response" != *'"errors"'* ]]; then
+        submitted=$((submitted + 1))
+        NAMES+=("$name"); RESULTS+=("submitted")
+        NONCE=$((NONCE + 1))
+      else
+        failed=$((failed + 1))
+        printf '%s\n' "$response" > "${OUT_DIR}/${name}.error"
+        NAMES+=("$name"); RESULTS+=("rejected, see ${name}.error")
+      fi
+    fi
+  else
+    failed=$((failed + 1))
+    NAMES+=("$name"); RESULTS+=("generation failed, see ${name}.raw")
+  fi
+done < "$MANIFEST"
+
+echo
+echo "results, written to ${OUT_DIR}:"
+for i in "${!NAMES[@]}"; do
+  printf '  %-24s %s\n' "${NAMES[$i]}" "${RESULTS[$i]}"
+done
+echo
+echo "generated ${generated}, submitted ${submitted}, failed ${failed}"
+
+[[ "$failed" -eq 0 ]]


### PR DESCRIPTION
Port of #19128 onto `release/mesa`, stacked on #19130.

## What

`scripts/zkapp-payloads/send-payloads.sh` generates a set of zkApp transactions with the zkApp test transaction tool and optionally submits them to a daemon's GraphQL endpoint. The variants live in `general.manifest`.

```
send-payloads.sh --tool ./mina-zkapp-test-transaction \
                 --fee-payer-key funder --zkapp-key zkapp \
                 --endpoint http://localhost:3085/graphql
```

`--dry-run` (or omitting `--endpoint`) generates without submitting; `--only NAME` runs one variant; `--nonce` skips the nonce query.

## Why a manifest

No variant names a protocol version — the saturating ones say `max` — so the same manifest can be replayed on either side of the fork and the payloads scale to whatever the tool binary's limits are. That keeps one plan rather than a pre-fork and post-fork copy that drift apart.

## Verification

All 11 variants generated against a build of this branch. Compared with the same manifest run against a `compatible` build:

| variant | compatible (ev/act) | this branch (ev/act) |
| --- | --- | --- |
| `empty` | 0/0 | 0/0 |
| `small` | 6/6 | 6/6 |
| `events-only` | 32/0 | 32/0 |
| `actions-only` | 0/32 | 0/32 |
| `saturate-events-short` | 100/0 | **1024/0** |
| `saturate-events-long` | 96/0 | **1024/0** |
| `saturate-actions-short` | 0/100 | **0/1024** |
| `saturate-actions-long` | 0/96 | **0/1024** |
| `repeated` | 32/32 | 32/32 |
| `multi-update` | 24/0 | 24/0 |
| `state` | 0/0 | 0/0 |

`shellcheck` clean.

## A limitation worth knowing

The `state` variant names 8 state fields. On this branch the emitted state array is 32 wide, but only those 8 are set — the rest are left untouched. Naming all 32 would need its own manifest line, because passing more values than the protocol version defines is an error, so it cannot be expressed in a version-agnostic way today. Exercising the full width from one line would need a `max`-style option for state fields, which is not part of this PR.

No changelog entry: this PR does not touch `src/`.