### PR TITLE
ci: RosettaBlockRaceTest depends on the Apps build instead of packages

### DIFF
--- a/buildkite/src/Jobs/Test/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Jobs/Test/RosettaBlockRaceTest.dhall
@@ -21,12 +21,11 @@ let Expr = ../../Pipeline/Expr.dhall
 let MainlineBranch = ../../Pipeline/MainlineBranch.dhall
 
 let dependsOn =
-        DebianVersions.dependsOn
-          DebianVersions.DepsSpec::{
-          , network = Network.Type.Mainnet
-          , profile = Profiles.Type.Mainnet
-          }
-      # DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+      DebianVersions.appDependsOn
+        DebianVersions.DepsSpec::{
+        , network = Network.Type.Mainnet
+        , profile = Profiles.Type.Mainnet
+        }
 
 in  Pipeline.build
       Pipeline.Config::{


### PR DESCRIPTION
## Summary

`RosettaBlockRaceTest` already runs **bare binaries** — it just never had its dependency flipped to match.

```
APPS_NETWORK=mainnet
APPS_BARE_BINARIES=mina.exe:mina,archive.exe:mina-archive,rosetta.exe:mina-rosetta
```

The `.deb`s (`mina-mainnet-generic,mina-archive-mainnet,mina-rosetta-mainnet`) are only the cache-miss fallback, yet the job still declared `DebianVersions.dependsOn`, so monorepo's dependency resolution pulled the whole package build in behind it.

```diff
 let dependsOn =
-        DebianVersions.dependsOn
-          DebianVersions.DepsSpec::{ network = Mainnet, profile = Mainnet }
-      # DebianVersions.dependsOn DebianVersions.DepsSpec::{=}
+      DebianVersions.appDependsOn
+        DebianVersions.DepsSpec::{ network = Mainnet, profile = Mainnet }
```

Two changes in one: package dep → apps dep, and the second (devnet) dependency is dropped — the test only ever uses mainnet binaries, so it was vestigial.

## Verification

- Rendered `depends_on` is a single `_MinaArtifactMainnetBullseyeApps-build-apps`, matching that job's step key. The apps job's scope (`AllButPullRequest`) covers the test's `[MainlineNightly, Release]`.
- Enumerated every remaining consumer of `build-deb-pkg` from the generated job specs; `RosettaBlockRaceTest` is gone from the list, leaving only the genuinely package-coupled ones:

  | Consumer | needs debs from |
  |---|---|
  | DebianUpgradeTest | MinaArtifactBullseye |
  | DebianAutomodeTransitionTest | MinaArtifactBullseye |
  | DebianAutomodeTransitionTestMainnet | MinaArtifactBullseye, MinaArtifactMainnetBullseye |
  | HardforkPackageConversion | MinaArtifactBullseye |
  | IntegrationTestDockerImages | MinaArtifactBullseye |

- `make all` in `buildkite/` → 45/45.

No script changes were needed — the runner already restores the bare binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
