### PR TITLE
ci: stop building debians and dockers on source-only PRs

### DIFF
--- a/buildkite/src/Jobs/Test/AutoHardforkTest.dhall
+++ b/buildkite/src/Jobs/Test/AutoHardforkTest.dhall
@@ -21,8 +21,7 @@ let Network = ../../Constants/Network.dhall
 let network = Network.Type.Devnet
 
 let dirtyWhen =
-      [ S.strictlyStart (S.contains "src")
-      , S.exactly "buildkite/src/Jobs/Test/AutoHardforkTest" "dhall"
+      [ S.exactly "buildkite/src/Jobs/Test/AutoHardforkTest" "dhall"
       , S.exactly_noext "dockerfiles/stages/daemon/4-auto-hardfork"
       , S.exactly_noext "dockerfiles/stages/1-base-deps"
       , S.exactly "scripts/hardfork/dispatcher" "sh"

--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTest.dhall
@@ -57,8 +57,7 @@ let buildTestCmd
                 }
 
 let dirtyWhen =
-      [ S.strictlyStart (S.contains "src")
-      , S.strictly (S.contains "Makefile")
+      [ S.strictly (S.contains "Makefile")
       , S.exactly "buildkite/src/Jobs/Test/DebianAutomodeTransitionTest" "dhall"
       , S.exactly "buildkite/scripts/tests/debian-automode-transition-test" "sh"
       , S.strictlyStart (S.contains "scripts/debian")

--- a/buildkite/src/Jobs/Test/DebianUpgradeTest.dhall
+++ b/buildkite/src/Jobs/Test/DebianUpgradeTest.dhall
@@ -59,8 +59,7 @@ in  Pipeline.build
       Pipeline.Config::{
       , spec =
           let dirtyWhen =
-                [ S.strictlyStart (S.contains "src")
-                , S.strictly (S.contains "Makefile")
+                [ S.strictly (S.contains "Makefile")
                 , S.exactly "buildkite/src/Jobs/Test/DebianUpgradeTest" "dhall"
                 , S.exactly "buildkite/scripts/tests/debian-upgrade-test" "sh"
                 , S.strictlyStart (S.contains "scripts/debian")


### PR DESCRIPTION
## Summary

**Stacked on #19145 — review/merge that first.**

The cutover: a source-only PR stops building debian packages and docker images entirely.

## The problem

`monorepo.sh` resolves dependencies (Phase 2): a selected job pulls in its build dependency even when that dependency's own `dirtyWhen` did not match. So the package job's narrow `packageDirtyWhen` was never the deciding factor — what mattered was that three tests carried a broad `src` `dirtyWhen` **and** PR scope:

- `DebianUpgradeTest`
- `DebianAutomodeTransitionTest`
- `AutoHardforkTest`

Any OCaml change selected them, and they dragged the debian build (#19145 splits the docker half out) in behind them.

All three are packaging/image tests, not source tests, so they are now gated on packaging and image paths — `scripts/debian/**`, `dockerfiles/**`, their own scripts and job definitions — instead of on `src/**`.

## Coverage is not lost

Nightly runs with **selection = Full**, which ignores `dirtyWhen` entirely — visible in the live triage labels (`Monorepo triage FastOnly nightly Full`, `LongAndVeryLong nightly Full`). These three tests are tagged `Long`/`Test` and keep nightly in scope, so they still run **every night** against the day's source changes. What changes is only that they stop running on each individual PR.

## Verification

Replayed the real triage locally against a source-only diff (`src/lib/mina_base/account.ml`), with `--selection-mode triaged --tags lint,release,test --scopes pullrequest`, matching what build 41904 actually used (`Monorepo triage AllTests pullrequestonly Triaged`):

| | pull-ins | artifact jobs selected |
|---|---|---|
| develop today | `MinaArtifactBullseye` (debs + all docker images) | — |
| with #19145 | `MinaArtifactBullseye` + `MinaArtifactBullseyeDocker` | — |
| **this PR** | **none** | `MinaArtifactBullseyeApps`, `MinaArtifactBullseyeInstrumentedApps` |

Selected job count drops 31 → 28, and the only artifact jobs left are the two **Apps** builds. `make all` → 45/45 with 0 unresolved dependencies.

## Not included

Dropping packages/dockers from **nightly** is deliberately out of scope: nightly uses selection=Full, so `dirtyWhen` is irrelevant there, and ten nightly-scope jobs genuinely consume those artifacts (test-executive integration tests, IntegrationTestDockerImages, Rosetta connectivity, RosettaBlockRace, the debian upgrade/automode tests). That needs a policy decision — keep nightly as the daily packaging gate, or move those consumers to a dedicated packaging pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
