### PR TITLE
ConnectToMainnet: depend on the Apps build instead of the package build

### DIFF
--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -23,12 +23,11 @@ let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
 let network = Network.Type.Mainnet
 
 let dependsOn =
-        DebianVersions.dependsOn
-          DebianVersions.DepsSpec::{
-          , network = network
-          , profile = Profile.Type.Mainnet
-          }
-      # DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+      DebianVersions.appDependsOn
+        DebianVersions.DepsSpec::{
+        , network = network
+        , profile = Profile.Type.Mainnet
+        }
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
## Summary

Finishes what #19137 started: **ConnectToMainnet** now depends on the Apps (bare-binary) build instead of the debian package build, matching ConnectToDevnet.

```diff
 let dependsOn =
-        DebianVersions.dependsOn
-          DebianVersions.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
-      # DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+      DebianVersions.appDependsOn
+        DebianVersions.DepsSpec::{ network = network, profile = Profile.Type.Mainnet }
```

Two changes in one: package dep → apps dep, and the second (devnet package) dep is dropped.

## Why no script change is needed

`buildkite/scripts/connect/connect-to-network.sh` was already made fully bare **and network-generic** by #19137 (merged). For `--mina-debian-network mainnet` it restores every current-version binary from the apps cache — `mina`, `mina-graphql-client`, `coda-libp2p_helper`, `mina-rocksdb-scanner` — plus `restore_daemon_config.sh mainnet`, and it already has an explicit mainnet branch for the downgrade step:

```sh
if [[ "$MINA_DEBIAN_NETWORK" == "mainnet" ]]; then
    source .../install_official.sh --package "mina-mainnet" --channel stable --version "$STABLE_VERSION*"
```

The released bits (official 3.3.0 daemon, stable recovery-storage-toolbox, the `mina-logproc` needed to satisfy its dpkg `Depends`) are not built here and correctly stay `.deb` installs from official apt / `packages.o1test.net` / the legacy cache. That is also why the second `DepsSpec::{=}` (devnet package) dep can go: `mina-logproc` no longer comes from this build.

## Verification

- `MinaArtifactMainnetBullseyeApps` runs the same `build-artifact.sh` as the devnet apps job, so `make build-daemon-utils` (which itself depends on `libp2p_helper`) produces `rocksdb_scanner.exe` and `mina_graphql_client_app.exe`, and `make build-mina` produces `mina.exe` — all cached under the `mainnet-mainnet` variant, exactly what `restore_app.sh` derives for `network=mainnet`.
- Rendered `depends_on` is a single `_MinaArtifactMainnetBullseyeApps-build-apps`, matching that job's rendered step key.
- Apps job scope `AllButPullRequest` ⊇ the test's `[MainlineNightly, Release]`; its `dirtyWhen` (broad `src`) is a superset of the test's.
- `cd buildkite && make all` → 45/45 green; `dhall format --check` clean.

## Caveat

Same as #19137: ConnectToMainnet is `excludeIf DescendantOf {Mesa, Develop}` ("Develop branch is incompatible with current mainnet network"), so this cannot get a live CI signal from a develop-lineage PR. Validation is pipeline-generation + dep-key resolution only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
