### PR TITLE
ci: run the rosetta connectivity tests from bare apps

### DIFF
--- a/buildkite/scripts/tests/rosetta/connectivity.sh
+++ b/buildkite/scripts/tests/rosetta/connectivity.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+
+# Rosetta devnet/mainnet connectivity test, run from bare binaries.
+#
+# This replaces running scripts/tests/rosetta-connectivity.sh against the
+# prebuilt mina-rosetta docker image. That image is a packaging artifact: to get
+# one, the test had to depend on the Debian build and the docker build, which is
+# the entire reason those run on ordinary PRs and in nightly.
+#
+# Everything the image provided is reproduced here from the repository:
+#
+#   binaries      -> restored from the apps cache (mina / mina-archive /
+#                    mina-rosetta / libp2p_helper), see restore-or-install.sh
+#   network config-> genesis_ledgers/${MINA_NETWORK}.json, which is byte for byte
+#                    what the mina-${network}-config deb installs as
+#                    /var/lib/coda/${network}.json (scripts/debian/builder-helpers.sh,
+#                    copy_common_daemon_configs)
+#   archive schema-> src/app/archive/create_schema.sql
+#   upgrade/downgrade SQL -> src/app/archive/{upgrade_to_mesa,downgrade_to_berkeley}.sql
+#                    (the image had them under /etc/mina/archive)
+#   postgres      -> a cluster created here, as the rosetta image's Dockerfile did
+#
+# The process layout (rosetta online+offline, archive, daemon, all on localhost)
+# is the same one src/app/rosetta/scripts/docker-start.sh sets up inside the
+# image, so the sanity/load/compatibility assertions are unchanged -- they just
+# talk to processes on this host instead of through `docker exec`.
+#
+# Not reproduced: mina-missing-blocks-guardian. It backfills gaps from the
+# precomputed-block bucket, and nothing this test asserts depends on it: the
+# blocks it checks for are the ones the connected daemon writes as it follows
+# the chain.
+#
+# Usage: connectivity.sh --network <devnet|mainnet> [options]
+
+set -eo pipefail
+
+NETWORK="devnet"
+SYNC_TIMEOUT=900
+NEW_BLOCK_TIMEOUT=600
+LOAD_TEST_DURATION=600
+RUN_LOAD_TEST=false
+COMPATIBILITY_BRANCH=""
+METRICS_MODE=""
+BRANCH=""
+COMMIT=""
+PERF_OUTPUT_FILE="rosetta.perf"
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -n|--network) NETWORK="$2"; shift;;
+  --sync-timeout) SYNC_TIMEOUT="$2"; shift;;
+  --new-block-timeout) NEW_BLOCK_TIMEOUT="$2"; shift;;
+  --run-load-test) RUN_LOAD_TEST=true ;;
+  --load-test-duration) LOAD_TEST_DURATION="$2"; shift;;
+  --perf-output-file) PERF_OUTPUT_FILE="$2"; shift;;
+  --run-compatibility-test) COMPATIBILITY_BRANCH="$2"; shift;;
+  --metrics-mode) METRICS_MODE="--metrics-mode" ;;
+  --branch) BRANCH="$2"; shift;;
+  --commit) COMMIT="$2"; shift;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+if [[ "$NETWORK" != "devnet" && "$NETWORK" != "mainnet" ]]; then
+  echo "Invalid network: $NETWORK (must be devnet or mainnet)"
+  exit 1
+fi
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+export MINA_NETWORK="$NETWORK"
+export LOG_LEVEL="${LOG_LEVEL:=Info}"
+
+# Provision the binaries. Falls back to installing the debs when
+# APPS_BARE_BINARIES is not set, so this script also works in a deb-based
+# context (see restore-or-install.sh).
+./buildkite/scripts/tests/rosetta/install-debs.sh
+
+# `mina daemon` refuses to load the libp2p keypair when an ancestor directory is
+# group/world readable. The toolchain image's $HOME is 0755; the mina-rosetta
+# image ran as root with a 0700 $HOME.
+chmod 700 "${HOME}"
+
+# The network's runtime config, straight from the repo -- no config deb, no
+# download. This is what makes the daemon join ${MINA_NETWORK}.
+MINA_CONFIG_FILE="genesis_ledgers/${MINA_NETWORK}.json"
+if [[ ! -f "$MINA_CONFIG_FILE" ]]; then
+  echo "Genesis ledger ${MINA_CONFIG_FILE} not found; run this from the repo root."
+  exit 1
+fi
+MINA_CONFIG_FILE="$(realpath "$MINA_CONFIG_FILE")"
+export MINA_CONFIG_FILE
+
+# Postgres
+POSTGRES_VERSION=$(psql -V | cut -d " " -f 3 | sed 's/.[[:digit:]]*$//g')
+export POSTGRES_VERSION
+export POSTGRES_USERNAME=${POSTGRES_USERNAME:=pguser}
+export POSTGRES_DBNAME=${POSTGRES_DBNAME:=archive}
+export POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:=/data/postgresql}
+export PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:5432/${POSTGRES_DBNAME}
+
+# Ports, matching src/app/rosetta/scripts/docker-start.sh so the assertions and
+# the rosetta-cli/sanity defaults keep working unchanged.
+export MINA_GRAPHQL_PORT=${MINA_GRAPHQL_PORT:=3085}
+export MINA_ARCHIVE_PORT=${MINA_ARCHIVE_PORT:=3086}
+export MINA_ROSETTA_ONLINE_PORT=${MINA_ROSETTA_ONLINE_PORT:=3087}
+export MINA_ROSETTA_OFFLINE_PORT=${MINA_ROSETTA_OFFLINE_PORT:=3088}
+
+export MINA_LIBP2P_HELPER_PATH=/usr/local/bin/libp2p_helper
+export MINA_LIBP2P_KEYPAIR_PATH="${MINA_LIBP2P_KEYPAIR_PATH:=$HOME/libp2p-keypair}"
+export MINA_LIBP2P_PASS=${MINA_LIBP2P_PASS:=''}
+export MINA_CONFIG_DIR="${MINA_CONFIG_DIR:=$HOME/.mina-config}"
+export PEER_LIST_URL=${PEER_LIST_URL:=https://storage.googleapis.com/seed-lists/${MINA_NETWORK}_seeds.txt}
+
+COLLECT_LOGS_DONE=0
+collect_logs() {
+  [ "$COLLECT_LOGS_DONE" = "1" ] && return 0
+  COLLECT_LOGS_DONE=1
+
+  echo "========================= COLLECTING LOGS ==========================="
+  mkdir -p test_output/artifacts
+
+  mina client status --json >test_output/artifacts/daemon-status.json 2>/dev/null \
+    || echo "Could not get daemon status" >test_output/artifacts/daemon-status.json
+
+  if [ -n "${DAEMON_PID:-}" ] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "Stopping daemon gracefully..."
+    if ! mina client stop-daemon 2>/dev/null; then
+      kill -TERM "$DAEMON_PID"
+      sleep 2
+    fi
+  fi
+
+  cp daemon-stdout.log daemon-stderr.log archive.log rosetta.log test_output/artifacts/ 2>/dev/null || true
+  cp -r "${MINA_CONFIG_DIR}" test_output/artifacts/mina-config 2>/dev/null || true
+
+  echo "Logs collected in test_output/artifacts/"
+}
+
+cleanup() {
+  local exit_code=$?
+  # Only collect logs on failure, as the docker-based script did.
+  if [[ $exit_code -ne 0 ]]; then
+    collect_logs
+  fi
+  exit $exit_code
+}
+trap cleanup EXIT
+
+echo "========================= INITIALIZING POSTGRESQL ==========================="
+# Cluster ops need root in the toolchain runner (the rosetta image ran as root).
+sudo pg_ctlcluster "${POSTGRES_VERSION}" main start || true
+sudo pg_dropcluster --stop "${POSTGRES_VERSION}" main || true
+sudo mkdir -p "${POSTGRES_DATA_DIR}"
+sudo chown postgres:postgres "${POSTGRES_DATA_DIR}"
+sudo pg_createcluster --start -d "${POSTGRES_DATA_DIR}" \
+  --createclusterconf ./src/app/rosetta/scripts/postgresql.conf "${POSTGRES_VERSION}" main
+sudo -u postgres psql --command "CREATE USER ${POSTGRES_USERNAME} WITH SUPERUSER PASSWORD '${POSTGRES_USERNAME}';"
+sudo -u postgres createdb -O "${POSTGRES_USERNAME}" "${POSTGRES_DBNAME}"
+psql -f ./src/app/archive/create_schema.sql "${PG_CONN}"
+
+echo "=========================== STARTING ROSETTA API ONLINE AND OFFLINE INSTANCES ==========================="
+for port in "$MINA_ROSETTA_ONLINE_PORT" "$MINA_ROSETTA_OFFLINE_PORT"; do
+  mina-rosetta \
+    --archive-uri "${PG_CONN}" \
+    --graphql-uri "http://127.0.0.1:${MINA_GRAPHQL_PORT}/graphql" \
+    --log-level "${LOG_LEVEL}" \
+    --port "${port}" >>rosetta.log 2>&1 &
+  sleep 5
+done
+
+echo "========================= STARTING ARCHIVE NODE on PORT ${MINA_ARCHIVE_PORT} ==========================="
+mina-archive run \
+  --postgres-uri "${PG_CONN}" \
+  --log-level "${LOG_LEVEL}" \
+  --server-port "${MINA_ARCHIVE_PORT}" >>archive.log 2>&1 &
+sleep 5
+
+echo "=========================== GENERATING KEYPAIR IN ${MINA_LIBP2P_KEYPAIR_PATH} ==========================="
+mina libp2p generate-keypair -privkey-path "${MINA_LIBP2P_KEYPAIR_PATH}"
+
+echo "========================= STARTING DAEMON connected to ${MINA_NETWORK} ==========================="
+mina daemon \
+  --config-file "${MINA_CONFIG_FILE}" \
+  --config-dir "${MINA_CONFIG_DIR}" \
+  --libp2p-keypair "${MINA_LIBP2P_KEYPAIR_PATH}" \
+  --peer-list-url "${PEER_LIST_URL}" \
+  --rest-port "${MINA_GRAPHQL_PORT}" \
+  -archive-address "127.0.0.1:${MINA_ARCHIVE_PORT}" \
+  -insecure-rest-server \
+  --log-level "${LOG_LEVEL}" \
+  >daemon-stdout.log 2>daemon-stderr.log &
+DAEMON_PID=$!
+echo "Daemon started with PID: ${DAEMON_PID}"
+
+sleep 30
+if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+  echo -e "${RED}Mina daemon failed to start${CLEAR}"
+  exit 1
+fi
+
+# Wait for new blocks to land in the archive database.
+wait_for_new_blocks() {
+  local previous_blocks=$1
+  local test_name=$2
+  local timeout_counter=0
+
+  echo "Waiting for new blocks after $test_name..."
+  while [[ $timeout_counter -lt $NEW_BLOCK_TIMEOUT ]]; do
+    current_blocks=$(psql "$PG_CONN" -t -c 'SELECT COUNT(*) FROM blocks;' | tr -d ' ')
+    if [[ "$current_blocks" -gt "$previous_blocks" ]]; then
+      echo -e "${GREEN}New blocks detected after $test_name. Test passed.${CLEAR}"
+      return 0
+    fi
+    sleep 10
+    timeout_counter=$((timeout_counter + 10))
+  done
+
+  echo -e "${RED}Timeout waiting for new blocks after $test_name. Test failed.${CLEAR}"
+  exit 1
+}
+
+execute_script() {
+  local script_path=$1
+  local script_name=$2
+
+  if psql "$PG_CONN" -f "$script_path"; then
+    echo "$script_name completed successfully."
+  else
+    echo -e "${RED}$script_name failed.${CLEAR}"
+    exit 1
+  fi
+}
+
+echo "========================= ROSETTA SANITY TEST ==========================="
+./scripts/tests/rosetta-sanity.sh \
+  --address "http://localhost:${MINA_ROSETTA_ONLINE_PORT}" \
+  --daemon-graphql-address "http://localhost:${MINA_GRAPHQL_PORT}/graphql" \
+  --network "$MINA_NETWORK" \
+  --wait-for-sync \
+  --timeout "$SYNC_TIMEOUT"
+
+if [[ "$RUN_LOAD_TEST" == true ]]; then
+  echo "========================= ROSETTA LOAD TEST ==========================="
+  # Runs in this shell rather than through `docker exec`; its pgrep/ps memory
+  # sampling now sees the archive and rosetta processes directly.
+  load_test_args=(
+    --address "http://localhost:${MINA_ROSETTA_ONLINE_PORT}"
+    --db-conn-str "$PG_CONN"
+    --duration "$LOAD_TEST_DURATION"
+    --network "$MINA_NETWORK"
+    --perf-output-file "$PERF_OUTPUT_FILE"
+  )
+  [[ -n "$METRICS_MODE" ]] && load_test_args+=("$METRICS_MODE")
+  [[ -n "$BRANCH" ]] && load_test_args+=(--branch "$BRANCH")
+  [[ -n "$COMMIT" ]] && load_test_args+=(--commit "$COMMIT")
+
+  if ./scripts/tests/rosetta-load.sh "${load_test_args[@]}"; then
+    echo -e "${GREEN}Load test completed successfully.${CLEAR}"
+  else
+    echo -e "${RED}Load test failed.${CLEAR}"
+    exit 1
+  fi
+else
+  echo "Skipping load test."
+fi
+
+if [[ -n "$COMPATIBILITY_BRANCH" ]]; then
+  echo "========================= SCHEMA COMPATIBILITY TEST ==========================="
+  echo "Running compatibility test with branch: $COMPATIBILITY_BRANCH"
+
+  # In-repo copies of what the image shipped under /etc/mina/archive.
+  upgrade_script_path="./src/app/archive/upgrade_to_mesa.sql"
+  rollback_script_path="./src/app/archive/downgrade_to_berkeley.sql"
+
+  initial_blocks=$(psql "$PG_CONN" -t -c 'SELECT COUNT(*) FROM blocks;' | tr -d ' ')
+
+  echo "Test 1: Running double upgrade test..."
+  execute_script "$upgrade_script_path" "First upgrade"
+  execute_script "$upgrade_script_path" "Second upgrade (should handle already upgraded state)"
+  wait_for_new_blocks "$initial_blocks" "double upgrade"
+
+  echo "Test 2: Running rollback and upgrade test..."
+  execute_script "$rollback_script_path" "Rollback"
+  rollback_blocks=$(psql "$PG_CONN" -t -c 'SELECT COUNT(*) FROM blocks;' | tr -d ' ')
+  execute_script "$upgrade_script_path" "Upgrade after rollback"
+  wait_for_new_blocks "$rollback_blocks" "rollback and upgrade"
+
+  echo "Test 3: Running second rollback and upgrade test..."
+  execute_script "$rollback_script_path" "Second rollback"
+  second_rollback_blocks=$(psql "$PG_CONN" -t -c 'SELECT COUNT(*) FROM blocks;' | tr -d ' ')
+  execute_script "$upgrade_script_path" "Second upgrade after rollback"
+  wait_for_new_blocks "$second_rollback_blocks" "second rollback and upgrade"
+
+  echo -e "${GREEN}All compatibility tests completed successfully.${CLEAR}"
+else
+  echo "Skipping compatibility test."
+fi
+
+echo -e "${GREEN}Rosetta ${MINA_NETWORK} connectivity test passed.${CLEAR}"

--- a/buildkite/scripts/tests/rosetta/install-debs.sh
+++ b/buildkite/scripts/tests/rosetta/install-debs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Installs the debian packages needed by the rosetta integration / indexer
-# tests on the host where the test script is running. Replaces the previous
-# pattern of running the tests inside the prebuilt mina-rosetta docker image.
+# Installs the debian packages needed by the rosetta integration / indexer /
+# connectivity tests on the host where the test script is running. Replaces the
+# previous pattern of running the tests inside the prebuilt mina-rosetta docker
+# image.
 #
 # Pulls the freshly-built debs out of the buildkite cache (per
 # buildkite/scripts/debian/install.sh) and installs them directly as local

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -1,5 +1,3 @@
-let Cmd = ../../Lib/Cmds.dhall
-
 let B = ../../External/Buildkite.dhall
 
 let S = ../../Lib/SelectFiles.dhall
@@ -18,13 +16,13 @@ let Size = ../../Command/Size.dhall
 
 let Network = ../../Constants/Network.dhall
 
-let Docker = ../../Constants/Docker/Package.dhall
-
 let Dockers = ../../Constants/Docker/Versions.dhall
 
-let Profiles = ../../Constants/Profiles.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let DockerRepo = ../../Constants/DockerRepo.dhall
+let Toolchain = ../../Constants/Toolchain.dhall
+
+let Profiles = ../../Constants/Profiles.dhall
 
 let Expr = ../../Pipeline/Expr.dhall
 
@@ -46,7 +44,6 @@ let Spec =
           , newBlockTimeout : Natural
           , profile : Profiles.Type
           , scope : List PipelineScope.Type
-          , repo : DockerRepo.Type
           , if_ : B/If
           , excludeIf : List Expr.Type
           , includeIf : List Expr.Type
@@ -60,7 +57,6 @@ let Spec =
           , newBlockTimeout = 600
           , profile = Profiles.Type.Devnet
           , scope = PipelineScope.Full
-          , repo = DockerRepo.Type.InternalEurope
           , includeIf = [] : List Expr.Type
           , excludeIf = [] : List Expr.Type
           , if_ =
@@ -68,23 +64,44 @@ let Spec =
           }
       }
 
+let bareBinaries =
+          "mina.exe:mina"
+      ++  ",archive.exe:mina-archive"
+      ++  ",rosetta.exe:mina-rosetta"
+      ++  ",libp2p_helper:libp2p_helper"
+
+let envExports =
+          \(spec : Spec.Type)
+      ->  [ "MINA_NETWORK_DEB=${Network.lowerName spec.network}"
+          , "MINA_DEB_CODENAME=${Dockers.lowerName spec.dockerType}"
+          , "APPS_NETWORK=${Network.lowerName spec.network}"
+          , "MINA_PROFILE=${Profiles.lowerName spec.profile}"
+          , "APPS_BARE_BINARIES=${bareBinaries}"
+          ]
+
+let connectivityScript =
+          \(spec : Spec.Type)
+      ->      "./buildkite/scripts/tests/rosetta/connectivity.sh"
+          ++  " --network ${Network.lowerName spec.network}"
+          ++  " --sync-timeout ${Natural/show spec.syncTimeout}"
+          ++  " --new-block-timeout ${Natural/show spec.newBlockTimeout}"
+          ++  " --run-compatibility-test develop"
+          ++  " --run-load-test"
+          ++  " --branch \\\${BUILDKITE_BRANCH}"
+          ++  " --commit \\\${BUILDKITE_COMMIT}"
+          ++  " --metrics-mode"
+          ++  " --perf-output-file /workdir/rosetta.perf"
+
 let command
     : Spec.Type -> Command.Type
     =     \(spec : Spec.Type)
       ->  Command.build
             Command.Config::{
             , commands =
-                  [ Cmd.chain
-                      [ "export MINA_DEB_CODENAME=${Dockers.lowerName
-                                                      spec.dockerType}"
-                      , "source ./buildkite/scripts/export-git-env-vars.sh"
-                      , "scripts/tests/rosetta-connectivity.sh --network ${Network.lowerName
-                                                                             spec.network} --tag \\\${MINA_DOCKER_TAG} --sync-timeout ${Natural/show
-                                                                                                                                          spec.syncTimeout} --new-block-timeout ${Natural/show
-                                                                                                                                                                                    spec.newBlockTimeout} --repo ${DockerRepo.show
-                                                                                                                                                                                                                     spec.repo} --run-compatibility-test develop --run-load-test --branch \\\${BUILDKITE_BRANCH} --commit \\\${BUILDKITE_COMMIT} --metrics-mode --perf-output-file /workdir/rosetta.perf"
-                      ]
-                  ]
+                  Toolchain.select
+                    Toolchain.Spec::{ debVersion = spec.dockerType }
+                    (envExports spec)
+                    (connectivityScript spec)
                 # RunInToolchain.runInDefaultToolchain
                     (Benchmarks.toEnvList Benchmarks.Type::{=})
                     "./buildkite/scripts/bench/send.sh"
@@ -97,11 +114,10 @@ let command
             , soft_fail = Some spec.softFail
             , if_ = Some spec.if_
             , depends_on =
-                Dockers.dependsOn
-                  Dockers.DepsSpec::{
-                  , codename = spec.dockerType
+                DebianVersions.appDependsOn
+                  DebianVersions.DepsSpec::{
+                  , deb_version = spec.dockerType
                   , network = spec.network
-                  , artifact = Docker.Type.Rosetta { network = spec.network }
                   , profile = spec.profile
                   }
             }
@@ -123,10 +139,12 @@ let pipeline
                   , S.exactly
                       "buildkite/src/Command/Rosetta/Connectivity"
                       "dhall"
-                  , S.exactly "scripts/tests/rosetta-connectivity" "sh"
-                  , S.exactly
-                      "buildkite/scripts/tests/rosetta/integration-tests"
-                      "sh"
+                  , S.strictlyStart
+                      (S.contains "buildkite/scripts/tests/rosetta")
+                  , S.strictlyStart (S.contains "scripts/tests/rosetta")
+                  , S.exactly "buildkite/scripts/debian/restore-or-install" "sh"
+                  , S.strictlyStart (S.contains "buildkite/scripts/apps")
+                  , S.strictlyStart (S.contains "genesis_ledgers")
                   ]
                 # spec.additionalDirtyWhen
             , path = "Test"

--- a/changes/19150.md
+++ b/changes/19150.md
@@ -1,0 +1,13 @@
+Run the rosetta connectivity tests from bare apps
+
+`RosettaDevnetConnect` and `RosettaMainnetConnect` ran the published
+`mina-rosetta` docker image, so they required both the debian and the docker
+build. They now stand the same stack up from the apps cache binaries:
+`genesis_ledgers/<network>.json` supplies the runtime config (the config deb
+copies that file verbatim) and `src/app/archive/*.sql` supplies the schema and
+the upgrade/downgrade scripts.
+
+The process layout and every assertion are unchanged — `rosetta-sanity.sh`,
+`rosetta-load.sh` and the compatibility test now run directly instead of through
+`docker exec`. `scripts/tests/rosetta-connectivity.sh` is kept for testing
+published images.

--- a/scripts/tests/ROSETTA_TESTS.md
+++ b/scripts/tests/ROSETTA_TESTS.md
@@ -236,6 +236,12 @@ The script loads realistic test data from the archive database:
 
 **Location**: `scripts/tests/rosetta-connectivity.sh`
 
+> **Note**: this script tests a *published* `mina-rosetta` image, and is kept for
+> that purpose. CI no longer uses it. `RosettaDevnetConnect` /
+> `RosettaMainnetConnect` run `buildkite/scripts/tests/rosetta/connectivity.sh`
+> instead, which stands the same stack up from bare binaries and the in-repo
+> genesis ledger — see section 5.
+
 **Key Features**:
 - **Docker Integration**: Automatically spins up Rosetta containers
 - **Network Support**: Both mainnet and devnet configurations  
@@ -288,6 +294,35 @@ The script loads realistic test data from the archive database:
 
 # Custom timeout for slow environments
 ./rosetta-connectivity.sh --tag 3.0.3-bullseye-devnet-generic --timeout 1800
+```
+
+### 5. buildkite/scripts/tests/rosetta/connectivity.sh
+
+**Purpose**: The connectivity test as CI runs it — same assertions as
+`rosetta-connectivity.sh`, but with no docker image involved.
+
+**Location**: `buildkite/scripts/tests/rosetta/connectivity.sh`
+
+Everything the `mina-rosetta` image used to supply comes from the repository or
+the CI apps cache instead:
+
+| From the image | From the repo / apps cache |
+| --- | --- |
+| `mina`, `mina-archive`, `mina-rosetta`, `libp2p_helper` | apps cache, via `buildkite/scripts/debian/restore-or-install.sh` |
+| `/var/lib/coda/<network>.json` | `genesis_ledgers/<network>.json` (the config deb copies this file verbatim) |
+| `/etc/mina/archive/create_schema.sql` | `src/app/archive/create_schema.sql` |
+| `/etc/mina/archive/{upgrade_to_mesa,downgrade_to_berkeley}.sql` | `src/app/archive/*.sql` |
+| postgres cluster baked into the image | a cluster created by the script |
+
+The process layout (rosetta online + offline, archive, daemon on localhost) is
+the one `src/app/rosetta/scripts/docker-start.sh` sets up inside the image, so
+`rosetta-sanity.sh` and `rosetta-load.sh` are called unchanged — directly,
+rather than through `docker exec`.
+
+**Usage**:
+```bash
+./buildkite/scripts/tests/rosetta/connectivity.sh --network devnet \
+  [--sync-timeout 1500] [--run-load-test] [--run-compatibility-test develop]
 ```
 
 ## Integration and Dependencies


### PR DESCRIPTION
## Why

`RosettaDevnetConnect` and `RosettaMainnetConnect` were the last two consumers of a **network-configured** production docker image (`mina-rosetta:<tag>-<network>`). To get that image, the packaging job had to build the debians *and* the docker images — which is exactly what we're trying to stop doing in PR and nightly.

## What

New `buildkite/scripts/tests/rosetta/connectivity.sh` stands the same stack up bare, and the jobs now `appDependsOn` the apps build instead of a docker step.

Everything the image supplied is reproduced from the repo or the apps cache:

| From the image | Now from |
| --- | --- |
| `mina`, `mina-archive`, `mina-rosetta`, `libp2p_helper` | apps cache, via `restore-or-install.sh` (`APPS_BARE_BINARIES`) |
| `/var/lib/coda/<network>.json` | **`genesis_ledgers/<network>.json`** — the config deb copies this file verbatim (`builder-helpers.sh`, `copy_common_daemon_configs`) |
| `/etc/mina/archive/create_schema.sql` | `src/app/archive/create_schema.sql` |
| `/etc/mina/archive/{upgrade_to_mesa,downgrade_to_berkeley}.sql` | `src/app/archive/*.sql` |
| postgres cluster baked into the image | a cluster the script creates (same `src/app/rosetta/scripts/postgresql.conf`) |

The process layout — rosetta online + offline, archive, daemon, all on localhost — is the one `src/app/rosetta/scripts/docker-start.sh` sets up inside the image, so **the assertions are unchanged**: `rosetta-sanity.sh`, `rosetta-load.sh` and the three-part upgrade/downgrade compatibility test run exactly as before, just directly instead of through `docker exec`. The load test's `pgrep`/`ps` memory sampling now sees the archive and rosetta processes without a container hop.

This follows the pattern already proven by `RosettaIntegrationTests` and `RosettaBlockRaceTest` (#19148).

## Not carried over

`mina-missing-blocks-guardian`. It backfills gaps from the precomputed-block bucket, and nothing this test asserts depends on it — the blocks it checks for are the ones the connected daemon writes as it follows the chain.

## Also

- `Connectivity.Spec` loses its now-unused `repo : DockerRepo.Type` field.
- `dirtyWhen` picks up `genesis_ledgers/`, the apps/restore scripts and the whole `buildkite/scripts/tests/rosetta` directory; the `scripts/tests/rosetta-connectivity` entry widens to the `scripts/tests/rosetta` prefix.
- `scripts/tests/rosetta-connectivity.sh` is **kept** — it tests a *published* image, which is still worth doing — with a pointer in `ROSETTA_TESTS.md` saying CI uses the bare script now.

## Verification

- `make all` in `buildkite/`: green (37 Dhall targets, 45 monorepo tests).
- Generated pipelines confirm the dependency flip: `RosettaDevnetConnect` → `_MinaArtifactBullseyeApps-build-apps`, `RosettaMainnetConnect` → `_MinaArtifactMainnetBullseyeApps-build-apps`.
- `shellcheck` clean on the new script.

Both jobs are `AllButPullRequest` / nightly-scoped, so the real proof is a nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4sFwLPykoFaZvg6fWiK8K