### PR TITLE
refactor: move zkApp and Vector Caqti helpers into archive_lib

### DIFF
--- a/maintenance/deps/baseline.json
+++ b/maintenance/deps/baseline.json
@@ -95,8 +95,8 @@
       "opam": 61
     },
     "exe:app/missing_blocks_auditor:missing_blocks_auditor": {
-      "libs": 102,
-      "opam": 36
+      "libs": 6,
+      "opam": 17
     },
     "exe:app/reformat:reformat": {
       "libs": 0,

--- a/maintenance/deps/rules.json
+++ b/maintenance/deps/rules.json
@@ -48,14 +48,14 @@
       "from": "lib:lib/mina_caqti:*",
       "to": "lib:app/*",
       "why": "The Caqti helpers must not depend on applications."
-    }
-  ],
-  "pending": [
+    },
     {
       "from": "lib:lib/mina_caqti:*",
       "to": "lib:lib/mina_base:*",
-      "why": "514 lines of Caqti helpers pull in 101 libraries for Zkapp_basic.Set_or_keep and Zkapp_basic.Or_ignore alone. Moving those four wrappers into archive_lib takes missing_blocks_auditor from 106 libraries to 5."
-    },
+      "why": "mina_caqti is a generic helper library over the Caqti bindings. Depending on the protocol stack for two variant types made every database tool carry the whole of Mina; the zkApp Set_or_keep/Or_ignore wrappers live in archive_lib instead (Zkapp_caqti)."
+    }
+  ],
+  "pending": [
     {
       "from": "exe:app/generate_keypair:*",
       "to": "lib:lib/transaction_snark:*",

--- a/src/app/archive/lib/caqti_vector.ml
+++ b/src/app/archive/lib/caqti_vector.ml
@@ -1,0 +1,100 @@
+(* caqti_vector.ml -- Caqti encoding for Pickles_types.Vector
+
+   Lives here rather than in Mina_caqti so that Mina_caqti needs no part of
+   the protocol stack: this is the only consumer, and Pickles_types brings 29
+   libraries with it. *)
+
+type (_, _, _, _) t =
+  | [] : ('elem, unit, unit, Pickles_types.Nat.z) t
+  | ( :: ) :
+      'elem Caqti_type.t * ('elem, 'fun_t, 'tup_t, 'n) t
+      -> ('elem, 'elem -> 'fun_t, 'elem * 'tup_t, 'n Pickles_types.Nat.s) t
+
+let rec vec_to_hlist :
+          'elem 'hlist 'tup 'n.
+             ('elem, 'hlist, 'tup, 'n) t
+          -> ('elem, 'n) Pickles_types.Vector.t
+          -> (unit, 'hlist) H_list.t =
+  fun (type elem hlist tup n) (spec : (elem, hlist, tup, n) t)
+      (v : (elem, n) Pickles_types.Vector.t) ->
+   match (spec, v) with
+   | [], [] ->
+       ([] : (unit, hlist) H_list.t)
+   | _ :: spec, x :: v ->
+       x :: vec_to_hlist spec v
+
+let rec hlist_to_vec :
+          'elem 'hlist 'tup 'n.
+             ('elem, 'hlist, 'tup, 'n) t
+          -> (unit, 'hlist) H_list.t
+          -> ('elem, 'n) Pickles_types.Vector.t =
+  fun (type elem hlist tup n) (spec : (elem, hlist, tup, n) t)
+      (l : (unit, hlist) H_list.t) ->
+   match (spec, l) with
+   | _ :: spec, x :: l ->
+       (x :: hlist_to_vec spec l : (elem, n) Pickles_types.Vector.t)
+   | [], [] ->
+       []
+
+module type Intf = sig
+  (** defines a function type, like ['elem -> 'elem -> ... -> 'elem -> unit] *)
+  type 'elem fun_t
+
+  (** defines a tuple type, like ['elem * 'elem * ... * 'elem * unit] *)
+  type 'elem tup_t
+
+  type n
+
+  val spec : 'elem Caqti_type.t -> ('elem, 'elem fun_t, 'elem tup_t, n) t
+
+  val type_spec :
+    'elem Caqti_type.t -> ('elem fun_t, 'elem tup_t) Mina_caqti.Type_spec.t
+end
+
+let rec spec_of_nat :
+    type n. n Plonkish_prelude.Nat.nat -> (module Intf with type n = n) =
+  function
+  | Z ->
+      let module N = struct
+        type 'elem fun_t = unit
+
+        type 'elem tup_t = unit
+
+        type n = Pickles_types.Nat.z
+
+        let spec _ = []
+
+        let type_spec _ = Mina_caqti.Type_spec.[]
+      end in
+      (module N : Intf with type n = n)
+  | S p ->
+      let (module Prev) = spec_of_nat p in
+      let module N = struct
+        type 'elem fun_t = 'elem -> 'elem Prev.fun_t
+
+        type 'elem tup_t = 'elem * 'elem Prev.tup_t
+
+        type n = Prev.n Pickles_types.Nat.s
+
+        let spec :
+            type elem. elem Caqti_type.t -> (elem, elem fun_t, elem tup_t, n) t
+            =
+         fun t -> t :: Prev.spec t
+
+        let type_spec :
+               'elem Caqti_type.t
+            -> ('elem fun_t, 'elem tup_t) Mina_caqti.Type_spec.t =
+         fun t -> t :: Prev.type_spec t
+      end in
+      (module N : Intf with type n = n)
+
+let typ :
+    type elem n.
+       elem Caqti_type.t * n Plonkish_prelude.Nat.nat
+    -> (elem, n) Pickles_types.Vector.vec Caqti_type.t =
+ fun (elem, n) ->
+  let (module M) = spec_of_nat n in
+  Mina_caqti.Type_spec.custom_type
+    ~to_hlist:(vec_to_hlist (M.spec elem))
+    ~of_hlist:(hlist_to_vec (M.spec elem))
+    (M.type_spec elem)

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -210,11 +210,11 @@ let update_of_id pool update_id =
     Set_or_keep.of_option perms_opt
   in
   let%bind zkapp_uri =
-    Mina_caqti.get_zkapp_set_or_keep zkapp_uri_id
+    Zkapp_caqti.get_zkapp_set_or_keep zkapp_uri_id
       ~f:(with_pool ~f:Processor.Zkapp_uri.load)
   in
   let%bind token_symbol =
-    Mina_caqti.get_zkapp_set_or_keep token_symbol_id
+    Zkapp_caqti.get_zkapp_set_or_keep token_symbol_id
       ~f:(with_pool ~f:Processor.Token_symbols.load)
   in
   let%bind timing =

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -433,7 +433,7 @@ module Zkapp_states_nullable = struct
         sprintf "element%d" n )
 
   let typ =
-    Mina_caqti.Vector.typ
+    Caqti_vector.typ
       (Caqti_type.(option int), Mina_base.Zkapp_state.Max_state_size.n)
 
   let table_name = "zkapp_states_nullable"
@@ -471,8 +471,7 @@ module Zkapp_states = struct
         sprintf "element%d" n )
 
   let typ =
-    Mina_caqti.Vector.typ
-      (Caqti_type.int, Mina_base.Zkapp_state.Max_state_size.n)
+    Caqti_vector.typ (Caqti_type.int, Mina_base.Zkapp_state.Max_state_size.n)
 
   let table_name = "zkapp_states"
 
@@ -505,7 +504,7 @@ module Zkapp_action_states = struct
 
   type t = (int, Len.n) Pickles_types.Vector.t
 
-  let typ = Mina_caqti.Vector.typ (Caqti_type.int, Len.n)
+  let typ = Caqti_vector.typ (Caqti_type.int, Len.n)
 
   let names =
     List.init (Pickles_types.Nat.to_int Len.n) ~f:(fun n ->
@@ -847,37 +846,37 @@ module Zkapp_updates = struct
       |> Zkapp_states_nullable.add_if_doesn't_exist (module Conn)
     in
     let%bind delegate_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Public_key.add_if_doesn't_exist (module Conn))
         update.delegate
     in
     let%bind verification_key_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Zkapp_verification_keys.add_if_doesn't_exist (module Conn))
         update.verification_key
     in
     let%bind permissions_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Zkapp_permissions.add_if_doesn't_exist (module Conn))
         update.permissions
     in
     let%bind timing_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Zkapp_timing_info.add_if_doesn't_exist (module Conn))
         update.timing
     in
     let%bind zkapp_uri_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Zkapp_uri.add_if_doesn't_exist (module Conn))
         update.zkapp_uri
     in
     let%bind token_symbol_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Token_symbols.add_if_doesn't_exist (module Conn))
         update.token_symbol
     in
     let%bind voting_for_id =
-      Mina_caqti.add_if_zkapp_set
+      Zkapp_caqti.add_if_zkapp_set
         (Voting_for.add_if_doesn't_exist (module Conn))
         update.voting_for
     in
@@ -993,17 +992,17 @@ module Zkapp_account_precondition = struct
       (acct : Zkapp_precondition.Account.t) =
     let open Deferred.Result.Let_syntax in
     let%bind balance_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_balance_bounds.add_if_doesn't_exist (module Conn))
         acct.balance
     in
     let%bind nonce_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_nonce_bounds.add_if_doesn't_exist (module Conn))
         acct.nonce
     in
     let%bind delegate_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Public_key.add_if_doesn't_exist (module Conn))
         acct.delegate
     in
@@ -1012,7 +1011,7 @@ module Zkapp_account_precondition = struct
       |> Zkapp_states_nullable.add_if_doesn't_exist (module Conn)
     in
     let%bind action_state_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_field.add_if_doesn't_exist (module Conn))
         acct.action_state
     in
@@ -1365,12 +1364,12 @@ module Zkapp_epoch_ledger = struct
       (epoch_ledger : _ Epoch_ledger.Poly.t) =
     let open Deferred.Result.Let_syntax in
     let%bind hash_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Snarked_ledger_hash.add_if_doesn't_exist (module Conn))
         epoch_ledger.hash
     in
     let%bind total_currency_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_amount_bounds.add_if_doesn't_exist (module Conn))
         epoch_ledger.total_currency
     in
@@ -1411,7 +1410,7 @@ module Zkapp_epoch_data = struct
       Zkapp_epoch_ledger.add_if_doesn't_exist (module Conn) epoch_data.ledger
     in
     let%bind epoch_length_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_length_bounds.add_if_doesn't_exist (module Conn))
         epoch_data.epoch_length
     in
@@ -1470,27 +1469,27 @@ module Zkapp_network_precondition = struct
       (ps : Mina_base.Zkapp_precondition.Protocol_state.t) =
     let open Deferred.Result.Let_syntax in
     let%bind snarked_ledger_hash_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Snarked_ledger_hash.add_if_doesn't_exist (module Conn))
         ps.snarked_ledger_hash
     in
     let%bind blockchain_length_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_length_bounds.add_if_doesn't_exist (module Conn))
         ps.blockchain_length
     in
     let%bind min_window_density_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_length_bounds.add_if_doesn't_exist (module Conn))
         ps.min_window_density
     in
     let%bind total_currency_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_amount_bounds.add_if_doesn't_exist (module Conn))
         ps.total_currency
     in
     let%bind global_slot_since_genesis =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_global_slot_bounds.add_if_doesn't_exist (module Conn))
         ps.global_slot_since_genesis
     in
@@ -1679,7 +1678,7 @@ module Zkapp_account_update_body = struct
         body.preconditions.account
     in
     let%bind zkapp_valid_while_precondition_id =
-      Mina_caqti.add_if_zkapp_check
+      Zkapp_caqti.add_if_zkapp_check
         (Zkapp_global_slot_bounds.add_if_doesn't_exist (module Conn))
         body.preconditions.valid_while
     in

--- a/src/app/archive/lib/zkapp_caqti.ml
+++ b/src/app/archive/lib/zkapp_caqti.ml
@@ -1,0 +1,33 @@
+(* zkapp_caqti.ml -- Caqti helpers for zkApp Set_or_keep / Or_ignore fields
+
+   These live here rather than in Mina_caqti so that Mina_caqti stays free of
+   Mina_base. Mina_caqti is a generic helper library over the Caqti bindings;
+   depending on Mina_base for two variant types pulled the whole protocol
+   stack into every tool that talks to the archive database. *)
+
+open Async
+open Core_kernel
+open Mina_base
+
+(* if zkApp-related item is Set, run `f` *)
+let add_if_zkapp_set (f : 'arg -> ('res, 'err) Deferred.Result.t) :
+    'arg Zkapp_basic.Set_or_keep.t -> ('res option, 'err) Deferred.Result.t =
+  Fn.compose (Mina_caqti.add_if_some f) Zkapp_basic.Set_or_keep.to_option
+
+(* if zkApp-related item is Check, run `f` *)
+let add_if_zkapp_check (f : 'arg -> ('res, 'err) Deferred.Result.t) :
+    'arg Zkapp_basic.Or_ignore.t -> ('res option, 'err) Deferred.Result.t =
+  Fn.compose (Mina_caqti.add_if_some f) Zkapp_basic.Or_ignore.to_option
+
+(** convert options to Set or Keep for zkApps-related results *)
+let get_zkapp_set_or_keep (item_opt : 'arg option)
+    ~(f : 'arg -> ('res, _) Deferred.Result.t) :
+    'res Zkapp_basic.Set_or_keep.t Deferred.t =
+  Mina_caqti.make_get_opt ~of_option:Zkapp_basic.Set_or_keep.of_option ~f
+    item_opt
+
+(** convert options to Check or Ignore for zkApps-related results *)
+let get_zkapp_or_ignore (item_opt : 'arg option)
+    ~(f : 'arg -> ('res, _) Deferred.Result.t) :
+    'res Zkapp_basic.Or_ignore.t Deferred.t =
+  Mina_caqti.make_get_opt item_opt ~of_option:Zkapp_basic.Or_ignore.of_option ~f

--- a/src/lib/mina_caqti/dune
+++ b/src/lib/mina_caqti/dune
@@ -11,7 +11,7 @@
   caqti
   async_kernel
   ;; local libraries
-  mina_base)
+  h_list)
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_custom_printf h_list.ppx))
  (instrumentation

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -2,7 +2,6 @@
 
 open Async
 open Core_kernel
-open Mina_base
 
 (* custom Caqti types for generating type annotations on queries *)
 let find_req t u s = Caqti_request.Infix.(t ->! u) s
@@ -103,101 +102,6 @@ module Type_spec = struct
     let encode t = Ok (hlist_to_tuple tys (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist tys t)) in
     Caqti_type.custom ~encode ~decode (to_rep tys)
-end
-
-module Vector = struct
-  type (_, _, _, _) t =
-    | [] : ('elem, unit, unit, Pickles_types.Nat.z) t
-    | ( :: ) :
-        'elem Caqti_type.t * ('elem, 'fun_t, 'tup_t, 'n) t
-        -> ('elem, 'elem -> 'fun_t, 'elem * 'tup_t, 'n Pickles_types.Nat.s) t
-
-  let rec vec_to_hlist :
-            'elem 'hlist 'tup 'n.
-               ('elem, 'hlist, 'tup, 'n) t
-            -> ('elem, 'n) Pickles_types.Vector.t
-            -> (unit, 'hlist) H_list.t =
-    fun (type elem hlist tup n) (spec : (elem, hlist, tup, n) t)
-        (v : (elem, n) Pickles_types.Vector.t) ->
-     match (spec, v) with
-     | [], [] ->
-         ([] : (unit, hlist) H_list.t)
-     | _ :: spec, x :: v ->
-         x :: vec_to_hlist spec v
-
-  let rec hlist_to_vec :
-            'elem 'hlist 'tup 'n.
-               ('elem, 'hlist, 'tup, 'n) t
-            -> (unit, 'hlist) H_list.t
-            -> ('elem, 'n) Pickles_types.Vector.t =
-    fun (type elem hlist tup n) (spec : (elem, hlist, tup, n) t)
-        (l : (unit, hlist) H_list.t) ->
-     match (spec, l) with
-     | _ :: spec, x :: l ->
-         (x :: hlist_to_vec spec l : (elem, n) Pickles_types.Vector.t)
-     | [], [] ->
-         []
-
-  module type Intf = sig
-    (** defines a function type, like ['elem -> 'elem -> ... -> 'elem -> unit] *)
-    type 'elem fun_t
-
-    (** defines a tuple type, like ['elem * 'elem * ... * 'elem * unit] *)
-    type 'elem tup_t
-
-    type n
-
-    val spec : 'elem Caqti_type.t -> ('elem, 'elem fun_t, 'elem tup_t, n) t
-
-    val type_spec : 'elem Caqti_type.t -> ('elem fun_t, 'elem tup_t) Type_spec.t
-  end
-
-  let rec spec_of_nat :
-      type n. n Plonkish_prelude.Nat.nat -> (module Intf with type n = n) =
-    function
-    | Z ->
-        let module N = struct
-          type 'elem fun_t = unit
-
-          type 'elem tup_t = unit
-
-          type n = Pickles_types.Nat.z
-
-          let spec _ = []
-
-          let type_spec _ = Type_spec.[]
-        end in
-        (module N : Intf with type n = n)
-    | S p ->
-        let (module Prev) = spec_of_nat p in
-        let module N = struct
-          type 'elem fun_t = 'elem -> 'elem Prev.fun_t
-
-          type 'elem tup_t = 'elem * 'elem Prev.tup_t
-
-          type n = Prev.n Pickles_types.Nat.s
-
-          let spec :
-              type elem.
-              elem Caqti_type.t -> (elem, elem fun_t, elem tup_t, n) t =
-           fun t -> t :: Prev.spec t
-
-          let type_spec :
-              'elem Caqti_type.t -> ('elem fun_t, 'elem tup_t) Type_spec.t =
-           fun t -> t :: Prev.type_spec t
-        end in
-        (module N : Intf with type n = n)
-
-  let typ :
-      type elem n.
-         elem Caqti_type.t * n Plonkish_prelude.Nat.nat
-      -> (elem, n) Pickles_types.Vector.vec Caqti_type.t =
-   fun (elem, n) ->
-    let (module M) = spec_of_nat n in
-    Type_spec.custom_type
-      ~to_hlist:(vec_to_hlist (M.spec elem))
-      ~of_hlist:(hlist_to_vec (M.spec elem))
-      (M.type_spec elem)
 end
 
 (* build coding for array type that can be interpreted as a string
@@ -331,16 +235,6 @@ let deferred_result_lift_opt :
 let add_if_some (f : 'arg -> ('res, 'err) Deferred.Result.t) :
     'arg option -> ('res option, 'err) Deferred.Result.t =
   Fn.compose deferred_result_lift_opt @@ Option.map ~f
-
-(* if zkApp-related item is Set, run `f` *)
-let add_if_zkapp_set (f : 'arg -> ('res, 'err) Deferred.Result.t) :
-    'arg Zkapp_basic.Set_or_keep.t -> ('res option, 'err) Deferred.Result.t =
-  Fn.compose (add_if_some f) Zkapp_basic.Set_or_keep.to_option
-
-(* if zkApp-related item is Check, run `f` *)
-let add_if_zkapp_check (f : 'arg -> ('res, 'err) Deferred.Result.t) :
-    'arg Zkapp_basic.Or_ignore.t -> ('res option, 'err) Deferred.Result.t =
-  Fn.compose (add_if_some f) Zkapp_basic.Or_ignore.to_option
 
 (* `select_cols ~select:"s0" ~table_name:"t0" ~cols:["col0";"col1";...] ()`
    creates the string
@@ -532,18 +426,6 @@ let make_get_opt ~of_option ~f item_opt =
             failwithf "Error querying db, error: %s" (Caqti_error.show msg) () )
   in
   of_option res_opt
-
-(** convert options to Set or Keep for zkApps-related results *)
-let get_zkapp_set_or_keep (item_opt : 'arg option)
-    ~(f : 'arg -> ('res, _) Deferred.Result.t) :
-    'res Zkapp_basic.Set_or_keep.t Deferred.t =
-  make_get_opt ~of_option:Zkapp_basic.Set_or_keep.of_option ~f item_opt
-
-(** convert options to Check or Ignore for zkApps-related results *)
-let get_zkapp_or_ignore (item_opt : 'arg option)
-    ~(f : 'arg -> ('res, _) Deferred.Result.t) :
-    'res Zkapp_basic.Or_ignore.t Deferred.t =
-  make_get_opt item_opt ~of_option:Zkapp_basic.Or_ignore.of_option ~f
 
 let get_opt_item (arg_opt : 'arg option)
     ~(f : 'arg -> ('res, _) Deferred.Result.t) : 'res option Deferred.t =


### PR DESCRIPTION
Stacked on #19153.

`src/lib/mina_caqti` is a helper library over the Caqti database bindings — 514 lines of query builders, connection pooling and type encodings. It depended on `mina_base`, and through it on **101 libraries**: the whole crypto, consensus and ledger stack.

What it used that for:

- `Zkapp_basic.Set_or_keep` and `Zkapp_basic.Or_ignore`, in four thin wrappers (8 call sites)
- `Pickles_types.Nat` / `Pickles_types.Vector`, in one `Vector` module

Both are consumed by exactly one place — the archive, which depends on `mina_base` anyway.

## Change

Two modules move from `mina_caqti` into `archive_lib`:

| new file | what it holds | consumers |
|---|---|---|
| `src/app/archive/lib/zkapp_caqti.ml` | `add_if_zkapp_set`, `add_if_zkapp_check`, `get_zkapp_set_or_keep`, `get_zkapp_or_ignore` | `processor.ml` (20), `load_data.ml` (2) |
| `src/app/archive/lib/caqti_vector.ml` | the `Vector` GADT and its Caqti encoding | `processor.ml` (3) |

`Mina_caqti.Type_spec`, which the wider tree does use (`replayer`, `extract_blocks`, `rosetta`), stays put — it needs no part of the protocol stack.

`mina_caqti` now declares `h_list` explicitly. It was already using `H_list` in `Type_spec` but reaching it transitively through `mina_base`; `h_list` is a leaf library with no dependencies of its own.

## Effect

| entrypoint | libs | opam |
|---|---|---|
| `missing_blocks_auditor` | **102 -> 6** | 36 -> 17 |

`missing_blocks_auditor` is a pure SQL tool — it opens a connection and runs five queries. It was carrying the entire protocol stack because the Caqti helper library did.

Nothing else regresses: `archive`, `replayer`, `extract_blocks`, `rosetta` and friends already depend on `mina_base` directly, so moving the modules across does not change their weight.

The `mina_caqti -> mina_base` rule moves from `pending` to `forbidden` in `maintenance/deps/rules.json`, so this cannot come back. 9 layering rules now enforced.

## Verification

- `dune build @src/check --profile=dev` — 0 errors.
- Linked: `archive.exe`, `missing_blocks_auditor.exe`, `replayer.exe`, `extract_blocks.exe`, `archive_blocks.exe`, `rosetta.exe`, `archive_hardfork_toolbox.exe`, `dump_slot_ledger.exe`.
- `dune build @fmt` clean.
- `make check-deps` green against the re-pinned baseline.

No behaviour change — the four functions and the `Vector` encoding are moved verbatim, with `Type_spec` references qualified as `Mina_caqti.Type_spec`.
