### PR TITLE
Key the apps cache by build flags only, not by network

### DIFF
--- a/buildkite/scripts/apps/restore_app.sh
+++ b/buildkite/scripts/apps/restore_app.sh
@@ -6,19 +6,26 @@
 # callers invoke the tool identically whether it came from the cache or a
 # package.
 #
-# Usage: restore_app.sh <network> <exe> <install-as>
-#   network    : devnet | mainnet | mesa  (selects the default build profile)
+# Usage: restore_app.sh <exe> <install-as>
 #   exe        : the .exe filename in the cache, e.g. runtime_genesis_ledger.exe
 #   install-as : the name to install it under on PATH, e.g. mina-create-genesis
 #
 # The cache location is derived from the build identity, so callers don't repeat
 # the variant string:
-#   apps/<codename>/<network>-<profile>[-instrumented][-arm64]/<exe>
+#   apps/<codename>[/<variant>]/<exe>
 # with
 #   codename : $MINA_DEB_CODENAME (default bullseye)
-#   profile  : $APPS_PROFILE      (default: devnet/mesa -> devnet, mainnet -> mainnet)
-#   flag     : $APPS_BUILD_FLAG   ("instrumented" appends -instrumented; default none)
-#   arch     : $APPS_ARCH         ("arm64" appends -arm64; default amd64)
+#   variant  : derived from $APPS_BUILD_FLAG ("instrumented") and $APPS_ARCH
+#              ("arm64"). It names only what deviates from the default build, so
+#              a standard amd64 build has NO variant segment and its binaries sit
+#              directly in apps/<codename>/.
+#
+# There is deliberately no network or profile in the path. The daemon binary the
+# cache holds is src/app/cli/src/mina.exe, which links no mina_signature_kind
+# library (see src/app/cli/src/dune) -- signature kind and proof level are
+# resolved at runtime from the config, so one binary serves every network and
+# profile. Only the compile-time flags (instrumentation) and the target
+# architecture actually change the bytes.
 #
 # Installs to ${MINA_BIN_DIR:-/usr/local/bin}/<install-as> (using sudo when not
 # root). Exits non-zero without side effects if not in Buildkite context or the
@@ -26,12 +33,11 @@
 
 set -eo pipefail
 
-NETWORK=$1
-EXE=$2
-INSTALL_AS=$3
+EXE=$1
+INSTALL_AS=$2
 
-if [[ -z "$NETWORK" || -z "$EXE" || -z "$INSTALL_AS" ]]; then
-  echo "Usage: $0 <network> <exe> <install-as>" >&2
+if [[ -z "$EXE" || -z "$INSTALL_AS" ]]; then
+  echo "Usage: $0 <exe> <install-as>" >&2
   exit 1
 fi
 
@@ -40,24 +46,14 @@ if [[ ! -v BUILDKITE_BUILD_ID ]]; then
   exit 1
 fi
 
-case "$NETWORK" in
-  devnet | mesa) default_profile=devnet ;;
-  mainnet) default_profile=mainnet ;;
-  *)
-    echo "restore_app: unknown network '$NETWORK'" >&2
-    exit 1
-    ;;
-esac
-
 CODENAME="${MINA_DEB_CODENAME:-bullseye}"
-PROFILE="${APPS_PROFILE:-$default_profile}"
 
-flag_seg=""
-[[ "${APPS_BUILD_FLAG:-}" == "instrumented" ]] && flag_seg="-instrumented"
-arch_seg=""
-[[ "${APPS_ARCH:-amd64}" == "arm64" ]] && arch_seg="-arm64"
+segments=()
+[[ "${APPS_BUILD_FLAG:-}" == "instrumented" ]] && segments+=("instrumented")
+[[ "${APPS_ARCH:-amd64}" == "arm64" ]] && segments+=("arm64")
+VARIANT=$(IFS=-; echo "${segments[*]}")
 
-VARIANT="${NETWORK}-${PROFILE}${flag_seg}${arch_seg}"
+SRC="apps/${CODENAME}${VARIANT:+/${VARIANT}}/${EXE}"
 BIN_DIR="${MINA_BIN_DIR:-/usr/local/bin}"
 
 SUDO=""
@@ -68,8 +64,8 @@ fi
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-if ! ./buildkite/scripts/cache/manager.sh read "apps/${CODENAME}/${VARIANT}/${EXE}" "$TMP_DIR" >&2; then
-  echo "restore_app: apps/${CODENAME}/${VARIANT}/${EXE} not found in cache" >&2
+if ! ./buildkite/scripts/cache/manager.sh read "$SRC" "$TMP_DIR" >&2; then
+  echo "restore_app: ${SRC} not found in cache" >&2
   exit 1
 fi
 

--- a/buildkite/scripts/apps/restore_binary.sh
+++ b/buildkite/scripts/apps/restore_binary.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-# Restore the freshly-built mina daemon binary for a network from the namespaced
-# apps CI cache (written by buildkite/scripts/apps/write_to_cache.sh) and install
-# it as `mina` on PATH -- mirroring the .deb -- so callers invoke `mina`
-# identically whether it came from the cache or a package.
+# Restore the freshly-built mina daemon binary from the namespaced apps CI cache
+# (written by buildkite/scripts/apps/write_to_cache.sh) and install it as `mina`
+# on PATH -- mirroring the .deb -- so callers invoke `mina` identically whether
+# it came from the cache or a package.
 #
-# Usage: restore_binary.sh <network>      (network: devnet | mainnet | mesa)
+# Usage: restore_binary.sh
 #
 # This is a thin convenience wrapper over restore_app.sh: it installs the daemon
 # binary as the plain `mina`, so client scripts never deal with the variant. The
 # app-build (and the .deb, see scripts/debian/builder-helpers.sh) ships
-# src/app/cli/src/mina.exe as `mina`; the network's signatures are baked in at
-# build time via the profile and encoded in the cache variant that restore_app.sh
-# derives from the network -- there is no separate mina_<sig>_signatures.exe in
-# the cache. The cache location (codename/profile/flag/arch) is derived from the
+# src/app/cli/src/mina.exe as `mina`. That binary is network-agnostic -- it links
+# no mina_signature_kind library, so the signature kind and the proof level come
+# from the runtime config -- which is why neither this script nor the cache path
+# takes a network. The cache location (codename/flag/arch) is derived from the
 # build identity by restore_app.sh -- see its header for the env knobs.
 #
 # Exits non-zero without side effects if not in Buildkite context or the binary
@@ -21,19 +21,4 @@
 
 set -eo pipefail
 
-NETWORK=$1
-
-if [[ -z "$NETWORK" ]]; then
-  echo "Usage: $0 <network>" >&2
-  exit 1
-fi
-
-case "$NETWORK" in
-  devnet | mesa | mainnet) ;;
-  *)
-    echo "restore_binary: unknown network '$NETWORK'" >&2
-    exit 1
-    ;;
-esac
-
-exec ./buildkite/scripts/apps/restore_app.sh "$NETWORK" mina.exe mina
+exec ./buildkite/scripts/apps/restore_app.sh mina.exe mina

--- a/buildkite/scripts/apps/restore_build_tree.sh
+++ b/buildkite/scripts/apps/restore_build_tree.sh
@@ -10,22 +10,23 @@
 # scripts/debian/builder-helpers.sh finds each binary at the dune path it
 # copies from.
 #
-# Usage: restore_build_tree.sh <codename> <apps-variant> <build-variant>
-#   apps-variant  : the apps-cache variant to pull binaries from (any network's
-#                   variant works -- write_to_cache.sh flattens every binary
-#                   into each one; the caller passes the build's primary net).
-#   build-variant : the manifest variant (network-agnostic build identity).
+# Usage: APPS_VARIANT=<variant> restore_build_tree.sh <codename> <build-variant>
+#   APPS_VARIANT  : the apps-cache variant to pull binaries from, empty for the
+#                   default (standard amd64) build -- see apps/write_to_cache.sh.
+#   build-variant : the manifest variant (the same build identity, prefixed with
+#                   the codename).
 
 set -eo pipefail
 
 CODENAME=$1
-APPS_VARIANT=$2
-BUILD_VARIANT=$3
+BUILD_VARIANT=$2
 
-if [[ -z "$CODENAME" || -z "$APPS_VARIANT" || -z "$BUILD_VARIANT" ]]; then
-  echo "Usage: $0 <codename> <apps-variant> <build-variant>" >&2
+if [[ -z "$CODENAME" || -z "$BUILD_VARIANT" ]]; then
+  echo "Usage: APPS_VARIANT=<variant> $0 <codename> <build-variant>" >&2
   exit 1
 fi
+
+APPS_DIR="apps/${CODENAME}${APPS_VARIANT:+/${APPS_VARIANT}}"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -44,8 +45,8 @@ while IFS= read -r relpath; do
   fetch_dir="${TMP_DIR}/fetch"
   mkdir -p "$fetch_dir"
   if ! ./buildkite/scripts/cache/manager.sh read \
-    "apps/${CODENAME}/${APPS_VARIANT}/${base}" "$fetch_dir" >/dev/null; then
-    echo "restore_build_tree: ${base} not found in apps/${CODENAME}/${APPS_VARIANT}" >&2
+    "${APPS_DIR}/${base}" "$fetch_dir" >/dev/null; then
+    echo "restore_build_tree: ${base} not found in ${APPS_DIR}" >&2
     exit 1
   fi
   install -D -m 0755 "${fetch_dir}/${base}" "$relpath"

--- a/buildkite/scripts/apps/write_to_cache.sh
+++ b/buildkite/scripts/apps/write_to_cache.sh
@@ -1,22 +1,34 @@
 #!/bin/bash
 
 # Writes the freshly-built application binaries to the CI cache under
-#   apps/<codename>/<variant>/
-# where <variant> identifies the build (network-profile[-instrumented][-arm64]).
+#   apps/<codename>[/<variant>]/
 #
-# The variant depth is required: several builds share a codename and produce
-# identically-named binaries (e.g. mina.exe is emitted by the devnet, mesa and
-# instrumented builds alike, differing only by build profile). Without the
-# variant they would overwrite each other in apps/<codename>/, leaving whichever
-# build finished last -- a non-deterministic, wrong artifact for any consumer.
+# <variant> names only what makes a build differ from the default one, and is
+# EMPTY for that default (a standard, non-instrumented amd64 build), which lands
+# directly in apps/<codename>/. The variants in use are "instrumented", "arm64"
+# and "instrumented-arm64".
+#
+# The variant depth is needed because an instrumented build emits binaries with
+# the same names as a standard one (mina.exe and friends); sharing a directory
+# they would overwrite each other, leaving whichever build finished last -- a
+# non-deterministic, wrong artifact for any consumer.
+#
+# The variant deliberately carries NO network or profile. The binaries here are
+# network-agnostic: src/app/cli/src/mina.exe links no mina_signature_kind
+# library (see src/app/cli/src/dune), so signature kind and proof level are
+# resolved at runtime from the config. Only instrumentation and the target
+# architecture change the bytes, so a devnet and a mainnet build of the same
+# codename produce the same binaries and share one variant directory.
 
 CODENAME=$1
 VARIANT=$2
 
-if [[ -z "$CODENAME" || -z "$VARIANT" ]]; then
-  echo "Usage: $0 <codename> <variant>" >&2
+if [[ -z "$CODENAME" ]]; then
+  echo "Usage: $0 <codename> [<variant>]" >&2
   exit 1
 fi
+
+DEST="apps/${CODENAME}${VARIANT:+/${VARIANT}}"
 
 find _build -type f -name "*.exe" | while read -r entry; do
   # Exclude files ending with ppx.exe
@@ -24,7 +36,7 @@ find _build -type f -name "*.exe" | while read -r entry; do
     continue
   fi
 
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$entry" "apps/${CODENAME}/${VARIANT}"
+  ./buildkite/scripts/cache/manager.sh write-to-dir "$entry" "$DEST"
 done
 
 # libp2p_helper is a Go binary (built under src/app/libp2p_helper/result/bin,
@@ -33,7 +45,7 @@ done
 # mirroring what the .deb installs.
 HELPER="src/app/libp2p_helper/result/bin/libp2p_helper"
 if [[ -f "$HELPER" ]]; then
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$HELPER" "apps/${CODENAME}/${VARIANT}"
+  ./buildkite/scripts/cache/manager.sh write-to-dir "$HELPER" "$DEST"
 fi
 
 # minimina is a Rust binary (built under src/app/minimina/target/release, not a
@@ -41,5 +53,5 @@ fi
 # restore it into the build tree without a separate copy of the binaries.
 MINIMINA="src/app/minimina/target/release/minimina"
 if [[ -f "$MINIMINA" ]]; then
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$MINIMINA" "apps/${CODENAME}/${VARIANT}"
+  ./buildkite/scripts/cache/manager.sh write-to-dir "$MINIMINA" "$DEST"
 fi

--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -112,7 +112,7 @@ elif [[ -n "$BARE_EXE" ]]; then
   git config --global --add safe.directory /workdir
   source buildkite/scripts/export-git-env-vars.sh
 
-  if ./buildkite/scripts/apps/restore_app.sh devnet "$BARE_EXE" "$BARE_AS"; then
+  if ./buildkite/scripts/apps/restore_app.sh "$BARE_EXE" "$BARE_AS"; then
     echo "Using bare $BARE_AS from apps cache (no .deb needed)"
     INSTALLED_BARE=true
   fi

--- a/buildkite/scripts/connect/connect-to-network.sh
+++ b/buildkite/scripts/connect/connect-to-network.sh
@@ -95,16 +95,16 @@ CURRENT_SCANNER_DIR="/usr/lib/mina/storage/${ROCKSDB_VERSION}/${GITTAG}"
 # restore_current_mina re-installs the current daemon (used initially and again
 # when upgrading back after the downgrade) bare from the apps cache.
 restore_current_mina() {
-  ./buildkite/scripts/apps/restore_binary.sh "$MINA_DEBIAN_NETWORK"
+  ./buildkite/scripts/apps/restore_binary.sh
 }
 
 # Restore the current-version binaries bare from the apps cache (mirroring the
 # .debs). No .deb fallback: the job depends on the Apps build, not the package
 # build, so a cache miss is a hard failure rather than a silent .deb install.
-./buildkite/scripts/apps/restore_binary.sh "$MINA_DEBIAN_NETWORK"
-./buildkite/scripts/apps/restore_app.sh "$MINA_DEBIAN_NETWORK" mina_graphql_client_app.exe mina-graphql-client
-./buildkite/scripts/apps/restore_app.sh "$MINA_DEBIAN_NETWORK" libp2p_helper coda-libp2p_helper
-MINA_BIN_DIR="$CURRENT_SCANNER_DIR" ./buildkite/scripts/apps/restore_app.sh "$MINA_DEBIAN_NETWORK" rocksdb_scanner.exe mina-rocksdb-scanner
+./buildkite/scripts/apps/restore_binary.sh
+./buildkite/scripts/apps/restore_app.sh mina_graphql_client_app.exe mina-graphql-client
+./buildkite/scripts/apps/restore_app.sh libp2p_helper coda-libp2p_helper
+MINA_BIN_DIR="$CURRENT_SCANNER_DIR" ./buildkite/scripts/apps/restore_app.sh rocksdb_scanner.exe mina-rocksdb-scanner
 ./buildkite/scripts/apps/restore_daemon_config.sh "$MINA_DEBIAN_NETWORK"
 # The converter is an in-repo script (the .deb just packages it); install it the
 # same way the .deb does.

--- a/buildkite/scripts/debian/build-from-cache.sh
+++ b/buildkite/scripts/debian/build-from-cache.sh
@@ -10,22 +10,26 @@
 # only restore the tree and package it. Keep the packaging logic below in sync
 # with build-release.sh.
 #
-# Usage: build-from-cache.sh <apps-variant> <build-variant> <package-token> [<package-token> ...]
+# Usage: APPS_VARIANT=<variant> build-from-cache.sh <build-variant> <package-token> [...]
+#
+# APPS_VARIANT selects the apps-cache directory to restore the binaries from. It
+# is EMPTY for the default (standard, non-instrumented, amd64) build, which is
+# why it travels in the environment rather than as a leading positional -- an
+# empty positional would silently shift <build-variant> into its place.
 
 set -eo pipefail
 
 [ -z "${MINA_DEB_CODENAME+x}" ] && echo "MINA_DEB_CODENAME env var was not provided" && exit 1
 
-APPS_VARIANT=$1
-BUILD_VARIANT=$2
-shift 2
+BUILD_VARIANT=$1
+shift 1
 
-if [[ -z "$APPS_VARIANT" || -z "$BUILD_VARIANT" ]]; then
-  echo "Usage: $0 <apps-variant> <build-variant> <package-token> [...]" >&2
+if [[ -z "$BUILD_VARIANT" ]]; then
+  echo "Usage: APPS_VARIANT=<variant> $0 <build-variant> <package-token> [...]" >&2
   exit 1
 fi
 
-./buildkite/scripts/apps/restore_build_tree.sh "${MINA_DEB_CODENAME}" "${APPS_VARIANT}" "${BUILD_VARIANT}"
+./buildkite/scripts/apps/restore_build_tree.sh "${MINA_DEB_CODENAME}" "${BUILD_VARIANT}"
 
 echo "--- Bundle all packages for Debian ${MINA_DEB_CODENAME}"
 echo " Includes mina daemon, archive-node, rosetta"

--- a/buildkite/scripts/debian/restore-or-install.sh
+++ b/buildkite/scripts/debian/restore-or-install.sh
@@ -9,8 +9,8 @@
 # pairs (e.g. "archive.exe:mina-archive,replayer.exe:mina-replayer"). When set,
 # each binary is restored from the namespaced apps cache (mirroring the binary a
 # deb would install) via restore_app.sh, and the package install is skipped. The
-# cache variant is derived by restore_app.sh from MINA_DEB_CODENAME / APPS_PROFILE
-# / APPS_BUILD_FLAG / APPS_ARCH -- so callers set those to match the build they
+# cache variant is derived by restore_app.sh from MINA_DEB_CODENAME /
+# APPS_BUILD_FLAG / APPS_ARCH -- so callers set those to match the build they
 # depend on (e.g. APPS_BUILD_FLAG=instrumented).
 #
 # If APPS_BARE_BINARIES is unset, or any restore fails (cache miss, not in
@@ -30,7 +30,6 @@ set -eo pipefail
 
 DEBS=$1
 RETRIES=${2:-1}
-NETWORK="${APPS_NETWORK:-devnet}"
 
 if [[ -z "$DEBS" ]]; then
   echo "Usage: $0 <comma-separated-debs> <retries>" >&2
@@ -62,7 +61,7 @@ for pair in "${pairs[@]}"; do
     ok=false
     break
   fi
-  if ! ./buildkite/scripts/apps/restore_app.sh "$NETWORK" "$exe" "$install_as"; then
+  if ! ./buildkite/scripts/apps/restore_app.sh "$exe" "$install_as"; then
     ok=false
     break
   fi

--- a/buildkite/scripts/dump-mina-type-shapes.sh
+++ b/buildkite/scripts/dump-mina-type-shapes.sh
@@ -13,7 +13,7 @@ source buildkite/scripts/export-git-env-vars.sh
 # freshly-built bare binary from the apps cache is sufficient; no debian package
 # (and its config/genesis payload) is required. Fall back to the .deb when the
 # bare binary is unavailable. Either way `mina` ends up on PATH.
-if ./buildkite/scripts/apps/restore_binary.sh devnet; then
+if ./buildkite/scripts/apps/restore_binary.sh; then
   echo "Using bare mina from apps cache"
 else
   echo "Using debian-installed mina"

--- a/buildkite/scripts/single-node-tests.sh
+++ b/buildkite/scripts/single-node-tests.sh
@@ -18,10 +18,10 @@ source buildkite/scripts/export-git-env-vars.sh
 #     (devnet-devnet-instrumented), so bisect_ppx coverage still works.
 # The daemon finds the helper as coda-libp2p_helper on PATH, exactly like the deb.
 # Fall back to the debs on any cache miss (e.g. outside Buildkite).
-if ./buildkite/scripts/apps/restore_binary.sh devnet \
-  && ./buildkite/scripts/apps/restore_app.sh devnet libp2p_helper coda-libp2p_helper \
-  && APPS_PROFILE=devnet APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh devnet command_line_tests.exe mina-command-line-tests \
-  && APPS_PROFILE=devnet APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh devnet node_status_mock_server.exe mina-node-status-mock-server; then
+if ./buildkite/scripts/apps/restore_binary.sh \
+  && ./buildkite/scripts/apps/restore_app.sh libp2p_helper coda-libp2p_helper \
+  && APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh command_line_tests.exe mina-command-line-tests \
+  && APPS_BUILD_FLAG=instrumented ./buildkite/scripts/apps/restore_app.sh node_status_mock_server.exe mina-node-status-mock-server; then
   echo "Using bare mina + libp2p_helper + mina-command-line-tests + mina-node-status-mock-server from apps cache"
 else
   echo "Falling back to debian-installed test-suite + lightnet daemon"

--- a/buildkite/scripts/test-chain-id.sh
+++ b/buildkite/scripts/test-chain-id.sh
@@ -17,7 +17,7 @@ source buildkite/scripts/export-git-env-vars.sh
 # package. Either way `mina` is on PATH and /var/lib/coda/<net>.json exists, so
 # chain-id resolves the genesis ledger identically. Fall back to the .deb on a
 # cache miss (e.g. outside Buildkite).
-if ./buildkite/scripts/apps/restore_binary.sh "${MINA_DEBIAN_NETWORK}" \
+if ./buildkite/scripts/apps/restore_binary.sh \
   && ./buildkite/scripts/apps/restore_daemon_config.sh "${MINA_DEBIAN_NETWORK}"; then
   echo "Using bare mina + replicated genesis config from apps cache"
 else

--- a/buildkite/scripts/tests/ledger_test_apply.sh
+++ b/buildkite/scripts/tests/ledger_test_apply.sh
@@ -24,8 +24,8 @@ export APPS_BUILD_FLAG=instrumented
 # mina-create-genesis uses the devnet constants (ledger_depth 35).
 export MINA_PROFILE=devnet
 
-if ./buildkite/scripts/apps/restore_binary.sh devnet \
-  && ./buildkite/scripts/apps/restore_app.sh devnet runtime_genesis_ledger.exe mina-create-genesis; then
+if ./buildkite/scripts/apps/restore_binary.sh \
+  && ./buildkite/scripts/apps/restore_app.sh runtime_genesis_ledger.exe mina-create-genesis; then
   echo "Using bare mina + mina-create-genesis from apps cache"
 else
   echo "Falling back to debian-installed mina"

--- a/buildkite/scripts/version-linter.sh
+++ b/buildkite/scripts/version-linter.sh
@@ -34,7 +34,7 @@ source buildkite/scripts/export-git-env-vars.sh
 # freshly-built bare binary from the apps cache is sufficient; no debian package
 # is required. Fall back to the .deb when the bare binary is unavailable. Either
 # way `mina` ends up on PATH.
-if ./buildkite/scripts/apps/restore_binary.sh devnet; then
+if ./buildkite/scripts/apps/restore_binary.sh; then
   echo "Using bare mina from apps cache"
 else
   echo "Falling back to debian-installed mina"

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -192,6 +192,18 @@ let expandDockerServices =
                 }
                 artifact
 
+let appsVariant
+    : MinaBuildSpec.Type -> Text
+    =     \(spec : MinaBuildSpec.Type)
+      ->  merge
+            { None = merge { Amd64 = "", Arm64 = "arm64" } spec.arch
+            , Instrumented =
+                merge
+                  { Amd64 = "instrumented", Arm64 = "instrumented-arm64" }
+                  spec.arch
+            }
+            spec.buildFlags
+
 let build_artifacts
     : MinaBuildSpec.Type -> Command.Type
     =     \(spec : MinaBuildSpec.Type)
@@ -207,22 +219,11 @@ let build_artifacts
                       spec.artifacts
                   )
 
-          let appsCacheWrites =
-                List/map
-                  Network.Type
-                  Cmd.Type
-                  (     \(net : Network.Type)
-                    ->  Cmd.run
-                          "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                          spec.debVersion} ${Network.lowerName
-                                                                                               net}-${Profiles.toSuffixLowercase
-                                                                                                        ( Profiles.fromNetwork
-                                                                                                            net
-                                                                                                        )}${BuildFlags.toLabelSegment
-                                                                                                              spec.buildFlags}${Arch.toSuffixLowercase
-                                                                                                                                  spec.arch}"
-                  )
-                  nets
+          let appsCacheWrite =
+                Cmd.run
+                  "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
+                                                                  spec.debVersion} ${appsVariant
+                                                                                       spec}"
 
           in  Command.build
                 Command.Config::{
@@ -253,8 +254,8 @@ let build_artifacts
                     # [ Cmd.run
                           "./buildkite/scripts/debian/write_to_cache.sh ${DebianVersions.lowerName
                                                                             spec.debVersion}"
+                      , appsCacheWrite
                       ]
-                    # appsCacheWrites
                 , label = "Debian: Build ${labelSuffix spec}"
                 , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
                 , target = Size.Multi
@@ -297,43 +298,14 @@ let appsJobName
     : MinaBuildSpec.Type -> Text
     = \(spec : MinaBuildSpec.Type) -> "${selfName spec}Apps"
 
-let primaryAppsVariant
-    : MinaBuildSpec.Type -> Text
-    =     \(spec : MinaBuildSpec.Type)
-      ->  let primary =
-                Optional/default
-                  Network.Type
-                  Network.Type.Devnet
-                  (List/head Network.Type (Artifact.networks spec.artifacts))
-
-          in  "${Network.lowerName
-                   primary}-${Profiles.toSuffixLowercase
-                                ( Profiles.fromNetwork primary
-                                )}${BuildFlags.toLabelSegment
-                                      spec.buildFlags}${Arch.toSuffixLowercase
-                                                          spec.arch}"
-
 let build_apps
     : MinaBuildSpec.Type -> Command.Type
     =     \(spec : MinaBuildSpec.Type)
-      ->  let nets = Artifact.networks spec.artifacts
-
-          let appsCacheWrites =
-                List/map
-                  Network.Type
-                  Cmd.Type
-                  (     \(net : Network.Type)
-                    ->  Cmd.run
-                          "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                          spec.debVersion} ${Network.lowerName
-                                                                                               net}-${Profiles.toSuffixLowercase
-                                                                                                        ( Profiles.fromNetwork
-                                                                                                            net
-                                                                                                        )}${BuildFlags.toLabelSegment
-                                                                                                              spec.buildFlags}${Arch.toSuffixLowercase
-                                                                                                                                  spec.arch}"
-                  )
-                  nets
+      ->  let appsCacheWrite =
+                Cmd.run
+                  "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
+                                                                  spec.debVersion} ${appsVariant
+                                                                                       spec}"
 
           in  Command.build
                 Command.Config::{
@@ -347,8 +319,8 @@ let build_apps
                         }
                         (commonBuildEnvs spec)
                         "./buildkite/scripts/build-artifact.sh"
-                    # appsCacheWrites
-                    # [ Cmd.run
+                    # [ appsCacheWrite
+                      , Cmd.run
                           "./buildkite/scripts/apps/write_build_manifest_to_cache.sh ${DebianVersions.lowerName
                                                                                          spec.debVersion} ${treeVariant
                                                                                                               spec}"
@@ -384,9 +356,9 @@ let buildDebianFromApps
             , submodules = False
             }
             (commonBuildEnvs spec)
-            "./buildkite/scripts/debian/build-from-cache.sh ${primaryAppsVariant
-                                                                spec} ${treeVariant
-                                                                          spec} ${tokens}"
+            "APPS_VARIANT=${appsVariant
+                              spec} ./buildkite/scripts/debian/build-from-cache.sh ${treeVariant
+                                                                                       spec} ${tokens}"
 
 let build_debian
     : MinaBuildSpec.Type -> Command.Type

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -74,7 +74,6 @@ let envExports =
           \(spec : Spec.Type)
       ->  [ "MINA_NETWORK_DEB=${Network.lowerName spec.network}"
           , "MINA_DEB_CODENAME=${Dockers.lowerName spec.dockerType}"
-          , "APPS_NETWORK=${Network.lowerName spec.network}"
           , "MINA_PROFILE=${Profiles.lowerName spec.profile}"
           , "APPS_BARE_BINARIES=${bareBinaries}"
           ]

--- a/buildkite/src/Command/RosettaBlockRaceTest.dhall
+++ b/buildkite/src/Command/RosettaBlockRaceTest.dhall
@@ -16,8 +16,7 @@ in  { step =
               Command.Config::{
               , commands =
                 [ RunWithPostgres.runInToolchainWithPostgresAndDebs
-                    [ "APPS_NETWORK=mainnet"
-                    , "MINA_PROFILE=mainnet"
+                    [ "MINA_PROFILE=mainnet"
                     , "APPS_BARE_BINARIES=mina.exe:mina,archive.exe:mina-archive,rosetta.exe:mina-rosetta"
                     ]
                     ( Some

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -46,7 +46,6 @@ let bareBinaries =
 let envExports =
       [ "MINA_NETWORK_DEB=${Network.lowerName network}"
       , "MINA_DEB_CODENAME=bullseye"
-      , "APPS_NETWORK=${Network.lowerName network}"
       , "MINA_PROFILE=${Network.lowerName network}"
       , "APPS_BARE_BINARIES=${bareBinaries}"
       ]


### PR DESCRIPTION
## Why

The apps CI cache was namespaced `apps/<codename>/<network>-<profile>[-instrumented][-arm64]/`. Two of those four segments carry no information:

- **The profile segment is a copy of the network segment.** It is computed as `Profiles.fromNetwork net`, and `Network.Type` is `Devnet | Mainnet`, so the variant only ever rendered as `devnet-devnet` or `mainnet-mainnet`.
- **The network segment does not change the binaries.** The daemon binary the cache holds is `src/app/cli/src/mina.exe`, which links no `mina_signature_kind` library (see `src/app/cli/src/dune` — that is what the separate `mina_testnet_signatures` / `mina_mainnet_signatures` executables are for, and they are not what the cache serves). Signature kind and proof level are resolved at runtime from the config. Only instrumentation and the target architecture actually change the bytes.

The result was pure duplication: a job whose artifacts span both networks wrote the *same* `_build` twice, once per variant directory. `MinaArtifactBookworm`, `Focal`, `Jammy` and `Noble` each did this. `restore_build_tree.sh` already conceded the point in its own header — "any network's variant works -- write_to_cache.sh flattens every binary into each one".

## What changed

The variant now names only what makes a build differ from the default one, and is empty for that default (a standard, non-instrumented amd64 build):

```
apps/<codename>[/<variant>]/      variant in { instrumented, arm64, instrumented-arm64 }
```

A standard amd64 build therefore lands directly in `apps/<codename>/` — there is no `standard` segment, because standard is what you get when nothing is said.

**Dhall**
- `Command/MinaArtifact.dhall`: new `appsVariant` helper, a merge over build flags x architecture; both `build_artifacts` and `build_apps` write one cache entry instead of mapping over the artifact networks. `primaryAppsVariant` is deleted and its one call site (the `build-from-cache.sh` invocation) now uses `appsVariant`.
- `APPS_NETWORK` is no longer set by `RosettaIntegrationTests`, `RosettaBlockRaceTest` or `Rosetta/Connectivity` — it only ever selected a cache path. `MINA_PROFILE`, which selects the network at *runtime*, is untouched.

**Scripts**
- `apps/restore_app.sh`: signature is now `restore_app.sh <exe> <install-as>`; the leading `<network>` argument and the `APPS_PROFILE` knob are gone. `APPS_BUILD_FLAG` and `APPS_ARCH` still select the variant.
- `apps/restore_binary.sh`: now takes no arguments.
- `apps/write_to_cache.sh`: the variant argument is now optional (it is the last positional, so an empty value is harmless).
- `debian/build-from-cache.sh` and `apps/restore_build_tree.sh`: the apps variant moved from a *leading* positional into the `APPS_VARIANT` environment variable. This is required, not cosmetic: an empty leading positional would silently shift `<build-variant>` into its place and corrupt every later argument.
- Callers updated: `single-node-tests.sh`, `bench/run.sh`, `tests/ledger_test_apply.sh`, `dump-mina-type-shapes.sh`, `version-linter.sh`, `test-chain-id.sh`, `connect/connect-to-network.sh`, `debian/restore-or-install.sh`.
- Headers of `write_to_cache.sh` and `restore_build_tree.sh` rewritten: the collision the variant depth guards against is standard-vs-instrumented, not network-vs-network.

## Verification

Rendered every `Jobs/Release/*` pipeline before and after. The cache key each job writes:

| Job | before | after |
|---|---|---|
| MinaArtifactBookworm | `devnet-devnet` + `mainnet-mainnet` | *(none)* |
| MinaArtifactBookwormArm64 | `devnet-devnet-arm64` + `mainnet-mainnet-arm64` | `arm64` |
| MinaArtifactFocal / Jammy / Noble | `devnet-devnet` + `mainnet-mainnet` | *(none)* |
| MinaArtifactBullseyeApps | `devnet-devnet` | *(none)* |
| MinaArtifactMainnetBullseyeApps | `mainnet-mainnet` | *(none)* |
| MinaArtifactBullseyeInstrumentedApps | `devnet-devnet-instrumented` | `instrumented` |
| MinaArtifactOnlyDebianBullseye | `devnet-devnet` | *(none)* |

Writer and reader agree. `MinaArtifactBullseyeApps` renders `apps/write_to_cache.sh bullseye` and the packaging job renders `APPS_VARIANT= ./buildkite/scripts/debian/build-from-cache.sh bullseye ...`; the instrumented pair renders `apps/write_to_cache.sh bullseye instrumented` and `APPS_VARIANT=instrumented ... build-from-cache.sh bullseye-instrumented ...`.

The two path derivations (writer in `write_to_cache.sh`, reader in `restore_app.sh`) were exercised directly for all four combinations and produce the same paths: `apps/bullseye`, `apps/bullseye/instrumented`, `apps/bookworm/arm64`, `apps/bookworm/instrumented-arm64`. The `build-from-cache.sh` argument parsing was also exercised with an empty `APPS_VARIANT=` prefix to confirm `<build-variant>` and the package tokens still land in the right positions.

The one case worth checking is `MinaArtifactBullseyeApps` and `MinaArtifactMainnetBullseyeApps`, which now share `bullseye/standard`. Both run the identical `./buildkite/scripts/build-artifact.sh`, and diffing their rendered build environments shows exactly one difference — `MINA_BUILD_MAINNET=false` vs `true` — a variable no Makefile, source file or script in the repo reads. So the two jobs produce the same binaries and sharing one directory is safe.

- `make all` in `buildkite/`: compiles, 45/45 monorepo tests pass.
- `shellcheck -S warning` clean on all twelve touched scripts.
- No `APPS_NETWORK` / `APPS_PROFILE` references remain anywhere; no caller still passes a network to `restore_app.sh` / `restore_binary.sh`.

## Follow-up, not in this PR

`MINA_BUILD_MAINNET` is dead: `Constants/Network.dhall` computes it into every build environment and nothing consumes it. It is the only reason a devnet and a mainnet build ever looked different. Worth deleting separately.

No changelog entry: the `Lint: Changelog` job's `dirtyWhen` covers `src`, `buildkite/scripts/changelog.sh` and `scripts/github/github_info`, none of which this PR touches.
