### PR TITLE
Fix mina-local-network block production: seat genesis winner at index 0, emit real num_accounts

### DIFF
--- a/scripts/mina-local-network/generate-mina-local-network-ledger.py
+++ b/scripts/mina-local-network/generate-mina-local-network-ledger.py
@@ -439,13 +439,13 @@ def generate_ledger(generate_remainder,
             )
             break
     print()
-    # TODO: dynamic num_accounts
     # Write ledger and annotated ledger to disk
+    num_accounts = len(ledger)
     out_genesis_ledger_file = str(out_genesis_ledger_file)
     with open(out_genesis_ledger_file, 'w') as outfile:
         ledger_wrapper = {
             "name": "release",
-            "num_accounts": 250,
+            "num_accounts": num_accounts,
             "accounts": ledger
         }
         json.dump(ledger_wrapper, outfile, indent=1)
@@ -455,7 +455,7 @@ def generate_ledger(generate_remainder,
     with open(out_annotated_ledger_file, 'w') as outfile:
         annotated_ledger_wrapper = {
             "name": "annotated_release",
-            "num_accounts": 250,
+            "num_accounts": num_accounts,
             "accounts": ledger
         }
         json.dump(annotated_ledger_wrapper, outfile, indent=1)

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -466,7 +466,13 @@ reset-genesis-ledger() {
         "2_to_the": 2 
       },
     },
-    ledger: .
+    # The genesis winner account is prepended by the daemon and must sit at
+    # index 0: the genesis stake proof hardcodes delegator = 0. It is only
+    # added by default when proof level is Full, so ask for it explicitly.
+    ledger: (. + {
+      add_genesis_winner: true,
+      num_accounts: ((.accounts | length) + 1)
+    })
   }
   ' < "${GENESIS_LEDGER_FOLDER}/genesis_ledger.json" > "${DAEMON_CONFIG}"
 }


### PR DESCRIPTION
Supersedes #19111.

## Problem

`scripts/mina-local-network/mina-local-network.sh -c reset ...` never produces blocks. Every block-production attempt aborts with:

```
Aborting block production: cannot generate a genesis proof
  error: Sparse_ledger.get: Bad index 0. Expected a node, but got a hash at depth 4 ... 243
```

`blockchain_length` stays at 1 (genesis only).

## Root cause

Two separate problems, only one of which actually stops block production.

**1. The genesis winner is missing from the ledger (this is what breaks it).**

The genesis stake proof hardcodes `delegator = 0` and builds its witness as a sparse ledger containing only the genesis winner account (`proof_of_stake.ml:783`). The blockchain constraint then reads index **0** of that witness — so the genesis winner must be the *first* account in the genesis ledger.

The daemon prepends it only when `add_genesis_winner` is set, and that defaults to `proof_level = Full` (`genesis_ledger_helper.ml:312-318`). The local network config never sets it, and a dev binary cannot run `full` at all — `dev` compiles with `proof_level = "check"` (`node_config/profiled/dev.ml:23`), and a runtime level of `full` on a `check` build is rejected outright (`genesis_ledger_helper.ml:843-857`). So on any dev local network the winner was silently absent, and `of_ledger_subset_exn` placed its witness at the first free index instead (`mina_ledger/sparse_ledger.ml:34-43`) — hence `Bad index 0`.

**2. `num_accounts` was a lie.**

`generate-mina-local-network-ledger.py` hardcoded `"num_accounts": 250` (with a standing `# TODO: dynamic num_accounts`), and the daemon honours it by padding the genesis ledger with deterministically generated filler accounts (`genesis_ledger_helper.ml:365`).

This is what determined *which* wrong index appeared: with padding the winner landed at 243, without it at 7. Either way the genesis proof fails, so removing the padding alone does not fix block production. It is still worth fixing — 236 filler accounts is pure waste and it skews the genesis ledger hash.

(For the curious: 243 rather than 250 because `pad_to` counts each account twice, so it pads to `n - len(accounts)`. And `243 = 0b0011110011` at ledger depth 10 is exactly why the error says *"at depth 4"*.)

## Fix

- `generate-mina-local-network-ledger.py`: emit `num_accounts = len(ledger)` for both the ledger and annotated-ledger wrappers.
- `mina-local-network.sh`: request the genesis winner explicitly and account for it in the count:

```diff
-    ledger: .
+    ledger: (. + {
+      add_genesis_winner: true,
+      num_accounts: ((.accounts | length) + 1)
+    })
```

With the count correct, `pad_to` becomes a no-op, so no filler accounts are generated either way.

## Verification

Ran end-to-end on a dev build at `-pl check` (the level that actually exercises the genesis proof — `none` short-circuits to a dummy proof without running any constraints, `prover.ml:232-240`):

```
scripts/mina-local-network/mina-local-network.sh -c reset -pl check -st 20000 --redirect-logs
```

- `daemon.json`: 7 accounts, `num_accounts: 8`, `add_genesis_winner: true`.
- Both producers log `Generating genesis proof (3 / 3)` — first attempt, no retries — and proceed to produce.
- No `Bad index`, no `cannot generate a genesis proof`, no `Failed to generate genesis breadcrumb` in any node log.
- After ~8 minutes: 23 blocks produced across the two whales, and all five nodes (seed, 2 whales, fish, plain node) agree on the same best tip, which keeps advancing. `Bootstrap` appears only at startup.

## Follow-ups (deliberately not in this PR)

- `pad_to` double-counts (`genesis_ledger_helper_lib.ml:394-405`: `let count = count + 1 in ... (account :: acc, count + 1)`), so any config relying on `num_accounts` gets `n - len(accounts)` accounts instead of `n`, and configs where `len(accounts) > n/2` get no padding at all. Fixing it shifts genesis ledger hashes, so it needs its own PR and a changelog entry.
- `annotated_ledger_wrapper` writes `ledger`, not `annotated_ledger` (`generate-mina-local-network-ledger.py:459`) — the annotated file has never contained annotations.

No `src/` changes, so no changelog entry is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
