### PR TITLE
ci: trigger packaging only on packaging paths

### DIFF
--- a/buildkite/src/Constants/DebianVersions.dhall
+++ b/buildkite/src/Constants/DebianVersions.dhall
@@ -114,9 +114,24 @@ let dirtyWhen =
             debVersion
 
 let packageDirtyWhen =
+    -- Strictly what a packaging job reads or produces: the .deb and docker
+    -- build scripts, the Dockerfiles, and the Dhall that defines the jobs.
+    --
+    -- It deliberately does NOT list the compile (buildkite/scripts/build-artifact.sh
+    -- and the apps-cache writers) -- packaging never runs those, it restores the
+    -- tree the app build already produced. The only apps script it touches is
+    -- restore_build_tree.sh, via buildkite/scripts/debian/build-from-cache.sh.
+    --
+    -- Nor does it list the packaging TESTS. Those used to be here so that a test
+    -- selected by its own dirty-when would not be left with a dangling
+    -- dependency on a packaging job that had not been selected. monorepo.sh
+    -- resolves dependencies itself now (phase 2): selecting DebianUpgradeTest
+    -- pulls MinaArtifactBullseye in regardless of this list, so listing the
+    -- tests here only made packaging run on changes it does not depend on.
       [ S.exactly "buildkite/src/Constants/DebianVersions" "dhall"
       , S.exactly "buildkite/src/Constants/ContainerImages" "dhall"
       , S.exactly "buildkite/src/Command/MinaArtifact" "dhall"
+      , S.exactly "buildkite/src/Command/DockerImage" "dhall"
       , S.strictlyStart (S.contains "buildkite/src/Jobs/Release/MinaArtifact")
       , S.strictlyStart (S.contains "dockerfiles")
       , S.strictlyStart (S.contains "scripts/debian")
@@ -124,13 +139,8 @@ let packageDirtyWhen =
       , S.strictlyStart (S.contains "scripts/hardfork")
       , S.strictlyStart (S.contains "buildkite/scripts/docker")
       , S.strictlyStart (S.contains "buildkite/scripts/debian")
-      , S.exactly "buildkite/scripts/build-artifact" "sh"
-      , S.strictlyStart (S.contains "buildkite/scripts/apps")
+      , S.exactly "buildkite/scripts/apps/restore_build_tree" "sh"
       , S.strictlyStart (S.contains "buildkite/scripts/cache")
-      , S.strictlyStart (S.contains "buildkite/scripts/tests/debian")
-      , S.strictlyStart (S.contains "buildkite/scripts/tests/hardfork")
-      , S.strictlyStart (S.contains "buildkite/src/Jobs/Test/Debian")
-      , S.exactly "buildkite/src/Jobs/Test/AutoHardforkTest" "dhall"
       ]
 
 let appDependsOn =


### PR DESCRIPTION
## Summary

**Stacked on #19182.** Makes `packageDirtyWhen` mean what its name says: a packaging job runs when packaging changes, and not otherwise.

## What was in there that should not have been

**The compile.** `buildkite/scripts/build-artifact.sh` and the broad `buildkite/scripts/apps` prefix. A packaging job never runs the compile — it restores the tree the app build already produced. The only apps script it touches is `restore_build_tree.sh`, via `buildkite/scripts/debian/build-from-cache.sh`, so that one file is now listed explicitly instead of the whole directory (the `write_*` scripts belong to the app build).

**The packaging tests.** `buildkite/scripts/tests/debian*`, `buildkite/scripts/tests/hardfork`, `buildkite/src/Jobs/Test/Debian*` and `AutoHardforkTest.dhall`. These were here to satisfy an invariant that no longer exists: a test selected by its own dirty-when must not be left with a dangling dependency on a packaging job nobody selected. `monorepo.sh` resolves dependencies itself now (phase 2), so listing the tests only made packaging run on changes it does not depend on.

That is doubly true today, because those tests no longer depend on a packaging job at all — `DebianUpgradeTest`, `DebianAutomodeTransitionTest` and `AutoHardforkTest` all build the debs they need from the apps cache via `buildDebianFromApps`. Only **two** consumers of a packaging job are left in the whole pipeline:

| consumer | needs |
|---|---|
| `DebianAutomodeTransitionTestMainnet` | debs from Bullseye + MainnetBullseye |
| `HardforkPackageConversion` | debs from Bullseye |

Both are covered by dependency resolution.

Also **adds** `buildkite/src/Command/DockerImage.dhall` — it defines the packaging docker steps and genuinely belongs.

## Verification

`make all` → compiles, 0 unresolved dependencies, 45/45.

Behaviour measured by running the real triage (`monorepo.sh --selection-mode triaged --scopes pullrequest`) against synthetic diffs:

| PR touches | packaging jobs | tests selected | pulled in as dependency |
|---|---|---|---|
| `scripts/debian/builder-helpers.sh` | **Bullseye, BullseyeInstrumented** | — | — |
| `buildkite/scripts/build-artifact.sh` | **none** | — | — |
| `buildkite/scripts/tests/debian-upgrade-test.sh` | **none** | DebianUpgradeTest | — |
| `scripts/hardfork/release/convert-daemon-debian-to-hf.sh` | **Bullseye, BullseyeInstrumented** | HardforkPackageConversion | the two `…Apps` builds |
| `src/lib/mina_base/account.ml` | **none** | — | — |

Rows 2 and 3 are the fix: editing the compile script, or a debian test's own script, no longer drags the packaging build along. Row 3 in particular used to match the old `buildkite/scripts/tests/debian` prefix and trigger a full packaging build for a test that now builds its own debs.

Row 4 is the check that nothing was lost: the one consumer that still needs packaging still gets it, with its app builds pulled in behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
