### PR TITLE
refactor: split keypair commands and libp2p secret into sublibraries

### DIFF
--- a/maintenance/deps/baseline.json
+++ b/maintenance/deps/baseline.json
@@ -7,7 +7,7 @@
   ],
   "entrypoints": {
     "exe:app/archive:archive": {
-      "libs": 184,
+      "libs": 185,
       "opam": 52
     },
     "exe:app/archive_blocks:archive_blocks": {
@@ -15,11 +15,11 @@
       "opam": 48
     },
     "exe:app/archive_hardfork_toolbox:archive_hardfork_toolbox": {
-      "libs": 183,
+      "libs": 184,
       "opam": 52
     },
     "exe:app/batch_txn_tool:batch_txn_tool": {
-      "libs": 231,
+      "libs": 232,
       "opam": 61
     },
     "exe:app/benchmarks:benchmarks": {
@@ -27,19 +27,19 @@
       "opam": 33
     },
     "exe:app/best_tip_merger:best_tip_merger": {
-      "libs": 175,
+      "libs": 176,
       "opam": 50
     },
     "exe:app/cli/src:mina": {
-      "libs": 248,
+      "libs": 250,
       "opam": 66
     },
     "exe:app/cli/src:mina_mainnet_signatures": {
-      "libs": 249,
+      "libs": 251,
       "opam": 66
     },
     "exe:app/cli/src:mina_testnet_signatures": {
-      "libs": 249,
+      "libs": 251,
       "opam": 66
     },
     "exe:app/coverage_utils/display_summary:main": {
@@ -47,7 +47,7 @@
       "opam": 3
     },
     "exe:app/delegation_verify:delegation_verify": {
-      "libs": 195,
+      "libs": 196,
       "opam": 51
     },
     "exe:app/disk_caching_stats:disk_caching_stats": {
@@ -59,7 +59,7 @@
       "opam": 46
     },
     "exe:app/dump_slot_ledger:dump_slot_ledger": {
-      "libs": 176,
+      "libs": 177,
       "opam": 52
     },
     "exe:app/extract_blocks:extract_blocks": {
@@ -67,11 +67,11 @@
       "opam": 48
     },
     "exe:app/generate_keypair:generate_keypair": {
-      "libs": 176,
-      "opam": 50
+      "libs": 106,
+      "opam": 36
     },
     "exe:app/graphql_schema_dump:graphql_schema_dump": {
-      "libs": 229,
+      "libs": 230,
       "opam": 61
     },
     "exe:app/heap_usage:heap_usage": {
@@ -87,11 +87,11 @@
       "opam": 15
     },
     "exe:app/mina_graphql_client:mina_graphql_client_app": {
-      "libs": 231,
+      "libs": 232,
       "opam": 61
     },
     "exe:app/mina_healthcheck:mina_healthcheck": {
-      "libs": 232,
+      "libs": 233,
       "opam": 61
     },
     "exe:app/missing_blocks_auditor:missing_blocks_auditor": {
@@ -103,7 +103,7 @@
       "opam": 6
     },
     "exe:app/replayer:replayer": {
-      "libs": 182,
+      "libs": 183,
       "opam": 52
     },
     "exe:app/rocksdb-scanner:rocksdb_scanner": {
@@ -111,47 +111,47 @@
       "opam": 11
     },
     "exe:app/rosetta/ocaml-signer:signer": {
-      "libs": 202,
+      "libs": 203,
       "opam": 55
     },
     "exe:app/rosetta/ocaml-signer:signer_mainnet_signatures": {
-      "libs": 202,
+      "libs": 203,
       "opam": 55
     },
     "exe:app/rosetta/ocaml-signer:signer_testnet_signatures": {
-      "libs": 202,
+      "libs": 203,
       "opam": 55
     },
     "exe:app/rosetta:rosetta": {
-      "libs": 200,
+      "libs": 201,
       "opam": 55
     },
     "exe:app/rosetta:rosetta_mainnet_signatures": {
-      "libs": 201,
+      "libs": 202,
       "opam": 55
     },
     "exe:app/rosetta:rosetta_testnet_signatures": {
-      "libs": 201,
+      "libs": 202,
       "opam": 55
     },
     "exe:app/runtime_genesis_ledger:runtime_genesis_ledger": {
-      "libs": 180,
+      "libs": 181,
       "opam": 50
     },
     "exe:app/test_executive:test_executive": {
-      "libs": 235,
+      "libs": 236,
       "opam": 62
     },
     "exe:app/validate_keypair:validate_keypair": {
-      "libs": 176,
-      "opam": 50
+      "libs": 106,
+      "opam": 36
     },
     "exe:app/zkapp_limits:zkapp_limits": {
       "libs": 101,
       "opam": 30
     },
     "exe:app/zkapp_test_transaction:zkapp_test_transaction": {
-      "libs": 230,
+      "libs": 231,
       "opam": 61
     },
     "exe:lib/blockchain_snark/tests/print_blockchain_snark_vk:print_blockchain_snark_vk": {
@@ -211,7 +211,7 @@
       "opam": 4
     },
     "exe:lib/snark_worker/standalone:run_snark_worker": {
-      "libs": 229,
+      "libs": 230,
       "opam": 61
     },
     "exe:lib/transaction_snark/test/print_transaction_snark_vk:print_transaction_snark_vk": {
@@ -223,11 +223,11 @@
       "opam": 40
     },
     "exe:test/archive/patch_archive_test:patch_archive_test": {
-      "libs": 246,
+      "libs": 248,
       "opam": 65
     },
     "exe:test/command_line_tests:command_line_tests": {
-      "libs": 248,
+      "libs": 250,
       "opam": 65
     },
     "exe:test/node_status_mock_server:node_status_mock_server": {

--- a/maintenance/deps/rules.json
+++ b/maintenance/deps/rules.json
@@ -53,23 +53,22 @@
       "from": "lib:lib/mina_caqti:*",
       "to": "lib:lib/mina_base:*",
       "why": "mina_caqti is a generic helper library over the Caqti bindings. Depending on the protocol stack for two variant types made every database tool carry the whole of Mina; the zkApp Set_or_keep/Or_ignore wrappers live in archive_lib instead (Zkapp_caqti)."
-    }
-  ],
-  "pending": [
+    },
     {
       "from": "exe:app/generate_keypair:*",
       "to": "lib:lib/transaction_snark:*",
-      "why": "generate_keypair uses one symbol from cli_lib (Cli_lib.Commands.generate_keypair) and pays 176 libraries for it. Splitting the keypair commands out of cli_lib would make this a bare binary."
+      "why": "mina-generate-keypair writes a keypair file. It has no business linking the transaction SNARK; the commands live in cli_lib.keypair so it does not pull the rest of cli_lib."
     },
     {
       "from": "exe:app/validate_keypair:*",
       "to": "lib:lib/transaction_snark:*",
-      "why": "Same as generate_keypair: one symbol from cli_lib, 176 libraries of cost."
+      "why": "mina-validate-keypair signs and verifies one dummy transaction. It needs mina_base and snark_params, but not the proof system."
     },
     {
       "from": "lib:lib/genesis_ledger_helper:*",
       "to": "lib:lib/cli_lib:*",
-      "why": "genesis_ledger_helper never references Cli_lib, but the edge drags the daemon CLI into the whole archive toolchain."
+      "why": "genesis_ledger_helper never referenced Cli_lib; the edge dragged the daemon CLI into the whole archive toolchain."
     }
-  ]
+  ],
+  "pending": []
 }

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -35,6 +35,7 @@
   cache_dir
   parallel
   secrets
+  secrets.libp2p
   logger
   mina_lib
   currency

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -737,7 +737,7 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
               | None ->
                   return None
               | Some s ->
-                  Secrets.Libp2p_keypair.Terminal_stdin.read_exn
+                  Secrets_libp2p.Libp2p_keypair.Terminal_stdin.read_exn
                     ~should_prompt_user:false ~which:"libp2p keypair" s
                   |> Deferred.map ~f:Option.some )
         in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1658,7 +1658,8 @@ let generate_libp2p_keypair_do privkey_path =
             let%bind me = Mina_net2.generate_random_keypair net in
             let%bind () = Mina_net2.shutdown net in
             let%map () =
-              Secrets.Libp2p_keypair.Terminal_stdin.write_exn ~privkey_path me
+              Secrets_libp2p.Libp2p_keypair.Terminal_stdin.write_exn
+                ~privkey_path me
             in
             printf "libp2p keypair:\n%s\n" (Mina_net2.Keypair.to_string me)
         | Error e ->
@@ -1689,7 +1690,7 @@ let dump_libp2p_keypair_do privkey_path =
         with
         | Ok net ->
             let%bind () = Mina_net2.shutdown net in
-            let%map me = Secrets.Libp2p_keypair.read_exn' privkey_path in
+            let%map me = Secrets_libp2p.Libp2p_keypair.read_exn' privkey_path in
             printf "libp2p keypair:\n%s\n" (Mina_net2.Keypair.to_string me)
         | Error e ->
             [%log fatal] "failed to dump libp2p keypair: $error"

--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -95,6 +95,7 @@
   daemon_rpcs
   trust_system
   secrets
+  secrets.libp2p
   participating_state
   staged_ledger
   mina_commands

--- a/src/app/generate_keypair/dune
+++ b/src/app/generate_keypair/dune
@@ -3,7 +3,7 @@
  (name generate_keypair)
  (public_name mina-generate-keypair)
  (modes native)
- (libraries async async_unix cli_lib core_kernel mina_version)
+ (libraries async async_unix cli_lib.keypair core_kernel mina_version)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/generate_keypair/generate_keypair.ml
+++ b/src/app/generate_keypair/generate_keypair.ml
@@ -11,4 +11,4 @@ let () =
   | [| _generate_keypair_exe; version |] when is_version_cmd version ->
       Mina_version.print_version ()
   | _ ->
-      Command.run Cli_lib.Commands.generate_keypair
+      Command.run Cli_lib_keypair.Commands.generate_keypair

--- a/src/app/validate_keypair/dune
+++ b/src/app/validate_keypair/dune
@@ -11,7 +11,7 @@
   ;; local libraries
   mina_version
   mina_stdlib
-  cli_lib)
+  cli_lib.keypair)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/validate_keypair/validate_keypair.ml
+++ b/src/app/validate_keypair/validate_keypair.ml
@@ -11,4 +11,4 @@ let () =
   | [| _generate_keypair_exe; version |] when is_version_cmd version ->
       Mina_version.print_version ()
   | _ ->
-      Command.run Cli_lib.Commands.validate_keypair
+      Command.run Cli_lib_keypair.Commands.validate_keypair

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -6,21 +6,9 @@ module Streams = Stream
 open Core_kernel
 open Async
 
-let generate_keypair =
-  Command.async ~summary:"Generate a new public, private keypair"
-    (let%map_open.Command privkey_path = Flag.privkey_write_path in
-     Exceptions.handle_nicely
-     @@ fun () ->
-     let env = Secrets.Keypair.env in
-     if Option.is_some (Sys.getenv env) then
-       eprintf "Using password from environment variable %s\n" env ;
-     let kp = Keypair.create () in
-     let%bind () = Secrets.Keypair.Terminal_stdin.write_exn kp ~privkey_path in
-     printf "Keypair generated\nPublic key: %s\nRaw public key: %s\n"
-       ( kp.public_key |> Public_key.compress
-       |> Public_key.Compressed.to_base58_check )
-       (Rosetta_coding.Coding.of_public_key kp.public_key) ;
-     exit 0 )
+let generate_keypair = Cli_lib_keypair.Commands.generate_keypair
+
+let validate_keypair = Cli_lib_keypair.Commands.validate_keypair
 
 let balance =
   Command.Arg_type.map Command.Param.string
@@ -65,80 +53,6 @@ let generate_test_ledger =
     in
     Yojson.Safe.pretty_print Format.std_formatter
     @@ Runtime_config.Json_layout.Accounts.to_yojson ledger ;
-    exit 0)
-
-let validate_keypair =
-  Command.async ~summary:"Validate a public, private keypair"
-    (let open Command.Let_syntax in
-    let open Core_kernel in
-    let%map_open privkey_path = Flag.privkey_write_path
-    and signature_kind = Flag.signature_kind in
-    Exceptions.handle_nicely
-    @@ fun () ->
-    let read_pk () =
-      let pubkey_path = privkey_path ^ ".pub" in
-      try
-        In_channel.with_file pubkey_path ~f:(fun in_channel ->
-            match In_channel.input_line in_channel with
-            | Some line -> (
-                try Public_key.Compressed.of_base58_check_exn line
-                with _exn ->
-                  eprintf
-                    "Could not create public key in file %s from text: %s\n"
-                    pubkey_path line ;
-                  exit 1 )
-            | None ->
-                eprintf "No public key found in file %s\n" pubkey_path ;
-                exit 1 )
-      with exn ->
-        eprintf "Could not read public key file %s, error: %s\n" pubkey_path
-          (Exn.to_string exn) ;
-        exit 1
-    in
-    let compare_public_keys ~pk_from_disk ~pk_from_keypair =
-      if Public_key.Compressed.equal pk_from_disk pk_from_keypair then
-        printf "Public key on-disk is derivable from private key\n"
-      else (
-        eprintf
-          "Public key read from disk %s different than public key %s derived \
-           from private key\n"
-          (Public_key.Compressed.to_base58_check pk_from_disk)
-          (Public_key.Compressed.to_base58_check pk_from_keypair) ;
-        exit 1 )
-    in
-    let validate_transaction keypair =
-      let dummy_payload = Mina_base.Signed_command_payload.dummy in
-      let signature =
-        Mina_base.Signed_command.sign_payload ~signature_kind
-          keypair.Keypair.private_key dummy_payload
-      in
-      let message = Mina_base.Signed_command.to_input_legacy dummy_payload in
-      let verified =
-        Schnorr.Legacy.verify ~signature_kind signature
-          (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
-          message
-      in
-      if verified then printf "Verified a transaction using specified keypair\n"
-      else (
-        eprintf "Failed to verify a transaction using the specific keypair\n" ;
-        exit 1 )
-    in
-    let open Deferred.Let_syntax in
-    let%bind () =
-      let password =
-        lazy (Secrets.Keypair.Terminal_stdin.prompt_password "Enter password: ")
-      in
-      match%map Secrets.Keypair.read ~privkey_path ~password with
-      | Ok keypair ->
-          let pk_from_disk = read_pk () in
-          compare_public_keys ~pk_from_disk
-            ~pk_from_keypair:(keypair.public_key |> Public_key.compress) ;
-          validate_transaction keypair
-      | Error err ->
-          eprintf "Could not read the specified keypair: %s\n"
-            (Secrets.Privkey_error.to_string err) ;
-          exit 1
-    in
     exit 0)
 
 let validate_transaction =

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -25,6 +25,7 @@
   bin_prot.shape
   stdio
   ;; local libraries
+  cli_lib.keypair
   genesis_constants
   random_oracle
   pickles

--- a/src/lib/cli_lib/exceptions.ml
+++ b/src/lib/cli_lib/exceptions.ml
@@ -1,10 +1,3 @@
-open Core_kernel
-open Async
-
-let handle_nicely (type a) (f : unit -> a Deferred.t) () : a Deferred.t =
-  match%bind Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true f with
-  | Ok e ->
-      return e
-  | Error e ->
-      eprintf "Error: %s" (Error.to_string_hum e) ;
-      exit 4
+(* Re-exported from cli_lib.keypair, which the standalone keypair
+   executables link without the rest of cli_lib. *)
+include Cli_lib_keypair.Exceptions

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -17,11 +17,7 @@ let performance =
         "Include performance histograms in status output (default: don't \
          include)")
 
-let privkey_write_path =
-  let open Command.Param in
-  flag "--privkey-path" ~aliases:[ "privkey-path" ]
-    ~doc:"FILE File to write private key into (public key will be FILE.pub)"
-    (required string)
+let privkey_write_path = Cli_lib_keypair.Flag.privkey_write_path
 
 let privkey_read_path =
   let open Command.Param in
@@ -452,20 +448,4 @@ module Signed_command = struct
       (optional string)
 end
 
-let signature_kind =
-  let open Command.Param in
-  let arg_type =
-    Command.Arg_type.create (fun s ->
-        match String.lowercase s with
-        | "mainnet" ->
-            Mina_signature_kind.Mainnet
-        | "testnet" ->
-            Mina_signature_kind.Testnet
-        | other ->
-            Mina_signature_kind.Other_network other )
-  in
-  flag "--signature-kind"
-    ~doc:
-      "mainnet|testnet|<other> Signature kind to use (default: value compiled \
-       into this binary)"
-    (optional_with_default Mina_signature_kind.t_DEPRECATED arg_type)
+let signature_kind = Cli_lib_keypair.Flag.signature_kind

--- a/src/lib/cli_lib/keypair/commands.ml
+++ b/src/lib/cli_lib/keypair/commands.ml
@@ -1,0 +1,99 @@
+(* keypair.ml -- the generate-keypair and validate-keypair commands
+
+   These live in their own library so that mina-generate-keypair and
+   mina-validate-keypair do not have to link the whole of cli_lib, which
+   carries the daemon's RPC, GraphQL and gossip surface with it. *)
+
+open Signature_lib
+open Core_kernel
+open Async
+
+let generate_keypair =
+  Command.async ~summary:"Generate a new public, private keypair"
+    (let%map_open.Command privkey_path = Flag.privkey_write_path in
+     Exceptions.handle_nicely
+     @@ fun () ->
+     let env = Secrets.Keypair.env in
+     if Option.is_some (Sys.getenv env) then
+       eprintf "Using password from environment variable %s\n" env ;
+     let kp = Keypair.create () in
+     let%bind () = Secrets.Keypair.Terminal_stdin.write_exn kp ~privkey_path in
+     printf "Keypair generated\nPublic key: %s\nRaw public key: %s\n"
+       ( kp.public_key |> Public_key.compress
+       |> Public_key.Compressed.to_base58_check )
+       (Rosetta_coding.Coding.of_public_key kp.public_key) ;
+     exit 0 )
+
+let validate_keypair =
+  Command.async ~summary:"Validate a public, private keypair"
+    (let open Command.Let_syntax in
+    let open Core_kernel in
+    let%map_open privkey_path = Flag.privkey_write_path
+    and signature_kind = Flag.signature_kind in
+    Exceptions.handle_nicely
+    @@ fun () ->
+    let read_pk () =
+      let pubkey_path = privkey_path ^ ".pub" in
+      try
+        In_channel.with_file pubkey_path ~f:(fun in_channel ->
+            match In_channel.input_line in_channel with
+            | Some line -> (
+                try Public_key.Compressed.of_base58_check_exn line
+                with _exn ->
+                  eprintf
+                    "Could not create public key in file %s from text: %s\n"
+                    pubkey_path line ;
+                  exit 1 )
+            | None ->
+                eprintf "No public key found in file %s\n" pubkey_path ;
+                exit 1 )
+      with exn ->
+        eprintf "Could not read public key file %s, error: %s\n" pubkey_path
+          (Exn.to_string exn) ;
+        exit 1
+    in
+    let compare_public_keys ~pk_from_disk ~pk_from_keypair =
+      if Public_key.Compressed.equal pk_from_disk pk_from_keypair then
+        printf "Public key on-disk is derivable from private key\n"
+      else (
+        eprintf
+          "Public key read from disk %s different than public key %s derived \
+           from private key\n"
+          (Public_key.Compressed.to_base58_check pk_from_disk)
+          (Public_key.Compressed.to_base58_check pk_from_keypair) ;
+        exit 1 )
+    in
+    let validate_transaction keypair =
+      let dummy_payload = Mina_base.Signed_command_payload.dummy in
+      let signature =
+        Mina_base.Signed_command.sign_payload ~signature_kind
+          keypair.Keypair.private_key dummy_payload
+      in
+      let message = Mina_base.Signed_command.to_input_legacy dummy_payload in
+      let verified =
+        Schnorr.Legacy.verify ~signature_kind signature
+          (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
+          message
+      in
+      if verified then printf "Verified a transaction using specified keypair\n"
+      else (
+        eprintf "Failed to verify a transaction using the specific keypair\n" ;
+        exit 1 )
+    in
+    let open Deferred.Let_syntax in
+    let%bind () =
+      let password =
+        lazy (Secrets.Keypair.Terminal_stdin.prompt_password "Enter password: ")
+      in
+      match%map Secrets.Keypair.read ~privkey_path ~password with
+      | Ok keypair ->
+          let pk_from_disk = read_pk () in
+          compare_public_keys ~pk_from_disk
+            ~pk_from_keypair:(keypair.public_key |> Public_key.compress) ;
+          validate_transaction keypair
+      | Error err ->
+          eprintf "Could not read the specified keypair: %s\n"
+            (Secrets.Privkey_error.to_string err) ;
+          exit 1
+    in
+    exit 0)

--- a/src/lib/cli_lib/keypair/dune
+++ b/src/lib/cli_lib/keypair/dune
@@ -1,0 +1,20 @@
+(library
+ (name cli_lib_keypair)
+ (public_name cli_lib.keypair)
+ (libraries
+  ;; opam libraries
+  async
+  core
+  core_kernel
+  ;; local libraries
+  mina_base
+  mina_signature_kind
+  rosetta_coding
+  secrets
+  signature_lib
+  snark_params)
+ (preprocess
+  (pps ppx_version ppx_jane))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "The generate-keypair and validate-keypair commands"))

--- a/src/lib/cli_lib/keypair/exceptions.ml
+++ b/src/lib/cli_lib/keypair/exceptions.ml
@@ -1,0 +1,10 @@
+open Core_kernel
+open Async
+
+let handle_nicely (type a) (f : unit -> a Deferred.t) () : a Deferred.t =
+  match%bind Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true f with
+  | Ok e ->
+      return e
+  | Error e ->
+      eprintf "Error: %s" (Error.to_string_hum e) ;
+      exit 4

--- a/src/lib/cli_lib/keypair/flag.ml
+++ b/src/lib/cli_lib/keypair/flag.ml
@@ -1,0 +1,31 @@
+(* flag.ml -- the command-line flags the keypair commands need
+
+   Kept here rather than in Cli_lib.Flag so that the keypair executables do
+   not link the daemon's flag surface. Cli_lib.Flag re-exports these. *)
+
+open Core
+open Async
+
+let privkey_write_path =
+  let open Command.Param in
+  flag "--privkey-path" ~aliases:[ "privkey-path" ]
+    ~doc:"FILE File to write private key into (public key will be FILE.pub)"
+    (required string)
+
+let signature_kind =
+  let open Command.Param in
+  let arg_type =
+    Command.Arg_type.create (fun s ->
+        match String.lowercase s with
+        | "mainnet" ->
+            Mina_signature_kind.Mainnet
+        | "testnet" ->
+            Mina_signature_kind.Testnet
+        | other ->
+            Mina_signature_kind.Other_network other )
+  in
+  flag "--signature-kind"
+    ~doc:
+      "mainnet|testnet|<other> Signature kind to use (default: value compiled \
+       into this binary)"
+    (optional_with_default Mina_signature_kind.t_DEPRECATED arg_type)

--- a/src/lib/crypto/secrets/dune
+++ b/src/lib/crypto/secrets/dune
@@ -27,7 +27,6 @@
   logger
   snark_params
   mina_stdlib
-  mina_net2
   mina_base
   base58_check
   signature_lib

--- a/src/lib/crypto/secrets/libp2p/dune
+++ b/src/lib/crypto/secrets/libp2p/dune
@@ -1,0 +1,15 @@
+(library
+ (name secrets_libp2p)
+ (public_name secrets.libp2p)
+ (libraries
+  ;; opam libraries
+  async
+  core
+  ;; local libraries
+  secrets
+  mina_net2)
+ (preprocess
+  (pps ppx_mina ppx_version ppx_jane))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Managing the libp2p keypair secret"))

--- a/src/lib/crypto/secrets/libp2p/libp2p_keypair.ml
+++ b/src/lib/crypto/secrets/libp2p/libp2p_keypair.ml
@@ -1,7 +1,8 @@
 open Core
 open Async
 open Async.Deferred.Let_syntax
-open Keypair_common
+open Secrets
+open Secrets.Keypair_common
 
 module T = struct
   type t = Mina_net2.Keypair.t


### PR DESCRIPTION
Stacked on #19154. Last in the series.

`mina-generate-keypair` writes a keypair file. It linked **176 libraries and 50 opam packages** to do it. `mina-validate-keypair` — which signs one dummy transaction and verifies the signature — linked the same.

Two independent causes, and fixing only one changes nothing, because each keeps the other's weight alive.

## 1. `cli_lib` for one symbol

Both executables call exactly one thing: `Cli_lib.Commands.generate_keypair` / `.validate_keypair`. `cli_lib` is the daemon's client library — GraphQL client, RPC surface, gossip config, Rosetta coding.

New sublibrary `cli_lib.keypair` (`src/lib/cli_lib/keypair/`) holding the two commands, the two flags they need (`privkey_write_path`, `signature_kind`), and `Exceptions`. `cli_lib` now depends on it and re-exports:

- `Cli_lib.Commands.generate_keypair` / `.validate_keypair`
- `Cli_lib.Flag.privkey_write_path` / `.signature_kind`
- `Cli_lib.Exceptions`

**No consumer changes.** `client.ml`, `mina_cli_entrypoint.ml`, `rosetta.ml` and `delegation_verify.ml` all keep calling the same paths. Only the two standalone executables point at the sublibrary directly.

## 2. `secrets` for `Mina_net2`

`secrets` (145 libraries) is the keypair-file reader. One of its modules — `libp2p_keypair.ml`, 61 lines — is the only reason it depends on `mina_net2`, and nothing inside `secrets` uses it.

Split into `secrets.libp2p`. Two call sites, both in the daemon (`client.ml`, `mina_cli_entrypoint.ml`), which links `mina_net2` regardless.

## Effect

| entrypoint | libs | opam |
|---|---|---|
| `mina-generate-keypair` | **176 -> 106** | 50 -> 36 |
| `mina-validate-keypair` | **176 -> 106** | 50 -> 36 |

Everything else moves by +1 or +2 (the daemon). That is the split itself: `cli_lib.keypair` and `secrets.libp2p` are new library *nodes*, so anything that already depended on `cli_lib` or `secrets` now counts one more library without gaining any code. The budget metric counts libraries, not bytes, and this is the one case where it reads worse than reality.

## Why not lower than 106

`validate_keypair` signs a `Signed_command` and verifies it with `Schnorr.Legacy`, so it genuinely needs `mina_base` (104 libs) and `snark_params`. Going below that means changing what the tool does, not how it is packaged. I had guessed "bare binary" earlier in this series; the measured floor is 106 while it still verifies a signature.

## Rules

All three remaining `pending` rules now hold and move to `forbidden`:

- `generate_keypair` must not reach `transaction_snark`
- `validate_keypair` must not reach `transaction_snark`
- `genesis_ledger_helper` must not reach `cli_lib` (fixed back in #19153)

12 layering rules enforced, `pending` is empty.

## Verification

- `dune build @src/check --profile=dev` — 0 errors, first attempt.
- Linked: `generate_keypair.exe`, `validate_keypair.exe`, `mina.exe`, `rosetta.exe`, `delegation_verify.exe`, `archive.exe`. `mina.exe` is the real test that the re-exports hold.
- `dune build @fmt` clean.
- `make check-deps` green.
