### PR TITLE
ci: give app builds their own spec, without artifacts or network

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -99,6 +99,95 @@ let MinaBuildSpec =
           }
       }
 
+let AppsSpec =
+    -- What an app build actually needs, and nothing else.
+    --
+    -- The app build compiles EVERYTHING: build-artifact.sh runs a fixed set of
+    -- make targets and never looks at an artifact list. Nor does anything
+    -- downstream of it -- the apps cache variant is derived from arch and build
+    -- flags alone (there is one cache per codename/arch/flags, not per network
+    -- or profile). So an app build has no artifacts, no network and no profile:
+    -- those describe what gets PACKAGED from the binaries afterwards, which is
+    -- the packaging job's business.
+    --
+    -- nameSegment exists only so a second app job can be told apart by name; it
+    -- is not a network selector. There is nothing network-specific to select.
+      { Type =
+          { prefix : Text
+          , nameSegment : Text
+          , debVersion : DebianVersions.DebVersion
+          , buildFlags : BuildFlags.Type
+          , arch : Arch.Type
+          , toolchainSelectMode : Toolchain.SelectionMode
+          , extraBuildEnvs : List Text
+          , scope : List PipelineScope.Type
+          , tags : List PipelineTag.Type
+          , if_ : Optional B/If
+          , includeIf : List Expr.Type
+          , excludeIf : List Expr.Type
+          }
+      , default =
+          { prefix = "MinaArtifact"
+          , nameSegment = ""
+          , debVersion = DebianVersions.DebVersion.Bullseye
+          , buildFlags = BuildFlags.Type.None
+          , arch = Arch.Type.Amd64
+          , toolchainSelectMode = Toolchain.SelectionMode.ByDebianAndArch
+          , extraBuildEnvs = [] : List Text
+          , scope = PipelineScope.Full
+          , tags = [ PipelineTag.Type.Long, PipelineTag.Type.Release ]
+          , if_ = None B/If
+          , includeIf = [] : List Expr.Type
+          , excludeIf = [] : List Expr.Type
+          }
+      }
+
+let appsLabelSuffix
+    : AppsSpec.Type -> Text
+    =     \(spec : AppsSpec.Type)
+      ->  "${DebianVersions.capitalName
+               spec.debVersion} ${BuildFlags.toSuffixUppercase
+                                    spec.buildFlags}${Arch.labelSuffix
+                                                        spec.arch}"
+
+let appsSpecVariant
+    : AppsSpec.Type -> Text
+    =     \(spec : AppsSpec.Type)
+      ->  merge
+            { None = merge { Amd64 = "", Arm64 = "arm64" } spec.arch
+            , Instrumented =
+                merge
+                  { Amd64 = "instrumented", Arm64 = "instrumented-arm64" }
+                  spec.arch
+            }
+            spec.buildFlags
+
+let appsSpecTreeVariant
+    : AppsSpec.Type -> Text
+    =     \(spec : AppsSpec.Type)
+      ->  "${DebianVersions.lowerName
+               spec.debVersion}${BuildFlags.toLabelSegment
+                                   spec.buildFlags}${Arch.toSuffixLowercase
+                                                       spec.arch}"
+
+let appsBuildEnvs =
+    -- Deliberately excludes MINA_BUILD_MAINNET and the PREFORK_* pair that the
+    -- packaging envs carry: MINA_BUILD_MAINNET is read by nothing at all, and
+    -- PREFORK_LEGACY_VERSION / PREFORK_GITHASH_CONFIG are read only by
+    -- scripts/debian/builder-helpers.sh when it assembles the prefork packages.
+    -- None of them influence compilation.
+          \(spec : AppsSpec.Type)
+      ->    [ "AWS_ACCESS_KEY_ID"
+            , "AWS_SECRET_ACCESS_KEY"
+            , "MINA_BRANCH=\$BUILDKITE_BRANCH"
+            , "MINA_COMMIT_SHA1=\$BUILDKITE_COMMIT"
+            , "MINA_DEB_CODENAME=${DebianVersions.lowerName spec.debVersion}"
+            , "ARCHITECTURE=${Arch.lowerName spec.arch}"
+            ]
+          # BuildFlags.buildEnvs spec.buildFlags
+          # spec.extraBuildEnvs
+          # DebianVersions.overrideEnvs
+
 let labelSuffix
     : MinaBuildSpec.Type -> Text
     =     \(spec : MinaBuildSpec.Type)
@@ -299,12 +388,12 @@ let appsJobName
     = \(spec : MinaBuildSpec.Type) -> "${selfName spec}Apps"
 
 let build_apps
-    : MinaBuildSpec.Type -> Command.Type
-    =     \(spec : MinaBuildSpec.Type)
+    : AppsSpec.Type -> Command.Type
+    =     \(spec : AppsSpec.Type)
       ->  let appsCacheWrite =
                 Cmd.run
                   "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                  spec.debVersion} ${appsVariant
+                                                                  spec.debVersion} ${appsSpecVariant
                                                                                        spec}"
 
           in  Command.build
@@ -317,15 +406,15 @@ let build_apps
                         , arch = spec.arch
                         , submodules = True
                         }
-                        (commonBuildEnvs spec)
+                        (appsBuildEnvs spec)
                         "./buildkite/scripts/build-artifact.sh"
                     # [ appsCacheWrite
                       , Cmd.run
                           "./buildkite/scripts/apps/write_build_manifest_to_cache.sh ${DebianVersions.lowerName
-                                                                                         spec.debVersion} ${treeVariant
+                                                                                         spec.debVersion} ${appsSpecTreeVariant
                                                                                                               spec}"
                       ]
-                , label = "Build apps: ${labelSuffix spec}"
+                , label = "Build apps: ${appsLabelSuffix spec}"
                 , key = "build-apps"
                 , target = Size.Multi
                 , if_ = spec.if_
@@ -664,13 +753,17 @@ let pipeline
       ->  pipelineBuilder spec ([ build_artifacts spec ] # docker_commands spec)
 
 let appsPipeline
-    : MinaBuildSpec.Type -> Pipeline.Config.Type
-    =     \(spec : MinaBuildSpec.Type)
+    : AppsSpec.Type -> Pipeline.Config.Type
+    =     \(spec : AppsSpec.Type)
       ->  Pipeline.Config::{
           , spec = JobSpec::{
             , dirtyWhen = DebianVersions.dirtyWhen spec.debVersion
             , path = "Release"
-            , name = "${appsJobName spec}"
+            , name =
+                "${spec.prefix}${spec.nameSegment}${DebianVersions.capitalName
+                                                      spec.debVersion}${BuildFlags.toSuffixUppercase
+                                                                          spec.buildFlags}${Arch.nameSuffix
+                                                                                              spec.arch}Apps"
             , tags = spec.tags
             , scope = spec.scope
             , includeIf = spec.includeIf
@@ -700,6 +793,7 @@ in  { pipeline = pipeline
     , appsPipeline = appsPipeline
     , packagePipeline = packagePipeline
     , MinaBuildSpec = MinaBuildSpec
+    , AppsSpec = AppsSpec
     , labelSuffix = labelSuffix
     , buildArtifacts = build_artifacts
     , buildApps = build_apps

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormApps.dhall
@@ -2,51 +2,16 @@ let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DelegationVerifier
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Bookworm
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -55,7 +20,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Bookworm
             ]
-          , debVersion = DebianVersions.DebVersion.Bookworm
           , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Apps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Apps.dhall
@@ -2,48 +2,18 @@ let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 let Arch = ../../Constants/Arch.dhall
 
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Bookworm
           , arch = Arch.Type.Arm64
           , tags =
             [ PipelineTag.Type.Long
@@ -53,7 +23,6 @@ in  Pipeline.build
             , PipelineTag.Type.Arm64
             , PipelineTag.Type.Bookworm
             ]
-          , debVersion = DebianVersions.DebVersion.Bookworm
           , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeApps.dhall
@@ -1,39 +1,15 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TestExecutive
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DaemonStorageToolbox
-            , Artifacts.Type.FunctionalTestSuite
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Bullseye
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedApps.dhall
@@ -1,10 +1,6 @@
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
-let Network = ../../Constants/Network.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let BuildFlags = ../../Constants/BuildFlags.dhall
 
@@ -14,23 +10,8 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.FunctionalTestSuite
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Bullseye
           , buildFlags = BuildFlags.Type.Instrumented
           , tags =
             [ PipelineTag.Type.Long

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalApps.dhall
@@ -2,51 +2,16 @@ let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
-
-let PipelineScope = ../../Pipeline/Scope.dhall
-
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
+let PipelineScope = ../../Pipeline/Scope.dhall
+
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
-          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Focal
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -55,6 +20,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Focal
             ]
-          , debVersion = DebianVersions.DebVersion.Focal
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyApps.dhall
@@ -2,50 +2,16 @@ let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Jammy
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -54,7 +20,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Jammy
             ]
-          , debVersion = DebianVersions.DebVersion.Jammy
           , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeApps.dhall
@@ -1,6 +1,11 @@
+-- NOTE: this job compiles exactly what MinaArtifactBullseyeApps compiles, and
+-- writes to the SAME apps cache (`write_to_cache.sh bullseye`) -- the cache
+-- variant is keyed on codename/arch/build-flags only, never on network. It is
+-- kept for now purely so the consumers that name it keep resolving; collapsing
+-- the two is a follow-up.
 let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
 
@@ -8,25 +13,11 @@ let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , nameSegment = "Mainnet"
+          , debVersion = DebianVersions.DebVersion.Bullseye
           , scope = PipelineScope.AllButPullRequest
           , tags =
             [ PipelineTag.Type.Long

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
@@ -2,50 +2,16 @@ let ArtifactPipelines = ../../Command/MinaArtifact.dhall
 
 let DebianVersions = ../../Constants/DebianVersions.dhall
 
-let Artifacts = ../../Constants/Artifact/Artifacts.dhall
-
 let Pipeline = ../../Pipeline/Dsl.dhall
 
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
 
-let Network = ../../Constants/Network.dhall
-
-let Profile = ../../Constants/Profiles.dhall
-
 in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.Daemon { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonGeneric
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
-            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonAutoHardfork
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Devnet }
-            , Artifacts.Type.CreatePreforkGenesis
-                { network = Network.Type.Mainnet }
-            , Artifacts.Type.ArchiveGeneric
-            , Artifacts.Type.Archive { network = Network.Type.Devnet }
-            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
-            , Artifacts.Type.RosettaGeneric
-            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
-            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
-            , Artifacts.Type.LogProc
-            , Artifacts.Type.TxTools
-            , Artifacts.Type.DaemonStorageToolbox
-            ]
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Noble
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release
@@ -54,7 +20,6 @@ in  Pipeline.build
             , PipelineTag.Type.Amd64
             , PipelineTag.Type.Noble
             ]
-          , debVersion = DebianVersions.DebVersion.Noble
           , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
           }
       )


### PR DESCRIPTION
## Summary

**Stacked on #19181** — it introduces the five new codename app jobs this rewrites. Review/merge that first.

An app build compiles **everything**, so it has no business enumerating artifacts. `AppsSpec` carries only what the compile actually needs; the eight `…Apps` jobs shrink from ~60 lines to ~25 and stop describing packaging concerns they do not control.

```diff
-      ( ArtifactPipelines.appsPipeline
-          ArtifactPipelines.MinaBuildSpec::{
-          , artifacts =
-            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
-            , Artifacts.Type.DaemonGeneric
-            ... 22 more ...
-            ]
+      ( ArtifactPipelines.appsPipeline
+          ArtifactPipelines.AppsSpec::{
+          , debVersion = DebianVersions.DebVersion.Bullseye
```

## Why the artifact list could never have mattered

- `build-artifact.sh` runs a fixed set of make targets (`build-mina`, `build-daemon-utils`, …). It reads exactly two env vars — `DUNE_INSTRUMENT_WITH` and `MINA_COMMIT_SHA1` — and never sees an artifact list.
- The apps cache variant is derived from **arch + build flags** only; the build-tree variant from codename + flags + arch. No network, no profile.
- The one value that *was* artifact-derived, `MINA_BUILD_MAINNET`, is **read by nothing in the repo** — it appears only in `Network.dhall` where it is produced, plus an unrelated `export` in `scripts/hardfork/release/build-packages.sh`.

`AppsSpec` fields: `prefix`, `nameSegment`, `debVersion`, `buildFlags`, `arch`, `toolchainSelectMode`, `extraBuildEnvs`, `scope`, `tags`, `if_`, `includeIf`, `excludeIf`. `nameSegment` is *only* a naming hook so a second app job can be told apart — it is not a network selector, because there is nothing network-specific to select.

## Also: three packaging-only envs dropped from the compile

| env | who reads it |
|---|---|
| `MINA_BUILD_MAINNET` | nothing, anywhere |
| `PREFORK_LEGACY_VERSION` | `scripts/debian/builder-helpers.sh` (packaging) |
| `PREFORK_GITHASH_CONFIG` | `scripts/debian/builder-helpers.sh` (packaging) |

None influence compilation. The packaging job's envs are untouched.

## Verification — the rendered command is otherwise byte-identical

I rendered all eight app jobs to YAML before and after, then diffed with the three dropped env flags normalised out:

```
NORMALISED DIFF EMPTY: the only change is the three dropped env vars
```

So every app job runs the same toolchain image, the same script, the same cache writes, under the same name, scope and tags. The raw diff is exactly one `docker run` line per job, differing only by those `--env` flags.

Plus `make all` in `buildkite/`: compiles, **0 unresolved dependencies**, 45/45, and `check_names` still matches every file to its job name.

## Follow-up (deliberately not here)

`MinaArtifactBullseyeApps` and `MinaArtifactMainnetBullseyeApps` both render `write_to_cache.sh bullseye` — the same compile writing the same cache. Now that nothing about an app build is network-specific, the mainnet one is a duplicate. Collapsing it means repointing `ChainIdTestMainnet`, `ConnectToMainnet` and `RosettaBlockRaceTest`, so it gets its own PR; a comment in that file records why it still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
