### PR TITLE
Update transaction pool vk refcounts when handling new transition frontier

### DIFF
--- a/changes/19162.md
+++ b/changes/19162.md
@@ -1,0 +1,1 @@
+Fix a verification-key refcount leak in the transaction pool. Commands dropped when the transition frontier is recreated now have their verification-key refcounts decremented, so table entries and their on-disk verification-key cache handles are no longer retained until the daemon restarts.

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -892,6 +892,16 @@ struct
                                 account"
                              (Base_ledger.get validation_ledger loc) )
                  in
+                 (* The dropped commands leave the pool here, so their vk
+                    refcounts must be decremented to match the increments
+                    made when they were added. *)
+                 let dec_vk_refcounts =
+                   Vk_refcount_table.lift_hashed t.verification_key_table
+                     (fun vk_table ~account_id ~vk ->
+                       Vk_refcount_table.dec vk_table ~account_id
+                         ~vk_hash:vk.hash )
+                 in
+                 Sequence.iter dropped ~f:dec_vk_refcounts ;
                  let dropped_locally_generated =
                    Sequence.filter dropped ~f:(fun cmd ->
                        let find_remove_bool tbl =
@@ -2675,6 +2685,41 @@ let%test_module _ =
             Broadcast_pipe.Writer.write t.frontier_pipe_w (Some frontier2)
           in
           assert_pool_txs t (List.drop independent_cmds 3) ;
+          Deferred.unit )
+
+    let%test_unit "vk refcounts are decremented for commands dropped when the \
+                   transition frontier is recreated (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          (* Set up initial frontier *)
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          let%bind zkapp_cmds = mk_zkapp_commands_single_block 7 t.txn_pool in
+          let%bind () = add_commands' t zkapp_cmds in
+          assert_pool_txs t zkapp_cmds ;
+          let vk_table_size () =
+            Hashtbl.length t.txn_pool.verification_key_table.verification_keys
+          in
+          (* With the deterministic generator seed, at least one command sets
+             the single shared vk, so the table holds exactly one entry;
+             asserting it also guards the final check against passing
+             vacuously. *)
+          [%test_eq: int] 1 (vk_table_size ()) ;
+          (* Destroy initial frontier *)
+          Broadcast_pipe.Writer.close t.best_tip_diff_w ;
+          let%bind _ = Broadcast_pipe.Writer.write t.frontier_pipe_w None in
+          (* Set up a second frontier whose ledger invalidates every zkApp
+             command in the pool *)
+          let ((_, ledger_ref2) as frontier2), _best_tip_diff_w2 =
+            Mock_transition_frontier.create ()
+          in
+          List.iter (List.range 0 7) ~f:(fun idx ->
+              modify_ledger !ledger_ref2 ~idx ~balance:20_000_000_000_000
+                ~nonce:5 ) ;
+          let%bind _ =
+            Broadcast_pipe.Writer.write t.frontier_pipe_w (Some frontier2)
+          in
+          assert_pool_txs t [] ;
+          [%test_eq: int] 0 (vk_table_size ()) ;
           Deferred.unit )
 
     let%test_unit "transaction replacement works" =


### PR DESCRIPTION
Explain your changes:

* When the transaction pool reacts to a recreated transition frontier
  (`Some frontier` on the frontier broadcast pipe), it revalidates the whole
  pool against the new best tip and drops now-invalid commands, but it never
  decremented those commands' entries in the verification-key refcount table.
  Every other drop site in `transaction_pool.ml` pairs the drop with
  `Vk_refcount_table` decrements; this path was the one exception, so each
  frontier recreation leaked table entries (and their on-disk vk cache
  handles) until restart. This PR decrements the refcounts of the dropped
  commands in that handler, using the same `lift_hashed`/`dec` idiom as the
  existing drop sites.
* The path only fires when a finality assumption is broken (frontier
  destroyed and recreated), matching the issue's "relatively low priority"
  framing; the fix is node-local pool accounting with no protocol or wire
  impact, hence targeting `compatible`.
* Two adjacent, pre-existing accounting gaps surfaced while auditing this
  change and are intentionally left out of scope (happy to file issues or
  follow up): commands re-added via `Indexed_pool.add_from_backtrack` are
  never inc'd even though later drop sites dec them (this predates and is
  consistent with the existing dec of `dropped_backtrack`), and
  `dropped_commit_conflicts` in the best-tip-diff handler leave the pool
  without a dec.

Explain how you tested your changes:

* Added an inline `let%test_unit` to the existing `transaction_pool.ml` test
  module: a zkApp twin of "Now-invalid transactions are removed from the pool
  when the transition frontier is recreated (user cmds)". It adds 7 zkApp
  commands sharing a single verification key, asserts the vk refcount table
  holds exactly one entry (a positive control so the final check cannot pass
  vacuously), destroys the frontier, installs a second frontier whose ledger
  invalidates every fee payer, and asserts the pool is emptied and the vk
  table with it. Without the fix, no other code path touches the table on
  this handler, so the entry survives the drops and the final assertion
  fails.
* Note: this change was authored with Claude (AI-assisted). A full local
  build was not run in the authoring environment; please rely on CI to
  exercise the `src/lib/network_pool` tests and the format check.

Checklist:

- [x] Dependency versions are unchanged
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules (no serialized types touched)
- [x] Does this close issues? List them

* Closes #13252
