### PR TITLE
ci: ChainIdTestMainnet depends on the Apps build instead of dockers

### DIFF
--- a/buildkite/src/Jobs/Test/ChainIdTestMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ChainIdTestMainnet.dhall
@@ -1,4 +1,4 @@
-let Dockers = ../../Constants/Docker/Versions.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Network = ../../Constants/Network.dhall
 
@@ -13,8 +13,11 @@ let scopes = [ PipelineScope.Type.MainlineNightly, PipelineScope.Type.Release ]
 let network = Network.Type.Mainnet
 
 let deps =
-      Dockers.dependsOn
-        Dockers.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
+      DebianVersions.appDependsOn
+        DebianVersions.DepsSpec::{
+        , network = network
+        , profile = Profile.Type.Mainnet
+        }
 
 let expectedChainId =
       "6bc1d75e39f3bbe2bd0418160775c6655d5854c1121dc5044c70e4481e4476c0"


### PR DESCRIPTION
## Summary

Moves **ChainIdTestMainnet** off the docker dependency onto the bare Apps build — the last chain-id job still gated on `Dockers.dependsOn`. `ChainIdTestDevnet` was already converted (#18958 / #19015 series); this brings the mainnet twin in line.

```diff
-let deps = Dockers.dependsOn Dockers.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
+let deps = DebianVersions.appDependsOn DebianVersions.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
```

## Why this is safe

The test never used the docker image. It runs in the toolchain and invokes `buildkite/scripts/test-chain-id.sh mainnet <expected>`, which already:

1. restores a bare `mina` from the apps cache (`apps/bullseye/mainnet-mainnet/mina.exe`) via `apps/restore_binary.sh`,
2. replicates the daemon config package payload with `apps/restore_daemon_config.sh mainnet` (copies in-repo `genesis_ledgers/mainnet.json` to `/var/lib/coda/mainnet.json` + `config_<githash>.json`),
3. falls back to the `.deb` on a cache miss.

So the docker dep was pure critical-path overhead: it made the mainnet chain-id check wait for the daemon image build.

No script changes were needed — `test-chain-id.sh` is already network-generic.

## Verification

- `MinaArtifactMainnetBullseyeApps` exists and writes the `mainnet-mainnet` apps variant that `restore_app.sh` derives for `network=mainnet` (`APPS_PROFILE` default `mainnet`).
- Rendered `depends_on` is `_MinaArtifactMainnetBullseyeApps-build-apps`, which matches that job's rendered step key exactly.
- Apps job scope `AllButPullRequest` ⊇ the test's `[MainlineNightly, Release]`; its `dirtyWhen` (bullseye, broad `src`) is a superset of the test's.
- `cd buildkite && make all` → 45/45 green; `dhall format --check` clean.

## Caveat

`ChainIdTest` is `excludeIf DescendantOf {Mesa, Develop}`, so neither chain-id job runs on develop-lineage branches — this cannot get a live CI signal from this PR. Validation here is pipeline-generation + dep-key resolution only, same situation as #19137 (ConnectToDevnet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
