### PR TITLE
ci: split docker image builds out of the artifact/package jobs

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -297,6 +297,10 @@ let appsJobName
     : MinaBuildSpec.Type -> Text
     = \(spec : MinaBuildSpec.Type) -> "${selfName spec}Apps"
 
+let dockerJobName
+    : MinaBuildSpec.Type -> Text
+    = \(spec : MinaBuildSpec.Type) -> "${selfName spec}Docker"
+
 let primaryAppsVariant
     : MinaBuildSpec.Type -> Text
     =     \(spec : MinaBuildSpec.Type)
@@ -425,9 +429,11 @@ let docker_step
               = [ { name = selfName spec, key = "build-deb-pkg" } ]
 
           let withDocker =
+              -- The .deb dependency stays on the debian job; sibling docker
+              -- images now live in the separate docker job.
                     \(dep : Docker.Type)
                 ->    deps
-                    # [ { name = selfName spec
+                    # [ { name = dockerJobName spec
                         , key = "${Docker.lowerName dep}${netSeg}"
                         }
                       ]
@@ -443,7 +449,7 @@ let docker_step
 
           let dependsOnGeneric =
                   deps
-                # [ { name = genericBuildName spec
+                # [ { name = "${genericBuildName spec}Docker"
                     , key =
                         "${Docker.lowerName
                              Docker.Type.DaemonGeneric}-${Network.lowerName
@@ -691,7 +697,7 @@ let onlyDebianPipeline
 let pipeline
     : MinaBuildSpec.Type -> Pipeline.Config.Type
     =     \(spec : MinaBuildSpec.Type)
-      ->  pipelineBuilder spec ([ build_artifacts spec ] # docker_commands spec)
+      ->  pipelineBuilder spec [ build_artifacts spec ]
 
 let appsPipeline
     : MinaBuildSpec.Type -> Pipeline.Config.Type
@@ -722,13 +728,30 @@ let packagePipeline
             , includeIf = spec.includeIf
             , excludeIf = spec.excludeIf
             }
-          , steps = [ build_debian spec ] # docker_commands spec
+          , steps = [ build_debian spec ]
+          }
+
+let dockerPipeline
+    : MinaBuildSpec.Type -> Pipeline.Config.Type
+    =     \(spec : MinaBuildSpec.Type)
+      ->  Pipeline.Config::{
+          , spec = JobSpec::{
+            , dirtyWhen = DebianVersions.packageDirtyWhen
+            , path = "Release"
+            , name = "${dockerJobName spec}"
+            , tags = spec.tags
+            , scope = spec.scope
+            , includeIf = spec.includeIf
+            , excludeIf = spec.excludeIf
+            }
+          , steps = docker_commands spec
           }
 
 in  { pipeline = pipeline
     , onlyDebianPipeline = onlyDebianPipeline
     , appsPipeline = appsPipeline
     , packagePipeline = packagePipeline
+    , dockerPipeline = dockerPipeline
     , MinaBuildSpec = MinaBuildSpec
     , labelSuffix = labelSuffix
     , buildArtifacts = build_artifacts

--- a/buildkite/src/Constants/Docker/Versions.dhall
+++ b/buildkite/src/Constants/Docker/Versions.dhall
@@ -79,7 +79,7 @@ let dependsOn =
           in  [ { name =
                     "${spec.prefix}${Network.namePrefixSegment
                                        spec.network}${capitalName
-                                                        spec.codename}${buildFlagSuffix}${archSuffix}"
+                                                        spec.codename}${buildFlagSuffix}${archSuffix}Docker"
                 , key = key
                 }
               ]

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Docker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Docker.dhall
@@ -1,0 +1,59 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDocker.dhall
@@ -1,0 +1,61 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DelegationVerifier
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeDocker.dhall
@@ -1,0 +1,47 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TestExecutive
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            , Artifacts.Type.FunctionalTestSuite
+            ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedDocker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let BuildFlags = ../../Constants/BuildFlags.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.FunctionalTestSuite
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , buildFlags = BuildFlags.Type.Instrumented
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDocker.dhall
@@ -1,0 +1,60 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Focal
+            ]
+          , debVersion = DebianVersions.DebVersion.Focal
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyDocker.dhall
@@ -1,0 +1,60 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Jammy
+            ]
+          , debVersion = DebianVersions.DebVersion.Jammy
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeDocker.dhall
@@ -1,0 +1,41 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , scope = PipelineScope.AllButPullRequest
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDocker.dhall
@@ -1,0 +1,60 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.MinaBuildSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , tags =
+            [ PipelineTag.Type.Long
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )


### PR DESCRIPTION
## Summary

Splits docker image building out of the artifact/package jobs. Every artifact job that produced docker images now has a sibling **`MinaArtifact<...>Docker`** job holding just those steps.

This is the enabler for dropping packaging work off ordinary PRs. Today the debian build and all ~8 docker images live in **one** job, so a consumer that needs only the `.deb` artifacts drags the entire docker image set in through monorepo's Phase-2 dependency resolution.

## Why it matters

Classifying every consumer of the artifact jobs by what it actually needs:

| Consumer | Needs |
|---|---|
| DebianUpgradeTest, DebianAutomodeTransitionTest(+Mainnet), HardforkPackageConversion, RosettaBlockRaceTest | **debs only** |
| AutoHardforkTest, RosettaDevnetConnect, RosettaMainnetConnect, TestnetIntegrationTestsLong | **docker only** |
| IntegrationTestDockerImages | debs + the generic daemon image |

Five of ten need debs only, yet every one of them currently pulls the whole docker set.

## Mechanism

- `Command/MinaArtifact.dhall`: new `dockerJobName` (`<selfName>Docker`) and `dockerPipeline`; `packagePipeline` and `pipeline` now build only their debian/artifact step. Intra-job docker→docker references (`withDocker`, `dependsOnGeneric`) point at the docker job; the `build-deb-pkg` dependency still points at the debian job, so ordering is unchanged.
- `Constants/Docker/Versions.dhall`: `dependsOn` resolves to `…Docker`.
- Eight new job files, one per artifact job that had docker steps (Bullseye, BullseyeInstrumented, MainnetBullseye, Bookworm, BookwormArm64, Jammy, Focal, Noble). All codenames are split, not just the PR-relevant ones, so there is no conditional naming rule to get wrong.

Scopes and tags are inherited from the same spec, so **what runs where is unchanged** — only the job boundary moves.

## Verification

- `make all` → 45/45, and `check_deps` reports **0 unresolved dependencies**. (It caught a real bug mid-change: splitting only the bullseye family left the other codenames' intra-job docker deps pointing at a non-existent `…Docker` job. Hence splitting all of them.)
- Replayed the real triage locally (`dump_dhall_to_pipelines.sh` + `monorepo.sh --selection-mode triaged --scopes pullrequest`) against a source-only diff. Before: one pull-in, `MinaArtifactBullseye` (debs **and** all docker images). After: the two are separated and correctly attributed —
  ```
  ➕ MinaArtifactBullseye        (required by DebianUpgradeTest)
  ➕ MinaArtifactBullseyeDocker  (required by AutoHardforkTest)
  ```

On its own this PR does not reduce PR work — it makes the two separable. The follow-up gates the consumers so neither is pulled at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
