### PR TITLE
ci: always bypass the apt cache for the Mina deb repos

### DIFF
--- a/changes/19144.md
+++ b/changes/19144.md
@@ -1,0 +1,5 @@
+Always bypass the apt cache for the Mina deb repos
+
+`configure-apt-proxy.sh` derived its DIRECT bypass solely from `DEB_REPO`, the repo the current build pulls from. Builds pointed elsewhere — notably `DebianRepo.Local`, which renders to `http://localhost:8080` — therefore left `packages.o1test.net` routed through apt-cacher-ng. That host redirects http to https at the CDN, and apt-cacher-ng cannot follow a redirect to TLS for a cached remote, so the fetch came back as a fatal `500 Remote or cache error`.
+
+The four Mina deb repo hosts are now bypassed unconditionally, alongside the existing carve-out for the Canonical archives. The `DEB_REPO`-derived bypass still applies to anything else, and is skipped when it duplicates one of the four.

--- a/dockerfiles/scripts/configure-apt-proxy.sh
+++ b/dockerfiles/scripts/configure-apt-proxy.sh
@@ -3,6 +3,14 @@
 #   1. Route most apt traffic through an apt-cacher-ng caching proxy
 #      (APT_CACHE_URL) while bypassing the Mina deb repo (DEB_REPO) so
 #      package publishes don't get cached.
+#   1b. Unconditionally bypass the known Mina deb repo hosts, whether or not
+#      DEB_REPO names them. DEB_REPO is per-build (a build using
+#      DebianRepo.Local passes http://localhost:8080), so deriving the
+#      bypass from it alone leaves packages.o1test.net proxied in exactly
+#      those builds. That host redirects http -> https at the CDN, and
+#      apt-cacher-ng cannot follow a redirect to TLS for a cached remote --
+#      it returns "500 Remote or cache error" and apt fails hard with
+#      "E: Failed to fetch .../InRelease  500  Remote or cache error".
 #   2. Unconditionally bypass the proxy for archive.ubuntu.com /
 #      security.ubuntu.com. The o1Labs apt-cacher-ng has the local
 #      (unsigned) apt repository publication first in its Remap-uburep chain — a
@@ -96,11 +104,37 @@ conf=/etc/apt/apt.conf.d/01proxy
 {
   echo "Acquire::http::Proxy \"${APT_CACHE_URL}\";"
   echo "Acquire::https::Proxy \"${APT_CACHE_URL}\";"
+  # The Mina deb repos ALWAYS go DIRECT, independently of DEB_REPO (see header
+  # note 1b). DEB_REPO only names the repo this particular build pulls from, so
+  # a build pointed elsewhere (e.g. DebianRepo.Local -> http://localhost:8080)
+  # would leave packages.o1test.net proxied -- and it must not be.
+  # packages.o1test.net redirects http -> https at the CDN, and apt-cacher-ng
+  # cannot follow a redirect to TLS for a cached remote: it answers
+  # "500 Remote or cache error", which apt treats as fatal. Fetched directly the
+  # same request succeeds (the 404s on InRelease/Release.gpg are expected for an
+  # unsigned repo and are demoted to Ign).
+  MINA_DEB_REPO_HOSTS="packages.o1test.net
+unstable.apt.packages.minaprotocol.com
+nightly.apt.packages.minaprotocol.com
+stable.apt.packages.minaprotocol.com"
+  for mina_repo_host in $MINA_DEB_REPO_HOSTS; do
+    echo "Acquire::http::Proxy::${mina_repo_host} \"DIRECT\";"
+    echo "Acquire::https::Proxy::${mina_repo_host} \"DIRECT\";"
+  done
+  # Any other repo named by DEB_REPO (a local file server, a mirror) is bypassed
+  # too, so publishes never land in the cache. Skipped when it is one of the
+  # hosts already emitted above, to keep the generated conf free of duplicates.
   if [ -n "$DEB_REPO" ]; then
     host="${DEB_REPO#*://}"
     host="${host%%[:/]*}"
-    echo "Acquire::http::Proxy::${host} \"DIRECT\";"
-    echo "Acquire::https::Proxy::${host} \"DIRECT\";"
+    already=0
+    for mina_repo_host in $MINA_DEB_REPO_HOSTS; do
+      [ "$host" = "$mina_repo_host" ] && already=1
+    done
+    if [ "$already" = "0" ]; then
+      echo "Acquire::http::Proxy::${host} \"DIRECT\";"
+      echo "Acquire::https::Proxy::${host} \"DIRECT\";"
+    fi
   fi
   # Ubuntu Canonical archives ALWAYS go DIRECT (see header note 2):
   # the o1Labs apt-cacher-ng's Remap-uburep chain has the local unsigned


### PR DESCRIPTION
## Problem

CI started failing with:

```
Ign:26 http://packages.o1test.net focal InRelease
Err:26 http://packages.o1test.net focal InRelease
  500  Remote or cache error [IP: 10.233.51.120 3142]
E: Failed to fetch http://packages.o1test.net/dists/focal/InRelease  500  Remote or cache error
E: Some index files failed to download.
```

Port 3142 is apt-cacher-ng, so the 500 is the **proxy's** error, not an upstream status. Nothing changed on the infra side — the proxy is configured by our own `dockerfiles/scripts/configure-apt-proxy.sh`.

## Root cause

Two things combine:

1. **`packages.o1test.net` 301-redirects `http` → `https` at the CDN.** apt-cacher-ng cannot follow a redirect to TLS for a cached remote, so it converts the fetch into `500 Remote or cache error`, which apt treats as fatal. Fetched *directly* the same request is fine: `InRelease` and `Release.gpg` are legitimately 404 on an unsigned deb-s3 repo (only `Release` is published), and apt demotes those to `Ign` and falls back.

2. **The DIRECT bypass was derived solely from `DEB_REPO`**, which names the repo *this particular build* pulls from. A build pointed elsewhere gets no bypass for the Mina repo. `DebianRepo.Local` renders to `http://localhost:8080` (`buildkite/src/Constants/DebianRepo.dhall:16`), so builds using it — e.g. the new `IntegrationTestDockerImages` job — wrote `Acquire::http::Proxy::localhost "DIRECT"` and left `packages.o1test.net` proxied.

The script's own header states the intent is to bypass the Mina deb repo so publishes don't get cached; this restores that guarantee regardless of `DEB_REPO`.

## Fix

Emit the DIRECT bypass for the four Mina deb repo hosts unconditionally, next to the existing unconditional carve-out for `archive.ubuntu.com` / `security.ubuntu.com`:

- `packages.o1test.net`
- `unstable.apt.packages.minaprotocol.com`
- `nightly.apt.packages.minaprotocol.com`
- `stable.apt.packages.minaprotocol.com`

The `DEB_REPO`-derived bypass is kept for anything else (a local file server, a mirror), and is skipped when it would duplicate one of the four.

## Verification

`shellcheck -s sh` clean, `sh -n` clean. Behaviour checked in a `ubuntu:focal` container:

| Case | Before | After |
|---|---|---|
| `deb_repo=http://localhost:8080` (the regression) | **0** `packages.o1test.net` DIRECT lines | 2 (http + https), plus `localhost` still bypassed |
| `deb_repo=http://packages.o1test.net` | 2 | 2 — no duplicates |
| no `deb_repo` | 0 | 2 |

Last known-passing commit was b8646442cb; `DebianRepo.Local` first reached a docker-build path in 80f223c7bc, 28 minutes later.

## Notes

Worth considering as follow-ups, not included here:

- Flipping the Dockerfiles' `ARG deb_repo` default to `https://packages.o1test.net` so the redirect never happens at all. Held back because it forces TLS in build stages that may lack `ca-certificates` — `[trusted=yes]` disables repo *signature* checking, not TLS *certificate* verification, so a slim image without a CA bundle fails with `Certificate verification failed` (reproduced on bare `ubuntu:focal`).
- Dropping the CDN's HTTP→HTTPS redirect, which would remove this whole class of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)