### PR TITLE
nix: build the daemon and archive docker images with nix

### DIFF
--- a/buildkite/scripts/nix/build-images.sh
+++ b/buildkite/scripts/nix/build-images.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Build the daemon/archive docker images with Nix instead of from Debian
+# packages, and put them in the shared CI cache the integration tests already
+# read from (buildkite/scripts/docker/load_from_cache.sh).
+#
+# Why: IntegrationTestDockerImages builds those two images by installing the
+# freshly-built .debs, which is what ties the integration tests to the whole
+# debian+docker packaging pipeline. nix/docker.nix already describes the same
+# two images (mina-image-full, mina-archive-image-full) straight from the
+# compiled binaries, and `nix build tests` already builds mina on every PR into
+# a shared binary cache -- so the images can come from there instead, with no
+# packages involved at all.
+#
+# No docker daemon is used anywhere in here, deliberately. This job runs inside
+# the nixos container, and Cmds.dhall mounts only /var/storagebox, /var/secrets,
+# /shared and the checkout into it -- there is no docker socket, so `docker
+# load` / `docker run` / `docker save` are not available (that is what killed
+# the first version of this script). It does not need them: streamLayeredImage
+# emits a docker-archive tarball on stdout, which is exactly the format
+# load_from_cache.sh feeds back into `docker load` on an agent that does have a
+# daemon. So the image goes store -> stream -> zstd -> cache in one pass.
+#
+# This script deliberately does NOT overwrite the images the integration tests
+# currently consume: it writes to <service>-nix so its output can be compared
+# against the .deb-built images without disturbing them. The suffix stays until
+# the tests are switched over, which is a separate change.
+#
+# Usage: build-images.sh
+# Env:
+#   MINA_DEB_CODENAME  codename segment of the cache tag (default bullseye)
+#   CACHE_ROOT         cache root (default /var/storagebox/docker-cache)
+#   DOCKER_REGISTRY    registry prefix baked into the image name
+
+set -euo pipefail
+
+CODENAME="${MINA_DEB_CODENAME:-bullseye}"
+CACHE_ROOT="${CACHE_ROOT:-/var/storagebox/docker-cache}"
+
+# The images are never pushed anywhere, but they still have to carry the
+# registry-prefixed name, because that is the name their consumer asks docker
+# for. scripts/docker/helper.sh builds the .deb-based images as
+# "${DOCKER_REGISTRY}/${SERVICE}:${TAG}" and run-test-executive-local.sh passes
+# that same full reference to test_executive. A bare "mina-daemon-nix:tag" would
+# load fine and then be invisible under the name the swarm looks up, sending it
+# to the registry for an image that was never pushed.
+DOCKER_REGISTRY="${DOCKER_REGISTRY:-europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo}"
+
+# Parameter expansion rather than $(dirname ...): this runs before the nix shell
+# below, and dirname is coreutils, which this container does not necessarily
+# have. Everything above the re-exec has to be builtins only.
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+
+# shellcheck source=buildkite/scripts/nix/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# This container ships a bare PATH: nix and git, but no coreutils, no sed, no
+# zstd, no python3. That is what killed the previous version of this script,
+# which sourced scripts/export-git-env-vars.sh and died on "sed: command not
+# found" (exit 127). Rather than guess which utilities happen to be there, bring
+# a known set in with nix and re-run this script inside it. This has to be the
+# first thing that happens, so nothing below has to care.
+if [[ "${NIX_IMAGES_TOOLS_READY:-0}" != "1" ]]; then
+  export NIX_IMAGES_TOOLS_READY=1
+  exec nix "${NIX_OPTS[@]}" shell \
+    nixpkgs#bash nixpkgs#coreutils nixpkgs#zstd nixpkgs#python3 \
+    --command bash "$0" "$@"
+fi
+
+# Fixes up the way Buildkite hands us the checkout (see lib.sh). It chowns
+# the tree and rewrites the current branch, which has no business happening on a
+# developer machine -- guarding it is what makes this script runnable locally
+# against the same images CI produces.
+if [[ -n "${BUILDKITE:-}" ]]; then
+  prepare_nix_workdir
+fi
+
+# Only GITHASH is needed out of export-git-env-vars.sh, and git alone can
+# produce it. Keep the semantics identical to that script: an 8-character hash
+# with the last character dropped.
+GITHASH_CONFIG=$(git rev-parse --short=8 --verify HEAD)
+GITHASH=${GITHASH_CONFIG%?}
+echo "Building images for ${GITHASH} (${CODENAME})"
+
+# The devnet attrs, not mina-image-full/mina-archive-image-full: those are built
+# from the dev profile and label themselves mainnet, whereas the integration
+# tests want devnet binaries with a matching PROFILE hint. They also share their
+# derivation with `nix build .#devnet`, which NixBuildTest already runs on every
+# PR, so the mina compile itself should come out of the shared nix cache. The
+# attribute names line up with the cache tags on purpose: -generic for the
+# config-free daemon, plain -devnet for the archive, same as the Debian packages.
+#
+# <flake attr>|<cache service>|<cache tag>|<runtime contract>|<expected profile>
+# The archive image carries no PROFILE hint, so it has nothing to assert.
+IMAGES=(
+  "mina-image-devnet-generic|mina-daemon-nix|${GITHASH}-${CODENAME}-devnet-generic|daemon|devnet"
+  "mina-archive-image-devnet|mina-archive-nix|${GITHASH}-${CODENAME}-devnet|archive|"
+)
+
+for entry in "${IMAGES[@]}"; do
+  IFS='|' read -r attr service tag contract profile <<< "$entry"
+
+  echo "--- Building ${attr} with nix"
+  # streamLayeredImage produces a SCRIPT that writes a docker-archive tarball to
+  # stdout, rather than a tarball in the store -- so it is piped, not copied.
+  #
+  # --no-link, emphatically: an out-link is an untracked file in the checkout,
+  # which makes the flake tree dirty, which makes nix resolve the revision as
+  # "<dirty>" and bake that into MINA_COMMIT_SHA1. Building the first image
+  # would then change the version stamped into the second one.
+  stream=$(nix "${NIX_OPTS[@]}" build --no-link --print-out-paths \
+    "$PWD?submodules=1#${attr}" | tail -n1)
+
+  # Registry-prefixed name inside the image, bare service name for the cache
+  # path -- load_from_cache.sh takes the last path component of the reference to
+  # find the file, so the two stay consistent.
+  target="${DOCKER_REGISTRY}/${service}:${tag}"
+  out="${CACHE_ROOT}/${service}/${tag}.tar.zst"
+  mkdir -p "$(dirname "$out")"
+
+  # --repo_tag overrides the RepoTags baked into the archive, which otherwise
+  # say "mina-full:<nix output hash>". load_from_cache.sh looks the image up by
+  # name after `docker load`, so the archive has to carry the name the cache
+  # filename implies, not the one nix picked.
+  #
+  # Write to a temp file next to the target and rename: a job killed mid-write
+  # would otherwise leave a truncated .tar.zst in the shared cache that later
+  # builds would happily try to load.
+  echo "--- Streaming ${target} into the CI cache"
+  tmp="${out}.$$.partial"
+  trap 'rm -f "$tmp"' EXIT
+  # shellcheck disable=SC2086 # $profile is deliberately unquoted: empty means
+  # "no profile hint to assert", and an empty quoted arg would be a bad one.
+  "$stream" --repo_tag "$target" \
+    | ./buildkite/scripts/nix/verify_image.py "$contract" $profile \
+    | zstd -T0 -3 -o "$tmp"
+  mv "$tmp" "$out"
+  trap - EXIT
+
+  ls -la "$out"
+done
+
+echo "✅ Nix-built daemon and archive images are in ${CACHE_ROOT}"

--- a/buildkite/scripts/nix/lib.sh
+++ b/buildkite/scripts/nix/lib.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Shared setup for the CI jobs that run nix inside the nixos container:
+# test.sh (NixBuildTest) and build-images.sh (NixDockerImages), both alongside
+# this file.
+#
+# Both have to fix up the Buildkite checkout the same way before nix can look at
+# it, and both had their own copy of that dance -- which is how the image job
+# shipped without the ownership fix and failed with exit 128 until it was
+# rediscovered. Keep it in one place so the next job to run nix in CI inherits
+# the fixes instead of relearning them.
+#
+# Sourced, not executed.
+
+# Base flags every nix invocation in CI needs. Callers may append their own
+# (test.sh adds the binary-cache signing and post-build-hook options).
+# shellcheck disable=SC2034 # consumed by the scripts that source this file
+NIX_OPTS=(--accept-flake-config --experimental-features 'nix-command flakes')
+
+# Make the Buildkite checkout usable by git, and therefore by nix, which
+# resolves the flake through git.
+#
+# Two separate problems, both fatal, both needing a fix before ANY git command:
+#
+#   * The checkout is owned by a different user than the one in the container,
+#     so git refuses with "detected dubious ownership" (exit 128) and submodule
+#     sync reports it is "not owned by current user". The safe.directory
+#     wildcard rather than just /workdir because `?submodules=1` makes git read
+#     each submodule as a repository in its own right.
+#   * Buildkite checks out a detached HEAD, and nix fails to resolve a flake
+#     from one ("fatal: reference is not a tree"), so put HEAD back on a branch.
+prepare_nix_workdir() {
+  chown -R "${USER:-root}" /workdir || true
+  git config --global --add safe.directory '*'
+
+  git branch -D "$BUILDKITE_BRANCH" 2>/dev/null || true
+  git checkout -b "$BUILDKITE_BRANCH"
+  git reset --hard "$BUILDKITE_COMMIT"
+}

--- a/buildkite/scripts/nix/test.sh
+++ b/buildkite/scripts/nix/test.sh
@@ -9,7 +9,9 @@ if [[ $# -ne 1 ]]; then
 fi
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-NIX_OPTS=( --accept-flake-config --experimental-features 'nix-command flakes' )
+
+# shellcheck source=buildkite/scripts/nix/lib.sh
+source "$SCRIPTPATH/lib.sh"
 
 if [[ "$NIX_CACHE_NAR_SECRET" != "" ]]; then
   echo "$NIX_CACHE_NAR_SECRET" > /tmp/nix-cache-secret
@@ -39,30 +41,11 @@ if [[ "$NIX_SECRET_KEY" != "" ]]; then
   NIX_OPTS+=( --secret-key-files "$NIX_SECRET_KEY" )
 fi
 
-# There's an error in CI syncing submodules saying
-# "...' is not owned by current user"
-# run chown to the current user to fix it
-chown -R "${USER}" /workdir
-
 nix-env -i git-lfs
 
-git config --global --add safe.directory /workdir
-
-# We are in buildkite context so all buildkite related envs are available
-# We can use BUILDKITE_BRANCH to checkout the PR branch
-# Checking out the PR branch is necessary to make nix happy as it doesn't like detached head.
-# To be more precise nix has issue when performing operations on detached head
-# On Ci machine it spit out issues like:
-# fatal: reference is not a tree: ....
-# error:
-#       … while fetching the input 'git+file:///workdir'
-#
-#       error: program 'git' failed with exit code 128
-# That is why we checkout branch explicitly
-
-git branch -D $BUILDKITE_BRANCH 2>/dev/null || true
-git checkout -b $BUILDKITE_BRANCH
-git reset --hard $BUILDKITE_COMMIT
+# Ownership fix + detached-HEAD checkout; see lib.sh for why both are
+# needed. Uses BUILDKITE_BRANCH/BUILDKITE_COMMIT from the Buildkite context.
+prepare_nix_workdir
 
 # Test developer terminal with lsp server
 nix "${NIX_OPTS[@]}" develop "$PWD?submodules=1#with-lsp" --command bash -c "echo tested"

--- a/buildkite/scripts/nix/verify_image.py
+++ b/buildkite/scripts/nix/verify_image.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Assert a docker-archive tarball contains the paths the runtime contract needs.
+
+Reads the tarball on stdin and writes it back out on stdout byte-for-byte, so it
+can sit in the middle of a pipeline:
+
+    ./result-mina-daemon-nix -t img:tag | verify_image.py daemon | zstd -o out
+
+Why a pass-through filter and not `docker run`: the nix job runs inside the
+nixos container, which has no docker socket (buildkite/src/Lib/Cmds.dhall mounts
+only /var/storagebox, /var/secrets, /shared and the checkout). The images are
+streamed straight from the nix store into the CI cache without a docker daemon
+ever seeing them, so the contract has to be checked on the byte stream instead.
+
+A docker-archive is a tar of uncompressed per-layer tars plus manifest.json, so
+the check is a nested tar walk: collect every member name in every layer, then
+assert the required paths turned up somewhere.
+"""
+
+import sys
+import tarfile
+
+# The daemon falls back on this file to resolve its proof level when MINA_PROFILE
+# is unset, so an image whose binaries and whose hint disagree is a live trap --
+# and one the mainnet-labelled, dev-profile mina-image-full walked straight into.
+# Worth asserting the contents, not just that the file is there.
+PROFILE_HINT = "etc/coda/build_config/PROFILE"
+
+# A config file sitting in the image gets picked up implicitly by every node,
+# and a fork element in it has broken the integration tests before. The images
+# are supposed to ship binaries only and let the tests pass the runtime config
+# on the command line, so assert that rather than trust it: no config of any
+# kind in the image root. Store paths are exempt -- those are dependencies
+# (python's stdlib and friends carry their own json files), not image config.
+STORE_PREFIX = "nix/store/"
+
+# What test_executive's docker engine drives: the entrypoint plus the puppeteer
+# wrapper it uses to control the daemon lifecycle. mina-daemon-scripts in
+# nix/docker.nix copies dockerfiles/puppeteer-context/* in -- assert it rather
+# than assume, since these images are not routinely built.
+CONTRACTS = {
+    "daemon": [
+        "entrypoint.sh",
+        "start.sh",
+        "stop.sh",
+        "mina_daemon_puppeteer.py",
+        "find_puppeteer.sh",
+        "healthcheck/utilities.sh",
+        "bin/mina",
+        PROFILE_HINT,
+    ],
+    "archive": [
+        "entrypoint.sh",
+        "healthcheck/utilities.sh",
+        "bin/mina-archive",
+    ],
+}
+
+
+class Tee:
+    """Read-only file object that copies everything it reads to `sink`."""
+
+    def __init__(self, source, sink):
+        self.source = source
+        self.sink = sink
+
+    def read(self, size=-1):
+        chunk = self.source.read(size)
+        if chunk:
+            self.sink.write(chunk)
+        return chunk
+
+
+def normalise(name):
+    """"./bin/mina", "/bin/mina" and "bin/mina" all name the same entry."""
+    if name.startswith("./"):
+        name = name[2:]
+    return name.lstrip("/")
+
+
+def collect(stream):
+    """Walk the outer tar and every nested layer tar.
+
+    Returns the set of names *inside the layers*, plus whatever PROFILE hints
+    were found. Outer members are deliberately not collected: a docker-archive
+    carries its own manifest.json and image-config json, which are metadata
+    about the image rather than files in it, and would otherwise trip the
+    no-config check below.
+
+    The customisation layer holds /etc/coda/build_config/PROFILE as a symlink
+    into the store, so the readable copy is the one in the store layer -- match
+    on the suffix to catch it wherever it lands.
+    """
+    names = set()
+    profiles = set()
+    with tarfile.open(fileobj=stream, mode="r|") as outer:
+        for member in outer:
+            if not member.isfile() or not member.name.endswith(".tar"):
+                continue
+            layer = outer.extractfile(member)
+            if layer is None:
+                continue
+            # A layer is an uncompressed tar; read it off the same stream.
+            with tarfile.open(fileobj=layer, mode="r|") as inner:
+                for entry in inner:
+                    names.add(normalise(entry.name))
+                    if entry.isfile() and entry.name.endswith(PROFILE_HINT):
+                        hint = inner.extractfile(entry)
+                        if hint is not None:
+                            profiles.add(hint.read().decode().strip())
+    return names, profiles
+
+
+def main():
+    if len(sys.argv) not in (2, 3) or sys.argv[1] not in CONTRACTS:
+        sys.stderr.write(
+            "Usage: %s {%s} [expected-profile]\n"
+            % (sys.argv[0], "|".join(CONTRACTS))
+        )
+        return 2
+
+    contract = sys.argv[1]
+    expected_profile = sys.argv[2] if len(sys.argv) == 3 else None
+    required = CONTRACTS[contract]
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+
+    try:
+        names, profiles = collect(Tee(stdin, stdout))
+
+        # Drain whatever trailing padding tarfile did not consume, so the image
+        # we hand downstream is the whole stream and not a truncated prefix.
+        while True:
+            rest = stdin.read(1 << 20)
+            if not rest:
+                break
+            stdout.write(rest)
+        stdout.flush()
+    except BrokenPipeError:
+        # Whatever consumes the image (zstd) died. Its own failure is the real
+        # error; report ours as a one-liner rather than a traceback.
+        sys.stderr.write("ERROR: image consumer closed the pipe early\n")
+        return 1
+
+    missing = [path for path in required if path not in names]
+    if missing:
+        sys.stderr.write(
+            "ERROR: %s image is missing required paths: %s\n"
+            % (contract, ", ".join("/" + m for m in missing))
+        )
+        return 1
+
+    configs = sorted(
+        n
+        for n in names
+        if n.endswith(".json") and not n.startswith(STORE_PREFIX)
+    )
+    if configs:
+        sys.stderr.write(
+            "ERROR: %s image ships config in its root, which every node would "
+            "load implicitly: %s\n"
+            % (contract, ", ".join("/" + c for c in configs))
+        )
+        return 1
+
+    if expected_profile is not None and profiles != {expected_profile}:
+        sys.stderr.write(
+            "ERROR: %s image should declare profile %r, found %s\n"
+            % (
+                contract,
+                expected_profile,
+                ", ".join(sorted(repr(p) for p in profiles)) or "nothing",
+            )
+        )
+        return 1
+
+    sys.stderr.write(
+        "Runtime contract OK for %s image (%d paths checked, %d entries seen, "
+        "no config in image root%s)\n"
+        % (
+            contract,
+            len(required),
+            len(names),
+            ", profile %s" % expected_profile if expected_profile else "",
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buildkite/src/Jobs/Test/NixBuildTest.dhall
+++ b/buildkite/src/Jobs/Test/NixBuildTest.dhall
@@ -22,7 +22,7 @@ in  Pipeline.build
         , dirtyWhen =
           [ S.strictlyStart (S.contains "src")
           , S.exactly "buildkite/src/Jobs/Test/NixBuildTest" "dhall"
-          , S.exactly "buildkite/scripts/test-nix" "sh"
+          , S.strictlyStart (S.contains "buildkite/scripts/nix")
           , S.strictlyStart (S.contains "nix")
           , S.exactly "flake" "nix"
           , S.exactly "flake" "lock"
@@ -47,7 +47,7 @@ in  Pipeline.build
                   , privileged = True
                   , useBash = False
                   }
-                  "./buildkite/scripts/test-nix.sh \$BUILDKITE_BRANCH"
+                  "./buildkite/scripts/nix/test.sh \$BUILDKITE_BRANCH"
               ]
             , label = "nix build tests"
             , key = "nix-build-tests"

--- a/buildkite/src/Jobs/Test/NixDockerImages.dhall
+++ b/buildkite/src/Jobs/Test/NixDockerImages.dhall
@@ -1,0 +1,87 @@
+-- Build the daemon/archive docker images with Nix and save them to the shared
+-- CI cache, as an alternative to IntegrationTestDockerImages building them from
+-- freshly-built Debian packages.
+--
+-- Nothing consumes these images: the script writes them under <service>-nix, so
+-- this runs alongside the .deb-built ones without disturbing anything. The job
+-- exists to keep the nix image definitions honest -- that they build at all,
+-- carry no config, satisfy the daemon runtime contract (entrypoint + puppeteer
+-- scripts) and land in the cache in a loadable shape.
+--
+-- Runs in the nixos container like NixBuildTest, and needs the same nix binary
+-- cache credentials, otherwise it would compile mina from scratch.
+--
+-- dirtyWhen covers what the images are built out of: the nix expressions, the
+-- scripts, and the entrypoint/puppeteer scripts nix/docker.nix copies in from
+-- dockerfiles/. default.nix and opam.export need entries of their own, being
+-- neither under nix/ nor caught by any prefix here. Deliberately not src/: the
+-- binaries come out of the shared nix cache and nothing consumes these images,
+-- so rebuilding them on every source change would put an XLarge job back onto
+-- PRs for no gain.
+--
+-- depends_on NixBuildTest because that job is what puts .#devnet into the shared
+-- cache -- it builds it and `nix copy`s the result up. A nightly runs on a
+-- commit whose sources have moved, so those paths reach the cache only once it
+-- has finished; running the two concurrently would leave this one compiling
+-- mina from scratch on an XLarge agent instead of fetching it.
+
+let ContainerImages = ../../Constants/ContainerImages.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Size = ../../Command/Size.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.strictlyStart (S.contains "dockerfiles")
+          , S.strictlyStart (S.contains "nix")
+          , S.exactly "flake" "nix"
+          , S.exactly "flake" "lock"
+          , S.exactly "default" "nix"
+          , S.exactly "opam" "export"
+          , S.strictlyStart (S.contains "buildkite/scripts/nix")
+          , S.exactly "buildkite/src/Jobs/Test/NixDockerImages" "dhall"
+          ]
+        , path = "Test"
+        , name = "NixDockerImages"
+        , tags =
+          [ PipelineTag.Type.Long
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Docker
+          ]
+        , scope = [ PipelineScope.Type.PullRequest, PipelineScope.Type.Nightly ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+              [ Cmd.runInDocker
+                  Cmd.Docker::{
+                  , image = ContainerImages.nixos
+                  , privileged = True
+                  , useBash = False
+                  }
+                  "./buildkite/scripts/nix/build-images.sh"
+              ]
+            , label = "Build daemon/archive docker images with Nix"
+            , key = "nix-docker-images"
+            , target = Size.XLarge
+            , depends_on =
+              [ { name = "NixBuildTest", key = "nix-build-tests" } ]
+            }
+        ]
+      }

--- a/flake.nix
+++ b/flake.nix
@@ -409,7 +409,7 @@
             zkapp-cli hardfork_test;
           inherit (dockerImages)
             mina-image-slim mina-image-full mina-archive-image-full
-            mina-image-instr-full;
+            mina-image-devnet-generic mina-archive-image-devnet;
           mina-deb = debianPackages.mina;
           impure-shell = (import ./nix/impure-shell.nix pkgs).inputDerivation;
         }) // {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -8,15 +8,21 @@ let
   mkdir = name:
     runCommand "mkdir-${name}" { } "mkdir -p $out${lib.escapeShellArg name}";
 
-  mina-build-config = stdenv.mkDerivation {
-    pname = "mina-build-config";
-    version = "dev";
+  # /etc/coda/build_config/PROFILE is the hint the daemon falls back on to
+  # resolve its proof level when MINA_PROFILE is not set in the environment, so
+  # it has to name the profile the binaries in the same image were built with.
+  # This mirrors build_profile_deb in scripts/debian/builder-helpers.sh, which
+  # ships the same file with the same contents.
+  mkBuildConfig = profile:
+    stdenv.mkDerivation {
+      pname = "mina-build-config-${profile}";
+      version = "dev";
 
-    buildCommand = ''
-      mkdir -p $out/etc/coda/build_config
-      printf "mainnet" > $out/etc/coda/build_config/PROFILE
-    '';
-  };
+      buildCommand = ''
+        mkdir -p $out/etc/coda/build_config
+        printf "${profile}" > $out/etc/coda/build_config/PROFILE
+      '';
+    };
 
   mina-daemon-scripts = stdenv.mkDerivation {
     pname = "mina-daemon-scripts";
@@ -81,6 +87,14 @@ let
       env = [
         "MINA_TIME_OFFSET=0"
         "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
+        # The daemon defaults its config directory to $HOME/.mina-config, and
+        # there is no /etc/passwd in this image for docker to derive HOME from,
+        # so without this it becomes /.mina-config. The integration test
+        # entrypoint imports account keys into /root/.mina-config explicitly, so
+        # a daemon reading /.mina-config finds an empty wallet and every test
+        # that unlocks an account fails with "Could not find owned account".
+        # The debian images get HOME=/root from their base image's passwd entry.
+        "HOME=/root"
       ];
       WorkingDir = "/root";
       cmd = [ "/bin/dumb-init" "/entrypoint.sh" ];
@@ -94,24 +108,13 @@ in {
   };
 
   mina-image-full = mkFullImage "mina" (with ocamlPackages_mina; [
-    mina-build-config
+    (mkBuildConfig "mainnet")
     mina-daemon-scripts
 
     mina.out
     mina.mainnet
     mina.genesis
   ]);
-
-  # Image with enhanced binary capable of generating coverage report on mina exit
-  # For more details please visit: https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#sigterm-handling
-  mina-image-instr-full = mkFullImage "mina-instr" (with ocamlPackages_mina; [
-    mina-build-config
-    mina-daemon-scripts
-
-    with_instrumentation.out
-    mina.mainnet
-    mina.genesis
-  ]) [ "BISECT_SIGTERM=yes" ];
 
   mina-archive-image-full = mkFullImage "mina-archive"
     (with ocamlPackages_mina; [
@@ -120,5 +123,45 @@ in {
       gzip
 
       mina.archive
+    ]);
+
+  # Devnet counterparts of the two images above, for the integration tests. Same
+  # layout, but every binary comes from the DUNE_PROFILE=devnet build
+  # (ocamlPackages_mina.devnet) instead of the dev-profile one, and the PROFILE
+  # hint matches what is in the image.
+  #
+  # These are the images the integration tests want: `mina-image-full` pairs
+  # dev-profile binaries with a PROFILE hint that says mainnet, which is neither
+  # of the two things a devnet test needs. `devnet` is also what NixBuildTest
+  # already builds on every PR, so these reuse the shared nix cache rather than
+  # pulling a second, otherwise-unused compile of mina.
+  #
+  # "generic" is meant in the same sense as the mina-${network}-generic Debian
+  # package: daemon binaries and the profile hint, with no network config baked
+  # in. That is not just a naming choice -- a config.json inside the image gets
+  # picked up implicitly by every node, and a fork element in it breaks the
+  # integration tests. Nothing here ships one: the only thing under /etc/coda is
+  # build_config/PROFILE, and devnet.genesis contributes an empty
+  # /var/lib/coda (ocaml.nix leaves the genesis copy commented out). The tests
+  # pass the runtime config they want on the command line instead.
+  mina-image-devnet-generic =
+    mkFullImage "mina-devnet-generic" (with ocamlPackages_mina; [
+      (mkBuildConfig "devnet")
+      mina-daemon-scripts
+
+      devnet.out
+      # Devnet is a testnet-signature network, so this is the counterpart of
+      # mina.mainnet above, not a different kind of thing.
+      devnet.testnet
+      devnet.genesis
+    ]);
+
+  mina-archive-image-devnet = mkFullImage "mina-archive-devnet"
+    (with ocamlPackages_mina; [
+      mina-archive-scripts
+      gnutar
+      gzip
+
+      devnet.archive
     ]);
 }


### PR DESCRIPTION
## What

Adds a CI job that builds the daemon and archive docker images from `nix/docker.nix` — straight from the compiled binaries in the shared nix cache, with no debian packages and no `docker build` — and checks they come out correct.

**Nothing consumes these images.** They are written to the CI cache under `<service>-nix`, alongside the `.deb`-built ones, so this disturbs nothing. The job exists to keep the nix image definitions honest; pointing anything at them is a separate change.

## Why it is cheap

`nix/docker.nix` already described this pair, but the definitions had rotted — nothing in CI ever evaluated them. Reviving them costs almost nothing, because `nix build .#devnet` already runs on every PR and populates `s3://mina-nix-cache`. The images are therefore a *fetch*, not a build: the job finishes in **6m36s with zero OCaml derivations built**, and never transfers a docker build context.

## Image definitions (`nix/docker.nix`)

- **`mina-image-instr-full` deleted.** It had been unbuildable since `mkFullImage` lost its third parameter — the call site still passed `[ "BISECT_SIGTERM=yes" ]` to a two-argument function, so it was an eval error. Nothing built it and nothing missed it.
- **Devnet counterparts added**: `mina-image-devnet-generic` and `mina-archive-image-devnet`, built from `ocamlPackages_mina.devnet`. `mina-image-full` pairs **dev**-profile binaries with a `PROFILE` hint that says `mainnet`, which is neither of the two things a devnet image needs; these pair devnet binaries with a devnet hint. `mina-build-config` becomes `mkBuildConfig <profile>`.
- **`HOME=/root`.** The daemon defaults its config directory to `$HOME/.mina-config`, and a `streamLayeredImage` has no `/etc/passwd` for docker to derive `HOME` from — so it was reading `/.mina-config` while anything importing keys wrote to `/root/.mina-config`.
- Named after the debian packages (`-generic` for the config-free daemon, plain `-devnet` for the archive) and carrying **no network config**: a `config.json` inside an image is loaded implicitly by every node, and a fork element in one has broken tests before.

## The job

There is no docker daemon involved anywhere. The nixos container has no docker socket — `Cmds.dhall` mounts only storagebox, secrets, shared and the checkout — and it does not need one: `streamLayeredImage` emits a docker-archive tarball on stdout, which is exactly what `load_from_cache.sh` feeds back into `docker load`. The image goes store → stream → zstd → cache in a single pass, with `--repo_tag` supplying the registry-prefixed name a consumer would look up.

`verify_image.py` sits in that pipe: it asserts the runtime contract while passing the bytes through untouched — entrypoint, puppeteer scripts, the binary, the `PROFILE` hint *and its contents*, and that no config was shipped. That replaces the `docker run` assertion this job cannot make.

`test-nix.sh` moves to `nix/test.sh` alongside it, and both jobs now source `nix/lib.sh` for the container prelude. Each previously carried its own copy of the ownership fix and the detached-HEAD checkout, which is how this job first shipped without the ownership fix and died with exit 128.

## Verification

- **Green in CI**: nightly 4345, both nix jobs pass.
- Images proved to be devnet by `mina advanced compile-time-constants`: `k=290`, `genesis_state_timestamp=2021-09-24`. Mainnet's is `2020-09-16`, and `devnet.ml` is `include Mainnet` with only that field overridden, so the timestamp is the one thing that distinguishes them.
- Archive image run against `postgres:16.2-bullseye` with the schema loaded → *"Archive process ready. Clients can now connect"*.
- Driven end to end: a branch that pointed `TestnetIntegrationTests` at these images passed **15 of 16** integration tests in nightly 4345. The single failure was a soft timeout caused by two consecutive empty slots, unrelated to the images. **That switch is deliberately not part of this PR.**
- `make all` in `buildkite/` → 45/45; `shellcheck` clean; rendered pipeline checked for scope, `dirtyWhen` and `depends_on`.

## Scope notes

`dirtyWhen` covers what the images are actually built from — the nix expressions, these scripts, and the entrypoint/puppeteer scripts `nix/docker.nix` copies out of `dockerfiles/`, plus `default.nix` and `opam.export`, which live under neither. Deliberately **not** `src/`: nothing consumes the images, so rebuilding them on every source change would put an XLarge job back onto PRs for no gain.

`depends_on NixBuildTest` because that job is what puts `.#devnet` into the shared cache. A nightly runs on a commit whose sources have moved, so those paths reach the cache only once it has finished — running the two concurrently would leave this one compiling mina from scratch instead of fetching it.

No changelog entry: `Lint: Changelog` triggers on repo-root `src/`, and this touches only `buildkite/`, `flake.nix` and `nix/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
