### PR TITLE
ci: build the auto-hardfork image inside AutoHardforkTest

### DIFF
--- a/buildkite/scripts/tests/hardfork/build-auto-hardfork-image.sh
+++ b/buildkite/scripts/tests/hardfork/build-auto-hardfork-image.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Builds the mina-daemon-auto-hardfork docker image for AutoHardforkTest, on the
+# test's own agent, from packages the test job built itself.
+#
+# This exists so AutoHardforkTest no longer depends on the artifact/packaging
+# job. Two things differ from the artifact job's docker step
+# (Command/DockerImage.dhall):
+#
+#   1. The postfork side's .deb files come from _build/*.deb -- packages built
+#      in this same job by buildkite/scripts/debian/build-from-cache.sh out of
+#      the app-build binaries -- instead of read_all_from_cache.sh pulling the
+#      packaging job's cached debians out of ${BUILDKITE_BUILD_ID}/debians.
+#   2. The image is only loaded into the agent's local docker daemon
+#      (--load-only), never pushed. The dispatcher tests run on this same agent
+#      in the same step, so a registry round-trip buys nothing.
+#
+# The legacy PREFORK .deb is still read from the cache's `legacy/debians` root.
+# That one is a fixed pre-fork release artifact (deb_legacy_version), not
+# something this build produces, so there is nothing to build it from.
+#
+# Requires MINA_DEB_CODENAME and a sourced export-git-env-vars.sh
+# (MINA_DEB_VERSION / MINA_DOCKER_TAG).
+#
+# Usage: build-auto-hardfork-image.sh --legacy-version <v> --docker-registry <r>
+#                                     [--network <n>] [--profile <p>]
+#                                     [--base-image <img>]
+#
+# --docker-registry must match the registry the caller derives the image tag
+# from (Constants/Docker/Package.dhall fullDockerTag), because that is what
+# scripts/docker/helper.sh tags the built image with and what the dispatcher
+# tests then `docker run`.
+
+set -eo pipefail
+
+NETWORK="devnet"
+PROFILE="devnet"
+LEGACY_VERSION=""
+BASE_IMAGE=""
+DOCKER_REGISTRY_ARG=""
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  --network) NETWORK="$2"; shift;;
+  --profile) PROFILE="$2"; shift;;
+  --legacy-version) LEGACY_VERSION="$2"; shift;;
+  --base-image) BASE_IMAGE="$2"; shift;;
+  --docker-registry) DOCKER_REGISTRY_ARG="$2"; shift;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+if [[ -z "${MINA_DEB_CODENAME:-}" ]]; then
+  echo "MINA_DEB_CODENAME is not set. Exiting."
+  exit 1
+fi
+
+if [[ -z "$LEGACY_VERSION" ]]; then
+  echo "--legacy-version is required (the prefork deb version to install)."
+  exit 1
+fi
+
+if [[ -z "$DOCKER_REGISTRY_ARG" ]]; then
+  echo "--docker-registry is required (it decides the tag the image is built under)."
+  exit 1
+fi
+
+# The docker build context. scripts/docker/build.sh picks up every *.deb sitting
+# here and stages it under _debs/, which the Dockerfile COPYs into the image for
+# install-mina-debs.sh -- no apt repo involved.
+DEB_STAGE="dockerfiles"
+
+echo "--- Staging locally built debian packages into ${DEB_STAGE}"
+shopt -s nullglob
+built_debs=(_build/*.deb)
+shopt -u nullglob
+
+if [[ "${#built_debs[@]}" -eq 0 ]]; then
+  echo "No .deb files found in _build/. The debian build step must run first." >&2
+  exit 1
+fi
+
+echo "Staging ${#built_debs[@]} locally built .deb file(s):"
+printf '  %s\n' "${built_debs[@]}"
+cp "${built_debs[@]}" "${DEB_STAGE}/"
+
+# The prefork package is a released artifact from before the fork; it is kept in
+# the cache under its own root and is never rebuilt here.
+echo "--- Reading legacy (prefork) debian packages from the CI cache"
+./buildkite/scripts/cache/manager.sh read --root legacy/debians \
+  "${MINA_DEB_CODENAME}/*" "${DEB_STAGE}"
+
+# Same prune the artifact job's docker steps run: docker builds are the heavy
+# disk consumers on an agent and this job now runs one.
+DISK_PRUNE_THRESHOLD=0 ./buildkite/scripts/docker/disk-cleanup.sh
+
+# Preload the published mina-base image so the staged build starts FROM it
+# instead of re-running the base-deps stage. Non-fatal: build.sh inlines the
+# base-deps fragment when the image is not available locally.
+BASE_IMAGE_ARG=()
+if [[ -n "$BASE_IMAGE" ]]; then
+  ./buildkite/scripts/docker/load_from_cache.sh "$BASE_IMAGE" \
+    || echo "mina-base-not-in-ci-cache-inlining-base-deps-stage"
+  BASE_IMAGE_ARG=(--base-image "$BASE_IMAGE")
+fi
+
+echo "--- Building the auto-hardfork image locally (no push)"
+./scripts/docker/build.sh \
+  --service mina-daemon-auto-hardfork \
+  --network "${NETWORK}" \
+  --version "${MINA_DOCKER_TAG}" \
+  --branch "${BUILDKITE_BRANCH}" \
+  --deb-codename "${MINA_DEB_CODENAME}" \
+  --deb-repo http://localhost:8080 \
+  --deb-release unstable \
+  --deb-version "${MINA_DEB_VERSION}" \
+  --deb-profile "${PROFILE}" \
+  --deb-build-flags none \
+  --deb-legacy-version "${LEGACY_VERSION}" \
+  "${BASE_IMAGE_ARG[@]}" \
+  --repo "${BUILDKITE_REPO}" \
+  --platform linux/amd64 \
+  --docker-registry "${DOCKER_REGISTRY_ARG}" \
+  --load-only

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -365,50 +365,55 @@ let build_apps
                   ]
                 }
 
+let debianTokens
+    : MinaBuildSpec.Type -> Text
+    =     \(spec : MinaBuildSpec.Type)
+      ->  Text/concatSep
+            " "
+            (List/map Artifact.Type Text Artifact.toDebianToken spec.artifacts)
+
+let buildDebianFromApps
+    : MinaBuildSpec.Type -> Text -> List Cmd.Type
+    =     \(spec : MinaBuildSpec.Type)
+      ->  \(tokens : Text)
+      ->  Toolchain.select
+            Toolchain.Spec::{
+            , mode = spec.toolchainSelectMode
+            , debVersion = spec.debVersion
+            , arch = spec.arch
+            , submodules = False
+            }
+            (commonBuildEnvs spec)
+            "./buildkite/scripts/debian/build-from-cache.sh ${primaryAppsVariant
+                                                                spec} ${treeVariant
+                                                                          spec} ${tokens}"
+
 let build_debian
     : MinaBuildSpec.Type -> Command.Type
     =     \(spec : MinaBuildSpec.Type)
-      ->  let debianTokens =
-                Text/concatSep
-                  " "
-                  ( List/map
-                      Artifact.Type
-                      Text
-                      Artifact.toDebianToken
-                      spec.artifacts
-                  )
-
-          in  Command.build
-                Command.Config::{
-                , commands =
-                      Toolchain.select
-                        Toolchain.Spec::{
-                        , mode = spec.toolchainSelectMode
-                        , debVersion = spec.debVersion
-                        , arch = spec.arch
-                        , submodules = False
-                        }
-                        (commonBuildEnvs spec)
-                        "./buildkite/scripts/debian/build-from-cache.sh ${primaryAppsVariant
-                                                                            spec} ${treeVariant
-                                                                                      spec} ${debianTokens} profile_devnet_generic profile_mainnet_generic"
-                    # [ Cmd.run
-                          "./buildkite/scripts/debian/write_to_cache.sh ${DebianVersions.lowerName
-                                                                            spec.debVersion}"
-                      ]
-                , label = "Debian: Build ${labelSuffix spec}"
-                , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
-                , depends_on =
-                  [ { name = appsJobName spec, key = "build-apps" } ]
-                , target = Size.Multi
-                , if_ = spec.if_
-                , retries =
-                  [ Command.Retry::{
-                    , exit_status = Command.ExitStatus.Code +2
-                    , limit = Some 2
-                    }
+      ->  Command.build
+            Command.Config::{
+            , commands =
+                  buildDebianFromApps
+                    spec
+                    "${debianTokens
+                         spec} profile_devnet_generic profile_mainnet_generic"
+                # [ Cmd.run
+                      "./buildkite/scripts/debian/write_to_cache.sh ${DebianVersions.lowerName
+                                                                        spec.debVersion}"
                   ]
+            , label = "Debian: Build ${labelSuffix spec}"
+            , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
+            , depends_on = [ { name = appsJobName spec, key = "build-apps" } ]
+            , target = Size.Multi
+            , if_ = spec.if_
+            , retries =
+              [ Command.Retry::{
+                , exit_status = Command.ExitStatus.Code +2
+                , limit = Some 2
                 }
+              ]
+            }
 
 let docker_step
     : DockerService -> MinaBuildSpec.Type -> List DockerImage.ReleaseSpec.Type
@@ -734,4 +739,6 @@ in  { pipeline = pipeline
     , buildArtifacts = build_artifacts
     , buildApps = build_apps
     , buildDebian = build_debian
+    , buildDebianFromApps = buildDebianFromApps
+    , debianTokens = debianTokens
     }

--- a/buildkite/src/Jobs/Test/AutoHardforkTest.dhall
+++ b/buildkite/src/Jobs/Test/AutoHardforkTest.dhall
@@ -1,3 +1,18 @@
+-- The dispatcher tests need a mina-daemon-auto-hardfork image, and used to get
+-- one by depending on the packaging job's docker step. That made every PR that
+-- touches src/ build the whole Debian + Docker artifact set, since selecting
+-- this job pulls its dependency in (monorepo.sh phase-2 dependency resolution).
+--
+-- So the job now produces the image itself, on its own agent, in two commands:
+--   1. build only the two .deb files the image installs from the freshly built
+--      binaries in the apps cache (mina-<network>-postfork-mesa + mina-logproc),
+--      reusing the exact packaging path the artifact job uses;
+--   2. build the image from those .debs and load it locally -- no push, since
+--      the tests run in the same step, on the same agent.
+--
+-- The legacy prefork .deb still comes from the cache's `legacy/debians` root:
+-- it is a released pre-fork artifact, not something this build can produce.
+
 let Cmd = ../../Lib/Cmds.dhall
 
 let S = ../../Lib/SelectFiles.dhall
@@ -12,13 +27,31 @@ let Command = ../../Command/Base.dhall
 
 let Size = ../../Command/Size.dhall
 
-let Dockers = ../../Constants/Docker/Versions.dhall
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
 
 let Docker = ../../Constants/Docker/Package.dhall
+
+let DockerRepo = ../../Constants/DockerRepo.dhall
+
+let BaseImage = ../../Constants/Docker/BaseImage.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
+
+let Arch = ../../Constants/Arch.dhall
 
 let Network = ../../Constants/Network.dhall
 
 let network = Network.Type.Devnet
+
+let profile = Profiles.Type.Devnet
+
+let debVersion = DebianVersions.DebVersion.Bullseye
+
+let arch = Arch.Type.Amd64
 
 let dirtyWhen =
       [ S.strictlyStart (S.contains "src")
@@ -27,13 +60,22 @@ let dirtyWhen =
       , S.exactly_noext "dockerfiles/stages/1-base-deps"
       , S.exactly "scripts/hardfork/dispatcher" "sh"
       , S.exactly "scripts/hardfork/create_runtime_config" "sh"
-      , S.exactly "buildkite/scripts/tests/hardfork/dispatcher-tests" "sh"
-      , S.exactly
-          "buildkite/scripts/tests/hardfork/create-runtime-config-tests"
-          "sh"
+      , S.strictlyStart (S.contains "buildkite/scripts/tests/hardfork")
       , S.exactly "scripts/docker/build" "sh"
       , S.exactly "scripts/debian/builder-helpers" "sh"
+      , S.exactly "buildkite/scripts/debian/build-from-cache" "sh"
+      , S.strictlyStart (S.contains "buildkite/scripts/apps")
       ]
+
+let buildSpec =
+      ArtifactPipelines.MinaBuildSpec::{
+      , artifacts =
+        [ Artifacts.Type.DaemonPostfork { network = network }
+        , Artifacts.Type.LogProc
+        ]
+      , debVersion = debVersion
+      , arch = arch
+      }
 
 let hardforkDocker =
       Docker.fullDockerTag
@@ -41,6 +83,14 @@ let hardforkDocker =
         , package = Docker.Type.DaemonAutoHardfork { network = network }
         , network = network
         }
+
+let buildImage =
+          "./buildkite/scripts/tests/hardfork/build-auto-hardfork-image.sh"
+      ++  " --network ${Network.lowerName network}"
+      ++  " --profile ${Profiles.lowerName profile}"
+      ++  " --legacy-version ${buildSpec.deb_legacy_version}"
+      ++  " --base-image ${BaseImage.imageFor debVersion arch}"
+      ++  " --docker-registry ${DockerRepo.show DockerRepo.Type.InternalEurope}"
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -58,22 +108,30 @@ in  Pipeline.build
         [ Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run
-                  "export MINA_DEB_CODENAME=bullseye && source ./buildkite/scripts/export-git-env-vars.sh"
-              , Cmd.run
-                  "buildkite/scripts/tests/hardfork/dispatcher-tests.sh --docker ${hardforkDocker}"
-              ]
+                  ArtifactPipelines.buildDebianFromApps
+                    buildSpec
+                    (ArtifactPipelines.debianTokens buildSpec)
+                # [ Cmd.run
+                      (     "export MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                                          debVersion}"
+                        ++  " && export BRANCH_NAME=\\\${BUILDKITE_BRANCH}"
+                        ++  " && source ./buildkite/scripts/export-git-env-vars.sh"
+                        ++  " && ${buildImage}"
+                      )
+                  , Cmd.run
+                      "buildkite/scripts/tests/hardfork/dispatcher-tests.sh --docker ${hardforkDocker}"
+                  ]
             , label = "Auto Hardfork: Dispatcher Tests"
             , key = "auto-hardfork-dispatcher-tests-bullseye"
-            , target = Size.Small
+            , target = Size.XLarge
             , artifact_paths = [ S.contains "test_output/artifacts/*" ]
             , depends_on =
-                Dockers.dependsOn
-                  Dockers.DepsSpec::{
-                  , codename = Dockers.Type.Bullseye
-                  , artifact =
-                      Docker.Type.DaemonAutoHardfork { network = network }
+                DebianVersions.appDependsOn
+                  DebianVersions.DepsSpec::{
+                  , deb_version = debVersion
                   , network = network
+                  , profile = profile
+                  , arch = arch
                   }
             }
         , Command.build

--- a/changes/19149.md
+++ b/changes/19149.md
@@ -1,0 +1,11 @@
+Build the auto-hardfork image inside AutoHardforkTest
+
+`AutoHardforkTest` depended on the packaging job's `daemon_auto_hardfork` docker
+step, so every PR touching `src/` pulled the whole Debian + Docker artifact
+build in as a dependency.
+
+The job now packages the two debs the image installs (`daemon_devnet_postfork`,
+`logproc`) from the app-build binaries and builds the image locally with
+`--load-only` — no cached debians, and no image push. The legacy prefork deb
+still comes from the cache's `legacy/debians` root, as it is a released
+pre-fork artifact.


### PR DESCRIPTION
## Why

`AutoHardforkTest` depended on the packaging job's `daemon_auto_hardfork-devnet-docker-image` step. Because monorepo triage pulls a selected job's dependency in (phase-2 resolution), and this test has a broad `src/` `dirtyWhen`, **every source PR ended up building the whole Debian + Docker artifact set** just to hand this test one image.

This is one of the consumers that has to be rehomed before the `MinaArtifact*` docker jobs can be split off / dropped from PR and nightly.

## What

The job now produces the image itself, on its own agent:

1. **Debians from binaries, not from the cache.** The step depends on `MinaArtifactBullseyeApps` (`appDependsOn`) and runs `buildkite/scripts/debian/build-from-cache.sh` for exactly the two packages the image installs — `daemon_devnet_postfork` and `logproc` — so the packages come from the freshly built app binaries rather than from the packaging job's cached `.deb`s.
2. **Docker image built locally, never pushed.** New `buildkite/scripts/tests/hardfork/build-auto-hardfork-image.sh` stages those `.deb`s into the docker build context and calls `scripts/docker/build.sh … --load-only`. The dispatcher tests run in the same step on the same agent, so a registry round-trip buys nothing — and this removes a production image push from PR and nightly.

The legacy **prefork** `.deb` is still read from the cache's `legacy/debians` root: it is a released pre-fork artifact at `deb_legacy_version`, not something this build can produce.

### Supporting refactor

`Command/MinaArtifact.dhall` grows two exports, `buildDebianFromApps` and `debianTokens`, factored out of `build_debian` so the test reuses the packaging path verbatim (same toolchain image, same build envs, same apps/tree cache variants) instead of re-deriving it. `build_debian` keeps appending `profile_devnet_generic profile_mainnet_generic`; the token list is now a parameter so the test builds only what it installs.

## Verification

- `make all` in `buildkite/`: green (37 Dhall targets, 45 monorepo tests).
- Generated pipelines diffed before/after: **only `AutoHardforkTest.yml` and its `.dirtywhen` change** — the `MinaArtifact.dhall` refactor is byte-for-byte behaviour-preserving for every artifact job.
- Triage on a `src/`-only diff now shows `AutoHardforkTest` selected with **no** artifact-job pull-in from it (`MinaArtifactBullseye` is still dragged in by `DebianUpgradeTest`, which is separate work).
- `shellcheck` clean on the new script.

## Also bumped

Step target `Small` → `XLarge`: the step now packages debs and builds a docker image before running the tests, so it needs the agent class the artifact job's docker steps use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4sFwLPykoFaZvg6fWiK8K