### PR TITLE
fix broken hardfork docker make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -614,6 +614,10 @@ debian-build-daemon-devnet-prefork: ## Build the Debian daemon package for autom
 debian-build-daemon-mainnet-prefork: ## Build the Debian daemon package for automote mainnet pre hardfork
 	$(call build_debian_package,daemon_mainnet_prefork)
 
+.PHONY: debian-build-config-devnet
+debian-build-config-devnet: ## Build the Debian config package for devnet
+	$(call build_debian_package,daemon_devnet_config)
+
 .PHONY: debian-build-config-mainnet
 debian-build-config-mainnet: ## Build the Debian config package for mainnet
 	$(call build_debian_package,daemon_mainnet_config)
@@ -889,10 +893,10 @@ docker-build-daemon-hardfork-docker: ## Generate hardfork packages
 		--network $(NETWORK_NAME) \
 		--deb-suffix generic \
 		--custom-suffix generic \
-		--load-only
+		--load-only \
 		--no-cache
 
-	cp _build/mina-devnet-config_*.deb .
+	cp _build/mina-$(NETWORK_NAME)-config_*.deb .
 
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
@@ -900,7 +904,7 @@ docker-build-daemon-hardfork-docker: ## Generate hardfork packages
 	. ./scripts/export-git-env-vars.sh && \
 	./scripts/docker/build.sh \
 		--deb-codename $(CODENAME) \
-		--service mina-daemon-config \
+		--service mina-daemon-configured \
 		--version "$$MINA_DOCKER_TAG" \
 		--deb-version "$$MINA_DEB_VERSION" \
 		--branch $(BRANCH_NAME) \
@@ -939,7 +943,7 @@ docker-build-hardfork-rosetta-docker: ## Generate hardfork packages
 		--load-only \
 		--no-cache
 
-	cp _build/mina-devnet-config_*.deb .
+	cp _build/mina-$(NETWORK_NAME)-config_*.deb .
 
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
@@ -947,7 +951,7 @@ docker-build-hardfork-rosetta-docker: ## Generate hardfork packages
 	. ./scripts/export-git-env-vars.sh && \
 	./scripts/docker/build.sh \
 		--deb-codename $(CODENAME) \
-		--service mina-rosetta-config \
+		--service mina-rosetta-configured \
 		--version "$$MINA_DOCKER_TAG" \
 		--deb-version "$$MINA_DEB_VERSION" \
 		--branch $(BRANCH_NAME) \


### PR DESCRIPTION
The two hardfork Docker make targets, `docker-build-daemon-hardfork-docker` and
`docker-build-hardfork-rosetta-docker`, cannot complete. This PR repairs them.
It changes the Makefile only.

### Defects

1. **Wrong service names.** The targets call `--service mina-daemon-config` and
   `--service mina-rosetta-config`. `scripts/docker/build.sh` knows these
   services as `mina-daemon-configured` and `mina-rosetta-configured`, so the
   build stops with "Unsupported service".

   The service check in `build.sh` did not catch this, because it uses a
   substring match (`grep -o "$SERVICE"`). The text `mina-daemon-config` is
   inside `mina-daemon-configured`, so the check passed and the build failed
   later, at the `case` statement.

2. **Missing line continuation.** In `docker-build-daemon-hardfork-docker`
   the `--load-only` line has no `\` at the end. Make thus runs `--no-cache`
   as its own recipe line.

3. **`debian-build-config-devnet` does not exist.** Both targets run
   `$(MAKE) debian-build-config-$(NETWORK_NAME)`, but only the mainnet target
   is defined. With `NETWORK_NAME=devnet` make stops with "No rule to make
   target". The new target uses the `daemon_devnet_config` package, which
   `scripts/debian/build.sh` already supports.

4. **The config package copy was fixed to devnet.** Both targets ran
   `cp _build/mina-devnet-config_*.deb .` while the rest of the recipe follows
   `$(NETWORK_NAME)`. On a mainnet build this copies the wrong file, or none.

### Verification

`make -n` now completes for both targets and for both networks. Before this
change, the devnet dry run stopped at defect 3.

```
$ CODENAME=bullseye NETWORK_NAME=devnet BRANCH_NAME=test \
    make -n docker-build-daemon-hardfork-docker
  --service mina-daemon
  --service mina-daemon-configured
  --no-cache            # now part of the build.sh command
  cp _build/mina-devnet-config_*.deb .

$ CODENAME=bullseye NETWORK_NAME=mainnet BRANCH_NAME=test \
    make -n docker-build-hardfork-rosetta-docker
  debian-build-config-mainnet
  --service mina-rosetta
  --service mina-rosetta-configured
  cp _build/mina-mainnet-config_*.deb .
```

Defect 1 stays possible while the service check accepts a partial name. A test
suite for `scripts/docker/build.sh`, which includes a check that a partial
service name is refused, comes in a separate PR.
