### PR TITLE
ci: remove leftover tagged docker images in disk-cleanup

### DIFF
--- a/buildkite/scripts/docker/disk-cleanup.sh
+++ b/buildkite/scripts/docker/disk-cleanup.sh
@@ -7,13 +7,23 @@
 # docker: the docker build job (DockerImage.dhall, forced), tests via
 # RunInToolchain (load_from_cache.sh) and the postgres tests via RunWithPostgres.
 #
-# CONCURRENCY-SAFE: agents (generic-multi) run several builds at once, so we must
-# not disturb other jobs. `docker system prune` (WITHOUT --all) removes only
-# dangling (<none>) images -- the ~24GB/build leftovers that fill the disk --
-# plus stopped containers and dangling build cache. It never touches running
-# containers, and it KEEPS all tagged images, so a concurrent job's toolchain /
-# base images (which it may have pulled but not yet started a container from) are
-# left intact. (We deliberately avoid --all, which would evict those.)
+# Two stages:
+#
+#   1. `docker system prune` (WITHOUT --all) removes dangling (<none>) images --
+#      the ~24GB/build leftovers -- plus stopped containers and dangling build
+#      cache. It never touches running containers and KEEPS tagged images.
+#
+#   2. `docker rmi -f` over the remaining TAGGED images. The prune alone is not
+#      enough: the tagged toolchain / base / mina-* images left behind by earlier
+#      jobs are what actually fill the disk. This stage skips
+#        - images backing a running container (so a co-located job is not killed),
+#        - anything matching KEEP_IMAGE_PATTERN (the buildkite-agent image).
+#      Removal failures are non-fatal by design (an image may be in use, or a
+#      concurrent job may have removed it already). Set SKIP_DOCKER_RMI=1 to
+#      keep only stage 1.
+#
+# Evicting tagged images can force a co-located job to re-pull / re-load an image
+# it had already fetched -- slower, but never fatal, and far cheaper than ENOSPC.
 #
 # Acts only when / usage >= DISK_PRUNE_THRESHOLD (default 80) so healthy agents
 # pay nothing; set DISK_PRUNE_THRESHOLD=0 to always prune (used by the build
@@ -28,6 +38,11 @@ fi
 
 THRESHOLD="${DISK_PRUNE_THRESHOLD:-80}"
 
+# Images we must never delete, as an extended regex matched against
+# "<repository>:<tag>". The buildkite-agent image is the agent running this very
+# job; removing it breaks the agent for every subsequent job on the host.
+KEEP_IMAGE_PATTERN="${KEEP_IMAGE_PATTERN:-buildkite[-/]agent}"
+
 USE=$(df --output=pcent / 2>/dev/null | tail -1 | tr -dc '0-9')
 if [[ -z "$USE" ]]; then
   echo "disk-cleanup: could not read / usage, skipping"
@@ -39,8 +54,55 @@ if [[ "$USE" -lt "$THRESHOLD" ]]; then
   exit 0
 fi
 
-echo "disk-cleanup: / at ${USE}% (>= ${THRESHOLD}%), pruning dangling docker data (concurrency-safe, no --all)"
+echo "disk-cleanup: / at ${USE}% (>= ${THRESHOLD}%), pruning dangling docker data"
 docker system prune --force
+
+if [[ "${SKIP_DOCKER_RMI:-0}" != "1" ]]; then
+  echo "disk-cleanup: removing tagged images (keeping /${KEEP_IMAGE_PATTERN}/ and images of running containers)"
+
+  listing=$(docker images -a --format '{{.ID}} {{.Repository}}:{{.Tag}}' 2>/dev/null)
+
+  all_ids=$(awk '{print $1}' <<< "$listing" | sort -u)
+
+  # Everything we must not touch, as short image IDs:
+  #  - any ID carrying a KEEP_IMAGE_PATTERN tag. Filter by ID, NOT by line: the
+  #    same ID shows up on several lines of `docker images -a` (extra tags, a
+  #    <none>:<none> entry), so a line-level grep -v would let the agent's own
+  #    ID back in through one of its other lines and delete it.
+  #  - any ID backing a running container, so a co-located job is not killed.
+  #    `docker inspect` reports full sha256 digests, `docker images` short IDs,
+  #    hence the cut to 12 chars.
+  keep_ids=$(
+    {
+      grep -E "$KEEP_IMAGE_PATTERN" <<< "$listing" | awk '{print $1}'
+      docker ps -q \
+        | xargs -r docker inspect --format '{{.Image}}' 2>/dev/null \
+        | sed 's/^sha256://' \
+        | cut -c1-12
+    } | sort -u
+  )
+
+  candidates=$(comm -23 <(echo "$all_ids") <(echo "$keep_ids"))
+
+  if [[ -n "$candidates" ]]; then
+    # Errors here are normal and MUST NOT fail the job:
+    #   "No such image: <id>:latest" -- the layer was already deleted as a
+    #      dependency of an image removed earlier in the same batch;
+    #   "conflict: ... image is being used by running container" -- a co-located
+    #      job (or the agent itself) holds it; -f cannot override this.
+    # Only the errors are echoed; the per-layer "Deleted:" spam is counted.
+    # shellcheck disable=SC2086
+    rmi_out=$(docker rmi -f $candidates 2>&1)
+    echo "disk-cleanup: removed $(grep -c '^Untagged:' <<< "$rmi_out") tags, $(grep -c '^Deleted:' <<< "$rmi_out") layers"
+    grep -E '^(Error|.*conflict)' <<< "$rmi_out" | sort -u | head -20
+    echo "disk-cleanup: image removal finished (errors above are expected and ignored)"
+  else
+    echo "disk-cleanup: no removable images"
+  fi
+
+  # Sweep the build cache and anything the rmi pass turned into garbage.
+  docker system prune --force
+fi
 
 echo "disk-cleanup: / usage after cleanup:"
 df -h / 2>/dev/null

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -207,9 +207,10 @@ let generateStep =
           let pruneDockerImages =
               -- Single source of truth for the prune (see disk-cleanup.sh).
               -- THRESHOLD=0 forces it before every build (builds are the heavy
-              -- disk consumers); the script is concurrency-safe (dangling-only,
-              -- keeps tagged images for co-located jobs) and honours
-              -- SKIP_DOCKER_PRUNE itself.
+              -- disk consumers). The script prunes dangling data AND removes
+              -- leftover tagged images, keeping the buildkite-agent image and
+              -- anything backing a running container. It honours
+              -- SKIP_DOCKER_PRUNE / SKIP_DOCKER_RMI itself.
                 "DISK_PRUNE_THRESHOLD=0 ./buildkite/scripts/docker/disk-cleanup.sh"
 
           let loadOnlyArg =


### PR DESCRIPTION
## Problem

CI agents keep hitting `no space left on device`. `disk-cleanup.sh` runs `docker system prune` (deliberately without `--all`), which only reclaims **dangling** layers. The tagged images left behind by earlier jobs — toolchain, base, `mina-*` — are never removed, and they are what actually fill the disk.

## Change

Adds a second stage to `disk-cleanup.sh` that removes leftover **tagged** images after the prune, with two independent guards instead of just swallowing the exit code:

1. `KEEP_IMAGE_PATTERN` (default `buildkite[-/]agent`) — never delete the agent image; matches both `buildkite/agent` and `buildkite-agent` naming.
2. Images backing a running container (`docker ps` → `docker inspect`) — so a co-located job is not killed, and the agent's own container is covered when the docker socket is shared.

Errors are non-fatal by design (`set +e`, output captured, script exits 0). The two signatures seen in practice cannot fail the job:

- `No such image: <id>:latest` — the layer was already deleted as a dependency of an image removed earlier in the same batch.
- `conflict: ... image is being used by running container` — `-f` cannot override this anyway.

Output is summarized to a tag/layer count plus deduped errors rather than hundreds of `Deleted:` lines.

Opt out with `SKIP_DOCKER_RMI=1`; the existing `SKIP_DOCKER_PRUNE` and `DISK_PRUNE_THRESHOLD` still apply.

## Note on the filter (subtle)

`docker images -a` lists the **same image ID on several lines** (extra tags, plus a `<none>:<none>` entry). A line-level `grep -v` therefore lets the agent's own ID back in through one of its other lines — and deletes the buildkite-agent image. The script builds a keep set of **IDs** and subtracts with `comm`, rather than filtering lines. A stubbed-docker test covering exactly that case is what caught it.

## Trade-off

This gives up the strict concurrency-safety the old comment promised. Removing tagged images can force a co-located job to re-pull or re-load an image from the Hetzner cache — slower, but never fatal, and far cheaper than ENOSPC. `DockerImage.dhall` passes `DISK_PRUNE_THRESHOLD=0`, so this now runs on **every** docker build job, not only on full agents. If the re-load churn proves costly, the narrower knob is dropping that `THRESHOLD=0` override so the rmi stage only fires above 80%.

`DockerImage.dhall` is a comment-only update — it still claimed "keeps tagged images".

## Testing

- `shellcheck` clean.
- `make all` in `buildkite/` green (45/45 monorepo tests).
- Ran the script against a stubbed `docker` covering: an agent image with both a tag line and a `<none>` line, an image backing a running container, removable toolchain images, and an `rmi` that emits errors on stderr. Both agent IDs survived; script exited 0.
- Verified the `SKIP_DOCKER_RMI=1`, below-threshold, and `SKIP_DOCKER_PRUNE` paths.

No changelog entry: the Changelog lint triggers on `src/` only, and this is `buildkite/`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
