### PR TITLE
ci: stop building debian packages and docker images in nightly

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseye.dhall
@@ -6,6 +6,8 @@ let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let PipelineScope = ../../Pipeline/Scope.dhall
+
 let Network = ../../Constants/Network.dhall
 
 let Profile = ../../Constants/Profiles.dhall
@@ -43,5 +45,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bullseye
             ]
+          , scope = PipelineScope.AllButNightly
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumented.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumented.dhall
@@ -12,6 +12,8 @@ let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let PipelineScope = ../../Pipeline/Scope.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.packagePipeline
           ArtifactPipelines.MinaBuildSpec::{
@@ -40,5 +42,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bullseye
             ]
+          , scope = PipelineScope.AllButNightly
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseye.dhall
@@ -27,7 +27,7 @@ in  Pipeline.build
             , Artifacts.Type.Archive { network = Network.Type.Mainnet }
             , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
             ]
-          , scope = PipelineScope.AllButPullRequest
+          , scope = PipelineScope.StableAndWeekly
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactOnlyDebianBullseye.dhall
@@ -6,6 +6,8 @@ let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let PipelineScope = ../../Pipeline/Scope.dhall
+
 let DebianChannel = ../../Constants/DebianChannel.dhall
 
 let Network = ../../Constants/Network.dhall
@@ -29,5 +31,6 @@ in  Pipeline.build
           , tags = [ PipelineTag.Type.Docker ]
           , channel = DebianChannel.Type.Experimental
           , prefix = "MinaArtifactOnlyDebian"
+          , scope = PipelineScope.AllButNightly
           }
       )

--- a/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
@@ -4,6 +4,8 @@ let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let PipelineScope = ../../Pipeline/Scope.dhall
+
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let Command = ../../Command/Base.dhall
@@ -33,6 +35,7 @@ in  Pipeline.build
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
           ]
+        , scope = PipelineScope.AllButNightly
         }
       , steps =
         [ Command.build

--- a/buildkite/src/Pipeline/Scope.dhall
+++ b/buildkite/src/Pipeline/Scope.dhall
@@ -10,6 +10,13 @@
 -- Scope is used to determine which jobs should be run in the pipeline.
 -- We can see scope as specialized tag that is applied to jobs. Single job can have multiple scopes.
 -- On Pipeline top level we can filter jobs based on scope, tags and mode.
+--
+-- AllButNightly and StableAndWeekly exist for the jobs that build or test debian
+-- packages and docker images. Nightly runs with job selection Full, which
+-- bypasses dirtyWhen entirely, so a packaging job left in the Nightly scope
+-- rebuilds the whole artifact matrix every night whether or not anything about
+-- packaging changed. Everything that consumed those artifacts now takes its
+-- binaries from the app-build cache instead, so nightly no longer needs them.
 
 let Prelude = ../External/Prelude.dhall
 
@@ -56,10 +63,17 @@ let PullRequestOnly = [ Scope.PullRequest ]
 let AllButPullRequest =
       [ Scope.Nightly, Scope.MainlineNightly, Scope.Weekly, Scope.Release ]
 
+let AllButNightly =
+      [ Scope.PullRequest, Scope.MainlineNightly, Scope.Weekly, Scope.Release ]
+
+let StableAndWeekly = [ Scope.MainlineNightly, Scope.Weekly, Scope.Release ]
+
 in  { Type = Scope
     , Full = Full
     , PullRequestOnly = PullRequestOnly
     , AllButPullRequest = AllButPullRequest
+    , AllButNightly = AllButNightly
+    , StableAndWeekly = StableAndWeekly
     , capitalName = capitalName
     , lowerName = lowerName
     , join = join


### PR DESCRIPTION
## Why

Nightly uploads its pipeline with `BUILDKITE_PIPELINE_JOB_SELECTION=Full`, which bypasses `dirtyWhen` entirely — only scope and tags are honoured. So the artifact jobs rebuilt every debian package and every docker image every night, whether or not anything about packaging had changed.

Nothing in nightly consumes them any more. Every test that used to install a `.deb` now takes its binaries from the app-build cache via `appDependsOn`, and `IntegrationTestDockerImages` builds its own images from that same cache. The artifacts were being produced for nobody.

## What

Scope the four package-producing jobs out of `Nightly`:

- `MinaArtifactBullseye`, `MinaArtifactBullseyeInstrumented`, `MinaArtifactOnlyDebianBullseye` — were on the default `Scope.Full`
- `MinaArtifactMainnetBullseye` — was `AllButPullRequest`, which includes `Nightly`

…and `HardforkPackageConversion` with them. That is the one nightly-scoped job left that depends on a real `.deb`, and leaving it in would point a `depends_on` at a step nobody uploads: phase 2 of the triage only pulls a dependency in when `select_job` would reject it, which never happens in `Full` mode, so a dangling dep would not be repaired.

The **app-build jobs are untouched** — nightly still compiles and caches the binaries, which is what everything downstream actually needs.

Two scope helpers added: `AllButNightly` (Full minus Nightly) and `StableAndWeekly` (AllButPullRequest minus Nightly).

## Pull requests are unaffected

`packageDirtyWhen` already contains no `src/` entry, so on PRs these jobs only run when packaging code changes. Verified per change type by running the real triage:

| PR diff touches | artifact jobs selected |
| --- | --- |
| `src/lib/mina_lib/mina_lib.ml` | Apps only — no packaging |
| `scripts/debian/builder-helpers.sh` | packaging builds |
| `dockerfiles/Dockerfile-mina-daemon` | packaging builds |

## Verification

Rendered both pipelines with `dump_dhall_to_pipelines.sh` and ran `monorepo.sh --dry-run` with the exact parameters the nightly pipeline uses (`selection=Full`, `scope=Nightly`, the `FastOnly` and `LongAndVeryLong` phases).

Nightly, `long,verylong` phase:

```
before:  MinaArtifactBullseye, MinaArtifactBullseyeApps,
         MinaArtifactBullseyeInstrumented, MinaArtifactBullseyeInstrumentedApps,
         MinaArtifactMainnetBullseye, MinaArtifactMainnetBullseyeApps
after:   MinaArtifactBullseyeApps, MinaArtifactBullseyeInstrumentedApps,
         MinaArtifactMainnetBullseyeApps
```

Nightly, `fast` phase:

```
before:  HardforkPackageConversion
after:   (none)
```

Dangling-dependency check across the union of both nightly phases — every `depends_on` step key resolved to a step some selected job produces:

```
before  selected=58  steps=112  dangling_deps=0
after   selected=54  steps=87   dangling_deps=0
```

Same check on a src-only PR: `selected=31 steps=39 dangling_deps=0`.

`make all` in `buildkite/` → 45/45.

## Trade-off worth a look

`HardforkPackageConversion` no longer runs nightly. It converts a daemon `.deb` to hardfork form, so it genuinely needs a real package — it can't move to the app-build cache without being rewritten to build its own debs the way `DebianUpgradeTest` does. It still runs on PRs when `scripts/hardfork/release/convert-daemon-debian-to-hf.sh` or `scripts/debian/session` changes, and in the weekly and release pipelines. If nightly coverage of that conversion matters, the follow-up is to give it a `build-from-cache.sh` step rather than to put the whole artifact matrix back.

No changelog entry: `Lint: Changelog` triggers on repo-root `src/`, and this only touches `buildkite/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
