### PR TITLE
ci: point TestnetIntegrationTestsLong at the integration images

### DIFF
--- a/buildkite/src/Constants/IntegrationImages.dhall
+++ b/buildkite/src/Constants/IntegrationImages.dhall
@@ -1,0 +1,70 @@
+-- The docker images the local-engine integration tests run against, and the
+-- Buildkite steps that produce them.
+--
+-- Single source of truth shared by the producer (Jobs/Test/IntegrationTestDockerImages)
+-- and its consumers (Jobs/Test/TestnetIntegrationTests, ...Long). The step keys
+-- used to be spelled out as string literals on the consumer side, which is how
+-- TestnetIntegrationTestsLong ended up pointing at the packaging job's docker
+-- steps instead: nothing tied the two ends together, so they drifted.
+--
+-- Keys are derived from DockerImage.stepKey, the same function that names the
+-- producer's steps, so a rename cannot desynchronise them.
+
+let Command = ../Command/Base.dhall
+
+let DockerImage = ../Command/DockerImage.dhall
+
+let Docker = ./Docker/Package.dhall
+
+let DebianVersions = ./DebianVersions.dhall
+
+let Network = ./Network.dhall
+
+let Profiles = ./Profiles.dhall
+
+let Size = ../Command/Size.dhall
+
+let producerJob = "IntegrationTestDockerImages"
+
+let network = Network.Type.Devnet
+
+let profile = Profiles.Type.Devnet
+
+let debVersion = DebianVersions.DebVersion.Bullseye
+
+let keySpec =
+          \(service : Docker.Type)
+      ->  DockerImage.ReleaseSpec::{
+          , service = service
+          , network = network
+          , deb_codename = debVersion
+          , deb_profile = profile
+          , size = Size.XLarge
+          }
+
+let daemonService = Docker.Type.DaemonProfiled { profile = profile }
+
+let archiveService = Docker.Type.Archive { network = network }
+
+let services = [ daemonService, archiveService ]
+
+let dependsOn
+    : List Command.TaggedKey.Type
+    = [ { name = producerJob
+        , key = DockerImage.stepKey (keySpec daemonService)
+        }
+      , { name = producerJob
+        , key = DockerImage.stepKey (keySpec archiveService)
+        }
+      ]
+
+in  { producerJob = producerJob
+    , network = network
+    , profile = profile
+    , debVersion = debVersion
+    , keySpec = keySpec
+    , daemonService = daemonService
+    , archiveService = archiveService
+    , services = services
+    , dependsOn = dependsOn
+    }

--- a/buildkite/src/Jobs/Test/IntegrationTestDockerImages.dhall
+++ b/buildkite/src/Jobs/Test/IntegrationTestDockerImages.dhall
@@ -47,6 +47,8 @@ let DockerImage = ../../Command/DockerImage.dhall
 
 let DockerFromLocalDebs = ../../Command/DockerFromLocalDebs.dhall
 
+let IntegrationImages = ../../Constants/IntegrationImages.dhall
+
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let Artifacts = ../../Constants/Artifact/Artifacts.dhall
@@ -57,19 +59,15 @@ let Docker = ../../Constants/Docker/Package.dhall
 
 let BaseImage = ../../Constants/Docker/BaseImage.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profiles = ../../Constants/Profiles.dhall
-
 let Arch = ../../Constants/Arch.dhall
 
 let Size = ../../Command/Size.dhall
 
-let network = Network.Type.Devnet
+let network = IntegrationImages.network
 
-let profile = Profiles.Type.Devnet
+let profile = IntegrationImages.profile
 
-let debVersion = DebianVersions.DebVersion.Bullseye
+let debVersion = IntegrationImages.debVersion
 
 let arch = Arch.Type.Amd64
 
@@ -110,15 +108,7 @@ let archiveBuildSpec =
       , arch = arch
       }
 
-let keySpec =
-          \(service : Docker.Type)
-      ->  DockerImage.ReleaseSpec::{
-          , service = service
-          , network = network
-          , deb_codename = debVersion
-          , deb_profile = profile
-          , size = Size.XLarge
-          }
+let keySpec = IntegrationImages.keySpec
 
 let genericImage =
       DockerFromLocalDebs.Spec::{
@@ -158,11 +148,9 @@ let daemonStep =
                       [ genericImage, profiledImage ]
                   ]
             , label =
-                DockerImage.stepLabel
-                  (keySpec (Docker.Type.DaemonProfiled { profile = profile }))
+                DockerImage.stepLabel (keySpec IntegrationImages.daemonService)
             , key =
-                DockerImage.stepKey
-                  (keySpec (Docker.Type.DaemonProfiled { profile = profile }))
+                DockerImage.stepKey (keySpec IntegrationImages.daemonService)
             , target = Size.XLarge
             , depends_on = appsDep
             }
@@ -177,11 +165,8 @@ let archiveStep =
                 (ArtifactPipelines.debianTokens archiveBuildSpec)
             # [ DockerFromLocalDebs.buildImages debVersion [ archiveImage ] ]
         , label =
-            DockerImage.stepLabel
-              (keySpec (Docker.Type.Archive { network = network }))
-        , key =
-            DockerImage.stepKey
-              (keySpec (Docker.Type.Archive { network = network }))
+            DockerImage.stepLabel (keySpec IntegrationImages.archiveService)
+        , key = DockerImage.stepKey (keySpec IntegrationImages.archiveService)
         , target = Size.XLarge
         , depends_on = appsDep
         }
@@ -200,6 +185,7 @@ in  Pipeline.build
           , S.strictlyStart (S.contains "scripts/docker")
           , S.strictlyStart (S.contains "scripts/debian")
           , S.strictlyStart (S.contains "buildkite/scripts/apps")
+          , S.exactly "buildkite/src/Constants/IntegrationImages" "dhall"
           ]
         , path = "Test"
         , name = "IntegrationTestDockerImages"

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -10,17 +10,9 @@ let PipelineScope = ../../Pipeline/Scope.dhall
 
 let TestExecutive = ../../Command/TestExecutive.dhall
 
-let Command = ../../Command/Base.dhall
+let IntegrationImages = ../../Constants/IntegrationImages.dhall
 
-let dependsOn
-    : List Command.TaggedKey.Type
-    = [ { name = "IntegrationTestDockerImages"
-        , key = "daemon_profile-devnet-docker-image"
-        }
-      , { name = "IntegrationTestDockerImages"
-        , key = "archive-devnet-docker-image"
-        }
-      ]
+let dependsOn = IntegrationImages.dependsOn
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -31,6 +23,7 @@ in  Pipeline.build
           , S.strictlyStart
               (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
           , S.strictlyStart (S.contains "buildkite/src/Command/TestExecutive")
+          , S.exactly "buildkite/src/Constants/IntegrationImages" "dhall"
           , S.strictlyStart
               (S.contains "buildkite/scripts/run-test-executive-local")
           ]

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
@@ -10,24 +10,9 @@ let PipelineScope = ../../Pipeline/Scope.dhall
 
 let TestExecutive = ../../Command/TestExecutive.dhall
 
-let Dockers = ../../Constants/Docker/Versions.dhall
+let IntegrationImages = ../../Constants/IntegrationImages.dhall
 
-let Docker = ../../Constants/Docker/Package.dhall
-
-let Network = ../../Constants/Network.dhall
-
-let Profiles = ../../Constants/Profiles.dhall
-
-let dependsOn =
-        Dockers.dependsOn
-          Dockers.DepsSpec::{
-          , artifact =
-              Docker.Type.DaemonProfiled { profile = Profiles.Type.Devnet }
-          }
-      # Dockers.dependsOn
-          Dockers.DepsSpec::{
-          , artifact = Docker.Type.Archive { network = Network.Type.Devnet }
-          }
+let dependsOn = IntegrationImages.dependsOn
 
 in  Pipeline.build
       Pipeline.Config::{
@@ -38,6 +23,7 @@ in  Pipeline.build
           , S.strictlyStart
               (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
           , S.strictlyStart (S.contains "buildkite/src/Command/TestExecutive")
+          , S.exactly "buildkite/src/Constants/IntegrationImages" "dhall"
           ]
         , path = "Test"
         , name = "TestnetIntegrationTestsLong"


### PR DESCRIPTION
## Why

`TestnetIntegrationTestsLong` depended on **`MinaArtifactBullseye`'s** `daemon_profile-devnet-docker-image` and `archive-devnet-docker-image`, while its sibling `TestnetIntegrationTests` depended on **`IntegrationTestDockerImages`** for the same two images.

That made it the last consumer of packaging-built docker images outside the packaging job itself. The drift was possible because the consumer side spelled the step keys out as string literals — nothing connected them to the job that produces them.

## What

New `buildkite/src/Constants/IntegrationImages.dhall` is the single source of truth: it names the producer job, the two services, and derives the step keys from `DockerImage.stepKey` — the same function that names the producer's steps, so a rename can't desynchronise them again.

- `TestnetIntegrationTestsLong` → `IntegrationImages.dependsOn` (**the actual fix**)
- `TestnetIntegrationTests` → same, replacing its hardcoded string literals
- `IntegrationTestDockerImages` → uses `IntegrationImages.keySpec` / `.network` / `.profile` / `.debVersion` for its own step keys and labels

All three gain a `dirtyWhen` entry for the new module.

## Verification

- `make all` in `buildkite/`: green (37 Dhall targets, 45 monorepo tests), including `check_deps`.
- Generated pipelines: `TestnetIntegrationTestsLong` now depends on `_IntegrationTestDockerImages-{daemon_profile-devnet,archive-devnet}-docker-image`, identical to `TestnetIntegrationTests`.
- `TestnetIntegrationTests` and `IntegrationTestDockerImages` are **byte-identical apart from `dirtyWhen`** — the refactor changes no keys, labels, deps or commands.

## Note

`TestnetIntegrationTestsLong` is `AllButPullRequest`-scoped, so this is exercised in a nightly, not on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4sFwLPykoFaZvg6fWiK8K