### PR TITLE
docker: create the hash tag in the registry, not from a local tag

### DIFF
--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -464,17 +464,9 @@ fi
 
 docker buildx build --load --network=host --progress=plain $PLATFORM $TARGET_ARG $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION --build-arg deb_profile="$DEB_PROFILE" --build-arg generic_network="$GENERIC_NETWORK_SEG" $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
 
-# Belt and braces, deliberately kept alongside the -t "$HASHTAG" above: the
-# buildx flag makes the hash tag part of the build's own output, so it does not
-# depend on a separate `docker tag` still holding at push time.
-#
-# In build 41899 three concurrent docker jobs each pushed $TAG fine and then died
-# on `docker push "$HASHTAG"` with "tag does not exist", i.e. the tag was gone
-# between tagging and pushing (the $TAG push takes minutes for an 8.6GB image).
-# The same code passed every docker job one build earlier (41895), so that was a
-# race or an agent-side eviction rather than the tagging being wrong -- but since
-# build.sh has no `set -e`, a lost/failed tag surfaces only as that confusing
-# push error, so having buildx name both tags is worth the redundant line.
+# Local hash tag: --save-to-ci-cache saves it, and --load-only consumers look
+# the image up by it. Also set by buildx above, and re-asserted here because the
+# local image store is not stable on agents shared between concurrent jobs.
 docker tag "$TAG" "$HASHTAG"
 
 if [[ -n "${SAVE_TO_CI_CACHE_ROOT:-}" ]]; then
@@ -502,7 +494,18 @@ fi
 
 if [[ "$DOCKER_ACTION" == "push" ]]; then
   docker push "$TAG"
-  docker push "$HASHTAG"
+
+  # The hash tag is an alias for a manifest that is now in the registry, so add
+  # it there instead of pushing the local tag again. A second `docker push`
+  # re-reads the local image store, which is not stable on agents shared between
+  # concurrent jobs, and fails with "tag does not exist" when the tag is evicted
+  # during the (multi-GB, multi-minute) push above.
+  #
+  # This publishes the hash tag as a single-entry manifest list, so it does not
+  # share a top-level digest with $TAG; both resolve to the same image, and
+  # consumers pull/run it, which handles a list transparently.
+  echo "📎 Tagging pushed image as ${HASHTAG} (registry-side)"
+  docker buildx imagetools create --tag "$HASHTAG" "$TAG"
 else
   echo "Skipping push to remote registry, image loaded to local docker daemon only."
 fi


### PR DESCRIPTION
Fixes the recurring `tag does not exist` failure, e.g. [build 41929](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/41929) (`Docker: DaemonProfiled Devnet Bullseye Devnet Instrumented`).

## The bug

`scripts/docker/build.sh` pushed two tags of the same image:

```bash
docker push "$TAG"
docker push "$HASHTAG"
```

The second push reads the image back out of the **local** daemon. That local tag kept vanishing while the first push — minutes long for a multi-GB image — was still in flight, and the job died with:

```
tag does not exist: .../mina-daemon:8cdaae8-bullseye-devnet-devnet-generic-instrumented
```

after `$TAG` had pushed fine. Four builds so far: **41899, 41914, 41916, 41929**. Agents are shared between concurrent docker jobs, so something on the host evicts images mid-build.

The previous attempt at this (adding `-t "$HASHTAG"` to the `buildx build`, develop `49c051cdbc`) did not fix it — and couldn't have. It makes the tag get *created*; the problem is it gets *taken away*.

## The fix

The hash tag is only an alias for a manifest that is already in the registry once `$TAG` is pushed. So create it there:

```bash
docker push "$TAG"
docker buildx imagetools create --tag "$HASHTAG" "$TAG"
```

Server-side manifest copy: no layer upload, no second traversal of the local image store, nothing left to race with. The local `docker tag` is still done — `--save-to-ci-cache` saves it and `--load-only` consumers look the image up by it — but nothing that talks to the registry depends on it any more.

## Verification

Reproduced the failure and the fix against a throwaway local registry, by deleting the local hash tag to simulate the eviction:

```
--- OLD behaviour: docker push $HASHTAG ---
The push refers to repository [localhost:5555/demo]
tag does not exist: localhost:5555/demo:abc1234-hash          ← exact CI error

--- NEW behaviour: registry-side imagetools create ---
#1 [internal] pushing localhost:5555/demo:abc1234-hash
#1 DONE 0.0s
```

Then confirmed the resulting tag is usable: `docker pull` + `docker run` returns the expected content, and `docker manifest inspect` succeeds.

## One behavioural difference, deliberately accepted

`imagetools create` publishes the hash tag as a **single-entry manifest list** pointing at the manifest `$TAG` resolves to, so the two tags no longer share a top-level digest (they still resolve to the same image, and the list contains that exact manifest digest).

Everything in this repo that consumes the hash tag does so through `docker pull` / `docker run` — `scripts/docker/verify.sh` (which is what `manager.sh --verify` calls), `scripts/docker/promote.sh`, `buildkite/scripts/docker/load_from_cache.sh` — all of which handle a manifest list transparently. Verified by pulling and running the list-wrapped tag above.

If anything outside this repo pins the hash tag *by digest*, that would need to be repinned; I'm not aware of anything that does.

## Also corrected

A comment claiming `build.sh has no set -e`. It does — `scripts/docker/helper.sh`, which it sources at line 17, sets `set -eox pipefail`. That mistaken belief is part of why the earlier diagnosis stopped where it did.

## Not in scope

`scripts/docker/promote.sh` does `pull` → `tag` → `push` to re-tag an image, which downloads a multi-GB image purely to create an alias and has the same class of hazard. `imagetools create` would replace all three lines. Left alone here because it is on the release-promotion path and is not currently failing — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4sFwLPykoFaZvg6fWiK8K