### PR TITLE
Split the other codenames into an apps build and a packaging job

### DIFF
--- a/buildkite/scripts/apps/restore_build_tree.sh
+++ b/buildkite/scripts/apps/restore_build_tree.sh
@@ -31,11 +31,25 @@ APPS_DIR="apps/${CODENAME}${APPS_VARIANT:+/${APPS_VARIANT}}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+# A missing cache entry is a HARD failure, never a fallback to building from
+# source. Packaging is a consumer of the app build: if the binaries are not
+# there, the app-build job did not run (or did not run for this variant), and
+# silently recompiling here would hide that the pipeline is wired wrong.
+fail_missing() {
+  echo "restore_build_tree: $1" >&2
+  echo "restore_build_tree: the app-build job for ${CODENAME} must run and write" >&2
+  echo "  the apps cache BEFORE this packaging job. Expected binaries in" >&2
+  echo "  ${APPS_DIR}/ and the manifest in" >&2
+  echo "  build-manifest/${CODENAME}/${BUILD_VARIANT}/build-manifest.txt" >&2
+  echo "  (written by buildkite/scripts/apps/write_to_cache.sh and" >&2
+  echo "  buildkite/scripts/apps/write_build_manifest_to_cache.sh)." >&2
+  exit 1
+}
+
 echo "--- Restoring build manifest for ${CODENAME}/${BUILD_VARIANT}"
 if ! ./buildkite/scripts/cache/manager.sh read \
   "build-manifest/${CODENAME}/${BUILD_VARIANT}/build-manifest.txt" "$TMP_DIR"; then
-  echo "restore_build_tree: manifest for ${CODENAME}/${BUILD_VARIANT} not found in cache" >&2
-  exit 1
+  fail_missing "manifest for ${CODENAME}/${BUILD_VARIANT} not found in cache"
 fi
 
 count=0
@@ -46,8 +60,7 @@ while IFS= read -r relpath; do
   mkdir -p "$fetch_dir"
   if ! ./buildkite/scripts/cache/manager.sh read \
     "${APPS_DIR}/${base}" "$fetch_dir" >/dev/null; then
-    echo "restore_build_tree: ${base} not found in ${APPS_DIR}" >&2
-    exit 1
+    fail_missing "${base} not found in ${APPS_DIR}"
   fi
   install -D -m 0755 "${fetch_dir}/${base}" "$relpath"
   rm -rf "$fetch_dir"

--- a/buildkite/src/Jobs/Release/MinaArtifactBookworm.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookworm.dhall
@@ -15,7 +15,7 @@ let Network = ../../Constants/Network.dhall
 let Profile = ../../Constants/Profiles.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.pipeline
+      ( ArtifactPipelines.packagePipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormApps.dhall
@@ -6,16 +6,16 @@ let Artifacts = ../../Constants/Artifact/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 let PipelineScope = ../../Pipeline/Scope.dhall
 
 let Network = ../../Constants/Network.dhall
 
 let Profile = ../../Constants/Profiles.dhall
 
-let PipelineTag = ../../Pipeline/Tag.dhall
-
 in  Pipeline.build
-      ( ArtifactPipelines.packagePipeline
+      ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
@@ -24,14 +24,14 @@ in  Pipeline.build
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
             , Artifacts.Type.CreatePreforkGenesis
                 { network = Network.Type.Devnet }
             , Artifacts.Type.CreatePreforkGenesis
@@ -44,17 +44,18 @@ in  Pipeline.build
             , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
             , Artifacts.Type.LogProc
             , Artifacts.Type.TxTools
+            , Artifacts.Type.DelegationVerifier
             , Artifacts.Type.DaemonStorageToolbox
             ]
-          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
-            [ PipelineTag.Type.Packaging
+            [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Devnet
             , PipelineTag.Type.Amd64
-            , PipelineTag.Type.Focal
+            , PipelineTag.Type.Bookworm
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64.dhall
@@ -17,7 +17,7 @@ let Profile = ../../Constants/Profiles.dhall
 let Arch = ../../Constants/Arch.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.pipeline
+      ( ArtifactPipelines.packagePipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Apps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Apps.dhall
@@ -6,16 +6,18 @@ let Artifacts = ../../Constants/Artifact/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 let PipelineScope = ../../Pipeline/Scope.dhall
 
 let Network = ../../Constants/Network.dhall
 
 let Profile = ../../Constants/Profiles.dhall
 
-let PipelineTag = ../../Pipeline/Tag.dhall
+let Arch = ../../Constants/Arch.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.packagePipeline
+      ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
@@ -24,10 +26,6 @@ in  Pipeline.build
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
@@ -46,15 +44,16 @@ in  Pipeline.build
             , Artifacts.Type.TxTools
             , Artifacts.Type.DaemonStorageToolbox
             ]
-          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          , arch = Arch.Type.Arm64
           , tags =
-            [ PipelineTag.Type.Packaging
+            [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Devnet
-            , PipelineTag.Type.Amd64
-            , PipelineTag.Type.Focal
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalApps.dhall
@@ -15,7 +15,7 @@ let Profile = ../../Constants/Profiles.dhall
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.packagePipeline
+      ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
@@ -48,7 +48,7 @@ in  Pipeline.build
             ]
           , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
-            [ PipelineTag.Type.Packaging
+            [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Devnet

--- a/buildkite/src/Jobs/Release/MinaArtifactJammy.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammy.dhall
@@ -15,7 +15,7 @@ let Network = ../../Constants/Network.dhall
 let Profile = ../../Constants/Profiles.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.pipeline
+      ( ArtifactPipelines.packagePipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyApps.dhall
@@ -6,16 +6,16 @@ let Artifacts = ../../Constants/Artifact/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 let PipelineScope = ../../Pipeline/Scope.dhall
 
 let Network = ../../Constants/Network.dhall
 
 let Profile = ../../Constants/Profiles.dhall
 
-let PipelineTag = ../../Pipeline/Tag.dhall
-
 in  Pipeline.build
-      ( ArtifactPipelines.packagePipeline
+      ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
@@ -24,14 +24,14 @@ in  Pipeline.build
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
             , Artifacts.Type.CreatePreforkGenesis
                 { network = Network.Type.Devnet }
             , Artifacts.Type.CreatePreforkGenesis
@@ -46,15 +46,15 @@ in  Pipeline.build
             , Artifacts.Type.TxTools
             , Artifacts.Type.DaemonStorageToolbox
             ]
-          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
-            [ PipelineTag.Type.Packaging
+            [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Devnet
             , PipelineTag.Type.Amd64
-            , PipelineTag.Type.Focal
+            , PipelineTag.Type.Jammy
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , debVersion = DebianVersions.DebVersion.Jammy
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactNoble.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNoble.dhall
@@ -15,7 +15,7 @@ let Network = ../../Constants/Network.dhall
 let Profile = ../../Constants/Profiles.dhall
 
 in  Pipeline.build
-      ( ArtifactPipelines.pipeline
+      ( ArtifactPipelines.packagePipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
@@ -6,16 +6,16 @@ let Artifacts = ../../Constants/Artifact/Artifacts.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
+let PipelineTag = ../../Pipeline/Tag.dhall
+
 let PipelineScope = ../../Pipeline/Scope.dhall
 
 let Network = ../../Constants/Network.dhall
 
 let Profile = ../../Constants/Profiles.dhall
 
-let PipelineTag = ../../Pipeline/Tag.dhall
-
 in  Pipeline.build
-      ( ArtifactPipelines.packagePipeline
+      ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.MinaBuildSpec::{
           , artifacts =
             [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
@@ -24,14 +24,14 @@ in  Pipeline.build
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
             , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
             , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
             , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
             , Artifacts.Type.CreatePreforkGenesis
                 { network = Network.Type.Devnet }
             , Artifacts.Type.CreatePreforkGenesis
@@ -46,15 +46,15 @@ in  Pipeline.build
             , Artifacts.Type.TxTools
             , Artifacts.Type.DaemonStorageToolbox
             ]
-          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           , tags =
-            [ PipelineTag.Type.Packaging
+            [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
             , PipelineTag.Type.Docker
             , PipelineTag.Type.Devnet
             , PipelineTag.Type.Amd64
-            , PipelineTag.Type.Focal
+            , PipelineTag.Type.Noble
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Pipeline/ScopeFilter.dhall
+++ b/buildkite/src/Pipeline/ScopeFilter.dhall
@@ -11,6 +11,7 @@ let Filter
       | Nightly
       | MainlineNightly
       | Weekly
+      | Release
       | All
       >
 
@@ -23,6 +24,7 @@ let scopes
             , Nightly = [ Scope.Type.Nightly ]
             , MainlineNightly = [ Scope.Type.MainlineNightly ]
             , Weekly = [ Scope.Type.Weekly ]
+            , Release = [ Scope.Type.Release ]
             , All =
               [ Scope.Type.PullRequest
               , Scope.Type.Nightly
@@ -42,6 +44,7 @@ let show
             , Nightly = "nightly"
             , MainlineNightly = "mainlinenightly"
             , Weekly = "weekly"
+            , Release = "release"
             , All = "all"
             }
             filter


### PR DESCRIPTION
> Stacked on #19180 — it needs the `Packaging` tag introduced there. Review/merge that one first; the base branch is set accordingly.

## Why

Bullseye already had its build split into an apps job (compile, fills the apps cache) and a packaging job (debs + docker images). The other codenames — Bookworm, Bookworm arm64, Focal, Jammy, Noble — still did both in a single job via `ArtifactPipelines.pipeline`, so there was no way to compile them without also packaging them.

## What changed

Each of the five becomes two jobs, mirroring the bullseye layout exactly:

| new apps job (`appsPipeline`, tagged `Long`) | packaging job (`packagePipeline`, tagged `Packaging`) |
|---|---|
| MinaArtifactBookwormApps | MinaArtifactBookworm |
| MinaArtifactBookwormArm64Apps | MinaArtifactBookwormArm64 |
| MinaArtifactFocalApps | MinaArtifactFocal |
| MinaArtifactJammyApps | MinaArtifactJammy |
| MinaArtifactNobleApps | MinaArtifactNoble |

The artifact list, `debVersion` and `scope` are carried over unchanged; only the pipeline function and the one tag differ between the halves. This buys the same two properties bullseye already has:

- the apps job triages on `DebianVersions.dirtyWhen` (source paths), so a source change still compiles it;
- the packaging job triages on `DebianVersions.packageDirtyWhen` (dockerfiles, `scripts/debian`, `scripts/docker`, `buildkite/scripts/apps`, …), so on a PR it runs **only if packaging was touched**.

**New `Release` scope filter** (`Pipeline/ScopeFilter.dhall`, `Release = [ Scope.Type.Release ]`). Jobs already carry the `Release` *scope*, but no scope *filter* selected it, so a publish pipeline could not ask for "everything scoped Release" — only `StableOnly` (which also drags in MainlineNightly) or `All`. This is what the publish pipeline runs with.

**Packaging fails soundly on a cold cache.** `restore_build_tree.sh` already exited non-zero on a miss; the message now names what is missing, which job was supposed to produce it, and where. Packaging never falls back to compiling from source — a missing cache means the app build did not run, and silently recompiling would hide that the pipeline is mis-wired.

## Resulting pipeline shape

Measured with `buildkite/scripts/pipeline/list_jobs.sh` (added in #19180) against the real job specs.

**Nightly / mainline — compiles, no packaging:**

| stage | artifact jobs |
|---|---|
| `SCOPE=MainlineNightly FILTER=LongAndVeryLong` | the 3 bullseye `…Apps` jobs |
| `SCOPE=MainlineNightly FILTER=Packaging` | 4 packaging jobs — only if that stage is configured |

**Weekly — all 8 apps jobs compile; packaging is a separate stage:**

| stage | artifact jobs |
|---|---|
| `SCOPE=Weekly FILTER=LongAndVeryLong` | Bookworm, BookwormArm64, Bullseye, BullseyeInstrumented, Focal, Jammy, MainnetBullseye, Noble — all `…Apps` |
| `SCOPE=Weekly FILTER=Packaging` | the 9 corresponding packaging jobs |

**Publishing — tests, app builds and packaging all available:**

| stage | count |
|---|---|
| `SCOPE=Release FILTER=LongAndVeryLong` | 37 jobs, including all 8 `…Apps` |
| `SCOPE=Release FILTER=Packaging` | all 9 packaging jobs |

**Pull request (triaged), the requirement "only if touched":**

| PR touches | `LongAndVeryLong` | `Packaging` |
|---|---|---|
| `src/lib/mina_lib/mina_lib.ml` | BullseyeApps, BullseyeInstrumentedApps | *(none — except the caveat below)* |
| `scripts/debian/builder-helpers.sh` | BullseyeApps, BullseyeInstrumentedApps | Bullseye, BullseyeInstrumented |

## Verification

- `make all` in `buildkite/`: compiles, 45/45 monorepo tests pass. `check_names` confirms each new file name matches its job name.
- Dependency wiring renders correctly: `MinaArtifactBookworm`'s deb step depends on `_MinaArtifactBookwormApps-build-apps`, identical in shape to the bullseye pair already running on develop. Same for the other four.
- All scope/filter combinations in the tables above were produced by running `list_jobs.sh`, including the two PR cases with synthetic diff files.
- `shellcheck -S warning` clean on `restore_build_tree.sh`.

## Caveat worth a decision

`MinaArtifactOnlyDebianBullseye` still runs on a **source-only** PR. It uses `onlyDebianPipeline`, whose dirty-when is source-level rather than packaging-level, so it does not follow the "packaging only if touched" rule. It looks deliberate — a single cheap debian build acting as a packaging canary on PRs — so I left it alone rather than quietly removing that coverage. Say the word and I will switch it to `packageDirtyWhen` too.
