### PR TITLE
Remove input debian repository argument from docker builds

### DIFF
--- a/buildkite/scripts/docker/build-from-local-debs.sh
+++ b/buildkite/scripts/docker/build-from-local-debs.sh
@@ -135,7 +135,6 @@ echo "--- Building ${SERVICE} locally (no push)"
   --version "${MINA_DOCKER_TAG}" \
   --branch "${BUILDKITE_BRANCH}" \
   --deb-codename "${MINA_DEB_CODENAME}" \
-  --deb-repo http://localhost:8080 \
   --deb-release unstable \
   --deb-version "${MINA_DEB_VERSION}" \
   --deb-profile "${PROFILE}" \

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -18,8 +18,6 @@ let Cmd = ../Lib/Cmds.dhall
 
 let DockerLogin = ../Command/DockerLogin/Type.dhall
 
-let DebianRepo = ../Constants/DebianRepo.dhall
-
 let DockerRepo = ../Constants/DockerRepo.dhall
 
 let DebianVersions = ../Constants/DebianVersions.dhall
@@ -58,7 +56,6 @@ let ReleaseSpec =
           , base_image : Optional Text
           , deb_suffix : Optional Text
           , deb_profile : Profiles.Type
-          , deb_repo : DebianRepo.Type
           , build_flags : BuildFlags.Type
           , step_key_suffix : Text
           , docker_publish : DockerPublish.Type
@@ -88,7 +85,6 @@ let ReleaseSpec =
           , base_image = None Text
           , deb_profile = Profiles.Type.Devnet
           , build_flags = BuildFlags.Type.None
-          , deb_repo = DebianRepo.Type.Local
           , docker_publish = DockerPublish.Type.Essential
           , no_cache = False
           , save_to_ci_cache = False
@@ -134,11 +130,12 @@ let generateStep =
 
           let maybeCacheOption = if spec.no_cache then "--no-cache" else ""
 
-          let maybeStartDebianRepo =
+          let maybeFetchLocalDebs =
                 merge
                   { DownloadOnly =
                       " && ROOT=${spec.deb_root_folder} LOCAL_DEB_FOLDER=\"dockerfiles\" ./buildkite/scripts/debian/read_all_from_cache.sh "
-                  , NoInstall = " && echo Skipping local debian repo setup "
+                  , NoInstall =
+                      " && echo Skipping local debian package download "
                   }
                   spec.deb_install_mode
 
@@ -270,7 +267,6 @@ let generateStep =
                 ++  " ${maybeCacheOption} "
                 ++  " --deb-codename ${DebianVersions.lowerName
                                          spec.deb_codename}"
-                ++  " --deb-repo ${DebianRepo.address spec.deb_repo}"
                 ++  " --deb-release ${spec.deb_release}"
                 ++  " --deb-version ${spec.deb_version}"
                 ++  " --deb-profile ${Profiles.lowerName spec.deb_profile}"
@@ -288,43 +284,21 @@ let generateStep =
                 ++  imageNameArg
                 ++  maybeSaveToCacheArg
 
-          let remoteRepoCmds =
+          let commands =
                 [ Cmd.run
                     (     exportMinaDebCmd
                       ++  " && "
                       ++  exportBranchNameCmd
-                      ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                       ++  " && "
                       ++  pruneDockerImages
+                      ++  maybeFetchLocalDebs
+                      ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                       ++  " && "
                       ++  maybeLoadBaseImage
                       ++  buildDockerCmd
                       ++  maybeVerify
                     )
                 ]
-
-          let commands =
-                merge
-                  { Unstable = remoteRepoCmds
-                  , Nightly = remoteRepoCmds
-                  , Stable = remoteRepoCmds
-                  , Local =
-                    [ Cmd.run
-                        (     exportMinaDebCmd
-                          ++  " && "
-                          ++  exportBranchNameCmd
-                          ++  " && "
-                          ++  pruneDockerImages
-                          ++  maybeStartDebianRepo
-                          ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
-                          ++  " && "
-                          ++  maybeLoadBaseImage
-                          ++  buildDockerCmd
-                          ++  maybeVerify
-                        )
-                    ]
-                  }
-                  spec.deb_repo
 
           let target =
                 merge { Arm64 = Size.XLarge, Amd64 = Size.XLarge } spec.arch

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -474,7 +474,6 @@ let docker_step
                           , deb_profile = profile
                           , build_flags = spec.buildFlags
                           , docker_publish = spec.docker_publish
-                          , deb_repo = DebianRepo.Type.Local
                           , deb_legacy_version = spec.deb_legacy_version
                           , size = size
                           }
@@ -496,7 +495,6 @@ let docker_step
                           , deb_profile = profile
                           , build_flags = spec.buildFlags
                           , docker_publish = spec.docker_publish
-                          , deb_repo = DebianRepo.Type.Local
                           , deb_legacy_version = spec.deb_legacy_version
                           , arch = spec.arch
                           , size = size
@@ -512,7 +510,6 @@ let docker_step
                     , deb_profile = profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
-                    , deb_repo = DebianRepo.Type.Local
                     , deb_legacy_version = spec.deb_legacy_version
                     , generic = True
                     , verify = True
@@ -561,7 +558,6 @@ let docker_step
                     , deb_profile = profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
-                    , deb_repo = DebianRepo.Type.Local
                     , deb_legacy_version = spec.deb_legacy_version
                     , arch = spec.arch
                     , if_ = spec.if_
@@ -577,7 +573,6 @@ let docker_step
                     , deb_profile = profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
-                    , deb_repo = DebianRepo.Type.Local
                     , deb_legacy_version = spec.deb_legacy_version
                     , arch = spec.arch
                     , if_ = spec.if_
@@ -595,7 +590,6 @@ let docker_step
                           , deb_profile = profile
                           , build_flags = spec.buildFlags
                           , docker_publish = spec.docker_publish
-                          , deb_repo = DebianRepo.Type.Local
                           , deb_legacy_version = spec.deb_legacy_version
                           , verify = True
                           , arch = spec.arch
@@ -612,7 +606,6 @@ let docker_step
                     , deb_profile = profile
                     , build_flags = spec.buildFlags
                     , docker_publish = spec.docker_publish
-                    , deb_repo = DebianRepo.Type.Local
                     , deb_legacy_version = spec.deb_legacy_version
                     , generic = True
                     , verify = True

--- a/buildkite/src/Constants/Debian/Repo.dhall
+++ b/buildkite/src/Constants/Debian/Repo.dhall
@@ -8,13 +8,12 @@ let Optional/toList = Prelude.Optional.toList
 
 let DebianRepo
     : Type
-    = < Local | Unstable | Nightly | Stable >
+    = < Unstable | Nightly | Stable >
 
 let address =
           \(repo : DebianRepo)
       ->  merge
-            { Local = "http://localhost:8080"
-            , Unstable = "https://unstable.apt.packages.minaprotocol.com"
+            { Unstable = "https://unstable.apt.packages.minaprotocol.com"
             , Nightly = "https://nightly.apt.packages.minaprotocol.com"
             , Stable = "https://stable.apt.packages.minaprotocol.com"
             }
@@ -23,8 +22,7 @@ let address =
 let bucket =
           \(repo : DebianRepo)
       ->  merge
-            { Local = None Text
-            , Unstable = Some "unstable.apt.packages.minaprotocol.com"
+            { Unstable = Some "unstable.apt.packages.minaprotocol.com"
             , Nightly = Some "nightly.apt.packages.minaprotocol.com"
             , Stable = Some "stable.apt.packages.minaprotocol.com"
             }
@@ -55,8 +53,7 @@ let bucketArg =
 let keyId =
           \(repo : DebianRepo)
       ->  merge
-            { Local = None Text
-            , Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
+            { Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Nightly = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Stable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             }
@@ -64,17 +61,14 @@ let keyId =
 
 let isSigned =
           \(repo : DebianRepo)
-      ->  merge
-            { Local = False, Unstable = True, Nightly = True, Stable = True }
-            repo
+      ->  merge { Unstable = True, Nightly = True, Stable = True } repo
 
 let keyAddress =
           \(repo : DebianRepo)
       ->  let keyPath = "/key.asc"
 
           in  merge
-                { Local = None Text
-                , Unstable = Some (address repo ++ keyPath)
+                { Unstable = Some (address repo ++ keyPath)
                 , Nightly = Some (address repo ++ keyPath)
                 , Stable = Some (address repo ++ keyPath)
                 }

--- a/buildkite/src/Constants/DebianRepo.dhall
+++ b/buildkite/src/Constants/DebianRepo.dhall
@@ -8,13 +8,12 @@ let Optional/toList = Prelude.Optional.toList
 
 let DebianRepo
     : Type
-    = < Local | Unstable | Nightly | Stable >
+    = < Unstable | Nightly | Stable >
 
 let address =
           \(repo : DebianRepo)
       ->  merge
-            { Local = "http://localhost:8080"
-            , Unstable = "https://unstable.apt.packages.minaprotocol.com"
+            { Unstable = "https://unstable.apt.packages.minaprotocol.com"
             , Nightly = "https://nightly.apt.packages.minaprotocol.com"
             , Stable = "https://stable.apt.packages.minaprotocol.com"
             }
@@ -23,8 +22,7 @@ let address =
 let bucket =
           \(repo : DebianRepo)
       ->  merge
-            { Local = None Text
-            , Unstable = Some "unstable.apt.packages.minaprotocol.com"
+            { Unstable = Some "unstable.apt.packages.minaprotocol.com"
             , Nightly = Some "nightly.apt.packages.minaprotocol.com"
             , Stable = Some "stable.apt.packages.minaprotocol.com"
             }
@@ -55,8 +53,7 @@ let bucketArg =
 let keyId =
           \(repo : DebianRepo)
       ->  merge
-            { Local = None Text
-            , Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
+            { Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Nightly = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Stable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             }
@@ -64,17 +61,14 @@ let keyId =
 
 let isSigned =
           \(repo : DebianRepo)
-      ->  merge
-            { Local = False, Unstable = True, Nightly = True, Stable = True }
-            repo
+      ->  merge { Unstable = True, Nightly = True, Stable = True } repo
 
 let keyAddress =
           \(repo : DebianRepo)
       ->  let keyPath = "/key.asc"
 
           in  merge
-                { Local = None Text
-                , Unstable = Some (address repo ++ keyPath)
+                { Unstable = Some (address repo ++ keyPath)
                 , Nightly = Some (address repo ++ keyPath)
                 , Stable = Some (address repo ++ keyPath)
                 }

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -26,8 +26,6 @@ let DockerImage = ../Command/DockerImage.dhall
 
 let DebianVersions = ../Constants/DebianVersions.dhall
 
-let DebianRepo = ../Constants/DebianRepo.dhall
-
 let Docker = ../Constants/Docker/Package.dhall
 
 let Artifact = ../Constants/Artifact/Artifacts.dhall
@@ -437,7 +435,6 @@ let generateHfRelatedStepsForCodename =
                 , network = spec.network
                 , deb_codename = codename.DebVersion
                 , deb_profile = profile
-                , deb_repo = DebianRepo.Type.Local
                 , deb_legacy_version = spec.deb_legacy_version
                 , step_key_suffix =
                     "-${DebianVersions.lowerName

--- a/dockerfiles/Dockerfile-delegation-stateless-verifier
+++ b/dockerfiles/Dockerfile-delegation-stateless-verifier
@@ -10,7 +10,6 @@ ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"

--- a/dockerfiles/scripts/configure-apt-proxy.sh
+++ b/dockerfiles/scripts/configure-apt-proxy.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
 # Configure APT for o1Labs CI/build environments:
 #   1. Route most apt traffic through an apt-cacher-ng caching proxy
-#      (APT_CACHE_URL) while bypassing the Mina deb repo (DEB_REPO) so
-#      package publishes don't get cached.
-#   1b. Unconditionally bypass the known Mina deb repo hosts, whether or not
-#      DEB_REPO names them. DEB_REPO is per-build (a build using
-#      DebianRepo.Local passes http://localhost:8080), so deriving the
-#      bypass from it alone leaves packages.o1test.net proxied in exactly
-#      those builds. That host redirects http -> https at the CDN, and
-#      apt-cacher-ng cannot follow a redirect to TLS for a cached remote --
-#      it returns "500 Remote or cache error" and apt fails hard with
+#      (APT_CACHE_URL) while bypassing the known Mina deb repo hosts, so
+#      package publishes don't get cached. The bypass list is fixed, not
+#      derived from a per-build repo argument: packages.o1test.net redirects
+#      http -> https at the CDN, and apt-cacher-ng cannot follow a redirect to
+#      TLS for a cached remote -- it returns "500 Remote or cache error" and
+#      apt fails hard with
 #      "E: Failed to fetch .../InRelease  500  Remote or cache error".
 #   2. Unconditionally bypass the proxy for archive.ubuntu.com /
 #      security.ubuntu.com. The o1Labs apt-cacher-ng has the local
@@ -45,11 +42,9 @@
 #           [trusted=yes] mirror-ubuntu.list pattern, see gitops-
 #           infrastructure PR #1287).
 #
-# Usage: configure-apt-proxy.sh [APT_CACHE_URL] [DEB_REPO] [APT_MIRROR_URL]
+# Usage: configure-apt-proxy.sh [APT_CACHE_URL] [APT_MIRROR_URL]
 #   APT_CACHE_URL   - apt-cacher-ng or similar caching proxy URL
 #                     (e.g. http://apt-cache-ingress.mirror-ingress:3142)
-#   DEB_REPO        - URL of the Mina deb repo that must bypass the proxy
-#                     (e.g. http://packages.o1test.net)
 #   APT_MIRROR_URL  - Base URL of the o1Labs deb-mirror's apt repository publication
 #                     (e.g. http://deb-mirror-ingress.mirror-ingress). When
 #                     omitted but APT_CACHE_URL looks like an in-cluster
@@ -91,8 +86,7 @@
 set -eu
 
 APT_CACHE_URL="${1:-}"
-DEB_REPO="${2:-}"
-APT_MIRROR_URL="${3:-}"
+APT_MIRROR_URL="${2:-}"
 
 # Nothing to configure when no proxy is requested.
 [ -n "$APT_CACHE_URL" ] || exit 0
@@ -104,10 +98,7 @@ conf=/etc/apt/apt.conf.d/01proxy
 {
   echo "Acquire::http::Proxy \"${APT_CACHE_URL}\";"
   echo "Acquire::https::Proxy \"${APT_CACHE_URL}\";"
-  # The Mina deb repos ALWAYS go DIRECT, independently of DEB_REPO (see header
-  # note 1b). DEB_REPO only names the repo this particular build pulls from, so
-  # a build pointed elsewhere (e.g. DebianRepo.Local -> http://localhost:8080)
-  # would leave packages.o1test.net proxied -- and it must not be.
+  # The Mina deb repos ALWAYS go DIRECT (see header note 1).
   # packages.o1test.net redirects http -> https at the CDN, and apt-cacher-ng
   # cannot follow a redirect to TLS for a cached remote: it answers
   # "500 Remote or cache error", which apt treats as fatal. Fetched directly the
@@ -121,21 +112,6 @@ stable.apt.packages.minaprotocol.com"
     echo "Acquire::http::Proxy::${mina_repo_host} \"DIRECT\";"
     echo "Acquire::https::Proxy::${mina_repo_host} \"DIRECT\";"
   done
-  # Any other repo named by DEB_REPO (a local file server, a mirror) is bypassed
-  # too, so publishes never land in the cache. Skipped when it is one of the
-  # hosts already emitted above, to keep the generated conf free of duplicates.
-  if [ -n "$DEB_REPO" ]; then
-    host="${DEB_REPO#*://}"
-    host="${host%%[:/]*}"
-    already=0
-    for mina_repo_host in $MINA_DEB_REPO_HOSTS; do
-      [ "$host" = "$mina_repo_host" ] && already=1
-    done
-    if [ "$already" = "0" ]; then
-      echo "Acquire::http::Proxy::${host} \"DIRECT\";"
-      echo "Acquire::https::Proxy::${host} \"DIRECT\";"
-    fi
-  fi
   # Ubuntu Canonical archives ALWAYS go DIRECT (see header note 2):
   # the o1Labs apt-cacher-ng's Remap-uburep chain has the local unsigned
   # apt repository publication first, so a proxied request for archive.ubuntu.com

--- a/dockerfiles/stages/1-base-deps
+++ b/dockerfiles/stages/1-base-deps
@@ -18,7 +18,6 @@ FROM ${image} AS base-deps
 # for the later stages of a concatenated build).
 ARG TARGETARCH
 ARG deb_codename=bullseye
-ARG deb_repo="http://packages.o1test.net"
 ARG apt_cache_url=""
 
 ARG GCLOUD_VERSION=476.0.0
@@ -34,10 +33,10 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libjemalloc2
 #    libssl
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
 RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \

--- a/dockerfiles/stages/archive/2-mina-archive
+++ b/dockerfiles/stages/archive/2-mina-archive
@@ -14,7 +14,6 @@ ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_profile=devnet
 ARG deb_suffix
 ARG build_flags_suffix

--- a/dockerfiles/stages/daemon/2-mina-daemon
+++ b/dockerfiles/stages/daemon/2-mina-daemon
@@ -14,7 +14,6 @@ ARG deb_version
 ARG deb_release=unstable
 ARG deb_codename=bullseye
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_profile
 ARG deb_suffix
 

--- a/dockerfiles/stages/daemon/3-prefork-genesis
+++ b/dockerfiles/stages/daemon/3-prefork-genesis
@@ -16,7 +16,6 @@ ARG deb_version
 ARG deb_release=unstable
 ARG deb_codename=bullseye
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_legacy_version
 
 # Prefork genesis ledger package name and version.

--- a/dockerfiles/stages/daemon/4-auto-hardfork
+++ b/dockerfiles/stages/daemon/4-auto-hardfork
@@ -18,7 +18,6 @@ ARG deb_version
 ARG deb_release=unstable
 ARG deb_codename=bullseye
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_legacy_version
 
 ENV MINA_DEB=mina-${network}-postfork-mesa

--- a/dockerfiles/stages/rosetta/1-base-deps
+++ b/dockerfiles/stages/rosetta/1-base-deps
@@ -13,17 +13,16 @@
 ARG image=europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ubuntu:focal
 FROM ${image} AS rosetta-base
 ARG deb_codename=focal
-ARG deb_repo="http://packages.o1test.net"
 ARG apt_cache_url=""
 
 ARG psql_version=15
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
 RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \

--- a/dockerfiles/stages/rosetta/2-mina-rosetta
+++ b/dockerfiles/stages/rosetta/2-mina-rosetta
@@ -12,7 +12,6 @@ ARG deb_codename=focal
 ARG deb_version
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_suffix
 ARG build_flags_suffix
 ARG deb_profile=devnet

--- a/dockerfiles/toolchain/1-build-deps
+++ b/dockerfiles/toolchain/1-build-deps
@@ -11,7 +11,6 @@ FROM ${image} AS build-deps
 ARG TARGETARCH
 
 ARG apt_cache_url
-ARG deb_repo=""
 
 # OCaml Version
 # The version must be the same as the version used in:
@@ -53,10 +52,10 @@ ARG RUST_NIGHTLY=2024-09-05
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
 RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 RUN CODENAME=$(grep "VERSION_CODENAME" /etc/os-release | cut -d= -f2); \
   case "${CODENAME}" in \

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -88,13 +88,9 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --deb-version) DEB_VERSION="$2"; shift;;
   --deb-legacy-version) INPUT_LEGACY_VERSION="$2"; shift;;
   --deb-profile) DEB_PROFILE="$2"; shift;;
-  --deb-repo) INPUT_REPO="$2"; shift;;
   --deb-arch) DEB_ARCH="$2"; shift;;
   --deb-build-flags) DEB_BUILD_FLAGS="$2"; shift;;
   --deb-suffix) export DOCKER_DEB_SUFFIX="$2"; shift;;
-  --deb-repo-key)
-      # shellcheck disable=SC2034
-      DEB_REPO_KEY="$2"; shift;;
   --custom-arg) CUSTOM_ARG="$2"; shift;;
   --docker-target) INPUT_DOCKER_TARGET="$2"; shift;;
   --base-image) INPUT_BASE_IMAGE="$2"; shift;;
@@ -207,27 +203,14 @@ else
   CACHE="--cache-from $INPUT_CACHE"
 fi
 
-if [[ -z "${INPUT_REPO:-}" ]]; then
-  echo "Debian repository is not set. Using the default (http://localhost:8080)"
-  DEB_REPO="--build-arg deb_repo=http://localhost:8080"
-else
-  echo "Using provided Debian repository: $INPUT_REPO"
-  DEB_REPO="--build-arg deb_repo=$INPUT_REPO"
-fi
-
-GW=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')
-LOCALHOST_REPLACEMENT=$GW
-if [[ -z "${INPUT_REPO:-}" ]]; then
-  echo "Debian repository is not set. Using the default (http://$LOCALHOST_REPLACEMENT:8080)"
-  DEB_REPO="--build-arg deb_repo=http://$LOCALHOST_REPLACEMENT:8080"
-else
-  echo "Converting localhost to $LOCALHOST_REPLACEMENT in repository URL"
-  CONVERTED_REPO=$(echo "$INPUT_REPO" | sed "s/localhost/$LOCALHOST_REPLACEMENT/g")
-  DEB_REPO="--build-arg deb_repo=$CONVERTED_REPO"
-fi
-
+# The mina packages are installed from the .deb files staged into the build
+# context (see the _debs staging below), never from an apt repository, so the
+# build takes no Debian repository argument at all. The only URL left to pass in
+# is the optional apt cache proxy, and "localhost" in it must be rewritten to the
+# docker bridge gateway: the host resolves it, the build container does not.
 APT_CACHE_ARG=""
 if [[ -n "${APT_CACHE_PROXY:-}" ]]; then
+  LOCALHOST_REPLACEMENT=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')
   CONVERTED_PROXY=$(echo "$APT_CACHE_PROXY" | sed "s/localhost/$LOCALHOST_REPLACEMENT/g")
   # Probe proxy reachability before passing to Docker build; fall back to direct if unreachable
   if curl -so /dev/null --connect-timeout 2 --max-time 4 "$CONVERTED_PROXY" 2>/dev/null; then
@@ -462,7 +445,7 @@ if [[ -n "${DOCKER_TARGET:-}" ]]; then
   TARGET_ARG="--target ${DOCKER_TARGET}"
 fi
 
-docker buildx build --load --network=host --progress=plain $PLATFORM $TARGET_ARG $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION --build-arg deb_profile="$DEB_PROFILE" --build-arg generic_network="$GENERIC_NETWORK_SEG" $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
+docker buildx build --load --network=host --progress=plain $PLATFORM $TARGET_ARG $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION --build-arg deb_profile="$DEB_PROFILE" --build-arg generic_network="$GENERIC_NETWORK_SEG" $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
 
 # Local hash tag: --save-to-ci-cache saves it, and --load-only consumers look
 # the image up by it. Also set by buildx above, and re-asserted here because the


### PR DESCRIPTION
## Why

Docker images install the mina packages from the `.deb` files staged into the build context (`_debs` -> `/opt/mina-local-debs` -> `install-mina-debs.sh`). No image resolves a mina package through an apt repository, so the `--deb-repo` argument and the `deb_repo` build-arg had no effect on any produced image.

The only place the value was read at all was the second argument of `configure-apt-proxy.sh`, and that was redundant too: the script already bypasses the Mina repo hosts from a fixed list.

## What changed

**`scripts/docker/build.sh`**
- Drop `--deb-repo` and `--deb-repo-key`. The latter was assigned to a variable nothing read, with a shellcheck suppression on it.
- Delete the two `INPUT_REPO` blocks. The first was dead code: the second overwrote `DEB_REPO` unconditionally.
- Keep the docker bridge gateway lookup, still needed to rewrite `localhost` in an apt cache proxy URL, and move it inside the `APT_CACHE_PROXY` branch so it only runs when used.

**`buildkite/src/Command/DockerImage.dhall`**
- Remove the `deb_repo` field and the `--deb-repo` argument.
- The `commands` merge on `deb_repo` was dead code: all seven `MinaArtifact` call sites plus `GenerateHardforkPackage` passed `Local`, so the `Unstable`/`Nightly`/`Stable` branch was unreachable. Collapsed to the `Local` behaviour, leaving `deb_install_mode` as the single control over whether the `.deb` files are fetched from the CI cache. Renamed `maybeStartDebianRepo` to `maybeFetchLocalDebs`, since it no longer starts a repo.

**`buildkite/src/Constants/DebianRepo.dhall`** - remove the now-unused `Local` variant from the union and from all five merges. The same removal is applied to `buildkite/src/Constants/Debian/Repo.dhall`, a byte-for-byte duplicate that nothing imports (worth deleting outright, left out of scope here).

**Dockerfiles** - drop `ARG deb_repo` from all nine (base-deps, daemon 2/3/4, archive, rosetta 1/2, toolchain, delegation-stateless-verifier).

**`dockerfiles/scripts/configure-apt-proxy.sh`** - signature is now `[APT_CACHE_URL] [APT_MIRROR_URL]`; the `DEB_REPO` parameter and its conditional bypass block are gone.

## Verification

- `make all` in `buildkite/`: compiles, 45/45 monorepo tests pass.
- Rendered `MinaArtifactBullseye`: `--deb-repo` gone, `read_all_from_cache.sh` still wired into all 16 docker steps.
- Rendered the publish entrypoint with `DebianRepo.Type.Unstable` to confirm dropping `Local` does not affect publishing: `--debian-repo unstable.apt.packages.minaprotocol.com`, `--debian-sign-key 386E9DAC...` and `--signed-debian-repo` are all still emitted.
- `docker buildx build --call=check` on the assembled daemon, archive, auto-hardfork, rosetta and toolchain Dockerfiles: clean. No `UndefinedVar`, which is what a leftover `$deb_repo` reference would raise.
- Real end-to-end `build.sh --service mina-base` build succeeded, both without and with `APT_CACHE_PROXY` set.
- `configure-apt-proxy.sh` exercised in a container across all three paths: derived mirror, explicit mirror as `$2`, and the empty-cache-URL no-op.
- `shellcheck -S warning` clean on the touched scripts. `make check-bash` / `make check-docker` failures are pre-existing and in untouched files.

No changelog entry: the `Lint: Changelog` job's `dirtyWhen` covers `src`, `buildkite/scripts/changelog.sh` and `scripts/github/github_info`, none of which this PR touches.
